### PR TITLE
Emmet remove dependency on vscode-html-languageservice

### DIFF
--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -438,6 +438,6 @@
         "@emmetio/math-expression": "^1.0.4",
         "image-size": "^0.5.2",
         "vscode-emmet-helper": "~2.0.0",
-        "vscode-html-languageservice": "^3.0.3"
+        "vscode-languageserver-textdocument": "^1.0.1"
     }
 }

--- a/extensions/emmet/src/imageSizeHelper.ts
+++ b/extensions/emmet/src/imageSizeHelper.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Based on @sergeche's work on the emmet plugin for atom
-// TODO: Move to https://github.com/emmetio/image-size
 
 import * as path from 'path';
 import * as http from 'http';

--- a/extensions/emmet/src/util.ts
+++ b/extensions/emmet/src/util.ts
@@ -639,23 +639,6 @@ export function isStyleAttribute(currentNode: FlatNode | undefined, offset: numb
 	return offset >= styleAttribute.value.start && offset <= styleAttribute.value.end;
 }
 
-
-export function trimQuotes(s: string) {
-	if (s.length <= 1) {
-		return s.replace(/['"]/, '');
-	}
-
-	if (s[0] === `'` || s[0] === `"`) {
-		s = s.slice(1);
-	}
-
-	if (s[s.length - 1] === `'` || s[s.length - 1] === `"`) {
-		s = s.slice(0, -1);
-	}
-
-	return s;
-}
-
 export function isNumber(obj: any): obj is number {
 	return typeof obj === 'number';
 }

--- a/extensions/emmet/yarn.lock
+++ b/extensions/emmet/yarn.lock
@@ -88,25 +88,10 @@ vscode-emmet-helper@~2.0.0:
     vscode-nls "^5.0.0"
     vscode-uri "^2.1.2"
 
-vscode-html-languageservice@^3.0.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/vscode-html-languageservice/-/vscode-html-languageservice-3.1.4.tgz#0316dff77ee38dc176f40560cbf55e4f64f4f433"
-  integrity sha512-3M+bm+hNvwQcScVe5/ok9BXvctOiGJ4nlOkkFf+WKSDrYNkarZ/RByKOa1/iylbvZxJUPzbeziembWPe/dMvhw==
-  dependencies:
-    vscode-languageserver-textdocument "^1.0.1"
-    vscode-languageserver-types "3.16.0-next.2"
-    vscode-nls "^5.0.0"
-    vscode-uri "^2.1.2"
-
 vscode-languageserver-textdocument@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
   integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
-
-vscode-languageserver-types@3.16.0-next.2:
-  version "3.16.0-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz#940bd15c992295a65eae8ab6b8568a1e8daa3083"
-  integrity sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==
 
 vscode-languageserver-types@^3.15.1:
   version "3.15.1"


### PR DESCRIPTION
This PR switches the VS Code Emmet extension to use html-matcher, instead of vscode-html-languageservice, for parsing everything HTML