### PR TITLE
Fix arch check for PowerShell enumeration

### DIFF
--- a/src/vs/base/node/powershell.ts
+++ b/src/vs/base/node/powershell.ts
@@ -19,7 +19,7 @@ const PwshPreviewMsixRegex: RegExp = /^Microsoft.PowerShellPreview_.*/;
 
 // The platform details descriptor for the platform we're on
 const isProcess64Bit: boolean = process.arch === 'x64';
-const isOS64Bit: boolean = isProcess64Bit || env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
+const isOS64Bit: boolean = isProcess64Bit || os.arch() === 'x64';
 
 export interface IPowerShellExeDetails {
 	readonly displayName: string;

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -39,16 +39,15 @@ if (platform.isWindows) {
 			checkPath(exePath!);
 		});
 
-		test('Can enumerate PowerShells', async () => { // https://github.com/microsoft/vscode/issues/114248
+		test('Can enumerate PowerShells', async () => {
+			const isOS64Bit = os.arch() === 'x64';
 			const pwshs = new Array<IPowerShellExeDetails>();
 			for await (const p of enumeratePowerShellInstallations()) {
 				pwshs.push(p);
 			}
 
-			// In Azure DevOps and GitHub Actions there should be an extra PowerShell since PowerShell 7 comes pre-installed
-			const minNumberOfPowerShells = process.env.TF_BUILD || process.env.CI ? 3 : 2;
-
-			assert.strictEqual(pwshs.length >= minNumberOfPowerShells, true, 'Found these PowerShells:\n' + pwshs.map(p => `${p.displayName}: ${p.exePath}`).join('\n'));
+			const powershellLog = 'Found these PowerShells:\n' + pwshs.map(p => `${p.displayName}: ${p.exePath}`).join('\n');
+			assert.strictEqual(pwshs.length >= (isOS64Bit ? 2 : 1), true, powershellLog);
 
 			for (const pwsh of pwshs) {
 				checkPath(pwsh.exePath);
@@ -61,23 +60,23 @@ if (platform.isWindows) {
 			// 64bit process on 64bit OS
 			if (process.arch === 'x64') {
 				checkPath(pwshs[secondToLastIndex].exePath);
-				assert.strictEqual(pwshs[secondToLastIndex].displayName, 'Windows PowerShell');
+				assert.strictEqual(pwshs[secondToLastIndex].displayName, 'Windows PowerShell', powershellLog);
 
 				checkPath(pwshs[lastIndex].exePath);
-				assert.strictEqual(pwshs[lastIndex].displayName, 'Windows PowerShell (x86)');
-			} else if (os.arch() === 'x64') {
+				assert.strictEqual(pwshs[lastIndex].displayName, 'Windows PowerShell (x86)', powershellLog);
+			} else if (isOS64Bit) {
 				// 32bit process on 64bit OS
 
 				// Windows PowerShell x86 comes first if vscode is 32bit
 				checkPath(pwshs[secondToLastIndex].exePath);
-				assert.strictEqual(pwshs[secondToLastIndex].displayName, 'Windows PowerShell (x86)');
+				assert.strictEqual(pwshs[secondToLastIndex].displayName, 'Windows PowerShell (x86)', powershellLog);
 
 				checkPath(pwshs[lastIndex].exePath);
-				assert.strictEqual(pwshs[lastIndex].displayName, 'Windows PowerShell');
+				assert.strictEqual(pwshs[lastIndex].displayName, 'Windows PowerShell', powershellLog);
 			} else {
 				// 32bit or ARM process
 				checkPath(pwshs[lastIndex].exePath);
-				assert.strictEqual(pwshs[lastIndex].displayName, 'Windows PowerShell (x86)');
+				assert.strictEqual(pwshs[lastIndex].displayName, 'Windows PowerShell (x86)', powershellLog);
 			}
 		});
 	});

--- a/src/vs/base/test/node/powershell.test.ts
+++ b/src/vs/base/test/node/powershell.test.ts
@@ -39,7 +39,7 @@ if (platform.isWindows) {
 			checkPath(exePath!);
 		});
 
-		test.skip('Can enumerate PowerShells', async () => { // https://github.com/microsoft/vscode/issues/114248
+		test('Can enumerate PowerShells', async () => { // https://github.com/microsoft/vscode/issues/114248
 			const pwshs = new Array<IPowerShellExeDetails>();
 			for await (const p of enumeratePowerShellInstallations()) {
 				pwshs.push(p);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #114248

We used the wrong check for architecture.

Additionally, on some AzDO instances PowerShell Core is not installed so we can't make that assuption anymore... so this also fixes the test to not make that assuption.