### PR TITLE
fix: prevent scroll when list focused in zone-widget

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1380,7 +1380,7 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 	}
 
 	domFocus(): void {
-		this.view.domNode.focus();
+		this.view.domNode.focus({ preventScroll: true });
 	}
 
 	layout(height?: number, width?: number): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes:

As monaco-editor is wrapped by a scrollable container element, when peeking references, the focus will be on the `ListView` in a zone-widget, and zone-widget moves from the `top:-1000px` position to the central of the page, causing the scrollable container scrolls to the top.

https://user-images.githubusercontent.com/6828924/105725548-0dedf900-5f64-11eb-8841-ee49588013c7.mp4
