### PR TITLE
Fixes #74505

### DIFF
--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -442,7 +442,7 @@ export function isValidLocationForEmmetAbbreviation(document: vscode.TextDocumen
 
 		// Get the abbreviation right now
 		// Fixes https://github.com/microsoft/vscode/issues/74505
-		// Stylesheet abbreviations starting with @ should only bring up suggestions
+		// Stylesheet abbreviations starting with @ should bring up suggestions
 		// even at outer-most level
 		const abbreviation = document.getText(new vscode.Range(abbreviationRange.start.line, abbreviationRange.start.character, abbreviationRange.end.line, abbreviationRange.end.character));
 		if (abbreviation.startsWith('@')) {

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -443,14 +443,10 @@ export function isValidLocationForEmmetAbbreviation(document: vscode.TextDocumen
 		// Get the abbreviation right now
 		// Fixes https://github.com/microsoft/vscode/issues/74505
 		// Stylesheet abbreviations starting with @ should only bring up suggestions
-		// at outer-most level
+		// even at outer-most level
 		const abbreviation = document.getText(new vscode.Range(abbreviationRange.start.line, abbreviationRange.start.character, abbreviationRange.end.line, abbreviationRange.end.character));
 		if (abbreviation.startsWith('@')) {
-			if (currentNode.parent && currentNode.parent.type === 'stylesheet') {
-				return true;
-			} else {
-				return false;
-			}
+			return true;
 		}
 
 		// Fix for https://github.com/microsoft/vscode/issues/34162

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -440,10 +440,22 @@ export function isValidLocationForEmmetAbbreviation(document: vscode.TextDocumen
 			return true;
 		}
 
+		// Get the abbreviation right now
+		// Fixes https://github.com/microsoft/vscode/issues/74505
+		// Stylesheet abbreviations starting with @ should only bring up suggestions
+		// at outer-most level
+		const abbreviation = document.getText(new vscode.Range(abbreviationRange.start.line, abbreviationRange.start.character, abbreviationRange.end.line, abbreviationRange.end.character));
+		if (abbreviation.startsWith('@')) {
+			if (currentNode.parent && currentNode.parent.type === 'stylesheet') {
+				return true;
+			} else {
+				return false;
+			}
+		}
+
 		// Fix for https://github.com/microsoft/vscode/issues/34162
 		// Other than sass, stylus, we can make use of the terminator tokens to validate position
 		if (syntax !== 'sass' && syntax !== 'stylus' && currentNode.type === 'property') {
-
 			// Fix for upstream issue https://github.com/emmetio/css-parser/issues/3
 			if (currentNode.parent
 				&& currentNode.parent.type !== 'rule'
@@ -451,7 +463,6 @@ export function isValidLocationForEmmetAbbreviation(document: vscode.TextDocumen
 				return false;
 			}
 
-			const abbreviation = document.getText(new vscode.Range(abbreviationRange.start.line, abbreviationRange.start.character, abbreviationRange.end.line, abbreviationRange.end.character));
 			const propertyNode = <Property>currentNode;
 			if (propertyNode.terminatorToken
 				&& propertyNode.separator

--- a/extensions/emmet/src/test/partialParsingStylesheet.test.ts
+++ b/extensions/emmet/src/test/partialParsingStylesheet.test.ts
@@ -60,7 +60,7 @@ p {
 /* .foo { op.3
 dn	{
 */
-	@
+	bgc
 } bg
 `;
 		return withRandomFileEditor(sassContents, '.scss', (_, doc) => {
@@ -69,7 +69,7 @@ dn	{
 				new vscode.Range(2, 3, 2, 7),		// Line commented selector
 				new vscode.Range(3, 3, 3, 7),		// Block commented selector
 				new vscode.Range(4, 0, 4, 2),		// dn inside block comment
-				new vscode.Range(6, 1, 6, 2),		// @ inside a rule whose opening brace is commented
+				new vscode.Range(6, 1, 6, 2),		// bgc inside a rule whose opening brace is commented
 				new vscode.Range(7, 2, 7, 4)		// bg after ending of badly constructed block
 			];
 			rangesNotEmmet.forEach(range => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #74505

It changes around some checks so that for stylesheet (e.g. CSS, SASS) abbreviations starting with @, suggestions also show up if that abbreviation was typed at the top level within a stylesheet file, rather than only within declaration blocks.

