### PR TITLE
fix #62531 add negative text filtering to Problems

### DIFF
--- a/src/vs/workbench/contrib/markers/browser/markersFilterOptions.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersFilterOptions.ts
@@ -48,7 +48,7 @@ export class FilterOptions {
 	readonly showWarnings: boolean = false;
 	readonly showErrors: boolean = false;
 	readonly showInfos: boolean = false;
-	readonly textFilter: string = '';
+	readonly textFilter: { text: string, negate: boolean } = { text: '', negate: false };
 	readonly excludesMatcher: ResourceGlobMatcher;
 	readonly includesMatcher: ResourceGlobMatcher;
 
@@ -80,22 +80,20 @@ export class FilterOptions {
 					if (unnegated) {
 						this.setPattern(excludesExpression, unnegated);
 						if (negatedTextFilter) {
-							this.textFilter += ` ${unnegated}`;
+							this.textFilter.text += ` ${unnegated}`;
 						}
 					}
 				} else {
 					this.setPattern(includeExpression, f);
-					this.textFilter += ` ${f}`;
+					this.textFilter.text += ` ${f}`;
 				}
 			}
 		}
 
 		this.excludesMatcher = new ResourceGlobMatcher(excludesExpression, filesExcludeByRoot, uriIdentityService);
 		this.includesMatcher = new ResourceGlobMatcher(includeExpression, [], uriIdentityService);
-		this.textFilter = this.textFilter.trim();
-		if (negatedTextFilter) {
-			this.textFilter = '!' + this.textFilter;
-		}
+		this.textFilter.text = this.textFilter.text.trim();
+		this.textFilter.negate = negatedTextFilter;
 	}
 
 	private setPattern(expression: IExpression, pattern: string) {

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -596,11 +596,8 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 			codeMatches = undefined;
 		}
 
