### PR TITLE
Mark DocumentSelector as readonly

### DIFF
--- a/extensions/typescript-language-features/src/utils/documentSelector.ts
+++ b/extensions/typescript-language-features/src/utils/documentSelector.ts
@@ -9,10 +9,10 @@ export interface DocumentSelector {
 	/**
 	 * Selector for files which only require a basic syntax server.
 	 */
-	readonly syntax: vscode.DocumentFilter[];
+	readonly syntax: readonly vscode.DocumentFilter[];
 
 	/**
 	 * Selector for files which require semantic server support.
 	 */
-	readonly semantic: vscode.DocumentFilter[];
+	readonly semantic: readonly vscode.DocumentFilter[];
 }

--- a/src/vs/base/common/arrays.ts
+++ b/src/vs/base/common/arrays.ts
@@ -545,6 +545,8 @@ export function mapArrayOrNot<T, U>(items: T | T[], fn: (_: T) => U): U | U[] {
 		fn(items);
 }
 
+export function asArray<T>(x: T | T[]): T[];
+export function asArray<T>(x: T | readonly T[]): readonly T[];
 export function asArray<T>(x: T | T[]): T[] {
 	return Array.isArray(x) ? x : [x];
 }

--- a/src/vs/editor/common/modes/languageSelector.ts
+++ b/src/vs/editor/common/modes/languageSelector.ts
@@ -8,17 +8,17 @@ import { URI } from 'vs/base/common/uri'; // TODO@Alex
 import { normalize } from 'vs/base/common/path';
 
 export interface LanguageFilter {
-	language?: string;
-	scheme?: string;
-	pattern?: string | IRelativePattern;
+	readonly language?: string;
+	readonly scheme?: string;
+	readonly pattern?: string | IRelativePattern;
 	/**
 	 * This provider is implemented in the UI thread.
 	 */
-	hasAccessToAllModels?: boolean;
-	exclusive?: boolean;
+	readonly hasAccessToAllModels?: boolean;
+	readonly exclusive?: boolean;
 }
 
-export type LanguageSelector = string | LanguageFilter | Array<string | LanguageFilter>;
+export type LanguageSelector = string | LanguageFilter | ReadonlyArray<string | LanguageFilter>;
 
 export function score(selector: LanguageSelector | undefined, candidateUri: URI, candidateLanguage: string, candidateIsSynchronized: boolean): number {
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1943,18 +1943,18 @@ declare module 'vscode' {
 		/**
 		 * A language id, like `typescript`.
 		 */
-		language?: string;
+		readonly language?: string;
 
 		/**
 		 * A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
 		 */
-		scheme?: string;
+		readonly scheme?: string;
 
 		/**
 		 * A [glob pattern](#GlobPattern) that is matched on the absolute path of the document. Use a [relative pattern](#RelativePattern)
 		 * to filter documents to a [workspace folder](#WorkspaceFolder).
 		 */
-		pattern?: GlobPattern;
+		readonly pattern?: GlobPattern;
 	}
 
 	/**
@@ -1969,7 +1969,7 @@ declare module 'vscode' {
 	 * @example
 	 * let sel:DocumentSelector = { scheme: 'file', language: 'typescript' };
 	 */
-	export type DocumentSelector = DocumentFilter | string | Array<DocumentFilter | string>;
+	export type DocumentSelector = DocumentFilter | string | ReadonlyArray<DocumentFilter | string>;
 
 	/**
 	 * A provider result represents the values a provider, like the [`HoverProvider`](#HoverProvider),

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -992,7 +992,7 @@ declare module 'vscode' {
 	//#region @jrieken -> exclusive document filters
 
 	export interface DocumentFilter {
-		exclusive?: boolean;
+		readonly exclusive?: boolean;
 	}
 
 	//#endregion


### PR DESCRIPTION
This change:

- Update  `DocumentSelector` use a readonly array
- Updates all properties of `DocumentFilter` to be readonly

`DocumentSelector` is used as a parameter in our provider APIs and does not need to be mutable. This change lets extensions pass in readonly values for the selector when registering a provider
