### PR TITLE
Check if VSCode runs serverless

### DIFF
--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -317,7 +317,10 @@ export class AzureActiveDirectoryService {
 		}
 
 		return new Promise(async (resolve, reject) => {
-			if (vscode.env.remoteName !== undefined) {
+			const runsRemote = vscode.env.remoteName !== undefined;
+			const runsServerless = vscode.env.remoteName === undefined && vscode.env.uiKind === vscode.UIKind.Web;
+
+			if (runsRemote || runsServerless) {
 				resolve(this.loginWithoutLocalServer(scope));
 				return;
 			}


### PR DESCRIPTION
In situations when VSCode runs as remote or serverless we should attempt authentication flow without a local server.

This PR partially fixes Microsoft authentication in Live Share Web where we hit local server flow by mistake and bump  into this error:
https://github.com/microsoft/vscode/blob/main/extensions/microsoft-authentication/src/env/browser/authServer.ts#L10 
