### PR TITLE
feat(quickinput): support codicons in prompt

### DIFF
--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -126,6 +126,11 @@
 	padding: 5px 5px 2px 5px;
 }
 
+.quick-input-message > .codicon {
+	margin: 0 0.2em;
+	vertical-align: text-bottom;
+}
+
 .quick-input-progress.monaco-progress-container {
 	position: relative;
 }

--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -27,7 +27,8 @@ import { IListVirtualDelegate, IListRenderer } from 'vs/base/browser/ui/list/lis
 import { List, IListOptions, IListStyles } from 'vs/base/browser/ui/list/listWidget';
 import { IInputBoxStyles } from 'vs/base/browser/ui/inputbox/inputBox';
 import { Color } from 'vs/base/common/color';
-import { registerIcon, Codicon } from 'vs/base/common/codicons';
+import { registerIcon, Codicon, renderCodicons } from 'vs/base/common/codicons';
+import { escape } from 'vs/base/common/strings';
 
 export interface IQuickInputOptions {
 	idPrefix: string;
@@ -942,10 +943,10 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 			}
 		}
 		if (this.validationMessage) {
-			this.ui.message.textContent = this.validationMessage;
+			this.ui.message.innerHTML = renderCodicons(escape(this.validationMessage));
 			this.showMessageDecoration(Severity.Error);
 		} else {
-			this.ui.message.textContent = null;
+			this.ui.message.innerHTML = '';
 			this.showMessageDecoration(Severity.Ignore);
 		}
 		this.ui.customButton.label = this.customLabel || '';
@@ -1072,14 +1073,11 @@ class InputBox extends QuickInput implements IInputBox {
 		if (this.ui.inputBox.password !== this.password) {
 			this.ui.inputBox.password = this.password;
 		}
-		if (!this.validationMessage && this.ui.message.textContent !== this.noValidationMessage) {
-			this.ui.message.textContent = this.noValidationMessage;
-			this.showMessageDecoration(Severity.Ignore);
+		let messageInnerHtml = renderCodicons(escape(this.validationMessage || this.noValidationMessage));
+		if (this.ui.message.innerHTML !== messageInnerHtml) {
+			this.ui.message.innerHTML = messageInnerHtml;
 		}
-		if (this.validationMessage && this.ui.message.textContent !== this.validationMessage) {
-			this.ui.message.textContent = this.validationMessage;
-			this.showMessageDecoration(Severity.Error);
-		}
+		this.showMessageDecoration(this.validationMessage ? Severity.Error : Severity.Ignore);
 	}
 }
 
@@ -1504,7 +1502,7 @@ export class QuickInputController extends Disposable {
 		ui.inputBox.showDecoration(Severity.Ignore);
 		ui.visibleCount.setCount(0);
 		ui.count.setCount(0);
-		ui.message.textContent = '';
+		ui.message.innerHTML = '';
 		ui.progressBar.stop();
 		ui.list.setElements([]);
 		ui.list.matchOnDescription = false;


### PR DESCRIPTION
Closes #96430

Just to be clear the issue title starts with `InputBox` which might mean the [generic `InputBox`](https://github.com/microsoft/vscode/blob/master/src/vs/base/browser/ui/inputbox/inputBox.ts) although that's not directly used in `showInputBox`, [quickinput's `InputBox`](https://github.com/microsoft/vscode/blob/6c21258b65e4c9448323c930fabb1ac6b734c597/src/vs/base/parts/quickinput/browser/quickInput.ts#L962) (`ui.inputBox`) along with a message dom node (`ui.message`) exclusive to quickinput is used instead. So this PR adds support of codicons for quick input's prompt and not for generic `InputBox`.

I think it's worth mentioning that quickinput should (afaict) use generic `InputBox`'s message for prompt which would also solve #82112, because the generic already supports rich text message. I might look into fixing this as well.

How to test:
1. Make a temporary extension and execute
```typescript
vscode.window.showInputBox({
	// using bigger prompt to check alignment when text gets wrapped into lines as well
	prompt: "$(add) Lorem ipsum, dolor sit amet consectetur adipisicing elit. Magni odio $(wrench) quisquam illo ea nobis provident laborum nam nostrum voluptatibus ullam ratione, eligendi rerum."
});
```
2. Check if you see the codicons.
3. Check if they're properly aligned.
