### PR TITLE
Fix requirejs in notebooks

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -322,6 +322,7 @@ export class BackLayerWebView extends Disposable {
 					self.require = {};
 				</script>
 				${coreDependencies}
+				<div id="__vscode_preloads"></div>
 				<div id='container' class="widgetarea" style="position: absolute;width:100%;top: 0px"></div>
 				<script>${preloadsScriptStr(outputNodePadding)}</script>
 			</body>

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -491,7 +491,7 @@ function webviewPreloads() {
 					scriptTag.setAttribute('src', uri);
 					preloadsContainer.appendChild(scriptTag);
 					preloadPromises.set(uri, new Promise<PreloadResult>(resolve => {
-						scriptTag.addEventListener('load', () => resolve(undefined));
+						scriptTag.addEventListener('load', () => resolve({ state: PreloadState.Ok }));
 						scriptTag.addEventListener('error', () =>
 							resolve({ state: PreloadState.Error, error: `Network error loading ${originalUri}, does the path exist?` })
 						);

--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -147,7 +147,7 @@
 	function getVsCodeApiScript(allowMultipleAPIAcquire, state) {
 		const encodedState = state ? encodeURIComponent(state) : undefined;
 		return `
-			globalThis.acquireVsCodeApi = (function() {
+			const acquireVsCodeApi = (function() {
 				const originalPostMessage = window.parent.postMessage.bind(window.parent);
 				const targetOrigin = '*';
 				let acquired = false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #https://github.com/microsoft/vscode/issues/110503

Rolling back https://github.com/microsoft/vscode/commit/c0289ea182a92d7bbf39813a9969ff24e89231bd#diff-d1114c772903dc03edfb17b438bb7a9f5ada02012dcaf65b469a6b6ca6a1a527 seems to fix the issue. 

I'm guessing this may break other things though. 

In order to test this, you'd need an extension that provides kernels for a notebook and in its preload scripts, attempt to find the window.requirejs.

This fix makes it possible for the jupyter extension to support ipywidgets in notebooks.
