### PR TITLE
Fix noDebug argument not being passed

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugActions.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugActions.ts
@@ -13,6 +13,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+import { deepClone } from 'vs/base/common/objects';
 
 export abstract class AbstractDebugAction extends Action {
 
@@ -129,7 +130,8 @@ export class StartAction extends AbstractDebugAction {
 
 	async run(): Promise<boolean> {
 		let { launch, name, config } = this.debugService.getConfigurationManager().selectedConfiguration;
-		return this.debugService.startDebugging(launch, config || name, { noDebug: this.isNoDebug() });
+		const clonedConfig = deepClone(config);
+		return this.debugService.startDebugging(launch, clonedConfig || name, { noDebug: this.isNoDebug() });
 	}
 
 	protected isNoDebug(): boolean {

--- a/src/vs/workbench/contrib/debug/browser/debugActions.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugActions.ts
@@ -13,7 +13,6 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
-import { deepClone } from 'vs/base/common/objects';
 
 export abstract class AbstractDebugAction extends Action {
 
@@ -130,8 +129,7 @@ export class StartAction extends AbstractDebugAction {
 
 	async run(): Promise<boolean> {
 		let { launch, name, config } = this.debugService.getConfigurationManager().selectedConfiguration;
-		const clonedConfig = deepClone(config);
-		return this.debugService.startDebugging(launch, clonedConfig || name, { noDebug: this.isNoDebug() });
+		return this.debugService.startDebugging(launch, config || name, { noDebug: this.isNoDebug() });
 	}
 
 	protected isNoDebug(): boolean {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -372,11 +372,8 @@ export class DebugService implements IDebugService {
 			// a no-folder workspace has no launch.config
 			config = Object.create(null);
 		}
+		config!.noDebug = !!(options && options.noDebug);
 		const unresolvedConfig = deepClone(config);
-
-		if (options && options.noDebug) {
-			config!.noDebug = true;
-		}
 
 		if (!type) {
 			const guess = await this.configurationManager.guessDebugger();

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -372,8 +372,12 @@ export class DebugService implements IDebugService {
 			// a no-folder workspace has no launch.config
 			config = Object.create(null);
 		}
-		config!.noDebug = !!(options && options.noDebug);
 		const unresolvedConfig = deepClone(config);
+		if (options && options.noDebug) {
+			config!.noDebug = true;
+		} else {
+			delete config!.noDebug;
+		}
 
 		if (!type) {
 			const guess = await this.configurationManager.guessDebugger();

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -375,8 +375,6 @@ export class DebugService implements IDebugService {
 		const unresolvedConfig = deepClone(config);
 		if (options && options.noDebug) {
 			config!.noDebug = true;
-		} else {
-			delete config!.noDebug;
 		}
 
 		if (!type) {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -375,6 +375,8 @@ export class DebugService implements IDebugService {
 		const unresolvedConfig = deepClone(config);
 		if (options && options.noDebug) {
 			config!.noDebug = true;
+		} else {
+			delete config!.noDebug;
 		}
 
 		if (!type) {


### PR DESCRIPTION
fixes #99576

The problem was that we started storing full configurations in storage for debug dynamic configurations.
This broke the `noDebug` flag which could be stored for launch config "Launch Program" and the next time that launch config is started the stored `noDebug` would be respected.

This commit simply always overwrites the `noDebug` flag to be allowed with what is passed and thus what the user requested.