### PR TITLE
Typo hightlight -> highlight

### DIFF
--- a/src/vs/editor/browser/viewParts/currentLineHighlight/currentLineHighlight.ts
+++ b/src/vs/editor/browser/viewParts/currentLineHighlight/currentLineHighlight.ts
@@ -23,7 +23,7 @@ export abstract class AbstractLineHighlightOverlay extends DynamicViewOverlay {
 	protected _contentLeft: number;
 	protected _contentWidth: number;
 	protected _selectionIsEmpty: boolean;
-	protected _renderLineHightlightOnlyWhenFocus: boolean;
+	protected _renderLineHighlightOnlyWhenFocus: boolean;
 	protected _focused: boolean;
 	private _cursorLineNumbers: number[];
 	private _selections: Selection[];
@@ -37,7 +37,7 @@ export abstract class AbstractLineHighlightOverlay extends DynamicViewOverlay {
 		const layoutInfo = options.get(EditorOption.layoutInfo);
 		this._lineHeight = options.get(EditorOption.lineHeight);
 		this._renderLineHighlight = options.get(EditorOption.renderLineHighlight);
-		this._renderLineHightlightOnlyWhenFocus = options.get(EditorOption.renderLineHighlightOnlyWhenFocus);
+		this._renderLineHighlightOnlyWhenFocus = options.get(EditorOption.renderLineHighlightOnlyWhenFocus);
 		this._contentLeft = layoutInfo.contentLeft;
 		this._contentWidth = layoutInfo.contentWidth;
 		this._selectionIsEmpty = true;

--- a/src/vs/editor/browser/viewParts/currentLineHighlight/currentLineHighlight.ts
+++ b/src/vs/editor/browser/viewParts/currentLineHighlight/currentLineHighlight.ts
@@ -85,7 +85,7 @@ export abstract class AbstractLineHighlightOverlay extends DynamicViewOverlay {
 		const layoutInfo = options.get(EditorOption.layoutInfo);
 		this._lineHeight = options.get(EditorOption.lineHeight);
 		this._renderLineHighlight = options.get(EditorOption.renderLineHighlight);
-		this._renderLineHightlightOnlyWhenFocus = options.get(EditorOption.renderLineHighlightOnlyWhenFocus);
+		this._renderLineHighlightOnlyWhenFocus = options.get(EditorOption.renderLineHighlightOnlyWhenFocus);
 		this._contentLeft = layoutInfo.contentLeft;
 		this._contentWidth = layoutInfo.contentWidth;
 		return true;
@@ -110,7 +110,7 @@ export abstract class AbstractLineHighlightOverlay extends DynamicViewOverlay {
 		return true;
 	}
 	public onFocusChanged(e: viewEvents.ViewFocusChangedEvent): boolean {
-		if (!this._renderLineHightlightOnlyWhenFocus) {
+		if (!this._renderLineHighlightOnlyWhenFocus) {
 			return false;
 		}
 
@@ -170,13 +170,13 @@ export class CurrentLineHighlightOverlay extends AbstractLineHighlightOverlay {
 		return (
 			(this._renderLineHighlight === 'line' || this._renderLineHighlight === 'all')
 			&& this._selectionIsEmpty
-			&& (!this._renderLineHightlightOnlyWhenFocus || this._focused)
+			&& (!this._renderLineHighlightOnlyWhenFocus || this._focused)
 		);
 	}
 	protected _shouldRenderOther(): boolean {
 		return (
 			(this._renderLineHighlight === 'gutter' || this._renderLineHighlight === 'all')
-			&& (!this._renderLineHightlightOnlyWhenFocus || this._focused)
+			&& (!this._renderLineHighlightOnlyWhenFocus || this._focused)
 		);
 	}
 }
@@ -189,14 +189,14 @@ export class CurrentLineMarginHighlightOverlay extends AbstractLineHighlightOver
 	protected _shouldRenderThis(): boolean {
 		return (
 			(this._renderLineHighlight === 'gutter' || this._renderLineHighlight === 'all')
-			&& (!this._renderLineHightlightOnlyWhenFocus || this._focused)
+			&& (!this._renderLineHighlightOnlyWhenFocus || this._focused)
 		);
 	}
 	protected _shouldRenderOther(): boolean {
 		return (
 			(this._renderLineHighlight === 'line' || this._renderLineHighlight === 'all')
 			&& this._selectionIsEmpty
-			&& (!this._renderLineHightlightOnlyWhenFocus || this._focused)
+			&& (!this._renderLineHighlightOnlyWhenFocus || this._focused)
 		);
 	}
 }


### PR DESCRIPTION
The original member was named `_renderLineHightlightOnlyWhenFocus`, but I believe that is a typo and should instead be `_renderLineHighlightOnlyWhenFocus`

Interestingly, I found this typo because I was trying to search for code related to highlighting, and made the same mistake, spelling it "hightlight", and this code appeared as a result.

I do not see `_renderLineHightlightOnlyWhenFocus` referenced elsewhere, so this fix should not cause any breakage. 