### PR TITLE
Fix tooltip for codelens-sample extension

### DIFF
--- a/src/vs/editor/contrib/codelens/codelensWidget.ts
+++ b/src/vs/editor/contrib/codelens/codelensWidget.ts
@@ -90,10 +90,10 @@ class CodeLensContentWidget implements IContentWidget {
 			if (lens.command) {
 				const title = renderLabelWithIcons(lens.command.title.trim());
 				if (lens.command.id) {
-					children.push(dom.$('a', { id: String(i) }, ...title));
+					children.push(dom.$('a', { id: String(i), title: lens.command.tooltip }, ...title));
 					this._commands.set(String(i), lens.command);
 				} else {
-					children.push(dom.$('span', undefined, ...title));
+					children.push(dom.$('span', { title: lens.command.tooltip }, ...title));
 				}
 				if (i + 1 < lenses.length) {
 					children.push(dom.$('span', undefined, '\u00a0|\u00a0'));


### PR DESCRIPTION
## Description

Tooltip not showing when hovering over codelens for *codelens-sample extension*. Thus, title attribute is used on dom-nodes to display tooltip.

Fixes #115732 

## Before fix
Windows & MacOS
:-------------------------:
<img src="https://user-images.githubusercontent.com/60047427/110217775-a27e3c00-7ebe-11eb-886b-6efb423eaadd.png" width="400">


## After fix
Windows | MacOS
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/60047427/110217933-8f1fa080-7ebf-11eb-9dcc-ddd7d78078fe.jpeg" width="400"> |  <img src="https://user-images.githubusercontent.com/60047427/110174344-af405880-7e08-11eb-8c75-aeadae7d3656.png" width="400">




#### Type of change
- [x] Bug fix

#### How Has This Been Tested?
- [X] unit
- [X] integration
- [ ] smoke
- [ ] ui

#### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
