### PR TITLE
Fix 100725: Allow empty repositories to be synced

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2054,6 +2054,36 @@ export class Repository {
 			return branch;
 		}
 
+		try {
+			let res4 = await this.exec(['config', '--get', 'branch.' + name + '.remote']);
+
+			if (!res4.stdout) {
+				throw new Error(`Could not fetch remote of ${name}`);
+			}
+
+			const remote = res4.stdout.trim();
+			res4 = await this.exec(['config', '--get', 'branch.' + name + '.merge']);
+
+			if (!res4.stdout) {
+				throw new Error(`Could not fetch remote branch name of ${name}`);
+			}
+
+			const longRemoteName = res4.stdout.trim();
+			const match = /^refs\/heads\/([^/]+)$/.exec(longRemoteName);
+
+			if (!match) {
+				throw new Error(`Could not parse upstream remote name: ${longRemoteName}`);
+			}
+
+			return {
+				name,
+				type: RefType.Head,
+				upstream: { remote: remote, name: match[1] }
+			};
+		} catch (err) {
+			// noop
+		}
+
 		return Promise.reject<Branch>(new Error('No such branch'));
 	}
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2054,21 +2054,18 @@ export class Repository {
 			return branch;
 		}
 
+		// for-each-ref will fail for repositories without a commit (i.e. empty repositories)
 		try {
-			let res4 = await this.exec(['config', '--get', 'branch.' + name + '.remote']);
+			const result2 = await this.exec(['config', '--get', 'branch.' + name + '.remote']);
+			const result3 = await this.exec(['config', '--get', 'branch.' + name + '.merge']);
 
-			if (!res4.stdout) {
-				throw new Error(`Could not fetch remote of ${name}`);
+			if (!result2.stdout || !result3.stdout) {
+				throw new Error(`Could not fetch remote (branch) of ${name}`);
 			}
 
-			const remote = res4.stdout.trim();
-			res4 = await this.exec(['config', '--get', 'branch.' + name + '.merge']);
+			const remote = result2.stdout.trim();
 
-			if (!res4.stdout) {
-				throw new Error(`Could not fetch remote branch name of ${name}`);
-			}
-
-			const longRemoteName = res4.stdout.trim();
+			const longRemoteName = result3.stdout.trim();
 			const match = /^refs\/heads\/([^/]+)$/.exec(longRemoteName);
 
 			if (!match) {

--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -140,7 +140,7 @@ class SyncStatusBar {
 		let command = '';
 		let tooltip = '';
 
-		if (HEAD && HEAD.name && HEAD.commit) {
+		if (HEAD && HEAD.name) {
 			if (HEAD.upstream) {
 				if (HEAD.ahead || HEAD.behind) {
 					text += this.repository.syncLabel;
@@ -151,7 +151,7 @@ class SyncStatusBar {
 
 				command = rebaseWhenSync ? 'git.syncRebase' : 'git.sync';
 				tooltip = this.repository.syncTooltip;
-			} else {
+			} else if (HEAD.commit) {
 				icon = '$(cloud-upload)';
 				command = 'git.publish';
 				tooltip = localize('publish changes', "Publish Changes");


### PR DESCRIPTION
This PR fixes #100725 and allows VSCode to properly sync git repositories that have been cloned before there were any commits.

### Reproducing and Testing
To test it, I have attached a zip file with an empty git repository that now has commits (i.e. should be syncable). 

1. Download and unpack this repository [empty.zip](https://github.com/microsoft/vscode/files/5797407/empty.zip).
If you feel uncomfortable downloading files from strangers, see below for git commands to simulate this state.
2. Open the folder in VSCode.
3. With the current version of VSCode (as seen in the gif in the issue https://github.com/microsoft/vscode/issues/100725#issuecomment-648862773), the git repository cannot be synced. Manually executing the command `git pull` works just fine. 
With the proposed fix, clicking the sync button works and syncs the repository as intended.  

### Proposed Changes
As described in the issue (#100725), the root cause is that the command used to fetch the upstream (`git rev-parse`) fails on an empty repository. This then causes this unexpected behavior. 

I propose the following changes to resolve the issue:

`extensions/git/src/git.ts` method: `getBranch(...)`
1. **Wrap fetching the latest commit in a try-catch**
Although the commit cannot be fetched for an empty repository, without this catch the function is exited. The commit should be left undefined, while still properly fetching the upstream.
2. **Fetch the upstream via the git.config**
Once a branch has an upstream, it will be stored in the git config. Unfortunately, this command uses an older syntax of git, so we have to manually construct the full upstream path. See this [stackoverflow post](https://stackoverflow.com/questions/43317872/understanding-git-configs-remote-and-branch-sections/43318586#43318586) for more information about this section of the git config. 

`extensions/git/src/statusbar.ts` method: `command()`
3. **Do not require commit for syncing**
Syncing a repository does not require a commit, whereas publishing does (git does not allow pushing branches without a history). 
In combination with the proposed changes above, this makes the sync button clickable.

<br>

You might feel uncomfortable changing from `git-rev` to `git-config` in all cases. Although I strongly believe that this should not be a problem and did not cause any issues whatsoever in my tests: If you feel so, I am open for discussion. In the worst case, I can revert the last commit and we use `git-config` as a fallback. This can be seen in this commit: https://github.com/microsoft/vscode/commit/4f3d47ce10f830c06cf13cac1a9d181a924f2e62
Personally, I would prefer the current changes.

### Simulate a freshly cloned empty git repo
    mkdir empty
    cd empty
    git init
    
    # Add some origin, you can use any repo, but this is very small
    git remote add origin https://github.com/plainerman/empty.git
    
    # Now track master as described in here https://stackoverflow.com/a/625460/4417954
    git config branch.master.remote origin
    git config branch.master.merge refs/heads/master