### PR TITLE
npm: Hide scripts matching pattern

### DIFF
--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -281,11 +281,11 @@
             "usesOnlineServices"
           ]
         },
-				"npm.excludeScripts": {
-					"type": "string",
-					"description": "%config.npm.excludeScripts%",
-					"default": "^\\..*"
-				}
+        "npm.excludeScripts": {
+          "type": "string",
+          "description": "%config.npm.excludeScripts%",
+          "default": "^\\..*"
+        }
       }
     },
     "jsonValidation": [

--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -280,7 +280,12 @@
           "tags": [
             "usesOnlineServices"
           ]
-        }
+        },
+				"npm.excludeScripts": {
+					"type": "string",
+					"description": "%config.npm.excludeScripts%",
+					"default": "^\\..*"
+				}
       }
     },
     "jsonValidation": [

--- a/extensions/npm/package.nls.json
+++ b/extensions/npm/package.nls.json
@@ -13,6 +13,7 @@
 	"config.npm.scriptExplorerAction": "The default click action used in the npm scripts explorer: `open` or `run`, the default is `open`.",
 	"config.npm.enableRunFromFolder": "Enable running npm scripts contained in a folder from the Explorer context menu.",
 	"config.npm.fetchOnlinePackageInfo": "Fetch data from https://registry.npmjs.org and https://registry.bower.io to provide auto-completion and information on hover features on npm dependencies.",
+	"config.npm.excludeScripts": "A regular expression to hide npm scripts. Scripts that match will not be listed.",
 	"npm.parseError": "Npm task detection: failed to parse the file {0}",
 	"taskdef.script": "The npm script to customize.",
 	"taskdef.path": "The path to the folder of the package.json file that provides the script. Can be omitted.",

--- a/extensions/npm/src/readScripts.ts
+++ b/extensions/npm/src/readScripts.ts
@@ -41,7 +41,7 @@ export const readScripts = (document: TextDocument, buffer = document.getText())
 			level--;
 		},
 		onLiteralValue(value: unknown, offset: number, length: number) {
-			if (buildingScript && typeof value === 'string') {
+			if (buildingScript && typeof value === 'string' && value.length && value.charAt(0) !== '.') {
 				scripts.push({
 					...buildingScript,
 					value,

--- a/extensions/npm/src/readScripts.ts
+++ b/extensions/npm/src/readScripts.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { JSONVisitor, visit } from 'jsonc-parser';
-import { Location, Position, Range, TextDocument } from 'vscode';
+import { Location, Position, Range, TextDocument, workspace } from 'vscode';
 
 export interface INpmScriptReference {
 	name: string;
@@ -41,7 +41,9 @@ export const readScripts = (document: TextDocument, buffer = document.getText())
 			level--;
 		},
 		onLiteralValue(value: unknown, offset: number, length: number) {
-			if (buildingScript && typeof value === 'string' && value.length && value.charAt(0) !== '.') {
+			const config = workspace.getConfiguration('npm');
+			const excludeRegex = new RegExp(config.get<string>('branchValidationRegex')!);
+			if (buildingScript && typeof value === 'string' && value.length && !excludeRegex.test(value)) {
 				scripts.push({
 					...buildingScript,
 					value,


### PR DESCRIPTION
This PR ignores npm scripts that start with `'.'` (DOT), providing clarity with scripts which are not necessary for development, yet needed for production building.