### PR TITLE
Add transition to window buttons

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -143,11 +143,11 @@
 	height: 100%;
 	width: 46px;
 	font-size: 16px;
+	transition: background 0.25s;
 }
 
 .monaco-workbench .part.titlebar > .window-controls-container > .window-icon:hover {
 	background-color: rgba(255, 255, 255, 0.1);
-	transition: background 0.25s;
 }
 
 .monaco-workbench .part.titlebar.light > .window-controls-container > .window-icon:hover {

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -147,6 +147,7 @@
 
 .monaco-workbench .part.titlebar > .window-controls-container > .window-icon:hover {
 	background-color: rgba(255, 255, 255, 0.1);
+	transition: background 0.25s;
 }
 
 .monaco-workbench .part.titlebar.light > .window-controls-container > .window-icon:hover {

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -143,11 +143,12 @@
 	height: 100%;
 	width: 46px;
 	font-size: 16px;
-	transition: background 0.25s;
+	transition: background 0.22s;
 }
 
 .monaco-workbench .part.titlebar > .window-controls-container > .window-icon:hover {
 	background-color: rgba(255, 255, 255, 0.1);
+	transition: background 0.13s;
 }
 
 .monaco-workbench .part.titlebar.light > .window-controls-container > .window-icon:hover {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #116076. It adds a 0.25-second-long transition to the window buttons for the Windows custom titlebar:

https://user-images.githubusercontent.com/13303232/107180568-d59be100-698d-11eb-9b19-26820e6df91f.mp4



