### PR TITLE
Pass credentials through args

### DIFF
--- a/src/vs/code/browser/workbench/workbench-dev.html
+++ b/src/vs/code/browser/workbench/workbench-dev.html
@@ -17,6 +17,9 @@
 		<!-- Builtin Extensions (running out of sources) -->
 		<meta id="vscode-workbench-builtin-extensions" data-settings="{{WORKBENCH_BUILTIN_EXTENSIONS}}">
 
+		<!-- Workbench Credentials (running out of sources) -->
+		<meta id="vscode-workbench-credentials" data-settings="{{WORKBENCH_CREDENTIALS}}">
+
 		<!-- Workarounds/Hacks (remote user data uri) -->
 		<meta id="vscode-remote-user-data-uri" data-settings="{{REMOTE_USER_DATA_URI}}">
 

--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -27,6 +27,13 @@ class LocalStorageCredentialsProvider implements ICredentialsProvider {
 
 	static readonly CREDENTIALS_OPENED_KEY = 'credentials.provider';
 
+	constructor(credentials: ICredential[]) {
+		this._credentials = credentials;
+		for (const { service, account, password } of this._credentials) {
+			this.setPassword(service, account, password);
+		}
+	}
+
 	private _credentials: ICredential[] | undefined;
 	private get credentials(): ICredential[] {
 		if (!this._credentials) {
@@ -430,6 +437,11 @@ class WindowIndicator implements IWindowIndicator {
 		window.location.href = `${window.location.origin}?${queryString}`;
 	};
 
+	// Find credentials from DOM
+	const credentialsElement = document.getElementById('vscode-workbench-credentials');
+	const credentialsElementAttribute = credentialsElement ? credentialsElement.getAttribute('data-settings') : undefined;
+	const credentialsProvider = new LocalStorageCredentialsProvider(credentialsElementAttribute ? JSON.parse(credentialsElementAttribute) : []);
+
 	// Finally create workbench
 	create(document.body, {
 		...config,
@@ -438,6 +450,6 @@ class WindowIndicator implements IWindowIndicator {
 		productQualityChangeHandler,
 		workspaceProvider,
 		urlCallbackProvider: new PollingURLCallbackProvider(),
-		credentialsProvider: new LocalStorageCredentialsProvider()
+		credentialsProvider
 	});
 })();


### PR DESCRIPTION
Passing credentials is helpful while testing VS Code web from sources for eg., testing Initialising user data

Setting to current milestone - without this support it is super hard to test/verify above feature