### PR TITLE
fix: typo in menusExtensionPoint

### DIFF
--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -266,7 +266,7 @@ namespace schema {
 
 	export function isValidItems(items: (IUserFriendlyMenuItem | IUserFriendlySubmenuItem)[], collector: ExtensionMessageCollector): boolean {
 		if (!Array.isArray(items)) {
-			collector.error(localize('requirearray', "submenu items must be an array"));
+			collector.error(localize('requirearray', "menu items must be an array"));
 			return false;
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #

Typos in `menusExtensionPoint.ts`, it should be `menu items` instead of `submenu items`;

![image](https://user-images.githubusercontent.com/6828924/110589259-1d8e6d80-81b1-11eb-9ac9-038fe7c0e754.png)

