### PR TITLE
Fix color token for notebook focused cell bg

### DIFF
--- a/extensions/theme-defaults/themes/light_defaults.json
+++ b/extensions/theme-defaults/themes/light_defaults.json
@@ -20,7 +20,7 @@
 		"statusBarItem.remoteBackground": "#16825D",
 		"sideBarSectionHeader.background": "#0000",
 		"sideBarSectionHeader.border": "#61616130",
-		"notebook.cellFocusBackground": "#c8ddf150",
+		"notebook.focusedCellBackground": "#c8ddf150",
 		"notebook.cellBorderColor": "#dae3e9",
 		"notebook.outputContainerBackgroundColor": "#c8ddf150",
 		"notebook.focusedCellShadow": "#00315040"


### PR DESCRIPTION
For #101867, this uses the correct color token for notebook focused cells in the Light theme. This was changed during endgame testing and was never updated in the default light theme.

![image](https://user-images.githubusercontent.com/35271042/86822180-22a68600-c040-11ea-96a5-262164828066.png)
