### PR TITLE
[typescript-language-features] Add telemetry for package.json auto imports

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/completions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/completions.ts
@@ -338,7 +338,7 @@ class CompletionAcceptedCommand implements Command {
 		if (item instanceof MyCompletionItem) {
 			/* __GDPR__
 				"completions.accept" : {
-					"isPackageJsonImport" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
+					"isPackageJsonImport" : { "classification": "SystemMetadata", "purpose": "FeatureInsight" },
 					"${include}": [
 						"${TypeScriptCommonProperties}"
 					]
@@ -557,11 +557,11 @@ class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider<
 	) {
 		/* __GDPR__
 			"completions.execute" : {
-				"duration" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
-				"type" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
-				"count" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
-				"updateGraphDurationMs" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
-				"includesPackageJsonImport" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
+				"duration" : { "classification": "SystemMetadata", "purpose": "FeatureInsight" },
+				"type" : { "classification": "SystemMetadata", "purpose": "FeatureInsight" },
+				"count" : { "classification": "SystemMetadata", "purpose": "FeatureInsight" },
+				"updateGraphDurationMs" : { "classification": "SystemMetadata", "purpose": "FeatureInsight" },
+				"includesPackageJsonImport" : { "classification": "SystemMetadata", "purpose": "FeatureInsight" },
 				"${include}": [
 					"${TypeScriptCommonProperties}"
 				]

--- a/extensions/typescript-language-features/src/languageFeatures/completions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/completions.ts
@@ -330,10 +330,25 @@ class CompletionAcceptedCommand implements Command {
 
 	public constructor(
 		private readonly onCompletionAccepted: (item: vscode.CompletionItem) => void,
+		private readonly telemetryReporter: TelemetryReporter,
 	) { }
 
 	public execute(item: vscode.CompletionItem) {
 		this.onCompletionAccepted(item);
+		if (item instanceof MyCompletionItem) {
+			/* __GDPR__
+				"completions.accept" : {
+					"isPackageJsonImport" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
+					"${include}": [
+						"${TypeScriptCommonProperties}"
+					]
+				}
+			*/
+			this.telemetryReporter.logTelemetry('completions.accept', {
+				// @ts-expect-error - remove after TS 4.0 protocol update
+				isPackageJsonImport: !!item.tsEntry.isPackageJsonImport,
+			});
+		}
 	}
 }
 
@@ -422,7 +437,7 @@ class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider<
 	) {
 		commandManager.register(new ApplyCompletionCodeActionCommand(this.client));
 		commandManager.register(new CompositeCommand());
-		commandManager.register(new CompletionAcceptedCommand(onCompletionAccepted));
+		commandManager.register(new CompletionAcceptedCommand(onCompletionAccepted, this.telemetryReporter));
 	}
 
 	public async provideCompletionItems(
@@ -471,34 +486,18 @@ class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider<
 		let dotAccessorContext: DotAccessorContext | undefined;
 		let entries: ReadonlyArray<Proto.CompletionEntry>;
 		let metadata: any | undefined;
+		let response: ServerResponse.Response<Proto.CompletionInfoResponse> | undefined;
+		let duration: number | undefined;
 		if (this.client.apiVersion.gte(API.v300)) {
 			const startTime = Date.now();
-			let response: ServerResponse.Response<Proto.CompletionInfoResponse> | undefined;
 			try {
 				response = await this.client.interruptGetErr(() => this.client.execute('completionInfo', args, token));
 			} finally {
-				const duration: number = Date.now() - startTime;
-
-				/* __GDPR__
-					"completions.execute" : {
-						"duration" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
-						"type" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
-						"count" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
-						"updateGraphDurationMs" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
-						"${include}": [
-							"${TypeScriptCommonProperties}"
-						]
-					}
-				*/
-				this.telemetryReporter.logTelemetry('completions.execute', {
-					duration: duration,
-					type: response?.type ?? 'unknown',
-					count: response?.type === 'response' && response.body ? response.body.entries.length : 0,
-					updateGraphDurationMs: response?.type === 'response' ? response.performanceData?.updateGraphDurationMs : undefined,
-				});
+				duration = Date.now() - startTime;
 			}
 
 			if (response.type !== 'response' || !response.body) {
+				this.logCompletionsTelemetry(duration, response);
 				return null;
 			}
 			isNewIdentifierLocation = response.body.isNewIdentifierLocation;
@@ -536,13 +535,45 @@ class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider<
 			useFuzzyWordRangeLogic: this.client.apiVersion.lt(API.v390),
 		};
 
+		let includesPackageJsonImport = false;
 		const items: MyCompletionItem[] = [];
 		for (let entry of entries) {
 			if (!shouldExcludeCompletionEntry(entry, completionConfiguration)) {
 				items.push(new MyCompletionItem(position, document, entry, completionContext, metadata));
+				// @ts-expect-error - remove after TS 4.0 protocol update
+				includesPackageJsonImport = !!entry.isPackageJsonImport;
 			}
 		}
+		if (duration !== undefined) {
+			this.logCompletionsTelemetry(duration, response, includesPackageJsonImport);
+		}
 		return new vscode.CompletionList(items, isIncomplete);
+	}
+
+	private logCompletionsTelemetry(
+		duration: number,
+		response: ServerResponse.Response<Proto.CompletionInfoResponse> | undefined,
+		includesPackageJsonImport?: boolean
+	) {
+		/* __GDPR__
+			"completions.execute" : {
+				"duration" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
+				"type" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
+				"count" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
+				"updateGraphDurationMs" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
+				"includesPackageJsonImport" : { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
+				"${include}": [
+					"${TypeScriptCommonProperties}"
+				]
+			}
+		*/
+		this.telemetryReporter.logTelemetry('completions.execute', {
+			duration: duration,
+			type: response?.type ?? 'unknown',
+			count: response?.type === 'response' && response.body ? response.body.entries.length : 0,
+			updateGraphDurationMs: response?.type === 'response' ? response.performanceData?.updateGraphDurationMs : undefined,
+			includesPackageJsonImport: includesPackageJsonImport ? 'true' : undefined,
+		});
 	}
 
 	private getTsTriggerCharacter(context: vscode.CompletionContext): Proto.CompletionsTriggerCharacter | undefined {

--- a/extensions/typescript-language-features/src/languageFeatures/completions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/completions.ts
@@ -346,7 +346,7 @@ class CompletionAcceptedCommand implements Command {
 			*/
 			this.telemetryReporter.logTelemetry('completions.accept', {
 				// @ts-expect-error - remove after TS 4.0 protocol update
-				isPackageJsonImport: !!item.tsEntry.isPackageJsonImport,
+				isPackageJsonImport: item.tsEntry.isPackageJsonImport ? 'true' : undefined,
 			});
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Counterpart to https://github.com/microsoft/TypeScript/pull/38923 (and #103037)

This is my first time messing with VS Code telemetry so I have some questions and need a careful review.

With https://github.com/microsoft/TypeScript/pull/38923, we are potentially doing extra work to offer more auto-imports in completion items, so we want to validate that it’s worth it. So, this PR adds a property to the existing `completions.execute` event that says whether any of these extra items are included in the response, and adds a new event, `completions.accept`, fired upon accepting a completion item, that includes a property that says whether the accepted item was one of these extra auto-import completion items. Between these two events, we can determine how often the extra work was what the user wanted.