### PR TITLE
Git: Add commands for staging/unstaging hunks

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -129,6 +129,11 @@
         "category": "Git"
       },
       {
+        "command": "git.stageSelectedHunk",
+        "title": "%command.stageSelectedHunk%",
+        "category": "Git"
+      },
+      {
         "command": "git.revertSelectedRanges",
         "title": "%command.revertSelectedRanges%",
         "category": "Git"
@@ -585,6 +590,10 @@
         },
         {
           "command": "git.stageSelectedRanges",
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
+        },
+        {
+          "command": "git.stageSelectedHunk",
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
         },
         {
@@ -1308,6 +1317,11 @@
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && isInDiffEditor && resourceScheme =~ /^git$|^file$/"
         },
         {
+          "command": "git.stageSelectedHunk",
+          "group": "2_git@1",
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && isInDiffEditor && resourceScheme =~ /^git$|^file$/"
+        },
+        {
           "command": "git.unstageSelectedRanges",
           "group": "2_git@2",
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && isInDiffEditor && resourceScheme =~ /^git$|^file$/"
@@ -1321,6 +1335,11 @@
       "editor/context": [
         {
           "command": "git.stageSelectedRanges",
+          "group": "2_git@1",
+          "when": "isInDiffRightEditor && !isInEmbeddedDiffEditor && config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && isInDiffEditor && resourceScheme =~ /^git$|^file$/"
+        },
+        {
+          "command": "git.stageSelectedHunk",
           "group": "2_git@1",
           "when": "isInDiffRightEditor && !isInEmbeddedDiffEditor && config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && isInDiffEditor && resourceScheme =~ /^git$|^file$/"
         },

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -168,6 +168,11 @@
         "category": "Git"
       },
       {
+        "command": "git.unstageSelectedHunk",
+        "title": "%command.unstageSelectedHunk%",
+        "category": "Git"
+      },
+      {
         "command": "git.clean",
         "title": "%command.clean%",
         "category": "Git",
@@ -622,6 +627,10 @@
         },
         {
           "command": "git.unstageSelectedRanges",
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
+        },
+        {
+          "command": "git.unstageSelectedHunk",
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
         },
         {
@@ -1327,6 +1336,11 @@
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && isInDiffEditor && resourceScheme =~ /^git$|^file$/"
         },
         {
+          "command": "git.unstageSelectedHunk",
+          "group": "2_git@2",
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && isInDiffEditor && resourceScheme =~ /^git$|^file$/"
+        },
+        {
           "command": "git.revertSelectedRanges",
           "group": "2_git@3",
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && isInDiffEditor && resourceScheme =~ /^git$|^file$/"
@@ -1345,6 +1359,11 @@
         },
         {
           "command": "git.unstageSelectedRanges",
+          "group": "2_git@2",
+          "when": "isInDiffRightEditor && !isInEmbeddedDiffEditor && config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && isInDiffEditor && resourceScheme =~ /^git$|^file$/"
+        },
+        {
+          "command": "git.unstageSelectedHunk",
           "group": "2_git@2",
           "when": "isInDiffRightEditor && !isInEmbeddedDiffEditor && config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && isInDiffEditor && resourceScheme =~ /^git$|^file$/"
         },

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -18,6 +18,7 @@
 	"command.stageAllUntracked": "Stage All Untracked Changes",
 	"command.stageAllMerge": "Stage All Merge Changes",
 	"command.stageSelectedRanges": "Stage Selected Ranges",
+	"command.stageSelectedHunk": "Stage Selected Hunk",
 	"command.revertSelectedRanges": "Revert Selected Ranges",
 	"command.stageChange": "Stage Change",
 	"command.revertChange": "Revert Change",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -25,6 +25,7 @@
 	"command.unstage": "Unstage Changes",
 	"command.unstageAll": "Unstage All Changes",
 	"command.unstageSelectedRanges": "Unstage Selected Ranges",
+	"command.unstageSelectedHunk": "Unstage Selected Hunk",
 	"command.rename": "Rename",
 	"command.clean": "Discard Changes",
 	"command.cleanAll": "Discard All Changes",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1014,6 +1014,29 @@ export class CommandCenter {
 		await this._stageChanges(textEditor, selectedChanges);
 	}
 
+	@command('git.stageSelectedHunk', { diff: true })
+	async stageSelectedHunk(changes: LineChange[]): Promise<void> {
+		const textEditor = window.activeTextEditor;
+
+		if (!textEditor) {
+			return;
+		}
+
+		const modifiedDocument = textEditor.document;
+		const selections = textEditor.selections;
+		const selectedChanges = changes.filter(change => {
+			const modifiedRange = getModifiedRange(modifiedDocument, change);
+			return selections.every(selection => selection.intersection(modifiedRange));
+		});
+
+		if (!selectedChanges.length) {
+			this.outputChannel.appendLine('Cannot stage hunk. No hunk selected.');
+			return;
+		}
+
+		await this._stageChanges(textEditor, selectedChanges);
+	}
+
 	private async _stageChanges(textEditor: TextEditor, changes: LineChange[]): Promise<void> {
 		const modifiedDocument = textEditor.document;
 		const modifiedUri = modifiedDocument.uri;


### PR DESCRIPTION
This PR introduces two new commands for staging and unstaging a hunk below the selection. This is a small step towards https://github.com/microsoft/vscode/issues/43887.

Unfortunately it's inconsistent with reverting changes, because of https://github.com/microsoft/vscode/issues/88369. It wasn't trivial to fix this bug and have separate commands for reverting the selected lines and hunk.