### PR TITLE
Add more frequently-used Ruby filenames to Ruby bundle (based on the actual TextMate bundle)

### DIFF
--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -13,7 +13,7 @@
 		"languages": [{
 			"id": "ruby",
 			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".rake", ".ru", ".erb", ".podspec", ".rbi" ],
-			"filenames": [ "rakefile", "gemfile", "guardfile", "podfile", "capfile" ],
+			"filenames": [ "rakefile", "gemfile", "guardfile", "podfile", "capfile", "cheffile", "hobofile", "vagrantfile", "appraisals", "rantfile", "berksfile", "berksfile.lock", "thorfile", "puppetfile", "dangerfile", "brewfile", "fastfile", "appfile", "deliverfile", "matchfile", "scanfile", "snapfile", "gymfile" ],
 			"aliases": [ "Ruby", "rb" ],
 			"firstLine": "^#!\\s*/.*\\bruby\\b",
 			"configuration": "./language-configuration.json"


### PR DESCRIPTION
This PR fixes an issue with many frequently-used Ruby DSLs not recognized by VSCode by default. In fact, it unifies this list with [this one](https://github.com/textmate/ruby.tmbundle/blob/master/Syntaxes/Ruby.plist) in the initial TextMate bundle. 
