### PR TITLE
Wrongly decodes 2%F when in path

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -662,8 +662,22 @@ function _asFormatted(uri: URI, skipEncoding: boolean): string {
 				path = `${String.fromCharCode(code + 32)}:${path.substr(2)}`; // "/c:".length === 3
 			}
 		}
-		// encode the rest of the path
-		res += encoder(path, true);
+		// exclude %2F from encoding
+		if (scheme.includes('http')) {
+			console.log('');
+		}
+		let idx = 0;
+		while (idx < path.length) {
+			const lastIdx = path.lastIndexOf(encodeTable[CharCode.Slash]);
+			if (lastIdx === -1) {
+				res += encoder(path.substr(idx), true);
+				idx = path.length;
+			}
+			else {
+				res += encoder(path.substring(idx, lastIdx), true);
+				idx += lastIdx + encodeTable[CharCode.Slash].length;
+			}
+		}
 	}
 	if (query) {
 		res += '?';

--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -663,9 +663,6 @@ function _asFormatted(uri: URI, skipEncoding: boolean): string {
 			}
 		}
 		// exclude %2F from encoding
-		if (scheme.includes('http')) {
-			console.log('');
-		}
 		let idx = 0;
 		while (idx < path.length) {
 			const lastIdx = path.lastIndexOf(encodeTable[CharCode.Slash]);


### PR DESCRIPTION
Removed encoding of 2%F from path. I think there is a larger bug lurking see #79474

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #106097
