### PR TITLE
fix #108673 Put FileSystemProvider error message into settings.json create-failure notification

### DIFF
--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -557,7 +557,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return this.textFileService.read(resource, { acceptTextOnly: true }).then(undefined, error => {
 			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_NOT_FOUND) {
 				return this.textFileService.write(resource, contents).then(undefined, error => {
-					return Promise.reject(new Error(nls.localize('fail.createSettings', "Unable to create '{0}' ({1}).", this.labelService.getUriLabel(resource, { relative: true }), error)));
+					return Promise.reject(new Error(nls.localize('fail.createSettings', "Unable to create '{0}' ({1}).", this.labelService.getUriLabel(resource, { relative: true }), error.message)));
 				});
 			}
 

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -40,6 +40,7 @@ import { getDefaultValue, IConfigurationRegistry, Extensions, OVERRIDE_PROPERTY_
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { CoreEditingCommands } from 'vs/editor/browser/controller/coreCommands';
+import { getErrorMessage } from 'vs/base/common/errors';
 
 const emptyEditableSettingsContent = '{\n}';
 
@@ -557,7 +558,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return this.textFileService.read(resource, { acceptTextOnly: true }).then(undefined, error => {
 			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_NOT_FOUND) {
 				return this.textFileService.write(resource, contents).then(undefined, error => {
-					return Promise.reject(new Error(nls.localize('fail.createSettings', "Unable to create '{0}' ({1}).", this.labelService.getUriLabel(resource, { relative: true }), error.message)));
+					return Promise.reject(new Error(nls.localize('fail.createSettings', "Unable to create '{0}' ({1}).", this.labelService.getUriLabel(resource, { relative: true }), getErrorMessage(error))));
 				});
 			}
 


### PR DESCRIPTION
This PR fixes #108673

To test, use the repro steps in the original issue and confirm that the notification now includes the error message from the FSP.
