### PR TITLE
Fix extension's readme not rendering images width and height

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -78,7 +78,8 @@ function removeEmbeddedSVGs(documentContent: string): string {
 		allowedAttributes: {
 			'*': [
 				'align',
-			]
+			],
+			img: ['src', 'alt', 'title', 'aria-label', 'width', 'height'],
 		},
 		filter(token: { tag: string, attrs: { readonly [key: string]: string } }): boolean {
 			return token.tag !== 'svg';


### PR DESCRIPTION
This PR fixes #117939 

While sanitizing rendered Markdown content, vscode remove `width` and `height` attributes of `img` tag. Add it back so that images are rendered with those attributes.

Checked against the screenshot in the original issue:

![2021-03-02 21_19_05-](https://user-images.githubusercontent.com/11912225/109634577-81a3a700-7b9d-11eb-8906-948b28555b6b.png)

![2021-03-02 21_23_01-Extension_ Terminal All In One - Code - OSS Dev](https://user-images.githubusercontent.com/11912225/109634579-836d6a80-7b9d-11eb-8ebe-3121b5372891.png)
