### PR TITLE
Fixed tab switching too fast when wheeling/scrolling

### DIFF
--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -72,7 +72,9 @@ export class TabsTitleControl extends TitleControl {
 	};
 
 	private static readonly TAB_HEIGHT = 35;
-	private static readonly TIME_THRESHOLD = 150;
+
+	private static readonly MOUSE_WHEEL_EVENT_THRESHOLD = 150;
+	private static readonly MOUSE_WHEEL_DISTANCE_THRESHOLD = 1.5;
 
 	private titleContainer: HTMLElement | undefined;
 	private tabsAndActionsContainer: HTMLElement | undefined;
@@ -340,29 +342,27 @@ export class TabsTitleControl extends TitleControl {
 				}
 			}
 
-			// Ignore event if the last one happened too recently.
+			// Ignore event if the last one happened too recently (https://github.com/microsoft/vscode/issues/96409)
 			// The restriction is relaxed according to the absolute value of `deltaX` and `deltaY`
 			// to support discrete (mouse wheel) and contiguous scrolling (touchpad) equally well
-			if (Date.now() - this.lastMouseWheelEventTime < TabsTitleControl.TIME_THRESHOLD - 2 * (Math.abs(e.deltaX) + Math.abs(e.deltaY))) {
+			const now = Date.now();
+			if (now - this.lastMouseWheelEventTime < TabsTitleControl.MOUSE_WHEEL_EVENT_THRESHOLD - 2 * (Math.abs(e.deltaX) + Math.abs(e.deltaY))) {
 				return;
 			}
-			this.lastMouseWheelEventTime = Date.now();
 
-			// Figure out scrolling direction (ignore direction if the scrolling is too subtile)
-			const distanceThreshold = 1.5;
-			let tabSwitchDirection = 0;
-			if (e.deltaX + e.deltaY < - distanceThreshold) {
+			this.lastMouseWheelEventTime = now;
+
+			// Figure out scrolling direction but ignore it if too subtle
+			let tabSwitchDirection: number;
+			if (e.deltaX + e.deltaY < - TabsTitleControl.MOUSE_WHEEL_DISTANCE_THRESHOLD) {
 				tabSwitchDirection = -1;
-			} else if (e.deltaX + e.deltaY > distanceThreshold) {
+			} else if (e.deltaX + e.deltaY > TabsTitleControl.MOUSE_WHEEL_DISTANCE_THRESHOLD) {
 				tabSwitchDirection = 1;
-			}
-
-			if (tabSwitchDirection === 0) {
+			} else {
 				return;
 			}
 
 			const nextEditor = this.group.getEditorByIndex(this.group.getIndexOfEditor(activeEditor) + tabSwitchDirection);
-
 			if (!nextEditor) {
 				return;
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #96409 - Trackpad: Tab switch on mouse scroll: horizontal scrolling sensitivity too high. 

PS: I created this new PR to avoid unrelated commits from the old one (#111901).
