### PR TITLE
Support the new 4.0 definition of isArray

### DIFF
--- a/src/vs/base/common/types.ts
+++ b/src/vs/base/common/types.ts
@@ -8,7 +8,7 @@ import { URI, UriComponents } from 'vs/base/common/uri';
 /**
  * @returns whether the provided parameter is a JavaScript Array or not.
  */
-export function isArray(array: any): array is any[] {
+export function isArray<T>(array: T | {}): array is T extends readonly any[] ? (unknown extends T ? never : readonly any[]) : any[] {
 	return Array.isArray(array);
 }
 


### PR DESCRIPTION
This PR relates to https://github.com/microsoft/TypeScript/pull/39258

Effectively, it brings your `isArray` type check inline with the version in this PR ^

Example:

```ts
// Original version, uses any 
export function isArrayOld(array: any): array is any[] {
      return Array.isArray(array);
}

// New, funky-looking, but retains readonly safely
function isArray<T>(array: T | {}): array is T extends readonly any[] ? (unknown extends T ? never : readonly any[]) : any[] {
    return Array.isArray(array);
}

const mutableArray: string[] = []
const immutableArray: readonly string[] = []

if (isArray(mutableArray)) {
  mutableArray.push("")
}

// Fails correctly
if(isArray(immutableArray)) {
  immutableArray.push("")
  // would error here
}


/// Previous behavior

if (isArrayOld(mutableArray)) {
  mutableArray.push("")
}

if (isArrayOld(immutableArray)) {
  immutableArray.push("")
  // No error on pushing to an readonly array
}
```

[Playground Link](https://www.staging-typescript.org/play?#code/PTAEHkCcEsHNoHYEMA2oBuBTSBnaB7BAGlAFcdMdQkEBPUAKEwA8AHfSAF1ADNSEAxpwIJQ0HAEFIkJLXAoAJgAok02QC5qdAJSbVM+uK20A2gF1QAbwahbdyJk6lIoqQYB04t7JVra2gG4GAF8GBhBQADlMAHcSPgQAa1oSACNSbgdOJEQqByQFQhR6HCQeTGKGBKERMUk-AB4AFQA+XwNNJtAAHytg3Wo-OtAulk5MBAU8zAKi+hpTCwB+UCV+RIR8GNExiamR0BWETCxIUE18woRi43Ntc9uLaztQLOdXP096g3bZQJCwgJCDhuABbDJIVIoTDeWiaEEwBCwcygAC8oHMDCBCBBYlB4OyUJhfguMyuNwRiGRFnRmIY0B4qy8fiUBMh0Nh2nuz1AbKJsPcrHIAAslAAiMXaAHhMAAMRyKCoQOkmCElQZSmZP2g+Ih-L8XKsNjxfI5nyFOFFEqloTCIDAAAUHOgCORQKlMMKkC6OGEGUzvrJ5MpTcSDIaeaGBRarZLpf7NYG5IpNbrCWbw9zjTqo+aReK47YIpF8KBsJAOKBCKAY1TQJxSzRXmS5oMDACgA)