### PR TITLE
Fixes #116060: Clone minimap options before changing them

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -1140,15 +1140,15 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		const clonedOptions = { ...options };
 		clonedOptions.inDiffEditor = true;
 		clonedOptions.automaticLayout = false;
-		clonedOptions.scrollbar = clonedOptions.scrollbar || {};
+		// Clone scrollbar options before changing them
+		clonedOptions.scrollbar = { ...(clonedOptions.scrollbar || {}) };
 		clonedOptions.scrollbar.vertical = 'visible';
 		clonedOptions.folding = false;
 		clonedOptions.codeLens = this._diffCodeLens;
 		clonedOptions.fixedOverflowWidgets = true;
 		// clonedOptions.lineDecorationsWidth = '2ch';
-		if (!clonedOptions.minimap) {
-			clonedOptions.minimap = {};
-		}
+		// Clone minimap options before changing them
+		clonedOptions.minimap = { ...(clonedOptions.minimap || {}) };
 		clonedOptions.minimap.enabled = false;
 		return clonedOptions;
 	}


### PR DESCRIPTION
This PR fixes #116060

Repro steps in https://github.com/microsoft/vscode/issues/116060#issuecomment-777274222

The problem was that the diff editor widget was "massaging" some passed in editor options without cloning them. The same objects would later be used to create other editors and thus the minimap would be turned off for them.
