### PR TITLE
Added a new "blankLine" option for move units

### DIFF
--- a/src/vs/editor/browser/controller/coreCommands.ts
+++ b/src/vs/editor/browser/controller/coreCommands.ts
@@ -554,6 +554,8 @@ export namespace CoreNavigationCommands {
 				case CursorMove_.Direction.Right:
 				case CursorMove_.Direction.Up:
 				case CursorMove_.Direction.Down:
+				case CursorMove_.Direction.PrevBlankLine:
+				case CursorMove_.Direction.NextBlankLine:
 				case CursorMove_.Direction.WrappedLineStart:
 				case CursorMove_.Direction.WrappedLineFirstNonWhitespaceCharacter:
 				case CursorMove_.Direction.WrappedLineColumnCenter:

--- a/src/vs/editor/browser/controller/coreCommands.ts
+++ b/src/vs/editor/browser/controller/coreCommands.ts
@@ -692,6 +692,17 @@ export namespace CoreNavigationCommands {
 		}
 	}));
 
+	export const CursorUpBlankLine: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
+		args: {
+			direction: CursorMove_.Direction.Up,
+			unit: CursorMove_.Unit.BlankLine,
+			select: false,
+			value: 1
+		},
+		id: 'cursorUpBlankLine',
+		precondition: undefined,
+	}));
+
 	export const CursorUpSelect: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
 		args: {
 			direction: CursorMove_.Direction.Up,
@@ -709,6 +720,17 @@ export namespace CoreNavigationCommands {
 			mac: { primary: KeyMod.Shift | KeyCode.UpArrow },
 			linux: { primary: KeyMod.Shift | KeyCode.UpArrow }
 		}
+	}));
+
+	export const CursorUpSelectBlankLine: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
+		args: {
+			direction: CursorMove_.Direction.Up,
+			unit: CursorMove_.Unit.BlankLine,
+			select: true,
+			value: 1
+		},
+		id: 'cursorUpSelectBlankLine',
+		precondition: undefined,
 	}));
 
 	export const CursorPageUp: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
@@ -760,6 +782,17 @@ export namespace CoreNavigationCommands {
 		}
 	}));
 
+	export const CursorDownBlankLine: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
+		args: {
+			direction: CursorMove_.Direction.Down,
+			unit: CursorMove_.Unit.BlankLine,
+			select: false,
+			value: 1
+		},
+		id: 'cursorDownBlankLine',
+		precondition: undefined,
+	}));
+
 	export const CursorDownSelect: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
 		args: {
 			direction: CursorMove_.Direction.Down,
@@ -777,6 +810,17 @@ export namespace CoreNavigationCommands {
 			mac: { primary: KeyMod.Shift | KeyCode.DownArrow },
 			linux: { primary: KeyMod.Shift | KeyCode.DownArrow }
 		}
+	}));
+
+	export const CursorDownSelectBlankLine: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
+		args: {
+			direction: CursorMove_.Direction.Down,
+			unit: CursorMove_.Unit.BlankLine,
+			select: true,
+			value: 1
+		},
+		id: 'cursorDownSelectBlankLine',
+		precondition: undefined,
 	}));
 
 	export const CursorPageDown: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({

--- a/src/vs/editor/browser/controller/coreCommands.ts
+++ b/src/vs/editor/browser/controller/coreCommands.ts
@@ -692,17 +692,6 @@ export namespace CoreNavigationCommands {
 		}
 	}));
 
-	export const CursorUpBlankLine: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
-		args: {
-			direction: CursorMove_.Direction.Up,
-			unit: CursorMove_.Unit.BlankLine,
-			select: false,
-			value: 1
-		},
-		id: 'cursorUpBlankLine',
-		precondition: undefined,
-	}));
-
 	export const CursorUpSelect: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
 		args: {
 			direction: CursorMove_.Direction.Up,
@@ -720,17 +709,6 @@ export namespace CoreNavigationCommands {
 			mac: { primary: KeyMod.Shift | KeyCode.UpArrow },
 			linux: { primary: KeyMod.Shift | KeyCode.UpArrow }
 		}
-	}));
-
-	export const CursorUpSelectBlankLine: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
-		args: {
-			direction: CursorMove_.Direction.Up,
-			unit: CursorMove_.Unit.BlankLine,
-			select: true,
-			value: 1
-		},
-		id: 'cursorUpSelectBlankLine',
-		precondition: undefined,
 	}));
 
 	export const CursorPageUp: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
@@ -782,17 +760,6 @@ export namespace CoreNavigationCommands {
 		}
 	}));
 
