### PR TITLE
Improvements to the SCM input font family setting

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/repositoryPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/repositoryPane.ts
@@ -1121,7 +1121,7 @@ export class RepositoryPane extends ViewPane {
 	private getInputEditorFontFamily(): string {
 		const inputFontFamily = this.configurationService.getValue<string>('scm.inputFontFamily');
 
-		if (inputFontFamily.toLowerCase() === 'inherit') {
+		if (inputFontFamily.toLowerCase() === 'editor') {
 			return this.configurationService.getValue<string>('editor.fontFamily');
 		}
 

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -152,7 +152,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		},
 		'scm.inputFontFamily': {
 			type: 'string',
-			description: localize('inputFontFamily', "Controls the font for the input message."),
+			markdownDescription: localize('inputFontFamily', "Controls the font for the input message. Use `default` for the workbench user interface font family, `editor` for the `#editor.fontFamily#`'s value, or a custom font family."),
 			default: 'default'
 		}
 	}


### PR DESCRIPTION
* Improved setting description
* Switched from `inherit` to `editor`