### PR TITLE
Run codeql job every Tuesday

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,8 @@
 name: "Code Scanning"
 
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '0 0 * * 2'
 
 jobs:
   CodeQL-Build:


### PR DESCRIPTION
Justification:
- This was using _a lot_ of vm time and not giving us much
- We only really need to run it once per release
- Weekly as opposed to monthly means we can catch things earlier than when the release happens

Fixes #105447

FYI @joaomoreno @sbatten @jhutchings1