### PR TITLE
Retry fetching release notes on failure, and display failures

### DIFF
--- a/src/vs/base/parts/request/browser/request.ts
+++ b/src/vs/base/parts/request/browser/request.ts
@@ -21,7 +21,7 @@ export function request(options: IRequestOptions, token: CancellationToken): Pro
 		setRequestHeaders(xhr, options);
 
 		xhr.responseType = 'arraybuffer';
-		xhr.onerror = e => reject(new Error(xhr.statusText && ('XHR failed: ' + xhr.statusText)));
+		xhr.onerror = e => reject(new Error(xhr.statusText && ('XHR failed: ' + xhr.statusText) || 'XHR failed'));
 		xhr.onload = (e) => {
 			resolve({
 				res: {

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -95,10 +95,10 @@ export class ReleaseNotesManager {
 		return true;
 	}
 
-	private loadReleaseNotes(version: string): Promise<string> {
+	private async loadReleaseNotes(version: string): Promise<string> {
 		const match = /^(\d+\.\d+)\./.exec(version);
 		if (!match) {
-			return Promise.reject(new Error('not found'));
+			throw new Error('not found');
 		}
 
 		const versionLabel = match[1].replace(/\./g, '_');
@@ -138,24 +138,30 @@ export class ReleaseNotesManager {
 				.replace(/kbstyle\(([^\)]+)\)/gi, kbstyle);
 		};
 
-		if (!this._releaseNotesCache.has(version)) {
-			this._releaseNotesCache.set(version, this._requestService.request({ url }, CancellationToken.None)
-				.catch(err => {
-					throw new Error('Failed to fetch release notes');
-				})
-				.then(asText)
-				.then(text => {
-					if (!text || !/^#\s/.test(text)) { // release notes always starts with `#` followed by whitespace
-						return Promise.reject(new Error('Invalid release notes'));
-					}
+		const fetchReleaseNotes = async () => {
+			let text;
+			try {
+				text = await asText(await this._requestService.request({ url }, CancellationToken.None));
+			} catch {
+				throw new Error('Failed to fetch release notes');
+			}
 
-					return Promise.resolve(text);
-				})
-				.then(text => patchKeybindings(text))
-				.catch(err => {
+			if (!text || !/^#\s/.test(text)) { // release notes always starts with `#` followed by whitespace
+				throw new Error('Invalid release notes');
+			}
+
+			return patchKeybindings(text);
+		};
+
+		if (!this._releaseNotesCache.has(version)) {
+			this._releaseNotesCache.set(version, (async () => {
+				try {
+					return await fetchReleaseNotes();
+				} catch (err) {
 					this._releaseNotesCache.delete(version);
 					throw err;
-				}));
+				}
+			})());
 		}
 
 		return this._releaseNotesCache.get(version)!;

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -148,7 +148,11 @@ export class ReleaseNotesManager {
 
 					return Promise.resolve(text);
 				})
-				.then(text => patchKeybindings(text)));
+				.then(text => patchKeybindings(text))
+				.catch(err => {
+					this._releaseNotesCache.delete(version);
+					throw err;
+				}));
 		}
 
 		return this._releaseNotesCache.get(version)!;

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -140,6 +140,9 @@ export class ReleaseNotesManager {
 
 		if (!this._releaseNotesCache.has(version)) {
 			this._releaseNotesCache.set(version, this._requestService.request({ url }, CancellationToken.None)
+				.catch(err => {
+					throw new Error('Failed to fetch release notes');
+				})
 				.then(asText)
 				.then(text => {
 					if (!text || !/^#\s/.test(text)) { // release notes always starts with `#` followed by whitespace

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -51,12 +51,12 @@ export class OpenLatestReleaseNotesInBrowserAction extends Action {
 		super('update.openLatestReleaseNotes', nls.localize('releaseNotes', "Release Notes"), undefined, true);
 	}
 
-	run(): Promise<any> {
+	async run(): Promise<void> {
 		if (this.productService.releaseNotesUrl) {
 			const uri = URI.parse(this.productService.releaseNotesUrl);
-			return this.openerService.open(uri);
+			await this.openerService.open(uri);
 		}
-		return Promise.resolve(false);
+		throw new Error('This version of Visual Studio Code does not have release notes');
 	}
 }
 
@@ -71,18 +71,22 @@ export abstract class AbstractShowReleaseNotesAction extends Action {
 		super(id, label, undefined, true);
 	}
 
-	run(): Promise<boolean> {
+	async run(): Promise<void> {
 		if (!this.enabled) {
-			return Promise.resolve(false);
+			return;
 		}
-
 		this.enabled = false;
 
-		return showReleaseNotes(this.instantiationService, this.version)
-			.then(undefined, () => {
-				const action = this.instantiationService.createInstance(OpenLatestReleaseNotesInBrowserAction);
-				return action.run().then(() => false);
-			});
+		try {
+			await showReleaseNotes(this.instantiationService, this.version);
+		} catch (err) {
+			const action = this.instantiationService.createInstance(OpenLatestReleaseNotesInBrowserAction);
+			try {
+				await action.run();
+			} catch (err2) {
+				throw new Error(`${err.message} and ${err2.message}`);
+			}
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -56,7 +56,7 @@ export class OpenLatestReleaseNotesInBrowserAction extends Action {
 			const uri = URI.parse(this.productService.releaseNotesUrl);
 			await this.openerService.open(uri);
 		}
-		throw new Error('This version of Visual Studio Code does not have release notes');
+		throw new Error('This version of Visual Studio Code does not have release notes online');
 	}
 }
 


### PR DESCRIPTION
This PR fixes #101132

As you can see in the issue, this is how to test it:

1. Go offline (you can also open devtools in vscode and go to the network tab and change the "online" at the top to "offline")
2. Try to open the release notes using Show Release Notes from the command palette.
3. Depending on whether you are on an official vscode build or a local build, the release notes page will be opened in your default browser. On a local build it should show an error stating that fetching the release notes failed and that this vscode doesn't have release notes online.

4. Go back online
5. Try to open the release notes again
6. The release notes should open in a webview

7. Go offline again
8. Try to open the release notes again
9. The release notes should open in a webview again, even though we're offline
