### PR TITLE
Support for .jenkinsfile extension and Jenkinsfile.* filename pattern

### DIFF
--- a/extensions/groovy/package.json
+++ b/extensions/groovy/package.json
@@ -13,8 +13,8 @@
 		"languages": [{
 			"id": "groovy",
 			"aliases": ["Groovy", "groovy"],
-			"extensions": [".groovy", ".gvy", ".gradle"],
-			"filenames": [ "Jenkinsfile" ],
+      "extensions": [".groovy", ".gvy", ".gradle", ".jenkinsfile"],
+      "filenamePatterns": ["Jenkinsfile.*"],
 			"firstLine": "^#!.*\\bgroovy\\b",
 			"configuration": "./language-configuration.json"
 		}],


### PR DESCRIPTION
So that it will be consistent with the support of `Dockerfile`s.
The file is using tabs AND spaces for indentation, this commit follows the formatting rules defined in `.editorconfig` (2 spaces).

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #105325 
