### PR TITLE
Replace map with forEach

### DIFF
--- a/extensions/github-authentication/src/github.ts
+++ b/extensions/github-authentication/src/github.ts
@@ -87,7 +87,7 @@ export class GitHubAuthenticationProvider {
 			}
 		});
 
-		this._sessions.map(session => {
+		this._sessions.forEach(session => {
 			const matchesExisting = storedSessions.some(s => s.id === session.id);
 			// Another window has logged out, remove from our state
 			if (!matchesExisting) {


### PR DESCRIPTION
The callback provided to the map call on this array should return a value, otherwise map will always return an array of undefined values. If the desired behaviour is to just iterate through all elements, then consider using forEach or a for-of loop instead.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

