### PR TITLE
disable submenus rendered as dropdowns

### DIFF
--- a/src/vs/base/browser/ui/dropdown/dropdown.css
+++ b/src/vs/base/browser/ui/dropdown/dropdown.css
@@ -12,3 +12,7 @@
 	cursor: pointer;
 	height: 100%;
 }
+
+.monaco-dropdown > .dropdown-label > .action-label.disabled {
+	cursor: default;
+}

--- a/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
+++ b/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
@@ -140,24 +140,10 @@ export class DropdownMenuActionViewItem extends BaseActionViewItem {
 		}
 	}
 
-	updateEnabled(): void {
-		if (this.getAction().enabled) {
-			if (this.actionItem) {
-				this.actionItem.classList.remove('disabled');
-			}
-
-			if (this.element) {
-				this.element.classList.remove('disabled');
-			}
-		} else {
-			if (this.actionItem) {
-				this.actionItem.classList.add('disabled');
-			}
-
-			if (this.element) {
-				this.element.classList.add('disabled');
-			}
-		}
+	protected updateEnabled(): void {
+		const disabled = !this.getAction().enabled;
+		this.actionItem?.classList.toggle('disabled', disabled);
+		this.element?.classList.toggle('disabled', disabled);
 	}
 }
 

--- a/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
+++ b/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
@@ -35,6 +35,7 @@ export class DropdownMenuActionViewItem extends BaseActionViewItem {
 	private menuActionsOrProvider: readonly IAction[] | IActionProvider;
 	private dropdownMenu: DropdownMenu | undefined;
 	private contextMenuProvider: IContextMenuProvider;
+	private actionItem: HTMLElement | null = null;
 
 	private _onDidChangeVisibility = this._register(new Emitter<boolean>());
 	readonly onDidChangeVisibility = this._onDidChangeVisibility.event;
@@ -56,6 +57,8 @@ export class DropdownMenuActionViewItem extends BaseActionViewItem {
 	}
 
 	render(container: HTMLElement): void {
+		this.actionItem = container;
+
 		const labelRenderer: ILabelRenderer = (el: HTMLElement): IDisposable | null => {
 			this.element = append(el, $('a.action-label'));
 
@@ -115,6 +118,8 @@ export class DropdownMenuActionViewItem extends BaseActionViewItem {
 				}
 			};
 		}
+
+		this.updateEnabled();
 	}
 
 	setActionContext(newContext: unknown): void {
@@ -132,6 +137,26 @@ export class DropdownMenuActionViewItem extends BaseActionViewItem {
 	show(): void {
 		if (this.dropdownMenu) {
 			this.dropdownMenu.show();
+		}
+	}
+
+	updateEnabled(): void {
+		if (this.getAction().enabled) {
+			if (this.actionItem) {
+				this.actionItem.classList.remove('disabled');
+			}
+
+			if (this.element) {
+				this.element.classList.remove('disabled');
+			}
+		} else {
+			if (this.actionItem) {
+				this.actionItem.classList.add('disabled');
+			}
+
+			if (this.element) {
+				this.element.classList.add('disabled');
+			}
 		}
 	}
 }

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -777,6 +777,12 @@ class SubmenuMenuActionViewItem extends BaseMenuActionViewItem {
 		}));
 	}
 
+	updateEnabled(): void {
+		// override on submenu entry
+		// native menus do not observe enablement on sumbenus
+		// we mimic that behavior
+	}
+
 	open(selectFirst?: boolean): void {
 		this.cleanupExistingSubmenu(false);
 		this.createSubmenu(selectFirst);

--- a/src/vs/base/common/actions.ts
+++ b/src/vs/base/common/actions.ts
@@ -242,7 +242,7 @@ export class SubmenuAction extends Action {
 	}
 
 	constructor(id: string, label: string, private _actions: IAction[], cssClass?: string) {
-		super(id, label, cssClass, true);
+		super(id, label, cssClass, !!_actions?.length);
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #109701

In PR to review the behavior:

For regular submenus, do what native has always done and show an empty menu with a single disabled item.
For icon/dropdown submenus, disable the item if there are no entries provided
