### PR TITLE
Replace `map` with `forEach`

### DIFF
--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
@@ -231,7 +231,7 @@ export class SearchEditor extends BaseTextEditor {
 		this._register(this.searchResultEditor.onDidChangeModelContent(() => this.getInput()?.setDirty(true)));
 
 		[this.queryEditorWidget.searchInputFocusTracker, this.queryEditorWidget.replaceInputFocusTracker, this.inputPatternExcludes.inputFocusTracker, this.inputPatternIncludes.inputFocusTracker]
-			.map(tracker => {
+			.forEach(tracker => {
 				this._register(tracker.onDidFocus(() => setTimeout(() => this.inputFocusContextKey.set(true), 0)));
 				this._register(tracker.onDidBlur(() => this.inputFocusContextKey.set(false)));
 			});


### PR DESCRIPTION
As it seems the desired behaviour is to just iterate through all elements, then consider using forEach or a for-of loop instead.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
