### PR TITLE
Update gitignore decorations when .git/info/exclude file is edited

### DIFF
--- a/extensions/git/src/decorationProvider.ts
+++ b/extensions/git/src/decorationProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { window, workspace, Uri, Disposable, Event, EventEmitter, Decoration, DecorationProvider, ThemeColor, TextDocument } from 'vscode';
+import { window, workspace, Uri, Disposable, Event, EventEmitter, Decoration, DecorationProvider, ThemeColor } from 'vscode';
 import * as path from 'path';
 import { Repository, GitResourceGroup } from './repository';
 import { Model } from './model';
@@ -21,7 +21,7 @@ class GitIgnoreDecorationProvider implements DecorationProvider {
 
 	constructor(private model: Model) {
 		this.onDidChangeDecorations = fireEvent(anyEvent<any>(
-			filterEvent(workspace.onDidSaveTextDocument, this.isIgnoreConfig),
+			filterEvent(workspace.onDidSaveTextDocument, e => /\.gitignore$|\.git\/info\/exclude$/.test(e.uri.path)),
 			model.onDidOpenRepository,
 			model.onDidCloseRepository
 		));
@@ -76,13 +76,6 @@ class GitIgnoreDecorationProvider implements DecorationProvider {
 				}
 			});
 		}
-	}
-
-	private isIgnoreConfig(document: TextDocument): boolean {
-		return (
-			document.fileName.endsWith('.gitignore') ||
-			document.fileName.replace(/\\/g, '/').endsWith('.git/info/exclude')
-		);
 	}
 
 	dispose(): void {

--- a/extensions/git/src/decorationProvider.ts
+++ b/extensions/git/src/decorationProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { window, workspace, Uri, Disposable, Event, EventEmitter, Decoration, DecorationProvider, ThemeColor } from 'vscode';
+import { window, workspace, Uri, Disposable, Event, EventEmitter, Decoration, DecorationProvider, ThemeColor, TextDocument } from 'vscode';
 import * as path from 'path';
 import { Repository, GitResourceGroup } from './repository';
 import { Model } from './model';
@@ -21,7 +21,7 @@ class GitIgnoreDecorationProvider implements DecorationProvider {
 
 	constructor(private model: Model) {
 		this.onDidChangeDecorations = fireEvent(anyEvent<any>(
-			filterEvent(workspace.onDidSaveTextDocument, e => e.fileName.endsWith('.gitignore')),
+			filterEvent(workspace.onDidSaveTextDocument, this.isIgnoreConfig),
 			model.onDidOpenRepository,
 			model.onDidCloseRepository
 		));
@@ -76,6 +76,13 @@ class GitIgnoreDecorationProvider implements DecorationProvider {
 				}
 			});
 		}
+	}
+
+	private isIgnoreConfig(document: TextDocument): boolean {
+		return (
+			document.fileName.endsWith('.gitignore') ||
+			document.fileName.replace(/\\/g, '/').endsWith('.git/info/exclude')
+		);
 	}
 
 	dispose(): void {


### PR DESCRIPTION
[According to git-scm](https://git-scm.com/docs/gitignore),

> Patterns which are specific to a particular repository but which do not need to be shared with other related repositories (e.g., auxiliary files that live inside the repository but are specific to one user’s workflow) should go into the `$GIT_DIR/info/exclude` file.

I use this file from time to time to remove some personal workflow specific files from the repo. Currently, when this file is edited, the file tree decorations do not update (the ignored files do not "gray out"), requiring me to reopen the repo for the update to occur. This PR fixes this issue.