### PR TITLE
Reduce markdown preview flickering on scroll

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -633,7 +633,7 @@ export interface INotebookCellList {
 	rowsContainer: HTMLElement;
 	readonly onDidRemoveOutput: Event<ICellOutputViewModel>;
 	readonly onDidHideOutput: Event<ICellOutputViewModel>;
-	readonly onDidHideMarkdownPreview: Event<ICellViewModel>;
+	readonly onDidRemoveCellFromView: Event<ICellViewModel>;
 	readonly onMouseUp: Event<IListMouseEvent<CellViewModel>>;
 	readonly onMouseDown: Event<IListMouseEvent<CellViewModel>>;
 	readonly onContextMenu: Event<IListContextMenuEvent<CellViewModel>>;

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -633,6 +633,7 @@ export interface INotebookCellList {
 	rowsContainer: HTMLElement;
 	readonly onDidRemoveOutput: Event<ICellOutputViewModel>;
 	readonly onDidHideOutput: Event<ICellOutputViewModel>;
+	readonly onDidHideMarkdownPreview: Event<ICellViewModel>;
 	readonly onMouseUp: Event<IListMouseEvent<CellViewModel>>;
 	readonly onMouseDown: Event<IListMouseEvent<CellViewModel>>;
 	readonly onContextMenu: Event<IListContextMenuEvent<CellViewModel>>;

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1140,13 +1140,19 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 			});
 		}));
 
-		this._list.attachViewModel(this.viewModel);
 		this._localStore.add(this._list.onDidRemoveOutput(output => {
 			this.removeInset(output);
 		}));
 		this._localStore.add(this._list.onDidHideOutput(output => {
 			this.hideInset(output);
 		}));
+		this._localStore.add(this._list.onDidHideMarkdownPreview(cell => {
+			if (cell.cellKind === CellKind.Markdown) {
+				this.removeMarkdownPreview(cell as MarkdownCellViewModel);
+			}
+		}));
+
+		this._list.attachViewModel(this.viewModel);
 
 		if (this._dimension) {
 			this._list.layout(this._dimension.height - SCROLLABLE_ELEMENT_PADDING_TOP, this._dimension.width);

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1146,7 +1146,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 		this._localStore.add(this._list.onDidHideOutput(output => {
 			this.hideInset(output);
 		}));
-		this._localStore.add(this._list.onDidHideMarkdownPreview(cell => {
+		this._localStore.add(this._list.onDidRemoveCellFromView(cell => {
 			if (cell.cellKind === CellKind.Markdown) {
 				this.removeMarkdownPreview(cell as MarkdownCellViewModel);
 			}

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
@@ -49,8 +49,8 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 	readonly onDidRemoveOutput: Event<ICellOutputViewModel> = this._onDidRemoveOutput.event;
 	private readonly _onDidHideOutput = new Emitter<ICellOutputViewModel>();
 	readonly onDidHideOutput: Event<ICellOutputViewModel> = this._onDidHideOutput.event;
-	private readonly _onDidHideMarkdownPreview = new Emitter<ICellViewModel>();
-	readonly onDidHideMarkdownPreview: Event<ICellViewModel> = this._onDidHideMarkdownPreview.event;
+	private readonly _onDidRemoveCellFromView = new Emitter<ICellViewModel>();
+	readonly onDidRemoveCellFromView: Event<ICellViewModel> = this._onDidRemoveCellFromView.event;
 	private _viewModel: NotebookViewModel | null = null;
 	private _hiddenRangeIds: string[] = [];
 	private hiddenRangesPrefixSum: PrefixSumComputer | null = null;
@@ -386,7 +386,7 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 		newRanges.reverse().forEach(range => {
 			const removedCells = viewCells.splice(range.start, range.end - range.start + 1);
 			removedCells.forEach(cell => {
-				this._onDidHideMarkdownPreview.fire(cell);
+				this._onDidRemoveCellFromView.fire(cell);
 			});
 		});
 
@@ -496,7 +496,7 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 
 			hideOutputs.forEach(output => this._onDidHideOutput.fire(output));
 			deletedOutputs.forEach(output => this._onDidRemoveOutput.fire(output));
-			removedMarkdownCells.forEach(cell => this._onDidHideMarkdownPreview.fire(cell));
+			removedMarkdownCells.forEach(cell => this._onDidRemoveCellFromView.fire(cell));
 		});
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
@@ -49,7 +49,8 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 	readonly onDidRemoveOutput: Event<ICellOutputViewModel> = this._onDidRemoveOutput.event;
 	private readonly _onDidHideOutput = new Emitter<ICellOutputViewModel>();
 	readonly onDidHideOutput: Event<ICellOutputViewModel> = this._onDidHideOutput.event;
-
+	private readonly _onDidHideMarkdownPreview = new Emitter<ICellViewModel>();
+	readonly onDidHideMarkdownPreview: Event<ICellViewModel> = this._onDidHideMarkdownPreview.event;
 	private _viewModel: NotebookViewModel | null = null;
 	private _hiddenRangeIds: string[] = [];
 	private hiddenRangesPrefixSum: PrefixSumComputer | null = null;
@@ -383,7 +384,10 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 		const newRanges = reduceCellRanges(hiddenRanges);
 		const viewCells = model.viewCells.slice(0) as CellViewModel[];
 		newRanges.reverse().forEach(range => {
-			viewCells.splice(range.start, range.end - range.start + 1);
+			const removedCells = viewCells.splice(range.start, range.end - range.start + 1);
+			removedCells.forEach(cell => {
+				this._onDidHideMarkdownPreview.fire(cell);
+			});
 		});
 
 		this.splice2(0, 0, viewCells);
@@ -473,6 +477,7 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 			// remove output in the webview
 			const hideOutputs: ICellOutputViewModel[] = [];
 			const deletedOutputs: ICellOutputViewModel[] = [];
+			const removedMarkdownCells: ICellViewModel[] = [];
 
 			for (let i = diff.start; i < diff.start + diff.deleteCount; i++) {
 				const cell = this.element(i);
@@ -482,6 +487,8 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 					} else {
 						deletedOutputs.push(...cell?.outputsViewModels);
 					}
+				} else {
+					removedMarkdownCells.push(cell);
 				}
 			}
 
@@ -489,6 +496,7 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 
 			hideOutputs.forEach(output => this._onDidHideOutput.fire(output));
 			deletedOutputs.forEach(output => this._onDidRemoveOutput.fire(output));
+			removedMarkdownCells.forEach(cell => this._onDidHideMarkdownPreview.fire(cell));
 		});
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/markdownCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/markdownCell.ts
@@ -479,7 +479,6 @@ export class StatefulMarkdownCell extends Disposable {
 	}
 
 	dispose() {
-		this.notebookEditor.removeMarkdownPreview(this.viewCell);
 		this.viewCell.detachTextEditor();
 		super.dispose();
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #117720.

The change will only hide/remove markdown preview from the webview when the cell is gone (deleted, or folded), other than removing them when the cell view element gets removed (scrolled out of view). So there is no re-rendering of markdown cells when scrolling up and down.
