### PR TITLE
Fix issue #114473

### DIFF
--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -318,7 +318,8 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 
 					default:
 						try {
-							return this.resolveFromMap(match, variable, commandValueMapping, undefined);
+							const key = argument ? `${variable}:${argument}` : variable;
+							return this.resolveFromMap(match, key, commandValueMapping, undefined);
 						} catch (error) {
 							return match;
 						}


### PR DESCRIPTION
This PR fixes #114473

The string `${abc:test} ${abc}` would result in `commandValueMapping` having:
```json
{
    "abc": "${abc}",
    "abc:test": "${abc:test}"
}
```
where `resolveFromMap` would get `"abc"` for both variables, resulting in `${abc:test}` being replaced with `${abc}`, disregarding the splitting of `abc:test` into `['abc', 'test']` that happened beforehand.

This PR makes the call to `resolveFromMap` recreate the original variable (`"abc:test"`) to pass to it. Running the example code in the mentioned issue with this fix produces the following output:
```
> Executing task: ABC <

Original: echo '${workspaceFolderBasename}' '${def:arg}' '${abc:test}' '${abc}' '${abc:def}' '${xyz:123}' '${xyz:456}'
Resolved: echo 'Empty workspace' '${def:arg}' '${abc:test}' '${abc}' '${abc:def}' '${xyz:123}' '${xyz:456}'

Terminal will be reused by tasks, press any key to close it.
```
The `${abc:test}` remains `${abc:test}`, unlike before where it would've been "resolved" to `${abc}` instead.