### PR TITLE
fix: use open to invoke the app from cli

### DIFF
--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -5,7 +5,9 @@
 
 import 'vs/platform/update/common/update.config.contribution';
 import { app, dialog } from 'electron';
-import { isWindows, IProcessEnvironment } from 'vs/base/common/platform';
+import { tmpdir } from 'os';
+import { join } from 'vs/base/common/path';
+import { isWindows, IProcessEnvironment, isMacintosh } from 'vs/base/common/platform';
 import product from 'vs/platform/product/common/product';
 import { parseMainProcessArgv, addArg } from 'vs/platform/environment/node/argvHelper';
 import { createWaitMarkerFile } from 'vs/platform/environment/node/waitMarkerFile';
@@ -297,6 +299,11 @@ class CodeMain {
 					const mainProcessInfo = await launchService.getMainProcessInfo();
 					const remoteDiagnostics = await launchService.getRemoteDiagnostics({ includeProcesses: true, includeWorkspaceMetadata: true });
 					const diagnostics = await diagnosticsService.getDiagnostics(mainProcessInfo, remoteDiagnostics);
+					if (isMacintosh) {
+						// the cli wrapper reads this file vs/code/node/cli.ts
+						// https://github.com/microsoft/vscode/pull/104470
+						await fs.promises.writeFile(join(tmpdir(), `${product.applicationName}-status.log`), diagnostics);
+					}
 					console.log(diagnostics);
 
 					throw new ExpectedError();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/102975
Fixes https://github.com/microsoft/vscode/issues/60579
Fixes https://github.com/microsoft/vscode/issues/104525

The breaking change here is that output of `--verbose, --status, --telemetry` cannot be redirected to the shell, because the app is no longer invoked as a subprocess of shell but rather via launchservices similar to opening from finder.

*TODO*

- [x] Implement [--log-file](https://source.chromium.org/chromium/chromium/src/+/master:content/public/common/content_switches.cc;l=560) in electron, to store verbose logging in disk https://github.com/electron/electron/pull/25089
- [ ] Create a test insiders build from this branch
- [ ] use `argv._` for parsing file paths
- [ ] Push support for `--status` behind dialog
- [ ] Find out about `--telemetry` usage
- [ ] what happens to `VSCODE_CLI` ?