### PR TITLE
Support for resolving code actions

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -655,7 +655,7 @@ export interface CodeActionProvider {
 	provideCodeActions(model: model.ITextModel, range: Range | Selection, context: CodeActionContext, token: CancellationToken): ProviderResult<CodeActionList>;
 
 	/**
-	 * Given a code action fill in the edit or command. Will only invoked when missing.
+	 * Given a code action fill in the edit. Will only invoked when missing.
 	 */
 	resolveCodeAction?(codeAction: CodeAction, token: CancellationToken): ProviderResult<CodeAction>;
 

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -655,6 +655,11 @@ export interface CodeActionProvider {
 	provideCodeActions(model: model.ITextModel, range: Range | Selection, context: CodeActionContext, token: CancellationToken): ProviderResult<CodeActionList>;
 
 	/**
+	 * Given a code action fill in the edit or command. Will only invoked when missing.
+	 */
+	resolveCodeAction?(codeAction: CodeAction, token: CancellationToken): ProviderResult<CodeAction>;
+
+	/**
 	 * Optional list of CodeActionKinds that this provider returns.
 	 */
 	readonly providedCodeActionKinds?: ReadonlyArray<string>;

--- a/src/vs/editor/contrib/codeAction/codeAction.ts
+++ b/src/vs/editor/contrib/codeAction/codeAction.ts
@@ -34,10 +34,14 @@ export class CodeActionItem {
 	async resolve(token: CancellationToken): Promise<this> {
 		// TODO@jrieken when is an item resolved already?
 		if (this.provider?.resolveCodeAction && !this.action.edit && !this.action.command) {
+			let action: modes.CodeAction | undefined | null;
 			try {
-				this.provider.resolveCodeAction(this.action, token);
+				action = await this.provider.resolveCodeAction(this.action, token);
 			} catch (err) {
 				onUnexpectedExternalError(err);
+			}
+			if (action) {
+				this.action.edit = action.edit;
 			}
 		}
 		return this;

--- a/src/vs/editor/contrib/codeAction/codeAction.ts
+++ b/src/vs/editor/contrib/codeAction/codeAction.ts
@@ -32,8 +32,7 @@ export class CodeActionItem {
 	) { }
 
 	async resolve(token: CancellationToken): Promise<this> {
-		// TODO@jrieken when is an item resolved already?
-		if (this.provider?.resolveCodeAction && !this.action.edit && !this.action.command) {
+		if (this.provider?.resolveCodeAction && !this.action.edit) {
 			let action: modes.CodeAction | undefined | null;
 			try {
 				action = await this.provider.resolveCodeAction(this.action, token);

--- a/src/vs/editor/contrib/codeAction/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionCommands.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IAnchor } from 'vs/base/browser/ui/contextview/contextview';
+import { CancellationToken } from 'vs/base/common/cancellation';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Lazy } from 'vs/base/common/lazy';
@@ -15,8 +16,8 @@ import { IBulkEditService, ResourceEdit } from 'vs/editor/browser/services/bulkE
 import { IPosition } from 'vs/editor/common/core/position';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
-import { CodeAction, CodeActionTriggerType } from 'vs/editor/common/modes';
-import { codeActionCommandId, CodeActionSet, fixAllCommandId, organizeImportsCommandId, refactorCommandId, sourceActionCommandId } from 'vs/editor/contrib/codeAction/codeAction';
+import { CodeActionTriggerType } from 'vs/editor/common/modes';
+import { codeActionCommandId, CodeActionItem, CodeActionSet, fixAllCommandId, organizeImportsCommandId, refactorCommandId, sourceActionCommandId } from 'vs/editor/contrib/codeAction/codeAction';
 import { CodeActionUi } from 'vs/editor/contrib/codeAction/codeActionUi';
 import { MessageController } from 'vs/editor/contrib/message/messageController';
 import * as nls from 'vs/nls';
@@ -130,14 +131,14 @@ export class QuickFixController extends Disposable implements IEditorContributio
 		return this._model.trigger(trigger);
 	}
 
-	private _applyCodeAction(action: CodeAction): Promise<void> {
+	private _applyCodeAction(action: CodeActionItem): Promise<void> {
 		return this._instantiationService.invokeFunction(applyCodeAction, action, this._editor);
 	}
 }
 
 export async function applyCodeAction(
 	accessor: ServicesAccessor,
-	action: CodeAction,
+	item: CodeActionItem,
 	editor?: ICodeEditor,
 ): Promise<void> {
 	const bulkEditService = accessor.get(IBulkEditService);
@@ -157,18 +158,20 @@ export async function applyCodeAction(
 	};
 
 	telemetryService.publicLog2<ApplyCodeActionEvent, ApplyCodeEventClassification>('codeAction.applyCodeAction', {
-		codeActionTitle: action.title,
-		codeActionKind: action.kind,
-		codeActionIsPreferred: !!action.isPreferred,
+		codeActionTitle: item.action.title,
+		codeActionKind: item.action.kind,
+		codeActionIsPreferred: !!item.action.isPreferred,
 	});
 
-	if (action.edit) {
-		await bulkEditService.apply(ResourceEdit.convert(action.edit), { editor, label: action.title });
+	await item.resolve(CancellationToken.None);
+
+	if (item.action.edit) {
+		await bulkEditService.apply(ResourceEdit.convert(item.action.edit), { editor, label: item.action.title });
 	}
 
-	if (action.command) {
+	if (item.action.command) {
 		try {
-			await commandService.executeCommand(action.command.id, ...(action.command.arguments || []));
+			await commandService.executeCommand(item.action.command.id, ...(item.action.command.arguments || []));
 		} catch (err) {
 			const message = asMessage(err);
 			notificationService.error(

--- a/src/vs/editor/contrib/codeAction/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionMenu.ts
@@ -14,14 +14,14 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { ScrollType } from 'vs/editor/common/editorCommon';
 import { CodeAction, CodeActionProviderRegistry, Command } from 'vs/editor/common/modes';
-import { codeActionCommandId, CodeActionSet, fixAllCommandId, organizeImportsCommandId, refactorCommandId, sourceActionCommandId } from 'vs/editor/contrib/codeAction/codeAction';
+import { codeActionCommandId, CodeActionItem, CodeActionSet, fixAllCommandId, organizeImportsCommandId, refactorCommandId, sourceActionCommandId } from 'vs/editor/contrib/codeAction/codeAction';
 import { CodeActionAutoApply, CodeActionCommandArgs, CodeActionTrigger, CodeActionKind } from 'vs/editor/contrib/codeAction/types';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
 
 interface CodeActionWidgetDelegate {
-	onSelectCodeAction: (action: CodeAction) => Promise<any>;
+	onSelectCodeAction: (action: CodeActionItem) => Promise<any>;
 }
 
 interface ResolveCodeActionKeybinding {
@@ -103,10 +103,10 @@ export class CodeActionMenu extends Disposable {
 
 	private getMenuActions(
 		trigger: CodeActionTrigger,
-		actionsToShow: readonly CodeAction[],
+		actionsToShow: readonly CodeActionItem[],
 		documentation: readonly Command[]
 	): IAction[] {
-		const toCodeActionAction = (action: CodeAction): CodeActionAction => new CodeActionAction(action, () => this._delegate.onSelectCodeAction(action));
+		const toCodeActionAction = (item: CodeActionItem): CodeActionAction => new CodeActionAction(item.action, () => this._delegate.onSelectCodeAction(item));
 
 		const result: IAction[] = actionsToShow
 			.map(toCodeActionAction);
@@ -117,16 +117,16 @@ export class CodeActionMenu extends Disposable {
 		if (model && result.length) {
 			for (const provider of CodeActionProviderRegistry.all(model)) {
 				if (provider._getAdditionalMenuItems) {
-					allDocumentation.push(...provider._getAdditionalMenuItems({ trigger: trigger.type, only: trigger.filter?.include?.value }, actionsToShow));
+					allDocumentation.push(...provider._getAdditionalMenuItems({ trigger: trigger.type, only: trigger.filter?.include?.value }, actionsToShow.map(item => item.action)));
 				}
 			}
 		}
 
 		if (allDocumentation.length) {
-			result.push(new Separator(), ...allDocumentation.map(command => toCodeActionAction({
+			result.push(new Separator(), ...allDocumentation.map(command => toCodeActionAction(new CodeActionItem({
 				title: command.title,
 				command: command,
-			})));
+			}, undefined))));
 		}
 
 		return result;

--- a/src/vs/editor/contrib/codeAction/test/codeAction.test.ts
+++ b/src/vs/editor/contrib/codeAction/test/codeAction.test.ts
@@ -8,7 +8,7 @@ import { URI } from 'vs/base/common/uri';
 import { Range } from 'vs/editor/common/core/range';
 import { TextModel } from 'vs/editor/common/model/textModel';
 import * as modes from 'vs/editor/common/modes';
-import { getCodeActions } from 'vs/editor/contrib/codeAction/codeAction';
+import { CodeActionItem, getCodeActions } from 'vs/editor/contrib/codeAction/codeAction';
 import { CodeActionKind } from 'vs/editor/contrib/codeAction/types';
 import { IMarkerData, MarkerSeverity } from 'vs/platform/markers/common/markers';
 import { CancellationToken } from 'vs/base/common/cancellation';
@@ -117,14 +117,14 @@ suite('CodeAction', () => {
 
 		const expected = [
 			// CodeActions with a diagnostics array are shown first ordered by diagnostics.message
-			testData.diagnostics.abc,
-			testData.diagnostics.bcd,
+			new CodeActionItem(testData.diagnostics.abc, provider),
+			new CodeActionItem(testData.diagnostics.bcd, provider),
 
 			// CodeActions without diagnostics are shown in the given order without any further sorting
-			testData.command.abc,
-			testData.spelling.bcd, // empty diagnostics array
-			testData.tsLint.bcd,
-			testData.tsLint.abc
+			new CodeActionItem(testData.command.abc, provider),
+			new CodeActionItem(testData.spelling.bcd, provider), // empty diagnostics array
+			new CodeActionItem(testData.tsLint.bcd, provider),
+			new CodeActionItem(testData.tsLint.abc, provider)
 		];
 
 		const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Manual }, Progress.None, CancellationToken.None);
@@ -144,14 +144,14 @@ suite('CodeAction', () => {
 		{
 			const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto, filter: { include: new CodeActionKind('a') } }, Progress.None, CancellationToken.None);
 			assert.equal(actions.length, 2);
-			assert.strictEqual(actions[0].title, 'a');
-			assert.strictEqual(actions[1].title, 'a.b');
+			assert.strictEqual(actions[0].action.title, 'a');
+			assert.strictEqual(actions[1].action.title, 'a.b');
 		}
 
 		{
 			const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto, filter: { include: new CodeActionKind('a.b') } }, Progress.None, CancellationToken.None);
 			assert.equal(actions.length, 1);
-			assert.strictEqual(actions[0].title, 'a.b');
+			assert.strictEqual(actions[0].action.title, 'a.b');
 		}
 
 		{
@@ -176,7 +176,7 @@ suite('CodeAction', () => {
 
 		const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto, filter: { include: new CodeActionKind('a') } }, Progress.None, CancellationToken.None);
 		assert.equal(actions.length, 1);
-		assert.strictEqual(actions[0].title, 'a');
+		assert.strictEqual(actions[0].action.title, 'a');
 	});
 
 	test('getCodeActions should not return source code action by default', async function () {
@@ -190,13 +190,13 @@ suite('CodeAction', () => {
 		{
 			const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto }, Progress.None, CancellationToken.None);
 			assert.equal(actions.length, 1);
-			assert.strictEqual(actions[0].title, 'b');
+			assert.strictEqual(actions[0].action.title, 'b');
 		}
 
 		{
 			const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto, filter: { include: CodeActionKind.Source, includeSourceActions: true } }, Progress.None, CancellationToken.None);
 			assert.equal(actions.length, 1);
-			assert.strictEqual(actions[0].title, 'a');
+			assert.strictEqual(actions[0].action.title, 'a');
 		}
 	});
 
@@ -218,7 +218,7 @@ suite('CodeAction', () => {
 				}
 			}, Progress.None, CancellationToken.None);
 			assert.equal(actions.length, 1);
-			assert.strictEqual(actions[0].title, 'b');
+			assert.strictEqual(actions[0].action.title, 'b');
 		}
 	});
 
@@ -255,7 +255,7 @@ suite('CodeAction', () => {
 			}, Progress.None, CancellationToken.None);
 			assert.strictEqual(didInvoke, false);
 			assert.equal(actions.length, 1);
-			assert.strictEqual(actions[0].title, 'a');
+			assert.strictEqual(actions[0].action.title, 'a');
 		}
 	});
 
@@ -282,4 +282,3 @@ suite('CodeAction', () => {
 		assert.strictEqual(wasInvoked, false);
 	});
 });
-

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -19,8 +19,21 @@ declare module 'vscode' {
 	//#region https://github.com/microsoft/vscode/issues/106410
 
 	export interface CodeActionProvider<T extends CodeAction = CodeAction> {
-		// TODO@jrieken make it clear that there is no support for commands, only code action
-		// TODO@jrieken only edit can be set
+
+		/**
+		 * Given a code action fill in its [`edit`](#CodeAction.edit)-property, changes to
+		 * all other properties, like title, are ignored. A code action that has an edit
+		 * will not be resolved.
+		 *
+		 * *Note* that a code action provider that returns commands, not code actions, cannot successfully
+		 * implement this function. Returning commands is deprecated and instead code actions should be
+		 * returned.
+		 *
+		 * @param codeAction A code action.
+		 * @param token A cancellation token.
+		 * @return The resolved code action or a thenable that resolve to such. It is OK to return the given
+		 * `item`. When no result is returned, the given `item` will be used.
+		 */
 		resolveCodeAction?(codeAction: T, token: CancellationToken): ProviderResult<T>;
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -16,6 +16,17 @@
 
 declare module 'vscode' {
 
+	//#region https://github.com/microsoft/vscode/issues/106410
+
+	export interface CodeActionProvider<T extends CodeAction = CodeAction> {
+		// TODO@jrieken make it clear that there is no support for commands, only code action
+		// TODO@jrieken only edit can be set
+		resolveCodeAction?(codeAction: T, token: CancellationToken): ProviderResult<T>;
+	}
+
+	//#endregion
+
+
 	// #region auth provider: https://github.com/microsoft/vscode/issues/88309
 
 	/**

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -380,7 +380,7 @@ export interface MainThreadLanguageFeaturesShape extends IDisposable {
 	$registerDocumentHighlightProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerOnTypeRenameProvider(handle: number, selector: IDocumentFilterDto[], stopPattern: IRegExpDto | undefined): void;
 	$registerReferenceSupport(handle: number, selector: IDocumentFilterDto[]): void;
-	$registerQuickFixSupport(handle: number, selector: IDocumentFilterDto[], metadata: ICodeActionProviderMetadataDto, displayName: string): void;
+	$registerQuickFixSupport(handle: number, selector: IDocumentFilterDto[], metadata: ICodeActionProviderMetadataDto, displayName: string, supportsResolve: boolean): void;
 	$registerDocumentFormattingSupport(handle: number, selector: IDocumentFilterDto[], extensionId: ExtensionIdentifier, displayName: string): void;
 	$registerRangeFormattingSupport(handle: number, selector: IDocumentFilterDto[], extensionId: ExtensionIdentifier, displayName: string): void;
 	$registerOnTypeFormattingSupport(handle: number, selector: IDocumentFilterDto[], autoFormatTriggerCharacters: string[], extensionId: ExtensionIdentifier): void;
@@ -1310,6 +1310,7 @@ export function reviveWorkspaceEditDto(data: IWorkspaceEditDto | undefined): mod
 export type ICommandDto = ObjectIdentifier & modes.Command;
 
 export interface ICodeActionDto {
+	cacheId?: ChainedCacheId;
 	title: string;
 	edit?: IWorkspaceEditDto;
 	diagnostics?: IMarkerData[];
@@ -1320,7 +1321,7 @@ export interface ICodeActionDto {
 }
 
 export interface ICodeActionListDto {
-	cacheId: number;
+	cacheId: CacheId;
 	actions: ReadonlyArray<ICodeActionDto>;
 }
 
@@ -1388,6 +1389,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideOnTypeRenameRanges(handle: number, resource: UriComponents, position: IPosition, token: CancellationToken): Promise<{ ranges: IRange[]; wordPattern?: IRegExpDto; } | undefined>;
 	$provideReferences(handle: number, resource: UriComponents, position: IPosition, context: modes.ReferenceContext, token: CancellationToken): Promise<ILocationDto[] | undefined>;
 	$provideCodeActions(handle: number, resource: UriComponents, rangeOrSelection: IRange | ISelection, context: modes.CodeActionContext, token: CancellationToken): Promise<ICodeActionListDto | undefined>;
+	$resolveCodeAction(handle: number, id: ChainedCacheId, token: CancellationToken): Promise<IWorkspaceEditDto | undefined>;
 	$releaseCodeActions(handle: number, cacheId: number): void;
 	$provideDocumentFormattingEdits(handle: number, resource: UriComponents, options: modes.FormattingOptions, token: CancellationToken): Promise<ISingleEditOperation[] | undefined>;
 	$provideDocumentRangeFormattingEdits(handle: number, resource: UriComponents, range: IRange, options: modes.FormattingOptions, token: CancellationToken): Promise<ISingleEditOperation[] | undefined>;

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -282,6 +282,8 @@ export class ExtHostApiCommands {
 				{ name: 'uri', description: 'Uri of a text document', constraint: URI },
 				{ name: 'rangeOrSelection', description: 'Range in a text document. Some refactoring provider requires Selection object.', constraint: types.Range },
 				{ name: 'kind', description: '(optional) Code action kind to return code actions for', constraint: (value: any) => !value || typeof value.value === 'string' },
+				{ name: 'itemResolveCount', description: '(optional) Number of code actions to resolve (too large numbers slow down code actions)', constraint: (value: any) => value === undefined || typeof value === 'number' }
+
 			],
 			returns: 'A promise that resolves to an array of Command-instances.'
 		});
@@ -436,13 +438,14 @@ export class ExtHostApiCommands {
 	}
 
 
-	private _executeCodeActionProvider(resource: URI, rangeOrSelection: types.Range | types.Selection, kind?: string): Promise<(vscode.CodeAction | vscode.Command | undefined)[] | undefined> {
+	private _executeCodeActionProvider(resource: URI, rangeOrSelection: types.Range | types.Selection, kind?: string, itemResolveCount?: number): Promise<(vscode.CodeAction | vscode.Command | undefined)[] | undefined> {
 		const args = {
 			resource,
 			rangeOrSelection: types.Selection.isSelection(rangeOrSelection)
 				? typeConverters.Selection.from(rangeOrSelection)
 				: typeConverters.Range.from(rangeOrSelection),
-			kind
+			kind,
+			itemResolveCount,
 		};
 		return this._commands.executeCommand<CustomCodeAction[]>('_executeCodeActionProvider', args)
 			.then(tryMapWith(codeAction => {

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1612,7 +1612,7 @@ export class ExtHostLanguageFeatures implements extHostProtocol.ExtHostLanguageF
 				kind: x.kind.value,
 				command: this._commands.converter.toInternal(x.command, store),
 			}))
-		}, ExtHostLanguageFeatures._extLabel(extension), Boolean(extension.enableProposedApi && provider.resolveCodeAction));
+		}, ExtHostLanguageFeatures._extLabel(extension), Boolean(provider.resolveCodeAction));
 		store.add(this._createDisposable(handle));
 		return store;
 	}

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -413,7 +413,8 @@ class CodeActionAdapter {
 			this._disposables.set(cacheId, disposables);
 
 			const actions: CustomCodeAction[] = [];
-			for (const candidate of commandsOrActions) {
+			for (let i = 0; i < commandsOrActions.length; i++) {
+				const candidate = commandsOrActions[i];
 				if (!candidate) {
 					continue;
 				}
@@ -439,6 +440,7 @@ class CodeActionAdapter {
 
 					// new school: convert code action
 					actions.push({
+						cacheId: [cacheId, i],
 						title: candidate.title,
 						command: candidate.command && this._commands.toInternal(candidate.command, disposables),
 						diagnostics: candidate.diagnostics && candidate.diagnostics.map(typeConvert.Diagnostic.from),
@@ -452,6 +454,21 @@ class CodeActionAdapter {
 
 			return { cacheId, actions };
 		});
+	}
+
+	public async resolveCodeAction(id: extHostProtocol.ChainedCacheId, token: CancellationToken): Promise<extHostProtocol.IWorkspaceEditDto | undefined> {
+		const [sessionId, itemId] = id;
+		const item = this._cache.get(sessionId, itemId);
+		if (!item || CodeActionAdapter._isCommand(item)) {
+			return undefined; // code actions only!
+		}
+		if (!this._provider.resolveCodeAction) {
+			return; // this should not happen...
+		}
+		const resolvedItem = await this._provider.resolveCodeAction(item, token);
+		return resolvedItem?.edit
+			? typeConvert.WorkspaceEdit.from(resolvedItem.edit)
+			: undefined;
 	}
 
 	public releaseCodeActions(cachedId: number): void {
@@ -1595,7 +1612,7 @@ export class ExtHostLanguageFeatures implements extHostProtocol.ExtHostLanguageF
 				kind: x.kind.value,
 				command: this._commands.converter.toInternal(x.command, store),
 			}))
-		}, ExtHostLanguageFeatures._extLabel(extension));
+		}, ExtHostLanguageFeatures._extLabel(extension), Boolean(extension.enableProposedApi && provider.resolveCodeAction));
 		store.add(this._createDisposable(handle));
 		return store;
 	}
@@ -1603,6 +1620,10 @@ export class ExtHostLanguageFeatures implements extHostProtocol.ExtHostLanguageF
 
 	$provideCodeActions(handle: number, resource: UriComponents, rangeOrSelection: IRange | ISelection, context: modes.CodeActionContext, token: CancellationToken): Promise<extHostProtocol.ICodeActionListDto | undefined> {
 		return this._withAdapter(handle, CodeActionAdapter, adapter => adapter.provideCodeActions(URI.revive(resource), rangeOrSelection, context, token), undefined);
+	}
+
+	$resolveCodeAction(handle: number, id: extHostProtocol.ChainedCacheId, token: CancellationToken): Promise<extHostProtocol.IWorkspaceEditDto | undefined> {
+		return this._withAdapter(handle, CodeActionAdapter, adapter => adapter.resolveCodeAction(id, token), undefined);
 	}
 
 	$releaseCodeActions(handle: number, cacheId: number): void {

--- a/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
@@ -344,7 +344,7 @@ class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
 			const actionsToRun = await this.getActionsToRun(model, codeActionKind, excludes, getActionProgress, token);
 			try {
 				for (const action of actionsToRun.validActions) {
-					progress.report({ message: localize('codeAction.apply', "Applying code action '{0}'.", action.title) });
+					progress.report({ message: localize('codeAction.apply', "Applying code action '{0}'.", action.action.title) });
 					await this.instantiationService.invokeFunction(applyCodeAction, action);
 				}
 			} catch {

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -691,14 +691,14 @@ export class MarkerViewModel extends Disposable {
 	}
 
 	private toActions(codeActions: CodeActionSet): IAction[] {
-		return codeActions.validActions.map(codeAction => new Action(
-			codeAction.command ? codeAction.command.id : codeAction.title,
-			codeAction.title,
+		return codeActions.validActions.map(item => new Action(
+			item.action.command ? item.action.command.id : item.action.title,
+			item.action.title,
 			undefined,
 			true,
 			() => {
 				return this.openFileAtMarker(this.marker)
-					.then(() => this.instantiationService.invokeFunction(applyCodeAction, codeAction));
+					.then(() => this.instantiationService.invokeFunction(applyCodeAction, item));
 			}));
 	}
 

--- a/src/vs/workbench/test/browser/api/extHostApiCommands.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostApiCommands.test.ts
@@ -925,6 +925,38 @@ suite('ExtHostLanguageFeatureCommands', function () {
 		});
 	});
 
+	test('resolving code action', async function () {
+
+		let didCallResolve = 0;
+		class MyAction extends types.CodeAction { }
+
+		disposables.push(extHost.registerCodeActionProvider(nullExtensionDescription, defaultSelector, {
+			provideCodeActions(document, rangeOrSelection): vscode.CodeAction[] {
+				return [new MyAction('title', types.CodeActionKind.Empty.append('foo'))];
+			},
+			resolveCodeAction(action): vscode.CodeAction {
+				assert.ok(action instanceof MyAction);
+
+				didCallResolve += 1;
+				action.title = 'resolved title';
+				action.edit = new types.WorkspaceEdit();
+				return action;
+			}
+		}));
+
+		const selection = new types.Selection(0, 0, 1, 1);
+
+		await rpcProtocol.sync();
+
+		const value = await commands.executeCommand<vscode.CodeAction[]>('vscode.executeCodeActionProvider', model.uri, selection, undefined, 1000);
+		assert.equal(didCallResolve, 1);
+		assert.equal(value.length, 1);
+
+		const [first] = value;
+		assert.equal(first.title, 'title'); // does NOT change
+		assert.ok(first.edit); // is set
+	});
+
 	// --- code lens
 
 	test('CodeLens, back and forth', function () {

--- a/src/vs/workbench/test/browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostLanguageFeatures.test.ts
@@ -594,10 +594,10 @@ suite('ExtHostLanguageFeatures', function () {
 		const { validActions: actions } = await getCodeActions(model, model.getFullModelRange(), { type: modes.CodeActionTriggerType.Manual }, Progress.None, CancellationToken.None);
 		assert.equal(actions.length, 2);
 		const [first, second] = actions;
-		assert.equal(first.title, 'Testing1');
-		assert.equal(first.command!.id, 'test1');
-		assert.equal(second.title, 'Testing2');
-		assert.equal(second.command!.id, 'test2');
+		assert.equal(first.action.title, 'Testing1');
+		assert.equal(first.action.command!.id, 'test1');
+		assert.equal(second.action.title, 'Testing2');
+		assert.equal(second.action.command!.id, 'test2');
 	});
 
 	test('Quick Fix, code action data conversion', async () => {
@@ -618,10 +618,10 @@ suite('ExtHostLanguageFeatures', function () {
 		const { validActions: actions } = await getCodeActions(model, model.getFullModelRange(), { type: modes.CodeActionTriggerType.Manual }, Progress.None, CancellationToken.None);
 		assert.equal(actions.length, 1);
 		const [first] = actions;
-		assert.equal(first.title, 'Testing1');
-		assert.equal(first.command!.title, 'Testing1Command');
-		assert.equal(first.command!.id, 'test1');
-		assert.equal(first.kind, 'test.scope');
+		assert.equal(first.action.title, 'Testing1');
+		assert.equal(first.action.command!.title, 'Testing1Command');
+		assert.equal(first.action.command!.id, 'test1');
+		assert.equal(first.action.kind, 'test.scope');
 	});
 
 


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode/issues/106410 by adding proposed API to resolve code actions. Changes in summary

* Adds `CodeActionItem`-object which hold a `modes.CodeAction` and its provider. This change has a big, but also straight-forward, ripple
* Adds cache id to code action DTO, using the already existing cache
* Updates the existing API command to allow to spec the number of items that should be resolved
