### PR TITLE
Fix conditional for overrideCommandForWebview

### DIFF
--- a/src/vs/workbench/contrib/webview/electron-browser/webview.contribution.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webview.contribution.ts
@@ -54,15 +54,14 @@ const PRIORITY = 100;
 
 function overrideCommandForWebview(command: MultiCommand | undefined, f: (webview: ElectronWebviewBasedWebview) => void) {
 	command?.addImplementation(PRIORITY, accessor => {
-		if (!isMacintosh || accessor.get(IConfigurationService).getValue<string>('window.titleBarStyle') !== 'native') {
-			return false;
+		if (isMacintosh || accessor.get(IConfigurationService).getValue<string>('window.titleBarStyle') === 'native') {
+			const webview = getActiveElectronBasedWebview(accessor);
+			if (webview) {
+				f(webview);
+				return true;
+			}
 		}
 
-		const webview = getActiveElectronBasedWebview(accessor);
-		if (webview) {
-			f(webview);
-			return true;
-		}
 		return false;
 	});
 }


### PR DESCRIPTION
For #101946

These command should be active if:

- We are on mac
- or we are not using custom title bars 

The previous code was incorrectly disabling these commands entirely on Mac (due to the check for `window.titleBarStyle`)

(for testing, make sure you do not have iframe based webviews enabled)