### PR TITLE
file name incrementing for files without extensions

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -379,6 +379,32 @@ export function incrementFileName(name: string, isFolder: boolean, incrementalNa
 		return `${name.substr(0, lastIndexOfDot)}.1${name.substr(lastIndexOfDot)}`;
 	}
 
+	// 123 => 124
+	let noNameNoExtensionRegex = RegExp('(\\d+)$');
+	if (!isFolder && lastIndexOfDot === -1 && name.match(noNameNoExtensionRegex)) {
+		return name.replace(noNameNoExtensionRegex, (match, g1?) => {
+			let number = parseInt(g1);
+			return number < maxNumber
+				? String(number + 1).padStart(g1.length, '0')
+				: `${g1}.1`;
+		});
+	}
+
+	// file => file1
+	// file1 => file2
+	let noExtensionRegex = RegExp('(.*)(\d*)$');
+	if (!isFolder && lastIndexOfDot === -1 && name.match(noExtensionRegex)) {
+		return name.replace(noExtensionRegex, (match, g1?, g2?) => {
+			let number = parseInt(g2);
+			if (isNaN(number)) {
+				number = 0;
+			}
+			return number < maxNumber
+				? g1 + String(number + 1).padStart(g2.length, '0')
+				: `${g1}${g2}.1`;
+		});
+	}
+
 	// folder.1=>folder.2
 	if (isFolder && name.match(/(\d+)$/)) {
 		return name.replace(/(\d+)$/, (match, ...groups) => {

--- a/src/vs/workbench/contrib/files/test/browser/fileActions.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/fileActions.test.ts
@@ -258,7 +258,7 @@ suite('Files - Increment file name smart', () => {
 		assert.strictEqual(result, '2-test.js');
 	});
 
-	test('Increment file name with prefix version with `-` as separator', function () {
+	test('Increment file name with prefix version with `_` as separator', function () {
 		const name = '1_test.js';
 		const result = incrementFileName(name, false, 'smart');
 		assert.strictEqual(result, '2_test.js');
@@ -268,6 +268,36 @@ suite('Files - Increment file name smart', () => {
 		const name = '9007199254740992.test.js';
 		const result = incrementFileName(name, false, 'smart');
 		assert.strictEqual(result, '9007199254740992.test.1.js');
+	});
+
+	test('Increment file name with just version and no extension', function () {
+		const name = '001004';
+		const result = incrementFileName(name, false, 'smart');
+		assert.strictEqual(result, '001005');
+	});
+
+	test('Increment file name with just version and no extension, too big number', function () {
+		const name = '9007199254740992';
+		const result = incrementFileName(name, false, 'smart');
+		assert.strictEqual(result, '9007199254740992.1');
+	});
+
+	test('Increment file name with no extension and no version', function () {
+		const name = 'file';
+		const result = incrementFileName(name, false, 'smart');
+		assert.strictEqual(result, 'file1');
+	});
+
+	test('Increment file name with no extension', function () {
+		const name = 'file1';
+		const result = incrementFileName(name, false, 'smart');
+		assert.strictEqual(result, 'file2');
+	});
+
+	test('Increment file name with no extension, too big number', function () {
+		const name = 'file9007199254740992';
+		const result = incrementFileName(name, false, 'smart');
+		assert.strictEqual(result, 'file9007199254740992.1');
 	});
 
 	test('Increment folder name with prefix version', function () {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

When a file does not have an extension, it properly increments.
`file => file1`
`file1 => file2`
`1 => 2`

Can test by creating a file without an extension, then copying and pasting the file in the explorer.  The version should be incremented. (Requires `explorer.incrementalNaming` to be set to `smart`.)

This PR fixes #113809
