### PR TITLE
typeahead: line wrap improvements

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
@@ -325,19 +325,26 @@ class HardBoundary implements IPrediction {
  * through its `matches` request.
  */
 class TentativeBoundary implements IPrediction {
+	private appliedCursor?: Cursor;
+
 	constructor(public readonly inner: IPrediction) { }
 
 	public apply(buffer: IBuffer, cursor: Cursor) {
-		this.inner.apply(buffer, cursor);
+		this.appliedCursor = cursor.clone();
+		this.inner.apply(buffer, this.appliedCursor);
 		return '';
 	}
 
 	public rollback(cursor: Cursor) {
-		this.inner.rollback(cursor);
+		this.inner.rollback(cursor.clone());
 		return '';
 	}
 
 	public rollForwards(cursor: Cursor, withInput: string) {
+		if (this.appliedCursor) {
+			cursor.moveTo(this.appliedCursor);
+		}
+
 		return withInput;
 	}
 
@@ -508,6 +515,10 @@ class LinewrapPrediction extends NewlinePrediction implements IPrediction {
 		this.prevPosition = cursor.coordinate;
 		cursor.move(0, cursor.y + 1);
 		return ' \r';
+	}
+
+	public rollback(cursor: Cursor) {
+		return this.prevPosition ? cursor.moveTo(this.prevPosition) : '';
 	}
 
 	public matches(input: StringReader) {
@@ -699,7 +710,12 @@ export class PredictionTimeline {
 	 * Cursor position -- kept outside the buffer since it can be ahead if
 	 * typing swiftly.
 	 */
-	private cursor: Cursor | undefined;
+	private _physicalCursor: Cursor | undefined;
+
+	/**
+	 * Cursor position taking into account (possibly not-yet-applied) predictions.
+	 */
+	private _tenativeCursor: Cursor | undefined;
 
 	/**
 	 * Previously sent data that was buffered and should be prepended to the
@@ -755,11 +771,11 @@ export class PredictionTimeline {
 
 		const toApply = this.currentGenerationPredictions;
 		if (show) {
-			this.cursor = undefined;
+			this.clearCursor();
 			this.style.expectIncomingStyle(toApply.reduce((count, p) => p.affectsStyle ? count + 1 : count, 0));
-			this.terminal.write(toApply.map(p => p.apply(buffer, this.getCursor(buffer))).join(''));
+			this.terminal.write(toApply.map(p => p.apply(buffer, this.physicalCursor(buffer))).join(''));
 		} else {
-			this.terminal.write(toApply.reverse().map(p => p.rollback(this.getCursor(buffer))).join(''));
+			this.terminal.write(toApply.reverse().map(p => p.rollback(this.physicalCursor(buffer))).join(''));
 		}
 	}
 
@@ -770,7 +786,7 @@ export class PredictionTimeline {
 		const buffer = this.getActiveBuffer();
 		if (this.showPredictions && buffer) {
 			this.terminal.write(this.currentGenerationPredictions.reverse()
-				.map(p => p.rollback(this.getCursor(buffer))).join(''));
+				.map(p => p.rollback(this.physicalCursor(buffer))).join(''));
 		}
 
 		this.expected = [];
@@ -812,7 +828,7 @@ export class PredictionTimeline {
 			emitPredictionOmitted();
 
 			const { p: prediction, gen } = this.expected[0];
-			const cursor = this.getCursor(buffer);
+			const cursor = this.physicalCursor(buffer);
 			let beforeTestReaderIndex = reader.index;
 			switch (prediction.matches(reader, this.lookBehind)) {
 				case MatchResult.Success:
@@ -822,7 +838,7 @@ export class PredictionTimeline {
 					if (gen === startingGen) {
 						output += prediction.rollForwards?.(cursor, eaten);
 					} else {
-						prediction.apply(buffer, this.getCursor(buffer)); // move cursor for additional apply
+						prediction.apply(buffer, this.physicalCursor(buffer)); // move cursor for additional apply
 						output += eaten;
 					}
 
@@ -840,7 +856,7 @@ export class PredictionTimeline {
 					// on a failure, roll back all remaining items in this generation
 					// and clear predictions, since they are no longer valid
 					const rollback = this.expected.filter(p => p.gen === startingGen).reverse();
-					output += rollback.map(({ p }) => p.rollback(this.getCursor(buffer))).join('');
+					output += rollback.map(({ p }) => p.rollback(this.physicalCursor(buffer))).join('');
 					if (rollback.some(r => r.p.affectsStyle)) {
 						// reading the current style should generally be safe, since predictions
 						// always restore the style if they modify it.
@@ -871,7 +887,7 @@ export class PredictionTimeline {
 					this.style.expectIncomingStyle();
 				}
 
-				output += p.apply(buffer, this.getCursor(buffer));
+				output += p.apply(buffer, this.physicalCursor(buffer));
 			}
 		}
 
@@ -883,8 +899,8 @@ export class PredictionTimeline {
 			return output;
 		}
 
-		if (this.cursor) {
-			output += this.cursor.moveInstruction();
+		if (this._physicalCursor) {
+			output += this._physicalCursor.moveInstruction();
 		}
 
 		// prevent cursor flickering while typing
@@ -899,7 +915,7 @@ export class PredictionTimeline {
 	 */
 	private clearPredictionState() {
 		this.expected = [];
-		this.cursor = undefined;
+		this.clearCursor();
 		this.lookBehind = undefined;
 	}
 
@@ -911,7 +927,9 @@ export class PredictionTimeline {
 		this.addedEmitter.fire(prediction);
 
 		if (this.currentGen === this.expected[0].gen) {
-			const text = prediction.apply(buffer, this.getCursor(buffer));
+			const text = prediction.apply(buffer, this.physicalCursor(buffer));
+			this._tenativeCursor = undefined; // next read will get or clone the physical cursor
+
 			if (this.showPredictions && text) {
 				if (prediction.affectsStyle) {
 					this.style.expectIncomingStyle();
@@ -923,6 +941,7 @@ export class PredictionTimeline {
 			return true;
 		}
 
+		prediction.apply(buffer, this.tentativeCursor(buffer));
 		return false;
 	}
 
@@ -936,7 +955,11 @@ export class PredictionTimeline {
 	public addBoundary(buffer?: IBuffer, prediction?: IPrediction) {
 		let applied = false;
 		if (buffer && prediction) {
-			applied = this.addPrediction(buffer, prediction);
+			// We apply the prediction so that it's matched against, but wrapped
+			// in a tentativeboundary so that it doesn't affect the physical cursor.
+			// Then we apply it specifically to the tentative cursor.
+			applied = this.addPrediction(buffer, new TentativeBoundary(prediction));
+			prediction.apply(buffer, this.tentativeCursor(buffer));
 		}
 		this.currentGen++;
 		return applied;
@@ -956,19 +979,35 @@ export class PredictionTimeline {
 		return this.expected[0]?.p;
 	}
 
-	public getCursor(buffer: IBuffer) {
-		if (!this.cursor) {
+	/**
+	 * Current position of the cursor in the terminal.
+	 */
+	public physicalCursor(buffer: IBuffer) {
+		if (!this._physicalCursor) {
 			if (this.showPredictions) {
 				flushOutput(this.terminal);
 			}
-			this.cursor = new Cursor(this.terminal.rows, this.terminal.cols, buffer);
+			this._physicalCursor = new Cursor(this.terminal.rows, this.terminal.cols, buffer);
 		}
 
-		return this.cursor;
+		return this._physicalCursor;
+	}
+
+	/**
+	 * Cursor position if all predictions and boundaries that have been inserted
+	 * so far turn out to be successfully predicted.
+	 */
+	public tentativeCursor(buffer: IBuffer) {
+		if (!this._tenativeCursor) {
+			this._tenativeCursor = this.physicalCursor(buffer).clone();
+		}
+
+		return this._tenativeCursor;
 	}
 
 	public clearCursor() {
-		this.cursor = undefined;
+		this._physicalCursor = undefined;
+		this._tenativeCursor = undefined;
 	}
 
 	private getActiveBuffer() {
@@ -1390,17 +1429,17 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 			this.lastRow = { y: actualY, startingX: buffer.cursorX, endingX: buffer.cursorX, charState: CharPredictState.Unknown };
 		} else {
 			this.lastRow.startingX = Math.min(this.lastRow.startingX, buffer.cursorX);
-			this.lastRow.endingX = Math.max(this.lastRow.endingX, this.timeline.getCursor(buffer).x);
+			this.lastRow.endingX = Math.max(this.lastRow.endingX, this.timeline.physicalCursor(buffer).x);
 		}
 
 		const addLeftNavigating = (p: IPrediction) =>
-			this.timeline!.getCursor(buffer).x <= this.lastRow!.startingX
-				? this.timeline!.addBoundary(buffer, new TentativeBoundary(p))
+			this.timeline!.tentativeCursor(buffer).x <= this.lastRow!.startingX
+				? this.timeline!.addBoundary(buffer, p)
 				: this.timeline!.addPrediction(buffer, p);
 
 		const addRightNavigating = (p: IPrediction) =>
-			this.timeline!.getCursor(buffer).x >= this.lastRow!.endingX - 1
-				? this.timeline!.addBoundary(buffer, new TentativeBoundary(p))
+			this.timeline!.tentativeCursor(buffer).x >= this.lastRow!.endingX - 1
+				? this.timeline!.addBoundary(buffer, p)
 				: this.timeline!.addPrediction(buffer, p);
 
 		/** @see https://github.com/xtermjs/xterm.js/blob/1913e9512c048e3cf56bb5f5df51bfff6899c184/src/common/input/Keyboard.ts */
@@ -1418,8 +1457,8 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 					flushOutput(this.timeline.terminal);
 				}
 
-				if (this.timeline!.getCursor(buffer).x <= this.lastRow!.startingX) {
-					this.timeline!.addBoundary(buffer, new TentativeBoundary(new BackspacePrediction(this.timeline.terminal)));
+				if (this.timeline.tentativeCursor(buffer).x <= this.lastRow!.startingX) {
+					this.timeline.addBoundary(buffer, new BackspacePrediction(this.timeline.terminal));
 				} else {
 					// Backspace decrements our ability to go right.
 					this.lastRow.endingX--;
@@ -1432,16 +1471,15 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 			if (reader.eatCharCode(32, 126)) { // alphanum
 				const char = data[reader.index - 1];
 				const prediction = new CharacterPrediction(this.typeaheadStyle!, char);
-				let applied: boolean;
 				if (this.lastRow.charState === CharPredictState.Unknown) {
-					applied = this.timeline.addBoundary(buffer, new TentativeBoundary(prediction));
+					this.timeline.addBoundary(buffer, prediction);
 					this.lastRow.charState = CharPredictState.HasPendingChar;
 				} else {
-					applied = this.timeline.addPrediction(buffer, prediction);
+					this.timeline.addPrediction(buffer, prediction);
 				}
 
-				if (applied && this.timeline.getCursor(buffer).x >= terminal.cols) {
-					this.timeline.addBoundary(buffer, new TentativeBoundary(new LinewrapPrediction()));
+				if (this.timeline.tentativeCursor(buffer).x >= terminal.cols) {
+					this.timeline.addBoundary(buffer, new LinewrapPrediction());
 				}
 				continue;
 			}

--- a/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
@@ -926,23 +926,23 @@ export class PredictionTimeline {
 		this.expected.push({ gen: this.currentGen, p: prediction });
 		this.addedEmitter.fire(prediction);
 
-		if (this.currentGen === this.expected[0].gen) {
-			const text = prediction.apply(buffer, this.physicalCursor(buffer));
-			this._tenativeCursor = undefined; // next read will get or clone the physical cursor
-
-			if (this.showPredictions && text) {
-				if (prediction.affectsStyle) {
-					this.style.expectIncomingStyle();
-				}
-				// console.log('predict:', JSON.stringify(text));
-				this.terminal.write(text);
-			}
-
-			return true;
+		if (this.currentGen !== this.expected[0].gen) {
+			prediction.apply(buffer, this.tentativeCursor(buffer));
+			return false;
 		}
 
-		prediction.apply(buffer, this.tentativeCursor(buffer));
-		return false;
+		const text = prediction.apply(buffer, this.physicalCursor(buffer));
+		this._tenativeCursor = undefined; // next read will get or clone the physical cursor
+
+		if (this.showPredictions && text) {
+			if (prediction.affectsStyle) {
+				this.style.expectIncomingStyle();
+			}
+			// console.log('predict:', JSON.stringify(text));
+			this.terminal.write(text);
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
@@ -517,10 +517,6 @@ class LinewrapPrediction extends NewlinePrediction implements IPrediction {
 		return ' \r';
 	}
 
-	public rollback(cursor: Cursor) {
-		return this.prevPosition ? cursor.moveTo(this.prevPosition) : '';
-	}
-
 	public matches(input: StringReader) {
 		// bash and zshell add a space which wraps in the terminal, then a CR
 		const r = input.eatGradually(' \r');

--- a/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
@@ -703,13 +703,17 @@ export class PredictionTimeline {
 	private currentGen = 0;
 
 	/**
-	 * Cursor position -- kept outside the buffer since it can be ahead if
-	 * typing swiftly.
+	 * Current cursor position -- kept outside the buffer since it can be ahead
+	 * if typing swiftly. The position of the cursor that the user is currently
+	 * looking at on their screen (or will be looking at after all pending writes
+	 * are flushed.)
 	 */
 	private _physicalCursor: Cursor | undefined;
 
 	/**
-	 * Cursor position taking into account (possibly not-yet-applied) predictions.
+	 * Cursor position taking into account all (possibly not-yet-applied)
+	 * predictions. A new prediction inserted, if applied, will be applied at
+	 * the position of the tentative cursor.
 	 */
 	private _tenativeCursor: Cursor | undefined;
 

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalTypeahead.test.ts
@@ -184,7 +184,7 @@ suite('Workbench - Terminal Typeahead', () => {
 			addon.activate(t.terminal);
 			addon.unlockNavigating();
 
-			const cursorXBefore = addon.getCursor(t.terminal.buffer.active)?.x!;
+			const cursorXBefore = addon.physicalCursor(t.terminal.buffer.active)?.x!;
 			t.onData(`${CSI}${CursorMoveDirection.Back}`);
 			t.expectWritten('');
 
@@ -192,7 +192,7 @@ suite('Workbench - Terminal Typeahead', () => {
 			onBeforeProcessData.fire({ data: 'xy' });
 
 			assert.strictEqual(
-				addon.getCursor(t.terminal.buffer.active)?.x,
+				addon.physicalCursor(t.terminal.buffer.active)?.x,
 				// The cursor should not have changed because we've hit the
 				// boundary (start of prompt)
 				cursorXBefore);
@@ -203,7 +203,7 @@ suite('Workbench - Terminal Typeahead', () => {
 			addon.activate(t.terminal);
 			addon.unlockNavigating();
 
-			const cursorXBefore = addon.getCursor(t.terminal.buffer.active)?.x!;
+			const cursorXBefore = addon.physicalCursor(t.terminal.buffer.active)?.x!;
 			t.onData(`${CSI}${CursorMoveDirection.Forwards}`);
 			t.expectWritten('');
 
@@ -211,7 +211,7 @@ suite('Workbench - Terminal Typeahead', () => {
 			onBeforeProcessData.fire({ data: 'xy' });
 
 			assert.strictEqual(
-				addon.getCursor(t.terminal.buffer.active)?.x,
+				addon.physicalCursor(t.terminal.buffer.active)?.x,
 				// The cursor should not have changed because we've hit the
 				// boundary (end of prompt)
 				cursorXBefore);
@@ -222,13 +222,13 @@ suite('Workbench - Terminal Typeahead', () => {
 			addon.activate(t.terminal);
 			addon.unlockNavigating();
 
-			const cursorXBefore = addon.getCursor(t.terminal.buffer.active)?.x!;
+			const cursorXBefore = addon.physicalCursor(t.terminal.buffer.active)?.x!;
 			t.onData(`${CSI}${CursorMoveDirection.Back}`);
 			t.expectWritten('');
 			addon.undoAllPredictions();
 
 			assert.strictEqual(
-				addon.getCursor(t.terminal.buffer.active)?.x,
+				addon.physicalCursor(t.terminal.buffer.active)?.x,
 				// The cursor should not have changed because we've hit the
 				// boundary (start of prompt)
 				cursorXBefore);
@@ -368,6 +368,22 @@ suite('Workbench - Terminal Typeahead', () => {
 			addon.reevaluateNow();
 			assert.strictEqual(addon.isShowing, true, 'expected to show again after vim closed');
 		});
+
+		test('adds line wrap prediction even if behind a boundary', () => {
+			const t = createMockTerminal({ lines: ['hello|'] });
+			addon.lockMakingPredictions();
+			addon.activate(t.terminal);
+
+			t.onData('hi'.repeat(50));
+			t.expectWritten('');
+			expectProcessed('hi', [
+				`${CSI}?25l`, // hide cursor
+				'hi', // this greeting characters
+				...new Array(36).fill(`${CSI}3mh${CSI}23m${CSI}3mi${CSI}23m`), // rest of the greetings that fit on this line
+				`${CSI}2;81H`, // move to end of line
+				`${CSI}?25h`
+			].join(''));
+		});
 	});
 });
 
@@ -396,8 +412,12 @@ class TestTypeAheadAddon extends TypeAheadAddon {
 		this.timeline?.undoAllPredictions();
 	}
 
-	public getCursor(buffer: IBuffer) {
-		return this.timeline?.getCursor(buffer);
+	public physicalCursor(buffer: IBuffer) {
+		return this.timeline?.physicalCursor(buffer);
+	}
+
+	public tentativeCursor(buffer: IBuffer) {
+		return this.timeline?.tentativeCursor(buffer);
 	}
 }
 


### PR DESCRIPTION
Some time ago we made it so that predictions would not start for a line
until the first character was successfully predicted, in order to not
accidentally predict passwords.

This was good, except when it came to wrapping. When predicting a
character, we check the cursor position determine whether we should
insert a line wrap boundary. However if no predictions are made (or if
there's any boundary in the way) the cursor would be behind the
position for prediction purposes. Namely caused wrapping issues when
pasting long commands in the terminal.

In this commit I separate the physicalCursor from the tentativeCursor,
the latter now always tracks the position of the cursor after _all_
currently-queued predictions have been validated.

This also changed how cursors are dealt with in boundaries -- I still
push the tentative prediction, but this now only moves the tentative
cursor, not the physical one.

This existed before, so I don't think this is candidate-worthy.

Fixes #115164
