### PR TITLE
Detect links in the terminal that don't have a path separator

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
@@ -16,14 +16,14 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { XtermLinkMatcherHandler } from 'vs/workbench/contrib/terminal/browser/links/terminalLinkManager';
 import { TerminalBaseLinkProvider } from 'vs/workbench/contrib/terminal/browser/links/terminalBaseLinkProvider';
 
-const unixPathPrefix = '(\\.\\.?|\\~|)';
-const unixPathSeparatorClause = '\\/';
+const pathPrefix = '(\\.\\.?|\\~|)';
+const pathSeparatorClause = '\\/';
 // '":; are allowed in paths but they are often separators so ignore them
 // Also disallow \\ to prevent a catastropic backtracking case #24798
-const unixExcludedPathCharactersClause = '[^\\0\\s!$`&*()\\[\\]+\'":;\\\\]';
-const unixPathPartClause = '(' + unixExcludedPathCharactersClause + ')+';
+const excludedPathCharactersClause = '[^\\0\\s!$`&*()\\[\\]+\'":;\\\\]';
+const pathPartClause = '(' + excludedPathCharactersClause + ')+';
 /** A regex that matches paths in the form /foo, ~/foo, ./foo, ../foo, foo/bar, foo */
-export const unixLocalLinkClause = '(((' + unixPathPrefix + ')?' + unixPathSeparatorClause + ')?' + unixPathPartClause + '(' + unixPathSeparatorClause + unixPathPartClause + ')*(' + unixPathSeparatorClause + ')?)';
+export const unixLocalLinkClause = '(((' + pathPrefix + ')?' + pathSeparatorClause + ')?' + pathPartClause + '(' + pathSeparatorClause + pathPartClause + ')*(' + pathSeparatorClause + ')?)';
 
 export const winDrivePrefix = '(?:\\\\\\\\\\?\\\\)?[a-zA-Z]:';
 const winPathPrefix = '(' + winDrivePrefix + '|\\.\\.?|\\~)';

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
@@ -16,19 +16,19 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { XtermLinkMatcherHandler } from 'vs/workbench/contrib/terminal/browser/links/terminalLinkManager';
 import { TerminalBaseLinkProvider } from 'vs/workbench/contrib/terminal/browser/links/terminalBaseLinkProvider';
 
-const unixPathPrefix = String.raw`(\.\.?|\~|)`;
-const unixPathSeparatorClause = String.raw`\/`;
+const unixPathPrefix = '(\\.\\.?|\\~|)';
+const unixPathSeparatorClause = '\\/';
 // '":; are allowed in paths but they are often separators so ignore them
 // Also disallow \\ to prevent a catastropic backtracking case #24798
-const unixExcludedPathCharactersClause = String.raw`[^\0\s!$\`&*()\[\]+'":;\\]`;
+const unixExcludedPathCharactersClause = '[^\\0\\s!$`&*()\\[\\]+\'":;\\\\]';
 const unixPathPartClause = '(' + unixExcludedPathCharactersClause + ')+';
 /** A regex that matches paths in the form /foo, ~/foo, ./foo, ../foo, foo/bar, foo */
 export const unixLocalLinkClause = '(((' + unixPathPrefix + ')?' + unixPathSeparatorClause + ')?' + unixPathPartClause + '(' + unixPathSeparatorClause + unixPathPartClause + ')*(' + unixPathSeparatorClause + ')?)';
 
