### PR TITLE
Emmet create new html-matcher override instead of using LS

### DIFF
--- a/extensions/emmet/src/balance.ts
+++ b/extensions/emmet/src/balance.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { getHtmlFlatNode, offsetRangeToSelection, validate } from './util';
-import { getRootNode } from './parseMarkupDocument';
+import { getRootNode } from './parseDocument';
 import { HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
 
 let balanceOutStack: Array<vscode.Selection[]> = [];
@@ -25,7 +25,10 @@ function balance(out: boolean) {
 	}
 	const editor = vscode.window.activeTextEditor;
 	const document = editor.document;
-	const rootNode = getRootNode(document, true);
+	const rootNode = <HtmlFlatNode>getRootNode(document, true);
+	if (!rootNode) {
+		return;
+	}
 
 	const rangeFn = out ? getRangeToBalanceOut : getRangeToBalanceIn;
 	let newSelections: vscode.Selection[] = [];
@@ -95,11 +98,11 @@ function getRangeToBalanceIn(document: vscode.TextDocument, rootNode: HtmlFlatNo
 		}
 	}
 
-	if (!nodeToBalance.children.length) {
+	if (!nodeToBalance.firstChild) {
 		return selection;
 	}
 
-	const firstChild = nodeToBalance.children[0];
+	const firstChild = nodeToBalance.firstChild;
 	if (selectionStart === firstChild.start
 		&& selectionEnd === firstChild.end
 		&& firstChild.open

--- a/extensions/emmet/src/balance.ts
+++ b/extensions/emmet/src/balance.ts
@@ -25,7 +25,7 @@ function balance(out: boolean) {
 	}
 	const editor = vscode.window.activeTextEditor;
 	const document = editor.document;
-	const rootNode = getRootNode(document);
+	const rootNode = getRootNode(document, true);
 
 	const rangeFn = out ? getRangeToBalanceOut : getRangeToBalanceIn;
 	let newSelections: vscode.Selection[] = [];

--- a/extensions/emmet/src/balance.ts
+++ b/extensions/emmet/src/balance.ts
@@ -60,7 +60,7 @@ function getRangeToBalanceOut(document: vscode.TextDocument, rootNode: HtmlFlatN
 	if (!nodeToBalance) {
 		return selection;
 	}
-	if (!nodeToBalance.close) {
+	if (!nodeToBalance.open || !nodeToBalance.close) {
 		return offsetRangeToSelection(document, nodeToBalance.start, nodeToBalance.end);
 	}
 
@@ -85,7 +85,7 @@ function getRangeToBalanceIn(document: vscode.TextDocument, rootNode: HtmlFlatNo
 
 	const selectionStart = document.offsetAt(selection.start);
 	const selectionEnd = document.offsetAt(selection.end);
-	if (nodeToBalance.close) {
+	if (nodeToBalance.open && nodeToBalance.close) {
 		const entireNodeSelected = selectionStart === nodeToBalance.start && selectionEnd === nodeToBalance.end;
 		const startInOpenTag = selectionStart > nodeToBalance.open.start && selectionStart < nodeToBalance.open.end;
 		const startInCloseTag = selectionStart > nodeToBalance.close.start && selectionStart < nodeToBalance.close.end;
@@ -102,6 +102,7 @@ function getRangeToBalanceIn(document: vscode.TextDocument, rootNode: HtmlFlatNo
 	const firstChild = nodeToBalance.children[0];
 	if (selectionStart === firstChild.start
 		&& selectionEnd === firstChild.end
+		&& firstChild.open
 		&& firstChild.close) {
 		return offsetRangeToSelection(document, firstChild.open.end, firstChild.close.start);
 	}

--- a/extensions/emmet/src/emmetCommon.ts
+++ b/extensions/emmet/src/emmetCommon.ts
@@ -17,7 +17,7 @@ import { fetchEditPoint } from './editPoint';
 import { fetchSelectItem } from './selectItem';
 import { evaluateMathExpression } from './evaluateMathExpression';
 import { incrementDecrement } from './incrementDecrement';
-import { LANGUAGE_MODES, getMappingForIncludedLanguages, updateEmmetExtensionsPath, getPathBaseName, toLSTextDocument, getSyntaxes, getEmmetMode } from './util';
+import { LANGUAGE_MODES, getMappingForIncludedLanguages, updateEmmetExtensionsPath, getPathBaseName, getSyntaxes, getEmmetMode } from './util';
 import { reflectCssValue } from './reflectCssValue';
 import { addFileToMarkupParseCache, removeFileFromMarkupParseCache } from './parseMarkupDocument';
 
@@ -150,14 +150,14 @@ export function activateEmmetExtension(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.workspace.onDidOpenTextDocument((e) => {
 		const emmetMode = getEmmetMode(e.languageId, []) ?? '';
 		if (getSyntaxes().markup.includes(emmetMode)) {
-			addFileToMarkupParseCache(toLSTextDocument(e));
+			addFileToMarkupParseCache(e);
 		}
 	}));
 
 	context.subscriptions.push(vscode.workspace.onDidCloseTextDocument((e) => {
 		const emmetMode = getEmmetMode(e.languageId, []) ?? '';
 		if (getSyntaxes().markup.includes(emmetMode)) {
-			removeFileFromMarkupParseCache(toLSTextDocument(e));
+			removeFileFromMarkupParseCache(e);
 		}
 	}));
 }

--- a/extensions/emmet/src/emmetCommon.ts
+++ b/extensions/emmet/src/emmetCommon.ts
@@ -19,7 +19,7 @@ import { evaluateMathExpression } from './evaluateMathExpression';
 import { incrementDecrement } from './incrementDecrement';
 import { LANGUAGE_MODES, getMappingForIncludedLanguages, updateEmmetExtensionsPath, getPathBaseName, getSyntaxes, getEmmetMode } from './util';
 import { reflectCssValue } from './reflectCssValue';
-import { addFileToMarkupParseCache, removeFileFromMarkupParseCache } from './parseMarkupDocument';
+import { addFileToParseCache, removeFileFromParseCache } from './parseDocument';
 
 export function activateEmmetExtension(context: vscode.ExtensionContext) {
 	registerCompletionProviders(context);
@@ -149,15 +149,17 @@ export function activateEmmetExtension(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.workspace.onDidOpenTextDocument((e) => {
 		const emmetMode = getEmmetMode(e.languageId, []) ?? '';
-		if (getSyntaxes().markup.includes(emmetMode)) {
-			addFileToMarkupParseCache(e);
+		const syntaxes = getSyntaxes();
+		if (syntaxes.markup.includes(emmetMode) || syntaxes.stylesheet.includes(emmetMode)) {
+			addFileToParseCache(e);
 		}
 	}));
 
 	context.subscriptions.push(vscode.workspace.onDidCloseTextDocument((e) => {
 		const emmetMode = getEmmetMode(e.languageId, []) ?? '';
-		if (getSyntaxes().markup.includes(emmetMode)) {
-			removeFileFromMarkupParseCache(e);
+		const syntaxes = getSyntaxes();
+		if (syntaxes.markup.includes(emmetMode) || syntaxes.stylesheet.includes(emmetMode)) {
+			removeFileFromParseCache(e);
 		}
 	}));
 }

--- a/extensions/emmet/src/matchTag.ts
+++ b/extensions/emmet/src/matchTag.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { toLSTextDocument, validate, getHtmlNodeLS, offsetRangeToSelection } from './util';
-import { TextDocument as LSTextDocument } from 'vscode-html-languageservice';
+import { validate, getHtmlFlatNode, offsetRangeToSelection } from './util';
+import { getRootNode } from './parseMarkupDocument';
+import { HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
 
 export function matchTag() {
 	if (!validate(false) || !vscode.window.activeTextEditor) {
@@ -13,11 +14,12 @@ export function matchTag() {
 	}
 
 	const editor = vscode.window.activeTextEditor;
-	const document = toLSTextDocument(editor.document);
+	const document = editor.document;
+	const rootNode = getRootNode(document, true);
 
 	let updatedSelections: vscode.Selection[] = [];
 	editor.selections.forEach(selection => {
-		const updatedSelection = getUpdatedSelections(document, selection.start);
+		const updatedSelection = getUpdatedSelections(document, rootNode, selection.start);
 		if (updatedSelection) {
 			updatedSelections.push(updatedSelection);
 		}
@@ -28,22 +30,20 @@ export function matchTag() {
 	}
 }
 
-function getUpdatedSelections(document: LSTextDocument, position: vscode.Position): vscode.Selection | undefined {
-	const currentNode = getHtmlNodeLS(document, position, true);
+function getUpdatedSelections(document: vscode.TextDocument, rootNode: HtmlFlatNode, position: vscode.Position): vscode.Selection | undefined {
+	const offset = document.offsetAt(position);
+	const currentNode = getHtmlFlatNode(document.getText(), rootNode, offset, true);
 	if (!currentNode) {
 		return;
 	}
 
-	const offset = document.offsetAt(position);
-
 	// If no closing tag or cursor is between open and close tag, then no-op
-	if (currentNode.endTagStart === undefined
-		|| currentNode.startTagEnd === undefined
-		|| (offset > currentNode.startTagEnd && offset < currentNode.endTagStart)) {
+	if (currentNode.close === undefined
+		|| (offset > currentNode.open.end && offset < currentNode.close.start)) {
 		return;
 	}
 
 	// Place cursor inside the close tag if cursor is inside the open tag, else place it inside the open tag
-	const finalOffset = (offset <= currentNode.startTagEnd) ? currentNode.endTagStart + 2 : currentNode.start + 1;
+	const finalOffset = (offset <= currentNode.open.end) ? currentNode.close.start + 2 : currentNode.start + 1;
 	return offsetRangeToSelection(document, finalOffset, finalOffset);
 }

--- a/extensions/emmet/src/matchTag.ts
+++ b/extensions/emmet/src/matchTag.ts
@@ -37,8 +37,9 @@ function getUpdatedSelections(document: vscode.TextDocument, rootNode: HtmlFlatN
 		return;
 	}
 
-	// If no closing tag or cursor is between open and close tag, then no-op
-	if (currentNode.close === undefined
+	// If no opening/closing tag or cursor is between open and close tag, then no-op
+	if (!currentNode.open
+		|| !currentNode.close
 		|| (offset > currentNode.open.end && offset < currentNode.close.start)) {
 		return;
 	}

--- a/extensions/emmet/src/matchTag.ts
+++ b/extensions/emmet/src/matchTag.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { validate, getHtmlFlatNode, offsetRangeToSelection } from './util';
-import { getRootNode } from './parseMarkupDocument';
+import { getRootNode } from './parseDocument';
 import { HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
 
 export function matchTag() {
@@ -15,7 +15,10 @@ export function matchTag() {
 
 	const editor = vscode.window.activeTextEditor;
 	const document = editor.document;
-	const rootNode = getRootNode(document, true);
+	const rootNode = <HtmlFlatNode>getRootNode(document, true);
+	if (!rootNode) {
+		return;
+	}
 
 	let updatedSelections: vscode.Selection[] = [];
 	editor.selections.forEach(selection => {

--- a/extensions/emmet/src/parseMarkupDocument.ts
+++ b/extensions/emmet/src/parseMarkupDocument.ts
@@ -3,20 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { HTMLDocument, TextDocument as LSTextDocument } from 'vscode-html-languageservice';
-import { getLanguageService } from './util';
+import { TextDocument } from 'vscode';
+import { HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
+import parse from '@emmetio/html-matcher';
 
 type Pair<K, V> = {
 	key: K;
 	value: V;
 };
 
-// Map(filename, Pair(fileVersion, parsedContent))
-const _parseCache = new Map<string, Pair<number, HTMLDocument> | undefined>();
+// Map(filename, Pair(fileVersion, rootNodeOfParsedContent))
+const _parseCache = new Map<string, Pair<number, HtmlFlatNode> | undefined>();
 
-export function parseMarkupDocument(document: LSTextDocument, useCache: boolean = true): HTMLDocument {
-	const languageService = getLanguageService();
-	const key = document.uri;
+export function getRootNode(document: TextDocument, useCache: boolean = true): HtmlFlatNode {
+	const key = document.uri.toString();
 	const result = _parseCache.get(key);
 	const documentVersion = document.version;
 	if (useCache && result) {
@@ -25,19 +25,19 @@ export function parseMarkupDocument(document: LSTextDocument, useCache: boolean 
 		}
 	}
 
-	const parsedDocument = languageService.parseHTMLDocument(document);
+	const rootNode = parse(document.getText());
 	if (useCache) {
-		_parseCache.set(key, { key: documentVersion, value: parsedDocument });
+		_parseCache.set(key, { key: documentVersion, value: rootNode });
 	}
-	return parsedDocument;
+	return rootNode;
 }
 
-export function addFileToMarkupParseCache(document: LSTextDocument) {
-	const filename = document.uri;
+export function addFileToMarkupParseCache(document: TextDocument) {
+	const filename = document.uri.toString();
 	_parseCache.set(filename, undefined);
 }
 
-export function removeFileFromMarkupParseCache(document: LSTextDocument) {
-	const filename = document.uri;
+export function removeFileFromMarkupParseCache(document: TextDocument) {
+	const filename = document.uri.toString();
 	_parseCache.delete(filename);
 }

--- a/extensions/emmet/src/parseMarkupDocument.ts
+++ b/extensions/emmet/src/parseMarkupDocument.ts
@@ -15,7 +15,7 @@ type Pair<K, V> = {
 // Map(filename, Pair(fileVersion, rootNodeOfParsedContent))
 const _parseCache = new Map<string, Pair<number, HtmlFlatNode> | undefined>();
 
-export function getRootNode(document: TextDocument, useCache: boolean = true): HtmlFlatNode {
+export function getRootNode(document: TextDocument, useCache: boolean): HtmlFlatNode {
 	const key = document.uri.toString();
 	const result = _parseCache.get(key);
 	const documentVersion = document.version;

--- a/extensions/emmet/src/removeTag.ts
+++ b/extensions/emmet/src/removeTag.ts
@@ -4,16 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { validate, getHtmlNodeLS, toLSTextDocument, offsetRangeToVsRange } from './util';
+import { getRootNode } from './parseMarkupDocument';
+import { validate, getHtmlFlatNode, offsetRangeToVsRange } from './util';
+import { HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
 
 export function removeTag() {
 	if (!validate(false) || !vscode.window.activeTextEditor) {
 		return;
 	}
 	const editor = vscode.window.activeTextEditor;
+	const document = editor.document;
+	const rootNode = getRootNode(document, true);
 	let finalRangesToRemove = editor.selections.reverse()
 		.reduce<vscode.Range[]>((prev, selection) =>
-			prev.concat(getRangesToRemove(editor.document, selection)), []);
+			prev.concat(getRangesToRemove(editor.document, rootNode, selection)), []);
 
 	return editor.edit(editBuilder => {
 		finalRangesToRemove.forEach(range => {
@@ -27,17 +31,17 @@ export function removeTag() {
  * It finds the node to remove based on the selection's start position
  * and then removes that node, reindenting the content in between.
  */
-function getRangesToRemove(document: vscode.TextDocument, selection: vscode.Selection): vscode.Range[] {
-	const lsDocument = toLSTextDocument(document);
-	const nodeToUpdate = getHtmlNodeLS(lsDocument, selection.start, true);
+function getRangesToRemove(document: vscode.TextDocument, rootNode: HtmlFlatNode, selection: vscode.Selection): vscode.Range[] {
+	const offset = document.offsetAt(selection.start);
+	const nodeToUpdate = getHtmlFlatNode(document.getText(), rootNode, offset, true);
 	if (!nodeToUpdate) {
 		return [];
 	}
 
-	const openTagRange = offsetRangeToVsRange(lsDocument, nodeToUpdate.start, nodeToUpdate.startTagEnd ?? nodeToUpdate.end);
+	const openTagRange = offsetRangeToVsRange(document, nodeToUpdate.open.start, nodeToUpdate.open.end);
 	let closeTagRange: vscode.Range | undefined;
-	if (nodeToUpdate.endTagStart !== undefined) {
-		closeTagRange = offsetRangeToVsRange(lsDocument, nodeToUpdate.endTagStart, nodeToUpdate.end);
+	if (nodeToUpdate.close !== undefined) {
+		closeTagRange = offsetRangeToVsRange(document, nodeToUpdate.close.start, nodeToUpdate.close.end);
 	}
 
 	let rangesToRemove = [openTagRange];

--- a/extensions/emmet/src/removeTag.ts
+++ b/extensions/emmet/src/removeTag.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { getRootNode } from './parseMarkupDocument';
+import { getRootNode } from './parseDocument';
 import { validate, getHtmlFlatNode, offsetRangeToVsRange } from './util';
 import { HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
 
@@ -14,7 +14,11 @@ export function removeTag() {
 	}
 	const editor = vscode.window.activeTextEditor;
 	const document = editor.document;
-	const rootNode = getRootNode(document, true);
+	const rootNode = <HtmlFlatNode>getRootNode(document, true);
+	if (!rootNode) {
+		return;
+	}
+
 	let finalRangesToRemove = editor.selections.reverse()
 		.reduce<vscode.Range[]>((prev, selection) =>
 			prev.concat(getRangesToRemove(editor.document, rootNode, selection)), []);

--- a/extensions/emmet/src/removeTag.ts
+++ b/extensions/emmet/src/removeTag.ts
@@ -38,19 +38,25 @@ function getRangesToRemove(document: vscode.TextDocument, rootNode: HtmlFlatNode
 		return [];
 	}
 
-	const openTagRange = offsetRangeToVsRange(document, nodeToUpdate.open.start, nodeToUpdate.open.end);
+	let openTagRange: vscode.Range | undefined;
+	if (nodeToUpdate.open) {
+		openTagRange = offsetRangeToVsRange(document, nodeToUpdate.open.start, nodeToUpdate.open.end);
+	}
 	let closeTagRange: vscode.Range | undefined;
-	if (nodeToUpdate.close !== undefined) {
+	if (nodeToUpdate.close) {
 		closeTagRange = offsetRangeToVsRange(document, nodeToUpdate.close.start, nodeToUpdate.close.end);
 	}
 
-	let rangesToRemove = [openTagRange];
-	if (closeTagRange) {
-		const indentAmountToRemove = calculateIndentAmountToRemove(document, openTagRange, closeTagRange);
-		for (let i = openTagRange.start.line + 1; i < closeTagRange.start.line; i++) {
-			rangesToRemove.push(new vscode.Range(i, 0, i, indentAmountToRemove));
+	let rangesToRemove = [];
+	if (openTagRange) {
+		rangesToRemove.push(openTagRange);
+		if (closeTagRange) {
+			const indentAmountToRemove = calculateIndentAmountToRemove(document, openTagRange, closeTagRange);
+			for (let i = openTagRange.start.line + 1; i < closeTagRange.start.line; i++) {
+				rangesToRemove.push(new vscode.Range(i, 0, i, indentAmountToRemove));
+			}
+			rangesToRemove.push(closeTagRange);
 		}
-		rangesToRemove.push(closeTagRange);
 	}
 	return rangesToRemove;
 }

--- a/extensions/emmet/src/splitJoinTag.ts
+++ b/extensions/emmet/src/splitJoinTag.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { validate, getEmmetMode, getEmmetConfiguration, toLSTextDocument, getHtmlNodeLS, offsetRangeToVsRange } from './util';
-import { Node as LSNode, TextDocument as LSTextDocument } from 'vscode-html-languageservice';
+import { validate, getEmmetMode, getEmmetConfiguration, getHtmlFlatNode, offsetRangeToVsRange } from './util';
+import { HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
+import { getRootNode } from './parseMarkupDocument';
 
 export function splitJoinTag() {
 	if (!validate(false) || !vscode.window.activeTextEditor) {
@@ -13,10 +14,13 @@ export function splitJoinTag() {
 	}
 
 	const editor = vscode.window.activeTextEditor;
-	const document = toLSTextDocument(editor.document);
+	const document = editor.document;
+	const rootNode = getRootNode(editor.document, true);
 	return editor.edit(editBuilder => {
 		editor.selections.reverse().forEach(selection => {
-			const nodeToUpdate = getHtmlNodeLS(document, selection.start, true);
+			const documentText = document.getText();
+			const offset = document.offsetAt(selection.start);
+			const nodeToUpdate = getHtmlFlatNode(documentText, rootNode, offset, true);
 			if (nodeToUpdate) {
 				const textEdit = getRangesToReplace(document, nodeToUpdate);
 				if (textEdit) {
@@ -27,15 +31,11 @@ export function splitJoinTag() {
 	});
 }
 
-function getRangesToReplace(document: LSTextDocument, nodeToUpdate: LSNode): vscode.TextEdit | undefined {
+function getRangesToReplace(document: vscode.TextDocument, nodeToUpdate: HtmlFlatNode): vscode.TextEdit | undefined {
 	let rangeToReplace: vscode.Range;
 	let textToReplaceWith: string;
 
-	if (!nodeToUpdate?.tag) {
-		return;
-	}
-
-	if (nodeToUpdate.endTagStart === undefined || nodeToUpdate.startTagEnd === undefined) {
+	if (nodeToUpdate.close === undefined) {
 		// Split Tag
 		const nodeText = document.getText().substring(nodeToUpdate.start, nodeToUpdate.end);
 		const m = nodeText.match(/(\s*\/)?>$/);
@@ -43,10 +43,10 @@ function getRangesToReplace(document: LSTextDocument, nodeToUpdate: LSNode): vsc
 		const start = m ? end - m[0].length : end;
 
 		rangeToReplace = offsetRangeToVsRange(document, start, end);
-		textToReplaceWith = `></${nodeToUpdate.tag}>`;
+		textToReplaceWith = `></${nodeToUpdate.name}>`;
 	} else {
 		// Join Tag
-		const start = nodeToUpdate.startTagEnd - 1;
+		const start = nodeToUpdate.open.end - 1;
 		const end = nodeToUpdate.end;
 		rangeToReplace = offsetRangeToVsRange(document, start, end);
 		textToReplaceWith = '/>';

--- a/extensions/emmet/src/splitJoinTag.ts
+++ b/extensions/emmet/src/splitJoinTag.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { validate, getEmmetMode, getEmmetConfiguration, getHtmlFlatNode, offsetRangeToVsRange } from './util';
 import { HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
-import { getRootNode } from './parseMarkupDocument';
+import { getRootNode } from './parseDocument';
 
 export function splitJoinTag() {
 	if (!validate(false) || !vscode.window.activeTextEditor) {
@@ -15,7 +15,11 @@ export function splitJoinTag() {
 
 	const editor = vscode.window.activeTextEditor;
 	const document = editor.document;
-	const rootNode = getRootNode(editor.document, true);
+	const rootNode = <HtmlFlatNode>getRootNode(editor.document, true);
+	if (!rootNode) {
+		return;
+	}
+
 	return editor.edit(editBuilder => {
 		editor.selections.reverse().forEach(selection => {
 			const documentText = document.getText();
@@ -23,15 +27,13 @@ export function splitJoinTag() {
 			const nodeToUpdate = getHtmlFlatNode(documentText, rootNode, offset, true);
 			if (nodeToUpdate) {
 				const textEdit = getRangesToReplace(document, nodeToUpdate);
-				if (textEdit) {
-					editBuilder.replace(textEdit.range, textEdit.newText);
-				}
+				editBuilder.replace(textEdit.range, textEdit.newText);
 			}
 		});
 	});
 }
 
-function getRangesToReplace(document: vscode.TextDocument, nodeToUpdate: HtmlFlatNode): vscode.TextEdit | undefined {
+function getRangesToReplace(document: vscode.TextDocument, nodeToUpdate: HtmlFlatNode): vscode.TextEdit {
 	let rangeToReplace: vscode.Range;
 	let textToReplaceWith: string;
 

--- a/extensions/emmet/src/splitJoinTag.ts
+++ b/extensions/emmet/src/splitJoinTag.ts
@@ -35,7 +35,7 @@ function getRangesToReplace(document: vscode.TextDocument, nodeToUpdate: HtmlFla
 	let rangeToReplace: vscode.Range;
 	let textToReplaceWith: string;
 
-	if (nodeToUpdate.close === undefined) {
+	if (!nodeToUpdate.open || !nodeToUpdate.close) {
 		// Split Tag
 		const nodeText = document.getText().substring(nodeToUpdate.start, nodeToUpdate.end);
 		const m = nodeText.match(/(\s*\/)?>$/);

--- a/extensions/emmet/src/typings/EmmetFlatNode.d.ts
+++ b/extensions/emmet/src/typings/EmmetFlatNode.d.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+declare module 'EmmetFlatNode' {
+    export interface Node {
+        start: number
+        end: number
+        type: string
+        parent: Node
+        firstChild: Node
+        nextSibling: Node
+        previousSibling: Node
+        children: Node[]
+    }
+
+    export interface Token {
+        start: number
+        end: number
+        stream: string
+        toString(): string
+    }
+
+    export interface CssToken extends Token {
+        size: number
+        item(number: number): any
+        type: string
+    }
+
+    export interface HtmlToken extends Token {
+        value: string
+    }
+
+    export interface Attribute extends Token {
+        name: Token
+        value: Token
+    }
+
+    export interface HtmlNode extends Node {
+        name: string
+        open: Token
+        close: Token | undefined
+        parent: HtmlNode
+        firstChild: HtmlNode
+        nextSibling: HtmlNode
+        previousSibling: HtmlNode
+        children: HtmlNode[]
+        attributes: Attribute[]
+    }
+
+    export interface CssNode extends Node {
+        name: string
+        parent: CssNode
+        firstChild: CssNode
+        nextSibling: CssNode
+        previousSibling: CssNode
+        children: CssNode[]
+    }
+
+    export interface Rule extends CssNode {
+        selectorToken: Token
+        contentStartToken: Token
+        contentEndToken: Token
+    }
+
+    export interface Property extends CssNode {
+        valueToken: Token
+        separator: string
+        parent: Rule
+        terminatorToken: Token
+        separatorToken: Token
+        value: string
+    }
+
+    export interface Stylesheet extends Node {
+        comments: Token[]
+    }
+}

--- a/extensions/emmet/src/typings/EmmetFlatNode.d.ts
+++ b/extensions/emmet/src/typings/EmmetFlatNode.d.ts
@@ -39,7 +39,7 @@ declare module 'EmmetFlatNode' {
 
     export interface HtmlNode extends Node {
         name: string
-        open: Token
+        open: Token | undefined
         close: Token | undefined
         parent: HtmlNode
         firstChild: HtmlNode

--- a/extensions/emmet/src/typings/EmmetFlatNode.d.ts
+++ b/extensions/emmet/src/typings/EmmetFlatNode.d.ts
@@ -8,10 +8,10 @@ declare module 'EmmetFlatNode' {
         start: number
         end: number
         type: string
-        parent: Node
-        firstChild: Node
-        nextSibling: Node
-        previousSibling: Node
+        parent: Node | undefined
+        firstChild: Node | undefined
+        nextSibling: Node | undefined
+        previousSibling: Node | undefined
         children: Node[]
     }
 
@@ -41,20 +41,20 @@ declare module 'EmmetFlatNode' {
         name: string
         open: Token | undefined
         close: Token | undefined
-        parent: HtmlNode
-        firstChild: HtmlNode
-        nextSibling: HtmlNode
-        previousSibling: HtmlNode
+        parent: HtmlNode | undefined
+        firstChild: HtmlNode | undefined
+        nextSibling: HtmlNode | undefined
+        previousSibling: HtmlNode | undefined
         children: HtmlNode[]
         attributes: Attribute[]
     }
 
     export interface CssNode extends Node {
         name: string
-        parent: CssNode
-        firstChild: CssNode
-        nextSibling: CssNode
-        previousSibling: CssNode
+        parent: CssNode | undefined
+        firstChild: CssNode | undefined
+        nextSibling: CssNode | undefined
+        previousSibling: CssNode | undefined
         children: CssNode[]
     }
 

--- a/extensions/emmet/src/typings/emmetio__css-parser.d.ts
+++ b/extensions/emmet/src/typings/emmetio__css-parser.d.ts
@@ -5,8 +5,10 @@
 
 declare module '@emmetio/css-parser' {
 	import { BufferStream, Stylesheet } from 'EmmetNode';
+	import { Stylesheet as FlatStylesheet } from 'EmmetFlatNode';
 
 	function parseStylesheet(stream: BufferStream): Stylesheet;
+	function parseStylesheet(stream: string): FlatStylesheet;
 
 	export default parseStylesheet;
 }

--- a/extensions/emmet/src/typings/emmetio__html-matcher.d.ts
+++ b/extensions/emmet/src/typings/emmetio__html-matcher.d.ts
@@ -5,8 +5,10 @@
 
 declare module '@emmetio/html-matcher' {
 	import { BufferStream, HtmlNode } from 'EmmetNode';
+	import { HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
 
 	function parse(stream: BufferStream): HtmlNode;
+	function parse(stream: string): HtmlFlatNode;
 
 	export default parse;
 }

--- a/extensions/emmet/src/updateTag.ts
+++ b/extensions/emmet/src/updateTag.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { getHtmlNodeLS, toLSTextDocument, validate } from './util';
-import { TextDocument as LSTextDocument, Node as LSNode } from 'vscode-html-languageservice';
+import { getHtmlFlatNode, validate } from './util';
+import { HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
+import { getRootNode } from './parseMarkupDocument';
 
 export function updateTag(tagName: string): Thenable<boolean> | undefined {
 	if (!validate(false) || !vscode.window.activeTextEditor) {
@@ -13,9 +14,10 @@ export function updateTag(tagName: string): Thenable<boolean> | undefined {
 	}
 
 	const editor = vscode.window.activeTextEditor;
+	const document = editor.document;
 	const rangesToUpdate = editor.selections.reverse()
 		.reduce<vscode.Range[]>((prev, selection) =>
-			prev.concat(getRangesToUpdate(editor, selection)), []);
+			prev.concat(getRangesToUpdate(document, selection)), []);
 
 	return editor.edit(editBuilder => {
 		rangesToUpdate.forEach(range => {
@@ -24,34 +26,28 @@ export function updateTag(tagName: string): Thenable<boolean> | undefined {
 	});
 }
 
-function getPositionFromOffset(offset: number | undefined, document: LSTextDocument): vscode.Position | undefined {
-	if (offset === undefined) {
-		return undefined;
-	}
-	const pos = document.positionAt(offset);
-	return new vscode.Position(pos.line, pos.character);
-}
-
-function getRangesFromNode(node: LSNode, document: LSTextDocument): vscode.Range[] {
-	const start = getPositionFromOffset(node.start, document)!;
-	const startTagEnd = getPositionFromOffset(node.startTagEnd, document);
-	const end = getPositionFromOffset(node.end, document)!;
-	const endTagStart = getPositionFromOffset(node.endTagStart, document);
+function getRangesFromNode(node: HtmlFlatNode, document: vscode.TextDocument): vscode.Range[] {
+	const start = document.positionAt(node.open.start);
+	const startTagEnd = document.positionAt(node.open.end);
 
 	let ranges: vscode.Range[] = [];
 	if (startTagEnd) {
 		ranges.push(new vscode.Range(start.translate(0, 1),
-			start.translate(0, 1).translate(0, node.tag!.length ?? 0)));
+			start.translate(0, 1).translate(0, node.name.length)));
 	}
-	if (endTagStart) {
+	if (node.close) {
+		const endTagStart = document.positionAt(node.close.start);
+		const end = document.positionAt(node.close.end);
 		ranges.push(new vscode.Range(endTagStart.translate(0, 2), end.translate(0, -1)));
 	}
 	return ranges;
 }
 
-function getRangesToUpdate(editor: vscode.TextEditor, selection: vscode.Selection): vscode.Range[] {
-	const document = toLSTextDocument(editor.document);
-	const nodeToUpdate = getHtmlNodeLS(document, selection.start, true);
+function getRangesToUpdate(document: vscode.TextDocument, selection: vscode.Selection): vscode.Range[] {
+	const documentText = document.getText();
+	const rootNode = getRootNode(document, true);
+	const offset = document.offsetAt(selection.start);
+	const nodeToUpdate = getHtmlFlatNode(documentText, rootNode, offset, true);
 	if (!nodeToUpdate) {
 		return [];
 	}

--- a/extensions/emmet/src/updateTag.ts
+++ b/extensions/emmet/src/updateTag.ts
@@ -27,11 +27,9 @@ export function updateTag(tagName: string): Thenable<boolean> | undefined {
 }
 
 function getRangesFromNode(node: HtmlFlatNode, document: vscode.TextDocument): vscode.Range[] {
-	const start = document.positionAt(node.open.start);
-	const startTagEnd = document.positionAt(node.open.end);
-
 	let ranges: vscode.Range[] = [];
-	if (startTagEnd) {
+	if (node.open) {
+		const start = document.positionAt(node.open.start);
 		ranges.push(new vscode.Range(start.translate(0, 1),
 			start.translate(0, 1).translate(0, node.name.length)));
 	}

--- a/extensions/emmet/src/util.ts
+++ b/extensions/emmet/src/util.ts
@@ -7,13 +7,12 @@ import * as vscode from 'vscode';
 import parse from '@emmetio/html-matcher';
 import parseStylesheet from '@emmetio/css-parser';
 import { Node, HtmlNode, CssToken, Property, Rule, Stylesheet } from 'EmmetNode';
+import { Node as FlatNode, HtmlNode as HtmlFlatNode } from 'EmmetFlatNode';
 import { DocumentStreamReader } from './bufferStream';
 import * as EmmetHelper from 'vscode-emmet-helper';
-import { Position as LSPosition, getLanguageService as getLanguageServiceInternal, LanguageService, LanguageServiceOptions, TextDocument as LSTextDocument, Node as LSNode } from 'vscode-html-languageservice';
-import { parseMarkupDocument } from './parseMarkupDocument';
+import { TextDocument as LSTextDocument } from 'vscode-languageserver-textdocument';
 
 let _emmetHelper: typeof EmmetHelper;
-let _languageService: LanguageService;
 let _currentExtensionsPath: string | undefined = undefined;
 
 let _homeDir: vscode.Uri | undefined;
@@ -31,16 +30,6 @@ export function getEmmetHelper() {
 	}
 	updateEmmetExtensionsPath();
 	return _emmetHelper;
-}
-
-export function getLanguageService(options?: LanguageServiceOptions): LanguageService {
-	if (!options) {
-		if (!_languageService) {
-			_languageService = getLanguageServiceInternal();
-		}
-		return _languageService;
-	}
-	return getLanguageServiceInternal(options);
 }
 
 /**
@@ -323,7 +312,7 @@ export function parsePartialStylesheet(document: vscode.TextDocument, position: 
 /**
  * Returns node corresponding to given position in the given root node
  */
-export function getNode(root: Node | undefined, position: vscode.Position, includeNodeBoundary: boolean) {
+export function getNode(root: Node | undefined, position: vscode.Position, includeNodeBoundary: boolean): Node | null {
 	if (!root) {
 		return null;
 	}
@@ -346,6 +335,41 @@ export function getNode(root: Node | undefined, position: vscode.Position, inclu
 	}
 
 	return foundNode;
+}
+
+export function getFlatNode(root: FlatNode | undefined, offset: number, includeNodeBoundary: boolean): FlatNode | undefined {
+	if (!root) {
+		return;
+	}
+
+	function getFlatNodeChild(child: FlatNode | undefined): FlatNode | undefined {
+		if (!child) {
+			return;
+		}
+		const nodeStart = child.start;
+		const nodeEnd = child.end;
+		if ((nodeStart < offset && nodeEnd > offset)
+			|| (includeNodeBoundary && nodeStart <= offset && nodeEnd >= offset)) {
+			return getFlatNodeChildren(child.children) ?? child;
+		}
+		else if ('close' in <any>child && !(<HtmlFlatNode>child).close) {
+			// in the case of invalid unpaired HTML nodes
+			// we still want to search the children of that node
+			return getFlatNodeChildren(child.children);
+		}
+	}
+
+	function getFlatNodeChildren(children: FlatNode[]): FlatNode | undefined {
+		for (let i = 0; i < children.length; i++) {
+			const foundChild = getFlatNodeChild(children[i]);
+			if (foundChild) {
+				return foundChild;
+			}
+		}
+		return;
+	}
+
+	return getFlatNodeChildren(root.children);
 }
 
 export const allowedMimeTypesInScriptTag = ['text/html', 'text/plain', 'text/x-template', 'text/template', 'text/ng-template'];
@@ -380,37 +404,23 @@ export function getHtmlNode(document: vscode.TextDocument, root: Node | undefine
 /**
  * Finds the HTML node within an HTML document at a given position
  */
-export function getHtmlNodeLS(document: LSTextDocument, position: vscode.Position, includeNodeBoundary: boolean): LSNode | undefined {
-	const documentText = document.getText();
-	const offset = document.offsetAt(position);
-	let selectionStartOffset = offset;
-	if (includeNodeBoundary && documentText.charAt(offset) === '<') {
-		selectionStartOffset++;
-	}
-	else if (includeNodeBoundary && documentText.charAt(offset) === '>') {
-		selectionStartOffset--;
-	}
-	return getHtmlNodeLSInternal(document, selectionStartOffset);
-}
+export function getHtmlFlatNode(documentText: string, root: FlatNode | undefined, offset: number, includeNodeBoundary: boolean): HtmlFlatNode | undefined {
+	const currentNode: HtmlFlatNode | undefined = <HtmlFlatNode | undefined>getFlatNode(root, offset, includeNodeBoundary);
+	if (!currentNode) { return; }
 
-function getHtmlNodeLSInternal(document: LSTextDocument, offset: number, isInTemplateNode: boolean = false): LSNode | undefined {
-	const useCache = !isInTemplateNode;
-	const parsedDocument = parseMarkupDocument(document, useCache);
-
-	const currentNode: LSNode = parsedDocument.findNodeAt(offset);
-	if (!currentNode.tag) { return; }
-
-	const isTemplateScript = isNodeTemplateScriptLS(currentNode);
+	const isTemplateScript = currentNode.name === 'script' &&
+		(currentNode.attributes &&
+			currentNode.attributes.some(x => x.name.toString() === 'type'
+				&& allowedMimeTypesInScriptTag.includes(x.value.toString())));
 	if (isTemplateScript
-		&& currentNode.startTagEnd
-		&& offset > currentNode.startTagEnd
-		&& (!currentNode.endTagStart || offset < currentNode.endTagStart)) {
+		&& offset > currentNode.open.end
+		&& (!currentNode.close || offset < currentNode.close.start)) {
 		// blank out the rest of the document and search for the node within
-		const documentText = document.getText();
-		const beforePadding = ' '.repeat(currentNode.startTagEnd);
-		const scriptBodyText = beforePadding + documentText.substring(currentNode.startTagEnd, currentNode.endTagStart ?? currentNode.end);
-		const scriptBodyDocument = LSTextDocument.create(document.uri, document.languageId, document.version, scriptBodyText);
-		const scriptBodyNode = getHtmlNodeLSInternal(scriptBodyDocument, offset, true);
+		const beforePadding = ' '.repeat(currentNode.open.end);
+		const endToUse = currentNode.close ? currentNode.close.start : currentNode.end;
+		const scriptBodyText = beforePadding + documentText.substring(currentNode.open.end, endToUse);
+		const innerRoot: HtmlFlatNode = parse(scriptBodyText);
+		const scriptBodyNode = getHtmlFlatNode(scriptBodyText, innerRoot, offset, includeNodeBoundary);
 		if (scriptBodyNode) {
 			scriptBodyNode.parent = currentNode;
 			currentNode.children.push(scriptBodyNode);
@@ -420,33 +430,16 @@ function getHtmlNodeLSInternal(document: LSTextDocument, offset: number, isInTem
 	return currentNode;
 }
 
-/**
- * Returns whether the node is a <script> node
- * that we want to search through and parse for more potential HTML nodes
- */
-function isNodeTemplateScriptLS(node: LSNode): boolean {
-	if (node.tag === 'script' && node.attributes && node.attributes['type']) {
-		let scriptType = node.attributes['type'];
-		scriptType = scriptType.substring(1, scriptType.length - 1);
-		return allowedMimeTypesInScriptTag.includes(scriptType);
-	}
-	return false;
-}
-
-function toVsPosition(position: LSPosition): vscode.Position {
-	return new vscode.Position(position.line, position.character);
-}
-
-export function offsetRangeToSelection(document: LSTextDocument, start: number, end: number): vscode.Selection {
+export function offsetRangeToSelection(document: vscode.TextDocument, start: number, end: number): vscode.Selection {
 	const startPos = document.positionAt(start);
 	const endPos = document.positionAt(end);
-	return new vscode.Selection(toVsPosition(startPos), toVsPosition(endPos));
+	return new vscode.Selection(startPos, endPos);
 }
 
-export function offsetRangeToVsRange(document: LSTextDocument, start: number, end: number): vscode.Range {
+export function offsetRangeToVsRange(document: vscode.TextDocument, start: number, end: number): vscode.Range {
 	const startPos = document.positionAt(start);
 	const endPos = document.positionAt(end);
-	return new vscode.Range(toVsPosition(startPos), toVsPosition(endPos));
+	return new vscode.Range(startPos, endPos);
 }
 
 /**

--- a/extensions/emmet/src/util.ts
+++ b/extensions/emmet/src/util.ts
@@ -352,11 +352,16 @@ export function getFlatNode(root: FlatNode | undefined, offset: number, includeN
 			|| (includeNodeBoundary && nodeStart <= offset && nodeEnd >= offset)) {
 			return getFlatNodeChildren(child.children) ?? child;
 		}
-		else if ('close' in <any>child && !(<HtmlFlatNode>child).close) {
-			// in the case of invalid unpaired HTML nodes
-			// we still want to search the children of that node
-			return getFlatNodeChildren(child.children);
+		else if ('close' in <any>child) {
+			// We have an HTML node in this case.
+			// In case this node is an invalid unpaired HTML node,
+			// we still want to search its children
+			const htmlChild = <HtmlFlatNode>child;
+			if (htmlChild.open && !htmlChild.close) {
+				return getFlatNodeChildren(htmlChild.children);
+			}
 		}
+		return;
 	}
 
 	function getFlatNodeChildren(children: FlatNode[]): FlatNode | undefined {
@@ -413,6 +418,7 @@ export function getHtmlFlatNode(documentText: string, root: FlatNode | undefined
 			currentNode.attributes.some(x => x.name.toString() === 'type'
 				&& allowedMimeTypesInScriptTag.includes(x.value.toString())));
 	if (isTemplateScript
+		&& currentNode.open
 		&& offset > currentNode.open.end
 		&& (!currentNode.close || offset < currentNode.close.start)) {
 		// blank out the rest of the document and search for the node within


### PR DESCRIPTION
This PR affects #110577

Originally, we were using @emmetio/html-matcher with a slow custom Bufferstream.
Then, I switched some of the Emmet functions to use vscode-html-languageservice, which works with TextDocuments from vscode-languageserver-textdocument.

It turns out that:

1. @emmetio/html-matcher provides some file information that vscode-html-languageservice does not include, such as the location of comment tags and HTML attributes.
2. @emmetio/html-matcher is faster than vscode-html-languageservice once I pass in strings directly to it, rather than a Bufferstream.

This PR therefore: 

1. Adds an override to pass strings into @emmetio/html-matcher and @emmetio/css-parser and get back a new data structure declared within `EmmetFlatNode.d.ts`.
2. Reverts some of the code to be in the format of vscode v1.51, which was using @emmetio/html-matcher with Bufferstream. However, there are some methods within `util.ts` that now ensure we are not using Bufferstream, but still using the functionality provided by @emmetio/html-matcher.
3. Polishes the cache to store Emmet Nodes within `EmmetFlatNode.d.ts` instead of HTML-only LSNodes.

