### PR TITLE
Handle rejected promise in history delayer when disposing of find widget

### DIFF
--- a/src/vs/editor/contrib/find/findWidget.ts
+++ b/src/vs/editor/contrib/find/findWidget.ts
@@ -380,7 +380,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 	}
 
 	private _delayedUpdateHistory() {
-		this._updateHistoryDelayer.trigger(this._updateHistory.bind(this));
+		this._updateHistoryDelayer.trigger(this._updateHistory.bind(this)).then(undefined, onUnexpectedError);
 	}
 
 	private _updateHistory() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

The find widget's update history is wrapped in a delayer promise which can cause an unhandled promise rejection when the widget is getting disposed of if the delayer's completion promise hasn't been cleanup up. This can happen if the editor is closed before the find widget has time to finish closing.
Steps to Reproduce:

1. Open new editor.
2. CMD-F to open the find widget.
3. ESC to close the find widget and quickly close the editor before the widget has time to close.

This PR fixes #111539 