### PR TITLE
Add support for opaque AAD access tokens

### DIFF
--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -64,7 +64,7 @@ export interface ITokenResponse {
 	refresh_token: string;
 	scope: string;
 	token_type: string;
-	id_token: string;
+	id_token?: string;
 }
 
 function parseQuery(uri: vscode.Uri) {
@@ -450,9 +450,13 @@ export class AzureActiveDirectoryService {
 
 		try {
 			claims = this.getTokenClaims(json.access_token);
-		} catch {
-			Logger.info('Failed to fetch token claims from access_token. Attempting to parse id_token instead');
-			claims = this.getTokenClaims(json.id_token);
+		} catch (e) {
+			if (json.id_token) {
+				Logger.info('Failed to fetch token claims from access_token. Attempting to parse id_token instead');
+				claims = this.getTokenClaims(json.id_token);
+			} else {
+				throw e;
+			}
 		}
 
 		return {

--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -64,6 +64,7 @@ export interface ITokenResponse {
 	refresh_token: string;
 	scope: string;
 	token_type: string;
+	id_token: string;
 }
 
 function parseQuery(uri: vscode.Uri) {
@@ -445,7 +446,15 @@ export class AzureActiveDirectoryService {
 	}
 
 	private getTokenFromResponse(json: ITokenResponse, scope: string, existingId?: string): IToken {
-		const claims = this.getTokenClaims(json.access_token);
+		let claims = undefined;
+
+		try {
+			claims = this.getTokenClaims(json.access_token);
+		} catch {
+			Logger.info('Failed to fetch token claims from access_token. Attempting to parse id_token instead');
+			claims = this.getTokenClaims(json.id_token);
+		}
+
 		return {
 			expiresIn: json.expires_in,
 			expiresAt: json.expires_in ? Date.now() + json.expires_in * 1000 : undefined,


### PR DESCRIPTION
Consider the following set of scopes:
'profile', 'openid', 'offline_access', '9bd5ab7f-4031-4045-ace9-6bebbad202f6/all'

where return JSON looks somewhat like this:
https://gist.github.com/olegoid/7fec1889e98844686f84ae903a2e8d50

`access_token` claim parsing fails with `Unable to read token claims` error. For some resource scopes, AAD can issue so-called "opaque" tokens that are not supposed to be parsed. In that situation, we can rely on `id_tokens` to fetch supplemental information such as user name, etc.

Here's the document that describes that scenario:
https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens

You can also try to manually validate the `access_token` from my JSON and it will turn out as gibberish. Although, the `id_token` is a totally valid JWT.