### PR TITLE
Add preferred_username to the list of msft token claims

### DIFF
--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -40,6 +40,7 @@ interface ITokenClaims {
 	tid: string;
 	email?: string;
 	unique_name?: string;
+	preferred_username?: string;
 	oid?: string;
 	altsecid?: string;
 	ipd?: string;
@@ -454,7 +455,7 @@ export class AzureActiveDirectoryService {
 			scope,
 			sessionId: existingId || `${claims.tid}/${(claims.oid || (claims.altsecid || '' + claims.ipd || ''))}/${uuid()}`,
 			account: {
-				label: claims.email || claims.unique_name || 'user@example.com',
+				label: claims.email || claims.unique_name || claims.preferred_username || 'user@example.com',
 				id: `${claims.tid}/${(claims.oid || (claims.altsecid || '' + claims.ipd || ''))}`
 			}
 		};


### PR DESCRIPTION
Add `preferred_username` to the list of MSFT token claims. Here's a sample token format:
https://gist.github.com/olegoid/f3457064caba0a905422b825d4dd8944

That format is used when the user requests a token with the following scopes:
'email', 'openid', 'offline_access', 'api://9db1d849-f699-4cfb-8160-64bed3335c72/All'

and that's the default set for Visual Studio Live Share authentication.

Basically, the PR aims to fix a UI bug where instead of the user's email address we show `user@example.com`
