### PR TITLE
fix: Remove extra whitespace in the untitled editor label

### DIFF
--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -356,10 +356,11 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 		// - cannot be only whitespace (so we trim())
 		// - cannot be only non-alphanumeric characters (so we run word definition regex over it)
 		// - cannot be longer than FIRST_LINE_MAX_TITLE_LENGTH
+		// - normalize multiple whitespaces to a single whitespace
 
 		let modelFirstWordsCandidate: string | undefined = undefined;
 
-		const firstLineText = this.textEditorModel?.getValueInRange({ startLineNumber: 1, endLineNumber: 1, startColumn: 1, endColumn: UntitledTextEditorModel.FIRST_LINE_NAME_MAX_LENGTH + 1 }).trim();
+		const firstLineText = this.textEditorModel?.getValueInRange({ startLineNumber: 1, endLineNumber: 1, startColumn: 1, endColumn: UntitledTextEditorModel.FIRST_LINE_NAME_MAX_LENGTH + 1 }).trim().replace(/\s+/g, ' ');
 		if (firstLineText && ensureValidWordDefinition().exec(firstLineText)) {
 			modelFirstWordsCandidate = firstLineText;
 		}


### PR DESCRIPTION
This PR fixes #107979

Normalize multiple whitespaces to a single whitespace for the untitled editor label:

Before:
![107979-before](https://user-images.githubusercontent.com/12998118/94994762-66237880-05cc-11eb-81d8-d26a953d0fdd.jpg)

After:
![107979-after](https://user-images.githubusercontent.com/12998118/94994763-6c195980-05cc-11eb-975e-72b1632abdff.jpg)
