### PR TITLE
Fix "new Promise" TypeScript snippet

### DIFF
--- a/extensions/typescript-basics/snippets/typescript.code-snippets
+++ b/extensions/typescript-basics/snippets/typescript.code-snippets
@@ -282,8 +282,8 @@
 	"new Promise": {
 		"prefix": "newpromise",
 		"body": [
-			"new Promise<$1:type>((resolve, reject) => {",
-			"\t$1",
+			"new Promise<${1:void}>((resolve, reject) => {",
+			"\t$0",
 			"})"
 		],
 		"description": "Create a new Promise"


### PR DESCRIPTION
### Issue

Incorrect cursor positions for the content of the "new Promise" snippet.

### Steps to repro

Type `newpromise` in the TypeScript file and select the suggested snippet.

### Current behaviour

<img width="404" alt="Screenshot 2021-03-10 at 06 20 48" src="https://user-images.githubusercontent.com/39991717/110576820-185a0000-816a-11eb-886e-25aef6a43789.png">

### Expected

<img width="336" alt="Screenshot 2021-03-10 at 06 21 53" src="https://user-images.githubusercontent.com/39991717/110576837-20b23b00-816a-11eb-8221-19c32cf3c84d.png">
