### PR TITLE
Remove transform output calls

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebook.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebook.ts
@@ -171,7 +171,6 @@ export class MainThreadNotebooks extends Disposable implements MainThreadNoteboo
 		if (!textModel) {
 			return false;
 		}
-		this._notebookService.transformEditsOutputs(textModel, cellEdits);
 		return textModel.applyEdits(modelVersionId, cellEdits, true, undefined, () => undefined, undefined);
 	}
 
@@ -479,8 +478,6 @@ export class MainThreadNotebooks extends Disposable implements MainThreadNoteboo
 				const edits: ICellEditOperation[] = [
 					{ editType: CellEditType.Replace, index: 0, count: mainthreadTextModel.cells.length, cells: data.cells }
 				];
-
-				this._notebookService.transformEditsOutputs(mainthreadTextModel, edits);
 				await new Promise(resolve => {
 					DOM.scheduleAtNextAnimationFrame(() => {
 						const ret = mainthreadTextModel!.applyEdits(mainthreadTextModel!.versionId, edits, true, undefined, () => undefined, undefined);
@@ -606,7 +603,6 @@ export class MainThreadNotebooks extends Disposable implements MainThreadNoteboo
 			return;
 		}
 
-		this._notebookService.transformSpliceOutputs(textModel, splices);
 		const cell = textModel.cells.find(cell => cell.handle === cellHandle);
 
 		if (!cell) {

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkCellEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkCellEdits.ts
@@ -12,7 +12,6 @@ import { IProgress } from 'vs/platform/progress/common/progress';
 import { UndoRedoGroup } from 'vs/platform/undoRedo/common/undoRedo';
 import { ICellEditOperation } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookEditorModelResolverService } from 'vs/workbench/contrib/notebook/common/notebookEditorModelResolverService';
-import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
 
 export class ResourceNotebookCellEdit extends ResourceEdit {
 
@@ -32,7 +31,6 @@ export class BulkCellEdits {
 		private _undoRedoGroup: UndoRedoGroup,
 		private readonly _progress: IProgress<void>,
 		private readonly _edits: ResourceNotebookCellEdit[],
-		@INotebookService private readonly _notebookService: INotebookService,
 		@INotebookEditorModelResolverService private readonly _notebookModelService: INotebookEditorModelResolverService,
 	) { }
 
@@ -52,7 +50,6 @@ export class BulkCellEdits {
 
 			// apply edits
 			const edits = group.map(entry => entry.cellEdit);
-			this._notebookService.transformEditsOutputs(ref.object.notebook, edits);
 			ref.object.notebook.applyEdits(ref.object.notebook.versionId, edits, true, undefined, () => undefined, this._undoRedoGroup);
 			ref.dispose();
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
@@ -732,6 +732,11 @@ export class NotebookService extends Disposable implements INotebookService, ICu
 		return Iterable.map(this._models.values(), data => data.model);
 	}
 
+	getMimeTypeInfo(textModel: NotebookTextModel, output: ITransformedDisplayOutputDto): readonly IOrderedMimeType[] {
+		// TODO@rebornix no string[] casting
+		return this._getOrderedMimeTypes(output, textModel.metadata.displayOrder as string[] ?? []);
+	}
+
 	private async transformTextModelOutputs(textModel: NotebookTextModel) {
 		for (let i = 0; i < textModel.cells.length; i++) {
 			const cell = textModel.cells[i];
@@ -739,11 +744,11 @@ export class NotebookService extends Disposable implements INotebookService, ICu
 			cell.outputs.forEach((output) => {
 				if (output.outputKind === CellOutputKind.Rich) {
 					// TODO@rebornix no string[] casting
-					const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
-					const orderedMimeTypes = ret.orderedMimeTypes!;
-					const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
-					output.pickedMimeTypeIndex = pickedMimeTypeIndex;
-					output.orderedMimeTypes = orderedMimeTypes;
+					// const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
+					// const orderedMimeTypes = ret.orderedMimeTypes!;
+					// const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
+					// output.pickedMimeTypeIndex = pickedMimeTypeIndex;
+					// output.orderedMimeTypes = orderedMimeTypes;
 				}
 			});
 		}
@@ -756,22 +761,22 @@ export class NotebookService extends Disposable implements INotebookService, ICu
 					const outputs = cell.outputs;
 					outputs.map((output) => {
 						if (output.outputKind === CellOutputKind.Rich) {
-							const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
-							const orderedMimeTypes = ret.orderedMimeTypes!;
-							const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
-							output.pickedMimeTypeIndex = pickedMimeTypeIndex;
-							output.orderedMimeTypes = orderedMimeTypes;
+							// const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
+							// const orderedMimeTypes = ret.orderedMimeTypes!;
+							// const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
+							// output.pickedMimeTypeIndex = pickedMimeTypeIndex;
+							// output.orderedMimeTypes = orderedMimeTypes;
 						}
 					});
 				});
 			} else if (edit.editType === CellEditType.Output) {
 				edit.outputs.map((output) => {
 					if (output.outputKind === CellOutputKind.Rich) {
-						const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
-						const orderedMimeTypes = ret.orderedMimeTypes!;
-						const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
-						output.pickedMimeTypeIndex = pickedMimeTypeIndex;
-						output.orderedMimeTypes = orderedMimeTypes;
+						// const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
+						// const orderedMimeTypes = ret.orderedMimeTypes!;
+						// const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
+						// output.pickedMimeTypeIndex = pickedMimeTypeIndex;
+						// output.orderedMimeTypes = orderedMimeTypes;
 					}
 				});
 			}
@@ -783,17 +788,17 @@ export class NotebookService extends Disposable implements INotebookService, ICu
 			const outputs = splice[2];
 			outputs.map((output) => {
 				if (output.outputKind === CellOutputKind.Rich) {
-					const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
-					const orderedMimeTypes = ret.orderedMimeTypes!;
-					const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
-					output.pickedMimeTypeIndex = pickedMimeTypeIndex;
-					output.orderedMimeTypes = orderedMimeTypes;
+					// const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
+					// const orderedMimeTypes = ret.orderedMimeTypes!;
+					// const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
+					// output.pickedMimeTypeIndex = pickedMimeTypeIndex;
+					// output.orderedMimeTypes = orderedMimeTypes;
 				}
 			});
 		});
 	}
 
