### PR TITLE
RPM: Don't generate build_id links

### DIFF
--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -14,6 +14,8 @@ AutoReq:  0
 %description
 Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle. See https://code.visualstudio.com/docs/setup/linux for installation instructions and FAQ.
 
+# Don't generate build_id links to prevent conflicts when installing multiple
+# versions of VS Code alongside each other (e.g. `code` and `code-insiders`)
 %define _build_id_links none
 
 %install

--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -14,6 +14,8 @@ AutoReq:  0
 %description
 Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle. See https://code.visualstudio.com/docs/setup/linux for installation instructions and FAQ.
 
+%define _build_id_links none
+
 %install
 mkdir -p %{buildroot}/usr/share/@@NAME@@
 mkdir -p %{buildroot}/usr/share/applications


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #116100 and #115856

By default, `rpmbuild` generates build_id links, which are debugging symbols for binaries included in a package. This causes problems for users trying to install two versions of VS Code at once (eg stable + insiders) which share the same Electron binary, as the debugging symbols conflict with each other.

As a workaround, this PR disables generating build_id links to prevent conflicting files between different versions of VS Code.

See also:

- https://access.redhat.com/discussions/5045161
- https://github.com/rpm-software-management/rpm/blob/rpm-4.16.1.2-release/macros.in#L508-L534
- https://unix.stackexchange.com/questions/411727/what-is-the-purpose-of-usr-lib-build-id-dir
