### PR TITLE
Fix random focus lost issues on CTRL+1/2 for a webview

### DIFF
--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -231,9 +231,11 @@ export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> impleme
 			return;
 		}
 
-		// Clear the existing focus first.
+		// Clear the existing focus first if not already on the webview.
 		// This is required because the next part where we set the focus is async.
-		if (document.activeElement && document.activeElement instanceof HTMLElement) {
+		if (document.activeElement && document.activeElement instanceof HTMLElement && document.activeElement?.tagName !== 'WEBVIEW') {
+			// Don't blur if on the webview because this will also happen async and may unset the focus
+			// after the focus trigger fires below.
 			document.activeElement.blur();
 		}
 

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -233,7 +233,7 @@ export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> impleme
 
 		// Clear the existing focus first if not already on the webview.
 		// This is required because the next part where we set the focus is async.
-		if (document.activeElement && document.activeElement instanceof HTMLElement && document.activeElement.tagName !== 'WEBVIEW') {
+		if (document.activeElement && document.activeElement instanceof HTMLElement && document.activeElement !== this.element) {
 			// Don't blur if on the webview because this will also happen async and may unset the focus
 			// after the focus trigger fires below.
 			document.activeElement.blur();

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -233,7 +233,7 @@ export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> impleme
 
 		// Clear the existing focus first if not already on the webview.
 		// This is required because the next part where we set the focus is async.
-		if (document.activeElement && document.activeElement instanceof HTMLElement && document.activeElement?.tagName !== 'WEBVIEW') {
+		if (document.activeElement && document.activeElement instanceof HTMLElement && document.activeElement.tagName !== 'WEBVIEW') {
 			// Don't blur if on the webview because this will also happen async and may unset the focus
 			// after the focus trigger fires below.
 			document.activeElement.blur();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #97992

What I believe is happening (after adding a bunch of logging) is that the blur here:
https://github.com/microsoft/vscode/blob/4d9277a23a035cb0493a856ce4b1174d0db5512c/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts#L237

is also async when sent to a webview. 

This can cause the blur to fire randomly, sometimes after the focus trigger has fired (but also sometimes before, when it works).

This should resolve the problem we've been having with https://github.com/microsoft/vscode-jupyter/issues/1293 (or at least make it possible for us to handle focus correctly)

/cc @mjbvz 
