### PR TITLE
SCM: Clear list of created resource groups once they are added

### DIFF
--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -516,6 +516,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
 		}
 
 		this._proxy.$registerGroups(this.handle, groups, splices);
+		this.createdResourceGroups.clear();
 	}
 
 	@debounce(100)


### PR DESCRIPTION
Previously, the `createdResourceGroups` map was never cleared.

This meant that every time a resource group was added, it would re-add all the resource groups that it added last time, and so on.

This PR fixes #105483

also fixes https://github.com/mjcrouch/vscode-perforce/issues/179
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->
