### PR TITLE
List: re-anounce element when focus did not change on typing

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -345,7 +345,7 @@ class TypeLabelController<T> implements IDisposable {
 
 	private automaticKeyboardNavigation = true;
 	private triggered = false;
-	private charactersTyped = 0;
+	private previouslyFocused = -1;
 
 	private readonly enabledDisposables = new DisposableStore();
 	private readonly disposables = new DisposableStore();
@@ -413,15 +413,15 @@ class TypeLabelController<T> implements IDisposable {
 
 	private onClear(): void {
 		const focus = this.list.getFocus();
-		if (focus.length > 0 && this.charactersTyped > 1) {
+		if (focus.length > 0 && focus[0] === this.previouslyFocused) {
 			// List: re-anounce element on typing end since typed keys will interupt aria label of focused element
-			// Do not announce if only one character typed to avoid duplicate announcment https://github.com/microsoft/vscode/issues/95961
+			// Do not announce if there was a focus change at the end to prevent duplication https://github.com/microsoft/vscode/issues/95961
 			const ariaLabel = this.list.options.accessibilityProvider?.getAriaLabel(this.list.element(focus[0]));
 			if (ariaLabel) {
 				alert(ariaLabel);
 			}
 		}
-		this.charactersTyped = 0;
+		this.previouslyFocused = -1;
 	}
 
 	private onInput(word: string | null): void {
@@ -431,7 +431,6 @@ class TypeLabelController<T> implements IDisposable {
 			return;
 		}
 
-		this.charactersTyped++;
 		const focus = this.list.getFocus();
 		const start = focus.length > 0 ? focus[0] : 0;
 		const delta = this.state === TypeLabelControllerState.Idle ? 1 : 0;
@@ -443,6 +442,7 @@ class TypeLabelController<T> implements IDisposable {
 			const labelStr = label && label.toString();
 
 			if (typeof labelStr === 'undefined' || matchesPrefix(word, labelStr)) {
+				this.previouslyFocused = start;
 				this.list.setFocus([index]);
 				this.list.reveal(index);
 				return;

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -345,6 +345,7 @@ class TypeLabelController<T> implements IDisposable {
 
 	private automaticKeyboardNavigation = true;
 	private triggered = false;
+	private charactersTyped = 0;
 
 	private readonly enabledDisposables = new DisposableStore();
 	private readonly disposables = new DisposableStore();
@@ -412,12 +413,15 @@ class TypeLabelController<T> implements IDisposable {
 
 	private onClear(): void {
 		const focus = this.list.getFocus();
-		if (focus.length > 0) {
+		if (focus.length > 0 && this.charactersTyped > 1) {
+			// List: re-anounce element on typing end since typed keys will interupt aria label of focused element
+			// Do not announce if only one character typed to avoid duplicate announcment https://github.com/microsoft/vscode/issues/95961
 			const ariaLabel = this.list.options.accessibilityProvider?.getAriaLabel(this.list.element(focus[0]));
 			if (ariaLabel) {
 				alert(ariaLabel);
 			}
 		}
+		this.charactersTyped = 0;
 	}
 
 	private onInput(word: string | null): void {
@@ -427,6 +431,7 @@ class TypeLabelController<T> implements IDisposable {
 			return;
 		}
 
+		this.charactersTyped++;
 		const focus = this.list.getFocus();
 		const start = focus.length > 0 ? focus[0] : 0;
 		const delta = this.state === TypeLabelControllerState.Idle ? 1 : 0;

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -394,6 +394,7 @@ class TypeLabelController<T> implements IDisposable {
 		const onInput = Event.reduce<string | null, string | null>(Event.any(onChar, onClear), (r, i) => i === null ? null : ((r || '') + i));
 
 		onInput(this.onInput, this, this.enabledDisposables);
+		onClear(this.onClear, this, this.enabledDisposables);
 
 		this.enabled = true;
 		this.triggered = false;
@@ -407,6 +408,16 @@ class TypeLabelController<T> implements IDisposable {
 		this.enabledDisposables.clear();
 		this.enabled = false;
 		this.triggered = false;
+	}
+
+	private onClear(): void {
+		const focus = this.list.getFocus();
+		if (focus.length > 0) {
+			const ariaLabel = this.list.options.accessibilityProvider?.getAriaLabel(this.list.element(focus[0]));
+			if (ariaLabel) {
+				alert(ariaLabel);
+			}
+		}
 	}
 
 	private onInput(word: string | null): void {
@@ -429,14 +440,6 @@ class TypeLabelController<T> implements IDisposable {
 			if (typeof labelStr === 'undefined' || matchesPrefix(word, labelStr)) {
 				this.list.setFocus([index]);
 				this.list.reveal(index);
-
-				if (index === start) {
-					// Focus did not change with typing, re-announce element https://github.com/microsoft/vscode/issues/95961
-					const ariaLabel = this.list.options.accessibilityProvider?.getAriaLabel(this.list.element(index));
-					if (ariaLabel) {
-						alert(ariaLabel);
-					}
-				}
 				return;
 			}
 		}

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -432,7 +432,7 @@ class TypeLabelController<T> implements IDisposable {
 
 				if (index === start) {
 					// Focus did not change with typing, re-announce element https://github.com/microsoft/vscode/issues/95961
-					const ariaLabel = this.list.options.accessibilityProvider ? this.list.options.accessibilityProvider.getAriaLabel(this.list.element(index)) : undefined;
+					const ariaLabel = this.list.options.accessibilityProvider?.getAriaLabel(this.list.element(index));
 					if (ariaLabel) {
 						alert(ariaLabel);
 					}

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -26,6 +26,7 @@ import { CombinedSpliceable } from 'vs/base/browser/ui/list/splice';
 import { clamp } from 'vs/base/common/numbers';
 import { matchesPrefix } from 'vs/base/common/filters';
 import { IDragAndDropData } from 'vs/base/browser/dnd';
+import { alert } from 'vs/base/browser/ui/aria/aria';
 
 interface ITraitChangeEvent {
 	indexes: number[];
@@ -428,6 +429,14 @@ class TypeLabelController<T> implements IDisposable {
 			if (typeof labelStr === 'undefined' || matchesPrefix(word, labelStr)) {
 				this.list.setFocus([index]);
 				this.list.reveal(index);
+
+				if (index === start) {
+					// Focus did not change with typing, re-announce element https://github.com/microsoft/vscode/issues/95961
+					const ariaLabel = this.list.options.accessibilityProvider ? this.list.options.accessibilityProvider.getAriaLabel(this.list.element(index)) : undefined;
+					if (ariaLabel) {
+						alert(ariaLabel);
+					}
+				}
 				return;
 			}
 		}


### PR DESCRIPTION
As suggested by @joanmarie here https://github.com/microsoft/vscode/issues/95961
We re-announce the element if we notice the focus did not change on typing.

I have tried this and unfortunetly does not work with Orca for me.
The problem is the following, let's say I have element `abc.txt`:
* If I type `a` the element gets focus and is nicely read
* If I type `ab` fastly we set the focus and nicely alert and all is good
* If I type `abc` fastly it does not work, because after user typed `b` we set the content of the aria-live region to be `abc.txt`, after user pressed `c` we set the content of the live region to the same content again and thus Orca does not announce anything.

So I see two ways to fix this
1) @joanmarie is it possible to somehow force orca to re-read the live content even though it did not change. Idealy if I clear the live content element and reset the content that should work, however it does not
2) @joaomoreno do we know when the user "stopped" typing for navigation. If yes, only then we could alert. However this would still not work 100%, since after stopping typing user could start typing the same element and nothing would be read, however it would cover most of the cases

If you want to repro:
1. Build vscode from this branch
2. Open Explorer and have file abc.txt and type as I explained above