### PR TITLE
Set override to false when reopening editors after dragging them to a different editor group

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
+++ b/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
@@ -283,7 +283,8 @@ class DropOverlay extends Themable {
 					// Open in target group
 					const options = getActiveTextEditorOptions(sourceGroup, draggedEditor.editor, EditorOptions.create({
 						pinned: true,										// always pin dropped editor
-						sticky: sourceGroup.isSticky(draggedEditor.editor)	// preserve sticky state
+						sticky: sourceGroup.isSticky(draggedEditor.editor),	// preserve sticky state
+						override: false, // Use `draggedEditor.editor` as is. If it is already a custom editor, it will stay so.
 					}));
 					const copyEditor = this.isCopyOperation(event, draggedEditor);
 					targetGroup.openEditor(draggedEditor.editor, options, copyEditor ? OpenEditorContext.COPY_EDITOR : OpenEditorContext.MOVE_EDITOR);


### PR DESCRIPTION
This seems to fix #109000.

![4e19bbb3-0e7c-412b-8630-b0ccedcd4759](https://user-images.githubusercontent.com/2931520/104110812-9705fe80-52db-11eb-94ff-0d4bbc06669d.gif)


Apparently this also prevents custom editor webviews from being recreated when they are moved to a different editor group 🎉
This is the behavior without this patch (notice the slow loading times):

![664eda65-2ca7-4d0c-8e3c-413734cd86a4](https://user-images.githubusercontent.com/2931520/104110797-645c0600-52db-11eb-851e-f8686732b181.gif)

This is with this patch (no loading times anymore *at all*):

![47e10a5c-9b4b-4744-b1e4-b14fda1fa5e8](https://user-images.githubusercontent.com/2931520/104110801-6de56e00-52db-11eb-9a07-1989ca97251d.gif)

It seems like this enables all webviews to be dragged around with zero costs which would be super awesome 😮

![webview](https://user-images.githubusercontent.com/2931520/104110806-7fc71100-52db-11eb-8736-57d20a6b318d.gif)

This was not that smooth before - the entire webview used to reload!


I only understand a tiny fraction of the custom editor logic, so this fix might have undesired consequences though.

#### Off-topic

It seems to me that the custom editor contribution is very complicated. I found the override mechanism to be hard to follow and to debug and after some debug sessions, I thought #109000 was nothing that could be easily fixed by the community.

From my understanding, this is a part of the control flow when a new custom editor is opened:
1. `DelegatingEditorService.openEditor` is called by the UI and calls
2. `EditorGroupView.openEditor` which triggers the event `EditorGroupView.onWillOpenEditor` and thus the listener
3. `EditorService.onGroupWillOpenEditor`, which notifies all open editor handlers, including
4. `CustomEditorContribution.onEditorOpening/.onResourceEditorOpening`, which calls
5. `CustomEditorService.openWith/.openEditorForResource`, which calls
6. `EditorService.openEditor` which calls then again (recursively, see (2), but with different arguments)
7. `EditorGroupView.openEditor` which again triggers the `EditorGroupView.onWillOpenEditor` event and the listener
8. `EditorService.onGroupWillOpenEditor`, which notifies all open editor handlers again, again including
9. `CustomEditorContribution.onEditorOpening`, which stops, as the editor already is a `CustomEditorInput`.

If I got it correctly, a `FileEditorInput` is always created in this scenario, and sometimes, custom editors prevent the file editor from being rendered by creating their own `CustomEditorInput` and recursively calling `EditorService.openEditor` to show this input.
I'm curious (with my very limited understanding) - what is the advantage of this design over just having default editors and custom editors both being specializations of some abstract editor view? This would get rid of the recursion. I don't find it trivial at all that a simple `override: false` fixes this issue.
