### PR TITLE
Fix find-widget staying revealed but disabled if it is opened and closed fast

### DIFF
--- a/src/vs/editor/contrib/find/findWidget.ts
+++ b/src/vs/editor/contrib/find/findWidget.ts
@@ -509,10 +509,8 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			this._tryUpdateWidgetWidth();
 			this._updateButtons();
 
-			setTimeout(() => {
-				dom.addClass(this._domNode, 'visible');
-				this._domNode.setAttribute('aria-hidden', 'false');
-			}, 0);
+			dom.addClass(this._domNode, 'visible');
+			this._domNode.setAttribute('aria-hidden', 'false');
 
 			// validate query again as it's being dismissed when we hide the find widget.
 			setTimeout(() => {


### PR DESCRIPTION
This PR fixes #94485

As the issue describes, to reproduce:

1. Press F3 and Escape at the same time (but in that order)
2. The find widget will open but be disabled

With this change, the find widget closes as expected.

---

#### Technical details:

The `FindReplaceState` thinks it is closed, the problem is that the DOM does not reflect the state.
After opening and closing fast, `FindWidget._onStateChanged` *does* get called twice with the correct parameters,
which calls `FindWidget._reveal()`, and the second time it calls `FindWidget._hide()`.

For some reason, `_reveal` defers the DOM updates with a `setTimeout(..., 0)`,
while `_hide` does the DOM updates synchronously.

They either both need to happen synchronously, or both asynchronously.
I couldn't find any reason for it to be async (it doesn't block or anything), so I made the reveal sync.