### PR TITLE
actionbar - one tab stop

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionViewItems.ts
+++ b/src/vs/base/browser/ui/actionbar/actionViewItems.ts
@@ -263,7 +263,15 @@ export class ActionViewItem extends BaseActionViewItem {
 		super.focus();
 
 		if (this.label) {
+			this.label.tabIndex = 0;
 			this.label.focus();
+		}
+	}
+
+	blur(): void {
+		super.blur();
+		if (this.label) {
+			this.label.tabIndex = -1;
 		}
 	}
 
@@ -320,7 +328,6 @@ export class ActionViewItem extends BaseActionViewItem {
 			if (this.label) {
 				this.label.removeAttribute('aria-disabled');
 				this.label.classList.remove('disabled');
-				this.label.tabIndex = 0;
 			}
 
 			if (this.element) {

--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -293,6 +293,9 @@ export class ActionBar extends Disposable implements IActionRunner {
 			item.actionRunner = this._actionRunner;
 			item.setActionContext(this.context);
 			item.render(actionViewItemElement);
+			if (this.viewItems.length === 0) {
+				actionViewItemElement.tabIndex = 0;
+			}
 
 			if (index === null || index < 0 || index >= this.actionsList.children.length) {
 				this.actionsList.appendChild(actionViewItemElement);

--- a/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
+++ b/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
@@ -78,7 +78,6 @@ export class DropdownMenuActionViewItem extends BaseActionViewItem {
 
 			this.element.classList.add(...classNames);
 
-			this.element.tabIndex = 0;
 			this.element.setAttribute('role', 'button');
 			this.element.setAttribute('aria-haspopup', 'true');
 			this.element.setAttribute('aria-expanded', 'false');
@@ -132,6 +131,20 @@ export class DropdownMenuActionViewItem extends BaseActionViewItem {
 			} else {
 				this.dropdownMenu.menuOptions = { context: newContext };
 			}
+		}
+	}
+
+	focus(): void {
+		super.focus();
+		if (this.element) {
+			this.element.tabIndex = 0;
+		}
+	}
+
+	blur(): void {
+		super.blur();
+		if (this.element) {
+			this.element.tabIndex = -1;
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -199,8 +199,6 @@ export class ActivityActionViewItem extends BaseActionViewItem {
 
 		this.container = container;
 
-		// Make the container tab-able for keyboard navigation
-		this.container.tabIndex = 0;
 		this.container.setAttribute('role', 'tab');
 
 		// Try hard to prevent keyboard only focus feedback when using mouse


### PR DESCRIPTION
This PR changes how the focus works in the `actionBar`. `ActionBar` would only be one tab stop and navigataing inside the action bar would be done via navigation keys.

fixes https://github.com/microsoft/vscode/issues/106441