### PR TITLE
Add postNotebookMessage helper function

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -5,8 +5,8 @@
 
 import type { Event } from 'vs/base/common/event';
 import type { IDisposable } from 'vs/base/common/lifecycle';
-import { ICellDragEndMessage, ICellDragMessage, ICellDragStartMessage, ToWebviewMessage } from 'vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView';
 import { RenderOutputType } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { FromWebviewMessage, IBlurOutputMessage, ICellDragEndMessage, ICellDragMessage, ICellDragStartMessage, IClickedDataUrlMessage, ICustomRendererMessage, IDimensionMessage, IFocusMarkdownPreviewMessage, IMouseEnterMarkdownPreviewMessage, IMouseEnterMessage, IMouseLeaveMarkdownPreviewMessage, IMouseLeaveMessage, IToggleMarkdownPreviewMessage, IWheelMessage, ToWebviewMessage } from 'vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView';
 
 // !! IMPORTANT !! everything must be in-line within the webviewPreloads
 // function. Imports are not allowed. This is stringifies and injected into
@@ -60,9 +60,7 @@ function webviewPreloads() {
 	};
 
 	const handleDataUrl = async (data: string | ArrayBuffer | null, downloadName: string) => {
-		vscode.postMessage({
-			__vscode_notebook_message: true,
-			type: 'clicked-data-url',
+		postNotebookMessage<IClickedDataUrlMessage>('clicked-data-url', {
 			data,
 			downloadName
 		});
@@ -146,9 +144,7 @@ function webviewPreloads() {
 				if (entry.target.id === id && entry.contentRect) {
 					if (entry.contentRect.height !== 0) {
 						entry.target.style.padding = `${__outputNodePadding__}px ${__outputNodePadding__}px ${__outputNodePadding__}px ${__outputNodeLeftPadding__}px`;
-						vscode.postMessage({
-							__vscode_notebook_message: true,
-							type: 'dimension',
+						postNotebookMessage<IDimensionMessage>('dimension', {
 							id: id,
 							data: {
 								height: entry.contentRect.height + __outputNodePadding__ * 2
@@ -157,9 +153,7 @@ function webviewPreloads() {
 						});
 					} else {
 						entry.target.style.padding = `0px`;
-						vscode.postMessage({
-							__vscode_notebook_message: true,
-							type: 'dimension',
+						postNotebookMessage<IDimensionMessage>('dimension', {
 							id: id,
 							data: {
 								height: entry.contentRect.height
@@ -201,10 +195,7 @@ function webviewPreloads() {
 		if (event.defaultPrevented || scrollWillGoToParent(event)) {
 			return;
 		}
-
-		vscode.postMessage({
-			__vscode_notebook_message: true,
-			type: 'did-scroll-wheel',
+		postNotebookMessage<IWheelMessage>('did-scroll-wheel', {
 			payload: {
 				deltaMode: event.deltaMode,
 				deltaX: event.deltaX,
@@ -228,9 +219,7 @@ function webviewPreloads() {
 		const element = document.createElement('div');
 		element.tabIndex = 0;
 		element.addEventListener('focus', () => {
-			vscode.postMessage({
-				__vscode_notebook_message: true,
-				type: 'focus-editor',
+			postNotebookMessage<IBlurOutputMessage>('focus-editor', {
 				id: outputId,
 				focusNext
 			});
@@ -246,19 +235,13 @@ function webviewPreloads() {
 
 	function addMouseoverListeners(element: HTMLElement, outputId: string): void {
 		element.addEventListener('mouseenter', () => {
-			vscode.postMessage({
-				__vscode_notebook_message: true,
-				type: 'mouseenter',
+			postNotebookMessage<IMouseEnterMessage>('mouseenter', {
 				id: outputId,
-				data: {}
 			});
 		});
 		element.addEventListener('mouseleave', () => {
-			vscode.postMessage({
-				__vscode_notebook_message: true,
-				type: 'mouseleave',
+			postNotebookMessage<IMouseLeaveMessage>('mouseleave', {
 				id: outputId,
-				data: {}
 			});
 		});
 	}
@@ -345,9 +328,7 @@ function webviewPreloads() {
 
 		return {
 			postMessage(message: unknown) {
-				vscode.postMessage({
-					__vscode_notebook_message: true,
-					type: 'customRendererMessage',
+				postNotebookMessage<ICustomRendererMessage>('customRendererMessage', {
 					rendererId: namespace,
 					message,
 				});
@@ -418,10 +399,7 @@ function webviewPreloads() {
 					createMarkdownPreview(cell.cellId, cell.content, -10000);
 				}
 
-				vscode.postMessage({
-					__vscode_notebook_message: true,
-					type: 'initializedMarkdownPreview',
-				});
+				postNotebookMessage('initializedMarkdownPreview', {});
 				break;
 			case 'createMarkdownPreview':
 				createMarkdownPreview(event.data.id, event.data.content, event.data.top);
@@ -524,9 +502,7 @@ function webviewPreloads() {
 
 					resizeObserve(outputNode, outputId, true);
 
-					vscode.postMessage({
-						__vscode_notebook_message: true,
-						type: 'dimension',
+					postNotebookMessage<IDimensionMessage>('dimension', {
 						id: outputId,
 						init: true,
 						data: {
@@ -602,9 +578,7 @@ function webviewPreloads() {
 						output.parentElement!.style.display = 'block';
 						output.style.top = top + 'px';
 
-						vscode.postMessage({
-							__vscode_notebook_message: true,
-							type: 'dimension',
+						postNotebookMessage<IDimensionMessage>('dimension', {
 							id: outputId,
 							data: {
 								height: output.clientHeight
@@ -674,15 +648,12 @@ function webviewPreloads() {
 		e.preventDefault();
 
 		const { cellId } = JSON.parse(data);
-		const msg: ICellDragEndMessage = {
-			__vscode_notebook_message: true,
-			type: 'cell-drag-end',
+		postNotebookMessage<ICellDragEndMessage>('cell-drag-end', {
 			cellId: cellId,
 			ctrlKey: e.ctrlKey,
 			altKey: e.altKey,
 			position: { clientX: e.clientX, clientY: e.clientY },
-		};
-		vscode.postMessage(msg);
+		});
 	});
 
 	function createMarkdownPreview(cellId: string, content: string, top: number) {
@@ -702,34 +673,19 @@ function webviewPreloads() {
 			previewContainerNode.classList.add('preview');
 
 			previewContainerNode.addEventListener('dblclick', () => {
-				vscode.postMessage({
-					__vscode_notebook_message: true,
-					type: 'toggleMarkdownPreview',
-					cellId,
-				});
+				postNotebookMessage<IToggleMarkdownPreviewMessage>('toggleMarkdownPreview', { cellId });
 			});
 
 			previewContainerNode.addEventListener('click', () => {
-				vscode.postMessage({
-					__vscode_notebook_message: true,
-					type: 'focusMarkdownPreview',
-					cellId,
-				});
+				postNotebookMessage<IFocusMarkdownPreviewMessage>('focusMarkdownPreview', { cellId });
 			});
 
 			previewContainerNode.addEventListener('mouseenter', () => {
-				vscode.postMessage({
-					__vscode_notebook_message: true,
-					type: 'mouseEnterMarkdownPreview',
-					cellId,
-				});
+				postNotebookMessage<IMouseEnterMarkdownPreviewMessage>('mouseEnterMarkdownPreview', { cellId });
 			});
+
 			previewContainerNode.addEventListener('mouseleave', () => {
-				vscode.postMessage({
-					__vscode_notebook_message: true,
-					type: 'mouseLeaveMarkdownPreview',
-					cellId,
-				});
+				postNotebookMessage<IMouseLeaveMarkdownPreviewMessage>('mouseLeaveMarkdownPreview', { cellId });
 			});
 
 			previewContainerNode.setAttribute('draggable', 'true');
@@ -742,23 +698,17 @@ function webviewPreloads() {
 
 				(e.target as HTMLElement).classList.add('dragging');
 
-				const msg: ICellDragStartMessage = {
-					__vscode_notebook_message: true,
-					type: 'cell-drag-start',
+				postNotebookMessage<ICellDragStartMessage>('cell-drag-start', {
 					cellId: cellId,
 					position: { clientX: e.clientX, clientY: e.clientY },
-				};
-				vscode.postMessage(msg);
+				});
 			});
 
 			previewContainerNode.addEventListener('drag', e => {
-				const msg: ICellDragMessage = {
-					__vscode_notebook_message: true,
-					type: 'cell-drag',
+				postNotebookMessage<ICellDragMessage>('cell-drag', {
 					cellId: cellId,
 					position: { clientX: e.clientX, clientY: e.clientY },
-				};
-				vscode.postMessage(msg);
+				});
 			});
 
 			previewContainerNode.addEventListener('dragend', e => {
@@ -778,19 +728,28 @@ function webviewPreloads() {
 
 			resizeObserve(previewContainerNode, `${cellId}_preview`, false);
 
-			vscode.postMessage({
-				__vscode_notebook_message: true,
-				type: 'dimension',
+			postNotebookMessage<IDimensionMessage>('dimension', {
 				id: `${cellId}_preview`,
 				init: true,
 				data: {
-					height: previewContainerNode.clientHeight
+					height: previewContainerNode.clientHeight,
 				},
 				isOutput: false
 			});
 		} else {
 			updateMarkdownPreview(cellId, content);
 		}
+	}
+
+	function postNotebookMessage<T extends FromWebviewMessage>(
+		type: T['type'],
+		properties: Omit<T, '__vscode_notebook_message' | 'type'>
+	) {
+		vscode.postMessage({
+			__vscode_notebook_message: true,
+			type,
+			...properties
+		});
 	}
 
 	function updateMarkdownPreview(cellId: string, content: string) {


### PR DESCRIPTION
This adds a new helper function called `postNotebookMessage` in the notebook webview. This method both reduces code duplication and enforces better typing for posting messages back the renderer from the webview

As a result of the stricter typing, I had to clean up a few property annotations and their usages

