### PR TITLE
Fix Issue #110091

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -430,7 +430,6 @@ export class ClearTerminalAction extends Action {
 	async run() {
 		this._terminalService.doWithActiveInstance(t => {
 			t.clear();
-			t.focus();
 		});
 	}
 }


### PR DESCRIPTION
This PR fixes[ #110091](https://github.com/microsoft/vscode/issues/110091), which mentions the running of workbench.action.terminal.clear command will steal the focus to the terminal. The issue is fixed by removing the forced focus on the terminal instance after running the command.



This PR fixes #
110091(https://github.com/microsoft/vscode/issues/110091)