### PR TITLE
Azure DevOps pipelines - Remove code hygiene tasks from Windows and Mac

### DIFF
--- a/build/azure-pipelines/darwin/continuous-build-darwin.yml
+++ b/build/azure-pipelines/darwin/continuous-build-darwin.yml
@@ -30,10 +30,6 @@ steps:
   displayName: Download Electron
 
 - script: |
-    yarn gulp hygiene
-  displayName: Run Hygiene Checks
-
-- script: |
     yarn monaco-compile-check
   displayName: Run Monaco Editor Checks
 

--- a/build/azure-pipelines/win32/continuous-build-win32.yml
+++ b/build/azure-pipelines/win32/continuous-build-win32.yml
@@ -36,10 +36,6 @@ steps:
     yarn electron
   displayName: Download Electron
 
-- script: |
-    yarn gulp hygiene
-  displayName: Run Hygiene Checks
-
 - powershell: |
     yarn monaco-compile-check
   displayName: Run Monaco Editor Checks


### PR DESCRIPTION
* Remove the code hygiene task from the Windows and Mac build (remove ~3 minutes from execution time)
* Task will still run as part of the Linux pipeline which is much faster than the Windows and Mac one