### PR TITLE
Update syntax grammar for Rust

### DIFF
--- a/extensions/rust/syntaxes/rust.tmLanguage.json
+++ b/extensions/rust/syntaxes/rust.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/dustypomerleau/rust-syntax/commit/f202e7c2b0e962d78d82477b97c25a6234210c78",
+	"version": "https://github.com/dustypomerleau/rust-syntax/commit/d4a98480d1e84a0ec72f4c7ee1e10a13be2f62cd",
 	"name": "Rust",
 	"scopeName": "source.rust",
 	"patterns": [
@@ -149,6 +149,9 @@
 				},
 				{
 					"include": "#keywords"
+				},
+				{
+					"include": "#lifetimes"
 				},
 				{
 					"include": "#punctuation"


### PR DESCRIPTION
Hello! I wanted to update to a newer version of Rust syntax grammar that fixes a bug in dustypomerleau/rust-syntax#12 where lifetimes couldn't be included within macro attributes. Without this, large parts of some files that I am working on are mistakenly highlighted as an unclosed quotation. It seems this is also related to #64488.