### PR TITLE
#98964: Fixed the restart frame icon

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/callStackView.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackView.ts
@@ -591,6 +591,25 @@ class StackFramesRenderer implements ITreeRenderer<IStackFrame, FuzzyScore, ISta
 		const label = new HighlightedLabel(labelDiv, false);
 		const actionBar = new ActionBar(stackFrame);
 
+		// Mouse enter listener, to check the size of the container and file label
+		// If the size is going above threshold, adding a class to change the css
+		// and fit the restart frame in the dom
+		dom.addDisposableListener(stackFrame, dom.EventType.MOUSE_ENTER, () => {
+			const thresholdBuffer = 46;
+			const labelDivWidth = dom.getContentWidth(labelDiv);
+			const containerWidth = dom.getContentWidth(container);
+			if (labelDivWidth + thresholdBuffer >= containerWidth) {
+				dom.addClass(labelDiv, 'threshold-label-view');
+			}
+		});
+
+		// Mouse leave listener, to remove the class added above
+		dom.addDisposableListener(stackFrame, dom.EventType.MOUSE_LEAVE, () => {
+			if (dom.hasClass(labelDiv, 'threshold-label-view')) {
+				dom.removeClass(labelDiv, 'threshold-label-view');
+			}
+		});
+
 		return { file, fileName, label, lineNumber, stackFrame, actionBar };
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -183,6 +183,10 @@
 	min-width: -moz-fit-content;
 }
 
+.debug-pane .debug-call-stack .stack-frame .threshold-label-view {
+	min-width: calc(100% - 64px);
+}
+
 .debug-pane .debug-call-stack .stack-frame.subtle {
 	font-style: italic;
 }


### PR DESCRIPTION
This PR fixes #98964 : Fixed the restart frame icon disappearance 

It adds a class to the `labelDiv`, it activates when we hover over it and the size is going out of bounds. That class' css has been also added. The class gets removed when the mouse leaves that `labelDiv`. The class name is `threshold-label-view`.