### PR TITLE
Improving performance of tree traversal on getViewState function

### DIFF
--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -990,16 +990,16 @@ export class AsyncDataTree<TInput, T, TFilterData = void> implements IDisposable
 
 		const expanded: string[] = [];
 		const root = this.tree.getNode();
-		const queue = [root];
+		const stack = [root];
 
-		while (queue.length > 0) {
-			const node = queue.shift()!;
+		while (stack.length > 0) {
+			const node = stack.pop()!;
 
 			if (node !== root && node.collapsible && !node.collapsed) {
 				expanded.push(getId(node.element!.element as T));
 			}
 
-			queue.push(...node.children);
+			stack.push(...node.children);
 		}
 
 		return { focus, selection, expanded, scrollTop: this.scrollTop };


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

Optimising getViewState tree traversal to improve performance on folders with too many children.

### Context
We are currently running VSCode in a monorepo folder that has hundreds of thousands of subfolders/files. There are a few performance issues happening due to that and the getViewState has been identified as one of them.

### Problem
Whenever a folder was opened, such as branches (88K children), the UI would freeze when opening new folders, changing tabs and also every few seconds. The reason for that was because the `onWillSaveWorkspace` is called every few secs and whenever VSCode becomes the active tab to save the list of folders that are expanded in storage so the user can refresh the page and still have their expanded folders open.

The issue was that the `getViewState()` function that returns a list of expanded folders was traversing the tree too slowly. 

### Solution
In this case, it does not matter by which order we traverse the tree to get all states. Array.shift() has O(n) performance while Array.pop() has O(1), therefore, changing it to pop makes it N times faster.

In the image below you can see that after changing from BFS traversal to DFS, the function improved from an average of 4.5 seconds to 4 milliseconds for the monorepo that contains a folder with a 100K children.

Before:
![Benchmark before optimisation ~4.6s](https://i.ibb.co/7WXV46w/Screen-Shot-2021-01-27-at-20-49-30.png)

After:
![Benchmark after optimisation ~4ms](https://i.ibb.co/7QkkZXt/Screen-Shot-2021-01-27-at-20-52-49.png)
