### PR TITLE
add 'deleteWordEntire' command

### DIFF
--- a/src/vs/editor/common/controller/cursorWordOperations.ts
+++ b/src/vs/editor/common/controller/cursorWordOperations.ts
@@ -374,6 +374,52 @@ export class WordOperations {
 		return null;
 	}
 
+	protected static _determineDeleteRange(wordSeparators: WordCharacterClassifier, model: ICursorSimpleModel, wordNavigationType: WordNavigationType, position: Position, isEntire: boolean): Range {
+		let lineNumber = position.lineNumber;
+		let column = position.column;
+		let columnEnd = position.column;
+		let lineContent = model.getLineContent(position.lineNumber);
+
+		let prevWordOnLine = WordOperations._findPreviousWordOnLine(wordSeparators, model, position);
+
+		if (wordNavigationType === WordNavigationType.WordStart) {
+			if (prevWordOnLine) {
+				column = prevWordOnLine.start + 1;
+				if (isEntire) {
+					columnEnd = prevWordOnLine.end + 1;
+					const chCode = lineContent.charCodeAt(columnEnd - 1);
+					if (chCode === CharCode.Space || chCode === CharCode.Tab) {
+						columnEnd++;
+					}
+				}
+			} else {
+				if (column > 1) {
+					column = 1;
+				} else {
+					lineNumber--;
+					column = model.getLineMaxColumn(lineNumber);
+				}
+			}
+		} else {
+			if (prevWordOnLine && column <= prevWordOnLine.end + 1) {
+				prevWordOnLine = WordOperations._findPreviousWordOnLine(wordSeparators, model, new Position(lineNumber, prevWordOnLine.start + 1));
+			}
+			if (prevWordOnLine) {
+				column = prevWordOnLine.end + 1;
+			} else {
+				if (column > 1) {
+					column = 1;
+				} else {
+					lineNumber--;
+					column = model.getLineMaxColumn(lineNumber);
+				}
+			}
+		}
+
+		return new Range(lineNumber, column, position.lineNumber, columnEnd);
+	}
+
+
 	public static deleteWordLeft(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range | null {
 		const wordSeparators = ctx.wordSeparators;
 		const model = ctx.model;
@@ -406,36 +452,56 @@ export class WordOperations {
 			}
 		}
 
-		let prevWordOnLine = WordOperations._findPreviousWordOnLine(wordSeparators, model, position);
+		return this._determineDeleteRange(wordSeparators, model, wordNavigationType, position, false);
+	}
 
