### PR TITLE
Allow ripgrep search provider to work for files backed by file scheme, but not file scheme themselves (vscode-userdata)

### DIFF
--- a/src/vs/workbench/api/node/extHostSearch.ts
+++ b/src/vs/workbench/api/node/extHostSearch.ts
@@ -35,6 +35,8 @@ export class NativeExtHostSearch extends ExtHostSearch {
 	) {
 		super(extHostRpc, _uriTransformer, _logService);
 
+		const outputChannel = new OutputChannel(this._logService);
+		this.registerTextSearchProvider(Schemas.userData, new RipgrepSearchProvider(outputChannel));
 		if (initData.remote.isRemote && initData.remote.authority) {
 			this._registerEHSearchProviders();
 		}
@@ -101,4 +103,3 @@ export class NativeExtHostSearch extends ExtHostSearch {
 		return new NativeTextSearchManager(query, provider);
 	}
 }
-

--- a/src/vs/workbench/api/node/extHostSearch.ts
+++ b/src/vs/workbench/api/node/extHostSearch.ts
@@ -35,7 +35,7 @@ export class NativeExtHostSearch extends ExtHostSearch {
 	) {
 		super(extHostRpc, _uriTransformer, _logService);
 
-		const outputChannel = new OutputChannel(this._logService);
+		const outputChannel = new OutputChannel('RipgrepSearchUD', this._logService);
 		this.registerTextSearchProvider(Schemas.userData, new RipgrepSearchProvider(outputChannel));
 		if (initData.remote.isRemote && initData.remote.authority) {
 			this._registerEHSearchProviders();
@@ -43,7 +43,7 @@ export class NativeExtHostSearch extends ExtHostSearch {
 	}
 
 	private _registerEHSearchProviders(): void {
-		const outputChannel = new OutputChannel(this._logService);
+		const outputChannel = new OutputChannel('RipgrepSearchEH', this._logService);
 		this.registerTextSearchProvider(Schemas.file, new RipgrepSearchProvider(outputChannel));
 		this.registerInternalFileSearchProvider(Schemas.file, new SearchService());
 	}

--- a/src/vs/workbench/contrib/search/common/queryBuilder.ts
+++ b/src/vs/workbench/contrib/search/common/queryBuilder.ts
@@ -211,8 +211,7 @@ export class QueryBuilder {
 
 			const providerExists = isAbsolutePath(file);
 			// Special case userdata as we don't have a search provider for it, but it can be searched.
-			const isUserdata = file.scheme === Schemas.userData;
-			if (providerExists && !isUserdata) {
+			if (providerExists) {
 				const searchRoot = this.workspaceContextService.getWorkspaceFolder(file)?.uri ?? file.with({ path: path.dirname(file.fsPath) });
 
 				let folderQuery = foldersToSearch.get(searchRoot);

--- a/src/vs/workbench/services/search/node/ripgrepSearchProvider.ts
+++ b/src/vs/workbench/services/search/node/ripgrepSearchProvider.ts
@@ -19,7 +19,7 @@ export class RipgrepSearchProvider implements TextSearchProvider {
 
 	provideTextSearchResults(query: TextSearchQuery, options: TextSearchOptions, progress: Progress<TextSearchResult>, token: CancellationToken): Promise<TextSearchComplete> {
 		const engine = new RipgrepTextSearchEngine(this.outputChannel);
-		if (options.folder.scheme !== Schemas.file) {
+		if (options.folder.scheme === Schemas.userData) {
 			// Ripgrep search engine can only provide file-scheme results, but we want to use it to search some schemes that are backed by the filesystem, but with some other provider as the frontend,
 			// case in point vscode-userdata. In these cases we translate the query to a file, and translate the results back to the frontend scheme.
 			const translatedOptions = { ...options, folder: options.folder.with({ scheme: Schemas.file }) };

--- a/src/vs/workbench/services/search/node/ripgrepSearchProvider.ts
+++ b/src/vs/workbench/services/search/node/ripgrepSearchProvider.ts
@@ -8,6 +8,7 @@ import { OutputChannel } from 'vs/workbench/services/search/node/ripgrepSearchUt
 import { RipgrepTextSearchEngine } from 'vs/workbench/services/search/node/ripgrepTextSearchEngine';
 import { TextSearchProvider, TextSearchComplete, TextSearchResult, TextSearchQuery, TextSearchOptions } from 'vs/workbench/services/search/common/searchExtTypes';
 import { Progress } from 'vs/platform/progress/common/progress';
+import { Schemas } from 'vs/base/common/network';
 
 export class RipgrepSearchProvider implements TextSearchProvider {
 	private inProgress: Set<CancellationTokenSource> = new Set();
@@ -18,7 +19,15 @@ export class RipgrepSearchProvider implements TextSearchProvider {
 
 	provideTextSearchResults(query: TextSearchQuery, options: TextSearchOptions, progress: Progress<TextSearchResult>, token: CancellationToken): Promise<TextSearchComplete> {
 		const engine = new RipgrepTextSearchEngine(this.outputChannel);
-		return this.withToken(token, token => engine.provideTextSearchResults(query, options, progress, token));
+		if (options.folder.scheme !== Schemas.file) {
+			// Ripgrep search engine can only provide file-scheme results, but we want to use it to search some schemes that are backed by the filesystem, but with some other provider as the frontend,
+			// case in point vscode-userdata. In these cases we translate the query to a file, and translate the results back to the frontend scheme.
+			const translatedOptions = { ...options, folder: options.folder.with({ scheme: Schemas.file }) };
+			const progressTranslator = new Progress<TextSearchResult>(data => progress.report({ ...data, uri: data.uri.with({ scheme: options.folder.scheme }) }));
+			return this.withToken(token, token => engine.provideTextSearchResults(query, translatedOptions, progressTranslator, token));
+		} else {
+			return this.withToken(token, token => engine.provideTextSearchResults(query, options, progress, token));
+		}
 	}
 
 	private async withToken<T>(token: CancellationToken, fn: (token: CancellationToken) => Promise<T>): Promise<T> {

--- a/src/vs/workbench/services/search/node/ripgrepSearchUtils.ts
+++ b/src/vs/workbench/services/search/node/ripgrepSearchUtils.ts
@@ -46,9 +46,9 @@ export interface IOutputChannel {
 }
 
 export class OutputChannel implements IOutputChannel {
-	constructor(@ILogService private readonly logService: ILogService) { }
+	constructor(private prefix: string, @ILogService private readonly logService: ILogService) { }
 
 	appendLine(msg: string): void {
-		this.logService.debug('RipgrepSearchEH#search', msg);
+		this.logService.debug(`${this.prefix}#search`, msg);
 	}
 }


### PR DESCRIPTION
Fixes #115434
