### PR TITLE
Remove redundant line

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -193,7 +193,6 @@ export type ToWebviewMessage =
 	| IHideOutputMessage
 	| IShowOutputMessage
 	| IUpdatePreloadResourceMessage
-	| IFocusOutputMessage
 	| IUpdateDecorationsMessage
 	| ICustomRendererMessage;
 


### PR DESCRIPTION
`IFocusOutputMessage` was included twice in type definition. Removing one of them.