### PR TITLE
Add wildcard support to workspace tags

### DIFF
--- a/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
+++ b/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
@@ -22,6 +22,19 @@ import { IWorkspaceTagsService, Tags } from 'vs/workbench/contrib/tags/common/wo
 import { getHashedRemotesFromConfig } from 'vs/workbench/contrib/tags/electron-browser/workspaceTags';
 import { IProductService } from 'vs/platform/product/common/productService';
 
+const MetaModulesToLookFor = [
+	// Azure packages
+	'@azure',
+	'@azure/ai',
+	'@azure/core',
+	'@azure/cosmos',
+	'@azure/event',
+	'@azure/identity',
+	'@azure/keyvault',
+	'@azure/search',
+	'@azure/storage'
+];
+
 const ModulesToLookFor = [
 	// Packages that suggest a node server
 	'express',
@@ -69,27 +82,35 @@ const ModulesToLookFor = [
 	'playwright-firefox',
 	'playwright-webkit'
 ];
+
+const PyMetaModulesToLookFor = [
+	'azure-ai',
+	'azure-cognitiveservices',
+	'azure-core',
+	'azure-cosmos',
+	'azure-event',
+	'azure-identity',
+	'azure-keyvault',
+	'azure-mgmt',
+	'azure-ml',
+	'azure-search',
+	'azure-storage'
+];
+
 const PyModulesToLookFor = [
 	'azure',
-	'azure-storage-common',
-	'azure-storage-blob',
-	'azure-storage-file',
-	'azure-storage-queue',
-	'azure-shell',
-	'azure-cosmos',
 	'azure-devtools',
 	'azure-elasticluster',
 	'azure-eventgrid',
 	'azure-functions',
 	'azure-graphrbac',
-	'azure-keyvault',
+	'azure-iothub-device-client',
 	'azure-loganalytics',
 	'azure-monitor',
 	'azure-servicebus',
 	'azure-servicefabric',
-	'azure-storage',
+	'azure-shell',
 	'azure-translator',
-	'azure-iothub-device-client',
 	'adal',
 	'pydocumentdb',
 	'botbuilder-core',
@@ -186,6 +207,15 @@ export class WorkspaceTagsService implements IWorkspaceTagsService {
 			"workspace.npm.vue" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.aws-sdk" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.aws-amplify-sdk" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.@azure" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.@azure/ai" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.@azure/core" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.@azure/cosmos" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.@azure/event" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.@azure/identity" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.@azure/keyvault" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.@azure/search" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.@azure/storage" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.azure" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.azure-storage" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.@google-cloud/common" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
@@ -227,30 +257,31 @@ export class WorkspaceTagsService implements IWorkspaceTagsService {
 			"workspace.py.Pipfile" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.conda" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.any-azure" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure-storage-common" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure-storage-blob" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure-storage-file" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure-storage-queue" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure-mgmt" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure-shell" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.pulumi-azure" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-ai" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-cognitiveservices" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-core" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-cosmos" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-devtools" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-elasticluster" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-event" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-eventgrid" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-functions" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-graphrbac" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-identity" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-iothub-device-client" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-keyvault" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-loganalytics" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-mgmt" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-ml" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-monitor" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-search" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-servicebus" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-servicefabric" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.py.azure-shell" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-storage" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.azure-translator" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure-iothub-device-client" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure-ml" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
-			"workspace.py.azure-cognitiveservices" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.adal" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.pydocumentdb" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.botbuilder-core" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
@@ -370,16 +401,13 @@ export class WorkspaceTagsService implements IWorkspaceTagsService {
 				if (PyModulesToLookFor.indexOf(packageName) > -1) {
 					tags['workspace.py.' + packageName] = true;
 				}
-				// cognitive services has a lot of tiny packages. e.g. 'azure-cognitiveservices-search-autosuggest'
-				if (packageName.indexOf('azure-cognitiveservices') > -1) {
-					tags['workspace.py.azure-cognitiveservices'] = true;
+
+				for (const metaModule of PyMetaModulesToLookFor) {
+					if (packageName.startsWith(metaModule)) {
+						tags['workspace.py.' + metaModule] = true;
+					}
 				}
-				if (packageName.indexOf('azure-mgmt') > -1) {
-					tags['workspace.py.azure-mgmt'] = true;
-				}
-				if (packageName.indexOf('azure-ml') > -1) {
-					tags['workspace.py.azure-ml'] = true;
-				}
+
 				if (!tags['workspace.py.any-azure']) {
 					tags['workspace.py.any-azure'] = /azure/i.test(packageName);
 				}
@@ -419,24 +447,25 @@ export class WorkspaceTagsService implements IWorkspaceTagsService {
 			const packageJsonPromises = getFilePromises('package.json', this.fileService, this.textFileService, content => {
 				try {
 					const packageJsonContents = JSON.parse(content.value);
-					let dependencies = packageJsonContents['dependencies'];
-					let devDependencies = packageJsonContents['devDependencies'];
-					for (let module of ModulesToLookFor) {
-						if ('react-native' === module) {
-							if ((dependencies && dependencies[module]) || (devDependencies && devDependencies[module])) {
-								tags['workspace.reactNative'] = true;
-							}
-						} else if ('tns-core-modules' === module) {
-							if ((dependencies && dependencies[module]) || (devDependencies && devDependencies[module])) {
-								tags['workspace.nativescript'] = true;
-							}
+					let deps = Object.keys(packageJsonContents['dependencies']);
+					let devDeps = Object.keys(packageJsonContents['devDependencies']);
+					let dependencies = new Set([...devDeps, ...deps]);
+
+					for (let dependency of dependencies) {
+						if ('react-native' === dependency) {
+							tags['workspace.reactNative'] = true;
+						} else if ('tns-core-modules' === dependency) {
+							tags['workspace.nativescript'] = true;
+						} else if (ModulesToLookFor.indexOf(dependency) > -1) {
+							tags['workspace.npm.' + dependency] = true;
 						} else {
-							if ((dependencies && dependencies[module]) || (devDependencies && devDependencies[module])) {
-								tags['workspace.npm.' + module] = true;
+							for (const metaModule of MetaModulesToLookFor) {
+								if (dependency.startsWith(metaModule)) {
+									tags['workspace.npm.' + metaModule] = true;
+								}
 							}
 						}
 					}
-
 				}
 				catch (e) {
 					// Ignore errors when resolving file or parsing file contents

--- a/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
+++ b/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
@@ -447,9 +447,7 @@ export class WorkspaceTagsService implements IWorkspaceTagsService {
 			const packageJsonPromises = getFilePromises('package.json', this.fileService, this.textFileService, content => {
 				try {
 					const packageJsonContents = JSON.parse(content.value);
-					let deps = Object.keys(packageJsonContents['dependencies']);
-					let devDeps = Object.keys(packageJsonContents['devDependencies']);
-					let dependencies = new Set([...devDeps, ...deps]);
+					let dependencies = Object.keys(packageJsonContents['dependencies']).concat(Object.keys(packageJsonContents['devDependencies']));
 
 					for (let dependency of dependencies) {
 						if ('react-native' === dependency) {


### PR DESCRIPTION
This PR allows support to use wildcards in the workspace tags.

The Azure team has hundreds of packages and making sure the list is up-to-date is a burden to anyone. This PR allows to specify a prefix, e.g.: `'@azure/*'. All packages that start with that string (minus `*`) will be reported.

/cc @sana-ajani

