### PR TITLE
debug: Add debugServerHost launch.json attribute

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -11469,7 +11469,7 @@ declare module 'vscode' {
 		 * If the method is not implemented the default behavior is this:
 		 *   createDebugAdapter(session: DebugSession, executable: DebugAdapterExecutable) {
 		 *      if (typeof session.configuration.debugServer === 'number') {
-		 *         return new DebugAdapterServer(session.configuration.debugServer);
+		 *         return new DebugAdapterServer(session.configuration.debugServer, session.configuration.debugServerHost);
 		 *      }
 		 *      return executable;
 		 *   }

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -793,7 +793,7 @@ export abstract class ExtHostDebugServiceBase implements IExtHostDebugService, E
 		// a "debugServer" attribute in the launch config takes precedence
 		const serverPort = session.configuration.debugServer;
 		if (typeof serverPort === 'number') {
-			return Promise.resolve(new DebugAdapterServer(serverPort));
+			return Promise.resolve(new DebugAdapterServer(serverPort, session.configuration.debugServerHost));
 		}
 
 		if (adapterDescriptorFactory) {

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -526,6 +526,7 @@ export interface IEnvConfig {
 	preLaunchTask?: string | TaskIdentifier;
 	postDebugTask?: string | TaskIdentifier;
 	debugServer?: number;
+	debugServerHost?: string;
 	noDebug?: boolean;
 }
 

--- a/src/vs/workbench/contrib/debug/common/debugger.ts
+++ b/src/vs/workbench/contrib/debug/common/debugger.ts
@@ -237,8 +237,12 @@ export class Debugger implements IDebugger {
 			};
 			properties['debugServer'] = {
 				type: 'number',
-				description: nls.localize('debugServer', "For debug extension development only: if a port is specified VS Code tries to connect to a debug adapter running in server mode"),
+				description: nls.localize('debugServer', "If a port is specified VS Code tries to connect to a debug adapter running in server mode on localhost"),
 				default: 4711
+			};
+			properties['debugServerHost'] = {
+				type: 'string',
+				description: nls.localize('debugServerHost', "If a host and port are specified, VS Code tries to connect to a debug adaptor running in server mode on this host")
 			};
 			properties['preLaunchTask'] = {
 				anyOf: [taskSchema, {


### PR DESCRIPTION
This allows connecting to a debug adapter running on a remote host.

This PR fixes #113192

To give a bit more context, the lldb-vscode project from LLVM implements the debug adapter protocol in a separate tool written in C++ named lldb-vscode. I want to run lldb-vscode in a container to allow remote debugging. I'm planning on accomplishing this by running it as a xinet style systemd service. systemd will accept connections at port 4711 and for each connection, spawn an instance of lldb-vscode and connect the socket to its stdin/stdout. This all works well except VSCode is missing an option to allow connecting to a debug adapter running remotely. 

The logic in vscode is already 99% percent there. The debugServer attribute already gives users the option to have vscode connect to a debug adapter listening on a socket on localhost. This PR extends that logic by also allowing users to set a debugServerHost attribute. When specified, this attribute is passed as the `host` argument to `DebugAdapterServer`'s constructor which will make it connect to the debug adapter running on the given host instead of localhost.

This PR can be tested by starting lldb-vscode and passing the `--port 4711` to have it wait for a connection on port 4711. Then, set the debugServer attribute in launch.json to 4711 and the debugServerHost attribute to the hostname of the host that lldb-vscode is running on. vscode will then connect to the remote instance of lldb-vscode running on the given remote host.