### PR TITLE
expose git clone api for git extension

### DIFF
--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -5,14 +5,13 @@
 
 import { Model } from '../model';
 import { Repository as BaseRepository, Resource } from '../repository';
-import { InputBox, Git, API, Repository, Remote, RepositoryState, Branch, ForcePushMode, Ref, Submodule, Commit, Change, RepositoryUIState, Status, LogOptions, APIState, CommitOptions, RefType, CredentialsProvider, BranchQuery, PushErrorHandler, PublishEvent, FetchOptions, RemoteSourceProvider, RemoteSourcePublisher } from './git';
-import { Event, SourceControlInputBox, Uri, SourceControl, Disposable, commands } from 'vscode';
+import { InputBox, Git, API, Repository, Remote, RepositoryState, Branch, ForcePushMode, Ref, Submodule, Commit, Change, RepositoryUIState, Status, LogOptions, APIState, CommitOptions, RefType, CredentialsProvider, BranchQuery, PushErrorHandler, PublishEvent, FetchOptions, RemoteSourceProvider, RemoteSourcePublisher, CloneOptions } from './git';
+import { Event, SourceControlInputBox, Uri, SourceControl, Disposable, commands, CancellationToken } from 'vscode';
 import { combinedDisposable, mapEvent } from '../util';
 import { toGitUri } from '../uri';
 import { GitExtensionImpl } from './extension';
 import { GitBaseApi } from '../git-base';
 import { PickRemoteSourceOptions } from './git-base';
-
 class ApiInputBox implements InputBox {
 	set value(value: string) { this._inputBox.value = value; }
 	get value(): string { return this._inputBox.value; }
@@ -281,6 +280,10 @@ export class ApiImpl implements API {
 	getRepository(uri: Uri): Repository | null {
 		const result = this._model.getRepository(uri);
 		return result ? new ApiRepository(result) : null;
+	}
+
+	async clone(url: string, options: CloneOptions, cancellationToken?: CancellationToken): Promise<string> {
+		return this._model.git.clone(url, options, cancellationToken);
 	}
 
 	async init(root: Uri): Promise<Repository | null> {

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri, Event, Disposable, ProviderResult } from 'vscode';
+import { Uri, Event, Disposable, ProviderResult, CancellationToken, Progress } from 'vscode';
 export { ProviderResult } from 'vscode';
 
 export interface Git {
@@ -99,6 +99,12 @@ export interface Change {
 	readonly originalUri: Uri;
 	readonly renameUri: Uri | undefined;
 	readonly status: Status;
+}
+
+export interface CloneOptions {
+	readonly parentPath: string;
+	readonly progress: Progress<{ increment: number }>;
+	readonly recursive?: boolean;
 }
 
 export interface RepositoryState {
@@ -272,6 +278,7 @@ export interface API {
 
 	toGitUri(uri: Uri, ref: string): Uri;
 	getRepository(uri: Uri): Repository | null;
+	clone(url: string, options: CloneOptions, cancellationToken?: CancellationToken): Promise<string>;
 	init(root: Uri): Promise<Repository | null>;
 	openRepository(root: Uri): Promise<Repository | null>
 


### PR DESCRIPTION
In some extensions that depend on Git, It may want to apply the built-in Git extension of vscode. After all, no one wants to invent the wheel again.

Currently, the only way is to execute the command `git.clone` or `git.cloneRecursive`

The user cannot define the behavior of the clone. For example, I have specified the cloned directory, and I don’t want the user to select the directory, and so on.

Exposing a clone API will be more flexible