### PR TITLE
bulkEdits: add copy to WorkspaceFileEditOptions

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1385,6 +1385,7 @@ export interface WorkspaceFileEditOptions {
 	ignoreIfNotExists?: boolean;
 	ignoreIfExists?: boolean;
 	recursive?: boolean;
+	copy?: boolean;
 }
 
 export interface WorkspaceFileEdit {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6260,6 +6260,7 @@ declare namespace monaco.languages {
 		ignoreIfNotExists?: boolean;
 		ignoreIfExists?: boolean;
 		recursive?: boolean;
+		copy?: boolean;
 	}
 
 	export interface WorkspaceFileEdit {

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
@@ -64,6 +64,36 @@ class RenameOperation implements IFileOperation {
 	}
 }
 
+class CopyOperation implements IFileOperation {
+
+	constructor(
+		readonly newUri: URI,
+		readonly oldUri: URI,
+		readonly options: WorkspaceFileEditOptions,
+		@IWorkingCopyFileService private readonly _workingCopyFileService: IWorkingCopyFileService,
+		@IFileService private readonly _fileService: IFileService,
+		@IInstantiationService private readonly _instaService: IInstantiationService
+	) { }
+
+	get uris() {
+		return [this.newUri, this.oldUri];
+	}
+
+	async perform(): Promise<IFileOperation> {
+		// copy
+		if (this.options.overwrite === undefined && this.options.ignoreIfExists && await this._fileService.exists(this.newUri)) {
+			return new Noop(); // not overwriting, but ignoring, and the target file exists
+		}
+
+		await this._workingCopyFileService.copy([{ source: this.oldUri, target: this.newUri }], { overwrite: this.options.overwrite });
+		return this._instaService.createInstance(DeleteOperation, this.newUri, this.options, true);
+	}
+
+	toString(): string {
+		return `(copy ${this.oldUri} to ${this.newUri})`;
+	}
+}
+
 class CreateOperation implements IFileOperation {
 
 	constructor(
@@ -190,9 +220,11 @@ export class BulkFileEdits {
 
 			const options = edit.options || {};
 			let op: IFileOperation | undefined;
-			if (edit.newResource && edit.oldResource) {
+			if (edit.newResource && edit.oldResource && !options.copy) {
 				// rename
 				op = this._instaService.createInstance(RenameOperation, edit.newResource, edit.oldResource, options);
+			} else if (edit.newResource && edit.oldResource && options.copy) {
+				op = this._instaService.createInstance(CopyOperation, edit.newResource, edit.oldResource, options);
 			} else if (!edit.newResource && edit.oldResource) {
 				// delete file
 				op = this._instaService.createInstance(DeleteOperation, edit.oldResource, options, false);


### PR DESCRIPTION
This PR:
* Adds `copy` to the `WorkspaceFileEditOptions`

I need this from the explorer to be able to undo Copying of files.

Similar to this I plan to create a PR which adds an option `folder` so it is possible to create `folders` via a `ResourceFileEdit`. But one step at a time, we should first discuss if this makes sense.

I have tested this with my changes in Explorer and it seems to work fine. 
I could not find unit tests to potentially add more, so let me know if I am missing something.