### PR TITLE
No need to use containers for compilation and hygiene jobs

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -31,16 +31,14 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: "Ubuntu-18.04"
-        container: vscode-x64
+          vmImage: "Ubuntu-20.04"
         variables:
           VSCODE_ARCH: x64
         steps:
           - template: product-compile.yml
       - job: Hygiene
         pool:
-          vmImage: "Ubuntu-18.04"
-        container: vscode-x64
+          vmImage: "Ubuntu-20.04"
         variables:
           VSCODE_ARCH: x64
         steps:

--- a/build/azure-pipelines/product-compile.yml
+++ b/build/azure-pipelines/product-compile.yml
@@ -1,11 +1,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: "12.18.3"
-
-  - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
-    inputs:
-      versionSpec: "1.x"
+      versionSpec: "12.x"
 
   - task: AzureKeyVault@1
     displayName: "Azure Key Vault: Get Secrets"
@@ -41,9 +37,10 @@ steps:
       node build/azure-pipelines/common/computeNodeModulesCacheKey.js $VSCODE_ARCH $ENABLE_TERRAPIN > .build/yarnlockhash
     displayName: Prepare yarn cache flags
 
+  # using `genericNodeModules` instead of `nodeModules` here to avoid sharing the cache with builds running inside containers
   - task: Cache@2
     inputs:
-      key: 'nodeModules | $(Agent.OS) | .build/yarnlockhash'
+      key: 'genericNodeModules | $(Agent.OS) | .build/yarnlockhash'
       path: .build/node_modules_cache
       cacheHitVar: NODE_MODULES_RESTORED
     displayName: Cache node_modules archive
@@ -56,19 +53,6 @@ steps:
 
   - script: |
       set -e
-      export npm_config_arch=$(NPM_ARCH)
-
-      if [ -z "$CC" ] || [ -z "$CXX" ]; then
-        export CC=$(which gcc-5)
-        export CXX=$(which g++-5)
-      fi
-
-      if [ "$VSCODE_ARCH" == "x64" ]; then
-        export VSCODE_REMOTE_CC=$(which gcc-4.8)
-        export VSCODE_REMOTE_CXX=$(which g++-4.8)
-        export VSCODE_REMOTE_NODE_GYP=$(which node-gyp)
-      fi
-
       for i in {1..3}; do # try 3 times, for Terrapin
         yarn --frozen-lockfile && break
         if [ $i -eq 3 ]; then

--- a/build/azure-pipelines/product-hygiene.yml
+++ b/build/azure-pipelines/product-hygiene.yml
@@ -1,11 +1,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: "12.18.3"
-
-  - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
-    inputs:
-      versionSpec: "1.x"
+      versionSpec: "12.x"
 
   - task: AzureKeyVault@1
     displayName: "Azure Key Vault: Get Secrets"
@@ -41,9 +37,10 @@ steps:
       node build/azure-pipelines/common/computeNodeModulesCacheKey.js $VSCODE_ARCH $ENABLE_TERRAPIN > .build/yarnlockhash
     displayName: Prepare yarn cache flags
 
+  # using `genericNodeModules` instead of `nodeModules` here to avoid sharing the cache with builds running inside containers
   - task: Cache@2
     inputs:
-      key: 'nodeModules | $(Agent.OS) | .build/yarnlockhash'
+      key: 'genericNodeModules | $(Agent.OS) | .build/yarnlockhash'
       path: .build/node_modules_cache
       cacheHitVar: NODE_MODULES_RESTORED
     displayName: Cache node_modules archive


### PR DESCRIPTION
This shaves off around 1m30s needed to initialize the container, and does not impact node modules shipped with the product, because the compile and hygiene jobs now use their own node module cache.

cc @joaomoreno 