### PR TITLE
Introduce new setting "editor.formatOnSaveBeforeRun"

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -49,6 +49,7 @@ import { DebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debugCompou
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
+import { SaveReason } from 'vs/workbench/common/editor';
 
 export class DebugService implements IDebugService {
 	declare readonly _serviceBrand: undefined;
@@ -281,7 +282,7 @@ export class DebugService implements IDebugService {
 			// make sure to save all files and that the configuration is up to date
 			await this.extensionService.activateByEvent('onDebug');
 			if (!options?.parentSession) {
-				await this.editorService.saveAll();
+				await this.saveAllEditors();
 			}
 			await this.configurationService.reloadConfiguration(launch ? launch.workspace : undefined);
 			await this.extensionService.whenInstalledExtensionsRegistered();
@@ -634,7 +635,7 @@ export class DebugService implements IDebugService {
 	}
 
 	async restartSession(session: IDebugSession, restartData?: any): Promise<any> {
-		await this.editorService.saveAll();
+		await this.saveAllEditors();
 		const isAutoRestart = !!restartData;
 
 		const runTasks: () => Promise<TaskRunResult> = async () => {
@@ -784,6 +785,12 @@ export class DebugService implements IDebugService {
 		}
 
 		return undefined;
+	}
+
+	private async saveAllEditors() {
+		const formatOnSaveBeforeRunTaskConfig = this.configurationService.getValue<boolean>('editor.formatOnSaveBeforeRun');
+		const saveReason = formatOnSaveBeforeRunTaskConfig ? SaveReason.EXPLICIT : SaveReason.AUTO;
+		this.editorService.saveAll({ reason: saveReason });
 	}
 
 	//---- focus management

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -379,6 +379,12 @@ configurationRegistry.registerConfiguration({
 			'markdownDescription': nls.localize('formatOnSaveMode', "Controls if format on save formats the whole file or only modifications. Only applies when `#editor.formatOnSave#` is `true`."),
 			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE,
 		},
+		'editor.formatOnSaveBeforeRun': {
+			'type': 'boolean',
+			'markdownDescription': nls.localize('formatOnSaveBeforeRun', "Controls whether formatting on save is also done when saving happens automatically before running a task (if `#task.saveBeforeRun#` is on) or before debugging. Only applies when `#editor.formatOnSave#` is `true`."),
+			'default': true,
+			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE,
+		},
 	}
 });
 

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -1480,7 +1480,9 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		const saveBeforeRunTaskConfig: SaveBeforeRunConfigOptions = this.configurationService.getValue('task.saveBeforeRun');
 
 		const saveAllEditorsAndDoAction = async (): Promise<ReturnType> => {
-			return this.editorService.saveAll({ reason: SaveReason.AUTO }).then(() => {
+			const formatOnSaveBeforeRunTaskConfig = this.configurationService.getValue<boolean>('editor.formatOnSaveBeforeRun');
+			const saveReason = formatOnSaveBeforeRunTaskConfig ? SaveReason.EXPLICIT : SaveReason.AUTO;
+			return this.editorService.saveAll({ reason: saveReason }).then(() => {
 				return action();
 			});
 		};

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2566,16 +2566,14 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			return;
 		}
 
-		ProblemMatcherRegistry.onReady().then(() => {
-			return this.editorService.saveAll({ reason: SaveReason.AUTO }).then(() => { // make sure all dirty editors are saved
-				let executeResult = this.getTaskSystem().rerun();
-				if (executeResult) {
-					return this.handleExecuteResult(executeResult);
-				} else {
-					this.doRunTaskCommand();
-					return Promise.resolve(undefined);
-				}
-			});
+		this.optionallySaveAllEditorsAndDoAction(async () => {
+			let executeResult = this.getTaskSystem().rerun();
+			if (executeResult) {
+				return this.handleExecuteResult(executeResult);
+			} else {
+				this.doRunTaskCommand();
+				return Promise.resolve(undefined);
+			}
 		});
 	}
 


### PR DESCRIPTION
This PR introduces a new setting `editor.formatOnSaveBeforeRun` that controls
whether files that are auto-saved as part of running a task or debugging are
also formatted (if `editor.formatOnSave` is true).

Along the way it fixes the problem that the reRunTask command didn't respect the
`task.saveBeforeRun` setting.

This PR addresses #104296.