### PR TITLE
only emit ctrl+h for cmd.exe when the terminal is in focus

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
@@ -171,7 +171,7 @@ if (platform.isWindows) {
 	// Delete word left: ctrl+h
 	// Windows cmd.exe requires ^H to delete full word left
 	registerSendSequenceKeybinding(String.fromCharCode('H'.charCodeAt(0) - CTRL_LETTER_OFFSET), {
-		when: ContextKeyExpr.equals(KEYBINDING_CONTEXT_TERMINAL_SHELL_TYPE_KEY, WindowsShellType.CommandPrompt),
+		when: ContextKeyExpr.and(KEYBINDING_CONTEXT_TERMINAL_FOCUS, ContextKeyExpr.equals(KEYBINDING_CONTEXT_TERMINAL_SHELL_TYPE_KEY, WindowsShellType.CommandPrompt)),
 		primary: KeyMod.CtrlCmd | KeyCode.Backspace,
 	});
 }


### PR DESCRIPTION
This resolves an issue introduced in #98494 in which ctrl+bksp, in the editor, would not delete a whole word when the currently open terminal was cmd.exe, regardless of focus. 

I thought I had tested for this case, but it seems I changed some things while debugging and forgot to add back this part. I'm not sure of a way to unit test for this.

This pull request is related to issue #98404

@Tyriar 