### PR TITLE
Fixes first line of terminal is clipped after zooming twice

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -319,8 +319,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		const newCols = Math.max(Math.floor(scaledWidthAvailable / scaledCharWidth), 1);
 
 		const scaledHeightAvailable = dimension.height * window.devicePixelRatio;
-		const scaledCharHeight = Math.ceil(font.charHeight * window.devicePixelRatio);
-		const scaledLineHeight = Math.floor(scaledCharHeight * font.lineHeight);
+		const scaledCharHeight = font.charHeight * window.devicePixelRatio;
+		const scaledLineHeight = scaledCharHeight * font.lineHeight;
 		const newRows = Math.max(Math.floor(scaledHeightAvailable / scaledLineHeight), 1);
 
 		if (this._cols !== newCols || this._rows !== newRows) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

Related to #102194

Depends on https://github.com/xtermjs/xterm.js/pull/3243

Forgot to mention that even though https://github.com/xtermjs/xterm.js/pull/3243 properly fixes #102194 on its own, what this fixes is that for some combinations of zoom level and font the early rounding makes underestimate the number of rows that fit in the available space
Before | After
-------- | -------
![Screenshot from 2021-02-06 03-49-08](https://user-images.githubusercontent.com/25115070/107114005-a4f26500-6830-11eb-9088-391199333e72.png) | ![Screenshot from 2021-02-06 03-49-53](https://user-images.githubusercontent.com/25115070/107114008-ac197300-6830-11eb-9aea-7fdb098e1179.png)

cc @Tyriar feel free to close this if you think it's nothing to worry about

