### PR TITLE
Prevent unwanted concatenation of "null" to feedback URL

### DIFF
--- a/src/vs/workbench/contrib/feedback/browser/feedbackStatusbarItem.ts
+++ b/src/vs/workbench/contrib/feedback/browser/feedbackStatusbarItem.ts
@@ -28,7 +28,7 @@ class TwitterFeedbackService implements IFeedbackDelegate {
 	}
 
 	submitFeedback(feedback: IFeedback, openerService: IOpenerService): void {
-		const queryString = `?${feedback.sentiment === 1 ? `hashtags=${this.combineHashTagsAsString()}&` : null}ref_src=twsrc%5Etfw&related=twitterapi%2Ctwitter&text=${encodeURIComponent(feedback.feedback)}&tw_p=tweetbutton&via=${TwitterFeedbackService.VIA_NAME}`;
+		const queryString = `?${feedback.sentiment === 1 ? `hashtags=${this.combineHashTagsAsString()}&` : ''}ref_src=twsrc%5Etfw&related=twitterapi%2Ctwitter&text=${encodeURIComponent(feedback.feedback)}&tw_p=tweetbutton&via=${TwitterFeedbackService.VIA_NAME}`;
 		const url = TwitterFeedbackService.TWITTER_URL + queryString;
 
 		openerService.open(URI.parse(url));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #111324 by replacing the null concatenation with an empty string instead so that the resulting query parameter for "sad" feedback is `ref_src`. To test:
1. Open the tweet feedback UI using the button in the bottom right of code.
2. Click the sad face
3. Enter some tweet content
4. Hit tweet
5. The resulting URL should contain `ref_src` and NOT `nullref_src`