### PR TITLE
Add vscode.Uri to types for vscode.RelativePattern's base parameter

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1905,7 +1905,7 @@ declare module 'vscode' {
 		 * @param pattern A file glob pattern like `*.{ts,js}` that will be matched on file paths
 		 * relative to the base path.
 		 */
-		constructor(base: WorkspaceFolder | string, pattern: string)
+		constructor(base: Uri | WorkspaceFolder | string, pattern: string)
 	}
 
 	/**

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2193,9 +2193,9 @@ export class RelativePattern implements IRelativePattern {
 
 	pattern: string;
 
-	constructor(base: vscode.WorkspaceFolder | string, pattern: string) {
+	constructor(base: URI | vscode.WorkspaceFolder | string, pattern: string) {
 		if (typeof base !== 'string') {
-			if (!base || !URI.isUri(base.uri)) {
+			if (!base || !URI.isUri(base) && !URI.isUri(base.uri)) {
 				throw illegalArgument('base');
 			}
 		}
@@ -2206,6 +2206,9 @@ export class RelativePattern implements IRelativePattern {
 
 		if (typeof base === 'string') {
 			this.base = base;
+		} else if (URI.isUri(base)) {
+			this.baseFolder = base;
+			this.base = base.fsPath;
 		} else {
 			this.baseFolder = base.uri;
 			this.base = base.uri.fsPath;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #111154.

It's a little more than just syntactic sugar, since using a `vscode.Uri` will set `baseFolder` which means the path doesn't need to be re-parsed back into a `vscode.Uri`, as is done in a couple parts of the codebase if `baseFolder` is not set.
