### PR TITLE
Hide API implementation proxies, add tests to check for "proxy leakage"

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/commands.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/commands.test.ts
@@ -7,8 +7,11 @@ import 'mocha';
 import * as assert from 'assert';
 import { join } from 'path';
 import { commands, workspace, window, Uri, Range, Position, ViewColumn } from 'vscode';
+import { assertNoRpc } from '../utils';
 
 suite('vscode API - commands', () => {
+
+	teardown(assertNoRpc);
 
 	test('getCommands', function (done) {
 

--- a/extensions/vscode-api-tests/src/singlefolder-tests/configuration.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/configuration.test.ts
@@ -6,8 +6,11 @@
 import 'mocha';
 import * as assert from 'assert';
 import * as vscode from 'vscode';
+import { assertNoRpc } from '../utils';
 
 suite('vscode API - configuration', () => {
+
+	teardown(assertNoRpc);
 
 	test('configurations, language defaults', function () {
 		const defaultLanguageSettings = vscode.workspace.getConfiguration().get('[abcLang]');

--- a/extensions/vscode-api-tests/src/singlefolder-tests/debug.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/debug.test.ts
@@ -5,10 +5,12 @@
 
 import * as assert from 'assert';
 import { debug, workspace, Disposable, commands, window } from 'vscode';
-import { disposeAll } from '../utils';
+import { assertNoRpc, disposeAll } from '../utils';
 import { basename } from 'path';
 
 suite('vscode API - debug', function () {
+
+	teardown(assertNoRpc);
 
 	test('breakpoints', async function () {
 		assert.equal(debug.breakpoints.length, 0);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/editor.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/editor.test.ts
@@ -5,11 +5,14 @@
 
 import * as assert from 'assert';
 import { workspace, window, Position, Range, commands, TextEditor, TextDocument, TextEditorCursorStyle, TextEditorLineNumbersStyle, SnippetString, Selection, Uri, env } from 'vscode';
-import { createRandomFile, deleteFile, closeAllEditors } from '../utils';
+import { createRandomFile, deleteFile, closeAllEditors, assertNoRpc } from '../utils';
 
 suite('vscode API - editors', () => {
 
-	teardown(closeAllEditors);
+	teardown(async function () {
+		assertNoRpc();
+		await closeAllEditors();
+	});
 
 	function withRandomFileEditor(initialContents: string, run: (editor: TextEditor, doc: TextDocument) => Thenable<void>): Thenable<boolean> {
 		return createRandomFile(initialContents).then(file => {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/env.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/env.test.ts
@@ -5,8 +5,11 @@
 
 import * as assert from 'assert';
 import { env, extensions, ExtensionKind, UIKind, Uri } from 'vscode';
+import { assertNoRpc } from '../utils';
 
 suite('vscode API - env', () => {
+
+	teardown(assertNoRpc);
 
 	test('env is set', function () {
 		assert.equal(typeof env.language, 'string');

--- a/extensions/vscode-api-tests/src/singlefolder-tests/languages.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/languages.test.ts
@@ -6,9 +6,11 @@
 import * as assert from 'assert';
 import { join } from 'path';
 import * as vscode from 'vscode';
-import { createRandomFile, testFs } from '../utils';
+import { assertNoRpc, createRandomFile, testFs } from '../utils';
 
 suite('vscode API - languages', () => {
+
+	teardown(assertNoRpc);
 
 	const isWindows = process.platform === 'win32';
 

--- a/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import { window, commands } from 'vscode';
-import { closeAllEditors } from '../utils';
+import { assertNoRpc, closeAllEditors } from '../utils';
 
 interface QuickPickExpected {
 	events: string[];
@@ -20,7 +20,10 @@ interface QuickPickExpected {
 
 suite('vscode API - quick input', function () {
 
-	teardown(closeAllEditors);
+	teardown(async function () {
+		assertNoRpc();
+		await closeAllEditors();
+	});
 
 	test('createQuickPick, select second', function (_done) {
 		let done = (err?: any) => {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
@@ -45,9 +45,9 @@ suite('vscode', function () {
 		} catch (err) {
 			assert.fail(err);
 		}
-		assert.strictEqual(rpcPaths.length, 0);
+		assert.strictEqual(rpcPaths.length, 0, rpcPaths.join('\n'));
 
-		// assert.strictEqual(proxyPaths.length, 0); // proxies are accessible...
+		// assert.strictEqual(proxyPaths.length, 0, proxyPaths.join('\n')); // proxies are accessible...
 	});
 
 });

--- a/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+suite('vscode', function () {
+
+	test('rpc protocol, proxies not reachable', function () {
+
+		const symProxy = Symbol.for('rpcProxy');
+		const symProtocol = Symbol.for('rpcProtocol');
+
+		const proxyPaths: string[] = [];
+		const rpcPaths: string[] = [];
+
+		function walk(obj: any, path: string, seen: Set<any>) {
+			if (!obj) {
+				return;
+			}
+			if (typeof obj !== 'object' && typeof obj !== 'function') {
+				return;
+			}
+			if (seen.has(obj)) {
+				return;
+			}
+			seen.add(obj);
+
+			if (obj[symProtocol]) {
+				rpcPaths.push(`PROTOCOL via ${path}`);
+			}
+			if (obj[symProxy]) {
+				proxyPaths.push(`PROXY '${obj[symProxy]}' via ${path}`);
+			}
+
+			for (const key in obj) {
+				walk(obj[key], `${path}.${String(key)}`, seen);
+			}
+		}
+
+		try {
+			walk(vscode, 'vscode', new Set());
+		} catch (err) {
+			assert.fail(err);
+		}
+		assert.strictEqual(rpcPaths.length, 0);
+
+		// assert.strictEqual(proxyPaths.length, 0); // proxies are accessible...
+	});
+
+});

--- a/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
@@ -37,6 +37,20 @@ suite('vscode', function () {
 		assertNoRpcFromEntry([item, 'DiagnosticCollection']);
 	});
 
+	test('no rpc, createQuickPick(...)', function () {
+		this.skip();
+		const item = vscode.window.createQuickPick();
+		dispo.push(item);
+		assertNoRpcFromEntry([item, 'QuickPick']);
+	});
+
+	test('no rpc, createInputBox(...)', function () {
+		this.skip();
+		const item = vscode.window.createInputBox();
+		dispo.push(item);
+		assertNoRpcFromEntry([item, 'InputBox']);
+	});
+
 	test('no rpc, createStatusBarItem(...)', function () {
 		this.skip();
 		const item = vscode.window.createStatusBarItem();
@@ -50,10 +64,31 @@ suite('vscode', function () {
 		dispo.push(item);
 		assertNoRpcFromEntry([item, 'SourceControl']);
 	});
+
 	test('no rpc, createCommentController(...)', function () {
 		this.skip();
 		const item = vscode.comments.createCommentController('foo', 'Hello');
 		dispo.push(item);
 		assertNoRpcFromEntry([item, 'CommentController']);
+	});
+
+	test('no rpc, createWebviewPanel(...)', function () {
+		const item = vscode.window.createWebviewPanel('webview', 'Hello', vscode.ViewColumn.Active);
+		dispo.push(item);
+		assertNoRpcFromEntry([item, 'WebviewPanel']);
+	});
+
+	test('no rpc, createTreeView(...)', function () {
+		const treeDataProvider = new class implements vscode.TreeDataProvider<string> {
+			getTreeItem(element: string): vscode.TreeItem | Thenable<vscode.TreeItem> {
+				return new vscode.TreeItem(element);
+			}
+			getChildren(_element?: string): vscode.ProviderResult<string[]> {
+				return ['foo', 'bar'];
+			}
+		};
+		const item = vscode.window.createTreeView('test.treeId', { treeDataProvider });
+		dispo.push(item);
+		assertNoRpcFromEntry([item, 'TreeView']);
 	});
 });

--- a/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
@@ -47,6 +47,10 @@ suite('vscode', function () {
 		}
 		assert.strictEqual(rpcPaths.length, 0, rpcPaths.join('\n'));
 		assert.strictEqual(proxyPaths.length, 0, proxyPaths.join('\n'));
+
+		// todo@jrieken
+		// this should be run after/before each test because some objects are short lived,
+		// like notebook-editor, documents etc.
 	});
 
 });

--- a/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
@@ -3,11 +3,58 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { assertNoRpc } from '../utils';
+import { assertNoRpcFromEntry, assertNoRpc, disposeAll } from '../utils';
+import * as vscode from 'vscode';
 
 suite('vscode', function () {
 
+	const dispo: vscode.Disposable[] = [];
+
+	teardown(() => {
+		assertNoRpc();
+		disposeAll(dispo);
+	});
+
 	test('no rpc', function () {
 		assertNoRpc();
+	});
+
+	test('no rpc, createTextEditorDecorationType(...)', function () {
+		this.skip();
+		const item = vscode.window.createTextEditorDecorationType({});
+		dispo.push(item);
+		assertNoRpcFromEntry([item, 'TextEditorDecorationType']);
+	});
+
+	test('no rpc, createOutputChannel(...)', function () {
+		const item = vscode.window.createOutputChannel('hello');
+		dispo.push(item);
+		assertNoRpcFromEntry([item, 'OutputChannel']);
+	});
+
+	test('no rpc, createDiagnosticCollection(...)', function () {
+		const item = vscode.languages.createDiagnosticCollection();
+		dispo.push(item);
+		assertNoRpcFromEntry([item, 'DiagnosticCollection']);
+	});
+
+	test('no rpc, createStatusBarItem(...)', function () {
+		this.skip();
+		const item = vscode.window.createStatusBarItem();
+		dispo.push(item);
+		assertNoRpcFromEntry([item, 'StatusBarItem']);
+	});
+
+	test('no rpc, createSourceControl(...)', function () {
+		this.skip();
+		const item = vscode.scm.createSourceControl('foo', 'Hello');
+		dispo.push(item);
+		assertNoRpcFromEntry([item, 'SourceControl']);
+	});
+	test('no rpc, createCommentController(...)', function () {
+		this.skip();
+		const item = vscode.comments.createCommentController('foo', 'Hello');
+		dispo.push(item);
+		assertNoRpcFromEntry([item, 'CommentController']);
 	});
 });

--- a/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
@@ -20,7 +20,6 @@ suite('vscode', function () {
 	});
 
 	test('no rpc, createTextEditorDecorationType(...)', function () {
-		this.skip();
 		const item = vscode.window.createTextEditorDecorationType({});
 		dispo.push(item);
 		assertNoRpcFromEntry([item, 'TextEditorDecorationType']);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
@@ -46,8 +46,7 @@ suite('vscode', function () {
 			assert.fail(err);
 		}
 		assert.strictEqual(rpcPaths.length, 0, rpcPaths.join('\n'));
-
-		// assert.strictEqual(proxyPaths.length, 0, proxyPaths.join('\n')); // proxies are accessible...
+		assert.strictEqual(proxyPaths.length, 0, proxyPaths.join('\n'));
 	});
 
 });

--- a/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/rpc.test.ts
@@ -3,54 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as assert from 'assert';
-import * as vscode from 'vscode';
+import { assertNoRpc } from '../utils';
 
 suite('vscode', function () {
 
-	test('rpc protocol, proxies not reachable', function () {
-
-		const symProxy = Symbol.for('rpcProxy');
-		const symProtocol = Symbol.for('rpcProtocol');
-
-		const proxyPaths: string[] = [];
-		const rpcPaths: string[] = [];
-
-		function walk(obj: any, path: string, seen: Set<any>) {
-			if (!obj) {
-				return;
-			}
-			if (typeof obj !== 'object' && typeof obj !== 'function') {
-				return;
-			}
-			if (seen.has(obj)) {
-				return;
-			}
-			seen.add(obj);
-
-			if (obj[symProtocol]) {
-				rpcPaths.push(`PROTOCOL via ${path}`);
-			}
-			if (obj[symProxy]) {
-				proxyPaths.push(`PROXY '${obj[symProxy]}' via ${path}`);
-			}
-
-			for (const key in obj) {
-				walk(obj[key], `${path}.${String(key)}`, seen);
-			}
-		}
-
-		try {
-			walk(vscode, 'vscode', new Set());
-		} catch (err) {
-			assert.fail(err);
-		}
-		assert.strictEqual(rpcPaths.length, 0, rpcPaths.join('\n'));
-		assert.strictEqual(proxyPaths.length, 0, proxyPaths.join('\n'));
-
-		// todo@jrieken
-		// this should be run after/before each test because some objects are short lived,
-		// like notebook-editor, documents etc.
+	test('no rpc', function () {
+		assertNoRpc();
 	});
-
 });

--- a/extensions/vscode-api-tests/src/singlefolder-tests/terminal.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/terminal.test.ts
@@ -5,6 +5,7 @@
 
 import { window, Pseudoterminal, EventEmitter, TerminalDimensions, workspace, ConfigurationTarget, Disposable, UIKind, env, EnvironmentVariableMutatorType, EnvironmentVariableMutator, extensions, ExtensionContext, TerminalOptions, ExtensionTerminalOptions } from 'vscode';
 import { doesNotThrow, equal, ok, deepEqual, throws } from 'assert';
+import { assertNoRpc } from '../utils';
 
 // Disable terminal tests:
 // - Web https://github.com/microsoft/vscode/issues/92826
@@ -30,6 +31,7 @@ import { doesNotThrow, equal, ok, deepEqual, throws } from 'assert';
 		let disposables: Disposable[] = [];
 
 		teardown(() => {
+			assertNoRpc();
 			disposables.forEach(d => d.dispose());
 			disposables.length = 0;
 		});

--- a/extensions/vscode-api-tests/src/singlefolder-tests/types.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/types.test.ts
@@ -6,8 +6,11 @@
 import 'mocha';
 import * as assert from 'assert';
 import * as vscode from 'vscode';
+import { assertNoRpc } from '../utils';
 
 suite('vscode API - types', () => {
+
+	teardown(assertNoRpc);
 
 	test('static properties, es5 compat class', function () {
 		assert.ok(vscode.ThemeIcon.File instanceof vscode.ThemeIcon);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import 'mocha';
 import * as os from 'os';
 import * as vscode from 'vscode';
-import { closeAllEditors, delay, disposeAll } from '../utils';
+import { assertNoRpc, closeAllEditors, delay, disposeAll } from '../utils';
 
 const webviewId = 'myWebview';
 
@@ -26,8 +26,8 @@ suite.skip('vscode API - webview', () => {
 	}
 
 	teardown(async () => {
+		assertNoRpc();
 		await closeAllEditors();
-
 		disposeAll(disposables);
 	});
 

--- a/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
@@ -6,12 +6,15 @@
 import * as assert from 'assert';
 import { workspace, window, commands, ViewColumn, TextEditorViewColumnChangeEvent, Uri, Selection, Position, CancellationTokenSource, TextEditorSelectionChangeKind, QuickPickItem, TextEditor } from 'vscode';
 import { join } from 'path';
-import { closeAllEditors, pathEquals, createRandomFile } from '../utils';
+import { closeAllEditors, pathEquals, createRandomFile, assertNoRpc } from '../utils';
 
 
 suite('vscode API - window', () => {
 
-	teardown(closeAllEditors);
+	teardown(async function () {
+		assertNoRpc();
+		await closeAllEditors();
+	});
 
 	test('editor, active text editor', async () => {
 		const doc = await workspace.openTextDocument(join(workspace.rootPath || '', './far.js'));
@@ -429,8 +432,8 @@ suite('vscode API - window', () => {
 	});
 
 	test('showQuickPick, select first two', async function () {
-		const label = 'showQuickPick, select first two';
-		let i = 0;
+		// const label = 'showQuickPick, select first two';
+		// let i = 0;
 		const resolves: ((value: string) => void)[] = [];
 		let done: () => void;
 		const unexpected = new Promise<void>((resolve, reject) => {
@@ -442,26 +445,26 @@ suite('vscode API - window', () => {
 			canPickMany: true
 		});
 		const first = new Promise(resolve => resolves.push(resolve));
-		console.log(`${label}: ${++i}`);
+		// console.log(`${label}: ${++i}`);
 		await new Promise(resolve => setTimeout(resolve, 100)); // Allow UI to update.
-		console.log(`${label}: ${++i}`);
+		// console.log(`${label}: ${++i}`);
 		await commands.executeCommand('workbench.action.quickOpenSelectNext');
-		console.log(`${label}: ${++i}`);
+		// console.log(`${label}: ${++i}`);
 		assert.equal(await first, 'eins');
-		console.log(`${label}: ${++i}`);
+		// console.log(`${label}: ${++i}`);
 		await commands.executeCommand('workbench.action.quickPickManyToggle');
-		console.log(`${label}: ${++i}`);
+		// console.log(`${label}: ${++i}`);
 		const second = new Promise(resolve => resolves.push(resolve));
 		await commands.executeCommand('workbench.action.quickOpenSelectNext');
-		console.log(`${label}: ${++i}`);
+		// console.log(`${label}: ${++i}`);
 		assert.equal(await second, 'zwei');
-		console.log(`${label}: ${++i}`);
+		// console.log(`${label}: ${++i}`);
 		await commands.executeCommand('workbench.action.quickPickManyToggle');
-		console.log(`${label}: ${++i}`);
+		// console.log(`${label}: ${++i}`);
 		await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
-		console.log(`${label}: ${++i}`);
+		// console.log(`${label}: ${++i}`);
 		assert.deepStrictEqual(await picks, ['eins', 'zwei']);
-		console.log(`${label}: ${++i}`);
+		// console.log(`${label}: ${++i}`);
 		done!();
 		return unexpected;
 	});

--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.event.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.event.test.ts
@@ -5,16 +5,15 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { createRandomFile, withLogDisabled } from '../utils';
+import { assertNoRpc, createRandomFile, disposeAll, withLogDisabled } from '../utils';
 
 suite('vscode API - workspace events', () => {
 
 	const disposables: vscode.Disposable[] = [];
 
 	teardown(() => {
-		for (const dispo of disposables) {
-			dispo.dispose();
-		}
+		assertNoRpc();
+		disposeAll(disposables);
 		disposables.length = 0;
 	});
 

--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.fs.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.fs.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { posix } from 'path';
+import { assertNoRpc } from '../utils';
 
 suite('vscode API - workspace-fs', () => {
 
@@ -14,6 +15,8 @@ suite('vscode API - workspace-fs', () => {
 	suiteSetup(function () {
 		root = vscode.workspace.workspaceFolders![0]!.uri;
 	});
+
+	teardown(assertNoRpc);
 
 	test('fs.stat', async function () {
 		const stat = await vscode.workspace.fs.stat(root);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.tasks.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.tasks.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import { window, tasks, Disposable, TaskDefinition, Task, EventEmitter, CustomExecution, Pseudoterminal, TaskScope, commands, env, UIKind, ShellExecution, TaskExecution, Terminal, Event } from 'vscode';
+import { assertNoRpc } from '../utils';
 
 // Disable tasks tests:
 // - Web https://github.com/microsoft/vscode/issues/90528
@@ -14,6 +15,7 @@ import { window, tasks, Disposable, TaskDefinition, Task, EventEmitter, CustomEx
 		let disposables: Disposable[] = [];
 
 		teardown(() => {
+			assertNoRpc();
 			disposables.forEach(d => d.dispose());
 			disposables.length = 0;
 		});

--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.test.ts
@@ -5,14 +5,17 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { createRandomFile, deleteFile, closeAllEditors, pathEquals, rndName, disposeAll, testFs, delay, withLogDisabled, revertAllDirty } from '../utils';
+import { createRandomFile, deleteFile, closeAllEditors, pathEquals, rndName, disposeAll, testFs, delay, withLogDisabled, revertAllDirty, assertNoRpc } from '../utils';
 import { join, posix, basename } from 'path';
 import * as fs from 'fs';
 import { TestFS } from '../memfs';
 
 suite('vscode API - workspace', () => {
 
-	teardown(closeAllEditors);
+	teardown(async function () {
+		assertNoRpc();
+		await closeAllEditors();
+	});
 
 	test('MarkdownString', function () {
 		let md = new vscode.MarkdownString();

--- a/extensions/vscode-api-tests/src/utils.ts
+++ b/extensions/vscode-api-tests/src/utils.ts
@@ -74,6 +74,10 @@ export function withLogDisabled(runnable: () => Promise<any>): () => Promise<voi
 }
 
 export function assertNoRpc() {
+	assertNoRpcFromEntry([vscode, 'vscode']);
+}
+
+export function assertNoRpcFromEntry(entry: [obj: any, name: string]) {
 
 	const symProxy = Symbol.for('rpcProxy');
 	const symProtocol = Symbol.for('rpcProtocol');
@@ -106,7 +110,7 @@ export function assertNoRpc() {
 	}
 
 	try {
-		walk(vscode, 'vscode', new Set());
+		walk(entry[0], entry[1], new Set());
 	} catch (err) {
 		assert.fail(err);
 	}

--- a/extensions/vscode-api-tests/src/utils.ts
+++ b/extensions/vscode-api-tests/src/utils.ts
@@ -72,3 +72,44 @@ export function withLogDisabled(runnable: () => Promise<any>): () => Promise<voi
 		}
 	};
 }
+
+export function assertNoRpc() {
+
+	const symProxy = Symbol.for('rpcProxy');
+	const symProtocol = Symbol.for('rpcProtocol');
+
+	const proxyPaths: string[] = [];
+	const rpcPaths: string[] = [];
+
+	function walk(obj: any, path: string, seen: Set<any>) {
+		if (!obj) {
+			return;
+		}
+		if (typeof obj !== 'object' && typeof obj !== 'function') {
+			return;
+		}
+		if (seen.has(obj)) {
+			return;
+		}
+		seen.add(obj);
+
+		if (obj[symProtocol]) {
+			rpcPaths.push(`PROTOCOL via ${path}`);
+		}
+		if (obj[symProxy]) {
+			proxyPaths.push(`PROXY '${obj[symProxy]}' via ${path}`);
+		}
+
+		for (const key in obj) {
+			walk(obj[key], `${path}.${String(key)}`, seen);
+		}
+	}
+
+	try {
+		walk(vscode, 'vscode', new Set());
+	} catch (err) {
+		assert.fail(err);
+	}
+	assert.strictEqual(rpcPaths.length, 0, rpcPaths.join('\n'));
+	assert.strictEqual(proxyPaths.length, 0, proxyPaths.join('\n')); // happens...
+}

--- a/src/vs/workbench/api/browser/mainThreadEditor.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditor.ts
@@ -79,7 +79,6 @@ export class MainThreadTextEditorProperties {
 		return {
 			insertSpaces: modelOptions.insertSpaces,
 			tabSize: modelOptions.tabSize,
-			indentSize: modelOptions.indentSize,
 			cursorStyle: cursorStyle,
 			lineNumbers: lineNumbers
 		};
@@ -146,7 +145,6 @@ export class MainThreadTextEditorProperties {
 		}
 		return (
 			a.tabSize === b.tabSize
-			&& a.indentSize === b.indentSize
 			&& a.insertSpaces === b.insertSpaces
 			&& a.cursorStyle === b.cursorStyle
 			&& a.lineNumbers === b.lineNumbers
@@ -376,13 +374,6 @@ export class MainThreadTextEditor {
 		}
 		if (typeof newConfiguration.tabSize !== 'undefined') {
 			newOpts.tabSize = newConfiguration.tabSize;
-		}
-		if (typeof newConfiguration.indentSize !== 'undefined') {
-			if (newConfiguration.indentSize === 'tabSize') {
-				newOpts.indentSize = newOpts.tabSize || creationOpts.tabSize;
-			} else {
-				newOpts.indentSize = newConfiguration.indentSize;
-			}
 		}
 		this._model.updateOptions(newOpts);
 	}

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -829,7 +829,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				return extHostFileSystem.registerFileSystemProvider(extension.identifier, scheme, provider, options);
 			},
 			get fs() {
-				return extHostConsumerFileSystem;
+				return extHostConsumerFileSystem.value;
 			},
 			registerFileSearchProvider: (scheme: string, provider: vscode.FileSearchProvider) => {
 				checkProposedApiEnabled(extension);
@@ -1290,9 +1290,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 
 class Extension<T> implements vscode.Extension<T> {
 
-	private _extensionService: IExtHostExtensionService;
-	private _originExtensionId: ExtensionIdentifier;
-	private _identifier: ExtensionIdentifier;
+	#extensionService: IExtHostExtensionService;
+	#originExtensionId: ExtensionIdentifier;
+	#identifier: ExtensionIdentifier;
 
 	readonly id: string;
 	readonly extensionUri: URI;
@@ -1301,9 +1301,9 @@ class Extension<T> implements vscode.Extension<T> {
 	readonly extensionKind: vscode.ExtensionKind;
 
 	constructor(extensionService: IExtHostExtensionService, originExtensionId: ExtensionIdentifier, description: IExtensionDescription, kind: extHostTypes.ExtensionKind) {
-		this._extensionService = extensionService;
-		this._originExtensionId = originExtensionId;
-		this._identifier = description.identifier;
+		this.#extensionService = extensionService;
+		this.#originExtensionId = originExtensionId;
+		this.#identifier = description.identifier;
 		this.id = description.identifier.value;
 		this.extensionUri = description.extensionLocation;
 		this.extensionPath = path.normalize(originalFSPath(description.extensionLocation));
@@ -1312,17 +1312,17 @@ class Extension<T> implements vscode.Extension<T> {
 	}
 
 	get isActive(): boolean {
-		return this._extensionService.isActivated(this._identifier);
+		return this.#extensionService.isActivated(this.#identifier);
 	}
 
 	get exports(): T {
 		if (this.packageJSON.api === 'none') {
 			return undefined!; // Strict nulloverride - Public api
 		}
-		return <T>this._extensionService.getExtensionExports(this._identifier);
+		return <T>this.#extensionService.getExtensionExports(this.#identifier);
 	}
 
 	activate(): Thenable<T> {
-		return this._extensionService.activateByIdWithErrors(this._identifier, { startup: false, extensionId: this._originExtensionId, activationEvent: 'api' }).then(() => this.exports);
+		return this.#extensionService.activateByIdWithErrors(this.#identifier, { startup: false, extensionId: this.#originExtensionId, activationEvent: 'api' }).then(() => this.exports);
 	}
 }

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -262,7 +262,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			registerDiffInformationCommand: (id: string, callback: (diff: vscode.LineChange[], ...args: any[]) => any, thisArg?: any): vscode.Disposable => {
 				checkProposedApiEnabled(extension);
 				return extHostCommands.registerCommand(true, id, async (...args: any[]): Promise<any> => {
-					const activeTextEditor = extHostEditors.getActiveTextEditor();
+					const activeTextEditor = extHostDocumentsAndEditors.activeEditor(true);
 					if (!activeTextEditor) {
 						extHostLogService.warn('Cannot execute ' + id + ' because there is no active text editor.');
 						return undefined;

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -288,9 +288,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			get appName() { return initData.environment.appName; },
 			get appRoot() { return initData.environment.appRoot?.fsPath ?? ''; },
 			get uriScheme() { return initData.environment.appUriScheme; },
-			get clipboard(): vscode.Clipboard {
-				return extHostClipboard;
-			},
+			get clipboard(): vscode.Clipboard { return extHostClipboard.value; },
 			get shell() {
 				return extHostTerminalService.getDefaultShell(false, configProvider);
 			},

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -237,7 +237,6 @@ export interface MainThreadDocumentsShape extends IDisposable {
 
 export interface ITextEditorConfigurationUpdate {
 	tabSize?: number | 'auto';
-	indentSize?: number | 'tabSize';
 	insertSpaces?: boolean | 'auto';
 	cursorStyle?: TextEditorCursorStyle;
 	lineNumbers?: RenderLineNumbersType;
@@ -245,7 +244,6 @@ export interface ITextEditorConfigurationUpdate {
 
 export interface IResolvedTextEditorConfiguration {
 	tabSize: number;
-	indentSize: number;
 	insertSpaces: boolean;
 	cursorStyle: TextEditorCursorStyle;
 	lineNumbers: RenderLineNumbersType;

--- a/src/vs/workbench/api/common/extHostClipboard.ts
+++ b/src/vs/workbench/api/common/extHostClipboard.ts
@@ -3,22 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IMainContext, MainContext, MainThreadClipboardShape } from 'vs/workbench/api/common/extHost.protocol';
+import { IMainContext, MainContext } from 'vs/workbench/api/common/extHost.protocol';
 import type * as vscode from 'vscode';
 
-export class ExtHostClipboard implements vscode.Clipboard {
+export class ExtHostClipboard {
 
-	private readonly _proxy: MainThreadClipboardShape;
+	readonly value: vscode.Clipboard;
 
 	constructor(mainContext: IMainContext) {
-		this._proxy = mainContext.getProxy(MainContext.MainThreadClipboard);
-	}
-
-	readText(): Promise<string> {
-		return this._proxy.$readText();
-	}
-
-	writeText(value: string): Promise<void> {
-		return this._proxy.$writeText(value);
+		const proxy = mainContext.getProxy(MainContext.MainThreadClipboard);
+		this.value = Object.freeze({
+			readText() {
+				return proxy.$readText();
+			},
+			writeText(value: string) {
+				return proxy.$writeText(value);
+			}
+		});
 	}
 }

--- a/src/vs/workbench/api/common/extHostCodeInsets.ts
+++ b/src/vs/workbench/api/common/extHostCodeInsets.ts
@@ -44,8 +44,8 @@ export class ExtHostEditorInsets implements ExtHostEditorInsetsShape {
 	createWebviewEditorInset(editor: vscode.TextEditor, line: number, height: number, options: vscode.WebviewOptions | undefined, extension: IExtensionDescription): vscode.WebviewEditorInset {
 
 		let apiEditor: ExtHostTextEditor | undefined;
-		for (const candidate of this._editors.getVisibleTextEditors()) {
-			if (candidate === editor) {
+		for (const candidate of this._editors.getVisibleTextEditors(true)) {
+			if (candidate.value === editor) {
 				apiEditor = <ExtHostTextEditor>candidate;
 				break;
 			}
@@ -121,7 +121,7 @@ export class ExtHostEditorInsets implements ExtHostEditorInsetsShape {
 			}
 		};
 
-		this._proxy.$createEditorInset(handle, apiEditor.id, apiEditor.document.uri, line + 1, height, options || {}, extension.identifier, extension.extensionLocation);
+		this._proxy.$createEditorInset(handle, apiEditor.id, apiEditor.value.document.uri, line + 1, height, options || {}, extension.identifier, extension.extensionLocation);
 		this._insets.set(handle, { editor, inset, onDidReceiveMessage });
 
 		return inset;

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -89,7 +89,7 @@ export abstract class ExtHostDebugServiceBase implements IExtHostDebugService, E
 	get onDidReceiveDebugSessionCustomEvent(): Event<vscode.DebugSessionCustomEvent> { return this._onDidReceiveDebugSessionCustomEvent.event; }
 
 	private _activeDebugConsole: ExtHostDebugConsole;
-	get activeDebugConsole(): ExtHostDebugConsole { return this._activeDebugConsole; }
+	get activeDebugConsole(): vscode.DebugConsole { return this._activeDebugConsole.value; }
 
 	private _breakpoints: Map<string, vscode.Breakpoint>;
 	private _breakpointEventsActive: boolean;
@@ -911,20 +911,20 @@ export class ExtHostDebugSession implements vscode.DebugSession {
 	}
 }
 
-export class ExtHostDebugConsole implements vscode.DebugConsole {
+export class ExtHostDebugConsole {
 
-	private _debugServiceProxy: MainThreadDebugServiceShape;
+	readonly value: vscode.DebugConsole;
 
 	constructor(proxy: MainThreadDebugServiceShape) {
-		this._debugServiceProxy = proxy;
-	}
 
-	append(value: string): void {
-		this._debugServiceProxy.$appendDebugConsole(value);
-	}
-
-	appendLine(value: string): void {
-		this.append(value + '\n');
+		this.value = Object.freeze({
+			append(value: string): void {
+				proxy.$appendDebugConsole(value);
+			},
+			appendLine(value: string): void {
+				this.append(value + '\n');
+			}
+		});
 	}
 }
 

--- a/src/vs/workbench/api/common/extHostStoragePaths.ts
+++ b/src/vs/workbench/api/common/extHostStoragePaths.ts
@@ -48,7 +48,7 @@ export class ExtensionStoragePaths implements IExtensionStoragePaths {
 		const storageUri = URI.joinPath(this._environment.workspaceStorageHome, storageName);
 
 		try {
-			await this._extHostFileSystem.stat(storageUri);
+			await this._extHostFileSystem.value.stat(storageUri);
 			this._logService.trace('[ExtHostStorage] storage dir already exists', storageUri);
 			return storageUri;
 		} catch {
@@ -57,8 +57,8 @@ export class ExtensionStoragePaths implements IExtensionStoragePaths {
 
 		try {
 			this._logService.trace('[ExtHostStorage] creating dir and metadata-file', storageUri);
-			await this._extHostFileSystem.createDirectory(storageUri);
-			await this._extHostFileSystem.writeFile(
+			await this._extHostFileSystem.value.createDirectory(storageUri);
+			await this._extHostFileSystem.value.writeFile(
 				URI.joinPath(storageUri, 'meta.json'),
 				new TextEncoder().encode(JSON.stringify({
 					id: this._workspace.id,

--- a/src/vs/workbench/api/common/extHostTask.ts
+++ b/src/vs/workbench/api/common/extHostTask.ts
@@ -341,7 +341,10 @@ export namespace TaskFilterDTO {
 
 class TaskExecutionImpl implements vscode.TaskExecution {
 
-	constructor(private readonly _tasks: ExtHostTaskBase, readonly _id: string, private readonly _task: vscode.Task) {
+	readonly #tasks: ExtHostTaskBase;
+
+	constructor(tasks: ExtHostTaskBase, readonly _id: string, private readonly _task: vscode.Task) {
+		this.#tasks = tasks;
 	}
 
 	public get task(): vscode.Task {
@@ -349,7 +352,7 @@ class TaskExecutionImpl implements vscode.TaskExecution {
 	}
 
 	public terminate(): void {
-		this._tasks.terminateTask(this);
+		this.#tasks.terminateTask(this);
 	}
 
 	public fireDidStartProcess(value: tasks.TaskProcessStartedDTO): void {

--- a/src/vs/workbench/api/common/extHostTextEditor.ts
+++ b/src/vs/workbench/api/common/extHostTextEditor.ts
@@ -16,22 +16,23 @@ import type * as vscode from 'vscode';
 import { ILogService } from 'vs/platform/log/common/log';
 import { Lazy } from 'vs/base/common/lazy';
 
-export class TextEditorDecorationType implements vscode.TextEditorDecorationType {
+export class TextEditorDecorationType {
 
 	private static readonly _Keys = new IdGenerator('TextEditorDecorationType');
 
-	private _proxy: MainThreadTextEditorsShape;
-	public key: string;
+	readonly value: vscode.TextEditorDecorationType;
 
 	constructor(proxy: MainThreadTextEditorsShape, options: vscode.DecorationRenderOptions) {
-		this.key = TextEditorDecorationType._Keys.nextId();
-		this._proxy = proxy;
-		this._proxy.$registerTextEditorDecorationType(this.key, TypeConverters.DecorationRenderOptions.from(options));
+		const key = TextEditorDecorationType._Keys.nextId();
+		proxy.$registerTextEditorDecorationType(key, TypeConverters.DecorationRenderOptions.from(options));
+		this.value = Object.freeze({
+			key,
+			dispose() {
+				proxy.$removeTextEditorDecorationType(key);
+			}
+		});
 	}
 
-	public dispose(): void {
-		this._proxy.$removeTextEditorDecorationType(this.key);
-	}
 }
 
 export interface ITextEditOperation {

--- a/src/vs/workbench/api/common/extHostTextEditor.ts
+++ b/src/vs/workbench/api/common/extHostTextEditor.ts
@@ -10,11 +10,11 @@ import { TextEditorCursorStyle } from 'vs/editor/common/config/editorOptions';
 import { IRange } from 'vs/editor/common/core/range';
 import { ISingleEditOperation } from 'vs/editor/common/model';
 import { IResolvedTextEditorConfiguration, ITextEditorConfigurationUpdate, MainThreadTextEditorsShape } from 'vs/workbench/api/common/extHost.protocol';
-import { ExtHostDocumentData } from 'vs/workbench/api/common/extHostDocumentData';
 import * as TypeConverters from 'vs/workbench/api/common/extHostTypeConverters';
 import { EndOfLine, Position, Range, Selection, SnippetString, TextEditorLineNumbersStyle, TextEditorRevealType } from 'vs/workbench/api/common/extHostTypes';
 import type * as vscode from 'vscode';
 import { ILogService } from 'vs/platform/log/common/log';
+import { Lazy } from 'vs/base/common/lazy';
 
 export class TextEditorDecorationType implements vscode.TextEditorDecorationType {
 
@@ -134,36 +134,63 @@ export class TextEditorEdit {
 	}
 }
 
-export class ExtHostTextEditorOptions implements vscode.TextEditorOptions {
+export class ExtHostTextEditorOptions {
 
 	private _proxy: MainThreadTextEditorsShape;
 	private _id: string;
 	private _logService: ILogService;
 
 	private _tabSize!: number;
-	private _indentSize!: number;
 	private _insertSpaces!: boolean;
 	private _cursorStyle!: TextEditorCursorStyle;
 	private _lineNumbers!: TextEditorLineNumbersStyle;
+
+	readonly value: vscode.TextEditorOptions;
 
 	constructor(proxy: MainThreadTextEditorsShape, id: string, source: IResolvedTextEditorConfiguration, logService: ILogService) {
 		this._proxy = proxy;
 		this._id = id;
 		this._accept(source);
 		this._logService = logService;
+
+		const that = this;
+
+		this.value = {
+			get tabSize(): number | string {
+				return that._tabSize;
+			},
+			set tabSize(value: number | string) {
+				that._setTabSize(value);
+			},
+			get insertSpaces(): boolean | string {
+				return that._insertSpaces;
+			},
+			set insertSpaces(value: boolean | string) {
+				that._setInsertSpaces(value);
+			},
+			get cursorStyle(): TextEditorCursorStyle {
+				return that._cursorStyle;
+			},
+			set cursorStyle(value: TextEditorCursorStyle) {
+				that._setCursorStyle(value);
+			},
+			get lineNumbers(): TextEditorLineNumbersStyle {
+				return that._lineNumbers;
+			},
+			set lineNumbers(value: TextEditorLineNumbersStyle) {
+				that._setLineNumbers(value);
+			}
+		};
 	}
 
 	public _accept(source: IResolvedTextEditorConfiguration): void {
 		this._tabSize = source.tabSize;
-		this._indentSize = source.indentSize;
 		this._insertSpaces = source.insertSpaces;
 		this._cursorStyle = source.cursorStyle;
 		this._lineNumbers = TypeConverters.TextEditorLineNumbersStyle.to(source.lineNumbers);
 	}
 
-	public get tabSize(): number | string {
-		return this._tabSize;
-	}
+	// --- internal: tabSize
 
 	private _validateTabSize(value: number | string): number | 'auto' | null {
 		if (value === 'auto') {
@@ -183,7 +210,7 @@ export class ExtHostTextEditorOptions implements vscode.TextEditorOptions {
 		return null;
 	}
 
-	public set tabSize(value: number | string) {
+	private _setTabSize(value: number | string) {
 		const tabSize = this._validateTabSize(value);
 		if (tabSize === null) {
 			// ignore invalid call
@@ -202,50 +229,7 @@ export class ExtHostTextEditorOptions implements vscode.TextEditorOptions {
 		}));
 	}
 
-	public get indentSize(): number | string {
-		return this._indentSize;
-	}
-
-	private _validateIndentSize(value: number | string): number | 'tabSize' | null {
-		if (value === 'tabSize') {
-			return 'tabSize';
-		}
-		if (typeof value === 'number') {
-			const r = Math.floor(value);
-			return (r > 0 ? r : null);
-		}
-		if (typeof value === 'string') {
-			const r = parseInt(value, 10);
-			if (isNaN(r)) {
-				return null;
-			}
-			return (r > 0 ? r : null);
-		}
-		return null;
-	}
-
-	public set indentSize(value: number | string) {
-		const indentSize = this._validateIndentSize(value);
-		if (indentSize === null) {
-			// ignore invalid call
-			return;
-		}
-		if (typeof indentSize === 'number') {
-			if (this._indentSize === indentSize) {
-				// nothing to do
-				return;
-			}
-			// reflect the new indentSize value immediately
-			this._indentSize = indentSize;
-		}
-		this._warnOnError(this._proxy.$trySetOptions(this._id, {
-			indentSize: indentSize
-		}));
-	}
-
-	public get insertSpaces(): boolean | string {
-		return this._insertSpaces;
-	}
+	// --- internal: insert spaces
 
 	private _validateInsertSpaces(value: boolean | string): boolean | 'auto' {
 		if (value === 'auto') {
@@ -254,7 +238,7 @@ export class ExtHostTextEditorOptions implements vscode.TextEditorOptions {
 		return (value === 'false' ? false : Boolean(value));
 	}
 
-	public set insertSpaces(value: boolean | string) {
+	private _setInsertSpaces(value: boolean | string) {
 		const insertSpaces = this._validateInsertSpaces(value);
 		if (typeof insertSpaces === 'boolean') {
 			if (this._insertSpaces === insertSpaces) {
@@ -269,11 +253,9 @@ export class ExtHostTextEditorOptions implements vscode.TextEditorOptions {
 		}));
 	}
 
-	public get cursorStyle(): TextEditorCursorStyle {
-		return this._cursorStyle;
-	}
+	// --- internal: cursor style
 
-	public set cursorStyle(value: TextEditorCursorStyle) {
+	private _setCursorStyle(value: TextEditorCursorStyle) {
 		if (this._cursorStyle === value) {
 			// nothing to do
 			return;
@@ -284,11 +266,9 @@ export class ExtHostTextEditorOptions implements vscode.TextEditorOptions {
 		}));
 	}
 
-	public get lineNumbers(): TextEditorLineNumbersStyle {
-		return this._lineNumbers;
-	}
+	// --- internal: line number
 
-	public set lineNumbers(value: TextEditorLineNumbersStyle) {
+	private _setLineNumbers(value: TextEditorLineNumbersStyle) {
 		if (this._lineNumbers === value) {
 			// nothing to do
 			return;
@@ -368,31 +348,170 @@ export class ExtHostTextEditorOptions implements vscode.TextEditorOptions {
 	}
 }
 
-export class ExtHostTextEditor implements vscode.TextEditor {
-
-	private readonly _documentData: ExtHostDocumentData;
+export class ExtHostTextEditor {
 
 	private _selections: Selection[];
 	private _options: ExtHostTextEditorOptions;
 	private _visibleRanges: Range[];
 	private _viewColumn: vscode.ViewColumn | undefined;
 	private _disposed: boolean = false;
-	private _hasDecorationsForKey: { [key: string]: boolean; };
+	private _hasDecorationsForKey = new Set<string>();
+
+	readonly value: vscode.TextEditor;
 
 	constructor(
 		readonly id: string,
 		private readonly _proxy: MainThreadTextEditorsShape,
 		private readonly _logService: ILogService,
-		document: ExtHostDocumentData,
+		document: Lazy<vscode.TextDocument>,
 		selections: Selection[], options: IResolvedTextEditorConfiguration,
 		visibleRanges: Range[], viewColumn: vscode.ViewColumn | undefined
 	) {
-		this._documentData = document;
 		this._selections = selections;
 		this._options = new ExtHostTextEditorOptions(this._proxy, this.id, options, _logService);
 		this._visibleRanges = visibleRanges;
 		this._viewColumn = viewColumn;
-		this._hasDecorationsForKey = Object.create(null);
+
+		const that = this;
+
+		this.value = Object.freeze({
+			get document(): vscode.TextDocument {
+				return document.getValue();
+			},
+			set document(_value) {
+				throw readonly('document');
+			},
+			// --- selection
+			get selection(): Selection {
+				return that._selections && that._selections[0];
+			},
+			set selection(value: Selection) {
+				if (!(value instanceof Selection)) {
+					throw illegalArgument('selection');
+				}
+				that._selections = [value];
+				that._trySetSelection();
+			},
+			get selections(): Selection[] {
+				return that._selections;
+			},
+			set selections(value: Selection[]) {
+				if (!Array.isArray(value) || value.some(a => !(a instanceof Selection))) {
+					throw illegalArgument('selections');
+				}
+				that._selections = value;
+				that._trySetSelection();
+			},
+			// --- visible ranges
+			get visibleRanges(): Range[] {
+				return that._visibleRanges;
+			},
+			set visibleRanges(_value: Range[]) {
+				throw readonly('visibleRanges');
+			},
+			// --- options
+			get options(): vscode.TextEditorOptions {
+				return that._options.value;
+			},
+			set options(value: vscode.TextEditorOptions) {
+				if (!that._disposed) {
+					that._options.assign(value);
+				}
+			},
+			// --- view column
+			get viewColumn(): vscode.ViewColumn | undefined {
+				return that._viewColumn;
+			},
+			set viewColumn(_value) {
+				throw readonly('viewColumn');
+			},
+			// --- edit
+			edit(callback: (edit: TextEditorEdit) => void, options: { undoStopBefore: boolean; undoStopAfter: boolean; } = { undoStopBefore: true, undoStopAfter: true }): Promise<boolean> {
+				if (that._disposed) {
+					return Promise.reject(new Error('TextEditor#edit not possible on closed editors'));
+				}
+				const edit = new TextEditorEdit(document.getValue(), options);
+				callback(edit);
+				return that._applyEdit(edit);
+			},
+			// --- snippet edit
+			insertSnippet(snippet: SnippetString, where?: Position | readonly Position[] | Range | readonly Range[], options: { undoStopBefore: boolean; undoStopAfter: boolean; } = { undoStopBefore: true, undoStopAfter: true }): Promise<boolean> {
+				if (that._disposed) {
+					return Promise.reject(new Error('TextEditor#insertSnippet not possible on closed editors'));
+				}
+				let ranges: IRange[];
+
+				if (!where || (Array.isArray(where) && where.length === 0)) {
+					ranges = that._selections.map(range => TypeConverters.Range.from(range));
+
+				} else if (where instanceof Position) {
+					const { lineNumber, column } = TypeConverters.Position.from(where);
+					ranges = [{ startLineNumber: lineNumber, startColumn: column, endLineNumber: lineNumber, endColumn: column }];
+
+				} else if (where instanceof Range) {
+					ranges = [TypeConverters.Range.from(where)];
+				} else {
+					ranges = [];
+					for (const posOrRange of where) {
+						if (posOrRange instanceof Range) {
+							ranges.push(TypeConverters.Range.from(posOrRange));
+						} else {
+							const { lineNumber, column } = TypeConverters.Position.from(posOrRange);
+							ranges.push({ startLineNumber: lineNumber, startColumn: column, endLineNumber: lineNumber, endColumn: column });
+						}
+					}
+				}
+				return _proxy.$tryInsertSnippet(id, snippet.value, ranges, options);
+			},
+			setDecorations(decorationType: vscode.TextEditorDecorationType, ranges: Range[] | vscode.DecorationOptions[]): void {
+				const willBeEmpty = (ranges.length === 0);
+				if (willBeEmpty && !that._hasDecorationsForKey.has(decorationType.key)) {
+					// avoid no-op call to the renderer
+					return;
+				}
+				if (willBeEmpty) {
+					that._hasDecorationsForKey.delete(decorationType.key);
+				} else {
+					that._hasDecorationsForKey.add(decorationType.key);
+				}
+				that._runOnProxy(() => {
+					if (TypeConverters.isDecorationOptionsArr(ranges)) {
+						return _proxy.$trySetDecorations(
+							id,
+							decorationType.key,
+							TypeConverters.fromRangeOrRangeWithMessage(ranges)
+						);
+					} else {
+						const _ranges: number[] = new Array<number>(4 * ranges.length);
+						for (let i = 0, len = ranges.length; i < len; i++) {
+							const range = ranges[i];
+							_ranges[4 * i] = range.start.line + 1;
+							_ranges[4 * i + 1] = range.start.character + 1;
+							_ranges[4 * i + 2] = range.end.line + 1;
+							_ranges[4 * i + 3] = range.end.character + 1;
+						}
+						return _proxy.$trySetDecorationsFast(
+							id,
+							decorationType.key,
+							_ranges
+						);
+					}
+				});
+			},
+			revealRange(range: Range, revealType: vscode.TextEditorRevealType): void {
+				that._runOnProxy(() => _proxy.$tryRevealRange(
+					id,
+					TypeConverters.Range.from(range),
+					(revealType || TextEditorRevealType.Default)
+				));
+			},
+			show(column: vscode.ViewColumn) {
+				_proxy.$tryShowEditor(id, TypeConverters.ViewColumn.from(column));
+			},
+			hide() {
+				_proxy.$tryHideEditor(id);
+			}
+		});
 	}
 
 	dispose() {
@@ -400,49 +519,11 @@ export class ExtHostTextEditor implements vscode.TextEditor {
 		this._disposed = true;
 	}
 
-	show(column: vscode.ViewColumn) {
-		this._proxy.$tryShowEditor(this.id, TypeConverters.ViewColumn.from(column));
-	}
-
-	hide() {
-		this._proxy.$tryHideEditor(this.id);
-	}
-
-	// ---- the document
-
-	get document(): vscode.TextDocument {
-		return this._documentData.document;
-	}
-
-	set document(value) {
-		throw readonly('document');
-	}
-
-	// ---- options
-
-	get options(): vscode.TextEditorOptions {
-		return this._options;
-	}
-
-	set options(value: vscode.TextEditorOptions) {
-		if (!this._disposed) {
-			this._options.assign(value);
-		}
-	}
+	// --- incoming: extension host MUST accept what the renderer says
 
 	_acceptOptions(options: IResolvedTextEditorConfiguration): void {
 		ok(!this._disposed);
 		this._options._accept(options);
-	}
-
-	// ---- visible ranges
-
-	get visibleRanges(): Range[] {
-		return this._visibleRanges;
-	}
-
-	set visibleRanges(value: Range[]) {
-		throw readonly('visibleRanges');
 	}
 
 	_acceptVisibleRanges(value: Range[]): void {
@@ -450,98 +531,9 @@ export class ExtHostTextEditor implements vscode.TextEditor {
 		this._visibleRanges = value;
 	}
 
-	// ---- view column
-
-	get viewColumn(): vscode.ViewColumn | undefined {
-		return this._viewColumn;
-	}
-
-	set viewColumn(value) {
-		throw readonly('viewColumn');
-	}
-
 	_acceptViewColumn(value: vscode.ViewColumn) {
 		ok(!this._disposed);
 		this._viewColumn = value;
-	}
-
-	// ---- selections
-
-	get selection(): Selection {
-		return this._selections && this._selections[0];
-	}
-
-	set selection(value: Selection) {
-		if (!(value instanceof Selection)) {
-			throw illegalArgument('selection');
-		}
-		this._selections = [value];
-		this._trySetSelection();
-	}
-
-	get selections(): Selection[] {
-		return this._selections;
-	}
-
-	set selections(value: Selection[]) {
-		if (!Array.isArray(value) || value.some(a => !(a instanceof Selection))) {
-			throw illegalArgument('selections');
-		}
-		this._selections = value;
-		this._trySetSelection();
-	}
-
-	setDecorations(decorationType: vscode.TextEditorDecorationType, ranges: Range[] | vscode.DecorationOptions[]): void {
-		const willBeEmpty = (ranges.length === 0);
-		if (willBeEmpty && !this._hasDecorationsForKey[decorationType.key]) {
-			// avoid no-op call to the renderer
-			return;
-		}
-		if (willBeEmpty) {
-			delete this._hasDecorationsForKey[decorationType.key];
-		} else {
-			this._hasDecorationsForKey[decorationType.key] = true;
-		}
-		this._runOnProxy(
-			() => {
-				if (TypeConverters.isDecorationOptionsArr(ranges)) {
-					return this._proxy.$trySetDecorations(
-						this.id,
-						decorationType.key,
-						TypeConverters.fromRangeOrRangeWithMessage(ranges)
-					);
-				} else {
-					const _ranges: number[] = new Array<number>(4 * ranges.length);
-					for (let i = 0, len = ranges.length; i < len; i++) {
-						const range = ranges[i];
-						_ranges[4 * i] = range.start.line + 1;
-						_ranges[4 * i + 1] = range.start.character + 1;
-						_ranges[4 * i + 2] = range.end.line + 1;
-						_ranges[4 * i + 3] = range.end.character + 1;
-					}
-					return this._proxy.$trySetDecorationsFast(
-						this.id,
-						decorationType.key,
-						_ranges
-					);
-				}
-			}
-		);
-	}
-
-	revealRange(range: Range, revealType: vscode.TextEditorRevealType): void {
-		this._runOnProxy(
-			() => this._proxy.$tryRevealRange(
-				this.id,
-				TypeConverters.Range.from(range),
-				(revealType || TextEditorRevealType.Default)
-			)
-		);
-	}
-
-	private _trySetSelection(): Promise<vscode.TextEditor | null | undefined> {
-		const selection = this._selections.map(TypeConverters.Selection.from);
-		return this._runOnProxy(() => this._proxy.$trySetSelections(this.id, selection));
 	}
 
 	_acceptSelections(selections: Selection[]): void {
@@ -549,15 +541,10 @@ export class ExtHostTextEditor implements vscode.TextEditor {
 		this._selections = selections;
 	}
 
-	// ---- editing
-
-	edit(callback: (edit: TextEditorEdit) => void, options: { undoStopBefore: boolean; undoStopAfter: boolean; } = { undoStopBefore: true, undoStopAfter: true }): Promise<boolean> {
-		if (this._disposed) {
-			return Promise.reject(new Error('TextEditor#edit not possible on closed editors'));
-		}
-		const edit = new TextEditorEdit(this._documentData.document, options);
-		callback(edit);
-		return this._applyEdit(edit);
+	private async _trySetSelection(): Promise<vscode.TextEditor | null | undefined> {
+		const selection = this._selections.map(TypeConverters.Selection.from);
+		await this._runOnProxy(() => this._proxy.$trySetSelections(this.id, selection));
+		return this.value;
 	}
 
 	private _applyEdit(editBuilder: TextEditorEdit): Promise<boolean> {
@@ -613,44 +600,12 @@ export class ExtHostTextEditor implements vscode.TextEditor {
 			undoStopAfter: editData.undoStopAfter
 		});
 	}
-
-	insertSnippet(snippet: SnippetString, where?: Position | readonly Position[] | Range | readonly Range[], options: { undoStopBefore: boolean; undoStopAfter: boolean; } = { undoStopBefore: true, undoStopAfter: true }): Promise<boolean> {
-		if (this._disposed) {
-			return Promise.reject(new Error('TextEditor#insertSnippet not possible on closed editors'));
-		}
-		let ranges: IRange[];
-
-		if (!where || (Array.isArray(where) && where.length === 0)) {
-			ranges = this._selections.map(range => TypeConverters.Range.from(range));
-
-		} else if (where instanceof Position) {
-			const { lineNumber, column } = TypeConverters.Position.from(where);
-			ranges = [{ startLineNumber: lineNumber, startColumn: column, endLineNumber: lineNumber, endColumn: column }];
-
-		} else if (where instanceof Range) {
-			ranges = [TypeConverters.Range.from(where)];
-		} else {
-			ranges = [];
-			for (const posOrRange of where) {
-				if (posOrRange instanceof Range) {
-					ranges.push(TypeConverters.Range.from(posOrRange));
-				} else {
-					const { lineNumber, column } = TypeConverters.Position.from(posOrRange);
-					ranges.push({ startLineNumber: lineNumber, startColumn: column, endLineNumber: lineNumber, endColumn: column });
-				}
-			}
-		}
-
-		return this._proxy.$tryInsertSnippet(this.id, snippet.value, ranges, options);
-	}
-
-	// ---- util
-
 	private _runOnProxy(callback: () => Promise<any>): Promise<ExtHostTextEditor | undefined | null> {
 		if (this._disposed) {
 			this._logService.warn('TextEditor is closed/disposed');
 			return Promise.resolve(undefined);
 		}
+
 		return callback().then(() => this, err => {
 			if (!(err instanceof Error && err.name === 'DISPOSED')) {
 				this._logService.warn(err);
@@ -659,4 +614,3 @@ export class ExtHostTextEditor implements vscode.TextEditor {
 		});
 	}
 }
-

--- a/src/vs/workbench/api/common/extHostTextEditors.ts
+++ b/src/vs/workbench/api/common/extHostTextEditors.ts
@@ -92,7 +92,7 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 	}
 
 	createTextEditorDecorationType(options: vscode.DecorationRenderOptions): vscode.TextEditorDecorationType {
-		return new TextEditorDecorationType(this._proxy, options);
+		return new TextEditorDecorationType(this._proxy, options).value;
 	}
 
 	// --- called from main thread

--- a/src/vs/workbench/api/common/extHostTextEditors.ts
+++ b/src/vs/workbench/api/common/extHostTextEditors.ts
@@ -41,12 +41,17 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 		this._extHostDocumentsAndEditors.onDidChangeActiveTextEditor(e => this._onDidChangeActiveTextEditor.fire(e));
 	}
 
-	getActiveTextEditor(): ExtHostTextEditor | undefined {
+	getActiveTextEditor(): vscode.TextEditor | undefined {
 		return this._extHostDocumentsAndEditors.activeEditor();
 	}
 
-	getVisibleTextEditors(): vscode.TextEditor[] {
-		return this._extHostDocumentsAndEditors.allEditors();
+	getVisibleTextEditors(): vscode.TextEditor[];
+	getVisibleTextEditors(internal: true): ExtHostTextEditor[];
+	getVisibleTextEditors(internal?: true): ExtHostTextEditor[] | vscode.TextEditor[] {
+		const editors = this._extHostDocumentsAndEditors.allEditors();
+		return internal
+			? editors
+			: editors.map(editor => editor.value);
 	}
 
 	showTextDocument(document: vscode.TextDocument, column: vscode.ViewColumn, preserveFocus: boolean): Promise<vscode.TextEditor>;
@@ -75,7 +80,7 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 		const editorId = await this._proxy.$tryShowTextDocument(document.uri, options);
 		const editor = editorId && this._extHostDocumentsAndEditors.getEditor(editorId);
 		if (editor) {
-			return editor;
+			return editor.value;
 		}
 		// we have no editor... having an id means that we had an editor
 		// on the main side and that it isn't the current editor anymore...
@@ -114,7 +119,7 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 		// (2) fire change events
 		if (data.options) {
 			this._onDidChangeTextEditorOptions.fire({
-				textEditor: textEditor,
+				textEditor: textEditor.value,
 				options: { ...data.options, lineNumbers: TypeConverters.TextEditorLineNumbersStyle.to(data.options.lineNumbers) }
 			});
 		}
@@ -122,7 +127,7 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 			const kind = TextEditorSelectionChangeKind.fromValue(data.selections.source);
 			const selections = data.selections.selections.map(TypeConverters.Selection.to);
 			this._onDidChangeTextEditorSelection.fire({
-				textEditor,
+				textEditor: textEditor.value,
 				selections,
 				kind
 			});
@@ -130,7 +135,7 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 		if (data.visibleRanges) {
 			const visibleRanges = arrays.coalesce(data.visibleRanges.map(TypeConverters.Range.to));
 			this._onDidChangeTextEditorVisibleRanges.fire({
-				textEditor,
+				textEditor: textEditor.value,
 				visibleRanges
 			});
 		}
@@ -143,9 +148,9 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 				throw new Error('Unknown text editor');
 			}
 			const viewColumn = TypeConverters.ViewColumn.to(data[id]);
-			if (textEditor.viewColumn !== viewColumn) {
+			if (textEditor.value.viewColumn !== viewColumn) {
 				textEditor._acceptViewColumn(viewColumn);
-				this._onDidChangeTextEditorViewColumn.fire({ textEditor, viewColumn });
+				this._onDidChangeTextEditorViewColumn.fire({ textEditor: textEditor.value, viewColumn });
 			}
 		}
 	}

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -60,7 +60,7 @@ export class ExtHostTerminalService extends BaseExtHostTerminalService {
 		const terminal = new ExtHostTerminal(this._proxy, generateUuid(), { name, shellPath, shellArgs }, name);
 		this._terminals.push(terminal);
 		terminal.create(shellPath, shellArgs);
-		return terminal;
+		return terminal.value;
 	}
 
 	public createTerminalFromOptions(options: vscode.TerminalOptions, isFeatureTerminal?: boolean): vscode.Terminal {
@@ -75,7 +75,7 @@ export class ExtHostTerminalService extends BaseExtHostTerminalService {
 			withNullAsUndefined(options.strictEnv),
 			withNullAsUndefined(options.hideFromUser),
 			withNullAsUndefined(isFeatureTerminal));
-		return terminal;
+		return terminal.value;
 	}
 
 	public getDefaultShell(useAutomationShell: boolean, configProvider: ExtHostConfigProvider): string {

--- a/src/vs/workbench/services/extensions/common/rpcProtocol.ts
+++ b/src/vs/workbench/services/extensions/common/rpcProtocol.ts
@@ -60,7 +60,12 @@ export interface IRPCProtocolLogger {
 
 const noop = () => { };
 
+const _RPCProtocolSymbol = Symbol.for('rpcProtocol');
+const _RPCProxySymbol = Symbol.for('rpcProxy');
+
 export class RPCProtocol extends Disposable implements IRPCProtocol {
+
+	[_RPCProtocolSymbol] = true;
 
 	private static readonly UNRESPONSIVE_TIME = 3 * 1000; // 3s
 
@@ -182,20 +187,23 @@ export class RPCProtocol extends Disposable implements IRPCProtocol {
 	}
 
 	public getProxy<T>(identifier: ProxyIdentifier<T>): T {
-		const rpcId = identifier.nid;
+		const { nid: rpcId, sid } = identifier;
 		if (!this._proxies[rpcId]) {
-			this._proxies[rpcId] = this._createProxy(rpcId);
+			this._proxies[rpcId] = this._createProxy(rpcId, sid);
 		}
 		return this._proxies[rpcId];
 	}
 
-	private _createProxy<T>(rpcId: number): T {
+	private _createProxy<T>(rpcId: number, debugName: string): T {
 		let handler = {
 			get: (target: any, name: PropertyKey) => {
 				if (typeof name === 'string' && !target[name] && name.charCodeAt(0) === CharCode.DollarSign) {
 					target[name] = (...myArgs: any[]) => {
 						return this._remoteCall(rpcId, name, myArgs);
 					};
+				}
+				if (name === _RPCProxySymbol) {
+					return debugName;
 				}
 				return target[name];
 			}


### PR DESCRIPTION
Our vscode API is mostly implemented through RPC'ing to the renderer. That's done through a protocol implementation and objects that represent a slice of the API, aka proxies, like `MainThreadTextEditorsShape`. These proxies usually mirror the capabilities of the API but are often more powerful.

This PR adds marker properties to proxies and the rpc-objects. It also adds a test-util that tries to reach these proxies using the API instance as entry point. In the name of being very strict, it's a test failure when any rpc object can be reached. 

_Note_ that the test can only checks on existing objects, e.g if `vscode.window.activeTextEditor` is `undefined` it cannot be traversed. That's why a check is performed during teardown of a single test. That increases the coverage but doesn't guarantee that everything is checked. 

The PR also changes how some APIs are implemented (so that proxies aren't accessible anymore). There is two strategies

1. Use a true private property, e.g `#proxy`, so that reflection doesn't find them. However, note that the emitted polyfill is significantly slower 
2. Use an object that only implements the API shape and has access to "internals" via scope variables. I have done that in most cases via the a `value` property, e.g `ExtHostTerminal#value`. There is another benefit to this approach which is TS checking that the literal only implements what is defined in the API, so  accidental API leakage is checked by the compiler


* fyi @Tyriar for changes in terminal land (see https://github.com/microsoft/vscode/pull/115530/commits/3d2ca29012c9dfc4e6671cbda949b458713d7827)
* fyi @alexr00 for changes in tasks land (see https://github.com/microsoft/vscode/pull/115530/commits/82c629eb3a4360f4ba5a47668e7e973839b5f6e8)
* fyi @weinand for changes in debug land (see https://github.com/microsoft/vscode/pull/115530/commits/3114b1c4c52c9efb624c2ba2c9cb1a0367650860)