-export const winDrivePrefix = String.raw`(?:\\\\\?\\)?[a-zA-Z]:`;
-const winPathPrefix = '(' + winDrivePrefix + String.raw`|\.\.?|\~)`;
-const winPathSeparatorClause = String.raw`(\\|\/)`;
-const winExcludedPathCharactersClause = String.raw`[^\0<>\?\|\/\s!$\`&*()\[\]+'":;]`;
+export const winDrivePrefix = '(?:\\\\\\\\\\?\\\\)?[a-zA-Z]:';
+const winPathPrefix = '(' + winDrivePrefix + '|\\.\\.?|\\~)';
+const winPathSeparatorClause = '(\\\\|\\/)';
+const winExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!$`&*()\\[\\]+\'":;]';
 const winPathPartClause = '(' + winExcludedPathCharactersClause + ')+';
 /** A regex that matches paths in the form \\?\c:\foo c:\foo, ~\foo, .\foo, ..\foo, foo\bar, foo */
 export const winLocalLinkClause = '(((' + winPathPrefix + ')?' + winPathSeparatorClause + ')?' + winPathPartClause + '(' + winPathSeparatorClause + winPathPartClause + ')*(' + winPathSeparatorClause + ')?)';

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
@@ -16,20 +16,22 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { XtermLinkMatcherHandler } from 'vs/workbench/contrib/terminal/browser/links/terminalLinkManager';
 import { TerminalBaseLinkProvider } from 'vs/workbench/contrib/terminal/browser/links/terminalBaseLinkProvider';
 
-const unixPathPrefix = '(\\.\\.?|\\~|\\/)';
+const unixPathPrefix = '(\\.\\.?|\\~|)';
 const unixPathSeparatorClause = '\\/';
 // '":; are allowed in paths but they are often separators so ignore them
 // Also disallow \\ to prevent a catastropic backtracking case #24798
 const unixExcludedPathCharactersClause = '[^\\0\\s!$`&*()\\[\\]+\'":;\\\\]';
-/** A regex that matches paths in the form /foo, ~/foo, ./foo, ../foo, foo/bar */
-export const unixLocalLinkClause = '((' + unixPathPrefix + ')?(' + unixExcludedPathCharactersClause + ')+(' + unixPathSeparatorClause + '(' + unixExcludedPathCharactersClause + ')+)*)';
+const unixPathPartClause = '(' + unixExcludedPathCharactersClause + ')+';
+/** A regex that matches paths in the form /foo, ~/foo, ./foo, ../foo, foo/bar, foo */
+export const unixLocalLinkClause = '(((' + unixPathPrefix + ')?' + unixPathSeparatorClause + ')?' + unixPathPartClause + '(' + unixPathSeparatorClause + unixPathPartClause + ')*)';
 
 export const winDrivePrefix = '(?:\\\\\\\\\\?\\\\)?[a-zA-Z]:';
 const winPathPrefix = '(' + winDrivePrefix + '|\\.\\.?|\\~)';
 const winPathSeparatorClause = '(\\\\|\\/)';
 const winExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!$`&*()\\[\\]+\'":;]';
-/** A regex that matches paths in the form \\?\c:\foo c:\foo, ~\foo, .\foo, ..\foo, foo\bar */
-export const winLocalLinkClause = '((' + winPathPrefix + ')?(' + winExcludedPathCharactersClause + ')+(' + winPathSeparatorClause + '(' + winExcludedPathCharactersClause + ')+)*)';
+const winPathPartClause = '(' + winExcludedPathCharactersClause + ')+';
+/** A regex that matches paths in the form \\?\c:\foo c:\foo, ~\foo, .\foo, ..\foo, foo\bar, foo */
+export const winLocalLinkClause = '(((' + winPathPrefix + ')?' + winPathSeparatorClause + ')?' + winPathPartClause + '(' + winPathSeparatorClause + winPathPartClause + ')*)';
 
 /** As xterm reads from DOM, space in that case is nonbreaking char ASCII code - 160,
 replacing space with nonBreakningSpace or space ASCII code - 32. */

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
@@ -23,7 +23,7 @@ const unixPathSeparatorClause = '\\/';
 const unixExcludedPathCharactersClause = '[^\\0\\s!$`&*()\\[\\]+\'":;\\\\]';
 const unixPathPartClause = '(' + unixExcludedPathCharactersClause + ')+';
 /** A regex that matches paths in the form /foo, ~/foo, ./foo, ../foo, foo/bar, foo */
-export const unixLocalLinkClause = '(((' + unixPathPrefix + ')?' + unixPathSeparatorClause + ')?' + unixPathPartClause + '(' + unixPathSeparatorClause + unixPathPartClause + ')*)';
+export const unixLocalLinkClause = '(((' + unixPathPrefix + ')?' + unixPathSeparatorClause + ')?' + unixPathPartClause + '(' + unixPathSeparatorClause + unixPathPartClause + ')*(' + unixPathSeparatorClause + ')?)';
 
 export const winDrivePrefix = '(?:\\\\\\\\\\?\\\\)?[a-zA-Z]:';
 const winPathPrefix = '(' + winDrivePrefix + '|\\.\\.?|\\~)';
