### PR TITLE
Use HTTPS urls for SchemaStore.org

### DIFF
--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -267,11 +267,11 @@
     "jsonValidation": [
       {
         "fileMatch": "package.json",
-        "url": "https://schemastore.azurewebsites.net/schemas/json/package.json"
+        "url": "https://json.schemastore.org/package"
       },
       {
         "fileMatch": "bower.json",
-        "url": "https://schemastore.azurewebsites.net/schemas/json/bower.json"
+        "url": "https://json.schemastore.org/bower"
       }
     ],
     "taskDefinitions": [


### PR DESCRIPTION
SchemaStore.org now supports HTTPS and no longer rely on *.azurewebsites.net as a backdoor to HTTPS

PS. I'm the owner and maintainer of SchemaStore.org