### PR TITLE
Add delegation back to renderer process for certain webview resource reads

### DIFF
--- a/src/vs/platform/webview/common/resourceLoader.ts
+++ b/src/vs/platform/webview/common/resourceLoader.ts
@@ -9,7 +9,6 @@ import { isUNC } from 'vs/base/common/extpath';
 import { Schemas } from 'vs/base/common/network';
 import { sep } from 'vs/base/common/path';
 import { URI } from 'vs/base/common/uri';
-import { IFileService } from 'vs/platform/files/common/files';
 import { IRemoteConnectionData } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { IRequestService } from 'vs/platform/request/common/request';
 import { getWebviewContentMimeType } from 'vs/platform/webview/common/mimeTypes';
@@ -35,6 +34,10 @@ export namespace WebviewResourceResponse {
 	export type StreamResponse = StreamSuccess | typeof Failed | typeof AccessDenied;
 }
 
+interface FileReader {
+	readFileStream(resource: URI): Promise<VSBufferReadableStream>;
+}
+
 export async function loadLocalResource(
 	requestUri: URI,
 	options: {
@@ -43,7 +46,7 @@ export async function loadLocalResource(
 		remoteConnectionData?: IRemoteConnectionData | null;
 		rewriteUri?: (uri: URI) => URI,
 	},
-	fileService: IFileService,
+	fileReader: FileReader,
 	requestService: IRequestService,
 ): Promise<WebviewResourceResponse.StreamResponse> {
 	let resourceToLoad = getResourceToLoad(requestUri, options.roots);
@@ -67,8 +70,8 @@ export async function loadLocalResource(
 	}
 
 	try {
-		const contents = await fileService.readFileStream(resourceToLoad);
-		return new WebviewResourceResponse.StreamSuccess(contents.value, mime);
+		const contents = await fileReader.readFileStream(resourceToLoad);
+		return new WebviewResourceResponse.StreamSuccess(contents, mime);
 	} catch (err) {
 		console.log(err);
 		return WebviewResourceResponse.Failed;
@@ -96,8 +99,14 @@ function normalizeRequestPath(requestUri: URI) {
 		//
 		// vscode-webview-resource://id/scheme//authority?/path
 		//
-		const resourceUri = URI.parse(requestUri.path.replace(/^\/([a-z0-9\-]+)\/{1,2}/i, '$1://'));
-
+		const resourceUri = URI.parse(requestUri.path.replace(/^\/([a-z0-9\-]+)(\/{1,2})/i, (_: string, scheme: string, sep: string) => {
+			if (sep.length === 1) {
+				return `${scheme}:///`; // Add empty authority.
+			} else {
+				return `${scheme}://`; // Url has own authority.
+			}
+		}));
+		console.log(requestUri, resourceUri);
 		return resourceUri.with({
 			query: requestUri.query,
 			fragment: requestUri.fragment

--- a/src/vs/platform/webview/common/webviewManagerService.ts
+++ b/src/vs/platform/webview/common/webviewManagerService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { VSBuffer } from 'vs/base/common/buffer';
 import { UriComponents } from 'vs/base/common/uri';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IRemoteConnectionData } from 'vs/platform/remote/common/remoteAuthorityResolver';
@@ -13,9 +14,11 @@ export const IWebviewManagerService = createDecorator<IWebviewManagerService>('w
 export interface IWebviewManagerService {
 	_serviceBrand: unknown;
 
-	registerWebview(id: string, webContentsId: number | undefined, metadata: RegisterWebviewMetadata): Promise<void>;
+	registerWebview(id: string, webContentsId: number | undefined, windowId: number, metadata: RegisterWebviewMetadata): Promise<void>;
 	unregisterWebview(id: string): Promise<void>;
 	updateWebviewMetadata(id: string, metadataDelta: Partial<RegisterWebviewMetadata>): Promise<void>;
+
+	didLoadResource(requestId: number, content: VSBuffer | undefined): void;
 
 	setIgnoreMenuShortcuts(webContentsId: number, enabled: boolean): Promise<void>;
 }

--- a/src/vs/platform/webview/electron-main/webviewProtocolProvider.ts
+++ b/src/vs/platform/webview/electron-main/webviewProtocolProvider.ts
@@ -3,19 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { session, protocol } from 'electron';
+import { protocol, session } from 'electron';
 import { Readable } from 'stream';
-import { VSBufferReadableStream } from 'vs/base/common/buffer';
+import { bufferToStream, VSBuffer, VSBufferReadableStream } from 'vs/base/common/buffer';
 import { Disposable, toDisposable } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
-import { IFileService } from 'vs/platform/files/common/files';
+import { FileOperationError, FileOperationResult, IFileService } from 'vs/platform/files/common/files';
 import { IRemoteConnectionData } from 'vs/platform/remote/common/remoteAuthorityResolver';
+import { REMOTE_HOST_SCHEME } from 'vs/platform/remote/common/remoteHosts';
 import { IRequestService } from 'vs/platform/request/common/request';
 import { loadLocalResource, webviewPartitionId, WebviewResourceResponse } from 'vs/platform/webview/common/resourceLoader';
-import { REMOTE_HOST_SCHEME } from 'vs/platform/remote/common/remoteHosts';
+import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
 
 interface WebviewMetadata {
+	readonly windowId: number;
 	readonly extensionLocation: URI | undefined;
 	readonly localResourceRoots: readonly URI[];
 	readonly remoteConnectionData: IRemoteConnectionData | null;
@@ -32,9 +34,13 @@ export class WebviewProtocolProvider extends Disposable {
 
 	private readonly webviewMetadata = new Map<string, WebviewMetadata>();
 
+	private requestIdPool = 1;
+	private readonly pendingResourceReads = new Map<number, { resolve: (content: VSBuffer | undefined) => void }>();
+
 	constructor(
 		@IFileService private readonly fileService: IFileService,
 		@IRequestService private readonly requestService: IRequestService,
+		@IWindowsMainService readonly windowsMainService: IWindowsMainService,
 	) {
 		super();
 
@@ -166,12 +172,42 @@ export class WebviewProtocolProvider extends Disposable {
 					};
 				}
 
+				const fileService = {
+					readFileStream: async (resource: URI): Promise<VSBufferReadableStream> => {
+						if (uri.scheme === Schemas.file) {
+							return (await this.fileService.readFileStream(resource)).value;
+						}
+
+						// Unknown uri scheme. Try delegating the file read back to the renderer
+						// process which should have a file system provider registered for the uri.
+
+						const window = this.windowsMainService.getWindowById(metadata.windowId);
+						if (!window) {
+							throw new FileOperationError('Could not find window for resource', FileOperationResult.FILE_NOT_FOUND);
+						}
+
+						const requestId = this.requestIdPool++;
+						const p = new Promise<VSBuffer | undefined>(resolve => {
+							this.pendingResourceReads.set(requestId, { resolve });
+						});
+
+						window.send(`vscode:loadWebviewResource-${id}`, requestId, uri);
+
+						const result = await p;
+						if (!result) {
+							throw new FileOperationError('Could not read file', FileOperationResult.FILE_NOT_FOUND);
+						}
+
+						return bufferToStream(result);
+					}
+				};
+
 				const result = await loadLocalResource(uri, {
 					extensionLocation: metadata.extensionLocation,
 					roots: metadata.localResourceRoots,
 					remoteConnectionData: metadata.remoteConnectionData,
 					rewriteUri,
-				}, this.fileService, this.requestService);
+				}, fileService, this.requestService);
 
 				if (result.type === WebviewResourceResponse.Type.Success) {
 					return callback({
@@ -194,5 +230,14 @@ export class WebviewProtocolProvider extends Disposable {
 		}
 
 		return callback({ data: null, statusCode: 404 });
+	}
+
+	public didLoadResource(requestId: number, content: VSBuffer | undefined) {
+		const pendingRead = this.pendingResourceReads.get(requestId);
+		if (!pendingRead) {
+			throw new Error('Unknown request');
+		}
+		this.pendingResourceReads.delete(requestId);
+		pendingRead.resolve(content);
 	}
 }

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -167,7 +167,9 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 				roots: this.content.options.localResourceRoots || [],
 				remoteConnectionData,
 				rewriteUri,
-			}, this.fileService, this.requestService);
+			}, {
+				readFileStream: (resource) => this.fileService.readFileStream(resource).then(x => x.value),
+			}, this.requestService);
 
 			if (result.type === WebviewResourceResponse.Type.Success) {
 				const { buffer } = await streamToBuffer(result.stream);


### PR DESCRIPTION
Fixes #102191

**Problem**
Webviews used to load local resources in the renderer process. This gave them access to all of the file system providers registered for that renderer (such as `untitled` and `git`).

However, last iteration we moved the webview protocol to the main process. This works fine for file resources, but the main process cannot read fancy uris such as `git:` or `untitled:`

**Fix**
To fix this, I've added code that delegates resource requests for non-file uris from the main process back to the renderer process. We tried to avoid this as it adds another round trip to each request, but I don't see a better way of doing this.

This problem only effects desktop VS Code. Web VS Code uses a service worker which always reads resources through the renderer process

