### PR TITLE
Respect soft revert for custom editors

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -477,7 +477,7 @@ class MainThreadCustomEditorModel extends Disposable implements ICustomEditorMod
 		}
 	}
 
-	public async revert(_options?: IRevertOptions) {
+	public async revert(options?: IRevertOptions) {
 		if (!this._editable) {
 			return;
 		}
@@ -486,7 +486,10 @@ class MainThreadCustomEditorModel extends Disposable implements ICustomEditorMod
 			return;
 		}
 
-		this._proxy.$revert(this._editorResource, this.viewType, CancellationToken.None);
+		if (!options?.soft) {
+			this._proxy.$revert(this._editorResource, this.viewType, CancellationToken.None);
+		}
+
 		this.change(() => {
 			this._isDirtyFromContentChange = false;
 			this._fromBackup = false;


### PR DESCRIPTION
Fixes #115591

If we are doing a soft revert, simply reset the custom editor's internal dirty state without reverting things on the extension host side