### PR TITLE
Language selector shows incorrect Icons for Javascript

### DIFF
--- a/src/vs/editor/common/services/getIconClasses.ts
+++ b/src/vs/editor/common/services/getIconClasses.ts
@@ -54,6 +54,11 @@ export function getIconClasses(modelService: IModelService, modeService: IModeSe
 	return classes;
 }
 
+
+export function getIconClassesForModeId(modeId: string): string[] {
+	return ['file-icon', `${cssEscape(modeId)}-lang-file-icon`];
+}
+
 export function detectModeId(modelService: IModelService, modeService: IModeService, resource: uri): string | null {
 	if (!resource) {
 		return null; // we need a resource at least

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -26,7 +26,6 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { IFileService, FILES_ASSOCIATIONS_CONFIG } from 'vs/platform/files/common/files';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IModeService, ILanguageSelection } from 'vs/editor/common/services/modeService';
-import { IModelService } from 'vs/editor/common/services/modelService';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
 import { TabFocus } from 'vs/editor/common/config/commonEditorConfig';
@@ -43,7 +42,7 @@ import { ICodeEditor, getCodeEditor } from 'vs/editor/browser/editorBrowser';
 import { Schemas } from 'vs/base/common/network';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 import { IQuickInputService, IQuickPickItem, QuickPickInput } from 'vs/platform/quickinput/common/quickInput';
-import { getIconClasses } from 'vs/editor/common/services/getIconClasses';
+import { getIconClassesForModeId } from 'vs/editor/common/services/getIconClasses';
 import { timeout } from 'vs/base/common/async';
 import { INotificationHandle, INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { Event } from 'vs/base/common/event';
@@ -1042,7 +1041,6 @@ export class ChangeModeAction extends Action {
 		actionId: string,
 		actionLabel: string,
 		@IModeService private readonly modeService: IModeService,
-		@IModelService private readonly modelService: IModelService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
@@ -1069,26 +1067,27 @@ export class ChangeModeAction extends Action {
 		}
 
 		// Compute mode
+		let currentLanguageId: string | undefined;
 		let currentModeId: string | undefined;
-		let modeId: string | undefined;
 		if (textModel) {
-			modeId = textModel.getLanguageIdentifier().language;
-			currentModeId = withNullAsUndefined(this.modeService.getLanguageName(modeId));
+			currentModeId = textModel.getLanguageIdentifier().language;
+			currentLanguageId = withNullAsUndefined(this.modeService.getLanguageName(currentModeId));
 		}
 
 		// All languages are valid picks
 		const languages = this.modeService.getRegisteredLanguageNames();
 		const picks: QuickPickInput[] = languages.sort().map((lang, index) => {
+			const modeId = this.modeService.getModeIdForLanguageName(lang.toLowerCase()) || 'unknown';
 			let description: string;
-			if (currentModeId === lang) {
-				description = nls.localize('languageDescription', "({0}) - Configured Language", this.modeService.getModeIdForLanguageName(lang.toLowerCase()));
+			if (currentLanguageId === lang) {
+				description = nls.localize('languageDescription', "({0}) - Configured Language", modeId);
 			} else {
-				description = nls.localize('languageDescriptionConfigured', "({0})", this.modeService.getModeIdForLanguageName(lang.toLowerCase()));
+				description = nls.localize('languageDescriptionConfigured', "({0})", modeId);
 			}
 
 			return {
 				label: lang,
-				iconClasses: getIconClasses(this.modelService, this.modeService, this.getFakeResource(lang)),
+				iconClasses: getIconClassesForModeId(modeId),
 				description
 			};
 		});
@@ -1109,7 +1108,7 @@ export class ChangeModeAction extends Action {
 				picks.unshift(galleryAction);
 			}
 
-			configureModeSettings = { label: nls.localize('configureModeSettings', "Configure '{0}' language based settings...", currentModeId) };
+			configureModeSettings = { label: nls.localize('configureModeSettings', "Configure '{0}' language based settings...", currentLanguageId) };
 			picks.unshift(configureModeSettings);
 			configureModeAssociations = { label: nls.localize('configureAssociationsExt', "Configure File Association for '{0}'...", ext) };
 			picks.unshift(configureModeAssociations);
@@ -1144,7 +1143,7 @@ export class ChangeModeAction extends Action {
 
 		// User decided to configure settings for current language
 		if (pick === configureModeSettings) {
-			this.preferencesService.openGlobalSettings(true, { editSetting: `[${withUndefinedAsNull(modeId)}]` });
+			this.preferencesService.openGlobalSettings(true, { editSetting: `[${withUndefinedAsNull(currentModeId)}]` });
 			return;
 		}
 
@@ -1182,12 +1181,12 @@ export class ChangeModeAction extends Action {
 
 		const languages = this.modeService.getRegisteredLanguageNames();
 		const picks: IQuickPickItem[] = languages.sort().map((lang, index) => {
-			const id = withNullAsUndefined(this.modeService.getModeIdForLanguageName(lang.toLowerCase()));
+			const id = withNullAsUndefined(this.modeService.getModeIdForLanguageName(lang.toLowerCase())) || 'unknown';
 
 			return {
 				id,
 				label: lang,
-				iconClasses: getIconClasses(this.modelService, this.modeService, this.getFakeResource(lang)),
+				iconClasses: getIconClassesForModeId(id),
 				description: (id === currentAssociation) ? nls.localize('currentAssociation', "Current Association") : undefined
 			};
 		});
@@ -1217,22 +1216,6 @@ export class ChangeModeAction extends Action {
 				this.configurationService.updateValue(FILES_ASSOCIATIONS_CONFIG, currentAssociations, target);
 			}
 		}, 50 /* quick input is sensitive to being opened so soon after another */);
-	}
-
-	private getFakeResource(lang: string): URI | undefined {
-		let fakeResource: URI | undefined;
-
-		const extensions = this.modeService.getExtensions(lang);
-		if (extensions?.length) {
-			fakeResource = URI.file(extensions[0]);
-		} else {
-			const filenames = this.modeService.getFilenames(lang);
-			if (filenames?.length) {
-				fakeResource = URI.file(filenames[0]);
-			}
-		}
-
-		return fakeResource;
 	}
 }
 


### PR DESCRIPTION
This PR fixes #105244

For the language icon in the mode selection dialog we use the icon of the first file extension of that language.
In #105244 that file extension has be reassigned to a different language, resulting in the wrong language icon.

The PR just uses the language icon.

Also some renames to avoid confusion about modeId / languageName