### PR TITLE
`relativeFileDirname` gives empty string when the Dirname equals to current working directory

### DIFF
--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -278,7 +278,8 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 						}
 						const dirname = paths.dirname(getFilePath());
 						if (folderUri || argument) {
-							return paths.relative(this.fsPath(getFolderUri()), dirname);
+							const relative = paths.relative(this.fsPath(getFolderUri()), dirname);
+							return relative.length === 0 ? '.' : relative;
 						}
 						return dirname;
 


### PR DESCRIPTION
Fixes #108437