### PR TITLE
Treat *.ts.map files as JSON

### DIFF
--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -26,6 +26,7 @@
           ".webmanifest",
           ".js.map",
           ".css.map",
+          ".ts.map",
           ".har",
           ".jslintrc",
           ".jsonld"


### PR DESCRIPTION
This PR fixes #98408

This instructs VS Code to treat `.ts.map` files as JSON by default.