### PR TITLE
Add command to manage proposed api enablement

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -226,12 +226,6 @@ function configureCommandlineSwitchesSync(cliArgs) {
 		SUPPORTED_ELECTRON_SWITCHES.push('force-renderer-accessibility');
 	}
 
-	const SUPPORTED_MAIN_PROCESS_SWITCHES = [
-
-		// Persistently enable proposed api via argv.json: https://github.com/microsoft/vscode/issues/99775
-		'enable-proposed-api'
-	];
-
 	// Read argv config
 	const argvConfig = readArgvConfigSync();
 
@@ -254,17 +248,6 @@ function configureCommandlineSwitchesSync(cliArgs) {
 					app.disableHardwareAcceleration(); // needs to be called explicitly
 				} else {
 					app.commandLine.appendSwitch(argvKey);
-				}
-			}
-		}
-
-		// Append main process flags to process.argv
-		else if (SUPPORTED_MAIN_PROCESS_SWITCHES.indexOf(argvKey) !== -1) {
-			if (argvKey === 'enable-proposed-api') {
-				if (Array.isArray(argvValue)) {
-					argvValue.forEach(id => id && typeof id === 'string' && process.argv.push('--enable-proposed-api', id));
-				} else {
-					console.error(`Unexpected value for \`enable-proposed-api\` in argv.json. Expected array of extension ids.`);
 				}
 			}
 		}

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -380,13 +380,6 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 			'crash-reporter-id': {
 				type: 'string',
 				markdownDescription: nls.localize('argv.crashReporterId', 'Unique id used for correlating crash reports sent from this app instance.')
-			},
-			'enable-proposed-api': {
-				type: 'array',
-				description: nls.localize('argv.enebleProposedApi', "Enable proposed APIs for a list of extension ids (such as \`vscode.git\`). Proposed APIs are unstable and subject to breaking without warning at any time. This should only be set for extension development and testing purposes."),
-				items: {
-					type: 'string'
-				}
 			}
 		}
 	};

--- a/src/vs/workbench/services/extensions/browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/browser/extensionService.ts
@@ -28,6 +28,7 @@ import { IExtensionManagementService } from 'vs/platform/extensionManagement/com
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { ExtensionHostManager } from 'vs/workbench/services/extensions/common/extensionHostManager';
 import { ExtensionHostExitCode } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { IStorageService } from 'vs/platform/storage/common/storage';
 
 export class ExtensionService extends AbstractExtensionService implements IExtensionService {
 
@@ -49,6 +50,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 		@IRemoteAgentService private readonly _remoteAgentService: IRemoteAgentService,
 		@IWebExtensionsScannerService private readonly _webExtensionsScannerService: IWebExtensionsScannerService,
 		@ILifecycleService private readonly _lifecycleService: ILifecycleService,
+		@IStorageService storageService: IStorageService,
 	) {
 		super(
 			new ExtensionRunningLocationClassifier(
@@ -66,6 +68,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 			extensionManagementService,
 			contextService,
 			configurationService,
+			storageService,
 		);
 
 		this._runningLocation = new Map<string, ExtensionRunningLocation>();

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -911,7 +911,7 @@ if (product.quality !== 'stable') {
 			const extensions = await accessor.get(IExtensionService).getExtensions();
 
 			const confirmation = await dialogService.confirm({
-				message: nls.localize('manageProposedApiWarning', "Use Proposed API during development only"),
+				message: nls.localize('manageProposedApiWarning', "Proposed API is Unstable"),
 				detail: nls.localize('manageProposedApiWarningDetail', "Extensions using Proposed API are subject to break at any point, without warning.\n\nProposed API should only be enabled for testing extensions under active development."),
 			});
 

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -913,6 +913,7 @@ if (product.quality !== 'stable') {
 			const confirmation = await dialogService.confirm({
 				message: nls.localize('manageProposedApiWarning', "Proposed API is Unstable"),
 				detail: nls.localize('manageProposedApiWarningDetail', "Extensions using Proposed API are subject to break at any point, without warning.\n\nProposed API should only be enabled for testing extensions under active development."),
+				primaryButton: nls.localize('continue', "Continue")
 			});
 
 			if (!confirmation.confirmed) { return; }

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -33,7 +33,7 @@ import { getExtensionKind } from 'vs/workbench/services/extensions/common/extens
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { Schemas } from 'vs/base/common/network';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
-import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
+import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
 import { CATEGORIES } from 'vs/workbench/common/actions';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
@@ -957,6 +957,7 @@ registerAction2(class extends Action2 {
 
 		if (!grant) { return; }
 		enabledProposedApiStorage.extensions = grant.map(grant => grant.label);
+		notificationService.info(nls.localize('restartRequired', "Changes require restart to take effect."));
 	}
 });
 

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -908,6 +908,11 @@ registerAction2(class extends Action2 {
 		const dialogService = accessor.get(IDialogService);
 		const notificationService = accessor.get(INotificationService);
 
+		if (productService.quality === 'stable') {
+			notificationService.error(nls.localize('notAvailableInStable', "Managing Proposed API is not available outside of VS Code Insiders"));
+			return;
+		}
+
 		const enabledProposedApiStorage = new GlobalyEnabledProposedAPIStorage(accessor.get(IStorageService), accessor.get(IConfigurationService));
 		const extensions = await accessor.get(IExtensionService).getExtensions();
 

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -40,6 +40,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { CATEGORIES } from 'vs/workbench/common/actions';
 import { Schemas } from 'vs/base/common/network';
 import { ExtensionHostExitCode } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { IStorageService } from 'vs/platform/storage/common/storage';
 
 export class ExtensionService extends AbstractExtensionService implements IExtensionService {
 
@@ -67,6 +68,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 		@IRemoteExplorerService private readonly _remoteExplorerService: IRemoteExplorerService,
 		@IExtensionGalleryService private readonly _extensionGalleryService: IExtensionGalleryService,
 		@ILogService private readonly _logService: ILogService,
+		@IStorageService storageService: IStorageService,
 	) {
 		super(
 			new ExtensionRunningLocationClassifier(
@@ -84,6 +86,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 			extensionManagementService,
 			contextService,
 			configurationService,
+			storageService,
 		);
 
 		this._enableLocalWebWorker = this._configurationService.getValue<boolean>(webWorkerExtHostConfig);


### PR DESCRIPTION
This PR fixes #106427. Well not really because we disallow it in stable, but it fixes the part where it broke in Insiders too.

New model: 
1. User sets hidden setting `"extensions.enableProposedAPIOverride": true`
2. Command "Developer: Manage Proposed API for Extensions" becomes available
3. Upon running the command, a big scary warning is shown:
![image](https://user-images.githubusercontent.com/8586769/99138412-301ede80-25e5-11eb-9051-729e2d3e1dd2.png)
4. Upon accepting, user can pick from a set of extensions which have requested proposed api but are not granted it via product.json/being builtin/etc. (some extra entries are shown here as they aren't in OSS's `product.json`)
![image](https://user-images.githubusercontent.com/8586769/99138446-65c3c780-25e5-11eb-8637-9974d8c321e6.png)
5. Upon choosing which extensions to enable, user gets notification to restart:
![image](https://user-images.githubusercontent.com/8586769/99138636-e0411700-25e6-11eb-99fa-e00080dd8d25.png)


The list of overrides is stored in local storage, so we can't access it from the `EnvironmentService` (sad @jrieken), but also it doesn't require a file read (happy @alexdima). Also I got rid of all of the modifications to `argv.json` (happy @bpasero)