### PR TITLE
Don't assume uncompleted category exists

### DIFF
--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
@@ -613,7 +613,7 @@ export class GettingStartedPage extends EditorPane {
 			const progressAmount = assertIsDefined(progress.querySelector('.progress-bar-inner') as HTMLDivElement).style.width;
 			if (!toFocus && progressAmount !== '100%') { toFocus = assertIsDefined(progress.parentElement?.parentElement); }
 		});
-		(toFocus ?? assertIsDefined(this.container.querySelector('button.skip')) as HTMLButtonElement).focus();
+		(toFocus ?? assertIsDefined(this.container.querySelector('button.getting-started-category')) as HTMLButtonElement)?.focus();
 	}
 
 	private setSlide(toEnable: 'details' | 'categories') {


### PR DESCRIPTION
Fixes #118251

We previously assumed we could fall back to focusing the `skip` button if all categories were completed, but with that button removed from the design this now throws an error, we should fall back to the first category instead.