### PR TITLE
Fix indentation and typo of json-language server readme

### DIFF
--- a/extensions/json-language-features/server/README.md
+++ b/extensions/json-language-features/server/README.md
@@ -62,14 +62,14 @@ The server supports the following settings:
 - json
   - `format`
     - `enable`: Whether the server should register the formatting support. This option is only applicable if the client supports *dynamicRegistration* for *rangeFormatting* and `initializationOptions.provideFormatter` is not defined.
-    - `schema`: Configures association of file names to schema URL or schemas and/or associations of schema URL to schema content.
-	  - `fileMatch`: an array of file names or paths (separated by `/`). `*` can be used as a wildcard. Exclusion patterns can also be defined and start with '!'. A file matches when there at least one matching pattern and the last matching pattern is not an exclusion pattern.
-	  - `url`: The URL of the schema, optional when also a schema is provided.
-	  - `schema`: The schema content.
-    - `resultLimit`: The max number foldig ranges and otline symbols to be computed (for performance reasons)
+  - `schemas`: Configures association of file names to schema URL or schemas and/or associations of schema URL to schema content.
+    - `fileMatch`: an array of file names or paths (separated by `/`). `*` can be used as a wildcard. Exclusion patterns can also be defined and start with '!'. A file matches when there at least one matching pattern and the last matching pattern is not an exclusion pattern.
+    - `url`: The URL of the schema, optional when also a schema is provided.
+    - `schema`: The schema content.
+  - `resultLimit`: The max number foldig ranges and otline symbols to be computed (for performance reasons)
 
 ```json
-	{
+    {
         "http": {
             "proxy": "",
             "proxyStrictSSL": true
@@ -86,7 +86,7 @@ The server supports the following settings:
                     ],
                     "url": "http://json.schemastore.org/foo",
                     "schema": {
-                    	"type": "array"
+                        "type": "array"
                     }
                 }
             ]


### PR DESCRIPTION
`schemas` and `resultLimit` are not a children of `format`.
They are its sibling.