### PR TITLE
editor: conoslidte computing of editor aria labels 

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -14,6 +14,7 @@ import { ISerializableView } from 'vs/base/browser/ui/grid/grid';
 import { getCodeEditor } from 'vs/editor/browser/editorBrowser';
 import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { IEditorService, IResourceEditorInputType } from 'vs/workbench/services/editor/common/editorService';
+import { localize } from 'vs/nls';
 
 export const EDITOR_TITLE_HEIGHT = 35;
 
@@ -40,6 +41,24 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	iconTheme: 'vs-seti',
 	splitSizing: 'distribute'
 };
+
+export function computeEditorAriaLabel(input: IEditorInput, group: IEditorGroup | undefined, groupCount: number): string {
+	let ariaLabel = input.ariaLabel;
+	if (group && !group.isPinned(input)) {
+		ariaLabel += localize('preview', ", preview");
+	}
+	if (group && group.isSticky(input)) {
+		ariaLabel += localize('pinned', ", pinned");
+	}
+	// Apply group information to help identify in
+	// which group we are (only if more than one group
+	// is actually opened)
+	if (group && groupCount > 1) {
+		ariaLabel += ', ' + group.ariaLabel;
+	}
+
+	return ariaLabel;
+}
 
 export function impactsEditorPartOptions(event: IConfigurationChangeEvent): boolean {
 	return event.affectsConfiguration('workbench.editor') || event.affectsConfiguration('workbench.iconTheme');

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -43,18 +43,18 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 };
 
 export function computeEditorAriaLabel(input: IEditorInput, group: IEditorGroup | undefined, groupCount: number): string {
-	let ariaLabel = input.ariaLabel;
+	let ariaLabel = input.getAriaLabel();
 	if (group && !group.isPinned(input)) {
-		ariaLabel += localize('preview', ", preview");
+		ariaLabel = `${ariaLabel}, ${localize('preview', "preview")}`;
 	}
 	if (group && group.isSticky(input)) {
-		ariaLabel += localize('pinned', ", pinned");
+		ariaLabel = `${ariaLabel}, ${localize('pinned', "pinned")}`;
 	}
 	// Apply group information to help identify in
 	// which group we are (only if more than one group
 	// is actually opened)
 	if (group && groupCount > 1) {
-		ariaLabel += ', ' + group.ariaLabel;
+		ariaLabel = `${ariaLabel}, ${group.ariaLabel}`;
 	}
 
 	return ariaLabel;

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -31,10 +31,10 @@ import { ResourcesDropHandler, DraggedEditorIdentifier, DraggedEditorGroupIdenti
 import { Color } from 'vs/base/common/color';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
-import { MergeGroupMode, IMergeGroupOptions, GroupsArrangement } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { MergeGroupMode, IMergeGroupOptions, GroupsArrangement, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { addClass, addDisposableListener, hasClass, EventType, EventHelper, removeClass, Dimension, scheduleAtNextAnimationFrame, findParentWithClass, clearNode } from 'vs/base/browser/dom';
 import { localize } from 'vs/nls';
-import { IEditorGroupsAccessor, IEditorGroupView, EditorServiceImpl, EDITOR_TITLE_HEIGHT } from 'vs/workbench/browser/parts/editor/editor';
+import { IEditorGroupsAccessor, IEditorGroupView, EditorServiceImpl, EDITOR_TITLE_HEIGHT, computeEditorAriaLabel } from 'vs/workbench/browser/parts/editor/editor';
 import { CloseOneEditorAction } from 'vs/workbench/browser/parts/editor/editorActions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { BreadcrumbsControl } from 'vs/workbench/browser/parts/editor/breadcrumbsControl';
@@ -102,7 +102,8 @@ export class TabsTitleControl extends TitleControl {
 		@IConfigurationService configurationService: IConfigurationService,
 		@IFileService fileService: IFileService,
 		@IEditorService private readonly editorService: EditorServiceImpl,
-		@IPathService private readonly pathService: IPathService
+		@IPathService private readonly pathService: IPathService,
+		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService
 	) {
 		super(parent, accessor, group, contextMenuService, instantiationService, contextKeyService, keybindingService, telemetryService, notificationService, menuService, quickInputService, themeService, extensionService, configurationService, fileService);
 
@@ -881,14 +882,13 @@ export class TabsTitleControl extends TitleControl {
 	private computeTabLabels(): void {
 		const { labelFormat } = this.accessor.partOptions;
 		const { verbosity, shortenDuplicates } = this.getLabelConfigFlags(labelFormat);
-
 		// Build labels and descriptions for each editor
 		const labels = this.group.editors.map(editor => ({
 			editor,
 			name: editor.getName(),
 			description: editor.getDescription(verbosity),
 			title: withNullAsUndefined(editor.getTitle(Verbosity.LONG)),
-			ariaLabel: editor.isReadonly() ? localize('readonlyEditor', "{0} readonly", editor.getTitle(Verbosity.SHORT)) : editor.getTitle(Verbosity.SHORT)
+			ariaLabel: computeEditorAriaLabel(editor, this.group, this.editorGroupService.count)
 		}));
 
 		// Shorten labels as needed

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -215,19 +215,6 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditorPan
 		return options;
 	}
 
-	protected getAriaLabel(): string {
-		let ariaLabel: string;
-
-		const inputName = this.input?.getName();
-		if (this.input?.isReadonly()) {
-			ariaLabel = inputName ? nls.localize('readonlyEditorWithInputAriaLabel', "{0} readonly compare", inputName) : nls.localize('readonlyEditorAriaLabel', "Readonly compare");
-		} else {
-			ariaLabel = inputName ? nls.localize('editableEditorWithInputAriaLabel', "{0} compare", inputName) : nls.localize('editableEditorAriaLabel', "Compare");
-		}
-
-		return ariaLabel;
-	}
-
 	private isFileBinaryError(error: Error[]): boolean;
 	private isFileBinaryError(error: Error): boolean;
 	private isFileBinaryError(error: Error | Error[]): boolean {

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -23,6 +23,7 @@ import { isCodeEditor, getCodeEditor } from 'vs/editor/browser/editorBrowser';
 import { IEditorGroupsService, IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { computeEditorAriaLabel } from 'vs/workbench/browser/parts/editor/editor';
 
 export interface IEditorConfiguration {
 	editor: object;
@@ -102,16 +103,7 @@ export abstract class BaseTextEditor extends BaseEditor implements ITextEditorPa
 	}
 
 	private computeAriaLabel(): string {
-		let ariaLabel = this.getAriaLabel();
-
-		// Apply group information to help identify in
-		// which group we are (only if more than one group
-		// is actually opened)
-		if (ariaLabel && this.group && this.editorGroupService.count > 1) {
-			ariaLabel = localize('editorLabelWithGroup', "{0}, {1}", ariaLabel, this.group.ariaLabel);
-		}
-
-		return ariaLabel;
+		return this._input ? computeEditorAriaLabel(this._input, this.group, this.editorGroupService.count) : localize('editor', "Editor");
 	}
 
 	protected getConfigurationOverrides(): IEditorOptions {
@@ -302,8 +294,6 @@ export abstract class BaseTextEditor extends BaseEditor implements ITextEditorPa
 
 		return undefined;
 	}
-
-	protected abstract getAriaLabel(): string;
 
 	dispose(): void {
 		this.lastAppliedEditorOptions = undefined;

--- a/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
@@ -25,7 +25,6 @@ import { IModelService } from 'vs/editor/common/services/modelService';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { PLAINTEXT_MODE_ID } from 'vs/editor/common/modes/modesRegistry';
 import { EditorOption, IEditorOptions } from 'vs/editor/common/config/editorOptions';
-import { basenameOrAuthority } from 'vs/base/common/resources';
 import { ModelConstants } from 'vs/editor/common/model';
 
 /**
@@ -106,11 +105,6 @@ export class AbstractTextResourceEditor extends BaseTextEditor {
 				control.restoreViewState(viewState);
 			}
 		}
-	}
-
-	protected getAriaLabel(): string {
-		const inputName = this.input instanceof UntitledTextEditorInput ? basenameOrAuthority(this.input.resource) : this.input?.getName() || nls.localize('writeableEditorAriaLabel', "Editor");
-		return this.input?.isReadonly() ? nls.localize('readonlyEditor', "{0} readonly", inputName) : inputName;
 	}
 
 	/**

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -383,6 +383,8 @@ export interface IEditorInput extends IDisposable {
 	 */
 	readonly resource: URI | undefined;
 
+	ariaLabel: string;
+
 	/**
 	 * Unique type identifier for this inpput.
 	 */
@@ -510,6 +512,10 @@ export abstract class EditorInput extends Disposable implements IEditorInput {
 
 	getTitle(verbosity?: Verbosity): string {
 		return this.getName();
+	}
+
+	get ariaLabel(): string {
+		return this.getTitle(Verbosity.SHORT);
 	}
 
 	/**

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -383,8 +383,6 @@ export interface IEditorInput extends IDisposable {
 	 */
 	readonly resource: URI | undefined;
 
-	ariaLabel: string;
-
 	/**
 	 * Unique type identifier for this inpput.
 	 */
@@ -404,6 +402,11 @@ export interface IEditorInput extends IDisposable {
 	 * Returns the display title of this input.
 	 */
 	getTitle(verbosity?: Verbosity): string | undefined;
+
+	/**
+	 * Returns the aria label to be read out by a screen reader.
+	 */
+	getAriaLabel(): string;
 
 	/**
 	 * Resolves the input.
@@ -514,7 +517,7 @@ export abstract class EditorInput extends Disposable implements IEditorInput {
 		return this.getName();
 	}
 
-	get ariaLabel(): string {
+	getAriaLabel(): string {
 		return this.getTitle(Verbosity.SHORT);
 	}
 

--- a/src/vs/workbench/contrib/files/browser/editors/textFileEditor.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/textFileEditor.ts
@@ -12,7 +12,7 @@ import { Action } from 'vs/base/common/actions';
 import { VIEWLET_ID, TEXT_FILE_EDITOR_ID, IExplorerService } from 'vs/workbench/contrib/files/common/files';
 import { ITextFileService, TextFileOperationError, TextFileOperationResult } from 'vs/workbench/services/textfile/common/textfiles';
 import { BaseTextEditor, IEditorConfiguration } from 'vs/workbench/browser/parts/editor/textEditor';
-import { EditorOptions, TextEditorOptions, IEditorCloseEvent, Verbosity } from 'vs/workbench/common/editor';
+import { EditorOptions, TextEditorOptions, IEditorCloseEvent } from 'vs/workbench/common/editor';
 import { BinaryEditorModel } from 'vs/workbench/common/editor/binaryEditorModel';
 import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
@@ -243,11 +243,6 @@ export class TextFileEditor extends BaseTextEditor {
 
 			this.explorerService.select(input.resource, true);
 		}
-	}
-
-	protected getAriaLabel(): string {
-		const title = this.input?.getTitle(Verbosity.SHORT) || nls.localize('fileEditorAriaLabel', "editor");
-		return this.input?.isReadonly() ? nls.localize('readonlyEditor', "{0} readonly", title) : title;
 	}
 
 	clearInput(): void {

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorInput.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorInput.ts
@@ -12,6 +12,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IFileService } from 'vs/platform/files/common/files';
 import { IFilesConfigurationService } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
+import { basenameOrAuthority } from 'vs/base/common/resources';
 
 /**
  * An editor input to be used for untitled text buffers.
@@ -48,6 +49,10 @@ export class UntitledTextEditorInput extends TextResourceEditorInput implements 
 
 	getTypeId(): string {
 		return UntitledTextEditorInput.ID;
+	}
+
+	get ariaLabel(): string {
+		return basenameOrAuthority(this.resource);
 	}
 
 	getName(): string {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/98180

This PR does the following:
* Moves editor `ariaLabel` computation from the Editor to the EditorInput
* Removes duplication of `ariaLabel` computation and moves it all to the helper method `computeEditorAriaLabel`
* Adds "pinned" to the aria label for pinned editors and "preview" for editors that are in preview
* Remove "readonly" from ariaLabel since it is already part of the editor title via "(read-only)"

The only downside I see is that i had to introduce a dependency to the `editorGroupService` to the `tabsTitleControl`.

I tried this out and seems to work good.