### PR TITLE
Allow numeric CLI argument

### DIFF
--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -256,7 +256,7 @@ export function parseArgs<T>(args: string[], options: OptionDescriptions<T>, err
 	const remainingArgs: any = parsedArgs;
 
 	// https://github.com/microsoft/vscode/issues/58177
-	cleanedArgs._ = parsedArgs._.filter(arg => arg.toString?.().length > 0);
+	cleanedArgs._ = parsedArgs._.filter(arg => String(arg).length > 0);
 
 	delete remainingArgs._;
 

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -256,7 +256,7 @@ export function parseArgs<T>(args: string[], options: OptionDescriptions<T>, err
 	const remainingArgs: any = parsedArgs;
 
 	// https://github.com/microsoft/vscode/issues/58177
-	cleanedArgs._ = parsedArgs._.filter(arg => arg.length > 0);
+	cleanedArgs._ = parsedArgs._.filter(arg => arg.toString?.().length > 0);
 
 	delete remainingArgs._;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #98439

We were discarding empty args as part of https://github.com/microsoft/vscode/issues/58177, however this would discard numbers too as they were not strings when the check took place
