### PR TITLE
Re-focus webview when navigating back from another editor.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -661,6 +661,14 @@ ${loaderJs}
 		this.reversedInsetMapping = new Map();
 	}
 
+	focusWebview() {
+		if (this._disposed) {
+			return;
+		}
+
+		this.webview.focus();
+	}
+
 	focusOutput(cellId: string) {
 		if (this._disposed) {
 			return;

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
@@ -309,6 +309,10 @@ export abstract class BaseCellViewModel extends Disposable {
 			return CursorAtBoundary.None;
 		}
 
+		if (!this.textModel) {
+			return CursorAtBoundary.None;
+		}
+
 		// only validate primary cursor
 		const selection = this._textEditor.getSelection();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Related to #91507. First attempt of moving focus to the right element after focus goes back to the notebook editor widget.