### PR TITLE
fix: add missing property to deserializeRunnable

### DIFF
--- a/test/unit/electron/index.js
+++ b/test/unit/electron/index.js
@@ -59,7 +59,8 @@ function deserializeRunnable(runnable) {
 		async: runnable.async,
 		slow: () => runnable.slow,
 		speed: runnable.speed,
-		duration: runnable.duration
+		duration: runnable.duration,
+		currentRetry: () => runnable.currentRetry
 	};
 }
 


### PR DESCRIPTION
This PR fixes an issue present when running non-default Mocha reporters, including JSON. 

Non-default reporters expect to see a `test.currentRetry` function [when deserializing](https://github.com/mochajs/mocha/blob/master/lib/reporters/json.js#L92), and it was not added in `deserializeRunnable` which caused it to error with `test.currentRetry is not a function`.

Now, the following:

```sh
./scripts/test.sh --reporter=json "Unit Tests"
```

will produce the correct output in the expected JSON format.

cc @deepak1556 