### PR TITLE
add breakpointMargin property to cell metadata

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1592,6 +1592,12 @@ declare module 'vscode' {
 		runnable?: boolean;
 
 		/**
+		 * Controls if the cell has a margin to support the breakpoint UI.
+		 * This metadata is ignored for markdown cell.
+		 */
+		breakpointMargin?: boolean;
+
+		/**
 		 * The order in which this cell was executed.
 		 */
 		executionOrder?: number;

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
@@ -159,6 +159,13 @@ export class CellEditorOptions {
 	get value(): IEditorOptions {
 		return this._value;
 	}
+
+	setGlyphMargin(gm: boolean): void {
+		if (gm !== this._value.glyphMargin) {
+			this._value.glyphMargin = gm;
+			this._onDidChange.fire(this.value);
+		}
+	}
 }
 
 abstract class AbstractCellRenderer {
@@ -988,6 +995,10 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 			templateData.timer.show(metadata.lastRunDuration);
 		} else {
 			templateData.timer.clear();
+		}
+
+		if (typeof metadata.breakpointMargin === 'boolean') {
+			this.editorOptions.setGlyphMargin(metadata.breakpointMargin);
 		}
 	}
 

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -79,6 +79,7 @@ export enum NotebookCellRunState {
 export interface NotebookCellMetadata {
 	editable?: boolean;
 	runnable?: boolean;
+	breakpointMargin?: boolean;
 	executionOrder?: number;
 	statusMessage?: string;
 	runState?: NotebookCellRunState;


### PR DESCRIPTION
This PR adds a new cell metadata property for controlling the left glyphmargin.