### PR TITLE
Fix #97192 - delete bad setting validation

### DIFF
--- a/src/vs/workbench/services/preferences/common/preferencesValidation.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesValidation.ts
@@ -69,7 +69,6 @@ export function getInvalidTypeError(value: any, type: undefined | string | strin
 		(valueType === 'boolean' && !canBeType(typeArr, 'boolean')) ||
 		(valueType === 'object' && !canBeType(typeArr, 'object', 'null', 'array')) ||
 		(valueType === 'string' && !canBeType(typeArr, 'string', 'number', 'integer')) ||
-		(typeof parseFloat(value) === 'number' && !isNaN(parseFloat(value)) && !canBeType(typeArr, 'number', 'integer')) ||
 		(Array.isArray(value) && !canBeType(typeArr, 'array'))
 	) {
 		if (typeof type !== 'undefined') {


### PR DESCRIPTION
This whole function is questionable, and the check I had for numeric type settings doesn't make sense. Just deleting it for release and I'll rewrite the whole thing in master.

Fix #97192