### PR TITLE
Silently ignore the screen size is bogus error in the Process Explorer

### DIFF
--- a/src/vs/base/node/ps.ts
+++ b/src/vs/base/node/ps.ts
@@ -219,7 +219,8 @@ export function listProcesses(rootPid: number): Promise<ProcessItem> {
 
 					// Set numeric locale to ensure '.' is used as the decimal separator
 					exec(`${ps} ${args}`, { maxBuffer: 1000 * 1024, env: { LC_NUMERIC: 'en_US.UTF-8' } }, (err, stdout, stderr) => {
-						if (err || stderr) {
+						// Silently ignoring the screen size is bogus error. See https://github.com/microsoft/vscode/issues/98590
+						if (err || (stderr && !stderr.includes('screen size is bogus'))) {
 							reject(err || new Error(stderr.toString()));
 						} else {
 							parsePsOutput(stdout, addToTree);


### PR DESCRIPTION
Fixes #98590

### What

This pr just ignores the "screen size is bogus" error.

<img
  alt="flex tape meme for silently ignoring screen size is bogus"
  src="https://user-images.githubusercontent.com/8235156/89695624-b939c180-d8e2-11ea-91dd-8e60e1bd8ef0.jpg"
  height="300px"
/>

We can try `spawn` instead of `exec`, which does not create a subshell.