### PR TITLE
fix #117718 fire onDidChangeResources event after unregistering group

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -242,6 +242,7 @@ class MainThreadSCMProvider implements ISCMProvider {
 
 		delete this._groupsByHandle[handle];
 		this.groups.splice(this.groups.elements.indexOf(group), 1);
+		this._onDidChangeResources.fire();
 	}
 
 	async getOriginalResource(uri: URI): Promise<URI | null> {


### PR DESCRIPTION
This PR fixes #117718 by firing the missing onDidChangeResources event after a SourceControlResourceGroup has been removed.
