### PR TITLE
Add check to ensure TS 4.0-RC and forward use '--serverMode'.

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -18,6 +18,7 @@ import { ILogDirectoryProvider } from './logDirectoryProvider';
 import { GetErrRoutingTsServer, ITypeScriptServer, ProcessBasedTsServer, SyntaxRoutingTsServer, TsServerDelegate, TsServerProcessFactory, TsServerProcessKind } from './server';
 import { TypeScriptVersionManager } from './versionManager';
 import { ITypeScriptVersionProvider, TypeScriptVersion } from './versionProvider';
+import * as semver from 'semver';
 
 const enum CompositeServerType {
 	/** Run a single server that handles all commands  */
@@ -163,7 +164,13 @@ export class TypeScriptServerSpawner {
 		let tsServerLogFile: string | undefined;
 
 		if (kind === TsServerProcessKind.Syntax) {
-			args.push('--syntaxOnly');
+			if (semver.gte(API.v400rc.fullVersionString, apiVersion.fullVersionString)) {
+				args.push('--serverMode');
+				args.push('partialSemantic');
+			}
+			else {
+				args.push('--syntaxOnly');
+			}
 		}
 
 		if (apiVersion.gte(API.v250)) {

--- a/extensions/typescript-language-features/src/utils/api.ts
+++ b/extensions/typescript-language-features/src/utils/api.ts
@@ -34,6 +34,7 @@ export default class API {
 	public static readonly v380 = API.fromSimpleString('3.8.0');
 	public static readonly v381 = API.fromSimpleString('3.8.1');
 	public static readonly v390 = API.fromSimpleString('3.9.0');
+	public static readonly v400rc = API.fromSimpleString('4.0.0-rc');
 	public static readonly v400 = API.fromSimpleString('4.0.0');
 
 	public static fromVersionString(versionString: string): API {


### PR DESCRIPTION
The semver thing is temporary. I think that in the future, you should be able to just make it 4.0.0 and use `gte`.

Also, haven't been able to test it out, I did the work in a codespace.

CC @mjbvz 