@@ -31,7 +31,7 @@ const winPathSeparatorClause = '(\\\\|\\/)';
 const winExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!$`&*()\\[\\]+\'":;]';
 const winPathPartClause = '(' + winExcludedPathCharactersClause + ')+';
 /** A regex that matches paths in the form \\?\c:\foo c:\foo, ~\foo, .\foo, ..\foo, foo\bar, foo */
-export const winLocalLinkClause = '(((' + winPathPrefix + ')?' + winPathSeparatorClause + ')?' + winPathPartClause + '(' + winPathSeparatorClause + winPathPartClause + ')*)';
+export const winLocalLinkClause = '(((' + winPathPrefix + ')?' + winPathSeparatorClause + ')?' + winPathPartClause + '(' + winPathSeparatorClause + winPathPartClause + ')*(' + winPathSeparatorClause + ')?)';
 
 /** As xterm reads from DOM, space in that case is nonbreaking char ASCII code - 160,
 replacing space with nonBreakingSpace or space ASCII code - 32. */

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
@@ -16,19 +16,19 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { XtermLinkMatcherHandler } from 'vs/workbench/contrib/terminal/browser/links/terminalLinkManager';
 import { TerminalBaseLinkProvider } from 'vs/workbench/contrib/terminal/browser/links/terminalBaseLinkProvider';
 
-const unixPathPrefix = '(\\.\\.?|\\~|)';
-const unixPathSeparatorClause = '\\/';
+const unixPathPrefix = String.raw`(\.\.?|\~|)`;
+const unixPathSeparatorClause = String.raw`\/`;
 // '":; are allowed in paths but they are often separators so ignore them
 // Also disallow \\ to prevent a catastropic backtracking case #24798
-const unixExcludedPathCharactersClause = '[^\\0\\s!$`&*()\\[\\]+\'":;\\\\]';
+const unixExcludedPathCharactersClause = String.raw`[^\0\s!$\`&*()\[\]+'":;\\]`;
 const unixPathPartClause = '(' + unixExcludedPathCharactersClause + ')+';
 /** A regex that matches paths in the form /foo, ~/foo, ./foo, ../foo, foo/bar, foo */
 export const unixLocalLinkClause = '(((' + unixPathPrefix + ')?' + unixPathSeparatorClause + ')?' + unixPathPartClause + '(' + unixPathSeparatorClause + unixPathPartClause + ')*(' + unixPathSeparatorClause + ')?)';
 
