### PR TITLE
Fixes typescript/js language-defined auto-closing brackets incorrectly treat template strings like whitespace

### DIFF
--- a/extensions/javascript/javascript-language-configuration.json
+++ b/extensions/javascript/javascript-language-configuration.json
@@ -25,7 +25,7 @@
 		["\"", "\""],
 		["`", "`"]
 	],
-	"autoCloseBefore": ";:.,=}])>` \n\t",
+	"autoCloseBefore": ";:.,=}])> \n\t",
 	"folding": {
 		"markers": {
 			"start": "^\\s*//\\s*#?region\\b",

--- a/extensions/typescript-basics/language-configuration.json
+++ b/extensions/typescript-basics/language-configuration.json
@@ -26,7 +26,7 @@
 		["`", "`"],
 		["<", ">"]
 	],
-	"autoCloseBefore": ";:.,=}])>` \n\t",
+	"autoCloseBefore": ";:.,=}])> \n\t",
 	"folding": {
 		"markers": {
 			"start": "^\\s*//\\s*#?region\\b",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #106778
