### PR TITLE
Backport #107952 to 1.50

### DIFF
--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -282,8 +282,8 @@ export class PackageJSONContribution implements IJSONContribution {
 
 	private npmView(pack: string): Promise<ViewPackageInfo | undefined> {
 		return new Promise((resolve, _reject) => {
-			const command = 'npm view --json ' + pack + ' description dist-tags.latest homepage version';
-			cp.exec(command, (error, stdout) => {
+			const args = ['view', '--json', pack, 'description', 'dist-tags.latest', 'homepage', 'version'];
+			cp.execFile('npm', args, (error, stdout) => {
 				if (!error) {
 					try {
 						const content = JSON.parse(stdout);


### PR DESCRIPTION
Backport #107952 to 1.50

Uses child_process.execFile() rather than child_process.exec() to more
effectively resolve the command injection vulnerability.

