### PR TITLE
Proper fix for #105202

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/versionManager.ts
+++ b/extensions/typescript-language-features/src/tsServer/versionManager.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import * as path from 'path';
 import { TypeScriptServiceConfiguration } from '../utils/configuration';
 import { Disposable } from '../utils/dispose';
 import { ITypeScriptVersionProvider, TypeScriptVersion } from './versionProvider';
@@ -110,7 +109,7 @@ export class TypeScriptVersionManager extends Disposable {
 				run: async () => {
 					await this.workspaceState.update(useWorkspaceTsdkStorageKey, true);
 					const tsConfig = vscode.workspace.getConfiguration('typescript');
-					await tsConfig.update('tsdk', path.dirname(version.tsServerPath), false);
+					await tsConfig.update('tsdk', version.pathLabel, false);
 					this.updateActiveVersion(version);
 				},
 			};

--- a/extensions/typescript-language-features/src/tsServer/versionProvider.electron.ts
+++ b/extensions/typescript-language-features/src/tsServer/versionProvider.electron.ts
@@ -104,7 +104,8 @@ export class DiskTypeScriptVersionProvider implements ITypeScriptVersionProvider
 			return [
 				new TypeScriptVersion(source,
 					serverPath,
-					DiskTypeScriptVersionProvider.getApiVersion(serverPath))
+					DiskTypeScriptVersionProvider.getApiVersion(serverPath),
+					tsdkPathSetting)
 			];
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

The `pathLabel` argument was not being passed to the `TypeScriptVersion` object when a path was an absolute path so it defaulted to the `tsServerPath` when updating the setting.

This PR fixes #105202
