### PR TITLE
Fixes settings editor scrolls slowly when `workbench.list.smoothScrolling` enabled

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -892,7 +892,9 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 			this.render(previousRenderRange, e.scrollTop, e.height, e.scrollLeft, e.scrollWidth);
 
 			if (this.supportDynamicHeights) {
-				this._rerender(e.scrollTop, e.height);
+				// Don't update scrollTop from within an scroll event
+				// so we don't break smooth scrolling. #104144
+				this._rerender(e.scrollTop, e.height, false);
 			}
 		} catch (err) {
 			console.error('Got bad scroll event:', e);
@@ -1162,7 +1164,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 	 * Given a stable rendered state, checks every rendered element whether it needs
 	 * to be probed for dynamic height. Adjusts scroll height and top if necessary.
 	 */
-	private _rerender(renderTop: number, renderHeight: number): void {
+	private _rerender(renderTop: number, renderHeight: number, updateScrollTop: boolean = true): void {
 		const previousRenderRange = this.getRenderRange(renderTop, renderHeight);
 
 		// Let's remember the second element's position, this helps in scrolling up
@@ -1228,7 +1230,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 					}
 				}
 
-				if (typeof anchorElementIndex === 'number') {
+				if (updateScrollTop && typeof anchorElementIndex === 'number') {
 					this.scrollTop = this.elementTop(anchorElementIndex) - anchorElementTopDelta!;
 				}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Updating `this.scrollTop` from within an scroll event will [cancel smooth scrolling](https://github.com/microsoft/vscode/blob/master/src/vs/base/common/scrollable.ts#L277-L280) so we avoid doing that. Also it was the root cause of this issue #102339

This PR fixes #104144