-	export const CursorDownBlankLine: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
-		args: {
-			direction: CursorMove_.Direction.Down,
-			unit: CursorMove_.Unit.BlankLine,
-			select: false,
-			value: 1
-		},
-		id: 'cursorDownBlankLine',
-		precondition: undefined,
-	}));
-
 	export const CursorDownSelect: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
 		args: {
 			direction: CursorMove_.Direction.Down,
@@ -810,17 +777,6 @@ export namespace CoreNavigationCommands {
 			mac: { primary: KeyMod.Shift | KeyCode.DownArrow },
 			linux: { primary: KeyMod.Shift | KeyCode.DownArrow }
 		}
-	}));
-
-	export const CursorDownSelectBlankLine: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({
-		args: {
-			direction: CursorMove_.Direction.Down,
-			unit: CursorMove_.Unit.BlankLine,
-			select: true,
-			value: 1
-		},
-		id: 'cursorDownSelectBlankLine',
-		precondition: undefined,
 	}));
 
 	export const CursorPageDown: CoreEditorCommand = registerEditorCommand(new CursorMoveBasedCommand({

--- a/src/vs/editor/common/controller/cursorMoveCommands.ts
+++ b/src/vs/editor/common/controller/cursorMoveCommands.ts
@@ -298,10 +298,18 @@ export class CursorMoveCommands {
 				}
 			}
 			case CursorMove.Direction.PrevBlankLine: {
-				return this._moveToPreviousBlankViewLine(viewModel, cursors, inSelectionMode);
+				if (unit === CursorMove.Unit.WrappedLine) {
+					return cursors.map(cursor => CursorState.fromViewState(MoveOperations.moveToPrevBlankLine(viewModel.cursorConfig, viewModel, cursor.viewState, inSelectionMode)));
+				} else {
+					return cursors.map(cursor => CursorState.fromModelState(MoveOperations.moveToPrevBlankLine(viewModel.cursorConfig, viewModel.model, cursor.modelState, inSelectionMode)));
+				}
 			}
 			case CursorMove.Direction.NextBlankLine: {
-				return this._moveToNextBlankViewLine(viewModel, cursors, inSelectionMode);
+				if (unit === CursorMove.Unit.WrappedLine) {
+					return cursors.map(cursor => CursorState.fromViewState(MoveOperations.moveToNextBlankLine(viewModel.cursorConfig, viewModel, cursor.viewState, inSelectionMode)));
+				} else {
+					return cursors.map(cursor => CursorState.fromModelState(MoveOperations.moveToNextBlankLine(viewModel.cursorConfig, viewModel.model, cursor.modelState, inSelectionMode)));
+				}
 			}
 			case CursorMove.Direction.WrappedLineStart: {
 				// Move to the beginning of the current view line
@@ -516,80 +524,6 @@ export class CursorMoveCommands {
 		for (let i = 0, len = cursors.length; i < len; i++) {
 			const cursor = cursors[i];
 			result[i] = CursorState.fromModelState(MoveOperations.moveUp(viewModel.cursorConfig, viewModel.model, cursor.modelState, inSelectionMode, linesCount));
-		}
-		return result;
-	}
-
-	private static _moveToPreviousBlankViewLine(viewModel: IViewModel, cursors: CursorState[], inSelectionMode: boolean): PartialCursorState[] {
-		let result: PartialCursorState[] = [];
-		outer:
-		for (let i = 0, len = cursors.length; i < len; i++) {
-			const cursor = cursors[i];
-			let viewLineNumber = cursor.viewState.position.lineNumber;
-
-			// If our current line is empty, skip to the next non-empty line
-			while (!viewModel.getLineContent(viewLineNumber).trim()) {
-				// If we on the first line, go to the first column
-				if (viewLineNumber === 0) {
-					result[i] = this._moveToViewPosition(viewModel, cursor, inSelectionMode, viewLineNumber, 0);
-
-					continue outer;
-				}
-
-				viewLineNumber--;
-			}
-
-			// Now skip to the next empty line
-			do {
-				// If we on the first line, go to the first column
-				if (viewLineNumber === 0) {
-					result[i] = this._moveToViewPosition(viewModel, cursor, inSelectionMode, viewLineNumber, 0);
-
-					continue outer;
-				}
-
-				viewLineNumber--;
-			} while (viewModel.getLineContent(viewLineNumber).trim());
-
-			result[i] = CursorState.fromViewState(cursor.viewState.move(inSelectionMode, viewLineNumber, 0, 0));
-		}
-		return result;
-	}
-
-	private static _moveToNextBlankViewLine(viewModel: IViewModel, cursors: CursorState[], inSelectionMode: boolean): PartialCursorState[] {
-		let result: PartialCursorState[] = [];
-		const lastLineNumber = viewModel.getLineCount();
-
-		outer:
-		for (let i = 0, len = cursors.length; i < len; i++) {
-			const cursor = cursors[i];
-			let viewLineNumber = cursor.viewState.position.lineNumber;
-
-			// If our current line is empty then skip to the next non-empty line
-			while (!viewModel.getLineContent(viewLineNumber).trim()) {
-				// If we on the last line, go to the first column
-				if (viewLineNumber === lastLineNumber) {
-					result[i] = this._moveToViewPosition(viewModel, cursor, inSelectionMode, viewLineNumber, 0);
-
-					continue outer;
-				}
-
-				viewLineNumber++;
-			}
-
-			// Now skip to the next empty line
-			do {
-				// If we on the last line, go to the first column
-				if (viewLineNumber === lastLineNumber) {
-					result[i] = this._moveToViewPosition(viewModel, cursor, inSelectionMode, viewLineNumber, 0);
-
-					continue outer;
-				}
-
-				viewLineNumber++;
-			} while (viewModel.getLineContent(viewLineNumber).trim());
-
-			result[i] = CursorState.fromViewState(cursor.viewState.move(inSelectionMode, viewLineNumber, 0, 0));
 		}
 		return result;
 	}

--- a/src/vs/editor/common/controller/cursorMoveOperations.ts
+++ b/src/vs/editor/common/controller/cursorMoveOperations.ts
@@ -229,6 +229,59 @@ export class MoveOperations {
 		);
 	}
 
+	public static moveToPrevBlankLine(config: CursorConfiguration, model: ICursorSimpleModel, cursor: SingleCursorState, inSelectionMode: boolean): SingleCursorState {
+		let lineNumber = cursor.position.lineNumber;
+
+		// If our current line is empty, skip to the next non-empty line
+		while (!model.getLineContent(lineNumber).trim()) {
+			// If we on the first line, go to the first column
+			if (lineNumber === 0) {
+				return cursor.move(inSelectionMode, lineNumber, 0, 0);
+			}
+
+			lineNumber--;
+		}
+
+		// Now skip to the next empty line
+		do {
+			// If we on the first line, go to the first column
+			if (lineNumber === 0) {
+				return cursor.move(inSelectionMode, lineNumber, 0, 0);
+			}
+
+			lineNumber--;
+		} while (model.getLineContent(lineNumber).trim());
+
+		return cursor.move(inSelectionMode, lineNumber, 0, 0);
+	}
+
+	public static moveToNextBlankLine(config: CursorConfiguration, model: ICursorSimpleModel, cursor: SingleCursorState, inSelectionMode: boolean): SingleCursorState {
+		const lastLineNumber = model.getLineCount();
+		let viewLineNumber = cursor.position.lineNumber;
+
+		// If our current line is empty then skip to the next non-empty line
+		while (!model.getLineContent(viewLineNumber).trim()) {
+			// If we on the last line, go to the first column
+			if (viewLineNumber === lastLineNumber) {
+				return cursor.move(inSelectionMode, viewLineNumber, 0, 0);
+			}
+
+			viewLineNumber++;
+		}
+
+		// Now skip to the next empty line
+		do {
+			// If we on the last line, go to the first column
+			if (viewLineNumber === lastLineNumber) {
+				return cursor.move(inSelectionMode, viewLineNumber, 0, 0);
+			}
+
+			viewLineNumber++;
+		} while (model.getLineContent(viewLineNumber).trim());
+
+		return cursor.move(inSelectionMode, viewLineNumber, 0, 0);
+	}
+
 	public static moveToBeginningOfLine(config: CursorConfiguration, model: ICursorSimpleModel, cursor: SingleCursorState, inSelectionMode: boolean): SingleCursorState {
 		let lineNumber = cursor.position.lineNumber;
 		let minColumn = model.getLineMinColumn(lineNumber);

--- a/src/vs/editor/common/controller/cursorMoveOperations.ts
+++ b/src/vs/editor/common/controller/cursorMoveOperations.ts
@@ -229,57 +229,45 @@ export class MoveOperations {
 		);
 	}
 
+	private static _isBlankLine(model: ICursorSimpleModel, lineNumber: number): boolean {
+		if (model.getLineFirstNonWhitespaceColumn(lineNumber) === 0) {
+			// empty or contains only whitespace
+			return true;
+		}
+		return false;
+	}
+
 	public static moveToPrevBlankLine(config: CursorConfiguration, model: ICursorSimpleModel, cursor: SingleCursorState, inSelectionMode: boolean): SingleCursorState {
 		let lineNumber = cursor.position.lineNumber;
 
-		// If our current line is empty, skip to the next non-empty line
-		while (!model.getLineContent(lineNumber).trim()) {
-			// If we on the first line, go to the first column
-			if (lineNumber === 0) {
-				return cursor.move(inSelectionMode, lineNumber, 0, 0);
-			}
-
+		// If our current line is blank, move to the previous non-blank line
+		while (lineNumber > 1 && this._isBlankLine(model, lineNumber)) {
 			lineNumber--;
 		}
 
-		// Now skip to the next empty line
-		do {
-			// If we on the first line, go to the first column
-			if (lineNumber === 0) {
-				return cursor.move(inSelectionMode, lineNumber, 0, 0);
-			}
-
+		// Find the previous blank line
+		while (lineNumber > 1 && !this._isBlankLine(model, lineNumber)) {
 			lineNumber--;
-		} while (model.getLineContent(lineNumber).trim());
+		}
 
-		return cursor.move(inSelectionMode, lineNumber, 0, 0);
+		return cursor.move(inSelectionMode, lineNumber, model.getLineMinColumn(lineNumber), 0);
 	}
 
 	public static moveToNextBlankLine(config: CursorConfiguration, model: ICursorSimpleModel, cursor: SingleCursorState, inSelectionMode: boolean): SingleCursorState {
-		const lastLineNumber = model.getLineCount();
-		let viewLineNumber = cursor.position.lineNumber;
+		const lineCount = model.getLineCount();
+		let lineNumber = cursor.position.lineNumber;
 
-		// If our current line is empty then skip to the next non-empty line
-		while (!model.getLineContent(viewLineNumber).trim()) {
-			// If we on the last line, go to the first column
-			if (viewLineNumber === lastLineNumber) {
-				return cursor.move(inSelectionMode, viewLineNumber, 0, 0);
-			}
-
-			viewLineNumber++;
+		// If our current line is blank, move to the next non-blank line
+		while (lineNumber < lineCount && this._isBlankLine(model, lineNumber)) {
+			lineNumber++;
 		}
 
-		// Now skip to the next empty line
-		do {
-			// If we on the last line, go to the first column
-			if (viewLineNumber === lastLineNumber) {
-				return cursor.move(inSelectionMode, viewLineNumber, 0, 0);
-			}
+		// Find the next blank line
+		while (lineNumber < lineCount && !this._isBlankLine(model, lineNumber)) {
+			lineNumber++;
+		}
 
-			viewLineNumber++;
-		} while (model.getLineContent(viewLineNumber).trim());
-
-		return cursor.move(inSelectionMode, viewLineNumber, 0, 0);
+		return cursor.move(inSelectionMode, lineNumber, model.getLineMinColumn(lineNumber), 0);
 	}
 
 	public static moveToBeginningOfLine(config: CursorConfiguration, model: ICursorSimpleModel, cursor: SingleCursorState, inSelectionMode: boolean): SingleCursorState {

--- a/src/vs/editor/test/browser/controller/cursorMoveCommand.test.ts
+++ b/src/vs/editor/test/browser/controller/cursorMoveCommand.test.ts
@@ -416,6 +416,91 @@ suite('Cursor move command test', () => {
 	});
 });
 
+suite('Cursor move by blankline test', () => {
+
+	const TEXT = [
+		'    \tMy First Line\t ',
+		'\tMy Second Line',
+		'    Third Line🐶',
+		'',
+		'1',
+		'2',
+		'3',
+		'',
+		'         ',
+		'a',
+		'b',
+	].join('\n');
+
+	function executeTest(callback: (editor: ITestCodeEditor, viewModel: ViewModel) => void): void {
+		withTestCodeEditor(TEXT, {}, (editor, viewModel) => {
+			callback(editor, viewModel);
+		});
+	}
+
+	test('move down should move to start of next blank line', () => {
+		executeTest((editor, viewModel) => {
+			moveDownByBlankLine(viewModel, false);
+			cursorEqual(viewModel, 4, 1);
+		});
+	});
+
+	test('move up should move to start of previous blank line', () => {
+		executeTest((editor, viewModel) => {
+			moveTo(viewModel, 7, 1);
+			moveUpByBlankLine(viewModel, false);
+			cursorEqual(viewModel, 4, 1);
+		});
+	});
+
+	test('move down should skip over whitespace if already on blank line', () => {
+		executeTest((editor, viewModel) => {
+			moveTo(viewModel, 8, 1);
+			moveDownByBlankLine(viewModel, false);
+			cursorEqual(viewModel, 11, 1);
+		});
+	});
+
+	test('move up should skip over whitespace if already on blank line', () => {
+		executeTest((editor, viewModel) => {
+			moveTo(viewModel, 9, 1);
+			moveUpByBlankLine(viewModel, false);
+			cursorEqual(viewModel, 4, 1);
+		});
+	});
+
+	test('move up should go to first column of first line if not empty', () => {
+		executeTest((editor, viewModel) => {
+			moveTo(viewModel, 2, 1);
+			moveUpByBlankLine(viewModel, false);
+			cursorEqual(viewModel, 1, 1);
+		});
+	});
+
+	test('move down should go to first column of last line if not empty', () => {
+		executeTest((editor, viewModel) => {
+			moveTo(viewModel, 10, 1);
+			moveDownByBlankLine(viewModel, false);
+			cursorEqual(viewModel, 11, 1);
+		});
+	});
+
+	test('select down should select to start of next blank line', () => {
+		executeTest((editor, viewModel) => {
+			moveDownByBlankLine(viewModel, true);
+			selectionEqual(viewModel.getSelection(), 4, 1, 1, 1);
+		});
+	});
+
+	test('select up should select to start of previous blank line', () => {
+		executeTest((editor, viewModel) => {
+			moveTo(viewModel, 7, 1);
+			moveUpByBlankLine(viewModel, true);
+			selectionEqual(viewModel.getSelection(), 4, 1, 7, 1);
+		});
+	});
+});
+
 // Move command
 
 function move(viewModel: ViewModel, args: any) {
@@ -454,12 +539,20 @@ function moveUp(viewModel: ViewModel, noOfLines: number = 1, select?: boolean) {
 	move(viewModel, { to: CursorMove.RawDirection.Up, by: CursorMove.RawUnit.WrappedLine, value: noOfLines, select: select });
 }
 
+function moveUpByBlankLine(viewModel: ViewModel, select?: boolean) {
+	move(viewModel, { to: CursorMove.RawDirection.Up, by: CursorMove.RawUnit.BlankLine, select: select });
+}
+
 function moveUpByModelLine(viewModel: ViewModel, noOfLines: number = 1, select?: boolean) {
 	move(viewModel, { to: CursorMove.RawDirection.Up, value: noOfLines, select: select });
 }
 
 function moveDown(viewModel: ViewModel, noOfLines: number = 1, select?: boolean) {
 	move(viewModel, { to: CursorMove.RawDirection.Down, by: CursorMove.RawUnit.WrappedLine, value: noOfLines, select: select });
+}
+
+function moveDownByBlankLine(viewModel: ViewModel, select?: boolean) {
+	move(viewModel, { to: CursorMove.RawDirection.Down, by: CursorMove.RawUnit.BlankLine, select: select });
 }
 
 function moveDownByModelLine(viewModel: ViewModel, noOfLines: number = 1, select?: boolean) {

--- a/src/vs/editor/test/browser/controller/cursorMoveCommand.test.ts
+++ b/src/vs/editor/test/browser/controller/cursorMoveCommand.test.ts
@@ -540,7 +540,7 @@ function moveUp(viewModel: ViewModel, noOfLines: number = 1, select?: boolean) {
 }
 
 function moveUpByBlankLine(viewModel: ViewModel, select?: boolean) {
-	move(viewModel, { to: CursorMove.RawDirection.Up, by: CursorMove.RawUnit.BlankLine, select: select });
+	move(viewModel, { to: CursorMove.RawDirection.PrevBlankLine, by: CursorMove.RawUnit.WrappedLine, select: select });
 }
 
 function moveUpByModelLine(viewModel: ViewModel, noOfLines: number = 1, select?: boolean) {
@@ -552,7 +552,7 @@ function moveDown(viewModel: ViewModel, noOfLines: number = 1, select?: boolean)
 }
 
 function moveDownByBlankLine(viewModel: ViewModel, select?: boolean) {
-	move(viewModel, { to: CursorMove.RawDirection.Down, by: CursorMove.RawUnit.BlankLine, select: select });
+	move(viewModel, { to: CursorMove.RawDirection.NextBlankLine, by: CursorMove.RawUnit.WrappedLine, select: select });
 }
 
 function moveDownByModelLine(viewModel: ViewModel, noOfLines: number = 1, select?: boolean) {


### PR DESCRIPTION
This PR fixes #114166

This option will move the cursor to the next/previous line which consists only of whitespace, skipping over folded or otherwise hidden lines. Unit tests are also added.

I also added core commands for each of these, defaulting to unbound, so that I could use them in the actual editor. Currently all the behavior present in these changes reflects the behavior of the plugin mentioned in the issue, with the exception of skipping over folds.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
