### PR TITLE
Show keyboard shortcuts inside integrated terminal in Screencast Mode

### DIFF
--- a/src/vs/editor/browser/controller/coreCommands.ts
+++ b/src/vs/editor/browser/controller/coreCommands.ts
@@ -410,7 +410,6 @@ export namespace CoreNavigationCommands {
 				precondition: undefined,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.LeftArrow,
 					linux: { primary: 0 }
 				}
@@ -429,7 +428,6 @@ export namespace CoreNavigationCommands {
 				precondition: undefined,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.RightArrow,
 					linux: { primary: 0 }
 				}
@@ -461,7 +459,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.UpArrow,
 			linux: { primary: 0 }
 		}
@@ -473,7 +470,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.PageUp,
 			linux: { primary: 0 }
 		}
@@ -499,7 +495,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.DownArrow,
 			linux: { primary: 0 }
 		}
@@ -511,7 +506,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.PageDown,
 			linux: { primary: 0 }
 		}
@@ -620,7 +614,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyCode.LeftArrow,
 			mac: { primary: KeyCode.LeftArrow, secondary: [KeyMod.WinCtrl | KeyCode.KEY_B] }
 		}
@@ -637,7 +630,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.Shift | KeyCode.LeftArrow
 		}
 	}));
@@ -653,7 +645,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyCode.RightArrow,
 			mac: { primary: KeyCode.RightArrow, secondary: [KeyMod.WinCtrl | KeyCode.KEY_F] }
 		}
@@ -670,7 +661,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.Shift | KeyCode.RightArrow
 		}
 	}));
@@ -686,7 +676,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyCode.UpArrow,
 			mac: { primary: KeyCode.UpArrow, secondary: [KeyMod.WinCtrl | KeyCode.KEY_P] }
 		}
@@ -703,7 +692,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.Shift | KeyCode.UpArrow,
 			secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow],
 			mac: { primary: KeyMod.Shift | KeyCode.UpArrow },
@@ -722,7 +710,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyCode.PageUp
 		}
 	}));
@@ -738,7 +725,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.Shift | KeyCode.PageUp
 		}
 	}));
@@ -754,7 +740,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyCode.DownArrow,
 			mac: { primary: KeyCode.DownArrow, secondary: [KeyMod.WinCtrl | KeyCode.KEY_N] }
 		}
@@ -771,7 +756,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.Shift | KeyCode.DownArrow,
 			secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow],
 			mac: { primary: KeyMod.Shift | KeyCode.DownArrow },
@@ -790,7 +774,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyCode.PageDown
 		}
 	}));
@@ -806,7 +789,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.Shift | KeyCode.PageDown
 		}
 	}));
@@ -920,7 +902,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyCode.Home,
 			mac: { primary: KeyCode.Home, secondary: [KeyMod.CtrlCmd | KeyCode.LeftArrow] }
 		}
@@ -932,7 +913,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.Shift | KeyCode.Home,
 			mac: { primary: KeyMod.Shift | KeyCode.Home, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.LeftArrow] }
 		}
@@ -974,7 +954,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: 0,
 			mac: { primary: KeyMod.WinCtrl | KeyCode.KEY_A }
 		}
@@ -986,7 +965,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: 0,
 			mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.KEY_A }
 		}
@@ -1019,7 +997,6 @@ export namespace CoreNavigationCommands {
 		kbOpts: {
 			args: { sticky: false },
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyCode.End,
 			mac: { primary: KeyCode.End, secondary: [KeyMod.CtrlCmd | KeyCode.RightArrow] }
 		},
@@ -1048,7 +1025,6 @@ export namespace CoreNavigationCommands {
 		kbOpts: {
 			args: { sticky: false },
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.Shift | KeyCode.End,
 			mac: { primary: KeyMod.Shift | KeyCode.End, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.RightArrow] }
 		},
@@ -1107,7 +1083,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: 0,
 			mac: { primary: KeyMod.WinCtrl | KeyCode.KEY_E }
 		}
@@ -1119,7 +1094,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: 0,
 			mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.KEY_E }
 		}
@@ -1151,7 +1125,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.CtrlCmd | KeyCode.Home,
 			mac: { primary: KeyMod.CtrlCmd | KeyCode.UpArrow }
 		}
