### PR TITLE
Fixes #95883.

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconlabel.css
+++ b/src/vs/base/browser/ui/iconLabel/iconlabel.css
@@ -75,6 +75,7 @@
 	font-weight: 600;
 	padding: 0 16px 0 5px;
 	text-align: center;
+	display: inline-table; /* #95883, force integer width (snap to pixels) */
 }
 
 /* make sure selection color wins when a label is being selected */


### PR DESCRIPTION
Added `display: inline-table;` to `.monaco-icon-label::after`
to force its integer width. This in turn forces action icons
to appear at integer positions and avoid blurring.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #95883.

Per this comment actually: https://stackoverflow.com/a/45234850/796121

Before:

![image](https://user-images.githubusercontent.com/993454/96837355-f6780f00-144e-11eb-9214-38aaeaf248c9.png)

After:

![image](https://user-images.githubusercontent.com/993454/96837378-0132a400-144f-11eb-9923-642c7473ddc8.png)
