### PR TITLE
Typo: Uncommited → Uncommitted

### DIFF
--- a/extensions/git/src/timelineProvider.ts
+++ b/extensions/git/src/timelineProvider.ts
@@ -200,7 +200,7 @@ export class GitTimelineProvider implements TimelineProvider {
 			if (working) {
 				const date = new Date();
 
-				const item = new GitTimelineItem('', index ? '~' : 'HEAD', localize('git.timeline.uncommitedChanges', 'Uncommited Changes'), date.getTime(), 'working', 'git:file:working');
+				const item = new GitTimelineItem('', index ? '~' : 'HEAD', localize('git.timeline.uncommitedChanges', 'Uncommitted Changes'), date.getTime(), 'working', 'git:file:working');
 				// TODO@eamodio: Replace with a better icon -- reflecting its status maybe?
 				item.iconPath = new (ThemeIcon as any)('git-commit');
 				item.description = '';


### PR DESCRIPTION
The Timeline extension contains a typo when there are uncommitted changes: "Uncommited Changes". This fixes that.