### PR TITLE
Fix scrolling of markdown preview. Close #65504

### DIFF
--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -58,7 +58,6 @@ function doAfterImagesLoaded(cb: () => void) {
 
 onceDocumentLoaded(() => {
 	const scrollProgress = state.scrollProgress;
-	scrollDisabledCount = 0;
 
 	if (typeof scrollProgress === 'number' && !settings.fragment) {
 		doAfterImagesLoaded(() => {

--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -47,6 +47,7 @@ function doAfterImagesLoaded(cb: () => void) {
 			} else {
 				return new Promise<void>((resolve) => {
 					e.addEventListener('load', () => resolve());
+					e.addEventListener('error', () => resolve());
 				});
 			}
 		});

--- a/extensions/markdown-language-features/preview-src/scroll-sync.ts
+++ b/extensions/markdown-language-features/preview-src/scroll-sync.ts
@@ -143,6 +143,7 @@ export function scrollToRevealSourceLine(line: number) {
 		const progressInElement = line - Math.floor(line);
 		scrollTo = previousTop + (rect.height * progressInElement);
 	}
+	scrollTo = Math.abs(scrollTo) < 1 ? Math.sign(scrollTo) : scrollTo;
 	window.scroll(window.scrollX, Math.max(1, window.scrollY + scrollTo));
 }
 


### PR DESCRIPTION
Fix scrolling of markdown preview. This PR fixes #65504.

- Ensure that `window.scrollTo` is called after images loaded.
- Ensure that `window.scrollTo` called from `onceDocumentLoaded` and `onUpdateView` does not lead to `messaging.postMessage('revealLine', { line })`.

I think that it is not guaranteed that `scrollDisabled = true` and `scrollDisabled = false` are alternately executed in order when users type very quickly. So, we have to use the counter `scrollDisabledCount` instead of the boolean `scrollDisabled`.


I have tested this PR with the document https://github.com/jlelong/LaTeX-Workshop-wiki/blob/master/Hover.md.

Before:

![Nov-21-2020 21-57-02](https://user-images.githubusercontent.com/10665499/99877924-e36e7f80-2c44-11eb-845e-169d20ac5195.gif)

After:
![Nov-22-2020 07-10-51](https://user-images.githubusercontent.com/10665499/99888672-03786000-2c92-11eb-8ff2-005b702827e3.gif)

