### PR TITLE
Move extension rating icon color to a theme color token

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
@@ -13,7 +13,7 @@ import { IExtensionManagementServerService } from 'vs/workbench/services/extensi
 import { IExtensionRecommendationsService } from 'vs/workbench/services/extensionRecommendations/common/extensionRecommendations';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { extensionButtonProminentBackground, extensionButtonProminentForeground, ExtensionToolTipAction } from 'vs/workbench/contrib/extensions/browser/extensionsActions';
-import { IThemeService, IColorTheme, ThemeIcon } from 'vs/platform/theme/common/themeService';
+import { IThemeService, IColorTheme, ThemeIcon, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { EXTENSION_BADGE_REMOTE_BACKGROUND, EXTENSION_BADGE_REMOTE_FOREGROUND } from 'vs/workbench/common/theme';
 import { Emitter, Event } from 'vs/base/common/event';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -21,6 +21,7 @@ import { CountBadge } from 'vs/base/browser/ui/countBadge/countBadge';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IUserDataAutoSyncEnablementService } from 'vs/platform/userDataSync/common/userDataSync';
 import { installCountIcon, ratingIcon, remoteIcon, starEmptyIcon, starFullIcon, starHalfIcon, syncIgnoredIcon } from 'vs/workbench/contrib/extensions/browser/extensionsIcons';
+import { registerColor } from 'vs/platform/theme/common/colorRegistry';
 
 export abstract class ExtensionWidget extends Disposable implements IExtensionContainer {
 	private _extension: IExtension | null = null;
@@ -368,3 +369,13 @@ export class SyncIgnoredWidget extends ExtensionWidget {
 		this.element.classList.toggle('hide', !(this.extension && this.extension.state === ExtensionState.Installed && this.userDataAutoSyncEnablementService.isEnabled() && this.extensionsWorkbenchService.isExtensionIgnoredToSync(this.extension)));
 	}
 }
+
+// Rating icon
+export const extensionRatingIconColor = registerColor('extensionIcon.starForeground', { light: '#DF6100', dark: '#FF8E00', hc: '#FF8E00' }, localize('extensionIconStarForeground', "The icon color for extension ratings."), true);
+
+registerThemingParticipant((theme, collector) => {
+	const extensionRatingIcon = theme.getColor(extensionRatingIconColor);
+	if (extensionRatingIcon) {
+		collector.addRule(`.extension-ratings .codicon-extensions-star-full, .extension-ratings .codicon-extensions-star-half { color: ${extensionRatingIcon}; }`);
+	}
+});

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionsWidgets.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionsWidgets.css
@@ -27,12 +27,6 @@
 	margin-left: 0;
 }
 
-/* TODO @misolori make this a color token */
-.extension-ratings .codicon-extensions-star-full,
-.extension-ratings .codicon-extensions-star-half {
-	color: #FF8E00 !important;
-}
-
 .extension-install-count .codicon,
 .extension-action.codicon-extensions-manage {
 	color: inherit;


### PR DESCRIPTION
Refs #115799

This moves the extension icon color into a theme token, `extensionIcon.starForeground`, and updates the color on light theme to meet color contrast ratio:

![image](https://user-images.githubusercontent.com/35271042/107405762-82747c00-6abc-11eb-979d-6ad4216701fd.png)

cc @aeschli 