### PR TITLE
Allow ResourceCommandResolver.getRightResource() to return undefined

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -79,8 +79,8 @@ export class Resource implements SourceControlResourceState {
 		return this.resources[0];
 	}
 
-	get rightUri(): Uri {
-		return this.resources[1] as Uri;
+	get rightUri(): Uri | undefined {
+		return this.resources[1];
 	}
 
 	get command(): Command {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -80,7 +80,7 @@ export class Resource implements SourceControlResourceState {
 	}
 
 	get rightUri(): Uri {
-		return this.resources[1];
+		return this.resources[1] as Uri;
 	}
 
 	get command(): Command {
@@ -88,7 +88,7 @@ export class Resource implements SourceControlResourceState {
 	}
 
 	@memoize
-	private get resources(): [Uri | undefined, Uri] {
+	private get resources(): [Uri | undefined, Uri | undefined] {
 		return this._commandResolver.getResources(this);
 	}
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -613,7 +613,7 @@ class ResourceCommandResolver {
 		}
 	}
 
-	getResources(resource: Resource): [Uri | undefined, Uri] {
+	getResources(resource: Resource): [Uri | undefined, Uri | undefined] {
 		for (const submodule of this.repository.submodules) {
 			if (path.join(this.repository.root, submodule.path) === resource.resourceUri.fsPath) {
 				return [undefined, toGitUri(resource.resourceUri, resource.resourceGroupType === ResourceGroupType.Index ? 'index' : 'wt', { submoduleOf: this.repository.root })];
@@ -641,7 +641,7 @@ class ResourceCommandResolver {
 		return undefined;
 	}
 
-	private getRightResource(resource: Resource): Uri {
+	private getRightResource(resource: Resource): Uri | undefined {
 		switch (resource.type) {
 			case Status.INDEX_MODIFIED:
 			case Status.INDEX_ADDED:
@@ -677,7 +677,7 @@ class ResourceCommandResolver {
 				return resource.resourceUri;
 		}
 
-		throw new Error('Should never happen');
+		return undefined;
 	}
 
 	private getTitle(resource: Resource): string {

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -139,7 +139,9 @@ suite('git smoke test', function () {
 		cp.execSync('git add .', { cwd });
 		await repository.commit('commit on master');
 
-		cp.execSync('git merge test', { cwd });
+		try {
+			cp.execSync('git merge test', { cwd });
+		} catch (e) {}
 		await new Promise(resolve => setTimeout(resolve, 5e3));
 
 		await commands.executeCommand('workbench.scm.focus');

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -126,6 +126,8 @@ suite('git smoke test', function () {
 	});
 		
 	test('rename/delete conflict', async function () {
+		await commands.executeCommand('workbench.scm.focus');
+
 		cp.execSync('git branch test', { cwd });
 		cp.execSync('git checkout test', { cwd });
 
@@ -141,10 +143,10 @@ suite('git smoke test', function () {
 
 		try {
 			cp.execSync('git merge test', { cwd });
-		} catch (e) {}
-		await new Promise(resolve => setTimeout(resolve, 5e3));
+		} catch (e) { }
 
-		await commands.executeCommand('workbench.scm.focus');
-		await new Promise(resolve => setTimeout(resolve, 5e3));
+		await new Promise(resolve => {
+			setTimeout(resolve, 5e3);
+		});
 	});
 });

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -124,4 +124,25 @@ suite('git smoke test', function () {
 		assert.equal(repository.state.workingTreeChanges.length, 0);
 		assert.equal(repository.state.indexChanges.length, 0);
 	});
+		
+	test('rename/delete conflict', async function () {
+		cp.execSync('git branch test', { cwd });
+		cp.execSync('git checkout test', { cwd });
+
+		fs.unlinkSync(file('app.js'));
+		cp.execSync('git add .', { cwd });
+
+		await repository.commit('commit on test');
+		cp.execSync('git checkout master', { cwd });
+
+		fs.renameSync(file('app.js'), file('rename.js'));
+		cp.execSync('git add .', { cwd });
+		await repository.commit('commit on master');
+
+		cp.execSync('git merge test', { cwd });
+		await new Promise(resolve => setTimeout(resolve, 5e3));
+
+		await commands.executeCommand('workbench.scm.focus');
+		await new Promise(resolve => setTimeout(resolve, 5e3));
+	});
 });

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -126,8 +126,6 @@ suite('git smoke test', function () {
 	});
 		
 	test('rename/delete conflict', async function () {
-		await commands.executeCommand('workbench.scm.focus');
-
 		cp.execSync('git branch test', { cwd });
 		cp.execSync('git checkout test', { cwd });
 
@@ -144,6 +142,10 @@ suite('git smoke test', function () {
 		try {
 			cp.execSync('git merge test', { cwd });
 		} catch (e) { }
+		
+		setTimeout(() => {
+			commands.executeCommand('workbench.scm.focus');
+		}, 2e3);
 
 		await new Promise(resolve => {
 			setTimeout(resolve, 5e3);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #112537 and related issues.

By allowing the `ResourceCommandResolver.getRightResource()` method to return undefined, the `Should never happen` error would not be thrown (#112713) in rename/delete conflicts, where only the `leftUri` property is accessed.
