### PR TITLE
Preserve all new lines in MarkdownString appendText

### DIFF
--- a/src/vs/base/common/htmlContent.ts
+++ b/src/vs/base/common/htmlContent.ts
@@ -45,7 +45,7 @@ export class MarkdownString implements IMarkdownString {
 		// escape markdown syntax tokens: http://daringfireball.net/projects/markdown/syntax#backslash
 		this._value += (this._supportThemeIcons ? escapeCodicons(value) : value)
 			.replace(/[\\`*_{}[\]()#+\-.!]/g, '\\$&')
-			.replace('\n', '\n\n');
+			.replace(/\n/g, '\n\n');
 
 		return this;
 	}

--- a/src/vs/workbench/contrib/views/browser/treeView.ts
+++ b/src/vs/workbench/contrib/views/browser/treeView.ts
@@ -40,6 +40,7 @@ import { isFalsyOrWhitespace } from 'vs/base/common/strings';
 import { SIDE_BAR_BACKGROUND, PANEL_BACKGROUND } from 'vs/workbench/common/theme';
 import { IHoverService, IHoverOptions, IHoverTarget } from 'vs/workbench/services/hover/browser/hover';
 import { ActionViewItem } from 'vs/base/browser/ui/actionbar/actionViewItems';
+import { IMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
 
 class Root implements ITreeItem {
 	label = { label: 'root' };
@@ -824,7 +825,13 @@ class TreeRenderer extends Disposable implements ITreeRenderer<ITreeItem, FuzzyS
 				if (node instanceof ResolvableTreeItem) {
 					await node.resolve();
 				}
-				const tooltip = node.tooltip ?? label;
+				let tooltip: IMarkdownString | undefined;
+				if (node.tooltip && !isString(node.tooltip)) {
+					tooltip = node.tooltip;
+				} else {
+					const text = node.tooltip ?? label;
+					tooltip = text ? new MarkdownString().appendText(text) : undefined;
+				}
 				if (isHovering && tooltip) {
 					if (!hoverOptions) {
 						const target: IHoverTarget = {


### PR DESCRIPTION
While using appendText, I noticed that only the first newline is getting preserved. 