### PR TITLE
Make PowerShell 7 default if available and show in choose shell menu

### DIFF
--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -247,6 +247,10 @@ export function renameIgnoreError(oldPath: string, newPath: string): Promise<voi
 	return new Promise(resolve => fs.rename(oldPath, newPath, () => resolve()));
 }
 
+export function readlink(path: string): Promise<string> {
+	return promisify(fs.readlink)(path);
+}
+
 export function unlink(path: string): Promise<void> {
 	return promisify(fs.unlink)(path);
 }
@@ -422,7 +426,15 @@ export async function dirExists(path: string): Promise<boolean> {
 
 		return fileStat.isDirectory();
 	} catch (error) {
-		return false;
+		// This catch will be called on some symbolic links on Windows (AppExecLink for example).
+		// So we try our best to see if it's a Directory.
+		try {
+			const fileStat = await stat(await readlink(path));
+
+			return fileStat.isDirectory();
+		} catch {
+			return false;
+		}
 	}
 }
 
@@ -432,7 +444,51 @@ export async function fileExists(path: string): Promise<boolean> {
 
 		return fileStat.isFile();
 	} catch (error) {
-		return false;
+		// This catch will be called on some symbolic links on Windows (AppExecLink for example).
+		// So we try our best to see if it's a File.
+		try {
+			const fileStat = await stat(await readlink(path));
+
+			return fileStat.isFile();
+		} catch {
+			return false;
+		}
+	}
+}
+
+export function dirExistsSync(path: string): boolean {
+	try {
+		const fileStat = fs.statSync(path);
+
+		return fileStat.isDirectory();
+	} catch (error) {
+		// This catch will be called on some symbolic links on Windows (AppExecLink for example).
+		// So we try our best to see if it's a Directory.
+		try {
+			const fileStat = fs.statSync(fs.readlinkSync(path));
+
+			return fileStat.isDirectory();
+		} catch {
+			return false;
+		}
+	}
+}
+
+export function fileExistsSync(path: string): boolean {
+	try {
+		const fileStat = fs.statSync(path);
+
+		return fileStat.isFile();
+	} catch (error) {
+		// This catch will be called on some symbolic links on Windows (AppExecLink for example).
+		// So we try our best to see if it's a File.
+		try {
+			const fileStat = fs.statSync(fs.readlinkSync(path));
+
+			return fileStat.isFile();
+		} catch {
+			return false;
+		}
 	}
 }
 

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -456,42 +456,6 @@ export async function fileExists(path: string): Promise<boolean> {
 	}
 }
 
