### PR TITLE
Add navigation role to settings-toc-wrapper

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -647,7 +647,10 @@ export class SettingsEditor2 extends BaseEditor {
 		this.tocTreeContainer = DOM.append(parent, $('.settings-toc-container'));
 
 		this.tocTree = this._register(this.instantiationService.createInstance(TOCTree,
-			DOM.append(this.tocTreeContainer, $('.settings-toc-wrapper')),
+			DOM.append(this.tocTreeContainer, $('.settings-toc-wrapper', {
+				'role': 'navigation',
+				'aria-label': localize('settings', "Settings"),
+			})),
 			this.viewState));
 
 		this._register(this.tocTree.onDidChangeFocus(e => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #101959 

This adds the "navigation" role to the TOC in the settings editor, which also adds an additional landmark that's readable by screen readers. This allows the user to go back to the previous landmark when in browse mode.

For example, with NVDA, if you're focused on some element in the settings editor:

1. Press `NVDA + space` to enter browse mode
2. Press `Shift + d` to go to the previous landmark (the TOC tree in this case)

![recording (2)](https://user-images.githubusercontent.com/8235156/86988605-9e025780-c166-11ea-81fd-1604456ca2c9.gif)
