### PR TITLE
Replace 'master' with branch head when publishing to github

### DIFF
--- a/extensions/github/src/publish.ts
+++ b/extensions/github/src/publish.ts
@@ -174,8 +174,9 @@ export async function publishRepository(gitAPI: GitAPI, repository?: Repository)
 		}
 
 		progress.report({ message: 'Uploading files', increment: 25 });
+		const branch = await repository.getBranch('HEAD');
 		await repository.addRemote('origin', createdGithubRepository.clone_url);
-		await repository.push('origin', 'master', true);
+		await repository.push('origin', branch.name, true);
 
 		return createdGithubRepository;
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Uses the current branch to publish to github, instead of always using `master`.

This PR fixes #105025
