### PR TITLE
Treat all files with `git{config,attributes,modules}`/`editorconfig` extensions as properties files

### DIFF
--- a/extensions/ini/package.json
+++ b/extensions/ini/package.json
@@ -18,8 +18,8 @@
 		},
 		{
 			"id": "properties",
-			"extensions": [ ".properties", ".cfg", ".conf", ".directory" ],
-			"filenames": [ ".gitattributes", ".gitconfig", "gitconfig", ".gitmodules", ".editorconfig" ],
+			"extensions": [ ".properties", ".cfg", ".conf", ".directory", ".gitattributes", ".gitconfig", ".gitmodules", ".editorconfig" ],
+			"filenames": [ "gitconfig" ],
 			"filenamePatterns": [ "**/.config/git/config", "**/.git/config" ],
 			"aliases": [ "Properties", "properties" ],
 			"configuration": "./properties.language-configuration.json"


### PR DESCRIPTION
This PR fixes #103042 (again), as I found more occurrences of the issue -
files with the extensions `.gitconfig`, `.gitattributes`, `.gitmodules`, `.editorconfig` are not being considered of type Properties,
unless they match that exact filename, with nothing before the dot.

**How to test:**
Create and open files named `john.gitconfig`, `server.gitattributes`, `client.gitmodules`, `windows.editorconfig`.
The language mode for them should be set to Properties.
