### PR TITLE
[json-language-features] Fix json/schemaAssociations parameters documentation

### DIFF
--- a/extensions/json-language-features/server/README.md
+++ b/extensions/json-language-features/server/README.md
@@ -143,34 +143,37 @@ In addition to the settings, schemas associations can also be provided through a
 
 Notification:
 - method: 'json/schemaAssociations'
-- params: `ISchemaAssociations | SchemaConfiguration[]` defined as follows
+- params: `ISchemaAssociations` or `ISchemaAssociation[]` defined as follows
 
 ```ts
-/**
- * An object where:
- *  - keys are file names or file paths (separated by `/`). `*` can be used as a wildcard.
- *  - values ar an arrays of schema URLs
- */
-type ISchemaAssociations = Record<string, string[]>
-
-interface SchemaConfiguration {
-    /**
-     * The URI of the schema, which is also the identifier of the schema.
-     */
-    uri: string;
-    /**
-     * A list of file path patterns that are associated to the schema. The '*' wildcard can be used. Exclusion patterns starting with '!'.
-     * For example '*.schema.json', 'package.json', '!foo*.schema.json'.
-     * A match succeeds when there is at least one pattern matching and last matching pattern does not start with '!'.
-     */
-    fileMatch?: string[];
-    /**
-     * The schema for the given URI.
-     * If no schema is provided, the schema will be fetched with the schema request service (if available).
-     */
-    schema?: JSONSchema;
+interface ISchemaAssociations {
+  /**
+   * An object where:
+   *  - keys are file names or file paths (using `/` as path separator). `*` can be used as a wildcard.
+   *  - values are an arrays of schema URIs
+   */
+  [pattern: string]: string[];
 }
+
+interface ISchemaAssociation {
+  /**
+   * The URI of the schema, which is also the identifier of the schema.
+   */
+  uri: string;
+
+  /**
+   * A list of file path patterns that are associated to the schema. The '*' wildcard can be used. Exclusion patterns starting with '!'.
+   * For example '*.schema.json', 'package.json', '!foo*.schema.json'.
+   * A match succeeds when there is at least one pattern matching and last matching pattern does not start with '!'.
+   */
+  fileMatch: string[];
+
+}
+
 ```
+`ISchemaAssociations`
+  - keys: a file names or file path (separated by `/`). `*` can be used as a wildcard.
+  - values: An array of schema URLs
 
 Notification:
 - method: 'json/schemaContent'

--- a/extensions/json-language-features/server/README.md
+++ b/extensions/json-language-features/server/README.md
@@ -143,15 +143,34 @@ In addition to the settings, schemas associations can also be provided through a
 
 Notification:
 - method: 'json/schemaAssociations'
-- params: `ISchemaAssociations` defined as follows
+- params: `ISchemaAssociations | SchemaConfiguration[]` defined as follows
 
 ```ts
-interface ISchemaAssociations {
-	[pattern: string]: string[];
+/**
+ * An object where:
+ *  - keys are file names or file paths (separated by `/`). `*` can be used as a wildcard.
+ *  - values ar an arrays of schema URLs
+ */
+type ISchemaAssociations = Record<string, string[]>
+
+interface SchemaConfiguration {
+    /**
+     * The URI of the schema, which is also the identifier of the schema.
+     */
+    uri: string;
+    /**
+     * A list of file path patterns that are associated to the schema. The '*' wildcard can be used. Exclusion patterns starting with '!'.
+     * For example '*.schema.json', 'package.json', '!foo*.schema.json'.
+     * A match succeeds when there is at least one pattern matching and last matching pattern does not start with '!'.
+     */
+    fileMatch?: string[];
+    /**
+     * The schema for the given URI.
+     * If no schema is provided, the schema will be fetched with the schema request service (if available).
+     */
+    schema?: JSONSchema;
 }
 ```
-  - keys: a file names or file path (separated by `/`). `*` can be used as a wildcard.
-  - values: An array of schema URLs
 
 Notification:
 - method: 'json/schemaContent'

--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -14,17 +14,10 @@ import { TextDocument, JSONDocument, JSONSchema, getLanguageService, DocumentLan
 import { getLanguageModelCache } from './languageModelCache';
 import { RequestService, basename, resolvePath } from './requests';
 
-interface ISchemaAssociations {
-	[pattern: string]: string[];
-}
-
-interface ISchemaAssociation {
-	fileMatch: string[];
-	uri: string;
-}
+type ISchemaAssociations = Record<string, string[]>;
 
 namespace SchemaAssociationNotification {
-	export const type: NotificationType<ISchemaAssociations | ISchemaAssociation[], any> = new NotificationType('json/schemaAssociations');
+	export const type: NotificationType<ISchemaAssociations | SchemaConfiguration[], any> = new NotificationType('json/schemaAssociations');
 }
 
 namespace VSCodeContentRequest {
@@ -212,7 +205,7 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 	}();
 
 	let jsonConfigurationSettings: JSONSchemaSettings[] | undefined = undefined;
-	let schemaAssociations: ISchemaAssociations | ISchemaAssociation[] | undefined = undefined;
+	let schemaAssociations: ISchemaAssociations | SchemaConfiguration[] | undefined = undefined;
 	let formatterRegistration: Thenable<Disposable> | null = null;
 
 	// The settings have changed. Is send on server activation as well.


### PR DESCRIPTION
The `json/schemaAssociations` documentation is not accurate in stating
that the only supported parameter is an object in `{ pattern: uri }`
format. It also supports the structure defined by `SchemaConfiguration`
interface from "vscode-json-languageservice".

Also updated the server code to match that.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #106060
