### PR TITLE
fix microsoft/vscode#117095 de-duplicate reference results

### DIFF
--- a/src/vs/editor/contrib/gotoSymbol/goToSymbol.ts
+++ b/src/vs/editor/contrib/gotoSymbol/goToSymbol.ts
@@ -40,16 +40,7 @@ function getLocationLinks<T>(
 			}
 		}
 
-		const uniqueResults: Set<LocationLink> = new Set();
-		let last: LocationLink | undefined;
-		// Preserve result order by sorting a copy and using that to compare with Set contents.
-		for (const link of [...result].sort(compareLocations)) {
-			if (last === undefined || compareLocations(last, link) !== 0) {
-				uniqueResults.add(link);
-				last = link;
-			}
-		}
-		return result.filter(link => uniqueResults.has(link));
+		return sortAndDeduplicate(result);
 	});
 }
 
@@ -92,7 +83,19 @@ export function getReferencesAtPosition(model: ITextModel, position: Position, c
 	});
 }
 
-export function compareLocations(a: Location, b: Location): number {
+export function sortAndDeduplicate(locations: Location[]): Location[] {
+	const result: LocationLink[] = [];
+	let last: LocationLink | undefined;
+	for (const link of locations.sort(compareLocations)) {
+		if (last === undefined || compareLocations(last, link) !== 0) {
+			result.push(link);
+			last = link;
+		}
+	}
+	return result;
+}
+
+function compareLocations(a: Location, b: Location): number {
 	return extUri.compare(a.uri, b.uri) || Range.compareRangesUsingStarts(a.range, b.range);
 }
 

--- a/src/vs/editor/contrib/gotoSymbol/referencesModel.ts
+++ b/src/vs/editor/contrib/gotoSymbol/referencesModel.ts
@@ -11,13 +11,15 @@ import * as strings from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
 import { defaultGenerator } from 'vs/base/common/idGenerator';
 import { Range, IRange } from 'vs/editor/common/core/range';
-import { Location, LocationLink } from 'vs/editor/common/modes';
+import { LocationLink } from 'vs/editor/common/modes';
 import { ITextModelService, ITextEditorModel } from 'vs/editor/common/services/resolverService';
 import { Position } from 'vs/editor/common/core/position';
 import { IMatch } from 'vs/base/common/filters';
 import { Constants } from 'vs/base/common/uint';
 import { ResourceMap } from 'vs/base/common/map';
 import { onUnexpectedError } from 'vs/base/common/errors';
+
+import { compareLocations } from './goToSymbol';
 
 export class OneReference {
 
@@ -157,7 +159,7 @@ export class ReferencesModel implements IDisposable {
 
 		// grouping and sorting
 		const [providersFirst] = links;
-		links.sort(ReferencesModel._compareReferences);
+		links.sort(compareLocations);
 
 		let current: FileReferences | undefined;
 		for (let link of links) {
@@ -168,7 +170,7 @@ export class ReferencesModel implements IDisposable {
 			}
 
 			// append, check for equality first!
-			if (current.children.length === 0 || ReferencesModel._compareReferences(link, current.children[current.children.length - 1]) !== 0) {
+			if (current.children.length === 0 || compareLocations(link, current.children[current.children.length - 1]) !== 0) {
 
 				const oneRef = new OneReference(
 					providersFirst === link,
@@ -288,9 +290,5 @@ export class ReferencesModel implements IDisposable {
 			}
 		}
 		return this.references[0];
-	}
-
-	private static _compareReferences(a: Location, b: Location): number {
-		return extUri.compare(a.uri, b.uri) || Range.compareRangesUsingStarts(a.range, b.range);
 	}
 }

--- a/src/vs/workbench/test/browser/api/extHostApiCommands.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostApiCommands.test.ts
@@ -280,15 +280,21 @@ suite('ExtHostLanguageFeatureCommands', function () {
 
 		disposables.push(extHost.registerDefinitionProvider(nullExtensionDescription, defaultSelector, <vscode.DefinitionProvider>{
 			provideDefinition(doc: any): any {
-				return new types.Location(doc.uri, new types.Range(0, 0, 0, 0));
+				return new types.Location(doc.uri, new types.Range(1, 0, 0, 0));
+			}
+		}));
+		disposables.push(extHost.registerDefinitionProvider(nullExtensionDescription, defaultSelector, <vscode.DefinitionProvider>{
+			provideDefinition(doc: any): any {
+				// duplicate result will get removed
+				return new types.Location(doc.uri, new types.Range(1, 0, 0, 0));
 			}
 		}));
 		disposables.push(extHost.registerDefinitionProvider(nullExtensionDescription, defaultSelector, <vscode.DefinitionProvider>{
 			provideDefinition(doc: any): any {
 				return [
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(2, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(3, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(4, 0, 0, 0)),
 				];
 			}
 		}));
@@ -309,7 +315,7 @@ suite('ExtHostLanguageFeatureCommands', function () {
 			provideDefinition(doc: any): (vscode.Location | vscode.LocationLink)[] {
 				return [
 					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					{ targetUri: doc.uri, targetRange: new types.Range(0, 0, 0, 0), targetSelectionRange: new types.Range(1, 1, 1, 1), originSelectionRange: new types.Range(2, 2, 2, 2) }
+					{ targetUri: doc.uri, targetRange: new types.Range(1, 0, 0, 0), targetSelectionRange: new types.Range(1, 1, 1, 1), originSelectionRange: new types.Range(2, 2, 2, 2) }
 				];
 			}
 		}));
@@ -338,15 +344,21 @@ suite('ExtHostLanguageFeatureCommands', function () {
 
 		disposables.push(extHost.registerDeclarationProvider(nullExtensionDescription, defaultSelector, <vscode.DeclarationProvider>{
 			provideDeclaration(doc: any): any {
-				return new types.Location(doc.uri, new types.Range(0, 0, 0, 0));
+				return new types.Location(doc.uri, new types.Range(1, 0, 0, 0));
+			}
+		}));
+		disposables.push(extHost.registerDeclarationProvider(nullExtensionDescription, defaultSelector, <vscode.DeclarationProvider>{
+			provideDeclaration(doc: any): any {
+				// duplicate result will get removed
+				return new types.Location(doc.uri, new types.Range(1, 0, 0, 0));
 			}
 		}));
 		disposables.push(extHost.registerDeclarationProvider(nullExtensionDescription, defaultSelector, <vscode.DeclarationProvider>{
 			provideDeclaration(doc: any): any {
 				return [
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(2, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(3, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(4, 0, 0, 0)),
 				];
 			}
 		}));
@@ -367,7 +379,7 @@ suite('ExtHostLanguageFeatureCommands', function () {
 			provideDeclaration(doc: any): (vscode.Location | vscode.LocationLink)[] {
 				return [
 					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					{ targetUri: doc.uri, targetRange: new types.Range(0, 0, 0, 0), targetSelectionRange: new types.Range(1, 1, 1, 1), originSelectionRange: new types.Range(2, 2, 2, 2) }
+					{ targetUri: doc.uri, targetRange: new types.Range(1, 0, 0, 0), targetSelectionRange: new types.Range(1, 1, 1, 1), originSelectionRange: new types.Range(2, 2, 2, 2) }
 				];
 			}
 		}));
@@ -407,15 +419,21 @@ suite('ExtHostLanguageFeatureCommands', function () {
 
 		disposables.push(extHost.registerTypeDefinitionProvider(nullExtensionDescription, defaultSelector, <vscode.TypeDefinitionProvider>{
 			provideTypeDefinition(doc: any): any {
-				return new types.Location(doc.uri, new types.Range(0, 0, 0, 0));
+				return new types.Location(doc.uri, new types.Range(1, 0, 0, 0));
+			}
+		}));
+		disposables.push(extHost.registerTypeDefinitionProvider(nullExtensionDescription, defaultSelector, <vscode.TypeDefinitionProvider>{
+			provideTypeDefinition(doc: any): any {
+				// duplicate result will get removed
+				return new types.Location(doc.uri, new types.Range(1, 0, 0, 0));
 			}
 		}));
 		disposables.push(extHost.registerTypeDefinitionProvider(nullExtensionDescription, defaultSelector, <vscode.TypeDefinitionProvider>{
 			provideTypeDefinition(doc: any): any {
 				return [
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(2, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(3, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(4, 0, 0, 0)),
 				];
 			}
 		}));
@@ -436,7 +454,7 @@ suite('ExtHostLanguageFeatureCommands', function () {
 			provideTypeDefinition(doc: any): (vscode.Location | vscode.LocationLink)[] {
 				return [
 					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					{ targetUri: doc.uri, targetRange: new types.Range(0, 0, 0, 0), targetSelectionRange: new types.Range(1, 1, 1, 1), originSelectionRange: new types.Range(2, 2, 2, 2) }
+					{ targetUri: doc.uri, targetRange: new types.Range(1, 0, 0, 0), targetSelectionRange: new types.Range(1, 1, 1, 1), originSelectionRange: new types.Range(2, 2, 2, 2) }
 				];
 			}
 		}));
@@ -476,15 +494,21 @@ suite('ExtHostLanguageFeatureCommands', function () {
 
 		disposables.push(extHost.registerImplementationProvider(nullExtensionDescription, defaultSelector, <vscode.ImplementationProvider>{
 			provideImplementation(doc: any): any {
-				return new types.Location(doc.uri, new types.Range(0, 0, 0, 0));
+				return new types.Location(doc.uri, new types.Range(1, 0, 0, 0));
+			}
+		}));
+		disposables.push(extHost.registerImplementationProvider(nullExtensionDescription, defaultSelector, <vscode.ImplementationProvider>{
+			provideImplementation(doc: any): any {
+				// duplicate result will get removed
+				return new types.Location(doc.uri, new types.Range(1, 0, 0, 0));
 			}
 		}));
 		disposables.push(extHost.registerImplementationProvider(nullExtensionDescription, defaultSelector, <vscode.ImplementationProvider>{
 			provideImplementation(doc: any): any {
 				return [
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(2, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(3, 0, 0, 0)),
+					new types.Location(doc.uri, new types.Range(4, 0, 0, 0)),
 				];
 			}
 		}));
@@ -505,7 +529,7 @@ suite('ExtHostLanguageFeatureCommands', function () {
 			provideImplementation(doc: any): (vscode.Location | vscode.LocationLink)[] {
 				return [
 					new types.Location(doc.uri, new types.Range(0, 0, 0, 0)),
-					{ targetUri: doc.uri, targetRange: new types.Range(0, 0, 0, 0), targetSelectionRange: new types.Range(1, 1, 1, 1), originSelectionRange: new types.Range(2, 2, 2, 2) }
+					{ targetUri: doc.uri, targetRange: new types.Range(1, 0, 0, 0), targetSelectionRange: new types.Range(1, 1, 1, 1), originSelectionRange: new types.Range(2, 2, 2, 2) }
 				];
 			}
 		}));

--- a/src/vs/workbench/test/browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostLanguageFeatures.test.ts
@@ -259,7 +259,7 @@ suite('ExtHostLanguageFeatures', function () {
 		}));
 		disposables.push(extHost.registerDefinitionProvider(defaultExtension, defaultSelector, new class implements vscode.DefinitionProvider {
 			provideDefinition(): any {
-				return new types.Location(model.uri, new types.Range(1, 1, 1, 1));
+				return new types.Location(model.uri, new types.Range(2, 1, 1, 1));
 			}
 		}));
 

--- a/src/vs/workbench/test/browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostLanguageFeatures.test.ts
@@ -268,7 +268,7 @@ suite('ExtHostLanguageFeatures', function () {
 		assert.strictEqual(value.length, 2);
 	});
 
-	test('Definition, registration order', async () => {
+	test('Definition, registration order ignored (results are sorted)', async () => {
 
 		disposables.push(extHost.registerDefinitionProvider(defaultExtension, defaultSelector, new class implements vscode.DefinitionProvider {
 			provideDefinition(): any {
@@ -286,8 +286,8 @@ suite('ExtHostLanguageFeatures', function () {
 		const value = await getDefinitionsAtPosition(model, new EditorPosition(1, 1), CancellationToken.None);
 		assert.strictEqual(value.length, 2);
 		// let [first, second] = value;
-		assert.strictEqual(value[0].uri.authority, 'second');
-		assert.strictEqual(value[1].uri.authority, 'first');
+		assert.strictEqual(value[0].uri.authority, 'first');
+		assert.strictEqual(value[1].uri.authority, 'second');
 	});
 
 	test('Definition, evil provider', async () => {
@@ -521,7 +521,7 @@ suite('ExtHostLanguageFeatures', function () {
 
 	// --- references
 
-	test('References, registration order', async () => {
+	test('References, registration order ignored (results are sorted)', async () => {
 
 		disposables.push(extHost.registerReferenceProvider(defaultExtension, defaultSelector, new class implements vscode.ReferenceProvider {
 			provideReferences(): any {
@@ -539,8 +539,8 @@ suite('ExtHostLanguageFeatures', function () {
 		let value = await getReferencesAtPosition(model, new EditorPosition(1, 2), false, CancellationToken.None);
 		assert.strictEqual(value.length, 2);
 		let [first, second] = value;
-		assert.strictEqual(first.uri.path, '/second');
-		assert.strictEqual(second.uri.path, '/first');
+		assert.strictEqual(first.uri.path, '/first');
+		assert.strictEqual(second.uri.path, '/second');
 	});
 
 	test('References, data conversion', async () => {


### PR DESCRIPTION
This commit de-duplicates reference and other location results from
API endpoints `executeDefinitionProvider`, `executeDeclarationProvider`,
`executeImplementationProvider`, `executeTypeDefinitionProvider`, and `executeReferenceProvider`
(all commands registered in `goToSymbol.ts` which share the
`getLocationsLinks` helper).

Previously, this work was only done in the `ReferencesModel` which is used by
the `editor.action.findReferences` command. Extensions which called the
`vscode.executeReferenceProvider` would still get the duplicate results.

fix microsoft/vscode#117095
