### PR TITLE
Add the tsec dependency with a Git URL instead of a GitHub URL.

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "style-loader": "^1.0.0",
     "terser": "^4.8.0",
     "ts-loader": "^6.2.1",
-    "tsec": "googleinterns/tsec#7bf4ab23686500522341b977b3e2cc04b1f720b1",
+    "tsec": "git+https://github.com/googleinterns/tsec.git#7bf4ab23686500522341b977b3e2cc04b1f720b1",
     "typescript": "4.2.0-dev.20201207",
     "typescript-formatter": "7.1.0",
     "underscore": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "style-loader": "^1.0.0",
     "terser": "^4.8.0",
     "ts-loader": "^6.2.1",
-    "tsec": "git+https://github.com/googleinterns/tsec.git#7bf4ab23686500522341b977b3e2cc04b1f720b1",
+    "tsec": "https://github.com/googleinterns/tsec.git#7bf4ab23686500522341b977b3e2cc04b1f720b1",
     "typescript": "4.2.0-dev.20201207",
     "typescript-formatter": "7.1.0",
     "underscore": "^1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10220,9 +10220,9 @@ ts-morph@^3.1.3:
     multimatch "^4.0.0"
     typescript "^3.0.1"
 
-"tsec@git+https://github.com/googleinterns/tsec.git#7bf4ab23686500522341b977b3e2cc04b1f720b1":
+"tsec@https://github.com/googleinterns/tsec.git#7bf4ab23686500522341b977b3e2cc04b1f720b1":
   version "0.0.1"
-  resolved "git+https://github.com/googleinterns/tsec.git#7bf4ab23686500522341b977b3e2cc04b1f720b1"
+  resolved "https://github.com/googleinterns/tsec.git#7bf4ab23686500522341b977b3e2cc04b1f720b1"
   dependencies:
     "@types/node" "^13.13.5"
     typescript "^4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10220,11 +10220,12 @@ ts-morph@^3.1.3:
     multimatch "^4.0.0"
     typescript "^3.0.1"
 
-tsec@googleinterns/tsec#7bf4ab23686500522341b977b3e2cc04b1f720b1:
+"tsec@git+https://github.com/googleinterns/tsec.git#7bf4ab23686500522341b977b3e2cc04b1f720b1":
   version "0.0.1"
-  resolved "https://codeload.github.com/googleinterns/tsec/tar.gz/7bf4ab23686500522341b977b3e2cc04b1f720b1"
+  resolved "git+https://github.com/googleinterns/tsec.git#7bf4ab23686500522341b977b3e2cc04b1f720b1"
   dependencies:
     "@types/node" "^13.13.5"
+    typescript "^4.1.2"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
@@ -10299,6 +10300,11 @@ typescript@^3.0.1:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This can trigger the prepare script in tsec so that it can correctly
compile itself.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes the problem described in googleinterns/tsec#20
