### PR TITLE
fix #98102

### DIFF
--- a/src/vs/editor/contrib/suggest/suggestMemory.ts
+++ b/src/vs/editor/contrib/suggest/suggestMemory.ts
@@ -26,7 +26,7 @@ export abstract class Memory {
 			return 0;
 		}
 		let topScore = items[0].score[0];
-		for (let i = 1; i < items.length; i++) {
+		for (let i = 0; i < items.length; i++) {
 			const { score, completion: suggestion } = items[i];
 			if (score[0] !== topScore) {
 				// stop when leaving the group of top matches


### PR DESCRIPTION
When VSCode selects preselected completion items, the index shouldn't start from 1. If there are multiple completion items with preselect=true, the first item will never be chosen.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #98102 
