### PR TITLE
Listener leak when scrolling PULL REQUESTS view

### DIFF
--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -328,7 +328,7 @@ export abstract class AbstractContextKeyService implements IContextKeyService {
 	public abstract getContextValuesContainer(contextId: number): Context;
 	public abstract createChildContext(parentContextId?: number): number;
 	public abstract disposeContext(contextId: number): void;
-	public abstract updateParent(parentContextKeyService: IContextKeyService): void;
+	public abstract updateParent(parentContextKeyService?: IContextKeyService): void;
 }
 
 export class ContextKeyService extends AbstractContextKeyService implements IContextKeyService {
@@ -423,6 +423,7 @@ class ScopedContextKeyService extends AbstractContextKeyService {
 	public dispose(): void {
 		this._isDisposed = true;
 		this._parent.disposeContext(this._myContextId);
+		this._parentChangeListener?.dispose();
 		if (this._domNode) {
 			this._domNode.removeAttribute(KEYBINDING_CONTEXT_ATTR);
 			this._domNode = undefined;
@@ -454,7 +455,11 @@ class ScopedContextKeyService extends AbstractContextKeyService {
 		this._parent.disposeContext(contextId);
 	}
 
-	public updateParent(parentContextKeyService: AbstractContextKeyService): void {
+	public updateParent(parentContextKeyService?: AbstractContextKeyService): void {
+		if (!parentContextKeyService) {
+			this._parentChangeListener?.dispose();
+			return;
+		}
 		const thisContainer = this._parent.getContextValuesContainer(this._myContextId);
 		const oldAllValues = thisContainer.collectAllValues();
 		this._parent = parentContextKeyService;

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -1139,7 +1139,7 @@ export interface IContextKeyService {
 	createScoped(target?: IContextKeyServiceTarget): IContextKeyService;
 	getContext(target: IContextKeyServiceTarget | null): IContext;
 
-	updateParent(parentContextKeyService: IContextKeyService): void;
+	updateParent(parentContextKeyService?: IContextKeyService): void;
 }
 
 export const SET_CONTEXT_COMMAND_ID = 'setContext';

--- a/src/vs/workbench/contrib/views/browser/treeView.ts
+++ b/src/vs/workbench/contrib/views/browser/treeView.ts
@@ -1027,7 +1027,9 @@ class TreeMenus extends Disposable implements IDisposable {
 		createAndFillInContextMenuActions(menu, { shouldForwardArgs: true }, result, this.contextMenuService, g => /^inline/.test(g));
 
 		menu.dispose();
-
+		// When called without a parameter, updateParent will dispose the parent change listener.
+		// We cannot call dispose on the contextKeyService because it will break submenus.
+		contextKeyService.updateParent();
 		return result;
 	}
 }


### PR DESCRIPTION
Fixes #107801

The linked bug was introduced by https://github.com/microsoft/vscode/commit/545414b668c35e85c6ecc45c1acd899ddda40604#diff-e94cf0f21222131e2f59ea90c06a7ba0R399

The listener added in the scoped context service there is never disposed, and you scroll in a tree view, you end up with an infinitely increasing number of listeners. This fix is a bit weird, but it is a minimal change. I'm certainly open to other options!