### PR TITLE
Introduce a service to resolve the shell environment

### DIFF
--- a/src/bootstrap-window.js
+++ b/src/bootstrap-window.js
@@ -159,7 +159,9 @@
 
 				// Wait for process environment being fully resolved
 				performance.mark('code/willWaitForShellEnv');
-				await whenEnvResolved;
+				if (!process.env['VSCODE_SKIP_PROCESS_ENV_PATCHING'] /* TODO@bpasero for https://github.com/microsoft/vscode/issues/108804 */) {
+					await whenEnvResolved;
+				}
 				performance.mark('code/didWaitForShellEnv');
 
 				// Callback only after process environment is resolved

--- a/src/vs/base/parts/sandbox/electron-browser/preload.js
+++ b/src/vs/base/parts/sandbox/electron-browser/preload.js
@@ -147,7 +147,12 @@
 			get type() { return 'renderer'; },
 			get execPath() { return process.execPath; },
 
-			get withShellEnv() { return shellEnv; },
+			/**
+			 * @returns {Promise<typeof process.env>}
+			 */
+			getShellEnv() {
+				return shellEnv;
+			},
 
 			/**
 			 * @param {{[key: string]: string}} userEnv

--- a/src/vs/base/parts/sandbox/electron-browser/preload.js
+++ b/src/vs/base/parts/sandbox/electron-browser/preload.js
@@ -254,7 +254,7 @@
 			// Resolve `shellEnv` from the main side
 			shellEnv = new Promise(function (resolve) {
 				ipcRenderer.once('vscode:acceptShellEnv', function (event, shellEnvResult) {
-					if (process.env['VSCODE_IGNORE_SHELL_ENV'] /* TODO@bpasero for https://github.com/microsoft/vscode/issues/108804 */) {
+					if (process.env['VSCODE_SKIP_PROCESS_ENV_PATCHING'] /* TODO@bpasero for https://github.com/microsoft/vscode/issues/108804 */) {
 						// Resolve with all keys of the shell environment and our process environment
 						// But make sure that the user environment wins in the end over shell environment
 						resolve({ ...process.env, ...shellEnvResult, ...userEnv });

--- a/src/vs/base/parts/sandbox/electron-sandbox/globals.ts
+++ b/src/vs/base/parts/sandbox/electron-sandbox/globals.ts
@@ -89,7 +89,7 @@ export interface ISandboxNodeProcess extends IPartialNodeProcess {
 	 * Returns a process environment that includes any shell environment even if the application
 	 * was not started from a shell / terminal / console.
 	 */
-	readonly withShellEnv: Promise<IProcessEnvironment>;
+	getShellEnv(): Promise<IProcessEnvironment>;
 }
 
 export interface ISandboxContext {

--- a/src/vs/base/parts/sandbox/electron-sandbox/globals.ts
+++ b/src/vs/base/parts/sandbox/electron-sandbox/globals.ts
@@ -84,6 +84,12 @@ export interface ISandboxNodeProcess extends IPartialNodeProcess {
 	 * set of environment in `process.env`.
 	 */
 	resolveEnv(userEnv: IProcessEnvironment): Promise<void>;
+
+	/**
+	 * Returns a process environment that includes any shell environment even if the application
+	 * was not started from a shell / terminal / console.
+	 */
+	readonly withShellEnv: Promise<IProcessEnvironment>;
 }
 
 export interface ISandboxContext {

--- a/src/vs/workbench/services/environment/electron-sandbox/shellEnvironmentService.ts
+++ b/src/vs/workbench/services/environment/electron-sandbox/shellEnvironmentService.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { IProcessEnvironment } from 'vs/base/common/platform';
+import { process } from 'vs/base/parts/sandbox/electron-sandbox/globals';
+import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+
+export const IShellEnvironmentService = createDecorator<IShellEnvironmentService>('shellEnvironmentService');
+
+export interface IShellEnvironmentService {
+
+	readonly _serviceBrand: undefined;
+
+	readonly withShellEnv: Promise<IProcessEnvironment>;
+}
+
+export class ShellEnvironmentService implements IShellEnvironmentService {
+
+	declare readonly _serviceBrand: undefined;
+
+	readonly withShellEnv = process.withShellEnv;
+}
+
+registerSingleton(IShellEnvironmentService, ShellEnvironmentService);

--- a/src/vs/workbench/services/environment/electron-sandbox/shellEnvironmentService.ts
+++ b/src/vs/workbench/services/environment/electron-sandbox/shellEnvironmentService.ts
@@ -14,14 +14,16 @@ export interface IShellEnvironmentService {
 
 	readonly _serviceBrand: undefined;
 
-	readonly withShellEnv: Promise<IProcessEnvironment>;
+	getShellEnv(): Promise<IProcessEnvironment>;
 }
 
 export class ShellEnvironmentService implements IShellEnvironmentService {
 
 	declare readonly _serviceBrand: undefined;
 
-	readonly withShellEnv = process.withShellEnv;
+	getShellEnv(): Promise<IProcessEnvironment> {
+		return process.getShellEnv();
+	}
 }
 
 registerSingleton(IShellEnvironmentService, ShellEnvironmentService);

--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -160,7 +160,7 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 			this._messageProtocol = Promise.all([
 				this._tryListenOnPipe(),
 				this._tryFindDebugPort(),
-				this._shellEnvironmentService.withShellEnv
+				this._shellEnvironmentService.getShellEnv()
 			]).then(([pipeName, portNumber, processEnv]) => {
 				const env = objects.mixin(processEnv, {
 					VSCODE_AMD_ENTRYPOINT: 'vs/workbench/services/extensions/node/extensionHostProcess',

--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -47,6 +47,7 @@ import { isUUID } from 'vs/base/common/uuid';
 import { join } from 'vs/base/common/path';
 import { Readable, Writable } from 'stream';
 import { StringDecoder } from 'string_decoder';
+import { IShellEnvironmentService } from 'vs/workbench/services/environment/electron-sandbox/shellEnvironmentService';
 
 export interface ILocalProcessExtensionHostInitData {
 	readonly autoStart: boolean;
@@ -104,7 +105,8 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 		@ILabelService private readonly _labelService: ILabelService,
 		@IExtensionHostDebugService private readonly _extensionHostDebugService: IExtensionHostDebugService,
 		@IHostService private readonly _hostService: IHostService,
-		@IProductService private readonly _productService: IProductService
+		@IProductService private readonly _productService: IProductService,
+		@IShellEnvironmentService private readonly _shellEnvironmentService: IShellEnvironmentService
 	) {
 		const devOpts = parseExtensionDevOptions(this._environmentService);
 		this._isExtensionDevHost = devOpts.isExtensionDevHost;
@@ -157,9 +159,10 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 		if (!this._messageProtocol) {
 			this._messageProtocol = Promise.all([
 				this._tryListenOnPipe(),
-				this._tryFindDebugPort()
-			]).then(([pipeName, portNumber]) => {
-				const env = objects.mixin(objects.deepClone(process.env), {
+				this._tryFindDebugPort(),
+				this._shellEnvironmentService.withShellEnv
+			]).then(([pipeName, portNumber, processEnv]) => {
+				const env = objects.mixin(processEnv, {
 					VSCODE_AMD_ENTRYPOINT: 'vs/workbench/services/extensions/node/extensionHostProcess',
 					VSCODE_PIPE_LOGGING: 'true',
 					VSCODE_VERBOSE_LOGGING: true,

--- a/src/vs/workbench/workbench.sandbox.main.ts
+++ b/src/vs/workbench/workbench.sandbox.main.ts
@@ -61,6 +61,7 @@ import 'vs/workbench/services/userDataSync/electron-sandbox/userDataSyncStoreMan
 import 'vs/workbench/services/userDataSync/electron-sandbox/userDataAutoSyncService';
 import 'vs/workbench/services/ipc/electron-sandbox/sharedProcessService';
 import 'vs/workbench/services/timer/electron-sandbox/timerService';
+import 'vs/workbench/services/environment/electron-sandbox/shellEnvironmentService';
 
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IUserDataInitializationService, UserDataInitializationService } from 'vs/workbench/services/userData/browser/userDataInit';


### PR DESCRIPTION
For #108804

@joaomoreno would like to get your initial feedback on this approach. A new service `IShellEnvironmentService` with `withShellEnv: Promise<IProcessEnvironment>` to get the resolved `process.env` including the shell envrionment.

I adopted this for the extension host to demonstrate the usage. A new temporary `VSCODE_IGNORE_SHELL_ENV` environment variable allows to disable our automated merge of `process.env`. Since you want to test this not from a terminal, this SO applies for how to configuring an environment variable not from the terminal: https://stackoverflow.com/questions/603785/environment-variables-in-mac-os-x/4567308#4567308