### PR TITLE
Fixes SnippetString.appendChoice does not escape commas in choices

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -782,7 +782,7 @@ export class SnippetString {
 	}
 
 	appendChoice(values: string[], number: number = this._tabstop++): SnippetString {
-		const value = SnippetString._escape(values.toString());
+		const value = values.map(s => s.replace(/\$|}|\\|,/g, '\\$&')).join(',');
 
 		this.value += '${';
 		this.value += number;

--- a/src/vs/workbench/test/browser/api/extHostTypes.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostTypes.test.ts
@@ -525,6 +525,10 @@ suite('ExtHostTypes', function () {
 		assert.equal(string.value, '${1|b,a,r|}');
 
 		string = new types.SnippetString();
+		string.appendChoice(['b,1', 'a,2', 'r,3']);
+		assert.equal(string.value, '${1|b\\,1,a\\,2,r\\,3|}');
+
+		string = new types.SnippetString();
 		string.appendChoice(['b', 'a', 'r'], 0);
 		assert.equal(string.value, '${0|b,a,r|}');
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #107220
