### PR TITLE
Fixes non-themed comment body border

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -884,13 +884,18 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 	}
 
 	private _applyTheme(theme: IColorTheme) {
-		const borderColor = theme.getColor(peekViewBorder) || Color.transparent;
+		const borderColor = theme.getColor(peekViewBorder);
 		this.style({
-			arrowColor: borderColor,
-			frameColor: borderColor
+			arrowColor: borderColor || Color.transparent,
+			frameColor: borderColor || Color.transparent
 		});
 
 		const content: string[] = [];
+
+		if (borderColor) {
+			content.push(`.monaco-editor .review-widget > .body { border-top: 1px solid ${borderColor} }`);
+		}
+
 		const linkColor = theme.getColor(textLinkForeground);
 		if (linkColor) {
 			content.push(`.monaco-editor .review-widget .body .comment-body a { color: ${linkColor} }`);


### PR DESCRIPTION
Currently the comment thread body has a top border that is not controlled by a theme color (it follows the foreground color) and sticks out.

## Before

![image](https://user-images.githubusercontent.com/641685/97749865-27e38100-1ac6-11eb-982e-91e7cd5a92dd.png)
![image](https://user-images.githubusercontent.com/641685/97750027-72fd9400-1ac6-11eb-9d29-74089e566008.png)

## After

![image](https://user-images.githubusercontent.com/641685/97749956-4cd7f400-1ac6-11eb-91ee-d5758b1a3acc.png)
![image](https://user-images.githubusercontent.com/641685/97750174-ad673100-1ac6-11eb-8595-5118298f2104.png)