### PR TITLE
File operation events support multiple resources

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadDocuments.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocuments.ts
@@ -126,8 +126,12 @@ export class MainThreadDocuments implements MainThreadDocumentsShape {
 		}));
 
 		this._toDispose.add(workingCopyFileService.onDidRunWorkingCopyFileOperation(e => {
-			if (e.source && (e.operation === FileOperation.MOVE || e.operation === FileOperation.DELETE)) {
-				this._modelReferenceCollection.remove(e.source);
+			if (e.operation === FileOperation.MOVE || e.operation === FileOperation.DELETE) {
+				for (const { source } of e.files) {
+					if (source) {
+						this._modelReferenceCollection.remove(source);
+					}
+				}
 			}
 		}));
 

--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -63,8 +63,8 @@ export class MainThreadFileSystemEventService {
 		});
 
 		// AFTER file operation
-		this._listener.add(textFileService.onDidCreateTextFile(e => proxy.$onDidRunFileOperation(FileOperation.CREATE, e.resource, undefined)));
-		this._listener.add(workingCopyFileService.onDidRunWorkingCopyFileOperation(e => proxy.$onDidRunFileOperation(e.operation, e.target, e.source)));
+		this._listener.add(textFileService.onDidCreateTextFile(e => proxy.$onDidRunFileOperation(FileOperation.CREATE, [{ target: e.resource, source: undefined }])));
+		this._listener.add(workingCopyFileService.onDidRunWorkingCopyFileOperation(e => proxy.$onDidRunFileOperation(e.operation, [{ target: e.target, source: e.source }])));
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -63,8 +63,8 @@ export class MainThreadFileSystemEventService {
 		});
 
 		// AFTER file operation
