### PR TITLE
fix(quickpick): validate default value for `showInputBox`

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1467,6 +1467,9 @@ export class QuickInputController extends Disposable {
 			input.placeholder = options.placeHolder;
 			input.password = !!options.password;
 			input.ignoreFocusOut = !!options.ignoreFocusLost;
+			validation.then(result => {
+				input.validationMessage = result || undefined;
+			});
 			input.show();
 		});
 	}


### PR DESCRIPTION
Fixes #97913

How to test:
1. Follow the steps 1-4 given in the issue to reproduce
2. Check if there's a invalid red decoration with message "Something is wrong"
