### PR TITLE
Pass first folder in multi-root workspace during variable resolution of launch configurations.

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -719,7 +719,7 @@ export class DebugService implements IDebugService {
 				folder = launch.workspace;
 			} else {
 				const folders = this.contextService.getWorkspace().folders;
-				if (folders.length === 1) {
+				if (folders.length > 0) {
 					folder = folders[0];
 				}
 			}


### PR DESCRIPTION
Tasks pass the first workspace folder in multi-root workspaces during variable resolution, but launch configurations do not. This makes their behaviors different, which is confusing to the user.

The discrepancy is also a potential source of bugs, as same behavior may be assumed and only one path is tested (e.g. #95482, #96570, #97202, #96522).

This PR fixes #96570 as a side effect, although it is not the motivation. That means `${relativeFile}` and `${relativeFileDirname}` without argument in launch configurations will now resolve as relative to the first workspace folder (same behavior as tasks), instead of an absolute path. Also, `${workspaceFolder}` without argument will resolve to the first workspace folder as in tasks, instead of throwing an error.

As @alexr00 mentioned in #96570, this change may potentially break configurations that depend on `${relativeFile}` and `${relativeFileDirname}` resolving as absolute paths, but I don't know if that is a strong enough argument to keep the discrepancy (I may be wrong though :) ).