### PR TITLE
ActionBar: only navigate on one key

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -479,27 +479,27 @@ export class ActionBar extends Disposable implements IActionRunner {
 			DOM.addClass(this.domNode, 'animated');
 		}
 
-		let previousKeys: KeyCode[];
-		let nextKeys: KeyCode[];
+		let previousKey: KeyCode;
+		let nextKey: KeyCode;
 
 		switch (this.options.orientation) {
 			case ActionsOrientation.HORIZONTAL:
-				previousKeys = [KeyCode.LeftArrow, KeyCode.UpArrow];
-				nextKeys = [KeyCode.RightArrow, KeyCode.DownArrow];
+				previousKey = KeyCode.LeftArrow;
+				nextKey = KeyCode.RightArrow;
 				break;
 			case ActionsOrientation.HORIZONTAL_REVERSE:
-				previousKeys = [KeyCode.RightArrow, KeyCode.DownArrow];
-				nextKeys = [KeyCode.LeftArrow, KeyCode.UpArrow];
+				previousKey = KeyCode.RightArrow;
+				nextKey = KeyCode.LeftArrow;
 				this.domNode.className += ' reverse';
 				break;
 			case ActionsOrientation.VERTICAL:
-				previousKeys = [KeyCode.LeftArrow, KeyCode.UpArrow];
-				nextKeys = [KeyCode.RightArrow, KeyCode.DownArrow];
+				previousKey = KeyCode.UpArrow;
+				nextKey = KeyCode.DownArrow;
 				this.domNode.className += ' vertical';
 				break;
 			case ActionsOrientation.VERTICAL_REVERSE:
-				previousKeys = [KeyCode.RightArrow, KeyCode.DownArrow];
-				nextKeys = [KeyCode.LeftArrow, KeyCode.UpArrow];
+				previousKey = KeyCode.DownArrow;
+				nextKey = KeyCode.UpArrow;
 				this.domNode.className += ' vertical reverse';
 				break;
 		}
@@ -508,9 +508,9 @@ export class ActionBar extends Disposable implements IActionRunner {
 			const event = new StandardKeyboardEvent(e);
 			let eventHandled = true;
 
-			if (previousKeys && (event.equals(previousKeys[0]) || event.equals(previousKeys[1]))) {
+			if (event.equals(previousKey)) {
 				this.focusPrevious();
-			} else if (nextKeys && (event.equals(nextKeys[0]) || event.equals(nextKeys[1]))) {
+			} else if (event.equals(nextKey)) {
 				this.focusNext();
 			} else if (event.equals(KeyCode.Escape)) {
 				this._onDidCancel.fire();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/99907

I have changed the action bar such that it navigates next with both `rigtht` and `down` key and to navigate previous with both `up` and `left`. Idea being that not all users can see the orientation.

Unfortunetly this breaks the custom menu which rellyes on the left / right navigation keys not being used to jump to other menus.

The fix is a simple revert and is low risk - we are just going to previous behavior.
I have verified this indeed fixes the issue.