### PR TITLE
Switch to tabular view for object renderer in settings

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -78,7 +78,7 @@
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row-header,
-.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row:nth-child(odd):not(:hover) {
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row:nth-child(odd):not(:hover):not(:focus):not(.selected) {
 	background-color: rgba(130, 130, 130, 0.04);
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -149,7 +149,7 @@
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-okButton {
-	margin-right: 10px;
+	margin-right: 4px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-widget,

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -29,11 +29,9 @@
 	max-width: 10%;
 }
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key {
-	min-width: 40%;
-}
-.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key {
 	margin-left: 4px;
 	flex: 2;
+	min-width: 40%;
 }
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value {
 	flex: 3;

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -32,6 +32,7 @@
 	min-width: 40%;
 }
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key {
+	margin-left: 4px;
 	flex: 2;
 }
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value {
@@ -84,11 +85,12 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row-header {
 	display: flex;
-	padding: 0 4px;
+	padding-right: 4px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row-header,
-.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row:nth-child(odd):not(:hover):not(:focus):not(.selected) {
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-row:nth-child(odd):not(:hover):not(:focus):not(.selected),
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-edit-row.setting-list-object-row:nth-child(odd):hover {
 	background-color: rgba(130, 130, 130, 0.04);
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -28,9 +28,19 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-sibling {
 	max-width: 10%;
 }
-.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key,
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key {
+	min-width: 40%;
+}
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key {
+	flex: 2;
+}
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value {
-	flex: 1;
+	flex: 3;
+}
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row:hover .setting-list-object-value,
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row:focus .setting-list-object-value,
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row.selected .setting-list-object-value {
+	margin-right: 44px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-value,
@@ -74,7 +84,7 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row-header {
 	display: flex;
-	padding: 0 8px;
+	padding: 0 4px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row-header,
@@ -117,7 +127,7 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .monaco-text-button.setting-list-addButton {
 	display: inline-block;
 	margin-top: 4px;
-	margin-right: 10px;
+	margin-right: 4px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-edit-row {
@@ -129,8 +139,13 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input {
 	height: 24px;
 	max-width: 320px;
-	flex: 1;
-	margin-right: 10px;
+	flex: 3;
+	margin-right: 4px;
+}
+
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-key {
+	flex: 2;
+	min-width: 40%;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-okButton {

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -17,7 +17,6 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-value,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-sibling,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key,
-.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-connector,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value {
 	white-space: pre;
 	overflow: hidden;
@@ -31,13 +30,12 @@
 }
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value {
-	max-width: 50%;
+	flex: 1;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-value,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-sibling,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key,
-.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-connector,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value {
 	display: inline-block;
 	line-height: 24px;
@@ -63,9 +61,25 @@
 	top: 0px;
 }
 
-.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row {
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row,
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row-header {
 	position: relative;
 	max-height: 24px;
+}
+
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row-header {
+	font-weight: bold;
+}
+
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row,
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row-header {
+	display: flex;
+	padding: 0 8px;
+}
+
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row-header,
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row:nth-child(odd):not(:hover) {
+	background-color: rgba(130, 130, 130, 0.04);
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row:focus {

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -110,7 +110,7 @@
 	padding: 2px 14px;
 }
 
-.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-item-control.setting-list-new-mode .setting-list-new-row {
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-item-control.setting-list-hide-add-button .setting-list-new-row {
 	display: none;
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -175,7 +175,15 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 		});
 	});
 
-	return items;
+	return items.sort((a, b) => {
+		if (a.key.data < b.key.data) {
+			return -1;
+		} else if (a.key.data > b.key.data) {
+			return 1;
+		} else {
+			return 0;
+		}
+	});
 }
 
 function getListDisplayValue(element: SettingsTreeSettingElement): IListDataItem[] {
@@ -1017,8 +1025,14 @@ export class SettingObjectRenderer extends AbstractSettingRenderer implements IT
 	}
 
 	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingObjectItemTemplate, onChange: (value: string) => void): void {
-		const value = getObjectDisplayValue(dataElement);
-		template.objectWidget.setValue(value);
+		const items = getObjectDisplayValue(dataElement);
+
+		template.objectWidget.setAddButtonVisibility(
+			isDefined(dataElement.setting.objectAdditionalProperties) ||
+			isDefined(dataElement.setting.objectPatternProperties)
+		);
+
+		template.objectWidget.setValue(items);
 		template.context = dataElement;
 	}
 }

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1015,16 +1015,13 @@ export class SettingObjectRenderer extends AbstractSettingRenderer implements IT
 	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingObjectItemTemplate, onChange: (value: string) => void): void {
 		const items = getObjectDisplayValue(dataElement);
 
-		template.objectWidget.setAddButtonVisibility(
-			isDefined(dataElement.setting.objectAdditionalProperties) ||
-			isDefined(dataElement.setting.objectPatternProperties) ||
-			!areAllPropertiesDefined(
-				Object.keys(dataElement.setting.objectProperties ?? {}),
-				items
-			)
-		);
-
-		template.objectWidget.setValue(items);
+		template.objectWidget.setValue(items, {
+			showAddButton: (
+				isDefined(dataElement.setting.objectAdditionalProperties) ||
+				isDefined(dataElement.setting.objectPatternProperties) ||
+				!areAllPropertiesDefined(Object.keys(dataElement.setting.objectProperties ?? {}), items)
+			),
+		});
 		template.context = dataElement;
 	}
 }

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -978,7 +978,9 @@ export class SettingObjectRenderer extends AbstractSettingRenderer implements IT
 
 	private onDidChangeObject(template: ISettingObjectItemTemplate, e: ISettingListChangeEvent<IObjectDataItem>): void {
 		if (template.context) {
-			const newValue: Record<string, string> = {};
+			const defaultValue: Record<string, unknown> = template.context.defaultValue;
+			const scopeValue: Record<string, unknown> = template.context.scopeValue;
+			const newValue: Record<string, unknown> = {};
 
 			template.objectWidget.items.forEach(item => {
 				// Item was updated
@@ -999,6 +1001,13 @@ export class SettingObjectRenderer extends AbstractSettingRenderer implements IT
 			else if (template.objectWidget.isItemNew(e.originalItem)) {
 				newValue[e.item.key.data] = e.item.value.data;
 			}
+
+			Object.entries(newValue).forEach(([key, value]) => {
+				// value from the scope has changed back to the default
+				if (scopeValue[key] !== value && defaultValue[key] === value) {
+					delete newValue[key];
+				}
+			});
 
 			this._onDidChangeSetting.fire({
 				key: template.context.setting.key,

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -30,7 +30,7 @@ import { Disposable, DisposableStore, dispose } from 'vs/base/common/lifecycle';
 import { isIOS } from 'vs/base/common/platform';
 import { ISpliceable } from 'vs/base/common/sequence';
 import { escapeRegExpCharacters, startsWith } from 'vs/base/common/strings';
-import { isArray, isDefined } from 'vs/base/common/types';
+import { isArray, isDefined, isUndefinedOrNull } from 'vs/base/common/types';
 import { localize } from 'vs/nls';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { ICommandService } from 'vs/platform/commands/common/commands';
@@ -132,7 +132,9 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 
 	const wellDefinedKeyEnumOptions = wellDefinedKeys.map(({ key, description }) => ({ value: key, description }));
 	wellDefinedKeys.forEach(({ key }) => {
+		const defaultValue = element.defaultValue[key] ?? objectProperties![key].default;
 		const valueEnumOptions = getEnumOptionsFromSchema(objectProperties![key]);
+
 		items.push({
 			key: {
 				type: 'enum',
@@ -141,9 +143,10 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 			},
 			value: {
 				type: valueEnumOptions.length > 0 ? 'enum' : 'string',
-				data: data[key] ?? objectProperties![key].default,
+				data: data[key] ?? defaultValue,
 				options: valueEnumOptions,
 			},
+			removable: isUndefinedOrNull(defaultValue),
 		});
 	});
 
@@ -156,6 +159,7 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 				data: data[key],
 				options: valueEnumOptions,
 			},
+			removable: true,
 		});
 	});
 
@@ -167,6 +171,7 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 				data: data[key],
 				options: additionalValueEnums,
 			},
+			removable: true,
 		});
 	});
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -297,6 +297,10 @@ abstract class AbstractListSettingWidget<TDataItem extends object> extends Dispo
 		return;
 	}
 
+	protected isAddButtonVisible(): boolean {
+		return true;
+	}
+
 	protected renderList(): void {
 		const focused = DOM.isAncestor(document.activeElement, this.listElement);
 
@@ -304,7 +308,7 @@ abstract class AbstractListSettingWidget<TDataItem extends object> extends Dispo
 		this.listDisposables.clear();
 
 		const newMode = this.model.items.some(item => !!(item.editing && this.isItemNew(item)));
-		DOM.toggleClass(this.container, 'setting-list-new-mode', newMode);
+		DOM.toggleClass(this.container, 'setting-list-hide-add-button', !this.isAddButtonVisible() || newMode);
 
 		const header = this.renderHeader();
 		const ITEM_HEIGHT = 24;
@@ -643,6 +647,17 @@ export interface IObjectDataItem {
 }
 
 export class ObjectSettingWidget extends AbstractListSettingWidget<IObjectDataItem> {
+	private showAddButton: boolean = true;
+
+	setAddButtonVisibility(isVisible: boolean): void {
+		this.showAddButton = isVisible;
+		this.renderList();
+	}
+
+	protected isAddButtonVisible(): boolean {
+		return this.showAddButton;
+	}
+
 	protected getEmptyItem(): IObjectDataItem {
 		return {
 			key: { type: 'string', data: '' },

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -237,6 +237,10 @@ abstract class AbstractListSettingWidget<TDataItem extends object> extends Dispo
 		return this.listElement;
 	}
 
+	get items(): TDataItem[] {
+		return this.model.items;
+	}
+
 	constructor(
 		private container: HTMLElement,
 		@IThemeService protected readonly themeService: IThemeService,
@@ -289,7 +293,6 @@ abstract class AbstractListSettingWidget<TDataItem extends object> extends Dispo
 	protected abstract getLocalizedStrings(): {
 		deleteActionTooltip: string
 		editActionTooltip: string
-		complexEditActionTooltip: string
 		addButtonLabel: string
 	};
 
@@ -591,7 +594,6 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 		return {
 			deleteActionTooltip: localize('removeItem', "Remove Item"),
 			editActionTooltip: localize('editItem', "Edit Item"),
-			complexEditActionTooltip: localize('editItemInSettingsJson', "Edit Item in settings.json"),
 			addButtonLabel: localize('addItem', "Add Item"),
 			inputPlaceholder: localize('itemInputPlaceholder', "String Item..."),
 			siblingInputPlaceholder: localize('listSiblingInputPlaceholder', "Sibling..."),
@@ -614,7 +616,6 @@ export class ExcludeSettingWidget extends ListSettingWidget {
 		return {
 			deleteActionTooltip: localize('removeExcludeItem', "Remove Exclude Item"),
 			editActionTooltip: localize('editExcludeItem', "Edit Exclude Item"),
-			complexEditActionTooltip: localize('editExcludeItemInSettingsJson', "Edit Exclude Item in settings.json"),
 			addButtonLabel: localize('addPattern', "Add Pattern"),
 			inputPlaceholder: localize('excludePatternInputPlaceholder', "Exclude Pattern..."),
 			siblingInputPlaceholder: localize('excludeSiblingInputPlaceholder', "When Pattern Is Present..."),
@@ -652,6 +653,10 @@ export class ObjectSettingWidget extends AbstractListSettingWidget<IObjectDataIt
 	setAddButtonVisibility(isVisible: boolean): void {
 		this.showAddButton = isVisible;
 		this.renderList();
+	}
+
+	isItemNew(item: IObjectDataItem): boolean {
+		return item.key.data === '' && item.value.data === '';
 	}
 
 	protected isAddButtonVisible(): boolean {
@@ -809,10 +814,6 @@ export class ObjectSettingWidget extends AbstractListSettingWidget<IObjectDataIt
 		return rowElement;
 	}
 
-	protected isItemNew(item: IObjectDataItem): boolean {
-		return item.key.data === '' && item.value.data === '';
-	}
-
 	protected getLocalizedRowTitle(item: IObjectDataItem): string {
 		const enumDescription = item.key.type === 'enum'
 			? item.key.options.find(({ value }) => item.key.data === value)?.description
@@ -826,7 +827,6 @@ export class ObjectSettingWidget extends AbstractListSettingWidget<IObjectDataIt
 			deleteActionTooltip: localize('removeItem', "Remove Item"),
 			resetActionTooltip: localize('resetItem', "Reset Item"),
 			editActionTooltip: localize('editItem', "Edit Item"),
-			complexEditActionTooltip: localize('editItemInSettingsJson', "Edit Item in settings.json"),
 			addButtonLabel: localize('addItem', "Add Item"),
 			keyHeaderText: localize('objectKeyHeader', "Item"),
 			valueHeaderText: localize('objectValueHeader', "Value"),

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -292,6 +292,10 @@ abstract class AbstractListSettingWidget<TDataItem extends object> extends Dispo
 		addButtonLabel: string
 	};
 
+	protected renderHeader(): HTMLElement | undefined {
+		return;
+	}
+
 	protected renderList(): void {
 		const focused = DOM.isAncestor(document.activeElement, this.listElement);
 
@@ -301,11 +305,19 @@ abstract class AbstractListSettingWidget<TDataItem extends object> extends Dispo
 		const newMode = this.model.items.some(item => !!(item.editing && this.isItemNew(item)));
 		DOM.toggleClass(this.container, 'setting-list-new-mode', newMode);
 
+		const header = this.renderHeader();
+		const ITEM_HEIGHT = 24;
+		let listHeight = ITEM_HEIGHT * this.model.items.length;
+
+		if (header) {
+			listHeight += ITEM_HEIGHT;
+			this.listElement.appendChild(header);
+		}
+
 		this.model.items
 			.map((item, i) => this.renderDataOrEditItem(item, i, focused))
 			.forEach(itemElement => this.listElement.appendChild(itemElement));
 
-		const listHeight = 24 * this.model.items.length;
 		this.listElement.style.height = listHeight + 'px';
 	}
 
@@ -647,15 +659,29 @@ export class ObjectSettingWidget extends AbstractListSettingWidget<IObjectDataIt
 		return ['setting-list-object-widget'];
 	}
 
+	protected renderHeader() {
+		if (this.model.items.length > 0) {
+			const header = $('.setting-list-row-header');
+			const keyHeader = DOM.append(header, $('.setting-list-object-key'));
+			const valueHeader = DOM.append(header, $('.setting-list-object-value'));
+			const { keyHeaderText, valueHeaderText } = this.getLocalizedStrings();
+
+			keyHeader.textContent = keyHeaderText;
+			valueHeader.textContent = valueHeaderText;
+
+			return header;
+		}
+
+		return;
+	}
+
 	protected renderItem(item: IObjectDataItem): HTMLElement {
 		const rowElement = $('.setting-list-row');
 
 		const keyElement = DOM.append(rowElement, $('.setting-list-object-key'));
-		const connector = DOM.append(rowElement, $('.setting-list-object-connector'));
 		const valueElement = DOM.append(rowElement, $('.setting-list-object-value'));
 
 		keyElement.textContent = item.key.data;
-		connector.textContent = this.getLocalizedStrings().connector;
 		valueElement.textContent = item.value.data;
 
 		return rowElement;
@@ -754,9 +780,10 @@ export class ObjectSettingWidget extends AbstractListSettingWidget<IObjectDataIt
 			editActionTooltip: localize('editItem', "Edit Item"),
 			complexEditActionTooltip: localize('editItemInSettingsJson', "Edit Item in settings.json"),
 			addButtonLabel: localize('addItem', "Add Item"),
+			keyHeaderText: localize('objectKeyHeader', "Item"),
+			valueHeaderText: localize('objectValueHeader', "Value"),
 			keyInputPlaceholder: localize('objectKeyInputPlaceholder', "Key"),
 			valueInputPlaceholder: localize('objectValueInputPlaceholder', "Value"),
-			connector: ' → ',
 		};
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -645,6 +645,7 @@ type ObjectKeyOrValue = IObjectStringData | IObjectEnumData;
 export interface IObjectDataItem {
 	key: ObjectKeyOrValue;
 	value: ObjectKeyOrValue;
+	removable: boolean
 }
 
 export class ObjectSettingWidget extends AbstractListSettingWidget<IObjectDataItem> {
@@ -652,6 +653,7 @@ export class ObjectSettingWidget extends AbstractListSettingWidget<IObjectDataIt
 		return {
 			key: { type: 'string', data: '' },
 			value: { type: 'string', data: '' },
+			removable: true,
 		};
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -734,6 +734,10 @@ export class ObjectSettingWidget extends AbstractListSettingWidget<IObjectDataIt
 		const rowElement = $('.setting-list-edit-row');
 
 		const keyWidget = this.renderEditWidget(item.key, rowElement);
+
+		// We have only rendered the key
+		rowElement.querySelector('.setting-list-object-input')?.classList.add('setting-list-object-input-key');
+
 		const valueWidget = this.renderEditWidget(item.value, rowElement);
 
 		const updatedItem = () => {


### PR DESCRIPTION
#99635 

- [x] Switch to tabular view
- [x] Show a revert to default value button for static properties in objects
- [x] Hide the 'Add Item' button for static objects
- [x] Keys should not be editable for static objects

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/8235156/84681580-517a8200-af02-11ea-8466-13a5599cb246.png)|![image](https://user-images.githubusercontent.com/8235156/84681595-5b9c8080-af02-11ea-97d1-d2f11c466877.png)|
|![image](https://user-images.githubusercontent.com/8235156/84681693-838be400-af02-11ea-9a31-6a04014f3c33.png)|![image](https://user-images.githubusercontent.com/8235156/84681741-969eb400-af02-11ea-914d-a841e63656db.png)|



