### PR TITLE
Show SCM uppercase in settings search titles

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -238,6 +238,7 @@ export const knownAcronyms = new Set<string>();
 	'ie',
 	'id',
 	'php',
+	'scm',
 ].forEach(str => knownAcronyms.add(str));
 
 export const knownTermMappings = new Map<string, string>();


### PR DESCRIPTION
This PR fixes #101678 

![image](https://user-images.githubusercontent.com/6726799/86477853-305ac380-bd41-11ea-8f57-ba986cc3829a.png)
