### PR TITLE
debug: allow a single debug extension to provide multiple configs

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
@@ -47,6 +47,8 @@ jsonRegistry.registerSchema(launchSchemaId, launchSchema);
 const DEBUG_SELECTED_CONFIG_NAME_KEY = 'debug.selectedconfigname';
 const DEBUG_SELECTED_ROOT = 'debug.selectedroot';
 
+interface IDynamicPickItem { label: string, launch: ILaunch, config: IConfig }
+
 export class ConfigurationManager implements IConfigurationManager {
 	private debuggers: Debugger[];
 	private breakpointModeIdsSet = new Set<string>();
@@ -251,23 +253,50 @@ export class ConfigurationManager implements IConfigurationManager {
 	async getDynamicProviders(): Promise<{ label: string, pick: () => Promise<{ launch: ILaunch, config: IConfig } | undefined> }[]> {
 		const extensions = await this.extensionService.getExtensions();
 		const onDebugDynamicConfigurationsName = 'onDebugDynamicConfigurations';
-		const debugDynamicExtensionsTypes = extensions.map(e => {
-			const activationEvent = e.activationEvents && e.activationEvents.find(e => e.includes(onDebugDynamicConfigurationsName));
-			if (activationEvent) {
-				const type = activationEvent.substr(onDebugDynamicConfigurationsName.length + 1);
-				return type || (e.contributes && e.contributes.debuggers && e.contributes.debuggers.length ? e.contributes.debuggers[0].type : undefined);
+		const debugDynamicExtensionsTypes = extensions.reduce((acc, e) => {
+			if (!e.activationEvents) {
+				return acc;
 			}
 
-			return undefined;
-		}).filter(type => typeof type === 'string' && !!this.getDebuggerLabel(type)) as string[];
+			const explicitTypes = e.activationEvents.filter(e => e.includes(`${onDebugDynamicConfigurationsName}:`)).map(type => type.slice(onDebugDynamicConfigurationsName.length + 1));
+			if (explicitTypes.length) {
+				return [...acc, ...explicitTypes];
+			}
+
+			if (e.activationEvents.includes(onDebugDynamicConfigurationsName)) {
+				const debuggerType = e.contributes?.debuggers?.[0].type;
+				return debuggerType ? [...acc, debuggerType] : acc;
+			}
+
+			return acc;
+		}, [] as string[]);
 
 		return debugDynamicExtensionsTypes.map(type => {
 			return {
 				label: this.getDebuggerLabel(type)!,
 				pick: async () => {
+					const input = this.quickInputService.createQuickPick<IDynamicPickItem>();
+					input.busy = true;
+					input.placeholder = nls.localize('selectConfiguration', "Select Launch Configuration");
+					input.show();
+
+					let chosenDidCancel = false;
+					const chosenPromise = new Promise<IDynamicPickItem | undefined>(resolve => {
+						input.onDidAccept(() => resolve(input.activeItems[0]));
+						input.onDidTriggerItemButton(async (context) => {
+							resolve(undefined);
+							const { launch, config } = context.item;
+							await launch.openConfigFile(false, config.type);
+							// Only Launch have a pin trigger button
+							await (launch as Launch).writeConfiguration(config);
+							this.selectConfiguration(launch, config.name);
+						});
+						input.onDidHide(() => { chosenDidCancel = true; resolve(); });
+					});
+
 					await this.activateDebuggers(onDebugDynamicConfigurationsName, type);
 					const token = new CancellationTokenSource();
-					const picks: Promise<{ label: string, launch: ILaunch, config: IConfig }[]>[] = [];
+					const picks: Promise<IDynamicPickItem[]>[] = [];
 					const provider = this.configProviders.filter(p => p.type === type && p.triggerKind === DebugConfigurationProviderTriggerKind.Dynamic && p.provideDebugConfigurations)[0];
 					this.getLaunches().forEach(launch => {
 						if (launch.workspace && provider) {
@@ -282,25 +311,25 @@ export class ConfigurationManager implements IConfigurationManager {
 							}))));
 						}
 					});
-					const promiseOfPicks = Promise.all(picks).then(result => result.reduce((first, second) => first.concat(second), []));
 
-					const result = await this.quickInputService.pick<{ label: string, launch: ILaunch, config: IConfig }>(promiseOfPicks, {
-						placeHolder: nls.localize('selectConfiguration', "Select Launch Configuration"),
-						onDidTriggerItemButton: async (context) => {
-							await this.quickInputService.cancel();
-							const { launch, config } = context.item;
-							await launch.openConfigFile(false, config.type);
-							// Only Launch have a pin trigger button
-							await (launch as Launch).writeConfiguration(config);
-							this.selectConfiguration(launch, config.name);
-						}
-					});
-					if (!result) {
-						// User canceled quick input we should notify the provider to cancel computing configurations
-						token.cancel();
+					const items = await Promise.all(picks).then(result => result.reduce((first, second) => first.concat(second), []));
+					let chosen: IDynamicPickItem | undefined;
+					if (items.length === 1 && !chosenDidCancel) {
+						chosen = items[0];
+					} else {
+						input.items = items;
+						input.busy = false;
+						chosen = await chosenPromise;
 					}
 
-					return result;
+					input.dispose();
+					if (!chosen) {
+						// User canceled quick input we should notify the provider to cancel computing configurations
+						token.cancel();
+						return;
+					}
+
+					return chosen;
 				}
 			};
 		});


### PR DESCRIPTION
Previously if a debug extension provided multiple dynamic
configurations, we would just use the first debugger -- whatever that
was. This change now shows all configurations for which dynamic configs
are registered.

I also adjusted the picker to automatically select the first item if
there's only a single configuration provided. This works well for the
debug terminal, but also means that the user doesn't see the name of
the selected item, which might not be desirable. Open to pushback.

Together these finish the request for a separate top-level contribution
for the terminal in  #98054

![](https://memes.peet.io/img/20-06-035f5d80-2f2b-4e5d-a60e-7115315c0a31.png)

Finally, with that adjustment I made a tweak so that the picker shows
up in a `busy` state while extensions are activating. Previously you
would select a dynamic configuration title and could have a few seconds
of delay before the picker came up, which is probably not desirable.

