### PR TITLE
Make editorGroupToViewColumn return 0 instead of throwing error

### DIFF
--- a/src/vs/workbench/api/common/shared/editor.ts
+++ b/src/vs/workbench/api/common/shared/editor.ts
@@ -32,7 +32,8 @@ export function viewColumnToEditorGroup(editorGroupService: IEditorGroupsService
 export function editorGroupToViewColumn(editorGroupService: IEditorGroupsService, editorGroup: IEditorGroup | GroupIdentifier): EditorViewColumn {
 	const group = (typeof editorGroup === 'number') ? editorGroupService.getGroup(editorGroup) : editorGroup;
 	if (!group) {
-		throw new Error('Invalid group provided');
+		// If we don't have a valid editorGroup, default to the first column
+		return 0;
 	}
 
 	return editorGroupService.getGroups(GroupsOrder.GRID_APPEARANCE).indexOf(group);


### PR DESCRIPTION
Returning 0 from the editorGroupToViewColumn would mean that the editorGroup will be assigned the first column or the most recently used column depending on how the functions interpret the output. This avoids the unexpected behaviour that is exhibited
when trying to revive a webview that was part of an already disposed editorGroup.

Bug: #107205

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
