### PR TITLE
add missing await for git.clone and git.cloneRecursive command

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -500,12 +500,12 @@ export class CommandCenter {
 
 	@command('git.clone')
 	async clone(url?: string, parentPath?: string): Promise<void> {
-		this.cloneRepository(url, parentPath);
+		await this.cloneRepository(url, parentPath);
 	}
 
 	@command('git.cloneRecursive')
 	async cloneRecursive(url?: string, parentPath?: string): Promise<void> {
-		this.cloneRepository(url, parentPath, { recursive: true });
+		await this.cloneRepository(url, parentPath, { recursive: true });
 	}
 
 	@command('git.init')


### PR DESCRIPTION
Since there is no `await`, when I call this command, it will return immediately