### PR TITLE
Add a compose language

### DIFF
--- a/extensions/yaml/package.json
+++ b/extensions/yaml/package.json
@@ -14,14 +14,18 @@
   "contributes": {
     "languages": [
       {
-        "id": "compose",
+        "id": "dockercompose",
         "aliases": [
           "Compose",
           "compose"
         ],
         "filenamePatterns": [
-          "*compose*.yml",
-          "*compose*.yaml"
+          "compose.yml",
+          "compose.yaml",
+          "compose.*.yml",
+          "compose.*.yaml",
+          "*docker*compose*.yml",
+          "*docker*compose*.yaml"
         ],
         "configuration": "./language-configuration.json"
       },
@@ -43,7 +47,7 @@
     ],
     "grammars": [
       {
-        "language": "compose",
+        "language": "dockercompose",
         "scopeName": "source.yaml",
         "path": "./syntaxes/yaml.tmLanguage.json"
       },

--- a/extensions/yaml/package.json
+++ b/extensions/yaml/package.json
@@ -14,6 +14,18 @@
   "contributes": {
     "languages": [
       {
+        "id": "compose",
+        "aliases": [
+          "Compose",
+          "compose"
+        ],
+        "filenamePatterns": [
+          "*compose*.yml",
+          "*compose*.yaml"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
         "id": "yaml",
         "aliases": [
           "YAML",
@@ -30,6 +42,11 @@
       }
     ],
     "grammars": [
+      {
+        "language": "compose",
+        "scopeName": "source.yaml",
+        "path": "./syntaxes/yaml.tmLanguage.json"
+      },
       {
         "language": "yaml",
         "scopeName": "source.yaml",


### PR DESCRIPTION
I heard from @bwateratmsft that adding a compose language would be useful for the docker extension, and I think it might make sense. It's easy to try this, so I figured why not. Some of the reasons this could be useful:

- Extensions can use `compose` as the language for activation
- Simplifies when clauses for users who what to scope things
- Easier to show the proper icon for icon themes
- Nice to use in `files.associations`