### PR TITLE
Fixes #95040

### DIFF
--- a/extensions/merge-conflict/src/mergeConflictParser.ts
+++ b/extensions/merge-conflict/src/mergeConflictParser.ts
@@ -58,7 +58,7 @@ export class MergeConflictParser {
 				currentConflict.commonAncestors.push(line);
 			}
 			// Are we within a conflict block and is this a splitter? =======
-			else if (currentConflict && !currentConflict.splitter && line.text.startsWith(splitterMarker)) {
+			else if (currentConflict && !currentConflict.splitter && line.text === splitterMarker) {
 				currentConflict.splitter = line;
 			}
 			// Are we within a conflict block and is this a footer? >>>>>>>

--- a/extensions/merge-conflict/src/mergeConflictParser.ts
+++ b/extensions/merge-conflict/src/mergeConflictParser.ts
@@ -8,7 +8,7 @@ import { DocumentMergeConflict } from './documentMergeConflict';
 
 const startHeaderMarker = '<<<<<<<';
 const commonAncestorsMarker = '|||||||';
-const splitterMarkerRegex = '^=======$';
+const splitterMarker = '=======';
 const endFooterMarker = '>>>>>>>';
 
 interface IScanMergedConflict {
@@ -58,7 +58,7 @@ export class MergeConflictParser {
 				currentConflict.commonAncestors.push(line);
 			}
 			// Are we within a conflict block and is this a splitter? =======
-			else if (currentConflict && !currentConflict.splitter && line.text.match(splitterMarkerRegex)) {
+			else if (currentConflict && !currentConflict.splitter && line.text.startsWith(splitterMarker)) {
 				currentConflict.splitter = line;
 			}
 			// Are we within a conflict block and is this a footer? >>>>>>>

--- a/extensions/merge-conflict/src/mergeConflictParser.ts
+++ b/extensions/merge-conflict/src/mergeConflictParser.ts
@@ -8,7 +8,7 @@ import { DocumentMergeConflict } from './documentMergeConflict';
 
 const startHeaderMarker = '<<<<<<<';
 const commonAncestorsMarker = '|||||||';
-const splitterMarker = '=======';
+const splitterMarkerRegex = '^=======$';
 const endFooterMarker = '>>>>>>>';
 
 interface IScanMergedConflict {
@@ -58,7 +58,7 @@ export class MergeConflictParser {
 				currentConflict.commonAncestors.push(line);
 			}
 			// Are we within a conflict block and is this a splitter? =======
-			else if (currentConflict && !currentConflict.splitter && line.text.startsWith(splitterMarker)) {
+			else if (currentConflict && !currentConflict.splitter && line.text.match(splitterMarkerRegex)) {
 				currentConflict.splitter = line;
 			}
 			// Are we within a conflict block and is this a footer? >>>>>>>


### PR DESCRIPTION
This PR fixes #95040

Check that the merge conflict splitter line contains exactly 7 '=' characters to avoid detecting Markdown titles as splitter line.
