### PR TITLE
#101995 extend tooltip of menu item that defines 'alt' command

### DIFF
--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -190,15 +190,13 @@ export class MenuEntryActionViewItem extends ActionViewItem {
 				? localize('titleAndKb', "{0} ({1})", tooltip, keybindingLabel)
 				: tooltip;
 			if (!this._wantsAltCommand && this._action.alt) {
-				const PREFIX = '[';
-				const SUFFIX = ']';
 				const altTooltip = this._action.alt.tooltip || this._action.alt.label;
 				const altKeybinding = this._keybindingService.lookupKeybinding(this._action.alt.id);
 				const altKeybindingLabel = altKeybinding && altKeybinding.getLabel();
-				title += `\n${PREFIX}${UILabelProvider.modifierLabels[OS].altKey}${SUFFIX} `;
-				title += altKeybindingLabel
+				const altTitleSection = altKeybindingLabel
 					? localize('titleAndKb', "{0} ({1})", altTooltip, altKeybindingLabel)
 					: altTooltip;
+				title += `\n[${UILabelProvider.modifierLabels[OS].altKey}] ${altTitleSection}`;
 			}
 			this.label.title = title;
 		}

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -12,11 +12,12 @@ import { localize } from 'vs/nls';
 import { ICommandAction, IMenu, IMenuActionOptions, MenuItemAction, SubmenuItemAction, Icon } from 'vs/platform/actions/common/actions';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { UILabelProvider } from 'vs/base/common/keybindingLabels';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { ActionViewItem } from 'vs/base/browser/ui/actionbar/actionViewItems';
 import { DropdownMenuActionViewItem } from 'vs/base/browser/ui/dropdown/dropdownActionViewItem';
-import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';
+import { isWindows, isLinux, OS } from 'vs/base/common/platform';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 export function createAndFillInContextMenuActions(menu: IMenu, options: IMenuActionOptions | undefined, target: IAction[] | { primary: IAction[]; secondary: IAction[]; }, isPrimaryGroup?: (group: string) => boolean): IDisposable {
@@ -189,12 +190,12 @@ export class MenuEntryActionViewItem extends ActionViewItem {
 				? localize('titleAndKb', "{0} ({1})", tooltip, keybindingLabel)
 				: tooltip;
 			if (!this._wantsAltCommand && this._action.alt) {
-				const PREFIX = '\u2B98'; // THREE-D TOP-LIGHTED LEFTWARDS EQUILATERAL ARROWHEAD
-				const SUFFIX = '\u2B9A'; // THREE-D TOP-LIGHTED RIGHTWARDS EQUILATERAL ARROWHEAD
+				const PREFIX = '[';
+				const SUFFIX = ']';
 				const altTooltip = this._action.alt.tooltip || this._action.alt.label;
 				const altKeybinding = this._keybindingService.lookupKeybinding(this._action.alt.id);
 				const altKeybindingLabel = altKeybinding && altKeybinding.getLabel();
-				title += `\n${PREFIX}${isMacintosh ? 'Option' : 'Alt'}${SUFFIX} `;
+				title += `\n${PREFIX}${UILabelProvider.modifierLabels[OS].altKey}${SUFFIX} `;
 				title += altKeybindingLabel
 					? localize('titleAndKb', "{0} ({1})", altTooltip, altKeybindingLabel)
 					: altTooltip;

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -185,9 +185,21 @@ export class MenuEntryActionViewItem extends ActionViewItem {
 			const keybindingLabel = keybinding && keybinding.getLabel();
 
 			const tooltip = this._commandAction.tooltip || this._commandAction.label;
-			this.label.title = keybindingLabel
+			let title = keybindingLabel
 				? localize('titleAndKb', "{0} ({1})", tooltip, keybindingLabel)
 				: tooltip;
+			if (!this._wantsAltCommand && this._action.alt) {
+				const PREFIX = '\u2B98'; // THREE-D TOP-LIGHTED LEFTWARDS EQUILATERAL ARROWHEAD
+				const SUFFIX = '\u2B9A'; // THREE-D TOP-LIGHTED RIGHTWARDS EQUILATERAL ARROWHEAD
+				const altTooltip = this._action.alt.tooltip || this._action.alt.label;
+				const altKeybinding = this._keybindingService.lookupKeybinding(this._action.alt.id);
+				const altKeybindingLabel = altKeybinding && altKeybinding.getLabel();
+				title += `\n${PREFIX}Alt${SUFFIX} `;
+				title += altKeybindingLabel
+					? localize('titleAndKb', "{0} ({1})", altTooltip, altKeybindingLabel)
+					: altTooltip;
+			}
+			this.label.title = title;
 		}
 	}
 

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -16,7 +16,7 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { ActionViewItem } from 'vs/base/browser/ui/actionbar/actionViewItems';
 import { DropdownMenuActionViewItem } from 'vs/base/browser/ui/dropdown/dropdownActionViewItem';
-import { isWindows, isLinux } from 'vs/base/common/platform';
+import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 export function createAndFillInContextMenuActions(menu: IMenu, options: IMenuActionOptions | undefined, target: IAction[] | { primary: IAction[]; secondary: IAction[]; }, isPrimaryGroup?: (group: string) => boolean): IDisposable {
@@ -194,7 +194,7 @@ export class MenuEntryActionViewItem extends ActionViewItem {
 				const altTooltip = this._action.alt.tooltip || this._action.alt.label;
 				const altKeybinding = this._keybindingService.lookupKeybinding(this._action.alt.id);
 				const altKeybindingLabel = altKeybinding && altKeybinding.getLabel();
-				title += `\n${PREFIX}Alt${SUFFIX} `;
+				title += `\n${PREFIX}${isMacintosh ? 'Option' : 'Alt'}${SUFFIX} `;
 				title += altKeybindingLabel
 					? localize('titleAndKb', "{0} ({1})", altTooltip, altKeybindingLabel)
 					: altTooltip;


### PR DESCRIPTION
This PR implements #101995

![junk](https://user-images.githubusercontent.com/6726799/107404074-c76cd280-6afd-11eb-99be-ced0c14409e8.gif)

If a menu item specifies an additional `alt` commmand the tooltip gets a second line displaying this when the <kbd>Alt</kbd> key is not down.

The goal is to improve discoverability of places where two alternative commands exist.

