### PR TITLE
Use js debug stable for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.46.0",
-  "distro": "26783d64d76b2c2772a6fd49b00b230b75ec3385",
+  "distro": "358cb39074b493e73fc931ad744770a1f00c4ad4",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/product.json
+++ b/product.json
@@ -89,8 +89,8 @@
 			}
 		},
 		{
-			"name": "ms-vscode.js-debug-nightly",
-			"version": "2020.6.208",
+			"name": "ms-vscode.js-debug",
+			"version": "1.46.0",
 			"repo": "https://github.com/Microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "7acbb4ce-c85a-49d4-8d95-a8054406ae97",

--- a/product.json
+++ b/product.json
@@ -90,7 +90,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.46.0",
+			"version": "1.46.1",
 			"repo": "https://github.com/Microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "7acbb4ce-c85a-49d4-8d95-a8054406ae97",


### PR DESCRIPTION
Last night we determined that we will ship js-debug as built-in in the May release. I've started a separate "stable" channel build for js-debug (to allow users to easily opt-in to nightly and update) and also updated distro with the js-debug exclusions removed from the VS Code stable build.