### PR TITLE
Change workbench.editor.enablePreview default to false

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -141,7 +141,7 @@ import { isStandalone } from 'vs/base/browser/browser';
 			'workbench.editor.enablePreview': {
 				'type': 'boolean',
 				'description': nls.localize('enablePreview', "Controls whether opened editors show as preview. Preview editors do not keep open and are reused until explicitly set to be kept open (e.g. via double click or editing) and show up with an italic font style."),
-				'default': true
+				'default': false
 			},
 			'workbench.editor.enablePreviewFromQuickOpen': {
 				'type': 'boolean',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

see https://stackoverflow.com/questions/38713405/open-files-always-in-a-new-tab 

Numerous requests to change the default behaviour to more sane default
