### PR TITLE
Add an option to strip starting separators in formatted ${path} substitutions

### DIFF
--- a/src/vs/platform/label/common/label.ts
+++ b/src/vs/platform/label/common/label.ts
@@ -49,4 +49,5 @@ export interface ResourceLabelFormatting {
 	normalizeDriveLetter?: boolean;
 	workspaceSuffix?: string;
 	authorityPrefix?: string;
+	stripPathStartingSeparator?: boolean;
 }

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -258,6 +258,7 @@ declare module 'vscode' {
 		normalizeDriveLetter?: boolean;
 		workspaceSuffix?: string;
 		authorityPrefix?: string;
+		stripPathStartingSeparator?: boolean;
 	}
 
 	export namespace workspace {

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -51,6 +51,10 @@ const resourceLabelFormattersExtPoint = ExtensionsRegistry.registerExtensionPoin
 							type: 'string',
 							description: localize('vscode.extension.contributes.resourceLabelFormatters.separator', "Separator to be used in the uri label display. '/' or '\' as an example.")
 						},
+						stripPathStartingSeparator: {
+							type: 'boolean',
+							description: localize('vscode.extension.contributes.resourceLabelFormatters.stripPathStartingSeparator', "Controls whether `${path}` substitutions should have starting separator characters stripped.")
+						},
 						tildify: {
 							type: 'boolean',
 							description: localize('vscode.extension.contributes.resourceLabelFormatters.tildify', "Controls if the start of the uri label should be tildified when possible.")
@@ -244,7 +248,10 @@ export class LabelService extends Disposable implements ILabelService {
 			switch (token) {
 				case 'scheme': return resource.scheme;
 				case 'authority': return resource.authority;
-				case 'path': return resource.path;
+				case 'path':
+					return formatting.stripPathStartingSeparator
+						? resource.path.slice(resource.path[0] === formatting.separator ? 1 : 0)
+						: resource.path;
 				default: {
 					if (qsToken === 'query') {
 						const { query } = resource;

--- a/src/vs/workbench/services/label/test/browser/label.test.ts
+++ b/src/vs/workbench/services/label/test/browser/label.test.ts
@@ -226,6 +226,26 @@ suite('multi-root worksapce', () => {
 			const generated = labelService.getUriLabel(URI.file(path), { relative: true });
 			assert.equal(generated, label, path);
 		});
+	});
 
+	test('stripPathStartingSeparator', () => {
+		labelService.registerFormatter({
+			scheme: 'file',
+			formatting: {
+				label: '${path}',
+				separator: '/',
+				stripPathStartingSeparator: true
+			}
+		});
+
+		const tests = {
+			'folder1/src/file': 'Sources • file',
+			'other/blah': 'other/blah',
+		};
+
+		Object.entries(tests).forEach(([path, label]) => {
+			const generated = labelService.getUriLabel(URI.file(path), { relative: true });
+			assert.equal(generated, label, path);
+		});
 	});
 });


### PR DESCRIPTION
Helps with rendering paths consistently - if a FS provider can also provide search results, it needs to format their URIs in a way that the Search Editor can understand: `this/path` is `WorkspaceFolder/this/path` whereas `/this/path` is `/this/path`.

With this, that can be done with: 
```
			{
				"scheme": "codespace",
				"authority": "*",
				"formatting": {
					"label": "${path}",
					"separator": "/",
					"stripPathStartingSeparator": true
				}
			}
```

cc @eamodio @isidorn pushing this through to help with self hosting, lmk if you have concerns. 