### PR TITLE
Make editor on type bg color themeable

### DIFF
--- a/src/vs/editor/contrib/rename/media/onTypeRename.css
+++ b/src/vs/editor/contrib/rename/media/onTypeRename.css
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-editor .on-type-rename-decoration {
-	background: rgba(255, 0, 0, 0.3);
-	border-left: 1px solid rgba(255, 0, 0, 0.3);
+	border-left: 1px solid transparent;
 	/* So border can be transparent */
 	background-clip: padding-box;
 }

--- a/src/vs/editor/contrib/rename/onTypeRename.ts
+++ b/src/vs/editor/contrib/rename/onTypeRename.ts
@@ -26,6 +26,9 @@ import { URI } from 'vs/base/common/uri';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { onUnexpectedError, onUnexpectedExternalError } from 'vs/base/common/errors';
 import * as strings from 'vs/base/common/strings';
+import { registerColor } from 'vs/platform/theme/common/colorRegistry';
+import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
+import { Color } from 'vs/base/common/color';
 
 export const CONTEXT_ONTYPE_RENAME_INPUT_VISIBLE = new RawContextKey<boolean>('onTypeRenameInputVisible', false);
 
@@ -360,6 +363,13 @@ export function getOnTypeRenameRanges(model: ITextModel, position: Position, tok
 	}), result => !!result && arrays.isNonEmptyArray(result?.ranges));
 }
 
+export const editorOnTypeRenameBackground = registerColor('editor.onTypeRenameBackground', { dark: Color.fromHex('#f00').transparent(0.3), light: Color.fromHex('#f00').transparent(0.3), hc: Color.fromHex('#f00').transparent(0.3) }, nls.localize('editorOnTypeRenameBackground', 'Background color when the editor auto renames on type.'));
+registerThemingParticipant((theme, collector) => {
+	const editorOnTypeRenameBackgroundColor = theme.getColor(editorOnTypeRenameBackground);
+	if (editorOnTypeRenameBackgroundColor) {
+		collector.addRule(`.monaco-editor .on-type-rename-decoration { background: ${editorOnTypeRenameBackgroundColor}; border-left-color: ${editorOnTypeRenameBackgroundColor}; }`);
+	}
+});
 
 registerModelAndPositionCommand('_executeRenameOnTypeProvider', (model, position) => getOnTypeRenameRanges(model, position, CancellationToken.None));
 


### PR DESCRIPTION
Fixes #102840 and introduces `editor.onTypeRenameBackground` as a color token. I believe this was an oversight when this feature was created. Make sure `editor.renameOnType` is enabled.

![image](https://user-images.githubusercontent.com/35271042/87968833-e2023000-ca75-11ea-94da-cbfb0bf66056.png)

@rebornix adding you as a reviewer since @aeschli is out on vacation