### PR TITLE
Fix: selecting entry should focus back to editor

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -717,10 +717,7 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 				info.mode = withNullAsUndefined(this.modeService.getLanguageName(modeId));
 			}
 		}
-		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
-		if (!activeTextEditorControl?.hasWidgetFocus()) {
-			activeTextEditorControl?.focus();
-		}
+
 		this.updateState(info);
 	}
 
@@ -1138,6 +1135,9 @@ export class ChangeModeAction extends Action {
 		const pick = await this.quickInputService.pick(picks, { placeHolder: nls.localize('pickLanguage', "Select Language Mode"), matchOnDescription: true });
 		if (!pick) {
 			return;
+		}
+		if (!activeTextEditorControl.hasWidgetFocus()) {
+			activeTextEditorControl.focus();
 		}
 
 		if (pick === galleryAction) {

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -586,6 +586,12 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 		this.updateEOLElement(this.state.EOL ? this.state.EOL === '\r\n' ? nlsEOLCRLF : nlsEOLLF : undefined);
 		this.updateModeElement(this.state.mode);
 		this.updateMetadataElement(this.state.metadata);
+
+		// Fix #106824
+		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
+		if (!activeTextEditorControl?.hasWidgetFocus()) {
+			activeTextEditorControl?.focus();
+		}
 	}
 
 	private getSelectionLabel(info: IEditorSelectionStatus): string | undefined {
@@ -1135,9 +1141,6 @@ export class ChangeModeAction extends Action {
 		const pick = await this.quickInputService.pick(picks, { placeHolder: nls.localize('pickLanguage', "Select Language Mode"), matchOnDescription: true });
 		if (!pick) {
 			return;
-		}
-		if (!activeTextEditorControl.hasWidgetFocus()) {
-			activeTextEditorControl.focus();
 		}
 
 		if (pick === galleryAction) {

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -1137,11 +1137,6 @@ export class ChangeModeAction extends Action {
 			return;
 		}
 
-		// refocus to editor if editor were not foucused
-		if (!activeTextEditorControl.hasWidgetFocus()) {
-			activeTextEditorControl.focus();
-		}
-
 		if (pick === galleryAction) {
 			galleryAction.run();
 			return;
@@ -1185,6 +1180,8 @@ export class ChangeModeAction extends Action {
 					modeSupport.setMode(languageSelection.languageIdentifier.language);
 				}
 			}
+
+			activeTextEditorControl.focus();
 		}
 	}
 
@@ -1283,10 +1280,7 @@ export class ChangeEOLAction extends Action {
 			}
 		}
 
-		// refocus to editor if editor were not foucused
-		if (!activeTextEditorControl.hasWidgetFocus()) {
-			activeTextEditorControl.focus();
-		}
+		activeTextEditorControl.focus();
 	}
 }
 
@@ -1308,7 +1302,8 @@ export class ChangeEncodingAction extends Action {
 	}
 
 	async run(): Promise<void> {
-		if (!getCodeEditor(this.editorService.activeTextEditorControl)) {
+		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
+		if (!activeTextEditorControl) {
 			await this.quickInputService.pick([{ label: nls.localize('noEditor', "No text editor active at this time") }]);
 			return;
 		}
@@ -1427,10 +1422,6 @@ export class ChangeEncodingAction extends Action {
 			activeEncodingSupport.setEncoding(encoding.id, isReopenWithEncoding ? EncodingMode.Decode : EncodingMode.Encode); // Set new encoding
 		}
 
-		// refocus to editor if editor were not foucused
-		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
-		if (!activeTextEditorControl?.hasWidgetFocus()) {
-			activeTextEditorControl?.focus();
-		}
+		activeTextEditorControl.focus();
 	}
 }

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -717,7 +717,10 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 				info.mode = withNullAsUndefined(this.modeService.getLanguageName(modeId));
 			}
 		}
-
+		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
+		if (!activeTextEditorControl?.hasWidgetFocus()) {
+			activeTextEditorControl?.focus();
+		}
 		this.updateState(info);
 	}
 

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -586,12 +586,6 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 		this.updateEOLElement(this.state.EOL ? this.state.EOL === '\r\n' ? nlsEOLCRLF : nlsEOLLF : undefined);
 		this.updateModeElement(this.state.mode);
 		this.updateMetadataElement(this.state.metadata);
-
-		// Fix #106824
-		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
-		if (!activeTextEditorControl?.hasWidgetFocus()) {
-			activeTextEditorControl?.focus();
-		}
 	}
 
 	private getSelectionLabel(info: IEditorSelectionStatus): string | undefined {
@@ -1143,6 +1137,11 @@ export class ChangeModeAction extends Action {
 			return;
 		}
 
+		// refocus to editor if editor were not foucused
+		if (!activeTextEditorControl.hasWidgetFocus()) {
+			activeTextEditorControl.focus();
+		}
+
 		if (pick === galleryAction) {
 			galleryAction.run();
 			return;
@@ -1283,6 +1282,11 @@ export class ChangeEOLAction extends Action {
 				textModel.pushStackElement();
 			}
 		}
+
+		// refocus to editor if editor were not foucused
+		if (!activeTextEditorControl.hasWidgetFocus()) {
+			activeTextEditorControl.focus();
+		}
 	}
 }
 
@@ -1421,6 +1425,12 @@ export class ChangeEncodingAction extends Action {
 		const activeEncodingSupport = toEditorWithEncodingSupport(this.editorService.activeEditorPane.input);
 		if (typeof encoding.id !== 'undefined' && activeEncodingSupport && activeEncodingSupport.getEncoding() !== encoding.id) {
 			activeEncodingSupport.setEncoding(encoding.id, isReopenWithEncoding ? EncodingMode.Decode : EncodingMode.Encode); // Set new encoding
+		}
+
+		// refocus to editor if editor were not foucused
+		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
+		if (!activeTextEditorControl?.hasWidgetFocus()) {
+			activeTextEditorControl?.focus();
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #106824

If active editor wasn't focused after selection, then manually focus editor.