### PR TITLE
Corrected typo in the localization string wordBasedSuggestionsMode

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -509,7 +509,7 @@ const editorConfiguration: IConfigurationNode = {
 				nls.localize('wordBasedSuggestionsMode.matchingDocuments', 'Suggest words from all open documents of the same language.'),
 				nls.localize('wordBasedSuggestionsMode.allDocuments', 'Suggest words from all open documents.')
 			],
-			description: nls.localize('wordBasedSuggestionsMode', "Controls form what documents word based completions are computed.")
+			description: nls.localize('wordBasedSuggestionsMode', "Controls from what documents word based completions are computed.")
 		},
 		'editor.semanticHighlighting.enabled': {
 			enum: [true, false, 'configuredByTheme'],


### PR DESCRIPTION
This PR fixes a minor typo in the localization string `wordBasedSuggestionsMode` in `commonEditorConfig.ts`.
