### PR TITLE
Add background color to lightbulb widget

### DIFF
--- a/src/vs/editor/contrib/codeAction/lightBulbWidget.css
+++ b/src/vs/editor/contrib/codeAction/lightBulbWidget.css
@@ -3,18 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-editor .lightbulb-glyph,
-.monaco-editor .codicon-lightbulb {
+.monaco-editor .contentWidgets .codicon-light-bulb,
+.monaco-editor .contentWidgets .codicon-lightbulb-autofix {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	height: 16px;
-	width: 20px;
-	padding-left: 2px;
 }
 
-.monaco-editor .lightbulb-glyph:hover,
-.monaco-editor .codicon-lightbulb:hover {
+.monaco-editor .contentWidgets .codicon-light-bulb:hover,
+.monaco-editor .contentWidgets .codicon-lightbulb-autofix:hover {
 	cursor: pointer;
-	/* transform: scale(1.3, 1.3); */
 }

--- a/src/vs/editor/contrib/codeAction/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/lightBulbWidget.ts
@@ -16,7 +16,7 @@ import * as nls from 'vs/nls';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { registerThemingParticipant, IColorTheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { editorLightBulbForeground, editorLightBulbAutoFixForeground } from 'vs/platform/theme/common/colorRegistry';
+import { editorLightBulbForeground, editorLightBulbAutoFixForeground, editorBackground, transparent } from 'vs/platform/theme/common/colorRegistry';
 import { Gesture } from 'vs/base/browser/touch';
 import type { CodeActionTrigger } from 'vs/editor/contrib/codeAction/types';
 import { Codicon } from 'vs/base/common/codicons';
@@ -233,12 +233,15 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 
 registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {
 
+	const editorBackgroundColor = theme.getColor(editorBackground)?.transparent(0.7);
+
 	// Lightbulb Icon
 	const editorLightBulbForegroundColor = theme.getColor(editorLightBulbForeground);
 	if (editorLightBulbForegroundColor) {
 		collector.addRule(`
 		.monaco-editor .contentWidgets ${Codicon.lightBulb.cssSelector} {
 			color: ${editorLightBulbForegroundColor};
+			background-color: ${editorBackgroundColor};
 		}`);
 	}
 
@@ -248,6 +251,7 @@ registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) =
 		collector.addRule(`
 		.monaco-editor .contentWidgets ${Codicon.lightbulbAutofix.cssSelector} {
 			color: ${editorLightBulbAutoFixForegroundColor};
+			background-color: ${editorBackgroundColor};
 		}`);
 	}
 

--- a/src/vs/editor/contrib/codeAction/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/lightBulbWidget.ts
@@ -16,7 +16,7 @@ import * as nls from 'vs/nls';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { registerThemingParticipant, IColorTheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { editorLightBulbForeground, editorLightBulbAutoFixForeground, editorBackground, transparent } from 'vs/platform/theme/common/colorRegistry';
+import { editorLightBulbForeground, editorLightBulbAutoFixForeground, editorBackground } from 'vs/platform/theme/common/colorRegistry';
 import { Gesture } from 'vs/base/browser/touch';
 import type { CodeActionTrigger } from 'vs/editor/contrib/codeAction/types';
 import { Codicon } from 'vs/base/common/codicons';


### PR DESCRIPTION
Fixes #108888

## Before
![image](https://user-images.githubusercontent.com/35271042/96648645-7f266c00-12e4-11eb-905d-8d397c8255d3.png)

## After
![image](https://user-images.githubusercontent.com/35271042/96648659-8483b680-12e4-11eb-99a7-a20adff55b95.png)

