### PR TITLE
Web - try to detect native fullscreen

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1326,12 +1326,15 @@ export function detectFullscreen(): IDetectedFullscreen | null {
 		return { mode: DetectedFullscreenMode.BROWSER, guess: false };
 	}
 
-	if (window.outerHeight === screen.height && window.outerWidth === screen.width) {
-		// if the height of the browser matches the screen height, we can
-		// only guess that we are in fullscreen. It is also possible that
-		// the user has turned off taskbars in the OS and the browser is
-		// simply able to span the entire size of the screen.
-		return { mode: DetectedFullscreenMode.BROWSER, guess: true };
+	if (platform.isMacintosh || platform.isLinux) {
+		// macOS and Linux do not properly report `innerHeight`, only Windows does
+		if (window.outerHeight === screen.height && window.outerWidth === screen.width) {
+			// if the height of the browser matches the screen height, we can
+			// only guess that we are in fullscreen. It is also possible that
+			// the user has turned off taskbars in the OS and the browser is
+			// simply able to span the entire size of the screen.
+			return { mode: DetectedFullscreenMode.BROWSER, guess: true };
+		}
 	}
 
 	// Not in fullscreen

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1277,3 +1277,26 @@ export function triggerDownload(dataOrUri: Uint8Array | URI, name: string): void
 	// Ensure to remove the element from DOM eventually
 	setTimeout(() => document.body.removeChild(anchor));
 }
