### PR TITLE
Running Extensions: sort slowest ⟶ fastest

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-browser/runtimeExtensionsEditor.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/runtimeExtensionsEditor.ts
@@ -233,11 +233,24 @@ export class RuntimeExtensionsEditor extends BaseEditor {
 		result = result.filter(element => element.status.activationTimes);
 
 		// bubble up extensions that have caused slowness
+
+		const isUnresponsive = (extension: IRuntimeExtension): boolean =>
+			extension.unresponsiveProfile === this._profileInfo;
+
+		const profileTime = (extension: IRuntimeExtension): number =>
+			extension.profileInfo?.totalTime ?? 0;
+
+		const activationTime = (extension: IRuntimeExtension): number =>
+			(extension.status.activationTimes?.codeLoadingTime ?? 0) +
+			(extension.status.activationTimes?.activateCallTime ?? 0);
+
 		result = result.sort((a, b) => {
-			if (a.unresponsiveProfile === this._profileInfo && !b.unresponsiveProfile) {
-				return -1;
-			} else if (!a.unresponsiveProfile && b.unresponsiveProfile === this._profileInfo) {
-				return 1;
+			if (isUnresponsive(a) || isUnresponsive(b)) {
+				return +isUnresponsive(b) - +isUnresponsive(a);
+			} else if (profileTime(a) || profileTime(b)) {
+				return profileTime(b) - profileTime(a);
+			} else if (activationTime(a) || activationTime(b)) {
+				return activationTime(b) - activationTime(a);
 			}
 			return a.originalIndex - b.originalIndex;
 		});


### PR DESCRIPTION
Before, the `> Developer: Show Running Extensions` page was sorted by:

1. whether or not they were unresponsive
2. name identifier

In Windows Task Manager, Mac System Monitor, and `top`, the default shows the **worst offenders**. But the running extensions view is sorted by **name identifier**. This makes it difficult to answer the question "what's slowing my system down?"

![image](https://user-images.githubusercontent.com/3344958/88467694-744b6f00-ce8e-11ea-828d-dbfae9bf3945.png)


Now, extensions are sorted by:

1. whether or not they were unresponsive
2. last profile time
3. activation time
4. name identifier

In practice this means the first time you open running extensions, it will be sorted by activation time:

![image](https://user-images.githubusercontent.com/3344958/88467460-46fdc180-ce8c-11ea-8b4d-25f20b0e8a63.png)

When you profile extensions, it will be sorted by profile time:

![image](https://user-images.githubusercontent.com/3344958/88467461-49601b80-ce8c-11ea-88ca-179bdfa53216.png)

I'm not sure if this is the absolute best way to do this - maybe users should be able to choose what to sort by - but it should make it a lot easier to find slow extensions quickly.
