### PR TITLE
Create HTML with dom.ts#$ function calls instead of string concatenation

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1009,6 +1009,18 @@ export function prepend<T extends Node>(parent: HTMLElement, child: T): T {
 
 const SELECTOR_REGEX = /([\w\-]+)?(#([\w\-]+))?((\.([\w\-]+))*)/;
 
+export function reset<T extends Node>(parent: HTMLElement, ...children: Array<Node | string>) {
+	parent.innerText = '';
+	coalesce(children)
+		.forEach(child => {
+			if (child instanceof Node) {
+				parent.appendChild(child);
+			} else {
+				parent.appendChild(document.createTextNode(child as string));
+			}
+		});
+}
+
 export enum Namespace {
 	HTML = 'http://www.w3.org/1999/xhtml',
 	SVG = 'http://www.w3.org/2000/svg'

--- a/src/vs/editor/standalone/browser/inspectTokens/inspectTokens.ts
+++ b/src/vs/editor/standalone/browser/inspectTokens/inspectTokens.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./inspectTokens';
+import { $, append, reset } from 'vs/base/browser/dom';
 import { CharCode } from 'vs/base/common/charCode';
 import { Color } from 'vs/base/common/color';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { escape } from 'vs/base/common/strings';
 import { ContentWidgetPositionPreference, IActiveCodeEditor, ICodeEditor, IContentWidget, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, ServicesAccessor, registerEditorAction, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { Position } from 'vs/editor/common/core/position';
@@ -115,23 +115,11 @@ function renderTokenText(tokenText: string): string {
 		let charCode = tokenText.charCodeAt(charIndex);
 		switch (charCode) {
 			case CharCode.Tab:
-				result += '&rarr;';
+				result += '\u2192'; // &rarr;
 				break;
 
 			case CharCode.Space:
-				result += '&middot;';
-				break;
-
-			case CharCode.LessThan:
-				result += '&lt;';
-				break;
-
-			case CharCode.GreaterThan:
-				result += '&gt;';
-				break;
-
-			case CharCode.Ampersand:
-				result += '&amp;';
+				result += '\u00B7'; // &middot;
 				break;
 
 			default:
@@ -211,8 +199,6 @@ class InspectTokensWidget extends Disposable implements IContentWidget {
 			}
 		}
 
-		let result = '';
-
 		let lineContent = this._model.getLineContent(position.lineNumber);
 		let tokenText = '';
 		if (token1Index < data.tokens1.length) {
@@ -220,26 +206,43 @@ class InspectTokensWidget extends Disposable implements IContentWidget {
 			let tokenEndIndex = token1Index + 1 < data.tokens1.length ? data.tokens1[token1Index + 1].offset : lineContent.length;
 			tokenText = lineContent.substring(tokenStartIndex, tokenEndIndex);
 		}
-		result += `<h2 class="tm-token">${renderTokenText(tokenText)}<span class="tm-token-length">(${tokenText.length} ${tokenText.length === 1 ? 'char' : 'chars'})</span></h2>`;
+		reset(this._domNode,
+			$('h2.tm-token', undefined, renderTokenText(tokenText),
+				$('span.tm-token-length', undefined, `${tokenText.length} ${tokenText.length === 1 ? 'char' : 'chars'}`)));
 
-		result += `<hr class="tokens-inspect-separator" style="clear:both"/>`;
+		append(this._domNode, $('hr.tokens-inspect-separator', { 'style': 'clear:both' }));
 
-		let metadata = (token2Index << 1) + 1 < data.tokens2.length ? this._decodeMetadata(data.tokens2[(token2Index << 1) + 1]) : null;
-		result += `<table class="tm-metadata-table"><tbody>`;
-		result += `<tr><td class="tm-metadata-key">language</td><td class="tm-metadata-value">${metadata ? escape(metadata.languageIdentifier.language) : '-?-'}</td>`;
-		result += `<tr><td class="tm-metadata-key">token type</td><td class="tm-metadata-value">${metadata ? this._tokenTypeToString(metadata.tokenType) : '-?-'}</td>`;
-		result += `<tr><td class="tm-metadata-key">font style</td><td class="tm-metadata-value">${metadata ? this._fontStyleToString(metadata.fontStyle) : '-?-'}</td>`;
-		result += `<tr><td class="tm-metadata-key">foreground</td><td class="tm-metadata-value">${metadata ? Color.Format.CSS.formatHex(metadata.foreground) : '-?-'}</td>`;
-		result += `<tr><td class="tm-metadata-key">background</td><td class="tm-metadata-value">${metadata ? Color.Format.CSS.formatHex(metadata.background) : '-?-'}</td>`;
-		result += `</tbody></table>`;
-
-		result += `<hr class="tokens-inspect-separator"/>`;
+		const metadata = (token2Index << 1) + 1 < data.tokens2.length ? this._decodeMetadata(data.tokens2[(token2Index << 1) + 1]) : null;
+		append(this._domNode, $('table.tm-metadata-table', undefined,
+			$('tbody', undefined,
+				$('tr', undefined,
+					$('td.tm-metadata-key', undefined, 'language'),
+					$('td.tm-metadata-value', undefined, `${metadata ? metadata.languageIdentifier.language : '-?-'}`)
+				),
+				$('tr', undefined,
+					$('td.tm-metadata-key', undefined, 'token type' as string),
+					$('td.tm-metadata-value', undefined, `${metadata ? this._tokenTypeToString(metadata.tokenType) : '-?-'}`)
+				),
+				$('tr', undefined,
+					$('td.tm-metadata-key', undefined, 'font style' as string),
+					$('td.tm-metadata-value', undefined, `${metadata ? this._fontStyleToString(metadata.fontStyle) : '-?-'}`)
+				),
+				$('tr', undefined,
+					$('td.tm-metadata-key', undefined, 'foreground'),
+					$('td.tm-metadata-value', undefined, `${metadata ? Color.Format.CSS.formatHex(metadata.foreground) : '-?-'}`)
+				),
+				$('tr', undefined,
+					$('td.tm-metadata-key', undefined, 'background'),
+					$('td.tm-metadata-value', undefined, `${metadata ? Color.Format.CSS.formatHex(metadata.background) : '-?-'}`)
+				)
+			)
+		));
+		append(this._domNode, $('hr.tokens-inspect-separator'));
 
 		if (token1Index < data.tokens1.length) {
-			result += `<span class="tm-token-type">${escape(data.tokens1[token1Index].type)}</span>`;
+			append(this._domNode, $('span.tm-token-type', undefined, data.tokens1[token1Index].type));
 		}
 
-		this._domNode.innerHTML = result;
 		this._editor.layoutContentWidget(this);
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #105501
It replaces construction of HTML elements by string concatenation in `src/vs/editor/standalone/browser/inspectTokens.ts` file by using `dom.ts#$` function calls instead. 
