### PR TITLE
feat(search): added breakpoint all action

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchIcons.ts
+++ b/src/vs/workbench/contrib/search/browser/searchIcons.ts
@@ -13,6 +13,7 @@ export const searchShowReplaceIcon = registerIcon('search-show-replace', Codicon
 export const searchReplaceAllIcon = registerIcon('search-replace-all', Codicon.replaceAll);
 export const searchReplaceIcon = registerIcon('search-replace', Codicon.replace);
 export const searchRemoveIcon = registerIcon('search-remove', Codicon.close);
+export const searchBreakpointAllIcon = registerIcon('activate-breakpoints', Codicon.activateBreakpoints);
 
 export const searchRefreshIcon = registerIcon('search-refresh', Codicon.refresh);
 export const searchCollapseAllIcon = registerIcon('search-collapse-results', Codicon.collapseAll);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

# Feature

This PR fixes #107996

Hey, seemed like an interesting issue to solve, added a "Breakpoint All" button next to the existing "Replace All" button in the search widget replace action bar (debatable if it should be placed there, but it seemed the most natural place for it to exist)

## Images

The "Breakpoint All" button is enabled only when a search has been executed (identical behavior to replace all), clicking it opens a dialog with multiple buttons and a checkbox:

![disabled state](https://i.imgur.com/XZQSL3z.png)

Clicking the "Breakpoint All" button after its enabled opens a dialog with a checkbox option and multiple buttons

![click event and enabled state](https://i.imgur.com/yFGVJgQ.png)

Adding breakpoints without ignore column numbers:

![add breakpoints without ignore column numbers](https://i.imgur.com/y1efmIf.png)

Adding breakpoints with ignore column numbers:

![add breakpoints with ignore column numbers](https://i.imgur.com/MynMnvM.png)

## Thoughts

- Placement, possibly move to a new action bar in the search input area or to the top widget action bar (where the "Clear Search Results", "Toggle Collapse and Expand", etc. are)
- Should the remove breakpoints button consider the ignore columns checkbox or ignore it? current functionality is ignore it.
- Fixing "Duplicate registration of codicon activate-breakpoints": wasn't sure whether to import the already registered codicon or to register the most fitting icon in the relevant file since it will most likely be temporary (?)

