### PR TITLE
fix h1 oversized bottom margin on markdown preview

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -153,7 +153,6 @@ h1 {
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
 	font-weight: normal;
-	margin-bottom: 1.5em;
 }
 
 table {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Screenshot from commit: c828a5339bca7222fd8f56ab98361a98f736d185

There's too much margin underneath the `h1`
i'm not sure why this issue didn't surface initially but now i see it using the latest insiders build.
The extra 1.5em margin is not needed.

Before:
![image](https://user-images.githubusercontent.com/936006/87458264-a395ec80-c601-11ea-953e-439e75dd3c98.png)


After:
![image](https://user-images.githubusercontent.com/936006/87458333-bc060700-c601-11ea-81ab-cfc8b79bfd75.png)

@mjbvz 