### PR TITLE
Adding .git/SQUASH_MSG detection to commit message auto-fill #101078

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1939,6 +1939,17 @@ export class Repository {
 		return message.replace(/^\s*#.*$\n?/gm, '').trim();
 	}
 
+	async getSquashMessage(): Promise<string | undefined> {
+		const squashMsgPath = path.join(this.repositoryRoot, '.git', 'SQUASH_MSG');
+
+		try {
+			const raw = await fs.readFile(squashMsgPath, 'utf8');
+			return this.stripCommitMessageComments(raw);
+		} catch {
+			return undefined;
+		}
+	}
+
 	async getMergeMessage(): Promise<string | undefined> {
 		const mergeMsgPath = path.join(this.repositoryRoot, '.git', 'MERGE_MSG');
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -865,8 +865,7 @@ export class Repository implements Disposable {
 	}
 
 	async getInputTemplate(): Promise<string> {
-		const commitMessage = await this.repository.getMergeMessage() || await this.repository.getSquashMessage();
-
+		const commitMessage = await Promise.race([this.repository.getMergeMessage(), this.repository.getSquashMessage()]);
 		if (commitMessage) {
 			return commitMessage;
 		}

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -865,13 +865,10 @@ export class Repository implements Disposable {
 	}
 
 	async getInputTemplate(): Promise<string> {
-		const mergeMessage = await this.repository.getMergeMessage();
-		const squashMessage = await this.repository.getSquashMessage();
+		const commitMessage = await this.repository.getMergeMessage() || await this.repository.getSquashMessage();
 
-		if (mergeMessage) {
-			return mergeMessage;
-		} else if (squashMessage) {
-			return squashMessage;
+		if (commitMessage) {
+			return commitMessage;
 		}
 
 		return await this.repository.getCommitTemplate();

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -864,8 +864,9 @@ export class Repository implements Disposable {
 		return toGitUri(uri, '', { replaceFileExtension: true });
 	}
 
-	async getInputTemplate(): Promise<string> {
-		const commitMessage = await Promise.race([this.repository.getMergeMessage(), this.repository.getSquashMessage()]);
+	async getInputTemplate(): Promise<string | undefined> {
+		const commitMessage = (await Promise.all([this.repository.getMergeMessage(), this.repository.getSquashMessage()])).find(msg => msg !== undefined);
+
 		if (commitMessage) {
 			return commitMessage;
 		}

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -866,9 +866,12 @@ export class Repository implements Disposable {
 
 	async getInputTemplate(): Promise<string> {
 		const mergeMessage = await this.repository.getMergeMessage();
+		const squashMessage = await this.repository.getSquashMessage();
 
 		if (mergeMessage) {
 			return mergeMessage;
+		} else if (squashMessage) {
+			return squashMessage;
 		}
 
 		return await this.repository.getCommitTemplate();

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -864,7 +864,7 @@ export class Repository implements Disposable {
 		return toGitUri(uri, '', { replaceFileExtension: true });
 	}
 
-	async getInputTemplate(): Promise<string | undefined> {
+	async getInputTemplate(): Promise<string> {
 		const commitMessage = (await Promise.all([this.repository.getMergeMessage(), this.repository.getSquashMessage()])).find(msg => msg !== undefined);
 
 		if (commitMessage) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #101078 

As discussed in the issue, just like `.git/MERGE_MSG` is auto-filled if there's no commit message in the box, `.git/SQUASH_MSG` should also be auto-filled if present. This behaviour works the same way as git-gui does, in the sense that `MERGE_MSG` has precedence over `SQUASH_MSG`, so it looks for MERGE first, then SQUASH.

This can be tested by using the `git merge <branch> --squash` command, or alternatively, going into the `.git` directory and adding `SQUASH_MSG` with some commit message inside.
