### PR TITLE
Make sure editor gets focus

### DIFF
--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -1504,6 +1504,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 					this._onDidContentSizeChange.fire(e);
 					break;
 				case OutgoingViewModelEventKind.FocusChanged:
+					this._editorFocus.setValue(e.hasFocus);
 					this._editorTextFocus.setValue(e.hasFocus);
 					break;
 				case OutgoingViewModelEventKind.ScrollChanged:


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/monaco-editor/issues/2339

I'm not completely confident about this change since it may result in over calling the listeners? However, this does catch the case in which text focus is called by not widget focus.
