### PR TITLE
Enforce validity of theme icon references for commands

### DIFF
--- a/src/vs/platform/theme/common/themeService.ts
+++ b/src/vs/platform/theme/common/themeService.ts
@@ -33,14 +33,22 @@ export namespace ThemeIcon {
 		return obj && typeof obj === 'object' && typeof (<ThemeIcon>obj).id === 'string';
 	}
 
-	const _regexFromString = /^\$\(([a-z.]+\/)?([a-z-~]+)\)$/i;
+	const _regexFromString = /^\$\(([a-z.]+\/)?(([a-z0-9\-]+?)(?:~([a-z0-9\-]*?))?)\)$/i;
 
-	export function fromString(str: string): ThemeIcon | undefined {
+	export function isInvalidReference(str: string): boolean {
+		const match = _regexFromString.exec(str);
+		if (!match) {
+			return false;
+		}
+		return match[4] !== undefined;
+	}
+
+	export function fromString(str: string): ThemeIcon | null | undefined {
 		const match = _regexFromString.exec(str);
 		if (!match) {
 			return undefined;
 		}
-		let [, owner, name] = match;
+		let [, owner, , name] = match;
 		if (!owner) {
 			owner = `codicon/`;
 		}

--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -421,6 +421,10 @@ namespace schema {
 			return true;
 		}
 		if (typeof icon === 'string') {
+			if (ThemeIcon.isInvalidReference(icon)) {
+				collector.error(localize('invalidThemeIconReference', "property `icon` is not a valid theme icon reference - animations aren't supported"));
+				return false;
+			}
 			return true;
 		} else if (typeof icon.dark === 'string' && typeof icon.light === 'string') {
 			return true;


### PR DESCRIPTION
Two things:

* Aligns regex with one in `src\vs\base\common\codicons.ts`, mainly that it allows numbers in the name
* Enforce no animations in the icon reference (e.g. `~spin`)

Right now there's very little error checking or feedback for the icon property on contributed commands. Referencing non-existent icons will silently succeed, adding an animation will silently succeed, etc. This seeks to add a little bit of sanity checking by telling developers that `~spin` is invalid, rather than leaving them to figure it out themselves. Without this, icon references such as `$(loading~spin)` will show the icon, but with no animation, which is confusing and a subpar DX.

It would be nice if it could also enforce a valid icon name, but that's more involved, and I don't know if all of that information is available at checking time.