### PR TITLE
Always use canonical uri inside `createModelReference`

### DIFF
--- a/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
+++ b/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
@@ -184,6 +184,9 @@ export class TextModelResolverService extends Disposable implements ITextModelSe
 
 	async createModelReference(resource: URI): Promise<IReference<IResolvedTextEditorModel>> {
 
+		// From this moment on, only operate on the canonical resource
+		// to ensure we reduce the chance of resolving the same resource
+		// with different resource forms (e.g. path casing on Windows)
 		resource = this.uriIdentityService.asCanonicalUri(resource);
 
 		const ref = this.resourceModelCollection.acquire(resource.toString());

--- a/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
+++ b/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
@@ -17,6 +17,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
 import { ModelUndoRedoParticipant } from 'vs/editor/common/services/modelUndoRedoParticipant';
+import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
 
 class ResourceModelCollection extends ReferenceCollection<Promise<ITextEditorModel>> {
 
@@ -174,13 +175,17 @@ export class TextModelResolverService extends Disposable implements ITextModelSe
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IFileService private readonly fileService: IFileService,
 		@IUndoRedoService private readonly undoRedoService: IUndoRedoService,
-		@IModelService private readonly modelService: IModelService
+		@IModelService private readonly modelService: IModelService,
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 	) {
 		super();
 		this._register(new ModelUndoRedoParticipant(this.modelService, this, this.undoRedoService));
 	}
 
 	async createModelReference(resource: URI): Promise<IReference<IResolvedTextEditorModel>> {
+
+		resource = this.uriIdentityService.asCanonicalUri(resource);
+
 		const ref = this.resourceModelCollection.acquire(resource.toString());
 
 		try {


### PR DESCRIPTION
This is for https://github.com/microsoft/vscode/issues/93368