### PR TITLE
php-language-features: Add html indent rule

### DIFF
--- a/extensions/php-language-features/src/phpMain.ts
+++ b/extensions/php-language-features/src/phpMain.ts
@@ -10,6 +10,8 @@ import PHPHoverProvider from './features/hoverProvider';
 import PHPSignatureHelpProvider from './features/signatureHelpProvider';
 import PHPValidationProvider from './features/validationProvider';
 
+const EMPTY_ELEMENTS: string[] = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'menuitem', 'meta', 'param', 'source', 'track', 'wbr'];
+
 export function activate(context: vscode.ExtensionContext): any {
 
 	let validator = new PHPValidationProvider(context.workspaceState);
@@ -51,5 +53,24 @@ export function activate(context: vscode.ExtensionContext): any {
 				action: { indentAction: vscode.IndentAction.None, removeText: 1 }
 			}
 		]
+	});
+
+	vscode.languages.setLanguageConfiguration('html', {
+		indentationRules: {
+			increaseIndentPattern: /<(?!\?|(?:area|base|br|col|frame|hr|html|img|input|link|meta|param)\b|[^>]*\/>)([-_\.A-Za-z0-9]+)(?=\s|>)\b[^>]*>(?!.*<\/\1>)|<!--(?!.*-->)|\{[^}"']*$/,
+			decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/
+		},
+		wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\s]+)/g,
+		onEnterRules: [
+			{
+				beforeText: new RegExp(`<(?!(?:${EMPTY_ELEMENTS.join('|')}))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
+				afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>/i,
+				action: { indentAction: vscode.IndentAction.IndentOutdent }
+			},
+			{
+				beforeText: new RegExp(`<(?!(?:${EMPTY_ELEMENTS.join('|')}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
+				action: { indentAction: vscode.IndentAction.Indent }
+			}
+		],
 	});
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #62077.

## Testing the change
1. Create new file.
2. Change file type to PHP.
3. Type in some nested matching html tags without manually indenting the line:

a. Without the change.
```
<div>
<div>
</div>
</div>
```

b. With the change.
```
<div>
    <div>
    </div>
</div>
```
