### PR TITLE
Proposal: Allow TS Server to be spawned with --inspect-brk

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -110,9 +110,10 @@ export class TypeScriptServerSpawner {
 
 	private getForkOptions(kind: ServerKind, configuration: TypeScriptServiceConfiguration) {
 		const debugPort = TypeScriptServerSpawner.getDebugPort(kind);
+		const inspectFlag = process.env['TSS_DEBUG_BRK'] ? '--inspect-brk' : '--inspect';
 		const tsServerForkOptions: electron.ForkOptions = {
 			execArgv: [
-				...(debugPort ? [`--inspect=${debugPort}`] : []),
+				...(debugPort ? [`${inspectFlag}=${debugPort}`] : []),
 				...(configuration.maxTsServerMemory ? [`--max-old-space-size=${configuration.maxTsServerMemory}`] : [])
 			]
 		};
@@ -200,7 +201,7 @@ export class TypeScriptServerSpawner {
 			// We typically only want to debug the main semantic server
 			return undefined;
 		}
-		const value = process.env['TSS_DEBUG'];
+		const value = process.env['TSS_DEBUG_BRK'] || process.env['TSS_DEBUG'];
 		if (value) {
 			const port = parseInt(value);
 			if (!isNaN(port)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

I’ve found this to be very useful while developing TS Server features, as a lot of work happens immediately after VS Code spawns TS Server, which doesn’t allow enough time to attach a debugger unless the process pauses. I plan on also updating my [vscode-tsserver-debug](https://github.com/andrewbranch/vscode-tsserver-debug) extension to leverage this if merged.

While this change would make my work (and likely the work of others working on TS Server) much easier, it should be considered with some caution, since it means that TS Server cannot start in the presence of a `TSS_DEBUG_BRK` environment variable until a debugger attaches and unpauses its execution. If by some very strange means (e.g., malicious extension code?) a user unknowingly ended up with this environment variable set, JS/TS language service operations wouldn’t work and it could be difficult to diagnose. So I’m open to feedback on other ways to accomplish this, depending on the level of concern from the team.

@mjbvz for thoughts, whenever you have a minute.
