### PR TITLE
fix(jsDoc): remove one space indentation on multiple enters after closing jsDoc

### DIFF
--- a/src/vs/editor/common/modes/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/modes/languageConfigurationRegistry.ts
@@ -419,7 +419,8 @@ export class LanguageConfigurationRegistryImpl {
 				};
 			}
 
-			if (honorIntentialIndent) {
+			// if precedingUnIgnoredLineContent is of jsDoc pattern then don't honour initial indent
+			if (honorIntentialIndent && !/\s*\*\/$/.test(precedingUnIgnoredLineContent)) {
 				return {
 					indentation: strings.getLeadingWhitespace(model.getLineContent(precedingUnIgnoredLine)),
 					action: null,

--- a/src/vs/editor/common/modes/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/modes/languageConfigurationRegistry.ts
@@ -419,8 +419,10 @@ export class LanguageConfigurationRegistryImpl {
 				};
 			}
 
-			// if precedingUnIgnoredLineContent is of jsDoc pattern then don't honour initial indent
-			if (honorIntentialIndent && !/\s*\*\/$/.test(precedingUnIgnoredLineContent)) {
+			const jsDocOpeningRegExp = /\s*\/\*\*\s*$/;
+			const jsDocClosingRegExp = /\s*\*\/$/;
+			// if precedingUnIgnoredLineContent is of jsDoc closing pattern then don't honour initial indent
+			if (honorIntentialIndent && !jsDocClosingRegExp.test(precedingUnIgnoredLineContent)) {
 				return {
 					indentation: strings.getLeadingWhitespace(model.getLineContent(precedingUnIgnoredLine)),
 					action: null,
@@ -451,7 +453,8 @@ export class LanguageConfigurationRegistryImpl {
 							action: null,
 							line: stopLine + 1
 						};
-					} else if (indentRulesSupport.shouldDecrease(lineContent)) {
+						// if precedingUnIgnoredLineContent is of jsDoc pattern and lineContent matches jsDoc opening pattern
+					} else if (indentRulesSupport.shouldDecrease(lineContent) || jsDocOpeningRegExp.test(lineContent)) {
 						return {
 							indentation: strings.getLeadingWhitespace(lineContent),
 							action: null,

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -3951,6 +3951,7 @@ suite('Editor Controller - Indentation Rules', () => {
 		model.dispose();
 		mode.dispose();
 	});
+
 	test('bug #92094: After JSDoc comment close, should not move cursor one space on multiple enter', () => {
 		usingCursor({
 			text: [
@@ -3971,6 +3972,33 @@ suite('Editor Controller - Indentation Rules', () => {
 			cursorCommand(cursor, H.Type, { text: '\n' }, 'keyboard');
 			assertCursor(cursor, new Selection(6, 1, 6, 1));
 			assert.deepEqual(model.getLineContent(6), '/** */');
+		});
+	});
+
+	test('bug #92094: After JSDoc comment close, enter should keep indentation of jsDoc opening tag', () => {
+		usingCursor({
+			text: [
+				'if(true) {',
+				'\tif(true) {',
+				'\t\t/**',
+				'\t\t\s* xyz',
+				'\t\t\s*/const a = 0;',
+				'\t}',
+				'}'
+			],
+			modelOpts: {
+				insertSpaces: true,
+				tabSize: 2
+			}
+		}, (model, cursor) => {
+			moveTo(cursor, 5, 6, false);
+			assertCursor(cursor, new Selection(5, 6, 5, 6));
+			cursorCommand(cursor, H.Type, { text: '\n' }, 'keyboard');
+			assertCursor(cursor, new Selection(6, 5, 6, 5));
+			assert.deepEqual(model.getLineContent(6), '    const a = 0;');
+			cursorCommand(cursor, H.Type, { text: '\n' }, 'keyboard');
+			assertCursor(cursor, new Selection(7, 5, 7, 5));
+			assert.deepEqual(model.getLineContent(7), '    const a = 0;');
 		});
 	});
 });

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -3951,6 +3951,28 @@ suite('Editor Controller - Indentation Rules', () => {
 		model.dispose();
 		mode.dispose();
 	});
+	test('bug #92094: After JSDoc comment close, should not move cursor one space on multiple enter', () => {
+		usingCursor({
+			text: [
+				'/**',
+				'\s*\s',
+				'\s*\s',
+				'\s*//** */'
+			],
+			modelOpts: {
+				insertSpaces: false,
+			}
+		}, (model, cursor) => {
+			moveTo(cursor, 4, 4, false);
+			assertCursor(cursor, new Selection(4, 4, 4, 4));
+			cursorCommand(cursor, H.Type, { text: '\n' }, 'keyboard');
+			assertCursor(cursor, new Selection(5, 1, 5, 1));
+			assert.deepEqual(model.getLineContent(5), '/** */');
+			cursorCommand(cursor, H.Type, { text: '\n' }, 'keyboard');
+			assertCursor(cursor, new Selection(6, 1, 6, 1));
+			assert.deepEqual(model.getLineContent(6), '/** */');
+		});
+	});
 });
 
 interface ICursorOpts {


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #92094
