### PR TITLE
Added extensibility points for searchView/context

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -62,7 +62,7 @@ import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation
 import { IExtHostDecorations } from 'vs/workbench/api/common/extHostDecorations';
 import { IExtHostTask } from 'vs/workbench/api/common/extHostTask';
 import { IExtHostDebugService } from 'vs/workbench/api/common/extHostDebugService';
-import { IExtHostSearch } from 'vs/workbench/api/common/extHostSearch';
+import { ExtHostSearch } from 'vs/workbench/api/common/extHostSearch';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IURITransformerService } from 'vs/workbench/api/common/extHostUriTransformerService';
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
@@ -123,11 +123,11 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostCommands = rpcProtocol.set(ExtHostContext.ExtHostCommands, accessor.get(IExtHostCommands));
 	const extHostTerminalService = rpcProtocol.set(ExtHostContext.ExtHostTerminalService, accessor.get(IExtHostTerminalService));
 	const extHostDebugService = rpcProtocol.set(ExtHostContext.ExtHostDebugService, accessor.get(IExtHostDebugService));
-	const extHostSearch = rpcProtocol.set(ExtHostContext.ExtHostSearch, accessor.get(IExtHostSearch));
 	const extHostTask = rpcProtocol.set(ExtHostContext.ExtHostTask, accessor.get(IExtHostTask));
 	const extHostOutputService = rpcProtocol.set(ExtHostContext.ExtHostOutputService, accessor.get(IExtHostOutputService));
 
 	// manually create and register addressable instances
+	const extHostSearch = rpcProtocol.set(ExtHostContext.ExtHostSearch, new ExtHostSearch(rpcProtocol, uriTransformer, extHostLogService, extHostCommands));
 	const extHostUrls = rpcProtocol.set(ExtHostContext.ExtHostUrls, new ExtHostUrls(rpcProtocol));
 	const extHostDocuments = rpcProtocol.set(ExtHostContext.ExtHostDocuments, new ExtHostDocuments(rpcProtocol, extHostDocumentsAndEditors));
 	const extHostDocumentContentProviders = rpcProtocol.set(ExtHostContext.ExtHostDocumentContentProviders, new ExtHostDocumentContentProvider(rpcProtocol, extHostDocumentsAndEditors, extHostLogService));

