### PR TITLE
Fixed Issue #110225 - Dragging to select text on Peek window should not hide it

### DIFF
--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -163,7 +163,7 @@ export class ModesHoverController implements IEditorContribution {
 		}
 
 		if (this._isHoverSticky && !mouseEvent.event.browserEvent.view?.getSelection()?.isCollapsed) {
-			// selected text within content hover widget return; }
+			// selected text within content hover widget
 			return;
 		}
 

--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -162,6 +162,10 @@ export class ModesHoverController implements IEditorContribution {
 			return;
 		}
 
+		if (this._isHoverSticky && !mouseEvent.event.browserEvent.view?.getSelection()?.isCollapsed) {
+			// selected text within content hover widget return; }
+			return;
+		}
 
 		if (
 			!this._isHoverSticky && targetType === MouseTargetType.CONTENT_WIDGET && mouseEvent.target.detail === ModesContentHoverWidget.ID


### PR DESCRIPTION
This PR fixes #110225

Fixes issue where attempting to drag to select text on Hover widget prematurely closes Hover immediately. Allows for users to drag and select text within hover and move outside it, without it closing.

![](https://user-images.githubusercontent.com/33930602/98549726-80bbd200-229b-11eb-8514-d67f93263523.gif)

With the newly implemented change, dragging outside does not close the popup like in the above visual.