### PR TITLE
Syntax highlighting for Dockerfile.*, Containerfile.*

### DIFF
--- a/extensions/docker/package.json
+++ b/extensions/docker/package.json
@@ -14,6 +14,7 @@
 			"id": "dockerfile",
 			"extensions": [ ".dockerfile", ".containerfile" ],
 			"filenames": [ "Dockerfile", "Containerfile" ],
+			"filenamePatterns": [ "Dockerfile.*", "Containerfile.*" ],
 			"aliases": [ "Dockerfile", "Containerfile" ],
 			"configuration": "./language-configuration.json"
 		}],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Allows syntax highlighting for `Dockerfile.*` and `Containerfile.*`.

This PR fixes https://github.com/microsoft/vscode/issues/102897

Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>