-		if (wordNavigationType === WordNavigationType.WordStart) {
-			if (prevWordOnLine) {
-				column = prevWordOnLine.start + 1;
-			} else {
-				if (column > 1) {
-					column = 1;
-				} else {
-					lineNumber--;
-					column = model.getLineMaxColumn(lineNumber);
-				}
-			}
-		} else {
-			if (prevWordOnLine && column <= prevWordOnLine.end + 1) {
-				prevWordOnLine = WordOperations._findPreviousWordOnLine(wordSeparators, model, new Position(lineNumber, prevWordOnLine.start + 1));
-			}
-			if (prevWordOnLine) {
-				column = prevWordOnLine.end + 1;
-			} else {
-				if (column > 1) {
-					column = 1;
-				} else {
-					lineNumber--;
-					column = model.getLineMaxColumn(lineNumber);
-				}
+
+	protected static _deleteWordEntireWhitespace(model: ICursorSimpleModel, position: Position): Range | null {
+		const lineContent = model.getLineContent(position.lineNumber);
+		const startIndex1 = position.column - 1; // deleteRight
+		const startIndex2 = position.column - 2; // deleteLeft
+		const firstNonWhitespace = this._findFirstNonWhitespaceChar(lineContent, startIndex1);
+		const lastNonWhitespace = strings.lastNonWhitespaceIndex(lineContent, startIndex2);
+		if ((startIndex1 + 1 < firstNonWhitespace && lastNonWhitespace + 1 < startIndex2) || (startIndex1 + 1 >= firstNonWhitespace && lastNonWhitespace + 1 < startIndex2) || (startIndex1 + 1 <= firstNonWhitespace && lastNonWhitespace + 1 === startIndex2)) {
+			return new Range(position.lineNumber, lastNonWhitespace + 2, position.lineNumber, firstNonWhitespace + 1);
+		}
+		return null;
+	}
+
+
+	public static deleteWordEntire(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range | null {
+		const wordSeparators = ctx.wordSeparators;
+		const model = ctx.model;
+		const selection = ctx.selection;
+		const whitespaceHeuristics = ctx.whitespaceHeuristics;
+
+		if (!selection.isEmpty()) {
+			return selection;
+		}
+
+		if (DeleteOperations.isAutoClosingPairDelete(ctx.autoClosingBrackets, ctx.autoClosingQuotes, ctx.autoClosingPairs.autoClosingPairsOpen, ctx.model, [ctx.selection])) {
+			const position = ctx.selection.getPosition();
+			return new Range(position.lineNumber, position.column - 1, position.lineNumber, position.column + 1);
+		}
+
+		const position = new Position(selection.positionLineNumber, selection.positionColumn);
+
+		let lineNumber = position.lineNumber;
+		let column = position.column;
+
+		if (lineNumber === 1 && column === 1) {
+			// Ignore deleting at beginning of file
+			return null;
+		}
+
+		if (whitespaceHeuristics) {
+			let r = this._deleteWordEntireWhitespace(model, position);
+			if (r) {
+				return r;
 			}
 		}
 
-		return new Range(lineNumber, column, position.lineNumber, position.column);
+		return this._determineDeleteRange(wordSeparators, model, wordNavigationType, position, true);
 	}
 
 	public static _deleteWordPartLeft(model: ICursorSimpleModel, selection: Selection): Range {

--- a/src/vs/editor/common/controller/cursorWordOperations.ts
+++ b/src/vs/editor/common/controller/cursorWordOperations.ts
@@ -438,22 +438,22 @@ export class WordOperations {
 		return new Range(lineNumber, column, position.lineNumber, position.column);
 	}
 
-	public static deleteWordEntire(wordSeparators: WordCharacterClassifier, model: ITextModel, selection: Selection): Range | null {
+	public static deleteInsideWord(wordSeparators: WordCharacterClassifier, model: ITextModel, selection: Selection): Range | null {
 		if (!selection.isEmpty()) {
 			return selection;
 		}
 
 		const position = new Position(selection.positionLineNumber, selection.positionColumn);
 
-		let r = this._deleteWordEntireWhitespace(model, position);
+		let r = this._deleteInsideWordWhitespace(model, position);
 		if (r) {
 			return r;
 		}
 
-		return this._determineDeleteRange(wordSeparators, model, position);
+		return this._deleteInsideWordDetermineDeleteRange(wordSeparators, model, position);
 	}
 
-	private static _deleteWordEntireWhitespace(model: ICursorSimpleModel, position: Position): Range | null {
+	private static _deleteInsideWordWhitespace(model: ICursorSimpleModel, position: Position): Range | null {
 		const lineContent = model.getLineContent(position.lineNumber);
 		const startIndex1 = position.column - 1; // deleteRight
 		const startIndex2 = position.column - 2; // deleteLeft
@@ -465,7 +465,7 @@ export class WordOperations {
 		return null;
 	}
 
-	private static _determineDeleteRange(wordSeparators: WordCharacterClassifier, model: ICursorSimpleModel, position: Position): Range {
+	private static _deleteInsideWordDetermineDeleteRange(wordSeparators: WordCharacterClassifier, model: ICursorSimpleModel, position: Position): Range {
 		let lineNumber = position.lineNumber;
 		let column = position.column;
 		let columnEnd = position.column;

--- a/src/vs/editor/contrib/wordOperations/test/wordOperations.test.ts
+++ b/src/vs/editor/contrib/wordOperations/test/wordOperations.test.ts
@@ -9,7 +9,7 @@ import { EditorCommand } from 'vs/editor/browser/editorExtensions';
 import { Position } from 'vs/editor/common/core/position';
 import { Selection } from 'vs/editor/common/core/selection';
 import { deserializePipePositions, serializePipePositions, testRepeatedActionAndExtractPositions } from 'vs/editor/contrib/wordOperations/test/wordTestUtils';
-import { CursorWordEndLeft, CursorWordEndLeftSelect, CursorWordEndRight, CursorWordEndRightSelect, CursorWordLeft, CursorWordLeftSelect, CursorWordRight, CursorWordRightSelect, CursorWordStartLeft, CursorWordStartLeftSelect, CursorWordStartRight, CursorWordStartRightSelect, DeleteWordEndLeft, DeleteWordEndRight, DeleteWordLeft, DeleteWordRight, DeleteWordStartLeft, DeleteWordStartRight, CursorWordAccessibilityLeft, CursorWordAccessibilityLeftSelect, CursorWordAccessibilityRight, CursorWordAccessibilityRightSelect } from 'vs/editor/contrib/wordOperations/wordOperations';
+import { CursorWordEndLeft, CursorWordEndLeftSelect, CursorWordEndRight, CursorWordEndRightSelect, CursorWordLeft, CursorWordLeftSelect, CursorWordRight, CursorWordRightSelect, CursorWordStartLeft, CursorWordStartLeftSelect, CursorWordStartRight, CursorWordStartRightSelect, DeleteWordEndLeft, DeleteWordEndRight, DeleteWordLeft, DeleteWordRight, DeleteWordStartLeft, DeleteWordStartRight, CursorWordAccessibilityLeft, CursorWordAccessibilityLeftSelect, CursorWordAccessibilityRight, CursorWordAccessibilityRightSelect, DeleteInsideWord } from 'vs/editor/contrib/wordOperations/wordOperations';
 import { withTestCodeEditor } from 'vs/editor/test/browser/testCodeEditor';
 import { CoreEditingCommands } from 'vs/editor/browser/controller/coreCommands';
 import { ViewModel } from 'vs/editor/common/viewModel/viewModelImpl';
@@ -42,6 +42,7 @@ suite('WordOperations', () => {
 	const _deleteWordRight = new DeleteWordRight();
 	const _deleteWordStartRight = new DeleteWordStartRight();
 	const _deleteWordEndRight = new DeleteWordEndRight();
+	const _deleteInsideWord = new DeleteInsideWord();
 
 	function runEditorCommand(editor: ICodeEditor, command: EditorCommand): void {
 		command.runEditorCommand(null, editor, null);
@@ -87,6 +88,9 @@ suite('WordOperations', () => {
 	}
 	function deleteWordEndRight(editor: ICodeEditor): void {
 		runEditorCommand(editor, _deleteWordEndRight);
+	}
+	function deleteInsideWord(editor: ICodeEditor): void {
+		runEditorCommand(editor, _deleteInsideWord);
 	}
 
 	test('cursorWordLeft - simple', () => {
@@ -749,5 +753,120 @@ suite('WordOperations', () => {
 
 		model.dispose();
 		mode.dispose();
+	});
+
+	test('deleteInsideWord - empty line', () => {
+		withTestCodeEditor([
+			'Line1',
+			'',
+			'Line2'
+		], {}, (editor, _) => {
+			const model = editor.getModel()!;
+			editor.setPosition(new Position(2, 1));
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'Line1\nLine2');
+		});
+	});
+
+	test('deleteInsideWord - in whitespace 1', () => {
+		withTestCodeEditor([
+			'Just  some text.'
+		], {}, (editor, _) => {
+			const model = editor.getModel()!;
+			editor.setPosition(new Position(1, 6));
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'Justsome text.');
+		});
+	});
+
+	test('deleteInsideWord - in whitespace 2', () => {
+		withTestCodeEditor([
+			'Just     some text.'
+		], {}, (editor, _) => {
+			const model = editor.getModel()!;
+			editor.setPosition(new Position(1, 6));
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'Justsome text.');
+		});
+	});
+
+	test('deleteInsideWord - in whitespace 3', () => {
+		withTestCodeEditor([
+			'Just     "some text.'
+		], {}, (editor, _) => {
+			const model = editor.getModel()!;
+			editor.setPosition(new Position(1, 6));
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'Just"some text.');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), '"some text.');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'some text.');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'text.');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), '.');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), '');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), '');
+		});
+	});
+
+	test('deleteInsideWord - in non-words', () => {
+		withTestCodeEditor([
+			'x=3+4+5+6'
+		], {}, (editor, _) => {
+			const model = editor.getModel()!;
+			editor.setPosition(new Position(1, 7));
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'x=3+45+6');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'x=3++6');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'x=36');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'x=');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'x');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), '');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), '');
+		});
+	});
+
+	test('deleteInsideWord - in words 1', () => {
+		withTestCodeEditor([
+			'This is interesting'
+		], {}, (editor, _) => {
+			const model = editor.getModel()!;
+			editor.setPosition(new Position(1, 7));
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'This interesting');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'This');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), '');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), '');
+		});
+	});
+
+	test('deleteInsideWord - in words 2', () => {
+		withTestCodeEditor([
+			'This  is  interesting'
+		], {}, (editor, _) => {
+			const model = editor.getModel()!;
+			editor.setPosition(new Position(1, 7));
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'This  interesting');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), 'This');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), '');
+			deleteInsideWord(editor);
+			assert.equal(model.getValue(), '');
+		});
 	});
 });

