### PR TITLE
fix #111587 Apply enablement to command links in welcome views

### DIFF
--- a/src/vs/platform/opener/browser/link.ts
+++ b/src/vs/platform/opener/browser/link.ts
@@ -20,11 +20,13 @@ export interface ILinkDescriptor {
 
 export interface ILinkStyles {
 	readonly textLinkForeground?: Color;
+	readonly disabled?: boolean;
 }
 
 export class Link extends Disposable {
 
 	readonly el: HTMLAnchorElement;
+	private disabled: boolean;
 	private styles: ILinkStyles = {
 		textLinkForeground: Color.fromHex('#006AB1')
 	};
@@ -50,9 +52,12 @@ export class Link extends Disposable {
 
 		this._register(onOpen(e => {
 			EventHelper.stop(e, true);
-			openerService.open(link.href);
+			if (!this.disabled) {
+				openerService.open(link.href);
+			}
 		}));
 
+		this.disabled = false;
 		this.applyStyles();
 	}
 
@@ -62,6 +67,26 @@ export class Link extends Disposable {
 	}
 
 	private applyStyles(): void {
-		this.el.style.color = this.styles.textLinkForeground?.toString() || '';
+		const color = this.styles.textLinkForeground?.toString();
+		if (color) {
+			this.el.style.color = color;
+		}
+		if (typeof this.styles.disabled === 'boolean' && this.styles.disabled !== this.disabled) {
+			if (this.styles.disabled) {
+				this.el.setAttribute('aria-disabled', 'true');
+				this.el.tabIndex = -1;
+				this.el.style.pointerEvents = 'none';
+				this.el.style.opacity = '0.4';
+				this.el.style.cursor = 'default';
+				this.disabled = true;
+			} else {
+				this.el.setAttribute('aria-disabled', 'false');
+				this.el.tabIndex = 0;
+				this.el.style.pointerEvents = 'auto';
+				this.el.style.opacity = '1';
+				this.el.style.cursor = 'pointer';
+				this.disabled = false;
+			}
+		}
 	}
 }

--- a/src/vs/workbench/browser/parts/views/viewPane.ts
+++ b/src/vs/workbench/browser/parts/views/viewPane.ts
@@ -603,6 +603,16 @@ export abstract class ViewPane extends Pane implements IView {
 							append(p, link.el);
 							disposables.add(link);
 							disposables.add(attachLinkStyler(link, this.themeService));
+
+							if (precondition && node.href.startsWith('command:')) {
+								const updateEnablement = () => link.style({ disabled: !this.contextKeyService.contextMatchesRules(precondition) });
+								updateEnablement();
+
+								const keys = new Set();
+								precondition.keys().forEach(key => keys.add(key));
+								const onDidChangeContext = Event.filter(this.contextKeyService.onDidChangeContext, e => e.affectsSome(keys));
+								onDidChangeContext(updateEnablement, null, disposables);
+							}
 						}
 					}
 				}

--- a/src/vs/workbench/contrib/welcome/common/viewsWelcomeExtensionPoint.ts
+++ b/src/vs/workbench/contrib/welcome/common/viewsWelcomeExtensionPoint.ts
@@ -68,7 +68,7 @@ const viewsWelcomeExtensionPointSchema = Object.freeze<IConfigurationPropertySch
 			},
 			[ViewsWelcomeExtensionPointFields.enablement]: {
 				type: 'string',
-				description: nls.localize('contributes.viewsWelcome.view.enablement', "Condition when the welcome content buttons should be enabled."),
+				description: nls.localize('contributes.viewsWelcome.view.enablement', "Condition when the welcome content buttons and command links should be enabled."),
 			},
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #111587

A `viewsWelcome` contribution from an extension in which an `enablement` expression is specified will now render command links inactive when the expression evaluates as false. Prior to this change only command buttons behaved that way.

To test, create an extension that contributes a welcome view with an enablement expression and at least one command link in the contents. Verify that the link is only clickable when the expression is true. Include a regular link in the content and verify it is always clickable.
