### PR TITLE
Step over surrogate pairs on zero-lenth matches (fixes #100134)

### DIFF
--- a/src/vs/editor/common/model/textModelSearch.ts
+++ b/src/vs/editor/common/model/textModelSearch.ts
@@ -548,8 +548,12 @@ export class Searcher {
 			if (matchStartIndex === this._prevMatchStartIndex && matchLength === this._prevMatchLength) {
 				if (matchLength === 0) {
 					// the search result is an empty string and won't advance `regex.lastIndex`, so `regex.exec` will stuck here
-					// we attempt to recover from that by advancing by one
-					this._searchRegex.lastIndex += 1;
+					// we attempt to recover from that by advancing by two if surrogate pair found and by one otherwise
+					if (strings.getNextCodePoint(text, textLength, this._searchRegex.lastIndex) > 0xFFFF) {
+						this._searchRegex.lastIndex += 2;
+					} else {
+						this._searchRegex.lastIndex += 1;
+					}
 					continue;
 				}
 				// Exit early if the regex matches the same range twice

--- a/src/vs/editor/test/common/model/textModelSearch.test.ts
+++ b/src/vs/editor/test/common/model/textModelSearch.test.ts
@@ -781,4 +781,29 @@ suite('TextModelSearch', () => {
 
 		model.dispose();
 	});
+
+	test('issue #100134. Zero-length matches should properly step over surrogate pairs', () => {
+		// 1[Laptop]1 - there shoud be no matches inside of [Laptop] emoji
+		assertFindMatches('1\uD83D\uDCBB1', '()', true, false, null,
+			[
+				[1, 1, 1, 1],
+				[1, 2, 1, 2],
+				[1, 4, 1, 4],
+				[1, 5, 1, 5],
+
+			]
+		);
+		// 1[Hacker Cat]1 = 1[Cat Face][ZWJ][Laptop]1 - there shoud be matches between emoji and ZWJ
+		// there shoud be no matches inside of [Cat Face] and [Laptop] emoji
+		assertFindMatches('1\uD83D\uDC31\u200D\uD83D\uDCBB1', '()', true, false, null,
+			[
+				[1, 1, 1, 1],
+				[1, 2, 1, 2],
+				[1, 4, 1, 4],
+				[1, 5, 1, 5],
+				[1, 7, 1, 7],
+				[1, 8, 1, 8]
+			]
+		);
+	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #100134

Problem lies in fact that regexp with `u` flag will change `lastIndex` to the start of surrogate pair if started after high pair:
```js
const unicodeRe = /()/gu;
const regularRe = /()/g;
unicodeRe.lastIndex = 1;
regularRe.lastIndex = 1;
console.log('unicode', unicodeRe.lastIndex, unicodeRe.exec('💻').index, unicodeRe.lastIndex); // unicode 1 0 0
console.log('regular', regularRe.lastIndex, regularRe.exec('💻').index, regularRe.lastIndex); // regular 1 1 1
```

Which ended attempts to step forward for zero-length matches in endless loop.

This PR takes into account surrogate pairs and propagates `lastIndex` accordingly.
Endless loop during find matches is fixed in this PR.

Not in this PR:
1. In some cases (for files with a lot of matches) it's impossible to use Find next button to get to the next match after surrogate pair. Can give a try in this PR if needed, but would prefer to leave it out of scope of this PR
_(new fallback logic not triggered in that case, but should use similar strategy - remember last position and advance for zero-length matches, but this should survive `reset`)_
What do you think?

1. Inconsistency of handling matches of for surrogate pairs between JS RegExp's with `u` flag and ripgrep
I can create issue with more details but simple example will be for file with 1💻 replace using RegExp `1.` - Find in files breaks surrogate, while replace in editor replaces whole emoji

