### PR TITLE
Focus notification area if empty

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsCenter.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsCenter.ts
@@ -94,8 +94,10 @@ export class NotificationsCenter extends Themable implements INotificationsCente
 		// Show all notifications that are present now
 		notificationsList.updateNotificationsList(0, 0, this.model.notifications);
 
-		// Focus first
-		notificationsList.focusFirst();
+		// Focus on first notification if it exists, otherwise focus on notification widget
+		if (!notificationsList.focusFirst()) {
+			this.notificationsCenterContainer?.focus();
+		}
 
 		// Theming
 		this.updateStyles();
@@ -127,6 +129,7 @@ export class NotificationsCenter extends Themable implements INotificationsCente
 		// Container
 		this.notificationsCenterContainer = document.createElement('div');
 		addClass(this.notificationsCenterContainer, 'notifications-center');
+		this.notificationsCenterContainer.tabIndex = -1;
 
 		// Header
 		this.notificationsCenterHeader = document.createElement('div');

--- a/src/vs/workbench/browser/parts/notifications/notificationsList.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsList.ts
@@ -231,13 +231,14 @@ export class NotificationsList extends Themable {
 		this.viewModel = [];
 	}
 
-	focusFirst(): void {
-		if (!this.isVisible || !this.list) {
-			return; // hidden
+	focusFirst(): boolean {
+		if (!this.isVisible || !this.list || this.list.length === 0) {
+			return false; // hidden or empty
 		}
 
 		this.list.focusFirst();
 		this.list.domFocus();
+		return true;
 	}
 
 	hasFocus(): boolean {


### PR DESCRIPTION
Solves #97513

I tried focusing the button that hides the notification area as suggested on the issue thread, however when opening notifications from the status bar using the "space" button, it would also go on and hide the notifications too after focusing the action arrow.
Therefore, if there are no notifications, the whole notifaction area is focused. As an added bonus NVDA says "No new notifications" (among other things...)


<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->