### PR TITLE
Revert "custom select box: react on KEY_UP to be aligned with actionBar

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -215,8 +215,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 
 		// Intercept keyboard handling
 
-		// React on KEY_UP since the actionBar also reacts on KEY_UP so that appropriate events get canceled
-		this._register(dom.addDisposableListener(this.selectElement, dom.EventType.KEY_UP, (e: KeyboardEvent) => {
+		this._register(dom.addDisposableListener(this.selectElement, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
 			const event = new StandardKeyboardEvent(e);
 			let showDropDown = false;
 
@@ -233,7 +232,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 
 			if (showDropDown) {
 				this.showSelectDropDown();
-				dom.EventHelper.stop(e, true);
+				dom.EventHelper.stop(e);
 			}
 		}));
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/104411

This simply reverts my bad fix for the custom select drop down.
