### PR TITLE
Provide option to default to github provider for git.api.getRemoteSources

### DIFF
--- a/extensions/git/src/remoteSource.ts
+++ b/extensions/git/src/remoteSource.ts
@@ -12,134 +12,134 @@ import { throttle, debounce } from './decorators';
 const localize = nls.loadMessageBundle();
 
 async function getQuickPickResult<T extends QuickPickItem>(quickpick: QuickPick<T>): Promise<T | undefined> {
-    const result = await new Promise<T | undefined>(c => {
-        quickpick.onDidAccept(() => c(quickpick.selectedItems[0]));
-        quickpick.onDidHide(() => c(undefined));
-        quickpick.show();
-    });
+	const result = await new Promise<T | undefined>(c => {
+		quickpick.onDidAccept(() => c(quickpick.selectedItems[0]));
+		quickpick.onDidHide(() => c(undefined));
+		quickpick.show();
+	});
 
-    quickpick.hide();
-    return result;
+	quickpick.hide();
+	return result;
 }
 
 class RemoteSourceProviderQuickPick {
 
-    private quickpick: QuickPick<QuickPickItem & { remoteSource?: RemoteSource }>;
+	private quickpick: QuickPick<QuickPickItem & { remoteSource?: RemoteSource }>;
 
-    constructor(private provider: RemoteSourceProvider) {
-        this.quickpick = window.createQuickPick();
-        this.quickpick.ignoreFocusOut = true;
+	constructor(private provider: RemoteSourceProvider) {
+		this.quickpick = window.createQuickPick();
+		this.quickpick.ignoreFocusOut = true;
 
-        if (provider.supportsQuery) {
-            this.quickpick.placeholder = localize('type to search', "Repository name (type to search)");
-            this.quickpick.onDidChangeValue(this.onDidChangeValue, this);
-        } else {
-            this.quickpick.placeholder = localize('type to filter', "Repository name");
-        }
-    }
+		if (provider.supportsQuery) {
+			this.quickpick.placeholder = localize('type to search', "Repository name (type to search)");
+			this.quickpick.onDidChangeValue(this.onDidChangeValue, this);
+		} else {
+			this.quickpick.placeholder = localize('type to filter', "Repository name");
+		}
+	}
 
-    @debounce(300)
-    private onDidChangeValue(): void {
-        this.query();
-    }
+	@debounce(300)
+	private onDidChangeValue(): void {
+		this.query();
+	}
 
-    @throttle
-    private async query(): Promise<void> {
-        this.quickpick.busy = true;
+	@throttle
+	private async query(): Promise<void> {
+		this.quickpick.busy = true;
 
-        try {
-            const remoteSources = await this.provider.getRemoteSources(this.quickpick.value) || [];
+		try {
+			const remoteSources = await this.provider.getRemoteSources(this.quickpick.value) || [];
 
-            if (remoteSources.length === 0) {
-                this.quickpick.items = [{
-                    label: localize('none found', "No remote repositories found."),
-                    alwaysShow: true
-                }];
-            } else {
-                this.quickpick.items = remoteSources.map(remoteSource => ({
-                    label: remoteSource.name,
-                    description: remoteSource.description || (typeof remoteSource.url === 'string' ? remoteSource.url : remoteSource.url[0]),
-                    remoteSource
-                }));
-            }
-        } catch (err) {
-            this.quickpick.items = [{ label: localize('error', "$(error) Error: {0}", err.message), alwaysShow: true }];
-            console.error(err);
-        } finally {
-            this.quickpick.busy = false;
-        }
-    }
+			if (remoteSources.length === 0) {
+				this.quickpick.items = [{
+					label: localize('none found', "No remote repositories found."),
+					alwaysShow: true
+				}];
+			} else {
+				this.quickpick.items = remoteSources.map(remoteSource => ({
+					label: remoteSource.name,
+					description: remoteSource.description || (typeof remoteSource.url === 'string' ? remoteSource.url : remoteSource.url[0]),
+					remoteSource
+				}));
+			}
+		} catch (err) {
+			this.quickpick.items = [{ label: localize('error', "$(error) Error: {0}", err.message), alwaysShow: true }];
+			console.error(err);
+		} finally {
+			this.quickpick.busy = false;
+		}
+	}
 
-    async pick(): Promise<RemoteSource | undefined> {
-        this.query();
-        const result = await getQuickPickResult(this.quickpick);
-        return result?.remoteSource;
-    }
+	async pick(): Promise<RemoteSource | undefined> {
+		this.query();
+		const result = await getQuickPickResult(this.quickpick);
+		return result?.remoteSource;
+	}
 }
 
 export interface PickRemoteSourceOptions {
-    readonly providerLabel?: (provider: RemoteSourceProvider) => string;
-    readonly urlLabel?: string;
-    readonly providerName?: string;
+	readonly providerLabel?: (provider: RemoteSourceProvider) => string;
+	readonly urlLabel?: string;
+	readonly providerName?: string;
 }
 
 export async function pickRemoteSource(model: Model, options: PickRemoteSourceOptions = {}): Promise<string | undefined> {
-    const quickpick = window.createQuickPick<(QuickPickItem & { provider?: RemoteSourceProvider, url?: string })>();
-    quickpick.ignoreFocusOut = true;
+	const quickpick = window.createQuickPick<(QuickPickItem & { provider?: RemoteSourceProvider, url?: string })>();
+	quickpick.ignoreFocusOut = true;
 
-    const targetProvider = model.getRemoteProviders().filter(provider => provider.name === options.providerName);
-    if (targetProvider && targetProvider.length === 1) {
-        await pickProviderSource(targetProvider[0]);
-    } else {
-        const providers = model.getRemoteProviders()
-            .map(provider => ({ label: (provider.icon ? `$(${provider.icon}) ` : '') + (options.providerLabel ? options.providerLabel(provider) : provider.name), alwaysShow: true, provider }));
+	const targetedProvider = model.getRemoteProviders().filter(provider => provider.name === options.providerName);
+	if (targetedProvider && targetedProvider.length === 1) {
+		await pickProviderSource(targetedProvider[0]);
+	} else {
+		const providers = model.getRemoteProviders()
+			.map(provider => ({ label: (provider.icon ? `$(${provider.icon}) ` : '') + (options.providerLabel ? options.providerLabel(provider) : provider.name), alwaysShow: true, provider }));
 
-        quickpick.placeholder = providers.length === 0
-            ? localize('provide url', "Provide repository URL")
-            : localize('provide url or pick', "Provide repository URL or pick a repository source.");
+		quickpick.placeholder = providers.length === 0
+			? localize('provide url', "Provide repository URL")
+			: localize('provide url or pick', "Provide repository URL or pick a repository source.");
 
-        const updatePicks = (value?: string) => {
-            if (value) {
-                quickpick.items = [{
-                    label: options.urlLabel ?? localize('url', "URL"),
-                    description: value,
-                    alwaysShow: true,
-                    url: value
-                },
-                ...providers];
-            } else {
-                quickpick.items = providers;
-            }
-        };
+		const updatePicks = (value?: string) => {
+			if (value) {
+				quickpick.items = [{
+					label: options.urlLabel ?? localize('url', "URL"),
+					description: value,
+					alwaysShow: true,
+					url: value
+				},
+				...providers];
+			} else {
+				quickpick.items = providers;
+			}
+		};
 
-        quickpick.onDidChangeValue(updatePicks);
-        updatePicks();
+		quickpick.onDidChangeValue(updatePicks);
+		updatePicks();
 
-        const result = await getQuickPickResult(quickpick);
+		const result = await getQuickPickResult(quickpick);
 
-        if (result) {
-            if (result.url) {
-                return result.url;
-            } else if (result.provider) {
-                return await pickProviderSource(result.provider);
-            }
-        }
-    }
+		if (result) {
+			if (result.url) {
+				return result.url;
+			} else if (result.provider) {
+				return await pickProviderSource(result.provider);
+			}
+		}
+	}
 
-    return undefined;
+	return undefined;
 }
 
 async function pickProviderSource(provider: RemoteSourceProvider): Promise<string | undefined> {
-    const quickpick = new RemoteSourceProviderQuickPick(provider);
-    const remote = await quickpick.pick();
+	const quickpick = new RemoteSourceProviderQuickPick(provider);
+	const remote = await quickpick.pick();
 
-    if (remote) {
-        if (typeof remote.url === 'string') {
-            return remote.url;
-        } else if (remote.url.length > 0) {
-            return await window.showQuickPick(remote.url, { ignoreFocusOut: true, placeHolder: localize('pick url', "Choose a URL to clone from.") });
-        }
-    }
+	if (remote) {
+		if (typeof remote.url === 'string') {
+			return remote.url;
+		} else if (remote.url.length > 0) {
+			return await window.showQuickPick(remote.url, { ignoreFocusOut: true, placeHolder: localize('pick url', "Choose a URL to clone from.") });
+		}
+	}
 
-    return undefined;
+	return undefined;
 }

