### PR TITLE
Mark .desktop files as ini

### DIFF
--- a/extensions/ini/package.json
+++ b/extensions/ini/package.json
@@ -18,7 +18,7 @@
 		},
 		{
 			"id": "properties",
-			"extensions": [ ".properties", ".cfg", ".conf", ".directory", ".gitattributes", ".gitconfig", ".gitmodules", ".editorconfig" ],
+			"extensions": [ ".properties", ".cfg", ".conf", ".desktop" , ".directory", ".gitattributes", ".gitconfig", ".gitmodules", ".editorconfig" ],
 			"filenames": [ "gitconfig" ],
 			"filenamePatterns": [ "**/.config/git/config", "**/.git/config" ],
 			"aliases": [ "Properties", "properties" ],


### PR DESCRIPTION
Linux desktop entries are ini files using the `.desktop` extension.