### PR TITLE
Sets terminal font to monospace automatically when incorrectly set to…

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -98,6 +98,7 @@ export class TerminalViewPane extends ViewPane {
 			if (e.affectsConfiguration('terminal.integrated.fontFamily') || e.affectsConfiguration('editor.fontFamily')) {
 				const configHelper = this._terminalService.configHelper;
 				if (!configHelper.configFontIsMonospace()) {
+					this.configurationService.updateValue('terminal.integrated.fontFamily', 'monospace');
 					const choices: IPromptChoice[] = [{
 						label: nls.localize('terminal.useMonospace', "Use 'monospace'"),
 						run: () => this.configurationService.updateValue('terminal.integrated.fontFamily', 'monospace'),


### PR DESCRIPTION
… proportional

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #73879

<img width="870" alt="Screen Shot 2020-12-15 at 8 23 08 AM" src="https://user-images.githubusercontent.com/35010303/102220417-c6794500-3eae-11eb-9626-31aab828004e.png">

In accordance with this comment, incorrectly assigned proportional fonts in the terminal editor are reassigned to monospace by default.
