### PR TITLE
[Settings Editor] Add extra bottom padding for lists in settings

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -320,7 +320,8 @@
 	bottom: 16px;
 }
 
-.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-item-contents.is-configured .setting-item-modified-indicator {
+.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-item-contents.is-configured .setting-item-modified-indicator,
+.settings-editor > .settings-body > .settings-tree-container .setting-item-list .setting-item-contents.is-configured .setting-item-modified-indicator {
 	bottom: 23px;
 }
 
@@ -444,7 +445,8 @@
 	display: block;
 }
 
-.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-item-contents {
+.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-item-contents,
+.settings-editor > .settings-body > .settings-tree-container .setting-item-list .setting-item-contents {
 	padding-bottom: 26px;
 }
 


### PR DESCRIPTION
Fixes: #101516

The add button was getting hidden under the next element in the settings
list, so I increased the bottom padding.