### PR TITLE
Remove unused vscode/src/vs/css.d.ts

### DIFF
--- a/build/gulpfile.editor.js
+++ b/build/gulpfile.editor.js
@@ -114,7 +114,6 @@ const createESMSourcesAndResourcesTask = task.define('extract-editor-esm', () =>
 			'vs/nls.d.ts',
 			'vs/css.js',
 			'vs/css.build.js',
-			'vs/css.d.ts',
 			'vs/base/worker/workerMain.ts',
 		],
 		renames: {

--- a/src/tsconfig.monaco.json
+++ b/src/tsconfig.monaco.json
@@ -17,7 +17,6 @@
 	"include": [
 		"typings/require.d.ts",
 		"typings/thenable.d.ts",
-		"vs/css.d.ts",
 		"vs/monaco.d.ts",
 		"vs/nls.d.ts",
 		"vs/editor/*",

--- a/src/vs/base/test/node/uri.test.data.txt
+++ b/src/vs/base/test/node/uri.test.data.txt
@@ -1926,7 +1926,6 @@
 /users/foo/src/vs/workbench/services/editor/test/browser/editorService.test.ts
 /users/foo/src/vs/workbench/services/editor/common
 /users/foo/src/vs/workbench/services/editor/common/editorService.ts
-/users/foo/src/vs/css.d.ts
 /users/foo/src/vs/nls.mock.ts
 /users/foo/src/vs/css.js
 /users/foo/src/vs/nls.build.js

--- a/src/vs/css.d.ts
+++ b/src/vs/css.d.ts
@@ -1,5 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-


### PR DESCRIPTION
This PR "vscode/src/vs/css.d.ts" file was removed from the project because it was not used.
File is empty last four years.