### PR TITLE
fix typeahead regex for move

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
@@ -22,7 +22,7 @@ const HIDE_CURSOR = `${CSI}?25l`;
 const DELETE_CHAR = `${CSI}X`;
 const DELETE_REST_OF_LINE = `${CSI}K`;
 const CSI_STYLE_RE = /^\x1b\[[0-9;]*m/;
-const CSI_MOVE_RE = /^\x1b\[([0-9]*)(;[35])?O?([DC])/;
+const CSI_MOVE_RE = /^\x1b\[?([0-9]*)(;[35])?O?([DC])/;
 const NOT_WORD_RE = /[^a-z0-9]/i;
 
 const statsBufferSize = 24;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

On macOS, we receive `\x1bOC` not `\x1b[OC`... this means that typeahead isn't "on" for arrow keys right now. This turns it "on".

fixes https://github.com/microsoft/vscode/issues/113853