### PR TITLE
Improve glob module to support OS separator agnostic matching

### DIFF
--- a/src/vs/base/common/glob.ts
+++ b/src/vs/base/common/glob.ts
@@ -393,15 +393,24 @@ function trivia3(pattern: string, options: IGlobOptions): ParsedStringPattern {
 }
 
 // common patterns: **/something/else just need endsWith check, something/else just needs and equals check
-function trivia4and5(path: string, pattern: string, matchPathEnds: boolean): ParsedStringPattern {
-	const nativePath = paths.sep !== paths.posix.sep ? path.replace(ALL_FORWARD_SLASHES, paths.sep) : path;
+function trivia4and5(targetPath: string, pattern: string, matchPathEnds: boolean): ParsedStringPattern {
+	const usingPosixSep = paths.sep === paths.posix.sep;
+	const nativePath = usingPosixSep ? targetPath : targetPath.replace(ALL_FORWARD_SLASHES, paths.sep);
 	const nativePathEnd = paths.sep + nativePath;
-	const parsedPattern: ParsedStringPattern = matchPathEnds ? function (path, basename) {
-		return typeof path === 'string' && (path === nativePath || path.endsWith(nativePathEnd)) ? pattern : null;
-	} : function (path, basename) {
-		return typeof path === 'string' && path === nativePath ? pattern : null;
+	const targetPathEnd = paths.posix.sep + nativePath;
+
+	const parsedPattern: ParsedStringPattern = matchPathEnds ? function (testPath, basename) {
+		return typeof testPath === 'string' &&
+			((testPath === nativePath || testPath.endsWith(nativePathEnd))
+				|| !usingPosixSep && (testPath === targetPath || testPath.endsWith(targetPathEnd)))
+			? pattern : null;
+	} : function (testPath, basename) {
+		return typeof testPath === 'string' &&
+			(testPath === nativePath
+				|| (!usingPosixSep && testPath === targetPath))
+			? pattern : null;
 	};
-	parsedPattern.allPaths = [(matchPathEnds ? '*/' : './') + path];
+	parsedPattern.allPaths = [(matchPathEnds ? '*/' : './') + targetPath];
 	return parsedPattern;
 }
 

--- a/src/vs/base/common/glob.ts
+++ b/src/vs/base/common/glob.ts
@@ -397,7 +397,7 @@ function trivia4and5(targetPath: string, pattern: string, matchPathEnds: boolean
 	const usingPosixSep = paths.sep === paths.posix.sep;
 	const nativePath = usingPosixSep ? targetPath : targetPath.replace(ALL_FORWARD_SLASHES, paths.sep);
 	const nativePathEnd = paths.sep + nativePath;
-	const targetPathEnd = paths.posix.sep + nativePath;
+	const targetPathEnd = paths.posix.sep + targetPath;
 
 	const parsedPattern: ParsedStringPattern = matchPathEnds ? function (testPath, basename) {
 		return typeof testPath === 'string' &&

--- a/src/vs/base/test/common/glob.test.ts
+++ b/src/vs/base/test/common/glob.test.ts
@@ -63,10 +63,12 @@ suite('Glob', () => {
 
 	function assertGlobMatch(pattern: string | glob.IRelativePattern, input: string) {
 		assert(glob.match(pattern, input), `${pattern} should match ${input}`);
+		assert(glob.match(pattern, nativeSep(input)), `${pattern} should match ${nativeSep(input)}`);
 	}
 
 	function assertNoGlobMatch(pattern: string | glob.IRelativePattern, input: string) {
 		assert(!glob.match(pattern, input), `${pattern} should not match ${input}`);
+		assert(!glob.match(pattern, nativeSep(input)), `${pattern} should not match ${nativeSep(input)}`);
 	}
 
 	test('simple', () => {
@@ -538,9 +540,13 @@ suite('Glob', () => {
 	});
 
 	test('full path', function () {
-		let p = 'testing/this/foo.txt';
+		assertGlobMatch('testing/this/foo.txt', 'testing/this/foo.txt');
+		// assertGlobMatch('testing/this/foo.txt', 'testing\\this\\foo.txt');
+	});
 
-		assert(glob.match(p, nativeSep('testing/this/foo.txt')));
+	test('ending path', function () {
+		assertGlobMatch('**/testing/this/foo.txt', 'some/path/testing/this/foo.txt');
+		// assertGlobMatch('**/testing/this/foo.txt', 'some\\path\\testing\\this\\foo.txt');
 	});
 
 	test('prefix agnostic', function () {

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -597,7 +597,6 @@ export function resolvePatternsForProvider(globalPattern: glob.IExpression | und
 		});
 }
 
-const ALL_FORWARD_SLASHES = /\//g;
 export class QueryGlobTester {
 
 	private _excludeExpression: glob.IExpression;
@@ -634,8 +633,6 @@ export class QueryGlobTester {
 	 * Guaranteed sync - siblingsFn should not return a promise.
 	 */
 	includedInQuerySync(testPath: string, basename?: string, hasSibling?: (name: string) => boolean): boolean {
-		testPath = paths.sep !== paths.posix.sep ? testPath.replace(ALL_FORWARD_SLASHES, paths.sep) : testPath;
-
 		if (this._parsedExcludeExpression && this._parsedExcludeExpression(testPath, basename, hasSibling)) {
 			return false;
 		}
@@ -651,8 +648,6 @@ export class QueryGlobTester {
 	 * Guaranteed async.
 	 */
 	includedInQuery(testPath: string, basename?: string, hasSibling?: (name: string) => boolean | Promise<boolean>): Promise<boolean> {
-		testPath = paths.sep !== paths.posix.sep ? testPath.replace(ALL_FORWARD_SLASHES, paths.sep) : testPath;
-
 		const excludeP = Promise.resolve(this._parsedExcludeExpression(testPath, basename, hasSibling)).then(result => !!result);
 
 		return excludeP.then(excluded => {


### PR DESCRIPTION
In #114794 I found that while the pattern `**a/file/**` will match `a/file` on both windows and mac, the pattern `a/file` will  match `a/file` on Mac but only `a\file` on windows. This seems counter to most all of the other glob matches, so to me looks like a bug.

We could go even further and allow `a/file` to match both `a\file` and `a/file` on both mac and windows, which again seems consistant with the other globs (see commented out test cases), not sure if that's desired. It'd likely result in a bit worse performance.