### PR TITLE
Fixes middle-clicking on a notification sometimes pastes the contents of the clipboard

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -306,6 +306,12 @@ export class NotificationTemplateRenderer extends Disposable {
 
 		// Container
 		this.template.container.classList.toggle('expanded', notification.expanded);
+		this.inputDisposables.add(addDisposableListener(this.template.container, EventType.MOUSE_UP, e => {
+			if (e.button === 1 /* Middle Button */) {
+				// Prevent firing the 'paste' event in the editor textarea - #109322
+				EventHelper.stop(e, true);
+			}
+		}));
 		this.inputDisposables.add(addDisposableListener(this.template.container, EventType.AUXCLICK, e => {
 			if (!notification.hasProgress && e.button === 1 /* Middle Button */) {
 				EventHelper.stop(e, true);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

Apparently the `mouseup` event with the middle button fires the [`paste` event on the editor textarea](https://github.com/microsoft/vscode/blob/16f4a29aa0ac05d3cba222b1f347b7404626c680/src/vs/editor/browser/controller/textAreaInput.ts#L355) after the notification closes.

This PR fixes #109322
