### PR TITLE
Add snippets for markdown

### DIFF
--- a/extensions/markdown-basics/snippets/markdown.code-snippets
+++ b/extensions/markdown-basics/snippets/markdown.code-snippets
@@ -14,43 +14,54 @@
 		"body": "> ${1:${TM_SELECTED_TEXT}}",
 		"description": "Insert quoted text"
 	},
-	"Insert code": {
+	"Insert inline code": {
 		"prefix": "code",
 		"body": "`${1:${TM_SELECTED_TEXT}}`$0",
-		"description": "Insert code"
+		"description": "Insert inline code"
 	},
 	"Insert fenced code block": {
 		"prefix": "fenced codeblock",
-		"body": [
-			"```${1:language}",
-			"${TM_SELECTED_TEXT}$0",
-			"```"
-		],
+		"body": ["```${1:language}", "${TM_SELECTED_TEXT}$0", "```"],
 		"description": "Insert fenced code block"
 	},
-	"Insert heading": {
-		"prefix": "heading",
+	"Insert heading level 1": {
+		"prefix": "heading1",
 		"body": "# ${1:${TM_SELECTED_TEXT}}",
-		"description": "Insert heading"
+		"description": "Insert heading level 1"
+	},
+	"Insert heading level 2": {
+		"prefix": "heading2",
+		"body": "## ${1:${TM_SELECTED_TEXT}}",
+		"description": "Insert heading level 2"
+	},
+	"Insert heading level 3": {
+		"prefix": "heading3",
+		"body": "### ${1:${TM_SELECTED_TEXT}}",
+		"description": "Insert heading level 3"
+	},
+	"Insert heading level 4": {
+		"prefix": "heading4",
+		"body": "#### ${1:${TM_SELECTED_TEXT}}",
+		"description": "Insert heading level 4"
+	},
+	"Insert heading level 5": {
+		"prefix": "heading5",
+		"body": "##### ${1:${TM_SELECTED_TEXT}}",
+		"description": "Insert heading level 5"
+	},
+	"Insert heading level 6": {
+		"prefix": "heading6",
+		"body": "###### ${1:${TM_SELECTED_TEXT}}",
+		"description": "Insert heading level 6"
 	},
 	"Insert unordered list": {
 		"prefix": "unordered list",
-		"body": [
-			"- ${1:first}",
-			"- ${2:second}",
-			"- ${3:third}",
-			"$0"
-		],
+		"body": ["- ${1:first}", "- ${2:second}", "- ${3:third}", "$0"],
 		"description": "Insert unordered list"
 	},
 	"Insert ordered list": {
 		"prefix": "ordered list",
-		"body": [
-			"1. ${1:first}",
-			"2. ${2:second}",
-			"3. ${3:third}",
-			"$0"
-		],
+		"body": ["1. ${1:first}", "2. ${2:second}", "3. ${3:third}", "$0"],
 		"description": "Insert ordered list"
 	},
 	"Insert horizontal rule": {
@@ -67,5 +78,10 @@
 		"prefix": "image",
 		"body": "![${TM_SELECTED_TEXT:${1:alt}}](https://${2:link})$0",
 		"description": "Insert image"
+	},
+	"Insert strikethrough": {
+		"prefix": "strikethrough",
+		"body": "~~${1:${TM_SELECTED_TEXT}}~~",
+		"description": "Insert strikethrough"
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #104720.

This change improves markdown snippets coverage for the basic syntax supported by VS Code.

Added snippets for all heading levels and strikethrough. 

Changed the name and description of "Insert code" to "Insert inline code", to make a clearer distinction between it and the "Insert fenced code block" snippet. 

Other line changes are due to *Prettier* formatting.