### PR TITLE
snap: set compression to lzo, #117852

### DIFF
--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -9,6 +9,7 @@ description: |
 architectures:
   - build-on: amd64
     run-on: @@ARCHITECTURE@@
+compression: lzo
 
 grade: stable
 confinement: classic


### PR DESCRIPTION
On ryzen 1800x + nvme first launch of vscode takes 6-7 seconds, that's too much.
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

https://ubuntu.com//blog/snap-speed-improvements-with-new-compression-algorithm
https://snapcraft.io/blog/why-lzo-was-chosen-as-the-new-compression-method


This PR fixes https://github.com/microsoft/vscode/issues/117852
