### PR TITLE
Refresh Images In Markdown Preview On Change

### DIFF
--- a/extensions/markdown-language-features/src/commands/renderDocument.ts
+++ b/extensions/markdown-language-features/src/commands/renderDocument.ts
@@ -15,6 +15,6 @@ export class RenderDocument implements Command {
 	) { }
 
 	public async execute(document: SkinnyTextDocument | string): Promise<string> {
-		return this.engine.render(document);
+		return (await (this.engine.render(document))).html;
 	}
 }

--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -231,9 +231,8 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 	}
 
 	/**
-	 * Eventually refreshes the preview.
-	 * First call immediatly refreshs the preview,
-	 * subsequent calls are debounced.
+	 * The first call immediately refreshes the preview,
+	 * calls happening shortly thereafter are debounced.
 	*/
 	public refresh() {
 		// Schedule update if none is pending

--- a/extensions/markdown-language-features/src/features/previewContentProvider.ts
+++ b/extensions/markdown-language-features/src/features/previewContentProvider.ts
@@ -54,23 +54,11 @@ export class MarkdownContentProvider {
 		private readonly logger: Logger
 	) { }
 
-	/**
-	 *
-	 * @param markdownDocument
-	 * @param resourceProvider
-	 * @param previewConfigurations
-	 * @param initialLine
-	 * @param imageCacheKeyBySrc Each image is identified by its "src".
-	 * Two images with the same src but different cache keys must not share the
-	 * same cache entry.
-	 * @param state
-	 */
 	public async provideTextDocumentContent(
 		markdownDocument: vscode.TextDocument,
 		resourceProvider: WebviewResourceProvider,
 		previewConfigurations: MarkdownPreviewConfigurationManager,
 		initialLine: number | undefined = undefined,
-		imageCacheKeyBySrc: ReadonlyMap</* src: */ string, string>,
 		state?: any
 	): Promise<MarkdownContentProviderOutput> {
 		const sourceUri = markdownDocument.uri;
@@ -92,7 +80,7 @@ export class MarkdownContentProvider {
 		const nonce = new Date().getTime() + '' + new Date().getMilliseconds();
 		const csp = this.getCsp(resourceProvider, sourceUri, nonce);
 
-		const body = await this.engine.render(markdownDocument, { imageCacheKeyBySrc });
+		const body = await this.engine.render(markdownDocument);
 		const html = `<!DOCTYPE html>
 			<html style="${escapeAttribute(this.getSettingsOverrideStyles(config))}">
 			<head>

--- a/extensions/markdown-language-features/src/test/engine.test.ts
+++ b/extensions/markdown-language-features/src/test/engine.test.ts
@@ -9,6 +9,7 @@ import 'mocha';
 
 import { InMemoryDocument } from './inMemoryDocument';
 import { createNewMarkdownEngine } from './engine';
+import { joinLines } from './util';
 
 const testFileName = vscode.Uri.file('test.md');
 
@@ -42,25 +43,6 @@ suite('markdown.engine', () => {
 					+ '<img src="http://example.org/img.png" alt="" class="loading" id="image-hash--1903814170"> '
 					+ '<img src="img.png" alt="" class="loading" id="image-hash--754511435"> '
 					+ '<img src="./img2.png" alt="" class="loading" id="image-hash-265238964">'
-					+ '</p>\n'
-				,
-				containingImages: [{ src: 'img.png' }, { src: 'http://example.org/img.png' }, { src: 'img.png' }, { src: './img2.png' }],
-			});
-		});
-
-		test('Cache-Keys are considered', async () => {
-			const engine = createNewMarkdownEngine();
-			const imageCacheKeyBySrc = new Map<string, string>();
-			imageCacheKeyBySrc.set('img.png', '1');
-			imageCacheKeyBySrc.set('./img2.png', '2');
-
-			assert.deepStrictEqual((await engine.render(input, { imageCacheKeyBySrc })), {
-				html: '<p data-line="0" class="code-line">'
-					+ '<img src="img.png?cacheKey=1" alt="" class="loading" src-origin="img.png" id="image-hash--754511435"> '
-					+ '<a href="no-img.png" data-href="no-img.png"></a> '
-					+ '<img src="http://example.org/img.png" alt="" class="loading" id="image-hash--1903814170"> '
-					+ '<img src="img.png?cacheKey=1" alt="" class="loading" src-origin="img.png" id="image-hash--754511435"> '
-					+ '<img src="./img2.png?cacheKey=2" alt="" class="loading" src-origin="./img2.png" id="image-hash-265238964">'
 					+ '</p>\n'
 				,
 				containingImages: [{ src: 'img.png' }, { src: 'http://example.org/img.png' }, { src: 'img.png' }, { src: './img2.png' }],

--- a/extensions/markdown-language-features/src/test/engine.test.ts
+++ b/extensions/markdown-language-features/src/test/engine.test.ts
@@ -21,12 +21,37 @@ suite('markdown.engine', () => {
 		test('Renders a document', async () => {
 			const doc = new InMemoryDocument(testFileName, input);
 			const engine = createNewMarkdownEngine();
-			assert.strictEqual(await engine.render(doc), output);
+			assert.strictEqual((await engine.render(doc)).html, output);
 		});
 
 		test('Renders a string', async () => {
 			const engine = createNewMarkdownEngine();
-			assert.strictEqual(await engine.render(input), output);
+			assert.strictEqual((await engine.render(input)).html, output);
+		});
+	});
+
+	// TODO: How can I run these tests? These tests are not finished yet.
+	suite('image-caching', () => {
+		const input = '![](img.png) [](no-img.png) ![](http://example.org/img.png) ![](img.png) ![](./img2.png)';
+
+		test('Extracts all images', async () => {
+			const engine = createNewMarkdownEngine();
+			assert.deepStrictEqual((await engine.render(input)).html, {
+				html: '',
+				containingImages: [{ src: 'img.png' }, { src: 'http://example.org/img.png' }, { src: 'img.png' }, {}],
+			});
+		});
+
+		test('Cache-Keys are considered', async () => {
+			const engine = createNewMarkdownEngine();
+			const imageCacheKeyBySrc = new Map<string, string>();
+			imageCacheKeyBySrc.set('img.png', '1');
+			imageCacheKeyBySrc.set('./img2.png', '2');
+
+			assert.deepStrictEqual((await engine.render(input, { imageCacheKeyBySrc })).html, {
+				html: '',
+				containingImages: [{ src: 'img.png' }, { src: 'http://example.org/img.png' }, { src: 'img.png' }, {}],
+			});
 		});
 	});
 });

--- a/extensions/markdown-language-features/src/test/engine.test.ts
+++ b/extensions/markdown-language-features/src/test/engine.test.ts
@@ -30,15 +30,21 @@ suite('markdown.engine', () => {
 		});
 	});
 
-	// TODO: How can I run these tests? These tests are not finished yet.
 	suite('image-caching', () => {
 		const input = '![](img.png) [](no-img.png) ![](http://example.org/img.png) ![](img.png) ![](./img2.png)';
 
 		test('Extracts all images', async () => {
 			const engine = createNewMarkdownEngine();
-			assert.deepStrictEqual((await engine.render(input)).html, {
-				html: '',
-				containingImages: [{ src: 'img.png' }, { src: 'http://example.org/img.png' }, { src: 'img.png' }, {}],
+			assert.deepStrictEqual((await engine.render(input)), {
+				html: '<p data-line="0" class="code-line">'
+					+ '<img src="img.png" alt="" class="loading" id="image-hash--754511435"> '
+					+ '<a href="no-img.png" data-href="no-img.png"></a> '
+					+ '<img src="http://example.org/img.png" alt="" class="loading" id="image-hash--1903814170"> '
+					+ '<img src="img.png" alt="" class="loading" id="image-hash--754511435"> '
+					+ '<img src="./img2.png" alt="" class="loading" id="image-hash-265238964">'
+					+ '</p>\n'
+				,
+				containingImages: [{ src: 'img.png' }, { src: 'http://example.org/img.png' }, { src: 'img.png' }, { src: './img2.png' }],
 			});
 		});
 
@@ -48,9 +54,16 @@ suite('markdown.engine', () => {
 			imageCacheKeyBySrc.set('img.png', '1');
 			imageCacheKeyBySrc.set('./img2.png', '2');
 
-			assert.deepStrictEqual((await engine.render(input, { imageCacheKeyBySrc })).html, {
-				html: '',
-				containingImages: [{ src: 'img.png' }, { src: 'http://example.org/img.png' }, { src: 'img.png' }, {}],
+			assert.deepStrictEqual((await engine.render(input, { imageCacheKeyBySrc })), {
+				html: '<p data-line="0" class="code-line">'
+					+ '<img src="img.png?cacheKey=1" alt="" class="loading" src-origin="img.png" id="image-hash--754511435"> '
+					+ '<a href="no-img.png" data-href="no-img.png"></a> '
+					+ '<img src="http://example.org/img.png" alt="" class="loading" id="image-hash--1903814170"> '
+					+ '<img src="img.png?cacheKey=1" alt="" class="loading" src-origin="img.png" id="image-hash--754511435"> '
+					+ '<img src="./img2.png?cacheKey=2" alt="" class="loading" src-origin="./img2.png" id="image-hash-265238964">'
+					+ '</p>\n'
+				,
+				containingImages: [{ src: 'img.png' }, { src: 'http://example.org/img.png' }, { src: 'img.png' }, { src: './img2.png' }],
 			});
 		});
 	});

--- a/extensions/markdown-language-features/src/test/engine.test.ts
+++ b/extensions/markdown-language-features/src/test/engine.test.ts
@@ -9,7 +9,6 @@ import 'mocha';
 
 import { InMemoryDocument } from './inMemoryDocument';
 import { createNewMarkdownEngine } from './engine';
-import { joinLines } from './util';
 
 const testFileName = vscode.Uri.file('test.md');
 

--- a/extensions/markdown-language-features/src/test/urlToUri.test.ts
+++ b/extensions/markdown-language-features/src/test/urlToUri.test.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { deepStrictEqual } from 'assert';
+import 'mocha';
+import { Uri } from 'vscode';
+import { urlToUri } from '../util/url';
+
+suite('urlToUri', () => {
+	test('Absolute File', () => {
+		deepStrictEqual(
+			urlToUri('file:///root/test.txt', Uri.parse('file:///usr/home/')),
+			Uri.parse('file:///root/test.txt')
+		);
+	});
+
+	test('Relative File', () => {
+		deepStrictEqual(
+			urlToUri('./file.ext', Uri.parse('file:///usr/home/')),
+			Uri.parse('file:///usr/home/file.ext')
+		);
+	});
+
+	test('Http Basic', () => {
+		deepStrictEqual(
+			urlToUri('http://example.org?q=10&f', Uri.parse('file:///usr/home/')),
+			Uri.parse('http://example.org?q=10&f')
+		);
+	});
+
+	test('Http Encoded Chars', () => {
+		deepStrictEqual(
+			urlToUri('http://example.org/%C3%A4', Uri.parse('file:///usr/home/')),
+			Uri.parse('http://example.org/%C3%A4')
+		);
+	});
+});

--- a/extensions/markdown-language-features/src/util/url.ts
+++ b/extensions/markdown-language-features/src/util/url.ts
@@ -4,36 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { URL } from 'url';
+
+declare const URL: typeof import('url').URL;
 
 /**
  * Tries to convert an url into a vscode uri and returns undefined if this is not possible.
  * `url` can be absolute or relative.
 */
-export function urlToFileUri(url: string, base: vscode.Uri): vscode.Uri | undefined {
+export function urlToUri(url: string, base: vscode.Uri): vscode.Uri | undefined {
 	try {
 		// `vscode.Uri.joinPath` cannot be used, since it understands
 		// `src` as path, not as relative url. This is problematic for query args.
 		const parsedUrl = new URL(url, base.toString());
 		const uri = vscode.Uri.parse(parsedUrl.toString());
-		return uri.scheme === 'file' ? uri : undefined;
+		return uri;
 	} catch (e) {
 		// Don't crash if `URL` cannot parse `src`.
 		return undefined;
-	}
-}
-
-/**
- * Tries to append `?name=arg` or `&name=arg` to `url`.
- * If `url` is malformed (and it cannot be decided whether to use `&` or `?`),
- * `url` is returned as is.
-*/
-export function tryAppendQueryArgToUrl(url: string, name: string, arg: string): string {
-	try {
-		const parsedUrl = new URL(url, 'file://');
-		const joinChar = (parsedUrl.search === '') ? '?' : '&';
-		return `${url}${joinChar}${name}=${arg}`;
-	} catch (e) {
-		return url;
 	}
 }

--- a/extensions/markdown-language-features/src/util/url.ts
+++ b/extensions/markdown-language-features/src/util/url.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { URL } from 'url';
+
+/**
+ * Tries to convert an url into a vscode uri and returns undefined if this is not possible.
+ * `url` can be absolute or relative.
+*/
+export function urlToFileUri(url: string, base: vscode.Uri): vscode.Uri | undefined {
+	try {
+		// `vscode.Uri.joinPath` cannot be used, since it understands
+		// `src` as path, not as relative url. This is problematic for query args.
+		const parsedUrl = new URL(url, base.toString());
+		const uri = vscode.Uri.parse(parsedUrl.toString());
+		return uri.scheme === 'file' ? uri : undefined;
+	} catch (e) {
+		// Don't crash if `URL` cannot parse `src`.
+		return undefined;
+	}
+}
+
+/**
+ * Tries to append `?name=arg` or `&name=arg` to `url`.
+ * If `url` is malformed (and it cannot be decided whether to use `&` or `?`),
+ * `url` is returned as is.
+*/
+export function tryAppendQueryArgToUrl(url: string, name: string, arg: string): string {
+	try {
+		const parsedUrl = new URL(url, 'file://');
+		const joinChar = (parsedUrl.search === '') ? '?' : '&';
+		return `${url}${joinChar}${name}=${arg}`;
+	} catch (e) {
+		return url;
+	}
+}

--- a/src/vs/platform/webview/common/resourceLoader.ts
+++ b/src/vs/platform/webview/common/resourceLoader.ts
@@ -25,7 +25,8 @@ export namespace WebviewResourceResponse {
 
 		constructor(
 			public readonly stream: VSBufferReadableStream,
-			public readonly mimeType: string
+			public readonly etag: string | undefined,
+			public readonly mimeType: string,
 		) { }
 	}
 
@@ -36,7 +37,7 @@ export namespace WebviewResourceResponse {
 }
 
 interface FileReader {
-	readFileStream(resource: URI): Promise<VSBufferReadableStream>;
+	readFileStream(resource: URI): Promise<{ stream: VSBufferReadableStream, etag?: string }>;
 }
 
 export async function loadLocalResource(
@@ -73,7 +74,7 @@ export async function loadLocalResource(
 		logService.debug(`loadLocalResource - Loaded over http(s). requestUri=${requestUri}, response=${response.res.statusCode}`);
 
 		if (response.res.statusCode === 200) {
-			return new WebviewResourceResponse.StreamSuccess(response.stream, mime);
+			return new WebviewResourceResponse.StreamSuccess(response.stream, undefined, mime);
 		}
 		return WebviewResourceResponse.Failed;
 	}
@@ -82,7 +83,7 @@ export async function loadLocalResource(
 		const contents = await fileReader.readFileStream(resourceToLoad);
 		logService.debug(`loadLocalResource - Loaded using fileReader. requestUri=${requestUri}`);
 
-		return new WebviewResourceResponse.StreamSuccess(contents, mime);
+		return new WebviewResourceResponse.StreamSuccess(contents.stream, contents.etag, mime);
 	} catch (err) {
 		logService.debug(`loadLocalResource - Error using fileReader. requestUri=${requestUri}`);
 		console.log(err);

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -202,7 +202,7 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 				remoteConnectionData,
 				rewriteUri,
 			}, {
-				readFileStream: (resource) => this.fileService.readFileStream(resource).then(x => x.value),
+				readFileStream: (resource) => this.fileService.readFileStream(resource).then(x => ({ stream: x.value, etag: x.etag })),
 			}, this.requestService, this.logService);
 
 			if (result.type === WebviewResourceResponse.Type.Success) {

--- a/src/vs/workbench/contrib/webview/electron-sandbox/resourceLoading.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/resourceLoading.ts
@@ -111,7 +111,7 @@ export class WebviewResourceRequestManager extends Disposable {
 					roots: this._localResourceRoots,
 					remoteConnectionData: remoteConnectionData,
 				}, {
-					readFileStream: (resource) => fileService.readFileStream(resource).then(x => x.value),
+					readFileStream: (resource) => fileService.readFileStream(resource).then(x => ({ stream: x.value, etag: x.etag })),
 				}, requestService, this._logService);
 				this._logService.debug(`WebviewResourceRequestManager(${this.id}): finished resource load. uri: ${uri}, type=${response.type}`);
 


### PR DESCRIPTION
This PR fixes #65258.

~The tests are still WIP as I haven't been able to figure out how to run them.
Running `./scripts/test` ended with `errorlevel: 0`. `yarn run mocha --run extensions\markdown-language-features\src\test\engine.test.ts` failed as it could not find the javascript source. `yarn run mocha --run extensions\markdown-language-features\dist\test\engine.test.js` failed with "`exports` is not defined".~
After seeing the CI, I noticed that it is an integration test and then found the launch configuration of the markdown test.

Demo:
![Demo](https://user-images.githubusercontent.com/2931520/104091822-444b2900-5280-11eb-8350-1cd9e0579795.gif)

Key of this implementation is this code:
```ts
// NEW: Return both the html and a list of all images.
export interface RenderOutput {
  html: string;
  containingImages: { src: string }[];
}

// NEW: The context provides cache keys for images.
export interface RenderContext {
  /**
   * Each image is identified by its "src".
   * Two images with the same src but different cache keys must not share the
   * same cache entry.
   */
  imageCacheKeyBySrc?: ReadonlyMap</* src: */ string, string>;
}

class MarkdownEngine {
  ...
  // NEW: Accept context to get image cache keys.
  // NEW: Return RenderOutput rather than string to communicate the src of all images.
  public async render(input: SkinnyTextDocument | string, context: RenderContext = {}): Promise<RenderOutput> {
    ...
  }
  ...
}

...


class MarkdownPreview {
  ...
  private async updatePreview(forceUpdate?: boolean): Promise<void> {
    ...
    // NEW: Pass this._imageCacheKeysBySrc here and content is not a string anymore
    const content = await this._contentProvider.provideTextDocumentContent(document, this,
      this._previewConfigurations, this.line, this._imageCacheKeysBySrc, this.state);

    // Another call to `doUpdate` may have happened.
    // Make sure we are still updating for the correct document
    if (this.currentVersion?.equals(pendingVersion)) {
      this.setContent(content);
    }
  }
  ...

  private setContent(content: MarkdownContentProviderOutput): void {
    ...
    // NEW: Synchronize file watchers with (relative) images in markdown

    const srcs = new Set(content.containingImages.map(img => img.src));

    // Delete stale file watchers.
    for (const [src, watcher] of [...this._fileWatchersBySrc]) {
      if (!srcs.has(src)) {
        watcher.dispose();
        this._fileWatchersBySrc.delete(src);
      }
    }

    // Create new file watchers.
    const root = vscode.Uri.joinPath(this._resource, '../');
    for (const src of srcs) {
      const uri = urlToFileUri(src, root);
      if (uri && !this._fileWatchersBySrc.has(src)) {
        const watcher = vscode.workspace.createFileSystemWatcher(uri.fsPath);
        watcher.onDidChange(() => {
          this.currentCacheKeyOffset++;
          this._imageCacheKeysBySrc.set(src, `${this.currentCacheKeyOffset}`);
          this.refresh();
        });
        this._fileWatchersBySrc.set(src, watcher);
      }
    }
  }
  ...
}

```

