### PR TITLE
Improve GitHub repository search

### DIFF
--- a/extensions/github/src/remoteSourceProvider.ts
+++ b/extensions/github/src/remoteSourceProvider.ts
@@ -76,7 +76,7 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 			return [];
 		}
 
-		const raw = await octokit.search.repos({ q: query, sort: 'updated' });
+		const raw = await octokit.search.repos({ q: query, sort: 'stars' });
 		return raw.data.items.map(asRemoteSource);
 	}
 


### PR DESCRIPTION
Currently, GitHub repository search results in the clone dialog are sorted by the updated timestamp and the results aren't always relevant.

For example, when searching for `vscode`, `microsoft/vscode` is not the first result.

<img width="642" alt="Screenshot 2021-02-19 at 18 25 26" src="https://user-images.githubusercontent.com/37362614/108545552-d878c900-72df-11eb-9c69-8a897f83bb08.png">
