### PR TITLE
Migrate off of require.toUrl

### DIFF
--- a/src/vs/platform/webview/electron-main/webviewProtocolProvider.ts
+++ b/src/vs/platform/webview/electron-main/webviewProtocolProvider.ts
@@ -7,7 +7,7 @@ import { protocol, session } from 'electron';
 import { Readable } from 'stream';
 import { bufferToStream, VSBuffer, VSBufferReadableStream } from 'vs/base/common/buffer';
 import { Disposable, toDisposable } from 'vs/base/common/lifecycle';
-import { Schemas } from 'vs/base/common/network';
+import { FileAccess, Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
 import { FileOperationError, FileOperationResult, IFileService } from 'vs/platform/files/common/files';
 import { IRemoteConnectionData } from 'vs/platform/remote/common/remoteAuthorityResolver';
@@ -130,13 +130,12 @@ export class WebviewProtocolProvider extends Disposable {
 			const uri = URI.parse(request.url);
 			const entry = WebviewProtocolProvider.validWebviewFilePaths.get(uri.path);
 			if (typeof entry === 'string') {
-				let url: string;
-				if (uri.path.startsWith('/electron-browser')) {
-					url = require.toUrl(`vs/workbench/contrib/webview/electron-browser/pre/${entry}`);
-				} else {
-					url = require.toUrl(`vs/workbench/contrib/webview/browser/pre/${entry}`);
-				}
-				return callback(decodeURIComponent(url.replace(`${Schemas.file}://`, '')));
+				const relativeResourcePath = uri.path.startsWith('/electron-browser')
+					? `vs/workbench/contrib/webview/electron-browser/pre/${entry}`
+					: `vs/workbench/contrib/webview/browser/pre/${entry}`;
+
+				const url = FileAccess.asFileUri(relativeResourcePath, require);
+				return callback(decodeURIComponent(url.fsPath));
 			}
 		} catch {
 			// noop


### PR DESCRIPTION
Fixes #107439

Switches to use `FileAccess` instead