### PR TITLE
Fix #97498. Fallback to default value for translate3d

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -278,7 +278,8 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		this.rowsContainer = document.createElement('div');
 		this.rowsContainer.className = 'monaco-list-rows';
 
-		if (options.transformOptimization) {
+		const transformOptimization = getOrDefault(options, o => o.transformOptimization, DefaultOptions.transformOptimization);
+		if (transformOptimization) {
 			this.rowsContainer.style.transform = 'translate3d(0px, 0px, 0px)';
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #97498

To verify the fix, run Code with flag `--show-mac-overlay-borders`, for example, `code-insider --show-mac-overlay-borders`

*Before the fix*
<img width="1648" alt="image" src="https://user-images.githubusercontent.com/876920/81723422-a7f22d80-9437-11ea-9632-1d73c43f1a01.png">

*After the fix*: please note the the file explorer now has a gray border, which indicates it's in its own layer
<img width="1648" alt="image" src="https://user-images.githubusercontent.com/876920/81723482-bd675780-9437-11ea-9e9b-3c2524e93a8f.png">

The other way to verify is to inspect the element and see if `monaco-list-rows` has `transform: translate3d(0, 0, 0)`.
