### PR TITLE
findExecutable should check PATH in a case-insensitive way

### DIFF
--- a/src/vs/base/common/objects.ts
+++ b/src/vs/base/common/objects.ts
@@ -220,3 +220,9 @@ export function distinct(base: obj, target: obj): obj {
 
 	return result;
 }
+
+export function getCaseInsensitive(target: obj, key: string): any {
+	const lowercaseKey = key.toLowerCase();
+	const equivalentKey = Object.keys(target).find(k => k.toLowerCase() === lowercaseKey);
+	return equivalentKey ? target[equivalentKey] : target[key];
+}

--- a/src/vs/base/test/common/objects.test.ts
+++ b/src/vs/base/test/common/objects.test.ts
@@ -212,4 +212,17 @@ suite('Objects', () => {
 		diff = objects.distinct(base, obj);
 		assert.deepEqual(diff, obj);
 	});
+
+	test('getCaseInsensitive', () => {
+		const obj1 = {
+			lowercase: 123,
+			mIxEdCaSe: 456
+		};
+
+		assert.equal(obj1.lowercase, objects.getCaseInsensitive(obj1, 'lowercase'));
+		assert.equal(obj1.lowercase, objects.getCaseInsensitive(obj1, 'lOwErCaSe'));
+
+		assert.equal(obj1.mIxEdCaSe, objects.getCaseInsensitive(obj1, 'MIXEDCASE'));
+		assert.equal(obj1.mIxEdCaSe, objects.getCaseInsensitive(obj1, 'mixedcase'));
+	});
 });

--- a/src/vs/workbench/contrib/terminal/node/terminalEnvironment.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalEnvironment.ts
@@ -7,6 +7,7 @@ import { IProcessEnvironment, isLinux, isMacintosh, isWindows } from 'vs/base/co
 import { readFile, exists } from 'vs/base/node/pfs';
 import * as path from 'vs/base/common/path';
 import { isString } from 'vs/base/common/types';
+import { getCaseInsensitive } from 'vs/base/common/objects';
 
 let mainProcessParentEnv: IProcessEnvironment | undefined;
 
@@ -94,8 +95,9 @@ export async function findExecutable(command: string, cwd?: string, paths?: stri
 		const fullPath = path.join(cwd, command);
 		return await exists(fullPath) ? fullPath : undefined;
 	}
-	if (paths === undefined && isString(env.PATH)) {
-		paths = env.PATH.split(path.delimiter);
+	const envPath = getCaseInsensitive(env, 'PATH');
+	if (paths === undefined && isString(envPath)) {
+		paths = envPath.split(path.delimiter);
 	}
 	// No PATH environment. Make path absolute to the cwd.
 	if (paths === undefined || paths.length === 0) {


### PR DESCRIPTION
Fix #109863

This is better than the previous PR. When spawning a terminal, we sort of construct two environments, one is only used for findExecutable, the other is what the new terminal gets. The first (previously process.env) is used in a pretty limited way. The second (always just some object) gets mutated and copied. The previous approach of creating a Proxy to guarantee total case-insensitive access is overkill because the first env is used in such a limited way, and because if this mattered for the second (it doesn't), we would lose the proxy by copying properties out of it into another object anyway.

Also, it seems likely that someone could break this again by changing the usage of the first to copy properties into another object in the same way. So, I think we should avoid replicating the magic of process.env and instead change the point of access to be aware of the case issue with PATH. I think we should avoid Proxy magic unless totally necessary.