### PR TITLE
config: disallow nested config resolver keys

### DIFF
--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -28,6 +28,7 @@ export interface IVariableResolveContext {
 
 export class AbstractVariableResolverService implements IConfigurationResolverService {
 
+	static readonly VARIABLE_LHS = '${';
 	static readonly VARIABLE_REGEXP = /\$\{(.*?)\}/g;
 
 	declare readonly _serviceBrand: undefined;
@@ -130,6 +131,10 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 
 		// loop through all variables occurrences in 'value'
 		const replaced = value.replace(AbstractVariableResolverService.VARIABLE_REGEXP, (match: string, variable: string) => {
+			// disallow attempted nesting, see #77289
+			if (variable.includes(AbstractVariableResolverService.VARIABLE_LHS)) {
+				return match;
+			}
 
 			let resolvedValue = this.evaluateSingleVariable(match, variable, folderUri, commandValueMapping);
 

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -175,6 +175,10 @@ suite('Configuration Resolver Service', () => {
 		}
 	});
 
+	test('disallows nested keys (#77289)', () => {
+		assert.strictEqual(configurationResolverService!.resolve(workspace, '${env:key1} ${env:key1${env:key2}}'), 'Value for key1 ${env:key1${env:key2}}');
+	});
+
 	// test('substitute keys and values in object', () => {
 	// 	const myObject = {
 	// 		'${workspaceRootFolderName}': '${lineNumber}',


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/77289. Will no-op if a key looks like it's nested.

Alternately, we _could_ decide to support nested keys with relative ease if we switch from a regex to a manual parsing loop. Either way -- right now, as reference, nested keys just half-work.