### PR TITLE
debug: filter exceptions from DAP telemetry on web

### DIFF
--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -548,6 +548,7 @@ export class StandaloneTelemetryService implements ITelemetryService {
 	_serviceBrand: undefined;
 
 	public isOptedIn = false;
+	public sendErrorTelemetry = false;
 
 	public setEnabled(value: boolean): void {
 	}

--- a/src/vs/platform/telemetry/common/telemetry.ts
+++ b/src/vs/platform/telemetry/common/telemetry.ts
@@ -23,6 +23,11 @@ export interface ITelemetryData {
 
 export interface ITelemetryService {
 
+	/**
+	 * Whether error telemetry will get sent. If false, `publicLogError` will no-op.
+	 */
+	readonly sendErrorTelemetry: boolean;
+
 	_serviceBrand: undefined;
 
 	/**

--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -35,7 +35,7 @@ export class TelemetryService implements ITelemetryService {
 	private _piiPaths: string[];
 	private _userOptIn: boolean;
 	private _enabled: boolean;
-	private _sendErrorTelemetry: boolean;
+	public readonly sendErrorTelemetry: boolean;
 
 	private readonly _disposables = new DisposableStore();
 	private _cleanupPatterns: RegExp[] = [];
@@ -49,7 +49,7 @@ export class TelemetryService implements ITelemetryService {
 		this._piiPaths = config.piiPaths || [];
 		this._userOptIn = true;
 		this._enabled = true;
-		this._sendErrorTelemetry = !!config.sendErrorTelemetry;
+		this.sendErrorTelemetry = !!config.sendErrorTelemetry;
 
 		// static cleanup pattern for: `file:///DANGEROUS/PATH/resources/app/Useful/Information`
 		this._cleanupPatterns = [/file:\/\/\/.*?\/resources\/app\//gi];
@@ -148,7 +148,7 @@ export class TelemetryService implements ITelemetryService {
 	}
 
 	publicLogError(errorEventName: string, data?: ITelemetryData): Promise<any> {
-		if (!this._sendErrorTelemetry) {
+		if (!this.sendErrorTelemetry) {
 			return Promise.resolve(undefined);
 		}
 

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -13,6 +13,8 @@ import { isObject } from 'vs/base/common/types';
 
 export const NullTelemetryService = new class implements ITelemetryService {
 	_serviceBrand: undefined;
+	readonly sendErrorTelemetry = false;
+
 	publicLog(eventName: string, data?: ITelemetryData) {
 		return Promise.resolve(undefined);
 	}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -848,7 +848,17 @@ export class DebugSession implements IDebugSession {
 					// and the user opted in telemetry
 					if (this.raw.customTelemetryService && this.telemetryService.isOptedIn) {
 						// __GDPR__TODO__ We're sending events in the name of the debug extension and we can not ensure that those are declared correctly.
-						this.raw.customTelemetryService.publicLog(event.body.output, event.body.data);
+						let data = event.body.data;
+						if (!this.raw.customTelemetryService.sendErrorTelemetry && event.body.data) {
+							data = {};
+							for (const key of Object.keys(event.body.data)) {
+								if (!key.startsWith('!')) {
+									data[key] = event.body.data[key];
+								}
+							}
+						}
+
+						this.raw.customTelemetryService.publicLog(event.body.output, data);
 					}
 
 					return;

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -35,6 +35,7 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';
 import { localize } from 'vs/nls';
 import { canceled } from 'vs/base/common/errors';
+import { filterExceptionsFromTelemetry } from 'vs/workbench/contrib/debug/common/debugUtils';
 
 export class DebugSession implements IDebugSession {
 
@@ -850,12 +851,7 @@ export class DebugSession implements IDebugSession {
 						// __GDPR__TODO__ We're sending events in the name of the debug extension and we can not ensure that those are declared correctly.
 						let data = event.body.data;
 						if (!this.raw.customTelemetryService.sendErrorTelemetry && event.body.data) {
-							data = {};
-							for (const key of Object.keys(event.body.data)) {
-								if (!key.startsWith('!')) {
-									data[key] = event.body.data[key];
-								}
-							}
+							data = filterExceptionsFromTelemetry(event.body.data);
 						}
 
 						this.raw.customTelemetryService.publicLog(event.body.output, data);

--- a/src/vs/workbench/contrib/debug/common/debugUtils.ts
+++ b/src/vs/workbench/contrib/debug/common/debugUtils.ts
@@ -23,6 +23,22 @@ export function formatPII(value: string, excludePII: boolean, args: { [key: stri
 	});
 }
 
+/**
+ * Filters exceptions (keys marked with "!") from the given object. Used to
+ * ensure exception data is not sent on web remotes, see #97628.
+ */
+export function filterExceptionsFromTelemetry<T extends { [key: string]: unknown }>(data: T): Partial<T> {
+	const output: Partial<T> = {};
+	for (const key of Object.keys(data) as (keyof T & string)[]) {
+		if (!key.startsWith('!')) {
+			output[key] = data[key];
+		}
+	}
+
+	return output;
+}
+
+
 export function isSessionAttach(session: IDebugSession): boolean {
 	return session.configuration.request === 'attach' && !getExtensionHostDebugSession(session);
 }

--- a/src/vs/workbench/contrib/debug/node/debugHelperService.ts
+++ b/src/vs/workbench/contrib/debug/node/debugHelperService.ts
@@ -10,9 +10,16 @@ import { getPathFromAmdModule } from 'vs/base/common/amd';
 import { TelemetryService } from 'vs/platform/telemetry/common/telemetryService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { cleanRemoteAuthority } from 'vs/platform/telemetry/common/telemetryUtils';
 
 export class NodeDebugHelperService implements IDebugHelperService {
 	_serviceBrand: undefined;
+
+	constructor(
+		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
+	) { }
+
 
 	createTelemetryService(configurationService: IConfigurationService, args: string[]): TelemetryService | undefined {
 
@@ -33,7 +40,10 @@ export class NodeDebugHelperService implements IDebugHelperService {
 		const channel = client.getChannel('telemetryAppender');
 		const appender = new TelemetryAppenderClient(channel);
 
-		return new TelemetryService({ appender, sendErrorTelemetry: true }, configurationService);
+		return new TelemetryService({
+			appender,
+			sendErrorTelemetry: cleanRemoteAuthority(this.environmentService.configuration.remoteAuthority) !== 'other'
+		}, configurationService);
 	}
 }
 

--- a/src/vs/workbench/contrib/debug/test/browser/telemetry.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/telemetry.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { MockDebugAdapter, createMockDebugModel } from 'vs/workbench/contrib/debug/test/common/mockDebug';
+import { DebugModel } from 'vs/workbench/contrib/debug/common/debugModel';
+import { DebugSession } from 'vs/workbench/contrib/debug/browser/debugSession';
+import { generateUuid } from 'vs/base/common/uuid';
+import { NullOpenerService } from 'vs/platform/opener/common/opener';
+import { RawDebugSession } from 'vs/workbench/contrib/debug/browser/rawDebugSession';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { stub, SinonStub } from 'sinon';
+import { timeout } from 'vs/base/common/async';
+
+suite('Debug - DebugSession telemetry', () => {
+	let model: DebugModel;
+	let session: DebugSession;
+	let adapter: MockDebugAdapter;
+	let telemetry: { isOptedIn: boolean; sendErrorTelemetry: boolean; publicLog: SinonStub };
+
+	setup(() => {
+		telemetry = { isOptedIn: true, sendErrorTelemetry: true, publicLog: stub() };
+		adapter = new MockDebugAdapter();
+		model = createMockDebugModel();
+
+		const telemetryService = telemetry as Partial<ITelemetryService> as ITelemetryService;
+		session = new DebugSession(generateUuid(), undefined!, undefined!, model, undefined, undefined!, telemetryService, undefined!, undefined!, undefined!, undefined!, undefined!, undefined!, NullOpenerService, undefined!, undefined!);
+		session.initializeForTest(new RawDebugSession(adapter, undefined!, undefined!, telemetryService, undefined!, undefined!, undefined!));
+	});
+
+	test('does not send telemetry when opted out', async () => {
+		telemetry.isOptedIn = false;
+		adapter.sendEventBody('output', {
+			category: 'telemetry',
+			output: 'someEvent',
+			data: { foo: 'bar', '!err': 'oh no!' }
+		});
+
+		await timeout(0);
+		assert.strictEqual(telemetry.publicLog.callCount, 0);
+	});
+
+	test('logs telemetry and exceptions when enabled', async () => {
+		adapter.sendEventBody('output', {
+			category: 'telemetry',
+			output: 'someEvent',
+			data: { foo: 'bar', '!err': 'oh no!' }
+		});
+
+		await timeout(0);
+		assert.deepStrictEqual(telemetry.publicLog.args[0], [
+			'someEvent',
+			{ foo: 'bar', '!err': 'oh no!' }
+		]);
+	});
+
+	test('filters exceptions when error reporting disabled', async () => {
+		telemetry.sendErrorTelemetry = false;
+
+		adapter.sendEventBody('output', {
+			category: 'telemetry',
+			output: 'someEvent',
+			data: { foo: 'bar', '!err': 'oh no!' }
+		});
+
+		await timeout(0);
+		assert.deepStrictEqual(telemetry.publicLog.args[0], [
+			'someEvent',
+			{ foo: 'bar' }
+		]);
+	});
+});

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -36,6 +36,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 	_serviceBrand: undefined;
 
 	private impl: ITelemetryService;
+	public readonly sendErrorTelemetry = false;
 
 	constructor(
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,

--- a/src/vs/workbench/services/telemetry/electron-browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/electron-browser/telemetryService.ts
@@ -24,6 +24,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 	_serviceBrand: undefined;
 
 	private impl: ITelemetryService;
+	public readonly sendErrorTelemetry: boolean;
 
 	constructor(
 		@IWorkbenchEnvironmentService environmentService: INativeWorkbenchEnvironmentService,
@@ -48,6 +49,8 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 		} else {
 			this.impl = NullTelemetryService;
 		}
+
+		this.sendErrorTelemetry = this.impl.sendErrorTelemetry;
 	}
 
 	setEnabled(value: boolean): void {

--- a/src/vs/workbench/test/electron-browser/textsearch.perf.integrationTest.ts
+++ b/src/vs/workbench/test/electron-browser/textsearch.perf.integrationTest.ts
@@ -163,6 +163,7 @@ suite.skip('TextSearch performance (integration)', () => {
 class TestTelemetryService implements ITelemetryService {
 	public _serviceBrand: undefined;
 	public isOptedIn = true;
+	public sendErrorTelemetry = true;
 
 	public events: any[] = [];
 


### PR DESCRIPTION
This change will filter DAP keys beginning with `!` when the remote
authority is "other", which SteVen recommended as a way to tell if we're
on web/codespaces.

Isidor mentioned previously that there was filtering for keys beginning
with an underscore, but this was only applied to some data in error
responses, not general telemetry events. An alternative approach to this
is filtering exceptions based on the environment on the extension side,
but I figured it would be better to have VS Code do that so that we
don't end up with N many possibly deviant sets of environment detection
logic.
