### PR TITLE
Why only for python?

### DIFF
--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -309,7 +309,7 @@
 				"keyword.operator.typeid",
 				"keyword.operator.alignas",
 				"keyword.operator.instanceof",
-				"keyword.operator.logical.python",
+				"keyword.operator.logical",
 				"keyword.operator.wordlike"
 			],
 			"settings": {


### PR DESCRIPTION
I think it is good to highlight logical operators in every language. I have extension for ST language and I would like it to work for this language too.