### PR TITLE
only prompt on imp ext recommendation pattern

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/fileBasedRecommendations.ts
+++ b/src/vs/workbench/contrib/extensions/browser/fileBasedRecommendations.ts
@@ -160,7 +160,9 @@ export class FileBasedRecommendations extends ExtensionRecommendations {
 			if (match(pattern, uri.toString())) {
 				for (const extensionId of extensionIds) {
 					// Add to recommendation to prompt if it is an important tip
-					if (this.importantExtensionTips[extensionId]) {
+					// Only prompt if the pattern matches the extensionImportantTips pattern
+					// Otherwise, assume pattern is from extensionTips, which means it should be a file based "passive" recommendation
+					if (this.importantExtensionTips[extensionId]?.pattern === pattern) {
 						recommendationsToPrompt.push(extensionId);
 					}
 					// Update file based recommendations


### PR DESCRIPTION
This PR is to ensure that we only show an important extension recommendation prompt if the file pattern matches the pattern in `extensionImportantTips`. Otherwise it assumes the pattern is found in `extensionTips` and should be a passive file based recommendation. This way we can provide important recommendations for some files, and passive for a broader set (e.g. recommend the Docker extension passivly when working on python or node projects, but don't prompt).
