### PR TITLE
Revert "fixes #107860"

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugActionViewItems.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugActionViewItems.ts
@@ -234,7 +234,6 @@ export class StartDebugActionViewItem implements IActionViewItem {
 export class FocusSessionActionViewItem extends SelectActionViewItem {
 	constructor(
 		action: IAction,
-		session: IDebugSession | undefined,
 		@IDebugService protected readonly debugService: IDebugService,
 		@IThemeService themeService: IThemeService,
 		@IContextViewService contextViewService: IContextViewService,
@@ -263,17 +262,15 @@ export class FocusSessionActionViewItem extends SelectActionViewItem {
 		});
 		this._register(this.debugService.onDidEndSession(() => this.update()));
 
-		this.update(session);
+		this.update();
 	}
 
 	protected getActionContext(_: string, index: number): any {
 		return this.getSessions()[index];
 	}
 
-	private update(session?: IDebugSession) {
-		if (!session) {
-			session = this.getSelectedSession();
-		}
+	private update() {
+		const session = this.getSelectedSession();
 		const sessions = this.getSessions();
 		const names = sessions.map(s => {
 			const label = s.getLabel();

--- a/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
@@ -75,7 +75,7 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 			orientation: ActionsOrientation.HORIZONTAL,
 			actionViewItemProvider: (action: IAction) => {
 				if (action.id === FocusSessionAction.ID) {
-					return this.instantiationService.createInstance(FocusSessionActionViewItem, action, undefined);
+					return this.instantiationService.createInstance(FocusSessionActionViewItem, action);
 				} else if (action instanceof MenuItemAction) {
 					return this.instantiationService.createInstance(MenuEntryActionViewItem, action);
 				} else if (action instanceof SubmenuItemAction) {

--- a/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
@@ -171,7 +171,7 @@ export class DebugViewPaneContainer extends ViewPaneContainer {
 			return this.startDebugActionViewItem;
 		}
 		if (action.id === FocusSessionAction.ID) {
-			return new FocusSessionActionViewItem(action, undefined, this.debugService, this.themeService, this.contextViewService, this.configurationService);
+			return new FocusSessionActionViewItem(action, this.debugService, this.themeService, this.contextViewService, this.configurationService);
 		}
 		if (action instanceof MenuItemAction) {
 			return this.instantiationService.createInstance(MenuEntryActionViewItem, action);

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -459,7 +459,7 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 
 	getActionViewItem(action: IAction): IActionViewItem | undefined {
 		if (action.id === SelectReplAction.ID) {
-			return this.instantiationService.createInstance(SelectReplActionViewItem, this.selectReplAction, this.tree.getInput());
+			return this.instantiationService.createInstance(SelectReplActionViewItem, this.selectReplAction);
 		} else if (action.id === FILTER_ACTION_ID) {
 			this.filterActionViewItem = this.instantiationService.createInstance(ReplFilterActionViewItem, action, localize('workbench.debug.filter.placeholder', "Filter (e.g. text, !exclude)"), this.filterState);
 			return this.filterActionViewItem;


### PR DESCRIPTION
This reverts commit b8e87aae6dca78fe0f8dbffd9d6a34921d9913f4.

Fixes #108202 and brings back https://github.com/microsoft/vscode/issues/107860

Basically `getActionViewItem` can be called when the header is being created, before the body has been created, and so `this.tree` is undefined.