### PR TITLE
fix: add an option to stopAll in compound launch configs

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -46,6 +46,7 @@ import { IViewsService } from 'vs/workbench/common/views';
 import { generateUuid } from 'vs/base/common/uuid';
 import { DebugStorage } from 'vs/workbench/contrib/debug/common/debugStorage';
 import { DebugTelemetry } from 'vs/workbench/contrib/debug/common/debugTelemetry';
+import { DebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debugCompoundRoot';
 
 export class DebugService implements IDebugService {
 	_serviceBrand: undefined;
@@ -304,6 +305,9 @@ export class DebugService implements IDebugService {
 						this.endInitializingState();
 						return false;
 					}
+				}
+				if (compound.stopAll) {
+					options = { ...options, compoundRoot: new DebugCompoundRoot() };
 				}
 
 				const values = await Promise.all(compound.configurations.map(configData => {

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -101,7 +101,7 @@ export class DebugSession implements IDebugSession {
 
 		const compoundRoot = this._options.compoundRoot;
 		if (compoundRoot) {
-			toDispose.push(compoundRoot.onShouldSessionsStop(() => this.terminate()));
+			toDispose.push(compoundRoot.onDidSessionStop(() => this.terminate()));
 		}
 	}
 
@@ -287,7 +287,7 @@ export class DebugSession implements IDebugSession {
 		}
 
 		if (!restart) {
-			this._options.compoundRoot?.didStop();
+			this._options.compoundRoot?.sessionStopped();
 		}
 	}
 
@@ -303,7 +303,7 @@ export class DebugSession implements IDebugSession {
 		await this.raw.disconnect(restart);
 
 		if (!restart) {
-			this._options.compoundRoot?.didStop();
+			this._options.compoundRoot?.sessionStopped();
 		}
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -98,6 +98,11 @@ export class DebugSession implements IDebugSession {
 				dispose(toDispose);
 			}));
 		}
+
+		const compoundRoot = this._options.compoundRoot;
+		if (compoundRoot) {
+			toDispose.push(compoundRoot.onShouldSessionsStop(() => this.terminate()));
+		}
 	}
 
 	getId(): string {
@@ -280,6 +285,10 @@ export class DebugSession implements IDebugSession {
 		} else {
 			await this.raw.disconnect(restart);
 		}
+
+		if (!restart) {
+			this._options.compoundRoot?.didStop();
+		}
 	}
 
 	/**
@@ -292,6 +301,10 @@ export class DebugSession implements IDebugSession {
 
 		this.cancelAllRequests();
 		await this.raw.disconnect(restart);
+
+		if (!restart) {
+			this._options.compoundRoot?.didStop();
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -24,6 +24,7 @@ import { TelemetryService } from 'vs/platform/telemetry/common/telemetryService'
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { DebugConfigurationProviderTriggerKind } from 'vs/workbench/api/common/extHostTypes';
+import { DebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debugCompoundRoot';
 
 export const VIEWLET_ID = 'workbench.view.debug';
 
@@ -155,7 +156,7 @@ export interface IDebugSessionOptions {
 	noDebug?: boolean;
 	parentSession?: IDebugSession;
 	repl?: IDebugSessionReplMode;
-	compoundRoot?: IDebugCompoundRoot;
+	compoundRoot?: DebugCompoundRoot;
 }
 
 export interface IDebugSession extends ITreeElement {
@@ -911,10 +912,4 @@ export interface IDebugHelperService {
 	_serviceBrand: undefined;
 
 	createTelemetryService(configurationService: IConfigurationService, args: string[]): TelemetryService | undefined;
-}
-
-export interface IDebugCompoundRoot {
-	onShouldSessionsStop: Event<void>;
-
-	didStop(): void;
 }

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -155,6 +155,7 @@ export interface IDebugSessionOptions {
 	noDebug?: boolean;
 	parentSession?: IDebugSession;
 	repl?: IDebugSessionReplMode;
+	compoundRoot?: IDebugCompoundRoot;
 }
 
 export interface IDebugSession extends ITreeElement {
@@ -518,6 +519,7 @@ export interface IConfig extends IEnvConfig {
 
 export interface ICompound {
 	name: string;
+	stopAll?: boolean;
 	preLaunchTask?: string | TaskIdentifier;
 	configurations: (string | { name: string, folder: string })[];
 	presentation?: IConfigPresentation;
@@ -909,4 +911,10 @@ export interface IDebugHelperService {
 	_serviceBrand: undefined;
 
 	createTelemetryService(configurationService: IConfigurationService, args: string[]): TelemetryService | undefined;
+}
+
+export interface IDebugCompoundRoot {
+	onShouldSessionsStop: Event<void>;
+
+	didStop(): void;
 }

--- a/src/vs/workbench/contrib/debug/common/debugCompoundRoot.ts
+++ b/src/vs/workbench/contrib/debug/common/debugCompoundRoot.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debug';
+import { Emitter } from 'vs/base/common/event';
+
+export class DebugCompoundRoot implements IDebugCompoundRoot {
+	private stopped = false;
+	private stopEmitter = new Emitter<void>();
+
+	onShouldSessionsStop = this.stopEmitter.event;
+
+	didStop(): void {
+		if (!this.stopped) { // avoid sending extranous terminate events
+			this.stopped = true;
+			this.stopEmitter.fire();
+		}
+	}
+}
+
+export const stubCompoundRoot: IDebugCompoundRoot = {
+	onShouldSessionsStop: new Emitter<void>().event,
+	didStop: () => undefined,
+};

--- a/src/vs/workbench/contrib/debug/common/debugCompoundRoot.ts
+++ b/src/vs/workbench/contrib/debug/common/debugCompoundRoot.ts
@@ -3,24 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IDebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debug';
 import { Emitter } from 'vs/base/common/event';
 
-export class DebugCompoundRoot implements IDebugCompoundRoot {
+export class DebugCompoundRoot {
 	private stopped = false;
 	private stopEmitter = new Emitter<void>();
 
-	onShouldSessionsStop = this.stopEmitter.event;
+	onDidSessionStop = this.stopEmitter.event;
 
-	didStop(): void {
+	sessionStopped(): void {
 		if (!this.stopped) { // avoid sending extranous terminate events
 			this.stopped = true;
 			this.stopEmitter.fire();
 		}
 	}
 }
-
-export const stubCompoundRoot: IDebugCompoundRoot = {
-	onShouldSessionsStop: new Emitter<void>().event,
-	didStop: () => undefined,
-};

--- a/src/vs/workbench/contrib/debug/common/debugSchemas.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSchemas.ts
@@ -218,7 +218,7 @@ export const launchSchema: IJSONSchema = {
 					stopAll: {
 						type: 'boolean',
 						default: false,
-						description: nls.localize('app.launch.json.compound.stopAll', "Whether to stop all of the compound sessions when any session is terminated.")
+						description: nls.localize('app.launch.json.compound.stopAll', "Controls whether manually terminating one session will stop all of the compound sessions.")
 					},
 					preLaunchTask: {
 						type: 'string',

--- a/src/vs/workbench/contrib/debug/common/debugSchemas.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSchemas.ts
@@ -215,6 +215,11 @@ export const launchSchema: IJSONSchema = {
 						},
 						description: nls.localize('app.launch.json.compounds.configurations', "Names of configurations that will be started as part of this compound.")
 					},
+					stopAll: {
+						type: 'boolean',
+						default: false,
+						description: nls.localize('app.launch.json.compound.stopAll', "Whether to stop all of the compound sessions when any session is terminated.")
+					},
 					preLaunchTask: {
 						type: 'string',
 						default: '',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #95964

It adds a "stopAll" attribute which tears down other sessions if a single debug session is _manually_ terminated. If a session ends automatically/from the DA message, we won't tear it down.
