### PR TITLE
Enforce editor options from lists/trees in extension commands

### DIFF
--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -100,7 +100,7 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { IDiffEditor } from 'vs/editor/common/editorCommon';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { QuickInputService } from 'vs/workbench/services/quickinput/browser/quickInputService';
-import { IListService } from 'vs/platform/list/browser/listService';
+import { IListService, IOpenEvent } from 'vs/platform/list/browser/listService';
 import { win32, posix } from 'vs/base/common/path';
 import { TestWorkingCopyService, TestContextService, TestStorageService, TestTextResourcePropertiesService, TestExtensionService } from 'vs/workbench/test/common/workbenchTestServices';
 import { IViewsService, IView, ViewContainer, ViewContainerLocation } from 'vs/workbench/common/views';
@@ -1234,9 +1234,17 @@ export class TestEditorPart extends EditorPart {
 }
 
 export class TestListService implements IListService {
+
 	declare readonly _serviceBrand: undefined;
 
 	lastFocusedList: any | undefined = undefined;
+	lastOpenContext: IOpenEvent<unknown> | undefined = undefined;
+
+	setOpenContext(context: IOpenEvent<unknown>): IDisposable {
+		this.lastOpenContext = context;
+
+		return Disposable.None;
+	}
 
 	register(): IDisposable {
 		return Disposable.None;


### PR DESCRIPTION
This is a continuation of https://github.com/microsoft/vscode/issues/109779 specifically for extensions (see https://github.com/microsoft/vscode/issues/85636 and https://github.com/microsoft/vscode/issues/101522).

We have 3 built in components that open editors from tree usages:
* custom trees (e.g. references view)
* timeline
* changes view

None of these currently have a way to enforce our list/tree options, specifically wether to:
* preserve focus
* open pinned or as preview
* open to the side

We discussed this in the API call yesterday and concluded that we should build a solution that does not require any adoption because we know an adoption will not happen for all extensions.

As such, if we keep the context of the user gesture for the duration of the command invocation and enforce it in very specific dedicated places where we know that an editor opens (`vscode.open`, `vscode.diff`), we can solve this for most cases.

My first solution was to add this entirely into `mainThreadEditors` but I felt it is wrong that e.g. custom trees, timeline and changes view depend on it. So now I made this API in `IListService` and want to put it out here to get some initial feedback. A slight variant I had in mind but did not push for is to let the `IListService` itself remember each open event for a specific duration, but that also felt wrong given that we only need this in very few places and not all trees/lists.

@joaomoreno mainly asking you for feedback if this direction is OK from the POV of list service and @jrieken for the hook in the extension commands (`vscode.open`, `vscode.diff`)

//cc @eamodio @alexr00 
