### PR TITLE
fix styling to improve heading spacing fixes #102036

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -12,7 +12,7 @@ html, body {
 }
 
 body {
-	padding-top: 1rem;
+	padding-top: 1em;
 }
 
 /* Reset margin top for elements */
@@ -154,7 +154,7 @@ h1 {
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
 	font-weight: normal;
-	margin-bottom: 1.5rem;
+	margin-bottom: 1.5em;
 }
 
 table {

--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -11,6 +11,22 @@ html, body {
 	word-wrap: break-word;
 }
 
+body {
+	padding-top: 1rem;
+}
+
+/* Reset margin top for elements */
+h1, h2, h3, h4, h5, h6,
+p, ol, ul, pre {
+	margin-top: 0;
+}
+
+h2, h3, h4, h5, h6 {
+  font-weight: normal;
+  margin-bottom: 0.2em;
+}
+  
+
 #code-csp-warning {
 	position: fixed;
 	top: 0;
@@ -112,6 +128,20 @@ textarea:focus {
 	outline-offset: -1px;
 }
 
+p {
+	margin-bottom: 1.5em;
+}
+  
+/* don't space 2 paragraphs too far apart */
+p + p {
+	margin-top: -0.8em;
+}
+
+ul,
+ol {
+	margin-bottom: 1.5em;
+}
+
 hr {
 	border: 0;
 	height: 2px;
@@ -123,10 +153,8 @@ h1 {
 	line-height: 1.2;
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
-}
-
-h1, h2, h3 {
 	font-weight: normal;
+	margin-bottom: 1.5rem;
 }
 
 table {


### PR DESCRIPTION
This PR fixes #102036

- So the first issue is that most elements have a margin-top and margin-bottom.
It made sense to remove the margin-top and let top elements push others down. (otherwise you fall into margin-collapse hell)
- This means the body needs a padding on the top so that any first element has a gap (and not just the H1)
- Headings have a smaller bottom margin so as to look more like a section
- If 2 paragraphs are next to each other, the second paragraph reduces its top margin to bring them closer together.

## Before
![image](https://user-images.githubusercontent.com/936006/87351758-ce286c80-c551-11ea-80e5-13af706cd8ac.png)


## After
![image](https://user-images.githubusercontent.com/936006/87352076-5d358480-c552-11ea-9fa0-c5fcf3861712.png)

pings @mjbvz 


