### PR TITLE
don't open file on paste

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -1302,9 +1302,6 @@ export const pasteFileHandler = async (accessor: ServicesAccessor) => {
 
 		if (stats.length >= 1) {
 			const stat = stats[0];
-			if (stat && !stat.isDirectory && stats.length === 1) {
-				await editorService.openEditor({ resource: stat.resource, options: { pinned: true, preserveFocus: true } });
-			}
 			if (stat) {
 				await explorerService.select(stat.resource);
 			}


### PR DESCRIPTION
when pasting a file in the explorer vscode opens that pasted file in editor.
if this file is a binary vscode will hang for a while to try to open it
if using vscode-remote you are stuck until vscode client downloads the pasted file to open it for you when you don't want to.

so the default behavior of pasting a file should not include opening it.
