### PR TITLE
Use the git submodule's name in source control view

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -261,7 +261,8 @@ export class Model implements IRemoteSourceProviderRegistry, IPushErrorHandlerRe
 			// This can happen whenever `path` has the wrong case sensitivity in
 			// case insensitive file systems
 			// https://github.com/Microsoft/vscode/issues/33498
-			const repositoryRoot = Uri.file(rawRoot).fsPath;
+			const repositoryRootUri = Uri.file(rawRoot);
+			const repositoryRoot = repositoryRootUri.fsPath;
 
 			if (this.getRepository(repositoryRoot)) {
 				return;
@@ -272,7 +273,14 @@ export class Model implements IRemoteSourceProviderRegistry, IPushErrorHandlerRe
 			}
 
 			const dotGit = await this.git.getRepositoryDotGit(repositoryRoot);
-			const repository = new Repository(this.git.open(repositoryRoot, dotGit), this, this, this.globalState, this.outputChannel);
+			const repository = new Repository(
+				this.git.open(repositoryRoot, dotGit),
+				this,
+				this,
+				this.globalState,
+				this.outputChannel,
+				this.getRepositoryForSubmodule(repositoryRootUri)
+			);
 
 			this.open(repository);
 			await repository.status();

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -687,7 +687,8 @@ export class Repository implements Disposable {
 		remoteSourceProviderRegistry: IRemoteSourceProviderRegistry,
 		private pushErrorHandlerRegistry: IPushErrorHandlerRegistry,
 		globalState: Memento,
-		outputChannel: OutputChannel
+		outputChannel: OutputChannel,
+		parentRepository: Repository | undefined
 	) {
 		const workspaceWatcher = workspace.createFileSystemWatcher('**');
 		this.disposables.push(workspaceWatcher);
@@ -721,8 +722,13 @@ export class Repository implements Disposable {
 
 		this.disposables.push(new FileEventLogger(onWorkspaceWorkingTreeFileChange, onDotGitFileChange, outputChannel));
 
+		const getModuleLabel = () => {
+			const submodule = parentRepository?.submodules.find(s => path.join(parentRepository.root, s.path) === repository.root);
+			return submodule ? submodule.name : 'Git';
+		};
+
 		const root = Uri.file(repository.root);
-		this._sourceControl = scm.createSourceControl('git', 'Git', root);
+		this._sourceControl = scm.createSourceControl('git', getModuleLabel(), root);
 
 		this._sourceControl.acceptInputCommand = { command: 'git.commit', title: localize('commit', "Commit"), arguments: [this._sourceControl] };
 		this._sourceControl.quickDiffProvider = this;

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -10672,6 +10672,12 @@ declare module 'vscode' {
 		 * input with this value when appropriate.
 		 */
 		commitTemplate?: string;
+		
+		/**
+		 * The optional human-readable name of the source control
+		 * that replaces the default name if specified.
+		 */
+		visibleName?: string;
 
 		/**
 		 * Optional accept input command.

--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -116,12 +116,16 @@ class MainThreadSCMProvider implements ISCMProvider {
 	get contextValue(): string { return this._contextValue; }
 
 	get commitTemplate(): string { return this.features.commitTemplate || ''; }
+	get visibleName(): string { return this.features.visibleName || ''; }
 	get acceptInputCommand(): Command | undefined { return this.features.acceptInputCommand; }
 	get statusBarCommands(): Command[] | undefined { return this.features.statusBarCommands; }
 	get count(): number | undefined { return this.features.count; }
 
 	private readonly _onDidChangeCommitTemplate = new Emitter<string>();
 	readonly onDidChangeCommitTemplate: Event<string> = this._onDidChangeCommitTemplate.event;
+
+	private readonly _onDidChangeVisibleName = new Emitter<string>();
+	readonly onDidChangeVisibleName: Event<string> = this._onDidChangeVisibleName.event;
 
 	private readonly _onDidChangeStatusBarCommands = new Emitter<Command[]>();
 	get onDidChangeStatusBarCommands(): Event<Command[]> { return this._onDidChangeStatusBarCommands.event; }
@@ -144,6 +148,10 @@ class MainThreadSCMProvider implements ISCMProvider {
 
 		if (typeof features.commitTemplate !== 'undefined') {
 			this._onDidChangeCommitTemplate.fire(this.commitTemplate!);
+		}
+
+		if (typeof features.visibleName !== 'undefined') {
+			this._onDidChangeVisibleName.fire(this.visibleName);
 		}
 
 		if (typeof features.statusBarCommands !== 'undefined') {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -834,6 +834,7 @@ export interface SCMProviderFeatures {
 	hasQuickDiffProvider?: boolean;
 	count?: number;
 	commitTemplate?: string;
+	visibleName?: string;
 	acceptInputCommand?: modes.Command;
 	statusBarCommands?: ICommandDto[];
 }

--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -414,6 +414,21 @@ class ExtHostSourceControl implements vscode.SourceControl {
 		this._proxy.$updateSourceControl(this.handle, { commitTemplate });
 	}
 
+	private _visibleName: string | undefined;
+
+	get visibleName(): string | undefined {
+		return this._visibleName;
+	}
+
+	set visibleName(visibleName: string | undefined) {
+		if (this._visibleName === visibleName) {
+			return;
+		}
+
+		this._visibleName = visibleName;
+		this._proxy.$updateSourceControl(this.handle, { visibleName });
+	}
+
 	private _acceptInputDisposables = new MutableDisposable<DisposableStore>();
 	private _acceptInputCommand: vscode.Command | undefined = undefined;
 

--- a/src/vs/workbench/contrib/scm/browser/scmRepositoryRenderer.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmRepositoryRenderer.ts
@@ -74,15 +74,24 @@ export class RepositoryRenderer implements ICompressibleTreeRenderer<ISCMReposit
 		const disposables = new DisposableStore();
 		const repository = isSCMRepository(arg) ? arg : arg.element;
 
-		if (repository.provider.rootUri) {
-			templateData.label.title = `${repository.provider.label}: ${repository.provider.rootUri.fsPath}`;
-			templateData.name.textContent = basename(repository.provider.rootUri);
-			templateData.description.textContent = repository.provider.label;
-		} else {
-			templateData.label.title = repository.provider.label;
-			templateData.name.textContent = repository.provider.label;
-			templateData.description.textContent = '';
-		}
+		const updateLabels = () => {
+			if (repository.provider.visibleName || repository.provider.rootUri) {
+				if (repository.provider.visibleName) {
+					templateData.label.title = `${repository.provider.label}: ${repository.provider.visibleName}`;
+					templateData.name.textContent = repository.provider.visibleName;
+				} else if (repository.provider.rootUri) {
+					templateData.label.title = `${repository.provider.label}: ${repository.provider.rootUri.fsPath}`;
+					templateData.name.textContent = basename(repository.provider.rootUri);
+				}
+				templateData.description.textContent = repository.provider.label;
+			} else {
+				templateData.label.title = repository.provider.label;
+				templateData.name.textContent = repository.provider.label;
+				templateData.description.textContent = '';
+			}
+		};
+		disposables.add(repository.provider.onDidChangeVisibleName(updateLabels));
+		updateLabels();
 
 		let statusPrimaryActions: IAction[] = [];
 		let menuPrimaryActions: IAction[] = [];

--- a/src/vs/workbench/contrib/scm/common/scm.ts
+++ b/src/vs/workbench/contrib/scm/common/scm.ts
@@ -59,7 +59,9 @@ export interface ISCMProvider extends IDisposable {
 	readonly rootUri?: URI;
 	readonly count?: number;
 	readonly commitTemplate: string;
+	readonly visibleName: string;
 	readonly onDidChangeCommitTemplate: Event<string>;
+	readonly onDidChangeVisibleName: Event<string>;
 	readonly onDidChangeStatusBarCommands?: Event<Command[]>;
 	readonly acceptInputCommand?: Command;
 	readonly statusBarCommands?: Command[];


### PR DESCRIPTION
This PR closes #105382

Adds a new `visibleName` property to the source control providers, which replaces the base name of the repository root in the UI as the displayed text when set. If it is not set, fallback to the previous behaviour. `visibleName` for git submodules is specified in the `.gitmodules` file and is parsed already.

Here's the result (original screenshot before changes is in the linked issue).

![Screenshot](https://i.imgur.com/X61FQZH.png)
