### PR TITLE
#117667 add a markup escape for filenames in error messages

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -711,8 +711,12 @@ export function validateFileName(item: ExplorerItem, name: string): { content: s
 	return null;
 }
 
-function escapeMarkdown(text: string) {
-	let unescaped = text.replace(/\\(\*|_|`|~|\\)/g, '$1');
+function escapeMarkdown(filename: string): string {
+	if (!filename) {
+		return filename;
+	}
+
+	let unescaped = filename.replace(/\\(\*|_|`|~|\\)/g, '$1');
 	let escaped = unescaped.replace(/(\*|_|`|~|\\)/g, '\\$1');
 	return escaped;
 }

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -660,6 +660,7 @@ export class ShowOpenedFileInNewWindow extends Action {
 export function validateFileName(item: ExplorerItem, name: string): { content: string, severity: Severity } | null {
 	// Produce a well formed file name
 	name = getWellFormedFileName(name);
+	const escaped_name = escapeMarkdown(name);
 
 	// Name not provided
 	if (!name || name.length === 0 || /^\s+$/.test(name)) {
@@ -685,7 +686,7 @@ export function validateFileName(item: ExplorerItem, name: string): { content: s
 		const child = parent?.getChild(name);
 		if (child && child !== item) {
 			return {
-				content: nls.localize('fileNameExistsError', "A file or folder **{0}** already exists at this location. Please choose a different name.", name),
+				content: nls.localize('fileNameExistsError', "A file or folder **{0}** already exists at this location. Please choose a different name.", escaped_name),
 				severity: Severity.Error
 			};
 		}
@@ -695,7 +696,7 @@ export function validateFileName(item: ExplorerItem, name: string): { content: s
 	const windowsBasenameValidity = item.resource.scheme === Schemas.file && isWindows;
 	if (names.some((folderName) => !extpath.isValidBasename(folderName, windowsBasenameValidity))) {
 		return {
-			content: nls.localize('invalidFileNameError', "The name **{0}** is not valid as a file or folder name. Please choose a different name.", trimLongName(name)),
+			content: nls.localize('invalidFileNameError', "The name **{0}** is not valid as a file or folder name. Please choose a different name.", trimLongName(escaped_name)),
 			severity: Severity.Error
 		};
 	}
@@ -708,6 +709,12 @@ export function validateFileName(item: ExplorerItem, name: string): { content: s
 	}
 
 	return null;
+}
+
+function escapeMarkdown(text: string) {
+	let unescaped = text.replace(/\\(\*|_|`|~|\\)/g, '$1');
+	let escaped = unescaped.replace(/(\*|_|`|~|\\)/g, '\\$1');
+	return escaped;
 }
 
 function trimLongName(name: string): string {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #117667
then:
![image](https://user-images.githubusercontent.com/59028866/109157876-e95b8b80-7772-11eb-802f-ea1acb5e31ff.png)
now:
![image](https://user-images.githubusercontent.com/59028866/109157843-dcd73300-7772-11eb-93fb-b086b0833944.png)
