### PR TITLE
Fix file location pattern in eslint-stylish problem matcher

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1294,7 +1294,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		});
 		this.add('eslint-stylish', [
 			{
-				regexp: /^([^\s].*)$/,
+				regexp: /^((?:[a-zA-Z]:)*[\\\/.]+.*?)$/,
 				kind: ProblemLocationKind.Location,
 				file: 1
 			},


### PR DESCRIPTION
eslint-stylish  file location pattern now match relative and absolute path in Window and *nix

This PR fixes #113306
