### PR TITLE
Do not overwrite users environment variables

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -2189,6 +2189,11 @@
           "default": false,
           "description": "%config.useCommitInputAsStashMessage%"
         },
+        "git.useIntegratedAskPass": {
+          "type": "boolean",
+          "default": true,
+          "description": "%config.useIntegratedAskPass%"
+        },
         "git.githubAuthentication": {
           "deprecationMessage": "This setting is now deprecated, please use `github.gitAuthentication` instead."
         },

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -200,6 +200,7 @@
 	"config.experimental.installGuide": "Experimental improvements for the git setup flow.",
 	"config.repositoryScanIgnoredFolders": "List of folders that are ignored while scanning for Git repositories when `#git.autoRepositoryDetection#` is set to `true` or `subFolders`.",
 	"config.repositoryScanMaxDepth": "Controls the depth used when scanning workspace folders for Git repositories when `#git.autoRepositoryDetection#` is set to `true` or `subFolders`. Can be set to `-1` for no limit.",
+	"config.useIntegratedAskPass": "Controls whether GIT_ASKPASS should be overwritten to use the integrated version.",
 	"submenu.explorer": "Git",
 	"submenu.commit": "Commit",
 	"submenu.commit.amend": "Amend",

--- a/extensions/git/src/askpass.ts
+++ b/extensions/git/src/askpass.ts
@@ -79,13 +79,19 @@ export class Askpass implements IIPCHandler {
 			};
 		}
 
-		return {
+		let env: { [key: string]: string; } = {
 			...this.ipc.getEnv(),
-			GIT_ASKPASS: path.join(__dirname, 'askpass.sh'),
 			VSCODE_GIT_ASKPASS_NODE: process.execPath,
 			VSCODE_GIT_ASKPASS_EXTRA_ARGS: (process.versions['electron'] && process.versions['microsoft-build']) ? '--ms-enable-electron-run-as-node' : '',
 			VSCODE_GIT_ASKPASS_MAIN: path.join(__dirname, 'askpass-main.js')
 		};
+
+		const config = workspace.getConfiguration('git');
+		if (config.get<boolean>('useIntegratedAskPass')) {
+			env.GIT_ASKPASS = path.join(__dirname, 'askpass.sh');
+		}
+
+		return env;
 	}
 
 	registerCredentialsProvider(provider: CredentialsProvider): Disposable {


### PR DESCRIPTION
These environment variables are currently enforced by vscode and there is no way to overwrite them. Turning this arround allows the user to use a custom GIT_ASKPASS inside vscode (e.g. /usr/bin/ksshaskpass for kde wallet). 

This PR fixes #111839