### PR TITLE
Handle backup data with custom editor input factory

### DIFF
--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -56,6 +56,8 @@ export namespace Schemas {
 
 	export const vscodeCustomEditor = 'vscode-custom-editor';
 
+	export const vscodeNotebook = 'vscode-notebook';
+
 	export const vscodeSettings = 'vscode-settings';
 
 	export const webviewPanel = 'webview-panel';

--- a/src/vs/workbench/contrib/customEditor/browser/customEditor.contribution.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditor.contribution.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Schemas } from 'vs/base/common/network';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
@@ -38,4 +39,4 @@ Registry.as<IEditorInputFactoryRegistry>(EditorInputExtensions.EditorInputFactor
 		CustomEditorInputFactory);
 
 Registry.as<IEditorInputFactoryRegistry>(EditorInputExtensions.EditorInputFactories)
-	.registerCustomEditorInputFactory(CustomEditorInputFactory);
+	.registerCustomEditorInputFactory(Schemas.vscodeCustomEditor, CustomEditorInputFactory);

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
@@ -124,4 +124,8 @@ export class CustomEditorInputFactory extends WebviewEditorInputFactory {
 			return editor;
 		});
 	}
+
+	public static canResolveBackup(editorInput: IEditorInput, backupResource: URI): boolean {
+		return false;
+	}
 }

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
@@ -12,6 +12,8 @@ import { IWebviewService, WebviewExtensionDescription } from 'vs/workbench/contr
 import { reviveWebviewExtensionDescription, SerializedWebview, WebviewEditorInputFactory, DeserializedWebview } from 'vs/workbench/contrib/webview/browser/webviewEditorInputFactory';
 import { IWebviewWorkbenchService, WebviewInputOptions } from 'vs/workbench/contrib/webview/browser/webviewWorkbenchService';
 import { IBackupFileService } from 'vs/workbench/services/backup/common/backup';
+import { isEqual } from 'vs/base/common/resources';
+import { Schemas } from 'vs/base/common/network';
 
 export interface CustomDocumentBackupData {
 	readonly viewType: string;
@@ -126,6 +128,12 @@ export class CustomEditorInputFactory extends WebviewEditorInputFactory {
 	}
 
 	public static canResolveBackup(editorInput: IEditorInput, backupResource: URI): boolean {
+		if (editorInput instanceof CustomEditorInput) {
+			if (editorInput.resource.path === backupResource.path && backupResource.authority === editorInput.viewType) {
+				return true;
+			}
+		}
+
 		return false;
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorInput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorInput.ts
@@ -13,9 +13,14 @@ import { NotebookEditorModel } from 'vs/workbench/contrib/notebook/common/notebo
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 
 let NOTEBOOK_EDITOR_INPUT_HANDLE = 0;
+
+interface NotebookEditorInputOptions {
+	startDirty?: boolean;
+}
+
 export class NotebookEditorInput extends EditorInput {
-	static create(instantiationService: IInstantiationService, resource: URI, name: string, viewType: string | undefined) {
-		return instantiationService.createInstance(NotebookEditorInput, resource, name, viewType);
+	static create(instantiationService: IInstantiationService, resource: URI, name: string, viewType: string | undefined, options: NotebookEditorInputOptions = {}) {
+		return instantiationService.createInstance(NotebookEditorInput, resource, name, viewType, options);
 	}
 
 	static readonly ID: string = 'workbench.input.notebook';
@@ -31,11 +36,14 @@ export class NotebookEditorInput extends EditorInput {
 		this._group = group;
 	}
 
+	private _defaultDirtyState: boolean = false;
+
 	readonly id: number = NOTEBOOK_EDITOR_INPUT_HANDLE++;
 	constructor(
 		public resource: URI,
 		public name: string,
 		public readonly viewType: string | undefined,
+		public readonly options: NotebookEditorInputOptions,
 		@INotebookService private readonly notebookService: INotebookService,
 		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService,
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
@@ -43,6 +51,7 @@ export class NotebookEditorInput extends EditorInput {
 		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) {
 		super();
+		this._defaultDirtyState = !!options.startDirty;
 	}
 
 	getTypeId(): string {
@@ -54,6 +63,10 @@ export class NotebookEditorInput extends EditorInput {
 	}
 
 	isDirty() {
+		if (!this.textModel) {
+			return !!this._defaultDirtyState;
+		}
+
 		return this.textModel?.isDirty() || false;
 	}
 

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -560,6 +560,11 @@ export interface INotebookTextModelBackup {
 	cells: ICellDto2[]
 }
 
+export interface NotebookDocumentBackupData {
+	readonly viewType: string;
+	readonly name: string;
+}
+
 export interface IEditor extends editorCommon.ICompositeCodeEditor {
 	readonly onDidChangeModel: Event<NotebookTextModel | undefined>;
 	readonly onDidFocusEditorWidget: Event<void>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #99056.

"Custom" editors might be using working copies with different scheme (which means `EditorInput.resource !== WorkingCopy.resource`), then when we restore backups and hook them with editor tabs during workbench restore, we have to ask custom editor contributions if a backup resource is identical to an editor input resource.
