### PR TITLE
fix logic for NPS/Language survey prompt

### DIFF
--- a/src/vs/workbench/contrib/surveys/browser/languageSurveys.contribution.ts
+++ b/src/vs/workbench/contrib/surveys/browser/languageSurveys.contribution.ts
@@ -36,6 +36,7 @@ class LanguageSurvey extends Disposable {
 	) {
 		super();
 
+		const SESSION_COUNT_THRESHOLD = 9;
 		const SESSION_COUNT_KEY = `${data.surveyId}.sessionCount`;
 		const LAST_SESSION_DATE_KEY = `${data.surveyId}.lastSessionDate`;
 		const SKIP_VERSION_KEY = `${data.surveyId}.skipVersion`;
@@ -83,7 +84,7 @@ class LanguageSurvey extends Disposable {
 		storageService.store(LAST_SESSION_DATE_KEY, date, StorageScope.GLOBAL);
 		storageService.store(SESSION_COUNT_KEY, sessionCount, StorageScope.GLOBAL);
 
-		if (sessionCount < 9) {
+		if (sessionCount < SESSION_COUNT_THRESHOLD) {
 			return;
 		}
 
@@ -121,7 +122,7 @@ class LanguageSurvey extends Disposable {
 				label: nls.localize('remindLater', "Remind Me later"),
 				run: () => {
 					telemetryService.publicLog(`${data.surveyId}.survey/remindMeLater`);
-					storageService.store(SESSION_COUNT_KEY, sessionCount - 3, StorageScope.GLOBAL);
+					storageService.store(SESSION_COUNT_KEY, SESSION_COUNT_THRESHOLD - 3, StorageScope.GLOBAL);
 				}
 			}, {
 				label: nls.localize('neverAgain', "Don't Show Again"),

--- a/src/vs/workbench/contrib/surveys/browser/nps.contribution.ts
+++ b/src/vs/workbench/contrib/surveys/browser/nps.contribution.ts
@@ -18,6 +18,7 @@ import { URI } from 'vs/base/common/uri';
 import { platform } from 'vs/base/common/process';
 
 const PROBABILITY = 0.15;
+const SESSION_COUNT_THRESHOLD = 9;
 const SESSION_COUNT_KEY = 'nps/sessionCount';
 const LAST_SESSION_DATE_KEY = 'nps/lastSessionDate';
 const SKIP_VERSION_KEY = 'nps/skipVersion';
@@ -59,7 +60,7 @@ class NPSContribution implements IWorkbenchContribution {
 		storageService.store(LAST_SESSION_DATE_KEY, date, StorageScope.GLOBAL);
 		storageService.store(SESSION_COUNT_KEY, sessionCount, StorageScope.GLOBAL);
 
-		if (sessionCount < 9) {
+		if (sessionCount < SESSION_COUNT_THRESHOLD) {
 			return;
 		}
 
@@ -87,7 +88,7 @@ class NPSContribution implements IWorkbenchContribution {
 				}
 			}, {
 				label: nls.localize('remindLater', "Remind Me later"),
-				run: () => storageService.store(SESSION_COUNT_KEY, sessionCount - 3, StorageScope.GLOBAL)
+				run: () => storageService.store(SESSION_COUNT_KEY, SESSION_COUNT_THRESHOLD - 3, StorageScope.GLOBAL)
 			}, {
 				label: nls.localize('neverAgain', "Don't Show Again"),
 				run: () => {


### PR DESCRIPTION
This PR fixes logic issue for NPS & language survey prompt.
The logic here should be: each day user created a VS Code session, session counter will increase by 1. When the counter reach threshold, the user will have 15% chance to be selected as a candidate, and a notification like below will prompt:

![image](https://user-images.githubusercontent.com/30518415/93181131-a7adca00-f76a-11ea-989b-173d57095e1a.png)

When the user click "Remind me later", the counter will decrease by 3. In other words, the notification will be disabled for two days, and then it will be shown again.

This is correct when user see and click the button immediately when they first see this notification. However, if user ignore or click "X", the counter will continue increase. As a result, after several days, even user click "Remind me later", the notification will be shown next day, which is inconsistent with the logic before. (e.g. The user ignored it for 4 days, then the counter will be 12, even it decrease by 3, it still pass the threshold of 9). So the counter should be set to THRESHOLD - 3 instead of sessionCount - 3.