-		const anyMatched = (sourceMatches || codeMatches || lineMatches.some(lineMatch => lineMatch.length > 0)) ? true : false;
-		if (anyMatched && negate) {
-			return false;
-		} else if (anyMatched || negate) {
-			return { visibility: true, data: { type: FilterDataType.Marker, lineMatches, sourceMatches: sourceMatches || [], codeMatches: codeMatches || [] } };
+		if (sourceMatches || codeMatches || lineMatches.some(lineMatch => lineMatch.length > 0)) {
+			return negate ? false : { visibility: true, data: { type: FilterDataType.Marker, lineMatches, sourceMatches: sourceMatches || [], codeMatches: codeMatches || [] } };
 		}
 
 		return parentVisibility;
@@ -616,10 +613,7 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 		const uriMatches = FilterOptions._filter(text, basename(relatedInformation.raw.resource));
 		const messageMatches = FilterOptions._messageFilter(text, paths.basename(relatedInformation.raw.message));
 
-		const anyMatched = (uriMatches || messageMatches) ? true : false;
-		if (anyMatched && negate) {
-			return false;
-		} else if (anyMatched || negate) {
+		if (uriMatches || messageMatches) {
 			return negate ? false : { visibility: true, data: { type: FilterDataType.RelatedInformation, uriMatches: uriMatches || [], messageMatches: messageMatches || [] } };
 		}
 

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -533,11 +533,11 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 			return false;
 		}
 
-		const negate = this.options.textFilter.startsWith('!');
-		const textFilter = this.options.textFilter.substring(negate ? 1 : 0);
+		const negate = this.options.textFilter.negate;
+		const text = this.options.textFilter.text;
 
-		if (textFilter) {
-			const uriMatches = FilterOptions._filter(textFilter, basename(resourceMarkers.resource));
+		if (text) {
+			const uriMatches = FilterOptions._filter(text, basename(resourceMarkers.resource));
 			if (uriMatches && negate) {
 				return false;
 			} else if (uriMatches || negate) {
@@ -571,19 +571,19 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 		}
 
 		const lineMatches: IMatch[][] = [];
-		const negate = this.options.textFilter.startsWith('!');
-		const textFilter = this.options.textFilter.substring(negate ? 1 : 0);
-		if (!textFilter) {
+		const negate = this.options.textFilter.negate;
+		const text = this.options.textFilter.text;
+		if (!text) {
 			return true;
 		}
 		for (const line of marker.lines) {
-			const lineMatch = FilterOptions._messageFilter(textFilter, line);
+			const lineMatch = FilterOptions._messageFilter(text, line);
 			lineMatches.push(lineMatch || []);
 		}
 
 		let sourceMatches: IMatch[] | null | undefined;
 		if (marker.marker.source) {
-			sourceMatches = FilterOptions._filter(textFilter, marker.marker.source);
+			sourceMatches = FilterOptions._filter(text, marker.marker.source);
 		} else {
 			sourceMatches = undefined;
 		}
@@ -591,7 +591,7 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 		let codeMatches: IMatch[] | null | undefined;
 		if (marker.marker.code) {
 			const codeText = typeof marker.marker.code === 'string' ? marker.marker.code : marker.marker.code.value;
-			codeMatches = FilterOptions._filter(textFilter, codeText);
+			codeMatches = FilterOptions._filter(text, codeText);
 		} else {
 			codeMatches = undefined;
 		}
@@ -607,14 +607,14 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 	}
 
 	private filterRelatedInformation(relatedInformation: RelatedInformation, parentVisibility: TreeVisibility): TreeFilterResult<FilterData> {
-		const negate = this.options.textFilter.startsWith('!');
-		const textFilter = this.options.textFilter.substring(negate ? 1 : 0);
-		if (!textFilter) {
+		const negate = this.options.textFilter.negate;
+		const text = this.options.textFilter.text;
+		if (!text) {
 			return true;
 		}
 
-		const uriMatches = FilterOptions._filter(this.options.textFilter, basename(relatedInformation.raw.resource));
-		const messageMatches = FilterOptions._messageFilter(this.options.textFilter, paths.basename(relatedInformation.raw.message));
+		const uriMatches = FilterOptions._filter(text, basename(relatedInformation.raw.resource));
+		const messageMatches = FilterOptions._messageFilter(text, paths.basename(relatedInformation.raw.message));
 
 		const anyMatched = (uriMatches || messageMatches) ? true : false;
 		if (anyMatched && negate) {

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -538,8 +538,10 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 
 		if (textFilter) {
 			const uriMatches = FilterOptions._filter(textFilter, basename(resourceMarkers.resource));
-			if (uriMatches) {
-				return negate ? false : { visibility: true, data: { type: FilterDataType.ResourceMarkers, uriMatches } };
+			if (uriMatches && negate) {
+				return false;
+			} else if (uriMatches || negate) {
+				return { visibility: true, data: { type: FilterDataType.ResourceMarkers, uriMatches: uriMatches || [] } };
 			}
 		}
 
@@ -614,7 +616,10 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 		const uriMatches = FilterOptions._filter(this.options.textFilter, basename(relatedInformation.raw.resource));
 		const messageMatches = FilterOptions._messageFilter(this.options.textFilter, paths.basename(relatedInformation.raw.message));
 
-		if (uriMatches || messageMatches) {
+		const anyMatched = (uriMatches || messageMatches) ? true : false;
+		if (anyMatched && negate) {
+			return false;
+		} else if (anyMatched || negate) {
 			return negate ? false : { visibility: true, data: { type: FilterDataType.RelatedInformation, uriMatches: uriMatches || [], messageMatches: messageMatches || [] } };
 		}
 

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -576,28 +576,12 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 		}
 		for (const line of marker.lines) {
 			const lineMatch = FilterOptions._messageFilter(textFilter, line);
-			if (!negate) {
-				lineMatches.push(lineMatch || []);
-			} else {
-				if (!lineMatch) {
-					lineMatches.push([{ start: 0, end: 0 }]);
-				} else {
-					shouldAppear = false;
-				}
-			}
+			lineMatches.push(lineMatch || []);
 		}
 
 		let sourceMatches: IMatch[] | null | undefined;
 		if (marker.marker.source) {
 			sourceMatches = FilterOptions._filter(textFilter, marker.marker.source);
-			if (negate) {
-				if (sourceMatches) {
-					sourceMatches = undefined;
-					shouldAppear = false;
-				} else {
-					sourceMatches = [{ start: 0, end: 0 }];
-				}
-			}
 		} else {
 			sourceMatches = undefined;
 		}
@@ -606,23 +590,14 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 		if (marker.marker.code) {
 			const codeText = typeof marker.marker.code === 'string' ? marker.marker.code : marker.marker.code.value;
 			codeMatches = FilterOptions._filter(textFilter, codeText);
-			if (negate) {
-				if (codeMatches) {
-					codeMatches = undefined;
-					shouldAppear = false;
-				} else {
-					codeMatches = [{ start: 0, end: 0 }];
-				}
-			}
 		} else {
 			codeMatches = undefined;
 		}
 
-		if (!shouldAppear) {
+		const anyMatched = (sourceMatches || codeMatches || lineMatches.some(lineMatch => lineMatch.length > 0)) ? true : false;
+		if (anyMatched && negate) {
 			return false;
-		}
-
-		if (sourceMatches || codeMatches || lineMatches.some(lineMatch => lineMatch.length > 0)) {
+		} else if (anyMatched || negate) {
 			return { visibility: true, data: { type: FilterDataType.Marker, lineMatches, sourceMatches: sourceMatches || [], codeMatches: codeMatches || [] } };
 		}
 


### PR DESCRIPTION
This PR fixes #62531 

If the first character of the filter field value is `!` then only problems that don't match the rest of the value will display.

To test:
1. Set up a situation where there are multiple problems listed and no filter is specified.
2. Enter a text filter that removes some of the problems.
3. Then prepend a `!` to your filter and confirm you see only the problems that the previous step had omitted.
