### PR TITLE
workginCopyFileService: only one event for multiple operations

### DIFF
--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -272,37 +272,40 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 	//#region File operations
 
 	create(operations: ICreateFileOperation[], undoInfo?: IFileOperationUndoRedoInfo, token?: CancellationToken): Promise<IFileStatWithMetadata[]> {
-		return Promise.all(operations.map(o => this.doCreateFileOrFolder(o, true, undoInfo, token)));
+		return this.doCreateFileOrFolder(operations, true, undoInfo, token);
 	}
 
 	createFolder(operations: ICreateOperation[], undoInfo?: IFileOperationUndoRedoInfo, token?: CancellationToken): Promise<IFileStatWithMetadata[]> {
-		return Promise.all(operations.map(o => this.doCreateFileOrFolder(o, false, undoInfo, token)));
+		return this.doCreateFileOrFolder(operations, false, undoInfo, token);
 	}
 
-	async doCreateFileOrFolder(operation: ICreateFileOperation | ICreateOperation, isFile: boolean, undoInfo?: IFileOperationUndoRedoInfo, token?: CancellationToken): Promise<IFileStatWithMetadata> {
+	async doCreateFileOrFolder(operations: (ICreateFileOperation | ICreateOperation)[], isFile: boolean, undoInfo?: IFileOperationUndoRedoInfo, token?: CancellationToken): Promise<IFileStatWithMetadata[]> {
 
 		// validate create operation before starting
 		if (isFile) {
-			const validateCreate = await this.fileService.canCreateFile(operation.resource, { overwrite: operation.overwrite });
-			if (validateCreate instanceof Error) {
-				throw validateCreate;
-			}
+			await Promise.all(operations.map(async operation => {
+				const validateCreate = await this.fileService.canCreateFile(operation.resource, { overwrite: operation.overwrite });
+				if (validateCreate instanceof Error) {
+					throw validateCreate;
+				}
+			}));
 		}
 
 		// file operation participant
-		await this.runFileOperationParticipants([{ target: operation.resource }], FileOperation.CREATE, undoInfo, token);
+		const files = operations.map(operation => ({ target: operation.resource }));
+		await this.runFileOperationParticipants(files, FileOperation.CREATE, undoInfo, token);
 
 		// before events
-		const event = { correlationId: this.correlationIds++, operation: FileOperation.CREATE, files: [{ target: operation.resource }] };
+		const event = { correlationId: this.correlationIds++, operation: FileOperation.CREATE, files };
 		await this._onWillRunWorkingCopyFileOperation.fireAsync(event, CancellationToken.None);
 
 		// now actually create on disk
-		let stat: IFileStatWithMetadata;
+		let stats: IFileStatWithMetadata[];
 		try {
 			if (isFile) {
-				stat = await this.fileService.createFile(operation.resource, (operation as ICreateFileOperation).contents, { overwrite: operation.overwrite });
+				stats = await Promise.all(operations.map(operation => this.fileService.createFile(operation.resource, (operation as ICreateFileOperation).contents, { overwrite: operation.overwrite })));
 			} else {
-				stat = await this.fileService.createFolder(operation.resource);
+				stats = await Promise.all(operations.map(operation => this.fileService.createFolder(operation.resource)));
 			}
 		} catch (error) {
 
@@ -315,7 +318,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		// after event
 		await this._onDidRunWorkingCopyFileOperation.fireAsync(event, CancellationToken.None);
 
-		return stat;
+		return stats;
 	}
 
 	async move(operations: IMoveOperation[], undoInfo?: IFileOperationUndoRedoInfo, token?: CancellationToken): Promise<IFileStatWithMetadata[]> {

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -283,12 +283,11 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 
 		// validate create operation before starting
 		if (isFile) {
-			await Promise.all(operations.map(async operation => {
-				const validateCreate = await this.fileService.canCreateFile(operation.resource, { overwrite: operation.overwrite });
-				if (validateCreate instanceof Error) {
-					throw validateCreate;
-				}
-			}));
+			const validateCreates = await Promise.all(operations.map(operation => this.fileService.canCreateFile(operation.resource, { overwrite: operation.overwrite })));
+			const error = validateCreates.find(validateCreate => validateCreate instanceof Error);
+			if (error instanceof Error) {
+				throw error;
+			}
 		}
 
 		// file operation participant

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -280,6 +280,9 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 	}
 
 	async doCreateFileOrFolder(operations: (ICreateFileOperation | ICreateOperation)[], isFile: boolean, undoInfo?: IFileOperationUndoRedoInfo, token?: CancellationToken): Promise<IFileStatWithMetadata[]> {
+		if (operations.length === 0) {
+			return [];
+		}
 
 		// validate create operation before starting
 		if (isFile) {


### PR DESCRIPTION
@bpasero for some weird reason I could not assign you to reviewer here.

This PR tackles the feedback from this comment https://github.com/microsoft/vscode/issues/111867#issuecomment-755300132

I did not merge this in to master because this breaks the following integration test https://github.com/microsoft/vscode/blob/c6cc7d614012c1073248be37db2a012746390008/extensions/vscode-api-tests/src/singlefolder-tests/workspace.event.test.ts#L23

@jrieken not sure if this needs to be adopted in some other place