### PR TITLE
Custom hover keeps lingering around

### DIFF
--- a/src/vs/workbench/contrib/views/browser/treeView.ts
+++ b/src/vs/workbench/contrib/views/browser/treeView.ts
@@ -40,7 +40,6 @@ import { isFalsyOrWhitespace } from 'vs/base/common/strings';
 import { SIDE_BAR_BACKGROUND, PANEL_BACKGROUND } from 'vs/workbench/common/theme';
 import { IHoverService, IHoverOptions, IHoverTarget } from 'vs/workbench/services/hover/browser/hover';
 import { ActionViewItem } from 'vs/base/browser/ui/actionbar/actionViewItems';
-import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { isMacintosh } from 'vs/base/common/platform';
 
 class Root implements ITreeItem {


### PR DESCRIPTION
@Tyriar has fixed this for the September release, but for August we will not use the custom hover in the custom tree view by default. This change is mostly a revert of 874c98d88499695c9081693ee56ec6dfbdadb8e3. In the September iteration, we will go back to using custom hovers by default in the custom tree view.
Fixes #106096