### PR TITLE
Revert "build: create asset should still try to add asset"

### DIFF
--- a/build/azure-pipelines/common/createAsset.ts
+++ b/build/azure-pipelines/common/createAsset.ts
@@ -93,11 +93,15 @@ async function main(): Promise<void> {
 	const blobExists = await doesAssetExist(blobService, quality, blobName);
 
 	if (blobExists) {
-		console.log(`Blob ${quality}, ${blobName} already exists, not uploading again.`);
-	} else {
-		await uploadBlob(blobService, quality, blobName, filePath, fileName);
-		console.log('Blobs successfully uploaded.');
+		console.log(`Blob ${quality}, ${blobName} already exists, not publishing again.`);
+		return;
 	}
+
+	console.log('Uploading blobs to Azure storage...');
+
+	await uploadBlob(blobService, quality, blobName, filePath, fileName);
+
+	console.log('Blobs successfully uploaded.');
 
 	const asset: Asset = {
 		platform,


### PR DESCRIPTION
I knew there was a reason this was as designed...

We can't simply update CosmosDB if the blob has already been uploaded since the checksum hashes won't match, since builds have time-dependent bits.