### PR TITLE
Allow to reopen closed webviews if the extension supports it

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewWorkbenchService.ts
@@ -99,9 +99,6 @@ export interface WebviewResolver {
 }
 
 function canRevive(reviver: WebviewResolver, webview: WebviewInput): boolean {
-	if (webview.isDisposed()) {
-		return false;
-	}
 	return reviver.canResolve(webview);
 }
 


### PR DESCRIPTION
This PR fixes #97285

It let's you reopen closed webviews with Ctrl+Shift+T, such as markdown previews.

When you close an editor it is "disposed", but the check for whether you can restore a webview editor checked whether the editor is not disposed, which will never be the case.

Note that this does NOT solve #86864, because I'm not sure how to register a reviver for the release notes, but it is a necessary change before fixing that.