### PR TITLE
fix: update `isUri()` to compare `fsPath` as `string`

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -108,7 +108,7 @@ export class URI implements UriComponents {
 			&& typeof (<URI>thing).path === 'string'
 			&& typeof (<URI>thing).query === 'string'
 			&& typeof (<URI>thing).scheme === 'string'
-			&& typeof (<URI>thing).fsPath === 'function'
+			&& typeof (<URI>thing).fsPath === 'string'
 			&& typeof (<URI>thing).with === 'function'
 			&& typeof (<URI>thing).toString === 'function';
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #114971

It looks like `typeof thing.fsPath === 'function'` should really be `typeof thing.fsPath === 'string'`, since `URI.fsPath` is a getter.

```typescript
class URI {
    static isUri(thing) {
        if (thing instanceof URI) {
            return true;
        }
        if (!thing) {
            return false;
        }

        // The code below will likely never be executed in VSCode since `thing instanceof URI === true`
        // but it may happen in monaco-editor.

        return typeof thing.authority === 'string'
            && typeof thing.fragment === 'string'
            && typeof thing.path === 'string'
            && typeof thing.query === 'string'
            && typeof thing.scheme === 'string'
            && typeof thing.fsPath === 'function' // this guy right here should be 'string'
            && typeof thing.with === 'function'
            && typeof thing.toString === 'function';
    }
}
```
