### PR TITLE
Adding workaround for images rendering from root folder

### DIFF
--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -246,6 +246,7 @@ export class MarkdownEngine {
 								scheme: uri.scheme,
 								fragment: uri.fragment,
 								query: uri.query,
+								path: '/file' + fileUri.path
 							});
 						}
 					}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #110812

To test use repro steps from the issue:

> Steps to Reproduce:
> 
> git clone git@github.com:vsudakov/issues_vscode_1_40_0_markdownPreviewRootRelativeImg.git
> cd issues_vscode_1_40_0_markdownPreviewRootRelativeImg
> code .
> Image doesn't display in readme.md:
> ![image](https://user-images.githubusercontent.com/3524380/104724692-5110c680-5731-11eb-84f6-3916b1b7a260.png)