@@ -1163,7 +1136,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Home,
 			mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow }
 		}
@@ -1195,7 +1167,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.CtrlCmd | KeyCode.End,
 			mac: { primary: KeyMod.CtrlCmd | KeyCode.DownArrow }
 		}
@@ -1207,7 +1178,6 @@ export namespace CoreNavigationCommands {
 		precondition: undefined,
 		kbOpts: {
 			weight: CORE_WEIGHT,
-			kbExpr: EditorContextKeys.textInputFocus,
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.End,
 			mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow }
 		}
@@ -1292,7 +1262,6 @@ export namespace CoreNavigationCommands {
 				precondition: undefined,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
 					mac: { primary: KeyMod.WinCtrl | KeyCode.PageUp }
 				}
@@ -1317,7 +1286,6 @@ export namespace CoreNavigationCommands {
 				precondition: undefined,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyMod.CtrlCmd | KeyCode.PageUp,
 					win: { primary: KeyMod.Alt | KeyCode.PageUp },
 					linux: { primary: KeyMod.Alt | KeyCode.PageUp }
@@ -1343,7 +1311,6 @@ export namespace CoreNavigationCommands {
 				precondition: undefined,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyMod.CtrlCmd | KeyCode.DownArrow,
 					mac: { primary: KeyMod.WinCtrl | KeyCode.PageDown }
 				}
@@ -1368,7 +1335,6 @@ export namespace CoreNavigationCommands {
 				precondition: undefined,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyMod.CtrlCmd | KeyCode.PageDown,
 					win: { primary: KeyMod.Alt | KeyCode.PageDown },
 					linux: { primary: KeyMod.Alt | KeyCode.PageDown }
@@ -1522,7 +1488,6 @@ export namespace CoreNavigationCommands {
 				precondition: undefined,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyMod.CtrlCmd | KeyCode.KEY_L
 				}
 			});
@@ -1547,7 +1512,6 @@ export namespace CoreNavigationCommands {
 				precondition: EditorContextKeys.hasNonEmptySelection,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyCode.Escape,
 					secondary: [KeyMod.Shift | KeyCode.Escape]
 				}
