### PR TITLE
CodeLens activated on mouse up #107736

### DIFF
--- a/src/vs/editor/contrib/codelens/codelensController.ts
+++ b/src/vs/editor/contrib/codelens/codelensController.ts
@@ -226,7 +226,7 @@ export class CodeLensContribution implements IEditorContribution {
 				this._disposeAllLenses(undefined, undefined);
 			}
 		}));
-		this._localToDispose.add(this._editor.onMouseUp(e => {
+		this._localToDispose.add(this._editor.onMouseDown(e => {
 			if (e.target.type !== MouseTargetType.CONTENT_WIDGET) {
 				return;
 			}


### PR DESCRIPTION
This PR fixes #107736. The original bug was that on drag, the code lens reference was expanded. Has been changed such that this only happens on click. 
