### PR TITLE
WorkspaceFileEditOptions add maxSize

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1387,6 +1387,7 @@ export interface WorkspaceFileEditOptions {
 	recursive?: boolean;
 	copy?: boolean;
 	folder?: boolean;
+	maxSize?: number;
 }
 
 export interface WorkspaceFileEdit {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6262,6 +6262,7 @@ declare namespace monaco.languages {
 		recursive?: boolean;
 		copy?: boolean;
 		folder?: boolean;
+		maxSize?: number;
 	}
 
 	export interface WorkspaceFileEdit {


### PR DESCRIPTION
This PR introduces a `maxSize` option to the `WorkspaceFileEditOptions`.
We need to limit how large a file we keep in memory, otherwise this can grow unbounded.

The idea is that Explorer would use this API to limit file sizes that we keep in memory to 5mb.
Corner case: what if the user deletes ten 9mb files. Thea each file is below the limit but will still take up space all together.
I think we can live with this limitation for now, and potentially the `UndoRedo` service could limit the number of items to 20 always.

fyi @alexdima who also came up with the idea of this approach