### PR TITLE
Add boundary for right arrow typeahead and fix bug with resetting Terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -465,7 +465,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			}
 		}));
 
-		this._xtermTypeAhead = this._register(this._instantiationService.createInstance(TypeAheadAddon, this._configHelper));
+		this._xtermTypeAhead = this._register(this._instantiationService.createInstance(TypeAheadAddon, this._processManager, this._configHelper));
 		this._xterm.loadAddon(this._xtermTypeAhead);
 
 		return xterm;
@@ -986,9 +986,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	}
 
 	private _createProcess(): void {
-		if (this._xtermTypeAhead) {
-			this._processManager.onBeforeProcessData(e => this._xtermTypeAhead?.onBeforeProcessData(e));
-		}
 		this._processManager.createProcess(this._shellLaunchConfig, this._cols, this._rows, this._accessibilityService.isScreenReaderOptimized()).then(error => {
 			if (error) {
 				this._onProcessExit(error);
@@ -1213,6 +1210,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 		this._processManager.onProcessData(data => this._onProcessData(data));
 		this._createProcess();
+
+		this._xtermTypeAhead?.reset(this._processManager);
 	}
 
 	public relaunch(): void {

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -89,6 +89,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	private _wrapperElement: (HTMLElement & { xterm?: XTermTerminal }) | undefined;
 	private _xterm: XTermTerminal | undefined;
 	private _xtermCore: XTermCore | undefined;
+	private _typeAheadAddOn: TypeAheadAddon | undefined;
 	private _xtermSearch: SearchAddon | undefined;
 	private _xtermUnicode11: Unicode11Addon | undefined;
 	private _xtermElement: HTMLDivElement | undefined;
@@ -464,8 +465,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			}
 		}));
 
-		const typeaheadAddon = this._register(this._instantiationService.createInstance(TypeAheadAddon, this._processManager, this._configHelper));
-		this._xterm.loadAddon(typeaheadAddon);
+		this._typeAheadAddOn = this._register(this._instantiationService.createInstance(TypeAheadAddon, this._processManager, this._configHelper));
+		this._xterm.loadAddon(this._typeAheadAddOn);
 
 		return xterm;
 	}
@@ -1166,6 +1167,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		if (this._xterm) {
 			if (reset) {
 				this._xterm.reset();
+				this._typeAheadAddOn?.reset(this._xterm);
 			} else {
 				// Ensure new processes' output starts at start of new line
 				this._xterm.write('\n\x1b[G');

--- a/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
@@ -1418,7 +1418,14 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 					flushOutput(this.timeline.terminal);
 				}
 
-				addLeftNavigating(new BackspacePrediction(this.timeline.terminal));
+				if (this.timeline!.getCursor(buffer).x <= this.lastRow!.startingX) {
+					this.timeline!.addBoundary(buffer, new TentativeBoundary(new BackspacePrediction(this.timeline.terminal)));
+				} else {
+					// Backspace decrements our ability to go right.
+					this.lastRow.endingX--;
+					this.timeline!.addPrediction(buffer, new BackspacePrediction(this.timeline.terminal));
+				}
+
 				continue;
 			}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
@@ -1224,7 +1224,7 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 	private typeaheadStyle?: TypeAheadStyle;
 	private typeaheadThreshold = this.config.config.localEchoLatencyThreshold;
 	private excludeProgramRe = compileExcludeRegexp(this.config.config.localEchoExcludePrograms);
-	protected lastRow?: { y: number; startingX: number; charState: CharPredictState };
+	protected lastRow?: { y: number; startingX: number; endingX: number; charState: CharPredictState };
 	protected timeline?: PredictionTimeline;
 	private terminalTitle = '';
 	public stats?: PredictionStats;
@@ -1289,6 +1289,12 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 
 			this.reevaluatePredictorState(stats, timeline);
 		}));
