### PR TITLE
Ignore less cached data when more is available

### DIFF
--- a/src/vs/loader.js
+++ b/src/vs/loader.js
@@ -870,6 +870,12 @@ var AMDLoader;
                     }
                     var cachedData = script.createCachedData();
                     if (cachedData.length === 0 || cachedData.length === lastSize || iteration >= 5) {
+                        // done
+                        return;
+                    }
+                    if (cachedData.length < lastSize) {
+                        // less data than before: skip, try again next round
+                        createLoop();
                         return;
                     }
                     lastSize = cachedData.length;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR helps with https://github.com/microsoft/vscode/issues/101685. While drilling into a potential startup regression I have realised that calling `createCachedData` can yield less data than returned in previous rounds. It's not entirely clear to me why but having less cached data will negatively impact startup performance. 
