### PR TITLE
Don't focus editor when un-expanded comment is hidden

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -928,9 +928,11 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 	}
 
 	hide() {
-		this._isExpanded = false;
-		// Focus the container so that the comment editor will be blurred before it is hidden
-		this.editor.focus();
+		if (this._isExpanded) {
+			this._isExpanded = false;
+			// Focus the container so that the comment editor will be blurred before it is hidden
+			this.editor.focus();
+		}
 		super.hide();
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #97100, where the terminal is defocused when comments are changed, which can be caused by terminal commands.

The problem was that when a comment was hidden, it would focus the editor, in order to not have the hidden inline reply editor still focused in the back. But if you hide a comment that is not already expanded, it will still focus the editor, which steals focus from whatever else you had focused.

We don't need to focus the editor if the comment is not expanded.

Tested this by making sure the terminal stays focused even if comments are updated/removed. Also made sure if you open a comment, then type in the reply box, then hide the comment by any means, it would focus the editor and not allow typing in the hidden reply box.
