### PR TITLE
Support `args` for `workbench.action.selectTheme`

### DIFF
--- a/src/vs/platform/quickinput/browser/commandsQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/commandsQuickAccess.ts
@@ -148,7 +148,7 @@ export abstract class AbstractCommandsQuickAccessProvider extends PickerQuickAcc
 					// Add to history
 					this.commandsHistory.push(commandPick.commandId);
 
-					// Telementry
+					// Telemetry
 					this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', {
 						id: commandPick.commandId,
 						from: 'quick open'
@@ -302,4 +302,3 @@ export class CommandsHistory extends Disposable {
 		CommandsHistory.saveState(storageService);
 	}
 }
-

--- a/src/vs/workbench/common/actions.ts
+++ b/src/vs/workbench/common/actions.ts
@@ -117,7 +117,7 @@ Registry.add(Extensions.WorkbenchActions, new class implements IWorkbenchActionR
 		// otherwise run and dispose
 		try {
 			const from = (args as any)?.from || 'keybinding';
-			await actionInstance.run(undefined, { from });
+			await actionInstance.run(args, { from });
 		} finally {
 			actionInstance.dispose();
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Fixes #100460

This PR adds optional `args` support for the `workbench.action.selectTheme` command, allowing users to define keybindings that directly switch to a specified theme (instead of opening the theme picker).

Such a keybinding can only be defined by directly editing `keybindings.json` because there is no GUI support for `args`.

Some examples:

```json
[
    {
        "key": "ctrl+t ctrl+l",
        "command": "workbench.action.selectTheme",
        "args": {
            "id": "Default Light+"
        }
    },
    {
        "key": "ctrl+t ctrl+d",
        "command": "workbench.action.selectTheme",
        "args": {
            "id": "Default Dark+"
        }
    }
]
```

Values of the `id` field should match the `"workbench.colorTheme"` setting in `settings.json`. However theme's ids are not exposed anywhere in GUI, so users can only get them by switching to the desired theme, then copying from the `"workbench.colorTheme"` setting (or checking `package.json` of the theme extension).

A keybinding without `args` or `args.id` will continue opening the theme picker, without breaking existing use cases. A keybinding with invalid `args.id` will show an error when invoked.

---

A side effect is that now the command palette may display one of the keybindings containing `args` as `Preferences: Color Theme` command's shortcut (despite that invoking from command palette will always open the theme picker, while the displayed shortcut will directly switch to some theme). I have filed #100830 for it. But since that issue is categorized into "Backlog Candidates", I assume it's low priority and won't block this PR.