### PR TITLE
Error if a new ScopedContextKeyService conflicts with an existing ScopedContextKeyService

### DIFF
--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -405,6 +405,9 @@ class ScopedContextKeyService extends AbstractContextKeyService {
 
 		if (domNode) {
 			this._domNode = domNode;
+			if (this._domNode.hasAttribute(KEYBINDING_CONTEXT_ATTR)) {
+				throw new Error('Element already has context attribute');
+			}
 			this._domNode.setAttribute(KEYBINDING_CONTEXT_ATTR, String(this._myContextId));
 		}
 	}


### PR DESCRIPTION
`ScopedContextKeyService` stores values using a dom attribute. This means that if you create two ScopedContextKeyService instances on a node, the second instance will end up effecting the first.

This seems unexpected to me and cause a lot of confusion while working  on c8877809c95b7eba887ec4269ce99de94fdb14c7. The specific bug I hit:

- Create scoped service A on an element
- Create scoped service B on the same element
- Dispose of scoped service A
- This also ends up clearing the context storage value for scoped service B

This PR makes creating a scoped context key service on a dom node that already has a scoped context key service throw an error
