### PR TITLE
Allow Markdown-Rendering Without Providing an Env-Parameter

### DIFF
--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -209,15 +209,6 @@ export class MarkdownEngine {
 	}
 
 	private addImageStabilizer(md: any): void {
-		md.core.ruler.push(
-			'initialize_vscode_image_stabilizer',
-			({ env }: { env: RenderEnv }) => {
-				if (!env.containingImages) {
-					env.containingImages = [];
-				}
-				return true;
-			});
-
 		const original = md.renderer.rules.image;
 		md.renderer.rules.image = (tokens: any, idx: number, options: any, env: RenderEnv, self: any) => {
 			const token = tokens[idx];
@@ -225,7 +216,7 @@ export class MarkdownEngine {
 
 			const src = token.attrGet('src');
 			if (src) {
-				env.containingImages.push({ src });
+				env.containingImages?.push({ src });
 				const imgHash = hash(src);
 				token.attrSet('id', `image-hash-${imgHash}`);
 			}

--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -209,6 +209,15 @@ export class MarkdownEngine {
 	}
 
 	private addImageStabilizer(md: any): void {
+		md.core.ruler.push(
+			'initialize_vscode_image_stabilizer',
+			({ env }: { env: RenderEnv }) => {
+				if (!env.containingImages) {
+					env.containingImages = [];
+				}
+				return true;
+			});
+
 		const original = md.renderer.rules.image;
 		md.renderer.rules.image = (tokens: any, idx: number, options: any, env: RenderEnv, self: any) => {
 			const token = tokens[idx];


### PR DESCRIPTION
This PR fixes #116987

Since the introduction of the new feature for stabilizing images, passing an `env`-parameter to the `markdown-it`-parser became mandatory as seen here:
https://github.com/microsoft/vscode/blob/a47f3244b36ae1b792f9c14b2576720ca9d19c52/extensions/markdown-language-features/src/markdownEngine.ts#L161-L168

As my extension uses vscode's `markdown-it`-parser, having to provide an `env`-object with pre-defined properties is quite inconvenient. For that reason I created this PR which makes passing an `env`-object optional as the necessary `env.containingImages`-property is created on the fly, if necessary, using a new `initialize_vscode_image_stabilizer`-rule.