### PR TITLE
Add a propopsed `isReadonly` field to `TextDocument`

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -2119,4 +2119,19 @@ declare module 'vscode' {
 		}): Disposable;
 	}
 	//#endregion
+
+	//#region https://github.com/microsoft/vscode/issues/91697
+
+	export interface TextDocument {
+
+		/**
+		 * True if the document is on a readonly file system.
+		 *
+		 * `isReadonly === false` does not guarantee that can write the file. There still may be permissions
+		 * issues or other problems that prevent the file from actually being written.
+		 */
+		readonly isReadonly: boolean;
+	}
+
+	//#endregion
 }

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -963,6 +963,7 @@ export interface IModelAddedData {
 	EOL: string;
 	modeId: string;
 	isDirty: boolean;
+	isReadonly: boolean;
 }
 export interface ExtHostDocumentsShape {
 	$acceptModelModeChanged(strURL: UriComponents, oldModeId: string, newModeId: string): void;

--- a/src/vs/workbench/api/common/extHostDocumentData.ts
+++ b/src/vs/workbench/api/common/extHostDocumentData.ts
@@ -37,6 +37,7 @@ export class ExtHostDocumentData extends MirrorTextModel {
 		uri: URI, lines: string[], eol: string, versionId: number,
 		private _languageId: string,
 		private _isDirty: boolean,
+		private readonly _isReadonly: boolean,
 		private readonly _notebook?: vscode.NotebookDocument | undefined
 	) {
 		super(uri, lines, eol, versionId);
@@ -66,6 +67,7 @@ export class ExtHostDocumentData extends MirrorTextModel {
 				get version() { return that._versionId; },
 				get isClosed() { return that._isDisposed; },
 				get isDirty() { return that._isDirty; },
+				get isReadonly() { return that._isReadonly; },
 				get notebook() { return that._notebook; },
 				save() { return that._save(); },
 				getText(range?) { return range ? that._getTextInRange(range) : that.getText(); },

--- a/src/vs/workbench/api/common/extHostDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/common/extHostDocumentsAndEditors.ts
@@ -104,6 +104,7 @@ export class ExtHostDocumentsAndEditors implements ExtHostDocumentsAndEditorsSha
 						data.versionId,
 						data.modeId,
 						data.isDirty,
+						data.isReadonly,
 						data.notebook
 					));
 					this._documents.set(resource, ref);

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -64,6 +64,7 @@ export class ExtHostCell extends Disposable {
 			modeId: cell.language,
 			uri: cell.uri,
 			isDirty: false,
+			isReadonly: false,
 			versionId: 1,
 			notebook
 		};

--- a/src/vs/workbench/test/browser/api/extHostApiCommands.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostApiCommands.test.ts
@@ -120,6 +120,7 @@ suite('ExtHostLanguageFeatureCommands', function () {
 		extHostDocumentsAndEditors.$acceptDocumentsAndEditorsDelta({
 			addedDocuments: [{
 				isDirty: false,
+				isReadonly: false,
 				versionId: model.getVersionId(),
 				modeId: model.getLanguageIdentifier().language,
 				uri: model.uri,

--- a/src/vs/workbench/test/browser/api/extHostDocumentData.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostDocumentData.test.ts
@@ -35,7 +35,7 @@ suite('ExtHostDocumentData', () => {
 			'and this is line number two', //27
 			'it is followed by #3', //20
 			'and finished with the fourth.', //29
-		], '\n', 1, 'text', false);
+		], '\n', 1, 'text', false, false);
 	});
 
 	test('readonly-ness', () => {
@@ -55,7 +55,7 @@ suite('ExtHostDocumentData', () => {
 				saved = uri;
 				return Promise.resolve(true);
 			}
-		}, URI.parse('foo:bar'), [], '\n', 1, 'text', true);
+		}, URI.parse('foo:bar'), [], '\n', 1, 'text', true, false);
 
 		return data.document.save().then(() => {
 			assert.equal(saved.toString(), 'foo:bar');
@@ -242,7 +242,7 @@ suite('ExtHostDocumentData', () => {
 	test('getWordRangeAtPosition', () => {
 		data = new ExtHostDocumentData(undefined!, URI.file(''), [
 			'aaaa bbbb+cccc abc'
-		], '\n', 1, 'text', false);
+		], '\n', 1, 'text', false, false);
 
 		let range = data.document.getWordRangeAtPosition(new Position(0, 2))!;
 		assert.equal(range.start.line, 0);
@@ -276,7 +276,7 @@ suite('ExtHostDocumentData', () => {
 			'function() {',
 			'	"far boo"',
 			'}'
-		], '\n', 1, 'text', false);
+		], '\n', 1, 'text', false, false);
 
 		let range = data.document.getWordRangeAtPosition(new Position(0, 0), /\/\*.+\*\//);
 		assert.equal(range, undefined);
@@ -304,7 +304,7 @@ suite('ExtHostDocumentData', () => {
 
 		data = new ExtHostDocumentData(undefined!, URI.file(''), [
 			perfData._$_$_expensive
-		], '\n', 1, 'text', false);
+		], '\n', 1, 'text', false, false);
 
 		let range = data.document.getWordRangeAtPosition(new Position(0, 1_177_170), regex)!;
 		assert.equal(range, undefined);
@@ -323,7 +323,7 @@ suite('ExtHostDocumentData', () => {
 
 		data = new ExtHostDocumentData(undefined!, URI.file(''), [
 			line
-		], '\n', 1, 'text', false);
+		], '\n', 1, 'text', false, false);
 
 		let range = data.document.getWordRangeAtPosition(new Position(0, 27), regex)!;
 		assert.equal(range.start.line, 0);
@@ -387,7 +387,7 @@ suite('ExtHostDocumentData updates line mapping', () => {
 	}
 
 	function testLineMappingDirectionAfterEvents(lines: string[], eol: string, direction: AssertDocumentLineMappingDirection, e: IModelChangedEvent): void {
-		let myDocument = new ExtHostDocumentData(undefined!, URI.file(''), lines.slice(0), eol, 1, 'text', false);
+		let myDocument = new ExtHostDocumentData(undefined!, URI.file(''), lines.slice(0), eol, 1, 'text', false, false);
 		assertDocumentLineMapping(myDocument, direction);
 
 		myDocument.onEvents(e);

--- a/src/vs/workbench/test/browser/api/extHostDocumentSaveParticipant.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostDocumentSaveParticipant.test.ts
@@ -40,6 +40,7 @@ suite('ExtHostDocumentSaveParticipant', () => {
 		documentsAndEditors.$acceptDocumentsAndEditorsDelta({
 			addedDocuments: [{
 				isDirty: false,
+				isReadonly: false,
 				modeId: 'foo',
 				uri: resource,
 				versionId: 1,

--- a/src/vs/workbench/test/browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostLanguageFeatures.test.ts
@@ -90,6 +90,7 @@ suite('ExtHostLanguageFeatures', function () {
 		extHostDocumentsAndEditors.$acceptDocumentsAndEditorsDelta({
 			addedDocuments: [{
 				isDirty: false,
+				isReadonly: false,
 				versionId: model.getVersionId(),
 				modeId: model.getLanguageIdentifier().language,
 				uri: model.uri,

--- a/src/vs/workbench/test/browser/api/extHostNotebook.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostNotebook.test.ts
@@ -196,6 +196,7 @@ suite('NotebookCell#Document', function () {
 			addData.push({
 				EOL: '\n',
 				isDirty: doc.isDirty,
+				isReadonly: false,
 				lines: doc.getText().split('\n'),
 				modeId: doc.languageId,
 				uri: doc.uri,

--- a/src/vs/workbench/test/browser/api/extHostTextEditor.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostTextEditor.test.ts
@@ -17,7 +17,7 @@ suite('ExtHostTextEditor', () => {
 	let editor: ExtHostTextEditor;
 	let doc = new ExtHostDocumentData(undefined!, URI.file(''), [
 		'aaaa bbbb+cccc abc'
-	], '\n', 1, 'text', false);
+	], '\n', 1, 'text', false, false);
 
 	setup(() => {
 		editor = new ExtHostTextEditor('fake', null!, new NullLogService(), doc, [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4, indentSize: 4 }, [], 1);

--- a/src/vs/workbench/test/browser/api/extHostTextEditors.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostTextEditors.test.ts
@@ -33,6 +33,7 @@ suite('ExtHostTextEditors.applyWorkspaceEdit', () => {
 		documentsAndEditors.$acceptDocumentsAndEditorsDelta({
 			addedDocuments: [{
 				isDirty: false,
+				isReadonly: false,
 				modeId: 'foo',
 				uri: resource,
 				versionId: 1337,

--- a/src/vs/workbench/test/browser/api/mainThreadDocumentsAndEditors.test.ts
+++ b/src/vs/workbench/test/browser/api/mainThreadDocumentsAndEditors.test.ts
@@ -99,6 +99,9 @@ suite('MainThreadDocumentsAndEditors', () => {
 				readText() {
 					return Promise.resolve('clipboard_contents');
 				}
+			},
+			new class extends mock<IFileService>() {
+
 			}
 		);
 	});


### PR DESCRIPTION
For #91697

This new field tracks if the file is on a readonly file system or not. This can be helpful for text based custom editors
