### PR TITLE
Fix focus outline oddly rendered for some action icons when panel is on the side

### DIFF
--- a/src/vs/workbench/browser/parts/panel/media/panelpart.css
+++ b/src/vs/workbench/browser/parts/panel/media/panelpart.css
@@ -178,15 +178,17 @@
 }
 
 /* Rotate icons when panel is on right */
-.monaco-workbench .part.panel.right .title-actions .codicon-split-horizontal,
-.monaco-workbench .part.panel.right .title-actions .codicon-panel-maximize,
-.monaco-workbench .part.panel.right .title-actions .codicon-panel-restore {
+.monaco-workbench .part.panel.right .title-actions .codicon-split-horizontal::before,
+.monaco-workbench .part.panel.right .title-actions .codicon-panel-maximize::before,
+.monaco-workbench .part.panel.right .title-actions .codicon-panel-restore::before {
+	display: inline-block;
 	transform: rotate(-90deg);
 }
 
 /* Rotate icons when panel is on left */
-.monaco-workbench .part.panel.left .title-actions .codicon-split-horizontal,
-.monaco-workbench .part.panel.left .title-actions .codicon-panel-maximize,
-.monaco-workbench .part.panel.left .title-actions .codicon-panel-restore {
+.monaco-workbench .part.panel.left .title-actions .codicon-split-horizontal::before,
+.monaco-workbench .part.panel.left .title-actions .codicon-panel-maximize::before,
+.monaco-workbench .part.panel.left .title-actions .codicon-panel-restore::before {
+	display: inline-block;
 	transform: rotate(90deg);
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #117833

![fix_icon_outline](https://user-images.githubusercontent.com/25115070/109398164-06c25e00-7909-11eb-8466-60b4223f669a.gif)

