### PR TITLE
Improve settings editor accessibility

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -299,8 +299,9 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	display: inline-block;
-	/* size to contents for hover to show context button */
+	display: inline-block; /* size to contents for hover to show context button */
+	padding-left: 7px;
+	border-radius: 5px;
 }
 
 

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -300,8 +300,10 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	display: inline-block; /* size to contents for hover to show context button */
-	padding-left: 7px;
 	border-radius: 5px;
+}
+.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.focused.selected .setting-item-contents .setting-item-title {
+	padding-left: 7px;
 }
 
 

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -531,22 +531,27 @@
 }
 
 .settings-editor > .settings-body > .settings-tree-container .settings-group-title-label {
+	display: inline-block;
 	margin: 0px;
 	font-weight: 600;
+	height: 100%;
+	box-sizing: border-box;
+	border-radius: 5px;
+	padding: 10px;
+	padding-left: 0;
+}
+
+.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.selected .settings-group-title-label {
+	padding-left: 10px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .settings-group-level-1 {
-	padding-top: 23px;
 	font-size: 24px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .settings-group-level-2 {
 	padding-top: 32px;
 	font-size: 20px;
-}
-
-.settings-editor > .settings-body > .settings-tree-container .settings-group-level-1.settings-group-first {
-	padding-top: 7px;
 }
 
 .settings-editor.search-mode > .settings-body .settings-toc-container .monaco-list-row .settings-toc-count {

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -507,6 +507,14 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 			}
 			return null;
 		}
+
+		function settingsEditorFocusSearch(accessor: ServicesAccessor) {
+			const preferencesEditor = getPreferencesEditor(accessor);
+			if (preferencesEditor) {
+				preferencesEditor.focusSearch();
+			}
+		}
+
 		registerAction2(class extends Action2 {
 			constructor() {
 				super({
@@ -521,12 +529,24 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 				});
 			}
 
-			run(accessor: ServicesAccessor) {
-				const preferencesEditor = getPreferencesEditor(accessor);
-				if (preferencesEditor) {
-					preferencesEditor.focusSearch();
-				}
+			run(accessor: ServicesAccessor) { settingsEditorFocusSearch(accessor); }
+		});
+
+		registerAction2(class extends Action2 {
+			constructor() {
+				super({
+					id: SETTINGS_EDITOR_COMMAND_SEARCH,
+					precondition: ContextKeyExpr.and(CONTEXT_SETTINGS_EDITOR, CONTEXT_TOC_ROW_FOCUS),
+					keybinding: {
+						primary: KeyCode.Escape,
+						weight: KeybindingWeight.WorkbenchContrib,
+						when: null
+					},
+					title: nls.localize('settings.focusSearch', "Focus settings search")
+				});
 			}
+
+			run(accessor: ServicesAccessor) { settingsEditorFocusSearch(accessor); }
 		});
 
 		registerAction2(class extends Action2 {
@@ -691,7 +711,11 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 			constructor() {
 				super({
 					id: SETTINGS_EDITOR_COMMAND_FOCUS_TOC,
-					precondition: CONTEXT_SETTINGS_EDITOR,
+					precondition: ContextKeyExpr.and(CONTEXT_SETTINGS_EDITOR, CONTEXT_TOC_ROW_FOCUS.negate()),
+					keybinding: {
+						primary: KeyCode.Escape,
+						weight: KeybindingWeight.WorkbenchContrib,
+					},
 					title: nls.localize('settings.focusSettingsTOC', "Focus settings TOC tree")
 				});
 			}

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -150,6 +150,7 @@ export class SettingsEditor2 extends BaseEditor {
 	private editorMemento: IEditorMemento<ISettingsEditor2State>;
 
 	private tocFocusedElement: SettingsTreeGroupElement | null = null;
+	private treeFocusedElement: SettingsTreeElement | null = null;
 	private settingsTreeScrollTop = 0;
 	private dimension!: DOM.Dimension;
 
@@ -717,7 +718,6 @@ export class SettingsEditor2 extends BaseEditor {
 			this.settingsTreeContainer,
 			this.viewState,
 			this.settingRenderers.allRenderers));
-		this.settingsTree.getHTMLElement().attributes.removeNamedItem('tabindex');
 
 		this._register(this.settingsTree.onDidScroll(() => {
 			if (this.settingsTree.scrollTop === this.settingsTreeScrollTop) {
@@ -731,6 +731,17 @@ export class SettingsEditor2 extends BaseEditor {
 			setTimeout(() => {
 				this.updateTreeScrollSync();
 			}, 0);
+		}));
+
+		// There is no different select state in the settings tree
+		this._register(this.settingsTree.onDidChangeFocus(e => {
+			const element = e.elements[0];
+			if (this.treeFocusedElement === element) {
+				return;
+			}
+
+			this.treeFocusedElement = element;
+			this.settingsTree.setSelection(element ? [element] : []);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -282,7 +282,7 @@ export class SettingsEditor2 extends BaseEditor {
 					}));
 
 					// Init TOC selection
-					this.updateTreeScrollSync();
+					this.syncTOCTree();
 				});
 			});
 	}
@@ -541,6 +541,7 @@ export class SettingsEditor2 extends BaseEditor {
 				const targetGroupTOCEntry = this.allSettingsModel.getTOCEntryByGroupElement(targetGroup);
 				this.settingsTreeModel.update(createRootTOCEntry(targetGroupTOCEntry));
 				this.refreshTree();
+				this.syncTOCTree();
 			}
 
 			const targetElement = this.settingsTreeModel.getElementById(elements[0].id);
@@ -726,12 +727,6 @@ export class SettingsEditor2 extends BaseEditor {
 
 			this.settingsTreeScrollTop = this.settingsTree.scrollTop;
 			updateSettingTreeTabOrder(this.settingsTreeContainer);
-
-			// setTimeout because calling setChildren on the settingsTree can trigger onDidScroll, so it fires when
-			// setChildren has called on the settings tree but not the toc tree yet, so their rendered elements are out of sync
-			setTimeout(() => {
-				this.updateTreeScrollSync();
-			}, 0);
 		}));
 
 		// There is no different select state in the settings tree
