### PR TITLE
Adding a quick tip in debug hover mode

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugHover.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugHover.ts
@@ -80,6 +80,7 @@ export class DebugHoverWidget implements IContentWidget {
 	private treeContainer!: HTMLElement;
 	private toDispose: lifecycle.IDisposable[];
 	private scrollbar!: DomScrollableElement;
+	private tip!: HTMLElement;
 
 	constructor(
 		private editor: ICodeEditor,
@@ -100,6 +101,7 @@ export class DebugHoverWidget implements IContentWidget {
 		this.complexValueTitle = dom.append(this.complexValueContainer, $('.title'));
 		this.treeContainer = dom.append(this.complexValueContainer, $('.debug-hover-tree'));
 		this.treeContainer.setAttribute('role', 'tree');
+		this.tip = dom.append(this.complexValueContainer, $('.tip'));
 		const dataSource = new DebugHoverDataSource();
 
 		this.tree = <WorkbenchAsyncDataTree<IExpression, IExpression, any>>this.instantiationService.createInstance(WorkbenchAsyncDataTree, 'DebugHover', this.treeContainer, new DebugHoverDelegate(), [this.instantiationService.createInstance(VariablesRenderer)],
@@ -116,10 +118,10 @@ export class DebugHoverWidget implements IContentWidget {
 		this.valueContainer = $('.value');
 		this.valueContainer.tabIndex = 0;
 		this.valueContainer.setAttribute('role', 'tooltip');
+		this.tip.innerText = 'Quick tip: Hold alt key to switch to editor hover';
 		this.scrollbar = new DomScrollableElement(this.valueContainer, { horizontal: ScrollbarVisibility.Hidden });
 		this.domNode.appendChild(this.scrollbar.getDomNode());
 		this.toDispose.push(this.scrollbar);
-
 		this.editor.applyFontInfo(this.domNode);
 
 		this.toDispose.push(attachStylerCallback(this.themeService, { editorHoverBackground, editorHoverBorder, editorHoverForeground }, colors => {

--- a/src/vs/workbench/contrib/debug/browser/debugHover.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugHover.ts
@@ -118,7 +118,7 @@ export class DebugHoverWidget implements IContentWidget {
 		this.valueContainer = $('.value');
 		this.valueContainer.tabIndex = 0;
 		this.valueContainer.setAttribute('role', 'tooltip');
-		this.tip.innerText = 'Quick tip: Hold alt key to switch to editor hover';
+		this.tip.innerText = nls.localize('quickTip', 'Quick tip: Hold alt key to switch to editor language hover');
 		this.scrollbar = new DomScrollableElement(this.valueContainer, { horizontal: ScrollbarVisibility.Hidden });
 		this.domNode.appendChild(this.scrollbar.getDomNode());
 		this.toDispose.push(this.scrollbar);

--- a/src/vs/workbench/contrib/debug/browser/media/debugHover.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugHover.css
@@ -32,6 +32,17 @@
 	border-bottom: 1px solid rgba(128, 128, 128, 0.35);
 }
 
+.tip {
+	padding-left: 15px;
+	padding-right: 2px;
+	font-size: 11px;
+	line-height: 18px;
+	word-break: normal;
+	height: 18px;
+	white-space: pre;
+	border-top: 1px solid rgba(128, 128, 128, 0.35);
+}
+
 .monaco-editor .debug-hover-widget .debug-hover-tree {
 	line-height: 18px;
 	cursor: pointer;

--- a/src/vs/workbench/contrib/debug/browser/media/debugHover.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugHover.css
@@ -19,7 +19,7 @@
 	max-width: 700px;
 }
 
-.monaco-editor .debug-hover-widget .complex-value .title {
+.monaco-editor .debug-hover-widget .complex-value .title .tip {
 	padding-left: 15px;
 	padding-right: 2px;
 	font-size: 11px;
@@ -30,17 +30,6 @@
 	overflow: hidden;
 	white-space: pre;
 	border-bottom: 1px solid rgba(128, 128, 128, 0.35);
-}
-
-.tip {
-	padding-left: 15px;
-	padding-right: 2px;
-	font-size: 11px;
-	line-height: 18px;
-	word-break: normal;
-	height: 18px;
-	white-space: pre;
-	border-top: 1px solid rgba(128, 128, 128, 0.35);
 }
 
 .monaco-editor .debug-hover-widget .debug-hover-tree {


### PR DESCRIPTION
This PR fixes #107697
As @isidorn suggested, I added a common HTML element `tip` which is used by both `complex-value` and `value` container.
@misolori Let me know if the design and the text -`'Quick tip: Hold alt key to switch to editor hover'` can be changed. 