### PR TITLE
editor use contenteditable instead of textarea

### DIFF
--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -86,7 +86,7 @@ export class TextAreaHandler extends ViewPart {
 	 */
 	private _lastRenderPosition: Position | null;
 
-	public readonly textArea: FastDomNode<HTMLTextAreaElement>;
+	public readonly textArea: FastDomNode<HTMLDivElement>;
 	public readonly textAreaCover: FastDomNode<HTMLElement>;
 	private readonly _textAreaInput: TextAreaInput;
 
@@ -116,7 +116,8 @@ export class TextAreaHandler extends ViewPart {
 		this._lastRenderPosition = null;
 
 		// Text Area (The focus will always be in the textarea when the cursor is blinking)
-		this.textArea = createFastDomNode(document.createElement('textarea'));
+		this.textArea = createFastDomNode(document.createElement('div'));
+		this.textArea.setAttribute('contenteditable', 'true');
 		PartFingerprints.write(this.textArea, PartFingerprint.TextArea);
 		this.textArea.setClassName(`inputarea ${MOUSE_CURSOR_TEXT_CSS_CLASS_NAME}`);
 		this.textArea.setAttribute('wrap', 'off');

--- a/src/vs/editor/test/browser/controller/imeTester.ts
+++ b/src/vs/editor/test/browser/controller/imeTester.ts
@@ -78,9 +78,10 @@ function doCreateTest(description: string, inputStr: string, expectedStr: string
 	container.appendChild(startBtn);
 
 
-	let input = document.createElement('textarea');
+	let input = document.createElement('div');
 	input.setAttribute('rows', '10');
 	input.setAttribute('cols', '40');
+	input.setAttribute('contenteditable', 'true');
 	container.appendChild(input);
 
 	let model = new SingleLineTestModel('some  text');


### PR DESCRIPTION
fixes #97154
Creating this PR to start discussion.

1. I have changed that the underlying element used is a `div` not a `textarea`
2. I measured performance by opening `checker.ts` and if we put 500+ line in one div the editor lags considerably. However we already have performance issues with a large text area due to chrome and thus we have a `accessibilityPageSize` setting. For the default value of this setting of 100 I could not notice any lag. 

@alexdima let me know what you think about this approach in general. If you think it makes sense I can pursue this further. I think the next steps is to allow editor decorations to be added to the hidden div element using `aria-description`. So
1) Add `ariaLabel` to the [`IModelDecorationOptions`](https://github.com/microsoft/vscode/blob/0618eaefe0979850aaa0f50b6923d80b49f3780a/src/vs/editor/common/model.ts#L75)
2) Add `textAreaHandler` api to `addAnnotation` or `addDecoration` which would add `aria-description` on the substring of the hidden div (which would have to be moved to a separate div)
3) Hoockup decorations that they call into the `textAreaHandler`
4) Line numbers could be the first client to use it, line number is just a decoration on the whole line sort of

As a consequence of this the hidden `div` can have an arbitary large dom substructure.
To make things simpler for start I suggest that we put one line in one div. And that decorations can be only put on the whole line. This will fix qiute some accessibiltiy issues.

Once we have that dom substructure per line we can look into measuring performance.