### PR TITLE
New accessibility feature: Dark+ (color blind) theme. (related to issue: #109132)

### DIFF
--- a/extensions/theme-defaults/package.json
+++ b/extensions/theme-defaults/package.json
@@ -16,6 +16,12 @@
 				"path": "./themes/dark_plus.json"
 			},
 			{
+				"id": "Dark+ Color blind",
+				"label": "Dark+ (color blind)",
+				"uiTheme": "vs-dark",
+				"path": "./themes/dark_plus_colorblind.json"
+			},
+			{
 				"id": "Default Light+",
 				"label": "Light+ (default light)",
 				"uiTheme": "vs",

--- a/extensions/theme-defaults/themes/dark_plus_colorblind.json
+++ b/extensions/theme-defaults/themes/dark_plus_colorblind.json
@@ -1,0 +1,200 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Dark+ (color blind)",
+	"include": "./dark_vs.json",
+	"tokenColors": [
+		{
+			"name": "Function declarations",
+			"scope": [
+				"entity.name.function",
+				"support.function",
+				"support.constant.handlebars",
+				"source.powershell variable.other.member",
+				"entity.name.operator.custom-literal" // See https://en.cppreference.com/w/cpp/language/user_literal
+			],
+			"settings": {
+				"foreground": "#DCDCB6"
+			}
+		},
+		{
+			"name": "Types declaration and references",
+			"scope": [
+				"meta.return-type",
+				"support.class",
+				"support.type",
+				"entity.name.type",
+				"entity.name.namespace",
+				"entity.other.attribute",
+				"entity.name.scope-resolution",
+				"entity.name.class",
+				"storage.type.numeric.go",
+				"storage.type.byte.go",
+				"storage.type.boolean.go",
+				"storage.type.string.go",
+				"storage.type.uintptr.go",
+				"storage.type.error.go",
+				"storage.type.rune.go",
+				"storage.type.cs",
+				"storage.type.generic.cs",
+				"storage.type.modifier.cs",
+				"storage.type.variable.cs",
+				"storage.type.annotation.java",
+				"storage.type.generic.java",
+				"storage.type.java",
+				"storage.type.object.array.java",
+				"storage.type.primitive.array.java",
+				"storage.type.primitive.java",
+				"storage.type.token.java",
+				"storage.type.groovy",
+				"storage.type.annotation.groovy",
+				"storage.type.parameters.groovy",
+				"storage.type.generic.groovy",
+				"storage.type.object.array.groovy",
+				"storage.type.primitive.array.groovy",
+				"storage.type.primitive.groovy"
+			],
+			"settings": {
+				"foreground": "#8384B6"
+			}
+		},
+		{
+			"name": "Types declaration and references, TS grammar specific",
+			"scope": [
+				"meta.type.cast.expr",
+				"meta.type.new.expr",
+				"support.constant.math",
+				"support.constant.dom",
+				"support.constant.json",
+				"entity.other.inherited-class"
+			],
+			"settings": {
+				"foreground": "#8384B6"
+			}
+		},
+		{
+			"name": "Control flow / Special keywords",
+			"scope": [
+				"keyword.control",
+				"source.cpp keyword.operator.new",
+				"keyword.operator.delete",
+				"keyword.other.using",
+				"keyword.other.operator",
+				"entity.name.operator"
+			],
+			"settings": {
+				"foreground": "#A9A9B1"
+			}
+		},
+		{
+			"name": "Variable and parameter name",
+			"scope": [
+				"variable",
+				"meta.definition.variable.name",
+				"support.variable",
+				"entity.name.variable"
+			],
+			"settings": {
+				"foreground": "#B7B8F5"
+			}
+		},
+		{
+			"name": "Constants and enums",
+			"scope": [
+				"variable.other.constant",
+				"variable.other.enummember"
+			],
+			"settings": {
+				"foreground": "#8081EF",
+			}
+		},
+		{
+			"name": "Object keys, TS grammar specific",
+			"scope": [
+				"meta.object-literal.key"
+			],
+			"settings": {
+				"foreground": "#B7B8F5"
+			}
+		},
+		{
+			"name": "CSS property value",
+			"scope": [
+				"support.constant.property-value",
+				"support.constant.font-name",
+				"support.constant.media-type",
+				"support.constant.media",
+				"constant.other.color.rgb-value",
+				"constant.other.rgb-value",
+				"support.constant.color"
+			],
+			"settings": {
+				"foreground": "#B3B37E"
+			}
+		},
+		{
+			"name": "Regular expression groups",
+			"scope": [
+				"punctuation.definition.group.regexp",
+				"punctuation.definition.group.assertion.regexp",
+				"punctuation.definition.character-class.regexp",
+				"punctuation.character.set.begin.regexp",
+				"punctuation.character.set.end.regexp",
+				"keyword.operator.negation.regexp",
+				"support.other.parenthesis.regexp"
+			],
+			"settings": {
+				"foreground": "#B3B37E"
+			}
+		},
+		{
+			"scope": [
+				"constant.character.character-class.regexp",
+				"constant.other.character-class.set.regexp",
+				"constant.other.character-class.regexp",
+				"constant.character.set.regexp"
+			],
+			"settings": {
+				"foreground": "#A3A369"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.or.regexp",
+				"keyword.control.anchor.regexp"
+			],
+			"settings": {
+				"foreground": "#DCDCB6"
+			}
+		},
+		{
+			"scope": "keyword.operator.quantifier.regexp",
+			"settings": {
+				"foreground": "#CACA8B"
+			}
+		},
+		{
+			"scope": "constant.character",
+			"settings": {
+				"foreground": "#7474C7"
+			}
+		},
+		{
+			"scope": "constant.character.escape",
+			"settings": {
+				"foreground": "#CACA8B"
+			}
+		},
+		{
+			"scope": "entity.name.label",
+			"settings": {
+				"foreground": "#C8C8C8"
+			}
+		}
+	],
+	"semanticTokenColors": {
+		"newOperator":"#A9A9B1",
+		"stringLiteral":"#B3B37E",
+		"customLiteral": "#DCDCB6",
+		"numberLiteral": "#BFC0B1",
+	}
+}


### PR DESCRIPTION
     -theme: Dark+ (color blind)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR address #109132 

This PR adds a new accessibility feature to our community: 
Theme Dark+ (color blind). 
My research was based on my own experience using VS Code (I'm blind color). The colour palette was generated by online tools that provide friendly colours to blind colors. The theme was tested against my eyes until I feel that it was the right solution; Using the theme, I found it much easier to read/understand the code. 
It's good to have a theme like this coming together with VS Code default installation.
I hope it helps our community. 

Thanks.
Pedro

<img width="1920" alt="Screen Shot 2020-10-27 at 2 54 55 AM" src="https://user-images.githubusercontent.com/60857409/97270012-c8a31980-1804-11eb-9919-c89a0007acf6.png">

<img width="1920" alt="Screen Shot 2020-10-27 at 2 55 14 AM" src="https://user-images.githubusercontent.com/60857409/97270105-f720f480-1804-11eb-893d-6e021d9a5b3c.png">




