### PR TITLE
Give default foreground to dark/light plus themes

### DIFF
--- a/extensions/theme-defaults/themes/dark_plus.json
+++ b/extensions/theme-defaults/themes/dark_plus.json
@@ -4,6 +4,11 @@
 	"include": "./dark_vs.json",
 	"tokenColors": [
 		{
+			"settings": {
+				"foreground": "#D4D4D4"
+			}
+		},
+		{
 			"name": "Function declarations",
 			"scope": [
 				"entity.name.function",

--- a/extensions/theme-defaults/themes/light_defaults.json
+++ b/extensions/theme-defaults/themes/light_defaults.json
@@ -2,7 +2,7 @@
 	"$schema": "vscode://schemas/color-theme",
 	"name": "Light Default Colors",
 	"colors": {
-		"editor.background": "#FFFFFF",
+		"editor.background": "#FFFFFE",
 		"editor.foreground": "#000000",
 		"editor.inactiveSelectionBackground": "#E5EBF1",
 		"editorIndentGuide.background": "#D3D3D3",

--- a/extensions/theme-defaults/themes/light_plus.json
+++ b/extensions/theme-defaults/themes/light_plus.json
@@ -4,6 +4,11 @@
 	"include": "./light_vs.json",
 	"tokenColors": [
 		{
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
 			"name": "Function declarations",
 			"scope": [
 				"entity.name.function",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes shikijs/shiki#45

Themes should set fallback foreground color with the first element of `tokenColors`. For example, https://github.com/microsoft/vscode/blob/c5fe5d7c1a1bb69ef83ac9064bea3210642d0cc4/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json#L4-L7

Also makes `themes.ts` consistent with the JSON themes.

I didn't make changes to `colorRegistry.ts`, but it seems it's inconsistent with these two as well...

/cc @misolori 👋 
