### PR TITLE
feat: detect default stash message microsoft#106907

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -2012,6 +2012,12 @@
           "default": true,
           "description": "%config.terminalAuthentication%"
         },
+        "git.defaultStashMessage": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": false,
+          "description": "%config.defaultStashMessage%"
+        },
         "git.githubAuthentication": {
           "deprecationMessage": "This setting is now deprecated, please use `github.gitAuthentication` instead."
         },

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -176,6 +176,7 @@
 	"config.timeline.date": "Controls which date to use for items in the Timeline view",
 	"config.timeline.date.committed": "Use the committed date",
 	"config.timeline.date.authored": "Use the authored date",
+	"config.defaultStashMessage": "Controls whether to use message from commit input box (if populated) as default stash messages",
 	"submenu.commit": "Commit",
 	"submenu.commit.amend": "Amend",
 	"submenu.commit.signoff": "Sign Off",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2506,7 +2506,14 @@ export class CommandCenter {
 			}
 		}
 
-		const message = await this.getStashMessage(repository.inputBox.value));
+		let defaultStashMessage: string;
+		const commitTemplate = repository.sourceControl.commitTemplate;
+		if (commitTemplate === undefined) {
+			defaultStashMessage = repository.inputBox.value;
+		} else {
+			defaultStashMessage = repository.inputBox.value.replace(commitTemplate, '');
+		}
+		const message = await this.getStashMessage(defaultStashMessage);
 
 		if (typeof message === 'undefined') {
 			return;
@@ -2515,9 +2522,9 @@ export class CommandCenter {
 		await repository.createStash(message, includeUntracked);
 	}
 
-	private async getStashMessage(message: string): Promise<string | undefined> {
+	private async getStashMessage(defaultStashMessage: string): Promise<string | undefined> {
 		return await window.showInputBox({
-			value: message,
+			value: defaultStashMessage,
 			prompt: localize('provide stash message', "Optionally provide a stash message"),
 			placeHolder: localize('stash message', "Stash message")
 		});

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2506,12 +2506,14 @@ export class CommandCenter {
 			}
 		}
 
-		let defaultStashMessage: string;
-		const commitTemplate = repository.sourceControl.commitTemplate;
-		if (commitTemplate === undefined) {
-			defaultStashMessage = repository.inputBox.value;
-		} else {
-			defaultStashMessage = repository.inputBox.value.replace(commitTemplate, '');
+		let defaultStashMessage = '';
+		if (config.get<boolean>('defaultStashMessage')) {
+			const commitTemplate = repository.sourceControl.commitTemplate;
+			if (commitTemplate === undefined) {
+				defaultStashMessage = repository.inputBox.value;
+			} else {
+				defaultStashMessage = repository.inputBox.value.replace(commitTemplate, '');
+			}
 		}
 		const message = await this.getStashMessage(defaultStashMessage);
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2506,7 +2506,7 @@ export class CommandCenter {
 			}
 		}
 
-		const message = await this.getStashMessage();
+		const message = await this.getStashMessage(repository.inputBox.value));
 
 		if (typeof message === 'undefined') {
 			return;
@@ -2515,8 +2515,9 @@ export class CommandCenter {
 		await repository.createStash(message, includeUntracked);
 	}
 
-	private async getStashMessage(): Promise<string | undefined> {
+	private async getStashMessage(message: string): Promise<string | undefined> {
 		return await window.showInputBox({
+			value: message,
 			prompt: localize('provide stash message', "Optionally provide a stash message"),
 			placeHolder: localize('stash message', "Stash message")
 		});


### PR DESCRIPTION
This PR fixes #106907

Use commit message as default stash message if commit message box is populated.