+	}
+
+	// We need a new reference to the Terminal object because the buffer appears to be
+	// corrupted.
+	public reset(terminal: Terminal) {
+		this.timeline = new PredictionTimeline(terminal, this.typeaheadStyle!);
 	}
 
 	private deferClearingPredictions() {
@@ -1381,13 +1387,19 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 		// the user gave input, and mark all additions before that as tentative.
 		const actualY = buffer.baseY + buffer.cursorY;
 		if (actualY !== this.lastRow?.y) {
-			this.lastRow = { y: actualY, startingX: buffer.cursorX, charState: CharPredictState.Unknown };
+			this.lastRow = { y: actualY, startingX: buffer.cursorX, endingX: buffer.cursorX, charState: CharPredictState.Unknown };
 		} else {
 			this.lastRow.startingX = Math.min(this.lastRow.startingX, buffer.cursorX);
+			this.lastRow.endingX = Math.max(this.lastRow.endingX, buffer.cursorX);
 		}
 
 		const addLeftNavigating = (p: IPrediction) =>
 			this.timeline!.getCursor(buffer).x <= this.lastRow!.startingX
+				? this.timeline!.addBoundary(buffer, new TentativeBoundary(p))
+				: this.timeline!.addPrediction(buffer, p);
+
+		const addRightNavigating = (p: IPrediction) =>
+			this.timeline!.getCursor(buffer).x >= this.lastRow!.endingX
 				? this.timeline!.addBoundary(buffer, new TentativeBoundary(p))
 				: this.timeline!.addPrediction(buffer, p);
 
@@ -1434,13 +1446,13 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 				if (direction === CursorMoveDirection.Back) {
 					addLeftNavigating(p);
 				} else {
-					this.timeline.addPrediction(buffer, p);
+					addRightNavigating(p);
 				}
 				continue;
 			}
 
 			if (reader.eatStr(`${ESC}f`)) {
-				this.timeline.addPrediction(buffer, new CursorMovePrediction(CursorMoveDirection.Forwards, true, 1));
+				addRightNavigating(new CursorMovePrediction(CursorMoveDirection.Forwards, true, 1));
 				continue;
 			}
 

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { IBuffer, IDisposable, Terminal } from 'xterm';
+import { IBuffer, Terminal } from 'xterm';
 import { SinonStub, stub, useFakeTimers } from 'sinon';
 import { Emitter } from 'vs/base/common/event';
 import { CharPredictState, IPrediction, PredictionStats, TypeAheadAddon } from 'vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon';

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { IBuffer, Terminal } from 'xterm';
+import { IBuffer, IDisposable, Terminal } from 'xterm';
 import { SinonStub, stub, useFakeTimers } from 'sinon';
 import { Emitter } from 'vs/base/common/event';
 import { CharPredictState, IPrediction, PredictionStats, TypeAheadAddon } from 'vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon';
