### PR TITLE
Add rnw and rnm to workspace tags

### DIFF
--- a/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
+++ b/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
@@ -46,6 +46,8 @@ const ModulesToLookFor = [
 	// JS frameworks
 	'react',
 	'react-native',
+	'react-native-macos',
+	'react-native-windows',
 	'rnpm-plugin-windows',
 	'@angular/core',
 	'@ionic',
@@ -243,6 +245,8 @@ export class WorkspaceTagsService implements IWorkspaceTagsService {
 			"workspace.npm.playwright-chromium" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.playwright-firefox" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.playwright-webkit" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.react-native-macos" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.react-native-windows" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.bower" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.yeoman.code.ext" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.cordova.high" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },


### PR DESCRIPTION
This adds the react-native-windows and react-native-macos to workspace tags.