### PR TITLE
Dimmed Monokai theme - improve markdown support

### DIFF
--- a/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
+++ b/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
@@ -558,6 +558,65 @@
 			}
 		},
 		{
+			"name": "Markdown Headings",
+			"scope": "markup.heading.markdown",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markdown Quote",
+			"scope": "markup.quote.markdown",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": ""
+			}
+		},
+		{
+			"name": "Markdown Bold",
+			"scope": "markup.bold.markdown",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markdown Link Title/Description",
+			"scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+			"settings": {
+				"foreground": "#AE81FF"
+			}
+		},
+		{
+			"name": "Markdown Underline Link/Image",
+			"scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+			"settings": {
+				"foreground": ""
+			}
+		},
+		{
+			"name": "Markdown Emphasis",
+			"scope": "markup.italic.markdown",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Markdown Punctuation Definition Link",
+			"scope": "markup.list.unnumbered.markdown, markup.list.numbered.markdown",
+			"settings": {
+				"foreground": ""
+			}
+		},
+		{
+			"name": "Markdown List Punctuation",
+			"scope": [
+				"punctuation.definition.list.begin.markdown"
+			],
+			"settings": {
+				"foreground": ""
+			}
+		},
+		{
 			"scope": "token.info-token",
 			"settings": {
 				"foreground": "#6796e6"


### PR DESCRIPTION
This PR fixes #104467 

- render bold/italic , link title color

Before:

![image](https://user-images.githubusercontent.com/250644/89973306-e05efe80-dc14-11ea-9e59-2529e8645502.png)

---
After:

![image](https://user-images.githubusercontent.com/250644/89973966-9d9e2600-dc16-11ea-99d2-9c72acd68ba9.png)
