### PR TITLE
Disabling the polling based loading for iframe based webviews

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -514,7 +514,7 @@
 					}, 0);
 				}
 
-				if (host.fakeLoad) {
+				if (host.fakeLoad && false) {
 					// On Safari for iframes with scripts disabled, the `DOMContentLoaded` never seems to be fired.
 					// Use polling instead.
 					const interval = setInterval(() => {


### PR DESCRIPTION
The polling was added in 3511db5846ef4db6bca087fb4b484a7d48ea1398 to workaround https://bugs.webkit.org/show_bug.cgi?id=215589

However this seems to cause problems when VS Code web is run in real world conditions (i.e. not on localhost)

Just disable this branch of the conditional for now until we can find a better fix

