### PR TITLE
Treat all files with `npmrc`/`npmignore`/`gitignore` extensions as properties/ignore files

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1801,7 +1801,7 @@
           "Ignore",
           "ignore"
         ],
-        "filenames": [
+        "extensions": [
           ".gitignore_global",
           ".gitignore"
         ],

--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -40,13 +40,13 @@
     "languages": [
       {
         "id": "ignore",
-        "filenames": [
+        "extensions": [
           ".npmignore"
         ]
       },
       {
         "id": "properties",
-        "filenames": [
+        "extensions": [
           ".npmrc"
         ]
       }


### PR DESCRIPTION
This PR fixes #103042

**How to test:**
Create and open files named `server.gitignore`, `server.npmignore`, `john.npmrc`
The language mode for them should be set to `Ignore`, `Ignore`, and `Properties` accordingly.