### PR TITLE
Don't force create a terminal on no reconnect

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -182,13 +182,10 @@ export class TerminalService implements ITerminalService {
 		const layoutInfo = await this._terminalInstanceService.getTerminalLayoutInfo();
 		if (layoutInfo && layoutInfo.tabs.length > 0) {
 			this._recreateTerminalTabs(layoutInfo);
-			// now that terminals have been restored,
-			// attach listeners to update local state when terminals are changed
-			this.attachProcessLayoutListeners(false);
-		} else {
-			this.createTerminal();
-			this.attachProcessLayoutListeners(false);
 		}
+		// now that terminals have been restored,
+		// attach listeners to update local state when terminals are changed
+		this.attachProcessLayoutListeners(false);
 		this._connectionState = TerminalConnectionState.Connected;
 		this._onDidChangeConnectionState.fire();
 	}


### PR DESCRIPTION
Fixes #118321

Tested:

- Reload without a terminal (no terminal is created, confirmOnExit does not prompt)
- Reload with a terminal creates the first terminal
- Reconnect works on single window and multiple windows