### PR TITLE
Change value widget in object renderer based on key

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -148,9 +148,12 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input {
 	max-width: unset;
 }
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value-container .setting-list-object-input {
+	margin-right: 0;
+}
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-ok-button {
-	margin-right: 4px;
+	margin: 0 4px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-widget,
@@ -160,6 +163,7 @@
 	padding: 1px;
 }
 
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value-container,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input select {
 	width: 100%;
 	height: 24px;

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -939,8 +939,6 @@ export class ObjectSettingWidget extends AbstractListSettingWidget<IObjectDataIt
 			)
 		);
 
-		// TODO @9at8: should I implement 'Enter to save' on SelectBox?
-
 		const wrapper = $('.setting-list-object-input');
 		wrapper.classList.add(
 			isKey ? 'setting-list-object-input-key' : 'setting-list-object-input-value',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

#99635

This PR adds functionality to render the correct value widget based on the key.

Providing a 'SelectBox' to select keys while adding new items will be in a separate PR.

## Before
![before](https://user-images.githubusercontent.com/8235156/85977499-baee9c00-b9aa-11ea-9ae6-09a9beca4257.gif)

## After
![after](https://user-images.githubusercontent.com/8235156/85977565-d9ed2e00-b9aa-11ea-869b-adc09d1e1ff1.gif)

## Settings to test

- `emmet.variables`: (keys - `lang`, `charset`)
- `tsserver.watchOptions`: (keys - `watchFile`, `watchDirectory`, `fallbackPolling`, `synchronousWatchDirectory`)
- You can also change the schema of an existing setting (like `files.associations`)

```typescript
[FILES_ASSOCIATIONS_CONFIG]: {
			'type': 'object',
			'markdownDescription': nls.localize('associations', "Configure file associations to languages (e.g. `\"*.extension\": \"html\"`). These have precedence over the default associations of the languages installed."),
			properties: {
				'foo bar': { type: 'string', default: 'baz' },
				'enum prop': { type: 'string', default: 'a', enum: ['a', 'b', 'c'] },
				'boolf': { type: 'boolean', default: false },
				'boolt': { type: 'boolean', default: true },
				'bool': { type: 'boolean' },
			},
			patternProperties: {
				'pa(tt)*ern': { type: 'string', default: 'b', enum: ['A', 'b', 'C'] },
				'another(1)*': { type: 'string', default: 'one' },
			},
			'additionalProperties': {
				'type': 'string',
				default: 'typescript',
			}
		},
```