### PR TITLE
Add period to list item for consistency

### DIFF
--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/editor/vs_code_editor_walkthrough.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/editor/vs_code_editor_walkthrough.ts
@@ -7,7 +7,7 @@ export default () => `
 ## Interactive Editor Playground
 The core editor in VS Code is packed with features.  This page highlights a number of them and lets you interactively try them out through the use of a number of embedded editors.  For full details on the editor features for VS Code and more head over to our [documentation](command:workbench.action.openDocumentationUrl).
 
-* [Multi-cursor Editing](#multi-cursor-editing) - block selection, select all occurrences, add additional cursors and more
+* [Multi-cursor Editing](#multi-cursor-editing) - block selection, select all occurrences, add additional cursors and more.
 * [IntelliSense](#intellisense) - get code assistance and parameter suggestions for your code and external modules.
 * [Line Actions](#line-actions) - quickly move lines around to re-order your code.
 * [Rename Refactoring](#rename-refactoring) - quickly rename symbols across your code base.


### PR DESCRIPTION
This PR adds a period to the end of the first list item under the `Interactive Editor Playground` section for consistency.

<img width="1148" alt="Period drama" src="https://user-images.githubusercontent.com/121322/106254041-1f860980-61cd-11eb-8b7a-3696d921f5cf.png">

Perhaps my greatest contribution to open source. Ever.