### PR TITLE
Enable rich settings object editor for schemas that use anyOf

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -556,8 +556,17 @@ function isObjectSetting({
 		schemas.push(objectAdditionalProperties);
 	}
 
+	// Flatten anyof schemas
+	const flatSchemas = arrays.flatten(schemas.map((schema): IJSONSchema[] => {
+		if (Array.isArray(schema.anyOf)) {
+			return schema.anyOf;
+		}
+		return [schema];
+	}));
+
+
 	// This should not render boolean only objects
-	return schemas.every(isObjectRenderableSchema) && schemas.some(({ type }) => type === 'string');
+	return flatSchemas.every(isObjectRenderableSchema) && flatSchemas.some(({ type }) => type === 'string');
 }
 
 function settingTypeEnumRenderable(_type: string | string[]) {


### PR DESCRIPTION
The `workbench.externalUriOpeners` settings uses `anyOf` in its schema to provide better intellisense. This prevented it from having a good editing experience in our UI settings editor

For #115155