### PR TITLE
Allow pasting in debug window #100235

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -606,16 +606,15 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 			await this.clipboardService.writeText(this.getVisibleContent());
 			return Promise.resolve();
 		}));
-		actions.push(new Action('debug.collapseRepl', localize('collapse', "Collapse All"), undefined, true, () => {
-			this.tree.collapseAll();
-			this.replInput.focus();
-			return Promise.resolve();
-		}));
-		actions.push(new Action('debug.replPaste', localize('paste', 'Paste'), undefined, true, async () => {
+		actions.push(new Action('debug.replPaste', localize('paste', "Pasted"), undefined, true, async () => {
 			const clipboardText = await this.clipboardService.readText();
 			if (clipboardText) {
 				this.replInput.setValue(this.replInput.getValue().concat(clipboardText));
 			}
+		}));
+		actions.push(new Action('debug.collapseRepl', localize('collapse', "Collapse All"), undefined, true, () => {
+			this.tree.collapseAll();
+			this.replInput.focus();
 			return Promise.resolve();
 		}));
 		actions.push(new Separator());

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -611,6 +611,13 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 			this.replInput.focus();
 			return Promise.resolve();
 		}));
+		actions.push(new Action('debug.replPaste', localize('paste', 'Paste'), undefined, true, async () => {
+			const clipboardText = await this.clipboardService.readText();
+			if (clipboardText) {
+				this.replInput.setValue(this.replInput.getValue().concat(clipboardText));
+			}
+			return Promise.resolve();
+		}));
 		actions.push(new Separator());
 		actions.push(this.clearReplAction);
 

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -606,7 +606,7 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 			await this.clipboardService.writeText(this.getVisibleContent());
 			return Promise.resolve();
 		}));
-		actions.push(new Action('debug.replPaste', localize('paste', "Pasted"), undefined, true, async () => {
+		actions.push(new Action('debug.replPaste', localize('paste', "Paste"), undefined, true, async () => {
 			const clipboardText = await this.clipboardService.readText();
 			if (clipboardText) {
 				this.replInput.setValue(this.replInput.getValue().concat(clipboardText));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #100235 

As discussed in the issue, this adds paste functionality to the debug window so that you can paste anywhere, instead of restricting it to the input field.

Here's a gif that shows how this functionality works - https://i.gyazo.com/f1cfe66ae6ad3ec7718c308c1c702d11.gif
