### PR TITLE
use ^H to delete word left in cmd.exe

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
@@ -175,6 +175,14 @@ registerSendSequenceKeybinding(String.fromCharCode('W'.charCodeAt(0) - 64), {
 	primary: KeyMod.CtrlCmd | KeyCode.Backspace,
 	mac: { primary: KeyMod.Alt | KeyCode.Backspace }
 });
+if (platform.isWindows) {
+	// Delete word left: ctrl+h
+	// Windows cmd.exe requires ^H to delete full word left
+	registerSendSequenceKeybinding(String.fromCharCode('H'.charCodeAt(0) - 64), {
+		when: ContextKeyExpr.equals(KEYBINDING_CONTEXT_TERMINAL_SHELL_TYPE_KEY, WindowsShellType.CommandPrompt),
+		primary: KeyMod.CtrlCmd | KeyCode.Backspace,
+	});
+}
 // Delete word right: alt+d
 registerSendSequenceKeybinding('\x1bd', {
 	primary: KeyMod.CtrlCmd | KeyCode.Delete,


### PR DESCRIPTION
This resolves https://github.com/microsoft/vscode/issues/98404 by conditionally changing which escape sequence is sent for `ctrl+bksp` based on the currently focused shell type.

Before:
![recording (5)](https://user-images.githubusercontent.com/39542938/82770461-bca2ce00-9e06-11ea-8f76-1b168cf03e3d.gif)

After:
![recording (4)](https://user-images.githubusercontent.com/39542938/82770356-430ae000-9e06-11ea-9229-288667544326.gif)


From the blame it looks like the best reviewer would be @Tyriar 

I was unable to get around an issue in which the keybinding would not register for `cmd.exe` until the user unfocuses the terminal, either by clicking out of it, closing it (`ctrl+backtick`), or minimizing vscode. It only occurs when there are two bindings to the key -- when removing the other (`^W`) binding this issue no longer occurs. 