### PR TITLE
Added display name to PowerShell task

### DIFF
--- a/build/azure-pipelines/win32/continuous-build-win32.yml
+++ b/build/azure-pipelines/win32/continuous-build-win32.yml
@@ -34,6 +34,7 @@ steps:
 
 - powershell: |
     yarn electron
+  displayName: Download Electron
 
 - script: |
     yarn gulp hygiene


### PR DESCRIPTION
Add display name so that the Windows pipeline is consistent with the Mac and Linux one.