### PR TITLE
Implement shouldPersist for all terminals processes

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -255,7 +255,7 @@ export interface ITerminalChildProcess {
 	/**
 	 * Whether the process should be persisted across reloads.
 	 */
-	shouldPersist?: boolean;
+	shouldPersist: boolean;
 
 	onProcessData: Event<IProcessDataEvent | string>;
 	onProcessExit: Event<number | undefined>;

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -26,6 +26,7 @@ const WRITE_INTERVAL_MS = 5;
 
 export class TerminalProcess extends Disposable implements ITerminalChildProcess {
 	readonly id = 0;
+	readonly shouldPersist = false;
 
 	private _exitCode: number | undefined;
 	private _exitMessage: string | undefined;

--- a/src/vs/workbench/api/common/extHostTerminalService.ts
+++ b/src/vs/workbench/api/common/extHostTerminalService.ts
@@ -185,6 +185,7 @@ export class ExtHostTerminal {
 
 export class ExtHostPseudoterminal implements ITerminalChildProcess {
 	readonly id = 0;
+	readonly shouldPersist = false;
 
 	private readonly _onProcessData = new Emitter<string>();
 	public readonly onProcessData: Event<string> = this._onProcessData.event;

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -202,7 +202,7 @@ export interface IRemoteTerminalService {
 	readonly _serviceBrand: undefined;
 	dispose(): void;
 	listTerminals(isInitialization?: boolean): Promise<IRemoteTerminalAttachTarget[]>;
-	createRemoteTerminalProcess(terminalId: number, shellLaunchConfig: IShellLaunchConfig, activeWorkspaceRootUri: URI | undefined, cols: number, rows: number, configHelper: ITerminalConfigHelper,): Promise<ITerminalChildProcess>;
+	createRemoteTerminalProcess(terminalId: number, shellLaunchConfig: IShellLaunchConfig, activeWorkspaceRootUri: URI | undefined, cols: number, rows: number, shouldPersist: boolean, configHelper: ITerminalConfigHelper,): Promise<ITerminalChildProcess>;
 
 	setTerminalLayoutInfo(layout: ITerminalsLayoutInfoById): Promise<void>;
 	getTerminalLayoutInfo(): Promise<ITerminalsLayoutInfo | undefined>;

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessExtHostProxy.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessExtHostProxy.ts
@@ -16,6 +16,7 @@ let hasReceivedResponseFromRemoteExtHost: boolean = false;
 
 export class TerminalProcessExtHostProxy extends Disposable implements ITerminalChildProcess, ITerminalProcessExtHostProxy {
 	readonly id = 0;
+	readonly shouldPersist = false;
 
 	private readonly _onProcessData = this._register(new Emitter<string>());
 	public readonly onProcessData: Event<string> = this._onProcessData.event;

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -90,7 +90,7 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 
 	public get environmentVariableInfo(): IEnvironmentVariableInfo | undefined { return this._environmentVariableInfo; }
 	public get persistentTerminalId(): number | undefined { return this._process?.id; }
-	public get shouldPersist(): boolean { return this._process?.shouldPersist || false; }
+	public get shouldPersist(): boolean { return this._process ? this._process.shouldPersist : false; }
 
 	public get hasWrittenData(): boolean {
 		return this._hasWrittenData;
@@ -187,7 +187,8 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 
 				const enableRemoteAgentTerminals = this._configHelper.config.serverSpawn;
 				if (enableRemoteAgentTerminals) {
-					this._process = await this._remoteTerminalService.createRemoteTerminalProcess(this._terminalId, shellLaunchConfig, activeWorkspaceRootUri, cols, rows, this._configHelper);
+					const shouldPersist = !shellLaunchConfig.isFeatureTerminal && this._configHelper.config.enablePersistentSessions;
+					this._process = await this._remoteTerminalService.createRemoteTerminalProcess(this._terminalId, shellLaunchConfig, activeWorkspaceRootUri, cols, rows, shouldPersist, this._configHelper);
 				} else {
 					this._process = this._instantiationService.createInstance(TerminalProcessExtHostProxy, this._terminalId, shellLaunchConfig, activeWorkspaceRootUri, cols, rows, this._configHelper);
 				}


### PR DESCRIPTION
shouldPersist was not being set on RemoteTerminalProcess, causing reconnect
to fail for all remote terminals. The fix was to push the persistent logic
up to where the process gets created in TerminalProcessManager just like is
done with local processes. The property was made non-optional to prevent
this sort of thing happening again.

Fixes #117896

This is a cherry pick with conflicts resolved of https://github.com/microsoft/vscode/commit/edadf1c7194f9121087eac8730dbca5cbdff5ef1 on `main`.