### PR TITLE
Use TextDecoder when decoding UTF-8

### DIFF
--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -64,7 +64,12 @@ class DecoderStream implements IDecoderStream {
 			const utf8TextDecoder = new TextDecoder();
 			decoder = {
 				write(buffer: Uint8Array): string {
-					return utf8TextDecoder.decode(buffer, { stream: true });
+					return utf8TextDecoder.decode(buffer, {
+						// Signal to TextDecoder that potentially more data is coming
+						// and that we are calling `decode` in the end to consume any
+						// remainders
+						stream: true
+					});
 				},
 
 				end(): string | undefined {

--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -45,22 +45,39 @@ export interface IDecoderStream {
 
 class DecoderStream implements IDecoderStream {
 
+	private static readonly utf8TextDecoder = new TextDecoder();
+
 	/**
 	 * This stream will only load iconv-lite lazily if the encoding
 	 * is not UTF-8. This ensures that for most common cases we do
 	 * not pay the price of loading the module from disk.
+	 *
+	 * We still need to be careful when converting UTF-8 to a string
+	 * though because we read the file in chunks of Buffer and thus
+	 * need to decode it via TextDecoder helper that is available
+	 * in browser and node.js environments.
 	 */
 	static async create(encoding: string): Promise<DecoderStream> {
 		let decoder: IDecoderStream | undefined = undefined;
 		if (encoding !== UTF8) {
 			const iconv = await import('iconv-lite-umd');
 			decoder = iconv.getDecoder(toNodeEncoding(encoding));
+		} else {
+			decoder = {
+				write(buffer: Uint8Array): string {
+					return DecoderStream.utf8TextDecoder.decode(buffer, { stream: true });
+				},
+
+				end(): string | undefined {
+					return DecoderStream.utf8TextDecoder.decode();
+				}
+			};
 		}
 
 		return new DecoderStream(decoder);
 	}
 
-	private constructor(private iconvLiteDecoder: IDecoderStream | undefined) { }
+	private constructor(private iconvLiteDecoder: IDecoderStream) { }
 
 	write(buffer: Uint8Array): string {
 		if (this.iconvLiteDecoder) {

--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -45,8 +45,6 @@ export interface IDecoderStream {
 
 class DecoderStream implements IDecoderStream {
 
-	private static readonly utf8TextDecoder = new TextDecoder();
-
 	/**
 	 * This stream will only load iconv-lite lazily if the encoding
 	 * is not UTF-8. This ensures that for most common cases we do
@@ -63,13 +61,14 @@ class DecoderStream implements IDecoderStream {
 			const iconv = await import('iconv-lite-umd');
 			decoder = iconv.getDecoder(toNodeEncoding(encoding));
 		} else {
+			const utf8TextDecoder = new TextDecoder();
 			decoder = {
 				write(buffer: Uint8Array): string {
-					return DecoderStream.utf8TextDecoder.decode(buffer, { stream: true });
+					return utf8TextDecoder.decode(buffer, { stream: true });
 				},
 
 				end(): string | undefined {
-					return DecoderStream.utf8TextDecoder.decode();
+					return utf8TextDecoder.decode();
 				}
 			};
 		}

--- a/src/vs/workbench/services/textfile/test/node/encoding/encoding.test.ts
+++ b/src/vs/workbench/services/textfile/test/node/encoding/encoding.test.ts
@@ -335,7 +335,7 @@ suite('Encoding', () => {
 		const source = newTestReadableStream(buffers);
 		const { stream } = await encoding.toDecodeStream(source, { minBytesRequiredForDetection: 4, guessEncoding: false, overwriteEncoding: async detected => detected || encoding.UTF8 });
 
-		const expected = incompleteEmojis.toString(encoding.UTF8);
+		const expected = new TextDecoder().decode(incompleteEmojis);
 		const actual = await readAllAsString(stream);
 
 		assert.equal(actual, expected);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #102202

We are no longer using `iconv-lite` when deocding files in UTF-8 encoding, however we cannot just `toString()` buffers, we need to decode properly, even if UTF-8. 

In node.js, `iconv-lite` seems to be using `StringDecoder`. Howeve that type is not available in browsers, rather `TextDecoder` is. 

Fix is to go through `TextDecoder`. I hope this will not result in perf issues as I have no experience how costly this type is.
