### PR TITLE
remove arbitrary 600 pixel limit on quick input widget

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -49,6 +49,8 @@ export interface IQuickInputOptions {
 	idPrefix: string;
 	container: HTMLElement;
 	ignoreFocusOut(): boolean;
+	maximumWidth(): number;
+	relativeWidth(): number;
 	backKeybindingLabel(): string | undefined;
 	setContextKey(id?: string): void;
 	linkOpenerDelegate(content: string): void;

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -729,7 +729,7 @@ export class QuickInputController extends Disposable {
 			this.ui.container.style.top = `${this.titleBarOffset}px`;
 
 			const style = this.ui.container.style;
-			const width = this.dimension!.width * 0.75;
+			const width = Math.min(this.dimension!.width * this.options.relativeWidth(), this.options.maximumWidth());
 			style.width = width + 'px';
 			style.marginLeft = '-' + (width / 2) + 'px';
 

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -29,8 +29,6 @@ import './quickInputActions.js';
 const $ = dom.$;
 
 export class QuickInputController extends Disposable {
-	private static readonly MAX_WIDTH = 600; // Max total width of quick input widget
-
 	private idPrefix: string;
 	private ui: QuickInputUI | undefined;
 	private dimension?: dom.IDimension;
@@ -731,7 +729,7 @@ export class QuickInputController extends Disposable {
 			this.ui.container.style.top = `${this.titleBarOffset}px`;
 
 			const style = this.ui.container.style;
-			const width = Math.min(this.dimension!.width * 0.62 /* golden cut */, QuickInputController.MAX_WIDTH);
+			const width = this.dimension!.width * 0.75;
 			style.width = width + 'px';
 			style.marginLeft = '-' + (width / 2) + 'px';
 

--- a/src/vs/platform/quickinput/browser/quickInputService.ts
+++ b/src/vs/platform/quickinput/browser/quickInputService.ts
@@ -70,6 +70,8 @@ export class QuickInputService extends Themable implements IQuickInputService {
 			idPrefix: 'quickInput_',
 			container: host.activeContainer,
 			ignoreFocusOut: () => false,
+			maximumWidth: () => 600,
+			relativeWidth: () => 0.62,
 			backKeybindingLabel: () => undefined,
 			setContextKey: (id?: string) => this.setContextKey(id),
 			linkOpenerDelegate: (content) => {

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -80,6 +80,8 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 				container: fixture,
 				idPrefix: 'testQuickInput',
 				ignoreFocusOut() { return true; },
+				maximumWidth() { return 600; },
+				relativeWidth() { return 0.62; },
 				returnFocus() { },
 				backKeybindingLabel() { return undefined; },
 				setContextKey() { return undefined; },

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -490,14 +490,14 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('workbench.quickOpen.preserveInput', "Controls whether the last typed input to Quick Open should be restored when opening it the next time."),
 				'default': false
 			},
-			'workbench.quickOpen.maximumWidth': {
+			'workbench.quickOpen.experimental.maximumWidth': {
 				'type': 'number',
 				'description': localize('workbench.quickOpen.maxWidth', "Limits the maximum width of Quick Open to the specified number of pixels."),
 				'default': 600,
 				'minimum': 200,
 				'maximum': 2000
 			},
-			'workbench.quickOpen.relativeWidth': {
+			'workbench.quickOpen.experimental.relativeWidth': {
 				'type': 'number',
 				'description': localize('workbench.quickOpen.relativeWidth', "Controls the width of Quick Open relative to the total window width."),
 				'default': 0.62,

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -501,8 +501,8 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'number',
 				'description': localize('workbench.quickOpen.relativeWidth', "Controls the width of Quick Open relative to the total window width."),
 				'default': 0.62,
-				'minimum': 0.1,
-				'maximum': 1.0
+				'minimum': 0.5,
+				'maximum': 0.9
 			},
 			'workbench.settings.openDefaultSettings': {
 				'type': 'boolean',

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -490,6 +490,20 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('workbench.quickOpen.preserveInput', "Controls whether the last typed input to Quick Open should be restored when opening it the next time."),
 				'default': false
 			},
+			'workbench.quickOpen.maximumWidth': {
+				'type': 'number',
+				'description': localize('workbench.quickOpen.maxWidth', "Limits the maximum width of Quick Open to the specified number of pixels."),
+				'default': 600,
+				'minimum': 200,
+				'maximum': 2000
+			},
+			'workbench.quickOpen.relativeWidth': {
+				'type': 'number',
+				'description': localize('workbench.quickOpen.relativeWidth', "Controls the width of Quick Open relative to the total window width."),
+				'default': 0.62,
+				'minimum': 0.1,
+				'maximum': 1.0
+			},
 			'workbench.settings.openDefaultSettings': {
 				'type': 'boolean',
 				'description': localize('openDefaultSettings', "Controls whether opening settings also opens an editor showing all default settings."),

--- a/src/vs/workbench/services/quickinput/browser/quickInputService.ts
+++ b/src/vs/workbench/services/quickinput/browser/quickInputService.ts
@@ -14,6 +14,7 @@ import { QuickInputService as BaseQuickInputService } from '../../../../platform
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { InQuickPickContextKey } from '../../../browser/quickaccess.js';
+import { clamp } from '../../../../base/common/numbers.js';
 
 export class QuickInputService extends BaseQuickInputService {
 
@@ -40,8 +41,8 @@ export class QuickInputService extends BaseQuickInputService {
 	protected override createController(): QuickInputController {
 		return super.createController(this.layoutService, {
 			ignoreFocusOut: () => !this.configurationService.getValue('workbench.quickOpen.closeOnFocusLost'),
-			maximumWidth: () => this.configurationService.getValue('workbench.quickOpen.maximumWidth'),
-			relativeWidth: () => this.configurationService.getValue('workbench.quickOpen.relativeWidth'),
+			maximumWidth: () => clamp(this.configurationService.getValue('workbench.quickOpen.experimental.maximumWidth'), 200, 2000),
+			relativeWidth: () => clamp(this.configurationService.getValue('workbench.quickOpen.experimental.relativeWidth'), 0.5, 0.9),
 			backKeybindingLabel: () => this.keybindingService.lookupKeybinding('workbench.action.quickInputBack')?.getLabel() || undefined,
 		});
 	}

--- a/src/vs/workbench/services/quickinput/browser/quickInputService.ts
+++ b/src/vs/workbench/services/quickinput/browser/quickInputService.ts
@@ -40,6 +40,8 @@ export class QuickInputService extends BaseQuickInputService {
 	protected override createController(): QuickInputController {
 		return super.createController(this.layoutService, {
 			ignoreFocusOut: () => !this.configurationService.getValue('workbench.quickOpen.closeOnFocusLost'),
+			maximumWidth: () => this.configurationService.getValue('workbench.quickOpen.maximumWidth'),
+			relativeWidth: () => this.configurationService.getValue('workbench.quickOpen.relativeWidth'),
 			backKeybindingLabel: () => this.keybindingService.lookupKeybinding('workbench.action.quickInputBack')?.getLabel() || undefined,
 		});
 	}


### PR DESCRIPTION
Add maximumWidth and relativeWidth settings to customize width of quickInput widget rather than the hardcoded minimum of 62% of available width or 600 pixel max width

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #85374
