### PR TITLE
UI items are incorrect order when applying the language pack

### DIFF
--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -180,8 +180,8 @@ class Menu implements IMenu {
 	}
 
 	private static _compareTitles(a: string | ILocalizedString, b: string | ILocalizedString) {
-		const aStr = typeof a === 'string' ? a : a.value;
-		const bStr = typeof b === 'string' ? b : b.value;
+		const aStr = typeof a === 'string' ? a : a.original;
+		const bStr = typeof b === 'string' ? b : b.original;
 		return aStr.localeCompare(bStr);
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #109286

https://code.visualstudio.com/api/references/contribution-points#Sorting-inside-groups

The current default sort order by is translated titles.

This order has the following problems:
- When install/uninstall the language pack, menu order would be unexpectedly changed.
- When translated title is changed, menu order would be unexpectedly changed.

I propose that the default sort order is by original titles.