### PR TITLE
Allow to get/inspect/update the current WorkspaceConfiguration

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4737,29 +4737,29 @@ declare module 'vscode' {
 	export interface WorkspaceConfiguration {
 
 		/**
-		 * Return a value from this configuration.
+		 * Return a value from this configuration. If no section or an empty section is provided, the current configuration is returned.
 		 *
 		 * @param section Configuration name, supports _dotted_ names.
 		 * @return The value `section` denotes or `undefined`.
 		 */
-		get<T>(section: string): T | undefined;
+		get<T>(section?: string): T | undefined;
 
 		/**
-		 * Return a value from this configuration.
+		 * Return a value from this configuration. If no section or an empty section is provided, the current configuration is returned.
 		 *
 		 * @param section Configuration name, supports _dotted_ names.
 		 * @param defaultValue A value should be returned when no value could be found, is `undefined`.
 		 * @return The value `section` denotes or the default.
 		 */
-		get<T>(section: string, defaultValue: T): T;
+		get<T>(section: string | undefined, defaultValue: T): T;
 
 		/**
-		 * Check if this configuration has a certain value.
+		 * Check if this configuration has a certain value.  If no section or an empty section is provided, the current configuration is tested.
 		 *
 		 * @param section Configuration name, supports _dotted_ names.
 		 * @return `true` if the section doesn't resolve to `undefined`.
 		 */
-		has(section: string): boolean;
+		has(section?: string): boolean;
 
 		/**
 		 * Retrieve all information about a configuration setting. A configuration value
@@ -4770,12 +4770,13 @@ declare module 'vscode' {
 		 * Also provides all language ids under which the given configuration setting is defined.
 		 *
 		 * *Note:* The configuration name must denote a leaf in the configuration tree
-		 * (`editor.fontSize` vs `editor`) otherwise no result is returned.
+		 * (`editor.fontSize` vs `editor`) otherwise no result is returned. If no section or an empty section is provided,
+		 * the current configuration is inspected.
 		 *
 		 * @param section Configuration name, supports _dotted_ names.
 		 * @return Information about a configuration setting or `undefined`.
 		 */
-		inspect<T>(section: string): {
+		inspect<T>(section?: string): {
 			key: string;
 
 			defaultValue?: T;
@@ -4804,7 +4805,8 @@ declare module 'vscode' {
 		 *
 		 * *Note:* To remove a configuration value use `undefined`, like so: `config.update('somekey', undefined)`
 		 *
-		 * @param section Configuration name, supports _dotted_ names.
+		 * @param section Configuration name, supports _dotted_ names. If no section or an empty section is provided,
+		 * the current configuration is updated.
 		 * @param value The new value.
 		 * @param configurationTarget The [configuration target](#ConfigurationTarget) or a boolean value.
 		 *	- If `true` updates [Global settings](#ConfigurationTarget.Global).
@@ -4821,7 +4823,7 @@ declare module 'vscode' {
 		 *	- configuration to workspace folder when there is no workspace folder settings.
 		 *	- configuration to workspace folder when [WorkspaceConfiguration](#WorkspaceConfiguration) is not scoped to a resource.
 		 */
-		update(section: string, value: any, configurationTarget?: ConfigurationTarget | boolean, overrideInLanguage?: boolean): Thenable<void>;
+		update(section: string | undefined, value: any, configurationTarget?: ConfigurationTarget | boolean, overrideInLanguage?: boolean): Thenable<void>;
 
 		/**
 		 * Readable dictionary that backs this configuration.

--- a/src/vs/workbench/test/browser/api/extHostConfiguration.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostConfiguration.test.ts
@@ -556,30 +556,17 @@ suite('ExtHostConfiguration', function () {
 		});
 
 		let config = all.getConfiguration('farboo.config0');
-		assert.equal(config.get(''), undefined);
-		assert.equal(config.has(''), false);
+		assert.equal(config.get(''), true);
+		assert.equal(config.get(), true);
+		assert.equal(config.has(''), true);
+		assert.equal(config.has(), true);
+		assert.equal(config.inspect('')?.globalValue, true);
+		assert.equal(config.inspect()?.globalValue, true);
 
 		config = all.getConfiguration('farboo');
 		assert.equal(config.get('config0'), true);
 		assert.equal(config.has('config0'), true);
-	});
-
-	test('getConfiguration vs get', function () {
-
-		const all = createExtHostConfiguration({
-			'farboo': {
-				'config0': true,
-				'config4': 38
-			}
-		});
-
-		let config = all.getConfiguration('farboo.config0');
-		assert.equal(config.get(''), undefined);
-		assert.equal(config.has(''), false);
-
-		config = all.getConfiguration('farboo');
-		assert.equal(config.get('config0'), true);
-		assert.equal(config.has('config0'), true);
+		assert.equal(config.inspect('config0')?.globalValue, true);
 	});
 
 	test('name vs property', function () {
@@ -634,6 +621,11 @@ suite('ExtHostConfiguration', function () {
 
 		config.update('foo.bar', 42, true);
 		assert.equal(shape.lastArgs[1], 'foo.bar');
+
+		config = allConfig.getConfiguration('foo.bar');
+		config.update('', 42, true);
+		assert.equal(shape.lastArgs[1], 'foo.bar');
+		assert.equal(shape.lastArgs[2], 42);
 	});
 
 	test('update, what is #15834', function () {


### PR DESCRIPTION
Accessing a setting requires two section keys: `workspace.getConfiguration(section1, resource).get(section2)`.
'section1' can be undefined, but 'section2'.

This PR is to make this symetrical and allow

`workspace.getConfiguration(key, resource).get()`.

PR also allows the empty string, and also adopts inspect and update.