### PR TITLE
Markdown reference links starting with ^ should not be clickable

### DIFF
--- a/extensions/markdown-language-features/src/features/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/features/documentLinkProvider.ts
@@ -105,7 +105,7 @@ function extractDocumentLink(
 export default class LinkProvider implements vscode.DocumentLinkProvider {
 	private readonly linkPattern = /(\[((!\[[^\]]*?\]\(\s*)([^\s\(\)]+?)\s*\)\]|(?:\\\]|[^\]])*\])\(\s*)(([^\s\(\)]|\(\S*?\))+)\s*(".*?")?\)/g;
 	private readonly referenceLinkPattern = /(\[((?:\\\]|[^\]])+)\]\[\s*?)([^\s\]]*?)\]/g;
-	private readonly definitionPattern = /^([\t ]*\[((?:\\\]|[^\]])+)\]:\s*)(\S+)/gm;
+	private readonly definitionPattern = /^([\t ]*\[(?!\^)((?:\\\]|[^\]])+)\]:\s*)(\S+)/gm;
 
 	public provideDocumentLinks(
 		document: vscode.TextDocument,

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -138,6 +138,12 @@ suite('markdown.DocumentLinkProvider', () => {
 			assertRangeEqual(link4.range, new vscode.Range(0, 50, 0, 59));
 		}
 	});
+
+	// #107471
+	test('Should not consider link references starting with ^ character valid', () => {
+		const links = getLinksForFile('[^reference]: https://example.com');
+		assert.strictEqual(links.length, 0);
+	});
 });
 
 


### PR DESCRIPTION
This PR closes #107471

Consider:

- `[ ^reference]: https://example.com` <- space before the `^` symbol still makes the link clickable.