### PR TITLE
feat: implement colour contributions for debug REPL

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -6,6 +6,7 @@
 import 'vs/css!./media/debug.contribution';
 import 'vs/css!./media/debugHover';
 import * as nls from 'vs/nls';
+import { Color } from 'vs/base/common/color';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { SyncActionDescriptor, MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -44,7 +45,7 @@ import { ClearReplAction, Repl } from 'vs/workbench/contrib/debug/browser/repl';
 import { DebugContentProvider } from 'vs/workbench/contrib/debug/common/debugContentProvider';
 import { WelcomeView } from 'vs/workbench/contrib/debug/browser/welcomeView';
 import { ThemeIcon, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
-import { registerColor, foreground, badgeBackground, badgeForeground, listDeemphasizedForeground, contrastBorder } from 'vs/platform/theme/common/colorRegistry';
+import { registerColor, foreground, badgeBackground, badgeForeground, listDeemphasizedForeground, contrastBorder, inputBorder, editorWarningForeground, errorForeground, editorInfoForeground } from 'vs/platform/theme/common/colorRegistry';
 import { DebugViewPaneContainer, OpenDebugConsoleAction } from 'vs/workbench/contrib/debug/browser/debugViewlet';
 import { registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { CallStackEditorContribution } from 'vs/workbench/contrib/debug/browser/callStackEditorContribution';
@@ -605,6 +606,12 @@ const debugViewStateLabelForeground = registerColor('debugView.stateLabelForegro
 const debugViewStateLabelBackground = registerColor('debugView.stateLabelBackground', { dark: '#88888844', light: '#88888844', hc: '#88888844' }, 'Background color for a label in the CALL STACK view showing the current session\'s or thread\'s state.');
 const debugViewValueChangedHighlight = registerColor('debugView.valueChangedHighlight', { dark: '#569CD6', light: '#569CD6', hc: '#569CD6' }, 'Color used to highlight value changes in the debug views (ie. in the Variables view).');
 
+const debugConsoleInfoForeground = registerColor('debugConsole.infoForeground', { dark: editorInfoForeground, light: editorInfoForeground, hc: foreground }, 'Foreground color for info messages in debug REPL console.');
+const debugConsoleWarningForeground = registerColor('debugConsole.warningForeground', { dark: editorWarningForeground, light: editorWarningForeground, hc: '#008000' }, 'Foreground color for warning messages in debug REPL console.');
+const debugConsoleErrorForeground = registerColor('debugConsole.errorForeground', { dark: errorForeground, light: errorForeground, hc: errorForeground }, 'Foreground color for error messages in debug REPL console.');
+const debugConsoleSourceForeground = registerColor('debugConsole.sourceForeground', { dark: foreground, light: foreground, hc: foreground }, 'Foreground color for source filenames in debug REPL console.');
+const debugConsoleInputIconForeground = registerColor('debugConsoleInputIcon.foreground', { dark: foreground, light: foreground, hc: foreground }, 'Foreground color for debug console input marker icon.');
+
 registerThemingParticipant((theme, collector) => {
 	// All these colours provide a default value so they will never be undefined, hence the `!`
 	const badgeBackgroundColor = theme.getColor(badgeBackground)!;
@@ -714,4 +721,53 @@ registerThemingParticipant((theme, collector) => {
 			color: ${tokenNumberColor};
 		}
 	`);
+
+	const debugConsoleInputBorderColor = theme.getColor(inputBorder) || Color.fromHex('#80808060');
+	const debugConsoleInfoForegroundColor = theme.getColor(debugConsoleInfoForeground)!;
+	const debugConsoleWarningForegroundColor = theme.getColor(debugConsoleWarningForeground)!;
+	const debugConsoleErrorForegroundColor = theme.getColor(debugConsoleErrorForeground)!;
+	const debugConsoleSourceForegroundColor = theme.getColor(debugConsoleSourceForeground)!;
+	const debugConsoleInputIconForegroundColor = theme.getColor(debugConsoleInputIconForeground)!;
+
+	collector.addRule(`
+		.repl .repl-input-wrapper {
+			border-top: 1px solid ${debugConsoleInputBorderColor};
+		}
+
+		.monaco-workbench .repl .repl-tree .output .expression .value.info {
+			color: ${debugConsoleInfoForegroundColor};
+		}
+
+		.monaco-workbench .repl .repl-tree .output .expression .value.warn {
+			color: ${debugConsoleWarningForegroundColor};
+		}
+
+		.monaco-workbench .repl .repl-tree .output .expression .value.error {
+			color: ${debugConsoleErrorForegroundColor};
+		}
+
+		.monaco-workbench .repl .repl-tree .output .expression .source {
+			color: ${debugConsoleSourceForegroundColor};
+		}
+
+		.monaco-workbench .repl .repl-tree .monaco-tl-contents .arrow {
+			color: ${debugConsoleInputIconForegroundColor};
+		}
+	`);
+
+	if (!theme.defines(debugConsoleInputIconForeground)) {
+		collector.addRule(`
+			.monaco-workbench.vs .repl .repl-tree .monaco-tl-contents .arrow {
+				opacity: 0.25;
+			}
+
+			.monaco-workbench.vs-dark .repl .repl-tree .monaco-tl-contents .arrow {
+				opacity: 0.4;
+			}
+
+			.monaco-workbench.hc-black .repl .repl-tree .monaco-tl-contents .arrow {
+				opacity: 1;
+			}
+		`);
+	}
 });

--- a/src/vs/workbench/contrib/debug/browser/media/repl.css
+++ b/src/vs/workbench/contrib/debug/browser/media/repl.css
@@ -41,11 +41,6 @@
 .monaco-workbench .repl .repl-tree .monaco-tl-contents .arrow {
 	position:absolute;
 	left: 2px;
-	opacity: 0.25;
-}
-
-.monaco-workbench.vs-dark .repl .repl-tree .monaco-tl-contents .arrow {
-	opacity: 0.4;
 }
 
 .monaco-workbench .repl .repl-tree .output.expression.value-and-source .source {
@@ -86,18 +81,6 @@
 /* Output coloring  and styling */
 .monaco-workbench .repl .repl-tree .output.expression > .ignore {
 	font-style: italic;
-}
-
-.monaco-workbench.vs .repl .repl-tree .output.expression > .warn {
-	color: #cd9731;
-}
-
-.monaco-workbench.vs-dark .repl .repl-tree .output.expression > .warn {
-	color: #cd9731;
-}
-
-.monaco-workbench.hc-black .repl .repl-tree .output.expression > .warn {
-	color: #008000;
 }
 
 /* ANSI Codes */

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -5,7 +5,6 @@
 
 import 'vs/css!./media/repl';
 import { URI as uri } from 'vs/base/common/uri';
-import { Color } from 'vs/base/common/color';
 import { IAction, IActionViewItem, Action } from 'vs/base/common/actions';
 import * as dom from 'vs/base/browser/dom';
 import * as aria from 'vs/base/browser/ui/aria/aria';
@@ -21,7 +20,7 @@ import { ServiceCollection } from 'vs/platform/instantiation/common/serviceColle
 import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
-import { IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ICodeEditor, isCodeEditor } from 'vs/editor/browser/editorBrowser';
 import { memoize } from 'vs/base/common/decorators';
 import { dispose, IDisposable, Disposable } from 'vs/base/common/lifecycle';
@@ -34,7 +33,7 @@ import { createAndBindHistoryNavigationWidgetScopedContextKeyService } from 'vs/
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { getSimpleEditorOptions, getSimpleCodeEditorWidgetOptions } from 'vs/workbench/contrib/codeEditor/browser/simpleEditorOptions';
 import { IDecorationOptions } from 'vs/editor/common/editorCommon';
-import { transparent, editorForeground, inputBorder } from 'vs/platform/theme/common/colorRegistry';
+import { transparent, editorForeground } from 'vs/platform/theme/common/colorRegistry';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { FocusSessionActionViewItem } from 'vs/workbench/contrib/debug/browser/debugActionViewItems';
 import { CompletionContext, CompletionList, CompletionProviderRegistry, CompletionItem, completionKindFromString, CompletionItemKind, CompletionItemInsertTextRule } from 'vs/editor/common/modes';
@@ -815,13 +814,3 @@ export class ClearReplAction extends Action {
 function getReplView(viewsService: IViewsService): Repl | undefined {
 	return viewsService.getActiveViewWithId(REPL_VIEW_ID) as Repl ?? undefined;
 }
-
-registerThemingParticipant((theme, collector) => {
-	const inputBorderColor = theme.getColor(inputBorder) || Color.fromHex('#80808060');
-
-	collector.addRule(`
-		.repl .repl-input-wrapper {
-			border-top: 1px solid ${inputBorderColor};
-		}
-	`);
-});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #97695.

Most of the debug REPL components are now theme-able. 🎉 🎨  The following new colour contributions have been added:

- `debugConsole.infoForeground`: info-level messages
- `debugConsole.warningForeground`: warning-level messages
- `debugConsole.errorForeground`: error-level messages
- `debugConsole.sourceForeground`: foreground colour of the source filename which generated the log message
- `debugConsoleInputIcon.foreground`: icon colour which marks the evaluation input. I remember seeing a very specific name for this icon but I cannot remember. I will happily update the naming of this contribution to match if this is not accurate.

#### Chores

I have moved the theming support for REPL out of the `repl.ts` file so we have it in one place.