### PR TITLE
storage - add isNew method

### DIFF
--- a/src/vs/editor/contrib/multicursor/test/multicursor.test.ts
+++ b/src/vs/editor/contrib/multicursor/test/multicursor.test.ts
@@ -70,7 +70,8 @@ suite('Multicursor selection', () => {
 		remove: (key) => undefined,
 		logStorage: () => undefined,
 		migrate: (toWorkspace) => Promise.resolve(undefined),
-		flush: () => undefined
+		flush: () => undefined,
+		isNew: () => true
 	} as IStorageService);
 
 	test('issue #8817: Cursor position changes when you cancel multicursor', () => {

--- a/src/vs/platform/storage/common/storage.ts
+++ b/src/vs/platform/storage/common/storage.ts
@@ -9,10 +9,6 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { isUndefinedOrNull } from 'vs/base/common/types';
 import { IWorkspaceInitializationPayload } from 'vs/platform/workspaces/common/workspaces';
 
-export enum WorkspaceStorageSettings {
-	WORKSPACE_FIRST_OPEN = 'workbench.workspaceFirstOpen'
-}
-
 export const IStorageService = createDecorator<IStorageService>('storageService');
 
 export enum WillSaveStateReason {
@@ -106,6 +102,14 @@ export interface IStorageService {
 	 * Migrate the storage contents to another workspace.
 	 */
 	migrate(toWorkspace: IWorkspaceInitializationPayload): Promise<void>;
+
+	/**
+	 * Wether the storage for the given scope was created during this session or
+	 * existed before.
+	 *
+	 * Note: currently only implemented for `WORKSPACE` scope.
+	 */
+	isNew(scope: StorageScope.WORKSPACE): boolean;
 
 	/**
 	 * Allows to flush state, e.g. in cases where a shutdown is
@@ -230,6 +234,10 @@ export class InMemoryStorageService extends Disposable implements IStorageServic
 
 	flush(): void {
 		this._onWillSaveState.fire({ reason: WillSaveStateReason.NONE });
+	}
+
+	isNew(): boolean {
+		return true; // always new when in-memory
 	}
 }
 

--- a/src/vs/platform/storage/node/storageService.ts
+++ b/src/vs/platform/storage/node/storageService.ts
@@ -6,7 +6,7 @@
 import { Disposable, IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { Emitter } from 'vs/base/common/event';
 import { ILogService, LogLevel } from 'vs/platform/log/common/log';
-import { IWorkspaceStorageChangeEvent, IStorageService, StorageScope, IWillSaveStateEvent, WillSaveStateReason, logStorage, WorkspaceStorageSettings } from 'vs/platform/storage/common/storage';
+import { IWorkspaceStorageChangeEvent, IStorageService, StorageScope, IWillSaveStateEvent, WillSaveStateReason, logStorage } from 'vs/platform/storage/common/storage';
 import { SQLiteStorageDatabase, ISQLiteStorageDatabaseLoggingOptions } from 'vs/base/parts/storage/node/storage';
 import { Storage, IStorageDatabase, IStorage, StorageHint } from 'vs/base/parts/storage/common/storage';
 import { mark } from 'vs/base/common/performance';
@@ -24,6 +24,8 @@ export class NativeStorageService extends Disposable implements IStorageService 
 
 	private static readonly WORKSPACE_STORAGE_NAME = 'state.vscdb';
 	private static readonly WORKSPACE_META_NAME = 'workspace.json';
+
+	private static readonly WORKSPACE_IS_NEW_KEY = '__$__isNewStorageMarker';
 
 	private readonly _onDidChangeStorage = this._register(new Emitter<IWorkspaceStorageChangeEvent>());
 	readonly onDidChangeStorage = this._onDidChangeStorage.event;
@@ -106,11 +108,11 @@ export class NativeStorageService extends Disposable implements IStorageService 
 				await workspaceStorage.init();
 
 				// Check to see if this is the first time we are "opening" this workspace
-				const firstOpen = workspaceStorage.getBoolean(WorkspaceStorageSettings.WORKSPACE_FIRST_OPEN);
+				const firstOpen = workspaceStorage.getBoolean(NativeStorageService.WORKSPACE_IS_NEW_KEY);
 				if (firstOpen === undefined) {
-					workspaceStorage.set(WorkspaceStorageSettings.WORKSPACE_FIRST_OPEN, !result.wasCreated);
+					workspaceStorage.set(NativeStorageService.WORKSPACE_IS_NEW_KEY, result.wasCreated);
 				} else if (firstOpen) {
-					workspaceStorage.set(WorkspaceStorageSettings.WORKSPACE_FIRST_OPEN, false);
+					workspaceStorage.set(NativeStorageService.WORKSPACE_IS_NEW_KEY, false);
 				}
 			} finally {
 				mark('didInitWorkspaceStorage');
@@ -277,5 +279,9 @@ export class NativeStorageService extends Disposable implements IStorageService 
 
 		// Recreate and init workspace storage
 		return this.createWorkspaceStorage(newWorkspaceStoragePath).init();
+	}
+
+	isNew(scope: StorageScope.WORKSPACE): boolean {
+		return this.getBoolean(NativeStorageService.WORKSPACE_IS_NEW_KEY, scope) === true;
 	}
 }

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -16,7 +16,7 @@ import { PanelPart } from 'vs/workbench/browser/parts/panel/panelPart';
 import { PanelRegistry, Extensions as PanelExtensions } from 'vs/workbench/browser/panel';
 import { Position, Parts, IWorkbenchLayoutService, positionFromString, positionToString } from 'vs/workbench/services/layout/browser/layoutService';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
-import { IStorageService, StorageScope, WillSaveStateReason, WorkspaceStorageSettings } from 'vs/platform/storage/common/storage';
+import { IStorageService, StorageScope, WillSaveStateReason } from 'vs/platform/storage/common/storage';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
@@ -569,7 +569,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 
 		// The `firstRun` flag check is a safety-net hack for Codespaces, until we can verify the first open fix
-		const firstOpen = (storageService.getBoolean(WorkspaceStorageSettings.WORKSPACE_FIRST_OPEN, StorageScope.WORKSPACE) || (defaultLayout as { firstRun: boolean })?.firstRun);
+		const firstOpen = (storageService.isNew(StorageScope.WORKSPACE) || (defaultLayout as { firstRun: boolean })?.firstRun);
 		if (!firstOpen) {
 			return;
 		}
@@ -791,8 +791,9 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 	private getInitialFilesToOpen(): { filesToOpenOrCreate?: IPath[], filesToDiff?: IPath[] } | undefined {
 		const defaultLayout = this.environmentService.options?.defaultLayout;
+
 		// The `firstRun` flag check is a safety-net hack for Codespaces, until we can verify the first open fix
-		if (defaultLayout?.editors?.length && (this.storageService.getBoolean(WorkspaceStorageSettings.WORKSPACE_FIRST_OPEN, StorageScope.WORKSPACE) || (defaultLayout as { firstRun: boolean })?.firstRun)) {
+		if (defaultLayout?.editors?.length && (this.storageService.isNew(StorageScope.WORKSPACE) || (defaultLayout as { firstRun: boolean })?.firstRun)) {
 			this._openedDefaultEditors = true;
 
 			return {


### PR DESCRIPTION
This PR does a couple of things:
* introduces an explicit `isNew` method for finding out if a storage scope is new or not. I found that slightly better over relying on a storage key that is exposed because it was not clear that the key is set from the outside
* changes the key to be `workbench` unspecific, given `platform` player
* fixes an actual bug ([1]) where `!result.wasCreated` was used instead of `result.wasCreated`

[1] https://github.com/microsoft/vscode/commit/b1dac58c7025e259d00c7be848049e1bbfa5c4ce#diff-db4beb17f7c0c1c21dc0281f7caff9d9R113

Given we have not yet shipped a stable release with the storage key, I think it is OK to change the storage key.