### PR TITLE
Polyfil test heirarchies

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
 			"restart": true,
 			"name": "Attach to Extension Host",
 			"timeout": 30000,
-			"port": 5870,
+			"port": 5555,
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js",
 				"${workspaceFolder}/extensions/*/out/**/*.js"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
 			"restart": true,
 			"name": "Attach to Extension Host",
 			"timeout": 30000,
-			"port": 5555,
+			"port": 5870,
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js",
 				"${workspaceFolder}/extensions/*/out/**/*.js"

--- a/src/vs/workbench/api/common/extHostTesting.ts
+++ b/src/vs/workbench/api/common/extHostTesting.ts
@@ -237,16 +237,45 @@ export class ExtHostTesting implements ExtHostTestingShape {
 		const onDidChangeTest = new Emitter<vscode.TestItem>();
 		workspaceHierarchy.onDidChangeTest(node => {
 			const wrapper = TestItemFilteredWrapper.getWrapperForTestItem(node, document.uri);
-			if (wrapper.doesHaveNodeMatchingFilter(true)) {
-				onDidChangeTest.fire(wrapper);
-			} else {
+			const previouslySeen = wrapper.hasNodeMatchingFilter;
+
+			if (previouslySeen) {
+				// reset cache and get whether you can currently see the TestItem.
+				wrapper.reset();
+				const currentlySeen = wrapper.hasNodeMatchingFilter;
+
+				if (currentlySeen) {
+					onDidChangeTest.fire(wrapper);
+					return;
+				}
+
+				// Fire the event to say that the current visible parent has changed.
 				onDidChangeTest.fire(wrapper.visibleParent);
+				return;
 			}
+
+			const previousParent = wrapper.visibleParent;
+			wrapper.reset();
+			const currentlySeen = wrapper.hasNodeMatchingFilter;
+
+			// It wasn't previously seen and isn't currently seen so
+			// nothing has actually changed.
+			if (!currentlySeen) {
+				return;
+			}
+
+			// The test is now visible so we need to refresh the cache
+			// of the previous visible parent and fire that it has changed.
+			previousParent.reset();
+			onDidChangeTest.fire(previousParent);
 		});
 
 		return {
 			root: TestItemFilteredWrapper.getWrapperForTestItem(workspaceHierarchy.root, document.uri),
-			dispose: () => onDidChangeTest.dispose(),
+			dispose: () => {
+				onDidChangeTest.dispose();
+				TestItemFilteredWrapper.removeFilter(document.uri);
+			},
 			onDidChangeTest: onDidChangeTest.event
 		};
 	}
@@ -257,15 +286,26 @@ export class ExtHostTesting implements ExtHostTestingShape {
  * to only the children that are located in a certain vscode.Uri.
  */
 class TestItemFilteredWrapper implements vscode.TestItem {
-	private static wrapperMap = new WeakMap<vscode.TestItem, TestItemFilteredWrapper>();
+	private static wrapperMap = new WeakMap<vscode.Uri, WeakMap<vscode.TestItem, TestItemFilteredWrapper>>();
+	public static removeFilter(uri: vscode.Uri): void {
+		this.wrapperMap.delete(uri);
+	}
 
 	// Wraps the TestItem specified in a TestItemFilteredWrapper and pulls from a cache if it already exists.
-	public static getWrapperForTestItem(item: vscode.TestItem, filterToUri: vscode.Uri, parent?: TestItemFilteredWrapper) {
-		if (TestItemFilteredWrapper.wrapperMap.has(item)) {
-			return TestItemFilteredWrapper.wrapperMap.get(item)!;
+	public static getWrapperForTestItem(item: vscode.TestItem, filterToUri: vscode.Uri, parent?: TestItemFilteredWrapper): TestItemFilteredWrapper {
+		let innerMap = this.wrapperMap.get(filterToUri);
+		if (innerMap?.has(item)) {
+			return innerMap.get(item)!;
 		}
+
+		if (!innerMap) {
+			innerMap = new WeakMap<vscode.TestItem, TestItemFilteredWrapper>();
+			this.wrapperMap.set(filterToUri, innerMap);
+
+		}
+
 		const w = new TestItemFilteredWrapper(item, filterToUri, parent);
-		TestItemFilteredWrapper.wrapperMap.set(item, w);
+		innerMap.set(item, w);
 		return w;
 	}
 
@@ -295,32 +335,41 @@ class TestItemFilteredWrapper implements vscode.TestItem {
 
 	public get children() {
 		// We only want children that match the filter.
-		return this.getWrappedChildren().filter(child => child.doesHaveNodeMatchingFilter());
+		return this.getWrappedChildren().filter(child => child.hasNodeMatchingFilter);
 	}
 
 	public get visibleParent(): TestItemFilteredWrapper {
-		return this.doesHaveNodeMatchingFilter() ? this : this.parent!.visibleParent;
+		return this.hasNodeMatchingFilter ? this : this.parent!.visibleParent;
 	}
 
-	private readonly matchesUri: boolean;
-	private hasNodeMatchingFilter: boolean | undefined;
+	private matchesFilter: boolean | undefined;
 
 	// Determines if the TestItem matches the filter. This would be true if:
 	// 1. We don't have a parent (because the root is the workspace root node)
 	// 2. The URI of the current node matches the filter URI
 	// 3. Some child of the current node matches the filter URI
-	public doesHaveNodeMatchingFilter(forceEvaluation?: boolean): boolean {
-		if (forceEvaluation || this.hasNodeMatchingFilter === undefined) {
-			this.hasNodeMatchingFilter = !this.parent
-				|| this.matchesUri
-				|| this.getWrappedChildren().some(child => child.doesHaveNodeMatchingFilter());
+	public get hasNodeMatchingFilter(): boolean {
+		if (this.matchesFilter === undefined) {
+			this.matchesFilter = !this.parent
+				|| this.actual.location?.uri.toString() === this.filterToUri.toString()
+				|| this.getWrappedChildren().some(child => child.hasNodeMatchingFilter);
 		}
 
-		return this.hasNodeMatchingFilter;
+		return this.matchesFilter;
+	}
+
+	// Reset the cache of whether or not you can see a node from a particular node
+	// up to it's visible parent.
+	public reset(): void {
+		if (this === this.visibleParent) {
+			this.matchesFilter = undefined;
+		} else {
+			this.parent?.reset();
+			this.matchesFilter = undefined;
+		}
 	}
 
 	constructor(public readonly actual: vscode.TestItem, private filterToUri: vscode.Uri, private readonly parent?: TestItemFilteredWrapper) {
-		this.matchesUri = this.actual.location?.uri.toString() === this.filterToUri.toString();
 		this.getWrappedChildren();
 	}
 

--- a/src/vs/workbench/api/common/extHostTesting.ts
+++ b/src/vs/workbench/api/common/extHostTesting.ts
@@ -285,7 +285,7 @@ export class ExtHostTesting implements ExtHostTestingShape {
  * A class which wraps a vscode.TestItem that provides the ability to filter a TestItem's children
  * to only the children that are located in a certain vscode.Uri.
  */
-class TestItemFilteredWrapper implements vscode.TestItem {
+export class TestItemFilteredWrapper implements vscode.TestItem {
 	private static wrapperMap = new WeakMap<vscode.Uri, WeakMap<vscode.TestItem, TestItemFilteredWrapper>>();
 	public static removeFilter(uri: vscode.Uri): void {
 		this.wrapperMap.delete(uri);
@@ -369,7 +369,7 @@ class TestItemFilteredWrapper implements vscode.TestItem {
 		}
 	}
 
-	constructor(public readonly actual: vscode.TestItem, private filterToUri: vscode.Uri, private readonly parent?: TestItemFilteredWrapper) {
+	private constructor(public readonly actual: vscode.TestItem, private filterToUri: vscode.Uri, private readonly parent?: TestItemFilteredWrapper) {
 		this.getWrappedChildren();
 	}
 

--- a/src/vs/workbench/test/browser/api/extHostTesting.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostTesting.test.ts
@@ -4,12 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { MirroredTestCollection } from 'vs/workbench/api/common/extHostTesting';
+import { MirroredTestCollection, TestItemFilteredWrapper } from 'vs/workbench/api/common/extHostTesting';
 import * as convert from 'vs/workbench/api/common/extHostTypeConverters';
 import { TestDiffOpType } from 'vs/workbench/contrib/testing/common/testCollection';
 import { stubTest, testStubs } from 'vs/workbench/contrib/testing/common/testStubs';
 import { TestOwnedTestCollection, TestSingleUseCollection } from 'vs/workbench/contrib/testing/test/common/ownedTestCollection';
 import { TestChangeEvent, TestItem } from 'vscode';
+import { URI } from 'vs/base/common/uri';
+import { Location } from 'vs/editor/common/modes';
+import { Range } from 'vs/editor/common/core/range';
 
 const simplify = (item: TestItem) => {
 	if ('toJSON' in item) {
@@ -260,6 +263,140 @@ suite('ExtHost Testing', () => {
 				m.apply(single.collectDiff());
 
 				assert.strictEqual(m.changeEvent.commonChangeAncestor?.label, 'root');
+			});
+		});
+
+		suite('TestItemFilteredWrapper', () => {
+			const stubTestWithLocation = (label: string, location: Location): TestItem => {
+				const t = stubTest(label);
+				t.location = location as any;
+				return t;
+			};
+
+			const location1: Location = {
+				range: new Range(0, 0, 0, 0),
+				uri: URI.parse('file:///foo.ts')
+			};
+
+			const location2: Location = {
+				range: new Range(0, 0, 0, 0),
+				uri: URI.parse('file:///bar.ts')
+			};
+
+			const location3: Location = {
+				range: new Range(0, 0, 0, 0),
+				uri: URI.parse('file:///baz.ts')
+			};
+
+			let testsWithLocation: TestItem;
+			setup(() => {
+				testsWithLocation = {
+					...stubTest('root'),
+					children: [
+						{
+							...stubTestWithLocation('a', location1),
+							children: [stubTestWithLocation('aa', location1), stubTestWithLocation('ab', location1)]
+						},
+						{
+							...stubTestWithLocation('b', location2),
+							children: [stubTestWithLocation('ba', location2), stubTestWithLocation('bb', location2)]
+						},
+						{
+							...stubTestWithLocation('b', location3),
+						}
+					],
+				};
+			});
+
+			teardown(() => {
+				TestItemFilteredWrapper.removeFilter(location1.uri);
+				TestItemFilteredWrapper.removeFilter(location2.uri);
+				TestItemFilteredWrapper.removeFilter(location3.uri);
+			});
+
+			test('gets all actual properties', () => {
+				const testItem: TestItem = stubTest('test1');
+				const wrapper: TestItemFilteredWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testItem, location1.uri);
+
+				assert.strictEqual(testItem.debuggable, wrapper.debuggable);
+				assert.strictEqual(testItem.description, wrapper.description);
+				assert.strictEqual(testItem.label, wrapper.label);
+				assert.strictEqual(testItem.location, wrapper.location);
+				assert.strictEqual(testItem.runnable, wrapper.runnable);
+				assert.strictEqual(testItem.state, wrapper.state);
+			});
+
+			test('gets no children if nothing matches Uri filter', () => {
+				let tests: TestItem = testStubs.nested();
+				const wrapper = TestItemFilteredWrapper.getWrapperForTestItem(tests, location1.uri);
+				assert.strictEqual(wrapper.children.length, 0);
+			});
+
+			test('filter is applied to children', () => {
+				const wrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, location1.uri);
+				assert.strictEqual(wrapper.label, 'root');
+				assert.strictEqual(wrapper.children.length, 1);
+				assert.strictEqual(wrapper.children[0] instanceof TestItemFilteredWrapper, true);
+				assert.strictEqual(wrapper.children[0].label, 'a');
+			});
+
+			test('can get if node has matching filter', () => {
+				const rootWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, location1.uri);
+
+				const invisible = testsWithLocation.children![1];
+				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, location1.uri);
+				const visible = testsWithLocation.children![0];
+				const visibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(visible, location1.uri);
+
+				// The root is always visible
+				assert.strictEqual(rootWrapper.hasNodeMatchingFilter, true);
+				assert.strictEqual(invisibleWrapper.hasNodeMatchingFilter, false);
+				assert.strictEqual(visibleWrapper.hasNodeMatchingFilter, true);
+			});
+
+			test('can get visible parent', () => {
+				const rootWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, location1.uri);
+
+				const invisible = testsWithLocation.children![1];
+				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, location1.uri);
+				const visible = testsWithLocation.children![0];
+				const visibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(visible, location1.uri);
+
+				// The root is always visible
+				assert.strictEqual(rootWrapper.visibleParent, rootWrapper);
+				assert.strictEqual(invisibleWrapper.visibleParent, rootWrapper);
+				assert.strictEqual(visibleWrapper.visibleParent, visibleWrapper);
+			});
+
+			test('can reset cached value of hasNodeMatchingFilter', () => {
+				TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, location1.uri);
+
+				const invisible = testsWithLocation.children![1];
+				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, location1.uri);
+
+				assert.strictEqual(invisibleWrapper.hasNodeMatchingFilter, false);
+				invisible.location = location1 as any;
+				assert.strictEqual(invisibleWrapper.hasNodeMatchingFilter, false);
+				invisibleWrapper.reset();
+				assert.strictEqual(invisibleWrapper.hasNodeMatchingFilter, true);
+			});
+
+			test('can reset cached value of hasNodeMatchingFilter of parents up to visible parent', () => {
+				const rootWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, location1.uri);
+
+				const invisibleParent = testsWithLocation.children![1];
+				const invisibleParentWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisibleParent, location1.uri);
+				const invisible = invisibleParent.children![1];
+				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, location1.uri);
+
+				assert.strictEqual(invisibleParentWrapper.hasNodeMatchingFilter, false);
+				invisible.location = location1 as any;
+				assert.strictEqual(invisibleParentWrapper.hasNodeMatchingFilter, false);
+				invisibleWrapper.reset();
+				assert.strictEqual(invisibleParentWrapper.hasNodeMatchingFilter, true);
+
+				// the root should be undefined due to the reset.
+				assert.strictEqual((rootWrapper as any).matchesFilter, undefined);
 			});
 		});
 	});

