### PR TITLE
Skip empty find match at the end of previous match (Part 2 for issue #116445)

### DIFF
--- a/src/vs/editor/common/model/textModelSearch.ts
+++ b/src/vs/editor/common/model/textModelSearch.ts
@@ -533,7 +533,8 @@ export class Searcher {
 
 		let m: RegExpExecArray | null;
 		do {
-			if (this._prevMatchStartIndex + this._prevMatchLength === textLength) {
+			const previousMatchEnd = this._prevMatchStartIndex + this._prevMatchLength;
+			if (previousMatchEnd === textLength) {
 				// Reached the end of the line
 				return null;
 			}
@@ -561,6 +562,11 @@ export class Searcher {
 			}
 			this._prevMatchStartIndex = matchStartIndex;
 			this._prevMatchLength = matchLength;
+
+			// do not return empty matches at he end of previous match
+			if (matchLength === 0 && matchStartIndex === previousMatchEnd) {
+				continue;
+			}
 
 			if (!this._wordSeparators || isValidMatch(this._wordSeparators, text, textLength, matchStartIndex, matchLength)) {
 				return m;

--- a/src/vs/editor/test/common/model/textModelSearch.test.ts
+++ b/src/vs/editor/test/common/model/textModelSearch.test.ts
@@ -771,11 +771,8 @@ suite('TextModelSearch', () => {
 		let actual = TextModelSearch.findMatches(model, searchParams, model.getFullModelRange(), true, 100);
 		assert.deepStrictEqual(actual, [
 			new FindMatch(new Range(1, 1, 1, 3), ['10']),
-			new FindMatch(new Range(1, 3, 1, 3), ['']),
 			new FindMatch(new Range(1, 4, 1, 7), ['243']),
-			new FindMatch(new Range(1, 7, 1, 7), ['']),
 			new FindMatch(new Range(1, 8, 1, 10), ['30']),
-			new FindMatch(new Range(1, 10, 1, 10), ['']),
 			new FindMatch(new Range(1, 11, 1, 13), ['10'])
 		]);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR is related to #116445

JS engine will provide empty string matches at the end of non-empty matches if RegExp has zero or more quantifier (`*`)
```js
[...'10.243.30.10'.matchAll(/\d*/g)]
```
```
[    
    ["10", index: 0, input: "10.243.30.10", groups: undefined],
    ["", index: 2, input: "10.243.30.10", groups: undefined],
    ["243", index: 3, input: "10.243.30.10", groups: undefined],
    ["", index: 6, input: "10.243.30.10", groups: undefined],
    ["30", index: 7, input: "10.243.30.10", groups: undefined],
    ["", index: 9, input: "10.243.30.10", groups: undefined],
    ["10", index: 10, input: "10.243.30.10", groups: undefined],
    ["", index: 12, input: "10.243.30.10", groups: undefined]
]
```

While currently VS Code provides same results as JS (which is expected), these empty matches do not provide any useful value and may be confusing to users (see linked issue).
Moreover it's hard to observe these matches - <kbd>Alt</kbd>+<kbd>Enter</kbd> will select all ranges, but because cursors at the end of these empty ranges overlap with end of previous selections they are basically ignored.

Moreover actions triggered on Previous/Next match will intentionally skip this kind of matches which leads to strange values for current selection index during navigation "1 of 9", "3 of 9", "4 of 9", "6 of 9" etc.
https://github.com/microsoft/vscode/blob/6c12d9f2c4aa9f14ce1ca81033ebf31ea48c0bc0/src/vs/editor/contrib/find/findModel.ts#L429

This change updates search model in a way that won't produce empty ranges at the end of previous matches. Empty matches that are not overlap with non-empty matches are preserved as previously.

@rebornix would love to hear your feedback about this proposal.

P.S. This is second part of the fix for #116445 which provides improvement for match behavior.
Part 1 for navigation fix (do not skip non-empty matches in same line) submitted as draft as well - #116823