### PR TITLE
debug: use previous node debug for auto attach in the the July release

### DIFF
--- a/extensions/debug-auto-launch/src/extension.ts
+++ b/extensions/debug-auto-launch/src/extension.ts
@@ -144,12 +144,8 @@ const transitions: { [S in State]: StateTransition<unknown> } = {
 	[State.Disabled]: {
 		async enter(context) {
 			statusItem?.hide();
-
-			// If there was js-debug state set, clear it and clear any environment variables
-			if (context.workspaceState.get<CachedIpcState>(JS_DEBUG_IPC_KEY)) {
-				await context.workspaceState.update(JS_DEBUG_IPC_KEY, undefined);
-				await vscode.commands.executeCommand('extension.js-debug.clearAutoAttachVariables');
-			}
+			await context.workspaceState.update(JS_DEBUG_IPC_KEY, undefined);
+			await vscode.commands.executeCommand('extension.js-debug.clearAutoAttachVariables');
 		},
 	},
 
@@ -190,7 +186,7 @@ const transitions: { [S in State]: StateTransition<unknown> } = {
 				})
 					.on('error', reject)
 					.listen(ipcAddress, () => resolve(s));
-			});
+			}).catch(console.error);
 
 			const statusItem = ensureStatusBarExists(context);
 			statusItem.text = ON_TEXT;

--- a/extensions/debug-auto-launch/src/extension.ts
+++ b/extensions/debug-auto-launch/src/extension.ts
@@ -95,9 +95,11 @@ function readCurrentState(): State {
 		case 'off':
 			return State.Off;
 		case 'on':
-			const jsDebugConfig = vscode.workspace.getConfiguration(JS_DEBUG_SETTINGS);
-			const useV3 = nodeConfig.get(NODE_DEBUG_USEV3) || jsDebugConfig.get(JS_DEBUG_USEPREVIEW);
-			return useV3 ? State.OnWithJsDebug : State.OnWithNodeDebug;
+			// todo: reenable after resolving https://github.com/microsoft/vscode/issues/102057
+			// const jsDebugConfig = vscode.workspace.getConfiguration(JS_DEBUG_SETTINGS);
+			// const useV3 = nodeConfig.get(NODE_DEBUG_USEV3) || jsDebugConfig.get(JS_DEBUG_USEPREVIEW);
+			// return useV3 ? State.OnWithJsDebug : State.OnWithNodeDebug;
+			return State.OnWithNodeDebug;
 		case 'disabled':
 		default:
 			return State.Disabled;


### PR DESCRIPTION
There have been several issues coming into auto attach. Although infrequent, they tend to be severe e.g. preventing Node processes from running at all if the bootloader is missing. There have been a number of code changes needed for this and one further root cause I am not yet sure how to deal with.

Therefore, in the recovery release, I would like to disable js-debug auto attach, to be re-enabled in the next release as appropriate.