### PR TITLE
Improve detection of line boundary assertions (Part 1 for issue #116445)

### DIFF
--- a/src/vs/editor/contrib/find/findModel.ts
+++ b/src/vs/editor/contrib/find/findModel.ts
@@ -256,7 +256,7 @@ export class FindModelBoundToEditorModel {
 		let isUsingLineStops = this._state.isRegex && (
 			this._state.searchString.indexOf('^') >= 0
 			|| this._state.searchString.indexOf('$') >= 0
-		);
+		) && hasLineBoundaryAssertion(this._state.searchString).any;
 		let { lineNumber, column } = before;
 		let model = this._editor.getModel();
 
@@ -350,7 +350,7 @@ export class FindModelBoundToEditorModel {
 		let isUsingLineStops = this._state.isRegex && (
 			this._state.searchString.indexOf('^') >= 0
 			|| this._state.searchString.indexOf('$') >= 0
-		);
+		) && hasLineBoundaryAssertion(this._state.searchString).any;
 
 		let { lineNumber, column } = after;
 		let model = this._editor.getModel();
@@ -593,4 +593,51 @@ export class FindModelBoundToEditorModel {
 			this._ignoreModelContentChanged = false;
 		}
 	}
+}
+/**
+ * Checks if given regular expression has line boundary assertions (`^` and `$)
+ *
+ * @param str source text of regular expression
+ * @returns
+ */
+function hasLineBoundaryAssertion(str: string) {
+	const res = {
+		any: false,
+		start: false,
+		end: false
+	};
+
+	let i = 0;
+	let inCharactersClass = false;
+
+	while (i < str.length) {
+		const char = str[i];
+		switch (char) {
+			case '^':
+				if (!inCharactersClass) {
+					res.any = true;
+					res.start = true;
+				}
+				break;
+			case '$':
+				if (!inCharactersClass) {
+					res.any = true;
+					res.end = true;
+				}
+				break;
+			case '[':
+				inCharactersClass = true;
+				break;
+			case ']':
+				if (inCharactersClass) {
+					inCharactersClass = false;
+				}
+				break;
+			case '\\':
+				i++;
+				break;
+		}
+		i++;
+	}
+	return res;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #116445

Currently `^` inside of character class `[^a]` will be detected in assumption that it's line boundary assertion, but it actually has different meaning.

This PR provides more precise detection of line boundary assettions as an example which will provide adequate behavior in case of #116445.

However I think that this check should be removed completely and next match search position should be propagated by 1 column (when possible, or to next line at the end of the string) because existence of start of line assertion may not be triggered at all if it's in specific branch.

Pathological case
```js
[...`123.23.3.123`.matchAll(/(?<=^|2?)\d*(?=$|2?)/g)]
```
```
[    
    ["123", index: 0, input: "123.23.3.123", groups: undefined],
    ["", index: 3, input: "123.23.3.123", groups: undefined],
    ["23", index: 4, input: "123.23.3.123", groups: undefined],
    ["", index: 6, input: "123.23.3.123", groups: undefined],
    ["3", index: 7, input: "123.23.3.123", groups: undefined],
    ["", index: 8, input: "123.23.3.123", groups: undefined],
    ["123", index: 9, input: "123.23.3.123", groups: undefined]
]
```

Will investigate if it's possible to remove check at all and if there are more cases hen even precise boundary check wont help.
Then will add corresponding tests.

@rebornix would love to hear whe do you think about removing checks like this one completely.
https://github.com/microsoft/vscode/pull/116823/files#diff-4bd68ef6798b8b4aea76c65b352d49515f4adfc9fce8d1d33b0b2963bfab2e58R256-R259