### PR TITLE
Fix webviews deserializing after extension updates

### DIFF
--- a/src/vs/workbench/contrib/webview/electron-sandbox/resourceLoading.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/resourceLoading.ts
@@ -96,15 +96,7 @@ export class WebviewResourceRequestManager extends Disposable {
 			if (foundExt !== undefined) {
 				latestExtensionLocation.extensionLocation = foundExt?.extensionLocation;
 				if (extension?.location !== undefined) {
-					latestExtensionLocation.localResourceRoots = this._localResourceRoots.map(root => {
-						const newPath = root.path.replace(extension?.location.path, foundExt!.extensionLocation.path);
-						if (root.path !== newPath) {
-							const newRoot = root.with({ path: newPath });
-							this._logService.info(`WebviewResourceRequestManager(${this.id}): replaced localResourceRoot: ${root.toString()} -> ${newRoot.toString()}`);
-							return newRoot;
-						}
-						return root;
-					});
+					latestExtensionLocation.localResourceRoots = this.getAssociatedLocalResources(extension?.location.path, foundExt!.extensionLocation.path);
 				}
 			}
 
@@ -157,6 +149,18 @@ export class WebviewResourceRequestManager extends Disposable {
 
 		ipcRenderer.on(loadResourceChannel, loadResourceListener);
 		this._register(toDisposable(() => ipcRenderer.removeListener(loadResourceChannel, loadResourceListener)));
+	}
+
+	private getAssociatedLocalResources(extPath: string, foundPath: string) {
+		return this._localResourceRoots.map(root => {
+			const newPath = root.path.replace(extPath, foundPath);
+			if (root.path !== newPath) {
+				const newRoot = root.with({ path: newPath });
+				this._logService.info(`WebviewResourceRequestManager(${this.id}): replaced localResourceRoot: ${root.toString()} -> ${newRoot.toString()}`);
+				return newRoot;
+			}
+			return root;
+		});
 	}
 
 	public update(options: WebviewContentOptions) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #114659

The issue is that webviews use the old extension location and local source roots from when it was serialized to load resources. This can break resource loading during webview deserialization after an extension is updated. This means resources loaded think they're in the wrong root and give access denied 401s. We can instead check the latest information of this extension id when setting up the webview resource manager, then use that location instead of the serialized one. Since we get the actual running extension version, this means it'll always use the right one to handle resources.

This affects us at FB quite a bit, due to our number of webviews and update cadence.

**How to test this:** (a bit involved, we need to simulate an extension update)
1. Build vscode from source
1. Build the [cat-coding webview sample extension](https://github.com/microsoft/vscode-extension-samples/tree/master/webview-sample)
2. Copy the package.json, out, media dirs into a new folder called sample-version1. The package.json has version 0.0.1.
3. Move this into a folder somewhere called test-ext-dir.
4. Launch vscode with that as the extensions dir: code --extensions-dir=/path/to/test-ext-dir
5. Open the webview (cmd-shift-p "cat coding")
6. Close vscode
7. Copy sample-version1 to sample-version2, update the package.json version to 0.0.2. The fake ext dir will have both versions/copies of the extension.
8. Relaunch vscode again with the same ext-dir.
9. Because the version is higher but the extension id is the same, vscode will prefer loading 0.0.2. But this disagrees with what was serialized from the last launch. It tries to load the webview but throws a 401 in the resource loader because it thinks it's accessing files from a different root, even though it's using the correct one. This results in the webview loading the HTML, but the JS not loading and the counter not counting. (this is repro'ing the issue)
10. Restarting vscode without closing the webview will keep exhibiting this bug (note: if you close and re-open the webview it'll fix itself because it won't use the serialized versions)
11. Rebuild vscode with this PR's patch
12. launch vscode again, and now the webview will deserialize properly.
13. The replaced roots are logged: `WebviewResourceRequestManager(111c646f-9a78-4a60-a6aa-482b922724a0): replaced localResourceRoot: file:///Users/evangrayk/code/test-ext-dir/sample-version1/media -> file:///Users/evangrayk/code/test-ext-dir/sample-version2/media`

I wasn't sure how to test the second `loadResourceListener` part. I just put in the same new locations there.

I implemented this fix at the resource manager loading step. I kind of think it would make sense to do this at deserialize time so we don't propagate wrong extension locations everywhere, but there's no easy place for this async work other than in the webview resource loader.

I don't think this is a security concern, since it is loading from the same extension, but worth noting that it is removing an "Access Denied".
