### PR TITLE
Fixed issue #108301 by escaping URI before creating a MarkdownString.

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkManager.ts
@@ -230,10 +230,10 @@ export class TerminalLinkManager extends DisposableStore {
 		}
 
 		// encode the uri so TerminalLink get rendered as anchor element https://github.com/microsoft/vscode/issues/108301
-		uri = encodeURI(uri);
-
 		// Use 'undefined' when uri is '' so the link displays correctly
-		return new MarkdownString(`[${label || nls.localize('followLink', "Follow Link")}](${uri || 'undefined'}) (${clickLabel})`, true);
+		const encodedUri = encodeURI(uri) || 'undefined';
+
+		return new MarkdownString(`[${label || nls.localize('followLink', "Follow Link")}](${encodedUri}) (${clickLabel})`, true);
 	}
 
 	private get osPath(): IPath {

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkManager.ts
@@ -229,6 +229,9 @@ export class TerminalLinkManager extends DisposableStore {
 			}
 		}
 
+		// encode the uri so TerminalLink get rendered as anchor element https://github.com/microsoft/vscode/issues/108301
+		uri = encodeURI(uri);
+
 		// Use 'undefined' when uri is '' so the link displays correctly
 		return new MarkdownString(`[${label || nls.localize('followLink', "Follow Link")}](${uri || 'undefined'}) (${clickLabel})`, true);
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixed issue #108301 by escaping URI with 'encodeURI' before creating a MarkdownString in 'TerminalLinkManager.ts::_getLinkHoverString'.

You can test the original bug and fix by creating an extension that registers a TerminalLinkProvider that returns a TerminalLink spanning a space.

The extension activate function I used for testing was:
```
export function activate(context: vscode.ExtensionContext) {

	// Use the console to output diagnostic information (console.log) and errors (console.error)
	// This line of code will only be executed once when your extension is activated
	console.log('Congratulations, your extension "terminallinktest" is now active!');


	vscode.window.activeTerminal?.show();


	vscode.window.registerTerminalLinkProvider({
		provideTerminalLinks: (context, token) => {

			return [{
				startIndex: 0,
				length: 10,
				tooltip: "crash the tooltip"
			}];
		},

		handleTerminalLink: (link: any) => { }
	});

	// The command has been defined in the package.json file
	// Now provide the implementation of the command with registerCommand
	// The commandId parameter must match the command field in package.json
	let disposable = vscode.commands.registerCommand('terminallinktest.testLink', () => {
		// The code you place here will be executed every time your command is executed

		vscode.window.showInformationMessage("Hello from termainLinkTest");

		// const crashPrefix = "package:test_api/src/frontend/expect.dart";
		// const crashMiddle = " 154:30";
		// const crashSuffix = "		fail";
		// const crashString = crashPrefix + crashMiddle + crashSuffix;

		let text = "";

		// Send all ascii chars
		for(var i = 32; i < 300; ++i) {

			let message = i+":";

			// escape quotes and ticks
			if(i === 34 || i === 96) {
				message = "'"+message+"\\"+String.fromCharCode(i)+"'";

			// escape "'"
			} else if(i === 39) {

				message = '"'+message+'\'"';

			// default
			} else {
				message = "'"+message+String.fromCharCode(i)+"'";
			}

			text+= message+" ";
		}

		vscode.window.activeTerminal?.sendText("echo "+text);
	});

	context.subscriptions.push(disposable);
}

```

This PR fixes #108301 
