### PR TITLE
Update to openChange() to fix #108856

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -797,7 +797,9 @@ export class CommandCenter {
 	@command('git.openChange')
 	async openChange(arg?: Resource | Uri, ...resourceStates: SourceControlResourceState[]): Promise<void> {
 		const preserveFocus = arg instanceof Resource;
-		const preview = !(arg instanceof Resource);
+
+		const config = workspace.getConfiguration('workbench.editor');
+		const preview = !(arg instanceof Resource) || config.enablePreview;
 
 		const preserveSelection = arg instanceof Uri || !arg;
 		let resources: Resource[] | undefined = undefined;


### PR DESCRIPTION
`const preview` should be `true` in case `workbench.editor.enablePreview` is `true`.

This PR fixes #108856