### PR TITLE
Enable web TS Server 

### DIFF
--- a/extensions/typescript-language-features/extension-browser.webpack.config.js
+++ b/extensions/typescript-language-features/extension-browser.webpack.config.js
@@ -6,6 +6,7 @@
 //@ts-check
 
 'use strict';
+const CopyPlugin = require('copy-webpack-plugin');
 
 const withBrowserDefaults = require('../shared.webpack.config').browser;
 
@@ -13,6 +14,13 @@ module.exports = withBrowserDefaults({
 	context: __dirname,
 	entry: {
 		extension: './src/extension.browser.ts',
-		'tsserver.browser': './src/tsserver.browser.ts',
-	}
+	},
+	plugins: [
+		// @ts-ignore
+		new CopyPlugin({
+			patterns: [
+				{ from: 'node_modules/typescript-web-server', to: 'typescript-web' }
+			],
+		}),
+	],
 });

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -27,6 +27,8 @@
     "@types/node": "^12.11.7",
     "@types/rimraf": "2.0.2",
     "@types/semver": "^5.5.0",
+    "copy-webpack-plugin": "^6.0.3",
+    "typescript-web-server": "git://github.com/mjbvz/ts-server-web-build",
     "vscode": "^1.1.36"
   },
   "scripts": {

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -30,7 +30,9 @@
     "vscode": "^1.1.36"
   },
   "scripts": {
-    "vscode:prepublish": "node ../../node_modules/gulp/bin/gulp.js --gulpfile ../../build/gulpfile.extensions.js compile-extension:typescript-language-features"
+    "vscode:prepublish": "node ../../node_modules/gulp/bin/gulp.js --gulpfile ../../build/gulpfile.extensions.js compile-extension:typescript-language-features",
+    "compile-web": "npx webpack-cli --config extension-browser.webpack.config --mode none",
+    "watch-web": "npx webpack-cli --config extension-browser.webpack.config --mode none --watch --info-verbosity verbose"
   },
   "activationEvents": [
     "onLanguage:javascript",
@@ -50,6 +52,7 @@
     "onLanguage:jsonc"
   ],
   "main": "./out/extension",
