### PR TITLE
Set terminal.integrated.altClickMovesCursor: false by default, considering multiCursorModifier

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -396,7 +396,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		const editorOptions = this._configurationService.getValue<IEditorOptions>('editor');
 
 		const xterm = new Terminal({
-			altClickMovesCursor: config.altClickMovesCursor,
+			altClickMovesCursor: config.altClickMovesCursor && editorOptions.multiCursorModifier == 'alt',
 			scrollback: config.scrollback,
 			theme: this._getXtermTheme(),
 			drawBoldTextInBrightColors: config.drawBoldTextInBrightColors,

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -396,7 +396,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		const editorOptions = this._configurationService.getValue<IEditorOptions>('editor');
 
 		const xterm = new Terminal({
-			altClickMovesCursor: config.altClickMovesCursor && editorOptions.multiCursorModifier == 'alt',
+			altClickMovesCursor: config.altClickMovesCursor && editorOptions.multiCursorModifier === 'alt',
 			scrollback: config.scrollback,
 			theme: this._getXtermTheme(),
 			drawBoldTextInBrightColors: config.drawBoldTextInBrightColors,

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -91,9 +91,9 @@ export const terminalConfiguration: IConfigurationNode = {
 			default: false
 		},
 		'terminal.integrated.altClickMovesCursor': {
-			description: localize('terminal.integrated.altClickMovesCursor', "If enabled, alt/option + click will move the prompt cursor to position underneath the mouse. This may not work reliably depending on your shell."),
+			description: localize('terminal.integrated.altClickMovesCursor', "If enabled, alt/option + click will re-posiition the prompt cursor to underneath the mouse when editor.multiCursorModifier is set to alt (the default value). This may not work reliably depending on your shell."),
 			type: 'boolean',
-			default: false
+			default: true
 		},
 		'terminal.integrated.copyOnSelection': {
 			description: localize('terminal.integrated.copyOnSelection', "Controls whether text selected in the terminal will be copied to the clipboard."),

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -93,7 +93,7 @@ export const terminalConfiguration: IConfigurationNode = {
 		'terminal.integrated.altClickMovesCursor': {
 			description: localize('terminal.integrated.altClickMovesCursor', "If enabled, alt/option + click will move the prompt cursor to position underneath the mouse. This may not work reliably depending on your shell."),
 			type: 'boolean',
-			default: true
+			default: false
 		},
 		'terminal.integrated.copyOnSelection': {
 			description: localize('terminal.integrated.copyOnSelection', "Controls whether text selected in the terminal will be copied to the clipboard."),

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -91,7 +91,7 @@ export const terminalConfiguration: IConfigurationNode = {
 			default: false
 		},
 		'terminal.integrated.altClickMovesCursor': {
-			description: localize('terminal.integrated.altClickMovesCursor', "If enabled, alt/option + click will re-posiition the prompt cursor to underneath the mouse when editor.multiCursorModifier is set to alt (the default value). This may not work reliably depending on your shell."),
+			description: localize('terminal.integrated.altClickMovesCursor', "If enabled, alt/option + click will reposition the prompt cursor to underneath the mouse when `#editor.multiCursorModifier#` is set to `'alt'` (the default value). This may not work reliably depending on your shell."),
 			type: 'boolean',
 			default: true
 		},


### PR DESCRIPTION
Fixed #101136