### PR TITLE
debug: fix being unable to debug extensions with js-debug on web

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/extensionHostDebugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/extensionHostDebugService.ts
@@ -104,6 +104,11 @@ class BrowserExtensionHostDebugService extends ExtensionHostDebugChannelClient i
 			environment.set('inspect-brk-extensions', inspectBrkExtensions);
 		}
 
+		const inspectExtensions = this.findArgument('inspect-extensions', args);
+		if (inspectExtensions) {
+			environment.set('inspect-extensions', inspectExtensions);
+		}
+
 		// Open debug window as new window. Pass ParsedArgs over.
 		return this.workspaceProvider.open(debugWorkspace, {
 			reuse: false, 								// debugging always requires a new window

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -269,6 +269,9 @@ export class BrowserWorkbenchEnvironmentService implements IWorkbenchEnvironment
 						extensionHostDebugEnvironment.params.port = parseInt(value);
 						extensionHostDebugEnvironment.params.break = true;
 						break;
+					case 'inspect-extensions':
+						extensionHostDebugEnvironment.params.port = parseInt(value);
+						break;
 					case 'enableProposedApi':
 						extensionHostDebugEnvironment.extensionEnabledProposedApi = [];
 						break;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #99222
