### PR TITLE
Clean up multi root labels

### DIFF
--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -141,21 +141,15 @@ export class LabelService extends Disposable implements ILabelService {
 		const baseResource = this.contextService?.getWorkspaceFolder(resource);
 
 		if (options.relative && baseResource) {
-			const rootName = baseResource?.name ?? basenameOrAuthority(baseResource.uri);
-
-			let relativeLabel: string;
-			if (isEqual(baseResource.uri, resource)) {
-				relativeLabel = ''; // no label if resources are identical
-			} else {
-				const baseResourceLabel = this.formatUri(baseResource.uri, formatting, options.noPrefix);
-				relativeLabel = this.formatUri(resource, formatting, options.noPrefix).substring(baseResourceLabel.lastIndexOf(formatting.separator) + 1);
-				if (relativeLabel.startsWith(rootName)) {
-					relativeLabel = relativeLabel.substring(rootName.length + (relativeLabel[rootName.length] === formatting.separator ? 1 : 0));
-				}
+			const baseResourceLabel = this.formatUri(baseResource.uri, formatting, options.noPrefix);
+			let relativeLabel = this.formatUri(resource, formatting, options.noPrefix);
+			if (relativeLabel.startsWith(baseResourceLabel)) {
+				relativeLabel = relativeLabel.substring(1 + baseResourceLabel.length);
 			}
 
 			const hasMultipleRoots = this.contextService.getWorkspace().folders.length > 1;
 			if (hasMultipleRoots && !options.noPrefix) {
+				const rootName = baseResource?.name ?? basenameOrAuthority(baseResource.uri);
 				relativeLabel = relativeLabel ? (rootName + ' • ' + relativeLabel) : rootName; // always show root basename if there are multiple
 			}
 

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -12,7 +12,7 @@ import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry, IWo
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IWorkspaceContextService, IWorkspace } from 'vs/platform/workspace/common/workspace';
-import { isEqual, basenameOrAuthority, basename, joinPath, dirname } from 'vs/base/common/resources';
+import { basenameOrAuthority, basename, joinPath, dirname } from 'vs/base/common/resources';
 import { tildify, getPathLabel } from 'vs/base/common/labels';
 import { IWorkspaceIdentifier, ISingleFolderWorkspaceIdentifier, isSingleFolderWorkspaceIdentifier, WORKSPACE_EXTENSION, toWorkspaceIdentifier, isWorkspaceIdentifier, isUntitledWorkspace } from 'vs/platform/workspaces/common/workspaces';
 import { ILabelService, ResourceLabelFormatter, ResourceLabelFormatting, IFormatterChangeEvent } from 'vs/platform/label/common/label';
@@ -21,6 +21,7 @@ import { match } from 'vs/base/common/glob';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
+import { trim } from 'vs/base/common/strings';
 
 const resourceLabelFormattersExtPoint = ExtensionsRegistry.registerExtensionPoint<ResourceLabelFormatter[]>({
 	extensionPoint: 'resourceLabelFormatters',
@@ -143,8 +144,11 @@ export class LabelService extends Disposable implements ILabelService {
 		if (options.relative && baseResource) {
 			const baseResourceLabel = this.formatUri(baseResource.uri, formatting, options.noPrefix);
 			let relativeLabel = this.formatUri(resource, formatting, options.noPrefix);
-			if (relativeLabel.startsWith(baseResourceLabel)) {
-				relativeLabel = relativeLabel.substring(1 + baseResourceLabel.length);
+
+			let overlap = 0;
+			while (relativeLabel[overlap] && relativeLabel[overlap] === baseResourceLabel[overlap]) { overlap++; }
+			if (!relativeLabel[overlap] || relativeLabel[overlap] === formatting.separator) {
+				relativeLabel = relativeLabel.substring(1 + overlap);
 			}
 
 			const hasMultipleRoots = this.contextService.getWorkspace().folders.length > 1;

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -21,7 +21,6 @@ import { match } from 'vs/base/common/glob';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
-import { trim } from 'vs/base/common/strings';
 
 const resourceLabelFormattersExtPoint = ExtensionsRegistry.registerExtensionPoint<ResourceLabelFormatter[]>({
 	extensionPoint: 'resourceLabelFormatters',

--- a/src/vs/workbench/services/label/test/browser/label.test.ts
+++ b/src/vs/workbench/services/label/test/browser/label.test.ts
@@ -159,7 +159,7 @@ suite('URI Label', () => {
 });
 
 
-suite.only('multi-root worksapce', () => {
+suite('multi-root worksapce', () => {
 	let labelService: LabelService;
 
 	setup(() => {
@@ -176,7 +176,9 @@ suite.only('multi-root worksapce', () => {
 					new WorkspaceFolder({ uri: other, index: 2, name: resources.basename(other) }, { uri: other.toString() }),
 				])),
 			new TestPathService());
+	});
 
+	test('labels of files in multiroot workspaces are the foldername folloed by offset from the folder', () => {
 		labelService.registerFormatter({
 			scheme: 'file',
 			formatting: {
@@ -188,9 +190,7 @@ suite.only('multi-root worksapce', () => {
 				workspaceSuffix: ''
 			}
 		});
-	});
 
-	test('labels of files in multiroot workspaces are the foldername folloed by offset from the folder', () => {
 		const tests = {
 			'folder1/src/file': 'Sources • file',
 			'folder1/src/folder/file': 'Sources • folder/file',
@@ -201,8 +201,31 @@ suite.only('multi-root worksapce', () => {
 		};
 
 		Object.entries(tests).forEach(([path, label]) => {
-			const generated = labelService.getUriLabel(URI.parse(path), { relative: true });
+			const generated = labelService.getUriLabel(URI.file(path), { relative: true });
 			assert.equal(generated, label);
 		});
+	});
+
+	test('labels with context after path', () => {
+		labelService.registerFormatter({
+			scheme: 'file',
+			formatting: {
+				label: '${path} (${scheme})',
+				separator: '/',
+			}
+		});
+
+		const tests = {
+			'folder1/src/file': 'Sources • file (file)',
+			'folder1/src/folder/file': 'Sources • folder/file (file)',
+			'folder1/other': '/folder1/other (file)',
+			'folder2/other': 'folder2 • other (file)',
+		};
+
+		Object.entries(tests).forEach(([path, label]) => {
+			const generated = labelService.getUriLabel(URI.file(path), { relative: true });
+			assert.equal(generated, label, path);
+		});
+
 	});
 });

--- a/src/vs/workbench/services/label/test/browser/label.test.ts
+++ b/src/vs/workbench/services/label/test/browser/label.test.ts
@@ -3,14 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as resources from 'vs/base/common/resources';
 import * as assert from 'assert';
 import { TestEnvironmentService, TestPathService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { URI } from 'vs/base/common/uri';
 import { LabelService } from 'vs/workbench/services/label/common/labelService';
 import { TestContextService } from 'vs/workbench/test/common/workbenchTestServices';
+import { Workspace, WorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 
 suite('URI Label', () => {
-
 	let labelService: LabelService;
 
 	setup(() => {
@@ -154,5 +155,54 @@ suite('URI Label', () => {
 
 		const uri1 = URI.parse('vscode://microsoft.com/1/2/3/4/5');
 		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABEL: /END');
+	});
+});
+
+
+suite.only('multi-root worksapce', () => {
+	let labelService: LabelService;
+
+	setup(() => {
+		const sources = URI.file('folder1/src');
+		const tests = URI.file('folder1/test');
+		const other = URI.file('folder2');
+
+		labelService = new LabelService(
+			TestEnvironmentService,
+			new TestContextService(
+				new Workspace('test-workspaace', [
+					new WorkspaceFolder({ uri: sources, index: 0, name: 'Sources' }, { uri: sources.toString() }),
+					new WorkspaceFolder({ uri: tests, index: 1, name: 'Tests' }, { uri: tests.toString() }),
+					new WorkspaceFolder({ uri: other, index: 2, name: resources.basename(other) }, { uri: other.toString() }),
+				])),
+			new TestPathService());
+
+		labelService.registerFormatter({
+			scheme: 'file',
+			formatting: {
+				label: '${authority}${path}',
+				separator: '/',
+				tildify: false,
+				normalizeDriveLetter: false,
+				authorityPrefix: '//',
+				workspaceSuffix: ''
+			}
+		});
+	});
+
+	test('labels of files in multiroot workspaces are the foldername folloed by offset from the folder', () => {
+		const tests = {
+			'folder1/src/file': 'Sources • file',
+			'folder1/src/folder/file': 'Sources • folder/file',
+			'folder1/src/': 'Sources',
+			'folder1/src': 'Sources',
+			'folder1/other': '/folder1/other',
+			'folder2/other': 'folder2 • other',
+		};
+
+		Object.entries(tests).forEach(([path, label]) => {
+			const generated = labelService.getUriLabel(URI.parse(path), { relative: true });
+			assert.equal(generated, label);
+		});
 	});
 });

--- a/src/vs/workbench/services/label/test/browser/label.test.ts
+++ b/src/vs/workbench/services/label/test/browser/label.test.ts
@@ -194,7 +194,6 @@ suite('multi-root worksapce', () => {
 		const tests = {
 			'folder1/src/file': 'Sources • file',
 			'folder1/src/folder/file': 'Sources • folder/file',
-			'folder1/src/': 'Sources',
 			'folder1/src': 'Sources',
 			'folder1/other': '/folder1/other',
 			'folder2/other': 'folder2 • other',
@@ -218,6 +217,7 @@ suite('multi-root worksapce', () => {
 		const tests = {
 			'folder1/src/file': 'Sources • file (file)',
 			'folder1/src/folder/file': 'Sources • folder/file (file)',
+			'folder1/src': 'Sources',
 			'folder1/other': '/folder1/other (file)',
 			'folder2/other': 'folder2 • other (file)',
 		};


### PR DESCRIPTION
fixes #100929

It looks like the basename of a workspace folder was getting duplicated if that workspace folder had an assigned name. Changed it do not do that and added some test cases wrt this and 073398241b82f1de997811b12e19c38c27a27b08. Let me know if you have concerns about this going in. 

cc @eamodio @isidorn 
