### PR TITLE
Swap order of commit and save

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1372,8 +1372,8 @@ export class CommandCenter {
 				const pick = await window.showWarningMessage(message, { modal: true }, saveAndCommit, commit);
 
 				if (pick === saveAndCommit) {
-					await Promise.all(documents.map(d => d.save()));
 					await repository.add(documents.map(d => d.uri));
+					await Promise.all(documents.map(d => d.save()));
 				} else if (pick !== commit) {
 					return false; // do not commit on cancel
 				}

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1367,7 +1367,7 @@ export class CommandCenter {
 				const message = documents.length === 1
 					? localize('unsaved files single', "The following file has unsaved changes which won't be included in the commit if you proceed: {0}.\n\nWould you like to save it before committing?", path.basename(documents[0].uri.fsPath))
 					: localize('unsaved files', "There are {0} unsaved files.\n\nWould you like to save them before committing?", documents.length);
-				const saveAndCommit = localize('save and commit', "Save All & Commit");
+				const saveAndCommit = localize('save and commit', "Commit & Save All");
 				const commit = localize('commit', "Commit Anyway");
 				const pick = await window.showWarningMessage(message, { modal: true }, saveAndCommit, commit);
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1367,7 +1367,7 @@ export class CommandCenter {
 				const message = documents.length === 1
 					? localize('unsaved files single', "The following file has unsaved changes which won't be included in the commit if you proceed: {0}.\n\nWould you like to save it before committing?", path.basename(documents[0].uri.fsPath))
 					: localize('unsaved files', "There are {0} unsaved files.\n\nWould you like to save them before committing?", documents.length);
-				const saveAndCommit = localize('save and commit', "Commit & Save All");
+				const saveAndCommit = localize('commit and save', "Commit & Save All");
 				const commit = localize('commit', "Commit Anyway");
 				const pick = await window.showWarningMessage(message, { modal: true }, saveAndCommit, commit);
 


### PR DESCRIPTION
This PR fixes #104945

The code currently saves all changes, then commits them. This is leading to unintended changes going through as part of a commit. Swapped the order of execution of those two calls. Committing first then saving open editors ensures that only the staged changes go through first before saving the ongoing edits.
