### PR TITLE
debug: bump js-debug to 1.47.5 for recovery

### DIFF
--- a/product.json
+++ b/product.json
@@ -90,7 +90,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.47.3",
+			"version": "1.47.5",
 			"repo": "https://github.com/Microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
Contains the fixes for candidates mentioned previously. Diff with last version: https://github.com/microsoft/vscode-js-debug/compare/candidate/v1.47.3...candidate/v1.47.5. Some noise in there due to adding options, recently turning on Organize Imports, and multiple commits to land on the right solution to version detection.