--- a/extensions/git/src/remoteSource.ts
+++ b/extensions/git/src/remoteSource.ts
@@ -89,7 +89,7 @@ export async function pickRemoteSource(model: Model, options: PickRemoteSourceOp
 
 	const targetedProvider = model.getRemoteProviders().filter(provider => provider.name === options.providerName);
 	if (targetedProvider && targetedProvider.length === 1) {
-		await pickProviderSource(targetedProvider[0]);
+		return await pickProviderSource(targetedProvider[0]);
 	} else {
 		const providers = model.getRemoteProviders()
 			.map(provider => ({ label: (provider.icon ? `$(${provider.icon}) ` : '') + (options.providerLabel ? options.providerLabel(provider) : provider.name), alwaysShow: true, provider }));

--- a/extensions/git/src/remoteSource.ts
+++ b/extensions/git/src/remoteSource.ts
@@ -12,122 +12,134 @@ import { throttle, debounce } from './decorators';
 const localize = nls.loadMessageBundle();
 
 async function getQuickPickResult<T extends QuickPickItem>(quickpick: QuickPick<T>): Promise<T | undefined> {
-	const result = await new Promise<T | undefined>(c => {
-		quickpick.onDidAccept(() => c(quickpick.selectedItems[0]));
-		quickpick.onDidHide(() => c(undefined));
-		quickpick.show();
-	});
+    const result = await new Promise<T | undefined>(c => {
+        quickpick.onDidAccept(() => c(quickpick.selectedItems[0]));
+        quickpick.onDidHide(() => c(undefined));
+        quickpick.show();
+    });
 
-	quickpick.hide();
-	return result;
+    quickpick.hide();
+    return result;
 }
 
 class RemoteSourceProviderQuickPick {
 
-	private quickpick: QuickPick<QuickPickItem & { remoteSource?: RemoteSource }>;
+    private quickpick: QuickPick<QuickPickItem & { remoteSource?: RemoteSource }>;
 
-	constructor(private provider: RemoteSourceProvider) {
-		this.quickpick = window.createQuickPick();
-		this.quickpick.ignoreFocusOut = true;
+    constructor(private provider: RemoteSourceProvider) {
+        this.quickpick = window.createQuickPick();
+        this.quickpick.ignoreFocusOut = true;
 
-		if (provider.supportsQuery) {
-			this.quickpick.placeholder = localize('type to search', "Repository name (type to search)");
-			this.quickpick.onDidChangeValue(this.onDidChangeValue, this);
-		} else {
-			this.quickpick.placeholder = localize('type to filter', "Repository name");
-		}
-	}
+        if (provider.supportsQuery) {
+            this.quickpick.placeholder = localize('type to search', "Repository name (type to search)");
+            this.quickpick.onDidChangeValue(this.onDidChangeValue, this);
+        } else {
+            this.quickpick.placeholder = localize('type to filter', "Repository name");
+        }
+    }
 
-	@debounce(300)
-	private onDidChangeValue(): void {
-		this.query();
-	}
+    @debounce(300)
+    private onDidChangeValue(): void {
+        this.query();
+    }
 
-	@throttle
-	private async query(): Promise<void> {
-		this.quickpick.busy = true;
+    @throttle
+    private async query(): Promise<void> {
+        this.quickpick.busy = true;
 
-		try {
-			const remoteSources = await this.provider.getRemoteSources(this.quickpick.value) || [];
+        try {
+            const remoteSources = await this.provider.getRemoteSources(this.quickpick.value) || [];
 
-			if (remoteSources.length === 0) {
-				this.quickpick.items = [{
-					label: localize('none found', "No remote repositories found."),
-					alwaysShow: true
-				}];
-			} else {
-				this.quickpick.items = remoteSources.map(remoteSource => ({
-					label: remoteSource.name,
-					description: remoteSource.description || (typeof remoteSource.url === 'string' ? remoteSource.url : remoteSource.url[0]),
-					remoteSource
-				}));
-			}
-		} catch (err) {
-			this.quickpick.items = [{ label: localize('error', "$(error) Error: {0}", err.message), alwaysShow: true }];
-			console.error(err);
-		} finally {
-			this.quickpick.busy = false;
-		}
-	}
+            if (remoteSources.length === 0) {
+                this.quickpick.items = [{
+                    label: localize('none found', "No remote repositories found."),
+                    alwaysShow: true
+                }];
+            } else {
+                this.quickpick.items = remoteSources.map(remoteSource => ({
+                    label: remoteSource.name,
+                    description: remoteSource.description || (typeof remoteSource.url === 'string' ? remoteSource.url : remoteSource.url[0]),
+                    remoteSource
+                }));
+            }
+        } catch (err) {
+            this.quickpick.items = [{ label: localize('error', "$(error) Error: {0}", err.message), alwaysShow: true }];
+            console.error(err);
+        } finally {
+            this.quickpick.busy = false;
+        }
+    }
 
-	async pick(): Promise<RemoteSource | undefined> {
-		this.query();
-		const result = await getQuickPickResult(this.quickpick);
-		return result?.remoteSource;
-	}
+    async pick(): Promise<RemoteSource | undefined> {
+        this.query();
+        const result = await getQuickPickResult(this.quickpick);
+        return result?.remoteSource;
+    }
 }
 
 export interface PickRemoteSourceOptions {
-	readonly providerLabel?: (provider: RemoteSourceProvider) => string;
-	readonly urlLabel?: string;
+    readonly providerLabel?: (provider: RemoteSourceProvider) => string;
+    readonly urlLabel?: string;
+    readonly providerName?: string;
 }
 
 export async function pickRemoteSource(model: Model, options: PickRemoteSourceOptions = {}): Promise<string | undefined> {
-	const quickpick = window.createQuickPick<(QuickPickItem & { provider?: RemoteSourceProvider, url?: string })>();
-	quickpick.ignoreFocusOut = true;
+    const quickpick = window.createQuickPick<(QuickPickItem & { provider?: RemoteSourceProvider, url?: string })>();
+    quickpick.ignoreFocusOut = true;
 
-	const providers = model.getRemoteProviders()
-		.map(provider => ({ label: (provider.icon ? `$(${provider.icon}) ` : '') + (options.providerLabel ? options.providerLabel(provider) : provider.name), alwaysShow: true, provider }));
+    const targetProvider = model.getRemoteProviders().filter(provider => provider.name === options.providerName);
+    if (targetProvider && targetProvider.length === 1) {
+        await pickProviderSource(targetProvider[0]);
+    } else {
+        const providers = model.getRemoteProviders()
+            .map(provider => ({ label: (provider.icon ? `$(${provider.icon}) ` : '') + (options.providerLabel ? options.providerLabel(provider) : provider.name), alwaysShow: true, provider }));
 
-	quickpick.placeholder = providers.length === 0
-		? localize('provide url', "Provide repository URL")
-		: localize('provide url or pick', "Provide repository URL or pick a repository source.");
+        quickpick.placeholder = providers.length === 0
+            ? localize('provide url', "Provide repository URL")
+            : localize('provide url or pick', "Provide repository URL or pick a repository source.");
 
-	const updatePicks = (value?: string) => {
-		if (value) {
-			quickpick.items = [{
-				label: options.urlLabel ?? localize('url', "URL"),
-				description: value,
-				alwaysShow: true,
-				url: value
-			},
-			...providers];
-		} else {
-			quickpick.items = providers;
-		}
-	};
+        const updatePicks = (value?: string) => {
+            if (value) {
+                quickpick.items = [{
+                    label: options.urlLabel ?? localize('url', "URL"),
+                    description: value,
+                    alwaysShow: true,
+                    url: value
+                },
+                ...providers];
+            } else {
+                quickpick.items = providers;
+            }
+        };
 
-	quickpick.onDidChangeValue(updatePicks);
-	updatePicks();
+        quickpick.onDidChangeValue(updatePicks);
+        updatePicks();
 
-	const result = await getQuickPickResult(quickpick);
+        const result = await getQuickPickResult(quickpick);
 
-	if (result) {
-		if (result.url) {
-			return result.url;
-		} else if (result.provider) {
-			const quickpick = new RemoteSourceProviderQuickPick(result.provider);
-			const remote = await quickpick.pick();
+        if (result) {
+            if (result.url) {
+                return result.url;
+            } else if (result.provider) {
+                return await pickProviderSource(result.provider);
+            }
+        }
+    }
 
-			if (remote) {
-				if (typeof remote.url === 'string') {
-					return remote.url;
-				} else if (remote.url.length > 0) {
-					return await window.showQuickPick(remote.url, { ignoreFocusOut: true, placeHolder: localize('pick url', "Choose a URL to clone from.") });
-				}
-			}
-		}
-	}
+    return undefined;
+}
 
-	return undefined;
+async function pickProviderSource(provider: RemoteSourceProvider): Promise<string | undefined> {
+    const quickpick = new RemoteSourceProviderQuickPick(provider);
+    const remote = await quickpick.pick();
+
+    if (remote) {
+        if (typeof remote.url === 'string') {
+            return remote.url;
+        } else if (remote.url.length > 0) {
+            return await window.showQuickPick(remote.url, { ignoreFocusOut: true, placeHolder: localize('pick url', "Choose a URL to clone from.") });
+        }
+    }
+
+    return undefined;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #106316 

@joaomoreno 

Add an optional param to the git.api.getRemoteSources api call to default to a specific provider.

You can test it by calling 
```
await commands.executeCommand('git.api.getRemoteSources', {
    providerName: 'GitHub'
})
```

This will skip the choose provider and show directly your repos in GitHub
