### PR TITLE
lazier loading of windowsProcessTree

### DIFF
--- a/src/vs/workbench/contrib/terminal/electron-browser/windowsShellHelper.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/windowsShellHelper.ts
@@ -52,10 +52,6 @@ export class WindowsShellHelper extends Disposable implements IWindowsShellHelpe
 	}
 
 	private async _startMonitoringShell(): Promise<void> {
-		if (!windowsProcessTree) {
-			windowsProcessTree = await import('windows-process-tree');
-		}
-
 		if (this._isDisposed) {
 			return;
 		}
@@ -133,7 +129,10 @@ export class WindowsShellHelper extends Disposable implements IWindowsShellHelpe
 		if (this._currentRequest) {
 			return this._currentRequest;
 		}
-		this._currentRequest = new Promise<string>(resolve => {
+		this._currentRequest = new Promise<string>(async resolve => {
+			if (!windowsProcessTree) {
+				windowsProcessTree = await import('windows-process-tree');
+			}
 			windowsProcessTree.getProcessTree(this._rootProcessId, (tree) => {
 				const name = this.traverseTree(tree);
 				this._currentRequest = undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

I believe this should load windowsProcessTree a bit lazier.

This PR fixes #107028.
