### PR TITLE
Sanitize Process Environment before spawning terminal instance

### DIFF
--- a/src/vs/workbench/contrib/externalTerminal/node/externalTerminalService.ts
+++ b/src/vs/workbench/contrib/externalTerminal/node/externalTerminalService.ts
@@ -14,6 +14,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { optional } from 'vs/platform/instantiation/common/instantiation';
 import { DEFAULT_TERMINAL_OSX } from 'vs/workbench/contrib/externalTerminal/node/externalTerminal';
 import { FileAccess } from 'vs/base/common/network';
+import { sanitizeProcessEnvironment } from 'vs/base/common/processes';
 
 const TERMINAL_TITLE = nls.localize('console.title', "VS Code Console");
 
@@ -99,6 +100,7 @@ export class WindowsExternalTerminalService implements IExternalTerminalService 
 
 		return new Promise<void>((c, e) => {
 			const env = cwd ? { cwd: cwd } : undefined;
+			if (env !== undefined) { sanitizeProcessEnvironment(env); }
 			const child = spawner.spawn(command, cmdArgs, env);
 			child.on('error', e);
 			child.on('exit', () => c());


### PR DESCRIPTION
This PR fixes #109216

The env is sanitized before spawning the terminal since it probably getting inherited from VS Code.

Steps to Reproduce:

1. Create a sample Electron project.

    In the main process log to console a sample text line

```
    const { app, BrowserWindow } = require('electron')
    ...
    console.log('SAMPLE TEXT LINE')
```

2.  Open VSCode

3.  Launch external terminal CtrlShiftC

4.  Run the electron app

`    electron .`

**Expected:**

It should log

```
electron .
SAMPLE TEXT LINE
```

