### PR TITLE
add missing icons for comments and ref prev

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/browser/mainThreadComments.ts
@@ -21,6 +21,7 @@ import { COMMENTS_VIEW_ID, COMMENTS_VIEW_TITLE } from 'vs/workbench/contrib/comm
 import { ViewContainer, IViewContainersRegistry, Extensions as ViewExtensions, ViewContainerLocation, IViewsRegistry, IViewsService, IViewDescriptorService } from 'vs/workbench/common/views';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer';
+import { Codicon } from 'vs/base/common/codicons';
 
 
 export class MainThreadCommentThread implements modes.CommentThread {
@@ -458,6 +459,7 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 				ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [COMMENTS_VIEW_ID, { mergeViewWithContainerWhenSingleView: true, donotShowContainerTitleWhenMergedWithContainer: true }]),
 				storageId: COMMENTS_VIEW_TITLE,
 				hideIfEmpty: true,
+				icon: Codicon.commentDiscussion.classNames,
 				order: 10,
 			}, ViewContainerLocation.Panel);
 
@@ -467,6 +469,7 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 				canToggleVisibility: false,
 				ctorDescriptor: new SyncDescriptor(CommentsPanel),
 				canMoveView: true,
+				containerIcon: Codicon.commentDiscussion.classNames,
 				focusCommand: {
 					id: 'workbench.action.focusCommentsPanel'
 				}

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEdit.contribution.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEdit.contribution.ts
@@ -28,6 +28,7 @@ import type { ServicesAccessor } from 'vs/platform/instantiation/common/instanti
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import Severity from 'vs/base/common/severity';
+import { Codicon } from 'vs/base/common/codicons';
 
 async function getBulkEditPane(viewsService: IViewsService): Promise<BulkEditPane | undefined> {
 	const view = await viewsService.openView(BulkEditPane.ID, true);
@@ -354,6 +355,7 @@ const container = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.V
 		ViewPaneContainer,
 		[BulkEditPane.ID, { mergeViewWithContainerWhenSingleView: true, donotShowContainerTitleWhenMergedWithContainer: true }]
 	),
+	icon: Codicon.lightbulb.classNames,
 	storageId: BulkEditPane.ID
 }, ViewContainerLocation.Panel);
 
@@ -362,5 +364,6 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	name: localize('panel', "Refactor Preview"),
 	when: BulkEditPreviewContribution.ctxEnabled,
 	ctorDescriptor: new SyncDescriptor(BulkEditPane),
+	containerIcon: Codicon.lightbulb.classNames,
 }], container);
 


### PR DESCRIPTION
Miguel found that comments panel was missing an activity bar icon as well as refactor preview. The fix just to add icons so risk isn't an issue. This is piggy backing on https://github.com/microsoft/vscode/pull/99692