### PR TITLE
Update example extension name

### DIFF
--- a/extensions/configuration-editing/src/extensionsProposals.ts
+++ b/extensions/configuration-editing/src/extensionsProposals.ts
@@ -24,7 +24,7 @@ export function provideInstalledExtensionProposals(existing: string[], range: vs
 			});
 		} else {
 			const example = new vscode.CompletionItem(localize('exampleExtension', "Example"));
-			example.insertText = '"vscode.csharp"';
+			example.insertText = '"ms-dotnettools.csharp"';
 			example.kind = vscode.CompletionItemKind.Value;
 			example.range = range;
 			return [example];

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -143,7 +143,7 @@ export const OPTIONS: OptionDescriptions<Required<ParsedArgs>> = {
 	'list-extensions': { type: 'boolean', cat: 'e', description: localize('listExtensions', "List the installed extensions.") },
 	'show-versions': { type: 'boolean', cat: 'e', description: localize('showVersions', "Show versions of installed extensions, when using --list-extension.") },
 	'category': { type: 'string', cat: 'e', description: localize('category', "Filters installed extensions by provided category, when using --list-extension.") },
-	'install-extension': { type: 'string[]', cat: 'e', args: 'extension-id[@version] | path-to-vsix', description: localize('installExtension', "Installs or updates the extension. Use `--force` argument to avoid prompts. The identifier of an extension is always `${publisher}.${name}`. To install a specific version provide `@${version}`. For example: 'vscode.csharp@1.2.3'.") },
+	'install-extension': { type: 'string[]', cat: 'e', args: 'extension-id[@version] | path-to-vsix', description: localize('installExtension', "Installs or updates the extension. Use `--force` argument to avoid prompts. The identifier of an extension is always `${publisher}.${name}`. To install a specific version provide `@${version}`. For example: 'ms-dotnettools.csharp@1.2.3'.") },
 	'uninstall-extension': { type: 'string[]', cat: 'e', args: 'extension-id', description: localize('uninstallExtension', "Uninstalls an extension.") },
 	'enable-proposed-api': { type: 'string[]', cat: 'e', args: 'extension-id', description: localize('experimentalApis', "Enables proposed API features for extensions. Can receive one or more extension IDs to enable individually.") },
 

--- a/src/vs/platform/userDataSync/common/userDataSync.ts
+++ b/src/vs/platform/userDataSync/common/userDataSync.ts
@@ -57,7 +57,7 @@ export function registerConfiguration(): IDisposable {
 			},
 			'sync.ignoredExtensions': {
 				'type': 'array',
-				'description': localize('sync.ignoredExtensions', "List of extensions to be ignored while synchronizing. The identifier of an extension is always ${publisher}.${name}. For example: vscode.csharp."),
+				'description': localize('sync.ignoredExtensions', "List of extensions to be ignored while synchronizing. The identifier of an extension is always ${publisher}.${name}. For example: ms-dotnettools.csharp."),
 				$ref: ignoredExtensionsSchemaId,
 				'default': [],
 				'scope': ConfigurationScope.APPLICATION,
@@ -95,7 +95,7 @@ export function registerConfiguration(): IDisposable {
 	jsonRegistry.registerSchema(ignoredExtensionsSchemaId, {
 		type: 'string',
 		pattern: EXTENSION_IDENTIFIER_PATTERN,
-		errorMessage: localize('app.extension.identifier.errorMessage', "Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.")
+		errorMessage: localize('app.extension.identifier.errorMessage', "Expected format '${publisher}.${name}'. Example: 'ms-dotnettools.csharp'.")
 	});
 	return configurationRegistry.onDidUpdateConfiguration(() => registerIgnoredSettingsSchema());
 }

--- a/src/vs/workbench/contrib/extensions/common/extensionsFileTemplate.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensionsFileTemplate.ts
@@ -18,20 +18,20 @@ export const ExtensionsConfigurationSchema: IJSONSchema = {
 	properties: {
 		recommendations: {
 			type: 'array',
-			description: localize('app.extensions.json.recommendations', "List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'."),
+			description: localize('app.extensions.json.recommendations', "List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'ms-dotnettools.csharp'."),
 			items: {
 				type: 'string',
 				pattern: EXTENSION_IDENTIFIER_PATTERN,
-				errorMessage: localize('app.extension.identifier.errorMessage', "Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.")
+				errorMessage: localize('app.extension.identifier.errorMessage', "Expected format '${publisher}.${name}'. Example: 'ms-dotnettools.csharp'.")
 			},
 		},
 		unwantedRecommendations: {
 			type: 'array',
-			description: localize('app.extensions.json.unwantedRecommendations', "List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'."),
+			description: localize('app.extensions.json.unwantedRecommendations', "List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'ms-dotnettools.csharp'."),
 			items: {
 				type: 'string',
 				pattern: EXTENSION_IDENTIFIER_PATTERN,
-				errorMessage: localize('app.extension.identifier.errorMessage', "Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.")
+				errorMessage: localize('app.extension.identifier.errorMessage', "Expected format '${publisher}.${name}'. Example: 'ms-dotnettools.csharp'.")
 			},
 		},
 	}
@@ -40,7 +40,7 @@ export const ExtensionsConfigurationSchema: IJSONSchema = {
 export const ExtensionsConfigurationInitialContent: string = [
 	'{',
 	'\t// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.',
-	'\t// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp',
+	'\t// Extension identifier format: ${publisher}.${name}. Example: ms-dotnettools.csharp',
 	'',
 	'\t// List of extensions which should be recommended for users of this workspace.',
 	'\t"recommendations": [',

--- a/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
@@ -354,7 +354,7 @@ export const schema: IJSONSchema = {
 			]
 		},
 		extensionDependencies: {
-			description: nls.localize('vscode.extension.extensionDependencies', 'Dependencies to other extensions. The identifier of an extension is always ${publisher}.${name}. For example: vscode.csharp.'),
+			description: nls.localize('vscode.extension.extensionDependencies', 'Dependencies to other extensions. The identifier of an extension is always ${publisher}.${name}. For example: ms-dotnettools.csharp.'),
 			type: 'array',
 			uniqueItems: true,
 			items: {
@@ -363,7 +363,7 @@ export const schema: IJSONSchema = {
 			}
 		},
 		extensionPack: {
-			description: nls.localize('vscode.extension.contributes.extensionPack', "A set of extensions that can be installed together. The identifier of an extension is always ${publisher}.${name}. For example: vscode.csharp."),
+			description: nls.localize('vscode.extension.contributes.extensionPack', "A set of extensions that can be installed together. The identifier of an extension is always ${publisher}.${name}. For example: ms-dotnettools.csharp."),
 			type: 'array',
 			uniqueItems: true,
 			items: {


### PR DESCRIPTION
Update the example extension name from `vscode.csharp` to `ms-dotnettools.csharp`.

While adding an `extensions.json` to a project of my own, I noticed that the "Intellisense" for the schema was suggesting an extension that no longer exists, so this updates it to the current Id.