### PR TITLE
Added word boundary on tsserver regex

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/serverError.ts
+++ b/extensions/typescript-language-features/src/tsServer/serverError.ts
@@ -79,7 +79,7 @@ export class TypeScriptServerError extends Error {
 		if (!message) {
 			return '';
 		}
-		const regex = /(tsserver)?(\.(?:ts|tsx|js|jsx)(?::\d+(?::\d+)?)?)\)?$/igm;
+		const regex = /(\btsserver)?(\.(?:ts|tsx|js|jsx)(?::\d+(?::\d+)?)?)\)?$/igm;
 		let serverStack = '';
 		while (true) {
 			const match = regex.exec(message);


### PR DESCRIPTION
Adds a word boundary on the tsserver regex so that sanitize doesn't get confused by other file names.

(No issue for this).
