### PR TITLE
Replace panel: allow to validate using keyboard any time, not only when replace string is active

### DIFF
--- a/src/vs/editor/contrib/find/findController.ts
+++ b/src/vs/editor/contrib/find/findController.ts
@@ -897,7 +897,7 @@ registerEditorCommand(new FindCommand({
 	handler: x => x.replaceAll(),
 	kbOpts: {
 		weight: KeybindingWeight.EditorContrib + 5,
-		kbExpr: ContextKeyExpr.and(EditorContextKeys.focus, CONTEXT_REPLACE_INPUT_FOCUSED),
+		kbExpr: EditorContextKeys.focus,
 		primary: undefined,
 		mac: {
 			primary: KeyMod.CtrlCmd | KeyCode.Enter,

--- a/src/vs/editor/contrib/find/findWidget.ts
+++ b/src/vs/editor/contrib/find/findWidget.ts
@@ -785,11 +785,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 	public focusFindInput(): void {
 		this._findInput.select();
 		// Edge browser requires focus() in addition to select()
-		if (this._replaceInput.getValue() === undefined) {
-			this._replaceInput.focus();
-		} else {
-			this._findInput.focus();
-		}
+		this._findInput.focus();
 	}
 
 	public focusReplaceInput(): void {

--- a/src/vs/editor/contrib/find/findWidget.ts
+++ b/src/vs/editor/contrib/find/findWidget.ts
@@ -785,7 +785,11 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 	public focusFindInput(): void {
 		this._findInput.select();
 		// Edge browser requires focus() in addition to select()
-		this._findInput.focus();
+		if (this._replaceInput.getValue() === undefined) {
+			this._replaceInput.focus();
+		} else {
+			this._findInput.focus();
+		}
 	}
 
 	public focusReplaceInput(): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #103816

It solves the issue by changing when the command + enter keyboard shortcut can be used, and no longer requires you to click on the find/replace widget before using command +enter.

Tested locally and functions as described above. 