### PR TITLE
Fixes #111754: Git - Checkout Type setting more resilient to incorrect values

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -208,13 +208,15 @@ function createCheckoutItems(repository: Repository): CheckoutItem[] {
 	const config = workspace.getConfiguration('git');
 	const checkoutTypeConfig = config.get<string | string[]>('checkoutType');
 	let checkoutTypes: string[];
+	const validCheckoutTypes: string[] = ['local', 'remote', 'tags'];
+	const checkValidity = (type: string): boolean => validCheckoutTypes.includes(type);
 
-	if (checkoutTypeConfig === 'all' || !checkoutTypeConfig || checkoutTypeConfig.length === 0) {
-		checkoutTypes = ['local', 'remote', 'tags'];
-	} else if (typeof checkoutTypeConfig === 'string') {
+	if (typeof checkoutTypeConfig === 'string' && checkValidity(checkoutTypeConfig)) {
 		checkoutTypes = [checkoutTypeConfig];
-	} else {
+	} else if (Array.isArray(checkoutTypeConfig) && checkoutTypeConfig.filter(checkValidity).length) {
 		checkoutTypes = checkoutTypeConfig;
+	} else {
+		checkoutTypes = validCheckoutTypes;
 	}
 
 	const processors = checkoutTypes.map(getCheckoutProcessor)


### PR DESCRIPTION
This PR fixes #111754

When provided with valid value(s), i.e one or more of `["local", "remote", "tags"]`, for `"git.checkoutType"` in `settings.json`, the list for the `Git: Checkout to...` command is populated with correct values. 

**Example: `"git.checkoutType" : ["local"] | "local"`**

![image](https://user-images.githubusercontent.com/29715725/103403662-d1b2ae80-4b05-11eb-985c-b5f8391a61a5.png)

**Example: `"git.checkoutType" : ["local", "remote", "someInvalidValue"] | ["local", "remote"]`**

![image](https://user-images.githubusercontent.com/29715725/103404140-5c47dd80-4b07-11eb-9a0c-7afb40fcf58c.png)

For any other  values (invalid, empty list, empty string, or "all"), the list is poplauted with **all** options (i.e `git.checkoutType` = `all` = `["local", "remote", "tags"]`)

**Example: `"git.checkoutType" : ["someInvalidValue"] | ["all"] | [] | ""`**

![image](https://user-images.githubusercontent.com/29715725/103404140-5c47dd80-4b07-11eb-9a0c-7afb40fcf58c.png)
![image](https://user-images.githubusercontent.com/29715725/103404377-235c3880-4b08-11eb-90f6-1ed66e3e19d2.png)
