### PR TITLE
Quick input multiline

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1427,7 +1427,8 @@ export class CommandCenter {
 					value,
 					placeHolder,
 					prompt: localize('provide commit message', "Please provide a commit message"),
-					ignoreFocusOut: true
+					ignoreFocusOut: true,
+					multiline: true
 				});
 			}
 

--- a/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
@@ -355,6 +355,14 @@ suite('window namespace tests', () => {
 		]);
 	});
 
+	test('showInputBox multiline - default value on Enter', function () {
+		const p = window.showInputBox({ value: 'foo\nbar', multiline: true });
+		return Promise.all<any>([
+			p.then(value => assert.equal(value, 'foo\nbar')),
+			commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem'),
+		]);
+	});
+
 	test('showInputBox - `undefined` on Esc', function () {
 		const p = window.showInputBox();
 		return Promise.all<any>([

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -119,6 +119,8 @@ export interface IInputOptions {
 	 */
 	password?: boolean;
 
+	multiline?: boolean;
+
 	ignoreFocusLost?: boolean;
 
 	/**
@@ -220,6 +222,8 @@ export interface IInputBox extends IQuickInput {
 	placeholder: string | undefined;
 
 	password: boolean;
+
+	readonly multiline: boolean;
 
 	readonly onDidChangeValue: Event<string>;
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1797,6 +1797,7 @@ declare module 'vscode' {
 
 		/**
 		 * Set to `true` to show a password prompt that will not show the typed value.
+		 * Note: has no effect when multiline is set to true
 		 */
 		password?: boolean;
 
@@ -1804,6 +1805,12 @@ declare module 'vscode' {
 		 * Set to `true` to keep the input box open when focus moves to another part of the editor or to another window.
 		 */
 		ignoreFocusOut?: boolean;
+
+		/**
+		 * Set to `true` to show a multiline prompt that inserts a new line when user presses 'Shift + Enter'
+		 * instead of submitting
+		 */
+		multiline?: boolean;
 
 		/**
 		 * An optional function that will be called to validate input and to give a hint

--- a/src/vs/workbench/api/browser/mainThreadQuickOpen.ts
+++ b/src/vs/workbench/api/browser/mainThreadQuickOpen.ts
@@ -94,6 +94,7 @@ export class MainThreadQuickOpen implements MainThreadQuickOpenShape {
 			inputOptions.prompt = options.prompt;
 			inputOptions.value = options.value;
 			inputOptions.ignoreFocusLost = options.ignoreFocusOut;
+			inputOptions.multiline = options.multiline;
 		}
 
 		if (validateInput) {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -504,6 +504,7 @@ export interface IInputBoxOptions {
 	placeHolder?: string;
 	password?: boolean;
 	ignoreFocusOut?: boolean;
+	multiline?: boolean;
 }
 
 export interface MainThreadQuickOpenShape extends IDisposable {

--- a/src/vs/workbench/browser/parts/quickinput/quickInputBox.ts
+++ b/src/vs/workbench/browser/parts/quickinput/quickInputBox.ts
@@ -5,7 +5,7 @@
 
 import 'vs/css!./media/quickInput';
 import * as dom from 'vs/base/browser/dom';
-import { InputBox, IRange, MessageType } from 'vs/base/browser/ui/inputbox/inputBox';
+import { InputBox, IRange, MessageType, IInputOptions } from 'vs/base/browser/ui/inputbox/inputBox';
 import { inputBackground, inputForeground, inputBorder, inputValidationInfoBackground, inputValidationInfoForeground, inputValidationInfoBorder, inputValidationWarningBackground, inputValidationWarningForeground, inputValidationWarningBorder, inputValidationErrorBackground, inputValidationErrorForeground, inputValidationErrorBorder } from 'vs/platform/theme/common/colorRegistry';
 import { ITheme } from 'vs/platform/theme/common/themeService';
 import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
@@ -21,11 +21,12 @@ export class QuickInputBox extends Disposable {
 	private inputBox: InputBox;
 
 	constructor(
-		private parent: HTMLElement
+		private parent: HTMLElement,
+		options?: IInputOptions
 	) {
 		super();
 		this.container = dom.append(this.parent, $('.quick-input-box'));
-		this.inputBox = this._register(new InputBox(this.container, undefined));
+		this.inputBox = this._register(new InputBox(this.container, undefined, options));
 	}
 
 	onKeyDown = (handler: (event: StandardKeyboardEvent) => void): IDisposable => {
@@ -73,6 +74,9 @@ export class QuickInputBox extends Disposable {
 	}
 
 	set password(password: boolean) {
+		if (this.inputBox.inputElement instanceof HTMLTextAreaElement) {
+			return;
+		}
 		this.inputBox.inputElement.type = password ? 'password' : 'text';
 	}
 


### PR DESCRIPTION
Closes #39969
Closes #40295

### What's happening

We can already create a multiline `InputBox` dom component via the `flexibleHeight: 
true` option. So multiline quick input uses that and inserts a newline on <kbd>Shift</kbd> + <Kbd>Enter</kbd> (instead of submitting). BUT...


<details>
<summary><strong>TLDR</strong>: We're making a new dom tree because the we require <code>textarea</code> instead of <code>input</code> and replacing <code>input</code> with <code>textarea</code> in existing dom tree will open up a bag of worms</summary><br/>

Let's first see how the password quick input works: When we get the password input request we set the input type of already appended `input`'s type as password hence doesn't require reconstructing the dom tree

But in case of multiline we can't reuse the same dom tree because we need `textarea` instead of `input`. This is also the reason why `flexibleHeight` isn't dynamic as in you can't change it after the component is constructed.

Now there are two solutions to this problem
1. (Bad solution) Make `flexibleHeight` dynamic like `type` which would require removing dom `input` and replacing it with `textarea` also we would have to reattach listeners, make sure the dom element passed downstream is only accessing it via a reference (so it's not stale) and no listeners are being attached downstream (because reattaching them is not trivia)
2. (Better solution) create another dom tree for multiline quickinput the only difference is it would have `textarea` instead of `input`.

So I picked the second one. The quickinput service request is "responded" in either in non-multiline context or multiline context which is governed by the `multiline` instance property. The 
non-multiline dom tree is `_ui` (ie old `ui`) and the multiline dom tree is `_uiMultiline`. The `ui` property reflects `_ui` or `_uiMultiline` depending upon the context.

<details><summary>Nitpicks and stuff</summary><br/>
1. the whole multiline context ceremony is to conditionally inject <code>ui</code> dependency in the methods (thus avoiding waterfall) and also to hide the "multiline-ui and non-multiline-ui" implementation detail from them.

```typescript
// without multiline instance property:
// conditionally access ui or uiMultiline is depending on multiline argument
this.methodA(multiline)
this.methodB(multiline)
this.methodC(multiline)


// with multiline instance property:
// methods stay as they were
this.multiline = true
this.methodA()
this.methodB()
this.methodC()
this.multiline = false
```

2. `flexibleHeight` should have been called `multiline` because not only it makes the height of inputbox flexible but also allows having linebreaks (which aren't allowed otherwise) in them hence making it actually `multiline`

3. Pardon my french but the code is a FP-ish guy (aka me)'s nightmare hahaha, kidding kidding ya'll do amazing stuff xD
 
</details>
</details>

### How to test

1. Use commit ammend option to open up a multline quick input
1.1. Check if the newlines are preserved in the default value
1.2. Check if pressing <kbd>SHIFT</kbd> + <kbd>ENTER</kbd> inserts a new line instead of submitting
1.3. Check if pressing <kbd>ENTER</kbd> submits it
1.4. Check is the commit message is what you would expect
2. (idk how but) Check if the feature doesn't affect existing behavior of `multiline: false` `showInputBox`
3. Make sure the new test case is passing

