### PR TITLE
Fix #71295 Permit command URIs in markdownDescription of extension setting

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -638,7 +638,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		// Rewrite `#editor.fontSize#` to link format
 		text = fixSettingLinks(text);
 
-		const renderedMarkdown = renderMarkdown({ value: text }, {
+		const renderedMarkdown = renderMarkdown({ value: text, isTrusted: true }, {
 			actionHandler: {
 				callback: (content: string) => {
 					if (startsWith(content, '#')) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #71295

To test:
* Clone https://github.com/gjsjohnmurray/vscode-extension-samples/tree/test-vscode-71295
* Open the configuration-sample folder and build and run that sample extension.
* Open the Settings page and search for 71295.

Without this PR it will look like this:
![image](https://user-images.githubusercontent.com/6726799/84792806-3edc7780-afec-11ea-980d-01f87d78a4c0.png)

With this PR the word 'here' becomes a hyperlink (`command:workbench,view.extensions`) that switches to Extensions view.
 
