### PR TITLE
Fix the wrong position of WebView View in a different way. #110450

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -247,7 +247,7 @@ export abstract class Pane extends Disposable implements IView {
 		}
 	}
 
-	layout(size: number): void {
+	layout(size: number, offset?: number): void {
 		const headerSize = this.headerVisible ? Pane.HEADER_SIZE : 0;
 
 		const width = this._orientation === Orientation.VERTICAL ? this.orthogonalSize : size;
@@ -255,7 +255,11 @@ export abstract class Pane extends Disposable implements IView {
 
 		if (this.isExpanded()) {
 			this.body.classList.toggle('wide', width >= 600);
-			this.layoutBody(height, width);
+			if (this.orientation === Orientation.VERTICAL) {
+				this.layoutBody(height, width, offset);
+			} else {
+				this.layoutBody(height, width);
+			}
 			this.expandedSize = size;
 		}
 	}
@@ -287,7 +291,7 @@ export abstract class Pane extends Disposable implements IView {
 
 	protected abstract renderHeader(container: HTMLElement): void;
 	protected abstract renderBody(container: HTMLElement): void;
-	protected abstract layoutBody(height: number, width: number): void;
+	protected abstract layoutBody(height: number, width: number, offset?: number): void;
 }
 
 interface IDndContext {

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -450,7 +450,7 @@ export abstract class ViewPane extends Pane implements IView {
 		this.updateViewWelcome();
 	}
 
-	protected layoutBody(height: number, width: number): void {
+	protected layoutBody(height: number, width: number, offset?: number): void {
 		this.viewWelcomeContainer.style.height = `${height}px`;
 		this.viewWelcomeContainer.style.width = `${width}px`;
 		this.scrollableElement.scanDomNode();

--- a/src/vs/workbench/contrib/webview/browser/dynamicWebviewEditorOverlay.ts
+++ b/src/vs/workbench/contrib/webview/browser/dynamicWebviewEditorOverlay.ts
@@ -115,7 +115,7 @@ export class DynamicWebviewEditorOverlay extends Disposable implements WebviewOv
 		}
 	}
 
-	public layoutWebviewOverElement(element: HTMLElement, dimension?: Dimension) {
+	public layoutWebviewOverElement(element: HTMLElement, dimension?: Dimension, offset?: number) {
 		if (!this.container || !this.container.parentElement) {
 			return;
 		}
@@ -124,7 +124,11 @@ export class DynamicWebviewEditorOverlay extends Disposable implements WebviewOv
 		const containerRect = this.container.parentElement.getBoundingClientRect();
 		this.container.style.position = 'absolute';
 		this.container.style.overflow = 'hidden';
-		this.container.style.top = `${frameRect.top - containerRect.top}px`;
+		if (offset !== undefined) {
+			this.container.style.top = `${offset + 79}px`;
+		} else {
+			this.container.style.top = `${frameRect.top - containerRect.top}px`;
+		}
 		this.container.style.left = `${frameRect.left - containerRect.left}px`;
 		this.container.style.width = `${dimension ? dimension.width : frameRect.width}px`;
 		this.container.style.height = `${dimension ? dimension.height : frameRect.height}px`;

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -150,5 +150,5 @@ export interface WebviewOverlay extends Webview {
 
 	getInnerWebview(): Webview | undefined;
 
-	layoutWebviewOverElement(element: HTMLElement, dimension?: Dimension): void;
+	layoutWebviewOverElement(element: HTMLElement, dimension?: Dimension, offset?: number): void;
 }

--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -132,15 +132,16 @@ export class WebviewViewPane extends ViewPane {
 		super.saveState();
 	}
 
-	protected layoutBody(height: number, width: number): void {
+	protected layoutBody(height: number, width: number, offset: number): void {
 		super.layoutBody(height, width);
 
 		if (!this._webview.value) {
 			return;
 		}
 
+		console.log(`h: ${height}, w: ${width}`);
 		if (this._container) {
-			this._webview.value.layoutWebviewOverElement(this._container, new DOM.Dimension(width, height));
+			this._webview.value.layoutWebviewOverElement(this._container, new DOM.Dimension(width, height), offset);
 		}
 	}
 


### PR DESCRIPTION
Fix the wrong position of WebView View by passing the offset to `layoutWebviewOverElement`. This PR fixes #110450 in a different way from #112426.

The magic number `79` is the sum of the title bar's height + the `div.composite.title` 's height + the `pane-header` 's height.

https://github.com/tamuratak/vscode/blob/79e9f33cd64f7e5a41957a6c1a9c42fc940831bd/src/vs/workbench/contrib/webview/browser/dynamicWebviewEditorOverlay.ts#L128


![Dec-14-2020 13-26-36](https://user-images.githubusercontent.com/10665499/102040378-04735c00-3e10-11eb-98cc-333922f675d7.gif)
