### PR TITLE
fix paragraphs inside of <ul>'s which are too spaced apart.

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -131,7 +131,7 @@ p {
 	margin-bottom: 1.5em;
 }
 
-ul p {
+li > p {
 	margin-bottom: 0;
 }
 

--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -131,6 +131,10 @@ p {
 	margin-bottom: 1.5em;
 }
 
+ul p {
+	margin-bottom: 0;
+}
+
 /* don't space 2 paragraphs too far apart */
 p + p {
 	margin-top: -0.8em;


### PR DESCRIPTION
* paragraphs inside of `<ul><li>`s were too spaced apart.
* It looks odd because markdown converts list items to `<p>`s

So I wasn't aware of this but it seems list items get rendered as `<p>` tags inside of `<ul><li>`s
This causes them to space each other out too much.
The fix is not to have a margin-bottom when in lists


**Before**
<img width="338" alt="list-spaced" src="https://user-images.githubusercontent.com/936006/87704771-cad0f300-c794-11ea-8441-a98b1c490d83.png">

**After**
<img width="329" alt="list-fixed" src="https://user-images.githubusercontent.com/936006/87704885-f2c05680-c794-11ea-8ccd-99dc132c031f.png">


Another one for you @mjbvz 

