### PR TITLE
add Education extension to category constants

### DIFF
--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -165,6 +165,7 @@ export const EXTENSION_CATEGORIES = [
 	'Data Science',
 	'Debuggers',
 	'Extension Packs',
+	'Education',
 	'Formatters',
 	'Keymaps',
 	'Language Packs',


### PR DESCRIPTION
This PR fixes #104568

Adds `Education` category to package.json autocompletions and `@category` autocompletions for the Extension Marketplace tab. 

2 extensions under the "Education" category right now: 
- [Python Education Extension Pack](https://marketplace.visualstudio.com/items?itemName=tanhakabir.python-education-extension-pack)
- [Node.js and JavaScript Education Extension Pack](https://marketplace.visualstudio.com/items?itemName=tanhakabir.node-js-education-extension-pack)


