### PR TITLE
editor: introduce anchor selection

### DIFF
--- a/src/vs/editor/contrib/anchorSelect/anchorSelect.css
+++ b/src/vs/editor/contrib/anchorSelect/anchorSelect.css
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.monaco-editor .selection-anchor {
+	background-color: #007ACC;
+	width: 2px !important;
+}

--- a/src/vs/editor/contrib/anchorSelect/anchorSelect.ts
+++ b/src/vs/editor/contrib/anchorSelect/anchorSelect.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'vs/css!./anchorSelect';
+import { EditorAction, ServicesAccessor, registerEditorAction, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
+import { localize } from 'vs/nls';
+import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
+import { Selection } from 'vs/editor/common/core/selection';
+import { KeyMod, KeyCode, KeyChord } from 'vs/base/common/keyCodes';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { RawContextKey, IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { IEditorContribution } from 'vs/editor/common/editorCommon';
+import { TrackedRangeStickiness } from 'vs/editor/common/model';
+import { MarkdownString } from 'vs/base/common/htmlContent';
+
+export const SelectionAnchorSet = new RawContextKey('selectionAnchorSet', false);
+
+class SelectionAnchorController implements IEditorContribution {
+
+	public static readonly ID = 'editor.contrib.selectionAnchorController';
+
+	static get(editor: ICodeEditor): SelectionAnchorController {
+		return editor.getContribution<SelectionAnchorController>(SelectionAnchorController.ID);
+	}
+
+	private decorationId: string | undefined;
+	private selectionAnchorSetContextKey: IContextKey<boolean>;
+
+	constructor(
+		private editor: ICodeEditor,
+		@IContextKeyService contextKeyService: IContextKeyService
+	) {
+		this.selectionAnchorSetContextKey = SelectionAnchorSet.bindTo(contextKeyService);
+	}
+
+	setSelectionAnchor(): void {
+		if (this.editor.hasModel()) {
+			const position = this.editor.getPosition();
+			const previousDecorations = this.decorationId ? [this.decorationId] : [];
+			const newDecorationId = this.editor.deltaDecorations(previousDecorations, [{
+				range: Selection.fromPositions(position, position),
+				options: {
+					stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+					hoverMessage: new MarkdownString().appendText(localize('selectionAnchor', "Selection Anchor")),
+					className: 'selection-anchor'
+				}
+			}]);
+			this.decorationId = newDecorationId.length === 1 ? newDecorationId[0] : undefined;
+			this.selectionAnchorSetContextKey.set(!!this.decorationId);
+		}
+	}
+
+	goToSelectionAnchor(): void {
+		if (this.editor.hasModel() && this.decorationId) {
+			const anchorPosition = this.editor.getModel().getDecorationRange(this.decorationId);
+			if (anchorPosition) {
+				this.editor.setPosition(anchorPosition.getStartPosition());
+			}
+		}
+	}
+
+	selectFromAnchorToCursor(): void {
+		if (this.editor.hasModel() && this.decorationId) {
+			const start = this.editor.getModel().getDecorationRange(this.decorationId);
+			if (start) {
+				const end = this.editor.getPosition();
+				this.editor.setSelection(Selection.fromPositions(start.getStartPosition(), end));
+				this.cancelSelectionAnchor();
+			}
+		}
+	}
+
+	cancelSelectionAnchor(): void {
+		if (this.decorationId) {
+			this.editor.deltaDecorations([this.decorationId], []);
+			this.decorationId = undefined;
+			this.selectionAnchorSetContextKey.set(false);
+		}
+	}
+
+	dispose(): void {
+		this.cancelSelectionAnchor();
+	}
+}
+
+class SetSelectionAnchor extends EditorAction {
+	constructor() {
+		super({
+			id: 'editor.action.setSelectionAnchor',
+			label: localize('setSelectionAnchor', "Set Selection Anchor"),
+			alias: 'Set Selection Anchor',
+			precondition: undefined,
+			kbOpts: {
+				kbExpr: EditorContextKeys.editorTextFocus,
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_B),
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	async run(_accessor: ServicesAccessor, editor: ICodeEditor): Promise<void> {
+		const controller = SelectionAnchorController.get(editor);
+		controller.setSelectionAnchor();
+	}
+}
+
+class GoToSelectionAnchor extends EditorAction {
+	constructor() {
+		super({
+			id: 'editor.action.goToSelectionAnchor',
+			label: localize('goToSelectionAnchor', "Go to Selection Anchor"),
+			alias: 'Go to Selection Anchor',
+			precondition: SelectionAnchorSet,
+		});
+	}
+
+	async run(_accessor: ServicesAccessor, editor: ICodeEditor): Promise<void> {
+		const controller = SelectionAnchorController.get(editor);
+		controller.goToSelectionAnchor();
+	}
+}
+
+class SelectFromAnchorToCursor extends EditorAction {
+	constructor() {
+		super({
+			id: 'editor.action.selectFromAnchorToCursor',
+			label: localize('selectFromAnchorToCursor', "Select from Anchor to Cursor"),
+			alias: 'Select from Anchor to Cursor',
+			precondition: SelectionAnchorSet,
+			kbOpts: {
+				kbExpr: EditorContextKeys.editorTextFocus,
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_K),
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	async run(_accessor: ServicesAccessor, editor: ICodeEditor): Promise<void> {
+		const controller = SelectionAnchorController.get(editor);
+		controller.selectFromAnchorToCursor();
+	}
+}
+
+class CancelSelectionAnchor extends EditorAction {
+	constructor() {
+		super({
+			id: 'editor.action.cancelSelectionAnchor',
+			label: localize('cancelSelectionAnchor', "Cancel Selection Anchor"),
+			alias: 'Cancel Selection Anchor',
+			precondition: SelectionAnchorSet,
+			kbOpts: {
+				kbExpr: EditorContextKeys.editorTextFocus,
+				primary: KeyCode.Escape,
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	async run(_accessor: ServicesAccessor, editor: ICodeEditor): Promise<void> {
+		const controller = SelectionAnchorController.get(editor);
+		controller.cancelSelectionAnchor();
+	}
+}
+
+registerEditorContribution(SelectionAnchorController.ID, SelectionAnchorController);
+registerEditorAction(SetSelectionAnchor);
+registerEditorAction(GoToSelectionAnchor);
+registerEditorAction(SelectFromAnchorToCursor);
+registerEditorAction(CancelSelectionAnchor);

--- a/src/vs/editor/contrib/anchorSelect/anchorSelect.ts
+++ b/src/vs/editor/contrib/anchorSelect/anchorSelect.ts
@@ -15,6 +15,7 @@ import { RawContextKey, IContextKeyService, IContextKey } from 'vs/platform/cont
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
 import { TrackedRangeStickiness } from 'vs/editor/common/model';
 import { MarkdownString } from 'vs/base/common/htmlContent';
+import { IDisposable } from 'vs/base/common/lifecycle';
 
 export const SelectionAnchorSet = new RawContextKey('selectionAnchorSet', false);
 
@@ -28,12 +29,14 @@ class SelectionAnchorController implements IEditorContribution {
 
 	private decorationId: string | undefined;
 	private selectionAnchorSetContextKey: IContextKey<boolean>;
+	private modelChangeListener: IDisposable;
 
 	constructor(
 		private editor: ICodeEditor,
 		@IContextKeyService contextKeyService: IContextKeyService
 	) {
 		this.selectionAnchorSetContextKey = SelectionAnchorSet.bindTo(contextKeyService);
+		this.modelChangeListener = editor.onDidChangeModel(() => this.selectionAnchorSetContextKey.reset());
 	}
 
 	setSelectionAnchor(): void {
@@ -48,7 +51,7 @@ class SelectionAnchorController implements IEditorContribution {
 					className: 'selection-anchor'
 				}
 			}]);
-			this.decorationId = newDecorationId.length === 1 ? newDecorationId[0] : undefined;
+			this.decorationId = newDecorationId[0];
 			this.selectionAnchorSetContextKey.set(!!this.decorationId);
 		}
 	}
@@ -83,6 +86,7 @@ class SelectionAnchorController implements IEditorContribution {
 
 	dispose(): void {
 		this.cancelSelectionAnchor();
+		this.modelChangeListener.dispose();
 	}
 }
 
@@ -95,7 +99,7 @@ class SetSelectionAnchor extends EditorAction {
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_B),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyCode.KEY_B),
 				weight: KeybindingWeight.EditorContrib
 			}
 		});
@@ -132,7 +136,7 @@ class SelectFromAnchorToCursor extends EditorAction {
 			precondition: SelectionAnchorSet,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_K),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyCode.KEY_K),
 				weight: KeybindingWeight.EditorContrib
 			}
 		});

--- a/src/vs/editor/editor.all.ts
+++ b/src/vs/editor/editor.all.ts
@@ -7,6 +7,7 @@ import 'vs/editor/browser/controller/coreCommands';
 import 'vs/editor/browser/widget/codeEditorWidget';
 import 'vs/editor/browser/widget/diffEditorWidget';
 import 'vs/editor/browser/widget/diffNavigator';
+import 'vs/editor/contrib/anchorSelect/anchorSelect';
 import 'vs/editor/contrib/bracketMatching/bracketMatching';
 import 'vs/editor/contrib/caretOperations/caretOperations';
 import 'vs/editor/contrib/caretOperations/transpose';
@@ -45,7 +46,6 @@ import 'vs/editor/contrib/viewportSemanticTokens/viewportSemanticTokens';
 import 'vs/editor/contrib/wordHighlighter/wordHighlighter';
 import 'vs/editor/contrib/wordOperations/wordOperations';
 import 'vs/editor/contrib/wordPartOperations/wordPartOperations';
-import 'vs/editor/contrib/anchorSelect/anchorSelect';
 
 // Load up these strings even in VSCode, even if they are not used
 // in order to get them translated

--- a/src/vs/editor/editor.all.ts
+++ b/src/vs/editor/editor.all.ts
@@ -45,6 +45,7 @@ import 'vs/editor/contrib/viewportSemanticTokens/viewportSemanticTokens';
 import 'vs/editor/contrib/wordHighlighter/wordHighlighter';
 import 'vs/editor/contrib/wordOperations/wordOperations';
 import 'vs/editor/contrib/wordPartOperations/wordPartOperations';
+import 'vs/editor/contrib/anchorSelect/anchorSelect';
 
 // Load up these strings even in VSCode, even if they are not used
 // in order to get them translated


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/95894

This PR introduces the following commands:
* Set Selection Anchor `Cmd + K, B` keybinding
* Go to Selection Anchor
* Select from Anchor to Cursor `Cmd + K, K` keybdining
* Cancel Selection Anchor `Esc` keybinding

As for changning default keybindings I woud like to have this in insiders so users try it out and then we can change it.

Potential follow up work:
1. Unit tests - not sure how much we gain
2. Make the Anchor Selection color themable - currently is just usses the status bar default blue
3. Better solution than using `width` with `!important`.

@alexdima let me know what you think