### PR TITLE
Update tags for Playwright packages

### DIFF
--- a/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
+++ b/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
@@ -80,6 +80,8 @@ const ModulesToLookFor = [
 	'beachball',
 	// Playwright packages
 	'playwright',
+	'playwright-cli',
+	'@playwright/test',
 	'playwright-core',
 	'playwright-chromium',
 	'playwright-firefox',
@@ -241,6 +243,8 @@ export class WorkspaceTagsService implements IWorkspaceTagsService {
 			"workspace.npm.beachball" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.electron" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.playwright" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.playwright-cli" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.@playwright/test" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.playwright-core" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.playwright-chromium" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.playwright-firefox" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },


### PR DESCRIPTION
Updated tags for two Playwright packages: [playwright-cli](https://www.npmjs.com/package/playwright-cli) and [@playwright/test](https://www.npmjs.com/package/@playwright/test).

cc @sana-ajani 