### PR TITLE
Allow calling extension language features even for big files

### DIFF
--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -343,11 +343,11 @@ export class TextModel extends Disposable implements model.ITextModel {
 				(bufferTextLength > TextModel.LARGE_FILE_SIZE_THRESHOLD)
 				|| (bufferLineCount > TextModel.LARGE_FILE_LINE_COUNT_THRESHOLD)
 			);
+			this._isTooLargeForSyncing = (bufferTextLength > TextModel.MODEL_SYNC_LIMIT);
 		} else {
 			this._isTooLargeForTokenization = false;
+			this._isTooLargeForSyncing = false;
 		}
-
-		this._isTooLargeForSyncing = (bufferTextLength > TextModel.MODEL_SYNC_LIMIT);
 
 		this._versionId = 1;
 		this._alternativeVersionId = 1;


### PR DESCRIPTION
This PR fixes #99686.

When `editor.largeFileOptimizations` is set to `false`, VSCode stops considering the limit of 50MB defined on textModel.ts to invoke language providers and synchronize buffer between extension host and extensions.

I've tested model.isTooLargeForTokenization() (which represents the setting editor.largeFileOptimizations) on languageFeatureRegistry.ts, however, the document is not found on ExtHostDocuments.ts when provider is called. The reason for that is: the text buffer hasn't been synchronized from extension host to other processes.

So I'm still considering editor.largeFileOptimizations setting, but using that to define this._isTooLargeForSyncing = false on textModel.ts.