### PR TITLE
Fix the wrong position of WebView View.  #110450

### DIFF
--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -134,14 +134,11 @@ export class WebviewViewPane extends ViewPane {
 
 	protected layoutBody(height: number, width: number): void {
 		super.layoutBody(height, width);
-
-		if (!this._webview.value) {
-			return;
-		}
-
-		if (this._container) {
-			this._webview.value.layoutWebviewOverElement(this._container, new DOM.Dimension(width, height));
-		}
+		setTimeout(() => {
+			if (this._container) {
+				this._webview.value?.layoutWebviewOverElement(this._container, new DOM.Dimension(width, height));
+			}
+		}, 1000);
 	}
 
 	private updateTreeVisibility() {


### PR DESCRIPTION
Fix the wrong position of WebView View by delaying the call of `layoutWebviewOverElement`. This PR fixes #110450.

The issue, #110450, happens with only one WebView View. See James-Yu/LaTeX-Workshop/issues/2433. You can reproduce the issue without installing TeX distributions.

The cause is getting `top` properties before the expansion of other views is completed.

https://github.com/microsoft/vscode/blob/96b426ef1da0f0a51ce9ef1931cd1fd2322547e4/src/vs/workbench/contrib/webview/browser/dynamicWebviewEditorOverlay.ts#L127

This PR fixes the issue by using `setTimeout`. The fix is definitely ad hoc.

![Dec-14-2020 13-17-12](https://user-images.githubusercontent.com/10665499/102039984-bf025f00-3e0e-11eb-9d2f-fede6b49d65f.gif)
