### PR TITLE
fix #98945 Handle `.git/info/exclude`

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1805,6 +1805,7 @@
           ".gitignore_global",
           ".gitignore"
         ],
+        "filenamePatterns": ["**/.git/info/exclude"],
         "configuration": "./languages/ignore.language-configuration.json"
       }
     ],

--- a/extensions/git/src/decorationProvider.ts
+++ b/extensions/git/src/decorationProvider.ts
@@ -21,7 +21,10 @@ class GitIgnoreDecorationProvider implements DecorationProvider {
 
 	constructor(private model: Model) {
 		this.onDidChangeDecorations = fireEvent(anyEvent<any>(
-			filterEvent(workspace.onDidSaveTextDocument, e => e.fileName.endsWith('.gitignore')),
+			filterEvent(workspace.onDidSaveTextDocument, e => {
+				return e.fileName.match(/([/\\]|^).gitignore$/) !== null
+					|| e.fileName.match(/([/\\]|^).git[/\\]info[/\\]exclude$/) !== null;
+			}),
 			model.onDidOpenRepository,
 			model.onDidCloseRepository
 		));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #98945

Git status refreshes:

- Add `.git/info/exclude` to the files triggering a git status refresh
- Make the detection of `.gitignore` file narrower: require the filename
  to have an empty stem (`hi.gitignore` won't trigger a refresh).

Language detection:

- `.git/info/exclude` is now detected as using the (git) `"ignore"` language