### PR TITLE
Remove padding left from first child label in a compacted folder label

### DIFF
--- a/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
+++ b/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
@@ -79,6 +79,10 @@
 	border-radius: 3px;
 }
 
+.explorer-viewlet .explorer-item .monaco-icon-name-container.multiple > .label-name:first-child > .monaco-highlighted-label {
+	padding-left: 0;
+}
+
 .explorer-viewlet .explorer-item .monaco-icon-name-container.multiple > .label-name:hover > .monaco-highlighted-label,
 .explorer-viewlet .monaco-list .monaco-list-row.focused .explorer-item .monaco-icon-name-container.multiple > .label-name.active > .monaco-highlighted-label {
 	text-decoration: underline;


### PR DESCRIPTION
# Remove padding left from first child label in a compacted folder label

This PR fixes #96918 

## To test

* Open a folder/workspace
* Go to the explorer tree-view
* Create a new folder
* Add an empty folder to this folder
* The explorer will compact the folders into one label as the folders contain no files
* Make sure the label of the first folder in the compacted folders label is aligned with other non-empty folders in the explorer tree-view

![98959-1](https://user-images.githubusercontent.com/16445037/83414383-b1126100-a41d-11ea-801d-3b1536ba6379.png)
