### PR TITLE
Add an option to prevent URI.parse from decoding the URI components

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -263,17 +263,17 @@ export class URI implements UriComponents {
 	 *
 	 * @param value A string which represents an URI (see `URI#toString`).
 	 */
-	static parse(value: string, _strict: boolean = false): URI {
+	static parse(value: string, _strict: boolean = false, _percentDecode = true): URI {
 		const match = _regexp.exec(value);
 		if (!match) {
 			return new Uri(_empty, _empty, _empty, _empty, _empty);
 		}
 		return new Uri(
 			match[2] || _empty,
-			percentDecode(match[4] || _empty),
-			percentDecode(match[5] || _empty),
-			percentDecode(match[7] || _empty),
-			percentDecode(match[9] || _empty),
+			_percentDecode ? percentDecode(match[4] || _empty) : match[4],
+			_percentDecode ? percentDecode(match[5] || _empty) : match[5],
+			_percentDecode ? percentDecode(match[7] || _empty) : match[7],
+			_percentDecode ? percentDecode(match[9] || _empty) : match[9],
 			_strict
 		);
 	}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -147,7 +147,7 @@ declare namespace monaco {
 		 *
 		 * @param value A string which represents an Uri (see `Uri#toString`).
 		 */
-		static parse(value: string, _strict?: boolean): Uri;
+		static parse(value: string, _strict?: boolean, _percentDecode?: boolean): Uri;
 		/**
 		 * Creates a new Uri from a file system path, e.g. `c:\my\files`,
 		 * `/usr/home`, or `\\server\share\some\path`.

--- a/src/vs/workbench/contrib/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -101,7 +101,7 @@ export class LinkDetector {
 		const link = this.createLink(url);
 
 		this.decorateLink(link, async () => {
-			const uri = URI.parse(url);
+			const uri = URI.parse(url, false, false);
 
 			if (uri.scheme === Schemas.file) {
 				// Just using fsPath here is unsafe: https://github.com/microsoft/vscode/issues/109076
@@ -118,7 +118,7 @@ export class LinkDetector {
 				return;
 			}
 
-			this.openerService.open(url, { allowTunneling: !!this.environmentService.remoteAuthority });
+			this.openerService.open(uri, { allowTunneling: !!this.environmentService.remoteAuthority });
 		});
 
 		return link;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #112032

Currently VS Code's implementation of `URI.parse` automatically decodes percent encoded components such as `%3D` to `=` and `%26` to `&`. While this is helpful in most cases this leads to us manipulating the URI for the user even when they don't want it to be, as seen in issue #112032. My proposed solution which I believe to be the least intrusive one is to add an optional flag to the parse method that prevent decoding of these percent encoded components.
