### PR TITLE
[markdown-language-features]: Fix starting scroll for URIs with fragment

### DIFF
--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -90,7 +90,7 @@ class StartingScrollLine {
 	) { }
 }
 
-class StartingScrollFragment {
+export class StartingScrollFragment {
 	public readonly type = 'fragment';
 
 	constructor(

--- a/extensions/markdown-language-features/src/features/previewContentProvider.ts
+++ b/extensions/markdown-language-features/src/features/previewContentProvider.ts
@@ -59,6 +59,7 @@ export class MarkdownContentProvider {
 		const config = previewConfigurations.loadAndCacheConfiguration(sourceUri);
 		const initialData = {
 			source: sourceUri.toString(),
+			fragment: state?.fragment || markdownDocument.uri.fragment || undefined,
 			line: initialLine,
 			lineCount: markdownDocument.lineCount,
 			scrollPreviewWithEditor: config.scrollPreviewWithEditor,

--- a/extensions/markdown-language-features/src/features/previewManager.ts
+++ b/extensions/markdown-language-features/src/features/previewManager.ts
@@ -9,7 +9,7 @@ import { MarkdownEngine } from '../markdownEngine';
 import { MarkdownContributionProvider } from '../markdownExtensions';
 import { Disposable, disposeAll } from '../util/dispose';
 import { TopmostLineMonitor } from '../util/topmostLineMonitor';
-import { DynamicMarkdownPreview, ManagedMarkdownPreview, StaticMarkdownPreview } from './preview';
+import { DynamicMarkdownPreview, ManagedMarkdownPreview, StartingScrollFragment, StaticMarkdownPreview } from './preview';
 import { MarkdownPreviewConfigurationManager } from './previewConfig';
 import { MarkdownContentProvider } from './previewContentProvider';
 
@@ -106,7 +106,10 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 			preview = this.createNewDynamicPreview(resource, settings);
 		}
 
-		preview.update(resource);
+		preview.update(
+			resource,
+			resource.fragment ? new StartingScrollFragment(resource.fragment) : undefined
+		);
 	}
 
 	public get activePreviewResource() {


### PR DESCRIPTION
I don't expect this PR will be merged as-is, but it does fix the issue. I expect a maintainer more familiar with `markdown-language-features` may want to tweak the implementation. In particular, there's `fragment` in multiple places when passed to the preview UI, and the `index.ts` file there is looking for `fragment` on `settings`, but it wasn't wired up there, so it would never be found. It's being passed in `state`, but I'm not sure how/why one is used over the other.

This PR fixes previewing URIs with a fragment, by having the starting scroll respect the fragment location. Currently links with a URL fragment work as expected within the markdown preview, but when a link jumps to another file, the fragment isn't used. Same with executing the `markdown.showPreview` command with a fragment on the URI.

@mjbvz @meganrogge 