### PR TITLE
Fixes #117537: Allow coping rich text when 'editor.fontFamily' has fallback fonts

### DIFF
--- a/src/vs/editor/common/config/fontInfo.ts
+++ b/src/vs/editor/common/config/fontInfo.ts
@@ -116,16 +116,16 @@ export class BareFontInfo {
 	 * @internal
 	 */
 	public getMassagedFontFamily(): string {
-		if (/[,"']/.test(this.fontFamily)) {
-			// Looks like the font family might be already escaped
-			return this.fontFamily;
-		}
-		if (/[+ ]/.test(this.fontFamily)) {
-			// Wrap a font family using + or <space> with quotes
-			return `"${this.fontFamily}"`;
-		}
-
-		return this.fontFamily;
+		return this.fontFamily
+		    	.split(/ *, */)
+				.filter(name => name !== '')
+				.map(name =>
+					// Change double quotes to single quotes so that rich text can be coped properly.
+					/["']/.test(name) ? name.replace(/"/g, "'") :
+					// Quotes are required around font-family names when they are not valid CSS identifiers.
+					/[^a-zA-Z\d\xa0-\uffff_-]/.test(name) ? `'${name}'` : name
+				)
+				.join(', ');
 	}
 }
 

--- a/src/vs/editor/common/config/fontInfo.ts
+++ b/src/vs/editor/common/config/fontInfo.ts
@@ -117,15 +117,15 @@ export class BareFontInfo {
 	 */
 	public getMassagedFontFamily(): string {
 		return this.fontFamily
-		    	.split(/ *, */)
-				.filter(name => name !== '')
-				.map(name =>
-					// Change double quotes to single quotes so that rich text can be coped properly.
-					/["']/.test(name) ? name.replace(/"/g, "'") :
+			.split(/ *, */)
+			.filter(name => name !== '')
+			.map(name =>
+				// Change double quotes to single quotes so that rich text can be coped properly.
+				/["']/.test(name) ? name.replace(/"/g, '\'') :
 					// Quotes are required around font-family names when they are not valid CSS identifiers.
 					/[^a-zA-Z\d\xa0-\uffff_-]/.test(name) ? `'${name}'` : name
-				)
-				.join(', ');
+			)
+			.join(', ');
 	}
 }
 

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -816,7 +816,7 @@ export class ViewModel extends Disposable implements IViewModel {
 
 		const fontInfo = this._configuration.options.get(EditorOption.fontInfo);
 		const colorMap = this._getColorMap();
-		const fontFamily = fontInfo.fontFamily === EDITOR_FONT_DEFAULTS.fontFamily ? fontInfo.fontFamily : `'${fontInfo.fontFamily}', ${EDITOR_FONT_DEFAULTS.fontFamily}`;
+		const fontFamily = fontInfo.fontFamily === EDITOR_FONT_DEFAULTS.fontFamily ? fontInfo.fontFamily : `${fontInfo.getMassagedFontFamily()}, ${EDITOR_FONT_DEFAULTS.fontFamily}`;
 
 		return {
 			mode: languageId.language,

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
@@ -615,8 +615,7 @@ class EditorTextRenderer {
 
 		const colorMap = this.getDefaultColorMap();
 		const fontInfo = editor.getOptions().get(EditorOption.fontInfo);
-		const fontFamily = fontInfo.fontFamily === EDITOR_FONT_DEFAULTS.fontFamily ? fontInfo.fontFamily : `'${fontInfo.fontFamily}', ${EDITOR_FONT_DEFAULTS.fontFamily}`;
-
+		const fontFamily = fontInfo.fontFamily === EDITOR_FONT_DEFAULTS.fontFamily ? fontInfo.fontFamily : `${fontInfo.getMassagedFontFamily()}, ${EDITOR_FONT_DEFAULTS.fontFamily}`;
 
 		const style = ``
 			+ `color: ${colorMap[modes.ColorId.DefaultForeground]};`


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #117537.
![after.gif](https://i.loli.net/2021/02/24/L8ztwmc792BuKbl.gif)
