### PR TITLE
fix list view default translate3d

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "7.2.2"
+target "7.2.4"
 runtime "electron"

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -60,12 +60,12 @@
 				"git": {
 					"name": "electron",
 					"repositoryUrl": "https://github.com/electron/electron",
-					"commitHash": "959e80cc53cbebf8eb1d62eb2d14fa8fd86b0394"
+					"commitHash": "0552e0d5de46ffa3b481d741f1db5c779e201565"
 				}
 			},
 			"isOnlyProductionDependency": true,
 			"license": "MIT",
-			"version": "7.2.2"
+			"version": "7.2.4"
 		},
 		{
 			"component": {

--- a/extensions/configuration-editing/schemas/devContainer.schema.json
+++ b/extensions/configuration-editing/schemas/devContainer.schema.json
@@ -282,33 +282,42 @@
 			]
 		}
 	},
-	"allOf": [
+	"oneOf": [
 		{
-			"oneOf": [
+			"allOf": [
 				{
-					"allOf": [
+					"oneOf": [
 						{
-							"oneOf": [
+							"allOf": [
 								{
-									"$ref": "#/definitions/dockerfileContainer"
+									"oneOf": [
+										{
+											"$ref": "#/definitions/dockerfileContainer"
+										},
+										{
+											"$ref": "#/definitions/imageContainer"
+										}
+									]
 								},
 								{
-									"$ref": "#/definitions/imageContainer"
+									"$ref": "#/definitions/nonComposeBase"
 								}
 							]
 						},
 						{
-							"$ref": "#/definitions/nonComposeBase"
+							"$ref": "#/definitions/composeContainer"
 						}
 					]
 				},
 				{
-					"$ref": "#/definitions/composeContainer"
+					"$ref": "#/definitions/devContainerCommon"
 				}
 			]
 		},
 		{
-			"$ref": "#/definitions/devContainerCommon"
+			"type": "object",
+			"$ref": "#/definitions/devContainerCommon",
+			"additionalProperties": false
 		}
 	]
 }

--- a/extensions/git/src/askpass.ts
+++ b/extensions/git/src/askpass.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { window, InputBoxOptions, Uri, OutputChannel, Disposable } from 'vscode';
+import { window, InputBoxOptions, Uri, OutputChannel, Disposable, workspace } from 'vscode';
 import { IDisposable, EmptyDisposable, toDisposable } from './util';
 import * as path from 'path';
 import { IIPCHandler, IIPCServer, createIPCServer } from './ipc/ipcServer';
@@ -31,6 +31,13 @@ export class Askpass implements IIPCHandler {
 	}
 
 	async handle({ request, host }: { request: string, host: string }): Promise<string> {
+		const config = workspace.getConfiguration('git', null);
+		const enabled = config.get<boolean>('enabled');
+
+		if (!enabled) {
+			return '';
+		}
+
 		const uri = Uri.parse(host);
 		const authority = uri.authority.replace(/^.*@/, '');
 		const password = /password/i.test(request);

--- a/extensions/git/src/github.ts
+++ b/extensions/git/src/github.ts
@@ -56,7 +56,8 @@ export class GithubCredentialProviderManager {
 	}
 
 	private refresh(): void {
-		this.enabled = workspace.getConfiguration('git', null).get('githubAuthentication', true);
+		const config = workspace.getConfiguration('git', null);
+		this.enabled = config.get<boolean>('enabled', true) && config.get('githubAuthentication', true);
 	}
 
 	dispose(): void {

--- a/extensions/git/src/terminal.ts
+++ b/extensions/git/src/terminal.ts
@@ -34,7 +34,8 @@ export class TerminalEnvironmentManager {
 	}
 
 	private refresh(): void {
-		this.enabled = workspace.getConfiguration('git', null).get('terminalAuthentication', true);
+		const config = workspace.getConfiguration('git', null);
+		this.enabled = config.get<boolean>('enabled', true) && config.get('terminalAuthentication', true);
 	}
 
 	dispose(): void {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "css-loader": "^3.2.0",
     "debounce": "^1.0.0",
     "deemon": "^1.4.0",
-    "electron": "7.2.2",
+    "electron": "7.2.4",
     "eslint": "6.8.0",
     "eslint-plugin-jsdoc": "^19.1.0",
     "event-stream": "3.3.4",

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -278,7 +278,8 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		this.rowsContainer = document.createElement('div');
 		this.rowsContainer.className = 'monaco-list-rows';
 
-		if (options.transformOptimization) {
+		const transformOptimization = getOrDefault(options, o => o.transformOptimization, DefaultOptions.transformOptimization);
+		if (transformOptimization) {
 			this.rowsContainer.style.transform = 'translate3d(0px, 0px, 0px)';
 		}
 

--- a/src/vs/code/electron-browser/proxy/auth.html
+++ b/src/vs/code/electron-browser/proxy/auth.html
@@ -5,7 +5,7 @@
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; img-src 'self' https: data:; media-src 'none'; child-src 'self'; object-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' https:;">
+		content="default-src 'none'; img-src 'self' https: data:; media-src 'none'; child-src 'self'; object-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' https:;">
 	<style>
 		html,
 		body {

--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -702,7 +702,8 @@ export class Menubar {
 			}
 
 			// DevTools focused
-			if (activeWindow.webContents.isDevToolsFocused()) {
+			if (activeWindow.webContents.isDevToolsFocused() &&
+				activeWindow.webContents.devToolsWebContents) {
 				return contextSpecificHandlers.inDevTools(activeWindow.webContents.devToolsWebContents);
 			}
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -7897,7 +7897,7 @@ declare module 'vscode' {
 		 * This will trigger the view to update the changed element/root and its children recursively (if shown).
 		 * To signal that root has changed, do not pass any argument or pass `undefined` or `null`.
 		 */
-		onDidChangeTreeData?: Event<T | undefined | null>;
+		onDidChangeTreeData?: Event<T | undefined | null | void>;
 
 		/**
 		 * Get [TreeItem](#TreeItem) representation of the `element`

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -153,7 +153,7 @@ export class ExtHostTreeViews implements ExtHostTreeViewsShape {
 	}
 }
 
-type Root = null | undefined;
+type Root = null | undefined | void;
 type TreeData<T> = { message: boolean, element: T | Root | false };
 
 interface TreeNode extends IDisposable {

--- a/src/vs/workbench/common/editor/editorGroup.ts
+++ b/src/vs/workbench/common/editor/editorGroup.ts
@@ -662,7 +662,7 @@ export class EditorGroup extends Disposable {
 			return null;
 		}));
 
-		this.mru = data.mru.map(i => this.editors[i]);
+		this.mru = coalesce(data.mru.map(i => this.editors[i]));
 
 		this.active = this.mru[0];
 

--- a/src/vs/workbench/contrib/search/browser/searchActions.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActions.ts
@@ -615,7 +615,7 @@ export class RemoveAction extends AbstractSearchAndReplaceAction {
 			this.viewer.setFocus([nextFocusElement], getSelectionKeyboardEvent());
 		}
 
-		this.element.parent().remove(<any>this.element);
+		this.element.parent().remove(<any>this.element, true);
 		this.viewer.domFocus();
 
 		return Promise.resolve();

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -192,8 +192,8 @@ export class FileMatch extends Disposable implements IFileMatch {
 		return (selected ? FileMatch._CURRENT_FIND_MATCH : FileMatch._FIND_MATCH);
 	}
 
-	private _onChange = this._register(new Emitter<{ didRemove?: boolean; forceUpdateModel?: boolean }>());
-	readonly onChange: Event<{ didRemove?: boolean; forceUpdateModel?: boolean }> = this._onChange.event;
+	private _onChange = this._register(new Emitter<{ didRemove?: boolean; forceUpdateModel?: boolean; userRemoved?: boolean }>());
+	readonly onChange: Event<{ didRemove?: boolean; forceUpdateModel?: boolean; userRemoved?: boolean }> = this._onChange.event;
 
 	private _onDispose = this._register(new Emitter<void>());
 	readonly onDispose: Event<void> = this._onDispose.event;
@@ -354,10 +354,10 @@ export class FileMatch extends Disposable implements IFileMatch {
 		return values(this._matches);
 	}
 
-	remove(match: Match): void {
+	remove(match: Match, userRemoved?: boolean): void {
 		this.removeMatch(match);
 		this._removedMatches.add(match.id());
-		this._onChange.fire({ didRemove: true });
+		this._onChange.fire({ didRemove: true, userRemoved });
 	}
 
 	replace(toReplace: Match): Promise<void> {
@@ -447,6 +447,7 @@ export interface IChangeEvent {
 	elements: FileMatch[];
 	added?: boolean;
 	removed?: boolean;
+	userRemoved?: boolean;
 }
 
 export class FolderMatch extends Disposable {
@@ -529,7 +530,7 @@ export class FolderMatch extends Disposable {
 				const fileMatch = this.instantiationService.createInstance(FileMatch, this._query.contentPattern, this._query.previewOptions, this._query.maxResults, this, rawFileMatch);
 				this.doAdd(fileMatch);
 				added.push(fileMatch);
-				const disposable = fileMatch.onChange(({ didRemove }) => this.onFileChange(fileMatch, didRemove));
+				const disposable = fileMatch.onChange(({ didRemove, userRemoved }) => this.onFileChange(fileMatch, didRemove, userRemoved));
 				fileMatch.onDispose(() => disposable.dispose());
 			}
 		});
@@ -540,14 +541,14 @@ export class FolderMatch extends Disposable {
 		}
 	}
 
-	clear(): void {
+	clear(userRemoved?: boolean): void {
 		const changed: FileMatch[] = this.matches();
 		this.disposeMatches();
-		this._onChange.fire({ elements: changed, removed: true });
+		this._onChange.fire({ elements: changed, removed: true, userRemoved });
 	}
 
-	remove(matches: FileMatch | FileMatch[]): void {
-		this.doRemove(matches);
+	remove(matches: FileMatch | FileMatch[], userRemoved?: boolean): void {
+		this.doRemove(matches, undefined, undefined, userRemoved);
 	}
 
 	replace(match: FileMatch): Promise<any> {
@@ -577,7 +578,7 @@ export class FolderMatch extends Disposable {
 		return this.matches().reduce<number>((prev, match) => prev + match.count(), 0);
 	}
 
-	private onFileChange(fileMatch: FileMatch, removed = false): void {
+	private onFileChange(fileMatch: FileMatch, removed = false, userRemoved = false): void {
 		let added = false;
 		if (!this._fileMatches.has(fileMatch.resource)) {
 			this.doAdd(fileMatch);
@@ -589,7 +590,7 @@ export class FolderMatch extends Disposable {
 			removed = true;
 		}
 		if (!this._replacingAll) {
-			this._onChange.fire({ elements: [fileMatch], added: added, removed: removed });
+			this._onChange.fire({ elements: [fileMatch], added: added, removed: removed, userRemoved });
 		}
 	}
 
@@ -600,7 +601,7 @@ export class FolderMatch extends Disposable {
 		}
 	}
 
-	private doRemove(fileMatches: FileMatch | FileMatch[], dispose: boolean = true, trigger: boolean = true): void {
+	private doRemove(fileMatches: FileMatch | FileMatch[], dispose: boolean = true, trigger: boolean = true, userRemoved: boolean = false): void {
 		if (!Array.isArray(fileMatches)) {
 			fileMatches = [fileMatches];
 		}
@@ -615,7 +616,7 @@ export class FolderMatch extends Disposable {
 		}
 
 		if (trigger) {
-			this._onChange.fire({ elements: fileMatches, removed: true });
+			this._onChange.fire({ elements: fileMatches, removed: true, userRemoved });
 		}
 	}
 
@@ -717,7 +718,7 @@ export class SearchResult extends Disposable {
 		this._register(this.modelService.onModelAdded(model => this.onModelAdded(model)));
 
 		this._register(this.onChange(e => {
-			if (e.removed) {
+			if (e.userRemoved) {
 				this._hasRemovedResults = true;
 			}
 		}));
@@ -808,14 +809,14 @@ export class SearchResult extends Disposable {
 		this._otherFilesMatch = null;
 	}
 
-	remove(matches: FileMatch | FolderMatch | (FileMatch | FolderMatch)[]): void {
+	remove(matches: FileMatch | FolderMatch | (FileMatch | FolderMatch)[], userRemoved?: boolean): void {
 		if (!Array.isArray(matches)) {
 			matches = [matches];
 		}
 
 		matches.forEach(m => {
 			if (m instanceof FolderMatch) {
-				m.clear();
+				m.clear(userRemoved);
 			}
 		});
 
@@ -827,11 +828,11 @@ export class SearchResult extends Disposable {
 				return;
 			}
 
-			this.getFolderMatch(matches[0].resource).remove(<FileMatch[]>matches);
+			this.getFolderMatch(matches[0].resource).remove(<FileMatch[]>matches, userRemoved);
 		});
 
 		if (other.length) {
-			this.getFolderMatch(other[0].resource).remove(<FileMatch[]>other);
+			this.getFolderMatch(other[0].resource).remove(<FileMatch[]>other, userRemoved);
 		}
 	}
 

--- a/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
@@ -236,7 +236,7 @@ suite('SearchResult', () => {
 		testObject.remove(objectToRemove);
 
 		assert.ok(target.calledOnce);
-		assert.deepEqual([{ elements: [objectToRemove], removed: true }], target.args[0]);
+		assert.deepEqual([{ elements: [objectToRemove], removed: true, userRemoved: false }], target.args[0]);
 	});
 
 	test('remove array triggers change event', function () {
@@ -253,7 +253,7 @@ suite('SearchResult', () => {
 		testObject.remove(arrayToRemove);
 
 		assert.ok(target.calledOnce);
-		assert.deepEqual([{ elements: arrayToRemove, removed: true }], target.args[0]);
+		assert.deepEqual([{ elements: arrayToRemove, removed: true, userRemoved: false }], target.args[0]);
 	});
 
 	test('remove triggers change event', function () {
@@ -268,7 +268,7 @@ suite('SearchResult', () => {
 		testObject.remove(objectToRemove);
 
 		assert.ok(target.calledOnce);
-		assert.deepEqual([{ elements: [objectToRemove], removed: true }], target.args[0]);
+		assert.deepEqual([{ elements: [objectToRemove], removed: true, userRemoved: false }], target.args[0]);
 	});
 
 	test('Removing all line matches and adding back will add file back to result', function () {
@@ -315,7 +315,7 @@ suite('SearchResult', () => {
 
 		return voidPromise.then(() => {
 			assert.ok(target.calledOnce);
-			assert.deepEqual([{ elements: [objectToRemove], removed: true }], target.args[0]);
+			assert.deepEqual([{ elements: [objectToRemove], removed: true, userRemoved: false }], target.args[0]);
 		});
 	});
 

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -229,6 +229,7 @@ export class TerminalTaskSystem implements ITaskSystem {
 	}
 
 	public run(task: Task, resolver: ITaskResolver, trigger: string = Triggers.command): ITaskExecuteResult {
+		task = task.clone(); // A small amount of task state is stored in the task (instance) and tasks passed in to run may have that set already.
 		const recentTaskKey = task.getRecentlyUsedKey() ?? '';
 		let validInstance = task.runOptions && task.runOptions.instanceLimit && this.instances[recentTaskKey] && this.instances[recentTaskKey].instances < task.runOptions.instanceLimit;
 		let instance = this.instances[recentTaskKey] ? this.instances[recentTaskKey].instances : 0;

--- a/src/vs/workbench/contrib/tasks/common/tasks.ts
+++ b/src/vs/workbench/contrib/tasks/common/tasks.ts
@@ -688,6 +688,10 @@ export class CustomTask extends CommonTask {
 		}
 	}
 
+	public clone(): CustomTask {
+		return new CustomTask(this._id, this._source, this._label, this.type, this.command, this.hasDefinedMatchers, this.runOptions, this.configurationProperties);
+	}
+
 	public customizes(): KeyedTaskIdentifier | undefined {
 		if (this._source && this._source.customizes) {
 			return this._source.customizes;
@@ -874,6 +878,10 @@ export class ContributedTask extends CommonTask {
 		this.command = command;
 	}
 
+	public clone(): ContributedTask {
+		return new ContributedTask(this._id, this._source, this._label, this.type, this.defines, this.command, this.hasDefinedMatchers, this.runOptions, this.configurationProperties);
+	}
+
 	public getDefinition(): KeyedTaskIdentifier {
 		return this.defines;
 	}
@@ -936,6 +944,10 @@ export class InMemoryTask extends CommonTask {
 		runOptions: RunOptions, configurationProperties: ConfigurationProperties) {
 		super(id, label, type, runOptions, configurationProperties, source);
 		this._source = source;
+	}
+
+	public clone(): InMemoryTask {
+		return new InMemoryTask(this._id, this._source, this._label, this.type, this.runOptions, this.configurationProperties);
 	}
 
 	public static is(value: any): value is InMemoryTask {

--- a/src/vs/workbench/contrib/terminal/browser/widgets/hoverWidget.ts
+++ b/src/vs/workbench/contrib/terminal/browser/widgets/hoverWidget.ts
@@ -93,7 +93,7 @@ export class HoverWidget extends Widget {
 			const actionsElement = $('div.actions');
 			this._actions.forEach(action => this._renderAction(actionsElement, action));
 			statusBarElement.appendChild(actionsElement);
-			this._domNode.appendChild(statusBarElement);
+			this._containerDomNode.appendChild(statusBarElement);
 		}
 
 		this._mouseTracker = new CompositeMouseTracker([this._containerDomNode, ..._target.targetElements]);

--- a/src/vs/workbench/contrib/webview/browser/dynamicWebviewEditorOverlay.ts
+++ b/src/vs/workbench/contrib/webview/browser/dynamicWebviewEditorOverlay.ts
@@ -97,6 +97,12 @@ export class DynamicWebviewEditorOverlay extends Disposable implements WebviewOv
 		if (!this.container || !this.container.parentElement) {
 			return;
 		}
+
+		// Workaround for #94805
+		if ((element.classList.contains('details-editor-container') || element.classList.contains('master-editor-container')) && !element.style.height) {
+			element.style.height = '100%';
+		}
+
 		const frameRect = element.getBoundingClientRect();
 		const containerRect = this.container.parentElement.getBoundingClientRect();
 		this.container.style.position = 'absolute';

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -115,7 +115,7 @@ export class BrowserWorkbenchEnvironmentService implements IWorkbenchEnvironment
 	get snippetsHome(): URI { return joinPath(this.userRoamingDataHome, 'snippets'); }
 
 	@memoize
-	get userDataSyncHome(): URI { return joinPath(this.userRoamingDataHome, 'sync'); }
+	get userDataSyncHome(): URI { return joinPath(this.userRoamingDataHome, 'sync', this.options.workspaceId); }
 
 	@memoize
 	get userDataSyncLogResource(): URI { return joinPath(this.options.logsPath, 'userDataSync.log'); }

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -117,7 +117,7 @@ export class BrowserWorkbenchEnvironmentService implements IWorkbenchEnvironment
 	/*
 	 * In Web every workspace can potentially have scoped user-data and/or extensions and if Sync state is shared then it can make
 	 * Sync error prone - say removing extensions from another workspace. Hence scope Sync state per workspace.
-	 * Sync scoped to a workspace is capable of handling even if workspaces/windows share same user data and extensions.
+	 * Sync scoped to a workspace is capable of handling opening same workspace in multiple windows.
 	 */
 	@memoize
 	get userDataSyncHome(): URI { return joinPath(this.userRoamingDataHome, 'sync', this.options.workspaceId); }

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -114,6 +114,11 @@ export class BrowserWorkbenchEnvironmentService implements IWorkbenchEnvironment
 	@memoize
 	get snippetsHome(): URI { return joinPath(this.userRoamingDataHome, 'snippets'); }
 
+	/*
+	 * In Web every workspace can potentially have scoped user-data and/or extensions and if Sync state is shared then it can make
+	 * Sync error prone - say removing extensions from another workspace. Hence scope Sync state per workspace.
+	 * Sync scoped to a workspace is capable of handling even if workspaces/windows share same user data and extensions.
+	 */
 	@memoize
 	get userDataSyncHome(): URI { return joinPath(this.userRoamingDataHome, 'sync', this.options.workspaceId); }
 

--- a/src/vs/workbench/services/preferences/common/preferencesValidation.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesValidation.ts
@@ -69,7 +69,6 @@ export function getInvalidTypeError(value: any, type: undefined | string | strin
 		(valueType === 'boolean' && !canBeType(typeArr, 'boolean')) ||
 		(valueType === 'object' && !canBeType(typeArr, 'object', 'null', 'array')) ||
 		(valueType === 'string' && !canBeType(typeArr, 'string', 'number', 'integer')) ||
-		(typeof parseFloat(value) === 'number' && !isNaN(parseFloat(value)) && !canBeType(typeArr, 'number', 'integer')) ||
 		(Array.isArray(value) && !canBeType(typeArr, 'array'))
 	) {
 		if (typeof type !== 'undefined') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,10 +2715,10 @@ electron-to-chromium@^1.2.7:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
   integrity sha1-eOy4o5kGYYe7N07t412ccFZagD0=
 
-electron@7.2.2:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-7.2.2.tgz#92b159fa6e6c31dfcfe0c2818c7baacb81fa1c5f"
-  integrity sha512-8ppCjch2LRbi5JJ9D+gn+Q9erShNLDcN5ODRAPr/MAHqhTTlGBqCcvNMlCzRCEVV75PouKxVm7NjSKXBYlD9QA==
+electron@7.2.4:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-7.2.4.tgz#9fc0446dae23ead897af8742470cb18da55c6ce9"
+  integrity sha512-Z+R692uTzXgP8AHrabE+kkrMlQJ6pnAYoINenwj9QSqaD2YbO8IuXU9DMCcUY0+VpA91ee09wFZJNUKYPMnCKg==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #97498

To verify the fix, run Code with flag `--show-mac-overlay-borders`, for example, `code-insider --show-mac-overlay-borders`

*Before the fix*
<img width="1648" alt="image" src="https://user-images.githubusercontent.com/876920/81723422-a7f22d80-9437-11ea-9632-1d73c43f1a01.png">

*After the fix*: please note the the file explorer now has a gray border, which indicates it's in its own layer
<img width="1648" alt="image" src="https://user-images.githubusercontent.com/876920/81723482-bd675780-9437-11ea-9e9b-3c2524e93a8f.png">

The other way to verify is to inspect the element and see if `monaco-list-rows` has `transform: translate3d(0, 0, 0)`.

