### PR TITLE
Fix: Notebook diff shows pointer on border of cell

### DIFF
--- a/src/vs/base/browser/ui/list/list.css
+++ b/src/vs/base/browser/ui/list/list.css
@@ -43,6 +43,10 @@
 	touch-action: none;
 }
 
+.monaco-list.mouse-support .monaco-list-row.no-pointer {
+	cursor: default;
+}
+
 /* for OS X ballistic scrolling */
 .monaco-list-row.scrolling {
 	display: none !important;

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffList.ts
@@ -70,6 +70,7 @@ export class CellDiffSingleSideRenderer implements IListRenderer<SingleSideDiffE
 	}
 
 	renderTemplate(container: HTMLElement): CellDiffSingleSideRenderTemplate {
+		container.classList.add('no-pointer');
 		const body = DOM.$('.cell-body');
 		DOM.append(container, body);
 		const diffEditorContainer = DOM.$('.cell-diff-editor-container');
@@ -170,6 +171,7 @@ export class CellDiffSideBySideRenderer implements IListRenderer<SideBySideDiffE
 	}
 
 	renderTemplate(container: HTMLElement): CellDiffSideBySideRenderTemplate {
+		container.classList.add('no-pointer');
 		const body = DOM.$('.cell-body');
 		DOM.append(container, body);
 		const diffEditorContainer = DOM.$('.cell-diff-editor-container');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #115145

Add extra css class for `monaco-list-row` in `notebook diff editor`
