### PR TITLE
Debug console do not render checkmark in main menu view menu

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
@@ -259,16 +259,31 @@ registerAction2(class extends Action2 {
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_Y,
 				weight: KeybindingWeight.WorkbenchContrib
 			},
-			toggled: ContextKeyDefinedExpr.create(`view.${REPL_VIEW_ID}.visible`),
 			icon: debugConsole,
+			menu: [{
+				id: MenuId.MenubarViewMenu,
+				group: '4_panels',
+				order: 2
+			}]
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IInstantiationService).createInstance(ToggleViewAction, OPEN_REPL_COMMAND_ID, 'Debug Console', REPL_VIEW_ID).run();
+	}
+});
+
+// Register the same action a second time, since in the main menu we should not render the checkmark (toggle)
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: OPEN_REPL_COMMAND_ID,
+			title: nls.localize('debugPanel', "Debug Console"),
+			toggled: ContextKeyDefinedExpr.create(`view.${REPL_VIEW_ID}.visible`),
 			menu: [{
 				id: ViewsSubMenu,
 				order: 30,
 				when: ContextKeyExpr.and(ContextKeyEqualsExpr.create('viewContainer', VIEWLET_ID))
-			}, {
-				id: MenuId.MenubarViewMenu,
-				group: '4_panels',
-				order: 2
 			}]
 		});
 	}

--- a/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
@@ -24,7 +24,7 @@ import { ViewPane } from 'vs/workbench/browser/parts/views/viewPane';
 import { MenuId, registerAction2, Action2, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { IContextKeyService, ContextKeyEqualsExpr, ContextKeyExpr, ContextKeyDefinedExpr } from 'vs/platform/contextkey/common/contextkey';
 import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
-import { IViewDescriptorService } from 'vs/workbench/common/views';
+import { IViewDescriptorService, IViewsService } from 'vs/workbench/common/views';
 import { WelcomeView } from 'vs/workbench/contrib/debug/browser/welcomeView';
 import { ShowViewletAction } from 'vs/workbench/browser/viewlet';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
@@ -273,11 +273,10 @@ registerAction2(class extends Action2 {
 	}
 });
 
-// Register the same action a second time, since in the main menu we should not render the checkmark (toggle)
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: OPEN_REPL_COMMAND_ID,
+			id: 'debug.toggleReplIgnoreFocus',
 			title: nls.localize('debugPanel', "Debug Console"),
 			toggled: ContextKeyDefinedExpr.create(`view.${REPL_VIEW_ID}.visible`),
 			menu: [{
@@ -289,7 +288,12 @@ registerAction2(class extends Action2 {
 	}
 
 	async run(accessor: ServicesAccessor): Promise<void> {
-		return accessor.get(IInstantiationService).createInstance(ToggleViewAction, OPEN_REPL_COMMAND_ID, 'Debug Console', REPL_VIEW_ID).run();
+		const viewsService = accessor.get(IViewsService);
+		if (viewsService.isViewVisible(REPL_VIEW_ID)) {
+			viewsService.closeView(REPL_VIEW_ID);
+		} else {
+			await viewsService.openView(REPL_VIEW_ID);
+		}
 	}
 });
 

--- a/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
@@ -281,6 +281,7 @@ registerAction2(class extends Action2 {
 			toggled: ContextKeyDefinedExpr.create(`view.${REPL_VIEW_ID}.visible`),
 			menu: [{
 				id: ViewsSubMenu,
+				group: '3_toggleRepl',
 				order: 30,
 				when: ContextKeyExpr.and(ContextKeyEqualsExpr.create('viewContainer', VIEWLET_ID))
 			}]

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -669,7 +669,7 @@ const registry = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.Workbenc
 
 // Show Search and Find in Files are redundant, but we can't break keybindings by removing one. So it's the same action, same keybinding, registered to different IDs.
 // Show Search 'when' is redundant but if the two conflict with exactly the same keybinding and 'when' clause, then they can show up as "unbound" - #51780
-registry.registerWorkbenchAction(SyncActionDescriptor.from(OpenSearchViewletAction, { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_F }, Constants.SearchViewVisibleKey.toNegated()), 'View: Show Search', CATEGORIES.View.value);
+registry.registerWorkbenchAction(SyncActionDescriptor.from(OpenSearchViewletAction), 'View: Show Search', CATEGORIES.View.value);
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	description: {
 		description: nls.localize('findInFiles.description', "Open the search viewlet"),

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -511,11 +511,10 @@ registerAction2(class extends Action2 {
 registerAction2(class OpenSearchEditorAction extends Action2 {
 	constructor() {
 		super({
-			id: SearchEditorConstants.OpenNewEditorCommandId,
-			title: localize('search.openNewEditor', "Open New Search Editor"),
+			id: 'search.action.openNewEditorFromView',
+			title: localize('search.openNewEditor', "Open New Search Editor from View"),
 			category,
 			icon: searchNewEditorIcon,
-			f1: true,
 			menu: [{
 				id: MenuId.ViewTitle,
 				group: 'navigation',

--- a/src/vs/workbench/services/views/browser/viewDescriptorService.ts
+++ b/src/vs/workbench/services/views/browser/viewDescriptorService.ts
@@ -764,6 +764,7 @@ export class ViewDescriptorService extends Disposable implements IViewDescriptor
 							title: viewDescriptor.name,
 							menu: [{
 								id: ViewsSubMenu,
+								group: '1_toggleViews',
 								when: ContextKeyAndExpr.create([
 									ContextKeyEqualsExpr.create('viewContainer', viewContainerModel.viewContainer.id),
 									ContextKeyEqualsExpr.create('viewContainerLocation', ViewContainerLocationToString(ViewContainerLocation.Sidebar)),


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode/issues/112755

We simply register the action a second time to ignore the toggle state.
Thus the aciton in the debug viewlet `...` actions will render the toggle and the main menu will not to align with the other items.