-	private _transformMimeTypes(output: IDisplayOutput, outputId: string, documentDisplayOrder: string[]): ITransformedDisplayOutputDto {
+	private _getOrderedMimeTypes(output: IDisplayOutput, documentDisplayOrder: string[]): IOrderedMimeType[] {
 		const mimeTypes = Object.keys(output.data);
 		const coreDisplayOrder = this._displayOrder;
 		const sorted = sortMimeTypes(mimeTypes, coreDisplayOrder?.userOrder || [], documentDisplayOrder, coreDisplayOrder?.defaultOrder || []);
@@ -832,13 +837,7 @@ export class NotebookService extends Disposable implements INotebookService, ICu
 			}
 		});
 
-		return {
-			outputKind: output.outputKind,
-			outputId,
-			data: output.data,
-			orderedMimeTypes: orderMimeTypes,
-			pickedMimeTypeIndex: 0
-		};
+		return orderMimeTypes;
 	}
 
 	private _findBestMatchedRenderer(mimeType: string): readonly NotebookOutputRendererInfo[] {

--- a/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
@@ -28,7 +28,7 @@ import { NotebookKernelProviderAssociationRegistry, NotebookViewTypesExtensionRe
 import { CellViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/notebookViewModel';
 import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellTextModel';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
-import { ACCESSIBLE_NOTEBOOK_DISPLAY_ORDER, BUILTIN_RENDERER_ID, CellEditType, CellKind, CellOutputKind, DisplayOrderKey, ICellEditOperation, IDisplayOutput, INotebookDecorationRenderOptions, INotebookKernelInfo2, INotebookKernelProvider, INotebookRendererInfo, INotebookTextModel, IOrderedMimeType, ITransformedDisplayOutputDto, mimeTypeSupportedByCore, NotebookCellOutputsSplice, notebookDocumentFilterMatch, NotebookEditorPriority, NOTEBOOK_DISPLAY_ORDER, sortMimeTypes } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { ACCESSIBLE_NOTEBOOK_DISPLAY_ORDER, BUILTIN_RENDERER_ID, CellKind, CellOutputKind, DisplayOrderKey, IDisplayOutput, INotebookDecorationRenderOptions, INotebookKernelInfo2, INotebookKernelProvider, INotebookRendererInfo, INotebookTextModel, IOrderedMimeType, ITransformedDisplayOutputDto, mimeTypeSupportedByCore, notebookDocumentFilterMatch, NotebookEditorPriority, NOTEBOOK_DISPLAY_ORDER, sortMimeTypes } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { NotebookOutputRendererInfo } from 'vs/workbench/contrib/notebook/common/notebookOutputRenderer';
 import { NotebookEditorDescriptor, NotebookProviderInfo } from 'vs/workbench/contrib/notebook/common/notebookProvider';
 import { IMainNotebookController, INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
@@ -718,8 +718,6 @@ export class NotebookService extends Disposable implements INotebookService, ICu
 
 		this._models.set(uri, modelData);
 		this._onDidAddNotebookDocument.fire(notebookModel);
-		// after the document is added to the store and sent to ext host, we transform the ouputs
-		await this.transformTextModelOutputs(notebookModel);
 
 		return modelData.model;
 	}
@@ -735,67 +733,6 @@ export class NotebookService extends Disposable implements INotebookService, ICu
 	getMimeTypeInfo(textModel: NotebookTextModel, output: ITransformedDisplayOutputDto): readonly IOrderedMimeType[] {
 		// TODO@rebornix no string[] casting
 		return this._getOrderedMimeTypes(output, textModel.metadata.displayOrder as string[] ?? []);
-	}
-
-	private async transformTextModelOutputs(textModel: NotebookTextModel) {
-		for (let i = 0; i < textModel.cells.length; i++) {
-			const cell = textModel.cells[i];
-
-			cell.outputs.forEach((output) => {
-				if (output.outputKind === CellOutputKind.Rich) {
-					// TODO@rebornix no string[] casting
-					// const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
-					// const orderedMimeTypes = ret.orderedMimeTypes!;
-					// const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
-					// output.pickedMimeTypeIndex = pickedMimeTypeIndex;
-					// output.orderedMimeTypes = orderedMimeTypes;
-				}
-			});
-		}
-	}
-
-	transformEditsOutputs(textModel: NotebookTextModel, edits: ICellEditOperation[]) {
-		edits.forEach((edit) => {
-			if (edit.editType === CellEditType.Replace) {
-				edit.cells.forEach((cell) => {
-					const outputs = cell.outputs;
-					outputs.map((output) => {
-						if (output.outputKind === CellOutputKind.Rich) {
-							// const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
-							// const orderedMimeTypes = ret.orderedMimeTypes!;
-							// const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
-							// output.pickedMimeTypeIndex = pickedMimeTypeIndex;
-							// output.orderedMimeTypes = orderedMimeTypes;
-						}
-					});
-				});
-			} else if (edit.editType === CellEditType.Output) {
-				edit.outputs.map((output) => {
-					if (output.outputKind === CellOutputKind.Rich) {
-						// const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
-						// const orderedMimeTypes = ret.orderedMimeTypes!;
-						// const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
-						// output.pickedMimeTypeIndex = pickedMimeTypeIndex;
-						// output.orderedMimeTypes = orderedMimeTypes;
-					}
-				});
-			}
-		});
-	}
-
-	transformSpliceOutputs(textModel: NotebookTextModel, splices: NotebookCellOutputsSplice[]) {
-		splices.forEach((splice) => {
-			const outputs = splice[2];
-			outputs.map((output) => {
-				if (output.outputKind === CellOutputKind.Rich) {
-					// const ret = this._transformMimeTypes(output, output.outputId, textModel.metadata.displayOrder as string[] || []);
-					// const orderedMimeTypes = ret.orderedMimeTypes!;
-					// const pickedMimeTypeIndex = ret.pickedMimeTypeIndex!;
-					// output.pickedMimeTypeIndex = pickedMimeTypeIndex;
-					// output.orderedMimeTypes = orderedMimeTypes;
-				}
-			});
-		});
 	}
 
 	private _getOrderedMimeTypes(output: IDisplayOutput, documentDisplayOrder: string[]): IOrderedMimeType[] {

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -190,8 +190,8 @@ export interface ITransformedDisplayOutputDto {
 	data: { [key: string]: unknown; }
 	metadata?: NotebookCellOutputMetadata;
 
-	orderedMimeTypes?: IOrderedMimeType[];
-	pickedMimeTypeIndex?: number;
+	// orderedMimeTypes?: IOrderedMimeType[];
+	// pickedMimeTypeIndex?: number;
 }
 
 export function isTransformedDisplayOutput(thing: unknown): thing is ITransformedDisplayOutputDto {

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -184,25 +184,12 @@ export interface IOrderedMimeType {
 	rendererId: string;
 }
 
-export interface ITransformedDisplayOutputDto {
-	outputKind: CellOutputKind.Rich;
+export interface ITransformedDisplayOutputDto extends IDisplayOutput {
 	outputId: string;
-	data: { [key: string]: unknown; }
-	metadata?: NotebookCellOutputMetadata;
-
-	// orderedMimeTypes?: IOrderedMimeType[];
-	// pickedMimeTypeIndex?: number;
 }
 
 export function isTransformedDisplayOutput(thing: unknown): thing is ITransformedDisplayOutputDto {
 	return (thing as ITransformedDisplayOutputDto).outputKind === CellOutputKind.Rich && !!(thing as ITransformedDisplayOutputDto).outputId;
-}
-
-export interface IGenericOutput {
-	outputKind: CellOutputKind;
-	pickedMimeType?: string;
-	pickedRenderer?: number;
-	transformedOutput?: { [key: string]: IDisplayOutput };
 }
 
 

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -10,7 +10,7 @@ import { NotebookExtensionDescription } from 'vs/workbench/api/common/extHost.pr
 import { Event } from 'vs/base/common/event';
 import {
 	INotebookTextModel, INotebookRendererInfo,
-	IEditor, ICellEditOperation, NotebookCellOutputsSplice, INotebookKernelProvider, INotebookKernelInfo2, TransientMetadata, NotebookDataDto, TransientOptions, INotebookDecorationRenderOptions, INotebookExclusiveDocumentFilter
+	IEditor, ICellEditOperation, NotebookCellOutputsSplice, INotebookKernelProvider, INotebookKernelInfo2, TransientMetadata, NotebookDataDto, TransientOptions, INotebookDecorationRenderOptions, INotebookExclusiveDocumentFilter, IOrderedMimeType, ITransformedDisplayOutputDto
 } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { CancellationToken } from 'vs/base/common/cancellation';
@@ -49,7 +49,10 @@ export interface INotebookService {
 	onDidChangeNotebookActiveKernel: Event<{ uri: URI, providerHandle: number | undefined, kernelId: string | undefined }>;
 	registerNotebookController(viewType: string, extensionData: NotebookExtensionDescription, controller: IMainNotebookController): IDisposable;
 
+	getMimeTypeInfo(textModel: NotebookTextModel, output: ITransformedDisplayOutputDto): readonly IOrderedMimeType[];
+	/** @deprecated */
 	transformEditsOutputs(textModel: NotebookTextModel, edits: ICellEditOperation[]): void;
+	/** @deprecated */
 	transformSpliceOutputs(textModel: NotebookTextModel, splices: NotebookCellOutputsSplice[]): void;
 	registerNotebookKernelProvider(provider: INotebookKernelProvider): IDisposable;
 	getContributedNotebookKernels(viewType: string, resource: URI, token: CancellationToken): Promise<INotebookKernelInfo2[]>;

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -10,7 +10,7 @@ import { NotebookExtensionDescription } from 'vs/workbench/api/common/extHost.pr
 import { Event } from 'vs/base/common/event';
 import {
 	INotebookTextModel, INotebookRendererInfo,
-	IEditor, ICellEditOperation, NotebookCellOutputsSplice, INotebookKernelProvider, INotebookKernelInfo2, TransientMetadata, NotebookDataDto, TransientOptions, INotebookDecorationRenderOptions, INotebookExclusiveDocumentFilter, IOrderedMimeType, ITransformedDisplayOutputDto
+	IEditor, INotebookKernelProvider, INotebookKernelInfo2, TransientMetadata, NotebookDataDto, TransientOptions, INotebookDecorationRenderOptions, INotebookExclusiveDocumentFilter, IOrderedMimeType, ITransformedDisplayOutputDto
 } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { CancellationToken } from 'vs/base/common/cancellation';
@@ -50,10 +50,7 @@ export interface INotebookService {
 	registerNotebookController(viewType: string, extensionData: NotebookExtensionDescription, controller: IMainNotebookController): IDisposable;
 
 	getMimeTypeInfo(textModel: NotebookTextModel, output: ITransformedDisplayOutputDto): readonly IOrderedMimeType[];
-	/** @deprecated */
-	transformEditsOutputs(textModel: NotebookTextModel, edits: ICellEditOperation[]): void;
-	/** @deprecated */
-	transformSpliceOutputs(textModel: NotebookTextModel, splices: NotebookCellOutputsSplice[]): void;
+
 	registerNotebookKernelProvider(provider: INotebookKernelProvider): IDisposable;
 	getContributedNotebookKernels(viewType: string, resource: URI, token: CancellationToken): Promise<INotebookKernelInfo2[]>;
 	getContributedNotebookOutputRenderers(id: string): NotebookOutputRendererInfo | undefined;


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode/issues/105846 and the removal of in-place transforming of output, e.g instead of adding UX properties like mime type order and selection to the data model this PR makes it an explicit service call which the sole user now calls. 