-		this._listener.add(textFileService.onDidCreateTextFile(e => proxy.$onDidRunFileOperation(FileOperation.CREATE, [{ target: e.resource, source: undefined }])));
-		this._listener.add(workingCopyFileService.onDidRunWorkingCopyFileOperation(e => proxy.$onDidRunFileOperation(e.operation, [{ target: e.target, source: e.source }])));
+		this._listener.add(textFileService.onDidCreateTextFile(e => proxy.$onDidRunFileOperation(FileOperation.CREATE, [{ target: e.resource }])));
+		this._listener.add(workingCopyFileService.onDidRunWorkingCopyFileOperation(e => proxy.$onDidRunFileOperation(e.operation, e.files)));
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -58,7 +58,7 @@ export class MainThreadFileSystemEventService {
 		// BEFORE file operation
 		workingCopyFileService.addFileOperationParticipant({
 			participate: (target, source, operation, progress, timeout, token) => {
-				return proxy.$onWillRunFileOperation(operation, target, source, timeout, token);
+				return proxy.$onWillRunFileOperation(operation, [{ target, source }], timeout, token);
 			}
 		});
 

--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -57,8 +57,8 @@ export class MainThreadFileSystemEventService {
 
 		// BEFORE file operation
 		workingCopyFileService.addFileOperationParticipant({
-			participate: (target, source, operation, progress, timeout, token) => {
-				return proxy.$onWillRunFileOperation(operation, [{ target, source }], timeout, token);
+			participate: (data, operation, progress, timeout, token) => {
+				return proxy.$onWillRunFileOperation(operation, data, timeout, token);
 			}
 		});
 

--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -57,8 +57,8 @@ export class MainThreadFileSystemEventService {
 
 		// BEFORE file operation
 		workingCopyFileService.addFileOperationParticipant({
-			participate: (data, operation, progress, timeout, token) => {
-				return proxy.$onWillRunFileOperation(operation, data, timeout, token);
+			participate: (files, operation, progress, timeout, token) => {
+				return proxy.$onWillRunFileOperation(operation, files, timeout, token);
 			}
 		});
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1068,10 +1068,15 @@ export interface FileSystemEvents {
 	deleted: UriComponents[];
 }
 
+export interface UriComponentsPair {
+	target: UriComponents;
+	source: UriComponents | undefined
+}
+
 export interface ExtHostFileSystemEventServiceShape {
 	$onFileEvent(events: FileSystemEvents): void;
-	$onWillRunFileOperation(operation: files.FileOperation, files: { target: UriComponents, source: UriComponents | undefined }[], timeout: number, token: CancellationToken): Promise<any>;
-	$onDidRunFileOperation(operation: files.FileOperation, target: UriComponents, source: UriComponents | undefined): void;
+	$onWillRunFileOperation(operation: files.FileOperation, files: UriComponentsPair[], timeout: number, token: CancellationToken): Promise<any>;
+	$onDidRunFileOperation(operation: files.FileOperation, files: UriComponentsPair[]): void;
 }
 
 export interface ObjectIdentifier {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1068,15 +1068,15 @@ export interface FileSystemEvents {
 	deleted: UriComponents[];
 }
 
-export interface UriComponentsPair {
+export interface SourceTargetPair {
+	source?: UriComponents;
 	target: UriComponents;
-	source: UriComponents | undefined
 }
 
 export interface ExtHostFileSystemEventServiceShape {
 	$onFileEvent(events: FileSystemEvents): void;
-	$onWillRunFileOperation(operation: files.FileOperation, files: UriComponentsPair[], timeout: number, token: CancellationToken): Promise<any>;
-	$onDidRunFileOperation(operation: files.FileOperation, files: UriComponentsPair[]): void;
+	$onWillRunFileOperation(operation: files.FileOperation, files: SourceTargetPair[], timeout: number, token: CancellationToken): Promise<any>;
+	$onDidRunFileOperation(operation: files.FileOperation, files: SourceTargetPair[]): void;
 }
 
 export interface ObjectIdentifier {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1070,7 +1070,7 @@ export interface FileSystemEvents {
 
 export interface ExtHostFileSystemEventServiceShape {
 	$onFileEvent(events: FileSystemEvents): void;
-	$onWillRunFileOperation(operation: files.FileOperation, target: UriComponents, source: UriComponents | undefined, timeout: number, token: CancellationToken): Promise<any>;
+	$onWillRunFileOperation(operation: files.FileOperation, files: { target: UriComponents, source: UriComponents | undefined }[], timeout: number, token: CancellationToken): Promise<any>;
 	$onDidRunFileOperation(operation: files.FileOperation, target: UriComponents, source: UriComponents | undefined): void;
 }
 

--- a/src/vs/workbench/api/common/extHostFileSystemEventService.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemEventService.ts
@@ -179,16 +179,16 @@ export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServ
 		};
 	}
 
-	async $onWillRunFileOperation(operation: FileOperation, target: UriComponents, source: UriComponents | undefined, timeout: number, token: CancellationToken): Promise<any> {
+	async $onWillRunFileOperation(operation: FileOperation, files: { target: UriComponents, source: UriComponents | undefined }[], timeout: number, token: CancellationToken): Promise<any> {
 		switch (operation) {
 			case FileOperation.MOVE:
-				await this._fireWillEvent(this._onWillRenameFile, { files: [{ oldUri: URI.revive(source!), newUri: URI.revive(target) }] }, timeout, token);
+				await this._fireWillEvent(this._onWillRenameFile, { files: files.map(f => ({ oldUri: URI.revive(f.source!), newUri: URI.revive(f.target) })) }, timeout, token);
 				break;
 			case FileOperation.DELETE:
-				await this._fireWillEvent(this._onWillDeleteFile, { files: [URI.revive(target)] }, timeout, token);
+				await this._fireWillEvent(this._onWillDeleteFile, { files: files.map(f => URI.revive(f.target)) }, timeout, token);
 				break;
 			case FileOperation.CREATE:
-				await this._fireWillEvent(this._onWillCreateFile, { files: [URI.revive(target)] }, timeout, token);
+				await this._fireWillEvent(this._onWillCreateFile, { files: files.map(f => URI.revive(f.target)) }, timeout, token);
 				break;
 			default:
 			//ignore, dont send

--- a/src/vs/workbench/api/common/extHostFileSystemEventService.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemEventService.ts
@@ -5,10 +5,10 @@
 
 import { AsyncEmitter, Emitter, Event, IWaitUntil } from 'vs/base/common/event';
 import { IRelativePattern, parse } from 'vs/base/common/glob';
-import { URI, UriComponents } from 'vs/base/common/uri';
+import { URI } from 'vs/base/common/uri';
 import { ExtHostDocumentsAndEditors } from 'vs/workbench/api/common/extHostDocumentsAndEditors';
 import type * as vscode from 'vscode';
-import { ExtHostFileSystemEventServiceShape, FileSystemEvents, IMainContext, MainContext, MainThreadTextEditorsShape, IWorkspaceFileEditDto, IWorkspaceTextEditDto } from './extHost.protocol';
+import { ExtHostFileSystemEventServiceShape, FileSystemEvents, IMainContext, MainContext, MainThreadTextEditorsShape, IWorkspaceFileEditDto, IWorkspaceTextEditDto, UriComponentsPair } from './extHost.protocol';
 import * as typeConverter from './extHostTypeConverters';
 import { Disposable, WorkspaceEdit } from './extHostTypes';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
@@ -142,16 +142,16 @@ export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServ
 
 	//--- file operations
 
-	$onDidRunFileOperation(operation: FileOperation, target: UriComponents, source: UriComponents | undefined): void {
+	$onDidRunFileOperation(operation: FileOperation, files: UriComponentsPair[]): void {
 		switch (operation) {
 			case FileOperation.MOVE:
-				this._onDidRenameFile.fire(Object.freeze({ files: [{ oldUri: URI.revive(source!), newUri: URI.revive(target) }] }));
+				this._onDidRenameFile.fire(Object.freeze({ files: files.map(f => ({ oldUri: URI.revive(f.source!), newUri: URI.revive(f.target) })) }));
 				break;
 			case FileOperation.DELETE:
-				this._onDidDeleteFile.fire(Object.freeze({ files: [URI.revive(target)] }));
+				this._onDidDeleteFile.fire(Object.freeze({ files: files.map(f => URI.revive(f.target)) }));
 				break;
 			case FileOperation.CREATE:
-				this._onDidCreateFile.fire(Object.freeze({ files: [URI.revive(target)] }));
+				this._onDidCreateFile.fire(Object.freeze({ files: files.map(f => URI.revive(f.target)) }));
 				break;
 			default:
 			//ignore, dont send
@@ -179,7 +179,7 @@ export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServ
 		};
 	}
 
-	async $onWillRunFileOperation(operation: FileOperation, files: { target: UriComponents, source: UriComponents | undefined }[], timeout: number, token: CancellationToken): Promise<any> {
+	async $onWillRunFileOperation(operation: FileOperation, files: UriComponentsPair[], timeout: number, token: CancellationToken): Promise<any> {
 		switch (operation) {
 			case FileOperation.MOVE:
 				await this._fireWillEvent(this._onWillRenameFile, { files: files.map(f => ({ oldUri: URI.revive(f.source!), newUri: URI.revive(f.target) })) }, timeout, token);

--- a/src/vs/workbench/api/common/extHostFileSystemEventService.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemEventService.ts
@@ -8,7 +8,7 @@ import { IRelativePattern, parse } from 'vs/base/common/glob';
 import { URI } from 'vs/base/common/uri';
 import { ExtHostDocumentsAndEditors } from 'vs/workbench/api/common/extHostDocumentsAndEditors';
 import type * as vscode from 'vscode';
-import { ExtHostFileSystemEventServiceShape, FileSystemEvents, IMainContext, MainContext, MainThreadTextEditorsShape, IWorkspaceFileEditDto, IWorkspaceTextEditDto, UriComponentsPair } from './extHost.protocol';
+import { ExtHostFileSystemEventServiceShape, FileSystemEvents, IMainContext, MainContext, MainThreadTextEditorsShape, IWorkspaceFileEditDto, IWorkspaceTextEditDto, SourceTargetPair } from './extHost.protocol';
 import * as typeConverter from './extHostTypeConverters';
 import { Disposable, WorkspaceEdit } from './extHostTypes';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
@@ -142,7 +142,7 @@ export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServ
 
 	//--- file operations
 
-	$onDidRunFileOperation(operation: FileOperation, files: UriComponentsPair[]): void {
+	$onDidRunFileOperation(operation: FileOperation, files: SourceTargetPair[]): void {
 		switch (operation) {
 			case FileOperation.MOVE:
 				this._onDidRenameFile.fire(Object.freeze({ files: files.map(f => ({ oldUri: URI.revive(f.source!), newUri: URI.revive(f.target) })) }));
@@ -179,7 +179,7 @@ export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServ
 		};
 	}
 
-	async $onWillRunFileOperation(operation: FileOperation, files: UriComponentsPair[], timeout: number, token: CancellationToken): Promise<any> {
+	async $onWillRunFileOperation(operation: FileOperation, files: SourceTargetPair[], timeout: number, token: CancellationToken): Promise<any> {
 		switch (operation) {
 			case FileOperation.MOVE:
 				await this._fireWillEvent(this._onWillRenameFile, { files: files.map(f => ({ oldUri: URI.revive(f.source!), newUri: URI.revive(f.target) })) }, timeout, token);

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -1033,7 +1033,7 @@ const downloadFileHandler = (accessor: ServicesAccessor) => {
 				defaultUri
 			});
 			if (destination) {
-				await workingCopyFileService.copy(s.resource, destination, true);
+				await workingCopyFileService.copy([{ source: s.resource, target: destination }], true);
 			} else {
 				// User canceled a download. In case there were multiple files selected we should cancel the remainder of the prompts #86100
 				canceled = true;
@@ -1085,7 +1085,7 @@ export const pasteFileHandler = async (accessor: ServicesAccessor) => {
 			if (pasteShouldMove) {
 				return await workingCopyFileService.move(fileToPaste, targetFile);
 			} else {
-				return await workingCopyFileService.copy(fileToPaste, targetFile);
+				return (await workingCopyFileService.copy([{ source: fileToPaste, target: targetFile }]))[0];
 			}
 		} catch (e) {
 			onError(notificationService, new Error(nls.localize('fileDeleted', "The file to paste has been deleted or moved since you copied it. {0}", getErrorMessage(e))));

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -15,7 +15,7 @@ import { Action } from 'vs/base/common/actions';
 import { dispose, IDisposable } from 'vs/base/common/lifecycle';
 import { VIEWLET_ID, IExplorerService, IFilesConfiguration, VIEW_ID } from 'vs/workbench/contrib/files/common/files';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
-import { IFileService } from 'vs/platform/files/common/files';
+import { IFileService, IFileStatWithMetadata } from 'vs/platform/files/common/files';
 import { toResource, SideBySideEditor } from 'vs/workbench/common/editor';
 import { ExplorerViewPaneContainer } from 'vs/workbench/contrib/files/browser/explorerViewlet';
 import { IQuickInputService, ItemActivation } from 'vs/platform/quickinput/common/quickInput';
@@ -1062,7 +1062,7 @@ export const pasteFileHandler = async (accessor: ServicesAccessor) => {
 
 	try {
 		// Check if target is ancestor of pasted folder
-		const files = await Promise.all(toPaste.map(async fileToPaste => {
+		const sourceTargetPairs = await Promise.all(toPaste.map(async fileToPaste => {
 
 			if (element.resource.toString() !== fileToPaste.toString() && resources.isEqualOrParent(element.resource, fileToPaste)) {
 				throw new Error(nls.localize('fileIsAncestor', "File to paste is an ancestor of the destination folder"));
@@ -1083,12 +1083,12 @@ export const pasteFileHandler = async (accessor: ServicesAccessor) => {
 			return { source: fileToPaste, target: targetFile };
 		}));
 
-		let stats = null;
+		let stats: IFileStatWithMetadata[] = [];
 		// Move/Copy File
 		if (pasteShouldMove) {
-			stats = await workingCopyFileService.move(files);
+			stats = await workingCopyFileService.move(sourceTargetPairs);
 		} else {
-			stats = await workingCopyFileService.copy(files);
+			stats = await workingCopyFileService.copy(sourceTargetPairs);
 		}
 
 		if (stats.length >= 1) {

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -222,7 +222,7 @@ async function deleteFiles(workingCopyFileService: IWorkingCopyFileService, dial
 
 	// Call function
 	try {
-		await Promise.all(distinctElements.map(e => workingCopyFileService.delete([e.resource], { useTrash: useTrash, recursive: true })));
+		await workingCopyFileService.delete(distinctElements.map(e => e.resource), { useTrash: useTrash, recursive: true });
 	} catch (error) {
 
 		// Handle error to delete file(s) from a modal confirmation dialog

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -947,7 +947,7 @@ export const renameHandler = async (accessor: ServicesAccessor) => {
 				const targetResource = resources.joinPath(parentResource, value);
 				if (stat.resource.toString() !== targetResource.toString()) {
 					try {
-						await workingCopyFileService.move(stat.resource, targetResource);
+						await workingCopyFileService.move([{ source: stat.resource, target: targetResource }]);
 						await refreshIfSeparator(value, explorerService);
 					} catch (e) {
 						notificationService.error(e);
@@ -1083,7 +1083,7 @@ export const pasteFileHandler = async (accessor: ServicesAccessor) => {
 
 			// Move/Copy File
 			if (pasteShouldMove) {
-				return await workingCopyFileService.move(fileToPaste, targetFile);
+				return (await workingCopyFileService.move([{ source: fileToPaste, target: targetFile }]))[0];
 			} else {
 				return (await workingCopyFileService.copy([{ source: fileToPaste, target: targetFile }]))[0];
 			}

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -222,7 +222,7 @@ async function deleteFiles(workingCopyFileService: IWorkingCopyFileService, dial
 
 	// Call function
 	try {
-		await workingCopyFileService.delete(distinctElements.map(e => e.resource), { useTrash: useTrash, recursive: true });
+		await workingCopyFileService.delete(distinctElements.map(e => e.resource), { useTrash, recursive: true });
 	} catch (error) {
 
 		// Handle error to delete file(s) from a modal confirmation dialog
@@ -1083,8 +1083,8 @@ export const pasteFileHandler = async (accessor: ServicesAccessor) => {
 			return { source: fileToPaste, target: targetFile };
 		}));
 
-		let stats: IFileStatWithMetadata[] = [];
 		// Move/Copy File
+		let stats: IFileStatWithMetadata[] = [];
 		if (pasteShouldMove) {
 			stats = await workingCopyFileService.move(sourceTargetPairs);
 		} else {
@@ -1100,11 +1100,9 @@ export const pasteFileHandler = async (accessor: ServicesAccessor) => {
 				await explorerService.select(stat.resource);
 			}
 		}
-	}
-	catch (e) {
+	} catch (e) {
 		onError(notificationService, new Error(nls.localize('fileDeleted', "The file(s) to paste have been deleted or moved since you copied them. {0}", getErrorMessage(e))));
-	}
-	finally {
+	} finally {
 		if (pasteShouldMove) {
 			// Cut is done. Make sure to clear cut state.
 			await explorerService.setToCopy([], false);

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -222,7 +222,7 @@ async function deleteFiles(workingCopyFileService: IWorkingCopyFileService, dial
 
 	// Call function
 	try {
-		await Promise.all(distinctElements.map(e => workingCopyFileService.delete(e.resource, { useTrash: useTrash, recursive: true })));
+		await Promise.all(distinctElements.map(e => workingCopyFileService.delete([e.resource], { useTrash: useTrash, recursive: true })));
 	} catch (error) {
 
 		// Handle error to delete file(s) from a modal confirmation dialog

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1351,8 +1351,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 		const files = [];
 		if (isCopy) {
 			const incrementalNaming = this.configurationService.getValue<IFilesConfiguration>().explorer.incrementalNaming;
-			for (let i = 0; i < sources.length; i++) {
-				const source = sources[i];
+			for (const source of sources) {
 				files.push({ source: source.resource, target: findValidPasteFileTarget(this.explorerService, target, { resource: source.resource, isDirectory: source.isDirectory, allowOverwrite: false }, incrementalNaming) });
 			}
 			const stats = await this.workingCopyFileService.copy(files);
@@ -1366,8 +1365,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 		}
 
 		// Otherwise move
-		for (let i = 0; i < sources.length; i++) {
-			const source = sources[i];
+		for (const source of sources) {
 			// Do not allow moving readonly items
 			if (!source.isReadonly) {
 				files.push({ source: source.resource, target: joinPath(target.resource, source.name) });

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1407,9 +1407,9 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 	private async doHandleExplorerDrop(sources: ExplorerItem[], target: ExplorerItem, isCopy: boolean): Promise<void> {
 		if (isCopy) {
-			this.doHandleExplorerDropOnCopy(sources, target);
+			return this.doHandleExplorerDropOnCopy(sources, target);
 		} else {
-			this.doHandleExplorerDropOnMove(sources, target);
+			return this.doHandleExplorerDropOnMove(sources, target);
 		}
 	}
 

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1368,12 +1368,8 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 			for (const source of sources) {
 				sourceTargetPairs.push({ source: source.resource, target: findValidPasteFileTarget(this.explorerService, target, { resource: source.resource, isDirectory: source.isDirectory, allowOverwrite: false }, incrementalNaming) });
 			}
-			const stats = await this.workingCopyFileService.copy(sourceTargetPairs);
-			stats.forEach(async stat => {
-				if (!stat.isDirectory) {
-					await this.editorService.openEditor({ resource: stat.resource, options: { pinned: true } });
-				}
-			});
+			const editors = (await this.workingCopyFileService.copy(sourceTargetPairs)).filter(stat => !stat.isDirectory).map(stat => ({ resource: stat.resource, options: { pinned: true } }));
+			await this.editorService.openEditors(editors);
 
 			return;
 		}

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1010,7 +1010,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 						continue;
 					}
 
-					await this.workingCopyFileService.delete(joinPath(target.resource, entry.name), { recursive: true });
+					await this.workingCopyFileService.delete([joinPath(target.resource, entry.name)], { recursive: true });
 				}
 
 				// Upload entry

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1263,7 +1263,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 					const sourceFile = resource;
 					const targetFile = joinPath(target.resource, basename(sourceFile));
 
-					const stat = await this.workingCopyFileService.copy(sourceFile, targetFile, true);
+					const stat = (await this.workingCopyFileService.copy([{ source: sourceFile, target: targetFile }], true))[0];
 					// if we only add one file, just open it directly
 					if (resources.length === 1 && !stat.isDirectory) {
 						this.editorService.openEditor({ resource: stat.resource, options: { pinned: true } });
@@ -1350,7 +1350,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 		// Reuse duplicate action if user copies
 		if (isCopy) {
 			const incrementalNaming = this.configurationService.getValue<IFilesConfiguration>().explorer.incrementalNaming;
-			const stat = await this.workingCopyFileService.copy(source.resource, findValidPasteFileTarget(this.explorerService, target, { resource: source.resource, isDirectory: source.isDirectory, allowOverwrite: false }, incrementalNaming));
+			const stat = (await this.workingCopyFileService.copy([{ source: source.resource, target: findValidPasteFileTarget(this.explorerService, target, { resource: source.resource, isDirectory: source.isDirectory, allowOverwrite: false }, incrementalNaming) }]))[0];
 			if (!stat.isDirectory) {
 				await this.editorService.openEditor({ resource: stat.resource, options: { pinned: true } });
 			}

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -715,8 +715,12 @@ export class FileSorter implements ITreeSorter<ExplorerItem> {
 }
 
 const getFileOverwriteConfirm = (name: string) => {
+	return getOverwriteConfirm(localize('confirmOverwrite', "A file or folder with the name '{0}' already exists in the destination folder. Do you want to replace it?", name));
+};
+
+const getOverwriteConfirm = (message: string) => {
 	return <IConfirmation>{
-		message: localize('confirmOverwrite', "A file or folder with the name '{0}' already exists in the destination folder. Do you want to replace it?", name),
+		message,
 		detail: localize('irreversible', "This action is irreversible!"),
 		primaryButton: localize({ key: 'replaceButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Replace"),
 		type: 'warning'
@@ -1377,7 +1381,10 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 		} catch (error) {
 			// Conflict
 			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_MOVE_CONFLICT) {
-				const confirm = getFileOverwriteConfirm(sources[0].name);
+				const confirm = getOverwriteConfirm(
+					localize('confirmManyOverwrites',
+						"Some files and/or folders already exist in the destination folder. Do you want to replace all of them?"));
+
 				// Move with overwrite if the user confirms
 				const { confirmed } = await this.dialogService.confirm(confirm);
 				if (confirmed) {

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1366,7 +1366,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 		}
 
 		try {
-			await this.workingCopyFileService.move(source.resource, targetResource);
+			await this.workingCopyFileService.move([{ source: source.resource, target: targetResource }]);
 		} catch (error) {
 			// Conflict
 			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_MOVE_CONFLICT) {
@@ -1375,7 +1375,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 				const { confirmed } = await this.dialogService.confirm(confirm);
 				if (confirmed) {
 					try {
-						await this.workingCopyFileService.move(source.resource, targetResource, true /* overwrite */);
+						await this.workingCopyFileService.move([{ source: source.resource, target: targetResource }], true /* overwrite */);
 					} catch (error) {
 						this.notificationService.error(error);
 					}

--- a/src/vs/workbench/services/bulkEdit/browser/bulkFileEdits.ts
+++ b/src/vs/workbench/services/bulkEdit/browser/bulkFileEdits.ts
@@ -46,7 +46,7 @@ class RenameOperation implements IFileOperation {
 		if (this.options.overwrite === undefined && this.options.ignoreIfExists && await this._fileService.exists(this.newUri)) {
 			return new Noop(); // not overwriting, but ignoring, and the target file exists
 		}
-		await this._workingCopyFileService.move(this.oldUri, this.newUri, this.options.overwrite);
+		await this._workingCopyFileService.move([{ source: this.oldUri, target: this.newUri }], this.options.overwrite);
 		return new RenameOperation(this.oldUri, this.newUri, this.options, this._workingCopyFileService, this._fileService);
 	}
 }
@@ -109,7 +109,7 @@ class DeleteOperation implements IFileOperation {
 		}
 
 		const useTrash = this._fileService.hasCapability(this.oldUri, FileSystemProviderCapabilities.Trash) && this._configurationService.getValue<boolean>('files.enableTrash');
-		await this._workingCopyFileService.delete(this.oldUri, { useTrash, recursive: this.options.recursive });
+		await this._workingCopyFileService.delete([this.oldUri], { useTrash, recursive: this.options.recursive });
 		return this._instaService.createInstance(CreateOperation, this.oldUri, this.options, contents);
 	}
 }

--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -155,7 +155,7 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 	async create(resource: URI, value?: string | ITextSnapshot | VSBuffer, options?: ICreateFileOptions): Promise<IFileStatWithMetadata> {
 
 		// file operation participation
-		await this.workingCopyFileService.runFileOperationParticipants(resource, undefined, FileOperation.CREATE);
+		await this.workingCopyFileService.runFileOperationParticipants([{ target: resource, source: undefined }], FileOperation.CREATE);
 
 		// create file on disk
 		const stat = await this.doCreate(resource, value, options);

--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -246,7 +246,7 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 		// However, this will only work if the source exists
 		// and is not orphaned, so we need to check that too.
 		if (this.fileService.canHandleResource(source) && this.uriIdentityService.extUri.isEqual(source, target) && (await this.fileService.exists(source))) {
-			await this.workingCopyFileService.move(source, target);
+			await this.workingCopyFileService.move([{ source, target }]);
 
 			return this.save(target, options);
 		}

--- a/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
@@ -135,50 +135,56 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 	private onWillRunWorkingCopyFileOperation(e: WorkingCopyFileEvent): void {
 
 		// Move / Copy: remember models to restore after the operation
-		const source = e.source;
-		if (source && (e.operation === FileOperation.COPY || e.operation === FileOperation.MOVE)) {
+		if (e.operation === FileOperation.COPY || e.operation === FileOperation.MOVE) {
 
-			// find all models that related to either source or target (can be many if resource is a folder)
-			const sourceModels: TextFileEditorModel[] = [];
-			const targetModels: TextFileEditorModel[] = [];
-			for (const model of this.models) {
-				const resource = model.resource;
-
-				if (extUri.isEqualOrParent(resource, e.target)) {
-					// EXPLICITLY do not ignorecase, see https://github.com/Microsoft/vscode/issues/56384
-					targetModels.push(model);
-				}
-
-				if (this.uriIdentityService.extUri.isEqualOrParent(resource, source)) {
-					sourceModels.push(model);
-				}
-			}
-
-			// remember each source model to load again after move is done
-			// with optional content to restore if it was dirty
 			const modelsToRestore: { source: URI, target: URI, snapshot?: ITextSnapshot; mode?: string; encoding?: string; }[] = [];
-			for (const sourceModel of sourceModels) {
-				const sourceModelResource = sourceModel.resource;
 
-				// If the source is the actual model, just use target as new resource
-				let targetModelResource: URI;
-				if (this.uriIdentityService.extUri.isEqual(sourceModelResource, e.source)) {
-					targetModelResource = e.target;
+			for (const { source, target } of e.files) {
+				if (source) {
+
+					// find all models that related to either source or target (can be many if resource is a folder)
+					const sourceModels: TextFileEditorModel[] = [];
+					const targetModels: TextFileEditorModel[] = [];
+					for (const model of this.models) {
+						const resource = model.resource;
+
+						if (extUri.isEqualOrParent(resource, target)) {
+							// EXPLICITLY do not ignorecase, see https://github.com/Microsoft/vscode/issues/56384
+							targetModels.push(model);
+						}
+
+						if (this.uriIdentityService.extUri.isEqualOrParent(resource, source)) {
+							sourceModels.push(model);
+						}
+					}
+
+					// remember each source model to load again after move is done
+					// with optional content to restore if it was dirty
+					for (const sourceModel of sourceModels) {
+						const sourceModelResource = sourceModel.resource;
+
+						// If the source is the actual model, just use target as new resource
+						let targetModelResource: URI;
+						if (this.uriIdentityService.extUri.isEqual(sourceModelResource, source)) {
+							targetModelResource = target;
+						}
+
+						// Otherwise a parent folder of the source is being moved, so we need
+						// to compute the target resource based on that
+						else {
+							targetModelResource = joinPath(target, sourceModelResource.path.substr(source.path.length + 1));
+						}
+
+						modelsToRestore.push({
+							source: sourceModelResource,
+							target: targetModelResource,
+							mode: sourceModel.getMode(),
+							encoding: sourceModel.getEncoding(),
+							snapshot: sourceModel.isDirty() ? sourceModel.createSnapshot() : undefined
+						});
+					}
+
 				}
-
-				// Otherwise a parent folder of the source is being moved, so we need
-				// to compute the target resource based on that
-				else {
-					targetModelResource = joinPath(e.target, sourceModelResource.path.substr(source.path.length + 1));
-				}
-
-				modelsToRestore.push({
-					source: sourceModelResource,
-					target: targetModelResource,
-					mode: sourceModel.getMode(),
-					encoding: sourceModel.getEncoding(),
-					snapshot: sourceModel.isDirty() ? sourceModel.createSnapshot() : undefined
-				});
 			}
 
 			this.mapCorrelationIdToModelsToRestore.set(e.correlationId, modelsToRestore);

--- a/src/vs/workbench/services/textfile/test/browser/textFileService.test.ts
+++ b/src/vs/workbench/services/textfile/test/browser/textFileService.test.ts
@@ -111,8 +111,8 @@ suite('Files - TextFileService', () => {
 		let eventCounter = 0;
 
 		const disposable1 = accessor.workingCopyFileService.addFileOperationParticipant({
-			participate: async data => {
-				assert.equal(data[0].target, model.resource.toString());
+			participate: async files => {
+				assert.equal(files[0].target, model.resource.toString());
 				eventCounter++;
 			}
 		});

--- a/src/vs/workbench/services/textfile/test/browser/textFileService.test.ts
+++ b/src/vs/workbench/services/textfile/test/browser/textFileService.test.ts
@@ -111,8 +111,8 @@ suite('Files - TextFileService', () => {
 		let eventCounter = 0;
 
 		const disposable1 = accessor.workingCopyFileService.addFileOperationParticipant({
-			participate: async target => {
-				assert.equal(target.toString(), model.resource.toString());
+			participate: async data => {
+				assert.equal(data[0].target, model.resource.toString());
 				eventCounter++;
 			}
 		});

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileOperationParticipant.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileOperationParticipant.ts
@@ -33,7 +33,7 @@ export class WorkingCopyFileOperationParticipant extends Disposable {
 		return toDisposable(() => remove());
 	}
 
-	async participate(target: URI, source: URI | undefined, operation: FileOperation): Promise<void> {
+	async participate(data: { target: URI, source: URI | undefined }[], operation: FileOperation): Promise<void> {
 		const timeout = this.configurationService.getValue<number>('files.participants.timeout');
 		if (timeout <= 0) {
 			return; // disabled
@@ -53,7 +53,7 @@ export class WorkingCopyFileOperationParticipant extends Disposable {
 				}
 
 				try {
-					const promise = participant.participate(target, source, operation, progress, timeout, cts.token);
+					const promise = participant.participate(data, operation, progress, timeout, cts.token);
 					await raceTimeout(promise, timeout, () => cts.dispose(true /* cancel */));
 				} catch (err) {
 					this.logService.warn(err);

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileOperationParticipant.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileOperationParticipant.ts
@@ -33,7 +33,7 @@ export class WorkingCopyFileOperationParticipant extends Disposable {
 		return toDisposable(() => remove());
 	}
 
-	async participate(data: { target: URI, source: URI | undefined }[], operation: FileOperation): Promise<void> {
+	async participate(files: { target: URI, source: URI | undefined }[], operation: FileOperation): Promise<void> {
 		const timeout = this.configurationService.getValue<number>('files.participants.timeout');
 		if (timeout <= 0) {
 			return; // disabled
@@ -53,7 +53,7 @@ export class WorkingCopyFileOperationParticipant extends Disposable {
 				}
 
 				try {
-					const promise = participant.participate(data, operation, progress, timeout, cts.token);
+					const promise = participant.participate(files, operation, progress, timeout, cts.token);
 					await raceTimeout(promise, timeout, () => cts.dispose(true /* cancel */));
 				} catch (err) {
 					this.logService.warn(err);

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileOperationParticipant.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileOperationParticipant.ts
@@ -33,7 +33,7 @@ export class WorkingCopyFileOperationParticipant extends Disposable {
 		return toDisposable(() => remove());
 	}
 
-	async participate(files: { target: URI, source: URI | undefined }[], operation: FileOperation): Promise<void> {
+	async participate(files: { source?: URI, target: URI }[], operation: FileOperation): Promise<void> {
 		const timeout = this.configurationService.getValue<number>('files.participants.timeout');
 		if (timeout <= 0) {
 			return; // disabled

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -137,13 +137,13 @@ export interface IWorkingCopyFileService {
 	moveMany(files: { source: URI, target: URI }[], overwrite?: boolean): Promise<IFileStatWithMetadata[]>;
 
 	/**
-	 * Will copy working copies matching the provided resource and children
-	 * to the target using the associated file service for that resource.
+	 * Will copy working copies matching the provided resources and corresponding children
+	 * to the target resources using the associated file service for those resources.
 	 *
 	 * Working copy owners can listen to the `onWillRunWorkingCopyFileOperation` and
 	 * `onDidRunWorkingCopyFileOperation` events to participate.
 	 */
-	copy(source: URI, target: URI, overwrite?: boolean): Promise<IFileStatWithMetadata>;
+	copy(files: { source: URI, target: URI }[], overwrite?: boolean): Promise<IFileStatWithMetadata[]>;
 
 	/**
 	 * Will delete working copies matching the provided resource and children
@@ -225,8 +225,8 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		return this.moveOrCopyMany(files, true, overwrite);
 	}
 
-	async copy(source: URI, target: URI, overwrite?: boolean): Promise<IFileStatWithMetadata> {
-		return this.moveOrCopy(source, target, false, overwrite);
+	async copy(files: { source: URI, target: URI }[], overwrite?: boolean): Promise<IFileStatWithMetadata[]> {
+		return this.moveOrCopyMany(files, false, overwrite);
 	}
 
 	private async moveOrCopy(source: URI, target: URI, move: boolean, overwrite?: boolean): Promise<IFileStatWithMetadata> {

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -32,12 +32,12 @@ export interface WorkingCopyFileEvent extends IWaitUntil {
 	readonly operation: FileOperation;
 
 	/**
-	 * The target resources the event is about.
 	 * The source resources that are defined for move operations.
+	 * The target resources the event is about.
 	 */
 	readonly files: {
-		readonly target: URI;
 		readonly source?: URI;
+		readonly target: URI;
 	}[]
 }
 
@@ -48,7 +48,7 @@ export interface IWorkingCopyFileOperationParticipant {
 	 * change the working copies before they are being saved to disk.
 	 */
 	participate(
-		files: { target: URI, source: URI | undefined }[],
+		files: { source?: URI, target: URI }[],
 		operation: FileOperation,
 		progress: IProgress<IProgressStep>,
 		timeout: number,
@@ -112,7 +112,7 @@ export interface IWorkingCopyFileService {
 	/**
 	 * Execute all known file operation participants.
 	 */
-	runFileOperationParticipants(files: { target: URI, source: URI | undefined }[], operation: FileOperation): Promise<void>
+	runFileOperationParticipants(files: { source?: URI, target: URI }[], operation: FileOperation): Promise<void>
 
 
 	//#region File operations
@@ -332,7 +332,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		return this.fileOperationParticipants.addFileOperationParticipant(participant);
 	}
 
-	runFileOperationParticipants(files: { target: URI, source: URI | undefined }[], operation: FileOperation): Promise<void> {
+	runFileOperationParticipants(files: { source?: URI, target: URI }[], operation: FileOperation): Promise<void> {
 		return this.fileOperationParticipants.participate(files, operation);
 	}
 

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -32,14 +32,13 @@ export interface WorkingCopyFileEvent extends IWaitUntil {
 	readonly operation: FileOperation;
 
 	/**
-	 * The resource the event is about.
+	 * The target resources the event is about.
+	 * The source resources that are defined for move operations.
 	 */
-	readonly target: URI;
-
-	/**
-	 * A property that is defined for move operations.
-	 */
-	readonly source?: URI;
+	readonly files: {
+		readonly target: URI;
+		readonly source?: URI;
+	}[]
 }
 
 export interface IWorkingCopyFileOperationParticipant {
@@ -249,7 +248,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 			}
 
 			// before event
-			const event = { correlationId: this.correlationIds++, operation: move ? FileOperation.MOVE : FileOperation.COPY, target, source };
+			const event = { correlationId: this.correlationIds++, operation: move ? FileOperation.MOVE : FileOperation.COPY, files: [{ target, source }] };
 			await this._onWillRunWorkingCopyFileOperation.fireAsync(event, CancellationToken.None);
 
 			// handle dirty working copies depending on the operation:
@@ -292,7 +291,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		await this.runFileOperationParticipants([{ target: resource, source: undefined }], FileOperation.DELETE);
 
 		// before events
-		const event = { correlationId: this.correlationIds++, operation: FileOperation.DELETE, target: resource };
+		const event = { correlationId: this.correlationIds++, operation: FileOperation.DELETE, files: [{ target: resource }] };
 		await this._onWillRunWorkingCopyFileOperation.fireAsync(event, CancellationToken.None);
 
 		// Check for any existing dirty working copies for the resource

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -221,8 +221,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 
 		let stats = [];
 
-		for (let i = 0; i < files.length; i++) {
-			const { source, target } = files[i];
+		for (const { source, target } of files) {
 
 			// validate move/copy operation before starting
 			const validateMoveOrCopy = await (move ? this.fileService.canMove(source, target, overwrite) : this.fileService.canCopy(source, target, overwrite));
@@ -234,8 +233,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		// file operation participant
 		await this.runFileOperationParticipants(files, move ? FileOperation.MOVE : FileOperation.COPY);
 
-		for (let i = 0; i < files.length; i++) {
-			const { source, target } = files[i];
+		for (const { source, target } of files) {
 
 			// Before doing the heavy operations, check first if source and target
 			// are either identical or are considered to be identical for the file

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -228,10 +228,10 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 
 		let stats: IFileStatWithMetadata[] = [];
 
-		for (const filesPair of files) {
+		for (const sourceTargetPair of files) {
 
 			// validate move/copy operation before starting
-			const validateMoveOrCopy = await (move ? this.fileService.canMove(filesPair.source!, filesPair.target, overwrite) : this.fileService.canCopy(filesPair.source!, filesPair.target, overwrite));
+			const validateMoveOrCopy = await (move ? this.fileService.canMove(sourceTargetPair.source!, sourceTargetPair.target, overwrite) : this.fileService.canCopy(sourceTargetPair.source!, sourceTargetPair.target, overwrite));
 			if (validateMoveOrCopy instanceof Error) {
 				throw validateMoveOrCopy;
 			}
@@ -241,8 +241,8 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		await this.runFileOperationParticipants(files, move ? FileOperation.MOVE : FileOperation.COPY);
 
 		const nonIdenticalPairs: SourceTargetPair[] = [];
-		for (const filesPair of files) {
-			const source = filesPair.source!, target = filesPair.target;
+		for (const sourceTargetPair of files) {
+			const source = sourceTargetPair.source!, target = sourceTargetPair.target;
 
 			// Before doing the heavy operations, check first if source and target
 			// are either identical or are considered to be identical for the file
@@ -255,7 +255,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 					stats.push(await this.fileService.copy(source, target, overwrite));
 				}
 			} else {
-				nonIdenticalPairs.push(filesPair);
+				nonIdenticalPairs.push(sourceTargetPair);
 			}
 		}
 
@@ -266,8 +266,8 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 			await this._onWillRunWorkingCopyFileOperation.fireAsync(event, CancellationToken.None);
 
 			try {
-				for (const filesPair of nonIdenticalPairs) {
-					const source = filesPair.source!, target = filesPair.target;
+				for (const sourceTargetPair of nonIdenticalPairs) {
+					const source = sourceTargetPair.source!, target = sourceTargetPair.target;
 
 					// handle dirty working copies depending on the operation:
 					// - move: revert both source and target (if any)

--- a/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
@@ -62,11 +62,12 @@ suite('WorkingCopyFileService', () => {
 			eventCounter++;
 		});
 
-		await accessor.workingCopyFileService.delete(model.resource);
+		await accessor.workingCopyFileService.delete([model.resource]);
 		assert.ok(!accessor.workingCopyService.isDirty(model.resource));
 
 		assert.equal(eventCounter, 3);
 
+		model.dispose();
 		participant.dispose();
 		listener1.dispose();
 		listener2.dispose();

--- a/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
@@ -325,25 +325,34 @@ suite('WorkingCopyFileService', () => {
 		let correlationId: number | undefined = undefined;
 
 		const participant = accessor.workingCopyFileService.addFileOperationParticipant({
-			participate: async ([{ target }], operation) => {
-				assert.equal(models.findIndex(m => m.resource.toString() === target.toString()) !== -1, true);
-				// assert.equal(target.toString(), models.resource.toString());
+			participate: async (files, operation) => {
+				for (let i = 0; i < models.length; i++) {
+					const model = models[i];
+					const file = files[i];
+					assert.equal(file.target.toString(), model.resource.toString());
+				}
 				assert.equal(operation, FileOperation.DELETE);
 				eventCounter++;
 			}
 		});
 
 		const listener1 = accessor.workingCopyFileService.onWillRunWorkingCopyFileOperation(e => {
-			assert.equal(models.findIndex(m => m.resource.toString() === e.files[0].target.toString()) !== -1, true);
-			// assert.equal(e.files[0].target.toString(), models.resource.toString());
+			for (let i = 0; i < models.length; i++) {
+				const model = models[i];
+				const file = e.files[i];
+				assert.equal(file.target.toString(), model.resource.toString());
+			}
 			assert.equal(e.operation, FileOperation.DELETE);
 			correlationId = e.correlationId;
 			eventCounter++;
 		});
 
 		const listener2 = accessor.workingCopyFileService.onDidRunWorkingCopyFileOperation(e => {
-			assert.equal(models.findIndex(m => m.resource.toString() === e.files[0].target.toString()) !== -1, true);
-			// assert.equal(e.files[0].target.toString(), models.resource.toString());
+			for (let i = 0; i < models.length; i++) {
+				const model = models[i];
+				const file = e.files[i];
+				assert.equal(file.target.toString(), model.resource.toString());
+			}
 			assert.equal(e.operation, FileOperation.DELETE);
 			assert.equal(e.correlationId, correlationId);
 			eventCounter++;
@@ -355,7 +364,7 @@ suite('WorkingCopyFileService', () => {
 			model.dispose();
 		}
 
-		assert.equal(eventCounter, 3 * models.length);
+		assert.equal(eventCounter, 3);
 
 		participant.dispose();
 		listener1.dispose();

--- a/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
@@ -102,7 +102,7 @@ suite('WorkingCopyFileService', () => {
 		sourceModel1.dispose();
 		sourceModel2.dispose();
 		targetModel2.dispose();
-		assert.equal(eventCounter, 4);
+		assert.equal(eventCounter, 3);
 	});
 
 	test('move multiple - dirty file', async function () {
@@ -146,7 +146,7 @@ suite('WorkingCopyFileService', () => {
 		sourceModel1.dispose();
 		sourceModel2.dispose();
 		targetModel2.dispose();
-		assert.equal(eventCounter, 4);
+		assert.equal(eventCounter, 3);
 	});
 
 	test('copy multiple - dirty file', async function () {
@@ -166,9 +166,7 @@ suite('WorkingCopyFileService', () => {
 
 		const participant = accessor.workingCopyFileService.addFileOperationParticipant({
 			participate: async files => {
-				for (let i = 0; i < files.length; i++) {
-					eventCounter++;
-				}
+				eventCounter++;
 			}
 		});
 
@@ -221,9 +219,11 @@ suite('WorkingCopyFileService', () => {
 
 					assert.equal(target.toString(), targetModel.resource.toString());
 					assert.equal(source?.toString(), sourceModel.resource.toString());
-					assert.equal(operation, move ? FileOperation.MOVE : FileOperation.COPY);
-					eventCounter++;
 				}
+
+				eventCounter++;
+
+				assert.equal(operation, move ? FileOperation.MOVE : FileOperation.COPY);
 			}
 		});
 
@@ -236,8 +236,9 @@ suite('WorkingCopyFileService', () => {
 
 				assert.equal(target.toString(), targetModel.resource.toString());
 				assert.equal(source?.toString(), sourceModel.resource.toString());
-				eventCounter++;
 			}
+
+			eventCounter++;
 
 			correlationId = e.correlationId;
 			assert.equal(e.operation, move ? FileOperation.MOVE : FileOperation.COPY);
@@ -249,8 +250,9 @@ suite('WorkingCopyFileService', () => {
 				const { targetModel, sourceModel } = models[i];
 				assert.equal(target.toString(), targetModel.resource.toString());
 				assert.equal(source?.toString(), sourceModel.resource.toString());
-				eventCounter++;
 			}
+
+			eventCounter++;
 
 			assert.equal(e.operation, move ? FileOperation.MOVE : FileOperation.COPY);
 			assert.equal(e.correlationId, correlationId);
@@ -277,7 +279,7 @@ suite('WorkingCopyFileService', () => {
 			sourceModel.dispose();
 			targetModel.dispose();
 		}
-		assert.equal(eventCounter, 3 * models.length);
+		assert.equal(eventCounter, 3);
 
 		participant.dispose();
 		listener1.dispose();

--- a/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
@@ -41,7 +41,7 @@ suite('WorkingCopyFileService', () => {
 		let correlationId: number | undefined = undefined;
 
 		const participant = accessor.workingCopyFileService.addFileOperationParticipant({
-			participate: async (target, source, operation) => {
+			participate: async ([{ target }], operation) => {
 				assert.equal(target.toString(), model.resource.toString());
 				assert.equal(operation, FileOperation.DELETE);
 				eventCounter++;
@@ -76,6 +76,13 @@ suite('WorkingCopyFileService', () => {
 		await testMoveOrCopy(toResource.call(this, '/path/file.txt'), toResource.call(this, '/path/file_target.txt'), true);
 	});
 
+	test('move multiple - dirty file', async function () {
+		await testMoveOrCopyMany([
+			{ source: toResource.call(this, '/path/file1.txt'), target: toResource.call(this, '/path/file1_target.txt') },
+			{ source: toResource.call(this, '/path/file2.txt'), target: toResource.call(this, '/path/file2_target.txt') }],
+			true);
+	});
+
 	test('move - dirty file (target exists and is dirty)', async function () {
 		await testMoveOrCopy(toResource.call(this, '/path/file.txt'), toResource.call(this, '/path/file_target.txt'), true, true);
 	});
@@ -108,7 +115,7 @@ suite('WorkingCopyFileService', () => {
 		let correlationId: number | undefined = undefined;
 
 		const participant = accessor.workingCopyFileService.addFileOperationParticipant({
-			participate: async (target, source, operation) => {
+			participate: async ([{ target, source }], operation) => {
 				assert.equal(target.toString(), targetModel.resource.toString());
 				assert.equal(source?.toString(), sourceModel.resource.toString());
 				assert.equal(operation, move ? FileOperation.MOVE : FileOperation.COPY);
@@ -151,6 +158,92 @@ suite('WorkingCopyFileService', () => {
 
 		sourceModel.dispose();
 		targetModel.dispose();
+
+		participant.dispose();
+		listener1.dispose();
+		listener2.dispose();
+	}
+
+	async function testMoveOrCopyMany(data: { source: URI, target: URI }[], move: boolean, targetDirty?: boolean): Promise<void> {
+
+		let eventCounter = 0;
+		const models = await Promise.all(data.map(async ({ source, target }, i) => {
+			let sourceModel: TextFileEditorModel = instantiationService.createInstance(TextFileEditorModel, source, 'utf8', undefined);
+			let targetModel: TextFileEditorModel = instantiationService.createInstance(TextFileEditorModel, target, 'utf8', undefined);
+			(<TestTextFileEditorModelManager>accessor.textFileService.files).add(sourceModel.resource, sourceModel);
+			(<TestTextFileEditorModelManager>accessor.textFileService.files).add(targetModel.resource, targetModel);
+
+			await sourceModel.load();
+			sourceModel.textEditorModel!.setValue('foo' + i);
+			assert.ok(accessor.textFileService.isDirty(sourceModel.resource));
+			if (targetDirty) {
+				await targetModel.load();
+				targetModel.textEditorModel!.setValue('bar' + i);
+				assert.ok(accessor.textFileService.isDirty(targetModel.resource));
+			}
+
+			return { sourceModel, targetModel };
+		}));
+
+		const participant = accessor.workingCopyFileService.addFileOperationParticipant({
+			participate: async (data, operation) => {
+				for (let i = 0; i < data.length; i++) {
+					const { target, source } = data[i];
+					const { targetModel, sourceModel } = models[i];
+
+					assert.equal(target.toString(), targetModel.resource.toString());
+					assert.equal(source?.toString(), sourceModel.resource.toString());
+					assert.equal(operation, move ? FileOperation.MOVE : FileOperation.COPY);
+					eventCounter++;
+				}
+			}
+		});
+
+		const correlationIds: Array<Number | undefined> = [];
+
+		const listener1 = accessor.workingCopyFileService.onWillRunWorkingCopyFileOperation(e => {
+			const foundIndex = models.findIndex(m => e.target.toString() === m.targetModel.resource.toString() &&
+				e.source?.toString() === m.sourceModel.resource.toString());
+
+			assert.equal(foundIndex !== -1, true);
+			assert.equal(e.operation, move ? FileOperation.MOVE : FileOperation.COPY);
+			eventCounter++;
+			correlationIds.push(e.correlationId);
+		});
+
+		const listener2 = accessor.workingCopyFileService.onDidRunWorkingCopyFileOperation(e => {
+			const foundIndex = models.findIndex(m => e.target.toString() === m.targetModel.resource.toString() &&
+				e.source?.toString() === m.sourceModel.resource.toString());
+
+			assert.equal(foundIndex !== -1, true);
+			assert.equal(e.operation, move ? FileOperation.MOVE : FileOperation.COPY);
+			eventCounter++;
+
+			assert.equal(correlationIds.includes(e.correlationId), true);
+		});
+
+		if (move) {
+			await accessor.workingCopyFileService.moveMany(models.map(m => ({ source: m.sourceModel.resource, target: m.targetModel.resource })), true);
+		} else {
+			// await accessor.workingCopyFileService.copy(sourceModel.resource, targetModel.resource, true);
+		}
+
+		for (let i = 0; i < models.length; i++) {
+			const { sourceModel, targetModel } = models[i];
+
+			assert.equal(targetModel.textEditorModel!.getValue(), 'foo' + i);
+
+			if (move) {
+				assert.ok(!accessor.textFileService.isDirty(sourceModel.resource));
+			} else {
+				assert.ok(accessor.textFileService.isDirty(sourceModel.resource));
+			}
+			assert.ok(accessor.textFileService.isDirty(targetModel.resource));
+
+			sourceModel.dispose();
+			targetModel.dispose();
+		}
+		assert.equal(eventCounter, 3 * models.length);
 
 		participant.dispose();
 		listener1.dispose();

--- a/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
@@ -186,9 +186,9 @@ suite('WorkingCopyFileService', () => {
 		}));
 
 		const participant = accessor.workingCopyFileService.addFileOperationParticipant({
-			participate: async (data, operation) => {
-				for (let i = 0; i < data.length; i++) {
-					const { target, source } = data[i];
+			participate: async (files, operation) => {
+				for (let i = 0; i < files.length; i++) {
+					const { target, source } = files[i];
 					const { targetModel, sourceModel } = models[i];
 
 					assert.equal(target.toString(), targetModel.resource.toString());

--- a/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
@@ -49,14 +49,14 @@ suite('WorkingCopyFileService', () => {
 		});
 
 		const listener1 = accessor.workingCopyFileService.onWillRunWorkingCopyFileOperation(e => {
-			assert.equal(e.target.toString(), model.resource.toString());
+			assert.equal(e.files[0].target.toString(), model.resource.toString());
 			assert.equal(e.operation, FileOperation.DELETE);
 			correlationId = e.correlationId;
 			eventCounter++;
 		});
 
 		const listener2 = accessor.workingCopyFileService.onDidRunWorkingCopyFileOperation(e => {
-			assert.equal(e.target.toString(), model.resource.toString());
+			assert.equal(e.files[0].target.toString(), model.resource.toString());
 			assert.equal(e.operation, FileOperation.DELETE);
 			assert.equal(e.correlationId, correlationId);
 			eventCounter++;
@@ -227,27 +227,33 @@ suite('WorkingCopyFileService', () => {
 			}
 		});
 
-		const correlationIds: Array<Number | undefined> = [];
+		let correlationId: number;
 
 		const listener1 = accessor.workingCopyFileService.onWillRunWorkingCopyFileOperation(e => {
-			const foundIndex = models.findIndex(m => e.target.toString() === m.targetModel.resource.toString() &&
-				e.source?.toString() === m.sourceModel.resource.toString());
+			for (let i = 0; i < e.files.length; i++) {
+				const { target, source } = files[i];
+				const { targetModel, sourceModel } = models[i];
 
-			assert.equal(foundIndex !== -1, true);
+				assert.equal(target.toString(), targetModel.resource.toString());
+				assert.equal(source?.toString(), sourceModel.resource.toString());
+				eventCounter++;
+			}
+
+			correlationId = e.correlationId;
 			assert.equal(e.operation, move ? FileOperation.MOVE : FileOperation.COPY);
-			eventCounter++;
-			correlationIds.push(e.correlationId);
 		});
 
 		const listener2 = accessor.workingCopyFileService.onDidRunWorkingCopyFileOperation(e => {
-			const foundIndex = models.findIndex(m => e.target.toString() === m.targetModel.resource.toString() &&
-				e.source?.toString() === m.sourceModel.resource.toString());
+			for (let i = 0; i < e.files.length; i++) {
+				const { target, source } = files[i];
+				const { targetModel, sourceModel } = models[i];
+				assert.equal(target.toString(), targetModel.resource.toString());
+				assert.equal(source?.toString(), sourceModel.resource.toString());
+				eventCounter++;
+			}
 
-			assert.equal(foundIndex !== -1, true);
 			assert.equal(e.operation, move ? FileOperation.MOVE : FileOperation.COPY);
-			eventCounter++;
-
-			assert.equal(correlationIds.includes(e.correlationId), true);
+			assert.equal(e.correlationId, correlationId);
 		});
 
 		if (move) {

--- a/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/workingCopyFileService.test.ts
@@ -142,7 +142,7 @@ suite('WorkingCopyFileService', () => {
 		if (move) {
 			await accessor.workingCopyFileService.move(sourceModel.resource, targetModel.resource, true);
 		} else {
-			await accessor.workingCopyFileService.copy(sourceModel.resource, targetModel.resource, true);
+			await accessor.workingCopyFileService.copy([{ source: sourceModel.resource, target: targetModel.resource }], true);
 		}
 
 		assert.equal(targetModel.textEditorModel!.getValue(), 'foo');

--- a/src/vs/workbench/test/browser/api/mainThreadEditors.test.ts
+++ b/src/vs/workbench/test/browser/api/mainThreadEditors.test.ts
@@ -107,7 +107,8 @@ suite('MainThreadEditors', () => {
 		});
 		services.set(IWorkingCopyFileService, new class extends mock<IWorkingCopyFileService>() {
 			onDidRunWorkingCopyFileOperation = Event.None;
-			move(source: URI, target: URI) {
+			move(files: { source: URI, target: URI }[]) {
+				const { source, target } = files[0];
 				movedResources.set(source, target);
 				return Promise.resolve(Object.create(null));
 			}

--- a/src/vs/workbench/test/browser/api/mainThreadEditors.test.ts
+++ b/src/vs/workbench/test/browser/api/mainThreadEditors.test.ts
@@ -117,8 +117,10 @@ suite('MainThreadEditors', () => {
 				copiedResources.set(source, target);
 				return Promise.resolve(Object.create(null));
 			}
-			delete(resource: URI) {
-				deletedResources.add(resource);
+			delete(resources: URI[]) {
+				for (const resource of resources) {
+					deletedResources.add(resource);
+				}
 				return Promise.resolve(undefined);
 			}
 		});

--- a/src/vs/workbench/test/browser/api/mainThreadEditors.test.ts
+++ b/src/vs/workbench/test/browser/api/mainThreadEditors.test.ts
@@ -111,7 +111,8 @@ suite('MainThreadEditors', () => {
 				movedResources.set(source, target);
 				return Promise.resolve(Object.create(null));
 			}
-			copy(source: URI, target: URI) {
+			copy(files: { source: URI, target: URI }[]) {
+				const { source, target } = files[0];
 				copiedResources.set(source, target);
 				return Promise.resolve(Object.create(null));
 			}

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -134,7 +134,7 @@ export class TestWorkingCopyFileService implements IWorkingCopyFileService {
 
 	addFileOperationParticipant(participant: IWorkingCopyFileOperationParticipant): IDisposable { return Disposable.None; }
 
-	async runFileOperationParticipants(target: URI, source: URI | undefined, operation: FileOperation): Promise<void> { }
+	async runFileOperationParticipants(data: { target: URI, source: URI | undefined }[], operation: FileOperation): Promise<void> { }
 
 	async delete(resource: URI, options?: { useTrash?: boolean | undefined; recursive?: boolean | undefined; } | undefined): Promise<void> { }
 
@@ -143,6 +143,10 @@ export class TestWorkingCopyFileService implements IWorkingCopyFileService {
 	getDirty(resource: URI): IWorkingCopy[] { return []; }
 
 	move(source: URI, target: URI, overwrite?: boolean | undefined): Promise<IFileStatWithMetadata> { throw new Error('Method not implemented.'); }
+
+	moveMany(data: { source: URI; target: URI; }[], overwrite?: boolean | undefined): Promise<IFileStatWithMetadata[]> {
+		throw new Error('Method not implemented.');
+	}
 
 	copy(source: URI, target: URI, overwrite?: boolean | undefined): Promise<IFileStatWithMetadata> { throw new Error('Method not implemented.'); }
 }

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -134,7 +134,7 @@ export class TestWorkingCopyFileService implements IWorkingCopyFileService {
 
 	addFileOperationParticipant(participant: IWorkingCopyFileOperationParticipant): IDisposable { return Disposable.None; }
 
-	async runFileOperationParticipants(data: { target: URI, source: URI | undefined }[], operation: FileOperation): Promise<void> { }
+	async runFileOperationParticipants(files: { target: URI, source: URI | undefined }[], operation: FileOperation): Promise<void> { }
 
 	async delete(resource: URI, options?: { useTrash?: boolean | undefined; recursive?: boolean | undefined; } | undefined): Promise<void> { }
 

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -134,7 +134,7 @@ export class TestWorkingCopyFileService implements IWorkingCopyFileService {
 
 	addFileOperationParticipant(participant: IWorkingCopyFileOperationParticipant): IDisposable { return Disposable.None; }
 
-	async runFileOperationParticipants(files: { target: URI, source: URI | undefined }[], operation: FileOperation): Promise<void> { }
+	async runFileOperationParticipants(files: { source?: URI, target: URI }[], operation: FileOperation): Promise<void> { }
 
 	async delete(resource: URI, options?: { useTrash?: boolean | undefined; recursive?: boolean | undefined; } | undefined): Promise<void> { }
 

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -136,7 +136,7 @@ export class TestWorkingCopyFileService implements IWorkingCopyFileService {
 
 	async runFileOperationParticipants(files: { source?: URI, target: URI }[], operation: FileOperation): Promise<void> { }
 
-	async delete(resource: URI, options?: { useTrash?: boolean | undefined; recursive?: boolean | undefined; } | undefined): Promise<void> { }
+	async delete(resources: URI[], options?: { useTrash?: boolean | undefined; recursive?: boolean | undefined; } | undefined): Promise<void> { }
 
 	registerWorkingCopyProvider(provider: (resourceOrFolder: URI) => IWorkingCopy[]): IDisposable { return Disposable.None; }
 

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -142,13 +142,9 @@ export class TestWorkingCopyFileService implements IWorkingCopyFileService {
 
 	getDirty(resource: URI): IWorkingCopy[] { return []; }
 
-	move(source: URI, target: URI, overwrite?: boolean | undefined): Promise<IFileStatWithMetadata> { throw new Error('Method not implemented.'); }
+	move(files: { source: URI; target: URI; }[], overwrite?: boolean | undefined): Promise<IFileStatWithMetadata[]> { throw new Error('Method not implemented.'); }
 
-	moveMany(files: { source: URI; target: URI; }[], overwrite?: boolean | undefined): Promise<IFileStatWithMetadata[]> {
-		throw new Error('Method not implemented.');
-	}
-
-	copy(source: URI, target: URI, overwrite?: boolean | undefined): Promise<IFileStatWithMetadata> { throw new Error('Method not implemented.'); }
+	copy(files: { source: URI; target: URI; }[], overwrite?: boolean | undefined): Promise<IFileStatWithMetadata[]> { throw new Error('Method not implemented.'); }
 }
 
 export function mock<T>(): Ctor<T> {

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -144,7 +144,7 @@ export class TestWorkingCopyFileService implements IWorkingCopyFileService {
 
 	move(source: URI, target: URI, overwrite?: boolean | undefined): Promise<IFileStatWithMetadata> { throw new Error('Method not implemented.'); }
 
-	moveMany(data: { source: URI; target: URI; }[], overwrite?: boolean | undefined): Promise<IFileStatWithMetadata[]> {
+	moveMany(files: { source: URI; target: URI; }[], overwrite?: boolean | undefined): Promise<IFileStatWithMetadata[]> {
 		throw new Error('Method not implemented.');
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #98309 

Hi @bpasero 
I made some changes. Can you tell me if I'm on the right track?
If I am, I will continue with the following:

- [x] add support move/copy multiple resources in workingCopyFileService (wcfs)
- [x] add support delete multiple resources in wcfs
- [x] support for onWillRunFileOperation in wcfs
- [x] support for onDidRunFileOperation in wcfs?
- [x] adoption in explorerViewer
- [x] adoption in fileActions?
~~- [ ] adoption in bulkEditService?~~
- [x] add tests if any
- [x] come up with a better name than `UriComponentsPair`?
- [x] check if it fixes given [repro](https://github.com/DanTup/vscode-repro-will-rename-files)

Let me know if there is anything missing on the above list.
Thanks.

