### PR TITLE
Apply scroll area to hover content, not status bar

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/widgets/hoverWidget.ts
+++ b/src/vs/workbench/contrib/terminal/browser/widgets/hoverWidget.ts
@@ -93,7 +93,7 @@ export class HoverWidget extends Widget {
 			const actionsElement = $('div.actions');
 			this._actions.forEach(action => this._renderAction(actionsElement, action));
 			statusBarElement.appendChild(actionsElement);
-			this._domNode.appendChild(statusBarElement);
+			this._containerDomNode.appendChild(statusBarElement);
 		}
 
 		this._mouseTracker = new CompositeMouseTracker([this._containerDomNode, ..._target.targetElements]);


### PR DESCRIPTION
Fixes #97016

![image](https://user-images.githubusercontent.com/2193314/81103580-1712d380-8ec6-11ea-8434-ecdcc54530a3.png)

