### PR TITLE
fix: window focus for second instance on macOS

### DIFF
--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -105,6 +105,9 @@ export class LaunchMainService implements ILaunchMainService {
 
 		const waitMarkerFileURI = args.wait && args.waitMarkerFilePath ? URI.file(args.waitMarkerFilePath) : undefined;
 
+		// Force focus the app before requesting window focus
+		app.focus({ steal: true });
+
 		// Special case extension development
 		if (!!args.extensionDevelopmentPath) {
 			this.windowsMainService.openExtensionDevelopmentHostWindow(args.extensionDevelopmentPath, { context, cli: args, userEnv, waitMarkerFileURI });
@@ -156,8 +159,6 @@ export class LaunchMainService implements ILaunchMainService {
 			else {
 				const lastActive = this.windowsMainService.getLastActiveWindow();
 				if (lastActive) {
-					// Force focus the app before requesting window focus
-					app.focus({ steal: true });
 					lastActive.focus();
 
 					usedWindows = [lastActive];


### PR DESCRIPTION
Since `8.3.0` the correct way to steal focus has been changed, since we no longer carry the patch in the internal build https://domoreexp.visualstudio.com/Teamspace/_git/electron-build?path=%2Fpatches%2Fcustomization%2Felectron%2Ffeat_allow_app_to_steal_focus_on_macos.patch&version=GBrelease%2F7-2-x&_a=contents

ref https://github.com/electron/electron/pull/23574
