### PR TITLE
fix: #111917. Change the max-width of debug dover widget to fit-content

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/media/debugHover.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugHover.css
@@ -16,7 +16,7 @@
 }
 
 .monaco-editor .debug-hover-widget .complex-value {
-	max-width: 700px;
+	max-width: fit-content;
 }
 
 .monaco-editor .debug-hover-widget .complex-value .title,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #111917.
