### PR TITLE
105160: Support configuring keyboard overlay timeout + mouse indicator color/size

### DIFF
--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -123,14 +123,37 @@ class ToggleScreencastModeAction extends Action2 {
 		const onMouseUp = domEvent(container, 'mouseup', true);
 		const onMouseMove = domEvent(container, 'mousemove', true);
 
+		let mouseIndicatorColor: string;
+		const updateMouseIndicatorColor = () => {
+			mouseIndicatorColor = configurationService.getValue<string>('screencastMode.mouseIndicatorColor');
+
+			let style = new Option().style;
+			style.color = mouseIndicatorColor;
+			if (mouseIndicatorColor === '' || !style.color) {
+				mouseIndicatorColor = 'red';
+			}
+		};
+
+		let mouseIndicatorSize: number;
+		const updateMouseIndicatorSize = () => {
+			mouseIndicatorSize = clamp(configurationService.getValue<number>('screencastMode.mouseIndicatorSize') || 20, 20, 100);
+		};
+
+		updateMouseIndicatorColor();
+		updateMouseIndicatorSize();
+
 		disposables.add(onMouseDown(e => {
-			mouseMarker.style.top = `${e.clientY - 10}px`;
-			mouseMarker.style.left = `${e.clientX - 10}px`;
+			mouseMarker.style.height = `${mouseIndicatorSize}px`;
+			mouseMarker.style.width = `${mouseIndicatorSize}px`;
+			mouseMarker.style.borderRadius = '50%';
+			mouseMarker.style.borderColor = mouseIndicatorColor;
+			mouseMarker.style.top = `${e.clientY - mouseIndicatorSize / 2}px`;
+			mouseMarker.style.left = `${e.clientX - mouseIndicatorSize / 2}px`;
 			mouseMarker.style.display = 'block';
 
 			const mouseMoveListener = onMouseMove(e => {
-				mouseMarker.style.top = `${e.clientY - 10}px`;
-				mouseMarker.style.left = `${e.clientX - 10}px`;
+				mouseMarker.style.top = `${e.clientY - mouseIndicatorSize / 2}px`;
+				mouseMarker.style.left = `${e.clientX - mouseIndicatorSize / 2}px`;
 			});
 
 			Event.once(onMouseUp)(() => {
@@ -170,6 +193,14 @@ class ToggleScreencastModeAction extends Action2 {
 
 			if (e.affectsConfiguration('screencastMode.keyboardOverlayTimeout')) {
 				updateKeyboardMarkerTimeout();
+			}
+
+			if (e.affectsConfiguration('screencastMode.mouseIndicatorColor')) {
+				updateMouseIndicatorColor();
+			}
+
+			if (e.affectsConfiguration('screencastMode.mouseIndicatorSize')) {
+				updateMouseIndicatorSize();
 			}
 		}));
 
@@ -295,6 +326,18 @@ configurationRegistry.registerConfiguration({
 			minimum: 500,
 			maximum: 5000,
 			description: nls.localize('screencastMode.keyboardOverlayTimeout', "Controls how long (in milliseconds) the keyboard overlay is shown in screencast mode.")
-		}
+		},
+		'screencastMode.mouseIndicatorColor': {
+			type: 'string',
+			default: 'red',
+			description: nls.localize('screencastMode.mouseIndicatorColor', "Controls the color (string or Hex) of the mouse indicator in screencast mode.")
+		},
+		'screencastMode.mouseIndicatorSize': {
+			type: 'number',
+			default: 20,
+			minimum: 20,
+			maximum: 100,
+			description: nls.localize('screencastMode.mouseIndicatorSize', "Controls the size (in pixels) of the mouse indicator in screencast mode.")
+		},
 	}
 });

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -190,7 +190,7 @@ class ToggleScreencastModeAction extends Action2 {
 				append(keyboardMarker, key);
 			}
 
-			const promise = timeout(800);
+			const promise = timeout(configurationService.getValue<number>('screencastMode.overlayTimeout'));
 			keyboardTimeout = toDisposable(() => promise.cancel());
 
 			promise.then(() => {
@@ -278,6 +278,13 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			description: nls.localize('screencastMode.onlyKeyboardShortcuts', "Only show keyboard shortcuts in Screencast Mode."),
 			default: false
+		},
+		'screencastMode.overlayTimeout': {
+			type: 'number',
+			default: 800,
+			minimum: 500,
+			maximum: 6000,
+			description: nls.localize('screencastMode.overlayTimeout', "Controls how long (in milliseconds) the screencast mode overlay is shown.")
 		}
 	}
 });

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -150,8 +150,14 @@ class ToggleScreencastModeAction extends Action2 {
 			keyboardMarker.style.bottom = `${clamp(configurationService.getValue<number>('screencastMode.verticalOffset') || 0, 0, 90)}%`;
 		};
 
