### PR TITLE
Add Julia indentation rules

### DIFF
--- a/extensions/julia/language-configuration.json
+++ b/extensions/julia/language-configuration.json
@@ -27,5 +27,9 @@
 			"start": "^\\s*#region",
 			"end": "^\\s*#endregion"
 		}
+	},
+	"indentationRules": {
+		"increaseIndentPattern": "^(\\s*|.*=\\s*|.*@\\w*\\s*)[\\w\\s]*(?:[\"'`][^\"'`]*[\"'`])*[\\w\\s]*\\b(if|while|for|function|macro|(mutable\\s+)?struct|abstract\\s+type|primitive\\s+type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!(?:.*\\bend\\b[^\\]]*)|(?:[^\\[]*\\].*)$).*$",
+		"decreaseIndentPattern": "^\\s*(end|else|elseif|catch|finally)\\b.*$"
 	}
 }


### PR DESCRIPTION
We currently add these things in the `activate` function in the Julia extension itself, see [here](https://github.com/julia-vscode/julia-vscode/blob/3337b8fec2d171e05f435a3a4a10c619e2b534ed/src/extension.ts#L52).

I have to admit I don't understand why this hasn't been part of our `language-configuration.json` from the beginning, but as far as I can tell there is really no reason to have this in our `activate` function. Just shipping it as part of the general Julia language configuration here seems like a better move?

@pfitzseb, could you also take a look at this and sign-off on this plan before someone were to merge this here?