### PR TITLE
Fix to address save defaults to .txt file

### DIFF
--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -462,7 +462,7 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 	}
 
 	suggestFilename(mode: string, untitledName: string) {
-		const extension = this.modeService.getExtensions(mode)[0];
+		const extension = this.modeService.getExtensions(this.modeService.getLanguageName(mode))[0];
 		if (extension) {
 			if (!untitledName.endsWith(extension)) {
 				return untitledName + extension;

--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -462,7 +462,8 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 	}
 
 	suggestFilename(mode: string, untitledName: string) {
-		const extension = this.modeService.getExtensions(this.modeService.getLanguageName(mode))[0];
+		const langName = this.modeService.getLanguageName(mode);
+		const extension = langName ? this.modeService.getExtensions(langName)[0] : undefined;
 		if (extension) {
 			if (!untitledName.endsWith(extension)) {
 				return untitledName + extension;


### PR DESCRIPTION
pass language not mode to get the extension.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Fix: getExtensions method expects language name but the textFileService is passing the mode. Get language by calling getLanguageName with.mode and then pass it in for getExtensions.

This PR fixes #103704 
