### PR TITLE
Changed shebang same as code.sh

### DIFF
--- a/scripts/generate-definitelytyped.sh
+++ b/scripts/generate-definitelytyped.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -eq 0 ]; then
 	echo "Pass in a version like ./scripts/generate-vscode-dts.sh 1.30."

--- a/scripts/node-electron.sh
+++ b/scripts/node-electron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }

--- a/scripts/npm.sh
+++ b/scripts/npm.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 yarn $*

--- a/scripts/test-documentation.sh
+++ b/scripts/test-documentation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -e
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }


### PR DESCRIPTION
This PR fixes #https://github.com/microsoft/vscode/issues/74929

The two different shebang can point to two different bash, specially in MacOS.