### PR TITLE
Remote CLI: Only manage remote extensions 

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagementCLIService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementCLIService.ts
@@ -232,6 +232,10 @@ export class ExtensionManagementCLIService implements IExtensionManagementCLISer
 			} else {
 				output.log(localize('installing', "Installing extension '{0}' v{1}...", id, galleryExtension.version));
 			}
+			if (!this.canInstall(manifest!)) {
+				output.log(localize('cannot install', "Cannot install extension '{0}'.", id));
+				return null;
+			}
 			await this.extensionManagementService.installFromGallery(galleryExtension, installOptions);
 			output.log(localize('successInstall', "Extension '{0}' v{1} was successfully installed.", id, galleryExtension.version));
 			return manifest;
@@ -243,6 +247,10 @@ export class ExtensionManagementCLIService implements IExtensionManagementCLISer
 				throw error;
 			}
 		}
+	}
+
+	protected canInstall(manifest: IExtensionManifest): boolean {
+		return true;
 	}
 
 	private async validate(manifest: IExtensionManifest, force: boolean, output: CLIOutput): Promise<boolean> {

--- a/src/vs/workbench/api/browser/mainThreadCLICommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadCLICommands.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Schemas } from 'vs/base/common/network';
 import { isString } from 'vs/base/common/types';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
@@ -13,9 +14,11 @@ import { ExtensionManagementCLIService } from 'vs/platform/extensionManagement/c
 import { getExtensionId } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { ILabelService } from 'vs/platform/label/common/label';
 import { ILocalizationsService } from 'vs/platform/localizations/common/localizations';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IProductService } from 'vs/platform/product/common/productService';
+import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IExtensionManagementServerService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { canExecuteOnWorkspace } from 'vs/workbench/services/extensions/common/extensionsUtil';
 import { IExtensionManifest } from 'vs/workbench/workbench.web.api';
