### PR TITLE
Revert "debug: stop supporting enableBreakpointsFor"

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -54,7 +54,7 @@ export class AdapterManager implements IAdapterManager {
 					if (!rawAdapter.type || (typeof rawAdapter.type !== 'string')) {
 						added.collector.error(nls.localize('debugNoType', "Debugger 'type' can not be omitted and must be of type 'string'."));
 					}
-					if (rawAdapter.enableBreakpointsFor) {
+					if (rawAdapter.enableBreakpointsFor && rawAdapter.enableBreakpointsFor.languageIds) {
 						rawAdapter.enableBreakpointsFor.languageIds.forEach(modeId => {
 							this.breakpointModeIdsSet.add(modeId);
 						});

--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -54,6 +54,11 @@ export class AdapterManager implements IAdapterManager {
 					if (!rawAdapter.type || (typeof rawAdapter.type !== 'string')) {
 						added.collector.error(nls.localize('debugNoType', "Debugger 'type' can not be omitted and must be of type 'string'."));
 					}
+					if (rawAdapter.enableBreakpointsFor) {
+						rawAdapter.enableBreakpointsFor.languageIds.forEach(modeId => {
+							this.breakpointModeIdsSet.add(modeId);
+						});
+					}
 
 					if (rawAdapter.type !== '*') {
 						const existing = this.getDebugger(rawAdapter.type);

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -629,7 +629,7 @@ export interface IDebuggerContribution extends IPlatformSpecificAdapterContribut
 
 	// supported languages
 	languages?: string[];
-	enableBreakpointsFor?: { languageIds: string[] };
+	enableBreakpointsFor?: { languageIds?: string[] };
 
 	// debug configuration support
 	configurationAttributes?: any;

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -629,6 +629,7 @@ export interface IDebuggerContribution extends IPlatformSpecificAdapterContribut
 
 	// supported languages
 	languages?: string[];
+	enableBreakpointsFor?: { languageIds: string[] };
 
 	// debug configuration support
 	configurationAttributes?: any;


### PR DESCRIPTION
This PR simply reverts the removal of support for `enableBreakpointsFor`.
I have verified that with this change it is possible to set breakpoints using the Felix Becker php-debug extension

fixes https://github.com/microsoft/vscode/issues/112564