### PR TITLE
rpm-spec: fix the wrong claim about working on EL7

### DIFF
--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -1,6 +1,6 @@
 Name:     @@NAME@@
 Version:  @@VERSION@@
-Release:  @@RELEASE@@.el7
+Release:  @@RELEASE@@.el8
 Summary:  Code editing. Redefined.
 Group:    Development/Tools
 Vendor:   Microsoft Corporation


### PR DESCRIPTION
This PR fixes #115784 and ensures that code is not automatically upgraded to an RPM the system cannot run without preloading a manually provided libstdc++.
