### PR TITLE
Make default text editor replace existing editors for resource

### DIFF
--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -154,7 +154,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 			...this.getAllCustomEditors(resource).allEditors,
 		]);
 
-		const existingEditorForResource = group && firstOrDefault(this.editorService.getEditorsForResource(resource, group));
+		const existingEditorForResource = group && firstOrDefault(this.editorService.findEditors(resource, group));
 		const currentlyOpenedEditorType: undefined | string = existingEditorForResource instanceof CustomEditorInput ? existingEditorForResource.viewType : defaultCustomEditor.id;
 
 		const resourceExt = extname(resource);
@@ -271,7 +271,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		}
 
 		// Try to replace existing editors for resource
-		const existing = firstOrDefault(this.editorService.getEditorsForResource(resource, targetGroup));
+		const existing = firstOrDefault(this.editorService.findEditors(resource, targetGroup));
 		if (existing) {
 			if (!input.matches(existing)) {
 				await this.editorService.replaceEditors([{
@@ -447,7 +447,7 @@ export class CustomEditorContribution extends Disposable implements IWorkbenchCo
 				return this.onEditorOpening(editor, options, group);
 			},
 			getEditorOverrides: (resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined): IOpenEditorOverrideEntry[] => {
-				const currentEditor = group && firstOrDefault(this.editorService.getEditorsForResource(resource, group));
+				const currentEditor = group && firstOrDefault(this.editorService.findEditors(resource, group));
 
 				const toOverride = (entry: CustomEditorInfo): IOpenEditorOverrideEntry => {
 					return {
@@ -536,7 +536,7 @@ export class CustomEditorContribution extends Disposable implements IWorkbenchCo
 			return;
 		}
 
-		const existingEditorForResource = firstOrDefault(this.editorService.getEditorsForResource(resource, group));
+		const existingEditorForResource = firstOrDefault(this.editorService.findEditors(resource, group));
 		if (existingEditorForResource) {
 			if (editor === existingEditorForResource) {
 				return;

--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { coalesce, distinct } from 'vs/base/common/arrays';
+import { coalesce, distinct, firstOrDefault } from 'vs/base/common/arrays';
 import { Codicon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
 import { Lazy } from 'vs/base/common/lazy';
@@ -154,13 +154,8 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 			...this.getAllCustomEditors(resource).allEditors,
 		]);
 
-		let currentlyOpenedEditorType: undefined | string;
-		for (const editor of group ? group.editors : []) {
-			if (editor.resource && isEqual(editor.resource, resource)) {
-				currentlyOpenedEditorType = editor instanceof CustomEditorInput ? editor.viewType : defaultCustomEditor.id;
-				break;
-			}
-		}
+		const existingEditorForResource = group && firstOrDefault(this.editorService.getEditorsForResource(resource, group));
+		const currentlyOpenedEditorType: undefined | string = existingEditorForResource instanceof CustomEditorInput ? existingEditorForResource.viewType : defaultCustomEditor.id;
 
 		const resourceExt = extname(resource);
 
@@ -276,9 +271,8 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		}
 
 		// Try to replace existing editors for resource
-		const existingEditors = targetGroup.editors.filter(editor => editor.resource && isEqual(editor.resource, resource));
-		if (existingEditors.length) {
-			const existing = existingEditors[0];
+		const existing = firstOrDefault(this.editorService.getEditorsForResource(resource, targetGroup));
+		if (existing) {
 			if (!input.matches(existing)) {
 				await this.editorService.replaceEditors([{
 					editor: existing,
@@ -453,7 +447,7 @@ export class CustomEditorContribution extends Disposable implements IWorkbenchCo
 				return this.onEditorOpening(editor, options, group);
 			},
 			getEditorOverrides: (resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined): IOpenEditorOverrideEntry[] => {
-				const currentEditor = group?.editors.find(editor => isEqual(editor.resource, resource));
+				const currentEditor = group && firstOrDefault(this.editorService.getEditorsForResource(resource, group));
 
 				const toOverride = (entry: CustomEditorInfo): IOpenEditorOverrideEntry => {
 					return {
@@ -542,7 +536,7 @@ export class CustomEditorContribution extends Disposable implements IWorkbenchCo
 			return;
 		}
 
-		const existingEditorForResource = group.editors.find(editor => isEqual(resource, editor.resource));
+		const existingEditorForResource = firstOrDefault(this.editorService.getEditorsForResource(resource, group));
 		if (existingEditorForResource) {
 			if (editor === existingEditorForResource) {
 				return;

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -230,7 +230,7 @@ export class NotebookContribution extends Disposable implements IWorkbenchContri
 		this._register(this.editorService.overrideOpenEditor({
 			getEditorOverrides: (resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined) => {
 
-				const currentEditorForResource = group && this.editorService.getEditorsForResource(resource, group);
+				const currentEditorForResource = group && this.editorService.findEditors(resource, group);
 
 				const associatedEditors = distinct([
 					...this.getUserAssociatedNotebookEditors(resource),
@@ -341,7 +341,7 @@ export class NotebookContribution extends Disposable implements IWorkbenchContri
 		}
 
 		if (id === undefined) {
-			const existingEditors = this.editorService.getEditorsForResource(notebookUri, group).filter(editor =>
+			const existingEditors = this.editorService.findEditors(notebookUri, group).filter(editor =>
 				!(editor instanceof NotebookEditorInput)
 				&& !(editor instanceof NotebookDiffEditorInput)
 			);
@@ -407,7 +407,7 @@ export class NotebookContribution extends Disposable implements IWorkbenchContri
 			return undefined;
 		}
 
-		const existingEditors = this.editorService.getEditorsForResource(notebookUri, group).filter(editor => !(editor instanceof NotebookEditorInput));
+		const existingEditors = this.editorService.findEditors(notebookUri, group).filter(editor => !(editor instanceof NotebookEditorInput));
 
 		if (existingEditors.length) {
 			return undefined;

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -230,7 +230,7 @@ export class NotebookContribution extends Disposable implements IWorkbenchContri
 		this._register(this.editorService.overrideOpenEditor({
 			getEditorOverrides: (resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined) => {
 
-				const currentEditorForResource = group?.editors.find(editor => isEqual(editor.resource, resource));
+				const currentEditorForResource = group && this.editorService.getEditorsForResource(resource, group);
 
 				const associatedEditors = distinct([
 					...this.getUserAssociatedNotebookEditors(resource),
@@ -341,10 +341,8 @@ export class NotebookContribution extends Disposable implements IWorkbenchContri
 		}
 
 		if (id === undefined) {
-			const existingEditors = group.editors.filter(editor =>
-				editor.resource
-				&& isEqual(editor.resource, notebookUri)
-				&& !(editor instanceof NotebookEditorInput)
+			const existingEditors = this.editorService.getEditorsForResource(notebookUri, group).filter(editor =>
+				!(editor instanceof NotebookEditorInput)
 				&& !(editor instanceof NotebookDiffEditorInput)
 			);
 
@@ -409,7 +407,7 @@ export class NotebookContribution extends Disposable implements IWorkbenchContri
 			return undefined;
 		}
 
-		const existingEditors = group.editors.filter(editor => editor.resource && isEqual(editor.resource, notebookUri) && !(editor instanceof NotebookEditorInput));
+		const existingEditors = this.editorService.getEditorsForResource(notebookUri, group).filter(editor => !(editor instanceof NotebookEditorInput));
 
 		if (existingEditors.length) {
 			return undefined;

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -758,10 +758,19 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 
 	//#region findEditor()
 
-	getEditorsForResource(resource: URI, group: IEditorGroup): IEditorInput[] {
-		const cononicalResource = this.asCanonicalEditorResource(resource);
-		return group.getEditors(EditorsOrder.SEQUENTIAL).filter(editor => {
-			return editor.resource && isEqual(editor.resource, cononicalResource);
+	findEditors(resource: URI, group: IEditorGroup | GroupIdentifier): IEditorInput[] {
+		if (!this.isOpen({ resource })) {
+			return [];
+		}
+
+		const canonicalResource = this.asCanonicalEditorResource(resource);
+		const targetGroup = typeof group === 'number' ? this.editorGroupService.getGroup(group) : group;
+		if (!targetGroup) {
+			return [];
+		}
+
+		return targetGroup.getEditors(EditorsOrder.SEQUENTIAL).filter(editor => {
+			return editor.resource && isEqual(editor.resource, canonicalResource);
 		});
 	}
 
@@ -1333,7 +1342,7 @@ export class DelegatingEditorService implements IEditorService {
 	isOpen(editor: IResourceEditorInput): boolean;
 	isOpen(editor: IEditorInput | IResourceEditorInput): boolean { return this.editorService.isOpen(editor as IResourceEditorInput /* TS fail */); }
 
-	getEditorsForResource(resource: URI, group: IEditorGroup) { return this.editorService.getEditorsForResource(resource, group); }
+	findEditors(resource: URI, group: IEditorGroup | GroupIdentifier) { return this.editorService.findEditors(resource, group); }
 
 	overrideOpenEditor(handler: IOpenEditorOverrideHandler): IDisposable { return this.editorService.overrideOpenEditor(handler); }
 	getEditorOverrides(resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined) { return this.editorService.getEditorOverrides(resource, options, group); }

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -756,6 +756,17 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 
 	//#endregion
 
+	//#region findEditor()
+
+	getEditorsForResource(resource: URI, group: IEditorGroup): IEditorInput[] {
+		const cononicalResource = this.asCanonicalEditorResource(resource);
+		return group.getEditors(EditorsOrder.SEQUENTIAL).filter(editor => {
+			return editor.resource && isEqual(editor.resource, cononicalResource);
+		});
+	}
+
+	//#endregion
+
 	//#region replaceEditors()
 
 	async replaceEditors(editors: IResourceEditorReplacement[], group: IEditorGroup | GroupIdentifier): Promise<void>;
@@ -1321,6 +1332,8 @@ export class DelegatingEditorService implements IEditorService {
 	isOpen(editor: IEditorInput): boolean;
 	isOpen(editor: IResourceEditorInput): boolean;
 	isOpen(editor: IEditorInput | IResourceEditorInput): boolean { return this.editorService.isOpen(editor as IResourceEditorInput /* TS fail */); }
+
+	getEditorsForResource(resource: URI, group: IEditorGroup) { return this.editorService.getEditorsForResource(resource, group); }
 
 	overrideOpenEditor(handler: IOpenEditorOverrideHandler): IDisposable { return this.editorService.overrideOpenEditor(handler); }
 	getEditorOverrides(resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined) { return this.editorService.getEditorOverrides(resource, options, group); }

--- a/src/vs/workbench/services/editor/common/editorOpenWith.ts
+++ b/src/vs/workbench/services/editor/common/editorOpenWith.ts
@@ -18,6 +18,7 @@ import { URI } from 'vs/base/common/uri';
 import { extname, basename, isEqual } from 'vs/base/common/resources';
 import { Codicon } from 'vs/base/common/codicons';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { firstOrDefault } from 'vs/base/common/arrays';
 
 /**
  * Id of the default editor for open with.
@@ -217,7 +218,7 @@ export function getAllAvailableEditors(
 					return {
 						override: (async () => {
 							// Try to replace existing editors for resource
-							const existingEditor = group.editors.find(editor => editor.resource && isEqual(editor.resource, resource));
+							const existingEditor = firstOrDefault(editorService.getEditorsForResource(resource, group));
 							if (existingEditor && !fileEditorInput.matches(existingEditor)) {
 								await editorService.replaceEditors([{
 									editor: existingEditor,

--- a/src/vs/workbench/services/editor/common/editorOpenWith.ts
+++ b/src/vs/workbench/services/editor/common/editorOpenWith.ts
@@ -218,7 +218,7 @@ export function getAllAvailableEditors(
 					return {
 						override: (async () => {
 							// Try to replace existing editors for resource
-							const existingEditor = firstOrDefault(editorService.getEditorsForResource(resource, group));
+							const existingEditor = firstOrDefault(editorService.findEditors(resource, group));
 							if (existingEditor && !fileEditorInput.matches(existingEditor)) {
 								await editorService.replaceEditors([{
 									editor: existingEditor,

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -234,9 +234,9 @@ export interface IEditorService {
 	isOpen(editor: IEditorInput): boolean;
 
 	/**
-	 * Get the existing editor for a given resource.
+	 * Find the existing editors for a given resource.
 	 */
-	getEditorsForResource(resource: URI, group: IEditorGroup): IEditorInput[];
+	findEditors(resource: URI, group: IEditorGroup | GroupIdentifier): IEditorInput[];
 
 	/**
 	 * Get all available editor overrides for the editor input.

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -234,6 +234,11 @@ export interface IEditorService {
 	isOpen(editor: IEditorInput): boolean;
 
 	/**
+	 * Get the existing editor for a given resource.
+	 */
+	getEditorsForResource(resource: URI, group: IEditorGroup): IEditorInput[];
+
+	/**
 	 * Get all available editor overrides for the editor input.
 	 */
 	getEditorOverrides(resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined): [IOpenEditorOverrideHandler, IOpenEditorOverrideEntry][];

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -704,6 +704,7 @@ export class TestEditorService implements EditorServiceImpl {
 
 	constructor(private editorGroupService?: IEditorGroupsService) { }
 	getEditors() { return []; }
+	getEditorsForResource() { return []; }
 	getEditorOverrides(resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined): [IOpenEditorOverrideHandler, IOpenEditorOverrideEntry][] { return []; }
 	overrideOpenEditor(_handler: IOpenEditorOverrideHandler): IDisposable { return toDisposable(() => undefined); }
 	registerCustomEditorViewTypesHandler(source: string, handler: ICustomEditorViewTypesHandler): IDisposable {

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -704,7 +704,7 @@ export class TestEditorService implements EditorServiceImpl {
 
 	constructor(private editorGroupService?: IEditorGroupsService) { }
 	getEditors() { return []; }
-	getEditorsForResource() { return []; }
+	findEditors() { return []; }
 	getEditorOverrides(resource: URI, options: IEditorOptions | undefined, group: IEditorGroup | undefined): [IOpenEditorOverrideHandler, IOpenEditorOverrideEntry][] { return []; }
 	overrideOpenEditor(_handler: IOpenEditorOverrideHandler): IDisposable { return toDisposable(() => undefined); }
 	registerCustomEditorViewTypesHandler(source: string, handler: ICustomEditorViewTypesHandler): IDisposable {


### PR DESCRIPTION
Fixes #111474

This ports the logic that we previously had for custom editors to the generic open with flow: https://github.com/microsoft/vscode/blob/f0bb23ca02f320816219017234e412caa425851e/src%2Fvs%2Fworkbench%2Fcontrib%2FcustomEditor%2Fbrowser%2FcustomEditors.ts#L281


