### PR TITLE
Fix argv.json proposed api flag

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -226,12 +226,6 @@ function configureCommandlineSwitchesSync(cliArgs) {
 		SUPPORTED_ELECTRON_SWITCHES.push('force-renderer-accessibility');
 	}
 
-	const SUPPORTED_MAIN_PROCESS_SWITCHES = [
-
-		// Persistently enable proposed api via argv.json: https://github.com/microsoft/vscode/issues/99775
-		'enable-proposed-api'
-	];
-
 	// Read argv config
 	const argvConfig = readArgvConfigSync();
 
@@ -254,17 +248,6 @@ function configureCommandlineSwitchesSync(cliArgs) {
 					app.disableHardwareAcceleration(); // needs to be called explicitly
 				} else {
 					app.commandLine.appendSwitch(argvKey);
-				}
-			}
-		}
-
-		// Append main process flags to process.argv
-		else if (SUPPORTED_MAIN_PROCESS_SWITCHES.indexOf(argvKey) !== -1) {
-			if (argvKey === 'enable-proposed-api') {
-				if (Array.isArray(argvValue)) {
-					argvValue.forEach(id => id && typeof id === 'string' && process.argv.push('--enable-proposed-api', id));
-				} else {
-					console.error(`Unexpected value for \`enable-proposed-api\` in argv.json. Expected array of extension ids.`);
 				}
 			}
 		}

--- a/src/vs/workbench/services/extensions/browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/browser/extensionService.ts
@@ -177,8 +177,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 			this._remoteAgentService.getEnvironment(),
 			this._remoteAgentService.scanExtensions()
 		]);
-		localExtensions = this._checkEnabledAndProposedAPI(localExtensions);
-		remoteExtensions = this._checkEnabledAndProposedAPI(remoteExtensions);
+		[localExtensions, remoteExtensions] = await Promise.all([this._checkEnabledAndProposedAPI(localExtensions), this._checkEnabledAndProposedAPI(remoteExtensions)]);
 
 		const remoteAgentConnection = this._remoteAgentService.getConnection();
 		this._runningLocation = this._runningLocationClassifier.determineRunningLocation(localExtensions, remoteExtensions);

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -123,7 +123,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 		return {
 			getInitData: async () => {
 				if (isInitialStart) {
-					const localExtensions = this._checkEnabledAndProposedAPI(await this._scanAllLocalExtensions());
+					const localExtensions = await this._checkEnabledAndProposedAPI(await this._scanAllLocalExtensions());
 					const runningLocation = this._runningLocationClassifier.determineRunningLocation(localExtensions, []);
 					const localProcessExtensions = filterByRunningLocation(localExtensions, runningLocation, desiredRunningLocation);
 					return {
@@ -283,7 +283,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 		const remoteAuthority = this._environmentService.remoteAuthority;
 		const localProcessExtensionHost = this._getExtensionHostManager(ExtensionHostKind.LocalProcess)!;
 
-		const localExtensions = this._checkEnabledAndProposedAPI(await this._scanAllLocalExtensions());
+		const localExtensions = await this._checkEnabledAndProposedAPI(await this._scanAllLocalExtensions());
 		let remoteEnv: IRemoteAgentEnvironment | null = null;
 		let remoteExtensions: IExtensionDescription[] = [];
 
@@ -328,7 +328,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 				this._remoteAgentService.getEnvironment(),
 				this._remoteAgentService.scanExtensions()
 			]);
-			remoteExtensions = this._checkEnabledAndProposedAPI(remoteExtensions);
+			remoteExtensions = await this._checkEnabledAndProposedAPI(remoteExtensions);
 
 			if (!remoteEnv) {
 				this._notificationService.notify({ severity: Severity.Error, message: nls.localize('getEnvironmentFailure', "Could not fetch remote environment") });


### PR DESCRIPTION
This PR fixes #106427

Previously we had checked `argv.json` once at startup in `src/main.js`, however in some cases the changes made to `process.argv` aren't captured by the environment service (#106427). 

With this PR, argv.json is directly read by the `ProposedApiController`, which requires threading some new `async`/`await`s around but doesn't make any previously sync routines async.

cc @bpasero 