### PR TITLE
Update CodeActionOnSaveParticipant

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
@@ -287,25 +287,7 @@ class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
 			? setting
 			: Object.keys(setting).filter(x => setting[x]);
 
-		if (!settingItems.length) {
-			return undefined;
-		}
-
-		const excludedActions = Array.isArray(setting)
-			? []
-			: Object.keys(setting)
-				.filter(x => setting[x] === false)
-				.map(x => new CodeActionKind(x));
-
-		let codeActionsOnSave = settingItems
-			.map(x => new CodeActionKind(x));
-
-		if (!excludedActions.some(a => a.equals(CodeActionKind.SourceFixAll))) {
-			codeActionsOnSave = [
-				CodeActionKind.SourceFixAll,
-				...codeActionsOnSave.filter(a => !CodeActionKind.SourceFixAll.contains(a))
-			];
-		}
+		const codeActionsOnSave = this.createCodeActionsOnSave(settingItems);
 
 		if (!Array.isArray(setting)) {
 			codeActionsOnSave.sort((a, b) => {
@@ -322,8 +304,40 @@ class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
 			});
 		}
 
+		if (!codeActionsOnSave.length) {
+			return undefined;
+		}
+
+		const excludedActions = Array.isArray(setting)
+			? []
+			: Object.keys(setting)
+				.filter(x => setting[x] === false)
+				.map(x => new CodeActionKind(x));
+
 		progress.report({ message: localize('codeaction', "Quick Fixes") });
 		await this.applyOnSaveActions(textEditorModel, codeActionsOnSave, excludedActions, progress, token);
+	}
+
+	private createCodeActionsOnSave(settingItems: string[]): CodeActionKind[] {
+		const actionSeeds = new Set<string>();
+
+		// Remove subsets
+		const len = settingItems.length;
+		outer: for (let i = 0; i < len; i++) {
+			const s1 = settingItems[i];
+			for (let j = 0; j < len; j++) {
+				if (j === i) {
+					continue;
+				}
+				const s2 = settingItems[j];
+				if (s1.startsWith(s2) && s1.length > s2.length) {
+					continue outer;
+				}
+			}
+			actionSeeds.add(s1);
+		}
+
+		return Array.from(actionSeeds).map(x => new CodeActionKind(x));
 	}
 
 	private async applyOnSaveActions(model: ITextModel, codeActionsOnSave: readonly CodeActionKind[], excludes: readonly CodeActionKind[], progress: IProgress<IProgressStep>, token: CancellationToken): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #106924.

I updated `CodeActionOnSaveParticipant#participate` method to filter out CodeActionKind with 'source.fixAll.eslint' from codeActionsOnSave when "source.fixAll" is true.

<hr />

The reason why the eslint code action provider is called twice with the settings:

```
{
    "editor.codeActionsOnSave": {
        "source.fixAll": true,
        "source.fixAll.eslint": true,
    }
}
```

is as follows.

1. `codeActionsOnSave` array has two `CodeActionKinds` with values of 'source.fixAll' and 'source.fixAll.eslint'
https://github.com/microsoft/vscode/blob/e1515f7ed04a5a9a99cf63fbf69b2c307dd29bb8/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts#L290-L291

2. `getActionsToRun` method returns `CodeActionSet` with provider from eslint for both of them.
https://github.com/microsoft/vscode/blob/e1515f7ed04a5a9a99cf63fbf69b2c307dd29bb8/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts#L343-L344

<hr />

Should I add filtering code for other CodeActionKind such as SourceOrganizeImports, Refactor, etc...?

Please let me know, in the first place, if there are better approaches.