@@ -74,14 +77,25 @@ CommandsRegistry.registerCommand('_remoteCLI.manageExtensions', async function (
 
 class RemoteExtensionCLIManagementService extends ExtensionManagementCLIService {
 
+	private _location: string | undefined;
+
 	constructor(
 		@IExtensionManagementService extensionManagementService: IExtensionManagementService,
 		@IProductService private readonly productService: IProductService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IExtensionGalleryService extensionGalleryService: IExtensionGalleryService,
 		@ILocalizationsService localizationsService: ILocalizationsService,
+		@ILabelService labelService: ILabelService,
+		@IWorkbenchEnvironmentService envService: IWorkbenchEnvironmentService
 	) {
 		super(extensionManagementService, extensionGalleryService, localizationsService);
+
+		const remoteAuthority = envService.remoteAuthority;
+		this._location = remoteAuthority ? labelService.getHostLabel(Schemas.vscodeRemote, remoteAuthority) : undefined;
+	}
+
+	protected get location(): string | undefined {
+		return this._location;
 	}
 
 	protected validateExtensionKind(manifest: IExtensionManifest, output: CLIOutput): boolean {

--- a/src/vs/workbench/api/browser/mainThreadCLICommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadCLICommands.ts
@@ -40,10 +40,10 @@ CommandsRegistry.registerCommand('_remoteCLI.manageExtensions', async function (
 
 	const instantiationService = accessor.get(IInstantiationService);
 	const extensionManagementServerService = accessor.get(IExtensionManagementServerService);
-	if (!extensionManagementServerService.remoteExtensionManagementServer) {
+	const remoteExtensionManagementService = extensionManagementServerService.remoteExtensionManagementServer?.extensionManagementService;
+	if (!remoteExtensionManagementService) {
 		return;
 	}
-	const remoteExtensionManagementService = extensionManagementServerService.remoteExtensionManagementServer.extensionManagementService;
 
 	const cliService = instantiationService.createChild(new ServiceCollection([IExtensionManagementService, remoteExtensionManagementService])).createInstance(RemoteExtensionCLIManagementService);
 
@@ -84,9 +84,9 @@ class RemoteExtensionCLIManagementService extends ExtensionManagementCLIService 
 		super(extensionManagementService, extensionGalleryService, localizationsService);
 	}
 
-	protected async validateExtensionKind(manifest: IExtensionManifest, output: CLIOutput): Promise<boolean> {
+	protected validateExtensionKind(manifest: IExtensionManifest, output: CLIOutput): boolean {
 		if (!canExecuteOnWorkspace(manifest, this.productService, this.configurationService)) {
-			output.log(localize('invalidExtensionKind', "Extension {0} can only not be installed. The remote CLI currently only supports installing workbench extensions", getExtensionId(manifest.publisher, manifest.name)));
+			output.log(localize('cannot be installed', "Cannot install '{0}' because this extension has defined that it cannot run on the remote server.", getExtensionId(manifest.publisher, manifest.name)));
 			return false;
 		}
 		return true;

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -5,7 +5,7 @@
 
 import { Event, EventMultiplexer } from 'vs/base/common/event';
 import {
-	ILocalExtension, IGalleryExtension, InstallExtensionEvent, DidInstallExtensionEvent, IExtensionIdentifier, DidUninstallExtensionEvent, IReportedExtension, IGalleryMetadata, IExtensionGalleryService, INSTALL_ERROR_NOT_SUPPORTED, InstallOptions, UninstallOptions, IExtensionManagementService
+	ILocalExtension, IGalleryExtension, InstallExtensionEvent, DidInstallExtensionEvent, IExtensionIdentifier, DidUninstallExtensionEvent, IReportedExtension, IGalleryMetadata, IExtensionGalleryService, INSTALL_ERROR_NOT_SUPPORTED, InstallOptions, UninstallOptions
 } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { IExtensionManagementServer, IExtensionManagementServerService, IWorkbenchExtensioManagementService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { ExtensionType, isLanguagePackExtension, IExtensionManifest } from 'vs/platform/extensions/common/extensions';
@@ -15,7 +15,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { localize } from 'vs/nls';
-import { prefersExecuteOnUI, getExtensionKind, canExecuteOnWorkspace } from 'vs/workbench/services/extensions/common/extensionsUtil';
+import { prefersExecuteOnUI, getExtensionKind } from 'vs/workbench/services/extensions/common/extensionsUtil';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { Schemas } from 'vs/base/common/network';
 import { IDownloadService } from 'vs/platform/download/common/download';
@@ -24,8 +24,6 @@ import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import Severity from 'vs/base/common/severity';
 import { canceled } from 'vs/base/common/errors';
 import { IUserDataAutoSyncEnablementService, IUserDataSyncResourceEnablementService, SyncResource } from 'vs/platform/userDataSync/common/userDataSync';
-import { ExtensionManagementCLIService } from 'vs/platform/extensionManagement/common/extensionManagementCLIService';
-import { ILocalizationsService } from 'vs/platform/localizations/common/localizations';
 
 export class ExtensionManagementService extends Disposable implements IWorkbenchExtensioManagementService {
 
@@ -348,22 +346,5 @@ export class ExtensionManagementService extends Disposable implements IWorkbench
 
 	private getServer(extension: ILocalExtension): IExtensionManagementServer | null {
 		return this.extensionManagementServerService.getExtensionManagementServer(extension);
-	}
-}
-
-export class RemoteExtensionCLIManagementService extends ExtensionManagementCLIService {
-
-	constructor(
-		@IExtensionManagementService extensionManagementService: IExtensionManagementService,
-		@IProductService private readonly productService: IProductService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IExtensionGalleryService extensionGalleryService: IExtensionGalleryService,
-		@ILocalizationsService localizationsService: ILocalizationsService,
-	) {
-		super(extensionManagementService, extensionGalleryService, localizationsService);
-	}
-
-	canInstall(manifest: IExtensionManifest): boolean {
-		return canExecuteOnWorkspace(manifest, this.productService, this.configurationService);
 	}
 }

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -93,9 +93,8 @@ import 'vs/workbench/services/outline/browser/outlineService';
 
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionGalleryService';
-import { ExtensionManagementCLIService } from 'vs/platform/extensionManagement/common/extensionManagementCLIService';
 import { GlobalExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionEnablementService';
-import { IExtensionGalleryService, IExtensionManagementCLIService, IGlobalExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IExtensionGalleryService, IGlobalExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ContextViewService } from 'vs/platform/contextview/browser/contextViewService';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IListService, ListService } from 'vs/platform/list/browser/listService';
@@ -127,7 +126,6 @@ registerSingleton(IIgnoredExtensionsManagementService, IgnoredExtensionsManageme
 registerSingleton(IGlobalExtensionEnablementService, GlobalExtensionEnablementService);
 registerSingleton(IExtensionsStorageSyncService, ExtensionsStorageSyncService);
 registerSingleton(IExtensionGalleryService, ExtensionGalleryService, true);
-registerSingleton(IExtensionManagementCLIService, ExtensionManagementCLIService);
 registerSingleton(IContextViewService, ContextViewService, true);
 registerSingleton(IListService, ListService, true);
 registerSingleton(IEditorWorkerService, EditorWorkerServiceImpl);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-remote-release/issues/4377
Fixes https://github.com/microsoft/vscode-remote-release/issues/4372

The remote CLI command now only work with remote extensions.
I also improved the command output to reflect that:

![image](https://user-images.githubusercontent.com/6461412/106157257-cf825500-6182-11eb-8054-4c87a721c87d.png)

![image](https://user-images.githubusercontent.com/6461412/106157347-e9239c80-6182-11eb-80ae-154ae311ced5.png)

![image](https://user-images.githubusercontent.com/6461412/106158148-bc23b980-6183-11eb-9f90-c875b1061a5d.png)

