### PR TITLE
suggestFilename: use modeService instead of mime

### DIFF
--- a/src/vs/base/common/mime.ts
+++ b/src/vs/base/common/mime.ts
@@ -5,7 +5,6 @@
 
 import { basename, posix, extname } from 'vs/base/common/path';
 import { startsWithUTF8BOM } from 'vs/base/common/strings';
-import { coalesce } from 'vs/base/common/arrays';
 import { match } from 'vs/base/common/glob';
 import { URI } from 'vs/base/common/uri';
 import { Schemas } from 'vs/base/common/network';
@@ -245,34 +244,6 @@ export function isUnspecific(mime: string[] | string): boolean {
 	}
 
 	return mime.length === 1 && isUnspecific(mime[0]);
-}
-
-/**
- * Returns a suggestion for the filename by the following logic:
- * 1. If a relevant extension exists and is an actual filename extension (starting with a dot), suggest the prefix appended by the first one.
- * 2. Otherwise, if there are other extensions, suggest the first one.
- * 3. Otherwise, suggest the prefix.
- */
-export function suggestFilename(mode: string | undefined, prefix: string): string {
-	const extensions = registeredAssociations
-		.filter(assoc => !assoc.userConfigured && assoc.extension && assoc.id === mode)
-		.map(assoc => assoc.extension);
-
-	const extensionsWithDotFirst = coalesce(extensions)
-		.filter(assoc => assoc.startsWith('.'));
-
-	if (extensionsWithDotFirst.length > 0) {
-		const candidateExtension = extensionsWithDotFirst[0];
-		if (prefix.endsWith(candidateExtension)) {
-			// do not add the prefix if it already exists
-			// https://github.com/microsoft/vscode/issues/83603
-			return prefix;
-		}
-
-		return prefix + candidateExtension;
-	}
-
-	return extensions[0] || prefix;
 }
 
 interface MapExtToMediaMimes {

--- a/src/vs/base/test/common/mime.test.ts
+++ b/src/vs/base/test/common/mime.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { guessMimeTypes, registerTextMime, suggestFilename } from 'vs/base/common/mime';
+import { guessMimeTypes, registerTextMime } from 'vs/base/common/mime';
 import { URI } from 'vs/base/common/uri';
 
 suite('Mime', () => {
@@ -125,54 +125,5 @@ suite('Mime', () => {
 		registerTextMime({ id: 'data', extension: '.data', mime: 'text/data' });
 
 		assert.deepEqual(guessMimeTypes(URI.parse(`data:;label:something.data;description:data,`)), ['text/data', 'text/plain']);
-	});
-
-	test('Filename Suggestion - Suggest prefix only when there are no relevant extensions', () => {
-		const id = 'plumbus0';
-		const mime = `text/${id}`;
-		for (let extension of ['one', 'two']) {
-			registerTextMime({ id, mime, extension });
-		}
-
-		let suggested = suggestFilename('shleem', 'Untitled-1');
-		assert.equal(suggested, 'Untitled-1');
-	});
-
-	test('Filename Suggestion - Suggest prefix with first extension that begins with a dot', () => {
-		const id = 'plumbus1';
-		const mime = `text/${id}`;
-		for (let extension of ['plumbus', '.shleem', '.gazorpazorp']) {
-			registerTextMime({ id, mime, extension });
-		}
-
-		let suggested = suggestFilename('plumbus1', 'Untitled-1');
-		assert.equal(suggested, 'Untitled-1.shleem');
-	});
-
-	test('Filename Suggestion - Suggest first relevant extension when there are none that begin with a dot', () => {
-		const id = 'plumbus2';
-		const mime = `text/${id}`;
-		for (let extension of ['plumbus', 'shleem', 'gazorpazorp']) {
-			registerTextMime({ id, mime, extension });
-		}
-
-		let suggested = suggestFilename('plumbus2', 'Untitled-1');
-		assert.equal(suggested, 'plumbus');
-	});
-
-	test('Filename Suggestion - Should ignore user-configured associations', () => {
-		registerTextMime({ id: 'plumbus3', mime: 'text/plumbus3', extension: 'plumbus', userConfigured: true });
-		registerTextMime({ id: 'plumbus3', mime: 'text/plumbus3', extension: '.shleem', userConfigured: true });
-		registerTextMime({ id: 'plumbus3', mime: 'text/plumbus3', extension: '.gazorpazorp', userConfigured: false });
-
-		let suggested = suggestFilename('plumbus3', 'Untitled-1');
-		assert.equal(suggested, 'Untitled-1.gazorpazorp');
-
-		registerTextMime({ id: 'plumbus4', mime: 'text/plumbus4', extension: 'plumbus', userConfigured: true });
-		registerTextMime({ id: 'plumbus4', mime: 'text/plumbus4', extension: '.shleem', userConfigured: true });
-		registerTextMime({ id: 'plumbus4', mime: 'text/plumbus4', extension: '.gazorpazorp', userConfigured: true });
-
-		suggested = suggestFilename('plumbus4', 'Untitled-1');
-		assert.equal(suggested, 'Untitled-1');
 	});
 });

--- a/src/vs/workbench/services/textfile/electron-browser/nativeTextFileService.ts
+++ b/src/vs/workbench/services/textfile/electron-browser/nativeTextFileService.ts
@@ -31,6 +31,7 @@ import { IWorkingCopyFileService } from 'vs/workbench/services/workingCopy/commo
 import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/environment/electron-browser/environmentService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
+import { IModeService } from 'vs/editor/common/services/modeService';
 
 export class NativeTextFileService extends AbstractTextFileService {
 
@@ -51,9 +52,10 @@ export class NativeTextFileService extends AbstractTextFileService {
 		@IPathService pathService: IPathService,
 		@IWorkingCopyFileService workingCopyFileService: IWorkingCopyFileService,
 		@ILogService private readonly logService: ILogService,
-		@IUriIdentityService uriIdentityService: IUriIdentityService
+		@IUriIdentityService uriIdentityService: IUriIdentityService,
+		@IModeService modeService: IModeService
 	) {
-		super(fileService, untitledTextEditorService, lifecycleService, instantiationService, modelService, environmentService, dialogService, fileDialogService, textResourceConfigurationService, filesConfigurationService, textModelService, codeEditorService, pathService, workingCopyFileService, uriIdentityService);
+		super(fileService, untitledTextEditorService, lifecycleService, instantiationService, modelService, environmentService, dialogService, fileDialogService, textResourceConfigurationService, filesConfigurationService, textModelService, codeEditorService, pathService, workingCopyFileService, uriIdentityService, modeService);
 	}
 
 	async read(resource: URI, options?: IReadTextFileOptions): Promise<ITextFileContent> {

--- a/src/vs/workbench/services/textfile/test/browser/textFileService.test.ts
+++ b/src/vs/workbench/services/textfile/test/browser/textFileService.test.ts
@@ -9,6 +9,7 @@ import { toResource } from 'vs/base/test/common/utils';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { TextFileEditorModel } from 'vs/workbench/services/textfile/common/textFileEditorModel';
 import { FileOperation } from 'vs/platform/files/common/files';
+import { ModesRegistry } from 'vs/editor/common/modes/modesRegistry';
 
 suite('Files - TextFileService', () => {
 
@@ -132,4 +133,36 @@ suite('Files - TextFileService', () => {
 		disposable1.dispose();
 		disposable2.dispose();
 	});
+
+	test('Filename Suggestion - Suggest prefix only when there are no relevant extensions', () => {
+		ModesRegistry.registerLanguage({
+			id: 'plumbus0',
+			extensions: ['.one', '.two']
+		});
+
+		let suggested = accessor.textFileService.suggestFilename('shleem', 'Untitled-1');
+		assert.equal(suggested, 'Untitled-1');
+	});
+
+	test('Filename Suggestion - Suggest prefix with first extension', () => {
+		ModesRegistry.registerLanguage({
+			id: 'plumbus1',
+			extensions: ['.shleem', '.gazorpazorp'],
+			filenames: ['plumbus']
+		});
+
+		let suggested = accessor.textFileService.suggestFilename('plumbus1', 'Untitled-1');
+		assert.equal(suggested, 'Untitled-1.shleem');
+	});
+
+	test('Filename Suggestion - Suggest filename if there are no extensions', () => {
+		ModesRegistry.registerLanguage({
+			id: 'plumbus2',
+			filenames: ['plumbus', 'shleem', 'gazorpazorp']
+		});
+
+		let suggested = accessor.textFileService.suggestFilename('plumbus2', 'Untitled-1');
+		assert.equal(suggested, 'plumbus');
+	});
+
 });

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -230,7 +230,8 @@ export class TestTextFileService extends BrowserTextFileService {
 		@ICodeEditorService codeEditorService: ICodeEditorService,
 		@IPathService pathService: IPathService,
 		@IWorkingCopyFileService workingCopyFileService: IWorkingCopyFileService,
-		@IUriIdentityService uriIdentityService: IUriIdentityService
+		@IUriIdentityService uriIdentityService: IUriIdentityService,
+		@IModeService modeService: IModeService
 	) {
 		super(
 			fileService,
@@ -247,7 +248,8 @@ export class TestTextFileService extends BrowserTextFileService {
 			codeEditorService,
 			pathService,
 			workingCopyFileService,
-			uriIdentityService
+			uriIdentityService,
+			modeService
 		);
 	}
 

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -41,6 +41,7 @@ import { INativeWindowConfiguration } from 'vs/platform/windows/node/window';
 import { TestContextService } from 'vs/workbench/test/common/workbenchTestServices';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
 import { MouseInputEvent } from 'vs/base/parts/sandbox/common/electronTypes';
+import { IModeService } from 'vs/editor/common/services/modeService';
 
 export const TestWindowConfiguration: INativeWindowConfiguration = {
 	windowId: 0,
@@ -78,7 +79,8 @@ export class TestTextFileService extends NativeTextFileService {
 		@IPathService athService: IPathService,
 		@IWorkingCopyFileService workingCopyFileService: IWorkingCopyFileService,
 		@ILogService logService: ILogService,
-		@IUriIdentityService uriIdentityService: IUriIdentityService
+		@IUriIdentityService uriIdentityService: IUriIdentityService,
+		@IModeService modeService: IModeService
 	) {
 		super(
 			fileService,
@@ -97,7 +99,8 @@ export class TestTextFileService extends NativeTextFileService {
 			athService,
 			workingCopyFileService,
 			logService,
-			uriIdentityService
+			uriIdentityService,
+			modeService
 		);
 	}
 


### PR DESCRIPTION
This PR is for #102032

#102101 will change that modeService.getExtension will first return the file extension that come from the 'primary' language contribution. The 'primary' language contribution is the one that defines the language configuration.

This PR simplifies the code for suggestFilename to not use the mime registry (which sorts mime types by the order that they were registered), but using the modeService.
