### PR TITLE
Use extensionUri and joinPath instead of asAbsolutePath

### DIFF
--- a/extensions/css-language-features/client/src/browser/cssClientMain.ts
+++ b/extensions/css-language-features/client/src/browser/cssClientMain.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionContext } from 'vscode';
+import { ExtensionContext, Uri } from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient';
 import { startClient, LanguageClientConstructor } from '../cssClient';
 import { LanguageClient } from 'vscode-languageclient/browser';
@@ -17,9 +17,9 @@ declare const TextDecoder: {
 
 // this method is called when vs code is activated
 export function activate(context: ExtensionContext) {
-	const serverMain = context.asAbsolutePath('server/dist/browser/cssServerMain.js');
+	const serverMain = Uri.joinPath(context.extensionUri, 'server/dist/browser/cssServerMain.js');
 	try {
-		const worker = new Worker(serverMain);
+		const worker = new Worker(serverMain.toString());
 		const newLanguageClient: LanguageClientConstructor = (id: string, name: string, clientOptions: LanguageClientOptions) => {
 			return new LanguageClient(id, name, clientOptions, worker);
 		};

--- a/extensions/html-language-features/client/src/browser/htmlClientMain.ts
+++ b/extensions/html-language-features/client/src/browser/htmlClientMain.ts
@@ -17,7 +17,7 @@ declare const TextDecoder: {
 
 // this method is called when vs code is activated
 export function activate(context: ExtensionContext) {
-	const serverMain = Uri.joinPath(context.extensionUri, 'server/dist/browser/cssServerMain.js');
+	const serverMain = Uri.joinPath(context.extensionUri, 'server/dist/browser/htmlServerMain.js');
 	try {
 		const worker = new Worker(serverMain.toString());
 		const newLanguageClient: LanguageClientConstructor = (id: string, name: string, clientOptions: LanguageClientOptions) => {

--- a/extensions/html-language-features/client/src/browser/htmlClientMain.ts
+++ b/extensions/html-language-features/client/src/browser/htmlClientMain.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionContext } from 'vscode';
+import { ExtensionContext, Uri } from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient';
 import { startClient, LanguageClientConstructor } from '../htmlClient';
 import { LanguageClient } from 'vscode-languageclient/browser';
@@ -17,9 +17,9 @@ declare const TextDecoder: {
 
 // this method is called when vs code is activated
 export function activate(context: ExtensionContext) {
-	const serverMain = context.asAbsolutePath('server/dist/browser/htmlServerMain.js');
+	const serverMain = Uri.joinPath(context.extensionUri, 'server/dist/browser/cssServerMain.js');
 	try {
-		const worker = new Worker(serverMain);
+		const worker = new Worker(serverMain.toString());
 		const newLanguageClient: LanguageClientConstructor = (id: string, name: string, clientOptions: LanguageClientOptions) => {
 			return new LanguageClient(id, name, clientOptions, worker);
 		};

--- a/extensions/json-language-features/client/src/browser/jsonClientMain.ts
+++ b/extensions/json-language-features/client/src/browser/jsonClientMain.ts
@@ -17,7 +17,7 @@ declare function fetch(uri: string, options: any): any;
 
 // this method is called when vs code is activated
 export function activate(context: ExtensionContext) {
-	const serverMain = Uri.joinPath(context.extensionUri, 'server/dist/browser/cssServerMain.js');
+	const serverMain = Uri.joinPath(context.extensionUri, 'server/dist/browser/jsonServerMain.js');
 	try {
 		const worker = new Worker(serverMain.toString());
 		const newLanguageClient: LanguageClientConstructor = (id: string, name: string, clientOptions: LanguageClientOptions) => {

--- a/extensions/json-language-features/client/src/browser/jsonClientMain.ts
+++ b/extensions/json-language-features/client/src/browser/jsonClientMain.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionContext } from 'vscode';
+import { ExtensionContext, Uri } from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient';
 import { startClient, LanguageClientConstructor } from '../jsonClient';
 import { LanguageClient } from 'vscode-languageclient/browser';
@@ -17,9 +17,9 @@ declare function fetch(uri: string, options: any): any;
 
 // this method is called when vs code is activated
 export function activate(context: ExtensionContext) {
-	const serverMain = context.asAbsolutePath('server/dist/browser/jsonServerMain.js');
+	const serverMain = Uri.joinPath(context.extensionUri, 'server/dist/browser/cssServerMain.js');
 	try {
-		const worker = new Worker(serverMain);
+		const worker = new Worker(serverMain.toString());
 		const newLanguageClient: LanguageClientConstructor = (id: string, name: string, clientOptions: LanguageClientOptions) => {
 			return new LanguageClient(id, name, clientOptions, worker);
 		};

--- a/extensions/typescript-language-features/src/extension.browser.ts
+++ b/extensions/typescript-language-features/src/extension.browser.ts
@@ -52,7 +52,7 @@ export function activate(
 	const versionProvider = new StaticVersionProvider(
 		new TypeScriptVersion(
 			TypeScriptVersionSource.Bundled,
-			context.asAbsolutePath('dist/browser/typescript-web/tsserver.web.js'),
+			vscode.Uri.joinPath(context.extensionUri, 'dist/browser/typescript-web/tsserver.web.js').toString(),
 			API.v400));
 
 	const lazyClientHost = createLazyClientHost(context, false, {
@@ -78,4 +78,3 @@ export function activate(
 
 	return getExtensionApi(onCompletionAccepted.event, pluginManager);
 }
-


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode/issues/105277


The PR adopts browser parts to construct worker urls using the proper API. Today, this only works because of this (which we should nuke)

https://github.com/microsoft/vscode/blob/df5d0e588ff6956c812b617895e4598ade4db428/src/vs/workbench/api/common/extHostExtensionService.ts#L388-L395