### PR TITLE
Expose output from executable debug adapter

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -11258,6 +11258,10 @@ declare module 'vscode' {
 		 * The debug adapter has exited with the given exit code or signal.
 		 */
 		onExit?(code: number | undefined, signal: string | undefined): void;
+		/**
+		 * The debug adapter has produced the given output string.
+		 */
+		onOutput?(output: string): void;
 	}
 
 	export interface DebugAdapterTrackerFactory {

--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -304,6 +304,10 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 		this.getDebugAdapter(handle).fireExit(handle, code, signal);
 	}
 
+	public $acceptDAOutput(handle: number, output: string) {
+		this.getDebugAdapter(handle).fireOutput(handle, output);
+	}
+
 	private getDebugAdapter(handle: number): ExtensionHostDebugAdapter {
 		const adapter = this._debugAdapters.get(handle);
 		if (!adapter) {
@@ -401,6 +405,10 @@ class ExtensionHostDebugAdapter extends AbstractDebugAdapter {
 
 	fireExit(handle: number, code: number, signal: string) {
 		this._onExit.fire(code);
+	}
+
+	fireOutput(handle: number, output: string) {
+		this._onOutput.fire(output);
 	}
 
 	startSession(): Promise<void> {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -911,6 +911,7 @@ export interface MainThreadDebugServiceShape extends IDisposable {
 	$acceptDAMessage(handle: number, message: DebugProtocol.ProtocolMessage): void;
 	$acceptDAError(handle: number, name: string, message: string, stack: string | undefined): void;
 	$acceptDAExit(handle: number, code: number | undefined, signal: string | undefined): void;
+	$acceptDAOutput(handle: number, output: string): void;
 	$registerDebugConfigurationProvider(type: string, triggerKind: DebugConfigurationProviderTriggerKind, hasProvideMethod: boolean, hasResolveMethod: boolean, hasResolve2Method: boolean, hasProvideDaMethod: boolean, handle: number): Promise<void>;
 	$registerDebugAdapterDescriptorFactory(type: string, handle: number): Promise<void>;
 	$unregisterDebugConfigurationProvider(handle: number): void;

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -496,6 +496,12 @@ export abstract class ExtHostDebugServiceBase implements IExtHostDebugService, E
 					}
 					this._debugServiceProxy.$acceptDAExit(debugAdapterHandle, withNullAsUndefined(code), undefined);
 				});
+				debugAdapter.onOutput((output: string) => {
+					if (tracker && tracker.onOutput) {
+						tracker.onOutput(output);
+					}
+					this._debugServiceProxy.$acceptDAOutput(debugAdapterHandle, output);
+				});
 
 				if (tracker && tracker.onWillStartSession) {
 					tracker.onWillStartSession();
@@ -1081,6 +1087,10 @@ class MultiTracker implements vscode.DebugAdapterTracker {
 
 	onExit(code: number, signal: string): void {
 		this.trackers.forEach(t => t.onExit ? t.onExit(code, signal) : undefined);
+	}
+
+	onOutput(output: string): void {
+		this.trackers.forEach(t => t.onOutput ? t.onOutput(output) : undefined);
 	}
 }
 

--- a/src/vs/workbench/contrib/debug/common/abstractDebugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/common/abstractDebugAdapter.ts
@@ -21,6 +21,7 @@ export abstract class AbstractDebugAdapter implements IDebugAdapter {
 	private queue: DebugProtocol.ProtocolMessage[] = [];
 	protected readonly _onError = new Emitter<Error>();
 	protected readonly _onExit = new Emitter<number | null>();
+	protected readonly _onOutput = new Emitter<string>();
 
 	constructor() {
 		this.sequence = 1;
@@ -38,6 +39,10 @@ export abstract class AbstractDebugAdapter implements IDebugAdapter {
 
 	get onExit(): Event<number | null> {
 		return this._onExit.event;
+	}
+
+	get onOutput(): Event<string> {
+		return this._onOutput.event;
 	}
 
 	onMessage(callback: (message: DebugProtocol.ProtocolMessage) => void): void {

--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -251,6 +251,10 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 				this._onError.fire(error);
 			});
 
+			this.serverProcess.stderr!.on('data', (data: Buffer) => {
+				this._onOutput.fire(data.toString());
+			});
+
 			const outputService = this.outputService;
 			if (outputService) {
 				const sanitize = (s: string) => s.toString().replace(/\r?\n$/mg, '');


### PR DESCRIPTION
This PR fixes #108145:

- Adds `onOutput: Event<string>` to `AbstractDebugAdapter` (and thus to all debug adapter classes)
- Adds `onOutput?(output: string): void` to `DebugAdapterTracker` and `MultiTracker`
- Adds `$acceptDAOutput(handle: number, output: string): void` to `MainThreadDebugServiceShape` and `MainThreadDebugService`
- Modifies `ExecutableDebugAdapter.startSession` to forward the child process' stderr to `onOutput`
- Modifies `ExtHostDebugServiceBase.$startDASession` to forward the debug adapter's `onOutput` to `tracker.onOutput` and to `debugServiceProxy.$acceptDAOutput`

This can be tested by adding `onOutput(s: string): void` to a debug adapter tracker that tracks a debug adapter that uses `DebugAdapterExecutable`/`ExecutableDebugAdapter` to spawn a process that outputs on stderr. For example:

```typescript
export function activate(context: vscode.ExtensionContext) {
    const debugAdapterID = '<ID>';

    context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory(debugAdapterID, {
        createDebugAdapterDescriptor(session: DebugSession, executable: DebugAdapterExecutable | undefined): ProviderResult<DebugAdapterDescriptor> {
            const program = '<program>';
            const args = ['<args>'];
            return new DebugAdapterExecutable(program, args);
        }
    }));

    context.subscriptions.push(vscode.debug.registerDebugAdapterTrackerFactory(debugAdapterID, {
        createDebugAdapterTracker(session: DebugSession): ProviderResult<DebugAdapterTracker> {
            return {
                onOutput(s: string): void {
                    console.log(`${session.name} onOutput =>`, s);
                }
            };
        }
    }));
}
```