### PR TITLE
Add .nf extension to Groovy file extensions

### DIFF
--- a/extensions/groovy/package.json
+++ b/extensions/groovy/package.json
@@ -13,7 +13,7 @@
 		"languages": [{
 			"id": "groovy",
 			"aliases": ["Groovy", "groovy"],
-      "extensions": [".groovy", ".gvy", ".gradle", ".jenkinsfile"],
+      "extensions": [".groovy", ".gvy", ".gradle", ".jenkinsfile", ".nf"],
       "filenamePatterns": ["Jenkinsfile.*"],
 			"firstLine": "^#!.*\\bgroovy\\b",
 			"configuration": "./language-configuration.json"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Add .nf extension to Groovy file extensions (so [nextflow](https://www.nextflow.io/) files are detected as Groovy)

This PR fixes #106017 
