### PR TITLE
Add ability to ignore snippets (from IntelliSense)

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -15,10 +15,9 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { Snippet, SnippetSource } from 'vs/workbench/contrib/snippets/browser/snippetsFile';
 import { IQuickPickItem, IQuickInputService, QuickPickInput } from 'vs/platform/quickinput/common/quickInput';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { Codicon } from 'vs/base/common/codicons';
+import { Event } from 'vs/base/common/event';
 
-interface ISnippetPick extends IQuickPickItem {
-	snippet: Snippet;
-}
 
 class Args {
 
@@ -91,7 +90,7 @@ class InsertSnippetAction extends EditorAction {
 		const clipboardService = accessor.get(IClipboardService);
 		const quickInputService = accessor.get(IQuickInputService);
 
-		const snippet = await new Promise<Snippet | undefined>(async (resolve, reject) => {
+		const snippet = await new Promise<Snippet | undefined>(async (resolve) => {
 
 			const { lineNumber, column } = editor.getPosition();
 			let { snippet, name, langId } = Args.fromUser(arg);
@@ -129,44 +128,13 @@ class InsertSnippetAction extends EditorAction {
 
 			if (name) {
 				// take selected snippet
-				(await snippetService.getSnippets(languageId)).every(snippet => {
-					if (snippet.name !== name) {
-						return true;
-					}
-					resolve(snippet);
-					return false;
-				});
+				const snippet = (await snippetService.getSnippets(languageId)).find(snippet => snippet.name === name);
+				resolve(snippet);
+
 			} else {
 				// let user pick a snippet
-				const snippets = (await snippetService.getSnippets(languageId)).sort(Snippet.compare);
-				const picks: QuickPickInput<ISnippetPick>[] = [];
-				let prevSnippet: Snippet | undefined;
-				for (const snippet of snippets) {
-					const pick: ISnippetPick = {
-						label: snippet.prefix,
-						detail: snippet.description,
-						snippet
-					};
-					if (!prevSnippet || prevSnippet.snippetSource !== snippet.snippetSource) {
-						let label = '';
-						switch (snippet.snippetSource) {
-							case SnippetSource.User:
-								label = nls.localize('sep.userSnippet', "User Snippets");
-								break;
-							case SnippetSource.Extension:
-								label = nls.localize('sep.extSnippet', "Extension Snippets");
-								break;
-							case SnippetSource.Workspace:
-								label = nls.localize('sep.workspaceSnippet', "Workspace Snippets");
-								break;
-						}
-						picks.push({ type: 'separator', label });
-
-					}
-					picks.push(pick);
-					prevSnippet = snippet;
-				}
-				return quickInputService.pick(picks, { matchOnDetail: true }).then(pick => resolve(pick && pick.snippet), reject);
+				const snippet = await this._pickSnippet(snippetService, quickInputService, languageId);
+				resolve(snippet);
 			}
 		});
 
@@ -178,6 +146,80 @@ class InsertSnippetAction extends EditorAction {
 			clipboardText = await clipboardService.readText();
 		}
 		SnippetController2.get(editor).insert(snippet.codeSnippet, { clipboardText });
+	}
+
+	private async _pickSnippet(snippetService: ISnippetsService, quickInputService: IQuickInputService, languageId: LanguageId): Promise<Snippet | undefined> {
+
+		interface ISnippetPick extends IQuickPickItem {
+			snippet: Snippet;
+		}
+
+		const snippets = (await snippetService.getSnippets(languageId, true)).sort(Snippet.compare);
+
+		const makeSnippetPicks = () => {
+			const result: QuickPickInput<ISnippetPick>[] = [];
+			let prevSnippet: Snippet | undefined;
+			for (const snippet of snippets) {
+				const pick: ISnippetPick = {
+					label: snippet.prefix,
+					detail: snippet.description,
+					snippet
+				};
+				if (!prevSnippet || prevSnippet.snippetSource !== snippet.snippetSource) {
+					let label = '';
+					switch (snippet.snippetSource) {
+						case SnippetSource.User:
+							label = nls.localize('sep.userSnippet', "User Snippets");
+							break;
+						case SnippetSource.Extension:
+							label = nls.localize('sep.extSnippet', "Extension Snippets");
+							break;
+						case SnippetSource.Workspace:
+							label = nls.localize('sep.workspaceSnippet', "Workspace Snippets");
+							break;
+					}
+					result.push({ type: 'separator', label });
+				}
+
+				if (snippet.snippetSource === SnippetSource.Extension) {
+					const isEnabled = snippetService.isEnabled(snippet);
+					if (isEnabled) {
+						pick.buttons = [{
+							iconClass: Codicon.eye.classNames,
+							tooltip: nls.localize('disableSnippet', 'Disable Snippet')
+						}];
+					} else {
+						pick.description = nls.localize('isDisabled', "(disabled)");
+						pick.buttons = [{
+							iconClass: Codicon.eyeClosed.classNames,
+							tooltip: nls.localize('enable.snippet', 'Enable Snippet')
+						}];
+					}
+				}
+
+				result.push(pick);
+				prevSnippet = snippet;
+			}
+			return result;
+		};
+
+		const picker = quickInputService.createQuickPick<ISnippetPick>();
+		picker.placeholder = nls.localize('pick.placeholder', "Select a snippet");
+		picker.matchOnDescription = true;
+		picker.ignoreFocusOut = false;
+		picker.onDidTriggerItemButton(ctx => {
+			const isEnabled = snippetService.isEnabled(ctx.item.snippet);
+			snippetService.updateEnablement(ctx.item.snippet, !isEnabled);
+			picker.items = makeSnippetPicks();
+		});
+		picker.items = makeSnippetPicks();
+		picker.show();
+
+		// wait for an item to be picked or the picker to become hidden
+		await Promise.race([Event.toPromise(picker.onDidAccept), Event.toPromise(picker.onDidHide)]);
+		const result = picker.selectedItems[0]?.snippet;
+		picker.dispose();
+		return result;
 	}
 }
 

--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -186,13 +186,13 @@ class InsertSnippetAction extends EditorAction {
 					if (isEnabled) {
 						pick.buttons = [{
 							iconClass: Codicon.eye.classNames,
-							tooltip: nls.localize('disableSnippet', 'Disable Snippet')
+							tooltip: nls.localize('disableSnippet', 'Hide from IntelliSense')
 						}];
 					} else {
-						pick.description = nls.localize('isDisabled', "(disabled)");
+						pick.description = nls.localize('isDisabled', "(hidden from IntelliSense)");
 						pick.buttons = [{
 							iconClass: Codicon.eyeClosed.classNames,
-							tooltip: nls.localize('enable.snippet', 'Enable Snippet')
+							tooltip: nls.localize('enable.snippet', 'Show in IntelliSense')
 						}];
 					}
 				}

--- a/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
@@ -21,7 +21,7 @@ export interface ISnippetsService {
 
 	isEnabled(snippet: Snippet): boolean;
 
-	updateEnablement(snippet: Snippet, enabled: string): void;
+	updateEnablement(snippet: Snippet, enabled: boolean): void;
 
 	getSnippets(languageId: LanguageId, includeDisabledSnippets?: boolean): Promise<Snippet[]>;
 

--- a/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
@@ -19,9 +19,13 @@ export interface ISnippetsService {
 
 	getSnippetFiles(): Promise<Iterable<SnippetFile>>;
 
-	getSnippets(languageId: LanguageId): Promise<Snippet[]>;
+	isEnabled(snippet: Snippet): boolean;
 
-	getSnippetsSync(languageId: LanguageId): Snippet[];
+	updateEnablement(snippet: Snippet, enabled: string): void;
+
+	getSnippets(languageId: LanguageId, includeDisabledSnippets?: boolean): Promise<Snippet[]>;
+
+	getSnippetsSync(languageId: LanguageId, includeDisabledSnippets?: boolean): Snippet[];
 }
 
 const languageScopeSchemaId = 'vscode://schemas/snippets';

--- a/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
@@ -15,6 +15,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { IdleValue } from 'vs/base/common/async';
 import { IExtensionResourceLoaderService } from 'vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader';
+import { relativePath } from 'vs/base/common/resources';
 
 class SnippetBodyInsights {
 
@@ -86,6 +87,7 @@ export class Snippet {
 		readonly body: string,
 		readonly source: string,
 		readonly snippetSource: SnippetSource,
+		readonly snippetIdentifier?: string
 	) {
 		//
 		this.prefixLow = prefix ? prefix.toLowerCase() : prefix;
@@ -289,7 +291,8 @@ export class SnippetFile {
 				description,
 				body,
 				source,
-				this.source
+				this.source,
+				this._extension && `${relativePath(this._extension.extensionLocation, this.location)}/${name}`
 			));
 		});
 	}

--- a/src/vs/workbench/contrib/snippets/browser/snippetsService.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsService.ts
@@ -207,7 +207,7 @@ class SnippetsService implements ISnippetsService {
 		return !snippet.snippetIdentifier || !this._enablement.isIgnored(snippet.snippetIdentifier);
 	}
 
-	updateEnablement(snippet: Snippet, enabled: string): void {
+	updateEnablement(snippet: Snippet, enabled: boolean): void {
 		if (snippet.snippetIdentifier) {
 			this._enablement.updateIgnored(snippet.snippetIdentifier, !enabled);
 		}

--- a/src/vs/workbench/contrib/snippets/test/browser/snippetsService.test.ts
+++ b/src/vs/workbench/contrib/snippets/test/browser/snippetsService.test.ts
@@ -16,8 +16,7 @@ import { CompletionContext, CompletionTriggerKind } from 'vs/editor/common/modes
 
 class SimpleSnippetService implements ISnippetsService {
 	declare readonly _serviceBrand: undefined;
-	constructor(readonly snippets: Snippet[]) {
-	}
+	constructor(readonly snippets: Snippet[]) { }
 	getSnippets() {
 		return Promise.resolve(this.getSnippetsSync());
 	}
@@ -25,6 +24,12 @@ class SimpleSnippetService implements ISnippetsService {
 		return this.snippets;
 	}
 	getSnippetFiles(): any {
+		throw new Error();
+	}
+	isEnabled(): boolean {
+		throw new Error();
+	}
+	updateEnablement(): void {
 		throw new Error();
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/10565

Add the ability to ignore snippets so that they don't appear in IntelliSense or tab completions. Tho, they can still be inserted via "Insert Snippet" and that's also the place at which ignoring is configure. 

The following gif shows how the `dowhile` TypeScript snippet is being ignored

![Nov-03-2020 16-29-21](https://user-images.githubusercontent.com/1794099/98006384-75c3f600-1df2-11eb-84c9-8d403c14eb6a.gif)

