### PR TITLE
Clojure: Use ;; instead of ; for line comments

### DIFF
--- a/extensions/clojure/language-configuration.json
+++ b/extensions/clojure/language-configuration.json
@@ -1,6 +1,6 @@
 {
 	"comments": {
-		"lineComment": ";"
+		"lineComment": ";;"
 	},
 	"brackets": [
 		["{", "}"],


### PR DESCRIPTION
@plexus says:

>LISPs in general and Clojure in particular by convention uses double semicolons
for regular line comments. Single semicolons are reserved for trailing comments
at the end of a line, and are treated (aligned) differently in some editors,
notably Emacs.