### PR TITLE
Using global-scope isWorkspaceShellAllowed with folderUri

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalConfigHelper.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalConfigHelper.ts
@@ -53,7 +53,7 @@ export class TerminalConfigHelper implements IBrowserTerminalConfigHelper {
 		@IHistoryService private readonly _historyService: IHistoryService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IProductService private readonly productService: IProductService,
-		@IStorageKeysSyncRegistryService storageKeysSyncRegistryService: IStorageKeysSyncRegistryService,
+		@IStorageKeysSyncRegistryService storageKeysSyncRegistryService: IStorageKeysSyncRegistryService
 	) {
 		this._updateConfig();
 		this._configurationService.onDidChangeConfiguration(e => {

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
@@ -79,7 +79,14 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 	}
 
 	private _isWorkspaceShellAllowed(): boolean {
-		return this._storageService.getBoolean(IS_WORKSPACE_SHELL_ALLOWED_STORAGE_KEY, StorageScope.WORKSPACE, false);
+		const activeWorkspaceRootUri = this._historyService.getLastActiveWorkspaceRoot();
+		const lastActiveWorkspace = activeWorkspaceRootUri ? this._workspaceContextService.getWorkspaceFolder(activeWorkspaceRootUri) : undefined;
+		if (lastActiveWorkspace) {
+			const folderUri = IS_WORKSPACE_SHELL_ALLOWED_STORAGE_KEY + '_' + lastActiveWorkspace.uri.path;
+			return this._storageService.getBoolean(folderUri, StorageScope.GLOBAL, false);
+		} else {
+			return this._storageService.getBoolean(IS_WORKSPACE_SHELL_ALLOWED_STORAGE_KEY, StorageScope.WORKSPACE, false);
+		}
 	}
 
 	public getDefaultShellAndArgs(useAutomationShell: boolean, platformOverride: Platform = platform): Promise<{ shell: string, args: string | string[] }> {

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalConfigHelper.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalConfigHelper.test.ts
@@ -30,7 +30,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		const configurationService = new TestConfigurationService();
 		configurationService.setUserConfiguration('editor', { fontFamily: 'foo' });
 		configurationService.setUserConfiguration('terminal', { integrated: { fontFamily: null } });
-		const configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		const configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.setLinuxDistro(LinuxDistro.Fedora);
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().fontFamily, '\'DejaVu Sans Mono\', monospace', 'Fedora should have its font overridden when terminal.integrated.fontFamily not set');
@@ -40,7 +40,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		const configurationService = new TestConfigurationService();
 		configurationService.setUserConfiguration('editor', { fontFamily: 'foo' });
 		configurationService.setUserConfiguration('terminal', { integrated: { fontFamily: null } });
-		const configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		const configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.setLinuxDistro(LinuxDistro.Ubuntu);
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().fontFamily, '\'Ubuntu Mono\', monospace', 'Ubuntu should have its font overridden when terminal.integrated.fontFamily not set');
@@ -50,7 +50,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		const configurationService = new TestConfigurationService();
 		configurationService.setUserConfiguration('editor', { fontFamily: 'foo' });
 		configurationService.setUserConfiguration('terminal', { integrated: { fontFamily: null } });
-		const configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		const configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().fontFamily, 'foo', 'editor.fontFamily should be the fallback when terminal.integrated.fontFamily not set');
 	});
@@ -68,7 +68,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 				fontSize: 10
 			}
 		});
-		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().fontSize, 10, 'terminal.integrated.fontSize should be selected over editor.fontSize');
 
@@ -81,12 +81,12 @@ suite('Workbench - TerminalConfigHelper', () => {
 				fontSize: 0
 			}
 		});
-		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.setLinuxDistro(LinuxDistro.Ubuntu);
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().fontSize, 8, 'The minimum terminal font size (with adjustment) should be used when terminal.integrated.fontSize less than it');
 
-		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().fontSize, 6, 'The minimum terminal font size should be used when terminal.integrated.fontSize less than it');
 
@@ -99,7 +99,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 				fontSize: 1500
 			}
 		});
-		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().fontSize, 25, 'The maximum terminal font size should be used when terminal.integrated.fontSize more than it');
 
@@ -112,12 +112,12 @@ suite('Workbench - TerminalConfigHelper', () => {
 				fontSize: null
 			}
 		});
-		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.setLinuxDistro(LinuxDistro.Ubuntu);
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().fontSize, EDITOR_FONT_DEFAULTS.fontSize + 2, 'The default editor font size (with adjustment) should be used when terminal.integrated.fontSize is not set');
 
-		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().fontSize, EDITOR_FONT_DEFAULTS.fontSize, 'The default editor font size should be used when terminal.integrated.fontSize is not set');
 	});
@@ -135,7 +135,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 				lineHeight: 2
 			}
 		});
-		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().lineHeight, 2, 'terminal.integrated.lineHeight should be selected over editor.lineHeight');
 
@@ -149,7 +149,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 				lineHeight: 0
 			}
 		});
-		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.getFont().lineHeight, 1, 'editor.lineHeight should be 1 when terminal.integrated.lineHeight not set');
 	});
@@ -162,7 +162,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 			}
 		});
 
-		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.configFontIsMonospace(), true, 'monospace is monospaced');
 	});
@@ -174,7 +174,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 				fontFamily: 'sans-serif'
 			}
 		});
-		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.configFontIsMonospace(), false, 'sans-serif is not monospaced');
 	});
@@ -186,7 +186,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 				fontFamily: 'serif'
 			}
 		});
-		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.configFontIsMonospace(), false, 'serif is not monospaced');
 	});
@@ -202,7 +202,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 			}
 		});
 
-		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.configFontIsMonospace(), true, 'monospace is monospaced');
 	});
@@ -218,7 +218,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 			}
 		});
 
-		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.configFontIsMonospace(), false, 'sans-serif is not monospaced');
 	});
@@ -234,7 +234,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 			}
 		});
 
-		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
+		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!, null!, null!, new StorageKeysSyncRegistryService());
 		configHelper.panelContainer = fixture;
 		assert.equal(configHelper.configFontIsMonospace(), false, 'serif is not monospaced');
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #80674 

Code change: 
If we can get the workspace folder, then store at a global scope with the folderUri. 
Otherwise, keep the original logic (store at workspace scope without folderUri).

Test: 
1. Add the following to `.vscode/settings.json` so that we get the pop up message:
`"terminal.integrated.env.<platform>": {
    "PATH": "/home"
}`

2. Open the terminal (`CTRL + SHIFT + ~`) and see the pop up message `Do you allow this workspace to modify your terminal shell?`

3. `CTRL + SHIFT + P` and enter the command `Workspaces: Duplicate workspace in new window`

4. Open the terminal (`CTRL + SHIFT + ~`) and note there is no pop up message.


