### PR TITLE
normalize EOL setting for build folder

### DIFF
--- a/build/.gitattributes
+++ b/build/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
in this commit: https://github.com/microsoft/vscode/commit/8fb69d722eafdeb67ae8c97b0d53ff40ffe2c034, the EOL of the generated JS files has become LF, on Windows the EOL is checked out as CR LF and checked in as LF. with the commit mentioned above, every time we build this folder, the JS files are overwritten with LF as the EOL, causing git treating them as changes.

![image](https://user-images.githubusercontent.com/13777222/93152914-c9e51080-f6b4-11ea-902f-c3babafd60b2.png)

This is the only folder that has both the TS files and the generated JS files checked in, to make it work regardless your local machine's EOL setting, I am introducing a local git attribute file just to this folder.

for existing local copies of this repo, based on my testing, 2 files will continue show up as changes because their corresponding TS files have template strings, since the EOL is CR-LF for files already checked out, the generated JS file will contains a few lines with CR-LF line ending. the workaround for that is to make changes to those TS files manually and then discard the changes (or something similar) to force a re-checkout of the TS files, after re-checkout there will be no CR-LF line endings.
