### PR TITLE
Only show `infer return type` refactoring when refactorings are requested

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/refactor.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/refactor.ts
@@ -309,7 +309,15 @@ class TypeScriptRefactorProvider implements vscode.CodeActionProvider<TsCodeActi
 			return undefined;
 		}
 
-		const actions = this.convertApplicableRefactors(response.body, document, rangeOrSelection);
+		const actions = this.convertApplicableRefactors(response.body, document, rangeOrSelection).filter(action => {
+			// Don't show 'infer return type' refactoring unless it has been explicitly requested
+			// https://github.com/microsoft/TypeScript/issues/42993
+			if (!context.only && action.kind?.value === 'refactor.rewrite.function.returnType') {
+				return false;
+			}
+			return true;
+		});
+
 		if (!context.only) {
 			return actions;
 		}


### PR DESCRIPTION
Fixes #117799
