### PR TITLE
Fix custom tree view to allow getting all root children

### DIFF
--- a/src/vs/workbench/contrib/views/browser/treeView.ts
+++ b/src/vs/workbench/contrib/views/browser/treeView.ts
@@ -164,6 +164,7 @@ export class TreeView extends Disposable implements ITreeView {
 		}
 
 		if (dataProvider) {
+			const self = this;
 			this._dataProvider = new class implements ITreeViewDataProvider {
 				private _isEmpty: boolean = true;
 				private _onDidChangeEmpty: Emitter<void> = new Emitter();
@@ -173,11 +174,12 @@ export class TreeView extends Disposable implements ITreeView {
 					return this._isEmpty;
 				}
 
-				async getChildren(node: ITreeItem): Promise<ITreeItem[]> {
+				async getChildren(node?: ITreeItem): Promise<ITreeItem[]> {
 					let children: ITreeItem[];
 					if (node && node.children) {
 						children = node.children;
 					} else {
+						node = node ?? self.root;
 						children = await (node instanceof Root ? dataProvider.getChildren() : dataProvider.getChildren(node));
 						node.children = children;
 					}


### PR DESCRIPTION
Small fix here to properly implement https://github.com/microsoft/vscode/blob/master/src/vs/workbench/common/views.ts#L704 and allow passing in undefined to get all the root children nodes. 