### PR TITLE
Implement generic invokeWithinContext for all editor panes

### DIFF
--- a/src/vs/platform/keybinding/test/common/mockKeybindingService.ts
+++ b/src/vs/platform/keybinding/test/common/mockKeybindingService.ts
@@ -71,6 +71,15 @@ export class MockContextKeyService implements IContextKeyService {
 	}
 }
 
+export class MockScopableContextKeyService extends MockContextKeyService {
+	/**
+	 * Don't implement this for all tests since we rarely depend on this behavior and it isn't implemented fully
+	 */
+	public createScoped(domNote: HTMLElement): IContextKeyService {
+		return new MockContextKeyService();
+	}
+}
+
 export class MockKeybindingService implements IKeybindingService {
 	public _serviceBrand: undefined;
 

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -7,7 +7,7 @@ import 'vs/css!./media/editorgroupview';
 import { EditorGroup, IEditorOpenOptions, EditorCloseEvent, ISerializedEditorGroup, isSerializedEditorGroup } from 'vs/workbench/common/editor/editorGroup';
 import { EditorInput, EditorOptions, GroupIdentifier, SideBySideEditorInput, CloseDirection, IEditorCloseEvent, ActiveEditorDirtyContext, IEditorPane, EditorGroupEditorsCountContext, SaveReason, IEditorPartOptionsChangeEvent, EditorsOrder, IVisibleEditorPane, ActiveEditorStickyContext, ActiveEditorPinnedContext, Deprecated_EditorPinnedContext, Deprecated_EditorDirtyContext } from 'vs/workbench/common/editor';
 import { Event, Emitter, Relay } from 'vs/base/common/event';
-import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { Dimension, trackFocus, addDisposableListener, EventType, EventHelper, findParentWithClass, clearNode, isAncestor } from 'vs/base/browser/dom';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -869,8 +869,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		}
 	}
 
-	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T {
-		return this.scopedInstantiationService.invokeFunction(fn);
+	getInternalContextKeyService(): IContextKeyService {
+		return this.scopedInstantiationService.invokeFunction(accessor => accessor.get(IContextKeyService));
 	}
 
 	//#endregion

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -106,7 +106,9 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 	private isRestored = false;
 
 	private readonly scopedInstantiationService: IInstantiationService;
+
 	private readonly _scopedContextKeyService: IContextKeyService;
+	get scopedContextKeyService(): IContextKeyService { return this._scopedContextKeyService; }
 
 	private titleContainer: HTMLElement;
 	private titleAreaControl: TitleControl;
@@ -868,10 +870,6 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 				this.titleAreaControl.unstickEditor(editor);
 			}
 		}
-	}
-
-	get scopedContextKeyService(): IContextKeyService {
-		return this._scopedContextKeyService;
 	}
 
 	//#endregion

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -105,7 +105,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 	private _whenRestored: Promise<void>;
 	private isRestored = false;
 
-	private scopedInstantiationService: IInstantiationService;
+	private readonly scopedInstantiationService: IInstantiationService;
+	private readonly _scopedContextKeyService: IContextKeyService;
 
 	private titleContainer: HTMLElement;
 	private titleAreaControl: TitleControl;
@@ -172,14 +173,14 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 			this.progressBar.hide();
 
 			// Scoped services
-			const scopedContextKeyService = this._register(this.contextKeyService.createScoped(this.element));
+			this._scopedContextKeyService = this._register(this.contextKeyService.createScoped(this.element));
 			this.scopedInstantiationService = this.instantiationService.createChild(new ServiceCollection(
-				[IContextKeyService, scopedContextKeyService],
+				[IContextKeyService, this._scopedContextKeyService],
 				[IEditorProgressService, this._register(new EditorProgressIndicator(this.progressBar, this))]
 			));
 
 			// Context keys
-			this.handleGroupContextKeys(scopedContextKeyService);
+			this.handleGroupContextKeys(this._scopedContextKeyService);
 
 			// Title container
 			this.titleContainer = document.createElement('div');
@@ -869,8 +870,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		}
 	}
 
