### PR TITLE
clarify effect of command enablement

### DIFF
--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -461,7 +461,7 @@ namespace schema {
 				type: 'string'
 			},
 			enablement: {
-				description: localize('vscode.extension.contributes.commandType.precondition', '(Optional) Condition which must be true to enable the command'),
+				description: localize('vscode.extension.contributes.commandType.precondition', '(Optional) Condition which must be true to enable the command in the UI. Does not affect executing the command by other means'),
 				type: 'string'
 			},
 			icon: {


### PR DESCRIPTION
Tweaks the wording for `enablement`'s description to be more clear on what will be affected. That property only affects the UI, which is not clear to extension developers from the current description.