### PR TITLE
Fix: breadcrumb not clickable if nothing to show

### DIFF
--- a/src/vs/base/browser/ui/breadcrumbs/breadcrumbsWidget.css
+++ b/src/vs/base/browser/ui/breadcrumbs/breadcrumbsWidget.css
@@ -25,6 +25,10 @@
 	outline: none;
 }
 
+.monaco-breadcrumbs .monaco-breadcrumb-item.non-clickable {
+	cursor: default;
+}
+
 .monaco-breadcrumbs .monaco-breadcrumb-item .codicon-breadcrumb-separator {
 	color: inherit;
 }

--- a/src/vs/base/browser/ui/breadcrumbs/breadcrumbsWidget.ts
+++ b/src/vs/base/browser/ui/breadcrumbs/breadcrumbsWidget.ts
@@ -15,6 +15,7 @@ import { Codicon, registerCodicon } from 'vs/base/common/codicons';
 import 'vs/css!./breadcrumbsWidget';
 
 export abstract class BreadcrumbsItem {
+	public clickable = true;
 	dispose(): void { }
 	abstract equals(other: BreadcrumbsItem): boolean;
 	abstract render(container: HTMLElement): void;
@@ -321,6 +322,7 @@ export class BreadcrumbsWidget {
 		container.tabIndex = -1;
 		container.setAttribute('role', 'listitem');
 		container.classList.add('monaco-breadcrumb-item');
+		if (!item.clickable) { container.classList.add('non-clickable'); }
 		const iconContainer = dom.$(breadcrumbSeparatorIcon.cssSelector);
 		container.appendChild(iconContainer);
 	}
@@ -328,7 +330,7 @@ export class BreadcrumbsWidget {
 	private _onClick(event: IMouseEvent): void {
 		for (let el: HTMLElement | null = event.target; el; el = el.parentElement) {
 			let idx = this._nodes.indexOf(el as HTMLDivElement);
-			if (idx >= 0) {
+			if (idx >= 0 && this._items[idx].clickable) {
 				this._focus(idx, event);
 				this._select(idx, event);
 				break;

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -112,6 +112,9 @@ class FileItem extends BreadcrumbsItem {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
 		super();
+		if (element.uri.scheme === 'git') {
+			this.clickable = false;
+		}
 	}
 
 	dispose(): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #115397

`breadcrumb` clickable  control by `clickable` flag 
