### PR TITLE
Prevent error when reopening markdown preview. (#107205)

### DIFF
--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1622,10 +1622,8 @@ export function viewColumnToEditorGroup(editorGroupService: IEditorGroupsService
 }
 
 export function editorGroupToViewColumn(editorGroupService: IEditorGroupsService, editorGroup: IEditorGroup | GroupIdentifier): EditorGroupColumn {
-	const group = (typeof editorGroup === 'number') ? editorGroupService.getGroup(editorGroup) : editorGroup;
-	if (!group) {
-		throw new Error('Invalid group provided');
-	}
+	let group = (typeof editorGroup === 'number') ? editorGroupService.getGroup(editorGroup) : editorGroup;
+	group = group ?? editorGroupService.activeGroup;
 
 	return editorGroupService.getGroups(GroupsOrder.GRID_APPEARANCE).indexOf(group);
 }


### PR DESCRIPTION
Default to active group instead of throwing error when calling `editorGroupToViewColumn()`. This fix makes markdown previews behave like text editors when reopening. The error was caused when the preview was opened in an editor group that has since closed.

I am not sure why @sohomdatta1 solution was not accepted but here is another attempt.

Fixes #107205
