### PR TITLE
MessageChannel-api to communicate with worker ext host

### DIFF
--- a/src/vs/workbench/services/extensions/common/webWorkerIframe.ts
+++ b/src/vs/workbench/services/extensions/common/webWorkerIframe.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const WEB_WORKER_IFRAME = {
-	sha: 'sha256-rSINb5Ths99Zj4Ml59jEdHS4WbO+H5Iw+oyRmyi2MLw=',
+	sha: 'sha256-r24mDVsMuFEo8ChaY9ppVJKbY3CUM4I12Aw/yscWZbg=',
 	js: `
 (function() {
 	const workerSrc = document.getElementById('vscode-worker-src').getAttribute('data-value');
@@ -13,8 +13,8 @@ export const WEB_WORKER_IFRAME = {
 
 	worker.onmessage = (event) => {
 		const { data } = event;
-		if (!(data instanceof ArrayBuffer)) {
-			console.warn('Unknown data received', data);
+		if (!(data instanceof MessagePort)) {
+			console.warn('Unknown data received', event);
 			window.parent.postMessage({
 				vscodeWebWorkerExtHostId,
 				error: {
@@ -42,16 +42,6 @@ export const WEB_WORKER_IFRAME = {
 			}
 		}, '*');
 	};
-
-	window.addEventListener('message', function(event) {
-		if (event.source !== window.parent) {
-			return;
-		}
-		if (event.data.vscodeWebWorkerExtHostId !== vscodeWebWorkerExtHostId) {
-			return;
-		}
-		worker.postMessage(event.data.data, [event.data.data]);
-	}, false);
 })();
 `
 };


### PR DESCRIPTION
This PR uses the [MessageChannel](https://developer.mozilla.org/en-US/docs/Web/API/Channel_Messaging_API)-api to communicate with the worker extension host. This eliminates the need for the iframe to receive and forward messages and speeds things up. F1 > Extension Host Latency shows the following roundtrip times:

| |  wo/ iframe | w/ iframe  | MsgChannel  |
|---|---|---|---|
| run1 | 0.364  | 0.597  | 0.638  |   
| run2 | 0.580 | 0.849  | 0.603  |   
| run3 | 0.351  | 0.635  | 0.603  |   
| run4 | 0.611  | 0.799  | 0.588  |   
| run5 | 0.543  | 0.833  | 0.543  |   
| **avg** | **0.489**  | **0.742**  | **0.543**  |   