@@ -771,35 +766,40 @@ export class SettingsEditor2 extends BaseEditor {
 		}
 	}
 
-	private updateTreeScrollSync(): void {
+	private syncTOCTree(): void {
 		this.settingRenderers.cancelSuggesters();
-		if (this.searchResultModel) {
+		if (this.searchResultModel || !this.tocTreeModel || !this.settingsTreeModel) {
 			return;
 		}
 
-		if (!this.tocTreeModel) {
+		const visibleGroup = unwrapRootElement(this.settingsTreeModel.root);
+		const tocSelectedGroup = this.tocTree.getSelection()[0];
+
+		if (visibleGroup.id === tocSelectedGroup?.id) {
 			return;
 		}
 
-		const elementToSync = this.settingsTree.firstVisibleElement;
-		const element = elementToSync instanceof SettingsTreeSettingElement ? elementToSync.parent :
-			elementToSync instanceof SettingsTreeGroupElement ? elementToSync :
-				null;
+		// visibleGroup and targetGroup are not referentially equal
+		const targetGroup = this.allSettingsModel.getElementById(visibleGroup.id);
+
+		if (!(targetGroup instanceof SettingsTreeGroupElement)) {
+			return;
+		}
 
 		// It's possible for this to be called when the TOC and settings tree are out of sync - e.g. when the settings tree has deferred a refresh because
 		// it is focused. So, bail if element doesn't exist in the TOC.
 		let nodeExists = true;
-		try { this.tocTree.getNode(element); } catch (e) { nodeExists = false; }
+		try { this.tocTree.getNode(targetGroup); } catch (e) { nodeExists = false; }
 		if (!nodeExists) {
 			return;
 		}
 
-		if (element && this.tocTree.getSelection()[0] !== element) {
-			const ancestors = this.getAncestors(element);
+		if (this.tocTree.getSelection()[0] !== targetGroup) {
+			const ancestors = this.getAncestors(targetGroup);
 			ancestors.forEach(e => this.tocTree.expand(<SettingsTreeGroupElement>e));
 
-			this.tocTree.reveal(element);
-			const elementTop = this.tocTree.getRelativeTop(element);
+			this.tocTree.reveal(targetGroup);
+			const elementTop = this.tocTree.getRelativeTop(targetGroup);
 			if (typeof elementTop !== 'number') {
 				return;
 			}
@@ -808,18 +808,18 @@ export class SettingsEditor2 extends BaseEditor {
 
 			ancestors.forEach(e => this.tocTree.expand(<SettingsTreeGroupElement>e));
 			if (elementTop < 0 || elementTop > 1) {
-				this.tocTree.reveal(element);
+				this.tocTree.reveal(targetGroup);
 			} else {
-				this.tocTree.reveal(element, elementTop);
+				this.tocTree.reveal(targetGroup, elementTop);
 			}
 
-			this.tocTree.expand(element);
+			this.tocTree.expand(targetGroup);
 
-			this.tocTree.setSelection([element]);
+			this.tocTree.setSelection([targetGroup]);
 
 			const fakeKeyboardEvent = new KeyboardEvent('keydown');
 			(<IFocusEventFromScroll>fakeKeyboardEvent).fromScroll = true;
-			this.tocTree.setFocus([element], fakeKeyboardEvent);
+			this.tocTree.setFocus([targetGroup], fakeKeyboardEvent);
 		}
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -45,7 +45,7 @@ import { attachSuggestEnabledInputBoxStyler, SuggestEnabledInput } from 'vs/work
 import { SettingsTarget, SettingsTargetsWidget } from 'vs/workbench/contrib/preferences/browser/preferencesWidgets';
 import { commonlyUsedData, ITOCEntry, tocData } from 'vs/workbench/contrib/preferences/browser/settingsLayout';
 import { AbstractSettingRenderer, ISettingLinkClickEvent, ISettingOverrideClickEvent, resolveExtensionsSettings, resolveSettingsTree, SettingsTree, SettingTreeRenderers, updateSettingTreeTabOrder } from 'vs/workbench/contrib/preferences/browser/settingsTree';
-import { ISettingsEditorViewState, parseQuery, SearchResultIdx, SearchResultModel, SettingsTreeElement, SettingsTreeGroupChild, SettingsTreeGroupElement, SettingsTreeModel, SettingsTreeSettingElement } from 'vs/workbench/contrib/preferences/browser/settingsTreeModels';
+import { ISettingsEditorViewState, parseQuery, SearchResultIdx, SearchResultModel, SettingsTreeElement, SettingsTreeGroupChild, SettingsTreeGroupElement, SettingsTreeModel } from 'vs/workbench/contrib/preferences/browser/settingsTreeModels';
 import { settingsTextInputBorder } from 'vs/workbench/contrib/preferences/browser/settingsWidgets';
 import { createTOCIterator, TOCTree, TOCTreeModel } from 'vs/workbench/contrib/preferences/browser/tocTree';
 import { CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, EXTENSION_SETTING_TAG, IPreferencesSearchService, ISearchProvider, MODIFIED_SETTING_TAG, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU } from 'vs/workbench/contrib/preferences/common/preferences';

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -509,6 +509,8 @@ export class SettingsEditor2 extends BaseEditor {
 			}
 
 			this.settingsTree.reveal(elements[0], sourceTop);
+			// Set focus on the element once the link is clicked
+			setTimeout(() => this.settingsTree.setFocus([elements[0]]), 50);
 
 			const domElements = this.settingRenderers.getDOMElementsForSettingKey(this.settingsTree.getHTMLElement(), evt.targetKey);
 			if (domElements && domElements[0]) {
@@ -615,6 +617,8 @@ export class SettingsEditor2 extends BaseEditor {
 				}
 			} else if (element && (!e.browserEvent || !(<IFocusEventFromScroll>e.browserEvent).fromScroll)) {
 				this.settingsTree.reveal(element, 0);
+				// Focus on the group heading after setting the status
+				setTimeout(() => this.settingsTree.setFocus([element]), 0);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -509,7 +509,10 @@ export class SettingsEditor2 extends BaseEditor {
 			}
 
 			this.settingsTree.reveal(elements[0], sourceTop);
-			// Set focus on the element once the link is clicked
+
+			// We need to shift focus from the setting that contains the link to the setting that's
+			//  linked. Clicking on the link sets focus on the setting that contains the link,
+			//  which is why we need the setTimeout
 			setTimeout(() => this.settingsTree.setFocus([elements[0]]), 50);
 
 			const domElements = this.settingRenderers.getDOMElementsForSettingKey(this.settingsTree.getHTMLElement(), evt.targetKey);
@@ -617,8 +620,7 @@ export class SettingsEditor2 extends BaseEditor {
 				}
 			} else if (element && (!e.browserEvent || !(<IFocusEventFromScroll>e.browserEvent).fromScroll)) {
 				this.settingsTree.reveal(element, 0);
-				// Focus on the group heading after setting the status
-				setTimeout(() => this.settingsTree.setFocus([element]), 0);
+				this.settingsTree.setFocus([element]);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -37,7 +37,7 @@ import { IContextMenuService, IContextViewService } from 'vs/platform/contextvie
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
-import { editorBackground, errorForeground, focusBorder, foreground, inputValidationErrorBackground, inputValidationErrorBorder, inputValidationErrorForeground } from 'vs/platform/theme/common/colorRegistry';
+import { editorBackground, errorForeground, focusBorder, foreground, inputValidationErrorBackground, inputValidationErrorBorder, inputValidationErrorForeground, listActiveSelectionBackground, listActiveSelectionForeground } from 'vs/platform/theme/common/colorRegistry';
 import { attachButtonStyler, attachInputBoxStyler, attachSelectBoxStyler, attachStyler } from 'vs/platform/theme/common/styler';
 import { ICssStyleCollector, IColorTheme, IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { getIgnoredSettings } from 'vs/platform/userDataSync/common/settingsMerge';
@@ -1247,6 +1247,7 @@ export class SettingTextRenderer extends AbstractSettingRenderer implements ITre
 			}));
 		common.toDispose.add(inputBox);
 		inputBox.inputElement.classList.add(AbstractSettingRenderer.CONTROL_CLASS);
+		inputBox.inputElement.tabIndex = 0;
 
 		const template: ISettingTextItemTemplate = {
 			...common,
@@ -1299,6 +1300,7 @@ export class SettingEnumRenderer extends AbstractSettingRenderer implements ITre
 		const selectElement = common.controlElement.querySelector('select');
 		if (selectElement) {
 			selectElement.classList.add(AbstractSettingRenderer.CONTROL_CLASS);
+			selectElement.tabIndex = 0;
 		}
 
 		common.toDispose.add(
@@ -1391,6 +1393,7 @@ export class SettingNumberRenderer extends AbstractSettingRenderer implements IT
 			}));
 		common.toDispose.add(inputBox);
 		inputBox.inputElement.classList.add(AbstractSettingRenderer.CONTROL_CLASS);
+		inputBox.inputElement.tabIndex = 0;
 
 		const template: ISettingNumberItemTemplate = {
 			...common,
@@ -1874,9 +1877,6 @@ export class SettingsTree extends ObjectTree<SettingsTreeElement> {
 					}
 				},
 				accessibilityProvider: {
-					getWidgetRole() {
-						return 'form';
-					},
 					getAriaLabel() {
 						// TODO@roblourens https://github.com/microsoft/vscode/issues/95862
 						return '';
@@ -1888,6 +1888,7 @@ export class SettingsTree extends ObjectTree<SettingsTreeElement> {
 				styleController: id => new DefaultStyleController(DOM.createStyleSheet(container), id),
 				filter: instantiationService.createInstance(SettingsTreeFilter, viewState),
 				smoothScrolling: configurationService.getValue<boolean>('workbench.list.smoothScrolling'),
+				multipleSelectionSupport: false,
 			});
 
 		this.disposables.clear();
@@ -1938,6 +1939,16 @@ export class SettingsTree extends ObjectTree<SettingsTreeElement> {
 			const focusBorderColor = theme.getColor(focusBorder);
 			if (focusBorderColor) {
 				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .setting-item-contents .setting-item-markdown a:focus { outline-color: ${focusBorderColor} }`);
+			}
+
+			const listActiveSelectionBackgroundColor = theme.getColor(listActiveSelectionBackground);
+			if (listActiveSelectionBackgroundColor) {
+				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.focused.selected .setting-item-contents .setting-item-title { background-color: ${listActiveSelectionBackgroundColor}; }`);
+			}
+
+			const listActiveSelectionForegroundColor = theme.getColor(listActiveSelectionForeground);
+			if (listActiveSelectionForegroundColor) {
+				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.focused.selected .setting-item-contents .setting-item-title { color: ${listActiveSelectionForegroundColor}; }`);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1290,6 +1290,14 @@ export class SettingTextRenderer extends AbstractSettingRenderer implements ITre
 		inputBox.inputElement.classList.add(AbstractSettingRenderer.CONTROL_CLASS);
 		inputBox.inputElement.tabIndex = 0;
 
+		// TODO@9at8: listWidget filters out all key events from input boxes, so we need to come up with a better way
+		// Disable ArrowUp and ArrowDown behaviour in favor of list navigation
+		common.toDispose.add(DOM.addStandardDisposableListener(inputBox.inputElement, DOM.EventType.KEY_DOWN, e => {
+			if (e.equals(KeyCode.UpArrow) || e.equals(KeyCode.DownArrow)) {
+				e.preventDefault();
+			}
+		}));
+
 		const template: ISettingTextItemTemplate = {
 			...common,
 			inputBox,

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1992,12 +1992,12 @@ export class SettingsTree extends ObjectTree<SettingsTreeElement> {
 
 			const listActiveSelectionBackgroundColor = theme.getColor(listActiveSelectionBackground);
 			if (listActiveSelectionBackgroundColor) {
-				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.focused.selected .setting-item-contents .setting-item-title { background-color: ${listActiveSelectionBackgroundColor}; }`);
+				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.selected .setting-item-contents .setting-item-title { background-color: ${listActiveSelectionBackgroundColor}; }`);
 			}
 
 			const listActiveSelectionForegroundColor = theme.getColor(listActiveSelectionForeground);
 			if (listActiveSelectionForegroundColor) {
-				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.focused.selected .setting-item-contents .setting-item-title { color: ${listActiveSelectionForegroundColor}; }`);
+				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.selected .setting-item-contents .setting-item-title { color: ${listActiveSelectionForegroundColor}; }`);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1880,11 +1880,7 @@ class SettingsTreeDelegate extends CachedListVirtualDelegate<SettingsTreeGroupCh
 
 	protected estimateHeight(element: SettingsTreeGroupChild): number {
 		if (element instanceof SettingsTreeGroupElement) {
-			if (element.isFirstGroup) {
-				return 31;
-			}
-
-			return 40 + (7 * element.level);
+			return 42;
 		}
 
 		return element instanceof SettingsTreeSettingElement && element.valueType === SettingValueType.Boolean ? 78 : 104;
@@ -1998,11 +1994,14 @@ export class SettingsTree extends WorkbenchObjectTree<SettingsTreeElement> {
 			const listActiveSelectionBackgroundColor = theme.getColor(listActiveSelectionBackground);
 			if (listActiveSelectionBackgroundColor) {
 				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.selected .setting-item-contents .setting-item-title { background-color: ${listActiveSelectionBackgroundColor}; }`);
+				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.selected .settings-group-title-label { background-color: ${listActiveSelectionBackgroundColor}; }`);
 			}
 
 			const listActiveSelectionForegroundColor = theme.getColor(listActiveSelectionForeground);
 			if (listActiveSelectionForegroundColor) {
 				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.selected .setting-item-contents .setting-item-title { color: ${listActiveSelectionForegroundColor}; }`);
+				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.selected .setting-item-label { color: ${listActiveSelectionForegroundColor}; }`);
+				collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .monaco-list-row.selected .settings-group-title-label { color: ${listActiveSelectionForegroundColor}; }`);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -284,6 +284,7 @@ export class SettingsTreeModel {
 	protected _root!: SettingsTreeGroupElement;
 	protected _treeElementsById = new Map<string, SettingsTreeElement>();
 	private _treeElementsBySettingName = new Map<string, SettingsTreeSettingElement[]>();
+	private _tocEntryByElementId = new Map<string, ITOCEntry>();
 	private _tocRoot!: ITOCEntry;
 
 	constructor(
@@ -298,17 +299,14 @@ export class SettingsTreeModel {
 	update(newTocRoot = this._tocRoot): void {
 		this._treeElementsById.clear();
 		this._treeElementsBySettingName.clear();
+		this._tocEntryByElementId.clear();
 
 		const newRoot = this.createSettingsTreeGroupElement(newTocRoot);
 		if (newRoot.children[0] instanceof SettingsTreeGroupElement) {
 			(<SettingsTreeGroupElement>newRoot.children[0]).isFirstGroup = true; // TODO
 		}
 
-		if (this._root) {
-			this._root.children = newRoot.children;
-		} else {
-			this._root = newRoot;
-		}
+		this._root = newRoot;
 	}
 
 	getElementById(id: string): SettingsTreeElement | null {
@@ -317,6 +315,16 @@ export class SettingsTreeModel {
 
 	getElementsByName(name: string): SettingsTreeSettingElement[] | null {
 		return withUndefinedAsNull(this._treeElementsBySettingName.get(name));
+	}
+
+	getTOCEntryByGroupElement(element: SettingsTreeGroupElement): ITOCEntry {
+		const tocEntry = this._tocEntryByElementId.get(element.id);
+
+		if (isUndefinedOrNull(tocEntry)) {
+			throw new Error('Group element does not have a corresponding TOC entry');
+		}
+
+		return tocEntry;
 	}
 
 	updateElementsByName(name: string): void {
@@ -351,6 +359,7 @@ export class SettingsTreeModel {
 		element.children = children;
 
 		this._treeElementsById.set(element.id, element);
+		this._tocEntryByElementId.set(element.id, tocEntry);
 		return element;
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/tocTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/tocTree.ts
@@ -6,7 +6,6 @@
 import * as DOM from 'vs/base/browser/dom';
 import { IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { DefaultStyleController, IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
-import { IObjectTreeOptions, ObjectTree } from 'vs/base/browser/ui/tree/objectTree';
 import { ITreeElement, ITreeNode, ITreeRenderer } from 'vs/base/browser/ui/tree/tree';
 import { Iterable } from 'vs/base/common/iterator';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -18,6 +17,11 @@ import { ISettingsEditorViewState, SearchResultModel, SettingsTreeElement, Setti
 import { settingsHeaderForeground } from 'vs/workbench/contrib/preferences/browser/settingsWidgets';
 import { localize } from 'vs/nls';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { IListService, IWorkbenchObjectTreeOptions, WorkbenchObjectTree } from 'vs/platform/list/browser/listService';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
 const $ = DOM.$;
 
@@ -187,17 +191,22 @@ class SettingsAccessibilityProvider implements IListAccessibilityProvider<Settin
 	}
 }
 
-export class TOCTree extends ObjectTree<SettingsTreeGroupElement> {
+export class TOCTree extends WorkbenchObjectTree<SettingsTreeGroupElement> {
 	constructor(
 		container: HTMLElement,
 		viewState: ISettingsEditorViewState,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IListService listService: IListService,
 		@IThemeService themeService: IThemeService,
-		@IInstantiationService instantiationService: IInstantiationService
+		@IConfigurationService configurationService: IConfigurationService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IAccessibilityService accessibilityService: IAccessibilityService,
+		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		// test open mode
 
 		const filter = instantiationService.createInstance(SettingsTreeFilter, viewState);
-		const options: IObjectTreeOptions<SettingsTreeGroupElement> = {
+		const options: IWorkbenchObjectTreeOptions<SettingsTreeGroupElement, void> = {
 			filter,
 			multipleSelectionSupport: false,
 			identityProvider: {
@@ -210,10 +219,19 @@ export class TOCTree extends ObjectTree<SettingsTreeGroupElement> {
 			collapseByDefault: true
 		};
 
-		super('SettingsTOC', container,
+		super(
+			'SettingsTOC',
+			container,
 			new TOCTreeDelegate(),
 			[new TOCRenderer()],
-			options);
+			options,
+			contextKeyService,
+			listService,
+			themeService,
+			configurationService,
+			keybindingService,
+			accessibilityService,
+		);
 
 		this.disposables.add(attachStyler(themeService, {
 			listBackground: editorBackground,


### PR DESCRIPTION
#97567

This PR includes a number of improvements in the settings editor.

## Settings is made up of smaller virtual lists for each category

Each group only renders its own settings, and scrolling the settings list doesn't cross into a different group. The current settings editor is just one giant list of all settings. This change makes the settings page easier to navigate, and also make it less intimidating.

|Before|After|
|---|---|
|![before](<https://user-images.githubusercontent.com/8235156/89697309-a080da00-d8e9-11ea-94ed-d35289e2f489.gif>)|![after](<https://user-images.githubusercontent.com/8235156/89697346-c73f1080-d8e9-11ea-9f25-1b0d3de44367.gif>)

## Settings are navigable using arrow keys instead of tab keys

This change makes navigating the settings editor experience closer to what it's like for lists and trees in other parts of VSCode. Before, the setting page behaved like a form. That is, users had to tab through each control on the page to navigate to a setting. Now, users can tab to the settings list once and then use arrow keys to jump from one setting to the next. To edit that setting, they can press the tab key to go into the settings control.

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/8235156/89703094-ad1b2780-d915-11ea-9913-0c88c5debb06.gif)|![after](https://user-images.githubusercontent.com/8235156/89703156-100cbe80-d916-11ea-8f77-e801559809d3.gif)|

## TOC tree can be focused by pressing `Escape` while navigating the settings list

Before, there was no easy way to focus on the table of contents on the left. Now, users can press the `Escape` key while focused on a setting to jump to the table of contents. Pressing escape again shifts focus back to the search box!

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/8235156/89703562-f9686680-d919-11ea-9b9f-071daa1b5b4a.gif)|![after](https://user-images.githubusercontent.com/8235156/89703598-316fa980-d91a-11ea-87bd-b14829a230c5.gif)|