### PR TITLE
Add back 'to run' for Windows tooltip

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets.ts
@@ -353,8 +353,8 @@ export function getExecuteCellPlaceholder(viewCell: BaseCellViewModel) {
 		command: undefined,
 		// text: `${keybinding?.getLabel() || 'Ctrl + Enter'} to run`,
 		// tooltip: `${keybinding?.getLabel() || 'Ctrl + Enter'} to run`,
-		text: isWindows ? 'Ctrl + Alt + Enter' : 'Ctrl + Enter to run',
-		tooltip: isWindows ? 'Ctrl + Alt + Enter' : 'Ctrl + Enter to run',
+		text: isWindows ? 'Ctrl + Alt + Enter to run' : 'Ctrl + Enter to run',
+		tooltip: isWindows ? 'Ctrl + Alt + Enter to run' : 'Ctrl + Enter to run',
 		visible: true,
 		opacity: '0.7'
 	};


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes an issue introduced in https://github.com/microsoft/vscode/commit/b617b725a06169c39dcae398ee7c21d44bebe6b2 where the tooltip for running a notebook cell on Windows specifies only the keybinding and not the 'to run' text. (/cc @rebornix)
