### PR TITLE
Use Array.flat()

### DIFF
--- a/extensions/markdown-language-features/src/features/foldingProvider.ts
+++ b/extensions/markdown-language-features/src/features/foldingProvider.ts
@@ -7,7 +7,6 @@ import { Token } from 'markdown-it';
 import * as vscode from 'vscode';
 import { MarkdownEngine } from '../markdownEngine';
 import { TableOfContentsProvider } from '../tableOfContentsProvider';
-import { flatten } from '../util/arrays';
 
 const rangeLimit = 5000;
 
@@ -27,7 +26,7 @@ export default class MarkdownFoldingProvider implements vscode.FoldingRangeProvi
 			this.getHeaderFoldingRanges(document),
 			this.getBlockFoldingRanges(document)
 		]);
-		return flatten(foldables).slice(0, rangeLimit);
+		return foldables.flat().slice(0, rangeLimit);
 	}
 
 	private async getRegions(document: vscode.TextDocument): Promise<vscode.FoldingRange[]> {

--- a/extensions/markdown-language-features/src/features/workspaceSymbolProvider.ts
+++ b/extensions/markdown-language-features/src/features/workspaceSymbolProvider.ts
@@ -9,7 +9,6 @@ import { isMarkdownFile } from '../util/file';
 import { Lazy, lazy } from '../util/lazy';
 import MDDocumentSymbolProvider from './documentSymbolProvider';
 import { SkinnyTextDocument, SkinnyTextLine } from '../tableOfContentsProvider';
-import { flatten } from '../util/arrays';
 
 export interface WorkspaceMarkdownDocumentProvider {
 	getAllMarkdownDocuments(): Thenable<Iterable<SkinnyTextDocument>>;
@@ -136,7 +135,7 @@ export default class MarkdownWorkspaceSymbolProvider extends Disposable implemen
 		}
 
 		const allSymbolsSets = await Promise.all(Array.from(this._symbolCache.values()).map(x => x.value));
-		const allSymbols = flatten(allSymbolsSets);
+		const allSymbols = allSymbolsSets.flat();
 		return allSymbols.filter(symbolInformation => symbolInformation.name.toLowerCase().indexOf(query.toLowerCase()) !== -1);
 	}
 

--- a/extensions/markdown-language-features/src/util/arrays.ts
+++ b/extensions/markdown-language-features/src/util/arrays.ts
@@ -16,7 +16,3 @@ export function equals<T>(one: ReadonlyArray<T>, other: ReadonlyArray<T>, itemEq
 
 	return true;
 }
-
-export function flatten<T>(arr: ReadonlyArray<T>[]): T[] {
-	return ([] as T[]).concat.apply([], arr);
-}

--- a/extensions/markdown-language-features/tsconfig.json
+++ b/extensions/markdown-language-features/tsconfig.json
@@ -6,6 +6,7 @@
 		"lib": [
 			"es6",
 			"es2015.promise",
+			"es2019.array",
 			"es2020.string",
 			"dom"
 		]


### PR DESCRIPTION
Use `Array.flat()` in `markdown-language-features` extension and drop the util.

I believe they should be functionally equivalent and so this should be safe. I tested a few cases by hand, and I also ran the existing implementation (which is removed in this PR) against the Test262 conformance tests for the functional aspects and it produced the same results.