### PR TITLE
add support to reuse undo-redo group when applying a nested bulk edit

### DIFF
--- a/src/vs/editor/browser/services/bulkEditService.ts
+++ b/src/vs/editor/browser/services/bulkEditService.ts
@@ -70,6 +70,7 @@ export interface IBulkEditOptions {
 	label?: string;
 	quotableLabel?: string;
 	undoRedoSource?: UndoRedoSource;
+	mergeWithActiveUndoRedoGroup?: boolean;
 }
 
 export interface IBulkEditResult {

--- a/src/vs/workbench/api/browser/mainThreadBulkEdits.ts
+++ b/src/vs/workbench/api/browser/mainThreadBulkEdits.ts
@@ -37,8 +37,8 @@ export class MainThreadBulkEdits implements MainThreadBulkEditsShape {
 
 	dispose(): void { }
 
-	$tryApplyWorkspaceEdit(dto: IWorkspaceEditDto): Promise<boolean> {
+	$tryApplyWorkspaceEdit(dto: IWorkspaceEditDto, options: { mergeWithActiveUndoRedoGroup?: boolean }): Promise<boolean> {
 		const edits = reviveWorkspaceEditDto2(dto);
-		return this._bulkEditService.apply(edits).then(() => true, _err => false);
+		return this._bulkEditService.apply(edits, options).then(() => true, _err => false);
 	}
 }

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -269,7 +269,7 @@ export interface ITextDocumentShowOptions {
 }
 
 export interface MainThreadBulkEditsShape extends IDisposable {
-	$tryApplyWorkspaceEdit(workspaceEditDto: IWorkspaceEditDto): Promise<boolean>;
+	$tryApplyWorkspaceEdit(workspaceEditDto: IWorkspaceEditDto, options?: { mergeWithActiveUndoRedoGroup?: boolean }): Promise<boolean>;
 }
 
 export interface MainThreadTextEditorsShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHostFileSystemEventService.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemEventService.ts
@@ -222,7 +222,7 @@ export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServ
 				let { edits } = typeConverter.WorkspaceEdit.from(edit, this._extHostDocumentsAndEditors);
 				dto.edits = dto.edits.concat(edits);
 			}
-			return this._mainThreadBulkEdits.$tryApplyWorkspaceEdit(dto);
+			return this._mainThreadBulkEdits.$tryApplyWorkspaceEdit(dto, { mergeWithActiveUndoRedoGroup: true });
 		}
 	}
 }


### PR DESCRIPTION
This PR makes sure that workspace edits triggered from a `onWill`-event are merged into the same undo/redo group the event originates from
