### PR TITLE
Fixes quick find symbol finder shows 'no matching results' after backspace

### DIFF
--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -66,6 +66,7 @@ function isEditorSymbolQuickPickItem(pick?: IAnythingQuickPickItem): pick is IEd
 export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnythingQuickPickItem> {
 
 	static PREFIX = '';
+	static NO_RESULTS_ID = 'noAnythingResults';
 
 	private static readonly MAX_RESULTS = 512;
 
@@ -174,6 +175,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		super(AnythingQuickAccessProvider.PREFIX, {
 			canAcceptInBackground: true,
 			noResultsPick: {
+				id: AnythingQuickAccessProvider.NO_RESULTS_ID,
 				label: localize('noAnythingResults', "No matching results")
 			}
 		});
@@ -278,13 +280,13 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		this.pickState.lastFilter = filter;
 
 		// Remember our pick state before returning new picks
-		// unless an editor symbol is selected. We can use this
-		// state to return back to the global pick when the
-		// user is narrowing back out of editor symbols.
+		// unless an editor symbol or noResultsPick is selected.
+		// We can use this state to return back to the global pick
+		// when the user is narrowing back out of editor symbols.
 		const picks = this.pickState.picker?.items;
 		const activePick = this.pickState.picker?.activeItems[0];
 		if (picks && activePick) {
-			if (!isEditorSymbolQuickPickItem(activePick)) {
+			if (!isEditorSymbolQuickPickItem(activePick) && activePick?.id !== AnythingQuickAccessProvider.NO_RESULTS_ID) {
 				this.pickState.lastGlobalPicks = {
 					items: picks,
 					active: activePick

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -66,7 +66,10 @@ function isEditorSymbolQuickPickItem(pick?: IAnythingQuickPickItem): pick is IEd
 export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnythingQuickPickItem> {
 
 	static PREFIX = '';
-	static NO_RESULTS_ID = 'noAnythingResults';
+
+	private static readonly NO_RESULTS_PICK: IAnythingQuickPickItem = {
+		label: localize('noAnythingResults', "No matching results")
+	};
 
 	private static readonly MAX_RESULTS = 512;
 
@@ -174,10 +177,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 	) {
 		super(AnythingQuickAccessProvider.PREFIX, {
 			canAcceptInBackground: true,
-			noResultsPick: {
-				id: AnythingQuickAccessProvider.NO_RESULTS_ID,
-				label: localize('noAnythingResults', "No matching results")
-			}
+			noResultsPick: AnythingQuickAccessProvider.NO_RESULTS_PICK
 		});
 	}
 
@@ -280,13 +280,15 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		this.pickState.lastFilter = filter;
 
 		// Remember our pick state before returning new picks
-		// unless an editor symbol or noResultsPick is selected.
+		// unless we are inside an editor symbol filter or result.
 		// We can use this state to return back to the global pick
 		// when the user is narrowing back out of editor symbols.
 		const picks = this.pickState.picker?.items;
 		const activePick = this.pickState.picker?.activeItems[0];
 		if (picks && activePick) {
-			if (!isEditorSymbolQuickPickItem(activePick) && activePick?.id !== AnythingQuickAccessProvider.NO_RESULTS_ID) {
+			const activePickIsEditorSymbol = isEditorSymbolQuickPickItem(activePick);
+			const activePickIsNoResultsInEditorSymbols = activePick === AnythingQuickAccessProvider.NO_RESULTS_PICK && filter.indexOf(GotoSymbolQuickAccessProvider.PREFIX) >= 0;
+			if (!activePickIsEditorSymbol && !activePickIsNoResultsInEditorSymbols) {
 				this.pickState.lastGlobalPicks = {
 					items: picks,
 					active: activePick


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->
Just validating that the `noResultsPick` pick item does not get stored in `this.pickState.lastGlobalPicks` seems to fix the issue.

This PR fixes #101708
