### PR TITLE
Revert "Support the new 4.0 definition of isArray"

### DIFF
--- a/src/vs/base/common/types.ts
+++ b/src/vs/base/common/types.ts
@@ -8,7 +8,7 @@ import { URI, UriComponents } from 'vs/base/common/uri';
 /**
  * @returns whether the provided parameter is a JavaScript Array or not.
  */
-export function isArray<T>(array: T | {}): array is T extends readonly any[] ? (unknown extends T ? never : readonly any[]) : any[] {
+export function isArray(array: any): array is any[] {
 	return Array.isArray(array);
 }
 


### PR DESCRIPTION
Reverts microsoft/vscode#102413 because the underlaying changes it relied on were removed from TypeScript in both https://github.com/microsoft/TypeScript/pull/41849 and https://github.com/microsoft/TypeScript/pull/41851

Should fix running against master TS