### PR TITLE
fix: gpu helper entitlements

### DIFF
--- a/build/azure-pipelines/darwin/helper-gpu-entitlements.plist
+++ b/build/azure-pipelines/darwin/helper-gpu-entitlements.plist
@@ -4,5 +4,7 @@
 <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes https://monacotools.visualstudio.com/DefaultCollection/Monaco/_build/results?buildId=74724

This was bit surprising to see libffmpeg.dylib linked to the gpu helper, but it makes sense because how electron rewrites rpath https://github.com/electron/electron/blob/master/build/config/BUILD.gn

```
 > otool -l /Applications/Visual\ Studio\ Code\ -\ Insiders.app/Contents/Frameworks/Code\ -\ Insiders\ Helper\ \(GPU\).app/Contents/MacOS/Code\ -\ Insiders\ Helper\ \(GPU\)  

Load command 13
          cmd LC_LOAD_DYLIB
      cmdsize 80
         name @rpath/Electron Framework.framework/Electron Framework (offset 24)
   time stamp 2 Wed Dec 31 16:00:02 1969
      current version 0.0.0
compatibility version 0.0.0
```

The ideal fix is to sign the libraries inside the `Electron framework` folder and remove this entitlement, will do that in a follow-up.