### PR TITLE
Undo/redo, bulk edit and onWill-file events

### DIFF
--- a/src/vs/editor/browser/services/bulkEditService.ts
+++ b/src/vs/editor/browser/services/bulkEditService.ts
@@ -70,6 +70,7 @@ export interface IBulkEditOptions {
 	label?: string;
 	quotableLabel?: string;
 	undoRedoSource?: UndoRedoSource;
+	undoRedoGroupId?: number;
 }
 
 export interface IBulkEditResult {

--- a/src/vs/workbench/api/browser/mainThreadBulkEdits.ts
+++ b/src/vs/workbench/api/browser/mainThreadBulkEdits.ts
@@ -37,8 +37,8 @@ export class MainThreadBulkEdits implements MainThreadBulkEditsShape {
 
 	dispose(): void { }
 
-	$tryApplyWorkspaceEdit(dto: IWorkspaceEditDto): Promise<boolean> {
+	$tryApplyWorkspaceEdit(dto: IWorkspaceEditDto, undoRedoGroupId?: number): Promise<boolean> {
 		const edits = reviveWorkspaceEditDto2(dto);
-		return this._bulkEditService.apply(edits).then(() => true, _err => false);
+		return this._bulkEditService.apply(edits, { undoRedoGroupId }).then(() => true, _err => false);
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -54,11 +54,13 @@ export class MainThreadFileSystemEventService {
 
 
 		// BEFORE file operation
-		workingCopyFileService.addFileOperationParticipant({
-			participate: (files, operation, progress, timeout, token) => {
-				return proxy.$onWillRunFileOperation(operation, files, timeout, token);
+		this._listener.add(workingCopyFileService.addFileOperationParticipant({
+			participate: async (files, operation, undoRedoGroupId, isUndoing, _progress, timeout, token) => {
+				if (!isUndoing) {
+					return proxy.$onWillRunFileOperation(operation, files, undoRedoGroupId, timeout, token);
+				}
 			}
-		});
+		}));
 
 		// AFTER file operation
 		this._listener.add(workingCopyFileService.onDidRunWorkingCopyFileOperation(e => proxy.$onDidRunFileOperation(e.operation, e.files)));

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -269,7 +269,7 @@ export interface ITextDocumentShowOptions {
 }
 
 export interface MainThreadBulkEditsShape extends IDisposable {
-	$tryApplyWorkspaceEdit(workspaceEditDto: IWorkspaceEditDto): Promise<boolean>;
+	$tryApplyWorkspaceEdit(workspaceEditDto: IWorkspaceEditDto, undoRedoGroupId?: number): Promise<boolean>;
 }
 
 export interface MainThreadTextEditorsShape extends IDisposable {
@@ -1139,7 +1139,7 @@ export interface SourceTargetPair {
 
 export interface ExtHostFileSystemEventServiceShape {
 	$onFileEvent(events: FileSystemEvents): void;
-	$onWillRunFileOperation(operation: files.FileOperation, files: SourceTargetPair[], timeout: number, token: CancellationToken): Promise<any>;
+	$onWillRunFileOperation(operation: files.FileOperation, files: SourceTargetPair[], undoRedoGroupId: number | undefined, timeout: number, token: CancellationToken): Promise<any>;
 	$onDidRunFileOperation(operation: files.FileOperation, files: SourceTargetPair[]): void;
 }
 

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileOperationParticipant.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileOperationParticipant.ts
@@ -33,7 +33,7 @@ export class WorkingCopyFileOperationParticipant extends Disposable {
 		return toDisposable(() => remove());
 	}
 
-	async participate(files: { source?: URI, target: URI }[], operation: FileOperation): Promise<void> {
+	async participate(files: { source?: URI, target: URI }[], operation: FileOperation, undoRedoGroupId: number | undefined, isUndoing: boolean | undefined): Promise<void> {
 		const timeout = this.configurationService.getValue<number>('files.participants.timeout');
 		if (timeout <= 0) {
 			return; // disabled
@@ -53,7 +53,7 @@ export class WorkingCopyFileOperationParticipant extends Disposable {
 				}
 
 				try {
-					const promise = participant.participate(files, operation, progress, timeout, cts.token);
+					const promise = participant.participate(files, operation, undoRedoGroupId, isUndoing, progress, timeout, cts.token);
 					await raceTimeout(promise, timeout, () => cts.dispose(true /* cancel */));
 				} catch (err) {
 					this.logService.warn(err);

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -60,6 +60,8 @@ export interface IWorkingCopyFileOperationParticipant {
 	participate(
 		files: SourceTargetPair[],
 		operation: FileOperation,
+		undoRedoGroupId: number | undefined,
+		isUndoing: boolean | undefined,
 		progress: IProgress<IProgressStep>,
 		timeout: number,
 		token: CancellationToken
@@ -130,7 +132,7 @@ export interface IWorkingCopyFileService {
 	 * Working copy owners can listen to the `onWillRunWorkingCopyFileOperation` and
 	 * `onDidRunWorkingCopyFileOperation` events to participate.
 	 */
-	create(resource: URI, contents?: VSBuffer | VSBufferReadable | VSBufferReadableStream, options?: { overwrite?: boolean }): Promise<IFileStatWithMetadata>;
+	create(resource: URI, contents?: VSBuffer | VSBufferReadable | VSBufferReadableStream, options?: { overwrite?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<IFileStatWithMetadata>;
 
 	/**
 	 * Will create a folder and any parent folder that needs to be created.
@@ -141,7 +143,7 @@ export interface IWorkingCopyFileService {
 	 * Note: events will only be emitted for the provided resource, but not any
 	 * parent folders that are being created as part of the operation.
 	 */
-	createFolder(resource: URI): Promise<IFileStatWithMetadata>;
+	createFolder(resource: URI, options?: { undoRedoGroupId?: number, isUndoing?: boolean }): Promise<IFileStatWithMetadata>;
 
 	/**
 	 * Will move working copies matching the provided resources and corresponding children
@@ -150,7 +152,7 @@ export interface IWorkingCopyFileService {
 	 * Working copy owners can listen to the `onWillRunWorkingCopyFileOperation` and
 	 * `onDidRunWorkingCopyFileOperation` events to participate.
 	 */
-	move(files: Required<SourceTargetPair>[], options?: { overwrite?: boolean }): Promise<IFileStatWithMetadata[]>;
+	move(files: Required<SourceTargetPair>[], options?: { overwrite?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<IFileStatWithMetadata[]>;
 
 	/**
 	 * Will copy working copies matching the provided resources and corresponding children
@@ -159,7 +161,7 @@ export interface IWorkingCopyFileService {
 	 * Working copy owners can listen to the `onWillRunWorkingCopyFileOperation` and
 	 * `onDidRunWorkingCopyFileOperation` events to participate.
 	 */
-	copy(files: Required<SourceTargetPair>[], options?: { overwrite?: boolean }): Promise<IFileStatWithMetadata[]>;
+	copy(files: Required<SourceTargetPair>[], options?: { overwrite?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<IFileStatWithMetadata[]>;
 
 	/**
 	 * Will delete working copies matching the provided resources and children
@@ -168,7 +170,7 @@ export interface IWorkingCopyFileService {
 	 * Working copy owners can listen to the `onWillRunWorkingCopyFileOperation` and
 	 * `onDidRunWorkingCopyFileOperation` events to participate.
 	 */
-	delete(resources: URI[], options?: { useTrash?: boolean, recursive?: boolean }): Promise<void>;
+	delete(resources: URI[], options?: { useTrash?: boolean, recursive?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<void>;
 
 	//#endregion
 
@@ -237,15 +239,15 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 
 	//#region File operations
 
-	create(resource: URI, contents?: VSBuffer | VSBufferReadable | VSBufferReadableStream, options?: { overwrite?: boolean }): Promise<IFileStatWithMetadata> {
+	create(resource: URI, contents?: VSBuffer | VSBufferReadable | VSBufferReadableStream, options?: { overwrite?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<IFileStatWithMetadata> {
 		return this.doCreateFileOrFolder(resource, true, contents, options);
 	}
 
-	createFolder(resource: URI, options?: { overwrite?: boolean }): Promise<IFileStatWithMetadata> {
-		return this.doCreateFileOrFolder(resource, false);
+	createFolder(resource: URI, options?: { overwrite?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<IFileStatWithMetadata> {
+		return this.doCreateFileOrFolder(resource, false, undefined, options);
 	}
 
-	async doCreateFileOrFolder(resource: URI, isFile: boolean, contents?: VSBuffer | VSBufferReadable | VSBufferReadableStream, options?: { overwrite?: boolean }): Promise<IFileStatWithMetadata> {
+	async doCreateFileOrFolder(resource: URI, isFile: boolean, contents?: VSBuffer | VSBufferReadable | VSBufferReadableStream, options?: { overwrite?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<IFileStatWithMetadata> {
 
 		// validate create operation before starting
 		if (isFile) {
@@ -256,7 +258,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		}
 
 		// file operation participant
-		await this.runFileOperationParticipants([{ target: resource }], FileOperation.CREATE);
+		await this.runFileOperationParticipants([{ target: resource }], FileOperation.CREATE, options?.undoRedoGroupId, options?.isUndoing);
 
 		// before events
 		const event = { correlationId: this.correlationIds++, operation: FileOperation.CREATE, files: [{ target: resource }] };
@@ -284,15 +286,15 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		return stat;
 	}
 
-	async move(files: Required<SourceTargetPair>[], options?: { overwrite?: boolean }): Promise<IFileStatWithMetadata[]> {
+	async move(files: Required<SourceTargetPair>[], options?: { overwrite?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<IFileStatWithMetadata[]> {
 		return this.doMoveOrCopy(files, true, options);
 	}
 
-	async copy(files: Required<SourceTargetPair>[], options?: { overwrite?: boolean }): Promise<IFileStatWithMetadata[]> {
+	async copy(files: Required<SourceTargetPair>[], options?: { overwrite?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<IFileStatWithMetadata[]> {
 		return this.doMoveOrCopy(files, false, options);
 	}
 
-	private async doMoveOrCopy(files: Required<SourceTargetPair>[], move: boolean, options?: { overwrite?: boolean }): Promise<IFileStatWithMetadata[]> {
+	private async doMoveOrCopy(files: Required<SourceTargetPair>[], move: boolean, options?: { overwrite?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<IFileStatWithMetadata[]> {
 		const overwrite = options?.overwrite;
 		const stats: IFileStatWithMetadata[] = [];
 
@@ -305,7 +307,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		}
 
 		// file operation participant
-		await this.runFileOperationParticipants(files, move ? FileOperation.MOVE : FileOperation.COPY);
+		await this.runFileOperationParticipants(files, move ? FileOperation.MOVE : FileOperation.COPY, options?.undoRedoGroupId, options?.isUndoing);
 
 		// before event
 		const event = { correlationId: this.correlationIds++, operation: move ? FileOperation.MOVE : FileOperation.COPY, files };
@@ -344,7 +346,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		return stats;
 	}
 
-	async delete(resources: URI[], options?: { useTrash?: boolean, recursive?: boolean }): Promise<void> {
+	async delete(resources: URI[], options?: { useTrash?: boolean, recursive?: boolean, undoRedoGroupId?: number, isUndoing?: boolean }): Promise<void> {
 
 		// validate delete operation before starting
 		for (const resource of resources) {
@@ -356,7 +358,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 
 		// file operation participant
 		const files = resources.map(target => ({ target }));
-		await this.runFileOperationParticipants(files, FileOperation.DELETE);
+		await this.runFileOperationParticipants(files, FileOperation.DELETE, options?.undoRedoGroupId, options?.isUndoing);
 
 		// before events
 		const event = { correlationId: this.correlationIds++, operation: FileOperation.DELETE, files };
@@ -398,8 +400,8 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		return this.fileOperationParticipants.addFileOperationParticipant(participant);
 	}
 
-	private runFileOperationParticipants(files: SourceTargetPair[], operation: FileOperation): Promise<void> {
-		return this.fileOperationParticipants.participate(files, operation);
+	private runFileOperationParticipants(files: SourceTargetPair[], operation: FileOperation, undoRedoGroupId: number | undefined, isUndoing: boolean | undefined): Promise<void> {
+		return this.fileOperationParticipants.participate(files, operation, undoRedoGroupId, isUndoing);
 	}
 
 	//#endregion


### PR DESCRIPTION
This PR makes it possible that additional workspace edits from an `onWill[Create|Rename|Delete]Files` are added to the same undo/redo groups as the initiating operation. The sample is the Java file rename which makes a text edit before the actual rename. Those should only require a single undo. 

This is PR is kinda large but simple. It spreads data because

* all `onWill`-events are triggered from the working copy service
* that service doesn't know anything about undo/redo (on purpose)
* the bulk edit service does know about undo/redo and consumes the working copy service
* some undo/redo information needs to travel to `onWill`-event listener
* therefore the bulk edit service can now pass data about undo/redo which the working copy service simply forwards to its event handlers

fyi - the alternative would have been to move all `onWill`-event logic into the bulk edit service but since there are still direct consumer of the working copy service it would have meant that the API now fires less event, like for "save as".

Somewhat open questions

* on the ext host the `onWill`-events will not fire anymore when undoing/redoing. That's to safe the undo-stack but might be unexpected?
* should the same happen for `onDid`-events that are caused by undoing/redoing? Those cannot piggy-bag extra edits tho.
