### PR TITLE
FS improvements for unit tests

### DIFF
--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -54,24 +54,6 @@ export async function rimraf(path: string, mode = RimRafMode.UNLINK): Promise<vo
 	return rimrafMove(path);
 }
 
-export async function rimrafWithRetries(path: string, retries: number = 5): Promise<void> {
-	for (let retry = retries - 1; retry >= 0; retry--) {
-		try {
-			await rimraf(path);
-			return;
-		} catch (err) {
-			// Check for ENOTEMPTY and EPERM errors. This can happen if someone else is writing
-			// to this directory while we are trying to delete it.
-			if (retry === 0 || (err.code !== 'ENOTEMPTY' && err.code !== 'EPERM')) {
-				// If this is the last retry or if this is another kind of error, simply
-				// rethrow the error
-				throw err;
-			}
-			console.warn(`Ignoring error in retry ${retries - retry} of ${retries}: `, err);
-		}
-	}
-}
-
 async function rimrafUnlink(path: string): Promise<void> {
 	try {
 		const stat = await lstat(path);

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -62,7 +62,7 @@ export async function rimrafWithRetries(path: string, retries: number = 5): Prom
 		} catch (err) {
 			// Check for ENOTEMPTY and EPERM errors. This can happen if someone else is writing
 			// to this directory while we are trying to delete it.
-			if (retry === 0 || err.code !== 'ENOTEMPTY' || err.code !== 'EPERM') {
+			if (retry === 0 || (err.code !== 'ENOTEMPTY' && err.code !== 'EPERM')) {
 				// If this is the last retry or if this is another kind of error, simply
 				// rethrow the error
 				throw err;

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -60,9 +60,9 @@ export async function rimrafWithRetries(path: string, retries: number = 5): Prom
 			await rimraf(path);
 			return;
 		} catch (err) {
-			// Check for a ENOTEMPTY error. This can happen if someone else is writing
+			// Check for ENOTEMPTY and EPERM errors. This can happen if someone else is writing
 			// to this directory while we are trying to delete it.
-			if (retry === 0 || err.code !== 'ENOTEMPTY') {
+			if (retry === 0 || err.code !== 'ENOTEMPTY' || err.code !== 'EPERM') {
 				// If this is the last retry or if this is another kind of error, simply
 				// rethrow the error
 				throw err;

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -67,6 +67,7 @@ export async function rimrafWithRetries(path: string, retries: number = 5): Prom
 				// rethrow the error
 				throw err;
 			}
+			console.warn(`Ignoring error in retry ${retries - retry} of ${retries}: `, err);
 		}
 	}
 }

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -54,6 +54,23 @@ export async function rimraf(path: string, mode = RimRafMode.UNLINK): Promise<vo
 	return rimrafMove(path);
 }
 
+export async function rimrafWithRetries(path: string, retries: number = 5): Promise<void> {
+	for (let retry = retries - 1; retry >= 0; retry--) {
+		try {
+			await rimraf(path);
+			return;
+		} catch (err) {
+			// Check for a ENOTEMPTY error. This can happen if someone else is writing
+			// to this directory while we are trying to delete it.
+			if (retry === 0 || err.code !== 'ENOTEMPTY') {
+				// If this is the last retry or if this is another kind of error, simply
+				// rethrow the error
+				throw err;
+			}
+		}
+	}
+}
+
 async function rimrafUnlink(path: string): Promise<void> {
 	try {
 		const stat = await lstat(path);

--- a/src/vs/base/parts/storage/test/node/storage.test.ts
+++ b/src/vs/base/parts/storage/test/node/storage.test.ts
@@ -9,7 +9,7 @@ import { generateUuid } from 'vs/base/common/uuid';
 import { join } from 'vs/base/common/path';
 import { tmpdir } from 'os';
 import { equal, ok } from 'assert';
-import { mkdirp, writeFile, exists, unlink, rimraf, RimRafMode } from 'vs/base/node/pfs';
+import { mkdirp, writeFile, exists, unlink, rimraf } from 'vs/base/node/pfs';
 import { timeout } from 'vs/base/common/async';
 import { Event, Emitter } from 'vs/base/common/event';
 import { isWindows } from 'vs/base/common/platform';
@@ -100,7 +100,7 @@ flakySuite('Storage Library', function () {
 		equal(deletePromiseResolved, true);
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('external changes', async () => {
@@ -155,7 +155,7 @@ flakySuite('Storage Library', function () {
 		equal(changes.size, 0);
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('close flushes data', async () => {
@@ -213,7 +213,7 @@ flakySuite('Storage Library', function () {
 		ok(!storage.get('bar'));
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('conflicting updates', async () => {
@@ -259,7 +259,7 @@ flakySuite('Storage Library', function () {
 		ok(setAndDeletePromiseResolved);
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('corrupt DB recovers', async () => {
@@ -289,7 +289,7 @@ flakySuite('Storage Library', function () {
 		equal(storage.get('foo'), 'bar');
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 });
 
@@ -387,7 +387,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await testDBBasics(join(storageDir, 'storage.db'));
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('basics (open multiple times)', async () => {
@@ -398,7 +398,7 @@ flakySuite('SQLite Storage Library', function () {
 		await testDBBasics(join(storageDir, 'storage.db'));
 		await testDBBasics(join(storageDir, 'storage.db'));
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('basics (corrupt DB falls back to empty DB)', async () => {
@@ -416,7 +416,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		ok(expectedError);
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('basics (corrupt DB restores from previous backup)', async () => {
@@ -454,7 +454,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		equal(recoveryCalled, false);
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('basics (corrupt DB falls back to empty DB if backup is corrupt)', async () => {
@@ -483,7 +483,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await testDBBasics(storagePath);
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('basics (DB that becomes corrupt during runtime stores all state from cache on close)', async () => {
@@ -551,7 +551,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		equal(recoveryCalled, false);
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('real world example', async function () {
@@ -640,7 +640,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await storage.close();
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('very large item value', async function () {
@@ -693,7 +693,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await storage.close();
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('multiple concurrent writes execute in sequence', async () => {
@@ -750,7 +750,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await storage.close();
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('lots of INSERT & DELETE (below inline max)', async () => {
@@ -782,7 +782,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await storage.close();
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 
 	test('lots of INSERT & DELETE (above inline max)', async () => {
@@ -814,6 +814,6 @@ flakySuite('SQLite Storage Library', function () {
 
 		await storage.close();
 
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 });

--- a/src/vs/base/parts/storage/test/node/storage.test.ts
+++ b/src/vs/base/parts/storage/test/node/storage.test.ts
@@ -100,7 +100,7 @@ flakySuite('Storage Library', function () {
 		equal(deletePromiseResolved, true);
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('external changes', async () => {
@@ -155,7 +155,7 @@ flakySuite('Storage Library', function () {
 		equal(changes.size, 0);
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('close flushes data', async () => {
@@ -213,7 +213,7 @@ flakySuite('Storage Library', function () {
 		ok(!storage.get('bar'));
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('conflicting updates', async () => {
@@ -259,7 +259,7 @@ flakySuite('Storage Library', function () {
 		ok(setAndDeletePromiseResolved);
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('corrupt DB recovers', async () => {
@@ -289,7 +289,7 @@ flakySuite('Storage Library', function () {
 		equal(storage.get('foo'), 'bar');
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 });
 
@@ -387,7 +387,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await testDBBasics(join(storageDir, 'storage.db'));
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('basics (open multiple times)', async () => {
@@ -398,7 +398,7 @@ flakySuite('SQLite Storage Library', function () {
 		await testDBBasics(join(storageDir, 'storage.db'));
 		await testDBBasics(join(storageDir, 'storage.db'));
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('basics (corrupt DB falls back to empty DB)', async () => {
@@ -416,7 +416,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		ok(expectedError);
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('basics (corrupt DB restores from previous backup)', async () => {
@@ -454,7 +454,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		equal(recoveryCalled, false);
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('basics (corrupt DB falls back to empty DB if backup is corrupt)', async () => {
@@ -483,7 +483,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await testDBBasics(storagePath);
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('basics (DB that becomes corrupt during runtime stores all state from cache on close)', async () => {
@@ -551,7 +551,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		equal(recoveryCalled, false);
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('real world example', async function () {
@@ -640,7 +640,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await storage.close();
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('very large item value', async function () {
@@ -693,7 +693,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await storage.close();
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('multiple concurrent writes execute in sequence', async () => {
@@ -750,7 +750,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await storage.close();
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('lots of INSERT & DELETE (below inline max)', async () => {
@@ -782,7 +782,7 @@ flakySuite('SQLite Storage Library', function () {
 
 		await storage.close();
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 
 	test('lots of INSERT & DELETE (above inline max)', async () => {
@@ -814,6 +814,6 @@ flakySuite('SQLite Storage Library', function () {
 
 		await storage.close();
 
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 });

--- a/src/vs/base/test/node/crypto.test.ts
+++ b/src/vs/base/test/node/crypto.test.ts
@@ -7,7 +7,7 @@ import { checksum } from 'vs/base/node/crypto';
 import { generateUuid } from 'vs/base/common/uuid';
 import { join } from 'vs/base/common/path';
 import { tmpdir } from 'os';
-import { mkdirp, rimraf, RimRafMode, writeFile } from 'vs/base/node/pfs';
+import { mkdirp, rimraf, writeFile } from 'vs/base/node/pfs';
 
 suite('Crypto', () => {
 
@@ -22,6 +22,6 @@ suite('Crypto', () => {
 
 		await checksum(testFile, '0a4d55a8d778e5022fab701977c5d840bbc486d0');
 
-		await rimraf(testDir, RimRafMode.UNLINK);
+		await rimraf(testDir);
 	});
 });

--- a/src/vs/base/test/node/crypto.test.ts
+++ b/src/vs/base/test/node/crypto.test.ts
@@ -22,6 +22,6 @@ suite('Crypto', () => {
 
 		await checksum(testFile, '0a4d55a8d778e5022fab701977c5d840bbc486d0');
 
-		await rimraf(testDir, RimRafMode.MOVE);
+		await rimraf(testDir, RimRafMode.UNLINK);
 	});
 });

--- a/src/vs/base/test/node/extpath.test.ts
+++ b/src/vs/base/test/node/extpath.test.ts
@@ -37,7 +37,7 @@ suite('Extpath', () => {
 			assert.equal(real, newDir);
 		}
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
 	});
 
 	test('realpath', async () => {
@@ -50,7 +50,7 @@ suite('Extpath', () => {
 		const realpathVal = await realpath(newDir);
 		assert.ok(realpathVal);
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
 	});
 
 	test('realpathSync', async () => {
@@ -68,6 +68,6 @@ suite('Extpath', () => {
 		}
 		assert.ok(realpath!);
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
 	});
 });

--- a/src/vs/base/test/node/extpath.test.ts
+++ b/src/vs/base/test/node/extpath.test.ts
@@ -37,7 +37,7 @@ suite('Extpath', () => {
 			assert.equal(real, newDir);
 		}
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(parentDir);
 	});
 
 	test('realpath', async () => {
@@ -50,7 +50,7 @@ suite('Extpath', () => {
 		const realpathVal = await realpath(newDir);
 		assert.ok(realpathVal);
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(parentDir);
 	});
 
 	test('realpathSync', async () => {
@@ -68,6 +68,6 @@ suite('Extpath', () => {
 		}
 		assert.ok(realpath!);
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(parentDir);
 	});
 });

--- a/src/vs/base/test/node/pfs/pfs.test.ts
+++ b/src/vs/base/test/node/pfs/pfs.test.ts
@@ -30,7 +30,7 @@ flakySuite('PFS', function () {
 		await pfs.writeFile(testFile, 'Hello World', (null!));
 		assert.equal(fs.readFileSync(testFile), 'Hello World');
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(parentDir);
 	});
 
 	test('writeFile - parallel write on different files works', async () => {
@@ -59,7 +59,7 @@ flakySuite('PFS', function () {
 		assert.equal(fs.readFileSync(testFile4), 'Hello World 4');
 		assert.equal(fs.readFileSync(testFile5), 'Hello World 5');
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(parentDir);
 	});
 
 	test('writeFile - parallel write on same files works and is sequentalized', async () => {
@@ -80,7 +80,7 @@ flakySuite('PFS', function () {
 		]);
 		assert.equal(fs.readFileSync(testFile), 'Hello World 5');
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(parentDir);
 	});
 
 	test('rimraf - simple - unlink', async () => {
@@ -254,7 +254,7 @@ flakySuite('PFS', function () {
 		assert.ok(!fs.existsSync(path.join(targetDir2, 'index.html')));
 		assert.ok(fs.existsSync(path.join(targetDir2, 'index_moved.html')));
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(parentDir);
 
 		assert.ok(!fs.existsSync(parentDir));
 	});
@@ -268,7 +268,7 @@ flakySuite('PFS', function () {
 
 		assert.ok(fs.existsSync(newDir));
 
-		return pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
+		return pfs.rimraf(parentDir);
 	});
 
 	test('readDirsInDir', async () => {

--- a/src/vs/base/test/node/pfs/pfs.test.ts
+++ b/src/vs/base/test/node/pfs/pfs.test.ts
@@ -30,7 +30,7 @@ flakySuite('PFS', function () {
 		await pfs.writeFile(testFile, 'Hello World', (null!));
 		assert.equal(fs.readFileSync(testFile), 'Hello World');
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
 	});
 
 	test('writeFile - parallel write on different files works', async () => {
@@ -59,7 +59,7 @@ flakySuite('PFS', function () {
 		assert.equal(fs.readFileSync(testFile4), 'Hello World 4');
 		assert.equal(fs.readFileSync(testFile5), 'Hello World 5');
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
 	});
 
 	test('writeFile - parallel write on same files works and is sequentalized', async () => {
@@ -80,7 +80,7 @@ flakySuite('PFS', function () {
 		]);
 		assert.equal(fs.readFileSync(testFile), 'Hello World 5');
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
 	});
 
 	test('rimraf - simple - unlink', async () => {
@@ -254,7 +254,7 @@ flakySuite('PFS', function () {
 		assert.ok(!fs.existsSync(path.join(targetDir2, 'index.html')));
 		assert.ok(fs.existsSync(path.join(targetDir2, 'index_moved.html')));
 
-		await pfs.rimraf(parentDir, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
 
 		assert.ok(!fs.existsSync(parentDir));
 	});
@@ -268,7 +268,7 @@ flakySuite('PFS', function () {
 
 		assert.ok(fs.existsSync(newDir));
 
-		return pfs.rimraf(parentDir, pfs.RimRafMode.MOVE);
+		return pfs.rimraf(parentDir, pfs.RimRafMode.UNLINK);
 	});
 
 	test('readDirsInDir', async () => {

--- a/src/vs/platform/backup/test/electron-main/backupMainService.test.ts
+++ b/src/vs/platform/backup/test/electron-main/backupMainService.test.ts
@@ -119,7 +119,7 @@ flakySuite('BackupMainService', () => {
 	setup(async () => {
 
 		// Delete any existing backups completely and then re-create it.
-		await pfs.rimraf(backupHome, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
 		await pfs.mkdirp(backupHome);
 
 		configService = new TestConfigurationService();
@@ -129,7 +129,7 @@ flakySuite('BackupMainService', () => {
 	});
 
 	teardown(() => {
-		return pfs.rimraf(backupHome, pfs.RimRafMode.MOVE);
+		return pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
 	});
 
 	test('service validates backup workspaces on startup and cleans up (folder workspaces)', async function () {

--- a/src/vs/platform/backup/test/electron-main/backupMainService.test.ts
+++ b/src/vs/platform/backup/test/electron-main/backupMainService.test.ts
@@ -119,7 +119,7 @@ flakySuite('BackupMainService', () => {
 	setup(async () => {
 
 		// Delete any existing backups completely and then re-create it.
-		await pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(backupHome);
 		await pfs.mkdirp(backupHome);
 
 		configService = new TestConfigurationService();
@@ -129,7 +129,7 @@ flakySuite('BackupMainService', () => {
 	});
 
 	teardown(() => {
-		return pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
+		return pfs.rimraf(backupHome);
 	});
 
 	test('service validates backup workspaces on startup and cleans up (folder workspaces)', async function () {

--- a/src/vs/platform/extensionManagement/test/node/extensionGalleryService.test.ts
+++ b/src/vs/platform/extensionManagement/test/node/extensionGalleryService.test.ts
@@ -9,7 +9,7 @@ import { NativeEnvironmentService } from 'vs/platform/environment/node/environme
 import { parseArgs, OPTIONS } from 'vs/platform/environment/node/argv';
 import { getRandomTestPath } from 'vs/base/test/node/testUtils';
 import { join } from 'vs/base/common/path';
-import { mkdirp, RimRafMode, rimraf } from 'vs/base/node/pfs';
+import { mkdirp, rimraf } from 'vs/base/node/pfs';
 import { resolveMarketplaceHeaders } from 'vs/platform/extensionManagement/common/extensionGalleryService';
 import { isUUID } from 'vs/base/common/uuid';
 import { DisposableStore } from 'vs/base/common/lifecycle';
@@ -39,7 +39,7 @@ suite('Extension Gallery Service', () => {
 		fileService.registerProvider(Schemas.file, diskFileSystemProvider);
 
 		// Delete any existing backups completely and then re-create it.
-		rimraf(marketplaceHome, RimRafMode.UNLINK).then(() => {
+		rimraf(marketplaceHome).then(() => {
 			mkdirp(marketplaceHome).then(() => {
 				done();
 			}, error => done(error));
@@ -48,7 +48,7 @@ suite('Extension Gallery Service', () => {
 
 	teardown(done => {
 		disposables.clear();
-		rimraf(marketplaceHome, RimRafMode.UNLINK).then(done, done);
+		rimraf(marketplaceHome).then(done, done);
 	});
 
 	test('marketplace machine id', () => {

--- a/src/vs/platform/extensionManagement/test/node/extensionGalleryService.test.ts
+++ b/src/vs/platform/extensionManagement/test/node/extensionGalleryService.test.ts
@@ -39,7 +39,7 @@ suite('Extension Gallery Service', () => {
 		fileService.registerProvider(Schemas.file, diskFileSystemProvider);
 
 		// Delete any existing backups completely and then re-create it.
-		rimraf(marketplaceHome, RimRafMode.MOVE).then(() => {
+		rimraf(marketplaceHome, RimRafMode.UNLINK).then(() => {
 			mkdirp(marketplaceHome).then(() => {
 				done();
 			}, error => done(error));
@@ -48,7 +48,7 @@ suite('Extension Gallery Service', () => {
 
 	teardown(done => {
 		disposables.clear();
-		rimraf(marketplaceHome, RimRafMode.MOVE).then(done, done);
+		rimraf(marketplaceHome, RimRafMode.UNLINK).then(done, done);
 	});
 
 	test('marketplace machine id', () => {

--- a/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
+++ b/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
@@ -12,7 +12,7 @@ import { flakySuite, getRandomTestPath } from 'vs/base/test/node/testUtils';
 import { generateUuid } from 'vs/base/common/uuid';
 import { join, basename, dirname, posix } from 'vs/base/common/path';
 import { getPathFromAmdModule } from 'vs/base/common/amd';
-import { copy, rimraf, symlink, RimRafMode, rimrafSync } from 'vs/base/node/pfs';
+import { copy, rimraf, symlink, rimrafSync } from 'vs/base/node/pfs';
 import { URI } from 'vs/base/common/uri';
 import { existsSync, statSync, readdirSync, readFileSync, writeFileSync, renameSync, unlinkSync, mkdirSync, createReadStream } from 'fs';
 import { FileOperation, FileOperationEvent, IFileStat, FileOperationResult, FileSystemProviderCapabilities, FileChangeType, IFileChange, FileChangesEvent, FileOperationError, etag, IStat, IFileStatWithMetadata } from 'vs/platform/files/common/files';
@@ -154,7 +154,7 @@ flakySuite('Disk File Service', function () {
 	teardown(async () => {
 		disposables.clear();
 
-		await rimraf(parentDir, RimRafMode.UNLINK);
+		await rimraf(parentDir);
 	});
 
 	test('createFolder', async () => {

--- a/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
+++ b/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
@@ -154,7 +154,7 @@ flakySuite('Disk File Service', function () {
 	teardown(async () => {
 		disposables.clear();
 
-		await rimraf(parentDir, RimRafMode.MOVE);
+		await rimraf(parentDir, RimRafMode.UNLINK);
 	});
 
 	test('createFolder', async () => {

--- a/src/vs/platform/state/test/node/state.test.ts
+++ b/src/vs/platform/state/test/node/state.test.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import * as path from 'vs/base/common/path';
 import { flakySuite, getRandomTestPath } from 'vs/base/test/node/testUtils';
 import { FileStorage } from 'vs/platform/state/node/stateService';
-import { mkdirp, rimraf, RimRafMode, writeFileSync } from 'vs/base/node/pfs';
+import { mkdirp, rimraf, writeFileSync } from 'vs/base/node/pfs';
 
 flakySuite('StateService', () => {
 	const parentDir = getRandomTestPath(os.tmpdir(), 'vsctests', 'stateservice');
@@ -43,6 +43,6 @@ flakySuite('StateService', () => {
 		service.setItem('some.null.key', null);
 		assert.equal(service.getItem('some.null.key', 'some.default'), 'some.default');
 
-		await rimraf(parentDir, RimRafMode.UNLINK);
+		await rimraf(parentDir);
 	});
 });

--- a/src/vs/platform/state/test/node/state.test.ts
+++ b/src/vs/platform/state/test/node/state.test.ts
@@ -43,6 +43,6 @@ flakySuite('StateService', () => {
 		service.setItem('some.null.key', null);
 		assert.equal(service.getItem('some.null.key', 'some.default'), 'some.default');
 
-		await rimraf(parentDir, RimRafMode.MOVE);
+		await rimraf(parentDir, RimRafMode.UNLINK);
 	});
 });

--- a/src/vs/platform/storage/test/electron-browser/storage.test.ts
+++ b/src/vs/platform/storage/test/electron-browser/storage.test.ts
@@ -8,7 +8,7 @@ import { FileStorageDatabase } from 'vs/platform/storage/browser/storageService'
 import { generateUuid } from 'vs/base/common/uuid';
 import { join } from 'vs/base/common/path';
 import { tmpdir } from 'os';
-import { rimraf, RimRafMode } from 'vs/base/node/pfs';
+import { rimraf } from 'vs/base/node/pfs';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { Storage } from 'vs/base/parts/storage/common/storage';
 import { URI } from 'vs/base/common/uri';
@@ -45,7 +45,7 @@ suite('Storage', () => {
 	teardown(async () => {
 		disposables.clear();
 
-		await rimraf(parentDir, RimRafMode.UNLINK);
+		await rimraf(parentDir);
 	});
 
 	test('File Based Storage', async () => {

--- a/src/vs/platform/storage/test/electron-browser/storage.test.ts
+++ b/src/vs/platform/storage/test/electron-browser/storage.test.ts
@@ -45,7 +45,7 @@ suite('Storage', () => {
 	teardown(async () => {
 		disposables.clear();
 
-		await rimraf(parentDir, RimRafMode.MOVE);
+		await rimraf(parentDir, RimRafMode.UNLINK);
 	});
 
 	test('File Based Storage', async () => {

--- a/src/vs/platform/storage/test/node/storageService.test.ts
+++ b/src/vs/platform/storage/test/node/storageService.test.ts
@@ -63,6 +63,6 @@ flakySuite('NativeStorageService', function () {
 		equal(storage.getBoolean('barBoolean', StorageScope.GLOBAL), true);
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.MOVE);
+		await rimraf(storageDir, RimRafMode.UNLINK);
 	});
 });

--- a/src/vs/platform/storage/test/node/storageService.test.ts
+++ b/src/vs/platform/storage/test/node/storageService.test.ts
@@ -9,7 +9,7 @@ import { NativeStorageService } from 'vs/platform/storage/node/storageService';
 import { generateUuid } from 'vs/base/common/uuid';
 import { join } from 'vs/base/common/path';
 import { tmpdir } from 'os';
-import { mkdirp, rimraf, RimRafMode } from 'vs/base/node/pfs';
+import { mkdirp, rimraf } from 'vs/base/node/pfs';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { NativeEnvironmentService } from 'vs/platform/environment/node/environmentService';
 import { parseArgs, OPTIONS } from 'vs/platform/environment/node/argv';
@@ -63,6 +63,6 @@ flakySuite('NativeStorageService', function () {
 		equal(storage.getBoolean('barBoolean', StorageScope.GLOBAL), true);
 
 		await storage.close();
-		await rimraf(storageDir, RimRafMode.UNLINK);
+		await rimraf(storageDir);
 	});
 });

--- a/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
+++ b/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
@@ -147,13 +147,13 @@ suite('WorkspacesMainService', () => {
 		service = new WorkspacesMainService(environmentService, logService, new TestBackupMainService(), new TestDialogMainService());
 
 		// Delete any existing backups completely and then re-create it.
-		await pfs.rimraf(untitledWorkspacesHomePath, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(untitledWorkspacesHomePath);
 
 		return pfs.mkdirp(untitledWorkspacesHomePath);
 	});
 
 	teardown(() => {
-		return pfs.rimraf(untitledWorkspacesHomePath, pfs.RimRafMode.UNLINK);
+		return pfs.rimraf(untitledWorkspacesHomePath);
 	});
 
 	function assertPathEquals(p1: string, p2: string): void {

--- a/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
+++ b/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
@@ -147,13 +147,13 @@ suite('WorkspacesMainService', () => {
 		service = new WorkspacesMainService(environmentService, logService, new TestBackupMainService(), new TestDialogMainService());
 
 		// Delete any existing backups completely and then re-create it.
-		await pfs.rimraf(untitledWorkspacesHomePath, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(untitledWorkspacesHomePath, pfs.RimRafMode.UNLINK);
 
 		return pfs.mkdirp(untitledWorkspacesHomePath);
 	});
 
 	teardown(() => {
-		return pfs.rimraf(untitledWorkspacesHomePath, pfs.RimRafMode.MOVE);
+		return pfs.rimraf(untitledWorkspacesHomePath, pfs.RimRafMode.UNLINK);
 	});
 
 	function assertPathEquals(p1: string, p2: string): void {

--- a/src/vs/workbench/contrib/backup/common/backupTracker.ts
+++ b/src/vs/workbench/contrib/backup/common/backupTracker.ts
@@ -18,7 +18,7 @@ export abstract class BackupTracker extends Disposable {
 	private readonly mapWorkingCopyToContentVersion = new Map<IWorkingCopy, number>();
 
 	// A map of scheduled pending backups for working copies
-	private readonly pendingBackups = new Map<IWorkingCopy, IDisposable>();
+	protected readonly pendingBackups = new Map<IWorkingCopy, IDisposable>();
 
 	constructor(
 		protected readonly backupFileService: IBackupFileService,

--- a/src/vs/workbench/contrib/backup/test/electron-browser/backupRestorer.test.ts
+++ b/src/vs/workbench/contrib/backup/test/electron-browser/backupRestorer.test.ts
@@ -67,7 +67,7 @@ flakySuite('BackupRestorer', () => {
 		));
 
 		// Delete any existing backups completely and then re-create it.
-		await pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(backupHome);
 		await pfs.mkdirp(backupHome);
 
 		return pfs.writeFile(workspacesJsonPath, '');
@@ -79,7 +79,7 @@ flakySuite('BackupRestorer', () => {
 
 		(<TextFileEditorModelManager>accessor.textFileService.files).dispose();
 
-		return pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
+		return pfs.rimraf(backupHome);
 	});
 
 	test('Restore backups', async function () {

--- a/src/vs/workbench/contrib/backup/test/electron-browser/backupRestorer.test.ts
+++ b/src/vs/workbench/contrib/backup/test/electron-browser/backupRestorer.test.ts
@@ -67,7 +67,7 @@ flakySuite('BackupRestorer', () => {
 		));
 
 		// Delete any existing backups completely and then re-create it.
-		await pfs.rimraf(backupHome, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
 		await pfs.mkdirp(backupHome);
 
 		return pfs.writeFile(workspacesJsonPath, '');
@@ -79,7 +79,7 @@ flakySuite('BackupRestorer', () => {
 
 		(<TextFileEditorModelManager>accessor.textFileService.files).dispose();
 
-		return pfs.rimraf(backupHome, pfs.RimRafMode.MOVE);
+		return pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
 	});
 
 	test('Restore backups', async function () {

--- a/src/vs/workbench/contrib/backup/test/electron-browser/backupTracker.test.ts
+++ b/src/vs/workbench/contrib/backup/test/electron-browser/backupTracker.test.ts
@@ -124,7 +124,10 @@ flakySuite('BackupTracker', function () {
 
 		(<TextFileEditorModelManager>accessor.textFileService.files).dispose();
 
-		return pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
+		// TODO: these tests cause ENOTEMPTY errors during rimraf which indicates
+		// that one or more tests continue writing to the fixture directory even
+		// after they signal completion.
+		return pfs.rimrafWithRetries(backupHome);
 	});
 
 	async function createTracker(autoSaveEnabled = false): Promise<[TestServiceAccessor, EditorPart, BackupTracker, IInstantiationService]> {

--- a/src/vs/workbench/contrib/backup/test/electron-browser/backupTracker.test.ts
+++ b/src/vs/workbench/contrib/backup/test/electron-browser/backupTracker.test.ts
@@ -124,7 +124,7 @@ flakySuite('BackupTracker', function () {
 
 		(<TextFileEditorModelManager>accessor.textFileService.files).dispose();
 
-		return pfs.rimraf(backupHome, pfs.RimRafMode.MOVE);
+		return pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
 	});
 
 	async function createTracker(autoSaveEnabled = false): Promise<[TestServiceAccessor, EditorPart, BackupTracker, IInstantiationService]> {

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionRecommendationsService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionRecommendationsService.test.ts
@@ -9,7 +9,7 @@ import * as path from 'vs/base/common/path';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as uuid from 'vs/base/common/uuid';
-import { mkdirp, rimraf, RimRafMode } from 'vs/base/node/pfs';
+import { mkdirp, rimraf } from 'vs/base/node/pfs';
 import {
 	IExtensionGalleryService, IGalleryExtensionAssets, IGalleryExtension, IExtensionManagementService,
 	DidInstallExtensionEvent, DidUninstallExtensionEvent, InstallExtensionEvent, IExtensionIdentifier, IExtensionTipsService
@@ -284,7 +284,7 @@ suite('ExtensionRecommendationsService Test', () => {
 	teardown(done => {
 		(<ExtensionRecommendationsService>testObject).dispose();
 		if (parentResource) {
-			rimraf(parentResource, RimRafMode.UNLINK).then(done, done);
+			rimraf(parentResource).then(done, done);
 		} else {
 			done();
 		}

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionRecommendationsService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionRecommendationsService.test.ts
@@ -284,7 +284,7 @@ suite('ExtensionRecommendationsService Test', () => {
 	teardown(done => {
 		(<ExtensionRecommendationsService>testObject).dispose();
 		if (parentResource) {
-			rimraf(parentResource, RimRafMode.MOVE).then(done, done);
+			rimraf(parentResource, RimRafMode.UNLINK).then(done, done);
 		} else {
 			done();
 		}

--- a/src/vs/workbench/services/backup/test/electron-browser/backupFileService.test.ts
+++ b/src/vs/workbench/services/backup/test/electron-browser/backupFileService.test.ts
@@ -29,6 +29,7 @@ import { VSBuffer } from 'vs/base/common/buffer';
 import { TestWorkbenchConfiguration } from 'vs/workbench/test/electron-browser/workbenchTestServices';
 import { TestProductService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
+import { insert } from 'vs/base/common/arrays';
 
 const userdataDir = getRandomTestPath(os.tmpdir(), 'vsctests', 'backupfileservice');
 const backupHome = path.join(userdataDir, 'Backups');
@@ -60,6 +61,7 @@ export class NodeTestBackupFileService extends NativeBackupFileService {
 	private backupResourceJoiners: Function[];
 	private discardBackupJoiners: Function[];
 	discardedBackups: URI[];
+	private pendingBackupsArr: Promise<void>[];
 
 	constructor(workspaceBackupPath: string) {
 		const environmentService = new TestWorkbenchEnvironmentService(workspaceBackupPath);
@@ -75,6 +77,11 @@ export class NodeTestBackupFileService extends NativeBackupFileService {
 		this.backupResourceJoiners = [];
 		this.discardBackupJoiners = [];
 		this.discardedBackups = [];
+		this.pendingBackupsArr = [];
+	}
+
+	async waitForAllBackups(): Promise<void> {
+		await Promise.all(this.pendingBackupsArr);
 	}
 
 	joinBackupResource(): Promise<void> {
@@ -82,7 +89,14 @@ export class NodeTestBackupFileService extends NativeBackupFileService {
 	}
 
 	async backup(resource: URI, content?: ITextSnapshot, versionId?: number, meta?: any, token?: CancellationToken): Promise<void> {
-		await super.backup(resource, content, versionId, meta, token);
+		const p = super.backup(resource, content, versionId, meta, token);
+		const removeFromPendingBackups = insert(this.pendingBackupsArr, p.then(undefined, undefined));
+
+		try {
+			await p;
+		} finally {
+			removeFromPendingBackups();
+		}
 
 		while (this.backupResourceJoiners.length) {
 			this.backupResourceJoiners.pop()!();

--- a/src/vs/workbench/services/backup/test/electron-browser/backupFileService.test.ts
+++ b/src/vs/workbench/services/backup/test/electron-browser/backupFileService.test.ts
@@ -118,14 +118,14 @@ suite('BackupFileService', () => {
 		service = new NodeTestBackupFileService(workspaceBackupPath);
 
 		// Delete any existing backups completely and then re-create it.
-		await pfs.rimraf(backupHome, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
 		await pfs.mkdirp(backupHome);
 
 		return pfs.writeFile(workspacesJsonPath, '');
 	});
 
 	teardown(() => {
-		return pfs.rimraf(backupHome, pfs.RimRafMode.MOVE);
+		return pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
 	});
 
 	suite('hashPath', () => {
@@ -573,14 +573,14 @@ suite('BackupFilesModel', () => {
 		service = new NodeTestBackupFileService(workspaceBackupPath);
 
 		// Delete any existing backups completely and then re-create it.
-		await pfs.rimraf(backupHome, pfs.RimRafMode.MOVE);
+		await pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
 		await pfs.mkdirp(backupHome);
 
 		return pfs.writeFile(workspacesJsonPath, '');
 	});
 
 	teardown(() => {
-		return pfs.rimraf(backupHome, pfs.RimRafMode.MOVE);
+		return pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
 	});
 
 	test('simple', () => {

--- a/src/vs/workbench/services/backup/test/electron-browser/backupFileService.test.ts
+++ b/src/vs/workbench/services/backup/test/electron-browser/backupFileService.test.ts
@@ -118,14 +118,14 @@ suite('BackupFileService', () => {
 		service = new NodeTestBackupFileService(workspaceBackupPath);
 
 		// Delete any existing backups completely and then re-create it.
-		await pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(backupHome);
 		await pfs.mkdirp(backupHome);
 
 		return pfs.writeFile(workspacesJsonPath, '');
 	});
 
 	teardown(() => {
-		return pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
+		return pfs.rimraf(backupHome);
 	});
 
 	suite('hashPath', () => {
@@ -573,14 +573,14 @@ suite('BackupFilesModel', () => {
 		service = new NodeTestBackupFileService(workspaceBackupPath);
 
 		// Delete any existing backups completely and then re-create it.
-		await pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
+		await pfs.rimraf(backupHome);
 		await pfs.mkdirp(backupHome);
 
 		return pfs.writeFile(workspacesJsonPath, '');
 	});
 
 	teardown(() => {
-		return pfs.rimraf(backupHome, pfs.RimRafMode.UNLINK);
+		return pfs.rimraf(backupHome);
 	});
 
 	test('simple', () => {

--- a/src/vs/workbench/services/configuration/test/electron-browser/configurationEditingService.test.ts
+++ b/src/vs/workbench/services/configuration/test/electron-browser/configurationEditingService.test.ts
@@ -128,7 +128,7 @@ suite('ConfigurationEditingService', () => {
 	teardown(() => {
 		disposables.clear();
 		if (workspaceDir) {
-			return rimraf(workspaceDir, RimRafMode.MOVE);
+			return rimraf(workspaceDir, RimRafMode.UNLINK);
 		}
 		return undefined;
 	});

--- a/src/vs/workbench/services/configuration/test/electron-browser/configurationEditingService.test.ts
+++ b/src/vs/workbench/services/configuration/test/electron-browser/configurationEditingService.test.ts
@@ -24,7 +24,7 @@ import { TestInstantiationService } from 'vs/platform/instantiation/test/common/
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { TextModelResolverService } from 'vs/workbench/services/textmodelResolver/common/textModelResolverService';
-import { mkdirp, rimraf, RimRafMode } from 'vs/base/node/pfs';
+import { mkdirp, rimraf } from 'vs/base/node/pfs';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { CommandService } from 'vs/workbench/services/commands/common/commandService';
@@ -128,7 +128,7 @@ suite('ConfigurationEditingService', () => {
 	teardown(() => {
 		disposables.clear();
 		if (workspaceDir) {
-			return rimraf(workspaceDir, RimRafMode.UNLINK);
+			return rimraf(workspaceDir);
 		}
 		return undefined;
 	});

--- a/src/vs/workbench/services/configuration/test/electron-browser/configurationService.test.ts
+++ b/src/vs/workbench/services/configuration/test/electron-browser/configurationService.test.ts
@@ -127,7 +127,7 @@ flakySuite('WorkspaceContextService - Folder', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
+			return pfs.rimraf(parentResource);
 		}
 		return undefined;
 	});
@@ -200,7 +200,7 @@ flakySuite('WorkspaceContextService - Workspace', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
+			return pfs.rimraf(parentResource);
 		}
 		return undefined;
 	});
@@ -263,7 +263,7 @@ flakySuite('WorkspaceContextService - Workspace Editing', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
+			return pfs.rimraf(parentResource);
 		}
 		return undefined;
 	});
@@ -524,7 +524,7 @@ flakySuite('WorkspaceService - Initialization', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
+			return pfs.rimraf(parentResource);
 		}
 		return undefined;
 	});
@@ -803,7 +803,7 @@ flakySuite('WorkspaceConfigurationService - Folder', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
+			return pfs.rimraf(parentResource);
 		}
 		return undefined;
 	});
@@ -1338,7 +1338,7 @@ flakySuite('WorkspaceConfigurationService-Multiroot', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
+			return pfs.rimraf(parentResource);
 		}
 		return undefined;
 	});
@@ -1965,7 +1965,7 @@ flakySuite('WorkspaceConfigurationService - Remote Folder', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
+			return pfs.rimraf(parentResource);
 		}
 		return undefined;
 	});

--- a/src/vs/workbench/services/configuration/test/electron-browser/configurationService.test.ts
+++ b/src/vs/workbench/services/configuration/test/electron-browser/configurationService.test.ts
@@ -127,7 +127,7 @@ flakySuite('WorkspaceContextService - Folder', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.MOVE);
+			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
 		}
 		return undefined;
 	});
@@ -200,7 +200,7 @@ flakySuite('WorkspaceContextService - Workspace', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.MOVE);
+			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
 		}
 		return undefined;
 	});
@@ -263,7 +263,7 @@ flakySuite('WorkspaceContextService - Workspace Editing', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.MOVE);
+			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
 		}
 		return undefined;
 	});
@@ -524,7 +524,7 @@ flakySuite('WorkspaceService - Initialization', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.MOVE);
+			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
 		}
 		return undefined;
 	});
@@ -803,7 +803,7 @@ flakySuite('WorkspaceConfigurationService - Folder', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.MOVE);
+			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
 		}
 		return undefined;
 	});
@@ -1338,7 +1338,7 @@ flakySuite('WorkspaceConfigurationService-Multiroot', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.MOVE);
+			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
 		}
 		return undefined;
 	});
@@ -1965,7 +1965,7 @@ flakySuite('WorkspaceConfigurationService - Remote Folder', () => {
 	teardown(() => {
 		disposables.clear();
 		if (parentResource) {
-			return pfs.rimraf(parentResource, pfs.RimRafMode.MOVE);
+			return pfs.rimraf(parentResource, pfs.RimRafMode.UNLINK);
 		}
 		return undefined;
 	});

--- a/src/vs/workbench/services/keybinding/test/electron-browser/keybindingEditing.test.ts
+++ b/src/vs/workbench/services/keybinding/test/electron-browser/keybindingEditing.test.ts
@@ -138,7 +138,7 @@ suite('KeybindingsEditing', () => {
 	teardown(() => {
 		return new Promise<void>((c) => {
 			if (testDir) {
-				rimraf(testDir, RimRafMode.MOVE).then(c, c);
+				rimraf(testDir, RimRafMode.UNLINK).then(c, c);
 			} else {
 				c(undefined);
 			}

--- a/src/vs/workbench/services/keybinding/test/electron-browser/keybindingEditing.test.ts
+++ b/src/vs/workbench/services/keybinding/test/electron-browser/keybindingEditing.test.ts
@@ -11,7 +11,7 @@ import * as json from 'vs/base/common/json';
 import { ChordKeybinding, KeyCode, SimpleKeybinding } from 'vs/base/common/keyCodes';
 import { OS } from 'vs/base/common/platform';
 import * as uuid from 'vs/base/common/uuid';
-import { mkdirp, rimraf, RimRafMode } from 'vs/base/node/pfs';
+import { mkdirp, rimraf } from 'vs/base/node/pfs';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { ModeServiceImpl } from 'vs/editor/common/services/modeServiceImpl';
 import { IModelService } from 'vs/editor/common/services/modelService';
@@ -138,7 +138,7 @@ suite('KeybindingsEditing', () => {
 	teardown(() => {
 		return new Promise<void>((c) => {
 			if (testDir) {
-				rimraf(testDir, RimRafMode.UNLINK).then(c, c);
+				rimraf(testDir).then(c, c);
 			} else {
 				c(undefined);
 			}

--- a/src/vs/workbench/services/telemetry/test/electron-browser/commonProperties.test.ts
+++ b/src/vs/workbench/services/telemetry/test/electron-browser/commonProperties.test.ts
@@ -25,7 +25,7 @@ suite('Telemetry - common properties', function () {
 	});
 
 	teardown(done => {
-		rimraf(parentDir, RimRafMode.MOVE).then(done, done);
+		rimraf(parentDir, RimRafMode.UNLINK).then(done, done);
 	});
 
 	test('default', async function () {

--- a/src/vs/workbench/services/telemetry/test/electron-browser/commonProperties.test.ts
+++ b/src/vs/workbench/services/telemetry/test/electron-browser/commonProperties.test.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import { resolveWorkbenchCommonProperties } from 'vs/workbench/services/telemetry/electron-browser/workbenchCommonProperties';
 import { getRandomTestPath } from 'vs/base/test/node/testUtils';
 import { IStorageService, StorageScope, InMemoryStorageService, StorageTarget } from 'vs/platform/storage/common/storage';
-import { mkdirp, rimraf, RimRafMode } from 'vs/base/node/pfs';
+import { mkdirp, rimraf } from 'vs/base/node/pfs';
 import { timeout } from 'vs/base/common/async';
 
 suite('Telemetry - common properties', function () {
@@ -25,7 +25,7 @@ suite('Telemetry - common properties', function () {
 	});
 
 	teardown(done => {
-		rimraf(parentDir, RimRafMode.UNLINK).then(done, done);
+		rimraf(parentDir).then(done, done);
 	});
 
 	test('default', async function () {

--- a/src/vs/workbench/services/textfile/test/electron-browser/nativeTextFileService.io.test.ts
+++ b/src/vs/workbench/services/textfile/test/electron-browser/nativeTextFileService.io.test.ts
@@ -8,7 +8,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { TextFileEditorModelManager } from 'vs/workbench/services/textfile/common/textFileEditorModelManager';
 import { Schemas } from 'vs/base/common/network';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
-import { rimraf, RimRafMode, copy, readFile, exists, stat } from 'vs/base/node/pfs';
+import { rimraf, copy, readFile, exists, stat } from 'vs/base/node/pfs';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { FileService } from 'vs/platform/files/common/fileService';
 import { NullLogService } from 'vs/platform/log/common/log';
@@ -65,7 +65,7 @@ flakySuite('Files - NativeTextFileService i/o', function () {
 
 			disposables.clear();
 
-			await rimraf(parentDir, RimRafMode.UNLINK);
+			await rimraf(parentDir);
 		},
 
 		exists,

--- a/src/vs/workbench/services/textfile/test/electron-browser/nativeTextFileService.io.test.ts
+++ b/src/vs/workbench/services/textfile/test/electron-browser/nativeTextFileService.io.test.ts
@@ -65,7 +65,7 @@ flakySuite('Files - NativeTextFileService i/o', function () {
 
 			disposables.clear();
 
-			await rimraf(parentDir, RimRafMode.MOVE);
+			await rimraf(parentDir, RimRafMode.UNLINK);
 		},
 
 		exists,


### PR DESCRIPTION
Towards fixing #114024

* many teardown methods of our unit tests are using `rimraf` with the `MOVE` option.
* this causes that the first error which occurs during moving is swallowed i.e. see the `error` being ignored here https://github.com/microsoft/vscode/blob/6d2e0aa21d386fbc4096c6a801b9248b866a0c6d/src/vs/base/node/pfs.ts#L96 
* this most likely hides the fact that some tests continue writing to the fixture directory even after the test has signaled completion (**this is the root problem here**)
* not waiting for unlinking and not using `graceful-fs` in our unit tests causes some tests which are unlucky and are not first in the mocha runner schedule to fail in their teardown hook
* mocha does not recover from a failure in a teardown hook even if retry is used (i.e. even if the test is decorated with `flakyTest`)


This PR aims to expose the tests which write to the fixture directory even after the test has signaled completion. By using `rimraf` with the `UNLINK` option, any error will immediately become visible. I have already seen a `ENOTEMPTY` being thrown from the `BackupTracker` test. The best fix would be for the tests to be analyzed and repaired to stop writing to the fixture directory after they signal completion. The bandaid approach that I have started is to leave a TODO in the test and to use `rimrafWithRetries` especially in these tests where this `ENOTEMPTY` is observed.