### PR TITLE
Use formatted link, fixes #115933

### DIFF
--- a/src/vs/workbench/contrib/url/browser/trustedDomainsValidator.ts
+++ b/src/vs/workbench/contrib/url/browser/trustedDomainsValidator.ts
@@ -101,6 +101,13 @@ export class OpenerValidatorContributions implements IWorkbenchContribution {
 				formattedLink += linkTail.charAt(0) + '...' + linkTail.substring(linkTail.length - linkTailLengthToKeep + 1);
 			}
 
+			const displayLink = typeof originalResource === 'string' ? originalResource : formattedLink;
+			let formattedDisplayLink = '';
+			const linkCharsToShowPerLine = 80;
+			for (let counter = 0; counter < displayLink.length; counter += linkCharsToShowPerLine) {
+				formattedDisplayLink += displayLink.substring(counter, counter + linkCharsToShowPerLine) + '\n';
+			}
+
 			const { choice } = await this._dialogService.show(
 				Severity.Info,
 				localize(
@@ -115,7 +122,7 @@ export class OpenerValidatorContributions implements IWorkbenchContribution {
 					localize('configureTrustedDomains', 'Configure Trusted Domains')
 				],
 				{
-					detail: typeof originalResource === 'string' ? originalResource : formattedLink,
+					detail: formattedDisplayLink,
 					cancelId: 2
 				}
 			);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #115933 by choosing to use the formatted link all the time. The formatted link uses dots in case the link is too long.

A few lines above (line 76), `URI.parse` is called anyway, so I'm not sure if there are any security risks by reverting the typecheck.
