### PR TITLE
FileSystemProvider extension: throwing a FileSystemError in readFile does not report to user

### DIFF
--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -545,7 +545,8 @@ export class FileService extends Disposable implements IFileService {
 				// End stream with data
 				stream.end(VSBuffer.wrap(buffer));
 			} catch (err) {
-				stream.end(err);
+				stream.error(err);
+				stream.end();
 			}
 		})();
 

--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -545,7 +545,7 @@ export class FileService extends Disposable implements IFileService {
 				// End stream with data
 				stream.end(VSBuffer.wrap(buffer));
 			} catch (err) {
-				stream.error(err);
+				stream.end(err);
 			}
 		})();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #118060
