### PR TITLE
Use dropdown.background color in debug dropdown container

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugActionViewItems.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugActionViewItems.ts
@@ -124,7 +124,9 @@ export class StartDebugActionViewItem implements IActionViewItem {
 		this.toDispose.push(attachStylerCallback(this.themeService, { selectBorder, selectBackground }, colors => {
 			this.container.style.border = colors.selectBorder ? `1px solid ${colors.selectBorder}` : '';
 			selectBoxContainer.style.borderLeft = colors.selectBorder ? `1px solid ${colors.selectBorder}` : '';
-			this.start.style.backgroundColor = colors.selectBackground ? `${colors.selectBackground}` : '';
+			const selectBackgroundColor = colors.selectBackground ? `${colors.selectBackground}` : '';
+			this.container.style.backgroundColor = selectBackgroundColor;
+			this.start.style.backgroundColor = selectBackgroundColor;
 		}));
 		this.debugService.getConfigurationManager().getDynamicProviders().then(providers => {
 			this.providers = providers;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Continuation of #96576

Set the container background color to `selectBackground` to make the widget look contiguous in mac OS due to the rounded corners of the select box.

cc @isidorn 