### PR TITLE
Fixes TypeScript select version inserts full path to tsserver.js

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/versionManager.ts
+++ b/extensions/typescript-language-features/src/tsServer/versionManager.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
+import * as path from 'path';
 import { TypeScriptServiceConfiguration } from '../utils/configuration';
 import { Disposable } from '../utils/dispose';
 import { ITypeScriptVersionProvider, TypeScriptVersion } from './versionProvider';
@@ -109,7 +110,7 @@ export class TypeScriptVersionManager extends Disposable {
 				run: async () => {
 					await this.workspaceState.update(useWorkspaceTsdkStorageKey, true);
 					const tsConfig = vscode.workspace.getConfiguration('typescript');
-					await tsConfig.update('tsdk', version.pathLabel, false);
+					await tsConfig.update('tsdk', path.dirname(version.tsServerPath), false);
 					this.updateActiveVersion(version);
 				},
 			};


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

To fix it, I just used the `dirname` of `tsServerPath`

This PR fixes #105202
