### PR TITLE
add clear all output command

### DIFF
--- a/src/vs/workbench/contrib/output/browser/output.contribution.ts
+++ b/src/vs/workbench/contrib/output/browser/output.contribution.ts
@@ -157,6 +157,28 @@ registerAction2(class extends Action2 {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
+			id: `workbench.output.action.clearAllOutput`,
+			title: { value: nls.localize('clearAllOutput.label', "Clear All Output"), original: 'Clear All Output' },
+			category: CATEGORIES.View,
+			menu: [{
+				id: MenuId.CommandPalette
+			}],
+			icon: Codicon.clearAll
+		});
+	}
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const outputService = accessor.get(IOutputService);
+		const channelDescriptors = outputService.getChannelDescriptors();
+		channelDescriptors.forEach((channelDescriptor) => {
+			outputService.getChannel(channelDescriptor.id)?.clear();
+		});
+		aria.status(nls.localize('allOutputCleared', "All output was cleared"));
+
+	}
+});
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
 			id: `workbench.output.action.toggleAutoScroll`,
 			title: { value: nls.localize('toggleAutoScroll', "Toggle Auto Scrolling"), original: 'Toggle Auto Scrolling' },
 			tooltip: nls.localize('outputScrollOff', "Turn Auto Scrolling Off"),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

Adds a clear all output command to the command palette.  Works in the same way as clearing a single output does, except for all outputs.

This PR fixes #111452
