### PR TITLE
SCM viewlet filter on type improvements

### DIFF
--- a/src/vs/base/browser/ui/list/list.ts
+++ b/src/vs/base/browser/ui/list/list.ts
@@ -66,11 +66,11 @@ export interface IIdentityProvider<T> {
 export interface IKeyboardNavigationLabelProvider<T> {
 
 	/**
-	 * Return a keyboard navigation label which will be used by the
-	 * list for filtering/navigating. Return `undefined` to make an
-	 * element always match.
+	 * Return a keyboard navigation label(s) which will be used by
+	 * the list for filtering/navigating. Return `undefined` to make
+	 * an element always match.
 	 */
-	getKeyboardNavigationLabel(element: T): { toString(): string | undefined; } | undefined;
+	getKeyboardNavigationLabel(element: T): { toString(): string | undefined; } | { toString(): string | undefined; }[] | undefined;
 }
 
 export interface IKeyboardNavigationDelegate {

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -507,8 +507,9 @@ class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListRenderer
 	}
 }
 
-class TypeFilter<T> implements ITreeFilter<T, FuzzyScore | { value: string; score: FuzzyScore }>, IDisposable {
+export type LabelFuzzyScore = { label: string; score: FuzzyScore };
 
+class TypeFilter<T> implements ITreeFilter<T, FuzzyScore | LabelFuzzyScore>, IDisposable {
 	private _totalCount = 0;
 	get totalCount(): number { return this._totalCount; }
 	private _matchCount = 0;
@@ -531,7 +532,7 @@ class TypeFilter<T> implements ITreeFilter<T, FuzzyScore | { value: string; scor
 		tree.onWillRefilter(this.reset, this, this.disposables);
 	}
 
-	filter(element: T, parentVisibility: TreeVisibility): TreeFilterResult<FuzzyScore | { value: string, score: FuzzyScore }> {
+	filter(element: T, parentVisibility: TreeVisibility): TreeFilterResult<FuzzyScore | LabelFuzzyScore> {
 		if (this._filter) {
 			const result = this._filter.filter(element, parentVisibility);
 
@@ -575,7 +576,7 @@ class TypeFilter<T> implements ITreeFilter<T, FuzzyScore | { value: string; scor
 				this._matchCount++;
 				return labels.length === 1 ?
 					{ data: score, visibility: true } :
-					{ data: { value: labelStr, score: score }, visibility: true };
+					{ data: { label: labelStr, score: score }, visibility: true };
 			}
 		}
 


### PR DESCRIPTION
This PR fixes #99117 

These changes will make the filter on type experience consistent between the SCM viewlet and quick open. It does so by adding the capability for a treeview to return multiple labels which are being used for filtering. In case of the SCM viewlet it returns the file name and the full path to be used for filtering.