### PR TITLE
cpp built-in extension: add gcc problem matcher

### DIFF
--- a/extensions/cpp/package.json
+++ b/extensions/cpp/package.json
@@ -51,6 +51,25 @@
 				"configuration": "./language-configuration.json"
 			}
 		],
+    "problemMatchers": [
+      {
+        "name": "gcc",
+        "source": "gcc",
+        "owner": "cpp",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}"
+        ],
+        "pattern": {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      }
+    ],
 		"grammars": [
 			{
 				"language": "c",


### PR DESCRIPTION
Submission containing materials of a third party: Microsoft, MIT

extracted from https://github.com/Microsoft/vscode-docs/blob/master/docs/editor/tasks.md license under https://github.com/microsoft/vscode-docs/blob/master/LICENSE.md


This PR covers a part of #97600 if there's positive feedback more matchers (like the one for cl) will follow.
