### PR TITLE
fix(quickinput): make `inputBox.enable` work

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -34,6 +34,7 @@ export interface IInputOptions extends IInputBoxStyles {
 	readonly flexibleWidth?: boolean;
 	readonly flexibleMaxHeight?: number;
 	readonly actions?: ReadonlyArray<IAction>;
+	readonly shouldNotBlurOnDisable?: boolean;
 }
 
 export interface IInputBoxStyles {
@@ -304,7 +305,9 @@ export class InputBox extends Widget {
 	}
 
 	public disable(): void {
-		this.blur();
+		if (!this.options.shouldNotBlurOnDisable) {
+			this.blur();
+		}
 		this.input.disabled = true;
 		this._hideMessage();
 	}

--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1492,7 +1492,7 @@ export class QuickInputController extends Disposable {
 			oldController.didHide();
 		}
 
-		this.setEnabled(true);
+		this.setEnabled(controller.enabled);
 		ui.leftActionBar.clear();
 		ui.title.textContent = '';
 		ui.description.textContent = '';
@@ -1568,7 +1568,7 @@ export class QuickInputController extends Disposable {
 				(item as ActionViewItem).getAction().enabled = enabled;
 			}
 			this.getUI().checkAll.disabled = !enabled;
-			// this.getUI().inputBox.enabled = enabled; Avoid loosing focus.
+			this.getUI().inputBox.enabled = enabled;
 			this.getUI().ok.enabled = enabled;
 			this.getUI().list.enabled = enabled;
 		}

--- a/src/vs/base/parts/quickinput/browser/quickInputBox.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInputBox.ts
@@ -23,7 +23,7 @@ export class QuickInputBox extends Disposable {
 	) {
 		super();
 		this.container = dom.append(this.parent, $('.quick-input-box'));
-		this.inputBox = this._register(new InputBox(this.container, undefined));
+		this.inputBox = this._register(new InputBox(this.container, undefined, { shouldNotBlurOnDisable: true }));
 	}
 
 	onKeyDown = (handler: (event: StandardKeyboardEvent) => void): IDisposable => {


### PR DESCRIPTION
Fixes #69441

How to test:
1. Follow steps for reproduction given in the issue
2. Check if the input is disabled
3. Find out in what case the input was getting focused out which led [this commenting](https://github.com/microsoft/vscode/commit/edb49f690017abfbae10370750f6494f5fee6732#diff-5fda188a521639e37ab9524324510e25R1069), check if the input is not getting focused out in that case.