-	getInternalContextKeyService(): IContextKeyService {
-		return this.scopedInstantiationService.invokeFunction(accessor => accessor.get(IContextKeyService));
+	get scopedContextKeyService(): IContextKeyService {
+		return this._scopedContextKeyService;
 	}
 
 	//#endregion

--- a/src/vs/workbench/browser/parts/editor/editorPane.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPane.ts
@@ -19,7 +19,7 @@ import { MementoObject } from 'vs/workbench/common/memento';
 import { joinPath, IExtUri } from 'vs/base/common/resources';
 import { indexOfPath } from 'vs/base/common/extpath';
 import { IDisposable } from 'vs/base/common/lifecycle';
-import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 /**
  * The base class of editors in the workbench. Editors register themselves for specific editor inputs.
@@ -87,8 +87,8 @@ export abstract class EditorPane extends Composite implements IEditorPane {
 	/**
 	 * Should be overridden by editors that have their own ScopedContextKeyService
 	 */
-	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T | null {
-		return null;
+	getInternalContextKeyService(): IContextKeyService | undefined {
+		return undefined;
 	}
 
 	/**

--- a/src/vs/workbench/browser/parts/editor/editorPane.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPane.ts
@@ -19,6 +19,7 @@ import { MementoObject } from 'vs/workbench/common/memento';
 import { joinPath, IExtUri } from 'vs/base/common/resources';
 import { indexOfPath } from 'vs/base/common/extpath';
 import { IDisposable } from 'vs/base/common/lifecycle';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 
 /**
  * The base class of editors in the workbench. Editors register themselves for specific editor inputs.
@@ -82,6 +83,13 @@ export abstract class EditorPane extends Composite implements IEditorPane {
 	 * this method to construct the editor widget.
 	 */
 	protected abstract createEditor(parent: HTMLElement): void;
+
+	/**
+	 * Should be overridden by editors that have their own ScopedContextKeyService
+	 */
+	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T | null {
+		return null;
+	}
 
 	/**
 	 * Note: Clients should not call this method, the workbench calls this

--- a/src/vs/workbench/browser/parts/editor/editorPane.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPane.ts
@@ -65,9 +65,7 @@ export abstract class EditorPane extends Composite implements IEditorPane {
 	/**
 	 * Should be overridden by editors that have their own ScopedContextKeyService
 	 */
-	get scopedContextKeyService(): IContextKeyService | undefined {
-		return undefined;
-	}
+	get scopedContextKeyService(): IContextKeyService | undefined { return undefined; }
 
 	constructor(
 		id: string,

--- a/src/vs/workbench/browser/parts/editor/editorPane.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPane.ts
@@ -62,6 +62,13 @@ export abstract class EditorPane extends Composite implements IEditorPane {
 	private _group: IEditorGroup | undefined;
 	get group(): IEditorGroup | undefined { return this._group; }
 
+	/**
+	 * Should be overridden by editors that have their own ScopedContextKeyService
+	 */
+	get scopedContextKeyService(): IContextKeyService | undefined {
+		return undefined;
+	}
+
 	constructor(
 		id: string,
 		telemetryService: ITelemetryService,
@@ -83,13 +90,6 @@ export abstract class EditorPane extends Composite implements IEditorPane {
 	 * this method to construct the editor widget.
 	 */
 	protected abstract createEditor(parent: HTMLElement): void;
-
-	/**
-	 * Should be overridden by editors that have their own ScopedContextKeyService
-	 */
-	getInternalContextKeyService(): IContextKeyService | undefined {
-		return undefined;
-	}
 
 	/**
 	 * Note: Clients should not call this method, the workbench calls this

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -17,7 +17,7 @@ import { TextDiffEditorModel } from 'vs/workbench/common/editor/textDiffEditorMo
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfigurationService';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { TextFileOperationError, TextFileOperationResult } from 'vs/workbench/services/textfile/common/textfiles';
 import { ScrollType, IDiffEditorViewState, IDiffEditorModel } from 'vs/editor/common/editorCommon';
@@ -58,6 +58,19 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditorPan
 		// in the onWillCloseEditor because at that time the editor has not yet
 		// been disposed and we can safely persist the view state still as needed.
 		this.doSaveOrClearTextDiffEditorViewState(editor);
+	}
+
+	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T | null {
+		const control = this.getControl();
+		if (!control) {
+			return null;
+		}
+
+		if (control.getOriginalEditor().hasTextFocus()) {
+			return control.getOriginalEditor().invokeWithinContext(fn);
+		} else {
+			return control.getModifiedEditor().invokeWithinContext(fn);
+		}
 	}
 
 	getTitle(): string {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -29,6 +29,7 @@ import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editor
 import { IEditorService, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { EditorActivation, IEditorOptions } from 'vs/platform/editor/common/editor';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 /**
  * The text editor that leverages the diff text editor for the editing experience.
@@ -60,10 +61,14 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditorPan
 		this.doSaveOrClearTextDiffEditorViewState(editor);
 	}
 
-	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T | null {
+	getInternalContextKeyService(): IContextKeyService | undefined {
+		return this.invokeWithinDiffEditorContext(accessor => accessor.get(IContextKeyService));
+	}
+
+	private invokeWithinDiffEditorContext<T>(fn: (accessor: ServicesAccessor) => T): T | undefined {
 		const control = this.getControl();
 		if (!control) {
-			return null;
+			return undefined;
 		}
 
 		if (control.getOriginalEditor().hasTextFocus()) {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -67,10 +67,9 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditorPan
 			return undefined;
 		}
 
-		const useEditor = control.getOriginalEditor().hasTextFocus() ?
+		return (control.getOriginalEditor().hasTextFocus() ?
 			control.getOriginalEditor() :
-			control.getModifiedEditor();
-		return useEditor.invokeWithinContext(accessor => accessor.get(IContextKeyService));
+			control.getModifiedEditor()).invokeWithinContext(accessor => accessor.get(IContextKeyService));
 	}
 
 	getTitle(): string {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -17,7 +17,7 @@ import { TextDiffEditorModel } from 'vs/workbench/common/editor/textDiffEditorMo
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfigurationService';
-import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { TextFileOperationError, TextFileOperationResult } from 'vs/workbench/services/textfile/common/textfiles';
 import { ScrollType, IDiffEditorViewState, IDiffEditorModel } from 'vs/editor/common/editorCommon';
@@ -61,21 +61,16 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditorPan
 		this.doSaveOrClearTextDiffEditorViewState(editor);
 	}
 
-	getInternalContextKeyService(): IContextKeyService | undefined {
-		return this.invokeWithinDiffEditorContext(accessor => accessor.get(IContextKeyService));
-	}
-
-	private invokeWithinDiffEditorContext<T>(fn: (accessor: ServicesAccessor) => T): T | undefined {
+	get scopedContextKeyService(): IContextKeyService | undefined {
 		const control = this.getControl();
 		if (!control) {
 			return undefined;
 		}
 
-		if (control.getOriginalEditor().hasTextFocus()) {
-			return control.getOriginalEditor().invokeWithinContext(fn);
-		} else {
-			return control.getModifiedEditor().invokeWithinContext(fn);
-		}
+		const useEditor = control.getOriginalEditor().hasTextFocus() ?
+			control.getOriginalEditor() :
+			control.getModifiedEditor();
+		return useEditor.invokeWithinContext(accessor => accessor.get(IContextKeyService));
 	}
 
 	getTitle(): string {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -47,9 +47,10 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditorPan
 			return undefined;
 		}
 
-		return (control.getOriginalEditor().hasTextFocus() ?
-			control.getOriginalEditor() :
-			control.getModifiedEditor()).invokeWithinContext(accessor => accessor.get(IContextKeyService));
+		const originalEditor = control.getOriginalEditor();
+		const modifiedEditor = control.getModifiedEditor();
+
+		return (originalEditor.hasTextFocus() ? originalEditor : modifiedEditor).invokeWithinContext(accessor => accessor.get(IContextKeyService));
 	}
 
 	constructor(

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -41,6 +41,17 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditorPan
 	private diffNavigator: DiffNavigator | undefined;
 	private readonly diffNavigatorDisposables = this._register(new DisposableStore());
 
+	get scopedContextKeyService(): IContextKeyService | undefined {
+		const control = this.getControl();
+		if (!control) {
+			return undefined;
+		}
+
+		return (control.getOriginalEditor().hasTextFocus() ?
+			control.getOriginalEditor() :
+			control.getModifiedEditor()).invokeWithinContext(accessor => accessor.get(IContextKeyService));
+	}
+
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -59,17 +70,6 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditorPan
 		// in the onWillCloseEditor because at that time the editor has not yet
 		// been disposed and we can safely persist the view state still as needed.
 		this.doSaveOrClearTextDiffEditorViewState(editor);
-	}
-
-	get scopedContextKeyService(): IContextKeyService | undefined {
-		const control = this.getControl();
-		if (!control) {
-			return undefined;
-		}
-
-		return (control.getOriginalEditor().hasTextFocus() ?
-			control.getOriginalEditor() :
-			control.getModifiedEditor()).invokeWithinContext(accessor => accessor.get(IContextKeyService));
 	}
 
 	getTitle(): string {

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -25,6 +25,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IExtUri } from 'vs/base/common/resources';
 import { MutableDisposable } from 'vs/base/common/lifecycle';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 export interface IEditorConfiguration {
 	editor: object;
@@ -200,12 +201,16 @@ export abstract class BaseTextEditor extends EditorPane implements ITextEditorPa
 		// Subclasses can override
 	}
 
-	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T | null {
+	getInternalContextKeyService(): IContextKeyService | undefined {
+		return this.invokeWithinContext(accessor => accessor.get(IContextKeyService));
+	}
+
+	private invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T | undefined {
 		if (!this.editorControl) {
-			return null;
+			return undefined;
 		}
 
-		return isCodeEditor(this.editorControl) ? this.editorControl.invokeWithinContext(fn) : null;
+		return isCodeEditor(this.editorControl) ? this.editorControl.invokeWithinContext(fn) : undefined;
 	}
 
 	focus(): void {

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -14,7 +14,7 @@ import { EditorInput, EditorOptions, IEditorMemento, ITextEditorPane, TextEditor
 import { EditorPane } from 'vs/workbench/browser/parts/editor/editorPane';
 import { IEditorViewState, IEditor, ScrollType } from 'vs/editor/common/editorCommon';
 import { IStorageService } from 'vs/platform/storage/common/storage';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfigurationService';
@@ -198,6 +198,14 @@ export abstract class BaseTextEditor extends EditorPane implements ITextEditorPa
 
 	protected onWillCloseEditorInGroup(editor: IEditorInput): void {
 		// Subclasses can override
+	}
+
+	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T | null {
+		if (!this.editorControl) {
+			return null;
+		}
+
+		return isCodeEditor(this.editorControl) ? this.editorControl.invokeWithinContext(fn) : null;
 	}
 
 	focus(): void {

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -52,6 +52,10 @@ export abstract class BaseTextEditor extends EditorPane implements ITextEditorPa
 	protected get instantiationService(): IInstantiationService { return this._instantiationService; }
 	protected set instantiationService(value: IInstantiationService) { this._instantiationService = value; }
 
+	get scopedContextKeyService(): IContextKeyService | undefined {
+		return isCodeEditor(this.editorControl) ? this.editorControl.invokeWithinContext(accessor => accessor.get(IContextKeyService)) : undefined;
+	}
+
 	constructor(
 		id: string,
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -199,10 +203,6 @@ export abstract class BaseTextEditor extends EditorPane implements ITextEditorPa
 
 	protected onWillCloseEditorInGroup(editor: IEditorInput): void {
 		// Subclasses can override
-	}
-
-	get scopedContextKeyService(): IContextKeyService | undefined {
-		return isCodeEditor(this.editorControl) ? this.editorControl.invokeWithinContext(accessor => accessor.get(IContextKeyService)) : undefined;
 	}
 
 	focus(): void {

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -202,10 +202,6 @@ export abstract class BaseTextEditor extends EditorPane implements ITextEditorPa
 	}
 
 	get scopedContextKeyService(): IContextKeyService | undefined {
-		if (!this.editorControl) {
-			return undefined;
-		}
-
 		return isCodeEditor(this.editorControl) ? this.editorControl.invokeWithinContext(accessor => accessor.get(IContextKeyService)) : undefined;
 	}
 

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -14,7 +14,7 @@ import { EditorInput, EditorOptions, IEditorMemento, ITextEditorPane, TextEditor
 import { EditorPane } from 'vs/workbench/browser/parts/editor/editorPane';
 import { IEditorViewState, IEditor, ScrollType } from 'vs/editor/common/editorCommon';
 import { IStorageService } from 'vs/platform/storage/common/storage';
-import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfigurationService';
@@ -201,16 +201,12 @@ export abstract class BaseTextEditor extends EditorPane implements ITextEditorPa
 		// Subclasses can override
 	}
 
-	getInternalContextKeyService(): IContextKeyService | undefined {
-		return this.invokeWithinContext(accessor => accessor.get(IContextKeyService));
-	}
-
-	private invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T | undefined {
+	get scopedContextKeyService(): IContextKeyService | undefined {
 		if (!this.editorControl) {
 			return undefined;
 		}
 
-		return isCodeEditor(this.editorControl) ? this.editorControl.invokeWithinContext(fn) : undefined;
+		return isCodeEditor(this.editorControl) ? this.editorControl.invokeWithinContext(accessor => accessor.get(IContextKeyService)) : undefined;
 	}
 
 	focus(): void {

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -13,7 +13,7 @@ import { IAction, IRunEvent, WorkbenchActionExecutedEvent, WorkbenchActionExecut
 import * as arrays from 'vs/base/common/arrays';
 import { ResolvedKeybinding } from 'vs/base/common/keyCodes';
 import { dispose, DisposableStore } from 'vs/base/common/lifecycle';
-import { getCodeEditor, isCodeEditor } from 'vs/editor/browser/editorBrowser';
+import { isCodeEditor } from 'vs/editor/browser/editorBrowser';
 import { localize } from 'vs/nls';
 import { createAndFillInActionBarActions, createAndFillInContextMenuActions, MenuEntryActionViewItem, SubmenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { ExecuteCommandAction, IMenu, IMenuService, MenuId, MenuItemAction, SubmenuItemAction } from 'vs/platform/actions/common/actions';
@@ -237,8 +237,7 @@ export abstract class TitleControl extends Themable {
 		// Editor actions require the editor control to be there, so we retrieve it via service
 		const activeEditorPane = this.group.activeEditorPane;
 		if (activeEditorPane instanceof EditorPane) {
-			const codeEditor = getCodeEditor(activeEditorPane.getControl());
-			const scopedContextKeyService = codeEditor?.invokeWithinContext(accessor => accessor.get(IContextKeyService)) || this.contextKeyService;
+			const scopedContextKeyService = activeEditorPane.invokeWithinContext(accessor => accessor.get(IContextKeyService)) || this.contextKeyService;
 			const titleBarMenu = this.menuService.createMenu(MenuId.EditorTitle, scopedContextKeyService);
 			this.editorToolBarMenuDisposables.add(titleBarMenu);
 			this.editorToolBarMenuDisposables.add(titleBarMenu.onDidChange(() => {

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -237,7 +237,7 @@ export abstract class TitleControl extends Themable {
 		// Editor actions require the editor control to be there, so we retrieve it via service
 		const activeEditorPane = this.group.activeEditorPane;
 		if (activeEditorPane instanceof EditorPane) {
-			const scopedContextKeyService = activeEditorPane.invokeWithinContext(accessor => accessor.get(IContextKeyService)) || this.contextKeyService;
+			const scopedContextKeyService = activeEditorPane.getInternalContextKeyService() ?? this.contextKeyService;
 			const titleBarMenu = this.menuService.createMenu(MenuId.EditorTitle, scopedContextKeyService);
 			this.editorToolBarMenuDisposables.add(titleBarMenu);
 			this.editorToolBarMenuDisposables.add(titleBarMenu.onDidChange(() => {

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -237,7 +237,7 @@ export abstract class TitleControl extends Themable {
 		// Editor actions require the editor control to be there, so we retrieve it via service
 		const activeEditorPane = this.group.activeEditorPane;
 		if (activeEditorPane instanceof EditorPane) {
-			const scopedContextKeyService = activeEditorPane.getInternalContextKeyService() ?? this.contextKeyService;
+			const scopedContextKeyService = activeEditorPane.scopedContextKeyService ?? this.contextKeyService;
 			const titleBarMenu = this.menuService.createMenu(MenuId.EditorTitle, scopedContextKeyService);
 			this.editorToolBarMenuDisposables.add(titleBarMenu);
 			this.editorToolBarMenuDisposables.add(titleBarMenu.onDidChange(() => {

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -123,6 +123,11 @@ export interface IEditorPane extends IComposite {
 	 * Finds out if this editor is visible or not.
 	 */
 	isVisible(): boolean;
+
+	/**
+	 * Should be overridden by editors that have their own ScopedContextKeyService
+	 */
+	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T | null;
 }
 
 /**

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -11,7 +11,7 @@ import { IDisposable, Disposable, toDisposable } from 'vs/base/common/lifecycle'
 import { IEditor, IEditorViewState, ScrollType, IDiffEditor } from 'vs/editor/common/editorCommon';
 import { IEditorModel, IEditorOptions, ITextEditorOptions, IBaseResourceEditorInput, IResourceEditorInput, EditorActivation, EditorOpenContext, ITextEditorSelection, TextEditorSelectionRevealType } from 'vs/platform/editor/common/editor';
 import { IInstantiationService, IConstructorSignature0, ServicesAccessor, BrandedService } from 'vs/platform/instantiation/common/instantiation';
-import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ITextModel } from 'vs/editor/common/model';
 import { IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
@@ -127,7 +127,7 @@ export interface IEditorPane extends IComposite {
 	/**
 	 * Should be overridden by editors that have their own ScopedContextKeyService
 	 */
-	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T | null;
+	getInternalContextKeyService(): IContextKeyService | undefined;
 }
 
 /**

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -113,6 +113,12 @@ export interface IEditorPane extends IComposite {
 	readonly onDidSizeConstraintsChange: Event<{ width: number; height: number; } | undefined>;
 
 	/**
+	 * The context key service for this editor. Should be overridden by
+	 * editors that have their own ScopedContextKeyService
+	 */
+	readonly scopedContextKeyService: IContextKeyService | undefined;
+
+	/**
 	 * Returns the underlying control of this editor. Callers need to cast
 	 * the control to a specific instance as needed, e.g. by using the
 	 * `isCodeEditor` helper method to access the text code editor.
@@ -123,11 +129,6 @@ export interface IEditorPane extends IComposite {
 	 * Finds out if this editor is visible or not.
 	 */
 	isVisible(): boolean;
-
-	/**
-	 * Should be overridden by editors that have their own ScopedContextKeyService
-	 */
-	getInternalContextKeyService(): IContextKeyService | undefined;
 }
 
 /**

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -27,6 +27,7 @@ import { IEditorGroup, IEditorGroupsService, GroupsOrder } from 'vs/workbench/se
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { NotebookEditorOptions } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 const NOTEBOOK_EDITOR_VIEW_STATE_PREFERENCE_KEY = 'NotebookEditorViewState';
 
@@ -86,6 +87,10 @@ export class NotebookEditor extends EditorPane {
 
 	get isNotebookEditor() {
 		return true;
+	}
+
+	get scopedContextKeyService(): IContextKeyService | undefined {
+		return this._widget.value?.contextKeyService;
 	}
 
 	protected createEditor(parent: HTMLElement): void {

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -27,7 +27,6 @@ import { IEditorGroup, IEditorGroupsService, GroupsOrder } from 'vs/workbench/se
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { NotebookEditorOptions } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 const NOTEBOOK_EDITOR_VIEW_STATE_PREFERENCE_KEY = 'NotebookEditorViewState';
 
@@ -90,7 +89,7 @@ export class NotebookEditor extends EditorPane {
 	}
 
 	get scopedContextKeyService(): IContextKeyService | undefined {
-		return this._widget.value?.contextKeyService;
+		return this._widget.value?.scopedContextKeyService;
 	}
 
 	protected createEditor(parent: HTMLElement): void {

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -228,7 +228,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 
 	readonly isEmbedded: boolean;
 
-	private readonly contextKeyService: IContextKeyService;
+	public readonly scopedContextKeyService: IContextKeyService;
 	private readonly instantiationService: IInstantiationService;
 
 	constructor(
@@ -247,8 +247,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 		this.isEmbedded = creationOptions.isEmbedded || false;
 
 		this._overlayContainer = document.createElement('div');
-		this.contextKeyService = contextKeyService.createScoped(this._overlayContainer);
-		this.instantiationService = instantiationService.createChild(new ServiceCollection([IContextKeyService, this.contextKeyService]));
+		this.scopedContextKeyService = contextKeyService.createScoped(this._overlayContainer);
+		this.instantiationService = instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService]));
 
 		this._memento = new Memento(NotebookEditorWidget.ID, storageService);
 		this._activeKernelMemento = new Memento(NotebookEditorActiveKernelCache, storageService);
@@ -389,15 +389,15 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 		this.layoutService.container.appendChild(this._overlayContainer);
 		this._createBody(this._overlayContainer);
 		this._generateFontInfo();
-		this._editorFocus = NOTEBOOK_EDITOR_FOCUSED.bindTo(this.contextKeyService);
+		this._editorFocus = NOTEBOOK_EDITOR_FOCUSED.bindTo(this.scopedContextKeyService);
 		this._isVisible = true;
-		this._outputFocus = NOTEBOOK_OUTPUT_FOCUSED.bindTo(this.contextKeyService);
-		this._editorEditable = NOTEBOOK_EDITOR_EDITABLE.bindTo(this.contextKeyService);
+		this._outputFocus = NOTEBOOK_OUTPUT_FOCUSED.bindTo(this.scopedContextKeyService);
+		this._editorEditable = NOTEBOOK_EDITOR_EDITABLE.bindTo(this.scopedContextKeyService);
 		this._editorEditable.set(true);
-		this._editorRunnable = NOTEBOOK_EDITOR_RUNNABLE.bindTo(this.contextKeyService);
+		this._editorRunnable = NOTEBOOK_EDITOR_RUNNABLE.bindTo(this.scopedContextKeyService);
 		this._editorRunnable.set(true);
-		this._notebookExecuting = NOTEBOOK_EDITOR_EXECUTING_NOTEBOOK.bindTo(this.contextKeyService);
-		this._notebookHasMultipleKernels = NOTEBOOK_HAS_MULTIPLE_KERNELS.bindTo(this.contextKeyService);
+		this._notebookExecuting = NOTEBOOK_EDITOR_EXECUTING_NOTEBOOK.bindTo(this.scopedContextKeyService);
+		this._notebookHasMultipleKernels = NOTEBOOK_HAS_MULTIPLE_KERNELS.bindTo(this.scopedContextKeyService);
 		this._notebookHasMultipleKernels.set(false);
 
 		let contributions: INotebookEditorContributionDescription[];
@@ -453,7 +453,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 			this._body,
 			this.instantiationService.createInstance(NotebookCellListDelegate),
 			renderers,
-			this.contextKeyService,
+			this.scopedContextKeyService,
 			{
 				setRowLineHeight: false,
 				setRowHeight: false,
@@ -561,7 +561,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 		this.contextMenuService.showContextMenu({
 			getActions: () => {
 				const result: IAction[] = [];
-				const menu = this.menuService.createMenu(MenuId.NotebookCellTitle, this.contextKeyService);
+				const menu = this.menuService.createMenu(MenuId.NotebookCellTitle, this.scopedContextKeyService);
 				const groups = menu.getActions();
 				menu.dispose();
 
@@ -640,7 +640,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 	}
 
 	setParentContextKeyService(parentContextKeyService: IContextKeyService): void {
-		this.contextKeyService.updateParent(parentContextKeyService);
+		this.scopedContextKeyService.updateParent(parentContextKeyService);
 	}
 
 	async setModel(textModel: NotebookTextModel, viewState: INotebookEditorViewState | undefined): Promise<void> {
@@ -673,7 +673,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 			const focused = this._list!.getFocusedElements()[0];
 			if (focused) {
 				if (!this._cellContextKeyManager) {
-					this._cellContextKeyManager = this._localStore.add(new CellContextKeyManager(this.contextKeyService, this, textModel, focused as CellViewModel));
+					this._cellContextKeyManager = this._localStore.add(new CellContextKeyManager(this.scopedContextKeyService, this, textModel, focused as CellViewModel));
 				}
 
 				this._cellContextKeyManager.updateForElement(focused as CellViewModel);

--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -10,7 +10,6 @@ import { IMenuService, MenuId, MenuItemAction, SubmenuItemAction, Action2 } from
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { timeout } from 'vs/base/common/async';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { DisposableStore, toDisposable, dispose } from 'vs/base/common/lifecycle';
 import { AbstractEditorCommandsQuickAccessProvider } from 'vs/editor/contrib/quickAccess/commandsQuickAccess';
 import { IEditor } from 'vs/editor/common/editorCommon';
@@ -95,11 +94,7 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 
 	private getGlobalCommandPicks(disposables: DisposableStore): ICommandQuickPick[] {
 		const globalCommandPicks: ICommandQuickPick[] = [];
-
-		const globalCommandsMenu = this.editorService.invokeWithinEditorContext(accessor =>
-			this.menuService.createMenu(MenuId.CommandPalette, accessor.get(IContextKeyService))
-		);
-
+		const globalCommandsMenu = this.menuService.createMenu(MenuId.CommandPalette, this.editorService.getEditorContextKeyService());
 		const globalCommandsMenuActions = globalCommandsMenu.getActions()
 			.reduce((r, [, actions]) => [...r, ...actions], <Array<MenuItemAction | SubmenuItemAction | string>>[])
 			.filter(action => action instanceof MenuItemAction) as MenuItemAction[];

--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -27,6 +27,7 @@ import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
+import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 
 export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAccessProvider {
 
@@ -58,7 +59,8 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 		@ICommandService commandService: ICommandService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@INotificationService notificationService: INotificationService,
-		@IConfigurationService private readonly configurationService: IConfigurationService
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService
 	) {
 		super({
 			showAlias: !Language.isDefaultVariant(),
@@ -94,7 +96,8 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 
 	private getGlobalCommandPicks(disposables: DisposableStore): ICommandQuickPick[] {
 		const globalCommandPicks: ICommandQuickPick[] = [];
-		const globalCommandsMenu = this.menuService.createMenu(MenuId.CommandPalette, this.editorService.getEditorContextKeyService());
+		const menuContextKeyService = this.editorService.activeEditorContextKeyService || this.editorGroupService.activeGroup.scopedContextKeyService;
+		const globalCommandsMenu = this.menuService.createMenu(MenuId.CommandPalette, menuContextKeyService);
 		const globalCommandsMenuActions = globalCommandsMenu.getActions()
 			.reduce((r, [, actions]) => [...r, ...actions], <Array<MenuItemAction | SubmenuItemAction | string>>[])
 			.filter(action => action instanceof MenuItemAction) as MenuItemAction[];

--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -96,8 +96,8 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 
 	private getGlobalCommandPicks(disposables: DisposableStore): ICommandQuickPick[] {
 		const globalCommandPicks: ICommandQuickPick[] = [];
-		const menuContextKeyService = this.editorService.activeEditorContextKeyService || this.editorGroupService.activeGroup.scopedContextKeyService;
-		const globalCommandsMenu = this.menuService.createMenu(MenuId.CommandPalette, menuContextKeyService);
+		const scopedContextKeyService = this.editorService.activeEditorPane?.scopedContextKeyService || this.editorGroupService.activeGroup.scopedContextKeyService;
+		const globalCommandsMenu = this.menuService.createMenu(MenuId.CommandPalette, scopedContextKeyService);
 		const globalCommandsMenuActions = globalCommandsMenu.getActions()
 			.reduce((r, [, actions]) => [...r, ...actions], <Array<MenuItemAction | SubmenuItemAction | string>>[])
 			.filter(action => action instanceof MenuItemAction) as MenuItemAction[];

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -459,8 +459,8 @@ export class NativeWindow extends Disposable {
 
 	private doUpdateTouchbarMenu(scheduler: RunOnceScheduler): void {
 		if (!this.touchBarMenu) {
-			const menuContextKeyService = this.editorService.activeEditorContextKeyService || this.editorGroupService.activeGroup.scopedContextKeyService;
-			this.touchBarMenu = this.menuService.createMenu(MenuId.TouchBarContext, menuContextKeyService);
+			const scopedContextKeyService = this.editorService.activeEditorPane?.scopedContextKeyService || this.editorGroupService.activeGroup.scopedContextKeyService;
+			this.touchBarMenu = this.menuService.createMenu(MenuId.TouchBarContext, scopedContextKeyService);
 			this.touchBarDisposables.add(this.touchBarMenu);
 			this.touchBarDisposables.add(this.touchBarMenu.onDidChange(() => scheduler.schedule()));
 		}

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -63,6 +63,7 @@ import { Event } from 'vs/base/common/event';
 import { clearAllFontInfos } from 'vs/editor/browser/config/configuration';
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { IAddressProvider, IAddress } from 'vs/platform/remote/common/remoteAgentConnection';
+import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 
 export class NativeWindow extends Disposable {
 
@@ -83,6 +84,7 @@ export class NativeWindow extends Disposable {
 
 	constructor(
 		@IEditorService private readonly editorService: IEditorService,
+		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ITitleService private readonly titleService: ITitleService,
 		@IWorkbenchThemeService protected themeService: IWorkbenchThemeService,
@@ -457,7 +459,8 @@ export class NativeWindow extends Disposable {
 
 	private doUpdateTouchbarMenu(scheduler: RunOnceScheduler): void {
 		if (!this.touchBarMenu) {
-			this.touchBarMenu = this.menuService.createMenu(MenuId.TouchBarContext, this.editorService.getEditorContextKeyService());
+			const menuContextKeyService = this.editorService.activeEditorContextKeyService || this.editorGroupService.activeGroup.scopedContextKeyService;
+			this.touchBarMenu = this.menuService.createMenu(MenuId.TouchBarContext, menuContextKeyService);
 			this.touchBarDisposables.add(this.touchBarMenu);
 			this.touchBarDisposables.add(this.touchBarMenu.onDidChange(() => scheduler.schedule()));
 		}

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -457,7 +457,7 @@ export class NativeWindow extends Disposable {
 
 	private doUpdateTouchbarMenu(scheduler: RunOnceScheduler): void {
 		if (!this.touchBarMenu) {
-			this.touchBarMenu = this.editorService.invokeWithinEditorContext(accessor => this.menuService.createMenu(MenuId.TouchBarContext, accessor.get(IContextKeyService)));
+			this.touchBarMenu = this.menuService.createMenu(MenuId.TouchBarContext, this.editorService.getEditorContextKeyService());
 			this.touchBarDisposables.add(this.touchBarMenu);
 			this.touchBarDisposables.add(this.touchBarMenu.onDidChange(() => scheduler.schedule()));
 		}

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -790,9 +790,9 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 	//#region invokeWithinEditorContext()
 
 	invokeWithinEditorContext<T>(fn: (accessor: ServicesAccessor) => T): T {
-		const activeTextEditorControl = this.activeTextEditorControl;
-		if (isCodeEditor(activeTextEditorControl)) {
-			return activeTextEditorControl.invokeWithinContext(fn);
+		const result = this.activeEditorPane?.invokeWithinContext(fn);
+		if (result) {
+			return result;
 		}
 
 		const activeGroup = this.editorGroupService.activeGroup;

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -39,7 +39,6 @@ import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'v
 import { IWorkingCopyService } from 'vs/workbench/services/workingCopy/common/workingCopyService';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
 import { IModelService } from 'vs/editor/common/services/modelService';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 type CachedEditorInput = ResourceEditorInput | IFileEditorInput | UntitledTextEditorInput;
 type OpenInEditorGroup = IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE;
@@ -427,10 +426,6 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		}
 
 		return activeCodeEditor?.getModel()?.getLanguageIdentifier().language;
-	}
-
-	get activeEditorContextKeyService(): IContextKeyService | undefined {
-		return this.activeEditorPane?.scopedContextKeyService;
 	}
 
 	get count(): number {
@@ -1316,7 +1311,6 @@ export class DelegatingEditorService implements IEditorService {
 	get visibleTextEditorControls(): ReadonlyArray<ICodeEditor | IDiffEditor> { return this.editorService.visibleTextEditorControls; }
 	get editors(): ReadonlyArray<IEditorInput> { return this.editorService.editors; }
 	get count(): number { return this.editorService.count; }
-	get activeEditorContextKeyService(): IContextKeyService | undefined { return this.editorService.activeEditorContextKeyService; }
 
 	getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): ReadonlyArray<IEditorIdentifier> { return this.editorService.getEditors(order, options); }
 

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -429,6 +429,10 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		return activeCodeEditor?.getModel()?.getLanguageIdentifier().language;
 	}
 
+	get activeEditorContextKeyService(): IContextKeyService | undefined {
+		return this.activeEditorPane?.scopedContextKeyService;
+	}
+
 	get count(): number {
 		return this.editorsObserver.count;
 	}
@@ -784,32 +788,6 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		if (targetGroup) {
 			return targetGroup.replaceEditors(typedEditors);
 		}
-	}
-
-	//#endregion
-
-	//#region getEditorContextKeyService()
-
-	getEditorContextKeyService(): IContextKeyService {
-		const activeEditorPane = this.activeEditorPane;
-		if (activeEditorPane) {
-			const result = activeEditorPane.getInternalContextKeyService();
-			if (result) {
-				return result;
-			}
-
-			const activeControl = activeEditorPane.getControl();
-			if (isCompositeEditor(activeControl) && isCodeEditor(activeControl.activeCodeEditor)) {
-				return activeControl.activeCodeEditor.invokeWithinContext(accessor => accessor.get(IContextKeyService));
-			}
-		}
-
-		const activeGroup = this.editorGroupService.activeGroup;
-		if (activeGroup) {
-			return activeGroup.getInternalContextKeyService();
-		}
-
-		return this.instantiationService.invokeFunction(accessor => accessor.get(IContextKeyService));
 	}
 
 	//#endregion
@@ -1338,6 +1316,7 @@ export class DelegatingEditorService implements IEditorService {
 	get visibleTextEditorControls(): ReadonlyArray<ICodeEditor | IDiffEditor> { return this.editorService.visibleTextEditorControls; }
 	get editors(): ReadonlyArray<IEditorInput> { return this.editorService.editors; }
 	get count(): number { return this.editorService.count; }
+	get activeEditorContextKeyService(): IContextKeyService | undefined { return this.editorService.activeEditorContextKeyService; }
 
 	getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): ReadonlyArray<IEditorIdentifier> { return this.editorService.getEditors(order, options); }
 
@@ -1359,8 +1338,6 @@ export class DelegatingEditorService implements IEditorService {
 
 	overrideOpenEditor(handler: IOpenEditorOverrideHandler): IDisposable { return this.editorService.overrideOpenEditor(handler); }
 	getEditorOverrides(resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined) { return this.editorService.getEditorOverrides(resource, options, group); }
-
-	getEditorContextKeyService(): IContextKeyService { return this.editorService.getEditorContextKeyService(); }
 
 	createEditorInput(input: IResourceEditorInputType): IEditorInput { return this.editorService.createEditorInput(input); }
 

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from 'vs/base/common/event';
-import { createDecorator, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorInput, IEditorPane, GroupIdentifier, IEditorInputWithOptions, CloseDirection, IEditorPartOptions, IEditorPartOptionsChangeEvent, EditorsOrder, IVisibleEditorPane, IEditorCloseEvent } from 'vs/workbench/common/editor';
 import { IEditorOptions, ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IDimension } from 'vs/editor/common/editorCommon';
 import { IDisposable } from 'vs/base/common/lifecycle';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 export const IEditorGroupsService = createDecorator<IEditorGroupsService>('editorGroupsService');
 
@@ -592,5 +593,5 @@ export interface IEditorGroup {
 	/**
 	 * Invoke a function in the context of the services of this group.
 	 */
-	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T;
+	getInternalContextKeyService(): IContextKeyService;
 }

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -452,6 +452,11 @@ export interface IEditorGroup {
 	readonly editors: ReadonlyArray<IEditorInput>;
 
 	/**
+	 * The scoped context key service for this group.
+	 */
+	readonly scopedContextKeyService: IContextKeyService;
+
+	/**
 	 * Get all editors that are currently opened in the group.
 	 *
 	 * @param order the order of the editors to use
@@ -589,9 +594,4 @@ export interface IEditorGroup {
 	 * Move keyboard focus into the group.
 	 */
 	focus(): void;
-
-	/**
-	 * Invoke a function in the context of the services of this group.
-	 */
-	getInternalContextKeyService(): IContextKeyService;
 }

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { createDecorator, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IResourceEditorInput, IEditorOptions, ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { IEditorInput, IEditorPane, GroupIdentifier, IEditorInputWithOptions, IUntitledTextResourceEditorInput, IResourceDiffEditorInput, ITextEditorPane, ITextDiffEditorPane, IEditorIdentifier, ISaveOptions, IRevertOptions, EditorsOrder, IVisibleEditorPane, IEditorCloseEvent } from 'vs/workbench/common/editor';
 import { Event } from 'vs/base/common/event';
@@ -11,6 +11,7 @@ import { IEditor, IDiffEditor } from 'vs/editor/common/editorCommon';
 import { IEditorGroup, IEditorReplacement, OpenEditorContext } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 export const IEditorService = createDecorator<IEditorService>('editorService');
 
@@ -253,9 +254,9 @@ export interface IEditorService {
 	registerCustomEditorViewTypesHandler(source: string, handler: ICustomEditorViewTypesHandler): IDisposable;
 
 	/**
-	 * Invoke a function in the context of the services of the active editor.
+	 * Get the context key service for the active editor.
 	 */
-	invokeWithinEditorContext<T>(fn: (accessor: ServicesAccessor) => T): T;
+	getEditorContextKeyService(): IContextKeyService;
 
 	/**
 	 * Converts a lightweight input to a workbench editor input.

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -11,7 +11,6 @@ import { IEditor, IDiffEditor } from 'vs/editor/common/editorCommon';
 import { IEditorGroup, IEditorReplacement, OpenEditorContext } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 export const IEditorService = createDecorator<IEditorService>('editorService');
 
@@ -131,12 +130,6 @@ export interface IEditorService {
 	 * @see `IEditorService.activeEditor`
 	 */
 	readonly activeTextEditorControl: IEditor | IDiffEditor | undefined;
-
-	/**
-	 * Get the context key service for the active editor or `undefined` if there is currently no
-	 * active editor
-	 */
-	readonly activeEditorContextKeyService: IContextKeyService | undefined;
 
 	/**
 	 * The currently active text editor mode or `undefined` if there is currently no active

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -133,6 +133,12 @@ export interface IEditorService {
 	readonly activeTextEditorControl: IEditor | IDiffEditor | undefined;
 
 	/**
+	 * Get the context key service for the active editor or `undefined` if there is currently no
+	 * active editor
+	 */
+	readonly activeEditorContextKeyService: IContextKeyService | undefined;
+
+	/**
 	 * The currently active text editor mode or `undefined` if there is currently no active
 	 * editor or the active editor control is neither a text nor a diff editor. If the active
 	 * editor is a diff editor, the modified side's mode will be taken.
@@ -252,11 +258,6 @@ export interface IEditorService {
 	 * and also notify the editor service when a custom editor view type is registered/unregistered.
 	 */
 	registerCustomEditorViewTypesHandler(source: string, handler: ICustomEditorViewTypesHandler): IDisposable;
-
-	/**
-	 * Get the context key service for the active editor.
-	 */
-	getEditorContextKeyService(): IContextKeyService;
 
 	/**
 	 * Converts a lightweight input to a workbench editor input.

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -7,11 +7,11 @@ import * as assert from 'assert';
 import { Event } from 'vs/base/common/event';
 import { workbenchInstantiationService, registerTestEditor, TestFileEditorInput, TestEditorPart, ITestInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { GroupDirection, GroupsOrder, MergeGroupMode, GroupOrientation, GroupChangeKind, GroupLocation, OpenEditorContext } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { EditorOptions, CloseDirection, IEditorPartOptions, EditorsOrder } from 'vs/workbench/common/editor';
 import { URI } from 'vs/base/common/uri';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
+import { MockScopableContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
 
 const TEST_EDITOR_ID = 'MyFileEditorForEditorGroupService';
 const TEST_EDITOR_INPUT_ID = 'testEditorInputForEditorGroupService';
@@ -38,7 +38,8 @@ suite('EditorGroupsService', () => {
 	}
 
 	test('groups basics', async function () {
-		const [part] = createPart();
+		const instantiationService = workbenchInstantiationService({ contextKeyService: instantiationService => instantiationService.createInstance(MockScopableContextKeyService) });
+		const [part] = createPart(instantiationService);
 
 		let activeGroupChangeCounter = 0;
 		const activeGroupChangeListener = part.onDidActiveGroupChange(() => {
@@ -161,19 +162,12 @@ suite('EditorGroupsService', () => {
 		assert.equal(mru[0], rightGroup);
 		assert.equal(mru[1], rootGroup);
 
-		let rightGroupInstantiator!: IInstantiationService;
-		part.activeGroup.invokeWithinContext(accessor => {
-			rightGroupInstantiator = accessor.get(IInstantiationService);
-		});
+		const rightGroupCKS = part.activeGroup.getInternalContextKeyService();
+		const rootGroupCKS = rootGroup.getInternalContextKeyService();
 
-		let rootGroupInstantiator!: IInstantiationService;
-		rootGroup.invokeWithinContext(accessor => {
-			rootGroupInstantiator = accessor.get(IInstantiationService);
-		});
-
-		assert.ok(rightGroupInstantiator);
-		assert.ok(rootGroupInstantiator);
-		assert.ok(rightGroupInstantiator !== rootGroupInstantiator);
+		assert.ok(rightGroupCKS);
+		assert.ok(rootGroupCKS);
+		assert.ok(rightGroupCKS !== rootGroupCKS);
 
 		part.removeGroup(rightGroup);
 		assert.equal(groupRemovedCounter, 2);

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -162,8 +162,8 @@ suite('EditorGroupsService', () => {
 		assert.equal(mru[0], rightGroup);
 		assert.equal(mru[1], rootGroup);
 
-		const rightGroupCKS = part.activeGroup.getInternalContextKeyService();
-		const rootGroupCKS = rootGroup.getInternalContextKeyService();
+		const rightGroupCKS = part.activeGroup.scopedContextKeyService;
+		const rootGroupCKS = rootGroup.scopedContextKeyService;
 
 		assert.ok(rightGroupCKS);
 		assert.ok(rootGroupCKS);

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -162,12 +162,12 @@ suite('EditorGroupsService', () => {
 		assert.equal(mru[0], rightGroup);
 		assert.equal(mru[1], rootGroup);
 
-		const rightGroupCKS = part.activeGroup.scopedContextKeyService;
-		const rootGroupCKS = rootGroup.scopedContextKeyService;
+		const rightGroupContextKeyService = part.activeGroup.scopedContextKeyService;
+		const rootGroupContextKeyService = rootGroup.scopedContextKeyService;
 
-		assert.ok(rightGroupCKS);
-		assert.ok(rootGroupCKS);
-		assert.ok(rightGroupCKS !== rootGroupCKS);
+		assert.ok(rightGroupContextKeyService);
+		assert.ok(rootGroupContextKeyService);
+		assert.ok(rightGroupContextKeyService !== rootGroupContextKeyService);
 
 		part.removeGroup(rightGroup);
 		assert.equal(groupRemovedCounter, 2);

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -1026,7 +1026,7 @@ suite('EditorService', () => {
 		part.dispose();
 	});
 
-	test('getEditorContextKeyService', async function () {
+	test('activeEditorContextKeyService', async function () {
 		const instantiationService = workbenchInstantiationService({ contextKeyService: instantiationService => instantiationService.createInstance(MockScopableContextKeyService) });
 		const [part, service] = createEditorService(instantiationService);
 
@@ -1038,8 +1038,8 @@ suite('EditorService', () => {
 		await service.openEditor(input1, { pinned: true });
 
 		const editorCKS = service.activeEditorContextKeyService;
-		assert.ok(editorCKS);
-		assert.ok(editorCKS === part.activeGroup.activeEditorPane?.scopedContextKeyService);
+		assert.ok(!!editorCKS);
+		assert.strictEqual(editorCKS, part.activeGroup.activeEditorPane?.scopedContextKeyService);
 
 		part.dispose();
 	});

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -9,7 +9,7 @@ import { URI } from 'vs/base/common/uri';
 import { Event } from 'vs/base/common/event';
 import { EditorPane } from 'vs/workbench/browser/parts/editor/editorPane';
 import { EditorInput, EditorsOrder, SideBySideEditorInput } from 'vs/workbench/common/editor';
-import { workbenchInstantiationService, TestServiceAccessor, registerTestEditor, TestFileEditorInput } from 'vs/workbench/test/browser/workbenchTestServices';
+import { workbenchInstantiationService, TestServiceAccessor, registerTestEditor, TestFileEditorInput, ITestInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { ResourceEditorInput } from 'vs/workbench/common/editor/resourceEditorInput';
 import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 import { EditorService, DelegatingEditorService } from 'vs/workbench/services/editor/browser/editorService';
@@ -29,6 +29,7 @@ import { NullFileSystemProvider } from 'vs/platform/files/test/common/nullFileSy
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 import { isLinux } from 'vs/base/common/platform';
+import { MockScopableContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
 
 const TEST_EDITOR_ID = 'MyTestEditorForEditorService';
 const TEST_EDITOR_INPUT_ID = 'testEditorInputForEditorService';
@@ -54,9 +55,7 @@ suite('EditorService', () => {
 		disposables = [];
 	});
 
-	function createEditorService(): [EditorPart, EditorService, TestServiceAccessor] {
-		const instantiationService = workbenchInstantiationService();
-
+	function createEditorService(instantiationService: ITestInstantiationService = workbenchInstantiationService()): [EditorPart, EditorService, TestServiceAccessor] {
 		const part = instantiationService.createInstance(EditorPart);
 		part.create(document.createElement('div'));
 		part.layout(400, 300);
@@ -1027,8 +1026,9 @@ suite('EditorService', () => {
 		part.dispose();
 	});
 
-	test('invokeWithinEditorContext', async function () {
-		const [part, service] = createEditorService();
+	test('getEditorContextKeyService', async function () {
+		const instantiationService = workbenchInstantiationService({ contextKeyService: instantiationService => instantiationService.createInstance(MockScopableContextKeyService) });
+		const [part, service] = createEditorService(instantiationService);
 
 		const input1 = new TestFileEditorInput(URI.parse('file://resource1'), TEST_EDITOR_INPUT_ID);
 		new TestFileEditorInput(URI.parse('file://resource2'), TEST_EDITOR_INPUT_ID);
@@ -1037,12 +1037,9 @@ suite('EditorService', () => {
 
 		await service.openEditor(input1, { pinned: true });
 
-		let hasAccessor = false;
-		service.invokeWithinEditorContext(accessor => {
-			hasAccessor = true;
-		});
-
-		assert.ok(hasAccessor);
+		const editorCKS = service.getEditorContextKeyService();
+		assert.ok(editorCKS);
+		assert.ok(editorCKS === part.activeGroup.activeEditorPane?.getInternalContextKeyService());
 
 		part.dispose();
 	});

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -1026,7 +1026,7 @@ suite('EditorService', () => {
 		part.dispose();
 	});
 
-	test('activeEditorContextKeyService', async function () {
+	test('activeEditorPane scopedContextKeyService', async function () {
 		const instantiationService = workbenchInstantiationService({ contextKeyService: instantiationService => instantiationService.createInstance(MockScopableContextKeyService) });
 		const [part, service] = createEditorService(instantiationService);
 
@@ -1037,9 +1037,9 @@ suite('EditorService', () => {
 
 		await service.openEditor(input1, { pinned: true });
 
-		const editorCKS = service.activeEditorContextKeyService;
-		assert.ok(!!editorCKS);
-		assert.strictEqual(editorCKS, part.activeGroup.activeEditorPane?.scopedContextKeyService);
+		const editorContextKeyService = service.activeEditorPane?.scopedContextKeyService;
+		assert.ok(!!editorContextKeyService);
+		assert.strictEqual(editorContextKeyService, part.activeGroup.activeEditorPane?.scopedContextKeyService);
 
 		part.dispose();
 	});

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -1037,9 +1037,9 @@ suite('EditorService', () => {
 
 		await service.openEditor(input1, { pinned: true });
 
-		const editorCKS = service.getEditorContextKeyService();
+		const editorCKS = service.activeEditorContextKeyService;
 		assert.ok(editorCKS);
-		assert.ok(editorCKS === part.activeGroup.activeEditorPane?.getInternalContextKeyService());
+		assert.ok(editorCKS === part.activeGroup.activeEditorPane?.scopedContextKeyService);
 
 		part.dispose();
 	});

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -631,7 +631,7 @@ export class TestEditorGroupView implements IEditorGroupView {
 	stickEditor(editor?: IEditorInput | undefined): void { }
 	unstickEditor(editor?: IEditorInput | undefined): void { }
 	focus(): void { }
-	getInternalContextKeyService(): IContextKeyService { throw new Error('not implemented'); }
+	get scopedContextKeyService(): IContextKeyService { throw new Error('not implemented'); }
 	setActive(_isActive: boolean): void { }
 	notifyIndexChanged(_index: number): void { }
 	dispose(): void { }
@@ -691,6 +691,7 @@ export class TestEditorService implements EditorServiceImpl {
 	count = this.editors.length;
 
 	constructor(private editorGroupService?: IEditorGroupsService) { }
+	activeEditorContextKeyService: IContextKeyService | undefined;
 	getEditors() { return []; }
 	getEditorOverrides(resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined): [IOpenEditorOverrideHandler, IOpenEditorOverrideEntry][] { return []; }
 	overrideOpenEditor(_handler: IOpenEditorOverrideHandler): IDisposable { return toDisposable(() => undefined); }

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -30,7 +30,7 @@ import { ModelServiceImpl } from 'vs/editor/common/services/modelServiceImpl';
 import { IResourceEncoding, ITextFileService, IReadTextFileOptions, ITextFileStreamContent } from 'vs/workbench/services/textfile/common/textfiles';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
-import { IInstantiationService, ServicesAccessor, ServiceIdentifier } from 'vs/platform/instantiation/common/instantiation';
+import { IInstantiationService, ServiceIdentifier } from 'vs/platform/instantiation/common/instantiation';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { MenuBarVisibility, IWindowOpenable, IOpenWindowOptions, IOpenEmptyWindowOptions } from 'vs/platform/windows/common/windows';
 import { TestWorkspace } from 'vs/platform/workspace/test/common/testWorkspace';
@@ -126,13 +126,14 @@ export interface ITestInstantiationService extends IInstantiationService {
 export function workbenchInstantiationService(overrides?: {
 	textFileService?: (instantiationService: IInstantiationService) => ITextFileService
 	pathService?: (instantiationService: IInstantiationService) => IPathService,
-	editorService?: (instantiationService: IInstantiationService) => IEditorService
+	editorService?: (instantiationService: IInstantiationService) => IEditorService,
+	contextKeyService?: (instantiationService: IInstantiationService) => IContextKeyService,
 }): ITestInstantiationService {
 	const instantiationService = new TestInstantiationService(new ServiceCollection([ILifecycleService, new TestLifecycleService()]));
 
 	instantiationService.stub(IWorkingCopyService, new TestWorkingCopyService());
 	instantiationService.stub(IEnvironmentService, TestEnvironmentService);
-	const contextKeyService = <IContextKeyService>instantiationService.createInstance(MockContextKeyService);
+	const contextKeyService = overrides?.contextKeyService ? overrides.contextKeyService(instantiationService) : instantiationService.createInstance(MockContextKeyService);
 	instantiationService.stub(IContextKeyService, contextKeyService);
 	instantiationService.stub(IProgressService, new TestProgressService());
 	const workspaceContextService = new TestContextService(TestWorkspace);
@@ -630,7 +631,7 @@ export class TestEditorGroupView implements IEditorGroupView {
 	stickEditor(editor?: IEditorInput | undefined): void { }
 	unstickEditor(editor?: IEditorInput | undefined): void { }
 	focus(): void { }
-	invokeWithinContext<T>(fn: (accessor: ServicesAccessor) => T): T { throw new Error('not implemented'); }
+	getInternalContextKeyService(): IContextKeyService { throw new Error('not implemented'); }
 	setActive(_isActive: boolean): void { }
 	notifyIndexChanged(_index: number): void { }
 	dispose(): void { }
@@ -712,7 +713,7 @@ export class TestEditorService implements EditorServiceImpl {
 	openEditors(_editors: any, _group?: any): Promise<IEditorPane[]> { throw new Error('not implemented'); }
 	isOpen(_editor: IEditorInput | IResourceEditorInput): boolean { return false; }
 	replaceEditors(_editors: any, _group: any) { return Promise.resolve(undefined); }
-	invokeWithinEditorContext<T>(fn: (accessor: ServicesAccessor) => T): T { throw new Error('not implemented'); }
+	getEditorContextKeyService(): IContextKeyService { throw new Error('not implemented'); }
 	createEditorInput(_input: IResourceEditorInput | IUntitledTextResourceEditorInput | IResourceDiffEditorInput): EditorInput { throw new Error('not implemented'); }
 	save(editors: IEditorIdentifier[], options?: ISaveEditorsOptions): Promise<boolean> { throw new Error('Method not implemented.'); }
 	saveAll(options?: ISaveEditorsOptions): Promise<boolean> { throw new Error('Method not implemented.'); }
@@ -1074,7 +1075,12 @@ export class TestEditorInput extends EditorInput {
 export function registerTestEditor(id: string, inputs: SyncDescriptor<EditorInput>[], factoryInputId?: string): IDisposable {
 	class TestEditor extends EditorPane {
 
-		constructor() { super(id, NullTelemetryService, new TestThemeService(), new TestStorageService()); }
+		private _scopedContextKeyService: IContextKeyService;
+
+		constructor() {
+			super(id, NullTelemetryService, new TestThemeService(), new TestStorageService());
+			this._scopedContextKeyService = new MockContextKeyService();
+		}
 
 		async setInput(input: EditorInput, options: EditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
 			super.setInput(input, options, context, token);
@@ -1085,6 +1091,10 @@ export function registerTestEditor(id: string, inputs: SyncDescriptor<EditorInpu
 		getId(): string { return id; }
 		layout(): void { }
 		createEditor(): void { }
+
+		getInternalContextKeyService() {
+			return this._scopedContextKeyService;
+		}
 	}
 
 	const disposables = new DisposableStore();

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -691,7 +691,6 @@ export class TestEditorService implements EditorServiceImpl {
 	count = this.editors.length;
 
 	constructor(private editorGroupService?: IEditorGroupsService) { }
-	activeEditorContextKeyService: IContextKeyService | undefined;
 	getEditors() { return []; }
 	getEditorOverrides(resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined): [IOpenEditorOverrideHandler, IOpenEditorOverrideEntry][] { return []; }
 	overrideOpenEditor(_handler: IOpenEditorOverrideHandler): IDisposable { return toDisposable(() => undefined); }
@@ -714,7 +713,6 @@ export class TestEditorService implements EditorServiceImpl {
 	openEditors(_editors: any, _group?: any): Promise<IEditorPane[]> { throw new Error('not implemented'); }
 	isOpen(_editor: IEditorInput | IResourceEditorInput): boolean { return false; }
 	replaceEditors(_editors: any, _group: any) { return Promise.resolve(undefined); }
-	getEditorContextKeyService(): IContextKeyService { throw new Error('not implemented'); }
 	createEditorInput(_input: IResourceEditorInput | IUntitledTextResourceEditorInput | IResourceDiffEditorInput): EditorInput { throw new Error('not implemented'); }
 	save(editors: IEditorIdentifier[], options?: ISaveEditorsOptions): Promise<boolean> { throw new Error('Method not implemented.'); }
 	saveAll(options?: ISaveEditorsOptions): Promise<boolean> { throw new Error('Method not implemented.'); }

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1093,7 +1093,7 @@ export function registerTestEditor(id: string, inputs: SyncDescriptor<EditorInpu
 		layout(): void { }
 		createEditor(): void { }
 
-		getInternalContextKeyService() {
+		get scopedContextKeyService() {
 			return this._scopedContextKeyService;
 		}
 	}


### PR DESCRIPTION
Continues PR #104694
and #104894

Breaking this part out to simplify things. I don't fully understand the hierarchy of editor types, but I think this should catch the cases that we have currently. BaseTextEditor can do the code editor check and delegate to the existing invokeWithinContext method for those, TextDiffEditor can override it for its deal, and I fixed the EditorService to use the new generic method.

Looking at other usages of the code editor's `invokeWithinContext`, it looks like they are all only concerned with code editors and so it would be ok to let them call it at that level. But @bpasero did you want to change those usages more aggressively?

To handle @eamodio's requirement properly, we also need to change the way that the Left/Right diff focus context keys work, so that they are set at the editor's top-level ContextKeyService and change in value, rather than being defined as constants in the individual left/right ContextKeyServices, because we need the CKS to trigger a change event that the menu is listening to.