### PR TITLE
Register a separate action for opening search editor from view

### DIFF
--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -511,11 +511,10 @@ registerAction2(class extends Action2 {
 registerAction2(class OpenSearchEditorAction extends Action2 {
 	constructor() {
 		super({
-			id: SearchEditorConstants.OpenNewEditorCommandId,
-			title: localize('search.openNewEditor', "Open New Search Editor"),
+			id: 'search.action.openNewEditorFromView',
+			title: localize('search.openNewEditor', "Open New Search Editor from View"),
 			category,
 			icon: searchNewEditorIcon,
-			f1: true,
 			menu: [{
 				id: MenuId.ViewTitle,
 				group: 'navigation',


### PR DESCRIPTION
Fixes #115509 

As part of https://github.com/microsoft/vscode/commit/56a6279a1c8616781180bfa52b4b5fb3a1ac243b this action was added:
https://github.com/microsoft/vscode/blob/e9a789fd11a38415c1c997ef27b7c2f143114085/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts#L511-L529

Which overwrote the existing action with the same ID:
https://github.com/microsoft/vscode/blob/e9a789fd11a38415c1c997ef27b7c2f143114085/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts#L254-L267

This caused keybindings passing arguments to no longer work. The two actions cannot be trivially combined into one because we want the view's action to copy the search configuration from the view, and the main action to accept arguments and potentially fallback to the prior configuration. So this just gives the view's action a new ID so as to not conflict with the existing action and removes it from the command palette.