### PR TITLE
Fix middle click closing tab even when click was initiated on another element

### DIFF
--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -652,13 +652,11 @@ export class TabsTitleControl extends TitleControl {
 
 			tab.blur();
 
-			if (e.button === 1 /* Middle Button*/) {
+			if (e.button === 1 /* Middle Button*/ && lastMiddleMouseDownItem && lastMiddleMouseDownItem === e.target) {
 				e.stopPropagation(); // for https://github.com/Microsoft/vscode/issues/56715
 
 				this.blockRevealActiveTabOnce();
-				if (lastMiddleMouseDownItem && lastMiddleMouseDownItem === e.target) {
-					this.closeOneEditorAction.run({ groupId: this.group.id, editorIndex: index });
-				}
+				this.closeOneEditorAction.run({ groupId: this.group.id, editorIndex: index });
 			}
 		}));
 

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -643,6 +643,10 @@ export class TabsTitleControl extends TitleControl {
 		}));
 
 		// Close on mouse middle click
+		let lastMiddleMouseDownItem: EventTarget | null;
+		disposables.add(addDisposableListener(tab, EventType.MOUSE_DOWN, (e: MouseEvent) => {
+			if (e.button === 1) { lastMiddleMouseDownItem = e.target; }
+		}));
 		disposables.add(addDisposableListener(tab, EventType.MOUSE_UP, (e: MouseEvent) => {
 			EventHelper.stop(e);
 
@@ -652,7 +656,9 @@ export class TabsTitleControl extends TitleControl {
 				e.stopPropagation(); // for https://github.com/Microsoft/vscode/issues/56715
 
 				this.blockRevealActiveTabOnce();
-				this.closeOneEditorAction.run({ groupId: this.group.id, editorIndex: index });
+				if (lastMiddleMouseDownItem && lastMiddleMouseDownItem === e.target) {
+					this.closeOneEditorAction.run({ groupId: this.group.id, editorIndex: index });
+				}
 			}
 		}));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #101028

Added mousedown event and check if mouseup event is on same element
