### PR TITLE
Fix #111299

### DIFF
--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -28,8 +28,7 @@ if (!/yarn[\w-.]*\.js$|yarnpkg$/.test(process.env['npm_execpath'])) {
 	err = true;
 }
 
-const os = process.platform;
-if (os === 'win32') {
+if (process.platform === 'win32') {
 	if (!hasSupportedVisualStudioVersion()) {
 		console.error('\033[1;31m*** Invalid C/C++ Compiler Toolchain. Please check https://github.com/microsoft/vscode/wiki/How-to-Contribute.\033[0;0m');
 		err = true;


### PR DESCRIPTION
This PR fixes #111299 by adding some steps to check if the user has VS 2017 or VS 2019 installed on Windows.
