### PR TITLE
Specify more specific text for progress around save participants

### DIFF
--- a/src/vs/workbench/services/textfile/common/textFileSaveParticipant.ts
+++ b/src/vs/workbench/services/textfile/common/textFileSaveParticipant.ts
@@ -34,7 +34,7 @@ export class TextFileSaveParticipant extends Disposable {
 		const cts = new CancellationTokenSource(token);
 
 		return this.progressService.withProgress({
-			title: localize('saveParticipants', "Saving '{0}'", model.name),
+			title: localize('saveParticipants', "Preparing to save '{0}'", model.name),
 			location: ProgressLocation.Notification,
 			cancellable: true,
 			delay: model.isDirty() ? 3000 : 5000


### PR DESCRIPTION
It is nothing related to actual saving (i.e. writing to disk) is happening 'under' this progress.

Also, it is confusing to see 'Saving <file>' as a notification, with Cancel button as the only option - maybe it would be better to use the window progress instead, and use an ellipsis at the end of the message?

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
