### PR TITLE
Revert more specific class names for editor tokens

### DIFF
--- a/src/vs/editor/common/modes/supports/tokenization.ts
+++ b/src/vs/editor/common/modes/supports/tokenization.ts
@@ -399,10 +399,10 @@ export function generateTokensCSSForColorMap(colorMap: Color[]): string {
 	let rules: string[] = [];
 	for (let i = 1, len = colorMap.length; i < len; i++) {
 		let color = colorMap[i];
-		rules[i] = `.monaco-editor .mtk${i} { color: ${color}; }`;
+		rules[i] = `.mtk${i} { color: ${color}; }`;
 	}
-	rules.push('.monaco-editor .mtki { font-style: italic; }');
-	rules.push('.monaco-editor .mtkb { font-weight: bold; }');
-	rules.push('.monaco-editor .mtku { text-decoration: underline; text-underline-position: under; }');
+	rules.push('.mtki { font-style: italic; }');
+	rules.push('.mtkb { font-weight: bold; }');
+	rules.push('.mtku { text-decoration: underline; text-underline-position: under; }');
 	return rules.join('\n');
 }


### PR DESCRIPTION
Reverts #103485
Fixes #106261

I believe that #103485 broke cases where the markdown renderer creates tokenized strings that are used outside of an editor's dom node (such as in hovers or in webviews)

The safest fix for now is to revert it. We can revist this and make the markdown renderer handle the tokenized output better next iteration

