### PR TITLE
Mixin ResolvableTreeItem properties

### DIFF
--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -24,6 +24,7 @@ import Severity from 'vs/base/common/severity';
 import { IPaneComposite } from 'vs/workbench/common/panecomposite';
 import { IAccessibilityInformation } from 'vs/platform/accessibility/common/accessibility';
 import { IMarkdownString } from 'vs/base/common/htmlContent';
+import { mixin } from 'vs/base/common/objects';
 
 export const TEST_VIEW_CONTAINER_ID = 'workbench.view.extension.test';
 
@@ -650,9 +651,9 @@ export interface ITreeItem {
 }
 
 export class ResolvableTreeItem implements ITreeItem {
-	handle: string;
+	handle!: string;
 	parentHandle?: string;
-	collapsibleState: TreeItemCollapsibleState;
+	collapsibleState!: TreeItemCollapsibleState;
 	label?: ITreeItemLabel;
 	description?: string | boolean;
 	icon?: UriComponents;
@@ -668,20 +669,7 @@ export class ResolvableTreeItem implements ITreeItem {
 	private resolved: boolean = false;
 	private _hasResolve: boolean = false;
 	constructor(treeItem: ITreeItem, resolve?: (() => Promise<ITreeItem | undefined>)) {
-		this.handle = treeItem.handle;
-		this.parentHandle = treeItem.parentHandle;
-		this.collapsibleState = treeItem.collapsibleState;
-		this.label = treeItem.label;
-		this.description = treeItem.description;
-		this.icon = treeItem.icon;
-		this.iconDark = treeItem.iconDark;
-		this.themeIcon = treeItem.themeIcon;
-		this.resourceUri = treeItem.resourceUri;
-		this.tooltip = treeItem.tooltip;
-		this.contextValue = treeItem.contextValue;
-		this.command = treeItem.command;
-		this.children = treeItem.children;
-		this.accessibilityInformation = treeItem.accessibilityInformation;
+		mixin(this, treeItem);
 		this._hasResolve = !!resolve;
 		this.resolve = async () => {
 			if (resolve && !this.resolved) {

--- a/src/vs/workbench/test/browser/api/mainThreadTreeViews.test.ts
+++ b/src/vs/workbench/test/browser/api/mainThreadTreeViews.test.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ExtHostTreeViewsShape, IExtHostContext } from 'vs/workbench/api/common/extHost.protocol';
+import { mock } from 'vs/base/test/common/mock';
+import { ITreeItem, IViewsRegistry, Extensions, ViewContainerLocation, IViewContainersRegistry, ITreeViewDescriptor, ITreeView, ViewContainer, IViewDescriptorService, TreeItemCollapsibleState } from 'vs/workbench/common/views';
+import { NullLogService } from 'vs/platform/log/common/log';
+import { MainThreadTreeViews } from 'vs/workbench/api/browser/mainThreadTreeViews';
+import { TestViewsService, workbenchInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
+import { TestExtensionService } from 'vs/workbench/test/common/workbenchTestServices';
+import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { CustomTreeView } from 'vs/workbench/contrib/views/browser/treeView';
+import { ViewDescriptorService } from 'vs/workbench/services/views/browser/viewDescriptorService';
+
+suite('MainThreadHostTreeView', function () {
+	const testTreeViewId = 'testTreeView';
+	const customValue = 'customValue';
+	const ViewsRegistry = Registry.as<IViewsRegistry>(Extensions.ViewsRegistry);
+
+	interface CustomTreeItem extends ITreeItem {
+		customProp: string;
+	}
+
+	class MockExtHostTreeViewsShape extends mock<ExtHostTreeViewsShape>() {
+		async $getChildren(treeViewId: string, treeItemHandle?: string): Promise<ITreeItem[]> {
+			return [<CustomTreeItem>{ handle: 'testItem1', collapsibleState: TreeItemCollapsibleState.Expanded, customProp: customValue }];
+		}
+
+		async $hasResolve(): Promise<boolean> {
+			return false;
+		}
+
+		$setVisible(): void { }
+	}
+
+	let container: ViewContainer;
+	let mainThreadTreeViews: MainThreadTreeViews;
+	let extHostTreeViewsShape: MockExtHostTreeViewsShape;
+
+	setup(async () => {
+		const instantiationService: TestInstantiationService = <TestInstantiationService>workbenchInstantiationService();
+		const viewDescriptorService = instantiationService.createInstance(ViewDescriptorService);
+		instantiationService.stub(IViewDescriptorService, viewDescriptorService);
+		container = Registry.as<IViewContainersRegistry>(Extensions.ViewContainersRegistry).registerViewContainer({ id: 'testContainer', name: 'test', ctorDescriptor: new SyncDescriptor(<any>{}) }, ViewContainerLocation.Sidebar);
+		const viewDescriptor: ITreeViewDescriptor = {
+			id: testTreeViewId,
+			ctorDescriptor: null!,
+			name: 'Test View 1',
+			treeView: instantiationService.createInstance(CustomTreeView, 'testTree', 'Test Title'),
+		};
+		ViewsRegistry.registerViews([viewDescriptor], container);
+
+		const testExtensionService = new TestExtensionService();
+		extHostTreeViewsShape = new MockExtHostTreeViewsShape();
+		mainThreadTreeViews = new MainThreadTreeViews(
+			new class implements IExtHostContext {
+				remoteAuthority = '';
+				assertRegistered() { }
+				set(v: any): any { return null; }
+				getProxy(): any {
+					return extHostTreeViewsShape;
+				}
+			}, new TestViewsService(), new TestNotificationService(), testExtensionService, new NullLogService());
+		mainThreadTreeViews.$registerTreeViewDataProvider(testTreeViewId, { showCollapseAll: false, canSelectMany: false });
+		await testExtensionService.whenInstalledExtensionsRegistered();
+	});
+
+	teardown(() => {
+		ViewsRegistry.deregisterViews(ViewsRegistry.getViews(container), container);
+	});
+
+	test('getChildren keeps custom properties', async () => {
+		const treeView: ITreeView = (<ITreeViewDescriptor>ViewsRegistry.getView(testTreeViewId)).treeView;
+		const children = await treeView.dataProvider?.getChildren({ handle: 'root', collapsibleState: TreeItemCollapsibleState.Expanded });
+		assert(children!.length === 1, 'Exactly one child should be returned');
+		assert((<CustomTreeItem>children![0]).customProp === customValue, 'Tree Items should keep custom properties');
+	});
+
+
+});


### PR DESCRIPTION
A little backstory here - I'm from the Azure Data Studio team which is a tool that is built from a fork of VS Code - we keep our fork up to date with the latest VS Code by merging in the changes from master periodically.

In our application we've been using the VS Code trees but adding our own custom properties to the tree items that are populated from getChildren. See https://github.com/microsoft/azuredatastudio/blob/main/src/sql/workbench/common/views.ts#L14 for an example.

In https://github.com/microsoft/vscode/commit/39a406daa381ddeb57323088f920d88f8bc8f40b#diff-0eb3282b885a6f58b7ea9416e390e5ac the logic was changed so that a new ResolvableTreeItem was created for every item which only copied the properties from the base ITreeItem interface. This ended up breaking our implementation since these custom properties were being lost when this happened.

So I'm proposing this change here which shouldn't affect the current VS Code logic but will allow us to continue to add these custom properties to tree items without needing to modify the code in our repo. (We generally try to avoid making modifications to core VS Code stuff since it makes merges more difficult and is more likely to break in future merges).