### PR TITLE
scmViewPane: do not render whitespace in commit message input field

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1433,7 +1433,8 @@ class SCMInputWidget extends Disposable {
 			padding: { top: 3, bottom: 3 },
 			quickSuggestions: false,
 			scrollbar: { alwaysConsumeMouseWheel: false },
-			overflowWidgetsDomNode
+			overflowWidgetsDomNode,
+			renderWhitespace: 'none'
 		};
 
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {


### PR DESCRIPTION
When entering a commit message we don't need to render whitespace, so let's disable the corresponding option in the `editorOptions` hash.

This PR fixes #107689
