### PR TITLE
Add more specific checks for being on TS 4.0.1

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -18,7 +18,6 @@ import { ILogDirectoryProvider } from './logDirectoryProvider';
 import { GetErrRoutingTsServer, ITypeScriptServer, ProcessBasedTsServer, SyntaxRoutingTsServer, TsServerDelegate, TsServerProcessFactory, TsServerProcessKind } from './server';
 import { TypeScriptVersionManager } from './versionManager';
 import { ITypeScriptVersionProvider, TypeScriptVersion } from './versionProvider';
-import * as semver from 'semver';
 
 const enum CompositeServerType {
 	/** Run a single server that handles all commands  */
@@ -164,11 +163,9 @@ export class TypeScriptServerSpawner {
 		let tsServerLogFile: string | undefined;
 
 		if (kind === TsServerProcessKind.Syntax) {
-			if (semver.gte(API.v400rc.fullVersionString, apiVersion.fullVersionString)) {
-				args.push('--serverMode');
-				args.push('partialSemantic');
-			}
-			else {
+			if (apiVersion.gte(API.v401)) {
+				args.push('--serverMode', 'partialSemantic');
+			} else {
 				args.push('--syntaxOnly');
 			}
 		}

--- a/extensions/typescript-language-features/src/utils/api.ts
+++ b/extensions/typescript-language-features/src/utils/api.ts
@@ -34,8 +34,8 @@ export default class API {
 	public static readonly v380 = API.fromSimpleString('3.8.0');
 	public static readonly v381 = API.fromSimpleString('3.8.1');
 	public static readonly v390 = API.fromSimpleString('3.9.0');
-	public static readonly v400rc = API.fromSimpleString('4.0.0-rc');
 	public static readonly v400 = API.fromSimpleString('4.0.0');
+	public static readonly v401 = API.fromSimpleString('4.0.1');
 
 	public static fromVersionString(versionString: string): API {
 		let version = semver.valid(versionString);


### PR DESCRIPTION
Fixes #104456

I believe the arguments to `.gte` were reversed previously. This caused us to always use the new command line arguments on older TS versions (which end up being silently ignored)
