### PR TITLE
Add back support for reading from clipboard in webviews

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -225,15 +225,20 @@ export class CodeApplication extends Disposable {
 				this.nativeHostMainService?.openExternal(undefined, url);
 			});
 
+			const webviewFrameUrl = 'about:blank?webviewFrame';
+
 			session.defaultSession.setPermissionRequestHandler((_webContents, permission /* 'media' | 'geolocation' | 'notifications' | 'midiSysex' | 'pointerLock' | 'fullscreen' | 'openExternal' */, callback, details) => {
-				if (permission === 'clipboard-read') {
-					return callback(true);
+				if (details.requestingUrl === webviewFrameUrl) {
+					return callback(permission === 'clipboard-read');
 				}
 				return callback(false);
 			});
 
-			session.defaultSession.setPermissionCheckHandler((_webContents, permission /* 'media' */) => {
-				return permission === 'clipboard-read';
+			session.defaultSession.setPermissionCheckHandler((_webContents, permission /* 'media' */, _origin, details) => {
+				if (details.requestingUrl === webviewFrameUrl) {
+					return permission === 'clipboard-read';
+				}
+				return false;
 			});
 		});
 

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -225,12 +225,15 @@ export class CodeApplication extends Disposable {
 				this.nativeHostMainService?.openExternal(undefined, url);
 			});
 
-			session.defaultSession.setPermissionRequestHandler((webContents, permission /* 'media' | 'geolocation' | 'notifications' | 'midiSysex' | 'pointerLock' | 'fullscreen' | 'openExternal' */, callback) => {
+			session.defaultSession.setPermissionRequestHandler((_webContents, permission /* 'media' | 'geolocation' | 'notifications' | 'midiSysex' | 'pointerLock' | 'fullscreen' | 'openExternal' */, callback, details) => {
+				if (permission === 'clipboard-read') {
+					return callback(true);
+				}
 				return callback(false);
 			});
 
-			session.defaultSession.setPermissionCheckHandler((webContents, permission /* 'media' */) => {
-				return false;
+			session.defaultSession.setPermissionCheckHandler((_webContents, permission /* 'media' */) => {
+				return permission === 'clipboard-read';
 			});
 		});
 

--- a/src/vs/platform/webview/electron-main/webviewMainService.ts
+++ b/src/vs/platform/webview/electron-main/webviewMainService.ts
@@ -35,12 +35,16 @@ export class WebviewMainService extends Disposable implements IWebviewManagerSer
 		this.portMappingProvider = this._register(new WebviewPortMappingProvider(tunnelService));
 
 		const sess = session.fromPartition(webviewPartitionId);
-		sess.setPermissionRequestHandler((webContents, permission /* 'media' | 'geolocation' | 'notifications' | 'midiSysex' | 'pointerLock' | 'fullscreen' | 'openExternal' */, callback) => {
+		sess.setPermissionRequestHandler((_webContents, permission, callback) => {
+			if (permission === 'clipboard-read') {
+				return callback(true);
+			}
+
 			return callback(false);
 		});
 
-		sess.setPermissionCheckHandler((webContents, permission /* 'media' */) => {
-			return false;
+		sess.setPermissionCheckHandler((_webContents, permission /* 'media' */) => {
+			return permission === 'clipboard-read';
 		});
 	}
 

--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -508,6 +508,7 @@
 				newFrame.setAttribute('id', 'pending-frame');
 				newFrame.setAttribute('frameborder', '0');
 				newFrame.setAttribute('sandbox', options.allowScripts ? 'allow-scripts allow-forms allow-same-origin allow-pointer-lock allow-downloads' : 'allow-same-origin allow-pointer-lock');
+				newFrame.setAttribute('allow', options.allowScripts ? 'clipboard-read; clipboard-write;' : '');
 				if (host.fakeLoad) {
 					// We should just be able to use srcdoc, but I wasn't
 					// seeing the service worker applying properly.

--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -515,6 +515,8 @@
 					// Fake load an empty on the correct origin and then write real html
 					// into it to get around this.
 					newFrame.src = `./fake.html?id=${ID}`;
+				} else {
+					newFrame.src = `about:blank?webviewFrame`;
 				}
 				newFrame.style.cssText = 'display: block; margin: 0; overflow: hidden; position: absolute; width: 100%; height: 100%; visibility: hidden';
 				document.body.appendChild(newFrame);

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -92,6 +92,7 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 		const element = document.createElement('iframe');
 		element.className = `webview ${options.customClasses || ''}`;
 		element.sandbox.add('allow-scripts', 'allow-same-origin', 'allow-forms', 'allow-pointer-lock', 'allow-downloads');
+		element.setAttribute('allow', 'clipboard-read; clipboard-write;');
 		element.style.border = 'none';
 		element.style.width = '100%';
 		element.style.height = '100%';


### PR DESCRIPTION
Fixes #115925

This was first blocked in  7d5052f50846a8d2d52106b782f6260ccd4f7deb. The fix allows clipboard access for webviews that are running on desktop with either an electron webview or an iframe
