### PR TITLE
Add panel maximization setting for #94930

### DIFF
--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -118,9 +118,14 @@ export class ToggleMaximizedPanelAction extends Action {
 	async run(): Promise<void> {
 		if (!this.layoutService.isVisible(Parts.PANEL_PART)) {
 			this.layoutService.setPanelHidden(false);
+			// If the panel is not already maximized, maximize it
+			if (!this.layoutService.isPanelMaximized()) {
+				this.layoutService.toggleMaximizedPanel();
+			}
 		}
-
-		this.layoutService.toggleMaximizedPanel();
+		else {
+			this.layoutService.toggleMaximizedPanel();
+		}
 	}
 }
 

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -233,6 +233,12 @@ import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuratio
 				'default': 'bottom',
 				'description': nls.localize('panelDefaultLocation', "Controls the default location of the panel (terminal, debug console, output, problems). It can either show at the bottom, right, or left of the workbench.")
 			},
+			'workbench.panel.opensMaximized': {
+				'type': 'string',
+				'enum': ['always', 'never', 'rememberLast'],
+				'default': 'rememberLast',
+				'description': nls.localize('panelOpensMaximized', "Controls whether the panel opens maximized. It can either always open maximized, never open maximized, or open maximized depending on whether or not it was maximized when last closed.")
+			},
 			'workbench.statusBar.visible': {
 				'type': 'boolean',
 				'default': true,

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -235,9 +235,14 @@ import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuratio
 			},
 			'workbench.panel.opensMaximized': {
 				'type': 'string',
-				'enum': ['always', 'never', 'rememberLast'],
-				'default': 'rememberLast',
-				'description': nls.localize('panelOpensMaximized', "Controls whether the panel opens maximized. It can either always open maximized, never open maximized, or open maximized depending on whether or not it was maximized when last closed.")
+				'enum': ['always', 'never', 'preserve'],
+				'default': 'preserve',
+				'description': nls.localize('panelOpensMaximized', "Controls whether the panel opens maximized. It can either always open maximized, never open maximized, or open to the last state it was in before being closed."),
+				'enumDescriptions': [
+					nls.localize('workbench.panel.opensMaximized.always', "Always maximize the panel when opening it."),
+					nls.localize('workbench.panel.opensMaximized.never', "Never maximize the panel when opening it. The panel will open un-maximized."),
+					nls.localize('workbench.panel.opensMaximized.preserve', "Open the panel to the state that it was in, before it was closed.")
+				]
 			},
 			'workbench.statusBar.visible': {
 				'type': 'boolean',

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -28,6 +28,12 @@ export const enum Position {
 	BOTTOM
 }
 
+export const enum PanelOpensMaximizedOptions {
+	ALWAYS,
+	NEVER,
+	REMEMBER_LAST
+}
+
 export function positionToString(position: Position): string {
 	switch (position) {
 		case Position.LEFT: return 'left';
@@ -45,6 +51,24 @@ const positionsByString: { [key: string]: Position } = {
 
 export function positionFromString(str: string): Position {
 	return positionsByString[str];
+}
+
+export function panelOpensMaximizedSettingToString(setting: PanelOpensMaximizedOptions): string {
+	switch (setting) {
+		case PanelOpensMaximizedOptions.ALWAYS: return 'always';
+		case PanelOpensMaximizedOptions.NEVER: return 'never';
+		case PanelOpensMaximizedOptions.REMEMBER_LAST: return 'rememberLast';
+	}
+}
+
+const panelOpensMaximizedByString: { [key: string]: PanelOpensMaximizedOptions } = {
+	[panelOpensMaximizedSettingToString(PanelOpensMaximizedOptions.ALWAYS)]: PanelOpensMaximizedOptions.ALWAYS,
+	[panelOpensMaximizedSettingToString(PanelOpensMaximizedOptions.NEVER)]: PanelOpensMaximizedOptions.NEVER,
+	[panelOpensMaximizedSettingToString(PanelOpensMaximizedOptions.REMEMBER_LAST)]: PanelOpensMaximizedOptions.REMEMBER_LAST
+};
+
+export function panelOpensMaximizedFromString(str: string): PanelOpensMaximizedOptions {
+	return panelOpensMaximizedByString[str];
 }
 
 export interface IWorkbenchLayoutService extends ILayoutService {

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -57,7 +57,8 @@ export function panelOpensMaximizedSettingToString(setting: PanelOpensMaximizedO
 	switch (setting) {
 		case PanelOpensMaximizedOptions.ALWAYS: return 'always';
 		case PanelOpensMaximizedOptions.NEVER: return 'never';
-		case PanelOpensMaximizedOptions.REMEMBER_LAST: return 'rememberLast';
+		case PanelOpensMaximizedOptions.REMEMBER_LAST: return 'preserve';
+		default: return 'preserve';
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #94930 

Changes:

- Add a setting to remember the previous maximized state of the panel before closing it for future re-opens, or to set the panel to always (or never) open

Testing:

- Change the setting and test various sequences of resizing the non-minimized panel, closing the panel, opening the pannel, and toggling maximized on the panel
- When the panel is closed, and the "toggle maximize panel" action is taken, the panel should always return maximized
