### PR TITLE
chore: fix run-on values for snap build

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -238,7 +238,8 @@ function prepareSnapPackage(arch) {
 		const snapcraft = gulp.src('resources/linux/snap/snapcraft.yaml', { base: '.' })
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(replace('@@VERSION@@', commit.substr(0, 8)))
-			.pipe(replace('@@ARCHITECTURE@@', arch))
+			// Possible run-on values https://snapcraft.io/docs/architectures
+			.pipe(replace('@@ARCHITECTURE@@', arch === 'x64' ? 'amd64' : arch))
 			.pipe(rename('snap/snapcraft.yaml'));
 
 		const electronLaunch = gulp.src('resources/linux/snap/electron-launch', { base: '.' })


### PR DESCRIPTION
Fixes regression from https://github.com/microsoft/vscode/commit/edf43e529a3a25133c7d59600d99ff6d0b59d2c8

/cc @joaomoreno 
