### PR TITLE
Fix properties being overridden by accessors

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -86,7 +86,14 @@ const DefaultOptions = {
 export class ElementsDragAndDropData<T, TContext = void> implements IDragAndDropData {
 
 	readonly elements: T[];
-	context: TContext | undefined;
+
+	private _context: TContext | undefined;
+	public get context(): TContext | undefined {
+		return this._context;
+	}
+	public set context(value: TContext | undefined) {
+		this._context = value;
+	}
 
 	constructor(elements: T[]) {
 		this.elements = elements;

--- a/src/vs/workbench/browser/parts/editor/baseEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/baseEditor.ts
@@ -38,10 +38,10 @@ export abstract class BaseEditor extends Composite implements IEditorPane {
 
 	private static readonly EDITOR_MEMENTOS = new Map<string, EditorMemento<any>>();
 
-	readonly minimumWidth = DEFAULT_EDITOR_MIN_DIMENSIONS.width;
-	readonly maximumWidth = DEFAULT_EDITOR_MAX_DIMENSIONS.width;
-	readonly minimumHeight = DEFAULT_EDITOR_MIN_DIMENSIONS.height;
-	readonly maximumHeight = DEFAULT_EDITOR_MAX_DIMENSIONS.height;
+	get minimumWidth() { return DEFAULT_EDITOR_MIN_DIMENSIONS.width; }
+	get maximumWidth() { return DEFAULT_EDITOR_MAX_DIMENSIONS.width; }
+	get minimumHeight() { return DEFAULT_EDITOR_MIN_DIMENSIONS.height; }
+	get maximumHeight() { return DEFAULT_EDITOR_MAX_DIMENSIONS.height; }
 
 	readonly onDidSizeConstraintsChange = Event.None;
 

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -44,10 +44,18 @@ export abstract class BaseTextEditor extends BaseEditor implements ITextEditorPa
 	private lastAppliedEditorOptions?: IEditorOptions;
 	private editorMemento: IEditorMemento<IEditorViewState>;
 
+	private _instantiationService: IInstantiationService;
+	protected get instantiationService(): IInstantiationService {
+		return this._instantiationService;
+	}
+	protected set instantiationService(value: IInstantiationService) {
+		this._instantiationService = value;
+	}
+
 	constructor(
 		id: string,
 		@ITelemetryService telemetryService: ITelemetryService,
-		@IInstantiationService protected readonly instantiationService: IInstantiationService,
+		@IInstantiationService instantiationService: IInstantiationService,
 		@IStorageService storageService: IStorageService,
 		@ITextResourceConfigurationService protected readonly textResourceConfigurationService: ITextResourceConfigurationService,
 		@IThemeService protected themeService: IThemeService,
@@ -55,6 +63,7 @@ export abstract class BaseTextEditor extends BaseEditor implements ITextEditorPa
 		@IEditorGroupsService protected editorGroupService: IEditorGroupsService
 	) {
 		super(id, telemetryService, themeService, storageService);
+		this._instantiationService = instantiationService;
 
 		this.editorMemento = this.getEditorMemento<IEditorViewState>(editorGroupService, BaseTextEditor.TEXT_EDITOR_VIEW_STATE_PREFERENCE_KEY, 100);
 

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -178,7 +178,11 @@ export abstract class ViewPane extends Pane implements IView {
 
 	private _isVisible: boolean = false;
 	readonly id: string;
-	title: string;
+
+	private _title: string;
+	public get title(): string {
+		return this._title;
+	}
 
 	private readonly menuActions: ViewMenuActions;
 	private progressBar!: ProgressBar;
@@ -211,7 +215,7 @@ export abstract class ViewPane extends Pane implements IView {
 		super({ ...options, ...{ orientation: viewDescriptorService.getViewLocationById(options.id) === ViewContainerLocation.Panel ? Orientation.HORIZONTAL : Orientation.VERTICAL } });
 
 		this.id = options.id;
-		this.title = options.title;
+		this._title = options.title;
 		this.showActionsAlways = !!options.showActionsAlways;
 		this.focusedViewContextKey = FocusedViewContext.bindTo(contextKeyService);
 
@@ -370,7 +374,7 @@ export abstract class ViewPane extends Pane implements IView {
 			this.iconContainer.setAttribute('aria-label', calculatedTitle);
 		}
 
-		this.title = title;
+		this._title = title;
 		this._onDidChangeTitleArea.fire();
 	}
 

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
@@ -99,11 +99,11 @@ async function setupTest() {
 	instantiationService.stub(IRemoteAgentService, RemoteAgentService);
 
 	instantiationService.stub(IExtensionManagementServerService, new class extends ExtensionManagementServerService {
-		private _localExtensionManagementServer: IExtensionManagementServer = { extensionManagementService: instantiationService.get(IExtensionManagementService), label: 'local', authority: 'vscode-local' };
+		#localExtensionManagementServer: IExtensionManagementServer = { extensionManagementService: instantiationService.get(IExtensionManagementService), label: 'local', authority: 'vscode-local' };
 		constructor() {
 			super(instantiationService.get(ISharedProcessService), instantiationService.get(IRemoteAgentService), instantiationService.get(IExtensionGalleryService), instantiationService.get(IConfigurationService), instantiationService.get(IProductService), instantiationService.get(ILogService), instantiationService.get(ILabelService));
 		}
-		get localExtensionManagementServer(): IExtensionManagementServer { return this._localExtensionManagementServer; }
+		get localExtensionManagementServer(): IExtensionManagementServer { return this.#localExtensionManagementServer; }
 		set localExtensionManagementServer(server: IExtensionManagementServer) { }
 	}());
 

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsViews.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsViews.test.ts
@@ -99,11 +99,11 @@ suite('ExtensionsListView Tests', () => {
 		instantiationService.stub(IMenuService, new TestMenuService());
 
 		instantiationService.stub(IExtensionManagementServerService, new class extends ExtensionManagementServerService {
-			private _localExtensionManagementServer: IExtensionManagementServer = { extensionManagementService: instantiationService.get(IExtensionManagementService), label: 'local', authority: 'vscode-local' };
+			#localExtensionManagementServer: IExtensionManagementServer = { extensionManagementService: instantiationService.get(IExtensionManagementService), label: 'local', authority: 'vscode-local' };
 			constructor() {
 				super(instantiationService.get(ISharedProcessService), instantiationService.get(IRemoteAgentService), instantiationService.get(IExtensionGalleryService), instantiationService.get(IConfigurationService), instantiationService.get(IProductService), instantiationService.get(ILogService), instantiationService.get(ILabelService));
 			}
-			get localExtensionManagementServer(): IExtensionManagementServer { return this._localExtensionManagementServer; }
+			get localExtensionManagementServer(): IExtensionManagementServer { return this.#localExtensionManagementServer; }
 			set localExtensionManagementServer(server: IExtensionManagementServer) { }
 		}());
 

--- a/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
@@ -80,7 +80,7 @@ export class PreferencesEditor extends BaseEditor {
 	set minimumWidth(value: number) { /*noop*/ }
 	set maximumWidth(value: number) { /*noop*/ }
 
-	readonly minimumHeight = 260;
+	get minimumHeight() { return 260; }
 
 	private _onDidCreateWidget = this._register(new Emitter<{ width: number; height: number; } | undefined>());
 	readonly onDidSizeConstraintsChange: Event<{ width: number; height: number; } | undefined> = this._onDidCreateWidget.event;

--- a/src/vs/workbench/contrib/remote/browser/explorerViewItems.ts
+++ b/src/vs/workbench/contrib/remote/browser/explorerViewItems.ts
@@ -6,7 +6,7 @@
 import * as nls from 'vs/nls';
 import * as dom from 'vs/base/browser/dom';
 
-import { IActionRunner, IAction, Action } from 'vs/base/common/actions';
+import { IAction, Action } from 'vs/base/common/actions';
 import { SelectActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { attachSelectBoxStyler, attachStylerCallback } from 'vs/platform/theme/common/styler';
@@ -26,8 +26,6 @@ export interface IRemoteSelectItem extends ISelectOptionItem {
 }
 
 export class SwitchRemoteViewItem extends SelectActionViewItem {
-
-	actionRunner!: IActionRunner;
 
 	constructor(
 		action: IAction,

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
@@ -90,7 +90,7 @@ export class SearchEditor extends BaseTextEditor {
 		@IModelService private readonly modelService: IModelService,
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
 		@ILabelService private readonly labelService: ILabelService,
-		@IInstantiationService readonly instantiationService: IInstantiationService,
+		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IContextKeyService readonly contextKeyService: IContextKeyService,

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionManagementServerService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionManagementServerService.ts
@@ -26,7 +26,10 @@ export class ExtensionManagementServerService implements IExtensionManagementSer
 
 	declare readonly _serviceBrand: undefined;
 
-	readonly localExtensionManagementServer: IExtensionManagementServer;
+	private readonly _localExtensionManagementServer: IExtensionManagementServer;
+	public get localExtensionManagementServer(): IExtensionManagementServer {
+		return this._localExtensionManagementServer;
+	}
 	readonly remoteExtensionManagementServer: IExtensionManagementServer | null = null;
 	readonly isSingleServer: boolean = false;
 
@@ -41,7 +44,7 @@ export class ExtensionManagementServerService implements IExtensionManagementSer
 	) {
 		const localExtensionManagementService = new ExtensionManagementChannelClient(sharedProcessService.getChannel('extensions'));
 
-		this.localExtensionManagementServer = { extensionManagementService: localExtensionManagementService, authority: localExtensionManagementServerAuthority, label: localize('local', "Local") };
+		this._localExtensionManagementServer = { extensionManagementService: localExtensionManagementService, authority: localExtensionManagementServerAuthority, label: localize('local', "Local") };
 		const remoteAgentConnection = remoteAgentService.getConnection();
 		if (remoteAgentConnection) {
 			const extensionManagementService = new RemoteExtensionManagementChannelClient(remoteAgentConnection.getChannel<IChannel>('extensions'), this.localExtensionManagementServer.extensionManagementService, galleryService, logService, configurationService, productService);

--- a/src/vs/workbench/services/textfile/electron-browser/nativeTextFileService.ts
+++ b/src/vs/workbench/services/textfile/electron-browser/nativeTextFileService.ts
@@ -325,7 +325,13 @@ export interface IEncodingOverride {
 }
 
 export class EncodingOracle extends Disposable implements IResourceEncodings {
-	protected encodingOverrides: IEncodingOverride[];
+	private _encodingOverrides: IEncodingOverride[];
+	protected get encodingOverrides(): IEncodingOverride[] {
+		return this._encodingOverrides;
+	}
+	protected set encodingOverrides(value: IEncodingOverride[]) {
+		this._encodingOverrides = value;
+	}
 
 	constructor(
 		@ITextResourceConfigurationService private textResourceConfigurationService: ITextResourceConfigurationService,
@@ -335,7 +341,7 @@ export class EncodingOracle extends Disposable implements IResourceEncodings {
 	) {
 		super();
 
-		this.encodingOverrides = this.getDefaultEncodingOverrides();
+		this._encodingOverrides = this.getDefaultEncodingOverrides();
 
 		this.registerListeners();
 	}


### PR DESCRIPTION
Fixes #99304

TS 4.0 will now warn if you try overriding a property using an accessor. See #99304 for details
