### PR TITLE
Re-shows existing hover (if visible) on show action

### DIFF
--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -224,8 +224,8 @@ export class ModesHoverController implements IEditorContribution {
 		this._glyphWidget.value = new ModesGlyphHoverWidget(this._editor, this._modeService, this._openerService);
 	}
 
-	public showContentHover(range: Range, mode: HoverStartMode, focus: boolean): void {
-		this.contentWidget.startShowingAt(range, mode, focus);
+	public showContentHover(range: Range, mode: HoverStartMode, focus: boolean, force?: boolean): void {
+		this.contentWidget.startShowingAt(range, mode, focus, force);
 	}
 
 	public dispose(): void {
@@ -267,10 +267,22 @@ class ShowHoverAction extends EditorAction {
 		if (!controller) {
 			return;
 		}
-		const position = editor.getPosition();
-		const range = new Range(position.lineNumber, position.column, position.lineNumber, position.column);
+
+		let force;
+		let range;
+		const hp = controller.contentWidget.getPosition();
+		if (hp?.range) {
+			force = true;
+			range = new Range(hp.range.startLineNumber, hp.range.startColumn, hp.range.endLineNumber, hp.range.endColumn);
+		} else if (hp?.position) {
+			force = true;
+			range = new Range(hp.position.lineNumber, hp.position.column, hp.position.lineNumber, hp.position.column);
+		} else {
+			const position = editor.getPosition();
+			range = new Range(position.lineNumber, position.column, position.lineNumber, position.column);
+		}
 		const focus = editor.getOption(EditorOption.accessibilitySupport) === AccessibilitySupport.Enabled;
-		controller.showContentHover(range, HoverStartMode.Immediate, focus);
+		controller.showContentHover(range, HoverStartMode.Immediate, focus, force);
 	}
 }
 

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -278,8 +278,8 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 		}
 	}
 
-	startShowingAt(range: Range, mode: HoverStartMode, focus: boolean): void {
-		if (this._lastRange && this._lastRange.equalsRange(range)) {
+	startShowingAt(range: Range, mode: HoverStartMode, focus: boolean, force: boolean = false): void {
+		if (!force && this._lastRange && this._lastRange.equalsRange(range)) {
 			// We have to show the widget at the exact same range as before, so no work is needed
 			return;
 		}


### PR DESCRIPTION
This will allow the `editor.action.showHover` command to re-show an existing visible hover (if there is one) when the command is run. This provides extension (e.g. GitLens) with a mechanism to "refresh" a showing hover.

I am looking for this, because in GitLens I have a new PR feature, which shows the PR associated with the commit in the hover. And I only wait a short time for that query to finishing before showing the hover (to not impact the user experience), and then if the query doesn't finish in time, I want to refresh the hover when it completes.
