### PR TITLE
Correctly resolve mapped drive on Windows

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -467,7 +467,7 @@ export class Git {
 
 					try {
 						const networkPath = await new Promise<string | undefined>(resolve =>
-							realpath.native(`${letter}:`, { encoding: 'utf8' }, (err, resolvedPath) =>
+							realpath.native(`${letter}:\\`, { encoding: 'utf8' }, (err, resolvedPath) =>
 								resolve(err !== null ? undefined : resolvedPath),
 							),
 						);


### PR DESCRIPTION
Backport of a fix from https://github.com/eamodio/vscode-gitlens as requested by @eamodio 

fs.realpath.native in NodeJS uses the Win32 API function GetFinalPathNameByHandle() on Windows hosts,
therefore a given path must follow the guidelines for Win32 API file functions.
Drive letters on Windows need to end on a backslash according to the Win32 File Naming Conventions (https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file)
Omitting the backslash results in Windows treating the remaining path components as a relative path starting from the current directory on the specified disk
https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#fully-qualified-vs-relative-paths

For further details please check the discussion to the original issue https://github.com/eamodio/vscode-gitlens/issues/1045