### PR TITLE
Fix progress bit overflow bug

### DIFF
--- a/src/vs/base/browser/ui/progressbar/progressbar.css
+++ b/src/vs/base/browser/ui/progressbar/progressbar.css
@@ -45,7 +45,7 @@
  * parent width: 5000%
  *    bit width: 100%
  * translateX should be as follow:
- *  50%: 5000% * 50% = 2500%
- * 100%: 5000% * 100% - 100% (do not overflow): 4900%
+ *  50%: 5000% * 50% - 50% (set to center) = 2450%
+ * 100%: 5000% * 100% - 100% (do not overflow) = 4900%
  */
 @keyframes progress { from { transform: translateX(0%) scaleX(1) } 50% { transform: translateX(2500%) scaleX(3) } to { transform: translateX(4900%) scaleX(1) } }

--- a/src/vs/base/browser/ui/progressbar/progressbar.css
+++ b/src/vs/base/browser/ui/progressbar/progressbar.css
@@ -42,7 +42,10 @@
  * The progress bit has a width: 2% (1/50) of the parent container. The animation moves it from 0% to 100% of
  * that container. Since translateX is relative to the progress bit size, we have to multiple it with
  * its relative size to the parent container:
- *  50%: 50 * 50 = 2500%
- * 100%: 50 * 100 - 50 (do not overflow): 4950%
+ * parent width: 5000%
+ *    bit width: 100%
+ * translateX should be as follow:
+ *  50%: 5000% * 50% = 2500%
+ * 100%: 5000% * 100% - 100% (do not overflow): 4900%
  */
-@keyframes progress { from { transform: translateX(0%) scaleX(1) } 50% { transform: translateX(2500%) scaleX(3) } to { transform: translateX(4950%) scaleX(1) } }
+@keyframes progress { from { transform: translateX(0%) scaleX(1) } 50% { transform: translateX(2500%) scaleX(3) } to { transform: translateX(4900%) scaleX(1) } }


### PR DESCRIPTION
parent width: 5000%
progress bit width: 100%
translateX should be:

```
  50%: 5000% * 50% = 2500%
 100%: 5000% * 100% - 100% (do not overflow): 4900%
```

`translateX(4950%)` will make half of progress bit overflow. :p

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