@@ -1574,7 +1538,6 @@ export namespace CoreNavigationCommands {
 				precondition: EditorContextKeys.hasMultipleSelections,
 				kbOpts: {
 					weight: CORE_WEIGHT + 1,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyCode.Escape,
 					secondary: [KeyMod.Shift | KeyCode.Escape]
 				}
@@ -1697,7 +1660,6 @@ export namespace CoreNavigationCommands {
 }
 
 const columnSelectionCondition = ContextKeyExpr.and(
-	EditorContextKeys.textInputFocus,
 	EditorContextKeys.columnSelection
 );
 function registerColumnSelection(id: string, keybinding: number): void {
@@ -1743,7 +1705,6 @@ export namespace CoreEditingCommands {
 				precondition: EditorContextKeys.writable,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: 0,
 					mac: { primary: KeyMod.WinCtrl | KeyCode.KEY_O }
 				}
@@ -1809,7 +1770,6 @@ export namespace CoreEditingCommands {
 				precondition: undefined,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyCode.Backspace,
 					secondary: [KeyMod.Shift | KeyCode.Backspace],
 					mac: { primary: KeyCode.Backspace, secondary: [KeyMod.Shift | KeyCode.Backspace, KeyMod.WinCtrl | KeyCode.KEY_H, KeyMod.WinCtrl | KeyCode.Backspace] }
@@ -1834,7 +1794,6 @@ export namespace CoreEditingCommands {
 				precondition: undefined,
 				kbOpts: {
 					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
 					primary: KeyCode.Delete,
 					mac: { primary: KeyCode.Delete, secondary: [KeyMod.WinCtrl | KeyCode.KEY_D, KeyMod.WinCtrl | KeyCode.Delete] }
 				}

--- a/src/vs/editor/contrib/caretOperations/transpose.ts
+++ b/src/vs/editor/contrib/caretOperations/transpose.ts
@@ -23,7 +23,6 @@ class TransposeLettersAction extends EditorAction {
 			alias: 'Transpose Letters',
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: 0,
 				mac: {
 					primary: KeyMod.WinCtrl | KeyCode.KEY_T

--- a/src/vs/editor/contrib/clipboard/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/clipboard.ts
@@ -136,7 +136,6 @@ class ExecCommandCopyWithSyntaxHighlightingAction extends EditorAction {
 			alias: 'Copy With Syntax Highlighting',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: 0,
 				weight: KeybindingWeight.EditorContrib
 			}

--- a/src/vs/editor/contrib/contextmenu/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/contextmenu.ts
@@ -13,7 +13,6 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { ICodeEditor, IEditorMouseEvent, MouseTargetType } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, ServicesAccessor, registerEditorAction, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { IEditorContribution, ScrollType } from 'vs/editor/common/editorCommon';
-import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { IMenuService, MenuId, SubmenuItemAction } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
@@ -267,7 +266,6 @@ class ShowContextMenu extends EditorAction {
 			alias: 'Show Editor Context Menu',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.Shift | KeyCode.F10,
 				weight: KeybindingWeight.EditorContrib
 			}

--- a/src/vs/editor/contrib/cursorUndo/cursorUndo.ts
+++ b/src/vs/editor/contrib/cursorUndo/cursorUndo.ts
@@ -10,7 +10,6 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, ServicesAccessor, registerEditorAction, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { Selection } from 'vs/editor/common/core/selection';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
-import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 
 class CursorState {
@@ -133,7 +132,6 @@ export class CursorUndo extends EditorAction {
 			alias: 'Cursor Undo',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.CtrlCmd | KeyCode.KEY_U,
 				weight: KeybindingWeight.EditorContrib
 			}

--- a/src/vs/editor/contrib/linesOperations/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/linesOperations.ts
@@ -341,7 +341,6 @@ export class DeleteLinesAction extends EditorAction {
 			alias: 'Delete Line',
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_K,
 				weight: KeybindingWeight.EditorContrib
 			}
@@ -582,7 +581,6 @@ export class DeleteAllLeftAction extends AbstractDeleteAllToBoundaryAction {
 			alias: 'Delete All Left',
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: 0,
 				mac: { primary: KeyMod.CtrlCmd | KeyCode.Backspace },
 				weight: KeybindingWeight.EditorContrib
@@ -660,7 +658,6 @@ export class DeleteAllRightAction extends AbstractDeleteAllToBoundaryAction {
 			alias: 'Delete All Right',
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: 0,
 				mac: { primary: KeyMod.WinCtrl | KeyCode.KEY_K, secondary: [KeyMod.CtrlCmd | KeyCode.Delete] },
 				weight: KeybindingWeight.EditorContrib

--- a/src/vs/editor/contrib/suggest/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/suggestController.ts
@@ -601,7 +601,6 @@ export class TriggerSuggestAction extends EditorAction {
 			alias: 'Trigger Suggest',
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasCompletionItemProvider),
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.CtrlCmd | KeyCode.Space,
 				secondary: [KeyMod.CtrlCmd | KeyCode.KEY_I],
 				mac: { primary: KeyMod.WinCtrl | KeyCode.Space, secondary: [KeyMod.Alt | KeyCode.Escape, KeyMod.CtrlCmd | KeyCode.KEY_I] },
@@ -640,7 +639,7 @@ registerEditorCommand(new SuggestCommand({
 // normal tab
 KeybindingsRegistry.registerKeybindingRule({
 	id: 'acceptSelectedSuggestion',
-	when: ContextKeyExpr.and(SuggestContext.Visible, EditorContextKeys.textInputFocus),
+	when: ContextKeyExpr.and(SuggestContext.Visible),
 	primary: KeyCode.Tab,
 	weight
 });
@@ -648,7 +647,7 @@ KeybindingsRegistry.registerKeybindingRule({
 // accept on enter has special rules
 KeybindingsRegistry.registerKeybindingRule({
 	id: 'acceptSelectedSuggestion',
-	when: ContextKeyExpr.and(SuggestContext.Visible, EditorContextKeys.textInputFocus, SuggestContext.AcceptSuggestionsOnEnter, SuggestContext.MakesTextEdit),
+	when: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.AcceptSuggestionsOnEnter, SuggestContext.MakesTextEdit),
 	primary: KeyCode.Enter,
 	weight,
 });
@@ -674,10 +673,9 @@ MenuRegistry.appendMenuItem(suggestWidgetStatusbarMenu, {
 
 registerEditorCommand(new SuggestCommand({
 	id: 'acceptAlternativeSelectedSuggestion',
-	precondition: ContextKeyExpr.and(SuggestContext.Visible, EditorContextKeys.textInputFocus),
+	precondition: ContextKeyExpr.and(SuggestContext.Visible),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyMod.Shift | KeyCode.Enter,
 		secondary: [KeyMod.Shift | KeyCode.Tab],
 	},
@@ -709,7 +707,6 @@ registerEditorCommand(new SuggestCommand({
 	handler: x => x.cancelSuggestWidget(),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyCode.Escape,
 		secondary: [KeyMod.Shift | KeyCode.Escape]
 	}
@@ -721,7 +718,6 @@ registerEditorCommand(new SuggestCommand({
 	handler: c => c.selectNextSuggestion(),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyCode.DownArrow,
 		secondary: [KeyMod.CtrlCmd | KeyCode.DownArrow],
 		mac: { primary: KeyCode.DownArrow, secondary: [KeyMod.CtrlCmd | KeyCode.DownArrow, KeyMod.WinCtrl | KeyCode.KEY_N] }
@@ -734,7 +730,6 @@ registerEditorCommand(new SuggestCommand({
 	handler: c => c.selectNextPageSuggestion(),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyCode.PageDown,
 		secondary: [KeyMod.CtrlCmd | KeyCode.PageDown]
 	}
@@ -752,7 +747,6 @@ registerEditorCommand(new SuggestCommand({
 	handler: c => c.selectPrevSuggestion(),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyCode.UpArrow,
 		secondary: [KeyMod.CtrlCmd | KeyCode.UpArrow],
 		mac: { primary: KeyCode.UpArrow, secondary: [KeyMod.CtrlCmd | KeyCode.UpArrow, KeyMod.WinCtrl | KeyCode.KEY_P] }
@@ -765,7 +759,6 @@ registerEditorCommand(new SuggestCommand({
 	handler: c => c.selectPrevPageSuggestion(),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyCode.PageUp,
 		secondary: [KeyMod.CtrlCmd | KeyCode.PageUp]
 	}
@@ -783,7 +776,6 @@ registerEditorCommand(new SuggestCommand({
 	handler: x => x.toggleSuggestionDetails(),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyMod.CtrlCmd | KeyCode.Space,
 		mac: { primary: KeyMod.WinCtrl | KeyCode.Space }
 	},
@@ -818,7 +810,6 @@ registerEditorCommand(new SuggestCommand({
 	handler: x => x.toggleSuggestionFocus(),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Space,
 		mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.Space }
 	}
@@ -829,7 +820,6 @@ registerEditorCommand(new SuggestCommand({
 registerEditorCommand(new SuggestCommand({
 	id: 'insertBestCompletion',
 	precondition: ContextKeyExpr.and(
-		EditorContextKeys.textInputFocus,
 		ContextKeyExpr.equals('config.editor.tabCompletion', 'on'),
 		WordContextKey.AtEnd,
 		SuggestContext.Visible.toNegated(),
@@ -849,7 +839,6 @@ registerEditorCommand(new SuggestCommand({
 registerEditorCommand(new SuggestCommand({
 	id: 'insertNextSuggestion',
 	precondition: ContextKeyExpr.and(
-		EditorContextKeys.textInputFocus,
 		ContextKeyExpr.equals('config.editor.tabCompletion', 'on'),
 		SuggestAlternatives.OtherSuggestions,
 		SuggestContext.Visible.toNegated(),
@@ -858,7 +847,6 @@ registerEditorCommand(new SuggestCommand({
 	handler: x => x.acceptNextSuggestion(),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyCode.Tab
 	}
 }));
@@ -866,7 +854,6 @@ registerEditorCommand(new SuggestCommand({
 registerEditorCommand(new SuggestCommand({
 	id: 'insertPrevSuggestion',
 	precondition: ContextKeyExpr.and(
-		EditorContextKeys.textInputFocus,
 		ContextKeyExpr.equals('config.editor.tabCompletion', 'on'),
 		SuggestAlternatives.OtherSuggestions,
 		SuggestContext.Visible.toNegated(),
@@ -875,7 +862,6 @@ registerEditorCommand(new SuggestCommand({
 	handler: x => x.acceptPrevSuggestion(),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyMod.Shift | KeyCode.Tab
 	}
 }));

--- a/src/vs/editor/contrib/wordOperations/wordOperations.ts
+++ b/src/vs/editor/contrib/wordOperations/wordOperations.ts
@@ -126,7 +126,6 @@ export class CursorWordLeft extends WordLeftCommand {
 			id: 'cursorWordLeft',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.CtrlCmd | KeyCode.LeftArrow,
 				mac: { primary: KeyMod.Alt | KeyCode.LeftArrow },
 				weight: KeybindingWeight.EditorContrib
@@ -165,7 +164,6 @@ export class CursorWordLeftSelect extends WordLeftCommand {
 			id: 'cursorWordLeftSelect',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.LeftArrow,
 				mac: { primary: KeyMod.Alt | KeyMod.Shift | KeyCode.LeftArrow },
 				weight: KeybindingWeight.EditorContrib
@@ -183,7 +181,7 @@ export class CursorWordAccessibilityLeft extends WordLeftCommand {
 			id: 'cursorWordAccessibilityLeft',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: ContextKeyExpr.and(EditorContextKeys.textInputFocus, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+				kbExpr: ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED),
 				win: { primary: KeyMod.CtrlCmd | KeyCode.LeftArrow },
 				weight: KeybindingWeight.EditorContrib + 1
 			}
@@ -203,7 +201,7 @@ export class CursorWordAccessibilityLeftSelect extends WordLeftCommand {
 			id: 'cursorWordAccessibilityLeftSelect',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: ContextKeyExpr.and(EditorContextKeys.textInputFocus, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+				kbExpr: ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED),
 				win: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.LeftArrow },
 				weight: KeybindingWeight.EditorContrib + 1
 			}
@@ -234,7 +232,6 @@ export class CursorWordEndRight extends WordRightCommand {
 			id: 'cursorWordEndRight',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.CtrlCmd | KeyCode.RightArrow,
 				mac: { primary: KeyMod.Alt | KeyCode.RightArrow },
 				weight: KeybindingWeight.EditorContrib
@@ -273,7 +270,6 @@ export class CursorWordEndRightSelect extends WordRightCommand {
 			id: 'cursorWordEndRightSelect',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.RightArrow,
 				mac: { primary: KeyMod.Alt | KeyMod.Shift | KeyCode.RightArrow },
 				weight: KeybindingWeight.EditorContrib
@@ -301,7 +297,7 @@ export class CursorWordAccessibilityRight extends WordRightCommand {
 			id: 'cursorWordAccessibilityRight',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: ContextKeyExpr.and(EditorContextKeys.textInputFocus, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+				kbExpr: ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED),
 				win: { primary: KeyMod.CtrlCmd | KeyCode.RightArrow },
 				weight: KeybindingWeight.EditorContrib + 1
 			}
@@ -321,7 +317,7 @@ export class CursorWordAccessibilityRightSelect extends WordRightCommand {
 			id: 'cursorWordAccessibilityRightSelect',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: ContextKeyExpr.and(EditorContextKeys.textInputFocus, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+				kbExpr: ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED),
 				win: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.RightArrow },
 				weight: KeybindingWeight.EditorContrib + 1
 			}
@@ -432,7 +428,6 @@ export class DeleteWordLeft extends DeleteWordLeftCommand {
 			id: 'deleteWordLeft',
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.CtrlCmd | KeyCode.Backspace,
 				mac: { primary: KeyMod.Alt | KeyCode.Backspace },
 				weight: KeybindingWeight.EditorContrib
@@ -471,7 +466,6 @@ export class DeleteWordRight extends DeleteWordRightCommand {
 			id: 'deleteWordRight',
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.CtrlCmd | KeyCode.Delete,
 				mac: { primary: KeyMod.Alt | KeyCode.Delete },
 				weight: KeybindingWeight.EditorContrib

--- a/src/vs/editor/contrib/wordPartOperations/wordPartOperations.ts
+++ b/src/vs/editor/contrib/wordPartOperations/wordPartOperations.ts
@@ -23,7 +23,6 @@ export class DeleteWordPartLeft extends DeleteWordCommand {
 			id: 'deleteWordPartLeft',
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: 0,
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.Backspace },
 				weight: KeybindingWeight.EditorContrib
@@ -48,7 +47,6 @@ export class DeleteWordPartRight extends DeleteWordCommand {
 			id: 'deleteWordPartRight',
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: 0,
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.Delete },
 				weight: KeybindingWeight.EditorContrib
@@ -80,7 +78,6 @@ export class CursorWordPartLeft extends WordPartLeftCommand {
 			id: 'cursorWordPartLeft',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: 0,
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.LeftArrow },
 				weight: KeybindingWeight.EditorContrib
@@ -99,7 +96,6 @@ export class CursorWordPartLeftSelect extends WordPartLeftCommand {
 			id: 'cursorWordPartLeftSelect',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: 0,
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyMod.Shift | KeyCode.LeftArrow },
 				weight: KeybindingWeight.EditorContrib
@@ -123,7 +119,6 @@ export class CursorWordPartRight extends WordPartRightCommand {
 			id: 'cursorWordPartRight',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: 0,
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.RightArrow },
 				weight: KeybindingWeight.EditorContrib
@@ -139,7 +134,6 @@ export class CursorWordPartRightSelect extends WordPartRightCommand {
 			id: 'cursorWordPartRightSelect',
 			precondition: undefined,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: 0,
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyMod.Shift | KeyCode.RightArrow },
 				weight: KeybindingWeight.EditorContrib

--- a/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
@@ -19,7 +19,6 @@ import { IThemeService, IColorTheme } from 'vs/platform/theme/common/themeServic
 import { createDecorator, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor, EditorCommand, registerEditorCommand } from 'vs/editor/browser/editorExtensions';
-import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { URI as uri } from 'vs/base/common/uri';
 import { CompletionProviderRegistry, CompletionList, CompletionContext, CompletionItemKind } from 'vs/editor/common/modes';
@@ -367,7 +366,6 @@ class CloseBreakpointWidgetCommand extends EditorCommand {
 			id: 'closeBreakpointWidget',
 			precondition: CONTEXT_BREAKPOINT_WIDGET_VISIBLE,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyCode.Escape,
 				secondary: [KeyMod.Shift | KeyCode.Escape],
 				weight: KeybindingWeight.EditorContrib

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -24,7 +24,6 @@ import { IThemeService, ThemeIcon } from 'vs/platform/theme/common/themeService'
 import { ICodeEditor, isCodeEditor } from 'vs/editor/browser/editorBrowser';
 import { memoize } from 'vs/base/common/decorators';
 import { dispose, IDisposable, Disposable } from 'vs/base/common/lifecycle';
-import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
 import { IDebugService, DEBUG_SCHEME, CONTEXT_IN_DEBUG_REPL, IDebugSession, State, IReplElement, IDebugConfiguration, REPL_VIEW_ID } from 'vs/workbench/contrib/debug/common/debug';
 import { HistoryNavigator } from 'vs/base/common/history';
@@ -750,7 +749,6 @@ class AcceptReplInputAction extends EditorAction {
 			alias: 'REPL Accept Input',
 			precondition: CONTEXT_IN_DEBUG_REPL,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyCode.Enter,
 				weight: KeybindingWeight.EditorContrib
 			}
@@ -773,7 +771,6 @@ class FilterReplAction extends EditorAction {
 			alias: 'REPL Filter',
 			precondition: CONTEXT_IN_DEBUG_REPL,
 			kbOpts: {
-				kbExpr: EditorContextKeys.textInputFocus,
 				primary: KeyMod.CtrlCmd | KeyCode.KEY_F,
 				weight: KeybindingWeight.EditorContrib
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #81537






test:
by enabling screencast mode with shortcut checked any shortcut with when textinputfocus that works with the editor can work now in terminal