### PR TITLE
web: missing settings change events from FileUserDataProvider

### DIFF
--- a/src/vs/workbench/services/userData/common/fileUserDataProvider.ts
+++ b/src/vs/workbench/services/userData/common/fileUserDataProvider.ts
@@ -19,7 +19,6 @@ export class FileUserDataProvider extends Disposable implements
 	IFileSystemProviderWithOpenReadWriteCloseCapability,
 	IFileSystemProviderWithFileReadStreamCapability {
 
-	readonly capabilities: FileSystemProviderCapabilities = this.fileSystemProvider.capabilities;
 	readonly onDidChangeCapabilities: Event<void> = this.fileSystemProvider.onDidChangeCapabilities;
 
 	private readonly _onDidChangeFile = this._register(new Emitter<readonly IFileChange[]>());
@@ -46,6 +45,9 @@ export class FileUserDataProvider extends Disposable implements
 		// Assumption: This path always exists
 		this._register(this.fileSystemProvider.watch(this.fileSystemUserDataHome, { recursive: false, excludes: [] }));
 		this._register(this.fileSystemProvider.onDidChangeFile(e => this.handleFileChanges(e)));
+	}
+	get capabilities() {
+		return this.fileSystemProvider.capabilities;
 	}
 
 	watch(resource: URI, opts: IWatchOptions): IDisposable {


### PR DESCRIPTION
This PR fixes #103949

The onDidChangeCapabilities event was received, but the old capabilities used.
- `extUri` stays case sensitive
- `toUserDataResource` is always undefined as `this.extUri.isEqualOrParent(fileSystemResource, this.fileSystemUserDataHome))` is false as the URI uses different casing for drive letters