--- a/src/vs/workbench/api/common/extHostSearch.ts
+++ b/src/vs/workbench/api/common/extHostSearch.ts
@@ -14,6 +14,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IRawFileQuery, ISearchCompleteStats, IFileQuery, IRawTextQuery, IRawQuery, ITextQuery, IFolderQuery } from 'vs/workbench/services/search/common/search';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { TextSearchManager } from 'vs/workbench/services/search/common/textSearchManager';
+import { ExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
 
 export interface IExtHostSearch extends ExtHostSearchShape {
 	registerTextSearchProvider(scheme: string, provider: vscode.TextSearchProvider): IDisposable;
@@ -37,8 +38,27 @@ export class ExtHostSearch implements ExtHostSearchShape {
 	constructor(
 		@IExtHostRpcService private extHostRpc: IExtHostRpcService,
 		@IURITransformerService protected _uriTransformer: IURITransformerService,
-		@ILogService protected _logService: ILogService
-	) { }
+		@ILogService protected _logService: ILogService,
+		commands: ExtHostCommands,
+	) {
+		commands.registerArgumentProcessor({
+			processArgument: arg => {
+				if (arg && Array.isArray(arg)) {
+					return arg.map(matchContext => {
+						if (matchContext.$mid === 13 /* SearchViewContextMid */) {
+							const filteredProperties = { ...matchContext };
+							delete filteredProperties.renderableMatch;
+							return filteredProperties;
+						} else {
+							return matchContext;
+						}
+					});
+				} else {
+					return arg;
+				}
+			}
+		});
+	}
 
 	protected _transformScheme(scheme: string): string {
 		return this._uriTransformer.transformOutgoingScheme(scheme);

--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -176,6 +176,11 @@ const apiMenus: IAPIMenu[] = [
 		id: MenuId.TimelineItemContext,
 		description: localize('view.timelineContext', "The Timeline view item context menu")
 	},
+	{
+		key: 'search/context',
+		id: MenuId.SearchContext,
+		description: localize('menus.searchContext', "The search context menu")
+	},
 ];
 
 namespace schema {

--- a/src/vs/workbench/api/node/extHostSearch.ts
+++ b/src/vs/workbench/api/node/extHostSearch.ts
@@ -19,6 +19,7 @@ import { ExtHostSearch, reviveQuery } from 'vs/workbench/api/common/extHostSearc
 import { Schemas } from 'vs/base/common/network';
 import { NativeTextSearchManager } from 'vs/workbench/services/search/node/textSearchManager';
 import { TextSearchManager } from 'vs/workbench/services/search/common/textSearchManager';
+import { ExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
 
 export class NativeExtHostSearch extends ExtHostSearch {
 
@@ -32,8 +33,9 @@ export class NativeExtHostSearch extends ExtHostSearch {
 		@IExtHostInitDataService initData: IExtHostInitDataService,
 		@IURITransformerService _uriTransformer: IURITransformerService,
 		@ILogService _logService: ILogService,
+		commands: ExtHostCommands,
 	) {
-		super(extHostRpc, _uriTransformer, _logService);
+		super(extHostRpc, _uriTransformer, _logService, commands);
 
 		if (initData.remote.isRemote && initData.remote.authority) {
 			this._registerEHSearchProviders();

--- a/src/vs/workbench/contrib/search/browser/searchActions.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActions.ts
@@ -15,7 +15,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { getSelectionKeyboardEvent, WorkbenchObjectTree } from 'vs/platform/list/browser/listService';
-import { SearchView } from 'vs/workbench/contrib/search/browser/searchView';
+import { IFileMatchContext, IFolderMatchWithResourceContext, IRenderableMatchContext, SearchView } from 'vs/workbench/contrib/search/browser/searchView';
 import * as Constants from 'vs/workbench/contrib/search/common/constants';
 import { IReplaceService } from 'vs/workbench/contrib/search/common/replace';
 import { FolderMatch, FileMatch, FolderMatchWithResource, Match, RenderableMatch, searchMatchComparer, SearchResult } from 'vs/workbench/contrib/search/common/searchModel';
@@ -776,7 +776,8 @@ export class ReplaceAction extends AbstractSearchAndReplaceAction {
 	}
 }
 
-export const copyPathCommand: ICommandHandler = async (accessor, fileMatch: FileMatch | FolderMatchWithResource | undefined) => {
+export const copyPathCommand: ICommandHandler = async (accessor, fileMatchArg: [IFileMatchContext | IFolderMatchWithResourceContext] | undefined) => {
+	let fileMatch = fileMatchArg ? fileMatchArg[0].renderableMatch : undefined; // For the time being we only support single-select
 	if (!fileMatch) {
 		const selection = getSelectedRow(accessor);
 		if (!(selection instanceof FileMatch || selection instanceof FolderMatchWithResource)) {
@@ -852,7 +853,8 @@ function folderMatchToString(folderMatch: FolderMatchWithResource | FolderMatch,
 }
 
 const maxClipboardMatches = 1e4;
-export const copyMatchCommand: ICommandHandler = async (accessor, match: RenderableMatch | undefined) => {
+export const copyMatchCommand: ICommandHandler = async (accessor, matchArg: [IRenderableMatchContext] | undefined) => {
+	let match = matchArg ? matchArg[0].renderableMatch : undefined; // For the time being we only support single-select
 	if (!match) {
 		const selection = getSelectedRow(accessor);
 		if (!selection) {

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -71,6 +71,7 @@ import { ServiceCollection } from 'vs/platform/instantiation/common/serviceColle
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { Orientation } from 'vs/base/browser/ui/sash/sash';
 import { searchDetailsIcon } from 'vs/workbench/contrib/search/browser/searchIcons';
+import { Range } from 'vs/editor/common/core/range';
 
 const $ = dom.$;
 
@@ -83,6 +84,90 @@ enum SearchUIState {
 export enum SearchViewPosition {
 	SideBar,
 	Panel
+}
+
+export type SearchViewContextMid = 13;
+export const SearchViewContextMid = 13;
+
+export interface IMatchContext {
+	/** Identifies which kind of match this is (text,file,folder) */
+	matchingKind: 'textMatch';
+	/** vscode id for this match */
+	id: string;
+	/** The text that was matched */
+	matchedText: string;
+	/** Text we would replace the matched text for, if we apply the match */
+	replacementText: string;
+	/** uri of the file were this match happened */
+	uri: URI;
+	/** location of where the matched text is inside the file */
+	matchRange: Range;
+	renderableMatch: Match;
+	$mid: SearchViewContextMid;
+}
+
+export interface IFileMatchContext {
+	/** Identifies which kind of match this is (text,file,folder) */
+	matchingKind: 'fileMatch';
+	/** uri of the file were all these matches happened */
+	uri: URI;
+	/** matches for this particular file */
+	matches: IMatchContext[];
+	renderableMatch: FileMatch;
+	$mid: SearchViewContextMid;
+}
+
+export interface IFolderMatchContext {
+	/** Identifies which kind of match this is (text,file,folder) */
+	matchingKind: 'folderMatch';
+	/** vscode id for this match */
+	id: string;
+	/** matches for this particular folder */
+	matches: IFileMatchContext[];
+	/** resource that might be associate with this match  */
+	resource: URI | null;
+	renderableMatch: FolderMatch;
+	$mid: SearchViewContextMid;
+}
+
+export interface IFolderMatchWithResourceContext extends IFolderMatchContext {
+	resource: URI;
+	renderableMatch: FolderMatchWithResource;
+}
+
+export type IRenderableMatchContext = (IMatchContext | IFileMatchContext | IFolderMatchContext);
+
+function toMatchContext(match: Match): IMatchContext {
+	return {
+		matchingKind: 'textMatch',
+		id: match.id(),
+		uri: URI.parse(match.parent().id()),
+		matchedText: match.fullMatchText(),
+		replacementText: match.replaceString,
+		matchRange: match.range(),
+		renderableMatch: match,
+		$mid: SearchViewContextMid
+	};
+}
+
+function toFileMatchContext(fileMatch: FileMatch): IFileMatchContext {
+	return {
+		matchingKind: 'fileMatch',
+		uri: URI.parse(fileMatch.id()),
+		matches: fileMatch.matches().map(toMatchContext),
+		renderableMatch: fileMatch,
+		$mid: SearchViewContextMid
+	};
+}
+
+function toFolderMatchContext<T extends IFolderMatchContext>(folderMatch: FolderMatch): T {
+	return {
+		matchingKind: 'folderMatch',
+		matches: folderMatch.matches().map(toFileMatchContext),
+		id: folderMatch.id(),
+		renderableMatch: folderMatch,
+		$mid: SearchViewContextMid
+	} as T;
 }
 
 const SEARCH_CANCELLED_MESSAGE = nls.localize('searchCanceled', "Search was canceled before any results could be found - ");
@@ -780,13 +865,24 @@ export class SearchView extends ViewPane {
 		e.browserEvent.preventDefault();
 		e.browserEvent.stopPropagation();
 
+		const match = e.element;
+		let context: IRenderableMatchContext | undefined = undefined;
+		if (match instanceof FileMatch) {
+			context = toFileMatchContext(match);
+		} else if (match instanceof Match) {
+			context = toMatchContext(match);
+		} else if (match instanceof FolderMatch) {
+			context = toFolderMatchContext(match);
+			context.resource = match.resource;
+		}
+
 		const actions: IAction[] = [];
 		const actionsDisposable = createAndFillInContextMenuActions(this.contextMenu, { shouldForwardArgs: true }, actions);
 
 		this.contextMenuService.showContextMenu({
 			getAnchor: () => e.anchor,
 			getActions: () => actions,
-			getActionsContext: () => e.element,
+			getActionsContext: () => [context],
 			onHide: () => dispose(actionsDisposable)
 		});
 	}

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -158,6 +158,10 @@ export class Match {
 	getMatchString(): string {
 		return this._oneLinePreviewText.substring(this._rangeInPreviewText.startColumn - 1, this._rangeInPreviewText.endColumn - 1);
 	}
+
+	toJSON(): object {
+		return {}; // We send an IRenderableMatchContext to the extensions
+	}
 }
 
 export class FileMatch extends Disposable implements IFileMatch {
@@ -445,6 +449,10 @@ export class FileMatch extends Disposable implements IFileMatch {
 		this._onDispose.fire();
 		super.dispose();
 	}
+
+	toJSON(): object {
+		return {}; // We send an IRenderableMatchContext to the extensions
+	}
 }
 
 export interface IChangeEvent {
@@ -634,6 +642,10 @@ export class FolderMatch extends Disposable {
 		this.disposeMatches();
 		this._onDispose.fire();
 		super.dispose();
+	}
+
+	toJSON(): object {
+		return {}; // We send an IRenderableMatchContext to the extensions
 	}
 }
 

--- a/src/vs/workbench/test/electron-browser/api/extHostSearch.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostSearch.test.ts
@@ -23,6 +23,7 @@ import { mock } from 'vs/base/test/common/mock';
 import { IExtHostInitDataService } from 'vs/workbench/api/common/extHostInitDataService';
 import { TextSearchManager } from 'vs/workbench/services/search/common/textSearchManager';
 import { NativeTextSearchManager } from 'vs/workbench/services/search/node/textSearchManager';
+import { ExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
 
 let rpcProtocol: TestRPCProtocol;
 let extHostSearch: NativeExtHostSearch;
@@ -146,7 +147,8 @@ suite('ExtHostSearch', () => {
 					rpcProtocol,
 					new class extends mock<IExtHostInitDataService>() { remote = { isRemote: false, authority: undefined, connectionData: null }; },
 					new URITransformerService(null),
-					logService
+					logService,
+					new ExtHostCommands(rpcProtocol, new NullLogService())
 				);
 				this._pfs = mockPFS as any;
 			}


### PR DESCRIPTION
2nd attempt to merge: https://github.com/microsoft/vscode/pull/109049
This PR fixes part of #107996

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

I tested this by writing a mini extension that contributes a menu for the search results:
```
	"contributes": {
		"commands": [
			{
				"command": "set-breakpoints-on-search-results.helloWorld",
				"title": "Hello World"
			}
		],
		"menus": {
			"search/context": [
				{
					"command": "set-breakpoints-on-search-results.helloWorld"
				}
			]
		}
	},
```

I got the menu to appear, and I got the expected parameters when I clicked on it:
![image](https://user-images.githubusercontent.com/14098140/96658986-c3bd0200-12fa-11eb-9b16-59624dd7e970.png)


cc @roblourens 