### PR TITLE
fix: remove unsed code on detecting file type

### DIFF
--- a/src/vs/base/common/mime.ts
+++ b/src/vs/base/common/mime.ts
@@ -169,7 +169,6 @@ function guessMimeTypeByPath(path: string, filename: string, associations: IText
 		// First exact name match
 		if (filename === association.filenameLowercase) {
 			filenameMatch = association;
-			break; // take it!
 		}
 
 		// Longest pattern match


### PR DESCRIPTION
This RP only remove unused code based on the comment on https://github.com/microsoft/vscode/blob/01d0314308fdf83801c3d7abf43b7a2702ea9263/src/vs/base/common/mime.ts#L172

Besides, it won't cause any functional change after remove the line. 