### PR TITLE
vscode.Uri.joinPath instead of Node's path.join

### DIFF
--- a/extensions/search-result/src/extension.ts
+++ b/extensions/search-result/src/extension.ts
@@ -134,7 +134,7 @@ function relativePathToUri(path: string, resultsUri: vscode.Uri): vscode.Uri | u
 	}
 
 	const uriFromFolderWithPath = (folder: vscode.WorkspaceFolder, path: string): vscode.Uri =>
-		folder.uri.with({ path: pathUtils.join(folder.uri.fsPath, path) });
+		vscode.Uri.joinPath(folder.uri, path);
 
 	if (vscode.workspace.workspaceFolders) {
 		const multiRootFormattedPath = /^(.*) • (.*)$/.exec(path);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/1280

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

The polyfilled `path` module that gets used in the browser build does not support joining to `\` (`/` is fine). This caused errors in search editors on serverless instances running on Windows browers when using some workspace filesystem providers that use `\` as their root path. 
