### PR TITLE
Update logging

### DIFF
--- a/extensions/javascript/snippets/javascript.code-snippets
+++ b/extensions/javascript/snippets/javascript.code-snippets
@@ -173,8 +173,7 @@
 	"Log to the console": {
 		"prefix": "log",
 		"body": [
-			"console.log($1);",
-			"$0"
+			"console.log($1);"
 		],
 		"description": "Log to the console"
 	},
@@ -182,7 +181,6 @@
 		"prefix": "warn",
 		"body": [
 			"console.warn($1);",
-			"$0"
 		],
 		"description": "Log warning to the console"
 	},
@@ -190,7 +188,6 @@
 		"prefix": "error",
 		"body": [
 			"console.error($1);",
-			"$0"
 		],
 		"description": "Log error to the console"
 	}


### PR DESCRIPTION

Remove enter after console.log/warn/error.

Issue: Beaucause it's really annoying...
Version: I just forked the last code so commit: 9c142ea3831a60fa62ee62cbcaa6a10e4b2a614d
This is just a small PR.