### PR TITLE
Add a pattern to the git BranchQuery

### DIFF
--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -135,6 +135,7 @@ export interface CommitOptions {
 export interface BranchQuery {
 	readonly remote?: boolean;
 	readonly pattern?: string;
+	readonly count?: number;
 	readonly contains?: string;
 }
 

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -134,6 +134,7 @@ export interface CommitOptions {
 
 export interface BranchQuery {
 	readonly remote?: boolean;
+	readonly pattern?: string;
 	readonly contains?: string;
 }
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1791,7 +1791,7 @@ export class Repository {
 			.map(([ref]) => ({ name: ref, type: RefType.Head } as Branch));
 	}
 
-	async getRefs(opts?: { sort?: 'alphabetically' | 'committerdate', contains?: string, pattern?: string }): Promise<Ref[]> {
+	async getRefs(opts?: { sort?: 'alphabetically' | 'committerdate', contains?: string, pattern?: string, count?: number }): Promise<Ref[]> {
 		const args = ['for-each-ref', '--format', '%(refname) %(objectname)'];
 
 		if (opts && opts.sort && opts.sort !== 'alphabetically') {
@@ -1800,6 +1800,10 @@ export class Repository {
 
 		if (opts?.pattern) {
 			args.push(opts.pattern);
+		}
+
+		if (opts?.count) {
+			args.push(`--count=${opts.count}`);
 		}
 
 		if (opts?.contains) {
@@ -1924,7 +1928,7 @@ export class Repository {
 	}
 
 	async getBranches(query: BranchQuery): Promise<Ref[]> {
-		const refs = await this.getRefs({ contains: query.contains, pattern: query.pattern ? `refs/${query.pattern}` : undefined });
+		const refs = await this.getRefs({ contains: query.contains, pattern: query.pattern ? `refs/${query.pattern}` : undefined, count: query.count });
 		return refs.filter(value => (value.type !== RefType.Tag) && (query.remote || !value.remote));
 	}
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1791,11 +1791,15 @@ export class Repository {
 			.map(([ref]) => ({ name: ref, type: RefType.Head } as Branch));
 	}
 
-	async getRefs(opts?: { sort?: 'alphabetically' | 'committerdate', contains?: string }): Promise<Ref[]> {
+	async getRefs(opts?: { sort?: 'alphabetically' | 'committerdate', contains?: string, pattern?: string }): Promise<Ref[]> {
 		const args = ['for-each-ref', '--format', '%(refname) %(objectname)'];
 
 		if (opts && opts.sort && opts.sort !== 'alphabetically') {
 			args.push('--sort', `-${opts.sort}`);
+		}
+
+		if (opts?.pattern) {
+			args.push(opts.pattern);
 		}
 
 		if (opts?.contains) {
@@ -1920,7 +1924,7 @@ export class Repository {
 	}
 
 	async getBranches(query: BranchQuery): Promise<Ref[]> {
-		const refs = await this.getRefs({ contains: query.contains });
+		const refs = await this.getRefs({ contains: query.contains, pattern: query.pattern ? `refs/${query.pattern}` : undefined });
 		return refs.filter(value => (value.type !== RefType.Tag) && (query.remote || !value.remote));
 	}
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1792,18 +1792,20 @@ export class Repository {
 	}
 
 	async getRefs(opts?: { sort?: 'alphabetically' | 'committerdate', contains?: string, pattern?: string, count?: number }): Promise<Ref[]> {
-		const args = ['for-each-ref', '--format', '%(refname) %(objectname)'];
+		const args = ['for-each-ref'];
+
+		if (opts?.count) {
+			args.push(`--count=${opts.count}`);
+		}
 
 		if (opts && opts.sort && opts.sort !== 'alphabetically') {
 			args.push('--sort', `-${opts.sort}`);
 		}
 
+		args.push('--format', '%(refname) %(objectname)');
+
 		if (opts?.pattern) {
 			args.push(opts.pattern);
-		}
-
-		if (opts?.count) {
-			args.push(`--count=${opts.count}`);
 		}
 
 		if (opts?.contains) {


### PR DESCRIPTION
It turns out that this:
```
git for-each-ref --format "%(refname) %(objectname)" --contains 4ea4be72675c61c1eb62caa36377df065a1cdd68
```
is impressively slow in repositories with many branches (I saw >15 seconds, which is unusable for what I was using it for). However, this:
```
git for-each-ref --format "%(refname) %(objectname)" refs/remotes/origin/HEAD --contains 4ea4be72675c61c1eb62caa36377df065a1cdd68
```
is much quicker (<4 seconds).

To accomplish this, I've added a pattern (which is what that arg is called in the [docs](https://git-scm.com/docs/git-for-each-ref)) to the API.