### PR TITLE
Fix #99002 - Deselecting a file using Ctrl-click doesn't work as expected

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -1044,7 +1044,9 @@ export const renameHandler = async (accessor: ServicesAccessor) => {
 
 export const moveFileToTrashHandler = async (accessor: ServicesAccessor) => {
 	const explorerService = accessor.get(IExplorerService);
-	const stats = explorerService.getContext(true).filter(s => !s.isRoot);
+	// The selecteds have priority over the focused when it comes to deleting files
+	let selections = explorerService.getSelections();
+	const stats = selections ? selections : explorerService.getContext(true).filter(s => !s.isRoot);
 	if (stats.length) {
 		await deleteFiles(accessor.get(IWorkingCopyFileService), accessor.get(IDialogService), accessor.get(IConfigurationService), stats, true);
 	}
@@ -1052,8 +1054,9 @@ export const moveFileToTrashHandler = async (accessor: ServicesAccessor) => {
 
 export const deleteFileHandler = async (accessor: ServicesAccessor) => {
 	const explorerService = accessor.get(IExplorerService);
-	const stats = explorerService.getContext(true).filter(s => !s.isRoot);
-
+	// The selecteds have priority over the focused when it comes to deleting files
+	let selections = explorerService.getSelections();
+	const stats = selections ? selections : explorerService.getContext(true).filter(s => !s.isRoot);
 	if (stats.length) {
 		await deleteFiles(accessor.get(IWorkingCopyFileService), accessor.get(IDialogService), accessor.get(IConfigurationService), stats, false);
 	}

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -306,6 +306,10 @@ export class ExplorerView extends ViewPane {
 		}
 	}
 
+	getSelections(): ExplorerItem[] {
+		return this.tree.getSelection();
+	}
+
 	getContext(respectMultiSelection: boolean): ExplorerItem[] {
 		return getContext(this.tree.getFocus(), this.tree.getSelection(), respectMultiSelection, this.renderer);
 	}

--- a/src/vs/workbench/contrib/files/common/explorerService.ts
+++ b/src/vs/workbench/contrib/files/common/explorerService.ts
@@ -87,6 +87,13 @@ export class ExplorerService implements IExplorerService {
 		this.view = contextProvider;
 	}
 
+	getSelections(): ExplorerItem[] {
+		if (!this.view) {
+			return [];
+		}
+		return this.view.getSelections();
+	}
+
 	getContext(respectMultiSelection: boolean): ExplorerItem[] {
 		if (!this.view) {
 			return [];

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -43,6 +43,7 @@ export interface IExplorerService {
 	readonly roots: ExplorerItem[];
 	readonly sortOrder: SortOrder;
 
+	getSelections(): ExplorerItem[];
 	getContext(respectMultiSelection: boolean): ExplorerItem[];
 	setEditable(stat: ExplorerItem, data: IEditableData | null): Promise<void>;
 	getEditable(): { stat: ExplorerItem, data: IEditableData } | undefined;
@@ -64,6 +65,7 @@ export interface IExplorerService {
 }
 
 export interface IExplorerView {
+	getSelections(): ExplorerItem[];
 	getContext(respectMultiSelection: boolean): ExplorerItem[];
 	refresh(recursive: boolean, item?: ExplorerItem): Promise<void>;
 	selectResource(resource: URI | undefined, reveal?: boolean | string): Promise<void>;


### PR DESCRIPTION
- Add `getSelections()` to `ExplorerView` and `ExplorerService`
- Try to `getSelections()` before `getContext()` when deleting files in `moveFileToTrashHandler` and `deleteFileHandler`

The cause of the issue is that the `stats` is assigned by `ExplorerService.getContext()`, which prefers to return the focused item rather than the selected items. 

It is possible to resolve this issue by trying to get selected items before getting the focused one. To do so, `ExplorerView.getSelections()` and `ExplorerService.getSelections()` are required and thus added. 

This PR fixes #99002
