### PR TITLE
fix #66000 VSCODE_ALWAYS_SHOW_SCROLLBARS env var

### DIFF
--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -625,7 +625,7 @@ function resolveOptions(opts: ScrollableElementCreationOptions): ScrollableEleme
 		result.className += ' mac';
 	}
 
-	if (process.env.VSCODE_ALWAYS_SHOW_SCROLLBARS === '1') {
+	if (process && process.env.VSCODE_ALWAYS_SHOW_SCROLLBARS === '1') {
 		if (result.vertical === ScrollbarVisibility.Auto) {
 			result.vertical = ScrollbarVisibility.Visible;
 		}

--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -625,5 +625,15 @@ function resolveOptions(opts: ScrollableElementCreationOptions): ScrollableEleme
 		result.className += ' mac';
 	}
 
+	if (process.env.VSCODE_ALWAYS_SHOW_SCROLLBARS === '1') {
+		if (result.vertical === ScrollbarVisibility.Auto) {
+			result.vertical = ScrollbarVisibility.Visible;
+		}
+
+		if (result.horizontal === ScrollbarVisibility.Auto) {
+			result.horizontal = ScrollbarVisibility.Visible;
+		}
+	}
+
 	return result;
 }

--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -625,7 +625,7 @@ function resolveOptions(opts: ScrollableElementCreationOptions): ScrollableEleme
 		result.className += ' mac';
 	}
 
-	if (process && process.env.VSCODE_ALWAYS_SHOW_SCROLLBARS === '1') {
+	if (typeof process === 'object' && process.env.VSCODE_ALWAYS_SHOW_SCROLLBARS === '1') {
 		if (result.vertical === ScrollbarVisibility.Auto) {
 			result.vertical = ScrollbarVisibility.Visible;
 		}


### PR DESCRIPTION
This PR fixes #66000 

Setting VSCODE_ALWAYS_SHOW_SCROLLBARS=1 before launching code will turn off the fading scrollbar style.

Using an environment variable allows the new feature to be implemented in a single place (scrollableElement) without having to refactor a lot of code in order to access the configuration service there.

I previously explored adding a CLI argument (with the potential for argv.json support), but that only got to the main process, whereas scrollableElement lives in the renderer process.
