### PR TITLE
Fix cursor position when at the start of RTL syntax tokens

### DIFF
--- a/src/vs/editor/browser/viewParts/lines/rangeUtil.ts
+++ b/src/vs/editor/browser/viewParts/lines/rangeUtil.ts
@@ -121,9 +121,9 @@ export class RangeUtil {
 		startChildIndex = Math.min(max, Math.max(min, startChildIndex));
 		endChildIndex = Math.min(max, Math.max(min, endChildIndex));
 
-		if (startChildIndex === endChildIndex && startOffset === endOffset && startOffset === 0) {
+		if (startChildIndex === endChildIndex && startOffset === endOffset && startOffset === 0 && !domNode.children[startChildIndex].firstChild) {
 			// We must find the position at the beginning of a <span>
-			// To cover cases of empty <span>s, aboid using a range and use the <span>'s bounding box
+			// To cover cases of empty <span>s, avoid using a range and use the <span>'s bounding box
 			const clientRects = domNode.children[startChildIndex].getClientRects();
 			return this._createHorizontalRangesFromClientRects(clientRects, clientRectDeltaLeft);
 		}


### PR DESCRIPTION
This PR fixes #117060

To test the changes, follow the repro in the issue.

I've added this extra condition because the comment says this `if` is to "cover cases of empty \<span\>s" - I haven't found any record of these issues, so an alternative fix is to just delete the entire `if` - If you're okay with it let me know and I'll edit

