### PR TITLE
Fixes terminal lags while scrollling when printing long line

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalValidatedLocalLinkProvider.ts
@@ -49,6 +49,8 @@ export const unixLineAndColumnMatchIndex = 11;
 // Each line and column clause have 6 groups (ie no. of expressions in round brackets)
 export const lineAndColumnClauseGroupCount = 6;
 
+const MAX_LENGTH = 2000;
+
 export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider {
 	constructor(
 		private readonly _xterm: Terminal,
@@ -85,6 +87,9 @@ export class TerminalValidatedLocalLinkProvider extends TerminalBaseLinkProvider
 		}
 
 		const text = getXtermLineContent(this._xterm.buffer.active, startLine, endLine, this._xterm.cols);
+		if (text.length > MAX_LENGTH) {
+			return [];
+		}
 
 		// clone regex to do a global search on text
 		const rex = new RegExp(this._localLinkRegex, 'g');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #100338

Copied the string max length from
https://github.com/microsoft/vscode/blob/776541c380657f8e1bf9f4acc459a33d84f755bd/src/vs/workbench/contrib/debug/browser/linkDetector.ts#L27
