### PR TITLE
statusBar: focusNext and focusPrevious

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -59,7 +59,7 @@ interface IStatusbarViewModelEntry {
 	labelContainer: HTMLElement;
 }
 
-const CONTEXT_STATUS_BAR_FOCUSED = new RawContextKey<boolean>('statusBarFocused', true);
+const CONTEXT_STATUS_BAR_FOCUSED = new RawContextKey<boolean>('statusBarFocused', false);
 
 class StatusbarViewModel extends Disposable {
 
@@ -498,7 +498,7 @@ export class StatusbarPart extends Part implements IStatusbarService {
 
 		// Track focus within container
 		const scopedContextKeyService = this.contextKeyService.createScoped(this.element);
-		CONTEXT_STATUS_BAR_FOCUSED.bindTo(scopedContextKeyService);
+		CONTEXT_STATUS_BAR_FOCUSED.bindTo(scopedContextKeyService).set(true);
 
 		// Left items container
 		this.leftItemsContainer = document.createElement('div');

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -659,8 +659,6 @@ export class StatusbarPart extends Part implements IStatusbarService {
 	private doCreateStatusItem(id: string, alignment: StatusbarAlignment, ...extraClasses: string[]): HTMLElement {
 		const itemContainer = document.createElement('div');
 		itemContainer.id = id;
-		// Allow focus via next and previous navigation commands
-		itemContainer.tabIndex = -1;
 
 		addClass(itemContainer, 'statusbar-item');
 		if (extraClasses) {

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -911,6 +911,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'workbench.statusBar.focusPrevious',
 	weight: KeybindingWeight.WorkbenchContrib,
 	primary: KeyCode.LeftArrow,
+	secondary: [KeyCode.UpArrow],
 	when: CONTEXT_STATUS_BAR_FOCUSED,
 	handler: (accessor: ServicesAccessor) => {
 		const statusBarService = accessor.get(IStatusbarService);
@@ -922,6 +923,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'workbench.statusBar.focusNext',
 	weight: KeybindingWeight.WorkbenchContrib,
 	primary: KeyCode.RightArrow,
+	secondary: [KeyCode.DownArrow],
 	when: CONTEXT_STATUS_BAR_FOCUSED,
 	handler: (accessor: ServicesAccessor) => {
 		const statusBarService = accessor.get(IStatusbarService);

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -696,7 +696,7 @@ class StatusbarEntryItem extends Disposable {
 
 	private entry!: IStatusbarEntry;
 
-	public labelContainer!: HTMLElement;
+	labelContainer!: HTMLElement;
 	private label!: CodiconLabel;
 
 	private readonly foregroundListener = this._register(new MutableDisposable());

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -491,6 +491,8 @@ export class StatusbarPart extends Part implements IStatusbarService {
 
 	createContentArea(parent: HTMLElement): HTMLElement {
 		this.element = parent;
+		
+		// Track focus within container
 		const scopedContextKeyService = this.contextKeyService.createScoped(this.element);
 		CONTEXT_STATUS_BAR_FOCUSED.bindTo(scopedContextKeyService);
 

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -768,7 +768,6 @@ class StatusbarEntryItem extends Disposable {
 
 			const command = entry.command;
 			if (command) {
-
 				this.commandMouseListener.value = addDisposableListener(this.labelContainer, EventType.CLICK, () => this.executeCommand(command));
 				this.commandKeyboardListener.value = addDisposableListener(this.labelContainer, EventType.KEY_UP, e => {
 					const event = new StandardKeyboardEvent(e);

--- a/src/vs/workbench/services/statusbar/common/statusbar.ts
+++ b/src/vs/workbench/services/statusbar/common/statusbar.ts
@@ -89,6 +89,16 @@ export interface IStatusbarService {
 	 * Allows to update an entry's visibility with the provided ID.
 	 */
 	updateEntryVisibility(id: string, visible: boolean): void;
+
+	/**
+	 * Focuses the next status bar entry. If none focused, focuses the first.
+	 */
+	focusNextEntry(): void;
+
+	/**
+	 * Focuses the previous status bar entry. If none focused, focuses the last.
+	 */
+	focusPreviousEntry(): void;
 }
 
 export interface IStatusbarEntryAccessor extends IDisposable {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/95433

This PR introduces:
* `statusBarFocus` context key
* `workbench.statusBar.focusPrevious` and `workbench.statusBar.focusNext` commands
* Uses the status hover background color for showing focus
* Exposes `focusNextEntry` and `focusPreviousEntry` on the `statusBarService`
* focus goes cyclic, so if you focus next and the last is focused we focus the first.
* Tab moves focus out of the status bar. 

All with the idea to make the status bar item navigable once the status bar is focused. So the flow is `F6` to focus status bar, `left` and `right` to go through the status bar items.
`Up` and `down` are secondary keybindings for `left` and `right`. MS Word behaves like that and I think it makes sense to also navigate like this to be aligned with activity bar and users might not know how status bar looks visually.

Also I decided to put focus on the `a` element, because that way Orca announces the most concise `aria-label`.

I tried this with Orca, NVDA and VoiceOver and seems to work nicely.

Two issues I hit:
* On Linux: `entries` are not ordered with how they are displayed. Though I could not repro this on Mac or Win. @bpasero might you know more (I know you use that flax trick but I thought you just use it for the display, not on the model level)
* Once an item is focused VoiceOver reads the ariaLabel of the item and the whole ariaLabel of the statusBar. This seems to work fine with Orca and NVDA. So we can file an issue with VoiceOver.

@bpasero let me know what you think and if it looks good to you I will merge. Thanks!