### PR TITLE
Add caching to Rich Navigation step to reuse node_modules

### DIFF
--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -10,10 +10,21 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
+      id: caching-stage
+      name: Cache VS Code dependencies
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-dependencies-${{ hashfiles('yarn.lock') }}
+        restore-keys: ${{ runner.os }}-dependencies-
+
     - name: Install dependencies
+      if: steps.caching-stage.outputs.cache-hit != 'true'
       run: yarn --frozen-lockfile
       env:
         CHILD_CONCURRENCY: 1
+
     - uses: microsoft/RichCodeNavIndexer@v0.1
       with:
         languages: typescript


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR adds caching to the Rich Code Navigation indexing task. It compares a hash of the yarn.lock file, and if that file has changed it install dependencies. Otherwise, it reuses the existing dependency cache, saving ~10 minutes from the total build time. 

Is this change something that would be accepted in the regular CI as well? I believe the caching occurs on a repository basis so would be re-used across both actions.