### PR TITLE
terminal: fix typeahead leaving stray characters with backspaces 

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
@@ -1092,7 +1092,7 @@ class TypeAheadStyle {
 export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 	private typeaheadStyle = new TypeAheadStyle(this.config.config.localEchoStyle);
 	private typeaheadThreshold = this.config.config.localEchoLatencyThreshold;
-	private lastRow?: { y: number; startingX: number };
+	protected lastRow?: { y: number; startingX: number };
 	private timeline?: PredictionTimeline;
 	public stats?: PredictionStats;
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
@@ -79,8 +79,12 @@ class Cursor implements ICoordinate {
 		this._baseY = buffer.baseY;
 	}
 
+	public getLine() {
+		return this.buffer.getLine(this._y + this._baseY);
+	}
+
 	public getCell(loadInto?: IBufferCell) {
-		return this.buffer.getLine(this._y + this._baseY)?.getCell(this._x, loadInto);
+		return this.getLine()?.getCell(this._x, loadInto);
 	}
 
 	public moveTo(coordinate: ICoordinate) {
@@ -403,17 +407,23 @@ class BackspacePrediction implements IPrediction {
 		pos: ICoordinate;
 		oldAttributes: string;
 		oldChar: string;
+		eol: boolean;
 	};
 
 	constructor(private readonly terminal: Terminal) { }
 
 	public apply(_: IBuffer, cursor: Cursor) {
+		// at eol if everything to the right is whitespace (zsh will emit a "clear line" code in this case)
+		// todo: can be optimized if `getTrimmedLength` is exposed from xterm
+		const eol = !cursor.getLine()?.translateToString(undefined, cursor.x).trim();
+		const pos = cursor.coordinate;
+		const move = cursor.shift(-1);
 		const cell = cursor.getCell();
 		this.appliedAt = cell
-			? { pos: cursor.coordinate, oldAttributes: attributesToSeq(cell), oldChar: cell.getChars() }
-			: { pos: cursor.coordinate, oldAttributes: '', oldChar: '' };
+			? { eol, pos, oldAttributes: attributesToSeq(cell), oldChar: cell.getChars() }
+			: { eol, pos, oldAttributes: '', oldChar: '' };
 
-		return cursor.shift(-1) + DELETE_CHAR;
+		return move + DELETE_CHAR;
 	}
 
 	public rollback(cursor: Cursor) {
@@ -434,8 +444,7 @@ class BackspacePrediction implements IPrediction {
 	}
 
 	public matches(input: StringReader) {
-		const isEOL = this.appliedAt?.oldChar === '';
-		if (isEOL) {
+		if (this.appliedAt?.eol) {
 			const r1 = input.eatGradually(`\b${CSI}K`);
 			if (r1 !== MatchResult.Failure) {
 				return r1;

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
@@ -219,7 +219,7 @@ suite('Workbench - Terminal Typeahead', () => {
 			(addon as any).lastRow = { y: 1, startingX: 1 };
 			t.onData('\x7F');
 			t.expectWritten(`${CSI}2;4H${CSI}X`);
-			expectProcessed('x', `${CSI}?25l${CSI}0ml${CSI}2;4H${CSI}0mx${CSI}?25h`);
+			expectProcessed('x', `${CSI}?25l${CSI}0ml${CSI}2;5H${CSI}0mx${CSI}?25h`);
 			assert.strictEqual(addon.stats?.accuracy, 0);
 		});
 

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
@@ -73,7 +73,7 @@ suite('Workbench - Terminal Typeahead', () => {
 		const onConfigChanged = new Emitter<void>();
 		let publicLog: SinonStub;
 		let config: ITerminalConfiguration;
-		let addon: TypeAheadAddon;
+		let addon: TestTypeAheadAddon;
 
 		const predictedHelloo = [
 			`${CSI}?25l`, // hide cursor
@@ -95,7 +95,7 @@ suite('Workbench - Terminal Typeahead', () => {
 				localEchoLatencyThreshold: 0
 			});
 			publicLog = stub();
-			addon = new TypeAheadAddon(
+			addon = new TestTypeAheadAddon(
 				upcastPartial<ITerminalProcessManager>({ onBeforeProcessData: onBeforeProcessData.event }),
 				upcastPartial<TerminalConfigHelper>({ config, onConfigChanged: onConfigChanged.event }),
 				upcastPartial<ITelemetryService>({ publicLog })
@@ -216,7 +216,7 @@ suite('Workbench - Terminal Typeahead', () => {
 		test('restores old character after invalid backspace', () => {
 			const t = createMockTerminal({ lines: ['hel|lo'] });
 			addon.activate(t.terminal);
-			(addon as any).lastRow = { y: 1, startingX: 1 };
+			addon.unlockLeftNavigating();
 			t.onData('\x7F');
 			t.expectWritten(`${CSI}2;4H${CSI}X`);
 			expectProcessed('x', `${CSI}?25l${CSI}0ml${CSI}2;5H${CSI}0mx${CSI}?25h`);
@@ -263,6 +263,12 @@ suite('Workbench - Terminal Typeahead', () => {
 		});
 	});
 });
+
+class TestTypeAheadAddon extends TypeAheadAddon {
+	public unlockLeftNavigating() {
+		this.lastRow = { y: 1, startingX: 1 };
+	}
+}
 
 function upcastPartial<T>(v: Partial<T>): T {
 	return v as T;


### PR DESCRIPTION
We were moving the cursor _after_ predicting the backspace and capturing whatever old character might have been there. This caused every backspace prediction which failed to roll back incorrectly. In many cases this was hidden since a failed backspace (e.g. midline) would happen when the PTY rewrote the entire line, but in certain cases, mainly backspacing at the end of the line which contained predictions, things could line up where this resulted in missing in incorrect characters in the terminal output.

If a character is restored in this way we would also leave the character's graphics attributes. This is now reset to the current cursor attributes after the character is restored.