### PR TITLE
Adds title description to view pane containers

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -24,6 +24,7 @@ export interface IPaneOptions {
 	expanded?: boolean;
 	orientation?: Orientation;
 	title: string;
+	titleDescription?: string;
 }
 
 export interface IPaneStyles {

--- a/src/vs/workbench/browser/parts/views/media/paneviewlet.css
+++ b/src/vs/workbench/browser/parts/views/media/paneviewlet.css
@@ -38,6 +38,26 @@
 	-webkit-margin-after: 0;
 }
 
+.monaco-pane-view .pane > .pane-header .description {
+	display: block;
+	font-weight: normal;
+	margin-left: 10px;
+	opacity: 0.6;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	text-transform: none;
+	white-space: nowrap;
+}
+
+.monaco-pane-view .pane > .pane-header .description .codicon {
+	font-size: 9px;
+	margin-left: 2px;
+}
+
+.monaco-pane-view .pane > .pane-header:not(.expanded) .description {
+	display: none;
+}
+
 .monaco-pane-view .pane.horizontal:not(.expanded) > .pane-header h3.title,
 .monaco-pane-view .pane.horizontal:not(.expanded) > .pane-header .description {
 	display: none;

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -184,6 +184,11 @@ export abstract class ViewPane extends Pane implements IView {
 		return this._title;
 	}
 
+	private _titleDescription: string | undefined;
+	public get titleDescription(): string | undefined {
+		return this._titleDescription;
+	}
+
 	private readonly menuActions: ViewMenuActions;
 	private progressBar!: ProgressBar;
 	private progressIndicator!: IProgressIndicator;
@@ -192,6 +197,7 @@ export abstract class ViewPane extends Pane implements IView {
 	private readonly showActionsAlways: boolean = false;
 	private headerContainer?: HTMLElement;
 	private titleContainer?: HTMLElement;
+	private titleDescriptionContainer?: HTMLElement;
 	private iconContainer?: HTMLElement;
 	protected twistiesContainer?: HTMLElement;
 
@@ -216,6 +222,7 @@ export abstract class ViewPane extends Pane implements IView {
 
 		this.id = options.id;
 		this._title = options.title;
+		this._titleDescription = options.titleDescription;
 		this.showActionsAlways = !!options.showActionsAlways;
 		this.focusedViewContextKey = FocusedViewContext.bindTo(contextKeyService);
 
@@ -334,7 +341,7 @@ export abstract class ViewPane extends Pane implements IView {
 		return this.viewDescriptorService.getViewDescriptorById(this.id)?.containerIcon || 'codicon-window';
 	}
 
-	protected renderHeaderTitle(container: HTMLElement, title: string): void {
+	protected renderHeaderTitle(container: HTMLElement, title: string, description?: string | undefined): void {
 		this.iconContainer = append(container, $('.icon', undefined));
 		const icon = this.getIcon();
 
@@ -360,6 +367,8 @@ export abstract class ViewPane extends Pane implements IView {
 
 		const calculatedTitle = this.calculateTitle(title);
 		this.titleContainer = append(container, $('h3.title', undefined, calculatedTitle));
+		this.titleDescriptionContainer = append(container, $('span.description', undefined, this._titleDescription ?? ''));
+
 		this.iconContainer.title = calculatedTitle;
 		this.iconContainer.setAttribute('aria-label', calculatedTitle);
 	}
@@ -376,6 +385,15 @@ export abstract class ViewPane extends Pane implements IView {
 		}
 
 		this._title = title;
+		this._onDidChangeTitleArea.fire();
+	}
+
+	protected updateTitleDescription(description?: string | undefined): void {
+		if (this.titleDescriptionContainer) {
+			this.titleDescriptionContainer.textContent = description ?? '';
+		}
+
+		this._titleDescription = description;
 		this._onDidChangeTitleArea.fire();
 	}
 

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -341,7 +341,7 @@ export abstract class ViewPane extends Pane implements IView {
 		return this.viewDescriptorService.getViewDescriptorById(this.id)?.containerIcon || 'codicon-window';
 	}
 
-	protected renderHeaderTitle(container: HTMLElement, title: string, description?: string | undefined): void {
+	protected renderHeaderTitle(container: HTMLElement, title: string): void {
 		this.iconContainer = append(container, $('.icon', undefined));
 		const icon = this.getIcon();
 
@@ -367,7 +367,10 @@ export abstract class ViewPane extends Pane implements IView {
 
 		const calculatedTitle = this.calculateTitle(title);
 		this.titleContainer = append(container, $('h3.title', undefined, calculatedTitle));
-		this.titleDescriptionContainer = append(container, $('span.description', undefined, this._titleDescription ?? ''));
+
+		if (this._titleDescription) {
+			this.setTitleDescription(this._titleDescription, container);
+		}
 
 		this.iconContainer.title = calculatedTitle;
 		this.iconContainer.setAttribute('aria-label', calculatedTitle);
@@ -388,10 +391,17 @@ export abstract class ViewPane extends Pane implements IView {
 		this._onDidChangeTitleArea.fire();
 	}
 
-	protected updateTitleDescription(description?: string | undefined): void {
+	private setTitleDescription(description: string | undefined, headerContainer: HTMLElement | undefined = this.headerContainer) {
 		if (this.titleDescriptionContainer) {
 			this.titleDescriptionContainer.textContent = description ?? '';
 		}
+		else if (description && headerContainer) {
+			this.titleDescriptionContainer = append(headerContainer, $('span.description', undefined, description));
+		}
+	}
+
+	protected updateTitleDescription(description?: string | undefined): void {
+		this.setTitleDescription(description);
 
 		this._titleDescription = description;
 		this._onDidChangeTitleArea.fire();

--- a/src/vs/workbench/contrib/timeline/browser/media/timelinePane.css
+++ b/src/vs/workbench/contrib/timeline/browser/media/timelinePane.css
@@ -7,26 +7,6 @@
 	position: relative;
 }
 
-.monaco-workbench .timeline-view.pane-header .description {
-	display: block;
-	font-weight: normal;
-	margin-left: 10px;
-	opacity: 0.6;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	text-transform: none;
-	white-space: nowrap;
-}
-
-.monaco-workbench .timeline-view.pane-header:not(.expanded) .description {
-	display: none;
-}
-
-.monaco-workbench .timeline-view.pane-header .description span.codicon {
-	font-size: 9px;
-	margin-left: 2px;
-}
-
 .monaco-workbench .timeline-tree-view .message.timeline-subtle {
 	opacity: 0.5;
 	padding: 10px 22px 0 22px;

--- a/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
+++ b/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
@@ -219,7 +219,6 @@ export class TimelinePane extends ViewPane {
 
 	private $container!: HTMLElement;
 	private $message!: HTMLDivElement;
-	private $titleDescription!: HTMLSpanElement;
 	private $tree!: HTMLDivElement;
 	private tree!: WorkbenchObjectTree<TreeElement, FuzzyScore>;
 	private treeRenderer: TimelineTreeRenderer | undefined;
@@ -276,7 +275,7 @@ export class TimelinePane extends ViewPane {
 		this._followActiveEditor = value;
 		this.followActiveEditorContext.set(value);
 
-		this.titleDescription = this.titleDescription;
+		this.updateFilename(this._filename);
 
 		if (value) {
 			this.onActiveEditorChanged();
@@ -315,7 +314,7 @@ export class TimelinePane extends ViewPane {
 		}
 
 		this.uri = uri;
-		this.titleDescription = uri ? basename(uri.fsPath) : '';
+		this.updateFilename(uri ? basename(uri.fsPath) : undefined);
 		this.treeRenderer?.setUri(uri);
 		this.loadTimeline(true);
 	}
@@ -407,17 +406,13 @@ export class TimelinePane extends ViewPane {
 		}
 	}
 
-	private _titleDescription: string | undefined;
-	get titleDescription(): string | undefined {
-		return this._titleDescription;
-	}
-
-	set titleDescription(description: string | undefined) {
-		this._titleDescription = description;
-		if (this.followActiveEditor || !description) {
-			this.$titleDescription.textContent = description ?? '';
+	private _filename: string | undefined;
+	updateFilename(filename: string | undefined) {
+		this._filename = filename;
+		if (this.followActiveEditor || !filename) {
+			this.updateTitleDescription(filename);
 		} else {
-			this.$titleDescription.textContent = `${description} (pinned)`;
+			this.updateTitleDescription(`${filename} (pinned)`);
 		}
 	}
 
@@ -781,17 +776,17 @@ export class TimelinePane extends ViewPane {
 		this._isEmpty = !this.hasVisibleItems;
 
 		if (this.uri === undefined) {
-			this.titleDescription = undefined;
+			this.updateFilename(undefined);
 			this.message = localize('timeline.editorCannotProvideTimeline', "The active editor cannot provide timeline information.");
 		} else if (this._isEmpty) {
 			if (this.pendingRequests.size !== 0) {
 				this.setLoadingUriMessage();
 			} else {
-				this.titleDescription = basename(this.uri.fsPath);
+				this.updateFilename(basename(this.uri.fsPath));
 				this.message = localize('timeline.noTimelineInfo', "No timeline information was provided.");
 			}
 		} else {
-			this.titleDescription = basename(this.uri.fsPath);
+			this.updateFilename(basename(this.uri.fsPath));
 			this.message = undefined;
 		}
 
@@ -849,7 +844,6 @@ export class TimelinePane extends ViewPane {
 		super.renderHeaderTitle(container, this.title);
 
 		DOM.addClass(container, 'timeline-view');
-		this.$titleDescription = DOM.append(container, DOM.$('span.description', undefined, this.titleDescription ?? ''));
 	}
 
 	protected renderBody(container: HTMLElement): void {
@@ -956,7 +950,7 @@ export class TimelinePane extends ViewPane {
 
 	setLoadingUriMessage() {
 		const file = this.uri && basename(this.uri.fsPath);
-		this.titleDescription = file ?? '';
+		this.updateFilename(file);
 		this.message = file ? localize('timeline.loading', "Loading timeline for {0}...", file) : '';
 	}
 


### PR DESCRIPTION
Adds a new `titleDescription` property to `ViewPane` -- to display a muted "description" to be displayed to the left of the title. Also adapts the timeline view to use this new property instead of a custom implementation.