### PR TITLE
Remove unnecessary model creation in walkthrough pages

### DIFF
--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution.ts
@@ -7,7 +7,7 @@ import { localize } from 'vs/nls';
 import { WalkThroughInput } from 'vs/workbench/contrib/welcome/walkThrough/browser/walkThroughInput';
 import { WalkThroughPart } from 'vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart';
 import { WalkThroughArrowUp, WalkThroughArrowDown, WalkThroughPageUp, WalkThroughPageDown } from 'vs/workbench/contrib/welcome/walkThrough/browser/walkThroughActions';
-import { WalkThroughContentProvider, WalkThroughSnippetContentProvider } from 'vs/workbench/contrib/welcome/walkThrough/common/walkThroughContentProvider';
+import { WalkThroughSnippetContentProvider } from 'vs/workbench/contrib/welcome/walkThrough/common/walkThroughContentProvider';
 import { EditorWalkThroughAction, EditorWalkThroughInputFactory } from 'vs/workbench/contrib/welcome/walkThrough/browser/editor/editorWalkThrough';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions as EditorInputExtensions, IEditorInputFactoryRegistry } from 'vs/workbench/common/editor';
@@ -33,9 +33,6 @@ Registry.as<IWorkbenchActionRegistry>(Extensions.WorkbenchActions)
 		'Help: Interactive Playground', CATEGORIES.Help.value);
 
 Registry.as<IEditorInputFactoryRegistry>(EditorInputExtensions.EditorInputFactories).registerEditorInputFactory(EditorWalkThroughInputFactory.ID, EditorWalkThroughInputFactory);
-
-Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
-	.registerWorkbenchContribution(WalkThroughContentProvider, LifecyclePhase.Starting);
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
 	.registerWorkbenchContribution(WalkThroughSnippetContentProvider, LifecyclePhase.Starting);

--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart.ts
@@ -39,7 +39,6 @@ import { Dimension, size } from 'vs/base/browser/dom';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { domEvent } from 'vs/base/browser/event';
-import { EndOfLinePreference } from 'vs/editor/common/model';
 
 export const WALK_THROUGH_FOCUS = new RawContextKey<boolean>('interactivePlaygroundFocus', false);
 
@@ -279,7 +278,7 @@ export class WalkThroughPart extends EditorPane {
 					return;
 				}
 
-				const content = model.main.textEditorModel.getValue(EndOfLinePreference.LF);
+				const content = model.main;
 				if (!input.resource.path.endsWith('.md')) {
 					this.content.innerHTML = content;
 					this.updateSizeClasses();

--- a/src/vs/workbench/contrib/welcome/walkThrough/common/walkThroughContentProvider.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/common/walkThroughContentProvider.ts
@@ -14,7 +14,7 @@ import { Schemas } from 'vs/base/common/network';
 import { Range } from 'vs/editor/common/core/range';
 import { createTextBufferFactory } from 'vs/editor/common/model/textModel';
 
-function requireToContent(resource: URI): Promise<string> {
+export function requireToContent(resource: URI): Promise<string> {
 	if (!resource.query) {
 		throw new Error('Welcome: invalid resource');
 	}
@@ -35,30 +35,6 @@ function requireToContent(resource: URI): Promise<string> {
 	});
 
 	return content;
-}
-
-export class WalkThroughContentProvider implements ITextModelContentProvider, IWorkbenchContribution {
-
-	constructor(
-		@ITextModelService private readonly textModelResolverService: ITextModelService,
-		@IModeService private readonly modeService: IModeService,
-		@IModelService private readonly modelService: IModelService,
-	) {
-		this.textModelResolverService.registerTextModelContentProvider(Schemas.walkThrough, this);
-	}
-
-	public async provideTextContent(resource: URI): Promise<ITextModel> {
-		const content = await requireToContent(resource);
-
-		let codeEditorModel = this.modelService.getModel(resource);
-		if (!codeEditorModel) {
-			codeEditorModel = this.modelService.createModel(content, this.modeService.createByFilepathOrFirstLine(resource), resource);
-		} else {
-			this.modelService.updateModel(codeEditorModel, content);
-		}
-
-		return codeEditorModel;
-	}
 }
 
 export class WalkThroughSnippetContentProvider implements ITextModelContentProvider, IWorkbenchContribution {


### PR DESCRIPTION
We don't need to create models if we're solely rendering the HTML/md. 

Still needed for the snippets as they get put into `CodeEditorWidget`s and there's some logic surrounding their URI's. 

cc @chrmarti @jrieken 