### PR TITLE
FileService improvements

### DIFF
--- a/src/vs/base/test/common/stream.test.ts
+++ b/src/vs/base/test/common/stream.test.ts
@@ -106,6 +106,8 @@ suite('Stream', () => {
 		error = false;
 		stream.removeListener('error', errorListener);
 
+		// always leave at least one error listener to streams to avoid unexpected errors during test running
+		stream.on('error', () => { });
 		stream.error(new Error());
 		assert.equal(error, false);
 	});

--- a/src/vs/base/test/common/stream.test.ts
+++ b/src/vs/base/test/common/stream.test.ts
@@ -335,16 +335,19 @@ suite('Stream', () => {
 		assert.equal(consumed, '11,22,33,44,55');
 	});
 
-	test('Events are not delivered if a listener is removed during delivery', () => {
+	test('events are delivered even if a listener is removed during delivery', () => {
 		const stream = newWriteableStream<string>(strings => strings.join());
+
 		let listener1Called = false;
 		let listener2Called = false;
+
 		const listener1 = () => { stream.removeListener('end', listener1); listener1Called = true; };
 		const listener2 = () => { listener2Called = true; };
 		stream.on('end', listener1);
 		stream.on('end', listener2);
 		stream.on('data', () => { });
 		stream.end('');
+
 		assert.strictEqual(listener1Called, true);
 		assert.strictEqual(listener2Called, true);
 	});

--- a/src/vs/base/test/common/stream.test.ts
+++ b/src/vs/base/test/common/stream.test.ts
@@ -332,4 +332,18 @@ suite('Stream', () => {
 		const consumed = await consumeStream(result, strings => strings.join());
 		assert.equal(consumed, '11,22,33,44,55');
 	});
+
+	test('Events are not delivered if a listener is removed during delivery', () => {
+		const stream = newWriteableStream<string>(strings => strings.join());
+		let listener1Called = false;
+		let listener2Called = false;
+		const listener1 = () => { stream.removeListener('end', listener1); listener1Called = true; };
+		const listener2 = () => { listener2Called = true; };
+		stream.on('end', listener1);
+		stream.on('end', listener2);
+		stream.on('data', () => { });
+		stream.end('');
+		assert.strictEqual(listener1Called, true);
+		assert.strictEqual(listener2Called, true);
+	});
 });

--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -454,7 +454,6 @@ export class FileService extends Disposable implements IFileService {
 			throw error;
 		});
 
-		let fileStream: VSBufferReadableStream | undefined = undefined;
 		let fileStreamObserver: IReadableStreamObservable | undefined = undefined;
 
 		try {
@@ -466,6 +465,8 @@ export class FileService extends Disposable implements IFileService {
 			if (options && typeof options.etag === 'string' && options.etag !== ETAG_DISABLED) {
 				await statPromise;
 			}
+
+			let fileStream: VSBufferReadableStream | undefined = undefined;
 
 			// read unbuffered (only if either preferred, or the provider has no buffered read capability)
 			if (!(hasOpenReadWriteCloseCapability(provider) || hasFileReadStreamCapability(provider)) || (hasReadWriteCapability(provider) && options?.preferUnbuffered)) {

--- a/src/vs/platform/files/common/io.ts
+++ b/src/vs/platform/files/common/io.ts
@@ -58,10 +58,10 @@ async function doReadFileIntoStream<T>(provider: IFileSystemProviderWithOpenRead
 	// open handle through provider
 	const handle = await provider.open(resource, { create: false });
 
-	// Check for cancellation
-	throwIfCancelled(token);
-
 	try {
+		// Check for cancellation
+		throwIfCancelled(token);
+
 		let totalBytesRead = 0;
 		let bytesRead = 0;
 		let allowedRemainingBytes = (options && typeof options.length === 'number') ? options.length : undefined;

--- a/src/vs/platform/files/common/io.ts
+++ b/src/vs/platform/files/common/io.ts
@@ -59,6 +59,7 @@ async function doReadFileIntoStream<T>(provider: IFileSystemProviderWithOpenRead
 	const handle = await provider.open(resource, { create: false });
 
 	try {
+
 		// Check for cancellation
 		throwIfCancelled(token);
 


### PR DESCRIPTION
Fixes #114024

* Fix case where a file handle could be left opened if cancellation was requested between the file open and the first file read.
* Wait for the `fileStream` to close before throwing a `FileOperationError`.
* Add test and fix problem where removing a listener during event delivery would cause subsequent listeners to not be invoked.
* Report any errors that are not listened to in stream to `onUnexpectedError`.