### PR TITLE
Update typescript.code-snippets

### DIFF
--- a/extensions/typescript-basics/snippets/typescript.code-snippets
+++ b/extensions/typescript-basics/snippets/typescript.code-snippets
@@ -123,7 +123,7 @@
 	"Throw Exception": {
 		"prefix": "throw",
 		"body": [
-			"throw \"$1\";",
+			"throw new Error(\"$1\");",
 			"$0"
 		],
 		"description": "Throw Exception"
@@ -167,7 +167,16 @@
 			"}"
 		],
 		"description": "For-Of Loop"
-	},
+    },
+    "For-Await-Of Loop": {
+        "prefix": "forawaitof",
+        "body": [
+			"for await (const ${1:iterator} of ${2:object}) {",
+			"\t$0",
+			"}"
+		],
+        "description": "For-Await-Of Loop"
+    },
 	"Function Statement": {
 		"prefix": "function",
 		"body": [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

1. Change code snippet `throw "$1"` to `throw new Error("$1")`. Throw a string is a bad practice because it will drop the execution stack.
2. Add a new snippet `for await of`