### PR TITLE
Update for-in loop to work with eslint:recommended

### DIFF
--- a/extensions/typescript-basics/snippets/typescript.code-snippets
+++ b/extensions/typescript-basics/snippets/typescript.code-snippets
@@ -151,7 +151,7 @@
 		"prefix": "forin",
 		"body": [
 			"for (const ${1:key} in ${2:object}) {",
-			"\tif (${2:object}.hasOwnProperty(${1:key})) {",
+			"\tif (Object.prototype.hasOwnProperty.call(${2:object}, ${1:key})) {",
 			"\t\tconst ${3:element} = ${2:object}[${1:key}];",
 			"\t\t$0",
 			"\t}",


### PR DESCRIPTION
The code in the automatic template will fail this eslint rule: https://eslint.org/docs/rules/no-prototype-builtins. This is just plain annoying.

This change will make the snippet generated code not fail the linter. It will also avoid the subtle bugs that the eslint rule was made to avoid in the first place.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #99720
