### PR TITLE
specifying node version on install dependencies step 

### DIFF
--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -19,11 +19,14 @@ jobs:
         key: ${{ runner.os }}-dependencies-${{ hashfiles('yarn.lock') }}
         restore-keys: ${{ runner.os }}-dependencies-
 
+    - name: Specify node version
+      if: steps.caching-stage.outputs.cache-hit != 'true'
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12'
     - name: Install dependencies
       if: steps.caching-stage.outputs.cache-hit != 'true'
       run: yarn --frozen-lockfile
-      with:
-        node-version: '12.x'
       env:
         CHILD_CONCURRENCY: 1
 

--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -22,6 +22,8 @@ jobs:
     - name: Install dependencies
       if: steps.caching-stage.outputs.cache-hit != 'true'
       run: yarn --frozen-lockfile
+      with:
+        node-version: '12.x'
       env:
         CHILD_CONCURRENCY: 1
 


### PR DESCRIPTION
If cache is unavailable, installing dependencies is failing because the default version of node is not between 10 and 12.x