### PR TITLE
fix for #101376

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -39,6 +39,7 @@ import { KeyCode } from 'vs/base/common/keyCodes';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { RawContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { HIDE_NOTIFICATIONS_CENTER, SHOW_NOTIFICATIONS_CENTER } from 'vs/workbench/browser/parts/notifications/notificationsCommands';
 
 interface IPendingStatusbarEntry {
 	id: string;
@@ -830,6 +831,14 @@ class StatusbarEntryItem extends Disposable {
 
 		this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id, from: 'status bar' });
 		try {
+			if (typeof command === 'string') {
+				if (command === 'help.tweetFeedback') {
+					this.executeCommand(HIDE_NOTIFICATIONS_CENTER);
+				}
+				else if (command === SHOW_NOTIFICATIONS_CENTER) {
+					this.executeCommand('help.hideTweetFeedback');
+				}
+			}
 			await this.commandService.executeCommand(id, ...args);
 		} catch (error) {
 			this.notificationService.error(toErrorMessage(error));

--- a/src/vs/workbench/contrib/feedback/browser/feedbackStatusbarItem.ts
+++ b/src/vs/workbench/contrib/feedback/browser/feedbackStatusbarItem.ts
@@ -72,6 +72,15 @@ export class FeedbackStatusbarConribution extends Disposable implements IWorkben
 					title: localize('status.feedback', "Tweet Feedback")
 				}
 			});
+
+			CommandsRegistry.registerCommand('help.hideTweetFeedback', () => this.hideFeedback());
+			MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
+				command: {
+					id: 'help.hideTweetFeedback',
+					category: localize('help', "Help"),
+					title: localize('status.feedback', "Tweet Feedback")
+				}
+			});
 		}
 	}
 
@@ -95,6 +104,14 @@ export class FeedbackStatusbarConribution extends Disposable implements IWorkben
 			if (!this.dropdown.isVisible()) {
 				this.dropdown.show();
 			} else {
+				this.dropdown.hide();
+			}
+		}
+	}
+
+	private hideFeedback(): void {
+		if (this.dropdown) {
+			if (this.dropdown.isVisible()) {
 				this.dropdown.hide();
 			}
 		}


### PR DESCRIPTION
This PR fixes #101376

When opening either the notifications center or the tweet feedback item, the other one hides to avoid overlapping.
