### PR TITLE
Adds move views command

### DIFF
--- a/src/vs/workbench/api/common/apiCommands.ts
+++ b/src/vs/workbench/api/common/apiCommands.ts
@@ -16,6 +16,7 @@ import { IWorkspacesService, hasWorkspaceFileExtension, IRecent } from 'vs/platf
 import { Schemas } from 'vs/base/common/network';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { IViewDescriptorService, IViewsService } from 'vs/workbench/common/views';
 
 // -----------------------------------------------------------------
 // The following commands are registered on both sides separately.
@@ -263,4 +264,46 @@ CommandsRegistry.registerCommand('_extensionTests.getLogLevel', function (access
 	const logService = accessor.get(ILogService);
 
 	return logService.getLevel();
+});
+
+
+CommandsRegistry.registerCommand('_workbench.action.moveViews', async function (accessor: ServicesAccessor, options: { viewIds: string[], destinationId: string }) {
+	const viewDescriptorService = accessor.get(IViewDescriptorService);
+
+	const destination = viewDescriptorService.getViewContainerById(options.destinationId);
+	if (!destination) {
+		return;
+	}
+
+	// FYI, don't use `moveViewsToContainer` in 1 shot, because it expects all views to have the same current location
+	for (const viewId of options.viewIds) {
+		const viewDescriptor = viewDescriptorService.getViewDescriptorById(viewId);
+		if (viewDescriptor?.canMoveView) {
+			viewDescriptorService.moveViewsToContainer([viewDescriptor], destination);
+		}
+	}
+
+	const focusView = options.viewIds[options.viewIds.length - 1];
+	if (focusView) {
+		await accessor.get(IViewsService).openView(focusView, true);
+	}
+});
+
+export class MoveViewsAPICommand {
+	public static readonly ID = 'vscode.moveViews';
+	public static execute(executor: ICommandsExecutor, options: { viewIds: string[], destinationId: string }): Promise<any> {
+		if (!Array.isArray(options?.viewIds) || typeof options?.destinationId !== 'string') {
+			return Promise.reject('Invalid arguments');
+		}
+
+		return executor.executeCommand('_workbench.action.moveViews', options);
+	}
+}
+CommandsRegistry.registerCommand({
+	id: MoveViewsAPICommand.ID,
+	handler: adjustHandler(MoveViewsAPICommand.execute),
+	description: {
+		description: 'Move Views',
+		args: []
+	}
 });

--- a/src/vs/workbench/api/common/apiCommands.ts
+++ b/src/vs/workbench/api/common/apiCommands.ts
@@ -283,10 +283,7 @@ CommandsRegistry.registerCommand('_workbench.action.moveViews', async function (
 		}
 	}
 
-	const focusView = options.viewIds[options.viewIds.length - 1];
-	if (focusView) {
-		await accessor.get(IViewsService).openView(focusView, true);
-	}
+	await accessor.get(IViewsService).openViewContainer(destination.id, true);
 });
 
 export class MoveViewsAPICommand {

--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -763,43 +763,6 @@ export class MoveFocusedViewAction extends Action {
 
 registry.registerWorkbenchAction(SyncActionDescriptor.from(MoveFocusedViewAction), 'View: Move Focused View', viewCategory.value, FocusedViewContext.notEqualsTo(''));
 
-export class MoveViewsAction extends Action2 {
-	constructor() {
-		super({
-			id: 'workbench.action.moveViews',
-			title: { value: nls.localize('moveViews', "Move Views"), original: 'Move Views' },
-			category: viewCategory,
-			f1: false
-		});
-	}
-
-	async run(accessor: ServicesAccessor, viewIds: string[], destinationId: string): Promise<void> {
-		const viewDescriptorService = accessor.get(IViewDescriptorService);
-
-		const destination = viewDescriptorService.getViewContainerById(destinationId);
-		if (!destination) {
-			return;
-		}
-
-		const viewDescriptors = viewIds.map(viewId => {
-			const viewDescriptor = viewDescriptorService.getViewDescriptorById(viewId);
-			return viewDescriptor?.canMoveView ? viewDescriptor : undefined;
-		}).filter(<T>(i: T | undefined): i is T => Boolean(i));
-
-		if (viewDescriptors.length) {
-			viewDescriptorService.moveViewsToContainer(viewDescriptors, destination);
-
-			const focusView = viewIds[viewIds.length - 1];
-			if (focusView) {
-				await accessor.get(IViewsService).openView(focusView, true);
-			}
-		}
-	}
-}
-
-registerAction2(MoveViewsAction);
-
-
 // --- Reset View Location with Command
 export class ResetFocusedViewLocationAction extends Action {
 	static readonly ID = 'workbench.action.resetFocusedViewLocation';

--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -763,6 +763,42 @@ export class MoveFocusedViewAction extends Action {
 
 registry.registerWorkbenchAction(SyncActionDescriptor.from(MoveFocusedViewAction), 'View: Move Focused View', viewCategory.value, FocusedViewContext.notEqualsTo(''));
 
+export class MoveViewsAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.moveViews',
+			title: { value: nls.localize('moveViews', "Move Views"), original: 'Move Views' },
+			category: viewCategory,
+			f1: false
+		});
+	}
+
+	async run(accessor: ServicesAccessor, viewIds: string[], destinationId: string): Promise<void> {
+		const viewDescriptorService = accessor.get(IViewDescriptorService);
+
+		const destination = viewDescriptorService.getViewContainerById(destinationId);
+		if (!destination) {
+			return;
+		}
+
+		const viewDescriptors = viewIds.map(viewId => {
+			const viewDescriptor = viewDescriptorService.getViewDescriptorById(viewId);
+			return viewDescriptor?.canMoveView ? viewDescriptor : undefined;
+		}).filter(<T>(i: T | undefined): i is T => Boolean(i));
+
+		if (viewDescriptors.length) {
+			viewDescriptorService.moveViewsToContainer(viewDescriptors, destination);
+
+			const focusView = viewIds[viewIds.length - 1];
+			if (focusView) {
+				await accessor.get(IViewsService).openView(focusView, true);
+			}
+		}
+	}
+}
+
+registerAction2(MoveViewsAction);
+
 
 // --- Reset View Location with Command
 export class ResetFocusedViewLocationAction extends Action {


### PR DESCRIPTION
This adds a move views command to allow extensions to control the layout of multiple views in one shot.

I really want to get this in so that in GitLens I can maintain my _GitLens: Set Views Layout_ command, as well as the view control from the Welcome view and Interactive Settings editor.

![image](https://user-images.githubusercontent.com/641685/91646816-52ab4d80-ea21-11ea-8e77-081b45036e63.png)