+
+export function isWindowFullscreen(): boolean {
+
+	// Browser fullscreen: use DOM APIs to detect
+	if (document.fullscreenElement || (<any>document).webkitFullscreenElement || (<any>document).webkitIsFullScreen) {
+		return true;
+	}
+
+	// There is no standard way to figure out if the browser
+	// is using native fullscreen. Via checking on screen
+	// height and comparing that to window height, we can guess
+	// it though.
+
+	// macOS: somehow innerHeight does not give a proper value
+	// but outerHeight seems to work
+	if (platform.isMacintosh) {
+		return window.outerHeight === screen.height;
+	}
+
+	// Windows/Linux: assume we are in fullscreen when the window
+	// covery the entire screen
+	return window.innerHeight === screen.height;
+}

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -73,7 +73,7 @@ class BrowserMain extends Disposable {
 	private logFullscreen(isInitial?: boolean, isResize?: boolean): void {
 		if (document.fullscreenElement || (<any>document).webkitFullscreenElement || (<any>document).webkitIsFullScreen) {
 			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected browser fullscreen`);
-		} else if ((isMacintosh && window.outerHeight === screen.height) || (!isMacintosh && window.innerHeight === screen.height)) {
+		} else if ((window.innerHeight === screen.height) || (window.outerHeight === screen.height && window.outerWidth === screen.width)) {
 			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected native fullscreen`);
 		} else {
 			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected NO fullscreen`);

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { mark } from 'vs/base/common/performance';
-import { domContentLoaded, addDisposableListener, EventType, EventHelper } from 'vs/base/browser/dom';
+import { domContentLoaded, addDisposableListener, EventType, EventHelper, isWindowFullscreen } from 'vs/base/browser/dom';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { ILogService, ConsoleLogService, MultiplexLogService } from 'vs/platform/log/common/log';
 import { ConsoleLogInAutomationService } from 'vs/platform/log/browser/log';
@@ -25,8 +25,8 @@ import { Schemas } from 'vs/base/common/network';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { onUnexpectedError } from 'vs/base/common/errors';
-import * as browser from 'vs/base/browser/browser';
-import * as platform from 'vs/base/common/platform';
+import { setFullscreen } from 'vs/base/browser/browser';
+import { isIOS, isMacintosh } from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
 import { IWorkspaceInitializationPayload } from 'vs/platform/workspaces/common/workspaces';
 import { WorkspaceService } from 'vs/workbench/services/configuration/browser/configurationService';
@@ -58,6 +58,24 @@ class BrowserMain extends Disposable {
 		private readonly configuration: IWorkbenchConstructionOptions
 	) {
 		super();
+
+		this.init();
+	}
+
+	private init(): void {
+
+		// Browser config
+		setFullscreen(isWindowFullscreen());
+
+		this.logFullscreen(true);
+	}
+
+	private logFullscreen(isInitial?: boolean, isResize?: boolean): void {
+		if (document.fullscreenElement || (<any>document).webkitFullscreenElement || (<any>document).webkitIsFullScreen) {
+			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected browser fullscreen`);
+		} else if ((isMacintosh && window.outerHeight === screen.height) || (!isMacintosh && window.innerHeight === screen.height)) {
+			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected native fullscreen`);
+		}
 	}
 
 	async open(): Promise<IWorkbench> {
@@ -98,9 +116,14 @@ class BrowserMain extends Disposable {
 
 	private registerListeners(workbench: Workbench, storageService: BrowserStorageService): void {
 
-		// Layout
-		const viewport = platform.isIOS && (<any>window).visualViewport ? (<any>window).visualViewport /** Visual viewport */ : window /** Layout viewport */;
-		this._register(addDisposableListener(viewport, EventType.RESIZE, () => workbench.layout()));
+		// Layout & Native Fullscreen
+		const viewport = isIOS && window.visualViewport ? window.visualViewport /** Visual viewport */ : window /** Layout viewport */;
+		this._register(addDisposableListener(viewport, EventType.RESIZE, () => {
+			workbench.layout();
+
+			setFullscreen(isWindowFullscreen());
+			this.logFullscreen(false, true);
+		}));
 
 		// Prevent the back/forward gestures in macOS
 		this._register(addDisposableListener(this.domElement, EventType.WHEEL, e => e.preventDefault(), { passive: false }));
@@ -123,15 +146,10 @@ class BrowserMain extends Disposable {
 		}));
 		this._register(workbench.onShutdown(() => this.dispose()));
 
-		// Fullscreen
+		// Fullscreen (Browser)
 		[EventType.FULLSCREEN_CHANGE, EventType.WK_FULLSCREEN_CHANGE].forEach(event => {
-			this._register(addDisposableListener(document, event, () => {
-				if (document.fullscreenElement || (<any>document).webkitFullscreenElement || (<any>document).webkitIsFullScreen) {
-					browser.setFullscreen(true);
-				} else {
-					browser.setFullscreen(false);
-				}
-			}));
+			this._register(addDisposableListener(document, event, () => setFullscreen(isWindowFullscreen())));
+			this.logFullscreen(false, false);
 		});
 	}
 

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { mark } from 'vs/base/common/performance';
-import { domContentLoaded, addDisposableListener, EventType, EventHelper, isWindowFullscreen, addDisposableThrottledListener } from 'vs/base/browser/dom';
+import { domContentLoaded, addDisposableListener, EventType, EventHelper, detectFullscreen, addDisposableThrottledListener } from 'vs/base/browser/dom';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { ILogService, ConsoleLogService, MultiplexLogService } from 'vs/platform/log/common/log';
 import { ConsoleLogInAutomationService } from 'vs/platform/log/browser/log';
@@ -65,7 +65,7 @@ class BrowserMain extends Disposable {
 	private init(): void {
 
 		// Browser config
-		setFullscreen(isWindowFullscreen());
+		setFullscreen(!!detectFullscreen());
 
 		this.logFullscreen(true);
 	}
@@ -145,13 +145,13 @@ class BrowserMain extends Disposable {
 
 		// Fullscreen (Browser)
 		[EventType.FULLSCREEN_CHANGE, EventType.WK_FULLSCREEN_CHANGE].forEach(event => {
-			this._register(addDisposableListener(document, event, () => setFullscreen(isWindowFullscreen())));
+			this._register(addDisposableListener(document, event, () => setFullscreen(!!detectFullscreen())));
 			this.logFullscreen(false, false);
 		});
 
 		// Fullscreen (Native)
 		this._register(addDisposableThrottledListener(viewport, EventType.RESIZE, () => {
-			setFullscreen(isWindowFullscreen());
+			setFullscreen(!!detectFullscreen());
 			this.logFullscreen(false, true);
 		}, undefined, isMacintosh ? 2000 /* adjust for macOS animation */ : 800 /* can be throttled */));
 	}

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -66,18 +66,6 @@ class BrowserMain extends Disposable {
 
 		// Browser config
 		setFullscreen(!!detectFullscreen());
-
-		this.logFullscreen(true);
-	}
-
-	private logFullscreen(isInitial?: boolean, isResize?: boolean): void {
-		if (document.fullscreenElement || (<any>document).webkitFullscreenElement || (<any>document).webkitIsFullScreen) {
-			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected browser fullscreen`);
-		} else if ((window.innerHeight === screen.height) || (window.outerHeight === screen.height && window.outerWidth === screen.width)) {
-			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected native fullscreen`);
-		} else {
-			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected NO fullscreen`);
-		}
 	}
 
 	async open(): Promise<IWorkbench> {
@@ -146,13 +134,11 @@ class BrowserMain extends Disposable {
 		// Fullscreen (Browser)
 		[EventType.FULLSCREEN_CHANGE, EventType.WK_FULLSCREEN_CHANGE].forEach(event => {
 			this._register(addDisposableListener(document, event, () => setFullscreen(!!detectFullscreen())));
-			this.logFullscreen(false, false);
 		});
 
 		// Fullscreen (Native)
 		this._register(addDisposableThrottledListener(viewport, EventType.RESIZE, () => {
 			setFullscreen(!!detectFullscreen());
-			this.logFullscreen(false, true);
 		}, undefined, isMacintosh ? 2000 /* adjust for macOS animation */ : 800 /* can be throttled */));
 	}
 

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -75,6 +75,8 @@ class BrowserMain extends Disposable {
 			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected browser fullscreen`);
 		} else if ((isMacintosh && window.outerHeight === screen.height) || (!isMacintosh && window.innerHeight === screen.height)) {
 			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected native fullscreen`);
+		} else {
+			console.log(`Fullscreen (initial: ${isInitial}, resize: ${isResize}): detected NO fullscreen`);
 		}
 	}
 


### PR DESCRIPTION
We have logic for web that unassigns certain useful keybindings such as `Cmd+W` when we are not running in a PWA (standalone) or browser-fullscreen mode. However we currently do not detect native fullscreen mode of the browser. I verified that in native fullscreen we can also use keybindings like `Cmd+W`.

@rebornix please take a look, there is a bit of heuristic involved to detect this, depending on the OS:
* Windows: seems proper with regards to `innerHeight`
* Linux: only seems to work with `outerHeight`
* macOS: same as Linux

As such, there is a slight chance of a wrong guess at least on Linux where one can likely disable taskbar and title bar and as such the browser appears as being fullscreen. 

But I think no harm is done if we wrongly assume the browser is fullscreen I think.