### PR TITLE
added libgbm1 for resolving missing dep in dev-container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update \
 		libnss3 \
 		libxss1 \
 		libasound2 \
+		libgbm1 \
 		xfonts-base \
 		xfonts-terminus \
 		fonts-noto \


### PR DESCRIPTION
I got this error when starting the devcontainer on local. Sorry, don't know how to paste it as plain text.
![image](https://user-images.githubusercontent.com/3168632/93024943-e4cd5d00-f5ae-11ea-8df7-5da97b1130aa.png)

The problem is caused by missing `libgbm1`
```
error while loading shared libraries: libgbm.so.1: cannot open shared object file: No such file or directory
```

Could do manual fixing by below command.
```bash
sudo apt-get update
sudo apt-get install libgbm1
```

This PR fixes above problem.
