### PR TITLE
Support keybinding browser context keys

### DIFF
--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -6,9 +6,9 @@
 import { Event } from 'vs/base/common/event';
 import { isFalsyOrWhitespace } from 'vs/base/common/strings';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { isMacintosh, isLinux, isWindows, isWeb } from 'vs/base/common/platform';
-import { isEdge, isOpera, isFirefox, isWebKit, isChrome, isSafari, isWebkitWebView, isIPad, isEdgeWebView, isStandalone } from 'vs/base/browser/browser';
+import { userAgent, isMacintosh, isLinux, isWindows, isWeb } from 'vs/base/common/platform';
 
+let _userAgent = userAgent || '';
 const STATIC_VALUES = new Map<string, boolean>();
 STATIC_VALUES.set('false', false);
 STATIC_VALUES.set('true', true);
@@ -17,16 +17,11 @@ STATIC_VALUES.set('isLinux', isLinux);
 STATIC_VALUES.set('isWindows', isWindows);
 STATIC_VALUES.set('isWeb', isWeb);
 STATIC_VALUES.set('isMacNative', isMacintosh && !isWeb);
-STATIC_VALUES.set('isEdge', isEdge);
-STATIC_VALUES.set('isOpera', isOpera);
-STATIC_VALUES.set('isFirefox', isFirefox);
-STATIC_VALUES.set('isWebKit', isWebKit);
-STATIC_VALUES.set('isChrome', isChrome);
-STATIC_VALUES.set('isSafari', isSafari);
-STATIC_VALUES.set('isWebkitWebView', isWebkitWebView);
-STATIC_VALUES.set('isIPad', isIPad);
-STATIC_VALUES.set('isEdgeWebView', isEdgeWebView);
-STATIC_VALUES.set('isStandalone', isStandalone);
+STATIC_VALUES.set('isEdge', _userAgent.indexOf('Edg/') >= 0);
+STATIC_VALUES.set('isFirefox', _userAgent.indexOf('Firefox') >= 0);
+STATIC_VALUES.set('isChrome', _userAgent.indexOf('Chrome') >= 0);
+STATIC_VALUES.set('isSafari', _userAgent.indexOf('Safari') >= 0);
+STATIC_VALUES.set('isIPad', _userAgent.indexOf('iPad') >= 0);
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -7,6 +7,7 @@ import { Event } from 'vs/base/common/event';
 import { isFalsyOrWhitespace } from 'vs/base/common/strings';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { isMacintosh, isLinux, isWindows, isWeb } from 'vs/base/common/platform';
+import { isEdge, isOpera, isFirefox, isWebKit, isChrome, isSafari, isWebkitWebView, isIPad, isEdgeWebView, isStandalone } from 'vs/base/browser/browser';
 
 const STATIC_VALUES = new Map<string, boolean>();
 STATIC_VALUES.set('false', false);
@@ -16,6 +17,16 @@ STATIC_VALUES.set('isLinux', isLinux);
 STATIC_VALUES.set('isWindows', isWindows);
 STATIC_VALUES.set('isWeb', isWeb);
 STATIC_VALUES.set('isMacNative', isMacintosh && !isWeb);
+STATIC_VALUES.set('isEdge', isEdge);
+STATIC_VALUES.set('isOpera', isOpera);
+STATIC_VALUES.set('isFirefox', isFirefox);
+STATIC_VALUES.set('isWebKit', isWebKit);
+STATIC_VALUES.set('isChrome', isChrome);
+STATIC_VALUES.set('isSafari', isSafari);
+STATIC_VALUES.set('isWebkitWebView', isWebkitWebView);
+STATIC_VALUES.set('isIPad', isIPad);
+STATIC_VALUES.set('isEdgeWebView', isEdgeWebView);
+STATIC_VALUES.set('isStandalone', isStandalone);
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 


### PR DESCRIPTION
Supplement to https://github.com/microsoft/vscode/issues/85058.

Support these keybindings↓

```js
{ "key": "ctrl+n",           "command": "isEdge" },
{ "key": "cmd+n",            "command": "isOpera" },
{ "key": "ctrl+shift+n",     "command": "isFirefox" },
{ "key": "cmd+shift+n",      "command": "isWebKit" },
{ "key": "cmd+q",            "command": "-workbench.action.quit", "when": "isChrome" },
{ "key": "cmd+q cmd+q",      "command": "workbench.action.quit", "when": "isSafari" }
```
