### PR TITLE
Plumb etags through rest of the webview resource pipeline

### DIFF
--- a/src/vs/platform/webview/common/resourceLoader.ts
+++ b/src/vs/platform/webview/common/resourceLoader.ts
@@ -9,6 +9,8 @@ import { isUNC } from 'vs/base/common/extpath';
 import { Schemas } from 'vs/base/common/network';
 import { sep } from 'vs/base/common/path';
 import { URI } from 'vs/base/common/uri';
+import { IHeaders } from 'vs/base/parts/request/common/request';
+import { FileOperationError, FileOperationResult, IFileService } from 'vs/platform/files/common/files';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IRemoteConnectionData } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { IRequestService } from 'vs/platform/request/common/request';
@@ -18,7 +20,7 @@ import { getWebviewContentMimeType } from 'vs/platform/webview/common/mimeTypes'
 export const webviewPartitionId = 'webview';
 
 export namespace WebviewResourceResponse {
-	export enum Type { Success, Failed, AccessDenied }
+	export enum Type { Success, Failed, AccessDenied, NotModified }
 
 	export class StreamSuccess {
 		readonly type = Type.Success;
@@ -33,24 +35,77 @@ export namespace WebviewResourceResponse {
 	export const Failed = { type: Type.Failed } as const;
 	export const AccessDenied = { type: Type.AccessDenied } as const;
 
-	export type StreamResponse = StreamSuccess | typeof Failed | typeof AccessDenied;
+	export class NotModified {
+		readonly type = Type.NotModified;
+
+		constructor(
+			public readonly mimeType: string,
+		) { }
+	}
+
+	export type StreamResponse = StreamSuccess | typeof Failed | typeof AccessDenied | NotModified;
 }
 
-interface FileReader {
-	readFileStream(resource: URI): Promise<{ stream: VSBufferReadableStream, etag?: string }>;
+export namespace WebviewFileReadResponse {
+	export enum Type { Success, NotModified }
+
+	export class StreamSuccess {
+		readonly type = Type.Success;
+
+		constructor(
+			public readonly stream: VSBufferReadableStream,
+			public readonly etag: string | undefined
+		) { }
+	}
+
+	export const NotModified = { type: Type.NotModified } as const;
+
+	export type Response = StreamSuccess | typeof NotModified;
+}
+
+/**
+ * Wraps a call to `IFileService.readFileStream` and converts the result to a `WebviewFileReadResponse.Response`
+ */
+export async function readFileStream(
+	fileService: IFileService,
+	resource: URI,
+	etag: string | undefined,
+): Promise<WebviewFileReadResponse.Response> {
+	try {
+		const result = await fileService.readFileStream(resource, { etag });
+		return new WebviewFileReadResponse.StreamSuccess(result.value, result.etag);
+	} catch (e) {
+		if (e instanceof FileOperationError) {
+			const result = e.fileOperationResult;
+
+			// NotModified status is expected and can be handled gracefully
+			if (result === FileOperationResult.FILE_NOT_MODIFIED_SINCE) {
+				return WebviewFileReadResponse.NotModified;
+			}
+		}
+
+		// Otherwise the error is unexpected. Re-throw and let caller handle it
+		throw e;
+	}
+}
+
+export interface WebviewResourceFileReader {
+	readFileStream(resource: URI, etag: string | undefined): Promise<WebviewFileReadResponse.Response>;
 }
 
 export async function loadLocalResource(
 	requestUri: URI,
+	ifNoneMatch: string | undefined,
 	options: {
 		extensionLocation: URI | undefined;
 		roots: ReadonlyArray<URI>;
 		remoteConnectionData?: IRemoteConnectionData | null;
 		rewriteUri?: (uri: URI) => URI,
 	},
-	fileReader: FileReader,
+	fileReader: WebviewResourceFileReader,
 	requestService: IRequestService,
 	logService: ILogService,
+	token: CancellationToken,
 ): Promise<WebviewResourceResponse.StreamResponse> {
 	logService.debug(`loadLocalResource - being. requestUri=${requestUri}`);
 
@@ -70,20 +125,39 @@ export async function loadLocalResource(
 	}
 
 	if (resourceToLoad.scheme === Schemas.http || resourceToLoad.scheme === Schemas.https) {
-		const response = await requestService.request({ url: resourceToLoad.toString(true) }, CancellationToken.None);
+		const headers: IHeaders = {};
+		if (ifNoneMatch) {
+			headers['If-None-Match'] = ifNoneMatch;
+		}
+
+		const response = await requestService.request({
+			url: resourceToLoad.toString(true),
+			headers: headers
+		}, token);
+
 		logService.debug(`loadLocalResource - Loaded over http(s). requestUri=${requestUri}, response=${response.res.statusCode}`);
 
 		if (response.res.statusCode === 200) {
-			return new WebviewResourceResponse.StreamSuccess(response.stream, undefined, mime);
+			return new WebviewResourceResponse.StreamSuccess(response.stream, response.res.headers['etag'], mime);
 		}
 		return WebviewResourceResponse.Failed;
 	}
 
 	try {
-		const contents = await fileReader.readFileStream(resourceToLoad);
+		const contents = await fileReader.readFileStream(resourceToLoad, ifNoneMatch);
 		logService.debug(`loadLocalResource - Loaded using fileReader. requestUri=${requestUri}`);
 
-		return new WebviewResourceResponse.StreamSuccess(contents.stream, contents.etag, mime);
+		switch (contents.type) {
+			case WebviewFileReadResponse.Type.Success:
+				return new WebviewResourceResponse.StreamSuccess(contents.stream, contents.etag, mime);
+
+			case WebviewFileReadResponse.Type.NotModified:
+				return new WebviewResourceResponse.NotModified(mime);
+
+			default:
+				logService.error(`loadLocalResource - Unknown file read response`);
+				return WebviewResourceResponse.Failed;
+		}
 	} catch (err) {
 		logService.debug(`loadLocalResource - Error using fileReader. requestUri=${requestUri}`);
 		console.log(err);

--- a/src/vs/platform/webview/common/webviewManagerService.ts
+++ b/src/vs/platform/webview/common/webviewManagerService.ts
@@ -19,6 +19,12 @@ export interface WebviewWindowId {
 	readonly windowId: number;
 }
 
+export type WebviewManagerDidLoadResourceResponse =
+	{ buffer: VSBuffer, etag: string | undefined }
+	| 'not-modified'
+	| 'access-denied'
+	| 'not-found';
+
 export interface IWebviewManagerService {
 	_serviceBrand: unknown;
 
@@ -26,7 +32,7 @@ export interface IWebviewManagerService {
 	unregisterWebview(id: string): Promise<void>;
 	updateWebviewMetadata(id: string, metadataDelta: Partial<RegisterWebviewMetadata>): Promise<void>;
 
-	didLoadResource(requestId: number, content: VSBuffer | undefined): void;
+	didLoadResource(requestId: number, response: WebviewManagerDidLoadResourceResponse): void;
 
 	setIgnoreMenuShortcuts(id: WebviewWebContentsId | WebviewWindowId, enabled: boolean): Promise<void>;
 }

--- a/src/vs/platform/webview/electron-main/webviewMainService.ts
+++ b/src/vs/platform/webview/electron-main/webviewMainService.ts
@@ -4,14 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { WebContents, webContents } from 'electron';
-import { VSBuffer } from 'vs/base/common/buffer';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ITunnelService } from 'vs/platform/remote/common/tunnel';
 import { IRequestService } from 'vs/platform/request/common/request';
-import { IWebviewManagerService, RegisterWebviewMetadata, WebviewWebContentsId, WebviewWindowId } from 'vs/platform/webview/common/webviewManagerService';
+import { IWebviewManagerService, RegisterWebviewMetadata, WebviewManagerDidLoadResourceResponse, WebviewWebContentsId, WebviewWindowId } from 'vs/platform/webview/common/webviewManagerService';
 import { WebviewPortMappingProvider } from 'vs/platform/webview/electron-main/webviewPortMappingProvider';
 import { WebviewProtocolProvider } from 'vs/platform/webview/electron-main/webviewProtocolProvider';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
@@ -95,7 +94,7 @@ export class WebviewMainService extends Disposable implements IWebviewManagerSer
 		}
 	}
 
-	public async didLoadResource(requestId: number, content: VSBuffer | undefined): Promise<void> {
-		this.protocolProvider.didLoadResource(requestId, content);
+	public async didLoadResource(requestId: number, response: WebviewManagerDidLoadResourceResponse): Promise<void> {
+		this.protocolProvider.didLoadResource(requestId, response);
 	}
 }

--- a/src/vs/platform/webview/electron-main/webviewProtocolProvider.ts
+++ b/src/vs/platform/webview/electron-main/webviewProtocolProvider.ts
@@ -5,7 +5,8 @@
 
 import { protocol, session } from 'electron';
 import { Readable } from 'stream';
-import { bufferToStream, VSBuffer, VSBufferReadableStream } from 'vs/base/common/buffer';
+import { bufferToStream, VSBufferReadableStream } from 'vs/base/common/buffer';
+import { CancellationToken } from 'vs/base/common/cancellation';
 import { Disposable, toDisposable } from 'vs/base/common/lifecycle';
 import { FileAccess, Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
@@ -13,7 +14,8 @@ import { FileOperationError, FileOperationResult, IFileService } from 'vs/platfo
 import { ILogService } from 'vs/platform/log/common/log';
 import { IRemoteConnectionData } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { IRequestService } from 'vs/platform/request/common/request';
-import { loadLocalResource, webviewPartitionId, WebviewResourceResponse } from 'vs/platform/webview/common/resourceLoader';
+import { loadLocalResource, readFileStream, WebviewFileReadResponse, webviewPartitionId, WebviewResourceFileReader, WebviewResourceResponse } from 'vs/platform/webview/common/resourceLoader';
+import { WebviewManagerDidLoadResourceResponse } from 'vs/platform/webview/common/webviewManagerService';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
 
 interface WebviewMetadata {
@@ -35,7 +37,7 @@ export class WebviewProtocolProvider extends Disposable {
 	private readonly webviewMetadata = new Map<string, WebviewMetadata>();
 
 	private requestIdPool = 1;
-	private readonly pendingResourceReads = new Map<number, { resolve: (content: VSBuffer | undefined) => void }>();
+	private readonly pendingResourceReads = new Map<number, { resolve: (content: WebviewManagerDidLoadResourceResponse) => void }>();
 
 	constructor(
 		@IFileService private readonly fileService: IFileService,
@@ -154,6 +156,7 @@ export class WebviewProtocolProvider extends Disposable {
 	) {
 		try {
 			const uri = URI.parse(request.url);
+			const ifNoneMatch = request.headers['If-None-Match'];
 
 			const id = uri.authority;
 			const metadata = this.webviewMetadata.get(id);
@@ -175,14 +178,10 @@ export class WebviewProtocolProvider extends Disposable {
 					};
 				}
 
-				const fileReader = {
-					readFileStream: async (resource: URI): Promise<{ stream: VSBufferReadableStream, etag?: string }> => {
+				const fileReader: WebviewResourceFileReader = {
+					readFileStream: async (resource: URI, etag: string | undefined): Promise<WebviewFileReadResponse.Response> => {
 						if (resource.scheme === Schemas.file) {
-							const result = (await this.fileService.readFileStream(resource));
-							return {
-								stream: result.value,
-								etag: result.etag
-							};
+							return readFileStream(this.fileService, resource, etag);
 						}
 
 						// Unknown uri scheme. Try delegating the file read back to the renderer
@@ -194,68 +193,97 @@ export class WebviewProtocolProvider extends Disposable {
 						}
 
 						const requestId = this.requestIdPool++;
-						const p = new Promise<VSBuffer | undefined>(resolve => {
+						const p = new Promise<WebviewManagerDidLoadResourceResponse>(resolve => {
 							this.pendingResourceReads.set(requestId, { resolve });
 						});
 
 						window.send(`vscode:loadWebviewResource-${id}`, requestId, uri);
 
 						const result = await p;
-						if (!result) {
-							throw new FileOperationError('Could not read file', FileOperationResult.FILE_NOT_FOUND);
-						}
+						switch (result) {
+							case 'access-denied':
+								throw new FileOperationError('Could not read file', FileOperationResult.FILE_PERMISSION_DENIED);
 
-						return { stream: bufferToStream(result), etag: undefined };
+							case 'not-found':
+								throw new FileOperationError('Could not read file', FileOperationResult.FILE_NOT_FOUND);
+
+							case 'not-modified':
+								return WebviewFileReadResponse.NotModified;
+
+							default:
+								return new WebviewFileReadResponse.StreamSuccess(bufferToStream(result.buffer), result.etag);
+						}
 					}
 				};
 
-				const result = await loadLocalResource(uri, {
+				const result = await loadLocalResource(uri, ifNoneMatch, {
 					extensionLocation: metadata.extensionLocation,
 					roots: metadata.localResourceRoots,
 					remoteConnectionData: metadata.remoteConnectionData,
 					rewriteUri,
-				}, fileReader, this.requestService, this.logService);
+				}, fileReader, this.requestService, this.logService, CancellationToken.None);
 
-				if (result.type === WebviewResourceResponse.Type.Success) {
-					const cacheHeaders: Record<string, string> = result.etag ? {
-						'ETag': result.etag,
-						'Cache-Control': 'no-cache'
-					} : {};
+				switch (result.type) {
+					case WebviewFileReadResponse.Type.Success:
+						{
+							const cacheHeaders: Record<string, string> = result.etag ? {
+								'ETag': result.etag,
+								'Cache-Control': 'no-cache'
+							} : {};
 
-					const ifNoneMatch = request.headers['If-None-Match'];
-					if (ifNoneMatch && result.etag === ifNoneMatch) {
-						/*
-						 * Note that the server generating a 304 response MUST
-						 * generate any of the following header fields that would
-						 * have been sent in a 200 (OK) response to the same request:
-						 * Cache-Control, Content-Location, Date, ETag, Expires, and Vary.
-						 * (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)
-						 */
-						return callback({
-							statusCode: 304, // not modified
-							data: undefined, // The request fails if `data` is not set
-							headers: {
-								'Content-Type': result.mimeType,
-								'Access-Control-Allow-Origin': '*',
-								...cacheHeaders
+							const ifNoneMatch = request.headers['If-None-Match'];
+							if (ifNoneMatch && result.etag === ifNoneMatch) {
+								/*
+								 * Note that the server generating a 304 response MUST
+								 * generate any of the following header fields that would
+								 * have been sent in a 200 (OK) response to the same request:
+								 * Cache-Control, Content-Location, Date, ETag, Expires, and Vary.
+								 * (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)
+								 */
+								return callback({
+									statusCode: 304, // not modified
+									data: undefined, // The request fails if `data` is not set
+									headers: {
+										'Content-Type': result.mimeType,
+										'Access-Control-Allow-Origin': '*',
+										...cacheHeaders
+									}
+								});
 							}
-						});
-					}
 
-					return callback({
-						statusCode: 200,
-						data: this.streamToNodeReadable(result.stream),
-						headers: {
-							'Content-Type': result.mimeType,
-							'Access-Control-Allow-Origin': '*',
-							...cacheHeaders
+							return callback({
+								statusCode: 200,
+								data: this.streamToNodeReadable(result.stream),
+								headers: {
+									'Content-Type': result.mimeType,
+									'Access-Control-Allow-Origin': '*',
+									...cacheHeaders
+								}
+							});
 						}
-					});
-				}
-
-				if (result.type === WebviewResourceResponse.Type.AccessDenied) {
-					console.error('Webview: Cannot load resource outside of protocol root');
-					return callback({ data: undefined, statusCode: 401 });
+					case WebviewResourceResponse.Type.NotModified:
+						{
+							/*
+							 * Note that the server generating a 304 response MUST
+							 * generate any of the following header fields that would
+							 * have been sent in a 200 (OK) response to the same request:
+							 * Cache-Control, Content-Location, Date, ETag, Expires, and Vary.
+							 * (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)
+							 */
+							return callback({
+								statusCode: 304, // not modified
+								data: undefined, // The request fails if `data` is not set
+								headers: {
+									'Content-Type': result.mimeType,
+									'Access-Control-Allow-Origin': '*',
+								}
+							});
+						}
+					case WebviewResourceResponse.Type.AccessDenied:
+						{
+							console.error('Webview: Cannot load resource outside of protocol root');
+							return callback({ data: undefined, statusCode: 401 });
+						}
 				}
 			}
 		} catch {
@@ -265,12 +293,12 @@ export class WebviewProtocolProvider extends Disposable {
 		return callback({ data: undefined, statusCode: 404 });
 	}
 
-	public didLoadResource(requestId: number, content: VSBuffer | undefined) {
+	public didLoadResource(requestId: number, response: WebviewManagerDidLoadResourceResponse) {
 		const pendingRead = this.pendingResourceReads.get(requestId);
 		if (!pendingRead) {
 			throw new Error('Unknown request');
 		}
 		this.pendingResourceReads.delete(requestId);
-		pendingRead.resolve(content);
+		pendingRead.resolve(response);
 	}
 }

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -5,6 +5,7 @@
 
 import { addDisposableListener } from 'vs/base/browser/dom';
 import { streamToBuffer } from 'vs/base/common/buffer';
+import { CancellationToken } from 'vs/base/common/cancellation';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
@@ -16,7 +17,7 @@ import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remot
 import { ITunnelService } from 'vs/platform/remote/common/tunnel';
 import { IRequestService } from 'vs/platform/request/common/request';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { loadLocalResource, WebviewResourceResponse } from 'vs/platform/webview/common/resourceLoader';
+import { loadLocalResource, readFileStream, WebviewResourceResponse } from 'vs/platform/webview/common/resourceLoader';
 import { WebviewPortMappingManager } from 'vs/platform/webview/common/webviewPortMapping';
 import { BaseWebview, WebviewMessageChannels } from 'vs/workbench/contrib/webview/browser/baseWebviewElement';
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
@@ -66,11 +67,11 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 			const rawPath = entry.path;
 			const normalizedPath = decodeURIComponent(rawPath);
 			const uri = URI.parse(normalizedPath.replace(/^\/([\w\-]+)\/(.+)$/, (_, scheme, path) => scheme + ':/' + path));
-			this.loadResource(rawPath, uri);
+			this.loadResource(entry.id, rawPath, uri, entry.ifNoneMatch);
 		}));
 
 		this._register(this.on(WebviewMessageChannels.loadLocalhost, (entry: any) => {
-			this.localLocalhost(entry.origin);
+			this.localLocalhost(entry.id, entry.origin);
 		}));
 
 		this._confirmBeforeClose = this._configurationService.getValue<string>('window.confirmBeforeClose');
@@ -172,7 +173,7 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 		throw new Error('Method not implemented.');
 	}
 
-	private async loadResource(requestPath: string, uri: URI) {
+	private async loadResource(id: number, requestPath: string, uri: URI, ifNoneMatch: string | undefined) {
 		try {
 			const remoteAuthority = this.environmentService.remoteAuthority;
 			const remoteConnectionData = remoteAuthority ? this._remoteAuthorityResolverService.getConnectionData(remoteAuthority) : null;
@@ -196,39 +197,63 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 				};
 			}
 
-			const result = await loadLocalResource(uri, {
+			const result = await loadLocalResource(uri, ifNoneMatch, {
 				extensionLocation: extensionLocation,
 				roots: this.content.options.localResourceRoots || [],
 				remoteConnectionData,
 				rewriteUri,
 			}, {
-				readFileStream: (resource) => this.fileService.readFileStream(resource).then(x => ({ stream: x.value, etag: x.etag })),
-			}, this.requestService, this.logService);
+				readFileStream: (resource, etag) => readFileStream(this.fileService, resource, etag),
+			}, this.requestService, this.logService, CancellationToken.None);
 
-			if (result.type === WebviewResourceResponse.Type.Success) {
-				const { buffer } = await streamToBuffer(result.stream);
-				return this._send('did-load-resource', {
-					status: 200,
-					path: requestPath,
-					mime: result.mimeType,
-					data: buffer,
-				});
+			switch (result.type) {
+				case WebviewResourceResponse.Type.Success:
+					{
+						const { buffer } = await streamToBuffer(result.stream);
+						return this._send('did-load-resource', {
+							id,
+							status: 200,
+							path: requestPath,
+							mime: result.mimeType,
+							data: buffer,
+							etag: result.etag,
+						});
+					}
+				case WebviewResourceResponse.Type.NotModified:
+					{
+						return this._send('did-load-resource', {
+							id,
+							status: 304, // not modified
+							path: requestPath,
+							mime: result.mimeType,
+						});
+					}
+				case WebviewResourceResponse.Type.AccessDenied:
+					{
+						return this._send('did-load-resource', {
+							id,
+							status: 401, // unauthorized
+							path: requestPath,
+						});
+					}
 			}
 		} catch {
 			// noop
 		}
 
 		return this._send('did-load-resource', {
+			id,
 			status: 404,
 			path: requestPath
 		});
 	}
 
-	private async localLocalhost(origin: string) {
+	private async localLocalhost(id: string, origin: string) {
 		const authority = this.environmentService.remoteAuthority;
 		const resolveAuthority = authority ? await this._remoteAuthorityResolverService.resolveAuthority(authority) : undefined;
 		const redirect = resolveAuthority ? await this._portMappingManager.getRedirect(resolveAuthority.authority, origin) : undefined;
 		return this._send('did-load-localhost', {
+			id,
 			origin,
 			location: redirect
 		});


### PR DESCRIPTION
This follows up on 1f8643ef7600def4619c2674f6e5c1b05d539eda to:

- Use etags to prevent file reads if the file has not changed
- Use etags inside the service worker based resource loading flow (this is used on web)
