### PR TITLE
Allow monaco-editor to work propertly with Jest

### DIFF
--- a/src/vs/editor/editor.api.ts
+++ b/src/vs/editor/editor.api.ts
@@ -8,8 +8,6 @@ import { createMonacoBaseAPI } from 'vs/editor/common/standalone/standaloneBase'
 import { createMonacoEditorAPI } from 'vs/editor/standalone/browser/standaloneEditor';
 import { createMonacoLanguagesAPI } from 'vs/editor/standalone/browser/standaloneLanguages';
 
-var global: any = self;
-
 // Set defaults for standalone editor
 EditorOptions.wrappingIndent.defaultValue = WrappingIndent.None;
 EditorOptions.glyphMargin.defaultValue = false;
@@ -34,10 +32,10 @@ export const Token = api.Token;
 export const editor = api.editor;
 export const languages = api.languages;
 
-global.monaco = api;
+self.monaco = api;
 
-if (typeof global.require !== 'undefined' && typeof global.require.config === 'function') {
-	global.require.config({
+if (typeof self.require !== 'undefined' && typeof self.require.config === 'function') {
+	self.require.config({
 		ignoreDuplicateModules: [
 			'vscode-languageserver-types',
 			'vscode-languageserver-types/main',

--- a/src/vs/editor/editor.api.ts
+++ b/src/vs/editor/editor.api.ts
@@ -8,7 +8,7 @@ import { createMonacoBaseAPI } from 'vs/editor/common/standalone/standaloneBase'
 import { createMonacoEditorAPI } from 'vs/editor/standalone/browser/standaloneEditor';
 import { createMonacoLanguagesAPI } from 'vs/editor/standalone/browser/standaloneLanguages';
 
-const global: any = self;
+var global: any = self;
 
 // Set defaults for standalone editor
 EditorOptions.wrappingIndent.defaultValue = WrappingIndent.None;


### PR DESCRIPTION
In Node.js environments where Jest is run, `global` is already an existing variable. Using `const` to redeclare it causes an error and therefore makes it impossible to run any `monaco-editor` related tests with Jest. Changing this line from `const` to `var` doesn't cause this issue.

We use `monaco-editor` in GitLab, and in order to upgrade it to the latest version and make it work with Jest, the only solution was to patch it using `patch-package`. The patch solution doesn't scale so well.

Here's a bit more info: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/46436#note_438312326