@@ -78,7 +78,7 @@ suite('Workbench - Terminal Typeahead', () => {
 		const onConfigChanged = new Emitter<void>();
 		let publicLog: SinonStub;
 		let config: ITerminalConfiguration;
-		let processManager: ITerminalProcessManager;
+		let eventToDispose: IDisposable;
 		let addon: TestTypeAheadAddon;
 
 		const predictedHelloo = [
@@ -109,12 +109,13 @@ suite('Workbench - Terminal Typeahead', () => {
 			addon.unlockMakingPredictions();
 
 			// Setup process manager that is normally done by terminalinstance.
-			processManager = upcastPartial<ITerminalProcessManager>({ onBeforeProcessData: onBeforeProcessData.event });
-			processManager.onBeforeProcessData(e => addon?.onBeforeProcessData(e));
+			const processManager = upcastPartial<ITerminalProcessManager>({ onBeforeProcessData: onBeforeProcessData.event });
+			eventToDispose = processManager.onBeforeProcessData(e => addon?.onBeforeProcessData(e));
 		});
 
 		teardown(() => {
 			addon.dispose();
+			eventToDispose.dispose();
 		});
 
 		test('predicts a single character', () => {

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
@@ -78,7 +78,6 @@ suite('Workbench - Terminal Typeahead', () => {
 		const onConfigChanged = new Emitter<void>();
 		let publicLog: SinonStub;
 		let config: ITerminalConfiguration;
-		let eventToDispose: IDisposable;
 		let addon: TestTypeAheadAddon;
 
 		const predictedHelloo = [
@@ -103,19 +102,15 @@ suite('Workbench - Terminal Typeahead', () => {
 			});
 			publicLog = stub();
 			addon = new TestTypeAheadAddon(
+				upcastPartial<ITerminalProcessManager>({ onBeforeProcessData: onBeforeProcessData.event }),
 				upcastPartial<TerminalConfigHelper>({ config, onConfigChanged: onConfigChanged.event }),
 				upcastPartial<ITelemetryService>({ publicLog })
 			);
 			addon.unlockMakingPredictions();
-
-			// Setup process manager that is normally done by terminalinstance.
-			const processManager = upcastPartial<ITerminalProcessManager>({ onBeforeProcessData: onBeforeProcessData.event });
-			eventToDispose = processManager.onBeforeProcessData(e => addon?.onBeforeProcessData(e));
 		});
 
 		teardown(() => {
 			addon.dispose();
-			eventToDispose.dispose();
 		});
 
 		test('predicts a single character', () => {

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
@@ -8,7 +8,7 @@ import { IBuffer, Terminal } from 'xterm';
 import { SinonStub, stub, useFakeTimers } from 'sinon';
 import { Emitter } from 'vs/base/common/event';
 import { CharPredictState, IPrediction, PredictionStats, TypeAheadAddon } from 'vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon';
-import { DEFAULT_LOCAL_ECHO_EXCLUDE, IBeforeProcessDataEvent, ITerminalConfiguration, ITerminalProcessManager } from 'vs/workbench/contrib/terminal/common/terminal';
+import { DEFAULT_LOCAL_ECHO_EXCLUDE, IBeforeProcessDataEvent, ITerminalConfiguration } from 'vs/workbench/contrib/terminal/common/terminal';
 import { TerminalConfigHelper } from 'vs/workbench/contrib/terminal/browser/terminalConfigHelper';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
@@ -102,7 +102,6 @@ suite('Workbench - Terminal Typeahead', () => {
 			});
 			publicLog = stub();
 			addon = new TestTypeAheadAddon(
-				upcastPartial<ITerminalProcessManager>({ onBeforeProcessData: onBeforeProcessData.event }),
 				upcastPartial<TerminalConfigHelper>({ config, onConfigChanged: onConfigChanged.event }),
 				upcastPartial<ITelemetryService>({ publicLog })
 			);

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
@@ -8,7 +8,7 @@ import { IBuffer, Terminal } from 'xterm';
 import { SinonStub, stub, useFakeTimers } from 'sinon';
 import { Emitter } from 'vs/base/common/event';
 import { CharPredictState, IPrediction, PredictionStats, TypeAheadAddon } from 'vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon';
-import { DEFAULT_LOCAL_ECHO_EXCLUDE, IBeforeProcessDataEvent, ITerminalConfiguration } from 'vs/workbench/contrib/terminal/common/terminal';
+import { DEFAULT_LOCAL_ECHO_EXCLUDE, IBeforeProcessDataEvent, ITerminalConfiguration, ITerminalProcessManager } from 'vs/workbench/contrib/terminal/common/terminal';
 import { TerminalConfigHelper } from 'vs/workbench/contrib/terminal/browser/terminalConfigHelper';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
@@ -78,6 +78,7 @@ suite('Workbench - Terminal Typeahead', () => {
 		const onConfigChanged = new Emitter<void>();
 		let publicLog: SinonStub;
 		let config: ITerminalConfiguration;
+		let processManager: ITerminalProcessManager;
 		let addon: TestTypeAheadAddon;
 
 		const predictedHelloo = [
@@ -106,6 +107,10 @@ suite('Workbench - Terminal Typeahead', () => {
 				upcastPartial<ITelemetryService>({ publicLog })
 			);
 			addon.unlockMakingPredictions();
+
+			// Setup process manager that is normally done by terminalinstance.
+			processManager = upcastPartial<ITerminalProcessManager>({ onBeforeProcessData: onBeforeProcessData.event });
+			processManager.onBeforeProcessData(e => addon?.onBeforeProcessData(e));
 		});
 
 		teardown(() => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #113857

This adds a similar boundary as the left boundary.... but for the right. The boundary will be equal to the furthest we've ever seen the cursor on the active line.

Additionally, I noticed a bug where when you reset/relaunch a terminal like when asked here:
![image](https://user-images.githubusercontent.com/2644648/103714065-9a635800-4f72-11eb-9286-d5e4267be8a2.png)

~xtermjs appears to get into a bad state. I need to check with @Tyriar about this but it seems like the `buffer` property on `Terminal` gets into a bad state where it always thinks the `baseY` and `cursorY` are 0 (even after spamming ENTER in the terminal). I've workedaround this in this PR.~ I was wrong about this because the problem was that the TypeAheadAddOn still had a reference to the old disposed of `processManager`.

This PR fixes that bug by refactoring the reference of `processManager` out of the `TypeAheadAddOn` because the lifecycle of the `ProcessManager` is not the same as the lifecycle as the AddOn ([processManager is disposed of and recreated](https://github.com/microsoft/vscode/blob/bd8b9d65b2c0d3c2cd3c4ad701faac34a1221ee8/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts#L1202-L1208)). The refactor sets the `OnBeforeDataProcessing` handler right before we create the new process that the processManager will manage