### PR TITLE
Use the right deb repository for Linux ARM builds

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -98,6 +98,7 @@ function prepareDebPackage(arch) {
 			.pipe(replace('@@ARCHITECTURE@@', debArch))
 			.pipe(replace('@@QUALITY@@', product.quality || '@@QUALITY@@'))
 			.pipe(replace('@@UPDATEURL@@', product.updateUrl || '@@UPDATEURL@@'))
+			.pipe(replace('@@REPOSITORY_NAME@@', arch === 'x64' ? 'vscode' : 'code'))
 			.pipe(rename('DEBIAN/postinst'));
 
 		const all = es.merge(control, postinst, postrm, prerm, desktops, appdata, workspaceMime, icon, bash_completion, zsh_completion, code);

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -73,6 +73,6 @@ NdCFTW7wY0Fb1fWJ+/KTsC4=
 	if [ "$WRITE_SOURCE" -eq "1" ]; then
 		echo "### THIS FILE IS AUTOMATICALLY CONFIGURED ###
 # You may comment out this entry, but any other modifications may be lost.
-deb [arch=amd64] http://packages.microsoft.com/repos/vscode stable main" > $CODE_SOURCE_PART
+deb [arch=amd64] http://packages.microsoft.com/repos/@@REPOSITORY_NAME@@ stable main" > $CODE_SOURCE_PART
 	fi
 fi


### PR DESCRIPTION
Next iteration we should create a proper migration path for x64 as well.