### PR TITLE
Backport #107952 to 1.49

### DIFF
--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -282,8 +282,8 @@ export class PackageJSONContribution implements IJSONContribution {
 
 	private npmView(pack: string): Promise<ViewPackageInfo | undefined> {
 		return new Promise((resolve, _reject) => {
-			const command = 'npm view --json ' + pack + ' description dist-tags.latest homepage version';
-			cp.exec(command, (error, stdout) => {
+			const args = ['view', '--json', pack, 'description', 'dist-tags.latest', 'homepage', 'version'];
+			cp.execFile('npm', args, (error, stdout) => {
 				if (!error) {
 					try {
 						const content = JSON.parse(stdout);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.49.2",
+  "version": "1.49.3",
   "distro": "97bd451b684ef610d9752cf941451085fc6e0d91",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
Backports #107952 to 1.49

Uses child_process.execFile() rather than child_process.exec() to more
effectively resolve the command injection vulnerability.