### PR TITLE
fix #99854 make 'Edit in settings.json' add object-type default

### DIFF
--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -614,7 +614,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		const type = schema ? schema.type : 'object' /* Override Identifier */;
 		let setting = settingsModel.getPreference(settingKey);
 		if (!setting) {
-			const defaultValue = type === 'array' ? this.configurationService.inspect(settingKey).defaultValue : getDefaultValue(type);
+			const defaultValue = (type === 'object' || type === 'array') ? this.configurationService.inspect(settingKey).defaultValue : getDefaultValue(type);
 			if (defaultValue !== undefined) {
 				const key = settingsModel instanceof WorkspaceConfigurationEditorModel ? ['settings', settingKey] : [settingKey];
 				await this.jsonEditingService.write(settingsModel.uri!, [{ path: key, value: defaultValue }], false);


### PR DESCRIPTION
This PR fixes #99854

To test:
1. Clone https://github.com/gjsjohnmurray/vscode-extension-samples/tree/test-vscode-99854
2. Run the modified configuration-sample this branch contains.
3. Open Settings UI.
4. Locate Configuration Samples section under Extensions and click 'Edit in settings.json' link
![image](https://user-images.githubusercontent.com/6726799/84434276-a333bb80-ac27-11ea-99d3-df460f6cbdff.png)
5. After dismissing the automatically-opened quickpick, verify that the defaults for this object-type setting have been inserted:
```json
	"conf.resource.insertEmptyLastLine": {
	
		"one": "FirstDefault",
		"two": {
			"alpha": "abc",
			"number": 123
		}
	}
```