### PR TITLE
106907-When-stashing-use-commit-message

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2352,7 +2352,11 @@ export class CommandCenter {
 			return;
 		}
 
-		const message = await this.getStashMessage();
+		let message: string | undefined = repository.inputBox.value;
+
+		if (!message) {
+			message = await this.getStashMessage();
+		}
 
 		if (typeof message === 'undefined') {
 			return;


### PR DESCRIPTION
This PR fixes #[106907](https://github.com/microsoft/vscode/issues/106907)

"When stashing, use commit message if populated"

