### PR TITLE
Suggest shouldn't trigger on all characters in comments

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
+++ b/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
@@ -106,7 +106,8 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 			acceptSuggestionOnEnter: 'smart',
 			minimap: {
 				enabled: false
-			}
+			},
+			quickSuggestions: false
 		};
 	}
 }


### PR DESCRIPTION
Setting `quickSuggestions: false` means that the suggest widget will only trigger on trigger characters and when manually triggered. Without this setting, the suggest widget is triggered on any typed character.

The same property is used in the SCM input box for example.