### PR TITLE
use performance.mark to get entry to timeline

### DIFF
--- a/src/vs/code/electron-browser/workbench/workbench.js
+++ b/src/vs/code/electron-browser/workbench/workbench.js
@@ -55,6 +55,7 @@ bootstrapWindow.load([
 ],
 	function (workbench, configuration) {
 		perf.mark('didLoadWorkbenchMain');
+		performance.mark('workbench-start');
 
 		return process['lazyEnv'].then(function () {
 			perf.mark('main/startup');

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -414,6 +414,10 @@ export class Workbench extends Layout {
 
 			// Telemetry: startup metrics
 			mark('didStartWorkbench');
+
+			// Perf reporting (devtools)
+			performance.mark('workbench-end');
+			performance.measure('perf: workbench create & restore', 'workbench-start', 'workbench-end');
 		}
 	}
 }


### PR DESCRIPTION
Using `performance.mark` with `performance.measure` allows to get a nice entry into the `Performance` tab of devtools (in the `Timings` group). I find this very helpful to know exactly where to look when checking for performance issues because the start of the bar is when code has finished loading and the end is our `ellapsed` time we use for all perf comparisons.

![image](https://user-images.githubusercontent.com/900690/85994163-b3091900-b9f7-11ea-8840-9e73ea5ad615.png)

I found no other way of marking this event in the timeline.