### PR TITLE
Zoom: remove webFrame dependency from renderer

### DIFF
--- a/src/bootstrap-window.js
+++ b/src/bootstrap-window.js
@@ -23,7 +23,6 @@
 }(this, function () {
 	const preloadGlobals = globals();
 	const sandbox = preloadGlobals.context.sandbox;
-	const webFrame = preloadGlobals.webFrame;
 	const safeProcess = sandbox ? preloadGlobals.process : process;
 
 	/**
@@ -44,12 +43,6 @@
 		 * nodeCachedDataDir?: string
 		 * }} */
 		const configuration = JSON.parse(args['config'] || '{}') || {};
-
-		// Apply zoom level early to avoid glitches
-		const zoomLevel = configuration.zoomLevel;
-		if (typeof zoomLevel === 'number' && zoomLevel !== 0) {
-			webFrame.setZoomLevel(zoomLevel);
-		}
 
 		// Error handler
 		safeProcess.on('uncaughtException', function (error) {

--- a/src/vs/base/parts/sandbox/electron-browser/preload.js
+++ b/src/vs/base/parts/sandbox/electron-browser/preload.js
@@ -7,7 +7,7 @@
 (function () {
 	'use strict';
 
-	const { ipcRenderer, webFrame, crashReporter, contextBridge } = require('electron');
+	const { ipcRenderer, crashReporter, contextBridge } = require('electron');
 
 	const globals = {
 
@@ -54,21 +54,6 @@
 			removeListener(channel, listener) {
 				if (validateIPC(channel)) {
 					ipcRenderer.removeListener(channel, listener);
-				}
-			}
-		},
-
-		/**
-		 * Support for subset of methods of Electron's `webFrame` type.
-		 */
-		webFrame: {
-
-			/**
-			 * @param {number} level
-			 */
-			setZoomLevel(level) {
-				if (typeof level === 'number') {
-					webFrame.setZoomLevel(level);
 				}
 			}
 		},

--- a/src/vs/base/parts/sandbox/electron-sandbox/globals.ts
+++ b/src/vs/base/parts/sandbox/electron-sandbox/globals.ts
@@ -39,16 +39,6 @@ export const ipcRenderer = (window as any).vscode.ipcRenderer as {
 	send(channel: string, ...args: any[]): void;
 };
 
-export const webFrame = (window as any).vscode.webFrame as {
-
-	/**
-	 * Changes the zoom level to the specified level. The original size is 0 and each
-	 * increment above or below represents zooming 20% larger or smaller to default
-	 * limits of 300% and 50% of original size, respectively.
-	 */
-	setZoomLevel(level: number): void;
-};
-
 export const crashReporter = (window as any).vscode.crashReporter as {
 
 	/**

--- a/src/vs/base/parts/sandbox/test/electron-sandbox/globals.test.ts
+++ b/src/vs/base/parts/sandbox/test/electron-sandbox/globals.test.ts
@@ -4,12 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { ipcRenderer, crashReporter, webFrame } from 'vs/base/parts/sandbox/electron-sandbox/globals';
+import { ipcRenderer, crashReporter } from 'vs/base/parts/sandbox/electron-sandbox/globals';
 
 suite('Sandbox', () => {
 	test('globals', () => {
 		assert.ok(ipcRenderer);
 		assert.ok(crashReporter);
-		assert.ok(webFrame);
 	});
 });

--- a/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
@@ -7,7 +7,7 @@ import 'vs/css!./media/issueReporter';
 import 'vs/base/browser/ui/codicons/codiconStyles'; // make sure codicon css is loaded
 import { ElectronService, IElectronService } from 'vs/platform/electron/electron-sandbox/electron';
 import { ipcRenderer, process } from 'vs/base/parts/sandbox/electron-sandbox/globals';
-import { applyZoom, zoomIn, zoomOut } from 'vs/platform/windows/electron-sandbox/window';
+import { zoomIn, zoomOut } from 'vs/platform/windows/electron-sandbox/window';
 import { $, windowOpenNoOpener, addClass } from 'vs/base/browser/dom';
 import { Button } from 'vs/base/browser/ui/button/button';
 import { CodiconLabel } from 'vs/base/browser/ui/codicons/codiconLabel';
@@ -24,7 +24,8 @@ import { isRemoteDiagnosticError, SystemInfo } from 'vs/platform/diagnostics/com
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { IMainProcessService, MainProcessService } from 'vs/platform/ipc/electron-sandbox/mainProcessService';
 import { ISettingsSearchIssueReporterData, IssueReporterData, IssueReporterExtensionData, IssueReporterFeatures, IssueReporterStyles, IssueType } from 'vs/platform/issue/common/issue';
-import { IWindowConfiguration } from 'vs/platform/windows/common/windows';
+import { IWindowConfiguration, zoomLevelToZoomFactor } from 'vs/platform/windows/common/windows';
+import { setZoomFactor, setZoomLevel } from 'vs/base/browser/browser';
 
 const MAX_URL_LENGTH = 2045;
 
@@ -145,7 +146,8 @@ export class IssueReporter extends Disposable {
 
 		this.setUpTypes();
 		this.setEventHandlers();
-		applyZoom(configuration.data.zoomLevel);
+		setZoomFactor(zoomLevelToZoomFactor(configuration.data.zoomLevel));
+		setZoomLevel(configuration.data.zoomLevel, true /* isTrusted */);
 		this.applyStyles(configuration.data.styles);
 		this.handleExtensionData(configuration.data.enabledExtensions);
 
@@ -462,12 +464,12 @@ export class IssueReporter extends Disposable {
 
 			// Cmd/Ctrl + zooms in
 			if (cmdOrCtrlKey && e.keyCode === 187) {
-				zoomIn();
+				zoomIn(this.electronService);
 			}
 
 			// Cmd/Ctrl - zooms out
 			if (cmdOrCtrlKey && e.keyCode === 189) {
-				zoomOut();
+				zoomOut(this.electronService);
 			}
 
 			// With latest electron upgrade, cmd+a is no longer propagating correctly for inputs in this window on mac

--- a/src/vs/platform/electron/common/electron.ts
+++ b/src/vs/platform/electron/common/electron.ts
@@ -44,6 +44,8 @@ export interface ICommonElectronService {
 	unmaximizeWindow(): Promise<void>;
 	minimizeWindow(): Promise<void>;
 
+	setZoomLevel(level: number): Promise<void>;
+
 	focusWindow(options?: { windowId?: number }): Promise<void>;
 
 	// Dialogs

--- a/src/vs/platform/electron/electron-main/electronMainService.ts
+++ b/src/vs/platform/electron/electron-main/electronMainService.ts
@@ -8,7 +8,7 @@ import { IWindowsMainService, ICodeWindow } from 'vs/platform/windows/electron-m
 import { MessageBoxOptions, MessageBoxReturnValue, shell, OpenDevToolsOptions, SaveDialogOptions, SaveDialogReturnValue, OpenDialogOptions, OpenDialogReturnValue, Menu, BrowserWindow, app, clipboard, powerMonitor } from 'electron';
 import { OpenContext } from 'vs/platform/windows/node/window';
 import { ILifecycleMainService } from 'vs/platform/lifecycle/electron-main/lifecycleMainService';
-import { IOpenedWindow, IOpenWindowOptions, IWindowOpenable, IOpenEmptyWindowOptions } from 'vs/platform/windows/common/windows';
+import { IOpenedWindow, IOpenWindowOptions, IWindowOpenable, IOpenEmptyWindowOptions, zoomLevelToZoomFactor } from 'vs/platform/windows/common/windows';
 import { INativeOpenDialogOptions } from 'vs/platform/dialogs/common/dialogs';
 import { isMacintosh, isWindows, isRootUser } from 'vs/base/common/platform';
 import { ICommonElectronService } from 'vs/platform/electron/common/electron';
@@ -169,6 +169,13 @@ export class ElectronMainService implements IElectronMainService {
 		const window = this.windowById(windowId);
 		if (window) {
 			window.win.minimize();
+		}
+	}
+
+	async setZoomLevel(windowId: number | undefined, level: number): Promise<void> {
+		const window = this.windowById(windowId);
+		if (window) {
+			window.win.webContents.setZoomFactor(zoomLevelToZoomFactor(level));
 		}
 	}
 

--- a/src/vs/platform/windows/electron-sandbox/window.ts
+++ b/src/vs/platform/windows/electron-sandbox/window.ts
@@ -3,27 +3,27 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { webFrame } from 'vs/base/parts/sandbox/electron-sandbox/globals';
 import { zoomLevelToZoomFactor } from 'vs/platform/windows/common/windows';
 import { setZoomFactor, setZoomLevel, getZoomLevel } from 'vs/base/browser/browser';
+import { IElectronService } from 'vs/platform/electron/electron-sandbox/electron';
 
 /**
  * Apply a zoom level to the window. Also sets it in our in-memory
  * browser helper so that it can be accessed in non-electron layers.
  */
-export function applyZoom(zoomLevel: number): void {
-	webFrame.setZoomLevel(zoomLevel);
+export async function applyZoom(electronService: IElectronService, zoomLevel: number): Promise<void> {
+	await electronService.setZoomLevel(zoomLevel);
 	setZoomFactor(zoomLevelToZoomFactor(zoomLevel));
-	// Cannot be trusted because the webFrame might take some time
+	// Cannot be trusted because the IPC call might take some time
 	// until it really applies the new zoom level
 	// See https://github.com/Microsoft/vscode/issues/26151
-	setZoomLevel(zoomLevel, false /* isTrusted */);
+	setZoomLevel(zoomLevel, false /* isTrusted */); // TODO verify this can be removed, maybe all of trust remove?
 }
 
-export function zoomIn(): void {
-	applyZoom(getZoomLevel() + 1);
+export function zoomIn(electronService: IElectronService): void {
+	applyZoom(electronService, getZoomLevel() + 1);
 }
 
-export function zoomOut(): void {
-	applyZoom(getZoomLevel() - 1);
+export function zoomOut(electronService: IElectronService): void {
+	applyZoom(electronService, getZoomLevel() - 1);
 }

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -340,7 +340,7 @@ export class NativeWindow extends Disposable {
 		}
 
 		if (getZoomLevel() !== configuredZoomLevel) {
-			applyZoom(configuredZoomLevel);
+			applyZoom(this.electronService, configuredZoomLevel);
 		}
 	}
 

--- a/src/vs/workbench/electron-sandbox/actions/windowActions.ts
+++ b/src/vs/workbench/electron-sandbox/actions/windowActions.ts
@@ -50,7 +50,8 @@ export abstract class BaseZoomAction extends Action {
 	constructor(
 		id: string,
 		label: string,
-		@IConfigurationService private readonly configurationService: IConfigurationService
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IElectronService private readonly electronService: IElectronService
 	) {
 		super(id, label);
 	}
@@ -64,7 +65,7 @@ export abstract class BaseZoomAction extends Action {
 
 		await this.configurationService.updateValue(BaseZoomAction.SETTING_KEY, level);
 
-		applyZoom(level);
+		applyZoom(this.electronService, level);
 	}
 }
 
@@ -76,9 +77,10 @@ export class ZoomInAction extends BaseZoomAction {
 	constructor(
 		id: string,
 		label: string,
-		@IConfigurationService configurationService: IConfigurationService
+		@IConfigurationService configurationService: IConfigurationService,
+		@IElectronService electronService: IElectronService
 	) {
-		super(id, label, configurationService);
+		super(id, label, configurationService, electronService);
 	}
 
 	async run(): Promise<void> {
@@ -94,9 +96,10 @@ export class ZoomOutAction extends BaseZoomAction {
 	constructor(
 		id: string,
 		label: string,
-		@IConfigurationService configurationService: IConfigurationService
+		@IConfigurationService configurationService: IConfigurationService,
+		@IElectronService electronService: IElectronService
 	) {
-		super(id, label, configurationService);
+		super(id, label, configurationService, electronService);
 	}
 
 	async run(): Promise<void> {
@@ -112,9 +115,10 @@ export class ZoomResetAction extends BaseZoomAction {
 	constructor(
 		id: string,
 		label: string,
-		@IConfigurationService configurationService: IConfigurationService
+		@IConfigurationService configurationService: IConfigurationService,
+		@IElectronService electronService: IElectronService
 	) {
-		super(id, label, configurationService);
+		super(id, label, configurationService, electronService);
 	}
 
 	async run(): Promise<void> {

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -183,6 +183,7 @@ export class TestElectronService implements IElectronService {
 	async maximizeWindow(): Promise<void> { }
 	async unmaximizeWindow(): Promise<void> { }
 	async minimizeWindow(): Promise<void> { }
+	async setZoomLevel(level: number): Promise<void> { }
 	async focusWindow(options?: { windowId?: number | undefined; } | undefined): Promise<void> { }
 	async showMessageBox(options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> { throw new Error('Method not implemented.'); }
 	async showSaveDialog(options: Electron.SaveDialogOptions): Promise<Electron.SaveDialogReturnValue> { throw new Error('Method not implemented.'); }


### PR DESCRIPTION
The idea is that we no longer use `webFrame` to set the zoom level, but rather use the related zoom APIs from the `electron-main` side.

Fix https://github.com/microsoft/vscode/issues/108920