+		let keyboardMarkerTimeout: number;
+		const updateKeyboardMarkerTimeout = () => {
+			keyboardMarkerTimeout = clamp(configurationService.getValue<number>('screencastMode.keyboardOverlayTimeout') || 800, 500, 5000);
+		};
+
 		updateKeyboardFontSize();
 		updateKeyboardMarker();
+		updateKeyboardMarkerTimeout();
 
 		disposables.add(configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('screencastMode.verticalOffset')) {
@@ -160,6 +166,10 @@ class ToggleScreencastModeAction extends Action2 {
 
 			if (e.affectsConfiguration('screencastMode.fontSize')) {
 				updateKeyboardFontSize();
+			}
+
+			if (e.affectsConfiguration('screencastMode.keyboardOverlayTimeout')) {
+				updateKeyboardMarkerTimeout();
 			}
 		}));
 
@@ -190,7 +200,7 @@ class ToggleScreencastModeAction extends Action2 {
 				append(keyboardMarker, key);
 			}
 
-			const promise = timeout(configurationService.getValue<number>('screencastMode.overlayTimeout'));
+			const promise = timeout(keyboardMarkerTimeout);
 			keyboardTimeout = toDisposable(() => promise.cancel());
 
 			promise.then(() => {
@@ -276,15 +286,15 @@ configurationRegistry.registerConfiguration({
 		},
 		'screencastMode.onlyKeyboardShortcuts': {
 			type: 'boolean',
-			description: nls.localize('screencastMode.onlyKeyboardShortcuts', "Only show keyboard shortcuts in Screencast Mode."),
+			description: nls.localize('screencastMode.onlyKeyboardShortcuts', "Only show keyboard shortcuts in screencast mode."),
 			default: false
 		},
-		'screencastMode.overlayTimeout': {
+		'screencastMode.keyboardOverlayTimeout': {
 			type: 'number',
 			default: 800,
 			minimum: 500,
-			maximum: 6000,
-			description: nls.localize('screencastMode.overlayTimeout', "Controls how long (in milliseconds) the screencast mode overlay is shown.")
+			maximum: 5000,
+			description: nls.localize('screencastMode.keyboardOverlayTimeout', "Controls how long (in milliseconds) the keyboard overlay is shown in screencast mode.")
 		}
 	}
 });

--- a/src/vs/workbench/browser/actions/media/actions.css
+++ b/src/vs/workbench/browser/actions/media/actions.css
@@ -9,12 +9,8 @@
 
 .monaco-workbench .screencast-mouse {
 	position: absolute;
-	border: 2px solid red;
-	border-radius: 20px;
-	width: 20px;
-	height: 20px;
-	top: 0;
-	left: 0;
+	border-width: 2px;
+	border-style: solid;
 	z-index: 100000;
 	content: ' ';
 	pointer-events: none;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #105160

Adds support for configuring the timeout of the screencast mode overlay via settings. The default value of 800 is identical to the current hardcoded value for backwards compatibility.

I arbitrarily selected 500 (half a second) and 6000 (10 seconds) as the min and max valid values.

To test:

1. Enable screencast mode
2. Try setting the timeout to something larger than 800 (3000 is good to notice the difference)
3. Type something (e.g. CTRL+P), confirm the overlay shows up then disappears after 5 seconds
4. Type something (e.g. CTRL+P) repeatedly in a very short period. Confirm the overlay shows up and then disappears 5 seconds after the last keypress.
5. Attempt to set a value lower than 500, confirm the settings UI prevents this and the previous value gets used
6. Attempt to set a value higher than 6000, confirm the settings UI prevents this and the previous value gets used