### PR TITLE
fix(search): Replace crash empty string pattern

### DIFF
--- a/src/vs/base/common/search.ts
+++ b/src/vs/base/common/search.ts
@@ -18,7 +18,7 @@ export function buildReplaceStringWithCasePreserved(matches: string[] | null, pa
 			return pattern.toUpperCase();
 		} else if (matches[0].toLowerCase() === matches[0]) {
 			return pattern.toLowerCase();
-		} else if (strings.containsUppercaseCharacter(matches[0][0])) {
+		} else if (strings.containsUppercaseCharacter(matches[0][0]) && pattern.length > 0) {
 			return pattern[0].toUpperCase() + pattern.substr(1);
 		} else {
 			// we don't understand its pattern yet.


### PR DESCRIPTION
Replacing by an empty string pattern could lead to an error when trying to conserve case

`Cannot read 'toUpperCase' property of undefined`

To test replace "somethingWithEnding" by searching "Ending" and replacing by "" with automatic case enabled

This PR fixes #80553 (probably)