--- a/src/vs/workbench/test/browser/api/extHostTesting.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostTesting.test.ts
@@ -9,7 +9,7 @@ import * as convert from 'vs/workbench/api/common/extHostTypeConverters';
 import { TestDiffOpType } from 'vs/workbench/contrib/testing/common/testCollection';
 import { stubTest, testStubs } from 'vs/workbench/contrib/testing/common/testStubs';
 import { TestOwnedTestCollection, TestSingleUseCollection } from 'vs/workbench/contrib/testing/test/common/ownedTestCollection';
-import { TestChangeEvent, TestItem } from 'vscode';
+import { TestChangeEvent, TestItem, TextDocument } from 'vscode';
 import { URI } from 'vs/base/common/uri';
 import { Location } from 'vs/editor/common/modes';
 import { Range } from 'vs/editor/common/core/range';
@@ -288,6 +288,10 @@ suite('ExtHost Testing', () => {
 				uri: URI.parse('file:///baz.ts')
 			};
 
+			const textDocumentFilter = {
+				uri: location1.uri
+			} as TextDocument;
+
 			let testsWithLocation: TestItem;
 			setup(() => {
 				testsWithLocation = {
@@ -309,14 +313,12 @@ suite('ExtHost Testing', () => {
 			});
 
 			teardown(() => {
-				TestItemFilteredWrapper.removeFilter(location1.uri);
-				TestItemFilteredWrapper.removeFilter(location2.uri);
-				TestItemFilteredWrapper.removeFilter(location3.uri);
+				TestItemFilteredWrapper.removeFilter(textDocumentFilter);
 			});
 
 			test('gets all actual properties', () => {
 				const testItem: TestItem = stubTest('test1');
-				const wrapper: TestItemFilteredWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testItem, location1.uri);
+				const wrapper: TestItemFilteredWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testItem, textDocumentFilter);
 
 				assert.strictEqual(testItem.debuggable, wrapper.debuggable);
 				assert.strictEqual(testItem.description, wrapper.description);
@@ -328,12 +330,12 @@ suite('ExtHost Testing', () => {
 
 			test('gets no children if nothing matches Uri filter', () => {
 				let tests: TestItem = testStubs.nested();
-				const wrapper = TestItemFilteredWrapper.getWrapperForTestItem(tests, location1.uri);
+				const wrapper = TestItemFilteredWrapper.getWrapperForTestItem(tests, textDocumentFilter);
 				assert.strictEqual(wrapper.children.length, 0);
 			});
 
 			test('filter is applied to children', () => {
-				const wrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, location1.uri);
+				const wrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, textDocumentFilter);
 				assert.strictEqual(wrapper.label, 'root');
 				assert.strictEqual(wrapper.children.length, 1);
 				assert.strictEqual(wrapper.children[0] instanceof TestItemFilteredWrapper, true);
@@ -341,12 +343,12 @@ suite('ExtHost Testing', () => {
 			});
 
 			test('can get if node has matching filter', () => {
-				const rootWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, location1.uri);
+				const rootWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, textDocumentFilter);
 
 				const invisible = testsWithLocation.children![1];
-				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, location1.uri);
+				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, textDocumentFilter);
 				const visible = testsWithLocation.children![0];
-				const visibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(visible, location1.uri);
+				const visibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(visible, textDocumentFilter);
 
 				// The root is always visible
 				assert.strictEqual(rootWrapper.hasNodeMatchingFilter, true);
@@ -355,12 +357,12 @@ suite('ExtHost Testing', () => {
 			});
 
 			test('can get visible parent', () => {
-				const rootWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, location1.uri);
+				const rootWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, textDocumentFilter);
 
 				const invisible = testsWithLocation.children![1];
-				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, location1.uri);
+				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, textDocumentFilter);
 				const visible = testsWithLocation.children![0];
-				const visibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(visible, location1.uri);
+				const visibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(visible, textDocumentFilter);
 
 				// The root is always visible
 				assert.strictEqual(rootWrapper.visibleParent, rootWrapper);
@@ -369,10 +371,10 @@ suite('ExtHost Testing', () => {
 			});
 
 			test('can reset cached value of hasNodeMatchingFilter', () => {
-				TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, location1.uri);
+				TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, textDocumentFilter);
 
 				const invisible = testsWithLocation.children![1];
-				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, location1.uri);
+				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, textDocumentFilter);
 
 				assert.strictEqual(invisibleWrapper.hasNodeMatchingFilter, false);
 				invisible.location = location1 as any;
@@ -382,12 +384,12 @@ suite('ExtHost Testing', () => {
 			});
 
 			test('can reset cached value of hasNodeMatchingFilter of parents up to visible parent', () => {
-				const rootWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, location1.uri);
+				const rootWrapper = TestItemFilteredWrapper.getWrapperForTestItem(testsWithLocation, textDocumentFilter);
 
 				const invisibleParent = testsWithLocation.children![1];
-				const invisibleParentWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisibleParent, location1.uri);
+				const invisibleParentWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisibleParent, textDocumentFilter);
 				const invisible = invisibleParent.children![1];
-				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, location1.uri);
+				const invisibleWrapper = TestItemFilteredWrapper.getWrapperForTestItem(invisible, textDocumentFilter);
 
 				assert.strictEqual(invisibleParentWrapper.hasNodeMatchingFilter, false);
 				invisible.location = location1 as any;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This allows extension authors to only need to provide a workspace `TestHeirachy` and when opening a document it will create a default document `TestHeirarchy` from the workspace one thus "polyfilling" the document hierarchies.