### PR TITLE
Update default color tokens for last pinned tab border

### DIFF
--- a/extensions/theme-abyss/themes/abyss-color-theme.json
+++ b/extensions/theme-abyss/themes/abyss-color-theme.json
@@ -390,7 +390,7 @@
 		"tab.inactiveBackground": "#10192c",
 		// "tab.activeForeground": "",
 		// "tab.inactiveForeground": "",
-		"tab.lastPinnedBorder": "#596F99",
+		"tab.lastPinnedBorder": "#2b3c5d",
 
 		// Workbench: Activity Bar
 		"activityBar.background": "#051336",

--- a/extensions/theme-defaults/themes/light_defaults.json
+++ b/extensions/theme-defaults/themes/light_defaults.json
@@ -20,7 +20,7 @@
 		"statusBarItem.remoteBackground": "#16825D",
 		"sideBarSectionHeader.background": "#0000",
 		"sideBarSectionHeader.border": "#61616130",
-		"tab.lastPinnedBorder": "#81818130",
+		"tab.lastPinnedBorder": "#61616130",
 		"notebook.focusedCellBackground": "#c8ddf150",
 		"notebook.cellBorderColor": "#dae3e9",
 		"notebook.outputContainerBackgroundColor": "#c8ddf150"

--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -23,7 +23,7 @@
 		"editorGroupHeader.tabsBackground": "#131510",
 		"editorLineNumber.activeForeground": "#adadad",
 		"tab.inactiveBackground": "#131510",
-		"tab.lastPinnedBorder": "#5e452b",
+		"tab.lastPinnedBorder": "#51412c",
 		"titleBar.activeBackground": "#423523",
 		"statusBar.background": "#423523",
 		"statusBar.debuggingBackground": "#423523",

--- a/extensions/theme-monokai/themes/monokai-color-theme.json
+++ b/extensions/theme-monokai/themes/monokai-color-theme.json
@@ -35,7 +35,7 @@
 		"tab.inactiveBackground": "#34352f",
 		"tab.border": "#1e1f1c",
 		"tab.inactiveForeground": "#ccccc7", // needs to be bright so it's readable when another editor group is focused
-		"tab.lastPinnedBorder": "#75715E",
+		"tab.lastPinnedBorder": "#414339",
 		"widget.shadow": "#000000",
 		"progressBar.background": "#75715E",
 		"badge.background": "#75715E",

--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -472,7 +472,7 @@
 		"peekViewResult.background": "#F2F8FC",
 		"peekView.border": "#705697",
 		"peekViewResult.matchHighlightBackground": "#93C6D6",
-		"tab.lastPinnedBorder": "#C9D0D988",
+		"tab.lastPinnedBorder": "#c9d0d9",
 		"statusBar.background": "#705697",
 		"statusBar.noFolderBackground": "#705697",
 		"statusBar.debuggingBackground": "#705697",

--- a/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
+++ b/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
@@ -436,7 +436,7 @@
 		// "tab.activeBackground": "",
 		// "tab.activeForeground": "",
 		// "tab.inactiveForeground": "",
-		"tab.lastPinnedBorder": "#EEE8D5",
+		"tab.lastPinnedBorder": "#FDF6E3",
 
 		// Workbench: Activity Bar
 		"activityBar.background": "#DDD6C1",

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from 'vs/nls';
-import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground } from 'vs/platform/theme/common/colorRegistry';
+import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke } from 'vs/platform/theme/common/colorRegistry';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { Color } from 'vs/base/common/color';
 
@@ -116,8 +116,8 @@ export const TAB_BORDER = registerColor('tab.border', {
 }, nls.localize('tabBorder', "Border to separate tabs from each other. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
 export const TAB_LAST_PINNED_BORDER = registerColor('tab.lastPinnedBorder', {
-	dark: null,
-	light: null,
+	dark: treeIndentGuidesStroke,
+	light: treeIndentGuidesStroke,
 	hc: contrastBorder
 }, nls.localize('lastPinnedTabBorder', "Border to separate pinned tabs from other tabs. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 


### PR DESCRIPTION
Fixes #108173 

I tested out various existing color tokens and none worked great because of the various arrays of theme styles (not everyone uses border). So I ended up using `treeIndentGuidesStroke` and some themes have this set. I also updated our default themes with some alternate colors.

## Light
![image](https://user-images.githubusercontent.com/35271042/95255748-b8d08080-07d6-11eb-8a24-678546b46c6e.png)

## Dark
![image](https://user-images.githubusercontent.com/35271042/95257431-27164280-07d9-11eb-962b-6a93e5a84112.png)

## Popular Themes
![gif](https://user-images.githubusercontent.com/35271042/95260252-43b47980-07dd-11eb-9238-da4d5c794b2a.gif)
