### PR TITLE
Fixes command 'markdown.api.render' generates different html content for the same markdown string

### DIFF
--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -129,7 +129,6 @@ export class MarkdownEngine {
 		}
 
 		this.currentDocument = document.uri;
-		this._slugCount = new Map<string, number>();
 
 		const tokens = this.tokenizeString(document.getText(), engine);
 		this._tokenCache.update(document, config, tokens);
@@ -137,6 +136,8 @@ export class MarkdownEngine {
 	}
 
 	private tokenizeString(text: string, engine: MarkdownIt) {
+		this._slugCount = new Map<string, number>();
+
 		return engine.parse(text.replace(UNICODE_NEWLINE_REGEX, ''), {});
 	}
 
@@ -355,4 +356,3 @@ function normalizeHighlightLang(lang: string | undefined) {
 			return lang;
 	}
 }
-


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #103076