--- a/src/vs/editor/contrib/wordOperations/wordOperations.ts
+++ b/src/vs/editor/contrib/wordOperations/wordOperations.ts
@@ -402,6 +402,23 @@ export class DeleteWordRightCommand extends DeleteWordCommand {
 	}
 }
 
+export class DeleteWordRight extends DeleteWordRightCommand {
+	constructor() {
+		super({
+			whitespaceHeuristics: true,
+			wordNavigationType: WordNavigationType.WordEnd,
+			id: 'deleteWordRight',
+			precondition: EditorContextKeys.writable,
+			kbOpts: {
+				kbExpr: EditorContextKeys.textInputFocus,
+				primary: KeyMod.CtrlCmd | KeyCode.Delete,
+				mac: { primary: KeyMod.Alt | KeyCode.Delete },
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+}
+
 export class DeleteWordStartLeft extends DeleteWordLeftCommand {
 	constructor() {
 		super({
@@ -463,22 +480,35 @@ export class DeleteWordEndRight extends DeleteWordRightCommand {
 	}
 }
 
-export class DeleteWordRight extends DeleteWordRightCommand {
+export class DeleteWordEntireCommand extends DeleteWordCommand {
+	protected _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range {
+		let r = WordOperations.deleteWordEntire(ctx, wordNavigationType);
+		if (r) {
+			return r;
+		}
+		const lineCount = ctx.model.getLineCount();
+		const maxColumn = ctx.model.getLineMaxColumn(lineCount);
+		return new Range(lineCount, maxColumn, lineCount, maxColumn);
+	}
+}
+
+export class DeleteWordEntire extends DeleteWordEntireCommand {
 	constructor() {
 		super({
 			whitespaceHeuristics: true,
-			wordNavigationType: WordNavigationType.WordEnd,
-			id: 'deleteWordRight',
+			wordNavigationType: WordNavigationType.WordStart,
+			id: 'deleteWordEntire',
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,
-				primary: KeyMod.CtrlCmd | KeyCode.Delete,
-				mac: { primary: KeyMod.Alt | KeyCode.Delete },
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_U,
+				mac: { primary: KeyMod.Alt | KeyMod.Shift | KeyCode.KEY_U },
 				weight: KeybindingWeight.EditorContrib
 			}
 		});
 	}
 }
+
 
 registerEditorCommand(new CursorWordStartLeft());
 registerEditorCommand(new CursorWordEndLeft());
@@ -502,3 +532,4 @@ registerEditorCommand(new DeleteWordLeft());
 registerEditorCommand(new DeleteWordStartRight());
 registerEditorCommand(new DeleteWordEndRight());
 registerEditorCommand(new DeleteWordRight());
+registerEditorCommand(new DeleteWordEntire());

--- a/src/vs/editor/contrib/wordOperations/wordOperations.ts
+++ b/src/vs/editor/contrib/wordOperations/wordOperations.ts
@@ -480,18 +480,12 @@ export class DeleteWordRight extends DeleteWordRightCommand {
 	}
 }
 
-export class DeleteWordEntire extends EditorCommand {
+export class DeleteInsideWord extends EditorCommand {
 
 	constructor() {
 		super({
-			id: 'deleteWordEntire',
-			precondition: EditorContextKeys.writable,
-			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_U,
-				mac: { primary: KeyMod.Alt | KeyMod.Shift | KeyCode.KEY_U },
-				weight: KeybindingWeight.EditorContrib
-			}
+			id: 'deleteInsideWord',
+			precondition: EditorContextKeys.writable
 		});
 	}
 
@@ -514,7 +508,7 @@ export class DeleteWordEntire extends EditorCommand {
 	}
 
 	private _delete(wordSeparators: WordCharacterClassifier, model: ITextModel, selection: Selection): Range {
-		let r = WordOperations.deleteWordEntire(wordSeparators, model, selection);
+		let r = WordOperations.deleteInsideWord(wordSeparators, model, selection);
 		if (r) {
 			return r;
 		}
@@ -546,4 +540,4 @@ registerEditorCommand(new DeleteWordLeft());
 registerEditorCommand(new DeleteWordStartRight());
 registerEditorCommand(new DeleteWordEndRight());
 registerEditorCommand(new DeleteWordRight());
-registerEditorCommand(new DeleteWordEntire());
+registerEditorCommand(new DeleteInsideWord());

--- a/src/vs/editor/contrib/wordOperations/wordOperations.ts
+++ b/src/vs/editor/contrib/wordOperations/wordOperations.ts
@@ -498,23 +498,13 @@ export class DeleteInsideWord extends EditorCommand {
 		const selections = editor.getSelections();
 
 		const commands = selections.map((sel) => {
-			const deleteRange = this._delete(wordSeparators, model, sel);
+			const deleteRange = WordOperations.deleteInsideWord(wordSeparators, model, sel);
 			return new ReplaceCommand(deleteRange, '');
 		});
 
 		editor.pushUndoStop();
 		editor.executeCommands(this.id, commands);
 		editor.pushUndoStop();
-	}
-
-	private _delete(wordSeparators: WordCharacterClassifier, model: ITextModel, selection: Selection): Range {
-		let r = WordOperations.deleteInsideWord(wordSeparators, model, selection);
-		if (r) {
-			return r;
-		}
-		const lineCount = model.getLineCount();
-		const maxColumn = model.getLineMaxColumn(lineCount);
-		return new Range(lineCount, maxColumn, lineCount, maxColumn);
 	}
 }
 

--- a/src/vs/editor/contrib/wordOperations/wordOperations.ts
+++ b/src/vs/editor/contrib/wordOperations/wordOperations.ts
@@ -402,23 +402,6 @@ export class DeleteWordRightCommand extends DeleteWordCommand {
 	}
 }
 
-export class DeleteWordRight extends DeleteWordRightCommand {
-	constructor() {
-		super({
-			whitespaceHeuristics: true,
-			wordNavigationType: WordNavigationType.WordEnd,
-			id: 'deleteWordRight',
-			precondition: EditorContextKeys.writable,
-			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
-				primary: KeyMod.CtrlCmd | KeyCode.Delete,
-				mac: { primary: KeyMod.Alt | KeyCode.Delete },
-				weight: KeybindingWeight.EditorContrib
-			}
-		});
-	}
-}
-
 export class DeleteWordStartLeft extends DeleteWordLeftCommand {
 	constructor() {
 		super({
@@ -480,6 +463,23 @@ export class DeleteWordEndRight extends DeleteWordRightCommand {
 	}
 }
 
+export class DeleteWordRight extends DeleteWordRightCommand {
+	constructor() {
+		super({
+			whitespaceHeuristics: true,
+			wordNavigationType: WordNavigationType.WordEnd,
+			id: 'deleteWordRight',
+			precondition: EditorContextKeys.writable,
+			kbOpts: {
+				kbExpr: EditorContextKeys.textInputFocus,
+				primary: KeyMod.CtrlCmd | KeyCode.Delete,
+				mac: { primary: KeyMod.Alt | KeyCode.Delete },
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+}
+
 export class DeleteWordEntireCommand extends DeleteWordCommand {
 	protected _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range {
 		let r = WordOperations.deleteWordEntire(ctx, wordNavigationType);
@@ -508,7 +508,6 @@ export class DeleteWordEntire extends DeleteWordEntireCommand {
 		});
 	}
 }
-
 
 registerEditorCommand(new CursorWordStartLeft());
 registerEditorCommand(new CursorWordEndLeft());


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #109510

We added a new shortcut key ‘deleteWordEntire’.
‘deleteWordLeft’ or ‘deleteWordRight’ commands already exist. However, it is rare that we want to delete letters in only one side from the cursor.
This ‘deleteWordEntire’ command can be executed by pressing ‘ctrl + Shift + U’ (on Linux). This command deletes a word the cursor is pointing to. Even if the cursor is in the middle of the word, we can delete the whole word (not only left or right side of the cursor). Furthermore, this command also deletes the following whitespace. For example,

- aaaaa _ bbb|bb _ ccccc  ->  aaaaa _ ccccc ('|' means the cursor)

So this command is convenient and will definitely improve our development efficency.
