### PR TITLE
Trusted Domains: Timeout filesystem access

### DIFF
--- a/src/vs/workbench/contrib/url/browser/trustedDomains.ts
+++ b/src/vs/workbench/contrib/url/browser/trustedDomains.ts
@@ -145,7 +145,7 @@ export function extractGitHubRemotesFromGitConfig(gitConfig: string): string[] {
 async function getRemotes(fileService: IFileService, textFileService: ITextFileService, contextService: IWorkspaceContextService): Promise<string[]> {
 	const workspaceUris = contextService.getWorkspace().folders.map(folder => folder.uri);
 	const domains = await Promise.race([
-		new Promise<string[][]>(resolve => setTimeout(() => resolve([]), 2000)),
+		new Promise<string[][]>(resolve => setTimeout(() => resolve([]), 250)),
 		Promise.all<string[]>(workspaceUris.map(async workspaceUri => {
 			const path = workspaceUri.path;
 			const uri = workspaceUri.with({ path: `${path !== '/' ? path : ''}/.git/config` });


### PR DESCRIPTION
In cases where the filesystem cannot be accessed until an auth link is opened, Stable currently indefinitely hangs as `/git/config` cannot be opened, so the remote-trusted domains cannot be extracted. This PR applies a patch @eamodio made for his serverless fs work that is already in Insiders.

This Fixes #100333 