### PR TITLE
Fix linux deb repo pointer

### DIFF
--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -73,6 +73,6 @@ NdCFTW7wY0Fb1fWJ+/KTsC4=
 	if [ "$WRITE_SOURCE" -eq "1" ]; then
 		echo "### THIS FILE IS AUTOMATICALLY CONFIGURED ###
 # You may comment out this entry, but any other modifications may be lost.
-deb [arch=amd64] http://packages.microsoft.com/repos/@@REPOSITORY_NAME@@ stable main" > $CODE_SOURCE_PART
+deb [arch=amd64,arm64,armhf] http://packages.microsoft.com/repos/@@REPOSITORY_NAME@@ stable main" > $CODE_SOURCE_PART
 	fi
 fi


### PR DESCRIPTION
This PR makes sure ARM architectures point to the right linux deb repo.
