### PR TITLE
Don't swallow escape when focusing on find widget options

### DIFF
--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -212,7 +212,7 @@ export class FindInput extends Widget {
 		// Arrow-Key support to navigate between options
 		let indexes = [this.caseSensitive.domNode, this.wholeWords.domNode, this.regex.domNode];
 		this.onkeydown(this.domNode, (event: IKeyboardEvent) => {
-			if (event.equals(KeyCode.LeftArrow) || event.equals(KeyCode.RightArrow) || event.equals(KeyCode.Escape)) {
+			if (event.equals(KeyCode.LeftArrow) || event.equals(KeyCode.RightArrow)) {
 				let index = indexes.indexOf(<HTMLElement>document.activeElement);
 				if (index >= 0) {
 					let newIndex: number = -1;
@@ -226,9 +226,7 @@ export class FindInput extends Widget {
 						}
 					}
 
-					if (event.equals(KeyCode.Escape)) {
-						indexes[index].blur();
-					} else if (newIndex >= 0) {
+					if (newIndex >= 0) {
 						indexes[newIndex].focus();
 					}
 


### PR DESCRIPTION
This PR fixes #94445

Like the issue says, the steps to reproduce:

1. Press <kbd>Ctrl</kbd>+<kbd>F</kbd> to open the find widget
2. Press <kbd>Tab</kbd> to focus on one of the find option buttons (e.g. Match Case)
3. Press <kbd>Escape</kbd>

Before, the option would be unfocused.
Now, it closes the find widget.

---

#### UX

I personally find it bad UX to not close the find widget when pressing <kbd>Escape</kbd>, especially when you're focused somewhere inside it.
The widget even closes on <kbd>Escape</kbd> if you're focused on the editor and not it.

Currently pressing <kbd>Escape</kbd> makes nothing be focused, which means you can't use the editor,
can't use the find widget, and also can't close it. All you can do is press a keybinding which doesn't require focusing anything.

Currently to close the find widget after you've pressed <kbd>Escape</kbd> on the find options,
you have to press <kbd>Ctrl</kbd>+<kbd>F</kbd> and then <kbd>Escape</kbd> again.