### PR TITLE
Better handling of configuration keys with objects in context keys

### DIFF
--- a/src/vs/base/common/map.ts
+++ b/src/vs/base/common/map.ts
@@ -351,10 +351,10 @@ export class TernarySearchTree<K, V> {
 	}
 
 	get(key: K): V | undefined {
-		return this.getNode(key)?.value;
+		return this._getNode(key)?.value;
 	}
 
-	private getNode(key: K) {
+	private _getNode(key: K) {
 		const iter = this._iter.reset(key);
 		let node = this._root;
 		while (node) {
@@ -377,7 +377,7 @@ export class TernarySearchTree<K, V> {
 	}
 
 	has(key: K): boolean {
-		return !!this.getNode(key);
+		return !!this._getNode(key);
 	}
 
 	delete(key: K): void {

--- a/src/vs/base/common/map.ts
+++ b/src/vs/base/common/map.ts
@@ -75,6 +75,57 @@ export class StringIterator implements IKeyIterator<string> {
 	}
 }
 
+export class ConfigKeysIterator implements IKeyIterator<string> {
+
+	private _value!: string;
+	private _from!: number;
+	private _to!: number;
+
+	constructor(
+		private readonly _caseSensitive: boolean = true
+	) { }
+
+	reset(key: string): this {
+		this._value = key;
+		this._from = 0;
+		this._to = 0;
+		return this.next();
+	}
+
+	hasNext(): boolean {
+		return this._to < this._value.length;
+	}
+
+	next(): this {
+		// this._data = key.split(/[\\/]/).filter(s => !!s);
+		this._from = this._to;
+		let justSeps = true;
+		for (; this._to < this._value.length; this._to++) {
+			const ch = this._value.charCodeAt(this._to);
+			if (ch === CharCode.Period) {
+				if (justSeps) {
+					this._from++;
+				} else {
+					break;
+				}
+			} else {
+				justSeps = false;
+			}
+		}
+		return this;
+	}
+
+	cmp(a: string): number {
+		return this._caseSensitive
+			? compareSubstring(a, this._value, 0, a.length, this._from, this._to)
+			: compareSubstringIgnoreCase(a, this._value, 0, a.length, this._from, this._to);
+	}
+
+	value(): string {
+		return this._value.substring(this._from, this._to);
+	}
+}
+
 export class PathIterator implements IKeyIterator<string> {
 
 	private _value!: string;
@@ -238,6 +289,10 @@ export class TernarySearchTree<K, V> {
 		return new TernarySearchTree<string, E>(new StringIterator());
 	}
 
+	static forConfigKeys<E>(): TernarySearchTree<string, E> {
+		return new TernarySearchTree<string, E>(new ConfigKeysIterator());
+	}
+
 	private _iter: IKeyIterator<K>;
 	private _root: TernarySearchTreeNode<K, V> | undefined;
 
@@ -296,6 +351,10 @@ export class TernarySearchTree<K, V> {
 	}
 
 	get(key: K): V | undefined {
+		return this.getNode(key)?.value;
+	}
+
+	private getNode(key: K) {
 		const iter = this._iter.reset(key);
 		let node = this._root;
 		while (node) {
@@ -314,7 +373,11 @@ export class TernarySearchTree<K, V> {
 				break;
 			}
 		}
-		return node ? node.value : undefined;
+		return node;
+	}
+
+	has(key: K): boolean {
+		return !!this.getNode(key);
 	}
 
 	delete(key: K): void {
@@ -347,11 +410,18 @@ export class TernarySearchTree<K, V> {
 				stack.push([0, node]);
 				node = node.mid;
 			} else {
-				// remove element
-				node.value = undefined;
+				if (superStr) {
+					// remove children
+					node.left = undefined;
+					node.mid = undefined;
+					node.right = undefined;
+				} else {
+					// remove element
+					node.value = undefined;
+				}
 
 				// clean up empty nodes
-				while (stack.length > 0 && (node.isEmpty() || superStr)) {
+				while (stack.length > 0 && node.isEmpty()) {
 					let [dir, parent] = stack.pop()!;
 					switch (dir) {
 						case 1: parent.left = undefined; break;
@@ -389,7 +459,7 @@ export class TernarySearchTree<K, V> {
 		return node && node.value || candidate;
 	}
 
-	findSuperstr(key: K): Iterator<V> | undefined {
+	findSuperstr(key: K): IterableIterator<[K, V]> | undefined {
 		const iter = this._iter.reset(key);
 		let node = this._root;
 		while (node) {
@@ -409,7 +479,7 @@ export class TernarySearchTree<K, V> {
 				if (!node.mid) {
 					return undefined;
 				} else {
-					return this._values(node.mid);
+					return this._entries(node.mid);
 				}
 			}
 		}
@@ -424,12 +494,6 @@ export class TernarySearchTree<K, V> {
 
 	*[Symbol.iterator](): IterableIterator<[K, V]> {
 		yield* this._entries(this._root);
-	}
-
-	private *_values(node: TernarySearchTreeNode<K, V>): IterableIterator<V> {
-		for (const [, value] of this._entries(node)) {
-			yield value;
-		}
 	}
 
 	private *_entries(node: TernarySearchTreeNode<K, V> | undefined): IterableIterator<[K, V]> {

--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -92,7 +92,6 @@ class NullContext extends Context {
 }
 
 class ConfigAwareContextValuesContainer extends Context {
-	private static readonly _configContextObject = Object.freeze({});
 	private static readonly _keyPrefix = 'config.';
 
 	private readonly _values = TernarySearchTree.forConfigKeys<any>();
@@ -108,7 +107,7 @@ class ConfigAwareContextValuesContainer extends Context {
 		this._listener = this._configurationService.onDidChangeConfiguration(event => {
 			if (event.source === ConfigurationTarget.DEFAULT) {
 				// new setting, reset everything
-				const allKeys = Array.from(Iterable.map(this._values, ([k, v]) => k));
+				const allKeys = Array.from(Iterable.map(this._values, ([k]) => k));
 				this._values.clear();
 				emitter.fire(new ArrayContextKeyChangeEvent(allKeys));
 			} else {
@@ -160,7 +159,7 @@ class ConfigAwareContextValuesContainer extends Context {
 				if (Array.isArray(configValue)) {
 					value = JSON.stringify(configValue);
 				} else {
-					value = ConfigAwareContextValuesContainer._configContextObject;
+					value = configValue;
 				}
 		}
 

--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -89,6 +89,8 @@ class NullContext extends Context {
 	}
 }
 
+const configContextObject = Object.freeze({});
+
 class ConfigAwareContextValuesContainer extends Context {
 
 	private static readonly _keyPrefix = 'config.';
@@ -112,10 +114,23 @@ class ConfigAwareContextValuesContainer extends Context {
 			} else {
 				const changedKeys: string[] = [];
 				for (const configKey of event.affectedKeys) {
-					const contextKey = `config.${configKey}`;
+					let contextKey = `config.${configKey}`;
 					if (this._values.has(contextKey)) {
+						const value = this._values.get(contextKey);
+
 						this._values.delete(contextKey);
 						changedKeys.push(contextKey);
+
+						if (value === configContextObject) {
+							contextKey += '.';
+
+							for (const key of this._values.keys()) {
+								if (key.startsWith(contextKey)) {
+									this._values.delete(key);
+									changedKeys.push(key);
+								}
+							}
+						}
 					}
 				}
 				emitter.fire(new ArrayContextKeyChangeEvent(changedKeys));
@@ -149,6 +164,8 @@ class ConfigAwareContextValuesContainer extends Context {
 			default:
 				if (Array.isArray(configValue)) {
 					value = JSON.stringify(configValue);
+				} else {
+					value = configContextObject;
 				}
 		}
 

--- a/src/vs/workbench/services/decorations/browser/decorationsService.ts
+++ b/src/vs/workbench/services/decorations/browser/decorationsService.ts
@@ -260,8 +260,9 @@ class DecorationProviderWrapper {
 			const iter = this.data.findSuperstr(uri);
 			if (iter) {
 				for (let item = iter.next(); !item.done; item = iter.next()) {
-					if (item.value && !(item.value instanceof DecorationDataRequest)) {
-						callback(item.value, true);
+					const value = item.value?.[1];
+					if (value && !(value instanceof DecorationDataRequest)) {
+						callback(value, true);
 					}
 				}
 			}


### PR DESCRIPTION
There are two issues I'm trying to solve with this PR.

First in `when` clauses, context keys with object values cannot be tested for existence, since we always save them in the cache as `undefined`. So to deal with that I am instead storing a constant empty object in the cache to allow existence checks to still work.

https://github.com/microsoft/vscode/blob/768e94ec188c9bea750e4313528230c0d4ed9280/src%2Fvs%2Fplatform%2Fcontextkey%2Fbrowser%2FcontextKeyService.ts#L164-L169

Second, accessing a property on a context key's object value, works fine for reading, but it won't be updated when the configuration key changes. While this PR doesn't actually attempt to fire change events for these nested properties (that would be prohibitively expensive IMO), by clearing the cached values, it does still enable a pattern that can be used to effectively deal with that. 

### Real world example
In GitLens, the `gitlens.menus` configuration key is used in lots of `when` clauses to determine the visibility of menu items. Today any changes in this key requires restarting vscode in order to see the change.

This config value looks like this: ([source](https://github.com/eamodio/vscode-gitlens/blob/0d565c7d216741964ac02ae0d677b62c8a3bd40f/package.json#L977-L1222))

```json
"gitlens.menus": {
	"editor": {
		"blame": false,
		"clipboard": true,
		"compare": true,
		"history": false,
		"remote": false
	},
	"editorGroup": {
		"blame": true,
		"compare": true
	},
	"editorTab": {
		"clipboard": true,
		"compare": true,
		"history": true,
		"remote": true
	},
	"explorer": {
		"clipboard": true,
		"compare": true,
		"history": true,
		"remote": true
	},
	"scm": {
		"authors": true
	},
	"scmGroupInline": {
		"stash": true
	},
	"scmGroup": {
		"compare": true,
		"openClose": true,
		"stash": true
	},
	"scmItem": {
		"clipboard": true,
		"compare": true,
		"history": true,
		"remote": false,
		"stash": true
	}
}
```

This gets used in many menu `when` clauses, e.g. ([source](https://github.com/eamodio/vscode-gitlens/blob/0d565c7d216741964ac02ae0d677b62c8a3bd40f/package.json#L5527-L5532))

```json
"editor/context": [
	{
		"submenu": "gitlens/editor/context/openChanges",
		"when": "editorTextFocus && config.gitlens.menus.editor.compare",
		"group": "2_gitlens@1"
	},
```

With this PR, I instead could change this to the following:

```json
"editor/context": [
	{
		"submenu": "gitlens/editor/context/openChanges",
		"when": "editorTextFocus && config.gitlens.menus && config.gitlens.menus.editor && config.gitlens.menus.editor.compare",
		"group": "2_gitlens@1"
	},
```

While slightly verbose, this allows the menus to dynamically adapt to the configuration key changes.