### PR TITLE
Do not ignore errors from $spawnExtHostProcess

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalService.ts
@@ -260,7 +260,7 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 			request.cols,
 			request.rows,
 			request.isWorkspaceShellAllowed
-		).then(request.callback);
+		).then(request.callback, request.callback);
 
 		proxy.onInput(data => this._proxy.$acceptProcessInput(proxy.terminalId, data));
 		proxy.onResize(dimensions => this._proxy.$acceptProcessResize(proxy.terminalId, dimensions.cols, dimensions.rows));


### PR DESCRIPTION
The callback from the request accepts error as well as undefined. However, we ignore error, when we call then. This change fixes it.