-export function dirExistsSync(path: string): boolean {
-	try {
-		const fileStat = fs.statSync(path);
-
-		return fileStat.isDirectory();
-	} catch (error) {
-		// This catch will be called on some symbolic links on Windows (AppExecLink for example).
-		// So we try our best to see if it's a Directory.
-		try {
-			const fileStat = fs.statSync(fs.readlinkSync(path));
-
-			return fileStat.isDirectory();
-		} catch {
-			return false;
-		}
-	}
-}
-
-export function fileExistsSync(path: string): boolean {
-	try {
-		const fileStat = fs.statSync(path);
-
-		return fileStat.isFile();
-	} catch (error) {
-		// This catch will be called on some symbolic links on Windows (AppExecLink for example).
-		// So we try our best to see if it's a File.
-		try {
-			const fileStat = fs.statSync(fs.readlinkSync(path));
-
-			return fileStat.isFile();
-		} catch {
-			return false;
-		}
-	}
-}
-
 export function whenDeleted(path: string): Promise<void> {
 
 	// Complete when wait marker file is deleted

--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -21,12 +21,12 @@ const PwshPreviewMsixRegex: RegExp = /^Microsoft.PowerShellPreview_.*/;
 const isProcess64Bit: boolean = process.arch === 'x64';
 const isOS64Bit: boolean = isProcess64Bit || env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
 
-interface IPowerShellExeDetails {
+export interface IPowerShellExeDetails {
 	readonly displayName: string;
 	readonly exePath: string;
 }
 
-interface IPossiblePowerShellExe extends IPowerShellExeDetails {
+export interface IPossiblePowerShellExe extends IPowerShellExeDetails {
 	exists(): boolean;
 }
 
@@ -103,7 +103,6 @@ function findPSCoreWindowsInstallation(
 		{ useAlternateBitness?: boolean; findPreview?: boolean } = {}): IPossiblePowerShellExe | null {
 
 	const programFilesPath = getProgramFilesPath({ useAlternateBitness });
-
 	if (!programFilesPath) {
 		return null;
 	}
@@ -130,13 +129,9 @@ function findPSCoreWindowsInstallation(
 			}
 
 			// Verify that the part before the dash is an integer
+			// and that the part after the dash is "preview"
 			const intPart: string = item.substring(0, dashIndex);
-			if (!IntRegex.test(intPart)) {
-				continue;
-			}
-
-			// Verify that the part after the dash is "preview"
-			if (item.substring(dashIndex + 1) !== 'preview') {
+			if (!IntRegex.test(intPart) || item.substring(dashIndex + 1) !== 'preview') {
 				continue;
 			}
 
@@ -169,10 +164,7 @@ function findPSCoreWindowsInstallation(
 		return null;
 	}
 
-	const bitness: string = programFilesPath.includes('x86')
-		? '(x86)'
-		: '(x64)';
-
+	const bitness: string = programFilesPath.includes('x86') ? '(x86)' : '(x64)';
 	const preview: string = findPreview ? ' Preview' : '';
 
 	return new PossiblePowerShellExe(pwshExePath, `PowerShell${preview} ${bitness}`);
@@ -210,6 +202,7 @@ function findPSCoreMsix({ findPreview }: { findPreview?: boolean } = {}): IPossi
 
 function findPSCoreDotnetGlobalTool(): IPossiblePowerShellExe {
 	const dotnetGlobalToolExePath: string = path.join(os.homedir(), '.dotnet', 'tools', 'pwsh.exe');
+
 	return new PossiblePowerShellExe(dotnetGlobalToolExePath, '.NET Core PowerShell Global Tool');
 }
 

--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import * as path from 'vs/base/common/path';
 import { env } from 'vs/base/common/process';
 
-const WindowsPowerShell64BitLabel = 'Windows PowerShell (x64)';
+const WindowsPowerShell64BitLabel = 'Windows PowerShell';
 const WindowsPowerShell32BitLabel = 'Windows PowerShell (x86)';
 
 // This is required, since parseInt("7-preview") will return 7.

--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -1,0 +1,331 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'vs/base/common/path';
+import { env } from 'vs/base/common/process';
+
+const WindowsPowerShell64BitLabel = 'Windows PowerShell (x64)';
+const WindowsPowerShell32BitLabel = 'Windows PowerShell (x86)';
+
+// This is required, since parseInt("7-preview") will return 7.
+const IntRegex: RegExp = /^\d+$/;
+
+const PwshMsixRegex: RegExp = /^Microsoft.PowerShell_.*/;
+const PwshPreviewMsixRegex: RegExp = /^Microsoft.PowerShellPreview_.*/;
+
+// The platform details descriptor for the platform we're on
+const isProcess64Bit: boolean = process.arch === 'x64';
+const isOS64Bit: boolean = isProcess64Bit || env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
+
+interface IPowerShellExeDetails {
+	readonly displayName: string;
+	readonly exePath: string;
+}
+
+interface IPossiblePowerShellExe extends IPowerShellExeDetails {
+	exists(): boolean;
+}
+
+class PossiblePowerShellExe implements IPossiblePowerShellExe {
+	public readonly exePath: string;
+	public readonly displayName: string;
+
+	private knownToExist: boolean | undefined;
+
+	constructor(
+		pathToExe: string,
+		installationName: string,
+		{ knownToExist = false }: { knownToExist?: boolean } = {}) {
+
+		this.exePath = pathToExe;
+		this.displayName = installationName;
+		this.knownToExist = knownToExist || undefined;
+	}
+
+	public exists(): boolean {
+		if (this.knownToExist === undefined) {
+			this.knownToExist = fs.existsSync(this.exePath);
+		}
+		return this.knownToExist;
+	}
+}
+
+function getProgramFilesPath(
+	{ useAlternateBitness = false }: { useAlternateBitness?: boolean } = {}): string | null {
+
+	if (!useAlternateBitness) {
+		// Just use the native system bitness
+		return env.ProgramFiles!;
+	}
+
+	// We might be a 64-bit process looking for 32-bit program files
+	if (isProcess64Bit) {
+		return env['ProgramFiles(x86)']!;
+	}
+
+	// We might be a 32-bit process looking for 64-bit program files
+	if (isOS64Bit) {
+		return env.ProgramW6432!;
+	}
+
+	// We're a 32-bit process on 32-bit Windows, there is no other Program Files dir
+	return null;
+}
+
+function getSystem32Path({ useAlternateBitness = false }: { useAlternateBitness?: boolean } = {}): string {
+	const windir: string = env.windir!;
+
+	if (!useAlternateBitness) {
+		// Just use the native system bitness
+		return path.join(windir, 'System32');
+	}
+
+	// We might be a 64-bit process looking for 32-bit system32
+	if (isProcess64Bit) {
+		return path.join(windir, 'SysWOW64');
+	}
+
+	// We might be a 32-bit process looking for 64-bit system32
+	if (isOS64Bit) {
+		return path.join(windir, 'Sysnative');
+	}
+
+	// We're on a 32-bit Windows, so no alternate bitness
+	return path.join(windir, 'System32');
+}
+
+function findPSCoreWindowsInstallation(
+	{ useAlternateBitness = false, findPreview = false }:
+		{ useAlternateBitness?: boolean; findPreview?: boolean } = {}): IPossiblePowerShellExe | null {
+
+	const programFilesPath = getProgramFilesPath({ useAlternateBitness });
+
+	if (!programFilesPath) {
+		return null;
+	}
+
+	const powerShellInstallBaseDir = path.join(programFilesPath, 'PowerShell');
+
+	// Ensure the base directory exists
+	if (!(fs.existsSync(powerShellInstallBaseDir) && fs.lstatSync(powerShellInstallBaseDir).isDirectory())) {
+		return null;
+	}
+
+	let highestSeenVersion: number = -1;
+	let pwshExePath: string | null = null;
+	for (const item of fs.readdirSync(powerShellInstallBaseDir)) {
+
+		let currentVersion: number = -1;
+		if (findPreview) {
+			// We are looking for something like "7-preview"
+
+			// Preview dirs all have dashes in them
+			const dashIndex = item.indexOf('-');
+			if (dashIndex < 0) {
+				continue;
+			}
+
+			// Verify that the part before the dash is an integer
+			const intPart: string = item.substring(0, dashIndex);
+			if (!IntRegex.test(intPart)) {
+				continue;
+			}
+
+			// Verify that the part after the dash is "preview"
+			if (item.substring(dashIndex + 1) !== 'preview') {
+				continue;
+			}
+
+			currentVersion = parseInt(intPart, 10);
+		} else {
+			// Search for a directory like "6" or "7"
+			if (!IntRegex.test(item)) {
+				continue;
+			}
+
+			currentVersion = parseInt(item, 10);
+		}
+
+		// Ensure we haven't already seen a higher version
+		if (currentVersion <= highestSeenVersion) {
+			continue;
+		}
+
+		// Now look for the file
+		const exePath = path.join(powerShellInstallBaseDir, item, 'pwsh.exe');
+		if (!fs.existsSync(exePath)) {
+			continue;
+		}
+
+		pwshExePath = exePath;
+		highestSeenVersion = currentVersion;
+	}
+
+	if (!pwshExePath) {
+		return null;
+	}
+
+	const bitness: string = programFilesPath.includes('x86')
+		? '(x86)'
+		: '(x64)';
+
+	const preview: string = findPreview ? ' Preview' : '';
+
+	return new PossiblePowerShellExe(pwshExePath, `PowerShell${preview} ${bitness}`);
+}
+
+function findPSCoreMsix({ findPreview }: { findPreview?: boolean } = {}): IPossiblePowerShellExe | null {
+	// We can't proceed if there's no LOCALAPPDATA path
+	if (!env.LOCALAPPDATA) {
+		return null;
+	}
+
+	// Find the base directory for MSIX application exe shortcuts
+	const msixAppDir = path.join(env.LOCALAPPDATA, 'Microsoft', 'WindowsApps');
+
+	if (!fs.existsSync(msixAppDir)) {
+		return null;
+	}
+
+	// Define whether we're looking for the preview or the stable
+	const { pwshMsixDirRegex, pwshMsixName } = findPreview
+		? { pwshMsixDirRegex: PwshPreviewMsixRegex, pwshMsixName: 'PowerShell Preview (Store)' }
+		: { pwshMsixDirRegex: PwshMsixRegex, pwshMsixName: 'PowerShell (Store)' };
+
+	// We should find only one such application, so return on the first one
+	for (const subdir of fs.readdirSync(msixAppDir)) {
+		if (pwshMsixDirRegex.test(subdir)) {
+			const pwshMsixPath = path.join(msixAppDir, subdir, 'pwsh.exe');
+			return new PossiblePowerShellExe(pwshMsixPath, pwshMsixName, { knownToExist: true });
+		}
+	}
+
+	// If we find nothing, return null
+	return null;
+}
+
+function findPSCoreDotnetGlobalTool(): IPossiblePowerShellExe {
+	const dotnetGlobalToolExePath: string = path.join(os.homedir(), '.dotnet', 'tools', 'pwsh.exe');
+	return new PossiblePowerShellExe(dotnetGlobalToolExePath, '.NET Core PowerShell Global Tool');
+}
+
+function findWinPS({ useAlternateBitness = false }: { useAlternateBitness?: boolean } = {}): IPossiblePowerShellExe | null {
+
+	// 32-bit OSes only have one WinPS on them
+	if (!isOS64Bit && useAlternateBitness) {
+		return null;
+	}
+
+	const systemFolderPath = getSystem32Path({ useAlternateBitness });
+
+	const winPSPath = path.join(systemFolderPath, 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+
+	let displayName: string;
+	if (isProcess64Bit) {
+		displayName = useAlternateBitness
+			? WindowsPowerShell32BitLabel
+			: WindowsPowerShell64BitLabel;
+	} else if (isOS64Bit) {
+		displayName = useAlternateBitness
+			? WindowsPowerShell64BitLabel
+			: WindowsPowerShell32BitLabel;
+	} else {
+		displayName = WindowsPowerShell32BitLabel;
+	}
+
+	return new PossiblePowerShellExe(winPSPath, displayName, { knownToExist: true });
+}
+
+/**
+ * Iterates through all the possible well-known PowerShell installations on a machine.
+ * Returned values may not exist, but come with an .exists property
+ * which will check whether the executable exists.
+ */
+function* enumerateDefaultPowerShellInstallations(): Iterable<IPossiblePowerShellExe> {
+	// Find PSCore stable first
+	let pwshExe = findPSCoreWindowsInstallation();
+	if (pwshExe) {
+		yield pwshExe;
+	}
+
+	// Windows may have a 32-bit pwsh.exe
+	pwshExe = findPSCoreWindowsInstallation({ useAlternateBitness: true });
+	if (pwshExe) {
+		yield pwshExe;
+	}
+
+	// Also look for the MSIX/UWP installation
+	pwshExe = findPSCoreMsix();
+	if (pwshExe) {
+		yield pwshExe;
+	}
+
+	// Look for the .NET global tool
+	// Some older versions of PowerShell have a bug in this where startup will fail,
+	// but this is fixed in newer versions
+	pwshExe = findPSCoreDotnetGlobalTool();
+	if (pwshExe) {
+		yield pwshExe;
+	}
+
+	// Look for PSCore preview
+	pwshExe = findPSCoreWindowsInstallation({ findPreview: true });
+	if (pwshExe) {
+		yield pwshExe;
+	}
+
+	// Find a preview MSIX
+	pwshExe = findPSCoreMsix({ findPreview: true });
+	if (pwshExe) {
+		yield pwshExe;
+	}
+
+	// Look for pwsh-preview with the opposite bitness
+	pwshExe = findPSCoreWindowsInstallation({ useAlternateBitness: true, findPreview: true });
+	if (pwshExe) {
+		yield pwshExe;
+	}
+
+	// Finally, get Windows PowerShell
+
+	// Get the natural Windows PowerShell for the process bitness
+	pwshExe = findWinPS();
+	if (pwshExe) {
+		yield pwshExe;
+	}
+
+	// Get the alternate bitness Windows PowerShell
+	pwshExe = findWinPS({ useAlternateBitness: true });
+	if (pwshExe) {
+		yield pwshExe;
+	}
+}
+
+/**
+ * Iterates through PowerShell installations on the machine according
+ * to configuration passed in through the constructor.
+ * PowerShell items returned by this object are verified
+ * to exist on the filesystem.
+ */
+export function* enumeratePowerShellInstallations(): Iterable<IPowerShellExeDetails> {
+	// Get the default PowerShell installations first
+	for (const defaultPwsh of enumerateDefaultPowerShellInstallations()) {
+		if (defaultPwsh && defaultPwsh.exists()) {
+			yield defaultPwsh;
+		}
+	}
+}
+
+/**
+* Returns the first available PowerShell executable found in the search order.
+*/
+export function getFirstAvailablePowerShellInstallation(): IPowerShellExeDetails | null {
+	for (const pwsh of enumeratePowerShellInstallations()) {
+		return pwsh;
+	}
+	return null;
+}

--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -309,7 +309,7 @@ async function* enumerateDefaultPowerShellInstallations(): AsyncIterable<IPossib
 export async function* enumeratePowerShellInstallations(): AsyncIterable<IPowerShellExeDetails> {
 	// Get the default PowerShell installations first
 	for await (const defaultPwsh of enumerateDefaultPowerShellInstallations()) {
-		if (defaultPwsh && defaultPwsh.exists()) {
+		if (await defaultPwsh.exists()) {
 			yield defaultPwsh;
 		}
 	}

--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -31,20 +31,10 @@ export interface IPossiblePowerShellExe extends IPowerShellExeDetails {
 }
 
 class PossiblePowerShellExe implements IPossiblePowerShellExe {
-	public readonly exePath: string;
-	public readonly displayName: string;
-
-	private knownToExist: boolean | undefined;
-
 	constructor(
-		pathToExe: string,
-		installationName: string,
-		{ knownToExist = false }: { knownToExist?: boolean } = {}) {
-
-		this.exePath = pathToExe;
-		this.displayName = installationName;
-		this.knownToExist = knownToExist || undefined;
-	}
+		public readonly exePath: string,
+		public readonly displayName: string,
+		private knownToExist?: boolean) { }
 
 	public async exists(): Promise<boolean> {
 		if (this.knownToExist === undefined) {
@@ -167,7 +157,7 @@ async function findPSCoreWindowsInstallation(
 	const bitness: string = programFilesPath.includes('x86') ? ' (x86)' : '';
 	const preview: string = findPreview ? ' Preview' : '';
 
-	return new PossiblePowerShellExe(pwshExePath, `PowerShell${preview}${bitness}`, { knownToExist: true });
+	return new PossiblePowerShellExe(pwshExePath, `PowerShell${preview}${bitness}`, true);
 }
 
 async function findPSCoreMsix({ findPreview }: { findPreview?: boolean } = {}): Promise<IPossiblePowerShellExe | null> {
@@ -232,7 +222,7 @@ function findWinPS({ useAlternateBitness = false }: { useAlternateBitness?: bool
 		displayName = WindowsPowerShell32BitLabel;
 	}
 
-	return new PossiblePowerShellExe(winPSPath, displayName, { knownToExist: true });
+	return new PossiblePowerShellExe(winPSPath, displayName, true);
 }
 
 /**

--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -49,17 +49,17 @@ function getProgramFilesPath(
 
 	if (!useAlternateBitness) {
 		// Just use the native system bitness
-		return env.ProgramFiles!;
+		return env.ProgramFiles || null;
 	}
 
 	// We might be a 64-bit process looking for 32-bit program files
 	if (isProcess64Bit) {
-		return env['ProgramFiles(x86)']!;
+		return env['ProgramFiles(x86)'] || null;
 	}
 
 	// We might be a 32-bit process looking for 64-bit program files
 	if (isOS64Bit) {
-		return env.ProgramW6432!;
+		return env.ProgramW6432 || null;
 	}
 
 	// We're a 32-bit process on 32-bit Windows, there is no other Program Files dir

--- a/src/vs/base/node/shell.ts
+++ b/src/vs/base/node/shell.ts
@@ -5,6 +5,7 @@
 
 import * as os from 'os';
 import * as platform from 'vs/base/common/platform';
+import { getFirstAvailablePowerShellInstallation } from 'vs/base/node/powershell';
 import * as processes from 'vs/base/node/processes';
 
 /**
@@ -15,7 +16,7 @@ import * as processes from 'vs/base/node/processes';
 export function getSystemShell(p: platform.Platform, env = process.env as platform.IProcessEnvironment): string {
 	if (p === platform.Platform.Windows) {
 		if (platform.isWindows) {
-			return getSystemShellWindows(env);
+			return getSystemShellWindows();
 		}
 		// Don't detect Windows shell when not on Windows
 		return processes.getWindowsShell(env);
@@ -59,12 +60,9 @@ function getSystemShellUnixLike(env: platform.IProcessEnvironment): string {
 }
 
 let _TERMINAL_DEFAULT_SHELL_WINDOWS: string | null = null;
-function getSystemShellWindows(env: platform.IProcessEnvironment): string {
+function getSystemShellWindows(): string {
 	if (!_TERMINAL_DEFAULT_SHELL_WINDOWS) {
-		const isAtLeastWindows10 = platform.isWindows && parseFloat(os.release()) >= 10;
-		const is32ProcessOn64Windows = env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
-		const powerShellPath = `${env['windir']}\\${is32ProcessOn64Windows ? 'Sysnative' : 'System32'}\\WindowsPowerShell\\v1.0\\powershell.exe`;
-		_TERMINAL_DEFAULT_SHELL_WINDOWS = isAtLeastWindows10 ? powerShellPath : processes.getWindowsShell(env);
+		_TERMINAL_DEFAULT_SHELL_WINDOWS = getFirstAvailablePowerShellInstallation()!.exePath;
 	}
 	return _TERMINAL_DEFAULT_SHELL_WINDOWS;
 }

--- a/src/vs/base/node/shell.ts
+++ b/src/vs/base/node/shell.ts
@@ -21,12 +21,8 @@ export async function getSystemShell(p: platform.Platform, env = process.env as 
 		// Don't detect Windows shell when not on Windows
 		return processes.getWindowsShell(env);
 	}
-	// Only use $SHELL for the current OS
-	if (platform.isLinux && p === platform.Platform.Mac || platform.isMacintosh && p === platform.Platform.Linux) {
-		return '/bin/bash';
-	}
 
-	return getSystemShellUnixLike(env);
+	return getSystemShellUnixLike(p, env);
 }
 
 export function getSystemShellSync(p: platform.Platform, env = process.env as platform.IProcessEnvironment): string {
@@ -37,16 +33,17 @@ export function getSystemShellSync(p: platform.Platform, env = process.env as pl
 		// Don't detect Windows shell when not on Windows
 		return processes.getWindowsShell(env);
 	}
+
+	return getSystemShellUnixLike(p, env);
+}
+
+let _TERMINAL_DEFAULT_SHELL_UNIX_LIKE: string | null = null;
+function getSystemShellUnixLike(p: platform.Platform, env: platform.IProcessEnvironment): string {
 	// Only use $SHELL for the current OS
 	if (platform.isLinux && p === platform.Platform.Mac || platform.isMacintosh && p === platform.Platform.Linux) {
 		return '/bin/bash';
 	}
 
-	return getSystemShellUnixLike(env);
-}
-
-let _TERMINAL_DEFAULT_SHELL_UNIX_LIKE: string | null = null;
-function getSystemShellUnixLike(env: platform.IProcessEnvironment): string {
 	if (!_TERMINAL_DEFAULT_SHELL_UNIX_LIKE) {
 		let unixLikeTerminal: string;
 		if (platform.isWindows) {

--- a/src/vs/base/node/shell.ts
+++ b/src/vs/base/node/shell.ts
@@ -13,7 +13,7 @@ import * as processes from 'vs/base/node/processes';
  * shell that the terminal uses by default.
  * @param p The platform to detect the shell of.
  */
-export function getSystemShell(p: platform.Platform, env = process.env as platform.IProcessEnvironment): string {
+export async function getSystemShell(p: platform.Platform, env = process.env as platform.IProcessEnvironment): Promise<string> {
 	if (p === platform.Platform.Windows) {
 		if (platform.isWindows) {
 			return getSystemShellWindows();
@@ -25,6 +25,23 @@ export function getSystemShell(p: platform.Platform, env = process.env as platfo
 	if (platform.isLinux && p === platform.Platform.Mac || platform.isMacintosh && p === platform.Platform.Linux) {
 		return '/bin/bash';
 	}
+
+	return getSystemShellUnixLike(env);
+}
+
+export function getSystemShellSync(p: platform.Platform, env = process.env as platform.IProcessEnvironment): string {
+	if (p === platform.Platform.Windows) {
+		if (platform.isWindows) {
+			return getSystemShellWindowsSync(env);
+		}
+		// Don't detect Windows shell when not on Windows
+		return processes.getWindowsShell(env);
+	}
+	// Only use $SHELL for the current OS
+	if (platform.isLinux && p === platform.Platform.Mac || platform.isMacintosh && p === platform.Platform.Linux) {
+		return '/bin/bash';
+	}
+
 	return getSystemShellUnixLike(env);
 }
 
@@ -60,9 +77,20 @@ function getSystemShellUnixLike(env: platform.IProcessEnvironment): string {
 }
 
 let _TERMINAL_DEFAULT_SHELL_WINDOWS: string | null = null;
-function getSystemShellWindows(): string {
+async function getSystemShellWindows(): Promise<string> {
 	if (!_TERMINAL_DEFAULT_SHELL_WINDOWS) {
-		_TERMINAL_DEFAULT_SHELL_WINDOWS = getFirstAvailablePowerShellInstallation()!.exePath;
+		_TERMINAL_DEFAULT_SHELL_WINDOWS = (await getFirstAvailablePowerShellInstallation())!.exePath;
 	}
 	return _TERMINAL_DEFAULT_SHELL_WINDOWS;
+}
+
+function getSystemShellWindowsSync(env: platform.IProcessEnvironment): string {
+	if (_TERMINAL_DEFAULT_SHELL_WINDOWS) {
+		return _TERMINAL_DEFAULT_SHELL_WINDOWS;
+	}
+
+	const isAtLeastWindows10 = platform.isWindows && parseFloat(os.release()) >= 10;
+	const is32ProcessOn64Windows = env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
+	const powerShellPath = `${env['windir']}\\${is32ProcessOn64Windows ? 'Sysnative' : 'System32'}\\WindowsPowerShell\\v1.0\\powershell.exe`;
+	return isAtLeastWindows10 ? powerShellPath : processes.getWindowsShell(env);
 }

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import * as platform from 'vs/base/common/platform';
+import * as powershell from 'vs/base/node/powershell';
+import * as fs from 'fs';
+
+function checkPath(exePath: string) {
+	// Check to see if the path exists
+	let pathCheckResult = false;
+	try {
+		const stat = fs.statSync(exePath);
+		pathCheckResult = stat.isFile() || stat.isSymbolicLink();
+	} catch {
+		// fs.exists throws on Windows with SymbolicLinks so we
+		// also use lstat to try and see if the file exists.
+		pathCheckResult = fs.lstatSync(exePath).isSymbolicLink();
+	}
+
+	assert.strictEqual(pathCheckResult, true);
+}
+
+if (platform.isWindows) {
+	suite('PowerShell finder', () => {
+
+		test('Can find first available PowerShell', () => {
+			const pwshExe = powershell.getFirstAvailablePowerShellInstallation();
+			const exePath = pwshExe?.exePath;
+			assert.notStrictEqual(exePath, null);
+			assert.notStrictEqual(pwshExe?.displayName, null);
+
+			checkPath(exePath!);
+		});
+
+		// In Azure DevOps or GitHub Actions, they have 3 PowerShell's available
+		// on Windows:
+		// 1. PowerShell stable
+		// 2. Windows PowerShell (x64)
+		// 3. Windows PowerShell (x86)
+		// Only run this test in CI where the result is predictable.
+		if (process.env.TF_BUILD || process.env.CI) {
+			test('Can enumerate PowerShells', () => {
+				const pwshs = Array.from(powershell.enumeratePowerShellInstallations());
+				assert.strictEqual(pwshs.length, 3);
+
+				checkPath(pwshs[0].exePath);
+				assert.strictEqual(pwshs[0].displayName, 'PowerShell (x64)');
+
+				checkPath(pwshs[1].exePath);
+				assert.strictEqual(pwshs[1].displayName, 'Windows PowerShell (x64)');
+
+				checkPath(pwshs[2].exePath);
+				assert.strictEqual(pwshs[2].displayName, 'Windows PowerShell (x86)');
+			});
+		}
+	});
+}

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -46,10 +46,10 @@ if (platform.isWindows) {
 				assert.strictEqual(pwshs.length, 3);
 
 				checkPath(pwshs[0].exePath);
-				assert.strictEqual(pwshs[0].displayName, 'PowerShell (x64)');
+				assert.strictEqual(pwshs[0].displayName, 'PowerShell');
 
 				checkPath(pwshs[1].exePath);
-				assert.strictEqual(pwshs[1].displayName, 'Windows PowerShell (x64)');
+				assert.strictEqual(pwshs[1].displayName, 'Windows PowerShell');
 
 				checkPath(pwshs[2].exePath);
 				assert.strictEqual(pwshs[2].displayName, 'Windows PowerShell (x86)');

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -52,13 +52,10 @@ if (platform.isWindows) {
 					pwshs.push(p);
 				}
 
-				assert.strictEqual(pwshs.length, 4, 'Found these PowerShells:\n' + pwshs.map(p => `${p.displayName}: ${p.exePath}`).join('\n'));
+				assert.strictEqual(pwshs.length, 3, 'Found these PowerShells:\n' + pwshs.map(p => `${p.displayName}: ${p.exePath}`).join('\n'));
 
 				checkPath(pwshs[0].exePath);
 				assert.strictEqual(pwshs[0].displayName, 'PowerShell');
-
-				checkPath(pwshs[1].exePath);
-				assert.strictEqual(pwshs[1].displayName, '.NET Core PowerShell Global Tool');
 
 				checkPath(pwshs[2].exePath);
 				assert.strictEqual(pwshs[2].displayName, 'Windows PowerShell');

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -57,6 +57,8 @@ if (platform.isWindows) {
 				checkPath(pwshs[0].exePath);
 				assert.strictEqual(pwshs[0].displayName, 'PowerShell');
 
+				assert.strictEqual(process.arch, 'x64');
+
 				checkPath(pwshs[2].exePath);
 				assert.strictEqual(pwshs[2].displayName, 'Windows PowerShell');
 

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
 import * as platform from 'vs/base/common/platform';
-import * as powershell from 'vs/base/node/powershell';
 import * as fs from 'fs';
+import { enumeratePowerShellInstallations, getFirstAvailablePowerShellInstallation, IPowerShellExeDetails } from 'vs/base/node/powershell';
 
 function checkPath(exePath: string) {
 	// Check to see if the path exists
@@ -25,8 +25,8 @@ function checkPath(exePath: string) {
 if (platform.isWindows) {
 	suite('PowerShell finder', () => {
 
-		test('Can find first available PowerShell', () => {
-			const pwshExe = powershell.getFirstAvailablePowerShellInstallation();
+		test('Can find first available PowerShell', async () => {
+			const pwshExe = await getFirstAvailablePowerShellInstallation();
 			const exePath = pwshExe?.exePath;
 			assert.notStrictEqual(exePath, null);
 			assert.notStrictEqual(pwshExe?.displayName, null);
@@ -41,8 +41,12 @@ if (platform.isWindows) {
 		// 3. Windows PowerShell (x86)
 		// Only run this test in CI where the result is predictable.
 		if (process.env.TF_BUILD || process.env.CI) {
-			test('Can enumerate PowerShells', () => {
-				const pwshs = Array.from(powershell.enumeratePowerShellInstallations());
+			test('Can enumerate PowerShells', async () => {
+				const pwshs = new Array<IPowerShellExeDetails>();
+				for await (const p of enumeratePowerShellInstallations()) {
+					pwshs.push(p);
+				}
+
 				assert.strictEqual(pwshs.length, 3);
 
 				checkPath(pwshs[0].exePath);

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -12,11 +12,11 @@ function checkPath(exePath: string) {
 	let pathCheckResult = false;
 	try {
 		const stat = fs.statSync(exePath);
-		pathCheckResult = stat.isFile() || stat.isSymbolicLink();
+		pathCheckResult = stat.isFile();
 	} catch {
 		// fs.exists throws on Windows with SymbolicLinks so we
 		// also use lstat to try and see if the file exists.
-		pathCheckResult = fs.lstatSync(exePath).isSymbolicLink();
+		pathCheckResult = fs.statSync(fs.readlinkSync(exePath)).isFile();
 	}
 
 	assert.strictEqual(pathCheckResult, true);

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -47,7 +47,7 @@ if (platform.isWindows) {
 					pwshs.push(p);
 				}
 
-				assert.strictEqual(pwshs.length, 3);
+				assert.strictEqual(pwshs.length, 3, 'Found these PowerShells:\n' + pwshs.map(p => `${p.displayName}: ${p.exePath}`).join('=\n'));
 
 				checkPath(pwshs[0].exePath);
 				assert.strictEqual(pwshs[0].displayName, 'PowerShell');

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -57,13 +57,11 @@ if (platform.isWindows) {
 				checkPath(pwshs[0].exePath);
 				assert.strictEqual(pwshs[0].displayName, 'PowerShell');
 
-				assert.strictEqual(process.arch, 'x64');
+				checkPath(pwshs[1].exePath);
+				assert.strictEqual(pwshs[1].displayName, 'Windows PowerShell');
 
 				checkPath(pwshs[2].exePath);
-				assert.strictEqual(pwshs[2].displayName, 'Windows PowerShell');
-
-				checkPath(pwshs[3].exePath);
-				assert.strictEqual(pwshs[3].displayName, 'Windows PowerShell (x86)');
+				assert.strictEqual(pwshs[2].displayName, 'Windows PowerShell (x86)');
 			});
 		}
 	});

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -16,7 +16,11 @@ function checkPath(exePath: string) {
 	} catch {
 		// fs.exists throws on Windows with SymbolicLinks so we
 		// also use lstat to try and see if the file exists.
-		pathCheckResult = fs.statSync(fs.readlinkSync(exePath)).isFile();
+		try {
+			pathCheckResult = fs.statSync(fs.readlinkSync(exePath)).isFile();
+		} catch {
+
+		}
 	}
 
 	assert.strictEqual(pathCheckResult, true);

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -37,6 +37,7 @@ if (platform.isWindows) {
 		// In Azure DevOps or GitHub Actions, they have 3 PowerShell's available
 		// on Windows:
 		// 1. PowerShell stable
+		// 2. PowerShell as a .NET Global Tool
 		// 2. Windows PowerShell (x64)
 		// 3. Windows PowerShell (x86)
 		// Only run this test in CI where the result is predictable.
@@ -47,16 +48,19 @@ if (platform.isWindows) {
 					pwshs.push(p);
 				}
 
-				assert.strictEqual(pwshs.length, 3, 'Found these PowerShells:\n' + pwshs.map(p => `${p.displayName}: ${p.exePath}`).join('=\n'));
+				assert.strictEqual(pwshs.length, 4, 'Found these PowerShells:\n' + pwshs.map(p => `${p.displayName}: ${p.exePath}`).join('\n'));
 
 				checkPath(pwshs[0].exePath);
 				assert.strictEqual(pwshs[0].displayName, 'PowerShell');
 
 				checkPath(pwshs[1].exePath);
-				assert.strictEqual(pwshs[1].displayName, 'Windows PowerShell');
+				assert.strictEqual(pwshs[1].displayName, '.NET Core PowerShell Global Tool');
 
 				checkPath(pwshs[2].exePath);
-				assert.strictEqual(pwshs[2].displayName, 'Windows PowerShell (x86)');
+				assert.strictEqual(pwshs[2].displayName, 'Windows PowerShell');
+
+				checkPath(pwshs[3].exePath);
+				assert.strictEqual(pwshs[3].displayName, 'Windows PowerShell (x86)');
 			});
 		}
 	});

--- a/src/vs/code/node/shellEnv.ts
+++ b/src/vs/code/node/shellEnv.ts
@@ -59,7 +59,7 @@ export async function resolveShellEnv(logService: ILogService, args: NativeParse
 let unixShellEnvPromise: Promise<typeof process.env> | undefined = undefined;
 
 async function doResolveUnixShellEnv(logService: ILogService): Promise<typeof process.env> {
-	const promise = new Promise<typeof process.env>((resolve, reject) => {
+	const promise = new Promise<typeof process.env>(async (resolve, reject) => {
 		const runAsNode = process.env['ELECTRON_RUN_AS_NODE'];
 		logService.trace('getUnixShellEnvironment#runAsNode', runAsNode);
 
@@ -79,7 +79,7 @@ async function doResolveUnixShellEnv(logService: ILogService): Promise<typeof pr
 		logService.trace('getUnixShellEnvironment#env', env);
 		logService.trace('getUnixShellEnvironment#spawn', command);
 
-		const systemShellUnix = getSystemShell(platform);
+		const systemShellUnix = await getSystemShell(platform);
 		const child = spawn(systemShellUnix, ['-ilc', command], {
 			detached: true,
 			stdio: ['ignore', 'pipe', process.stderr],

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -45,6 +45,10 @@ export class ExtHostTerminalService extends BaseExtHostTerminalService {
 		@IExtHostInitDataService private _extHostInitDataService: IExtHostInitDataService
 	) {
 		super(true, extHostRpc);
+
+		// Getting the SystemShell is an async operation, however, the ExtHost terminal service is mostly synchronous
+		// and the API `vscode.env.shell` is also synchronous. The default shell _should_ be set when extensions are
+		// starting up but if not, we run getSystemShellSync below which gets a sane default.
 		getSystemShell(platform.platform).then(s => this._defaultShell = s);
 
 		this._updateLastActiveWorkspace();

--- a/src/vs/workbench/contrib/terminal/browser/terminal.web.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.web.contribution.ts
@@ -8,12 +8,12 @@ import { KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/co
 import { Registry } from 'vs/platform/registry/common/platform';
 import { TERMINAL_COMMAND_ID } from 'vs/workbench/contrib/terminal/common/terminal';
 import { IConfigurationRegistry, Extensions } from 'vs/platform/configuration/common/configurationRegistry';
-import { getTerminalShellConfiguration } from 'vs/workbench/contrib/terminal/common/terminalConfiguration';
+import { getNoDefaultTerminalShellConfiguration } from 'vs/workbench/contrib/terminal/common/terminalConfiguration';
 
 // Desktop shell configuration are registered in electron-browser as their default values rely
 // on process.env
 const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
-configurationRegistry.registerConfiguration(getTerminalShellConfiguration());
+configurationRegistry.registerConfiguration(getNoDefaultTerminalShellConfiguration());
 
 // Register standard external terminal keybinding as integrated terminal when in web as the
 // external terminal is not available

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -436,7 +436,7 @@ export function getNoDefaultTerminalShellConfiguration(): IConfigurationNode {
 
 export async function getTerminalShellConfiguration(getSystemShell: (p: Platform) => Promise<string>): Promise<IConfigurationNode> {
 	return getTerminalShellConfigurationStub(
-		await getSystemShell(Platform.Linux),
-		await getSystemShell(Platform.Mac),
-		await getSystemShell(Platform.Windows));
+		localize('terminal.integrated.shell.linux', "The path of the shell that the terminal uses on Linux (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", await getSystemShell(Platform.Linux)),
+		localize('terminal.integrated.shell.osx', "The path of the shell that the terminal uses on macOS (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", await getSystemShell(Platform.Mac)),
+		localize('terminal.integrated.shell.windows', "The path of the shell that the terminal uses on Windows (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", await getSystemShell(Platform.Windows)));
 }

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -401,7 +401,7 @@ export const terminalConfiguration: IConfigurationNode = {
 	}
 };
 
-export function getTerminalShellConfiguration(getSystemShell?: (p: Platform) => string): IConfigurationNode {
+function getTerminalShellConfigurationStub(linux: string, osx: string, windows: string): IConfigurationNode {
 	return {
 		id: 'terminal',
 		order: 100,
@@ -409,29 +409,34 @@ export function getTerminalShellConfiguration(getSystemShell?: (p: Platform) => 
 		type: 'object',
 		properties: {
 			'terminal.integrated.shell.linux': {
-				markdownDescription:
-					getSystemShell
-						? localize('terminal.integrated.shell.linux', "The path of the shell that the terminal uses on Linux (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", getSystemShell(Platform.Linux))
-						: localize('terminal.integrated.shell.linux.noDefault', "The path of the shell that the terminal uses on Linux. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."),
+				markdownDescription: linux,
 				type: ['string', 'null'],
 				default: null
 			},
 			'terminal.integrated.shell.osx': {
-				markdownDescription:
-					getSystemShell
-						? localize('terminal.integrated.shell.osx', "The path of the shell that the terminal uses on macOS (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", getSystemShell(Platform.Mac))
-						: localize('terminal.integrated.shell.osx.noDefault', "The path of the shell that the terminal uses on macOS. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."),
+				markdownDescription: osx,
 				type: ['string', 'null'],
 				default: null
 			},
 			'terminal.integrated.shell.windows': {
-				markdownDescription:
-					getSystemShell
-						? localize('terminal.integrated.shell.windows', "The path of the shell that the terminal uses on Windows (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", getSystemShell(Platform.Windows))
-						: localize('terminal.integrated.shell.windows.noDefault', "The path of the shell that the terminal uses on Windows. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."),
+				markdownDescription: windows,
 				type: ['string', 'null'],
 				default: null
 			}
 		}
 	};
+}
+
+export function getNoDefaultTerminalShellConfiguration(): IConfigurationNode {
+	return getTerminalShellConfigurationStub(
+		localize('terminal.integrated.shell.linux.noDefault', "The path of the shell that the terminal uses on Linux. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."),
+		localize('terminal.integrated.shell.osx.noDefault', "The path of the shell that the terminal uses on macOS. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."),
+		localize('terminal.integrated.shell.windows.noDefault', "The path of the shell that the terminal uses on Windows. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."));
+}
+
+export async function getTerminalShellConfiguration(getSystemShell: (p: Platform) => Promise<string>): Promise<IConfigurationNode> {
+	return getTerminalShellConfigurationStub(
+		await getSystemShell(Platform.Linux),
+		await getSystemShell(Platform.Mac),
+		await getSystemShell(Platform.Windows));
 }

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminal.contribution.ts
@@ -24,4 +24,5 @@ workbenchRegistry.registerWorkbenchContribution(TerminalNativeContribution, Life
 
 // Register configurations
 const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
-configurationRegistry.registerConfiguration(getTerminalShellConfiguration(getSystemShell));
+
+getTerminalShellConfiguration(getSystemShell).then(config => configurationRegistry.registerConfiguration(config));

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
@@ -82,7 +82,7 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 		return this._storageService.getBoolean(IS_WORKSPACE_SHELL_ALLOWED_STORAGE_KEY, StorageScope.WORKSPACE, false);
 	}
 
-	public getDefaultShellAndArgs(useAutomationShell: boolean, platformOverride: Platform = platform): Promise<{ shell: string, args: string | string[] }> {
+	public async getDefaultShellAndArgs(useAutomationShell: boolean, platformOverride: Platform = platform): Promise<{ shell: string, args: string | string[] }> {
 		const isWorkspaceShellAllowed = this._isWorkspaceShellAllowed();
 		const activeWorkspaceRootUri = this._historyService.getLastActiveWorkspaceRoot();
 		let lastActiveWorkspace = activeWorkspaceRootUri ? this._workspaceContextService.getWorkspaceFolder(activeWorkspaceRootUri) : undefined;
@@ -90,7 +90,7 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 		const shell = getDefaultShell(
 			(key) => this._configurationService.inspect(key),
 			isWorkspaceShellAllowed,
-			getSystemShell(platformOverride),
+			await getSystemShell(platformOverride),
 			process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432'),
 			process.env.windir,
 			createVariableResolver(lastActiveWorkspace, this._configurationResolverService),

--- a/src/vs/workbench/contrib/terminal/node/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminal.ts
@@ -5,10 +5,11 @@
 
 import * as os from 'os';
 import * as platform from 'vs/base/common/platform';
-import { readFile, fileExists, stat } from 'vs/base/node/pfs';
+import { readFile, fileExists, stat, lstat } from 'vs/base/node/pfs';
 import { LinuxDistro, IShellDefinition } from 'vs/workbench/contrib/terminal/common/terminal';
 import { coalesce } from 'vs/base/common/arrays';
 import { normalize, basename } from 'vs/base/common/path';
+import { enumeratePowerShellInstallations } from 'vs/base/node/powershell';
 
 let detectedDistro = LinuxDistro.Unknown;
 if (platform.isLinux) {
@@ -58,8 +59,6 @@ async function detectAvailableWindowsShells(): Promise<IShellDefinition[]> {
 
 	const expectedLocations: { [key: string]: string[] } = {
 		'Command Prompt': [`${system32Path}\\cmd.exe`],
-		'Windows PowerShell': [`${system32Path}\\WindowsPowerShell\\v1.0\\powershell.exe`],
-		'PowerShell': [await getShellPathFromRegistry('pwsh')],
 		'WSL Bash': [`${system32Path}\\${useWSLexe ? 'wsl.exe' : 'bash.exe'}`],
 		'Git Bash': [
 			`${process.env['ProgramW6432']}\\Git\\bin\\bash.exe`,
@@ -74,6 +73,12 @@ async function detectAvailableWindowsShells(): Promise<IShellDefinition[]> {
 		// 	`${process.env['HOMEDRIVE']}\\cygwin\\bin\\bash.exe`
 		// ]
 	};
+
+	// Add all of the different kinds of PowerShells
+	for (const pwshExe of enumeratePowerShellInstallations()) {
+		expectedLocations[pwshExe.displayName] = [pwshExe.exePath];
+	}
+
 	const promises: Promise<IShellDefinition | undefined>[] = [];
 	Object.keys(expectedLocations).forEach(key => promises.push(validateShellPaths(key, expectedLocations[key])));
 	const shells = await Promise.all(promises);
@@ -107,16 +112,22 @@ async function validateShellPaths(label: string, potentialPaths: string[]): Prom
 				path: current
 			};
 		}
-	} catch { /* noop */ }
-	return validateShellPaths(label, potentialPaths);
-}
-
-async function getShellPathFromRegistry(shellName: string): Promise<string> {
-	const Registry = await import('vscode-windows-registry');
-	try {
-		const shellPath = Registry.GetStringRegKey('HKEY_LOCAL_MACHINE', `SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${shellName}.exe`, '');
-		return shellPath ? shellPath : '';
-	} catch (error) {
-		return '';
+	} catch (e) {
+		// Also try using lstat as some symbolic links on Windows
+		// throw 'permission denied' using 'stat' but don't throw
+		// using 'lstat'
+		try {
+			const result = await lstat(normalize(current));
+			if (result.isFile() || result.isSymbolicLink()) {
+				return {
+					label,
+					path: current
+				};
+			}
+		}
+		catch (e) {
+			// noop
+		}
 	}
+	return validateShellPaths(label, potentialPaths);
 }

--- a/src/vs/workbench/contrib/terminal/node/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminal.ts
@@ -75,7 +75,7 @@ async function detectAvailableWindowsShells(): Promise<IShellDefinition[]> {
 	};
 
 	// Add all of the different kinds of PowerShells
-	for (const pwshExe of enumeratePowerShellInstallations()) {
+	for await (const pwshExe of enumeratePowerShellInstallations()) {
 		expectedLocations[pwshExe.displayName] = [pwshExe.exePath];
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/110828

This adds a new file whos goal is to find all of the PowerShell's available on the system. This is heavily adopted by the one over in the PowerShell extension for VS Code: https://github.com/PowerShell/vscode-powershell/blob/master/src/platform.ts

This is so large because PowerShell can be installed in the following ways:

1. PowerShell via MSI
2. PowerShell x86 via MSI
2. PowerShell via MSIX or Microsoft Store
3. PowerShell via .NET Global Tool
4. PowerShell Preview via MSI
5. PowerShell Preview x86 via MSI
2. PowerShell Preview via MSIX or Microsoft Store
4. Windows PowerShell (installed by default)
5. WIndows PowerShell (x86) (installed by default)

(this is also the order we look)

Feature-wise, this lights up:

1. If no default shell is set, PowerShell 7+ will be the default if it is available:
![image](https://user-images.githubusercontent.com/2644648/102542733-100c9000-4067-11eb-9993-5cf46c95f1ae.png)
2. Selecting a default shell on Windows will add in all of the PowerShells installed on the system:
![image](https://user-images.githubusercontent.com/2644648/102542801-303c4f00-4067-11eb-8df9-ea97050d5172.png)