-export const winDrivePrefix = '(?:\\\\\\\\\\?\\\\)?[a-zA-Z]:';
-const winPathPrefix = '(' + winDrivePrefix + '|\\.\\.?|\\~)';
-const winPathSeparatorClause = '(\\\\|\\/)';
-const winExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!$`&*()\\[\\]+\'":;]';
+export const winDrivePrefix = String.raw`(?:\\\\\?\\)?[a-zA-Z]:`;
+const winPathPrefix = '(' + winDrivePrefix + String.raw`|\.\.?|\~)`;
+const winPathSeparatorClause = String.raw`(\\|\/)`;
+const winExcludedPathCharactersClause = String.raw`[^\0<>\?\|\/\s!$\`&*()\[\]+'":;]`;
 const winPathPartClause = '(' + winExcludedPathCharactersClause + ')+';
 /** A regex that matches paths in the form \\?\c:\foo c:\foo, ~\foo, .\foo, ..\foo, foo\bar, foo */
 export const winLocalLinkClause = '(((' + winPathPrefix + ')?' + winPathSeparatorClause + ')?' + winPathPartClause + '(' + winPathSeparatorClause + winPathPartClause + ')*(' + winPathSeparatorClause + ')?)';

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
@@ -34,7 +34,7 @@ const winPathPartClause = '(' + winExcludedPathCharactersClause + ')+';
 export const winLocalLinkClause = '(((' + winPathPrefix + ')?' + winPathSeparatorClause + ')?' + winPathPartClause + '(' + winPathSeparatorClause + winPathPartClause + ')*)';
 
 /** As xterm reads from DOM, space in that case is nonbreaking char ASCII code - 160,
-replacing space with nonBreakningSpace or space ASCII code - 32. */
+replacing space with nonBreakingSpace or space ASCII code - 32. */
 export const lineAndColumnClause = [
 	'((\\S*)", line ((\\d+)( column (\\d+))?))', // "(file path)", line 45 [see #40468]
 	'((\\S*)",((\\d+)(:(\\d+))?))', // "(file path)",45 [see #78205]

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
@@ -16,20 +16,20 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { XtermLinkMatcherHandler } from 'vs/workbench/contrib/terminal/browser/links/terminalLinkManager';
 import { TerminalBaseLinkProvider } from 'vs/workbench/contrib/terminal/browser/links/terminalBaseLinkProvider';
 
-const pathPrefix = '(\\.\\.?|\\~)';
-const pathSeparatorClause = '\\/';
+const unixPathPrefix = '(\\.\\.?|\\~|\\/)';
+const unixPathSeparatorClause = '\\/';
 // '":; are allowed in paths but they are often separators so ignore them
 // Also disallow \\ to prevent a catastropic backtracking case #24798
-const excludedPathCharactersClause = '[^\\0\\s!$`&*()\\[\\]+\'":;\\\\]';
+const unixExcludedPathCharactersClause = '[^\\0\\s!$`&*()\\[\\]+\'":;\\\\]';
 /** A regex that matches paths in the form /foo, ~/foo, ./foo, ../foo, foo/bar */
-export const unixLocalLinkClause = '((' + pathPrefix + '|(' + excludedPathCharactersClause + ')+)?(' + pathSeparatorClause + '(' + excludedPathCharactersClause + ')+)+)';
+export const unixLocalLinkClause = '((' + unixPathPrefix + ')?(' + unixExcludedPathCharactersClause + ')+(' + unixPathSeparatorClause + '(' + unixExcludedPathCharactersClause + ')+)*)';
 
 export const winDrivePrefix = '(?:\\\\\\\\\\?\\\\)?[a-zA-Z]:';
 const winPathPrefix = '(' + winDrivePrefix + '|\\.\\.?|\\~)';
 const winPathSeparatorClause = '(\\\\|\\/)';
 const winExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!$`&*()\\[\\]+\'":;]';
 /** A regex that matches paths in the form \\?\c:\foo c:\foo, ~\foo, .\foo, ..\foo, foo\bar */
-export const winLocalLinkClause = '((' + winPathPrefix + '|(' + winExcludedPathCharactersClause + ')+)?(' + winPathSeparatorClause + '(' + winExcludedPathCharactersClause + ')+)+)';
+export const winLocalLinkClause = '((' + winPathPrefix + ')?(' + winExcludedPathCharactersClause + ')+(' + winPathSeparatorClause + '(' + winExcludedPathCharactersClause + ')+)*)';
 
 /** As xterm reads from DOM, space in that case is nonbreaking char ASCII code - 160,
 replacing space with nonBreakningSpace or space ASCII code - 32. */


### PR DESCRIPTION
This PR fixes #101155

It makes it so that when searching for links in the terminal output, text without any slashes (e.g. `file.cpp` or `file`) is also taken into consideration (this is before filtering files which actually exist).

It also makes it look at whether it has a trailing slash, so that paths like `./README.md/` will not work, intentionally.

It basically changes the regex from:
`(<root> | <path-part>)? (<separator> <path-part>)+`
to
`(<root>? <separator>)? <path-part> (<separator> <path-part>)* <separator>?`


The following are all the possible cases I can think of which should be considered as valid paths, and whether the old and new regexes detect them:
```
                   old  new
~                  [ ]  [ ]
~/file             [x]  [x]
~/dir/file         [x]  [x]
file               [ ]  [x]
dir/file           [x]  [x]
/file              [x]  [x]
/dir/file          [x]  [x]
```
As you can see, this PR allows using just `file` to link to a file at the root of the current workspace.

Note that as mentioned before, paths like these except that end in another slash work by having the line-number regex ignore the slash.
Now the file path regex considers it, so paths to non-directories which end in a slash will not be considered valid links anymore.
