### PR TITLE
Changing autofetch to a string config which has "current", "all" and

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1644,10 +1644,20 @@
           "default": true
         },
         "git.autofetch": {
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "all"
+              ]
+            }
+          ],
           "scope": "resource",
           "description": "%config.autofetch%",
-          "default": "off",
+          "default": false,
           "tags": [
             "usesOnlineServices"
           ]

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1644,10 +1644,10 @@
           "default": true
         },
         "git.autofetch": {
-          "type": "boolean",
+          "type": "string",
           "scope": "resource",
           "description": "%config.autofetch%",
-          "default": false,
+          "default": "off",
           "tags": [
             "usesOnlineServices"
           ]

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -97,7 +97,7 @@
 	"config.autoRepositoryDetection.subFolders": "Scan for subfolders of the currently opened folder.",
 	"config.autoRepositoryDetection.openEditors": "Scan for parent folders of open files.",
 	"config.autorefresh": "Whether auto refreshing is enabled.",
-	"config.autofetch": "When enabled, commits will automatically be fetched from the default remote of the current Git repository.",
+	"config.autofetch": "When set to `current`, commits will automatically be fetched from the default remote of the current Git repository. Setting to `all` will fetch from all remotes",
 	"config.autofetchPeriod": "Duration in seconds between each automatic git fetch, when `git.autofetch` is enabled.",
 	"config.confirmSync": "Confirm before synchronizing git repositories.",
 	"config.countBadge": "Controls the Git count badge.",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -97,7 +97,7 @@
 	"config.autoRepositoryDetection.subFolders": "Scan for subfolders of the currently opened folder.",
 	"config.autoRepositoryDetection.openEditors": "Scan for parent folders of open files.",
 	"config.autorefresh": "Whether auto refreshing is enabled.",
-	"config.autofetch": "When set to `current`, commits will automatically be fetched from the default remote of the current Git repository. Setting to `all` will fetch from all remotes",
+	"config.autofetch": "When set to true, commits will automatically be fetched from the default remote of the current Git repository. Setting to `all` will fetch from all remotes",
 	"config.autofetchPeriod": "Duration in seconds between each automatic git fetch, when `git.autofetch` is enabled.",
 	"config.confirmSync": "Confirm before synchronizing git repositories.",
 	"config.countBadge": "Controls the Git count badge.",

--- a/extensions/git/src/autofetch.ts
+++ b/extensions/git/src/autofetch.ts
@@ -62,7 +62,7 @@ export class AutoFetcher {
 
 		if (result === yes) {
 			const gitConfig = workspace.getConfiguration('git', Uri.file(this.repository.root));
-			gitConfig.update('autofetch', 'all', ConfigurationTarget.Global);
+			gitConfig.update('autofetch', true, ConfigurationTarget.Global);
 		}
 
 		this.globalState.update(AutoFetcher.DidInformUser, true);
@@ -74,9 +74,11 @@ export class AutoFetcher {
 		switch (gitConfig.get<string | boolean>('autofetch')) {
 			case true:
 				this.enable();
+				break;
 			case 'all':
 				this.enable();
 				this._fetchAll = true;
+				break;
 			case false:
 			default:
 				this.disable();

--- a/extensions/git/src/autofetch.ts
+++ b/extensions/git/src/autofetch.ts
@@ -71,16 +71,18 @@ export class AutoFetcher {
 	private onConfiguration(): void {
 		const gitConfig = workspace.getConfiguration('git', Uri.file(this.repository.root));
 
-		switch (gitConfig.get<string | boolean>('autofetch')) {
+		switch (gitConfig.get<boolean | 'all'>('autofetch')) {
 			case true:
+				this._fetchAll = false;
 				this.enable();
 				break;
 			case 'all':
-				this.enable();
 				this._fetchAll = true;
+				this.enable();
 				break;
 			case false:
 			default:
+				this._fetchAll = false;
 				this.disable();
 				break;
 		}

--- a/extensions/git/src/autofetch.ts
+++ b/extensions/git/src/autofetch.ts
@@ -71,13 +71,13 @@ export class AutoFetcher {
 	private onConfiguration(): void {
 		const gitConfig = workspace.getConfiguration('git', Uri.file(this.repository.root));
 
-		switch (gitConfig.get<string>('autofetch')) {
-			case 'current':
+		switch (gitConfig.get<string | boolean>('autofetch')) {
+			case true:
 				this.enable();
 			case 'all':
 				this.enable();
 				this._fetchAll = true;
-			case 'off':
+			case false:
 			default:
 				this.disable();
 				break;
@@ -106,8 +106,11 @@ export class AutoFetcher {
 			}
 
 			try {
-				const fetchAction = this._fetchAll ? this.repository.fetchDefault({ silent: true }) : this.repository.fetchAll();
-				await fetchAction;
+				if (this._fetchAll) {
+					await this.repository.fetchAll();
+				} else {
+					await this.repository.fetchDefault({ silent: true });
+				}
 			} catch (err) {
 				if (err.gitErrorCode === GitErrorCodes.AuthenticationFailed) {
 					this.disable();


### PR DESCRIPTION
Changing autofetch to a string config which has "current", "all" and "off".
This allows users to fetch from all remotes instead of just their origin.
For developers working on a Fork, this should make extensions work more intuitively.

This PR fixes #110811
