### PR TITLE
Add activation events for providing/resolving tasks (TaskProvider extension API)

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -6931,6 +6931,10 @@ declare module 'vscode' {
 		/**
 		 * Register a task provider.
 		 *
+		 * When looking for tasks, VS Code fires an `onTaskProvide:taskType` activation event.
+		 * When a task is being resolved, VS Code fires an `onTaskResolve:taskType` activation event.
+		 * Your extension can listen to these events to make sure the task provider is available.
+		 *
 		 * @param type The task kind type this provider is registered for.
 		 * @param provider A task provider.
 		 * @return A {@link Disposable} that unregisters this provider when being disposed.
@@ -10927,6 +10931,10 @@ declare module 'vscode' {
 		 * Register a task provider.
 		 *
 		 * @deprecated Use the corresponding function on the `tasks` namespace instead
+		 *
+		 * When looking for tasks, VS Code fires an `onTaskProvide:taskType` activation event.
+		 * When a task is being resolved, VS Code fires an `onTaskResolve:taskType` activation event.
+		 * Your extension can listen to these events to make sure the task provider is available.
 		 *
 		 * @param type The task kind type this provider is registered for.
 		 * @param provider A task provider.

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -700,6 +700,19 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		return types;
 	}
 
+	public async getPossibleTaskTypes(): Promise<string[]> {
+		const types: string[] = this.taskTypes();
+		if (this.isProvideTasksEnabled()) {
+			await TaskDefinitionRegistry.onReady();
+			for (const task of TaskDefinitionRegistry.all()) {
+				if (!types.includes(task.taskType)) {
+					types.push(task.taskType);
+				}
+			}
+		}
+		return types;
+	}
+
 	public createSorter(): TaskSorter {
 		return new TaskSorter(this.contextService.getWorkspace() ? this.contextService.getWorkspace().folders : []);
 	}

--- a/src/vs/workbench/contrib/tasks/browser/taskQuickPick.ts
+++ b/src/vs/workbench/contrib/tasks/browser/taskQuickPick.ts
@@ -147,7 +147,7 @@ export class TaskQuickPick extends Disposable {
 		}
 		let recentTasks: (Task | ConfiguringTask)[] = (await this.taskService.readRecentTasks()).reverse();
 		const configuredTasks: (Task | ConfiguringTask)[] = this.handleFolderTaskResult(await this.taskService.getWorkspaceTasks());
-		const extensionTaskTypes = this.taskService.taskTypes();
+		const extensionTaskTypes = await this.taskService.getPossibleTaskTypes();
 		this.topLevelEntries = [];
 		// Dedupe will update recent tasks if they've changed in tasks.json.
 		const dedupeAndPrune = this.dedupeConfiguredAndRecent(recentTasks, configuredTasks);

--- a/src/vs/workbench/contrib/tasks/common/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskService.ts
@@ -70,6 +70,7 @@ export interface ITaskService {
 	terminate(task: Task): Promise<TaskTerminateResponse>;
 	tasks(filter?: TaskFilter): Promise<Task[]>;
 	taskTypes(): string[];
+	getPossibleTaskTypes(): Promise<string[]>;
 	getWorkspaceTasks(runSource?: TaskRunSource): Promise<Map<string, WorkspaceFolderTaskResult>>;
 	readRecentTasks(): Promise<(Task | ConfiguringTask)[]>;
 	removeRecentlyUsedTask(taskRecentlyUsedKey: string): void;

--- a/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
@@ -310,6 +310,16 @@ export const schema: IJSONSchema = {
 						description: nls.localize('vscode.extension.activationEvents.onCustomEditor', 'An activation event emitted whenever the specified custom editor becomes visible.'),
 					},
 					{
+						label: 'onTaskProvide',
+						description: nls.localize('vscode.extension.activationEvents.onTaskProvide', 'An activation event emitted whenever VS Code is looking for tasks of a given (or any) type.'),
+						body: 'onTaskResolve:${1:taskType}'
+					},
+					{
+						label: 'onTaskResolve',
+						description: nls.localize('vscode.extension.activationEvents.onTaskResolve', 'An activation event emitted whenever a task with the given type gets resolved.'),
+						body: 'onTaskResolve:${1:taskType}'
+					},
+					{
 						label: 'onNotebook',
 						body: 'onNotebook:${1:type}',
 						description: nls.localize('vscode.extension.activationEvents.onNotebook', 'An activation event emitted whenever the specified notebook document is opened.'),


### PR DESCRIPTION
This PR is related to issue #99797 and its consequent PR #99957.

This PR makes the following changes:
- Add `onTaskProvide:taskType` activation event whenever VS Code queries TaskProviders for tasks
- Add `onTaskResolve:taskType` activation event whenever VS Code needs to resolve a TaskProvider's task
- Add and implement `ITaskService.getPossibleTaskTypes(): Promise<string[]>`
    An async version of `.taskTypes()` which also checks all task definitions defined in package.json of _(inactive)_ extensions
- Make TaskQuickPick use this new `getPossibleTaskTypes()`
    Task types for inactive extensions _(that specify `taskDefinitions` in their package.json)_ also get listed now

Related activation events and triggers:
- `onTaskProvide:taskType` triggered by selecting `Show All Tasks` in the `Tasks: Run Task`'s TaskQuickPick
   This is fired for every task type registered in TaskDefinitionRegistry _(except for `shell` and `process`)_
- `onTaskProvide:taskType` triggered by selecting an extension top level entry in the `Tasks: Run Task`'s TaskQuickPick
   This is fired for just the selected task type
- `onTaskResolve:taskType` triggered by trying to resolve a task, if it has a type defined

_____

I recently added a TaskProvider for my extension, and noticed that in certain cases, it couldn't be resolved. After taking a look, it seemed to be caused by the extension not being activated yet, hence not having registered the TaskProvider. With this PR, extensions can now add a proper activation event to deal with providing/resolving their tasks.

I noticed while working on this that #99957 made it that extensions can activate on `onCommand:...runTask` or even `*` instead. This PR provides more specific activation events, instead of having to rely on the aforementioned events.

Another possibility that I have thought about but decided against:
Since we can use `taskDefinitions` _(TaskDefinitionRegistry)_ to figure out which extensions will _(should)_ provide TaskProviders for which types, we can automatically start an extension when we need to provide/resolve using such a provider. The `taskDefinitions` would basically also register the extension for the appropriate `onTaskProvide`/`onTaskResolve` activation events.
The same could be done for commands, since similar to `taskDefinitions` we can access `commands` too, including from inactive extensions. Since this auto-registration isn't actually the case for commands, I assume it shouldn't be the case for task definitions either.
