### PR TITLE
fix: use node and yarn even if cache is present

### DIFF
--- a/build/azure-pipelines/product-compile.yml
+++ b/build/azure-pipelines/product-compile.yml
@@ -17,12 +17,10 @@ steps:
 - task: NodeTool@0
   inputs:
     versionSpec: "12.13.0"
-  condition: and(succeeded(), ne(variables['CacheExists-Compilation'], 'true'))
 
 - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
   inputs:
     versionSpec: "1.x"
-  condition: and(succeeded(), ne(variables['CacheExists-Compilation'], 'true'))
 
 - task: AzureKeyVault@1
   displayName: 'Azure Key Vault: Get Secrets'


### PR DESCRIPTION
Yarn is used later on in the build process; if we don't get it because there's a cached build, it will fail, see https://dev.azure.com/monacotools/Monaco/_build/results?buildId=75247&view=logs&j=c7493abb-a1f4-533f-2d24-71780a69f247&t=f5d49255-f229-5ab6-a621-e5b2039a4806
