### PR TITLE
Use options.delay for delaying the progress to appear in the window s…

### DIFF
--- a/src/vs/platform/progress/common/progress.ts
+++ b/src/vs/platform/progress/common/progress.ts
@@ -68,6 +68,7 @@ export interface IProgressNotificationOptions extends IProgressOptions {
 export interface IProgressWindowOptions extends IProgressOptions {
 	readonly location: ProgressLocation.Window;
 	readonly command?: string;
+	readonly delay?: number;
 }
 
 export interface IProgressCompositeOptions extends IProgressOptions {

--- a/src/vs/workbench/services/progress/browser/progressService.ts
+++ b/src/vs/workbench/services/progress/browser/progressService.ts
@@ -111,7 +111,7 @@ export class ProgressService extends Disposable implements IProgressService {
 				this.windowProgressStack.splice(idx, 1);
 				this.updateWindowProgress();
 			});
-		}, 150);
+		}, (options.delay && options.delay > 0) ? options.delay : 150);
 
 		// cancel delay if promise finishes below 150ms
 		return promise.finally(() => clearTimeout(delayHandle));


### PR DESCRIPTION
…tatus bar

Currently it is 150 ms, which leads to the blinking of short tasks in the window status bar.
I see that this option is already used for other types of progresses, for instance, for the notification progress.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
