### PR TITLE
Fix: `debug.console.wordWrap` dont need restart

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -961,6 +961,7 @@ export interface IAbstractTreeOptionsUpdate extends ITreeRendererOptions {
 	readonly filterOnType?: boolean;
 	readonly smoothScrolling?: boolean;
 	readonly horizontalScrolling?: boolean;
+	readonly supportDynamicHeights?: boolean;
 	readonly expandOnlyOnDoubleClick?: boolean;
 	readonly expandOnlyOnTwistieClick?: boolean | ((e: any) => boolean); // e is T
 }

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -358,12 +358,11 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 			const treeElement = this.tree.getHTMLElement();
 			treeElement.parentElement?.classList.toggle('word-wrap', wordWrap);
 			this.tree.updateOptions({
-				horizontalScrolling: !wordWrap
+				horizontalScrolling: !wordWrap,
+				supportDynamicHeights: wordWrap,
 			});
 
-			setTimeout(() => {
-				this.tree.rerender();
-			}, 0);
+			this.tree.rerender();
 
 			if (this.dimension) {
 				this.layoutBody(this.dimension.height, this.dimension.width);

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -236,7 +236,12 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 			}
 		}));
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('debug.console.lineHeight') || e.affectsConfiguration('debug.console.fontSize') || e.affectsConfiguration('debug.console.fontFamily')) {
+			if (
+				e.affectsConfiguration('debug.console.lineHeight')
+				|| e.affectsConfiguration('debug.console.fontSize')
+				|| e.affectsConfiguration('debug.console.fontFamily')
+				|| e.affectsConfiguration('debug.console.wordWrap')
+			) {
 				this.onDidStyleChange();
 			}
 		}));
@@ -313,6 +318,7 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 	private onDidStyleChange(): void {
 		if (this.styleElement) {
 			const debugConsole = this.configurationService.getValue<IDebugConfiguration>('debug').console;
+			const wordWrap = debugConsole.wordWrap;
 			const fontSize = debugConsole.fontSize;
 			const fontFamily = debugConsole.fontFamily === 'default' ? 'var(--monaco-monospace-font)' : `${debugConsole.fontFamily}`;
 			const lineHeight = debugConsole.lineHeight ? `${debugConsole.lineHeight}px` : '1.4em';
@@ -349,6 +355,11 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 				}
 			`;
 			this.container.style.setProperty(`--vscode-repl-font-family`, fontFamily);
+			const treeElement = this.tree.getHTMLElement();
+			treeElement.parentElement?.classList.toggle('word-wrap', wordWrap);
+			this.tree.updateOptions({
+				horizontalScrolling: !wordWrap
+			});
 
 			this.tree.rerender();
 

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -361,7 +361,9 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 				horizontalScrolling: !wordWrap
 			});
 
-			this.tree.rerender();
+			setTimeout(() => {
+				this.tree.rerender();
+			}, 0);
 
 			if (this.dimension) {
 				this.layoutBody(this.dimension.height, this.dimension.width);

--- a/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
+++ b/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
@@ -55,7 +55,6 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 		// Debug console word wrap
 		if (typeof config.debug?.console.wordWrap === 'boolean' && config.debug.console.wordWrap !== this.debugConsoleWordWrap) {
 			this.debugConsoleWordWrap = config.debug.console.wordWrap;
-			changed = true;
 		}
 
 		if (isNative) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #76095

Change `debug.console.wordWrap` trigger `onDidStyleChange`
