### PR TITLE
support to delete remote tag from command palette.

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -308,6 +308,11 @@
         "category": "Git"
       },
       {
+        "command": "git.deleteRemoteTag",
+        "title": "%command.deleteRemoteTag%",
+        "category": "Git"
+      },
+      {
         "command": "git.fetch",
         "title": "%command.fetch%",
         "category": "Git"

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -52,6 +52,7 @@
 	"command.merge": "Merge Branch...",
 	"command.createTag": "Create Tag",
 	"command.deleteTag": "Delete Tag",
+	"command.deleteRemoteTag": "Delete Remote Tag",
 	"command.fetch": "Fetch",
 	"command.fetchPrune": "Fetch (Prune)",
 	"command.fetchAll": "Fetch From All Remotes",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1890,6 +1890,42 @@ export class CommandCenter {
 		await repository.deleteTag(choice.label);
 	}
 
+	@command('git.deleteRemoteTag', { repository: true })
+	async deleteRemoteTag(repository: Repository): Promise<void> {
+		const picks = repository.refs.filter(ref => ref.type === RefType.Tag)
+			.map(ref => new TagItem(ref));
+
+		if (picks.length === 0) {
+			window.showWarningMessage(localize('no tags', "This repository has no tags."));
+			return;
+		}
+
+		const placeHolder = localize('select a tag to delete from remote', 'Select a tag to delete from remote');
+		const tag = await window.showQuickPick(picks, { placeHolder });
+
+		if (!tag) {
+			return;
+		}
+
+		const remotes = repository.remotes;
+
+		if (remotes.length === 0) {
+			window.showErrorMessage(localize('no remotes added', "Your repository has no remotes."));
+			return;
+		}
+
+		const picksRemote = remotes.map(r => r.name);
+		const placeHolderRemote = localize('select remote', "Pick a remote to delete the tag from");
+
+		const remoteName = await window.showQuickPick(picksRemote, { placeHolderRemote });
+
+		if (!remoteName) {
+			return;
+		}
+
+		await repository.deleteRemoteTag(remoteName, tag.label);
+	}
+
 	@command('git.fetch', { repository: true })
 	async fetch(repository: Repository): Promise<void> {
 		if (repository.remotes.length === 0) {

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1914,16 +1914,22 @@ export class CommandCenter {
 			return;
 		}
 
-		const picksRemote = remotes.map(r => r.name);
+		const picksRemote = remotes.filter(r => r.fetchUrl !== undefined).map(r => ({ label: r.name, description: r.fetchUrl! }));
+
+		if (picksRemote.length === 0) {
+			window.showWarningMessage(localize('no remotes', "This repository has no remotes."));
+			return;
+		}
+
 		const placeHolderRemote = localize('select remote', "Pick a remote to delete the tag from");
 
-		const remoteName = await window.showQuickPick(picksRemote, { placeHolderRemote });
+		const remoteName = await window.showQuickPick(picksRemote, { placeHolder: placeHolderRemote });
 
 		if (!remoteName) {
 			return;
 		}
 
-		await repository.deleteRemoteTag(remoteName, tag.label);
+		await repository.deleteRemoteTag(remoteName.label, tag.label);
 	}
 
 	@command('git.fetch', { repository: true })

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1446,6 +1446,11 @@ export class Repository {
 		await this.run(args);
 	}
 
+	async deleteRemoteTag(remote: string, tag: string): Promise<void> {
+		let args = ['push', '--delete', remote, tag];
+		await this.run(args);
+	}
+
 	async clean(paths: string[]): Promise<void> {
 		const pathsByGroup = groupBy(paths.map(sanitizePath), p => path.dirname(p));
 		const groups = Object.keys(pathsByGroup).map(k => pathsByGroup[k]);

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -305,6 +305,7 @@ export const enum Operation {
 	Ignore = 'Ignore',
 	Tag = 'Tag',
 	DeleteTag = 'DeleteTag',
+	DeleteRemoteTag = 'DeleteRemoteTag',
 	Stash = 'Stash',
 	CheckIgnore = 'CheckIgnore',
 	GetObjectDetails = 'GetObjectDetails',
@@ -1075,6 +1076,10 @@ export class Repository implements Disposable {
 
 	async deleteTag(name: string): Promise<void> {
 		await this.run(Operation.DeleteTag, () => this.repository.deleteTag(name));
+	}
+
+	async deleteRemoteTag(remote: string, tag: string): Promise<void> {
+		await this.run(Operation.DeleteRemoteTag, () => this.repository.deleteRemoteTag(remote, tag));
 	}
 
 	async checkout(treeish: string): Promise<void> {


### PR DESCRIPTION
This PR fixes #104845

Added support to delete remote tag using the following git command - 'git push --delete <remote_name> <tag_name>'.

The 'deleteRemoteTag' function in 'repository.ts' is the function which has all the logic. The following actions happen when the user selects 'Delete: Remote Tag' from command palette:

1. The user is prompted to choose a tag from the repository.
2. The user is prompted to choose a remote from the repository.
3. After that the above-mentioned git command is executed to delete the tag from the remote specified.
