### PR TITLE
Fixes isInDiff*Editor context in title toolbar

### DIFF
--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -1044,12 +1044,18 @@ export function isCompositeEditor(thing: any): thing is editorCommon.ICompositeC
 /**
  *@internal
  */
-export function getCodeEditor(thing: any): ICodeEditor | null {
+export function getCodeEditor(thing: any, focused: boolean = false): ICodeEditor | null {
 	if (isCodeEditor(thing)) {
 		return thing;
 	}
 
 	if (isDiffEditor(thing)) {
+		if (focused) {
+			let editor = thing.getOriginalEditor();
+			if (editor.hasTextFocus()) {
+				return editor;
+			}
+		}
 		return thing.getModifiedEditor();
 	}
 

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -237,7 +237,7 @@ export abstract class TitleControl extends Themable {
 		// Editor actions require the editor control to be there, so we retrieve it via service
 		const activeEditorPane = this.group.activeEditorPane;
 		if (activeEditorPane instanceof BaseEditor) {
-			const codeEditor = getCodeEditor(activeEditorPane.getControl());
+			const codeEditor = getCodeEditor(activeEditorPane.getControl(), true);
 			const scopedContextKeyService = codeEditor?.invokeWithinContext(accessor => accessor.get(IContextKeyService)) || this.contextKeyService;
 			const titleBarMenu = this.menuService.createMenu(MenuId.EditorTitle, scopedContextKeyService);
 			this.editorToolBarMenuDisposables.add(titleBarMenu);


### PR DESCRIPTION
This PR allows the `isInDiffLeftEditor` & `isInDiffRightEditor` context keys to be used in the editor title toolbar. Currently we were always getting the right editor to get the ContextKeyService from, but now it gets the service from the focused editor.
