### PR TITLE
Fix debug console URI being decoded

### DIFF
--- a/src/vs/editor/browser/services/openerService.ts
+++ b/src/vs/editor/browser/services/openerService.ts
@@ -166,7 +166,7 @@ export class OpenerService implements IOpenerService {
 		// check with contributed validators
 		const targetURI = typeof target === 'string' ? URI.parse(target) : target;
 		// validate against the original URI that this URI resolves to, if one exists
-		const validationTarget = this._resolvedUriTargets.get(targetURI) ?? targetURI;
+		const validationTarget = this._resolvedUriTargets.get(targetURI) ?? target;
 		for (const validator of this._validators) {
 			if (!(await validator.shouldOpen(validationTarget))) {
 				return false;

--- a/src/vs/editor/test/browser/services/openerService.test.ts
+++ b/src/vs/editor/test/browser/services/openerService.test.ts
@@ -127,6 +127,20 @@ suite('OpenerService', function () {
 		assert.equal(openCount, 2);
 	});
 
+	test('links aren\'t manipulated before being passed to validator: PR #118226', async function () {
+		const openerService = new OpenerService(editorService, commandService);
+
+		openerService.registerValidator({
+			shouldOpen: (resource) => {
+				// We don't want it to convert strings into URIs
+				assert.strictEqual(resource instanceof URI, false);
+				return Promise.resolve(false);
+			}
+		});
+		await openerService.open('https://wwww.microsoft.com');
+		await openerService.open('https://www.microsoft.com??params=CountryCode%3DUSA%26Name%3Dvscode"');
+	});
+
 	test('links validated by multiple validators', async function () {
 		const openerService = new OpenerService(editorService, commandService);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #112032


This bug was previously fixed, but appears to have regressed due to https://github.com/microsoft/vscode/commit/a53084475d911b3fe8ed6aea7b04907af9b30fa6. I'm not sure why we switched to falling back to targetURI instead of target as before, but I've reverted that as we want to hold off on URIs whenever possible in the open flow as our `URI.parse` method automatically decodes URI components.
