### PR TITLE
Add new property to IConfigurationPropertySchema

### DIFF
--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -113,6 +113,7 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	included?: boolean;
 	tags?: string[];
 	disallowSyncIgnore?: boolean;
+	showEnumDescriptionInSelectBox?: boolean;
 }
 
 export interface IConfigurationExtensionInfo {

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -113,7 +113,7 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	included?: boolean;
 	tags?: string[];
 	disallowSyncIgnore?: boolean;
-	showEnumDescriptionInSelectBox?: boolean;
+	enumItemLabels?: string[];
 }
 
 export interface IConfigurationExtensionInfo {

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -248,7 +248,8 @@ configurationRegistry.registerConfiguration({
 			'default': 'utf8',
 			'description': nls.localize('encoding', "The default character set encoding to use when reading and writing files. This setting can also be configured per language."),
 			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			'enumDescriptions': Object.keys(SUPPORTED_ENCODINGS).map(key => SUPPORTED_ENCODINGS[key].labelLong)
+			'enumDescriptions': Object.keys(SUPPORTED_ENCODINGS).map(key => SUPPORTED_ENCODINGS[key].labelLong),
+			'showEnumDescriptionInSelectBox': true
 		},
 		'files.autoGuessEncoding': {
 			'type': 'boolean',

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -249,7 +249,7 @@ configurationRegistry.registerConfiguration({
 			'description': nls.localize('encoding', "The default character set encoding to use when reading and writing files. This setting can also be configured per language."),
 			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE,
 			'enumDescriptions': Object.keys(SUPPORTED_ENCODINGS).map(key => SUPPORTED_ENCODINGS[key].labelLong),
-			'showEnumDescriptionInSelectBox': true
+			'enumItemLabels': Object.keys(SUPPORTED_ENCODINGS).map(key => SUPPORTED_ENCODINGS[key].labelLong)
 		},
 		'files.autoGuessEncoding': {
 			'type': 'boolean',

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1327,17 +1327,20 @@ export class SettingEnumRenderer extends AbstractSettingRenderer implements ITre
 		const displayOptions = dataElement.setting.enum!
 			.map(String)
 			.map(escapeInvisibleChars)
-			.map((data, index) => <ISelectOptionItem>{
-				text: data,
-				description: (enumDescriptions && enumDescriptions[index] && (enumDescriptionsAreMarkdown ? fixSettingLinks(enumDescriptions[index], false) : enumDescriptions[index])),
-				descriptionIsMarkdown: enumDescriptionsAreMarkdown,
-				descriptionMarkdownActionHandler: {
-					callback: (content) => {
-						this._openerService.open(content).catch(onUnexpectedError);
+			.map((data, index) => {
+				const description = (enumDescriptions && enumDescriptions[index] && (enumDescriptionsAreMarkdown ? fixSettingLinks(enumDescriptions[index], false) : enumDescriptions[index]));
+				return <ISelectOptionItem>{
+					text: dataElement.setting.showEnumDescriptionInSelectBox ? description : data,
+					description: dataElement.setting.showEnumDescriptionInSelectBox ? data : description,
+					descriptionIsMarkdown: enumDescriptionsAreMarkdown,
+					descriptionMarkdownActionHandler: {
+						callback: (content) => {
+							this._openerService.open(content).catch(onUnexpectedError);
+						},
+						disposeables: disposables
 					},
-					disposeables: disposables
-				},
-				decoratorRight: (data === dataElement.defaultValue ? localize('settings.Default', "default") : '')
+					decoratorRight: (data === dataElement.defaultValue ? localize('settings.Default', "default") : '')
+				};
 			});
 
 		template.selectBox.setOptions(displayOptions);

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1318,6 +1318,7 @@ export class SettingEnumRenderer extends AbstractSettingRenderer implements ITre
 	}
 
 	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingEnumItemTemplate, onChange: (value: string) => void): void {
+		const enumItemLabels = dataElement.setting.enumItemLabels;
 		const enumDescriptions = dataElement.setting.enumDescriptions;
 		const enumDescriptionsAreMarkdown = dataElement.setting.enumDescriptionsAreMarkdown;
 
@@ -1328,10 +1329,9 @@ export class SettingEnumRenderer extends AbstractSettingRenderer implements ITre
 			.map(String)
 			.map(escapeInvisibleChars)
 			.map((data, index) => {
-				const description = (enumDescriptions && enumDescriptions[index] && (enumDescriptionsAreMarkdown ? fixSettingLinks(enumDescriptions[index], false) : enumDescriptions[index]));
 				return <ISelectOptionItem>{
-					text: dataElement.setting.showEnumDescriptionInSelectBox ? description : data,
-					description: dataElement.setting.showEnumDescriptionInSelectBox ? data : description,
+					text: enumItemLabels && enumItemLabels[index] ? enumItemLabels[index] : data,
+					description: (enumDescriptions && enumDescriptions[index] && (enumDescriptionsAreMarkdown ? fixSettingLinks(enumDescriptions[index], false) : enumDescriptions[index])),
 					descriptionIsMarkdown: enumDescriptionsAreMarkdown,
 					descriptionMarkdownActionHandler: {
 						callback: (content) => {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1328,17 +1328,20 @@ export class SettingEnumRenderer extends AbstractSettingRenderer implements ITre
 		const displayOptions = dataElement.setting.enum!
 			.map(String)
 			.map(escapeInvisibleChars)
-			.map((data, index) => <ISelectOptionItem>{
-				text: enumItemLabels && enumItemLabels[index] ? enumItemLabels[index] : data,
-				description: (enumDescriptions && enumDescriptions[index] && (enumDescriptionsAreMarkdown ? fixSettingLinks(enumDescriptions[index], false) : enumDescriptions[index])),
-				descriptionIsMarkdown: enumDescriptionsAreMarkdown,
-				descriptionMarkdownActionHandler: {
-					callback: (content) => {
-						this._openerService.open(content).catch(onUnexpectedError);
+			.map((data, index) => {
+				const description = (enumDescriptions && enumDescriptions[index] && (enumDescriptionsAreMarkdown ? fixSettingLinks(enumDescriptions[index], false) : enumDescriptions[index]));
+				return <ISelectOptionItem>{
+					text: enumItemLabels && enumItemLabels[index] ? enumItemLabels[index] : data,
+					description: enumItemLabels && enumItemLabels[index] ? `[${data}] ${description}` : description,
+					descriptionIsMarkdown: enumDescriptionsAreMarkdown,
+					descriptionMarkdownActionHandler: {
+						callback: (content) => {
+							this._openerService.open(content).catch(onUnexpectedError);
+						},
+						disposeables: disposables
 					},
-					disposeables: disposables
-				},
-				decoratorRight: (data === dataElement.defaultValue ? localize('settings.Default', "default") : '')
+					decoratorRight: (data === dataElement.defaultValue ? localize('settings.Default', "default") : '')
+				};
 			});
 
 		template.selectBox.setOptions(displayOptions);

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1328,19 +1328,17 @@ export class SettingEnumRenderer extends AbstractSettingRenderer implements ITre
 		const displayOptions = dataElement.setting.enum!
 			.map(String)
 			.map(escapeInvisibleChars)
-			.map((data, index) => {
-				return <ISelectOptionItem>{
-					text: enumItemLabels && enumItemLabels[index] ? enumItemLabels[index] : data,
-					description: (enumDescriptions && enumDescriptions[index] && (enumDescriptionsAreMarkdown ? fixSettingLinks(enumDescriptions[index], false) : enumDescriptions[index])),
-					descriptionIsMarkdown: enumDescriptionsAreMarkdown,
-					descriptionMarkdownActionHandler: {
-						callback: (content) => {
-							this._openerService.open(content).catch(onUnexpectedError);
-						},
-						disposeables: disposables
+			.map((data, index) => <ISelectOptionItem>{
+				text: enumItemLabels && enumItemLabels[index] ? enumItemLabels[index] : data,
+				description: (enumDescriptions && enumDescriptions[index] && (enumDescriptionsAreMarkdown ? fixSettingLinks(enumDescriptions[index], false) : enumDescriptions[index])),
+				descriptionIsMarkdown: enumDescriptionsAreMarkdown,
+				descriptionMarkdownActionHandler: {
+					callback: (content) => {
+						this._openerService.open(content).catch(onUnexpectedError);
 					},
-					decoratorRight: (data === dataElement.defaultValue ? localize('settings.Default', "default") : '')
-				};
+					disposeables: disposables
+				},
+				decoratorRight: (data === dataElement.defaultValue ? localize('settings.Default', "default") : '')
 			});
 
 		template.selectBox.setOptions(displayOptions);

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -76,6 +76,7 @@ export interface ISetting {
 	disallowSyncIgnore?: boolean;
 	extensionInfo?: IConfigurationExtensionInfo;
 	validator?: (value: any) => string | null;
+	showEnumDescriptionInSelectBox?: boolean;
 }
 
 export interface IExtensionSetting extends ISetting {

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -76,7 +76,7 @@ export interface ISetting {
 	disallowSyncIgnore?: boolean;
 	extensionInfo?: IConfigurationExtensionInfo;
 	validator?: (value: any) => string | null;
-	showEnumDescriptionInSelectBox?: boolean;
+	enumItemLabels?: string[];
 }
 
 export interface IExtensionSetting extends ISetting {

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -646,7 +646,8 @@ export class DefaultSettings extends Disposable {
 					extensionInfo: extensionInfo,
 					deprecationMessage: prop.markdownDeprecationMessage || prop.deprecationMessage,
 					deprecationMessageIsMarkdown: !!prop.markdownDeprecationMessage,
-					validator: createValidator(prop)
+					validator: createValidator(prop),
+					showEnumDescriptionInSelectBox: prop.showEnumDescriptionInSelectBox
 				});
 			}
 		}

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -647,7 +647,7 @@ export class DefaultSettings extends Disposable {
 					deprecationMessage: prop.markdownDeprecationMessage || prop.deprecationMessage,
 					deprecationMessageIsMarkdown: !!prop.markdownDeprecationMessage,
 					validator: createValidator(prop),
-					showEnumDescriptionInSelectBox: prop.showEnumDescriptionInSelectBox
+					enumItemLabels: prop.enumItemLabels
 				});
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #106737

### What it does

This adds the `showEnumDescriptionInSelectBox?: boolean` property to `IConfigurationPropertySchema` so that enum configuration settings can elect to show their `enumDescription` in selectboxes and dropdowns insead of the enum value. This new option is only used by `files.encoding`.

### How to verify

1. Open Settings (UI) and go to Text Editor > Files > Encoding.
> The selectbox should show the encoding's description instead of its value, e.g. `UTF-8` instead of `utf8`.

2. Click on the File: Encoding selectbox.
> The options in the dropdown should be the description not the value, e.g. `DOS (CP 437)`.
> The footer of the dropdown should be the value, e.g. `cp437`.

### Open questions

> I think we should add an option to the schema contribution for this but I have no clue what to call it
@roblourens  https://github.com/microsoft/vscode/issues/106737#issuecomment-694344103

1. Is `showEnumDescriptionInSelectBox` a good name?

2. I couldn't find any tests to add to for this bit of code. Are there any?

