### PR TITLE
fix #102289

### DIFF
--- a/src/vs/workbench/services/editor/common/editorOpenWith.ts
+++ b/src/vs/workbench/services/editor/common/editorOpenWith.ts
@@ -49,7 +49,12 @@ export async function openEditorWith(
 		return;
 	}
 
-	const overrideToUse = typeof id === 'string' && allEditorOverrides.find(([_, entry]) => entry.id === id);
+	let overrideToUse;
+	if (typeof id === 'string') {
+		overrideToUse = allEditorOverrides.find(([_, entry]) => entry.id === id);
+	} else if (allEditorOverrides.length === 1) {
+		overrideToUse = allEditorOverrides[0];
+	}
 	if (overrideToUse) {
 		return overrideToUse[0].open(input, overrideOptions, group, OpenEditorContext.NEW_EDITOR)?.override;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #102289 by open with the editor if it's the only one available.

To test it in the current master branch, disable the builtin "vscode-notebook-tests" extension and create a new file. It should open the new file without asking for picking editor.

Enable the "vscode-notebook-tests" extension will add two candidates to the editor list, when create new file the picker should show up again.
