### PR TITLE
fix: use correct codicon names for folding control colour customisation

### DIFF
--- a/src/vs/editor/contrib/folding/folding.ts
+++ b/src/vs/editor/contrib/folding/folding.ts
@@ -15,7 +15,7 @@ import { ITextModel } from 'vs/editor/common/model';
 import { registerEditorAction, registerEditorContribution, ServicesAccessor, EditorAction, registerInstantiatedEditorAction } from 'vs/editor/browser/editorExtensions';
 import { ICodeEditor, IEditorMouseEvent, MouseTargetType } from 'vs/editor/browser/editorBrowser';
 import { FoldingModel, setCollapseStateAtLevel, CollapseMemento, setCollapseStateLevelsDown, setCollapseStateLevelsUp, setCollapseStateForMatchingLines, setCollapseStateForType, toggleCollapseState, setCollapseStateUp } from 'vs/editor/contrib/folding/foldingModel';
-import { FoldingDecorationProvider } from './foldingDecorations';
+import { FoldingDecorationProvider, foldingCollapsedIcon, foldingExpandedIcon } from './foldingDecorations';
 import { FoldingRegions, FoldingRegion } from './foldingRanges';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { ConfigurationChangedEvent, EditorOption } from 'vs/editor/common/config/editorOptions';
@@ -909,8 +909,8 @@ registerThemingParticipant((theme, collector) => {
 	const editorFoldColor = theme.getColor(editorFoldForeground);
 	if (editorFoldColor) {
 		collector.addRule(`
-		.monaco-editor .cldr.codicon-chevron-right,
-		.monaco-editor .cldr.codicon-chevron-down {
+		.monaco-editor .cldr${foldingExpandedIcon.cssSelector},
+		.monaco-editor .cldr${foldingCollapsedIcon.cssSelector} {
 			color: ${editorFoldColor} !important;
 		}
 		`);

--- a/src/vs/editor/contrib/folding/foldingDecorations.ts
+++ b/src/vs/editor/contrib/folding/foldingDecorations.ts
@@ -9,8 +9,8 @@ import { IDecorationProvider } from 'vs/editor/contrib/folding/foldingModel';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { Codicon, registerIcon } from 'vs/base/common/codicons';
 
-const foldingExpandedIcon = registerIcon('folding-expanded', Codicon.chevronDown);
-const foldingCollapsedIcon = registerIcon('folding-collapsed', Codicon.chevronRight);
+export const foldingExpandedIcon = registerIcon('folding-expanded', Codicon.chevronDown);
+export const foldingCollapsedIcon = registerIcon('folding-collapsed', Codicon.chevronRight);
 
 export class FoldingDecorationProvider implements IDecorationProvider {
 


### PR DESCRIPTION
This fixes the `editorGutter.foldingControlForeground` colour contribution point by using the correct codicon names in the CSS.

Not sure when this regressed, I just noticed this while playing around with colour contributions and did not see any effect when I customised it.