### PR TITLE
Mark  _serviceBrand properties using declare

### DIFF
--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -95,7 +95,7 @@ class MainProcessService implements IMainProcessService {
 		private mainRouter: StaticRouter
 	) { }
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	getChannel(channelName: string): IChannel {
 		return this.server.getChannel(channelName, this.mainRouter);

--- a/src/vs/code/electron-main/auth.ts
+++ b/src/vs/code/electron-main/auth.ts
@@ -23,7 +23,7 @@ type Credentials = {
 
 export class ProxyAuthHandler extends Disposable {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private retryCount = 0;
 

--- a/src/vs/editor/browser/core/keybindingCancellation.ts
+++ b/src/vs/editor/browser/core/keybindingCancellation.ts
@@ -17,7 +17,7 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 const IEditorCancellationTokens = createDecorator<IEditorCancellationTokens>('IEditorCancelService');
 
 interface IEditorCancellationTokens {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	add(editor: ICodeEditor, cts: CancellationTokenSource): () => void;
 	cancel(editor: ICodeEditor): void;
 }
@@ -26,7 +26,7 @@ const ctxCancellableOperation = new RawContextKey('cancellableOperation', false)
 
 registerSingleton(IEditorCancellationTokens, class implements IEditorCancellationTokens {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _tokens = new WeakMap<ICodeEditor, { key: IContextKey<boolean>, tokens: LinkedList<CancellationTokenSource> }>();
 

--- a/src/vs/editor/browser/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/browser/services/abstractCodeEditorService.ts
@@ -13,7 +13,7 @@ import { IResourceEditorInput } from 'vs/platform/editor/common/editor';
 
 export abstract class AbstractCodeEditorService extends Disposable implements ICodeEditorService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onCodeEditorAdd: Emitter<ICodeEditor> = this._register(new Emitter<ICodeEditor>());
 	public readonly onCodeEditorAdd: Event<ICodeEditor> = this._onCodeEditorAdd.event;

--- a/src/vs/editor/browser/services/bulkEditService.ts
+++ b/src/vs/editor/browser/services/bulkEditService.ts
@@ -26,7 +26,7 @@ export interface IBulkEditResult {
 export type IBulkEditPreviewHandler = (edit: WorkspaceEdit, options?: IBulkEditOptions) => Promise<WorkspaceEdit>;
 
 export interface IBulkEditService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	hasPreviewHandler(): boolean;
 

--- a/src/vs/editor/browser/services/codeEditorService.ts
+++ b/src/vs/editor/browser/services/codeEditorService.ts
@@ -13,7 +13,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const ICodeEditorService = createDecorator<ICodeEditorService>('codeEditorService');
 
 export interface ICodeEditorService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly onCodeEditorAdd: Event<ICodeEditor>;
 	readonly onCodeEditorRemove: Event<ICodeEditor>;

--- a/src/vs/editor/browser/services/openerService.ts
+++ b/src/vs/editor/browser/services/openerService.ts
@@ -85,7 +85,7 @@ class EditorOpener implements IOpener {
 
 export class OpenerService implements IOpenerService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _openers = new LinkedList<IOpener>();
 	private readonly _validators = new LinkedList<IValidator>();

--- a/src/vs/editor/common/services/editorWorkerService.ts
+++ b/src/vs/editor/common/services/editorWorkerService.ts
@@ -19,7 +19,7 @@ export interface IDiffComputationResult {
 }
 
 export interface IEditorWorkerService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	canComputeDiff(original: URI, modified: URI): boolean;
 	computeDiff(original: URI, modified: URI, ignoreTrimWhitespace: boolean, maxComputationTime: number): Promise<IDiffComputationResult | null>;

--- a/src/vs/editor/common/services/editorWorkerServiceImpl.ts
+++ b/src/vs/editor/common/services/editorWorkerServiceImpl.ts
@@ -46,7 +46,7 @@ function canSyncModel(modelService: IModelService, resource: URI): boolean {
 
 export class EditorWorkerServiceImpl extends Disposable implements IEditorWorkerService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _modelService: IModelService;
 	private readonly _workerManager: WorkerManager;

--- a/src/vs/editor/common/services/markerDecorationsServiceImpl.ts
+++ b/src/vs/editor/common/services/markerDecorationsServiceImpl.ts
@@ -70,7 +70,7 @@ class MarkerDecorations extends Disposable {
 
 export class MarkerDecorationsService extends Disposable implements IMarkerDecorationsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidChangeMarker = this._register(new Emitter<ITextModel>());
 	readonly onDidChangeMarker: Event<ITextModel> = this._onDidChangeMarker.event;

--- a/src/vs/editor/common/services/markersDecorationService.ts
+++ b/src/vs/editor/common/services/markersDecorationService.ts
@@ -12,7 +12,7 @@ import { Range } from 'vs/editor/common/core/range';
 export const IMarkerDecorationsService = createDecorator<IMarkerDecorationsService>('markerDecorationsService');
 
 export interface IMarkerDecorationsService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	onDidChangeMarker: Event<ITextModel>;
 

--- a/src/vs/editor/common/services/modeService.ts
+++ b/src/vs/editor/common/services/modeService.ts
@@ -28,7 +28,7 @@ export interface ILanguageSelection extends IDisposable {
 }
 
 export interface IModeService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	onDidCreateMode: Event<IMode>;
 	onLanguagesMaybeChanged: Event<void>;

--- a/src/vs/editor/common/services/modelService.ts
+++ b/src/vs/editor/common/services/modelService.ts
@@ -16,7 +16,7 @@ export const IModelService = createDecorator<IModelService>('modelService');
 export type DocumentTokensProvider = DocumentSemanticTokensProvider | DocumentRangeSemanticTokensProvider;
 
 export interface IModelService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	createModel(value: string | ITextBufferFactory, languageSelection: ILanguageSelection | null, resource?: URI, isForSimpleWidget?: boolean): ITextModel;
 

--- a/src/vs/editor/common/services/resolverService.ts
+++ b/src/vs/editor/common/services/resolverService.ts
@@ -12,7 +12,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const ITextModelService = createDecorator<ITextModelService>('textModelService');
 
 export interface ITextModelService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Provided a resource URI, it will return a model reference

--- a/src/vs/editor/common/services/textResourceConfigurationService.ts
+++ b/src/vs/editor/common/services/textResourceConfigurationService.ts
@@ -31,7 +31,7 @@ export interface ITextResourceConfigurationChangeEvent {
 
 export interface ITextResourceConfigurationService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Event that fires when the configuration changes.
@@ -70,7 +70,7 @@ export const ITextResourcePropertiesService = createDecorator<ITextResourcePrope
 
 export interface ITextResourcePropertiesService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Returns the End of Line characters for the given resource

--- a/src/vs/editor/contrib/codelens/codeLensCache.ts
+++ b/src/vs/editor/contrib/codelens/codeLensCache.ts
@@ -17,7 +17,7 @@ import { once } from 'vs/base/common/functional';
 export const ICodeLensCache = createDecorator<ICodeLensCache>('ICodeLensCache');
 
 export interface ICodeLensCache {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	put(model: ITextModel, data: CodeLensModel): void;
 	get(model: ITextModel): CodeLensModel | undefined;
 	delete(model: ITextModel): void;
@@ -38,7 +38,7 @@ class CacheItem {
 
 export class CodeLensCache implements ICodeLensCache {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _fakeProvider = new class implements CodeLensProvider {
 		provideCodeLenses(): CodeLensList {

--- a/src/vs/editor/contrib/gotoSymbol/symbolNavigation.ts
+++ b/src/vs/editor/contrib/gotoSymbol/symbolNavigation.ts
@@ -26,7 +26,7 @@ export const ctxHasSymbols = new RawContextKey('hasSymbols', false);
 export const ISymbolNavigationService = createDecorator<ISymbolNavigationService>('ISymbolNavigationService');
 
 export interface ISymbolNavigationService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	reset(): void;
 	put(anchor: OneReference): void;
 	revealNext(source: ICodeEditor): Promise<any>;
@@ -34,7 +34,7 @@ export interface ISymbolNavigationService {
 
 class SymbolNavigationService implements ISymbolNavigationService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _ctxHasSymbols: IContextKey<boolean>;
 

--- a/src/vs/editor/contrib/peekView/peekView.ts
+++ b/src/vs/editor/contrib/peekView/peekView.ts
@@ -30,12 +30,12 @@ import { Codicon } from 'vs/base/common/codicons';
 
 export const IPeekViewService = createDecorator<IPeekViewService>('IPeekViewService');
 export interface IPeekViewService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	addExclusiveWidget(editor: ICodeEditor, widget: PeekViewWidget): void;
 }
 
 registerSingleton(IPeekViewService, class implements IPeekViewService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _widgets = new Map<ICodeEditor, { widget: PeekViewWidget, listener: IDisposable; }>();
 
@@ -103,7 +103,7 @@ const defaultOptions: IPeekViewOptions = {
 
 export abstract class PeekViewWidget extends ZoneWidget {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidClose = new Emitter<PeekViewWidget>();
 	readonly onDidClose = this._onDidClose.event;

--- a/src/vs/editor/contrib/snippet/test/snippetVariables.test.ts
+++ b/src/vs/editor/contrib/snippet/test/snippetVariables.test.ts
@@ -302,7 +302,7 @@ suite('Snippet Variables Resolver', function () {
 		let workspace: IWorkspace;
 		let resolver: VariableResolver;
 		const workspaceService = new class implements IWorkspaceContextService {
-			_serviceBrand: undefined;
+			declare readonly _serviceBrand: undefined;
 			_throw = () => { throw new Error(); };
 			onDidChangeWorkbenchState = this._throw;
 			onDidChangeWorkspaceName = this._throw;

--- a/src/vs/editor/contrib/suggest/suggestMemory.ts
+++ b/src/vs/editor/contrib/suggest/suggestMemory.ts
@@ -308,7 +308,7 @@ export class SuggestMemoryService implements ISuggestMemoryService {
 export const ISuggestMemoryService = createDecorator<ISuggestMemoryService>('ISuggestMemories');
 
 export interface ISuggestMemoryService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	memorize(model: ITextModel, pos: IPosition, item: CompletionItem): void;
 	select(model: ITextModel, pos: IPosition, items: CompletionItem[]): number;
 }

--- a/src/vs/editor/contrib/suggest/test/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/suggestModel.test.ts
@@ -51,7 +51,7 @@ function createMockEditor(model: TextModel): ITestCodeEditor {
 			[IStorageService, new InMemoryStorageService()],
 			[IKeybindingService, new MockKeybindingService()],
 			[ISuggestMemoryService, new class implements ISuggestMemoryService {
-				_serviceBrand: undefined;
+				declare readonly _serviceBrand: undefined;
 				memorize(): void {
 				}
 				select(): number {

--- a/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputServiceImpl.ts
+++ b/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputServiceImpl.ts
@@ -52,7 +52,7 @@ export class EditorScopedQuickInputServiceImpl extends QuickInputService {
 
 export class StandaloneQuickInputServiceImpl implements IQuickInputService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private mapEditorToService = new Map<ICodeEditor, EditorScopedQuickInputServiceImpl>();
 	private get activeService(): IQuickInputService {

--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -155,7 +155,7 @@ export class SimpleEditorModelResolverService implements ITextModelService {
 }
 
 export class SimpleEditorProgressService implements IEditorProgressService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static NULL_PROGRESS_RUNNER: IProgressRunner = {
 		done: () => { },
@@ -251,7 +251,7 @@ export class SimpleNotificationService implements INotificationService {
 }
 
 export class StandaloneCommandService implements ICommandService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _instantiationService: IInstantiationService;
 
@@ -420,7 +420,7 @@ function isConfigurationOverrides(thing: any): thing is IConfigurationOverrides 
 
 export class SimpleConfigurationService implements IConfigurationService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
 	public readonly onDidChangeConfiguration: Event<IConfigurationChangeEvent> = this._onDidChangeConfiguration.event;
@@ -498,7 +498,7 @@ export class SimpleConfigurationService implements IConfigurationService {
 
 export class SimpleResourceConfigurationService implements ITextResourceConfigurationService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidChangeConfiguration = new Emitter<ITextResourceConfigurationChangeEvent>();
 	public readonly onDidChangeConfiguration = this._onDidChangeConfiguration.event;
@@ -527,7 +527,7 @@ export class SimpleResourceConfigurationService implements ITextResourceConfigur
 
 export class SimpleResourcePropertiesService implements ITextResourcePropertiesService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -544,7 +544,7 @@ export class SimpleResourcePropertiesService implements ITextResourcePropertiesS
 }
 
 export class StandaloneTelemetryService implements ITelemetryService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	public isOptedIn = false;
 	public sendErrorTelemetry = false;
@@ -648,7 +648,7 @@ export function applyConfigurationValues(configurationService: IConfigurationSer
 }
 
 export class SimpleBulkEditService implements IBulkEditService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private readonly _modelService: IModelService) {
 		//
@@ -703,7 +703,7 @@ export class SimpleBulkEditService implements IBulkEditService {
 
 export class SimpleUriLabelService implements ILabelService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	public readonly onDidChangeFormatters: Event<IFormatterChangeEvent> = Event.None;
 
@@ -736,7 +736,7 @@ export class SimpleUriLabelService implements ILabelService {
 }
 
 export class SimpleLayoutService implements ILayoutService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	public onLayout = Event.None;
 

--- a/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
@@ -172,7 +172,7 @@ function newBuiltInTheme(builtinTheme: BuiltinTheme): StandaloneTheme {
 
 export class StandaloneThemeServiceImpl extends Disposable implements IStandaloneThemeService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onColorThemeChange = this._register(new Emitter<IStandaloneTheme>());
 	public readonly onDidColorThemeChange = this._onColorThemeChange.event;

--- a/src/vs/editor/standalone/common/standaloneThemeService.ts
+++ b/src/vs/editor/standalone/common/standaloneThemeService.ts
@@ -26,7 +26,7 @@ export interface IStandaloneTheme extends IColorTheme {
 }
 
 export interface IStandaloneThemeService extends IThemeService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	setTheme(themeName: string): string;
 

--- a/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
+++ b/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
@@ -33,7 +33,7 @@ suite('TokenizationSupport2Adapter', () => {
 	}
 
 	class MockThemeService implements IStandaloneThemeService {
-		_serviceBrand: undefined;
+		declare readonly _serviceBrand: undefined;
 		public setTheme(themeName: string): string {
 			throw new Error('Not implemented');
 		}

--- a/src/vs/editor/test/browser/editorTestServices.ts
+++ b/src/vs/editor/test/browser/editorTestServices.ts
@@ -25,7 +25,7 @@ export class TestCodeEditorService extends AbstractCodeEditorService {
 }
 
 export class TestCommandService implements ICommandService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _instantiationService: IInstantiationService;
 

--- a/src/vs/editor/test/browser/services/openerService.test.ts
+++ b/src/vs/editor/test/browser/services/openerService.test.ts
@@ -16,7 +16,7 @@ suite('OpenerService', function () {
 	let lastCommand: { id: string; args: any[] } | undefined;
 
 	const commandService = new (class implements ICommandService {
-		_serviceBrand: undefined;
+		declare readonly _serviceBrand: undefined;
 		onWillExecuteCommand = () => Disposable.None;
 		onDidExecuteCommand = () => Disposable.None;
 		executeCommand(id: string, ...args: any[]): Promise<any> {

--- a/src/vs/editor/test/common/services/modelService.test.ts
+++ b/src/vs/editor/test/common/services/modelService.test.ts
@@ -442,7 +442,7 @@ assertComputeEdits(file1, file2);
 
 export class TestTextResourcePropertiesService implements ITextResourcePropertiesService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,

--- a/src/vs/platform/accessibility/common/accessibility.ts
+++ b/src/vs/platform/accessibility/common/accessibility.ts
@@ -10,7 +10,7 @@ import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 export const IAccessibilityService = createDecorator<IAccessibilityService>('accessibilityService');
 
 export interface IAccessibilityService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly onDidChangeScreenReaderOptimized: Event<void>;
 

--- a/src/vs/platform/accessibility/common/accessibilityService.ts
+++ b/src/vs/platform/accessibility/common/accessibilityService.ts
@@ -10,7 +10,7 @@ import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/c
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export class AccessibilityService extends Disposable implements IAccessibilityService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _accessibilityModeEnabledContext: IContextKey<boolean>;
 	protected _accessibilitySupport = AccessibilitySupport.Unknown;

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -149,7 +149,7 @@ export const IMenuService = createDecorator<IMenuService>('menuService');
 
 export interface IMenuService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	createMenu(id: MenuId, scopedKeybindingService: IContextKeyService): IMenu;
 }

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -11,7 +11,7 @@ import { IContextKeyService, IContextKeyChangeEvent, ContextKeyExpression } from
 
 export class MenuService implements IMenuService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@ICommandService private readonly _commandService: ICommandService

--- a/src/vs/platform/authentication/common/authentication.ts
+++ b/src/vs/platform/authentication/common/authentication.ts
@@ -15,7 +15,7 @@ export interface IUserDataSyncAuthToken {
 }
 
 export interface IAuthenticationTokenService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly token: IUserDataSyncAuthToken | undefined;
 	readonly onDidChangeToken: Event<IUserDataSyncAuthToken | undefined>;

--- a/src/vs/platform/backup/electron-main/backup.ts
+++ b/src/vs/platform/backup/electron-main/backup.ts
@@ -22,7 +22,7 @@ export function isWorkspaceBackupInfo(obj: unknown): obj is IWorkspaceBackupInfo
 }
 
 export interface IBackupMainService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	isHotExitEnabled(): boolean;
 

--- a/src/vs/platform/backup/electron-main/backupMainService.ts
+++ b/src/vs/platform/backup/electron-main/backupMainService.ts
@@ -23,7 +23,7 @@ import { Schemas } from 'vs/base/common/network';
 
 export class BackupMainService implements IBackupMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	protected backupHome: string;
 	protected workspacesJsonPath: string;

--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -9,7 +9,7 @@ import { $ } from 'vs/base/browser/dom';
 
 export class BrowserClipboardService implements IClipboardService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly mapTextToType = new Map<string, string>(); // unsupported in web (only in-memory)
 

--- a/src/vs/platform/clipboard/common/clipboardService.ts
+++ b/src/vs/platform/clipboard/common/clipboardService.ts
@@ -10,7 +10,7 @@ export const IClipboardService = createDecorator<IClipboardService>('clipboardSe
 
 export interface IClipboardService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Writes text to the system clipboard.

--- a/src/vs/platform/commands/common/commands.ts
+++ b/src/vs/platform/commands/common/commands.ts
@@ -19,7 +19,7 @@ export interface ICommandEvent {
 }
 
 export interface ICommandService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	onWillExecuteCommand: Event<ICommandEvent>;
 	onDidExecuteCommand: Event<ICommandEvent>;
 	executeCommand<T = any>(commandId: string, ...args: any[]): Promise<T | undefined>;

--- a/src/vs/platform/configuration/common/configuration.ts
+++ b/src/vs/platform/configuration/common/configuration.ts
@@ -88,7 +88,7 @@ export interface IConfigurationValue<T> {
 }
 
 export interface IConfigurationService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	onDidChangeConfiguration: Event<IConfigurationChangeEvent>;
 

--- a/src/vs/platform/configuration/common/configurationService.ts
+++ b/src/vs/platform/configuration/common/configurationService.ts
@@ -15,7 +15,7 @@ import { RunOnceScheduler } from 'vs/base/common/async';
 
 export class ConfigurationService extends Disposable implements IConfigurationService, IDisposable {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private configuration: Configuration;
 	private userConfiguration: UserSettings;

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -974,7 +974,7 @@ export interface IContextKeyChangeEvent {
 }
 
 export interface IContextKeyService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	dispose(): void;
 
 	onDidChangeContext: Event<IContextKeyChangeEvent>;

--- a/src/vs/platform/contextview/browser/contextMenuService.ts
+++ b/src/vs/platform/contextview/browser/contextMenuService.ts
@@ -14,7 +14,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { Disposable } from 'vs/base/common/lifecycle';
 
 export class ContextMenuService extends Disposable implements IContextMenuService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _onDidContextMenu = this._register(new Emitter<void>());
 	readonly onDidContextMenu: Event<void> = this._onDidContextMenu.event;

--- a/src/vs/platform/contextview/browser/contextView.ts
+++ b/src/vs/platform/contextview/browser/contextView.ts
@@ -13,7 +13,7 @@ export const IContextViewService = createDecorator<IContextViewService>('context
 
 export interface IContextViewService extends IContextViewProvider {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	showContextView(delegate: IContextViewDelegate, container?: HTMLElement): void;
 	hideContextView(data?: any): void;
@@ -37,7 +37,7 @@ export const IContextMenuService = createDecorator<IContextMenuService>('context
 
 export interface IContextMenuService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	showContextMenu(delegate: IContextMenuDelegate): void;
 	onDidContextMenu: Event<void>; // TODO@isidor these event should be removed once we get async context menus

--- a/src/vs/platform/contextview/browser/contextViewService.ts
+++ b/src/vs/platform/contextview/browser/contextViewService.ts
@@ -9,7 +9,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 
 export class ContextViewService extends Disposable implements IContextViewService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private contextView: ContextView;
 	private container: HTMLElement;

--- a/src/vs/platform/credentials/common/credentials.ts
+++ b/src/vs/platform/credentials/common/credentials.ts
@@ -9,7 +9,7 @@ export const ICredentialsService = createDecorator<ICredentialsService>('ICreden
 
 export interface ICredentialsService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getPassword(service: string, account: string): Promise<string | null>;
 	setPassword(service: string, account: string, password: string): Promise<void>;

--- a/src/vs/platform/credentials/node/credentialsService.ts
+++ b/src/vs/platform/credentials/node/credentialsService.ts
@@ -9,7 +9,7 @@ import { IdleValue } from 'vs/base/common/async';
 type KeytarModule = typeof import('keytar');
 export class KeytarCredentialsService implements ICredentialsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _keytar = new IdleValue<Promise<KeytarModule>>(() => import('keytar'));
 

--- a/src/vs/platform/debug/common/extensionHostDebug.ts
+++ b/src/vs/platform/debug/common/extensionHostDebug.ts
@@ -35,7 +35,7 @@ export interface ICloseSessionEvent {
 }
 
 export interface IExtensionHostDebugService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	reload(sessionId: string): void;
 	readonly onReload: Event<IReloadSessionEvent>;

--- a/src/vs/platform/debug/common/extensionHostDebugIpc.ts
+++ b/src/vs/platform/debug/common/extensionHostDebugIpc.ts
@@ -55,7 +55,7 @@ export class ExtensionHostDebugBroadcastChannel<TContext> implements IServerChan
 
 export class ExtensionHostDebugChannelClient extends Disposable implements IExtensionHostDebugService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private channel: IChannel) {
 		super();

--- a/src/vs/platform/diagnostics/node/diagnosticsIpc.ts
+++ b/src/vs/platform/diagnostics/node/diagnosticsIpc.ts
@@ -36,7 +36,7 @@ export class DiagnosticsChannel implements IServerChannel {
 
 export class DiagnosticsService implements IDiagnosticsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private channel: IChannel) { }
 

--- a/src/vs/platform/diagnostics/node/diagnosticsService.ts
+++ b/src/vs/platform/diagnostics/node/diagnosticsService.ts
@@ -23,7 +23,7 @@ export const ID = 'diagnosticsService';
 export const IDiagnosticsService = createDecorator<IDiagnosticsService>(ID);
 
 export interface IDiagnosticsService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getPerformanceInfo(mainProcessInfo: IMainProcessInfo, remoteInfo: (IRemoteDiagnosticInfo | IRemoteDiagnosticError)[]): Promise<PerformanceInfo>;
 	getSystemInfo(mainProcessInfo: IMainProcessInfo, remoteInfo: (IRemoteDiagnosticInfo | IRemoteDiagnosticError)[]): Promise<SystemInfo>;
@@ -223,7 +223,7 @@ export function collectLaunchConfigs(folder: string): Promise<WorkspaceStatItem[
 
 export class DiagnosticsService implements IDiagnosticsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(@ITelemetryService private readonly telemetryService: ITelemetryService) { }
 

--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -160,7 +160,7 @@ export interface IDialogOptions {
  */
 export interface IDialogService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Ask the user for confirmation with a modal dialog.
@@ -189,7 +189,7 @@ export const IFileDialogService = createDecorator<IFileDialogService>('fileDialo
  */
 export interface IFileDialogService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * The default path for a new file based on previously used files.

--- a/src/vs/platform/dialogs/electron-main/dialogs.ts
+++ b/src/vs/platform/dialogs/electron-main/dialogs.ts
@@ -21,7 +21,7 @@ export const IDialogMainService = createDecorator<IDialogMainService>('dialogMai
 
 export interface IDialogMainService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	pickFileFolder(options: INativeOpenDialogOptions, window?: BrowserWindow): Promise<string[] | undefined>;
 	pickFolder(options: INativeOpenDialogOptions, window?: BrowserWindow): Promise<string[] | undefined>;
@@ -44,7 +44,7 @@ interface IInternalNativeOpenDialogOptions extends INativeOpenDialogOptions {
 
 export class DialogMainService implements IDialogMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly workingDirPickerStorageKey = 'pickerWorkingDir';
 

--- a/src/vs/platform/dialogs/test/common/testDialogService.ts
+++ b/src/vs/platform/dialogs/test/common/testDialogService.ts
@@ -8,7 +8,7 @@ import { IConfirmation, IConfirmationResult, IDialogService, IDialogOptions, ISh
 
 export class TestDialogService implements IDialogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	confirm(_confirmation: IConfirmation): Promise<IConfirmationResult> { return Promise.resolve({ confirmed: false }); }
 	show(_severity: Severity, _message: string, _buttons: string[], _options?: IDialogOptions): Promise<IShowResult> { return Promise.resolve({ choice: 0 }); }

--- a/src/vs/platform/download/common/download.ts
+++ b/src/vs/platform/download/common/download.ts
@@ -11,7 +11,7 @@ export const IDownloadService = createDecorator<IDownloadService>('downloadServi
 
 export interface IDownloadService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	download(uri: URI, to: URI, cancellationToken?: CancellationToken): Promise<void>;
 

--- a/src/vs/platform/download/common/downloadIpc.ts
+++ b/src/vs/platform/download/common/downloadIpc.ts
@@ -27,7 +27,7 @@ export class DownloadServiceChannel implements IServerChannel {
 
 export class DownloadServiceChannelClient implements IDownloadService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private channel: IChannel, private getUriTransformer: () => IURITransformer | null) { }
 

--- a/src/vs/platform/download/common/downloadService.ts
+++ b/src/vs/platform/download/common/downloadService.ts
@@ -12,7 +12,7 @@ import { Schemas } from 'vs/base/common/network';
 
 export class DownloadService implements IDownloadService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IRequestService private readonly requestService: IRequestService,

--- a/src/vs/platform/driver/common/driver.ts
+++ b/src/vs/platform/driver/common/driver.ts
@@ -19,7 +19,7 @@ export interface IElement {
 }
 
 export interface IDriver {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getWindowIds(): Promise<number[]>;
 	capturePage(windowId: number): Promise<string>;

--- a/src/vs/platform/driver/electron-main/driver.ts
+++ b/src/vs/platform/driver/electron-main/driver.ts
@@ -27,7 +27,7 @@ function isSilentKeyCode(keyCode: KeyCode) {
 
 export class Driver implements IDriver, IWindowDriverRegistry {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private registeredWindowIds = new Set<number>();
 	private reloadingWindowIds = new Set<number>();

--- a/src/vs/platform/driver/node/driver.ts
+++ b/src/vs/platform/driver/node/driver.ts
@@ -42,7 +42,7 @@ export class DriverChannel implements IServerChannel {
 
 export class DriverChannelClient implements IDriver {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private channel: IChannel) { }
 
@@ -136,7 +136,7 @@ export class WindowDriverRegistryChannel implements IServerChannel {
 
 export class WindowDriverRegistryChannelClient implements IWindowDriverRegistry {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private channel: IChannel) { }
 
@@ -177,7 +177,7 @@ export class WindowDriverChannel implements IServerChannel {
 
 export class WindowDriverChannelClient implements IWindowDriver {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private channel: IChannel) { }
 

--- a/src/vs/platform/electron/common/electron.ts
+++ b/src/vs/platform/electron/common/electron.ts
@@ -11,7 +11,7 @@ import { ISerializableCommandAction } from 'vs/platform/actions/common/actions';
 
 export interface ICommonElectronService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	// Properties
 	readonly windowId: number;

--- a/src/vs/platform/electron/electron-main/electronMainService.ts
+++ b/src/vs/platform/electron/electron-main/electronMainService.ts
@@ -29,7 +29,7 @@ export const IElectronMainService = createDecorator<IElectronMainService>('elect
 
 export class ElectronMainService implements IElectronMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,

--- a/src/vs/platform/electron/electron-sandbox/electron.ts
+++ b/src/vs/platform/electron/electron-sandbox/electron.ts
@@ -14,7 +14,7 @@ export interface IElectronService extends ICommonElectronService { }
 
 export class ElectronService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		readonly windowId: number,

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -26,7 +26,7 @@ export interface IEnvironmentService {
 	// UNLESS THIS PROPERTY IS SUPPORTED BOTH IN WEB AND DESKTOP!!!!
 	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	// --- user roaming data
 	userRoamingDataHome: URI;

--- a/src/vs/platform/environment/node/environmentService.ts
+++ b/src/vs/platform/environment/node/environmentService.ts
@@ -50,7 +50,7 @@ export interface INativeEnvironmentService extends IEnvironmentService {
 
 export class EnvironmentService implements INativeEnvironmentService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	get args(): ParsedArgs { return this._args; }
 

--- a/src/vs/platform/extensionManagement/common/extensionEnablementService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionEnablementService.ts
@@ -12,7 +12,7 @@ import { isUndefinedOrNull } from 'vs/base/common/types';
 
 export class GlobalExtensionEnablementService extends Disposable implements IGlobalExtensionEnablementService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _onDidChangeEnablement = new Emitter<{ readonly extensions: IExtensionIdentifier[], readonly source?: string }>();
 	readonly onDidChangeEnablement: Event<{ readonly extensions: IExtensionIdentifier[], readonly source?: string }> = this._onDidChangeEnablement.event;

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -325,7 +325,7 @@ interface IRawExtensionsReport {
 
 export class ExtensionGalleryService implements IExtensionGalleryService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private extensionsGalleryUrl: string | undefined;
 	private extensionsControlUrl: string | undefined;

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -149,7 +149,7 @@ export interface ITranslation {
 }
 
 export interface IExtensionGalleryService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	isEnabled(): boolean;
 	query(token: CancellationToken): Promise<IPager<IGalleryExtension>>;
 	query(options: IQueryOptions, token: CancellationToken): Promise<IPager<IGalleryExtension>>;
@@ -196,7 +196,7 @@ export class ExtensionManagementError extends Error {
 }
 
 export interface IExtensionManagementService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	onInstallExtension: Event<InstallExtensionEvent>;
 	onDidInstallExtension: Event<DidInstallExtensionEvent>;
@@ -221,7 +221,7 @@ export const ENABLED_EXTENSIONS_STORAGE_PATH = 'extensionsIdentifiers/enabled';
 export const IGlobalExtensionEnablementService = createDecorator<IGlobalExtensionEnablementService>('IGlobalExtensionEnablementService');
 
 export interface IGlobalExtensionEnablementService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	readonly onDidChangeEnablement: Event<{ readonly extensions: IExtensionIdentifier[], readonly source?: string }>;
 
 	getDisabledExtensions(): IExtensionIdentifier[];
@@ -242,7 +242,7 @@ export type IWorkspaceTips = { readonly remoteSet: string[]; readonly recommenda
 
 export const IExtensionTipsService = createDecorator<IExtensionTipsService>('IExtensionTipsService');
 export interface IExtensionTipsService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getConfigBasedTips(folder: URI): Promise<IConfigBasedExtensionTip[]>;
 	getImportantExecutableBasedTips(): Promise<IExecutableBasedExtensionTip[]>;

--- a/src/vs/platform/extensionManagement/common/extensionManagementIpc.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementIpc.ts
@@ -77,7 +77,7 @@ export class ExtensionManagementChannel implements IServerChannel {
 
 export class ExtensionManagementChannelClient implements IExtensionManagementService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		private readonly channel: IChannel,

--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -62,7 +62,7 @@ interface InstallableExtension {
 
 export class ExtensionManagementService extends Disposable implements IExtensionManagementService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly extensionsScanner: ExtensionsScanner;
 	private reportedExtensions: Promise<IReportedExtension[]> | undefined;

--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -22,7 +22,7 @@ import { createReadStream } from 'vs/platform/files/common/io';
 
 export class FileService extends Disposable implements IFileService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly BUFFER_SIZE = 64 * 1024;
 

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -21,7 +21,7 @@ export const IFileService = createDecorator<IFileService>('fileService');
 
 export interface IFileService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * An event that is fired when a file system provider is added or removed

--- a/src/vs/platform/instantiation/common/instantiation.ts
+++ b/src/vs/platform/instantiation/common/instantiation.ts
@@ -85,7 +85,7 @@ type GetLeadingNonServiceArgs<Args> =
 
 export interface IInstantiationService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Synchronously creates an instance that is denoted by

--- a/src/vs/platform/instantiation/common/instantiationService.ts
+++ b/src/vs/platform/instantiation/common/instantiationService.ts
@@ -22,7 +22,7 @@ class CyclicDependencyError extends Error {
 
 export class InstantiationService implements IInstantiationService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _services: ServiceCollection;
 	private readonly _strict: boolean;

--- a/src/vs/platform/instantiation/test/common/instantiationService.test.ts
+++ b/src/vs/platform/instantiation/test/common/instantiationService.test.ts
@@ -12,48 +12,48 @@ import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 let IService1 = createDecorator<IService1>('service1');
 
 interface IService1 {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	c: number;
 }
 
 class Service1 implements IService1 {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	c = 1;
 }
 
 let IService2 = createDecorator<IService2>('service2');
 
 interface IService2 {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	d: boolean;
 }
 
 class Service2 implements IService2 {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	d = true;
 }
 
 let IService3 = createDecorator<IService3>('service3');
 
 interface IService3 {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	s: string;
 }
 
 class Service3 implements IService3 {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	s = 'farboo';
 }
 
 let IDependentService = createDecorator<IDependentService>('dependentService');
 
 interface IDependentService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	name: string;
 }
 
 class DependentService implements IDependentService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	constructor(@IService1 service: IService1) {
 		assert.equal(service.c, 1);
 	}
@@ -116,7 +116,7 @@ class DependentServiceTarget2 {
 
 
 class ServiceLoop1 implements IService1 {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	c = 1;
 
 	constructor(@IService2 s: IService2) {
@@ -125,7 +125,7 @@ class ServiceLoop1 implements IService1 {
 }
 
 class ServiceLoop2 implements IService2 {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	d = true;
 
 	constructor(@IService1 s: IService1) {
@@ -364,7 +364,7 @@ suite('Instantiation Service', () => {
 		let serviceInstanceCount = 0;
 
 		const CtorCounter = class implements Service1 {
-			_serviceBrand: undefined;
+			declare readonly _serviceBrand: undefined;
 			c = 1;
 			constructor() {
 				serviceInstanceCount += 1;

--- a/src/vs/platform/ipc/electron-browser/sharedProcessService.ts
+++ b/src/vs/platform/ipc/electron-browser/sharedProcessService.ts
@@ -10,7 +10,7 @@ export const ISharedProcessService = createDecorator<ISharedProcessService>('sha
 
 export interface ISharedProcessService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getChannel(channelName: string): IChannel;
 	registerChannel(channelName: string, channel: IServerChannel<string>): void;

--- a/src/vs/platform/ipc/electron-main/sharedProcessMainService.ts
+++ b/src/vs/platform/ipc/electron-main/sharedProcessMainService.ts
@@ -9,7 +9,7 @@ export const ISharedProcessMainService = createDecorator<ISharedProcessMainServi
 
 export interface ISharedProcessMainService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	whenSharedProcessReady(): Promise<void>;
 	toggleSharedProcessWindow(): Promise<void>;
@@ -22,7 +22,7 @@ export interface ISharedProcess {
 
 export class SharedProcessMainService implements ISharedProcessMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private sharedProcess: ISharedProcess) { }
 

--- a/src/vs/platform/ipc/electron-sandbox/mainProcessService.ts
+++ b/src/vs/platform/ipc/electron-sandbox/mainProcessService.ts
@@ -12,7 +12,7 @@ export const IMainProcessService = createDecorator<IMainProcessService>('mainPro
 
 export interface IMainProcessService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getChannel(channelName: string): IChannel;
 
@@ -21,7 +21,7 @@ export interface IMainProcessService {
 
 export class MainProcessService extends Disposable implements IMainProcessService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private mainProcessConnection: Client;
 

--- a/src/vs/platform/issue/common/issue.ts
+++ b/src/vs/platform/issue/common/issue.ts
@@ -88,7 +88,7 @@ export interface ProcessExplorerData extends WindowData {
 }
 
 export interface ICommonIssueService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	openReporter(data: IssueReporterData): Promise<void>;
 	openProcessExplorer(data: ProcessExplorerData): Promise<void>;
 	getSystemStatus(): Promise<string>;

--- a/src/vs/platform/issue/electron-main/issueMainService.ts
+++ b/src/vs/platform/issue/electron-main/issueMainService.ts
@@ -28,7 +28,7 @@ export const IIssueMainService = createDecorator<IIssueMainService>('issueMainSe
 export interface IIssueMainService extends ICommonIssueService { }
 
 export class IssueMainService implements ICommonIssueService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	_issueWindow: BrowserWindow | null = null;
 	_issueParentWindow: BrowserWindow | null = null;
 	_processExplorerWindow: BrowserWindow | null = null;

--- a/src/vs/platform/keybinding/common/keybinding.ts
+++ b/src/vs/platform/keybinding/common/keybinding.ts
@@ -48,7 +48,7 @@ export interface KeybindingsSchemaContribution {
 export const IKeybindingService = createDecorator<IKeybindingService>('keybindingService');
 
 export interface IKeybindingService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly inChordMode: boolean;
 

--- a/src/vs/platform/label/common/label.ts
+++ b/src/vs/platform/label/common/label.ts
@@ -16,7 +16,7 @@ export const ILabelService = createDecorator<ILabelService>('labelService');
 
 export interface ILabelService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Gets the human readable label for a uri.

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -51,7 +51,7 @@ function parseOpenUrl(args: ParsedArgs): URI[] {
 }
 
 export interface ILaunchMainService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	start(args: ParsedArgs, userEnv: IProcessEnvironment): Promise<void>;
 	getMainProcessId(): Promise<number>;
 	getMainProcessInfo(): Promise<IMainProcessInfo>;
@@ -60,7 +60,7 @@ export interface ILaunchMainService {
 
 export class LaunchMainService implements ILaunchMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@ILogService private readonly logService: ILogService,

--- a/src/vs/platform/layout/browser/layoutService.ts
+++ b/src/vs/platform/layout/browser/layoutService.ts
@@ -11,7 +11,7 @@ export const ILayoutService = createDecorator<ILayoutService>('layoutService');
 
 export interface ILayoutService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * The dimensions of the container.

--- a/src/vs/platform/lifecycle/common/lifecycle.ts
+++ b/src/vs/platform/lifecycle/common/lifecycle.ts
@@ -123,7 +123,7 @@ export function LifecyclePhaseToString(phase: LifecyclePhase) {
  */
 export interface ILifecycleService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Value indicates how this window got loaded.

--- a/src/vs/platform/lifecycle/common/lifecycleService.ts
+++ b/src/vs/platform/lifecycle/common/lifecycleService.ts
@@ -12,7 +12,7 @@ import { mark } from 'vs/base/common/performance';
 
 export abstract class AbstractLifecycleService extends Disposable implements ILifecycleService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	protected readonly _onBeforeShutdown = this._register(new Emitter<BeforeShutdownEvent>());
 	readonly onBeforeShutdown = this._onBeforeShutdown.event;

--- a/src/vs/platform/lifecycle/electron-main/lifecycleMainService.ts
+++ b/src/vs/platform/lifecycle/electron-main/lifecycleMainService.ts
@@ -41,7 +41,7 @@ export interface ShutdownEvent {
 
 export interface ILifecycleMainService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Will be true if the program was restarted (e.g. due to explicit request or update).
@@ -137,7 +137,7 @@ export const enum LifecycleMainPhase {
 
 export class LifecycleMainService extends Disposable implements ILifecycleMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly QUIT_FROM_RESTART_MARKER = 'quit.from.restart'; // use a marker to find out if the session was restarted
 

--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -33,7 +33,7 @@ export const IListService = createDecorator<IListService>('listService');
 
 export interface IListService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Returns the currently focused list widget if any.
@@ -48,7 +48,7 @@ interface IRegisteredList {
 
 export class ListService implements IListService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private disposables = new DisposableStore();
 	private lists: IRegisteredList[] = [];

--- a/src/vs/platform/localizations/common/localizations.ts
+++ b/src/vs/platform/localizations/common/localizations.ts
@@ -26,7 +26,7 @@ export const enum LanguageType {
 
 export const ILocalizationsService = createDecorator<ILocalizationsService>('localizationsService');
 export interface ILocalizationsService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly onDidLanguagesChange: Event<void>;
 	getLanguageIds(type?: LanguageType): Promise<string[]>;

--- a/src/vs/platform/localizations/node/localizations.ts
+++ b/src/vs/platform/localizations/node/localizations.ts
@@ -35,7 +35,7 @@ if (product.quality !== 'stable') {
 
 export class LocalizationsService extends Disposable implements ILocalizationsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly cache: LanguagePacksCache;
 

--- a/src/vs/platform/log/browser/log.ts
+++ b/src/vs/platform/log/browser/log.ts
@@ -18,7 +18,7 @@ export class ConsoleLogInAutomationService extends LogServiceAdapter implements 
 
 	declare codeAutomationLog: any;
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(logLevel: LogLevel = DEFAULT_LOG_LEVEL) {
 		super({ consoleLog: (type, args) => this.consoleLog(type, args) }, logLevel);

--- a/src/vs/platform/log/common/bufferLog.ts
+++ b/src/vs/platform/log/common/bufferLog.ts
@@ -24,7 +24,7 @@ function getLogFunction(logger: ILogService, level: LogLevel): Function {
 
 export class BufferLogService extends AbstractLogService implements ILogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	private buffer: ILog[] = [];
 	private _logger: ILogService | undefined = undefined;
 

--- a/src/vs/platform/log/common/fileLogService.ts
+++ b/src/vs/platform/log/common/fileLogService.ts
@@ -17,7 +17,7 @@ const MAX_FILE_SIZE = 1024 * 1024 * 5;
 
 export class FileLogService extends AbstractLogService implements ILogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly initializePromise: Promise<void>;
 	private readonly queue: Queue<void>;
@@ -157,7 +157,7 @@ export class FileLogService extends AbstractLogService implements ILogService {
 
 export class FileLoggerService extends Disposable implements ILoggerService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly loggers = new Map<string, ILogger>();
 

--- a/src/vs/platform/log/common/log.ts
+++ b/src/vs/platform/log/common/log.ts
@@ -50,11 +50,11 @@ export interface ILogger extends IDisposable {
 }
 
 export interface ILogService extends ILogger {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 }
 
 export interface ILoggerService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getLogger(file: URI): ILogger;
 }
@@ -80,7 +80,7 @@ export abstract class AbstractLogService extends Disposable {
 
 export class ConsoleLogMainService extends AbstractLogService implements ILogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	private useColors: boolean;
 
 	constructor(logLevel: LogLevel = DEFAULT_LOG_LEVEL) {
@@ -161,7 +161,7 @@ export class ConsoleLogMainService extends AbstractLogService implements ILogSer
 
 export class ConsoleLogService extends AbstractLogService implements ILogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(logLevel: LogLevel = DEFAULT_LOG_LEVEL) {
 		super();
@@ -215,7 +215,7 @@ export class ConsoleLogService extends AbstractLogService implements ILogService
 
 export class LogServiceAdapter extends AbstractLogService implements ILogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private readonly adapter: { consoleLog: (type: string, args: any[]) => void }, logLevel: LogLevel = DEFAULT_LOG_LEVEL) {
 		super();
@@ -277,7 +277,7 @@ export class LogServiceAdapter extends AbstractLogService implements ILogService
 
 export class ConsoleLogInMainService extends LogServiceAdapter implements ILogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(client: LoggerChannelClient, logLevel: LogLevel = DEFAULT_LOG_LEVEL) {
 		super({ consoleLog: (type, args) => client.consoleLog(type, args) }, logLevel);
@@ -285,7 +285,7 @@ export class ConsoleLogInMainService extends LogServiceAdapter implements ILogSe
 }
 
 export class MultiplexLogService extends AbstractLogService implements ILogService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private readonly logServices: ReadonlyArray<ILogService>) {
 		super();
@@ -351,7 +351,7 @@ export class MultiplexLogService extends AbstractLogService implements ILogServi
 }
 
 export class DelegatedLogService extends Disposable implements ILogService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private logService: ILogService) {
 		super();
@@ -400,7 +400,7 @@ export class DelegatedLogService extends Disposable implements ILogService {
 }
 
 export class NullLogService implements ILogService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	readonly onDidChangeLogLevel: Event<LogLevel> = new Emitter<LogLevel>().event;
 	setLevel(level: LogLevel): void { }
 	getLevel(): LogLevel { return LogLevel.Info; }

--- a/src/vs/platform/log/common/logIpc.ts
+++ b/src/vs/platform/log/common/logIpc.ts
@@ -73,7 +73,7 @@ export class LoggerChannelClient {
 }
 
 export class FollowerLogService extends DelegatedLogService implements ILogService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private master: LoggerChannelClient, logService: ILogService) {
 		super(logService);

--- a/src/vs/platform/log/node/loggerService.ts
+++ b/src/vs/platform/log/node/loggerService.ts
@@ -14,7 +14,7 @@ import { SpdLogService } from 'vs/platform/log/node/spdlogService';
 
 export class LoggerService extends Disposable implements ILoggerService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly loggers = new Map<string, ILogger>();
 

--- a/src/vs/platform/log/node/spdlogService.ts
+++ b/src/vs/platform/log/node/spdlogService.ts
@@ -44,7 +44,7 @@ function log(logger: spdlog.RotatingLogger, level: LogLevel, message: string): v
 
 export class SpdLogService extends AbstractLogService implements ILogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private buffer: ILog[] = [];
 	private _loggerCreationPromise: Promise<void> | undefined = undefined;

--- a/src/vs/platform/markers/common/markerService.ts
+++ b/src/vs/platform/markers/common/markerService.ts
@@ -139,7 +139,7 @@ class MarkerStats implements MarkerStatistics {
 
 export class MarkerService implements IMarkerService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onMarkerChanged = new Emitter<readonly URI[]>();
 	readonly onMarkerChanged: Event<readonly URI[]> = Event.debounce(this._onMarkerChanged.event, MarkerService._debouncer, 0);

--- a/src/vs/platform/markers/common/markers.ts
+++ b/src/vs/platform/markers/common/markers.ts
@@ -10,7 +10,7 @@ import { localize } from 'vs/nls';
 import Severity from 'vs/base/common/severity';
 
 export interface IMarkerService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getStatistics(): MarkerStatistics;
 

--- a/src/vs/platform/menubar/electron-main/menubarMainService.ts
+++ b/src/vs/platform/menubar/electron-main/menubarMainService.ts
@@ -12,12 +12,12 @@ import { ILifecycleMainService, LifecycleMainPhase } from 'vs/platform/lifecycle
 export const IMenubarMainService = createDecorator<IMenubarMainService>('menubarMainService');
 
 export interface IMenubarMainService extends ICommonMenubarService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 }
 
 export class MenubarMainService implements IMenubarMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private menubar: Promise<Menubar>;
 

--- a/src/vs/platform/menubar/electron-sandbox/menubar.ts
+++ b/src/vs/platform/menubar/electron-sandbox/menubar.ts
@@ -9,5 +9,5 @@ import { ICommonMenubarService } from 'vs/platform/menubar/common/menubar';
 export const IMenubarService = createDecorator<IMenubarService>('menubarService');
 
 export interface IMenubarService extends ICommonMenubarService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 }

--- a/src/vs/platform/notification/common/notification.ts
+++ b/src/vs/platform/notification/common/notification.ts
@@ -284,7 +284,7 @@ export enum NotificationsFilter {
  */
 export interface INotificationService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Show the provided notification to the user. The returned `INotificationHandle`

--- a/src/vs/platform/notification/test/common/testNotificationService.ts
+++ b/src/vs/platform/notification/test/common/testNotificationService.ts
@@ -8,7 +8,7 @@ import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 
 export class TestNotificationService implements INotificationService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly NO_OP: INotificationHandle = new NoOpNotification();
 

--- a/src/vs/platform/opener/common/opener.ts
+++ b/src/vs/platform/opener/common/opener.ts
@@ -53,7 +53,7 @@ export interface IExternalUriResolver {
 
 export interface IOpenerService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Register a participant that can handle the open() call.

--- a/src/vs/platform/product/common/productService.ts
+++ b/src/vs/platform/product/common/productService.ts
@@ -11,7 +11,7 @@ export const IProductService = createDecorator<IProductService>('productService'
 
 export interface IProductService extends Readonly<IProductConfiguration> {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 }
 

--- a/src/vs/platform/progress/common/progress.ts
+++ b/src/vs/platform/progress/common/progress.ts
@@ -15,7 +15,7 @@ export const IProgressService = createDecorator<IProgressService>('progressServi
  */
 export interface IProgressService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	withProgress<R>(
 		options: IProgressOptions | IProgressNotificationOptions | IProgressWindowOptions | IProgressCompositeOptions,
@@ -179,5 +179,5 @@ export const IEditorProgressService = createDecorator<IEditorProgressService>('e
  */
 export interface IEditorProgressService extends IProgressIndicator {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 }

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -23,7 +23,7 @@ export interface IQuickInputControllerHost extends ILayoutService { }
 
 export class QuickInputService extends Themable implements IQuickInputService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	get backButton(): IQuickInputButton { return this.controller.backButton; }
 

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -17,7 +17,7 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export interface IQuickInputService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Provides access to the back button in quick input.

--- a/src/vs/platform/remote/browser/remoteAuthorityResolverService.ts
+++ b/src/vs/platform/remote/browser/remoteAuthorityResolverService.ts
@@ -9,7 +9,7 @@ import { URI } from 'vs/base/common/uri';
 
 export class RemoteAuthorityResolverService implements IRemoteAuthorityResolverService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		resourceUriProvider: ((uri: URI) => URI) | undefined

--- a/src/vs/platform/remote/common/remoteAuthorityResolver.ts
+++ b/src/vs/platform/remote/common/remoteAuthorityResolver.ts
@@ -77,7 +77,7 @@ export class RemoteAuthorityResolverError extends Error {
 
 export interface IRemoteAuthorityResolverService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	resolveAuthority(authority: string): Promise<ResolverResult>;
 

--- a/src/vs/platform/remote/common/tunnel.ts
+++ b/src/vs/platform/remote/common/tunnel.ts
@@ -29,7 +29,7 @@ export interface ITunnelProvider {
 }
 
 export interface ITunnelService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly tunnels: Promise<readonly RemoteTunnel[]>;
 	readonly onTunnelOpened: Event<RemoteTunnel>;

--- a/src/vs/platform/remote/electron-browser/remoteAuthorityResolverService.ts
+++ b/src/vs/platform/remote/electron-browser/remoteAuthorityResolverService.ts
@@ -18,7 +18,7 @@ class PendingResolveAuthorityRequest {
 
 export class RemoteAuthorityResolverService implements IRemoteAuthorityResolverService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _resolveAuthorityRequests: { [authority: string]: PendingResolveAuthorityRequest; };
 

--- a/src/vs/platform/request/browser/requestService.ts
+++ b/src/vs/platform/request/browser/requestService.ts
@@ -16,7 +16,7 @@ import { IRequestService } from 'vs/platform/request/common/request';
  */
 export class RequestService implements IRequestService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,

--- a/src/vs/platform/request/common/request.ts
+++ b/src/vs/platform/request/common/request.ts
@@ -14,7 +14,7 @@ import { IRequestOptions, IRequestContext } from 'vs/base/parts/request/common/r
 export const IRequestService = createDecorator<IRequestService>('requestService');
 
 export interface IRequestService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	request(options: IRequestOptions, token: CancellationToken): Promise<IRequestContext>;
 

--- a/src/vs/platform/request/common/requestIpc.ts
+++ b/src/vs/platform/request/common/requestIpc.ts
@@ -40,7 +40,7 @@ export class RequestChannel implements IServerChannel {
 
 export class RequestChannelClient {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private readonly channel: IChannel) { }
 

--- a/src/vs/platform/request/node/requestService.ts
+++ b/src/vs/platform/request/node/requestService.ts
@@ -36,7 +36,7 @@ export interface NodeRequestOptions extends IRequestOptions {
  */
 export class RequestService extends Disposable implements IRequestService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private proxyUrl?: string;
 	private strictSSL: boolean | undefined;

--- a/src/vs/platform/resource/common/resourceIdentityService.ts
+++ b/src/vs/platform/resource/common/resourceIdentityService.ts
@@ -10,12 +10,12 @@ import { Disposable } from 'vs/base/common/lifecycle';
 
 export const IResourceIdentityService = createDecorator<IResourceIdentityService>('IResourceIdentityService');
 export interface IResourceIdentityService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	resolveResourceIdentity(resource: URI): Promise<string>;
 }
 
 export class WebResourceIdentityService extends Disposable implements IResourceIdentityService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	async resolveResourceIdentity(resource: URI): Promise<string> {
 		return hash(resource.toString()).toString(16);
 	}

--- a/src/vs/platform/resource/node/resourceIdentityServiceImpl.ts
+++ b/src/vs/platform/resource/node/resourceIdentityServiceImpl.ts
@@ -14,7 +14,7 @@ import { ResourceMap } from 'vs/base/common/map';
 
 export class NativeResourceIdentityService extends Disposable implements IResourceIdentityService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly cache: ResourceMap<Promise<string>> = new ResourceMap<Promise<string>>();
 

--- a/src/vs/platform/sign/browser/signService.ts
+++ b/src/vs/platform/sign/browser/signService.ts
@@ -7,7 +7,7 @@ import { ISignService } from 'vs/platform/sign/common/sign';
 
 export class SignService implements ISignService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _tkn: string | null;
 

--- a/src/vs/platform/sign/common/sign.ts
+++ b/src/vs/platform/sign/common/sign.ts
@@ -9,7 +9,7 @@ export const SIGN_SERVICE_ID = 'signService';
 export const ISignService = createDecorator<ISignService>(SIGN_SERVICE_ID);
 
 export interface ISignService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	sign(value: string): Promise<string>;
 }

--- a/src/vs/platform/sign/node/signService.ts
+++ b/src/vs/platform/sign/node/signService.ts
@@ -13,7 +13,7 @@ declare module vsda {
 }
 
 export class SignService implements ISignService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private vsda(): Promise<typeof vsda> {
 		return new Promise((resolve, reject) => require(['vsda'], resolve, reject));

--- a/src/vs/platform/state/node/state.ts
+++ b/src/vs/platform/state/node/state.ts
@@ -8,7 +8,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const IStateService = createDecorator<IStateService>('stateService');
 
 export interface IStateService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getItem<T>(key: string, defaultValue: T): T;
 	getItem<T>(key: string, defaultValue?: T): T | undefined;

--- a/src/vs/platform/state/node/stateService.ts
+++ b/src/vs/platform/state/node/stateService.ts
@@ -126,7 +126,7 @@ export class FileStorage {
 
 export class StateService implements IStateService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly STATE_FILE = 'storage.json';
 

--- a/src/vs/platform/storage/browser/storageService.ts
+++ b/src/vs/platform/storage/browser/storageService.ts
@@ -18,7 +18,7 @@ import { assertIsDefined, assertAllDefined } from 'vs/base/common/types';
 
 export class BrowserStorageService extends Disposable implements IStorageService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidChangeStorage = this._register(new Emitter<IWorkspaceStorageChangeEvent>());
 	readonly onDidChangeStorage = this._onDidChangeStorage.event;

--- a/src/vs/platform/storage/common/storage.ts
+++ b/src/vs/platform/storage/common/storage.ts
@@ -22,7 +22,7 @@ export interface IWillSaveStateEvent {
 
 export interface IStorageService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Emitted whenever data is updated or deleted.
@@ -131,7 +131,7 @@ export interface IWorkspaceStorageChangeEvent {
 
 export class InMemoryStorageService extends Disposable implements IStorageService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidChangeStorage = this._register(new Emitter<IWorkspaceStorageChangeEvent>());
 	readonly onDidChangeStorage = this._onDidChangeStorage.event;

--- a/src/vs/platform/storage/node/storageIpc.ts
+++ b/src/vs/platform/storage/node/storageIpc.ts
@@ -164,7 +164,7 @@ export class GlobalStorageDatabaseChannel extends Disposable implements IServerC
 
 export class GlobalStorageDatabaseChannelClient extends Disposable implements IStorageDatabase {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidChangeItemsExternal = this._register(new Emitter<IStorageItemsChangeEvent>());
 	readonly onDidChangeItemsExternal = this._onDidChangeItemsExternal.event;

--- a/src/vs/platform/storage/node/storageMainService.ts
+++ b/src/vs/platform/storage/node/storageMainService.ts
@@ -17,7 +17,7 @@ export const IStorageMainService = createDecorator<IStorageMainService>('storage
 
 export interface IStorageMainService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Emitted whenever data is updated or deleted.
@@ -86,7 +86,7 @@ export interface IStorageChangeEvent {
 
 export class StorageMainService extends Disposable implements IStorageMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly STORAGE_NAME = 'state.vscdb';
 

--- a/src/vs/platform/storage/node/storageService.ts
+++ b/src/vs/platform/storage/node/storageService.ts
@@ -20,7 +20,7 @@ import { RunOnceScheduler, runWhenIdle } from 'vs/base/common/async';
 
 export class NativeStorageService extends Disposable implements IStorageService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly WORKSPACE_STORAGE_NAME = 'state.vscdb';
 	private static readonly WORKSPACE_META_NAME = 'workspace.json';

--- a/src/vs/platform/telemetry/common/telemetry.ts
+++ b/src/vs/platform/telemetry/common/telemetry.ts
@@ -28,7 +28,7 @@ export interface ITelemetryService {
 	 */
 	readonly sendErrorTelemetry: boolean;
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Sends a telemetry event that has been privacy approved.

--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -28,7 +28,7 @@ export class TelemetryService implements ITelemetryService {
 	static readonly IDLE_START_EVENT_NAME = 'UserIdleStart';
 	static readonly IDLE_STOP_EVENT_NAME = 'UserIdleStop';
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _appender: ITelemetryAppender;
 	private _commonProperties: Promise<{ [name: string]: any; }>;

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -12,7 +12,7 @@ import { safeStringify } from 'vs/base/common/objects';
 import { isObject } from 'vs/base/common/types';
 
 export const NullTelemetryService = new class implements ITelemetryService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	readonly sendErrorTelemetry = false;
 
 	publicLog(eventName: string, data?: ITelemetryData) {

--- a/src/vs/platform/telemetry/test/electron-browser/appInsightsAppender.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/appInsightsAppender.test.ts
@@ -28,7 +28,7 @@ class AppInsightsMock extends TelemetryClient {
 }
 
 class TestableLogService extends AbstractLogService implements ILogService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	public logs: string[] = [];
 

--- a/src/vs/platform/theme/common/themeService.ts
+++ b/src/vs/platform/theme/common/themeService.ts
@@ -137,7 +137,7 @@ export interface IThemingParticipant {
 }
 
 export interface IThemeService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getColorTheme(): IColorTheme;
 

--- a/src/vs/platform/theme/electron-main/themeMainService.ts
+++ b/src/vs/platform/theme/electron-main/themeMainService.ts
@@ -18,14 +18,14 @@ const THEME_BG_STORAGE_KEY = 'themeBackground';
 export const IThemeMainService = createDecorator<IThemeMainService>('themeMainService');
 
 export interface IThemeMainService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getBackgroundColor(): string;
 }
 
 export class ThemeMainService implements IThemeMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(@IStateService private stateService: IStateService) {
 		ipc.on('vscode:changeColorTheme', (e: Event, windowId: number, broadcast: string) => {

--- a/src/vs/platform/theme/test/common/testThemeService.ts
+++ b/src/vs/platform/theme/test/common/testThemeService.ts
@@ -45,7 +45,7 @@ export class TestFileIconTheme implements IFileIconTheme {
 
 export class TestThemeService implements IThemeService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	_colorTheme: IColorTheme;
 	_fileIconTheme: IFileIconTheme;
 	_onThemeChange = new Emitter<IColorTheme>();

--- a/src/vs/platform/undoRedo/common/undoRedo.ts
+++ b/src/vs/platform/undoRedo/common/undoRedo.ts
@@ -53,7 +53,7 @@ export interface UriComparisonKeyComputer {
 }
 
 export interface IUndoRedoService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	registerUriComparisonKeyComputer(uriComparisonKeyComputer: UriComparisonKeyComputer): IDisposable;
 

--- a/src/vs/platform/undoRedo/common/undoRedoService.ts
+++ b/src/vs/platform/undoRedo/common/undoRedoService.ts
@@ -346,7 +346,7 @@ class EditStackSnapshot {
 }
 
 export class UndoRedoService implements IUndoRedoService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _editStacks: Map<string, ResourceEditStack>;
 	private readonly _uriComparisonKeyComputers: UriComparisonKeyComputer[];

--- a/src/vs/platform/update/common/update.ts
+++ b/src/vs/platform/update/common/update.ts
@@ -81,7 +81,7 @@ export interface IAutoUpdater extends Event.NodeEventEmitter {
 export const IUpdateService = createDecorator<IUpdateService>('updateService');
 
 export interface IUpdateService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly onStateChange: Event<State>;
 	readonly state: State;

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -25,7 +25,7 @@ export type UpdateNotAvailableClassification = {
 
 export abstract class AbstractUpdateService implements IUpdateService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	protected url: string | undefined;
 

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -19,7 +19,7 @@ import { IRequestService } from 'vs/platform/request/common/request';
 
 export class DarwinUpdateService extends AbstractUpdateService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly disposables = new DisposableStore();
 

--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -18,7 +18,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 
 export class LinuxUpdateService extends AbstractUpdateService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@ILifecycleMainService lifecycleMainService: ILifecycleMainService,

--- a/src/vs/platform/update/electron-main/updateService.snap.ts
+++ b/src/vs/platform/update/electron-main/updateService.snap.ts
@@ -18,7 +18,7 @@ import { UpdateNotAvailableClassification } from 'vs/platform/update/electron-ma
 
 abstract class AbstractUpdateService2 implements IUpdateService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _state: State = State.Uninitialized;
 
@@ -135,7 +135,7 @@ abstract class AbstractUpdateService2 implements IUpdateService {
 
 export class SnapUpdateService extends AbstractUpdateService2 {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		private snap: string,

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -50,7 +50,7 @@ function getUpdateType(): UpdateType {
 
 export class Win32UpdateService extends AbstractUpdateService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private availableUpdate: IAvailableUpdate | undefined;
 

--- a/src/vs/platform/url/common/url.ts
+++ b/src/vs/platform/url/common/url.ts
@@ -26,7 +26,7 @@ export interface IURLHandler {
 
 export interface IURLService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Create a URL that can be called to trigger IURLhandlers.

--- a/src/vs/platform/url/common/urlService.ts
+++ b/src/vs/platform/url/common/urlService.ts
@@ -12,7 +12,7 @@ import product from 'vs/platform/product/common/product';
 
 export abstract class AbstractURLService extends Disposable implements IURLService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private handlers = new Set<IURLHandler>();
 

--- a/src/vs/platform/userDataSync/common/userDataSync.ts
+++ b/src/vs/platform/userDataSync/common/userDataSync.ts
@@ -160,7 +160,7 @@ export interface IResourceRefHandle {
 export const IUserDataSyncStoreService = createDecorator<IUserDataSyncStoreService>('IUserDataSyncStoreService');
 export type ServerResource = SyncResource | 'machines';
 export interface IUserDataSyncStoreService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	readonly userDataSyncStore: IUserDataSyncStore | undefined;
 	read(resource: ServerResource, oldValue: IUserData | null): Promise<IUserData>;
 	write(resource: ServerResource, content: string, ref: string | null): Promise<string>;
@@ -173,7 +173,7 @@ export interface IUserDataSyncStoreService {
 
 export const IUserDataSyncBackupStoreService = createDecorator<IUserDataSyncBackupStoreService>('IUserDataSyncBackupStoreService');
 export interface IUserDataSyncBackupStoreService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	backup(resource: SyncResource, content: string): Promise<void>;
 	getAllRefs(resource: SyncResource): Promise<IResourceRefHandle[]>;
 	resolveContent(resource: SyncResource, ref?: string): Promise<string | null>;
@@ -367,7 +367,7 @@ export interface IUserDataAutoSyncService {
 
 export const IUserDataSyncUtilService = createDecorator<IUserDataSyncUtilService>('IUserDataSyncUtilService');
 export interface IUserDataSyncUtilService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	resolveUserBindings(userbindings: string[]): Promise<IStringDictionary<string>>;
 	resolveFormattingOptions(resource: URI): Promise<FormattingOptions>;
 	resolveDefaultIgnoredSettings(): Promise<string[]>;

--- a/src/vs/platform/userDataSync/common/userDataSyncIpc.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncIpc.ts
@@ -101,7 +101,7 @@ export class UserDataSycnUtilServiceChannel implements IServerChannel {
 
 export class UserDataSyncUtilServiceClient implements IUserDataSyncUtilService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private readonly channel: IChannel) {
 	}
@@ -142,7 +142,7 @@ export class StorageKeysSyncRegistryChannel implements IServerChannel {
 
 export class StorageKeysSyncRegistryChannelClient extends Disposable implements IStorageKeysSyncRegistryService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _storageKeys: ReadonlyArray<IStorageKey> = [];
 	get storageKeys(): ReadonlyArray<IStorageKey> { return this._storageKeys; }

--- a/src/vs/platform/userDataSync/common/userDataSyncLog.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncLog.ts
@@ -9,7 +9,7 @@ import { IEnvironmentService } from 'vs/platform/environment/common/environment'
 
 export class UserDataSyncLogService extends AbstractLogService implements IUserDataSyncLogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	private readonly logger: ILogger;
 
 	constructor(

--- a/src/vs/platform/webview/electron-main/webviewMainService.ts
+++ b/src/vs/platform/webview/electron-main/webviewMainService.ts
@@ -11,7 +11,7 @@ import { UriComponents, URI } from 'vs/base/common/uri';
 
 export class WebviewMainService implements IWebviewManagerService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private protocolProvider: WebviewProtocolProvider;
 

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -99,7 +99,7 @@ export interface IWindowsCountChangedEvent {
 
 export interface IWindowsMainService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly onWindowReady: Event<ICodeWindow>;
 	readonly onWindowsCountChanged: Event<IWindowsCountChangedEvent>;

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -152,7 +152,7 @@ interface IWorkspacePathToOpen {
 
 export class WindowsMainService extends Disposable implements IWindowsMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly windowsStateStorageKey = 'windowsState';
 

--- a/src/vs/platform/workspace/common/workspace.ts
+++ b/src/vs/platform/workspace/common/workspace.ts
@@ -14,7 +14,7 @@ import { IWorkspaceFolderProvider } from 'vs/base/common/labels';
 export const IWorkspaceContextService = createDecorator<IWorkspaceContextService>('contextService');
 
 export interface IWorkspaceContextService extends IWorkspaceFolderProvider {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * An event which fires on workbench state changes.

--- a/src/vs/platform/workspaces/common/workspaces.ts
+++ b/src/vs/platform/workspaces/common/workspaces.ts
@@ -29,7 +29,7 @@ export const IWorkspacesService = createDecorator<IWorkspacesService>('workspace
 
 export interface IWorkspacesService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	// Workspaces Management
 	enterWorkspace(path: URI): Promise<IEnterWorkspaceResult | null>;

--- a/src/vs/platform/workspaces/electron-main/workspacesHistoryMainService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesHistoryMainService.ts
@@ -30,7 +30,7 @@ export const IWorkspacesHistoryMainService = createDecorator<IWorkspacesHistoryM
 
 export interface IWorkspacesHistoryMainService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly onRecentlyOpenedChange: CommonEvent<void>;
 
@@ -57,7 +57,7 @@ export class WorkspacesHistoryMainService extends Disposable implements IWorkspa
 
 	private static readonly recentlyOpenedStorageKey = 'openedPathsList';
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onRecentlyOpenedChange = new Emitter<void>();
 	readonly onRecentlyOpenedChange: CommonEvent<void> = this._onRecentlyOpenedChange.event;

--- a/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
@@ -38,7 +38,7 @@ export interface IWorkspaceEnteredEvent {
 
 export interface IWorkspacesMainService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly onUntitledWorkspaceDeleted: Event<IWorkspaceIdentifier>;
 	readonly onWorkspaceEntered: Event<IWorkspaceEnteredEvent>;
@@ -65,7 +65,7 @@ export interface IStoredWorkspace {
 
 export class WorkspacesMainService extends Disposable implements IWorkspacesMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly untitledWorkspacesHome: URI; // local URI that contains all untitled workspaces
 

--- a/src/vs/platform/workspaces/electron-main/workspacesService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesService.ts
@@ -13,7 +13,7 @@ import { IBackupMainService } from 'vs/platform/backup/electron-main/backup';
 
 export class WorkspacesService implements AddFirstParameterToFunctions<IWorkspacesService, Promise<unknown> /* only methods, not events */, number /* window ID */> {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IWorkspacesMainService private readonly workspacesMainService: IWorkspacesMainService,

--- a/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
+++ b/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
@@ -24,7 +24,7 @@ import { IBackupMainService, IWorkspaceBackupInfo } from 'vs/platform/backup/ele
 import { IEmptyWindowBackupInfo } from 'vs/platform/backup/node/backup';
 
 export class TestDialogMainService implements IDialogMainService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	pickFileFolder(options: INativeOpenDialogOptions, window?: Electron.BrowserWindow | undefined): Promise<string[] | undefined> {
 		throw new Error('Method not implemented.');
@@ -57,7 +57,7 @@ export class TestDialogMainService implements IDialogMainService {
 
 export class TestBackupMainService implements IBackupMainService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	isHotExitEnabled(): boolean {
 		throw new Error('Method not implemented.');

--- a/src/vs/workbench/api/common/extHostApiDeprecationService.ts
+++ b/src/vs/workbench/api/common/extHostApiDeprecationService.ts
@@ -10,7 +10,7 @@ import * as extHostProtocol from 'vs/workbench/api/common/extHost.protocol';
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
 
 export interface IExtHostApiDeprecationService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	report(apiId: string, extension: IExtensionDescription, migrationSuggestion: string): void;
 }
@@ -19,7 +19,7 @@ export const IExtHostApiDeprecationService = createDecorator<IExtHostApiDeprecat
 
 export class ExtHostApiDeprecationService implements IExtHostApiDeprecationService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _reportedUsages = new Set<string>();
 	private readonly _telemetryShape: extHostProtocol.MainThreadTelemetryShape;
@@ -63,7 +63,7 @@ export class ExtHostApiDeprecationService implements IExtHostApiDeprecationServi
 
 
 export const NullApiDeprecationService = Object.freeze(new class implements IExtHostApiDeprecationService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	public report(_apiId: string, _extension: IExtensionDescription, _warningMessage: string): void {
 		// noop

--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -48,7 +48,7 @@ interface INewTestRunner {
 export const IHostUtils = createDecorator<IHostUtils>('IHostUtils');
 
 export interface IHostUtils {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	exit(code?: number): void;
 	exists(path: string): Promise<boolean>;
 	realpath(path: string): Promise<string>;
@@ -824,7 +824,7 @@ function getTelemetryActivationEvent(extensionDescription: IExtensionDescription
 export const IExtHostExtensionService = createDecorator<IExtHostExtensionService>('IExtHostExtensionService');
 
 export interface IExtHostExtensionService extends AbstractExtHostExtensionService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	initialize(): Promise<void>;
 	isActivated(extensionId: ExtensionIdentifier): boolean;
 	activateByIdWithErrors(extensionId: ExtensionIdentifier, reason: ExtensionActivationReason): Promise<void>;

--- a/src/vs/workbench/api/common/extHostInitDataService.ts
+++ b/src/vs/workbench/api/common/extHostInitDataService.ts
@@ -9,6 +9,6 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const IExtHostInitDataService = createDecorator<IExtHostInitDataService>('IExtHostInitDataService');
 
 export interface IExtHostInitDataService extends Readonly<IInitData> {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 }
 

--- a/src/vs/workbench/api/common/extHostRpcService.ts
+++ b/src/vs/workbench/api/common/extHostRpcService.ts
@@ -9,7 +9,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const IExtHostRpcService = createDecorator<IExtHostRpcService>('IExtHostRpcService');
 
 export interface IExtHostRpcService extends IRPCProtocol {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 }
 
 export class ExtHostRpcService implements IExtHostRpcService {

--- a/src/vs/workbench/api/common/extHostStoragePaths.ts
+++ b/src/vs/workbench/api/common/extHostStoragePaths.ts
@@ -9,7 +9,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const IExtensionStoragePaths = createDecorator<IExtensionStoragePaths>('IExtensionStoragePaths');
 
 export interface IExtensionStoragePaths {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	whenReady: Promise<any>;
 	workspaceValue(extension: IExtensionDescription): string | undefined;
 	globalValue(extension: IExtensionDescription): string;

--- a/src/vs/workbench/api/common/extHostTerminalService.ts
+++ b/src/vs/workbench/api/common/extHostTerminalService.ts
@@ -20,7 +20,7 @@ import { ISerializableEnvironmentVariableCollection } from 'vs/workbench/contrib
 
 export interface IExtHostTerminalService extends ExtHostTerminalServiceShape {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	activeTerminal: vscode.Terminal | undefined;
 	terminals: vscode.Terminal[];

--- a/src/vs/workbench/api/common/extHostTimeline.ts
+++ b/src/vs/workbench/api/common/extHostTimeline.ts
@@ -22,7 +22,7 @@ export interface IExtHostTimeline extends ExtHostTimelineShape {
 export const IExtHostTimeline = createDecorator<IExtHostTimeline>('IExtHostTimeline');
 
 export class ExtHostTimeline implements IExtHostTimeline {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _proxy: MainThreadTimelineShape;
 

--- a/src/vs/workbench/api/common/extHostTunnelService.ts
+++ b/src/vs/workbench/api/common/extHostTunnelService.ts
@@ -41,7 +41,7 @@ export interface IExtHostTunnelService extends ExtHostTunnelServiceShape {
 export const IExtHostTunnelService = createDecorator<IExtHostTunnelService>('IExtHostTunnelService');
 
 export class ExtHostTunnelService implements IExtHostTunnelService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	onDidChangeTunnels: vscode.Event<void> = (new Emitter<void>()).event;
 	private readonly _proxy: MainThreadTunnelServiceShape;
 

--- a/src/vs/workbench/api/common/extHostUriTransformerService.ts
+++ b/src/vs/workbench/api/common/extHostUriTransformerService.ts
@@ -8,13 +8,13 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 import { URI, UriComponents } from 'vs/base/common/uri';
 
 export interface IURITransformerService extends IURITransformer {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 }
 
 export const IURITransformerService = createDecorator<IURITransformerService>('IURITransformerService');
 
 export class URITransformerService implements IURITransformerService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	transformIncoming: (uri: UriComponents) => UriComponents;
 	transformOutgoing: (uri: UriComponents) => UriComponents;

--- a/src/vs/workbench/api/worker/extHostLogService.ts
+++ b/src/vs/workbench/api/worker/extHostLogService.ts
@@ -11,7 +11,7 @@ import { UriComponents } from 'vs/base/common/uri';
 
 export class ExtHostLogService extends AbstractLogService implements ILogService, ExtHostLogServiceShape {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _proxy: MainThreadLogShape;
 	private readonly _logFile: UriComponents;

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -104,7 +104,7 @@ interface SideBarActivityState {
 
 export abstract class Layout extends Disposable implements IWorkbenchLayoutService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	//#region Events
 

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -69,7 +69,7 @@ interface ICachedViewContainer {
 
 export class ActivitybarPart extends Part implements IActivityBarService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly ACTION_HEIGHT = 48;
 	static readonly PINNED_VIEW_CONTAINERS = 'workbench.activity.pinnedViewlets2';

--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -19,7 +19,7 @@ export const IBreadcrumbsService = createDecorator<IBreadcrumbsService>('IEditor
 
 export interface IBreadcrumbsService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	register(group: GroupIdentifier, widget: BreadcrumbsWidget): IDisposable;
 
@@ -29,7 +29,7 @@ export interface IBreadcrumbsService {
 
 export class BreadcrumbsService implements IBreadcrumbsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _map = new Map<number, BreadcrumbsWidget>();
 

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -82,7 +82,7 @@ class GridWidgetView<T extends IView> implements IView {
 
 export class EditorPart extends Part implements IEditorGroupsService, IEditorGroupsAccessor {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly EDITOR_PART_UI_STATE_STORAGE_KEY = 'editorpart.state';
 	private static readonly EDITOR_PART_CENTERED_VIEW_STORAGE_KEY = 'editorpart.centeredview';

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -63,7 +63,7 @@ export class PanelPart extends CompositePart<Panel> implements IPanelService {
 	static readonly PLACEHOLDER_VIEW_CONTAINERS = 'workbench.panel.placeholderPanels';
 	private static readonly MIN_COMPOSITE_BAR_WIDTH = 50;
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	//#region IView
 

--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -38,7 +38,7 @@ import { IViewDescriptorService, ViewContainerLocation } from 'vs/workbench/comm
 
 export class SidebarPart extends CompositePart<Viewlet> implements IViewletService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	static readonly activeViewletSettingsKey = 'workbench.sidebar.activeviewletid';
 

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -373,7 +373,7 @@ class HideStatusbarEntryAction extends Action {
 
 export class StatusbarPart extends Part implements IStatusbarService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	//#region IView
 

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -60,7 +60,7 @@ export class TitlebarPart extends Part implements ITitleService {
 	private _onMenubarVisibilityChange = this._register(new Emitter<boolean>());
 	readonly onMenubarVisibilityChange = this._onMenubarVisibilityChange.event;
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	protected title!: HTMLElement;
 	protected customMenubar: CustomMenubarControl | undefined;

--- a/src/vs/workbench/browser/parts/views/viewsService.ts
+++ b/src/vs/workbench/browser/parts/views/viewsService.ts
@@ -34,7 +34,7 @@ import { IProgressIndicator } from 'vs/platform/progress/common/progress';
 
 export class ViewsService extends Disposable implements IViewsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly viewDisposable: Map<IViewDescriptor, IDisposable>;
 	private readonly viewPaneContainers: Map<string, { viewPaneContainer: ViewPaneContainer, disposable: IDisposable }>;

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -473,7 +473,7 @@ export interface IView {
 export const IViewsService = createDecorator<IViewsService>('viewsService');
 export interface IViewsService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	// View Container APIs
 	readonly onDidChangeViewContainerVisibility: Event<{ id: string, visible: boolean, location: ViewContainerLocation }>;
@@ -501,7 +501,7 @@ export const IViewDescriptorService = createDecorator<IViewDescriptorService>('v
 
 export interface IViewDescriptorService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	// ViewContainers
 	readonly viewContainers: ReadonlyArray<ViewContainer>;

--- a/src/vs/workbench/contrib/comments/browser/commentService.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentService.ts
@@ -33,7 +33,7 @@ export interface IWorkspaceCommentThreadsEvent {
 }
 
 export interface ICommentService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	readonly onDidSetResourceCommentInfos: Event<IResourceCommentThreadEvent>;
 	readonly onDidSetAllCommentThreads: Event<IWorkspaceCommentThreadsEvent>;
 	readonly onDidUpdateCommentThreads: Event<ICommentThreadChangedEvent>;
@@ -60,7 +60,7 @@ export interface ICommentService {
 }
 
 export class CommentService extends Disposable implements ICommentService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidSetDataProvider: Emitter<void> = this._register(new Emitter<void>());
 	readonly onDidSetDataProvider: Event<void> = this._onDidSetDataProvider.event;

--- a/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
@@ -41,7 +41,7 @@ import { IEditorOptions, EditorOption } from 'vs/editor/common/config/editorOpti
 const $ = dom.$;
 const IPrivateBreakpointWidgetService = createDecorator<IPrivateBreakpointWidgetService>('privateBreakpointWidgetService');
 export interface IPrivateBreakpointWidgetService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	close(success: boolean): void;
 }
 const DECORATION_KEY = 'breakpointwidgetdecoration';
@@ -75,7 +75,7 @@ function createDecorations(theme: IColorTheme, placeHolder: string): IDecoration
 }
 
 export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWidgetService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private selectContainer!: HTMLElement;
 	private inputContainer!: HTMLElement;

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -48,7 +48,7 @@ import { DebugTelemetry } from 'vs/workbench/contrib/debug/common/debugTelemetry
 import { DebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debugCompoundRoot';
 
 export class DebugService implements IDebugService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidChangeState: Emitter<State>;
 	private readonly _onDidNewSession: Emitter<IDebugSession>;

--- a/src/vs/workbench/contrib/debug/browser/extensionHostDebugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/extensionHostDebugService.ts
@@ -127,7 +127,7 @@ registerSingleton(IExtensionHostDebugService, BrowserExtensionHostDebugService);
 
 class BrowserDebugHelperService implements IDebugHelperService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	createTelemetryService(configurationService: IConfigurationService, args: string[]): TelemetryService | undefined {
 		return undefined;

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -74,7 +74,7 @@ function revealLastElement(tree: WorkbenchAsyncDataTree<any, any, any>) {
 const sessionsToIgnore = new Set<IDebugSession>();
 
 export class Repl extends ViewPane implements IHistoryNavigationWidget {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly REFRESH_DELAY = 100; // delay in ms to refresh the repl for new elements to show
 	private static readonly URI = uri.parse(`${DEBUG_SCHEME}:replinput`);

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -731,7 +731,7 @@ export interface ILaunch {
 export const IDebugService = createDecorator<IDebugService>(DEBUG_SERVICE_ID);
 
 export interface IDebugService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Gets the current debug state.
@@ -909,7 +909,7 @@ export const DEBUG_HELPER_SERVICE_ID = 'debugHelperService';
 export const IDebugHelperService = createDecorator<IDebugHelperService>(DEBUG_HELPER_SERVICE_ID);
 
 export interface IDebugHelperService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	createTelemetryService(configurationService: IConfigurationService, args: string[]): TelemetryService | undefined;
 }

--- a/src/vs/workbench/contrib/debug/node/debugHelperService.ts
+++ b/src/vs/workbench/contrib/debug/node/debugHelperService.ts
@@ -14,7 +14,7 @@ import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/
 import { cleanRemoteAuthority } from 'vs/platform/telemetry/common/telemetryUtils';
 
 export class NodeDebugHelperService implements IDebugHelperService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,

--- a/src/vs/workbench/contrib/experiments/common/experimentService.ts
+++ b/src/vs/workbench/contrib/experiments/common/experimentService.ts
@@ -70,7 +70,7 @@ export interface IExperiment {
 }
 
 export interface IExperimentService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	getExperimentById(id: string): Promise<IExperiment>;
 	getExperimentsByType(type: ExperimentActionType): Promise<IExperiment[]>;
 	getCuratedExtensionsList(curatedExtensionsKey: string): Promise<string[]>;
@@ -163,7 +163,7 @@ export const getCurrentActivationRecord = (previous?: IActivationEventRecord, da
 };
 
 export class ExperimentService extends Disposable implements IExperimentService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	private _experiments: IExperiment[] = [];
 	private _loadExperimentsPromise: Promise<void>;
 	private _curatedMapping = Object.create(null);

--- a/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
@@ -35,7 +35,7 @@ const ignoredRecommendationsStorageKey = 'extensionsAssistant/ignored_recommenda
 
 export class ExtensionRecommendationsService extends Disposable implements IExtensionRecommendationsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	// Recommendations
 	private readonly fileBasedRecommendations: FileBasedRecommendations;

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -476,7 +476,7 @@ class Extensions extends Disposable {
 export class ExtensionsWorkbenchService extends Disposable implements IExtensionsWorkbenchService, IURLHandler {
 
 	private static readonly SyncPeriod = 1000 * 60 * 60 * 12; // 12 hours
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly localExtensions: Extensions | null = null;
 	private readonly remoteExtensions: Extensions | null = null;

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -71,7 +71,7 @@ export const SERVICE_ID = 'extensionsWorkbenchService';
 export const IExtensionsWorkbenchService = createDecorator<IExtensionsWorkbenchService>(SERVICE_ID);
 
 export interface IExtensionsWorkbenchService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	onChange: Event<IExtension | undefined>;
 	local: IExtension[];
 	installed: IExtension[];

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionProfileService.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionProfileService.ts
@@ -23,7 +23,7 @@ import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 
 export class ExtensionHostProfileService extends Disposable implements IExtensionHostProfileService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidChangeState: Emitter<void> = this._register(new Emitter<void>());
 	public readonly onDidChangeState: Event<void> = this._onDidChangeState.event;

--- a/src/vs/workbench/contrib/extensions/electron-browser/runtimeExtensionsEditor.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/runtimeExtensionsEditor.ts
@@ -62,7 +62,7 @@ export enum ProfileSessionState {
 }
 
 export interface IExtensionHostProfileService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly onDidChangeState: Event<void>;
 	readonly onDidChangeLastProfile: Event<void>;

--- a/src/vs/workbench/contrib/externalTerminal/common/externalTerminal.ts
+++ b/src/vs/workbench/contrib/externalTerminal/common/externalTerminal.ts
@@ -14,7 +14,7 @@ export interface IExternalTerminalSettings {
 }
 
 export interface IExternalTerminalService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	openTerminal(path: string): void;
 	runInTerminal(title: string, cwd: string, args: string[], env: { [key: string]: string | null; }, settings: IExternalTerminalSettings): Promise<number | undefined>;
 }

--- a/src/vs/workbench/contrib/files/common/explorerService.ts
+++ b/src/vs/workbench/contrib/files/common/explorerService.ts
@@ -28,7 +28,7 @@ function getFileEventsExcludes(configurationService: IConfigurationService, root
 }
 
 export class ExplorerService implements IExplorerService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly EXPLORER_FILE_CHANGES_REACT_DELAY = 500; // delay in ms to react to file changes to give our internal events a chance to react first
 

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -39,7 +39,7 @@ export const VIEW_ID = 'workbench.explorer.fileView';
 export const DEFAULT_EDITOR_ID = 'default';
 
 export interface IExplorerService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	readonly roots: ExplorerItem[];
 	readonly sortOrder: SortOrder;
 

--- a/src/vs/workbench/contrib/issue/browser/issueService.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueService.ts
@@ -18,12 +18,12 @@ export interface IIssueReporterOptions {
 }
 
 export interface IWebIssueService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	openReporter(options?: IIssueReporterOptions): Promise<void>;
 }
 
 export class WebIssueService implements IWebIssueService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,

--- a/src/vs/workbench/contrib/issue/electron-browser/issue.ts
+++ b/src/vs/workbench/contrib/issue/electron-browser/issue.ts
@@ -9,7 +9,7 @@ import { IssueReporterData } from 'vs/platform/issue/common/issue';
 export const IWorkbenchIssueService = createDecorator<IWorkbenchIssueService>('workbenchIssueService');
 
 export interface IWorkbenchIssueService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	openReporter(dataOverrides?: Partial<IssueReporterData>): Promise<void>;
 	openProcessExplorer(): Promise<void>;
 }

--- a/src/vs/workbench/contrib/issue/electron-browser/issueService.ts
+++ b/src/vs/workbench/contrib/issue/electron-browser/issueService.ts
@@ -18,7 +18,7 @@ import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/enviro
 import { ExtensionType } from 'vs/platform/extensions/common/extensions';
 
 export class WorkbenchIssueService implements IWorkbenchIssueService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IIssueService private readonly issueService: IIssueService,

--- a/src/vs/workbench/contrib/markers/browser/markers.ts
+++ b/src/vs/workbench/contrib/markers/browser/markers.ts
@@ -19,12 +19,12 @@ import { ResourceMap } from 'vs/base/common/map';
 export const IMarkersWorkbenchService = createDecorator<IMarkersWorkbenchService>('markersWorkbenchService');
 
 export interface IMarkersWorkbenchService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	readonly markersModel: MarkersModel;
 }
 
 export class MarkersWorkbenchService extends Disposable implements IMarkersWorkbenchService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	readonly markersModel: MarkersModel;
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
@@ -136,7 +136,7 @@ class ModelData implements IDisposable {
 	}
 }
 export class NotebookService extends Disposable implements INotebookService, ICustomEditorViewTypesHandler {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	private readonly _notebookProviders = new Map<string, { controller: IMainNotebookController, extensionData: NotebookExtensionDescription }>();
 	private readonly _notebookRenderers = new Map<string, INotebookRendererInfo>();
 	private readonly _notebookKernels = new Map<string, INotebookKernelInfo>();

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -28,7 +28,7 @@ export interface IMainNotebookController {
 }
 
 export interface INotebookService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	modelManager: INotebookEditorModelManager;
 	canResolve(viewType: string): Promise<boolean>;
 	onDidChangeActiveEditor: Event<string | null>;

--- a/src/vs/workbench/contrib/output/browser/outputServices.ts
+++ b/src/vs/workbench/contrib/output/browser/outputServices.ts
@@ -56,7 +56,7 @@ class OutputChannel extends Disposable implements IOutputChannel {
 
 export class OutputService extends Disposable implements IOutputService, ITextModelContentProvider {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private channels: Map<string, OutputChannel> = new Map<string, OutputChannel>();
 	private activeChannelIdInStorage: string;

--- a/src/vs/workbench/contrib/output/common/output.ts
+++ b/src/vs/workbench/contrib/output/common/output.ts
@@ -60,7 +60,7 @@ export const IOutputService = createDecorator<IOutputService>(OUTPUT_SERVICE_ID)
  * The output service to manage output from the various processes running.
  */
 export interface IOutputService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Given the channel id returns the output channel instance.

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -33,7 +33,7 @@ export interface IEndpointDetails {
 }
 
 export class PreferencesSearchService extends Disposable implements IPreferencesSearchService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _installedExtensions: Promise<ILocalExtension[]>;
 

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -33,7 +33,7 @@ export interface IEndpointDetails {
 export const IPreferencesSearchService = createDecorator<IPreferencesSearchService>('preferencesSearchService');
 
 export interface IPreferencesSearchService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getLocalSearchProvider(filter: string): ISearchProvider;
 	getRemoteSearchProvider(filter: string, newExtensionsOnly?: boolean): ISearchProvider | undefined;

--- a/src/vs/workbench/contrib/scm/common/scmService.ts
+++ b/src/vs/workbench/contrib/scm/common/scmService.ts
@@ -113,7 +113,7 @@ class SCMRepository implements ISCMRepository {
 
 export class SCMService implements ISCMService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _providerIds = new Set<string>();
 	private _repositories: ISCMRepository[] = [];

--- a/src/vs/workbench/contrib/search/browser/replaceService.ts
+++ b/src/vs/workbench/contrib/search/browser/replaceService.ts
@@ -88,7 +88,7 @@ class ReplacePreviewModel extends Disposable {
 
 export class ReplaceService implements IReplaceService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@ITextFileService private readonly textFileService: ITextFileService,

--- a/src/vs/workbench/contrib/search/common/replace.ts
+++ b/src/vs/workbench/contrib/search/common/replace.ts
@@ -11,7 +11,7 @@ export const IReplaceService = createDecorator<IReplaceService>('replaceService'
 
 export interface IReplaceService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Replaces the given match in the file that match belongs to

--- a/src/vs/workbench/contrib/search/common/searchHistoryService.ts
+++ b/src/vs/workbench/contrib/search/common/searchHistoryService.ts
@@ -9,7 +9,7 @@ import { isEmptyObject } from 'vs/base/common/types';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
 export interface ISearchHistoryService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	onDidClearHistory: Event<void>;
 	clearHistory(): void;
 	load(): ISearchHistoryValues;
@@ -26,7 +26,7 @@ export interface ISearchHistoryValues {
 }
 
 export class SearchHistoryService implements ISearchHistoryService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly SEARCH_HISTORY_KEY = 'workbench.search.history';
 

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -1181,7 +1181,7 @@ export type RenderableMatch = FolderMatch | FolderMatchWithResource | FileMatch 
 
 export class SearchWorkbenchService implements ISearchWorkbenchService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	private _searchModel: SearchModel | null = null;
 
 	constructor(@IInstantiationService private readonly instantiationService: IInstantiationService) {
@@ -1198,7 +1198,7 @@ export class SearchWorkbenchService implements ISearchWorkbenchService {
 export const ISearchWorkbenchService = createDecorator<ISearchWorkbenchService>('searchWorkbenchService');
 
 export interface ISearchWorkbenchService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly searchModel: SearchModel;
 }

--- a/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
@@ -15,7 +15,7 @@ export const ISnippetsService = createDecorator<ISnippetsService>('snippetServic
 
 export interface ISnippetsService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getSnippetFiles(): Promise<Iterable<SnippetFile>>;
 

--- a/src/vs/workbench/contrib/snippets/test/browser/snippetsService.test.ts
+++ b/src/vs/workbench/contrib/snippets/test/browser/snippetsService.test.ts
@@ -15,7 +15,7 @@ import { LanguageConfigurationRegistry } from 'vs/editor/common/modes/languageCo
 import { CompletionContext, CompletionTriggerKind } from 'vs/editor/common/modes';
 
 class SimpleSnippetService implements ISnippetsService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	constructor(readonly snippets: Snippet[]) {
 	}
 	getSnippets() {

--- a/src/vs/workbench/contrib/tags/browser/workspaceTagsService.ts
+++ b/src/vs/workbench/contrib/tags/browser/workspaceTagsService.ts
@@ -10,7 +10,7 @@ import { IWorkspaceTagsService, Tags } from 'vs/workbench/contrib/tags/common/wo
 
 export class NoOpWorkspaceTagsService implements IWorkspaceTagsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	getTags(): Promise<Tags> {
 		return Promise.resolve({});

--- a/src/vs/workbench/contrib/tags/common/workspaceTags.ts
+++ b/src/vs/workbench/contrib/tags/common/workspaceTags.ts
@@ -12,7 +12,7 @@ export type Tags = { [index: string]: boolean | number | string | undefined };
 export const IWorkspaceTagsService = createDecorator<IWorkspaceTagsService>('workspaceTagsService');
 
 export interface IWorkspaceTagsService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getTags(): Promise<Tags>;
 

--- a/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
+++ b/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
@@ -92,7 +92,7 @@ const PyModulesToLookFor = [
 ];
 
 export class WorkspaceTagsService implements IWorkspaceTagsService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	private _tags: Tags | undefined;
 
 	constructor(

--- a/src/vs/workbench/contrib/tasks/common/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskService.ts
@@ -53,7 +53,7 @@ export interface WorkspaceFolderTaskResult extends WorkspaceTaskResult {
 export const USER_TASKS_GROUP_KEY = 'settings';
 
 export interface ITaskService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	onDidStateChange: Event<TaskEvent>;
 	supportsMultipleTaskExecutions: boolean;
 

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -24,7 +24,7 @@ export const ITerminalInstanceService = createDecorator<ITerminalInstanceService
  * dependency on ITerminalService.
  */
 export interface ITerminalInstanceService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	// These events are optional as the requests they make are only needed on the browser side
 	onRequestDefaultShellAndArgs?: Event<IDefaultShellAndArgsRequest>;
@@ -70,7 +70,7 @@ export interface ITerminalTab {
 }
 
 export interface ITerminalService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	activeTabIndex: number;
 	configHelper: ITerminalConfigHelper;

--- a/src/vs/workbench/contrib/terminal/common/environmentVariable.ts
+++ b/src/vs/workbench/contrib/terminal/common/environmentVariable.ts
@@ -61,7 +61,7 @@ export interface IMergedEnvironmentVariableCollection {
  * Tracks and persists environment variable collections as defined by extensions.
  */
 export interface IEnvironmentVariableService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Gets a single collection constructed by merging all environment variable collections into

--- a/src/vs/workbench/contrib/terminal/common/environmentVariableService.ts
+++ b/src/vs/workbench/contrib/terminal/common/environmentVariableService.ts
@@ -22,7 +22,7 @@ interface ISerializableExtensionEnvironmentVariableCollection {
  * Tracks and persists environment variable collections as defined by extensions.
  */
 export class EnvironmentVariableService implements IEnvironmentVariableService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	collections: Map<string, IEnvironmentVariableCollectionWithPersistence> = new Map();
 	mergedCollection: IMergedEnvironmentVariableCollection;

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -237,7 +237,7 @@ export interface IShellLaunchConfig {
  * Provides access to native or electron APIs to other terminal services.
  */
 export interface ITerminalNativeService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly linuxDistro: LinuxDistro;
 

--- a/src/vs/workbench/contrib/terminal/test/browser/links/terminalLinkManager.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/links/terminalLinkManager.test.ts
@@ -37,7 +37,7 @@ class MockTerminalInstanceService implements ITerminalInstanceService {
 	getDefaultShellAndArgs(): Promise<{ shell: string; args: string | string[] | undefined; }> {
 		throw new Error('Method not implemented.');
 	}
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	getXtermConstructor(): Promise<any> {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/contrib/timeline/common/timelineService.ts
+++ b/src/vs/workbench/contrib/timeline/common/timelineService.ts
@@ -13,7 +13,7 @@ import { ITimelineService, TimelineChangeEvent, TimelineOptions, TimelineProvide
 import { IViewsService } from 'vs/workbench/common/views';
 
 export class TimelineService implements ITimelineService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidChangeProviders = new Emitter<TimelineProvidersChangeEvent>();
 	readonly onDidChangeProviders: Event<TimelineProvidersChangeEvent> = this._onDidChangeProviders.event;

--- a/src/vs/workbench/contrib/userDataSync/electron-browser/userDataAutoSyncService.ts
+++ b/src/vs/workbench/contrib/userDataSync/electron-browser/userDataAutoSyncService.ts
@@ -13,7 +13,7 @@ import { UserDataSyncTrigger } from 'vs/workbench/contrib/userDataSync/browser/u
 
 export class UserDataAutoSyncService extends Disposable implements IUserDataAutoSyncService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly channel: IChannel;
 	get onError(): Event<UserDataSyncError> { return Event.map(this.channel.listen<Error>('onError'), e => UserDataSyncError.toUserDataSyncError(e)); }

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -34,7 +34,7 @@ export interface WebviewIcons {
  * Handles the creation of webview elements.
  */
 export interface IWebviewService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	createWebviewElement(
 		id: string,

--- a/src/vs/workbench/contrib/webview/browser/webviewService.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewService.ts
@@ -12,7 +12,7 @@ import { DynamicWebviewEditorOverlay } from './dynamicWebviewEditorOverlay';
 import { WebviewIconManager } from './webviewIconManager';
 
 export class WebviewService implements IWebviewService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _webviewThemeDataProvider: WebviewThemeDataProvider;
 	private readonly _iconManager: WebviewIconManager;

--- a/src/vs/workbench/contrib/webview/browser/webviewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewWorkbenchService.ts
@@ -46,7 +46,7 @@ export function areWebviewInputOptionsEqual(a: WebviewInputOptions, b: WebviewIn
 }
 
 export interface IWebviewWorkbenchService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	createWebview(
 		id: string,
@@ -173,7 +173,7 @@ class RevivalPool {
 
 
 export class WebviewEditorService implements IWebviewWorkbenchService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _revivers = new Set<WebviewResolver>();
 	private readonly _revivalPool = new RevivalPool();

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewService.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewService.ts
@@ -13,7 +13,7 @@ import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/common/th
 import { ElectronWebviewBasedWebview } from 'vs/workbench/contrib/webview/electron-browser/webviewElement';
 
 export class ElectronWebviewService implements IWebviewService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _webviewThemeDataProvider: WebviewThemeDataProvider;
 	private readonly _iconManager: WebviewIconManager;

--- a/src/vs/workbench/services/accessibility/electron-browser/accessibilityService.ts
+++ b/src/vs/workbench/services/accessibility/electron-browser/accessibilityService.ts
@@ -27,7 +27,7 @@ type AccessibilityMetricsClassification = {
 
 export class NativeAccessibilityService extends AccessibilityService implements IAccessibilityService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private didSendTelemetry = false;
 

--- a/src/vs/workbench/services/activity/common/activity.ts
+++ b/src/vs/workbench/services/activity/common/activity.ts
@@ -18,7 +18,7 @@ export const IActivityService = createDecorator<IActivityService>('activityServi
 
 export interface IActivityService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Show activity for the given view container

--- a/src/vs/workbench/services/activityBar/browser/activityBarService.ts
+++ b/src/vs/workbench/services/activityBar/browser/activityBarService.ts
@@ -10,7 +10,7 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 export const IActivityBarService = createDecorator<IActivityBarService>('activityBarService');
 
 export interface IActivityBarService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Show an activity in a viewlet.

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -19,7 +19,7 @@ import { IStorageService, StorageScope } from 'vs/platform/storage/common/storag
 export const IAuthenticationService = createDecorator<IAuthenticationService>('IAuthenticationService');
 
 export interface IAuthenticationService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	isAuthenticationProviderRegistered(id: string): boolean;
 	getProviderIds(): string[];
@@ -66,7 +66,7 @@ export interface SessionRequestInfo {
 }
 
 export class AuthenticationService extends Disposable implements IAuthenticationService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	private _placeholderMenuItem: IDisposable | undefined;
 	private _noAccountsMenuItem: IDisposable | undefined;
 	private _signInRequestItems = new Map<string, SessionRequestInfo>();

--- a/src/vs/workbench/services/authentication/electron-browser/authenticationTokenService.ts
+++ b/src/vs/workbench/services/authentication/electron-browser/authenticationTokenService.ts
@@ -12,7 +12,7 @@ import { IAuthenticationTokenService, IUserDataSyncAuthToken } from 'vs/platform
 
 export class AuthenticationTokenService extends Disposable implements IAuthenticationTokenService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly channel: IChannel;
 

--- a/src/vs/workbench/services/backup/common/backup.ts
+++ b/src/vs/workbench/services/backup/common/backup.ts
@@ -19,7 +19,7 @@ export interface IResolvedBackup<T extends object> {
  */
 export interface IBackupFileService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Finds out if there are any backups stored.

--- a/src/vs/workbench/services/backup/common/backupFileService.ts
+++ b/src/vs/workbench/services/backup/common/backupFileService.ts
@@ -109,7 +109,7 @@ export class BackupFilesModel implements IBackupFilesModel {
 
 export class BackupFileService implements IBackupFileService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private impl: BackupFileServiceImpl | InMemoryBackupFileService;
 
@@ -188,7 +188,7 @@ class BackupFileServiceImpl extends Disposable implements IBackupFileService {
 	private static readonly PREAMBLE_META_SEPARATOR = ' '; // using a character that is know to be escaped in a URI as separator
 	private static readonly PREAMBLE_MAX_LENGTH = 10000;
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private backupWorkspacePath!: URI;
 
@@ -403,7 +403,7 @@ class BackupFileServiceImpl extends Disposable implements IBackupFileService {
 
 export class InMemoryBackupFileService implements IBackupFileService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private backups: Map<string, ITextSnapshot> = new Map();
 

--- a/src/vs/workbench/services/bulkEdit/browser/bulkEditService.ts
+++ b/src/vs/workbench/services/bulkEdit/browser/bulkEditService.ts
@@ -383,7 +383,7 @@ class BulkEdit {
 
 export class BulkEditService implements IBulkEditService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _previewHandler?: IBulkEditPreviewHandler;
 

--- a/src/vs/workbench/services/clipboard/electron-browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/electron-browser/clipboardService.ts
@@ -14,7 +14,7 @@ export class NativeClipboardService implements IClipboardService {
 
 	private static readonly FILE_FORMAT = 'code/file-list'; // Clipboard format for files
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IElectronService private readonly electronService: IElectronService

--- a/src/vs/workbench/services/commands/common/commandService.ts
+++ b/src/vs/workbench/services/commands/common/commandService.ts
@@ -14,7 +14,7 @@ import { timeout } from 'vs/base/common/async';
 
 export class CommandService extends Disposable implements ICommandService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _extensionHostIsReady: boolean = false;
 	private _starActivation: Promise<void> | null;

--- a/src/vs/workbench/services/configuration/common/jsonEditing.ts
+++ b/src/vs/workbench/services/configuration/common/jsonEditing.ts
@@ -34,7 +34,7 @@ export interface IJSONValue {
 
 export interface IJSONEditingService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	write(resource: URI, values: IJSONValue[], save: boolean): Promise<void>;
 }

--- a/src/vs/workbench/services/configurationResolver/common/configurationResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/configurationResolver.ts
@@ -11,7 +11,7 @@ import { ConfigurationTarget } from 'vs/platform/configuration/common/configurat
 export const IConfigurationResolverService = createDecorator<IConfigurationResolverService>('configurationResolverService');
 
 export interface IConfigurationResolverService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	resolve(folder: IWorkspaceFolder | undefined, value: string): string;
 	resolve(folder: IWorkspaceFolder | undefined, value: string[]): string[];

--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -30,7 +30,7 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 	static readonly VARIABLE_REGEXP = /\$\{(.*?)\}/g;
 	static readonly VARIABLE_REGEXP_SINGLE = /\$\{(.*?)\}/;
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _context: IVariableResolveContext;
 	private _envVariables?: IProcessEnvironment;

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -591,7 +591,7 @@ class MockCommandService implements ICommandService {
 }
 
 class MockQuickInputService implements IQuickInputService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	readonly onShow = Event.None;
 	readonly onHide = Event.None;

--- a/src/vs/workbench/services/contextmenu/electron-sandbox/contextmenuService.ts
+++ b/src/vs/workbench/services/contextmenu/electron-sandbox/contextmenuService.ts
@@ -29,7 +29,7 @@ import { stripCodicons } from 'vs/base/common/codicons';
 
 export class ContextMenuService extends Disposable implements IContextMenuService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	get onDidContextMenu(): Event<void> { return this.impl.onDidContextMenu; }
 
@@ -64,7 +64,7 @@ export class ContextMenuService extends Disposable implements IContextMenuServic
 
 class NativeContextMenuService extends Disposable implements IContextMenuService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _onDidContextMenu = this._register(new Emitter<void>());
 	readonly onDidContextMenu: Event<void> = this._onDidContextMenu.event;

--- a/src/vs/workbench/services/credentials/browser/credentialsService.ts
+++ b/src/vs/workbench/services/credentials/browser/credentialsService.ts
@@ -20,7 +20,7 @@ export interface ICredentialsProvider {
 
 export class BrowserCredentialsService implements ICredentialsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private credentialsProvider: ICredentialsProvider;
 

--- a/src/vs/workbench/services/credentials/common/credentials.ts
+++ b/src/vs/workbench/services/credentials/common/credentials.ts
@@ -9,7 +9,7 @@ export const ICredentialsService = createDecorator<ICredentialsService>('ICreden
 
 export interface ICredentialsService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getPassword(service: string, account: string): Promise<string | null>;
 	setPassword(service: string, account: string, password: string): Promise<void>;

--- a/src/vs/workbench/services/decorations/browser/decorationsService.ts
+++ b/src/vs/workbench/services/decorations/browser/decorationsService.ts
@@ -309,7 +309,7 @@ class DecorationProviderWrapper {
 
 export class DecorationsService implements IDecorationsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _data = new LinkedList<DecorationProviderWrapper>();
 	private readonly _onDidChangeDecorationsDelayed = new Emitter<URI | URI[]>();

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -28,7 +28,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 
 export abstract class AbstractFileDialogService implements IFileDialogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IHostService protected readonly hostService: IHostService,

--- a/src/vs/workbench/services/dialogs/browser/dialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/dialogService.ts
@@ -22,7 +22,7 @@ import { fromNow } from 'vs/base/common/date';
 
 export class DialogService implements IDialogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private allowableCommands = ['copy', 'cut'];
 

--- a/src/vs/workbench/services/dialogs/electron-browser/dialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/dialogService.ts
@@ -42,7 +42,7 @@ interface IMassagedMessageBoxOptions {
 
 export class DialogService implements IDialogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private nativeImpl: IDialogService;
 	private customImpl: IDialogService;
@@ -89,7 +89,7 @@ export class DialogService implements IDialogService {
 
 class NativeDialogService implements IDialogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@ILogService private readonly logService: ILogService,

--- a/src/vs/workbench/services/dialogs/electron-browser/fileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/fileDialogService.ts
@@ -26,7 +26,7 @@ import { NativeSimpleFileDialog } from 'vs/workbench/services/dialogs/electron-b
 
 export class FileDialogService extends AbstractFileDialogService implements IFileDialogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IHostService hostService: IHostService,

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -45,7 +45,7 @@ type OpenInEditorGroup = IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTI
 
 export class EditorService extends Disposable implements EditorServiceImpl {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	//#region events
 
@@ -1275,7 +1275,7 @@ export interface IEditorOpenHandler {
  */
 export class DelegatingEditorService implements IEditorService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		private editorOpenHandler: IEditorOpenHandler,

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -140,7 +140,7 @@ export const enum GroupsOrder {
 
 export interface IEditorGroupsService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * An event for when the active editor group changes. The active editor

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -87,7 +87,7 @@ export interface ICustomEditorViewTypesHandler {
 
 export interface IEditorService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Emitted when the currently active editor changes.

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -99,7 +99,7 @@ interface IExtensionHostDebugEnvironment {
 
 export class BrowserWorkbenchEnvironmentService implements IWorkbenchEnvironmentService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _configuration: IEnvironmentConfiguration | undefined = undefined;
 	get configuration(): IEnvironmentConfiguration {

--- a/src/vs/workbench/services/environment/common/environmentService.ts
+++ b/src/vs/workbench/services/environment/common/environmentService.ts
@@ -17,7 +17,7 @@ export interface IEnvironmentConfiguration extends IWindowConfiguration {
 
 export interface IWorkbenchEnvironmentService extends IEnvironmentService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly configuration: IEnvironmentConfiguration;
 

--- a/src/vs/workbench/services/environment/electron-browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-browser/environmentService.ts
@@ -32,7 +32,7 @@ export interface INativeEnvironmentConfiguration extends IEnvironmentConfigurati
 
 export class NativeWorkbenchEnvironmentService extends EnvironmentService implements INativeWorkbenchEnvironmentService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	@memoize
 	get webviewExternalEndpoint(): string {

--- a/src/vs/workbench/services/extensionManagement/common/extensionEnablementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionEnablementService.ts
@@ -23,7 +23,7 @@ const SOURCE = 'IWorkbenchExtensionEnablementService';
 
 export class ExtensionEnablementService extends Disposable implements IWorkbenchExtensionEnablementService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onEnablementChanged = new Emitter<readonly IExtension[]>();
 	public readonly onEnablementChanged: Event<readonly IExtension[]> = this._onEnablementChanged.event;

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
@@ -20,7 +20,7 @@ export interface IExtensionManagementServer {
 }
 
 export interface IExtensionManagementServerService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	readonly localExtensionManagementServer: IExtensionManagementServer | null;
 	readonly remoteExtensionManagementServer: IExtensionManagementServer | null;
 	getExtensionManagementServer(location: URI): IExtensionManagementServer | null;
@@ -38,7 +38,7 @@ export const enum EnablementState {
 export const IWorkbenchExtensionEnablementService = createDecorator<IWorkbenchExtensionEnablementService>('extensionEnablementService');
 
 export interface IWorkbenchExtensionEnablementService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly allUserExtensionsDisabled: boolean;
 
@@ -115,7 +115,7 @@ export interface IExtensionRecommendationReson {
 export const IExtensionRecommendationsService = createDecorator<IExtensionRecommendationsService>('extensionRecommendationsService');
 
 export interface IExtensionRecommendationsService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	getAllRecommendationsWithReason(): IStringDictionary<IExtensionRecommendationReson>;
 	getFileBasedRecommendations(): IExtensionRecommendation[];

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementServerService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementServerService.ts
@@ -15,7 +15,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 
 export class ExtensionManagementServerService implements IExtensionManagementServerService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	readonly localExtensionManagementServer: IExtensionManagementServer | null = null;
 	readonly remoteExtensionManagementServer: IExtensionManagementServer | null = null;

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -22,7 +22,7 @@ import { IDownloadService } from 'vs/platform/download/common/download';
 
 export class ExtensionManagementService extends Disposable implements IExtensionManagementService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	readonly onInstallExtension: Event<InstallExtensionEvent>;
 	readonly onDidInstallExtension: Event<DidInstallExtensionEvent>;

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionManagementServerService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionManagementServerService.ts
@@ -24,7 +24,7 @@ const localExtensionManagementServerAuthority: string = 'vscode-local';
 
 export class ExtensionManagementServerService implements IExtensionManagementServerService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	readonly localExtensionManagementServer: IExtensionManagementServer;
 	readonly remoteExtensionManagementServer: IExtensionManagementServer | null = null;

--- a/src/vs/workbench/services/extensionResourceLoader/browser/extensionResourceLoaderService.ts
+++ b/src/vs/workbench/services/extensionResourceLoader/browser/extensionResourceLoaderService.ts
@@ -12,7 +12,7 @@ import { Schemas } from 'vs/base/common/network';
 
 class ExtensionResourceLoaderService implements IExtensionResourceLoaderService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IFileService private readonly _fileService: IFileService

--- a/src/vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader.ts
+++ b/src/vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader.ts
@@ -12,7 +12,7 @@ export const IExtensionResourceLoaderService = createDecorator<IExtensionResourc
  * A service useful for reading resources from within extensions.
  */
 export interface IExtensionResourceLoaderService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Read a certain resource within an extension.

--- a/src/vs/workbench/services/extensionResourceLoader/electron-sandbox/extensionResourceLoaderService.ts
+++ b/src/vs/workbench/services/extensionResourceLoader/electron-sandbox/extensionResourceLoaderService.ts
@@ -10,7 +10,7 @@ import { IExtensionResourceLoaderService } from 'vs/workbench/services/extension
 
 export class ExtensionResourceLoaderService implements IExtensionResourceLoaderService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IFileService private readonly _fileService: IFileService

--- a/src/vs/workbench/services/extensions/common/extensions.ts
+++ b/src/vs/workbench/services/extensions/common/extensions.ts
@@ -131,7 +131,7 @@ export interface IResponsiveStateChangeEvent {
 }
 
 export interface IExtensionService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * An event emitted when extensions are registered after their extension points got handled.
@@ -259,7 +259,7 @@ export function toExtension(extensionDescription: IExtensionDescription): IExten
 
 
 export class NullExtensionService implements IExtensionService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	onDidRegisterExtensions: Event<void> = Event.None;
 	onDidChangeExtensionsStatus: Event<ExtensionIdentifier[]> = Event.None;
 	onDidChangeExtensions: Event<void> = Event.None;

--- a/src/vs/workbench/services/extensions/common/staticExtensions.ts
+++ b/src/vs/workbench/services/extensions/common/staticExtensions.ts
@@ -11,13 +11,13 @@ import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/
 export const IStaticExtensionsService = createDecorator<IStaticExtensionsService>('IStaticExtensionsService');
 
 export interface IStaticExtensionsService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	getExtensions(): Promise<IExtensionDescription[]>;
 }
 
 export class StaticExtensionsService implements IStaticExtensionsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _descriptions: IExtensionDescription[] = [];
 

--- a/src/vs/workbench/services/extensions/electron-browser/remoteExtensionManagementIpc.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/remoteExtensionManagementIpc.ts
@@ -24,7 +24,7 @@ import { joinPath } from 'vs/base/common/resources';
 
 export class RemoteExtensionManagementChannelClient extends ExtensionManagementChannelClient {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		channel: IChannel,

--- a/src/vs/workbench/services/extensions/node/extensionHostProcessSetup.ts
+++ b/src/vs/workbench/services/extensions/node/extensionHostProcessSetup.ts
@@ -299,7 +299,7 @@ export async function startExtensionHostProcess(): Promise<void> {
 
 	// host abstraction
 	const hostUtils = new class NodeHost implements IHostUtils {
-		_serviceBrand: undefined;
+		declare readonly _serviceBrand: undefined;
 		exit(code: number) { nativeExit(code); }
 		exists(path: string) { return exists(path); }
 		realpath(path: string) { return realpath(path); }

--- a/src/vs/workbench/services/extensions/worker/extensionHostWorker.ts
+++ b/src/vs/workbench/services/extensions/worker/extensionHostWorker.ts
@@ -36,7 +36,7 @@ self.addEventLister = () => console.trace(`'addEventListener' has been blocked`)
 //#endregion ---
 
 const hostUtil = new class implements IHostUtils {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	exit(_code?: number | undefined): void {
 		nativeClose();
 	}

--- a/src/vs/workbench/services/filesConfiguration/common/filesConfigurationService.ts
+++ b/src/vs/workbench/services/filesConfiguration/common/filesConfigurationService.ts
@@ -35,7 +35,7 @@ export const IFilesConfigurationService = createDecorator<IFilesConfigurationSer
 
 export interface IFilesConfigurationService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	//#region Auto Save
 
@@ -60,7 +60,7 @@ export interface IFilesConfigurationService {
 
 export class FilesConfigurationService extends Disposable implements IFilesConfigurationService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static DEFAULT_AUTO_SAVE_MODE = isWeb ? AutoSaveConfiguration.AFTER_DELAY : AutoSaveConfiguration.OFF;
 

--- a/src/vs/workbench/services/history/browser/history.ts
+++ b/src/vs/workbench/services/history/browser/history.ts
@@ -93,7 +93,7 @@ interface IRecentlyClosedFile {
 
 export class HistoryService extends Disposable implements IHistoryService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly activeEditorListeners = this._register(new DisposableStore());
 	private lastActiveEditor?: IEditorIdentifier;

--- a/src/vs/workbench/services/history/common/history.ts
+++ b/src/vs/workbench/services/history/common/history.ts
@@ -12,7 +12,7 @@ export const IHistoryService = createDecorator<IHistoryService>('historyService'
 
 export interface IHistoryService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Re-opens the last closed editor if any.

--- a/src/vs/workbench/services/host/browser/browserHostService.ts
+++ b/src/vs/workbench/services/host/browser/browserHostService.ts
@@ -59,7 +59,7 @@ export interface IWorkspaceProvider {
 
 export class BrowserHostService extends Disposable implements IHostService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private workspaceProvider: IWorkspaceProvider;
 

--- a/src/vs/workbench/services/host/browser/host.ts
+++ b/src/vs/workbench/services/host/browser/host.ts
@@ -11,7 +11,7 @@ export const IHostService = createDecorator<IHostService>('hostService');
 
 export interface IHostService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	//#region Focus
 

--- a/src/vs/workbench/services/host/electron-sandbox/desktopHostService.ts
+++ b/src/vs/workbench/services/host/electron-sandbox/desktopHostService.ts
@@ -14,7 +14,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 
 export class DesktopHostService extends Disposable implements IHostService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IElectronService private readonly electronService: IElectronService,

--- a/src/vs/workbench/services/integrity/browser/integrityService.ts
+++ b/src/vs/workbench/services/integrity/browser/integrityService.ts
@@ -8,7 +8,7 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
 export class BrowserIntegrityServiceImpl implements IIntegrityService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	async isPure(): Promise<IntegrityTestResult> {
 		return { isPure: true, proof: [] };

--- a/src/vs/workbench/services/integrity/common/integrity.ts
+++ b/src/vs/workbench/services/integrity/common/integrity.ts
@@ -21,7 +21,7 @@ export interface IntegrityTestResult {
 }
 
 export interface IIntegrityService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	isPure(): Promise<IntegrityTestResult>;
 }

--- a/src/vs/workbench/services/integrity/node/integrityService.ts
+++ b/src/vs/workbench/services/integrity/node/integrityService.ts
@@ -56,7 +56,7 @@ class IntegrityStorage {
 
 export class IntegrityServiceImpl implements IIntegrityService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _storage: IntegrityStorage;
 	private _isPurePromise: Promise<IntegrityTestResult>;

--- a/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
+++ b/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
@@ -10,7 +10,7 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
 export class IssueService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(@IMainProcessService mainProcessService: IMainProcessService) {
 		return createChannelSender<IIssueService>(mainProcessService.getChannel('issue'));

--- a/src/vs/workbench/services/keybinding/common/keybindingEditing.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingEditing.ts
@@ -30,7 +30,7 @@ export const IKeybindingEditingService = createDecorator<IKeybindingEditingServi
 
 export interface IKeybindingEditingService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	editKeybinding(keybindingItem: ResolvedKeybindingItem, key: string, when: string | undefined): Promise<void>;
 

--- a/src/vs/workbench/services/keybinding/common/keymapInfo.ts
+++ b/src/vs/workbench/services/keybinding/common/keymapInfo.ts
@@ -94,7 +94,7 @@ export type IKeyboardLayoutInfo = (IWindowsKeyboardLayoutInfo | ILinuxKeyboardLa
 export const IKeymapService = createDecorator<IKeymapService>('keymapService');
 
 export interface IKeymapService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	onDidChangeKeyboardMapper: Event<void>;
 	getKeyboardMapper(dispatchConfig: DispatchConfig): IKeyboardMapper;
 	getCurrentKeyboardLayout(): IKeyboardLayoutInfo | null;

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -92,7 +92,7 @@ Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).regi
 
 export class LabelService extends Disposable implements ILabelService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private formatters: ResourceLabelFormatter[] = [];
 

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -50,7 +50,7 @@ export function positionFromString(str: string): Position {
 
 export interface IWorkbenchLayoutService extends ILayoutService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Emits when the zen mode is enabled or disabled.

--- a/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
@@ -11,7 +11,7 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
 export class BrowserLifecycleService extends AbstractLifecycleService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@ILogService readonly logService: ILogService

--- a/src/vs/workbench/services/lifecycle/electron-sandbox/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/electron-sandbox/lifecycleService.ts
@@ -20,7 +20,7 @@ export class NativeLifecycleService extends AbstractLifecycleService {
 
 	private static readonly LAST_SHUTDOWN_REASON_KEY = 'lifecyle.lastShutdownReason';
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private shutdownReason: ShutdownReason | undefined;
 

--- a/src/vs/workbench/services/localizations/electron-browser/localizationsService.ts
+++ b/src/vs/workbench/services/localizations/electron-browser/localizationsService.ts
@@ -10,7 +10,7 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
 export class LocalizationsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@ISharedProcessService sharedProcessService: ISharedProcessService,

--- a/src/vs/workbench/services/menubar/electron-sandbox/menubarService.ts
+++ b/src/vs/workbench/services/menubar/electron-sandbox/menubarService.ts
@@ -10,7 +10,7 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
 export class MenubarService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(@IMainProcessService mainProcessService: IMainProcessService) {
 		return createChannelSender<IMenubarService>(mainProcessService.getChannel('menubar'));

--- a/src/vs/workbench/services/notification/common/notificationService.ts
+++ b/src/vs/workbench/services/notification/common/notificationService.ts
@@ -14,7 +14,7 @@ import { IStorageService, StorageScope } from 'vs/platform/storage/common/storag
 
 export class NotificationService extends Disposable implements INotificationService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _model: INotificationsModel = this._register(new NotificationsModel());
 	get model(): INotificationsModel { return this._model; }

--- a/src/vs/workbench/services/output/common/outputChannelModel.ts
+++ b/src/vs/workbench/services/output/common/outputChannelModel.ts
@@ -31,7 +31,7 @@ export interface IOutputChannelModel extends IDisposable {
 export const IOutputChannelModelService = createDecorator<IOutputChannelModelService>('outputChannelModelService');
 
 export interface IOutputChannelModelService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	createOutputChannelModel(id: string, modelUri: URI, mimeType: string, file?: URI): IOutputChannelModel;
 

--- a/src/vs/workbench/services/output/common/outputChannelModelService.ts
+++ b/src/vs/workbench/services/output/common/outputChannelModelService.ts
@@ -7,7 +7,7 @@ import { IOutputChannelModelService, AsbtractOutputChannelModelService } from 'v
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
 export class OutputChannelModelService extends AsbtractOutputChannelModelService implements IOutputChannelModelService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 }
 
 registerSingleton(IOutputChannelModelService, OutputChannelModelService);

--- a/src/vs/workbench/services/output/electron-browser/outputChannelModelService.ts
+++ b/src/vs/workbench/services/output/electron-browser/outputChannelModelService.ts
@@ -200,7 +200,7 @@ class DelegatedOutputChannelModel extends Disposable implements IOutputChannelMo
 
 export class OutputChannelModelService extends AsbtractOutputChannelModelService implements IOutputChannelModelService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,

--- a/src/vs/workbench/services/panel/common/panelService.ts
+++ b/src/vs/workbench/services/panel/common/panelService.ts
@@ -20,7 +20,7 @@ export interface IPanelIdentifier {
 
 export interface IPanelService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly onDidPanelOpen: Event<{ readonly panel: IPanel, readonly focus: boolean }>;
 	readonly onDidPanelClose: Event<IPanel>;

--- a/src/vs/workbench/services/path/common/pathService.ts
+++ b/src/vs/workbench/services/path/common/pathService.ts
@@ -18,7 +18,7 @@ export const IPathService = createDecorator<IPathService>('path');
  */
 export interface IPathService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * The correct path library to use for the target environment. If
@@ -53,7 +53,7 @@ export interface IPathService {
 
 export abstract class AbstractPathService implements IPathService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private remoteOS: Promise<OperatingSystem>;
 

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -46,7 +46,7 @@ const emptyEditableSettingsContent = '{\n}';
 
 export class PreferencesService extends Disposable implements IPreferencesService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private lastOpenedSettingsInput: PreferencesEditorInput | null = null;
 

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -188,7 +188,7 @@ export interface IKeybindingsEditorModel<T> extends IPreferencesEditorModel<T> {
 export const IPreferencesService = createDecorator<IPreferencesService>('preferencesService');
 
 export interface IPreferencesService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	userSettingsResource: URI;
 	workspaceSettingsResource: URI | null;

--- a/src/vs/workbench/services/progress/browser/progressIndicator.ts
+++ b/src/vs/workbench/services/progress/browser/progressIndicator.ts
@@ -61,7 +61,7 @@ export class ProgressBarIndicator extends Disposable implements IProgressIndicat
 
 export class EditorProgressIndicator extends ProgressBarIndicator {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(progressBar: ProgressBar, private readonly group: IEditorGroupView) {
 		super(progressBar);

--- a/src/vs/workbench/services/progress/browser/progressService.ts
+++ b/src/vs/workbench/services/progress/browser/progressService.ts
@@ -29,7 +29,7 @@ import { IViewsService, IViewDescriptorService, ViewContainerLocation } from 'vs
 
 export class ProgressService extends Disposable implements IProgressService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IActivityService private readonly activityService: IActivityService,

--- a/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
@@ -25,7 +25,7 @@ import { ITelemetryData } from 'vs/platform/telemetry/common/telemetry';
 
 export abstract class AbstractRemoteAgentService extends Disposable {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _environment: Promise<IRemoteAgentEnvironment | null> | null;
 

--- a/src/vs/workbench/services/remote/common/remoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/remoteAgentService.ts
@@ -16,7 +16,7 @@ export const RemoteExtensionLogFileName = 'remoteagent';
 export const IRemoteAgentService = createDecorator<IRemoteAgentService>('remoteAgentService');
 
 export interface IRemoteAgentService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly socketFactory: ISocketFactory;
 

--- a/src/vs/workbench/services/remote/common/remoteExplorerService.ts
+++ b/src/vs/workbench/services/remote/common/remoteExplorerService.ts
@@ -224,7 +224,7 @@ export class TunnelModel extends Disposable {
 }
 
 export interface IRemoteExplorerService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	onDidChangeTargetType: Event<string[]>;
 	targetType: string[];
 	readonly tunnelModel: TunnelModel;

--- a/src/vs/workbench/services/remote/common/tunnelService.ts
+++ b/src/vs/workbench/services/remote/common/tunnelService.ts
@@ -10,7 +10,7 @@ import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/
 import { ILogService } from 'vs/platform/log/common/log';
 
 export abstract class AbstractTunnelService implements ITunnelService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _onTunnelOpened: Emitter<RemoteTunnel> = new Emitter();
 	public onTunnelOpened: Event<RemoteTunnel> = this._onTunnelOpened.event;

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -31,7 +31,7 @@ export const ISearchService = createDecorator<ISearchService>('searchService');
  * A service that enables to search for files or with in files.
  */
 export interface ISearchService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	textSearch(query: ITextQuery, token?: CancellationToken, onProgress?: (result: ISearchProgressItem) => void): Promise<ISearchComplete>;
 	fileSearch(query: IFileQuery, token?: CancellationToken): Promise<ISearchComplete>;
 	clearCache(cacheKey: string): Promise<void>;

--- a/src/vs/workbench/services/search/common/searchService.ts
+++ b/src/vs/workbench/services/search/common/searchService.ts
@@ -24,7 +24,7 @@ import { DeferredPromise } from 'vs/base/test/common/utils';
 
 export class SearchService extends Disposable implements ISearchService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	protected diskSearch: ISearchResultProvider | null = null;
 	private readonly fileSearchProviders = new Map<string, ISearchResultProvider>();

--- a/src/vs/workbench/services/sharedProcess/electron-browser/sharedProcessService.ts
+++ b/src/vs/workbench/services/sharedProcess/electron-browser/sharedProcessService.ts
@@ -15,7 +15,7 @@ import { IElectronService } from 'vs/platform/electron/electron-sandbox/electron
 
 export class SharedProcessService implements ISharedProcessService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private withSharedProcessConnection: Promise<Client<string>>;
 	private sharedProcessMainChannel: IChannel;

--- a/src/vs/workbench/services/statusbar/common/statusbar.ts
+++ b/src/vs/workbench/services/statusbar/common/statusbar.ts
@@ -61,7 +61,7 @@ export interface IStatusbarEntry {
 
 export interface IStatusbarService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Adds an entry to the statusbar with the given alignment and priority. Use the returned accessor

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -33,7 +33,7 @@ export class WebTelemetryAppender implements ITelemetryAppender {
 
 export class TelemetryService extends Disposable implements ITelemetryService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private impl: ITelemetryService;
 	public readonly sendErrorTelemetry = false;

--- a/src/vs/workbench/services/telemetry/electron-browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/electron-browser/telemetryService.ts
@@ -21,7 +21,7 @@ import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/enviro
 
 export class TelemetryService extends Disposable implements ITelemetryService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private impl: ITelemetryService;
 	public readonly sendErrorTelemetry: boolean;

--- a/src/vs/workbench/services/textMate/common/textMateService.ts
+++ b/src/vs/workbench/services/textMate/common/textMateService.ts
@@ -10,7 +10,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const ITextMateService = createDecorator<ITextMateService>('textMateService');
 
 export interface ITextMateService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	onDidEncounterLanguage: Event<LanguageId>;
 

--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -41,7 +41,7 @@ import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/ur
  */
 export abstract class AbstractTextFileService extends Disposable implements ITextFileService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	//#region events
 

--- a/src/vs/workbench/services/textfile/common/textfiles.ts
+++ b/src/vs/workbench/services/textfile/common/textfiles.ts
@@ -27,7 +27,7 @@ export interface TextFileCreateEvent extends IWaitUntil {
 
 export interface ITextFileService extends IDisposable {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Access to the manager of text file editor models providing further

--- a/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
+++ b/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
@@ -163,7 +163,7 @@ class ResourceModelCollection extends ReferenceCollection<Promise<ITextEditorMod
 
 export class TextModelResolverService extends Disposable implements ITextModelService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly resourceModelCollection = this.instantiationService.createInstance(ResourceModelCollection);
 

--- a/src/vs/workbench/services/textresourceProperties/common/textResourcePropertiesService.ts
+++ b/src/vs/workbench/services/textresourceProperties/common/textResourcePropertiesService.ts
@@ -16,7 +16,7 @@ import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteA
 
 export class TextResourcePropertiesService implements ITextResourcePropertiesService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private remoteEnvironment: IRemoteAgentEnvironment | null = null;
 

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -69,7 +69,7 @@ const fileIconThemesExtPoint = registerFileIconThemeExtensionPoint();
 const productIconThemesExtPoint = registerProductIconThemeExtensionPoint();
 
 export class WorkbenchThemeService implements IWorkbenchThemeService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly container: HTMLElement;
 	private settings: ThemeConfiguration;

--- a/src/vs/workbench/services/themes/common/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/common/workbenchThemeService.ts
@@ -61,7 +61,7 @@ export interface IWorkbenchProductIconTheme extends IWorkbenchTheme {
 
 
 export interface IWorkbenchThemeService extends IThemeService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	setColorTheme(themeId: string | undefined, settingsTarget: ConfigurationTarget | undefined | 'auto'): Promise<IWorkbenchColorTheme | null>;
 	getColorTheme(): IWorkbenchColorTheme;
 	getColorThemes(): Promise<IWorkbenchColorTheme[]>;

--- a/src/vs/workbench/services/timer/electron-browser/timerService.ts
+++ b/src/vs/workbench/services/timer/electron-browser/timerService.ts
@@ -292,13 +292,13 @@ export interface IStartupMetrics {
 }
 
 export interface ITimerService {
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 	readonly startupMetrics: Promise<IStartupMetrics>;
 }
 
 class TimerService implements ITimerService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _startupMetrics?: Promise<IStartupMetrics>;
 

--- a/src/vs/workbench/services/title/common/titleService.ts
+++ b/src/vs/workbench/services/title/common/titleService.ts
@@ -16,7 +16,7 @@ export interface ITitleProperties {
 
 export interface ITitleService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * An event when the menubar visibility changes.

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorService.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorService.ts
@@ -110,12 +110,12 @@ export interface IUntitledTextEditorModelManager {
 
 export interface IUntitledTextEditorService extends IUntitledTextEditorModelManager {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 }
 
 export class UntitledTextEditorService extends Disposable implements IUntitledTextEditorService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidChangeDirty = this._register(new Emitter<IUntitledTextEditorModel>());
 	readonly onDidChangeDirty = this._onDidChangeDirty.event;

--- a/src/vs/workbench/services/update/browser/updateService.ts
+++ b/src/vs/workbench/services/update/browser/updateService.ts
@@ -26,7 +26,7 @@ export interface IUpdateProvider {
 
 export class BrowserUpdateService extends Disposable implements IUpdateService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _onStateChange = this._register(new Emitter<State>());
 	readonly onStateChange: Event<State> = this._onStateChange.event;

--- a/src/vs/workbench/services/update/electron-sandbox/updateService.ts
+++ b/src/vs/workbench/services/update/electron-sandbox/updateService.ts
@@ -11,7 +11,7 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
 export class NativeUpdateService implements IUpdateService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onStateChange = new Emitter<State>();
 	readonly onStateChange: Event<State> = this._onStateChange.event;

--- a/src/vs/workbench/services/uriIdentity/common/uriIdentity.ts
+++ b/src/vs/workbench/services/uriIdentity/common/uriIdentity.ts
@@ -16,7 +16,7 @@ export const IUriIdentityService = createDecorator<IUriIdentityService>('IUriIde
 
 export interface IUriIdentityService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Uri extensions that are aware of casing.

--- a/src/vs/workbench/services/uriIdentity/common/uriIdentityService.ts
+++ b/src/vs/workbench/services/uriIdentity/common/uriIdentityService.ts
@@ -22,7 +22,7 @@ class Entry {
 
 export class UriIdentityService implements IUriIdentityService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	readonly extUri: IExtUri;
 

--- a/src/vs/workbench/services/url/browser/urlService.ts
+++ b/src/vs/workbench/services/url/browser/urlService.ts
@@ -38,7 +38,7 @@ export interface IURLCallbackProvider {
 
 export class BrowserURLService extends AbstractURLService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private provider: IURLCallbackProvider | undefined;
 

--- a/src/vs/workbench/services/userDataSync/common/userDataSyncUtil.ts
+++ b/src/vs/workbench/services/userDataSync/common/userDataSyncUtil.ts
@@ -14,7 +14,7 @@ import { ITextResourcePropertiesService, ITextResourceConfigurationService } fro
 
 class UserDataSyncUtilService implements IUserDataSyncUtilService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IKeybindingService private readonly keybindingsService: IKeybindingService,

--- a/src/vs/workbench/services/userDataSync/electron-browser/userDataSyncMachinesService.ts
+++ b/src/vs/workbench/services/userDataSync/electron-browser/userDataSyncMachinesService.ts
@@ -11,7 +11,7 @@ import { IUserDataSyncMachinesService, IUserDataSyncMachine } from 'vs/platform/
 
 class UserDataSyncMachinesService extends Disposable implements IUserDataSyncMachinesService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly channel: IChannel;
 

--- a/src/vs/workbench/services/userDataSync/electron-browser/userDataSyncService.ts
+++ b/src/vs/workbench/services/userDataSync/electron-browser/userDataSyncService.ts
@@ -14,7 +14,7 @@ import { URI } from 'vs/base/common/uri';
 
 export class UserDataSyncService extends Disposable implements IUserDataSyncService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly channel: IChannel;
 

--- a/src/vs/workbench/services/viewlet/browser/viewlet.ts
+++ b/src/vs/workbench/services/viewlet/browser/viewlet.ts
@@ -13,7 +13,7 @@ export const IViewletService = createDecorator<IViewletService>('viewletService'
 
 export interface IViewletService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	readonly onDidViewletRegister: Event<ViewletDescriptor>;
 	readonly onDidViewletDeregister: Event<ViewletDescriptor>;

--- a/src/vs/workbench/services/views/browser/viewDescriptorService.ts
+++ b/src/vs/workbench/services/views/browser/viewDescriptorService.ts
@@ -27,7 +27,7 @@ interface ICachedViewContainerInfo {
 
 export class ViewDescriptorService extends Disposable implements IViewDescriptorService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private static readonly CACHED_VIEW_POSITIONS = 'views.cachedViewPositions';
 	private static readonly CACHED_VIEW_CONTAINER_LOCATIONS = 'views.cachedViewContainerLocations';

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -73,7 +73,7 @@ type WorkingCopyProvider = (resourceOrFolder: URI) => IWorkingCopy[];
  */
 export interface IWorkingCopyFileService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	//#region Events
 
@@ -169,7 +169,7 @@ export interface IWorkingCopyFileService {
 
 export class WorkingCopyFileService extends Disposable implements IWorkingCopyFileService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	//#region Events
 

--- a/src/vs/workbench/services/workingCopy/common/workingCopyService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyService.ts
@@ -117,7 +117,7 @@ export const IWorkingCopyService = createDecorator<IWorkingCopyService>('working
 
 export interface IWorkingCopyService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 
 	//#region Events
@@ -163,7 +163,7 @@ export interface IWorkingCopyService {
 
 export class WorkingCopyService extends Disposable implements IWorkingCopyService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	//#region Events
 

--- a/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
@@ -27,7 +27,7 @@ import { Schemas } from 'vs/base/common/network';
 
 export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditingService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IJSONEditingService private readonly jsonEditingService: IJSONEditingService,

--- a/src/vs/workbench/services/workspaces/browser/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/browser/workspaceEditingService.ts
@@ -22,7 +22,7 @@ import { URI } from 'vs/base/common/uri';
 
 export class BrowserWorkspaceEditingService extends AbstractWorkspaceEditingService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IJSONEditingService jsonEditingService: IJSONEditingService,

--- a/src/vs/workbench/services/workspaces/browser/workspacesService.ts
+++ b/src/vs/workbench/services/workspaces/browser/workspacesService.ts
@@ -22,7 +22,7 @@ export class BrowserWorkspacesService extends Disposable implements IWorkspacesS
 
 	static readonly RECENTLY_OPENED_KEY = 'recently.opened';
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onRecentlyOpenedChange = this._register(new Emitter<void>());
 	readonly onRecentlyOpenedChange = this._onRecentlyOpenedChange.event;

--- a/src/vs/workbench/services/workspaces/common/workspaceEditing.ts
+++ b/src/vs/workbench/services/workspaces/common/workspaceEditing.ts
@@ -11,7 +11,7 @@ export const IWorkspaceEditingService = createDecorator<IWorkspaceEditingService
 
 export interface IWorkspaceEditingService {
 
-	_serviceBrand: undefined;
+	readonly _serviceBrand: undefined;
 
 	/**
 	 * Add folders to the existing workspace.

--- a/src/vs/workbench/services/workspaces/electron-browser/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/electron-browser/workspaceEditingService.ts
@@ -35,7 +35,7 @@ import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/enviro
 
 export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IJSONEditingService jsonEditingService: IJSONEditingService,

--- a/src/vs/workbench/services/workspaces/electron-sandbox/workspacesService.ts
+++ b/src/vs/workbench/services/workspaces/electron-sandbox/workspacesService.ts
@@ -11,7 +11,7 @@ import { IElectronService } from 'vs/platform/electron/electron-sandbox/electron
 
 export class NativeWorkspacesService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IMainProcessService mainProcessService: IMainProcessService,

--- a/src/vs/workbench/test/browser/api/extHostMessagerService.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostMessagerService.test.ts
@@ -13,7 +13,7 @@ import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
 import * as platform from 'vs/base/common/platform';
 
 const emptyDialogService = new class implements IDialogService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	show(): never {
 		throw new Error('not implemented');
 	}
@@ -37,7 +37,7 @@ const emptyCommandService: ICommandService = {
 };
 
 const emptyNotificationService = new class implements INotificationService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 	notify(...args: any[]): never {
 		throw new Error('not implemented');
 	}
@@ -62,7 +62,7 @@ const emptyNotificationService = new class implements INotificationService {
 };
 
 class EmptyNotificationService implements INotificationService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private withNotify: (notification: INotification) => void) {
 	}

--- a/src/vs/workbench/test/browser/api/mainThreadDocumentsAndEditors.test.ts
+++ b/src/vs/workbench/test/browser/api/mainThreadDocumentsAndEditors.test.ts
@@ -82,7 +82,7 @@ suite('MainThreadDocumentsAndEditors', () => {
 			editorGroupService,
 			null!,
 			new class extends mock<IPanelService>() implements IPanelService {
-				_serviceBrand: undefined;
+				declare readonly _serviceBrand: undefined;
 				onDidPanelOpen = Event.None;
 				onDidPanelClose = Event.None;
 				getActivePanel() {

--- a/src/vs/workbench/test/browser/api/mainThreadEditors.test.ts
+++ b/src/vs/workbench/test/browser/api/mainThreadEditors.test.ts
@@ -133,7 +133,7 @@ suite('MainThreadEditors', () => {
 
 		});
 		services.set(IPanelService, new class extends mock<IPanelService>() implements IPanelService {
-			_serviceBrand: undefined;
+			declare readonly _serviceBrand: undefined;
 			onDidPanelOpen = Event.None;
 			onDidPanelClose = Event.None;
 			getActivePanel() {

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -281,7 +281,7 @@ export const TestEnvironmentService = new TestEnvironmentServiceWithArgs(Object.
 
 export class TestProgressService implements IProgressService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	withProgress(
 		options: IProgressOptions | IProgressWindowOptions | IProgressNotificationOptions | IProgressCompositeOptions,
@@ -294,7 +294,7 @@ export class TestProgressService implements IProgressService {
 
 export class TestAccessibilityService implements IAccessibilityService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	onDidChangeScreenReaderOptimized = Event.None;
 
@@ -306,7 +306,7 @@ export class TestAccessibilityService implements IAccessibilityService {
 
 export class TestDecorationsService implements IDecorationsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	onDidChangeDecorations: Event<IResourceDecorationChangeEvent> = Event.None;
 
@@ -316,7 +316,7 @@ export class TestDecorationsService implements IDecorationsService {
 
 export class TestMenuService implements IMenuService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	createMenu(_id: MenuId, _scopedKeybindingService: IContextKeyService): IMenu {
 		return {
@@ -329,7 +329,7 @@ export class TestMenuService implements IMenuService {
 
 export class TestHistoryService implements IHistoryService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private root?: URI) { }
 
@@ -350,7 +350,7 @@ export class TestHistoryService implements IHistoryService {
 
 export class TestFileDialogService implements IFileDialogService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private confirmResult!: ConfirmResult;
 
@@ -375,7 +375,7 @@ export class TestFileDialogService implements IFileDialogService {
 
 export class TestLayoutService implements IWorkbenchLayoutService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	openedDefaultEditors = false;
 
@@ -435,7 +435,7 @@ export class TestLayoutService implements IWorkbenchLayoutService {
 let activeViewlet: Viewlet = {} as any;
 
 export class TestViewletService implements IViewletService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	onDidViewletRegisterEmitter = new Emitter<ViewletDescriptor>();
 	onDidViewletDeregisterEmitter = new Emitter<ViewletDescriptor>();
@@ -460,7 +460,7 @@ export class TestViewletService implements IViewletService {
 }
 
 export class TestPanelService implements IPanelService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	onDidPanelOpen = new Emitter<{ panel: IPanel, focus: boolean }>().event;
 	onDidPanelClose = new Emitter<IPanel>().event;
@@ -479,7 +479,7 @@ export class TestPanelService implements IPanelService {
 }
 
 export class TestViewsService implements IViewsService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 
 	onDidChangeViewContainerVisibility = new Emitter<{ id: string; visible: boolean; location: ViewContainerLocation }>().event;
@@ -499,7 +499,7 @@ export class TestViewsService implements IViewsService {
 
 export class TestEditorGroupsService implements IEditorGroupsService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(public groups: TestEditorGroupView[] = []) { }
 
@@ -630,7 +630,7 @@ export class TestEditorGroupAccessor implements IEditorGroupsAccessor {
 
 export class TestEditorService implements EditorServiceImpl {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	onDidActiveEditorChange: Event<void> = Event.None;
 	onDidVisibleEditorsChange: Event<void> = Event.None;
@@ -690,7 +690,7 @@ export class TestEditorService implements EditorServiceImpl {
 
 export class TestFileService implements IFileService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private readonly _onDidFilesChange = new Emitter<FileChangesEvent>();
 	private readonly _onDidRunOperation = new Emitter<FileOperationEvent>();
@@ -840,7 +840,7 @@ export class TestFileService implements IFileService {
 }
 
 export class TestBackupFileService implements IBackupFileService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	hasBackups(): Promise<boolean> { return Promise.resolve(false); }
 	hasBackup(_resource: URI): Promise<boolean> { return Promise.resolve(false); }
@@ -862,7 +862,7 @@ export class TestBackupFileService implements IBackupFileService {
 
 export class TestLifecycleService implements ILifecycleService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	phase!: LifecyclePhase;
 	startupKind!: StartupKind;
@@ -890,7 +890,7 @@ export class TestLifecycleService implements ILifecycleService {
 
 export class TestTextResourceConfigurationService implements ITextResourceConfigurationService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private configurationService = new TestConfigurationService()) { }
 
@@ -947,7 +947,7 @@ export const productService: IProductService = { _serviceBrand: undefined, ...pr
 
 export class TestHostService implements IHostService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private _hasFocus = true;
 	get hasFocus() { return this._hasFocus; }
@@ -1132,7 +1132,7 @@ export class TestEditorPart extends EditorPart {
 }
 
 export class TestListService implements IListService {
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	lastFocusedList: any | undefined = undefined;
 
@@ -1143,7 +1143,7 @@ export class TestListService implements IListService {
 
 export class TestPathService implements IPathService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(private readonly fallbackUserHome: URI = URI.from({ scheme: Schemas.vscodeRemote, path: '/' })) { }
 

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -22,7 +22,7 @@ import { FileOperation, IFileStatWithMetadata } from 'vs/platform/files/common/f
 
 export class TestTextResourcePropertiesService implements ITextResourcePropertiesService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -40,7 +40,7 @@ export class TestTextResourcePropertiesService implements ITextResourcePropertie
 
 export class TestContextService implements IWorkspaceContextService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	private workspace: Workspace;
 	private options: object;
@@ -126,7 +126,7 @@ export class TestWorkingCopyService extends WorkingCopyService { }
 
 export class TestWorkingCopyFileService implements IWorkingCopyFileService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	onWillRunWorkingCopyFileOperation: Event<WorkingCopyFileEvent> = Event.None;
 	onDidFailWorkingCopyFileOperation: Event<WorkingCopyFileEvent> = Event.None;

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -152,7 +152,7 @@ class TestEncodingOracle extends EncodingOracle {
 
 export class TestSharedProcessService implements ISharedProcessService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	getChannel(channelName: string): any { return undefined; }
 
@@ -164,7 +164,7 @@ export class TestSharedProcessService implements ISharedProcessService {
 
 export class TestElectronService implements IElectronService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	readonly windowId = -1;
 
@@ -260,7 +260,7 @@ export class TestServiceAccessor {
 
 export class TestNativePathService extends TestPathService {
 
-	_serviceBrand: undefined;
+	declare readonly _serviceBrand: undefined;
 
 	constructor(@IWorkbenchEnvironmentService environmentService: INativeWorkbenchEnvironmentService) {
 		super(environmentService.userHome);


### PR DESCRIPTION
_serviceBrand is only used for typing and should not result in emit

Also adds `readonly` to all `_serviceBrand` declarations


For #99304