### PR TITLE
Add filename patterns for jsconfig.json

### DIFF
--- a/extensions/typescript-basics/package.json
+++ b/extensions/typescript-basics/package.json
@@ -45,7 +45,9 @@
         ],
         "filenamePatterns": [
           "tsconfig.*.json",
-          "tsconfig-*.json"
+          "jsconfig.*.json",
+          "tsconfig-*.json",
+          "jsconfig-*.json"
         ]
       }
     ],


### PR DESCRIPTION
Add alternative filename patterns for `jsconfig.json` that will be recognized as JSONC when opened. This mirrors the accepted filename patterns for `tsconfig.json`.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #103240 
