### PR TITLE
Mark .ember-cli as jsonc instead of json

### DIFF
--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -33,8 +33,7 @@
         ],
         "filenames": [
           "composer.lock",
-          ".watchmanconfig",
-          ".ember-cli"
+          ".watchmanconfig"
         ],
         "mimetypes": [
           "application/json",
@@ -56,6 +55,9 @@
           ".swcrc",
           ".hintrc",
           ".babelrc"
+        ],
+        "filenames": [
+          ".ember-cli"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
The .ember-cli file generated by Ember is JSON with Comments (jsonc): https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/.ember-cli

I've changed its associated language accordingly because it being the JSON type by default causes red underlines in the generated file.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #110540
