### PR TITLE
[microsoft-authentication] Extend authentication session to return id tokens

### DIFF
--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -16,6 +16,7 @@ import { toBase64UrlEncoding } from './utils';
 import fetch, { Response } from 'node-fetch';
 import { sha256 } from './env/node/sha256';
 import * as nls from 'vscode-nls';
+import { MicrosoftAuthenticationSession } from './microsoft-authentication';
 
 const localize = nls.loadMessageBundle();
 
@@ -74,10 +75,6 @@ export interface ITokenResponse {
 
 export interface IMicrosoftTokens {
 	accessToken: string;
-	idToken?: string;
-}
-
-export interface MicrosoftAuthenticationSession extends vscode.AuthenticationSession {
 	idToken?: string;
 }
 

--- a/extensions/microsoft-authentication/src/microsoft-authentication.api.d.ts
+++ b/extensions/microsoft-authentication/src/microsoft-authentication.api.d.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export { MicrosoftAuthenticationSession } from './AADHelper';

--- a/extensions/microsoft-authentication/src/microsoft-authentication.d.ts
+++ b/extensions/microsoft-authentication/src/microsoft-authentication.d.ts
@@ -3,4 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export { MicrosoftAuthenticationSession } from './AADHelper';
+import { AuthenticationSession } from 'vscode';
+
+/**
+ * Represents a session of a currently logged in Microsoft user.
+ */
+export interface MicrosoftAuthenticationSession extends AuthenticationSession {
+	/**
+	 * The id token.
+	 */
+	idToken?: string;
+}


### PR DESCRIPTION
In some scenarios, id tokens are returned alongside access tokens and are used for user identification. So, the idea of this change is to pass id tokens to the consumers of the integrated authentication API.


cc: @RMacfarlane 
