### PR TITLE
Fix user data init freeze

### DIFF
--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -217,7 +217,7 @@ class BrowserMain extends Disposable {
 			// Initialize required resources - settings & global state
 			await userDataInitializationService.initializeRequiredResources();
 
-			// Important Reload only local user configuration after initializing
+			// Important: Reload only local user configuration after initializing
 			// Reloading complete configuraiton blocks workbench until remote configuration is loaded.
 			await configurationService.reloadLocalUserConfiguration();
 			mark('didInitRequiredUserData');

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -213,11 +213,14 @@ class BrowserMain extends Disposable {
 		serviceCollection.set(IUserDataInitializationService, userDataInitializationService);
 
 		if (await userDataInitializationService.requiresInitialization()) {
+			mark('willInitRequiredUserData');
 			// Initialize required resources - settings & global state
 			await userDataInitializationService.initializeRequiredResources();
 
-			// Reload configuration after initializing
-			await configurationService.reloadConfiguration();
+			// Important Reload only local user configuration after initializing
+			// Reloading complete configuraiton blocks workbench until remote configuration is loaded.
+			await configurationService.reloadLocalUserConfiguration();
+			mark('didInitRequiredUserData');
 		}
 
 		return { serviceCollection, logService, storageService };

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -213,14 +213,12 @@ class BrowserMain extends Disposable {
 		serviceCollection.set(IUserDataInitializationService, userDataInitializationService);
 
 		if (await userDataInitializationService.requiresInitialization()) {
-			mark('willInitRequiredUserData');
 			// Initialize required resources - settings & global state
 			await userDataInitializationService.initializeRequiredResources();
 
 			// Important: Reload only local user configuration after initializing
 			// Reloading complete configuraiton blocks workbench until remote configuration is loaded.
 			await configurationService.reloadLocalUserConfiguration();
-			mark('didInitRequiredUserData');
 		}
 
 		return { serviceCollection, logService, storageService };

--- a/src/vs/workbench/services/userData/browser/userDataInit.ts
+++ b/src/vs/workbench/services/userData/browser/userDataInit.ts
@@ -107,19 +107,23 @@ export class UserDataInitializationService implements IUserDataInitializationSer
 	}
 
 	async requiresInitialization(): Promise<boolean> {
+		this.logService.trace(`UserDataInitializationService#requiresInitialization`);
 		const userDataSyncStoreClient = await this.createUserDataSyncStoreClient();
 		return !!userDataSyncStoreClient;
 	}
 
 	async initializeRequiredResources(): Promise<void> {
+		this.logService.trace(`UserDataInitializationService#initializeRequiredResources`);
 		return this.initialize([SyncResource.Settings, SyncResource.GlobalState]);
 	}
 
 	async initializeOtherResources(): Promise<void> {
+		this.logService.trace(`UserDataInitializationService#initializeOtherResources`);
 		return this.initialize([SyncResource.Keybindings, SyncResource.Snippets]);
 	}
 
 	async initializeExtensions(instantiationService: IInstantiationService): Promise<void> {
+		this.logService.trace(`UserDataInitializationService#initializeExtensions`);
 		return this.initialize([SyncResource.Extensions], instantiationService);
 	}
 


### PR DESCRIPTION
Freeze is caused because of reloading complete configuration during start up - this is causing to reload

- local user config
- remote user config
- workspace config

Which waits until remote connection is established and fetch remote configurations.

Fix: Since initialisation only includes local settings, it is enough to reload only local settings.
