### PR TITLE
Set HTMLElement's content by providing it as a child, not by .innerHTML

### DIFF
--- a/src/vs/workbench/contrib/welcome/overlay/browser/welcomeOverlay.ts
+++ b/src/vs/workbench/contrib/welcome/overlay/browser/welcomeOverlay.ts
@@ -38,31 +38,31 @@ interface Key {
 const keys: Key[] = [
 	{
 		id: 'explorer',
-		arrow: '&larr;',
+		arrow: '\u2190', // &larr;
 		label: localize('welcomeOverlay.explorer', "File explorer"),
 		command: 'workbench.view.explorer'
 	},
 	{
 		id: 'search',
-		arrow: '&larr;',
+		arrow: '\u2190', // &larr;
 		label: localize('welcomeOverlay.search', "Search across files"),
 		command: 'workbench.view.search'
 	},
 	{
 		id: 'git',
-		arrow: '&larr;',
+		arrow: '\u2190', // &larr;
 		label: localize('welcomeOverlay.git', "Source code management"),
 		command: 'workbench.view.scm'
 	},
 	{
 		id: 'debug',
-		arrow: '&larr;',
+		arrow: '\u2190', // &larr;
 		label: localize('welcomeOverlay.debug', "Launch and debug"),
 		command: 'workbench.view.debug'
 	},
 	{
 		id: 'extensions',
-		arrow: '&larr;',
+		arrow: '\u2190', // &larr;
 		label: localize('welcomeOverlay.extensions', "Manage extensions"),
 		command: 'workbench.view.extensions'
 	},
@@ -74,7 +74,7 @@ const keys: Key[] = [
 	// },
 	{
 		id: 'problems',
-		arrow: '&larrpl;',
+		arrow: '\u2939', // &larrpl;
 		label: localize('welcomeOverlay.problems', "View errors and warnings"),
 		command: 'workbench.actions.view.problems'
 	},
@@ -92,13 +92,13 @@ const keys: Key[] = [
 	// },
 	{
 		id: 'commandPalette',
-		arrow: '&nwarr;',
+		arrow: '\u2196', // &nwarr;
 		label: localize('welcomeOverlay.commandPalette', "Find and run all commands"),
 		command: ShowAllCommandsAction.ID
 	},
 	{
 		id: 'notifications',
-		arrow: '&cudarrr;',
+		arrow: '\u2935', // &cudarrr;
 		arrowLast: true,
 		label: localize('welcomeOverlay.notifications', "Show notifications"),
 		command: 'notifications.showList'
@@ -186,7 +186,7 @@ class WelcomeOverlay extends Disposable {
 			.forEach(({ id, arrow, label, command, arrowLast }) => {
 				const div = dom.append(this._overlay, $(`.key.${id}`));
 				if (arrow && !arrowLast) {
-					dom.append(div, $('span.arrow')).innerHTML = arrow;
+					dom.append(div, $('span.arrow', undefined, arrow));
 				}
 				dom.append(div, $('span.label')).textContent = label;
 				if (command) {
@@ -196,7 +196,7 @@ class WelcomeOverlay extends Disposable {
 					}
 				}
 				if (arrow && arrowLast) {
-					dom.append(div, $('span.arrow')).innerHTML = arrow;
+					dom.append(div, $('span.arrow', undefined, arrow));
 				}
 			});
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #105505 
It replaces: `dom.append(parent, $(‘span’)).innerHTML = text` with `dom.append(parent, $(‘span’, {}, text))`. 
