### PR TITLE
fix #100151 display context menu on correct Explorer item when triggered by ContextMenu key

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1159,7 +1159,11 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 		const fromKeyup = Event.chain(domEvent(this.view.domNode, 'keyup'))
 			.filter(() => {
 				const didJustPressContextMenuKey = this.didJustPressContextMenuKey;
-				this.didJustPressContextMenuKey = false;
+				if (didJustPressContextMenuKey) {
+					// Delay clearing this so it is still set when the subsequent fromMouse event gets triggered by the ContextMenu key
+					// See https://github.com/microsoft/vscode/issues/100151
+					setTimeout(() => this.didJustPressContextMenuKey = false, 10);
+				}
 				return didJustPressContextMenuKey;
 			})
 			.filter(() => this.getFocus().length > 0 && !!this.view.domElement(this.getFocus()[0]))


### PR DESCRIPTION
This PR fixes #100151

It seems that when the ContextMenu key is pressed (on Windows at least, which is the platform I work on) a mouse event occurs immediately after the pair of keyboard events. There was already some logic in listWidget.ts that appeared designed to ignore this mouse event, but the flag that implemented this was being cleared by the onKeyup before the mouse event got handled.

I have fixed this by using setTimeout() to delay clearing the flag.
