### PR TITLE
Add option to hide title bar in Zen Mode (even outside full screen mode)

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -491,6 +491,16 @@ import { isStandalone } from 'vs/base/browser/browser';
 				'default': true,
 				'description': localize('zenMode.hideLineNumbers', "Controls whether turning on Zen Mode also hides the editor line numbers.")
 			},
+			'zenMode.hideTitleBar': {
+				'type': 'string',
+				'enum': ['fullScreen', 'always'],
+				'enumDescriptions': [
+					localize('zenMode.hideTitleBar.fullScreen', "Hide the title bar only when in Zen Mode and full screen mode."),
+					localize('zenMode.hideTitleBar.always', "Always hide the title bar when in Zen Mode."),
+				],
+				'default': 'fullScreen',
+				'description': localize('zenMode.hideTitleBar', "Controls when to hide the title bar in zen mode. Currently this requires 'window.menuBarVisibility' to be set to 'toggle'")
+			},
 			'zenMode.restore': {
 				'type': 'boolean',
 				'default': true,


### PR DESCRIPTION
This adds a new option `zenMode.hideTitleBar` to hide the title bar in Zen Mode, even when not in full screen mode.

It works fine when `window.menuBarVisibility` set to `toggle`, but currently not for `classic`. This happens because the menu bar focus / unfocus logic cannot query whether Zen Mode is currently active or not.

https://github.com/microsoft/vscode/blob/11cd76005bc7516dcc726d7389d0bce1744e5c85/src/vs/base/browser/ui/menu/menubar.ts#L749

Furthermore, during debugging I discovered that some functions in [`layout.ts`](https://github.com/microsoft/vscode/blob/11cd76005bc7516dcc726d7389d0bce1744e5c85/src/vs/workbench/browser/layout.ts#L1577-L1595) related to the menu bar might be dead code, namely `getMenubarVisibility` and `toggleMenuBar`.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR is related to #33607, #115570, #117136.