### PR TITLE
Use SaveReason.EXPLICIT when saving files before executing build tasks (#104296)

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -1479,7 +1479,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		};
 
 		const saveAllEditorsAndExecTask = async (task: Task, resolver: ITaskResolver): Promise<ITaskSummary> => {
-			return this.editorService.saveAll({ reason: SaveReason.AUTO }).then(() => {
+			return this.editorService.saveAll({ reason: SaveReason.EXPLICIT }).then(() => {
 				return execTask(task, resolver);
 			});
 		};
@@ -2554,7 +2554,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		}
 
 		ProblemMatcherRegistry.onReady().then(() => {
-			return this.editorService.saveAll({ reason: SaveReason.AUTO }).then(() => { // make sure all dirty editors are saved
+			return this.editorService.saveAll({ reason: SaveReason.EXPLICIT }).then(() => { // make sure all dirty editors are saved
 				let executeResult = this.getTaskSystem().rerun();
 				if (executeResult) {
 					return this.handleExecuteResult(executeResult);


### PR DESCRIPTION
This way, files are auto-formatted and code actions are run. Which is desirable,
as saving happens in direct response to an explicit user action, as opposed to
auto-saving after a delay, in which case we don't want to modify files.

Also, it's consistent with what happens when saving files before debugging, in
which case we also save using `SaveReason.EXPLICIT`.

This PR fixes #104296.