+  "browser": "./dist/browser/extension",
   "contributes": {
     "jsonValidation": [
       {

--- a/extensions/typescript-language-features/src/extension.browser.ts
+++ b/extensions/typescript-language-features/src/extension.browser.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { WorkerServerProcess } from './tsServer/workerServerProcess';
 import { Api, getExtensionApi } from './api';
 import { registerCommands } from './commands/index';
 import { LanguageConfigurationManager } from './features/languageConfiguration';
@@ -49,7 +50,7 @@ export function activate(
 	const versionProvider = new StaticVersionProvider(
 		new TypeScriptVersion(TypeScriptVersionSource.Bundled, 'todo', API.v400));
 
-	const lazyClientHost = createLazyClientHost(context, false, pluginManager, commandManager, noopLogDirectoryProvider, noopRequestCancellerFactory, versionProvider, item => {
+	const lazyClientHost = createLazyClientHost(context, false, pluginManager, commandManager, noopLogDirectoryProvider, noopRequestCancellerFactory, versionProvider, WorkerServerProcess, item => {
 		onCompletionAccepted.fire(item);
 	});
 

--- a/extensions/typescript-language-features/src/extension.browser.ts
+++ b/extensions/typescript-language-features/src/extension.browser.ts
@@ -4,14 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { noopLogDirectoryProvider } from './tsServer/logDirectoryProvider';
 import { Api, getExtensionApi } from './api';
 import { registerCommands } from './commands/index';
 import { LanguageConfigurationManager } from './features/languageConfiguration';
 import { createLazyClientHost, lazilyActivateClient } from './lazyClientHost';
+import { noopRequestCancellerFactory } from './tsServer/cancellation';
+import { noopLogDirectoryProvider } from './tsServer/logDirectoryProvider';
 import { CommandManager } from './utils/commandManager';
 import { PluginManager } from './utils/plugins';
-import { noopRequestCancellerFactory } from './tsServer/cancellation';
+import { TypeScriptVersionProvider } from './utils/versionProvider';
 
 export function activate(
 	context: vscode.ExtensionContext
@@ -25,7 +26,9 @@ export function activate(
 	const onCompletionAccepted = new vscode.EventEmitter<vscode.CompletionItem>();
 	context.subscriptions.push(onCompletionAccepted);
 
-	const lazyClientHost = createLazyClientHost(context, pluginManager, commandManager, noopLogDirectoryProvider, noopRequestCancellerFactory, item => {
+	const versionProvider = new TypeScriptVersionProvider();
+
+	const lazyClientHost = createLazyClientHost(context, false, pluginManager, commandManager, noopLogDirectoryProvider, noopRequestCancellerFactory, versionProvider, item => {
 		onCompletionAccepted.fire(item);
 	});
 

--- a/extensions/typescript-language-features/src/extension.browser.ts
+++ b/extensions/typescript-language-features/src/extension.browser.ts
@@ -48,7 +48,10 @@ export function activate(
 	context.subscriptions.push(onCompletionAccepted);
 
 	const versionProvider = new StaticVersionProvider(
-		new TypeScriptVersion(TypeScriptVersionSource.Bundled, 'todo', API.v400));
+		new TypeScriptVersion(
+			TypeScriptVersionSource.Bundled,
+			'/builtin-extension/typescript-language-features/dist/browser/typescript-web/tsserver.js',
+			API.v400));
 
 	const lazyClientHost = createLazyClientHost(context, false, pluginManager, commandManager, noopLogDirectoryProvider, noopRequestCancellerFactory, versionProvider, WorkerServerProcess, item => {
 		onCompletionAccepted.fire(item);

--- a/extensions/typescript-language-features/src/extension.browser.ts
+++ b/extensions/typescript-language-features/src/extension.browser.ts
@@ -10,9 +10,29 @@ import { LanguageConfigurationManager } from './features/languageConfiguration';
 import { createLazyClientHost, lazilyActivateClient } from './lazyClientHost';
 import { noopRequestCancellerFactory } from './tsServer/cancellation';
 import { noopLogDirectoryProvider } from './tsServer/logDirectoryProvider';
+import API from './utils/api';
 import { CommandManager } from './utils/commandManager';
+import { TypeScriptServiceConfiguration } from './utils/configuration';
 import { PluginManager } from './utils/plugins';
-import { TypeScriptVersionProvider } from './utils/versionProvider';
+import { ITypeScriptVersionProvider, TypeScriptVersion, TypeScriptVersionSource } from './utils/versionProvider';
+
+class StaticVersionProvider implements ITypeScriptVersionProvider {
+
+	constructor(
+		private readonly _version: TypeScriptVersion
+	) { }
+
+	updateConfiguration(_configuration: TypeScriptServiceConfiguration): void {
+		// noop
+	}
+
+	get defaultVersion() { return this._version; }
+	get bundledVersion() { return this._version; }
+
+	readonly globalVersion = undefined;
+	readonly localVersion = undefined;
+	readonly localVersions = [];
+}
 
 export function activate(
 	context: vscode.ExtensionContext
@@ -26,7 +46,8 @@ export function activate(
 	const onCompletionAccepted = new vscode.EventEmitter<vscode.CompletionItem>();
 	context.subscriptions.push(onCompletionAccepted);
 
-	const versionProvider = new TypeScriptVersionProvider();
+	const versionProvider = new StaticVersionProvider(
+		new TypeScriptVersion(TypeScriptVersionSource.Bundled, 'todo', API.v400));
 
 	const lazyClientHost = createLazyClientHost(context, false, pluginManager, commandManager, noopLogDirectoryProvider, noopRequestCancellerFactory, versionProvider, item => {
 		onCompletionAccepted.fire(item);

--- a/extensions/typescript-language-features/src/extension.ts
+++ b/extensions/typescript-language-features/src/extension.ts
@@ -5,16 +5,18 @@
 
 import * as rimraf from 'rimraf';
 import * as vscode from 'vscode';
-import { NodeLogDirectoryProvider } from './tsServer/logDirectoryProvider.electron';
 import { Api, getExtensionApi } from './api';
 import { registerCommands } from './commands/index';
 import { LanguageConfigurationManager } from './features/languageConfiguration';
 import * as task from './features/task';
 import { createLazyClientHost, lazilyActivateClient } from './lazyClientHost';
 import { nodeRequestCancellerFactory } from './tsServer/cancellation.electron';
+import { NodeLogDirectoryProvider } from './tsServer/logDirectoryProvider.electron';
 import { CommandManager } from './utils/commandManager';
 import * as electron from './utils/electron';
+import { onCaseInsenitiveFileSystem } from './utils/fileSystem';
 import { PluginManager } from './utils/plugins';
+import { TypeScriptVersionProvider } from './utils/versionProvider';
 
 export function activate(
 	context: vscode.ExtensionContext
@@ -30,7 +32,9 @@ export function activate(
 
 	const logDirectoryProvider = new NodeLogDirectoryProvider(context);
 
-	const lazyClientHost = createLazyClientHost(context, pluginManager, commandManager, logDirectoryProvider, nodeRequestCancellerFactory, item => {
+	const versionProvider = new TypeScriptVersionProvider();
+
+	const lazyClientHost = createLazyClientHost(context, onCaseInsenitiveFileSystem(), pluginManager, commandManager, logDirectoryProvider, nodeRequestCancellerFactory, versionProvider, item => {
 		onCompletionAccepted.fire(item);
 	});
 

--- a/extensions/typescript-language-features/src/extension.ts
+++ b/extensions/typescript-language-features/src/extension.ts
@@ -16,6 +16,7 @@ import { CommandManager } from './utils/commandManager';
 import * as electron from './utils/electron';
 import { onCaseInsenitiveFileSystem } from './utils/fileSystem';
 import { PluginManager } from './utils/plugins';
+import { ChildServerProcess } from './utils/serverProcess';
 import { DiskTypeScriptVersionProvider } from './utils/versionProvider.electron';
 
 export function activate(
@@ -34,7 +35,7 @@ export function activate(
 
 	const versionProvider = new DiskTypeScriptVersionProvider();
 
-	const lazyClientHost = createLazyClientHost(context, onCaseInsenitiveFileSystem(), pluginManager, commandManager, logDirectoryProvider, nodeRequestCancellerFactory, versionProvider, item => {
+	const lazyClientHost = createLazyClientHost(context, onCaseInsenitiveFileSystem(), pluginManager, commandManager, logDirectoryProvider, nodeRequestCancellerFactory, versionProvider, ChildServerProcess, item => {
 		onCompletionAccepted.fire(item);
 	});
 

--- a/extensions/typescript-language-features/src/extension.ts
+++ b/extensions/typescript-language-features/src/extension.ts
@@ -16,7 +16,7 @@ import { CommandManager } from './utils/commandManager';
 import * as electron from './utils/electron';
 import { onCaseInsenitiveFileSystem } from './utils/fileSystem';
 import { PluginManager } from './utils/plugins';
-import { TypeScriptVersionProvider } from './utils/versionProvider';
+import { DiskTypeScriptVersionProvider } from './utils/versionProvider.electron';
 
 export function activate(
 	context: vscode.ExtensionContext
@@ -32,7 +32,7 @@ export function activate(
 
 	const logDirectoryProvider = new NodeLogDirectoryProvider(context);
 
-	const versionProvider = new TypeScriptVersionProvider();
+	const versionProvider = new DiskTypeScriptVersionProvider();
 
 	const lazyClientHost = createLazyClientHost(context, onCaseInsenitiveFileSystem(), pluginManager, commandManager, logDirectoryProvider, nodeRequestCancellerFactory, versionProvider, item => {
 		onCompletionAccepted.fire(item);

--- a/extensions/typescript-language-features/src/features/callHierarchy.ts
+++ b/extensions/typescript-language-features/src/features/callHierarchy.ts
@@ -123,9 +123,9 @@ export function register(
 ) {
 	return conditionalRegistration([
 		requireMinVersion(client, TypeScriptCallHierarchySupport.minVersion),
-		requireSomeCapability(client, ClientCapability.EnhancedSyntax, ClientCapability.Semantic),
+		requireSomeCapability(client, ClientCapability.Semantic),
 	], () => {
-		return vscode.languages.registerCallHierarchyProvider(selector.syntax,
+		return vscode.languages.registerCallHierarchyProvider(selector.semantic,
 			new TypeScriptCallHierarchySupport(client));
 	});
 }

--- a/extensions/typescript-language-features/src/features/fileConfigurationManager.ts
+++ b/extensions/typescript-language-features/src/features/fileConfigurationManager.ts
@@ -9,7 +9,6 @@ import { ITypeScriptServiceClient } from '../typescriptService';
 import API from '../utils/api';
 import { Disposable } from '../utils/dispose';
 import * as fileSchemes from '../utils/fileSchemes';
-import { onCaseInsenitiveFileSystem } from '../utils/fileSystem';
 import { isTypeScriptDocument } from '../utils/languageModeIds';
 import { equals } from '../utils/objects';
 import { ResourceMap } from '../utils/resourceMap';
@@ -34,10 +33,11 @@ export default class FileConfigurationManager extends Disposable {
 	private readonly formatOptions: ResourceMap<Promise<FileConfiguration | undefined>>;
 
 	public constructor(
-		private readonly client: ITypeScriptServiceClient
+		private readonly client: ITypeScriptServiceClient,
+		onCaseInsenitiveFileSystem: boolean
 	) {
 		super();
-		this.formatOptions = new ResourceMap(undefined, { onCaseInsenitiveFileSystem: onCaseInsenitiveFileSystem() });
+		this.formatOptions = new ResourceMap(undefined, { onCaseInsenitiveFileSystem });
 		vscode.workspace.onDidCloseTextDocument(textDocument => {
 			// When a document gets closed delete the cached formatting options.
 			// This is necessary since the tsserver now closed a project when its

--- a/extensions/typescript-language-features/src/features/organizeImports.ts
+++ b/extensions/typescript-language-features/src/features/organizeImports.ts
@@ -6,11 +6,11 @@
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import type * as Proto from '../protocol';
-import { ITypeScriptServiceClient } from '../typescriptService';
+import { ClientCapability, ITypeScriptServiceClient } from '../typescriptService';
 import API from '../utils/api';
 import { nulToken } from '../utils/cancellation';
 import { Command, CommandManager } from '../utils/commandManager';
-import { conditionalRegistration, requireMinVersion } from '../utils/dependentRegistration';
+import { conditionalRegistration, requireMinVersion, requireSomeCapability } from '../utils/dependentRegistration';
 import { DocumentSelector } from '../utils/documentSelector';
 import { TelemetryReporter } from '../utils/telemetry';
 import * as typeconverts from '../utils/typeConverters';
@@ -108,10 +108,10 @@ export function register(
 ) {
 	return conditionalRegistration([
 		requireMinVersion(client, OrganizeImportsCodeActionProvider.minVersion),
-
+		requireSomeCapability(client, ClientCapability.Semantic),
 	], () => {
 		const organizeImportsProvider = new OrganizeImportsCodeActionProvider(client, commandManager, fileConfigurationManager, telemetryReporter);
-		return vscode.languages.registerCodeActionsProvider(selector.syntax,
+		return vscode.languages.registerCodeActionsProvider(selector.semantic,
 			organizeImportsProvider,
 			organizeImportsProvider.metadata);
 	});

--- a/extensions/typescript-language-features/src/lazyClientHost.ts
+++ b/extensions/typescript-language-features/src/lazyClientHost.ts
@@ -14,23 +14,28 @@ import * as ProjectStatus from './utils/largeProjectStatus';
 import { lazy, Lazy } from './utils/lazy';
 import ManagedFileContextManager from './utils/managedFileContext';
 import { PluginManager } from './utils/plugins';
+import { ITypeScriptVersionProvider } from './utils/versionProvider';
 
 export function createLazyClientHost(
 	context: vscode.ExtensionContext,
+	onCaseInsenitiveFileSystem: boolean,
 	pluginManager: PluginManager,
 	commandManager: CommandManager,
 	logDirectoryProvider: ILogDirectoryProvider,
 	cancellerFactory: OngoingRequestCancellerFactory,
+	versionProvider: ITypeScriptVersionProvider,
 	onCompletionAccepted: (item: vscode.CompletionItem) => void,
 ): Lazy<TypeScriptServiceClientHost> {
 	return lazy(() => {
 		const clientHost = new TypeScriptServiceClientHost(
 			standardLanguageDescriptions,
 			context.workspaceState,
+			onCaseInsenitiveFileSystem,
 			pluginManager,
 			commandManager,
 			logDirectoryProvider,
 			cancellerFactory,
+			versionProvider,
 			onCompletionAccepted);
 
 		context.subscriptions.push(clientHost);
@@ -45,7 +50,6 @@ export function createLazyClientHost(
 		return clientHost;
 	});
 }
-
 
 export function lazilyActivateClient(
 	lazyClientHost: Lazy<TypeScriptServiceClientHost>,

--- a/extensions/typescript-language-features/src/lazyClientHost.ts
+++ b/extensions/typescript-language-features/src/lazyClientHost.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { TsServerProcessFactory } from './tsServer/server';
 import { OngoingRequestCancellerFactory } from './tsServer/cancellation';
 import { ILogDirectoryProvider } from './tsServer/logDirectoryProvider';
 import TypeScriptServiceClientHost from './typeScriptServiceClientHost';
@@ -24,6 +25,7 @@ export function createLazyClientHost(
 	logDirectoryProvider: ILogDirectoryProvider,
 	cancellerFactory: OngoingRequestCancellerFactory,
 	versionProvider: ITypeScriptVersionProvider,
+	processFactory: TsServerProcessFactory,
 	onCompletionAccepted: (item: vscode.CompletionItem) => void,
 ): Lazy<TypeScriptServiceClientHost> {
 	return lazy(() => {
@@ -36,6 +38,7 @@ export function createLazyClientHost(
 			logDirectoryProvider,
 			cancellerFactory,
 			versionProvider,
+			processFactory,
 			onCompletionAccepted);
 
 		context.subscriptions.push(clientHost);

--- a/extensions/typescript-language-features/src/tsServer/server.ts
+++ b/extensions/typescript-language-features/src/tsServer/server.ts
@@ -41,6 +41,13 @@ export interface TsServerDelegate {
 	onFatalError(command: string, error: Error): void;
 }
 
+export const enum TsServerProcessKind {
+	Main = 'main',
+	Syntax = 'syntax',
+	Semantic = 'semantic',
+	Diagnostics = 'diagnostics'
+}
+
 export interface TsServerProcess {
 	write(serverRequest: Proto.Request): void;
 
@@ -50,7 +57,6 @@ export interface TsServerProcess {
 
 	kill(): void;
 }
-
 
 export class ProcessBasedTsServer extends Disposable implements ITypeScriptServer {
 	private readonly _requestQueue = new RequestQueue();

--- a/extensions/typescript-language-features/src/tsServer/server.ts
+++ b/extensions/typescript-language-features/src/tsServer/server.ts
@@ -7,14 +7,16 @@ import * as vscode from 'vscode';
 import type * as Proto from '../protocol';
 import { EventName } from '../protocol.const';
 import { CallbackMap } from '../tsServer/callbackMap';
-import { OngoingRequestCanceller } from './cancellation';
 import { RequestItem, RequestQueue, RequestQueueingType } from '../tsServer/requestQueue';
 import { TypeScriptServerError } from '../tsServer/serverError';
 import { ServerResponse, TypeScriptRequests } from '../typescriptService';
+import { TypeScriptServiceConfiguration } from '../utils/configuration';
 import { Disposable } from '../utils/dispose';
 import { TelemetryReporter } from '../utils/telemetry';
 import Tracer from '../utils/tracer';
+import { TypeScriptVersionManager } from '../utils/versionManager';
 import { TypeScriptVersion } from '../utils/versionProvider';
+import { OngoingRequestCanceller } from './cancellation';
 
 export enum ExectuionTarget {
 	Semantic,
@@ -46,6 +48,16 @@ export const enum TsServerProcessKind {
 	Syntax = 'syntax',
 	Semantic = 'semantic',
 	Diagnostics = 'diagnostics'
+}
+
+export interface TsServerProcessFactory {
+	fork(
+		tsServerPath: string,
+		args: readonly string[],
+		kind: TsServerProcessKind,
+		configuration: TypeScriptServiceConfiguration,
+		versionManager: TypeScriptVersionManager,
+	): TsServerProcess;
 }
 
 export interface TsServerProcess {

--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -6,25 +6,19 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { OngoingRequestCancellerFactory } from '../tsServer/cancellation';
+import { WorkerServerProcess } from '../tsServer/workerServerProcess';
 import { ClientCapabilities, ClientCapability } from '../typescriptService';
 import API from '../utils/api';
 import { SeparateSyntaxServerConfiguration, TsServerLogLevel, TypeScriptServiceConfiguration } from '../utils/configuration';
-import * as electron from '../utils/electron';
-import { ILogDirectoryProvider } from './logDirectoryProvider';
 import Logger from '../utils/logger';
 import { TypeScriptPluginPathsProvider } from '../utils/pluginPathsProvider';
 import { PluginManager } from '../utils/plugins';
+//import { ChildServerProcess } from '../utils/serverProcess';
 import { TelemetryReporter } from '../utils/telemetry';
 import Tracer from '../utils/tracer';
-import { TypeScriptVersion, TypeScriptVersionProvider } from '../utils/versionProvider';
-import { GetErrRoutingTsServer, ITypeScriptServer, ProcessBasedTsServer, SyntaxRoutingTsServer, TsServerDelegate } from './server';
-
-const enum ServerKind {
-	Main = 'main',
-	Syntax = 'syntax',
-	Semantic = 'semantic',
-	Diagnostics = 'diagnostics'
-}
+import { ITypeScriptVersionProvider, TypeScriptVersion } from '../utils/versionProvider';
+import { ILogDirectoryProvider } from './logDirectoryProvider';
+import { GetErrRoutingTsServer, ITypeScriptServer, ProcessBasedTsServer, SyntaxRoutingTsServer, TsServerDelegate, TsServerProcess, TsServerProcessKind } from './server';
 
 const enum CompositeServerType {
 	/** Run a single server that handles all commands  */
@@ -42,7 +36,7 @@ const enum CompositeServerType {
 
 export class TypeScriptServerSpawner {
 	public constructor(
-		private readonly _versionProvider: TypeScriptVersionProvider,
+		private readonly _versionProvider: ITypeScriptVersionProvider,
 		private readonly _logDirectoryProvider: ILogDirectoryProvider,
 		private readonly _pluginPathsProvider: TypeScriptPluginPathsProvider,
 		private readonly _logger: Logger,
@@ -66,26 +60,26 @@ export class TypeScriptServerSpawner {
 				{
 					const enableDynamicRouting = serverType === CompositeServerType.DynamicSeparateSyntax;
 					primaryServer = new SyntaxRoutingTsServer({
-						syntax: this.spawnTsServer(ServerKind.Syntax, version, configuration, pluginManager, cancellerFactory),
-						semantic: this.spawnTsServer(ServerKind.Semantic, version, configuration, pluginManager, cancellerFactory),
+						syntax: this.spawnTsServer(TsServerProcessKind.Syntax, version, configuration, pluginManager, cancellerFactory),
+						semantic: this.spawnTsServer(TsServerProcessKind.Semantic, version, configuration, pluginManager, cancellerFactory),
 					}, delegate, enableDynamicRouting);
 					break;
 				}
 			case CompositeServerType.Single:
 				{
-					primaryServer = this.spawnTsServer(ServerKind.Main, version, configuration, pluginManager, cancellerFactory);
+					primaryServer = this.spawnTsServer(TsServerProcessKind.Main, version, configuration, pluginManager, cancellerFactory);
 					break;
 				}
 			case CompositeServerType.SyntaxOnly:
 				{
-					primaryServer = this.spawnTsServer(ServerKind.Syntax, version, configuration, pluginManager, cancellerFactory);
+					primaryServer = this.spawnTsServer(TsServerProcessKind.Syntax, version, configuration, pluginManager, cancellerFactory);
 					break;
 				}
 		}
 
 		if (this.shouldUseSeparateDiagnosticsServer(configuration)) {
 			return new GetErrRoutingTsServer({
-				getErr: this.spawnTsServer(ServerKind.Diagnostics, version, configuration, pluginManager, cancellerFactory),
+				getErr: this.spawnTsServer(TsServerProcessKind.Diagnostics, version, configuration, pluginManager, cancellerFactory),
 				primary: primaryServer,
 			}, delegate);
 		}
@@ -123,7 +117,7 @@ export class TypeScriptServerSpawner {
 	}
 
 	private spawnTsServer(
-		kind: ServerKind,
+		kind: TsServerProcessKind,
 		version: TypeScriptVersion,
 		configuration: TypeScriptServiceConfiguration,
 		pluginManager: PluginManager,
@@ -142,13 +136,18 @@ export class TypeScriptServerSpawner {
 			}
 		}
 
-		this._logger.info(`<${kind}> Forking...`);
-		const childProcess = electron.fork(version.tsServerPath, args, this.getForkOptions(kind, configuration));
-		this._logger.info(`<${kind}> Starting...`);
+		let process: TsServerProcess;
+		if (version.apiVersion?.gte(API.v400)) {
+			process = WorkerServerProcess.fork(args);
+		} else {
+			this._logger.info(`<${kind}> Forking...`);
+			//	process = ChildServerProcess.fork(version.tsServerPath, args, kind, configuration);
+			this._logger.info(`<${kind}> Starting...`);
+		}
 
 		return new ProcessBasedTsServer(
 			kind,
-			process,
+			process!,
 			tsServerLogFile,
 			canceller,
 			version,
@@ -156,20 +155,8 @@ export class TypeScriptServerSpawner {
 			this._tracer);
 	}
 
-	private getForkOptions(kind: ServerKind, configuration: TypeScriptServiceConfiguration) {
-		const debugPort = TypeScriptServerSpawner.getDebugPort(kind);
-		const inspectFlag = process.env['TSS_DEBUG_BRK'] ? '--inspect-brk' : '--inspect';
-		const tsServerForkOptions: electron.ForkOptions = {
-			execArgv: [
-				...(debugPort ? [`${inspectFlag}=${debugPort}`] : []),
-				...(configuration.maxTsServerMemory ? [`--max-old-space-size=${configuration.maxTsServerMemory}`] : [])
-			]
-		};
-		return tsServerForkOptions;
-	}
-
 	private getTsServerArgs(
-		kind: ServerKind,
+		kind: TsServerProcessKind,
 		configuration: TypeScriptServiceConfiguration,
 		currentVersion: TypeScriptVersion,
 		apiVersion: API,
@@ -179,7 +166,7 @@ export class TypeScriptServerSpawner {
 		const args: string[] = [];
 		let tsServerLogFile: string | undefined;
 
-		if (kind === ServerKind.Syntax) {
+		if (kind === TsServerProcessKind.Syntax) {
 			args.push('--syntaxOnly');
 		}
 
@@ -189,11 +176,11 @@ export class TypeScriptServerSpawner {
 			args.push('--useSingleInferredProject');
 		}
 
-		if (configuration.disableAutomaticTypeAcquisition || kind === ServerKind.Syntax || kind === ServerKind.Diagnostics) {
+		if (configuration.disableAutomaticTypeAcquisition || kind === TsServerProcessKind.Syntax || kind === TsServerProcessKind.Diagnostics) {
 			args.push('--disableAutomaticTypingAcquisition');
 		}
 
-		if (kind === ServerKind.Semantic || kind === ServerKind.Main) {
+		if (kind === TsServerProcessKind.Semantic || kind === TsServerProcessKind.Main) {
 			args.push('--enableTelemetry');
 		}
 
@@ -244,21 +231,6 @@ export class TypeScriptServerSpawner {
 		}
 
 		return { args, tsServerLogFile };
-	}
-
-	private static getDebugPort(kind: ServerKind): number | undefined {
-		if (kind === 'syntax') {
-			// We typically only want to debug the main semantic server
-			return undefined;
-		}
-		const value = process.env['TSS_DEBUG_BRK'] || process.env['TSS_DEBUG'];
-		if (value) {
-			const port = parseInt(value);
-			if (!isNaN(port)) {
-				return port;
-			}
-		}
-		return undefined;
 	}
 
 	private static isLoggingEnabled(configuration: TypeScriptServiceConfiguration) {

--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -14,7 +14,6 @@ import { ILogDirectoryProvider } from './logDirectoryProvider';
 import Logger from '../utils/logger';
 import { TypeScriptPluginPathsProvider } from '../utils/pluginPathsProvider';
 import { PluginManager } from '../utils/plugins';
-import { ChildServerProcess } from '../utils/serverProcess';
 import { TelemetryReporter } from '../utils/telemetry';
 import Tracer from '../utils/tracer';
 import { TypeScriptVersion, TypeScriptVersionProvider } from '../utils/versionProvider';
@@ -149,7 +148,7 @@ export class TypeScriptServerSpawner {
 
 		return new ProcessBasedTsServer(
 			kind,
-			new ChildServerProcess(childProcess),
+			process,
 			tsServerLogFile,
 			canceller,
 			version,

--- a/extensions/typescript-language-features/src/tsServer/workerServerProcess.ts
+++ b/extensions/typescript-language-features/src/tsServer/workerServerProcess.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as Proto from '../protocol';
+import { TsServerProcess } from './server';
+
+declare const Worker: any;
+declare type Worker = any;
+
+export class WorkerServerProcess implements TsServerProcess {
+
+	public static fork(
+		args: readonly string[]
+	) {
+		const worker = new Worker('/builtin-extension/typescript-language-features/node_modules/typescript/tsserver.js');
+		return new WorkerServerProcess(worker, args);
+	}
+
+	private _onDataHandlers = new Set<(data: Proto.Response) => void>();
+	private _onErrorHandlers = new Set<(err: Error) => void>();
+	private _onExitHandlers = new Set<(code: number | null) => void>();
+
+	public constructor(
+		private readonly worker: Worker,
+		args: readonly string[],
+	) {
+		worker.addEventListener('message', (msg: any) => {
+			for (const handler of this._onDataHandlers) {
+				handler(msg.data);
+			}
+		});
+		worker.postMessage(args);
+	}
+
+	write(serverRequest: Proto.Request): void {
+		this.worker.postMessage(serverRequest);
+	}
+
+	onData(handler: (response: Proto.Response) => void): void {
+		this._onDataHandlers.add(handler);
+	}
+
+	onError(handler: (err: Error) => void): void {
+		this._onErrorHandlers.add(handler);
+		// Todo: not implemented
+	}
+
+	onExit(handler: (code: number | null) => void): void {
+		this._onExitHandlers.add(handler);
+		// Todo: not implemented
+	}
+
+	kill(): void {
+		this.worker.terminate();
+	}
+}

--- a/extensions/typescript-language-features/src/tsServer/workerServerProcess.ts
+++ b/extensions/typescript-language-features/src/tsServer/workerServerProcess.ts
@@ -13,12 +13,12 @@ declare type Worker = any;
 export class WorkerServerProcess implements TsServerProcess {
 
 	public static fork(
-		_tsServerPath: string,
+		tsServerPath: string,
 		args: readonly string[],
 		_kind: TsServerProcessKind,
 		_configuration: TypeScriptServiceConfiguration,
 	) {
-		const worker = new Worker('/builtin-extension/typescript-language-features/node_modules/typescript/tsserver.js');
+		const worker = new Worker(tsServerPath);
 		return new WorkerServerProcess(worker, args);
 	}
 

--- a/extensions/typescript-language-features/src/tsServer/workerServerProcess.ts
+++ b/extensions/typescript-language-features/src/tsServer/workerServerProcess.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as Proto from '../protocol';
-import { TsServerProcess } from './server';
+import { TypeScriptServiceConfiguration } from '../utils/configuration';
+import { TsServerProcess, TsServerProcessKind } from './server';
 
 declare const Worker: any;
 declare type Worker = any;
@@ -12,7 +13,10 @@ declare type Worker = any;
 export class WorkerServerProcess implements TsServerProcess {
 
 	public static fork(
-		args: readonly string[]
+		_tsServerPath: string,
+		args: readonly string[],
+		_kind: TsServerProcessKind,
+		_configuration: TypeScriptServiceConfiguration,
 	) {
 		const worker = new Worker('/builtin-extension/typescript-language-features/node_modules/typescript/tsserver.js');
 		return new WorkerServerProcess(worker, args);

--- a/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
+++ b/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
@@ -16,6 +16,7 @@ import * as Proto from './protocol';
 import * as PConst from './protocol.const';
 import { OngoingRequestCancellerFactory } from './tsServer/cancellation';
 import { ILogDirectoryProvider } from './tsServer/logDirectoryProvider';
+import { TsServerProcessFactory } from './tsServer/server';
 import TypeScriptServiceClient from './typescriptServiceClient';
 import { coalesce, flatten } from './utils/arrays';
 import { CommandManager } from './utils/commandManager';
@@ -66,6 +67,7 @@ export default class TypeScriptServiceClientHost extends Disposable {
 		logDirectoryProvider: ILogDirectoryProvider,
 		cancellerFactory: OngoingRequestCancellerFactory,
 		versionProvider: ITypeScriptVersionProvider,
+		processFactory: TsServerProcessFactory,
 		onCompletionAccepted: (item: vscode.CompletionItem) => void,
 	) {
 		super();
@@ -78,6 +80,7 @@ export default class TypeScriptServiceClientHost extends Disposable {
 			logDirectoryProvider,
 			cancellerFactory,
 			versionProvider,
+			processFactory,
 			allModeIds));
 
 		this.client.onDiagnosticsReceived(({ kind, resource, diagnostics }) => {

--- a/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
+++ b/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
@@ -15,16 +15,17 @@ import LanguageProvider from './languageProvider';
 import * as Proto from './protocol';
 import * as PConst from './protocol.const';
 import { OngoingRequestCancellerFactory } from './tsServer/cancellation';
+import { ILogDirectoryProvider } from './tsServer/logDirectoryProvider';
 import TypeScriptServiceClient from './typescriptServiceClient';
 import { coalesce, flatten } from './utils/arrays';
 import { CommandManager } from './utils/commandManager';
 import { Disposable } from './utils/dispose';
 import * as errorCodes from './utils/errorCodes';
 import { DiagnosticLanguage, LanguageDescription } from './utils/languageDescription';
-import { ILogDirectoryProvider } from './tsServer/logDirectoryProvider';
 import { PluginManager } from './utils/plugins';
 import * as typeConverters from './utils/typeConverters';
 import TypingsStatus, { AtaProgressReporter } from './utils/typingsStatus';
+import { ITypeScriptVersionProvider } from './utils/versionProvider';
 import VersionStatus from './utils/versionStatus';
 
 namespace Experimental {
@@ -59,10 +60,12 @@ export default class TypeScriptServiceClientHost extends Disposable {
 	constructor(
 		descriptions: LanguageDescription[],
 		workspaceState: vscode.Memento,
+		onCaseInsenitiveFileSystem: boolean,
 		pluginManager: PluginManager,
 		private readonly commandManager: CommandManager,
 		logDirectoryProvider: ILogDirectoryProvider,
 		cancellerFactory: OngoingRequestCancellerFactory,
+		versionProvider: ITypeScriptVersionProvider,
 		onCompletionAccepted: (item: vscode.CompletionItem) => void,
 	) {
 		super();
@@ -70,9 +73,11 @@ export default class TypeScriptServiceClientHost extends Disposable {
 		const allModeIds = this.getAllModeIds(descriptions, pluginManager);
 		this.client = this._register(new TypeScriptServiceClient(
 			workspaceState,
+			onCaseInsenitiveFileSystem,
 			pluginManager,
 			logDirectoryProvider,
 			cancellerFactory,
+			versionProvider,
 			allModeIds));
 
 		this.client.onDiagnosticsReceived(({ kind, resource, diagnostics }) => {
@@ -85,7 +90,7 @@ export default class TypeScriptServiceClientHost extends Disposable {
 		this._register(new VersionStatus(this.client, commandManager));
 		this._register(new AtaProgressReporter(this.client));
 		this.typingsStatus = this._register(new TypingsStatus(this.client));
-		this.fileConfigurationManager = this._register(new FileConfigurationManager(this.client));
+		this.fileConfigurationManager = this._register(new FileConfigurationManager(this.client, onCaseInsenitiveFileSystem));
 
 		for (const description of descriptions) {
 			const manager = new LanguageProvider(this.client, description, this.commandManager, this.client.telemetryReporter, this.typingsStatus, this.fileConfigurationManager, onCompletionAccepted);

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -3,15 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { OngoingRequestCancellerFactory } from './tsServer/cancellation';
 import BufferSyncSupport from './features/bufferSyncSupport';
 import { DiagnosticKind, DiagnosticsManager } from './features/diagnostics';
 import * as Proto from './protocol';
 import { EventName } from './protocol.const';
+import { OngoingRequestCancellerFactory } from './tsServer/cancellation';
+import { ILogDirectoryProvider } from './tsServer/logDirectoryProvider';
 import { ITypeScriptServer } from './tsServer/server';
 import { TypeScriptServerError } from './tsServer/serverError';
 import { TypeScriptServerSpawner } from './tsServer/spawner';
@@ -20,16 +20,15 @@ import API from './utils/api';
 import { TsServerLogLevel, TypeScriptServiceConfiguration } from './utils/configuration';
 import { Disposable } from './utils/dispose';
 import * as fileSchemes from './utils/fileSchemes';
-import { onCaseInsenitiveFileSystem } from './utils/fileSystem';
-import { ILogDirectoryProvider } from './tsServer/logDirectoryProvider';
 import Logger from './utils/logger';
+import { isWeb } from './utils/platform';
 import { TypeScriptPluginPathsProvider } from './utils/pluginPathsProvider';
 import { PluginManager } from './utils/plugins';
 import { TelemetryProperties, TelemetryReporter, VSCodeTelemetryReporter } from './utils/telemetry';
 import Tracer from './utils/tracer';
 import { inferredProjectCompilerOptions, ProjectType } from './utils/tsconfig';
 import { TypeScriptVersionManager } from './utils/versionManager';
-import { TypeScriptVersion, TypeScriptVersionProvider } from './utils/versionProvider';
+import { ITypeScriptVersionProvider, TypeScriptVersion } from './utils/versionProvider';
 
 const localize = nls.loadMessageBundle();
 
@@ -100,7 +99,6 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 
 	private _onReady?: { promise: Promise<void>; resolve: () => void; reject: () => void; };
 	private _configuration: TypeScriptServiceConfiguration;
-	private versionProvider: TypeScriptVersionProvider;
 	private pluginPathsProvider: TypeScriptPluginPathsProvider;
 	private readonly _versionManager: TypeScriptVersionManager;
 
@@ -123,9 +121,11 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 
 	constructor(
 		private readonly workspaceState: vscode.Memento,
+		onCaseInsenitiveFileSystem: boolean,
 		public readonly pluginManager: PluginManager,
 		private readonly logDirectoryProvider: ILogDirectoryProvider,
 		private readonly cancellerFactory: OngoingRequestCancellerFactory,
+		private readonly versionProvider: ITypeScriptVersionProvider,
 		allModeIds: readonly string[]
 	) {
 		super();
@@ -143,17 +143,18 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		this.numberRestarts = 0;
 
 		this._configuration = TypeScriptServiceConfiguration.loadFromWorkspace();
-		this.versionProvider = new TypeScriptVersionProvider(this._configuration);
+		this.versionProvider.updateConfiguration(this._configuration);
+
 		this.pluginPathsProvider = new TypeScriptPluginPathsProvider(this._configuration);
 		this._versionManager = this._register(new TypeScriptVersionManager(this._configuration, this.versionProvider, this.workspaceState));
 		this._register(this._versionManager.onDidPickNewVersion(() => {
 			this.restartTsServer();
 		}));
 
-		this.bufferSyncSupport = new BufferSyncSupport(this, allModeIds, onCaseInsenitiveFileSystem());
+		this.bufferSyncSupport = new BufferSyncSupport(this, allModeIds, onCaseInsenitiveFileSystem);
 		this.onReady(() => { this.bufferSyncSupport.listen(); });
 
-		this.diagnosticsManager = new DiagnosticsManager('typescript', onCaseInsenitiveFileSystem());
+		this.diagnosticsManager = new DiagnosticsManager('typescript', onCaseInsenitiveFileSystem);
 		this.bufferSyncSupport.onDelete(resource => {
 			this.cancelInflightRequestsForResource(resource);
 			this.diagnosticsManager.delete(resource);
@@ -206,12 +207,19 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 	}
 
 	public get capabilities() {
+		if (isWeb()) {
+			return new ClientCapabilities(
+				ClientCapability.Syntax,
+				ClientCapability.EnhancedSyntax);
+		}
+
 		if (this.apiVersion.gte(API.v400)) {
 			return new ClientCapabilities(
 				ClientCapability.Syntax,
 				ClientCapability.EnhancedSyntax,
 				ClientCapability.Semantic);
 		}
+
 		return new ClientCapabilities(
 			ClientCapability.Syntax,
 			ClientCapability.Semantic);
@@ -345,12 +353,12 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		let version = this._versionManager.currentVersion;
 
 		this.info(`Using tsserver from: ${version.path}`);
-		if (!fs.existsSync(version.tsServerPath)) {
-			vscode.window.showWarningMessage(localize('noServerFound', 'The path {0} doesn\'t point to a valid tsserver install. Falling back to bundled TypeScript version.', version.path));
+		// if (!fs.existsSync(version.tsServerPath)) {
+		// 	vscode.window.showWarningMessage(localize('noServerFound', 'The path {0} doesn\'t point to a valid tsserver install. Falling back to bundled TypeScript version.', version.path));
 
-			this._versionManager.reset();
-			version = this._versionManager.currentVersion;
-		}
+		// 	this._versionManager.reset();
+		// 	version = this._versionManager.currentVersion;
+		// }
 
 		const apiVersion = version.apiVersion || API.defaultVersion;
 		let mytoken = ++this.token;
@@ -433,7 +441,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 
 		handle.onEvent(event => this.dispatchEvent(event));
 
-		if (apiVersion.gte(API.v300)) {
+		if (apiVersion.gte(API.v300) && this.capabilities.has(ClientCapability.Semantic)) {
 			this.loadingIndicator.startedLoadingProject(undefined /* projectName */);
 		}
 

--- a/extensions/typescript-language-features/src/utils/electron.ts
+++ b/extensions/typescript-language-features/src/utils/electron.ts
@@ -59,7 +59,7 @@ export interface ForkOptions {
 
 export function fork(
 	modulePath: string,
-	args: string[],
+	args: readonly string[],
 	options: ForkOptions,
 ): cp.ChildProcess {
 	const newEnv = generatePatchedEnv(process.env, modulePath);

--- a/extensions/typescript-language-features/src/utils/platform.ts
+++ b/extensions/typescript-language-features/src/utils/platform.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function isWeb(): boolean {
+	return typeof process !== 'undefined';
+}

--- a/extensions/typescript-language-features/src/utils/versionManager.ts
+++ b/extensions/typescript-language-features/src/utils/versionManager.ts
@@ -5,9 +5,9 @@
 
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { TypeScriptVersion, TypeScriptVersionProvider } from './versionProvider';
-import { Disposable } from './dispose';
 import { TypeScriptServiceConfiguration } from '../utils/configuration';
+import { Disposable } from './dispose';
+import { ITypeScriptVersionProvider, TypeScriptVersion } from './versionProvider';
 
 const localize = nls.loadMessageBundle();
 
@@ -24,7 +24,7 @@ export class TypeScriptVersionManager extends Disposable {
 
 	public constructor(
 		private configuration: TypeScriptServiceConfiguration,
-		private readonly versionProvider: TypeScriptVersionProvider,
+		private readonly versionProvider: ITypeScriptVersionProvider,
 		private readonly workspaceState: vscode.Memento
 	) {
 		super();

--- a/extensions/typescript-language-features/src/utils/versionProvider.electron.ts
+++ b/extensions/typescript-language-features/src/utils/versionProvider.electron.ts
@@ -1,0 +1,187 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import API from '../utils/api';
+import { TypeScriptServiceConfiguration } from './configuration';
+import { RelativeWorkspacePathResolver } from './relativePathResolver';
+import { ITypeScriptVersionProvider, localize, TypeScriptVersion, TypeScriptVersionSource } from './versionProvider';
+
+export class DiskTypeScriptVersionProvider implements ITypeScriptVersionProvider {
+
+	public constructor(
+		private configuration?: TypeScriptServiceConfiguration
+	) { }
+
+
+	public updateConfiguration(configuration: TypeScriptServiceConfiguration): void {
+		this.configuration = configuration;
+	}
+
+	public get defaultVersion(): TypeScriptVersion {
+		return this.globalVersion || this.bundledVersion;
+	}
+
+	public get globalVersion(): TypeScriptVersion | undefined {
+		if (this.configuration?.globalTsdk) {
+			const globals = this.loadVersionsFromSetting(TypeScriptVersionSource.UserSetting, this.configuration.globalTsdk);
+			if (globals && globals.length) {
+				return globals[0];
+			}
+		}
+		return this.contributedTsNextVersion;
+	}
+
+	public get localVersion(): TypeScriptVersion | undefined {
+		const tsdkVersions = this.localTsdkVersions;
+		if (tsdkVersions && tsdkVersions.length) {
+			return tsdkVersions[0];
+		}
+
+		const nodeVersions = this.localNodeModulesVersions;
+		if (nodeVersions && nodeVersions.length === 1) {
+			return nodeVersions[0];
+		}
+		return undefined;
+	}
+
+
+	public get localVersions(): TypeScriptVersion[] {
+		const allVersions = this.localTsdkVersions.concat(this.localNodeModulesVersions);
+		const paths = new Set<string>();
+		return allVersions.filter(x => {
+			if (paths.has(x.path)) {
+				return false;
+			}
+			paths.add(x.path);
+			return true;
+		});
+	}
+
+	public get bundledVersion(): TypeScriptVersion {
+		const version = this.getContributedVersion(TypeScriptVersionSource.Bundled, 'vscode.typescript-language-features', ['..', 'node_modules']);
+		if (version) {
+			return version;
+		}
+
+		vscode.window.showErrorMessage(localize(
+			'noBundledServerFound',
+			'VS Code\'s tsserver was deleted by another application such as a misbehaving virus detection tool. Please reinstall VS Code.'));
+		throw new Error('Could not find bundled tsserver.js');
+	}
+
+	private get contributedTsNextVersion(): TypeScriptVersion | undefined {
+		return this.getContributedVersion(TypeScriptVersionSource.TsNightlyExtension, 'ms-vscode.vscode-typescript-next', ['node_modules']);
+	}
+
+	private getContributedVersion(source: TypeScriptVersionSource, extensionId: string, pathToTs: readonly string[]): TypeScriptVersion | undefined {
+		try {
+			const extension = vscode.extensions.getExtension(extensionId);
+			if (extension) {
+				const typescriptPath = path.join(extension.extensionPath, ...pathToTs, 'typescript', 'lib');
+				const bundledVersion = new TypeScriptVersion(source, typescriptPath, DiskTypeScriptVersionProvider.getApiVersion(typescriptPath), '');
+				if (bundledVersion.isValid) {
+					return bundledVersion;
+				}
+			}
+		} catch {
+			// noop
+		}
+		return undefined;
+	}
+
+	private get localTsdkVersions(): TypeScriptVersion[] {
+		const localTsdk = this.configuration?.localTsdk;
+		return localTsdk ? this.loadVersionsFromSetting(TypeScriptVersionSource.WorkspaceSetting, localTsdk) : [];
+	}
+
+	private loadVersionsFromSetting(source: TypeScriptVersionSource, tsdkPathSetting: string): TypeScriptVersion[] {
+		if (path.isAbsolute(tsdkPathSetting)) {
+			return [new TypeScriptVersion(source, tsdkPathSetting, DiskTypeScriptVersionProvider.getApiVersion(tsdkPathSetting))];
+		}
+
+		const workspacePath = RelativeWorkspacePathResolver.asAbsoluteWorkspacePath(tsdkPathSetting);
+		if (workspacePath !== undefined) {
+			return [new TypeScriptVersion(source, workspacePath, DiskTypeScriptVersionProvider.getApiVersion(tsdkPathSetting), tsdkPathSetting)];
+		}
+
+		return this.loadTypeScriptVersionsFromPath(source, tsdkPathSetting);
+	}
+
+	private get localNodeModulesVersions(): TypeScriptVersion[] {
+		return this.loadTypeScriptVersionsFromPath(TypeScriptVersionSource.NodeModules, path.join('node_modules', 'typescript', 'lib'))
+			.filter(x => x.isValid);
+	}
+
+	private loadTypeScriptVersionsFromPath(source: TypeScriptVersionSource, relativePath: string): TypeScriptVersion[] {
+		if (!vscode.workspace.workspaceFolders) {
+			return [];
+		}
+
+		const versions: TypeScriptVersion[] = [];
+		for (const root of vscode.workspace.workspaceFolders) {
+			let label: string = relativePath;
+			if (vscode.workspace.workspaceFolders.length > 1) {
+				label = path.join(root.name, relativePath);
+			}
+
+			const serverPath = path.join(root.uri.fsPath, relativePath);
+			versions.push(new TypeScriptVersion(source, serverPath, DiskTypeScriptVersionProvider.getApiVersion(serverPath), label));
+		}
+		return versions;
+	}
+
+	private static getApiVersion(serverPath: string): API | undefined {
+		const version = DiskTypeScriptVersionProvider.getTypeScriptVersion(serverPath);
+		if (version) {
+			return version;
+		}
+
+		// Allow TS developers to provide custom version
+		const tsdkVersion = vscode.workspace.getConfiguration().get<string | undefined>('typescript.tsdk_version', undefined);
+		if (tsdkVersion) {
+			return API.fromVersionString(tsdkVersion);
+		}
+
+		return undefined;
+	}
+
+	private static getTypeScriptVersion(serverPath: string): API | undefined {
+		if (!fs.existsSync(serverPath)) {
+			return undefined;
+		}
+
+		const p = serverPath.split(path.sep);
+		if (p.length <= 2) {
+			return undefined;
+		}
+		const p2 = p.slice(0, -2);
+		const modulePath = p2.join(path.sep);
+		let fileName = path.join(modulePath, 'package.json');
+		if (!fs.existsSync(fileName)) {
+			// Special case for ts dev versions
+			if (path.basename(modulePath) === 'built') {
+				fileName = path.join(modulePath, '..', 'package.json');
+			}
+		}
+		if (!fs.existsSync(fileName)) {
+			return undefined;
+		}
+
+		const contents = fs.readFileSync(fileName).toString();
+		let desc: any = null;
+		try {
+			desc = JSON.parse(contents);
+		} catch (err) {
+			return undefined;
+		}
+		if (!desc || !desc.version) {
+			return undefined;
+		}
+		return desc.version ? API.fromVersionString(desc.version) : undefined;
+	}
+}

--- a/extensions/typescript-language-features/src/utils/versionProvider.electron.ts
+++ b/extensions/typescript-language-features/src/utils/versionProvider.electron.ts
@@ -83,7 +83,7 @@ export class DiskTypeScriptVersionProvider implements ITypeScriptVersionProvider
 			const extension = vscode.extensions.getExtension(extensionId);
 			if (extension) {
 				const typescriptPath = path.join(extension.extensionPath, ...pathToTs, 'typescript', 'lib');
-				const bundledVersion = new TypeScriptVersion(source, typescriptPath, DiskTypeScriptVersionProvider.getApiVersion(typescriptPath), '');
+				const bundledVersion = new TypeScriptVersion(source, path.join(typescriptPath, 'tsserver.js'), DiskTypeScriptVersionProvider.getApiVersion(typescriptPath), '');
 				if (bundledVersion.isValid) {
 					return bundledVersion;
 				}
@@ -101,12 +101,21 @@ export class DiskTypeScriptVersionProvider implements ITypeScriptVersionProvider
 
 	private loadVersionsFromSetting(source: TypeScriptVersionSource, tsdkPathSetting: string): TypeScriptVersion[] {
 		if (path.isAbsolute(tsdkPathSetting)) {
-			return [new TypeScriptVersion(source, tsdkPathSetting, DiskTypeScriptVersionProvider.getApiVersion(tsdkPathSetting))];
+			return [
+				new TypeScriptVersion(source,
+					path.join(tsdkPathSetting, 'tsserver.js'),
+					DiskTypeScriptVersionProvider.getApiVersion(tsdkPathSetting))
+			];
 		}
 
 		const workspacePath = RelativeWorkspacePathResolver.asAbsoluteWorkspacePath(tsdkPathSetting);
 		if (workspacePath !== undefined) {
-			return [new TypeScriptVersion(source, workspacePath, DiskTypeScriptVersionProvider.getApiVersion(tsdkPathSetting), tsdkPathSetting)];
+			return [
+				new TypeScriptVersion(source,
+					path.join(workspacePath, 'tsserver.js'),
+					DiskTypeScriptVersionProvider.getApiVersion(tsdkPathSetting),
+					tsdkPathSetting)
+			];
 		}
 
 		return this.loadTypeScriptVersionsFromPath(source, tsdkPathSetting);
@@ -130,7 +139,7 @@ export class DiskTypeScriptVersionProvider implements ITypeScriptVersionProvider
 			}
 
 			const serverPath = path.join(root.uri.fsPath, relativePath);
-			versions.push(new TypeScriptVersion(source, serverPath, DiskTypeScriptVersionProvider.getApiVersion(serverPath), label));
+			versions.push(new TypeScriptVersion(source, path.join(serverPath, 'tsserver.js'), DiskTypeScriptVersionProvider.getApiVersion(serverPath), label));
 		}
 		return versions;
 	}

--- a/extensions/typescript-language-features/src/utils/versionProvider.ts
+++ b/extensions/typescript-language-features/src/utils/versionProvider.ts
@@ -4,15 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
-import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import API from './api';
 import { TypeScriptServiceConfiguration } from './configuration';
-import { RelativeWorkspacePathResolver } from './relativePathResolver';
 
-const localize = nls.loadMessageBundle();
+export const localize = nls.loadMessageBundle();
 
-const enum TypeScriptVersionSource {
+export const enum TypeScriptVersionSource {
 	Bundled = 'bundled',
 	TsNightlyExtension = 'ts-nightly-extension',
 	NodeModules = 'node-modules',
@@ -22,16 +20,12 @@ const enum TypeScriptVersionSource {
 
 export class TypeScriptVersion {
 
-	public readonly apiVersion: API | undefined;
-
 	constructor(
 		public readonly source: TypeScriptVersionSource,
 		public readonly path: string,
+		public readonly apiVersion: API | undefined,
 		private readonly _pathLabel?: string,
-		apiVersion?: API,
-	) {
-		this.apiVersion = apiVersion ?? TypeScriptVersion.getApiVersion(this.tsServerPath);
-	}
+	) { }
 
 	public get tsServerPath(): string {
 		return path.join(this.path, 'tsserver.js');
@@ -64,59 +58,6 @@ export class TypeScriptVersion {
 		return version ? version.displayName : localize(
 			'couldNotLoadTsVersion', 'Could not load the TypeScript version at this path');
 	}
-
-	private static getApiVersion(serverPath: string): API | undefined {
-		const version = TypeScriptVersion.getTypeScriptVersion(serverPath);
-		if (version) {
-			return version;
-		}
-
-		// Allow TS developers to provide custom version
-		const tsdkVersion = vscode.workspace.getConfiguration().get<string | undefined>('typescript.tsdk_version', undefined);
-		if (tsdkVersion) {
-			return API.fromVersionString(tsdkVersion);
-		}
-
-		return undefined;
-	}
-
-	private static getTypeScriptVersion(_serverPath: string): API | undefined {
-		return API.v400;
-		/*const fs = require('fs');
-
-		if (!fs.existsSync(serverPath)) {
-			return undefined;
-		}
-
-		const p = serverPath.split(path.sep);
-		if (p.length <= 2) {
-			return undefined;
-		}
-		const p2 = p.slice(0, -2);
-		const modulePath = p2.join(path.sep);
-		let fileName = path.join(modulePath, 'package.json');
-		if (!fs.existsSync(fileName)) {
-			// Special case for ts dev versions
-			if (path.basename(modulePath) === 'built') {
-				fileName = path.join(modulePath, '..', 'package.json');
-			}
-		}
-		if (!fs.existsSync(fileName)) {
-			return undefined;
-		}
-
-		const contents = fs.readFileSync(fileName).toString();
-		let desc: any = null;
-		try {
-			desc = JSON.parse(contents);
-		} catch (err) {
-			return undefined;
-		}
-		if (!desc || !desc.version) {
-			return undefined;
-		}
-		return desc.version ? API.fromVersionString(desc.version) : undefined;*/
-	}
 }
 
 export interface ITypeScriptVersionProvider {
@@ -127,126 +68,4 @@ export interface ITypeScriptVersionProvider {
 	readonly localVersion: TypeScriptVersion | undefined;
 	readonly localVersions: readonly TypeScriptVersion[];
 	readonly bundledVersion: TypeScriptVersion;
-}
-
-export class TypeScriptVersionProvider implements ITypeScriptVersionProvider {
-
-	public constructor(
-		private configuration?: TypeScriptServiceConfiguration,
-	) { }
-
-	public updateConfiguration(configuration: TypeScriptServiceConfiguration): void {
-		this.configuration = configuration;
-	}
-
-	public get defaultVersion(): TypeScriptVersion {
-		return this.globalVersion || this.bundledVersion;
-	}
-
-	public get globalVersion(): TypeScriptVersion | undefined {
-		if (this.configuration?.globalTsdk) {
-			const globals = this.loadVersionsFromSetting(TypeScriptVersionSource.UserSetting, this.configuration.globalTsdk);
-			if (globals && globals.length) {
-				return globals[0];
-			}
-		}
-		return this.contributedTsNextVersion;
-	}
-
-	public get localVersion(): TypeScriptVersion | undefined {
-		const tsdkVersions = this.localTsdkVersions;
-		if (tsdkVersions && tsdkVersions.length) {
-			return tsdkVersions[0];
-		}
-
-		const nodeVersions = this.localNodeModulesVersions;
-		if (nodeVersions && nodeVersions.length === 1) {
-			return nodeVersions[0];
-		}
-		return undefined;
-	}
-
-	public get localVersions(): TypeScriptVersion[] {
-		const allVersions = this.localTsdkVersions.concat(this.localNodeModulesVersions);
-		const paths = new Set<string>();
-		return allVersions.filter(x => {
-			if (paths.has(x.path)) {
-				return false;
-			}
-			paths.add(x.path);
-			return true;
-		});
-	}
-
-	public get bundledVersion(): TypeScriptVersion {
-		const version = this.getContributedVersion(TypeScriptVersionSource.Bundled, 'vscode.typescript-language-features', ['..', 'node_modules']);
-		if (version) {
-			return version;
-		}
-
-		vscode.window.showErrorMessage(localize(
-			'noBundledServerFound',
-			'VS Code\'s tsserver was deleted by another application such as a misbehaving virus detection tool. Please reinstall VS Code.'));
-		throw new Error('Could not find bundled tsserver.js');
-	}
-
-	private get contributedTsNextVersion(): TypeScriptVersion | undefined {
-		return this.getContributedVersion(TypeScriptVersionSource.TsNightlyExtension, 'ms-vscode.vscode-typescript-next', ['node_modules']);
-	}
-
-	private getContributedVersion(source: TypeScriptVersionSource, extensionId: string, pathToTs: readonly string[]): TypeScriptVersion | undefined {
-		try {
-			const extension = vscode.extensions.getExtension(extensionId);
-			if (extension) {
-				const typescriptPath = path.join(extension.extensionPath, ...pathToTs, 'typescript', 'lib');
-				const bundledVersion = new TypeScriptVersion(source, typescriptPath, '');
-				if (bundledVersion.isValid) {
-					return bundledVersion;
-				}
-			}
-		} catch {
-			// noop
-		}
-		return undefined;
-	}
-
-	private get localTsdkVersions(): TypeScriptVersion[] {
-		const localTsdk = this.configuration?.localTsdk;
-		return localTsdk ? this.loadVersionsFromSetting(TypeScriptVersionSource.WorkspaceSetting, localTsdk) : [];
-	}
-
-	private loadVersionsFromSetting(source: TypeScriptVersionSource, tsdkPathSetting: string): TypeScriptVersion[] {
-		if (path.isAbsolute(tsdkPathSetting)) {
-			return [new TypeScriptVersion(source, tsdkPathSetting)];
-		}
-
-		const workspacePath = RelativeWorkspacePathResolver.asAbsoluteWorkspacePath(tsdkPathSetting);
-		if (workspacePath !== undefined) {
-			return [new TypeScriptVersion(source, workspacePath, tsdkPathSetting)];
-		}
-
-		return this.loadTypeScriptVersionsFromPath(source, tsdkPathSetting);
-	}
-
-	private get localNodeModulesVersions(): TypeScriptVersion[] {
-		return this.loadTypeScriptVersionsFromPath(TypeScriptVersionSource.NodeModules, path.join('node_modules', 'typescript', 'lib'))
-			.filter(x => x.isValid);
-	}
-
-	private loadTypeScriptVersionsFromPath(source: TypeScriptVersionSource, relativePath: string): TypeScriptVersion[] {
-		if (!vscode.workspace.workspaceFolders) {
-			return [];
-		}
-
-		const versions: TypeScriptVersion[] = [];
-		for (const root of vscode.workspace.workspaceFolders) {
-			let label: string = relativePath;
-			if (vscode.workspace.workspaceFolders.length > 1) {
-				label = path.join(root.name, relativePath);
-			}
-
-			versions.push(new TypeScriptVersion(source, path.join(root.uri.fsPath, relativePath), label));
-		}
-		return versions;
-	}
 }

--- a/extensions/typescript-language-features/src/utils/versionProvider.ts
+++ b/extensions/typescript-language-features/src/utils/versionProvider.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import * as nls from 'vscode-nls';
 import API from './api';
 import { TypeScriptServiceConfiguration } from './configuration';
@@ -28,7 +27,7 @@ export class TypeScriptVersion {
 	) { }
 
 	public get tsServerPath(): string {
-		return path.join(this.path, 'tsserver.js');
+		return this.path;
 	}
 
 	public get pathLabel(): string {

--- a/extensions/typescript-language-features/yarn.lock
+++ b/extensions/typescript-language-features/yarn.lock
@@ -2,6 +2,34 @@
 # yarn lockfile v1
 
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
+    fastq "^1.6.0"
+
+"@npmcli/move-file@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.0.1.tgz#de103070dac0f48ce49cf6693c23af59c0f70464"
+  integrity sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==
+  dependencies:
+    mkdirp "^1.0.4"
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -15,6 +43,11 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/json-schema@^7.0.4":
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
+  integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -51,6 +84,29 @@ agent-base@4, agent-base@^4.3.0:
   dependencies:
     es6-promisify "^5.0.0"
 
+aggregate-error@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
+  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
+
+ajv-keywords@^3.4.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.1.tgz#b83ca89c5d42d69031f424cad49aada0236c6957"
+  integrity sha512-KWcq3xN8fDjSB+IMoh2VaXVhRI0BBGxoYp3rx7Pkb6z0cFjYR9Q9l4yZqqals0/zsioCmocC5H6UvsGD4MoIBA==
+
+ajv@^6.12.2:
+  version "6.12.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
+  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 ajv@^6.5.5:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
@@ -69,6 +125,11 @@ applicationinsights@1.0.8:
     diagnostic-channel "0.2.0"
     diagnostic-channel-publishers "0.2.1"
     zone.js "0.7.6"
+
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 asn1@~0.2.3:
   version "0.2.4"
@@ -109,6 +170,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -116,6 +182,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+braces@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -127,10 +200,43 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+cacache@^15.0.4:
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.0.5.tgz#69162833da29170d6732334643c60e005f5f17d0"
+  integrity sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==
+  dependencies:
+    "@npmcli/move-file" "^1.0.1"
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    glob "^7.1.4"
+    infer-owner "^1.0.4"
+    lru-cache "^6.0.0"
+    minipass "^3.1.1"
+    minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.2"
+    mkdirp "^1.0.3"
+    p-map "^4.0.0"
+    promise-inflight "^1.0.1"
+    rimraf "^3.0.2"
+    ssri "^8.0.0"
+    tar "^6.0.2"
+    unique-filename "^1.1.1"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -144,10 +250,32 @@ commander@2.15.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+copy-webpack-plugin@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-6.0.3.tgz#2b3d2bfc6861b96432a65f0149720adbd902040b"
+  integrity sha512-q5m6Vz4elsuyVEIUXr7wJdIdePWTubsqVbEMvf1WQnHGv0Q+9yPRu7MtYFPt+GBOXRav9lvIINifTQ1vSCs+eA==
+  dependencies:
+    cacache "^15.0.4"
+    fast-glob "^3.2.4"
+    find-cache-dir "^3.3.1"
+    glob-parent "^5.1.1"
+    globby "^11.0.1"
+    loader-utils "^2.0.0"
+    normalize-path "^3.0.0"
+    p-limit "^3.0.1"
+    schema-utils "^2.7.0"
+    serialize-javascript "^4.0.0"
+    webpack-sources "^1.4.3"
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -197,6 +325,13 @@ diff@3.5.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -204,6 +339,11 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+emojis-list@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
 es6-promise@^4.0.3:
   version "4.2.8"
@@ -242,10 +382,58 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-glob@^3.1.1, fast-glob@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
+  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM= sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+
+fastq@^1.6.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
+  integrity sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==
+  dependencies:
+    reusify "^1.0.4"
+
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+find-cache-dir@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
+  integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
+
+find-up@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -261,6 +449,13 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -272,6 +467,13 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+glob-parent@^5.1.0, glob-parent@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob@7.1.2:
   version "7.1.2"
@@ -285,7 +487,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.2, glob@^7.1.3:
+glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -296,6 +498,18 @@ glob@^7.1.2, glob@^7.1.3:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+globby@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
+  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
 
 growl@1.10.5:
   version "1.10.5"
@@ -350,6 +564,26 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
+ignore@^5.1.4:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+infer-owner@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
+  integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -362,6 +596,23 @@ inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
+is-glob@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -393,6 +644,13 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json5@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
+  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
+
 jsonc-parser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.2.1.tgz#db73cd59d78cce28723199466b2a03d1be1df2bc"
@@ -407,6 +665,49 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+loader-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
+  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
+make-dir@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
+
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 mime-db@1.43.0:
   version "1.43.0"
@@ -432,12 +733,58 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minipass-collect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-1.0.2.tgz#22b813bf745dc6edba2576b940022ad6edc8c617"
+  integrity sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-flush@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
+  integrity sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-pipeline@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.3.tgz#55f7839307d74859d6e8ada9c3ebe72cec216a34"
+  integrity sha512-cFOknTvng5vqnwOpDsZTWhNll6Jf8o2x+/diplafmxpuIymAjzoOolZG0VvQf3V2HgqzJNhnuKHYp2BqDgz8IQ==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass@^3.0.0, minipass@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
+  integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.0.tgz#fd52c645301ef09a63a2c209697c294c6ce02cf3"
+  integrity sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mkdirp@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^1.0.3, mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^5.2.0:
   version "5.2.0"
@@ -466,6 +813,11 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -478,15 +830,75 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+p-limit@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
+p-limit@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
+  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
+  dependencies:
+    p-try "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
+
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picomatch@^2.0.5, picomatch@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+pkg-dir@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
+promise-inflight@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
+  integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
 psl@^1.1.24:
   version "1.7.0"
@@ -512,6 +924,13 @@ querystringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
+randombytes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
 
 request@^2.88.0:
   version "2.88.0"
@@ -544,6 +963,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -551,15 +975,41 @@ rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
+safe-buffer@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+schema-utils@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
+  integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
+  dependencies:
+    "@types/json-schema" "^7.0.4"
+    ajv "^6.12.2"
+    ajv-keywords "^3.4.1"
 
 semver@5.5.1:
   version "5.5.1"
@@ -571,6 +1021,28 @@ semver@^5.3.0, semver@^5.4.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
+semver@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+serialize-javascript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+source-list-map@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
+  integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
 source-map-support@^0.5.0:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
@@ -579,7 +1051,7 @@ source-map-support@^0.5.0:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0:
+source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -599,12 +1071,38 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+ssri@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.0.tgz#79ca74e21f8ceaeddfcb4b90143c458b8d988808"
+  integrity sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==
+  dependencies:
+    minipass "^3.1.1"
+
 supports-color@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   integrity sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==
   dependencies:
     has-flag "^3.0.0"
+
+tar@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.2.tgz#5df17813468a6264ff14f766886c622b84ae2f39"
+  integrity sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.0"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
 
 tough-cookie@~2.4.3:
   version "2.4.3"
@@ -630,6 +1128,24 @@ typescript-vscode-sh-plugin@^0.6.14:
   version "0.6.14"
   resolved "https://registry.yarnpkg.com/typescript-vscode-sh-plugin/-/typescript-vscode-sh-plugin-0.6.14.tgz#a81031b502f6346a26ea49ce082438c3e353bb38"
   integrity sha512-AkNlRBbI6K7gk29O92qthNSvc6jjmNQ6isVXoYxkFwPa8D04tIv2SOPd+sd+mNpso4tNdL2gy7nVtrd5yFqvlA==
+
+"typescript-web-server@git://github.com/mjbvz/ts-server-web-build":
+  version "0.0.0"
+  resolved "git://github.com/mjbvz/ts-server-web-build#6018bbd0049444cccee29c57ddabf394564fbf35"
+
+unique-filename@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
+  integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
+  dependencies:
+    unique-slug "^2.0.0"
+
+unique-slug@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c"
+  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
+  dependencies:
+    imurmurhash "^0.1.4"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -693,10 +1209,23 @@ vscode@^1.1.36:
     url-parse "^1.4.4"
     vscode-test "^0.4.1"
 
+webpack-sources@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
+  integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
+  dependencies:
+    source-list-map "^2.0.0"
+    source-map "~0.6.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 zone.js@0.7.6:
   version "0.7.6"


### PR DESCRIPTION
This enables running the TS Server on web. This currently requires a special version of the TypeScript server (microsoft/TypeScript#39656)

TODO:

- [x] Fix commented code in `versionProvider` and `spawner` and `typescriptServiceClient`(they import `fs`)
- [ ] Sync with TS team about how tsserver work will be shipped