### PR TITLE
Multiple tab labels for diff editors

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconLabel.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabel.ts
@@ -108,7 +108,16 @@ export class IconLabel extends Disposable {
 	constructor(container: HTMLElement, options?: IIconLabelCreationOptions) {
 		super();
 
-		this.domNode = this._register(new FastLabelNode(dom.append(container, dom.$('.monaco-icon-label'))));
+		// If there is already an IconLabel in the container, place new IconLabel after it.
+		// Otherwise, append it in the container.
+		const existingLabels = container.querySelectorAll<HTMLElement>('.monaco-icon-label');
+		const newLabel = dom.$('.monaco-icon-label');
+		if (existingLabels.length > 0) {
+			existingLabels[existingLabels.length - 1].after(newLabel);
+			this.domNode = this._register(new FastLabelNode(newLabel));
+		} else {
+			this.domNode = this._register(new FastLabelNode(dom.append(container, newLabel)));
+		}
 
 		this.labelContainer = dom.append(this.domNode.element, dom.$('.monaco-icon-label-container'));
 

--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -44,7 +44,7 @@ import { ISingleFolderWorkspaceIdentifier, IWorkspaceIdentifier } from 'vs/platf
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { SimpleServicesNLS } from 'vs/editor/common/standaloneStrings';
 import { ClassifiedEvent, StrictPropertyCheck, GDPRClassification } from 'vs/platform/telemetry/common/gdprTypings';
-import { basename } from 'vs/base/common/resources';
+import { basename, dirname } from 'vs/base/common/resources';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { ILogService } from 'vs/platform/log/common/log';
 
@@ -734,6 +734,10 @@ export class SimpleUriLabelService implements ILabelService {
 
 	getUriBasenameLabel(resource: URI): string {
 		return basename(resource);
+	}
+
+	getUriDirLabel(resource: URI): string {
+		return dirname(resource).toString();
 	}
 
 	public getWorkspaceLabel(workspace: IWorkspaceIdentifier | URI | IWorkspace, options?: { verbose: boolean; }): string {

--- a/src/vs/platform/label/common/label.ts
+++ b/src/vs/platform/label/common/label.ts
@@ -23,6 +23,7 @@ export interface ILabelService {
 	 */
 	getUriLabel(resource: URI, options?: { relative?: boolean, noPrefix?: boolean, endWithSeparator?: boolean }): string;
 	getUriBasenameLabel(resource: URI): string;
+	getUriDirLabel(resource: URI): string;
 	getWorkspaceLabel(workspace: (IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | IWorkspace), options?: { verbose: boolean }): string;
 	getHostLabel(scheme: string, authority?: string): string;
 	getSeparator(scheme: string, authority?: string): '/' | '\\';

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -411,9 +411,25 @@ export interface IEditorInput extends IDisposable {
 	getName(): string;
 
 	/**
+	 * Returns an array of display names of this input. Editors that
+	 * open multiple files can have multiple display names. If
+	 * getName is not undefined, the first array element is the value
+	 * of getName.
+	 */
+	getNames(verbosity?: Verbosity): string[];
+
+	/**
 	 * Returns the display description of this input.
 	 */
 	getDescription(verbosity?: Verbosity): string | undefined;
+
+	/**
+	 * Returns an array of display descriptions of this input. Editors that
+	 * open multiple files can have multiple display descriptions. If
+	 * getDescription is not undefined, the first array element is the value
+	 * of getDescription.
+	 */
+	getDescriptions(verbosity?: Verbosity): (string | undefined)[];
 
 	/**
 	 * Returns the display title of this input.
@@ -533,8 +549,21 @@ export abstract class EditorInput extends Disposable implements IEditorInput {
 		return `Editor ${this.getTypeId()}`;
 	}
 
+	getNames(): string[] {
+		return [this.getName()];
+	}
+
 	getDescription(verbosity?: Verbosity): string | undefined {
 		return undefined;
+	}
+
+	getDescriptions(verbosity?: Verbosity): string[] {
+		const description = this.getDescription();
+		if (description !== undefined) {
+			return [description];
+		} else {
+			return [];
+		}
 	}
 
 	getTitle(verbosity?: Verbosity): string {

--- a/src/vs/workbench/common/editor/diffEditorInput.ts
+++ b/src/vs/workbench/common/editor/diffEditorInput.ts
@@ -67,9 +67,9 @@ export class DiffEditorInput extends SideBySideEditorInput {
 				];
 			} else {
 				labels = [
-					this.originalInput.getName(),
+					...this.originalInput.getNames(),
 					splitter,
-					this.modifiedInput.getName()
+					...this.modifiedInput.getNames()
 				];
 			}
 
@@ -79,18 +79,20 @@ export class DiffEditorInput extends SideBySideEditorInput {
 		return [this.name];
 	}
 
-	getDescription(verbosity: Verbosity = Verbosity.MEDIUM): string | undefined {
-		if (typeof this.description !== 'string') {
-
-			// Pass the description of the modified side in case both original
-			// and modified input have the same parent and we compare file resources.
-			const fileResources = this.asFileResources();
-			if (fileResources && dirname(fileResources.original).path === dirname(fileResources.modified).path) {
-				return this.modifiedInput.getDescription(verbosity);
-			}
+	getDescriptions(verbosity: Verbosity = Verbosity.MEDIUM): string[] {
+		if (!this.description) {
+			return [
+				...this.originalInput.getDescriptions(verbosity),
+				'',
+				...this.modifiedInput.getDescriptions(verbosity)
+			];
 		}
 
-		return this.description;
+		return [this.description];
+	}
+
+	getDescription(verbosity: Verbosity = Verbosity.MEDIUM): string | undefined {
+		return this.getDescriptions().join(' ');
 	}
 
 	private asFileResources(): { original: URI, modified: URI } | undefined {

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -708,6 +708,9 @@ class MockLabelService implements ILabelService {
 	getUriBasenameLabel(resource: uri): string {
 		throw new Error('Method not implemented.');
 	}
+	getUriDirLabel(resource: uri): string {
+		throw new Error('Method not implemented.');
+	}
 	getWorkspaceLabel(workspace: uri | IWorkspaceIdentifier | IWorkspace, options?: { verbose: boolean; }): string {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -167,6 +167,19 @@ export class LabelService extends Disposable implements ILabelService {
 		return options.endWithSeparator ? this.appendSeparatorIfMissing(label, formatting) : label;
 	}
 
+	getUriDirLabel(resource: URI): string {
+		const formatting = this.findFormatting(resource);
+		const label = this.doGetUriLabel(resource, formatting);
+		if (formatting) {
+			switch (formatting.separator) {
+				case paths.win32.sep: return paths.win32.dirname(label);
+				case paths.posix.sep: return paths.posix.dirname(label);
+			}
+		}
+
+		return paths.dirname(label);
+	}
+
 	getUriBasenameLabel(resource: URI): string {
 		const formatting = this.findFormatting(resource);
 		const label = this.doGetUriLabel(resource, formatting);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #110694

Diff editors can have a tab label that is too long in some cases. This PR implements the ability for tabs to have multiple labels, each with separate code icons and shortened paths, and makes use of that for diff editors.

The alternative to this would be to just shorten the paths but keeping the current way of labeling. I have implemented that as well. See #110694 and https://github.com/microsoft/vscode/compare/master...goldst:shorten-diff-title-A for details.

Test this by opening two files with the same name but different paths, then <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>p</kbd> -> compare active file with...

Overview of the most important changes from a technical point of view:
- add `getNames` and `getDescriptions` to `IEditorInput` so editors can have one or multiple labels. Implement these in `EditorInput` where they return the name and description, and override them in `DiffEditorInput` to return all three labels (left editor, compare arrow, right editor)
- change the logic for rendering tabs:
  - `tabTitleControl.ts` gets all names and descriptions and shortens paths even when there are multiple paths in one label
  - add some classes in `label.ts` (eg `MultipleResourceLabels` and `ResourceLabelWidgets`) that have mostly the same methods as the ones previously in use, but they are a wrapper for multiple objects of the previous classes. Also added some interfaces/parent classes (eg `IResourceLabels`, `IResourceLabelWidget` and `ResourceLabelGroupBase`) to make sure they behave in the same way as the ones used previously.
 
This PR might have some implications that weren't clear to me, that's why I suggest that it should be reviewed thoroughly. I would also like to have a general yes or no for this approach before I/we fix the merge conflicts.
