### PR TITLE
Update markdown themes

### DIFF
--- a/extensions/theme-abyss/themes/abyss-color-theme.json
+++ b/extensions/theme-abyss/themes/abyss-color-theme.json
@@ -234,6 +234,20 @@
 			}
 		},
 		{
+			"name": "Markup: Strong",
+			"scope": "markup.bold",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markup: Emphasis",
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
 			"name": "Markup Inline",
 			"scope": "markup.inline.raw",
 			"settings": {
@@ -242,11 +256,14 @@
 			}
 		},
 		{
-			"name": "Markup Setext Header",
-			"scope": "markup.heading.setext",
+			"name": "Markup Headings",
+			"scope": [
+				"markup.heading",
+				"markup.heading.setext"
+			],
 			"settings": {
-				"fontStyle": "",
-				"foreground": "#ddbb88"
+				"fontStyle": "bold",
+				"foreground": "#6688cc"
 			}
 		}
 	],

--- a/extensions/theme-defaults/themes/hc_black_defaults.json
+++ b/extensions/theme-defaults/themes/hc_black_defaults.json
@@ -136,6 +136,7 @@
 		{
 			"scope": "markup.heading",
 			"settings": {
+				"fontStyle": "bold",
 				"foreground": "#6796e6"
 			}
 		},

--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -260,7 +260,7 @@
 				"entity.name.section"
 			],
 			"settings": {
-				"fontStyle": "",
+				"fontStyle": "bold",
 				"foreground": "#8ab1b0"
 			}
 		},

--- a/extensions/theme-red/themes/Red-color-theme.json
+++ b/extensions/theme-red/themes/Red-color-theme.json
@@ -351,6 +351,20 @@
 			}
 		},
 		{
+			"name": "Markup: Strong",
+			"scope": "markup.bold",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markup: Emphasis",
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
 			"name": "Markup Inline",
 			"scope": "markup.inline.raw",
 			"settings": {
@@ -359,17 +373,15 @@
 			}
 		},
 		{
-			"name": "Markup Headings",
-			"scope": "markup.heading",
+			"name": "Headings",
+			"scope": [
+				"markup.heading",
+				"markup.heading.setext",
+				"punctuation.definition.heading",
+				"entity.name.section"
+			],
 			"settings": {
-				"foreground": "#fec758ff"
-			}
-		},
-		{
-			"name": "Markup Setext Header",
-			"scope": "markup.heading.setext",
-			"settings": {
-				"fontStyle": "",
+				"fontStyle": "bold",
 				"foreground": "#fec758ff"
 			}
 		},

--- a/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
+++ b/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
@@ -271,6 +271,20 @@
 			}
 		},
 		{
+			"name": "Markup: Strong",
+			"scope": "markup.bold",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markup: Emphasis",
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
 			"name": "Markup Inline",
 			"scope": "markup.inline.raw",
 			"settings": {
@@ -282,6 +296,7 @@
 			"name": "Markup Headings",
 			"scope": "markup.heading",
 			"settings": {
+				"fontStyle": "bold",
 				"foreground": "#268BD2"
 			}
 		},

--- a/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
+++ b/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
@@ -274,6 +274,20 @@
 			}
 		},
 		{
+			"name": "Markup: Strong",
+			"scope": "markup.bold",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markup: Emphasis",
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
 			"name": "Markup Inline",
 			"scope": "markup.inline.raw",
 			"settings": {
@@ -285,6 +299,7 @@
 			"name": "Markup Headings",
 			"scope": "markup.heading",
 			"settings": {
+				"fontStyle": "bold",
 				"foreground": "#268BD2"
 			}
 		},

--- a/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-theme.json
+++ b/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-theme.json
@@ -224,11 +224,32 @@
 			}
 		},
 		{
+			"name": "Markup: Strong",
+			"scope": "markup.bold",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markup: Emphasis",
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
 			"name": "Markup Inline",
 			"scope": "markup.inline.raw",
 			"settings": {
 				"fontStyle": "",
 				"foreground": "#FF9DA4"
+			}
+		},
+		{
+			"name": "Markup Headings",
+			"scope": "markup.heading",
+			"settings": {
+				"fontStyle": "bold"
 			}
 		},
 		{


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #104530

Fix missing bold and italics, including theme:

- theme-tomorrow-night-blue
![image](https://user-images.githubusercontent.com/15615524/91082259-05268d80-e67b-11ea-8a21-5ac8d8840e3b.png)
- theme-solarized-dark
![image](https://user-images.githubusercontent.com/15615524/91082436-3e5efd80-e67b-11ea-984e-ce852f9236b8.png)
- theme-solarized-light
![image](https://user-images.githubusercontent.com/15615524/91082466-49199280-e67b-11ea-8371-4bb1924cbf25.png)
- theme-red
![image](https://user-images.githubusercontent.com/15615524/91082506-56368180-e67b-11ea-9210-575b662a903d.png)
- theme-kimbie-dark
![image](https://user-images.githubusercontent.com/15615524/91082561-6c444200-e67b-11ea-9be7-10cf3955a9f8.png)
- theme-abyss
![image](https://user-images.githubusercontent.com/15615524/91082606-7c5c2180-e67b-11ea-8af1-647f455faae3.png)
- hc_black_defaults(High Contrast)
![image](https://user-images.githubusercontent.com/15615524/91082676-93027880-e67b-11ea-97de-1399e358c96b.png)
