### PR TITLE
add ExtensionKindController

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -36,7 +36,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { IExtensionManifest, ExtensionType, IExtension as IPlatformExtension } from 'vs/platform/extensions/common/extensions';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { IProductService } from 'vs/platform/product/common/productService';
-import { getExtensionKind } from 'vs/workbench/services/extensions/common/extensionsUtil';
+import { ExtensionKindController } from 'vs/workbench/services/extensions/common/extensionsUtil';
 import { FileAccess } from 'vs/base/common/network';
 import { IIgnoredExtensionsManagementService } from 'vs/platform/userDataSync/common/ignoredExtensions';
 import { IUserDataAutoSyncService } from 'vs/platform/userDataSync/common/userDataSync';
@@ -506,6 +506,8 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 
 	private installing: IExtension[] = [];
 
+	private readonly extensionKindController: ExtensionKindController;
+
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IEditorService private readonly editorService: IEditorService,
@@ -568,6 +570,8 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			this.updateContexts();
 			this.updateActivity();
 		}));
+
+		this.extensionKindController = new ExtensionKindController(productService, configurationService);
 	}
 
 	get local(): IExtension[] {
@@ -694,7 +698,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			return extensionsToChoose[0];
 		}
 
-		const extensionKinds = getExtensionKind(manifest, this.productService, this.configurationService);
+		const extensionKinds = this.extensionKindController.getExtensionKind(manifest);
 
 		let extension = extensionsToChoose.find(extension => {
 			for (const extensionKind of extensionKinds) {

--- a/src/vs/workbench/services/extensionManagement/common/remoteExtensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/remoteExtensionManagementService.ts
@@ -5,13 +5,15 @@
 
 import { IChannel } from 'vs/base/parts/ipc/common/ipc';
 import { IExtensionManagementService, IGalleryExtension, IExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionManagement';
-import { canExecuteOnWorkspace } from 'vs/workbench/services/extensions/common/extensionsUtil';
+import { ExtensionKindController } from 'vs/workbench/services/extensions/common/extensionsUtil';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ExtensionManagementChannelClient } from 'vs/platform/extensionManagement/common/extensionManagementIpc';
 
 export class WebRemoteExtensionManagementService extends ExtensionManagementChannelClient implements IExtensionManagementService {
+
+	protected readonly extensionKindController: ExtensionKindController;
 
 	constructor(
 		channel: IChannel,
@@ -20,11 +22,13 @@ export class WebRemoteExtensionManagementService extends ExtensionManagementChan
 		@IProductService protected readonly productService: IProductService
 	) {
 		super(channel);
+
+		this.extensionKindController = new ExtensionKindController(productService, configurationService);
 	}
 
 	async canInstall(extension: IGalleryExtension): Promise<boolean> {
 		const manifest = await this.galleryService.getManifest(extension, CancellationToken.None);
-		return !!manifest && canExecuteOnWorkspace(manifest, this.productService, this.configurationService);
+		return !!manifest && this.extensionKindController.canExecuteOnWorkspace(manifest);
 	}
 
 }

--- a/src/vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService.ts
@@ -10,7 +10,6 @@ import { ExtensionType, IExtensionManifest } from 'vs/platform/extensions/common
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { ILogService } from 'vs/platform/log/common/log';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
-import { prefersExecuteOnUI } from 'vs/workbench/services/extensions/common/extensionsUtil';
 import { isNonEmptyArray } from 'vs/base/common/arrays';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { localize } from 'vs/nls';
@@ -126,7 +125,7 @@ export class NativeRemoteExtensionManagementService extends WebRemoteExtensionMa
 		for (let idx = 0; idx < extensions.length; idx++) {
 			const extension = extensions[idx];
 			const manifest = manifests[idx];
-			if (manifest && prefersExecuteOnUI(manifest, this.productService, this.configurationService) === uiExtension) {
+			if (manifest && this.extensionKindController.prefersExecuteOnUI(manifest) === uiExtension) {
 				result.set(extension.identifier.id.toLowerCase(), extension);
 				extensionsManifests.push(manifest);
 			}

--- a/src/vs/workbench/services/extensions/browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/browser/extensionService.ts
@@ -50,8 +50,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 	) {
 		super(
 			new ExtensionRunningLocationClassifier(
-				productService,
-				configurationService,
+				manifest => this._getExtensionKind(manifest),
 				(extensionKinds, isInstalledLocally, isInstalledRemotely) => ExtensionService.pickRunningLocation(extensionKinds, isInstalledLocally, isInstalledRemotely)
 			),
 			instantiationService,

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -21,7 +21,7 @@ import { ExtensionMessageCollector, ExtensionPoint, ExtensionsRegistry, IExtensi
 import { ExtensionDescriptionRegistry } from 'vs/workbench/services/extensions/common/extensionDescriptionRegistry';
 import { ResponsiveState } from 'vs/workbench/services/extensions/common/rpcProtocol';
 import { ExtensionHostManager } from 'vs/workbench/services/extensions/common/extensionHostManager';
-import { ExtensionIdentifier, IExtensionDescription, ExtensionType, ITranslatedScannedExtension, IExtension, ExtensionKind, IExtensionContributions } from 'vs/platform/extensions/common/extensions';
+import { ExtensionIdentifier, IExtensionDescription, ExtensionType, ITranslatedScannedExtension, IExtension, ExtensionKind, IExtensionContributions, IExtensionManifest } from 'vs/platform/extensions/common/extensions';
 import { IFileService } from 'vs/platform/files/common/files';
 import { parseExtensionDevOptions } from 'vs/workbench/services/extensions/common/extensionDevOptions';
 import { IProductService } from 'vs/platform/product/common/productService';
@@ -29,7 +29,7 @@ import { ExtensionActivationReason } from 'vs/workbench/api/common/extHostExtens
 import { IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { IExtensionActivationHost as IWorkspaceContainsActivationHost, checkGlobFileExists, checkActivateWorkspaceContainsExtension } from 'vs/workbench/api/common/shared/workspaceContains';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
-import { getExtensionKind } from 'vs/workbench/services/extensions/common/extensionsUtil';
+import { ExtensionKindController } from 'vs/workbench/services/extensions/common/extensionsUtil';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { Schemas } from 'vs/base/common/network';
 
@@ -98,6 +98,8 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 	private _extensionHostActivationTimes: Map<string, ActivationTimes>;
 	private _extensionHostExtensionRuntimeErrors: Map<string, Error[]>;
 
+	private readonly _extensionKindController: ExtensionKindController;
+
 	constructor(
 		protected readonly _runningLocationClassifier: ExtensionRunningLocationClassifier,
 		@IInstantiationService protected readonly _instantiationService: IInstantiationService,
@@ -137,6 +139,8 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 		this._inHandleDeltaExtensions = false;
 		this._runningLocation = new Map<string, ExtensionRunningLocation>();
 
+		this._extensionKindController = new ExtensionKindController(this._productService, this._configurationService);
+
 		this._register(this._extensionEnablementService.onEnablementChanged((extensions) => {
 			let toAdd: IExtension[] = [];
 			let toRemove: string[] = [];
@@ -167,6 +171,10 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 				this._handleDeltaExtensions(new DeltaExtensionsQueueItem([], [event.identifier.id]));
 			}
 		}));
+	}
+
+	protected _getExtensionKind(manifest: IExtensionManifest): ExtensionKind[] {
+		return this._extensionKindController.getExtensionKind(manifest);
 	}
 
 	protected _getExtensionHostManager(kind: ExtensionHostKind): ExtensionHostManager | null {
@@ -277,7 +285,7 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 			groupedToAdd[extensionHostKind] = filterByRunningLocation(toAdd, ext => ext.identifier, this._runningLocation, extensionRunningLocation);
 		};
 		for (const extension of toAdd) {
-			const extensionKind = getExtensionKind(extension, this._productService, this._configurationService);
+			const extensionKind = this._getExtensionKind(extension);
 			const isRemote = extension.extensionLocation.scheme === Schemas.vscodeRemote;
 			const runningLocation = this._runningLocationClassifier.pickRunningLocation(extensionKind, !isRemote, isRemote);
 			this._runningLocation.set(ExtensionIdentifier.toKey(extension.identifier), runningLocation);
@@ -318,7 +326,7 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 			return false;
 		}
 
-		const extensionKind = getExtensionKind(extension.manifest, this._productService, this._configurationService);
+		const extensionKind = this._getExtensionKind(extension.manifest);
 		const isRemote = extension.location.scheme === Schemas.vscodeRemote;
 		const runningLocation = this._runningLocationClassifier.pickRunningLocation(extensionKind, !isRemote, isRemote);
 		if (runningLocation === ExtensionRunningLocation.None) {
@@ -771,16 +779,15 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 
 export class ExtensionRunningLocationClassifier {
 	constructor(
-		@IProductService private readonly _productService: IProductService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		public readonly getExtensionKind: (manifest: IExtensionManifest) => ExtensionKind[],
 		public readonly pickRunningLocation: (extensionKinds: ExtensionKind[], isInstalledLocally: boolean, isInstalledRemotely: boolean) => ExtensionRunningLocation,
 	) {
 	}
 
 	public determineRunningLocation(localExtensions: IExtensionDescription[], remoteExtensions: IExtensionDescription[]): Map<string, ExtensionRunningLocation> {
 		const allExtensionKinds = new Map<string, ExtensionKind[]>();
-		localExtensions.forEach(ext => allExtensionKinds.set(ExtensionIdentifier.toKey(ext.identifier), getExtensionKind(ext, this._productService, this._configurationService)));
-		remoteExtensions.forEach(ext => allExtensionKinds.set(ExtensionIdentifier.toKey(ext.identifier), getExtensionKind(ext, this._productService, this._configurationService)));
+		localExtensions.forEach(ext => allExtensionKinds.set(ExtensionIdentifier.toKey(ext.identifier), this.getExtensionKind(ext)));
+		remoteExtensions.forEach(ext => allExtensionKinds.set(ExtensionIdentifier.toKey(ext.identifier), this.getExtensionKind(ext)));
 
 		const localExtensionsSet = new Set<string>();
 		localExtensions.forEach(ext => localExtensionsSet.add(ExtensionIdentifier.toKey(ext.identifier)));

--- a/src/vs/workbench/services/extensions/common/extensionsUtil.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsUtil.ts
@@ -10,56 +10,64 @@ import { getGalleryExtensionId } from 'vs/platform/extensionManagement/common/ex
 import { isNonEmptyArray } from 'vs/base/common/arrays';
 import { IProductService } from 'vs/platform/product/common/productService';
 
-export function prefersExecuteOnUI(manifest: IExtensionManifest, productService: IProductService, configurationService: IConfigurationService): boolean {
-	const extensionKind = getExtensionKind(manifest, productService, configurationService);
-	return (extensionKind.length > 0 && extensionKind[0] === 'ui');
-}
 
-export function prefersExecuteOnWorkspace(manifest: IExtensionManifest, productService: IProductService, configurationService: IConfigurationService): boolean {
-	const extensionKind = getExtensionKind(manifest, productService, configurationService);
-	return (extensionKind.length > 0 && extensionKind[0] === 'workspace');
-}
-
-export function prefersExecuteOnWeb(manifest: IExtensionManifest, productService: IProductService, configurationService: IConfigurationService): boolean {
-	const extensionKind = getExtensionKind(manifest, productService, configurationService);
-	return (extensionKind.length > 0 && extensionKind[0] === 'web');
-}
-
-export function canExecuteOnUI(manifest: IExtensionManifest, productService: IProductService, configurationService: IConfigurationService): boolean {
-	const extensionKind = getExtensionKind(manifest, productService, configurationService);
-	return extensionKind.some(kind => kind === 'ui');
-}
-
-export function canExecuteOnWorkspace(manifest: IExtensionManifest, productService: IProductService, configurationService: IConfigurationService): boolean {
-	const extensionKind = getExtensionKind(manifest, productService, configurationService);
-	return extensionKind.some(kind => kind === 'workspace');
-}
-
-export function canExecuteOnWeb(manifest: IExtensionManifest, productService: IProductService, configurationService: IConfigurationService): boolean {
-	const extensionKind = getExtensionKind(manifest, productService, configurationService);
-	return extensionKind.some(kind => kind === 'web');
-}
-
-export function getExtensionKind(manifest: IExtensionManifest, productService: IProductService, configurationService: IConfigurationService): ExtensionKind[] {
-	// check in config
-	let result = getConfiguredExtensionKind(manifest, configurationService);
-	if (typeof result !== 'undefined') {
-		return toArray(result);
+export class ExtensionKindController {
+	constructor(
+		@IProductService private readonly productService: IProductService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+	) {
+	}
+	prefersExecuteOnUI(manifest: IExtensionManifest): boolean {
+		const extensionKind = this.getExtensionKind(manifest);
+		return (extensionKind.length > 0 && extensionKind[0] === 'ui');
 	}
 
-	// check product.json
-	result = getProductExtensionKind(manifest, productService);
-	if (typeof result !== 'undefined') {
-		return result;
+	prefersExecuteOnWorkspace(manifest: IExtensionManifest): boolean {
+		const extensionKind = this.getExtensionKind(manifest);
+		return (extensionKind.length > 0 && extensionKind[0] === 'workspace');
 	}
 
-	// check the manifest itself
-	result = manifest.extensionKind;
-	if (typeof result !== 'undefined') {
-		return toArray(result);
+	prefersExecuteOnWeb(manifest: IExtensionManifest): boolean {
+		const extensionKind = this.getExtensionKind(manifest);
+		return (extensionKind.length > 0 && extensionKind[0] === 'web');
 	}
 
-	return deduceExtensionKind(manifest);
+	canExecuteOnUI(manifest: IExtensionManifest): boolean {
+		const extensionKind = this.getExtensionKind(manifest);
+		return extensionKind.some(kind => kind === 'ui');
+	}
+
+	canExecuteOnWorkspace(manifest: IExtensionManifest): boolean {
+		const extensionKind = this.getExtensionKind(manifest);
+		return extensionKind.some(kind => kind === 'workspace');
+	}
+
+	canExecuteOnWeb(manifest: IExtensionManifest): boolean {
+		const extensionKind = this.getExtensionKind(manifest);
+		return extensionKind.some(kind => kind === 'web');
+	}
+
+	getExtensionKind(manifest: IExtensionManifest): ExtensionKind[] {
+		// check in config
+		let result = getConfiguredExtensionKind(manifest, this.configurationService);
+		if (typeof result !== 'undefined') {
+			return toArray(result);
+		}
+
+		// check product.json
+		result = getProductExtensionKind(manifest, this.productService);
+		if (typeof result !== 'undefined') {
+			return result;
+		}
+
+		// check the manifest itself
+		result = manifest.extensionKind;
+		if (typeof result !== 'undefined') {
+			return toArray(result);
+		}
+
+		return deduceExtensionKind(manifest);
+	}
 }
 
 export function deduceExtensionKind(manifest: IExtensionManifest): ExtensionKind[] {
@@ -141,3 +149,4 @@ function toArray(extensionKind: ExtensionKind | ExtensionKind[]): ExtensionKind[
 	}
 	return extensionKind === 'ui' ? ['ui', 'workspace'] : [extensionKind];
 }
+

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -70,8 +70,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 	) {
 		super(
 			new ExtensionRunningLocationClassifier(
-				productService,
-				configurationService,
+				manifest => this._getExtensionKind(manifest),
 				(extensionKinds, isInstalledLocally, isInstalledRemotely) => this._pickRunningLocation(extensionKinds, isInstalledLocally, isInstalledRemotely)
 			),
 			instantiationService,


### PR DESCRIPTION
`extensionsUtil.getExtensionKind `evaluates the extension kind of a extension at runtime, based settings in the manifest, configurations and `product.json`.

When working on on #118663 I first thought I would change `extensionsUtil.getExtensionKind ` to also look at the cli arguments.
That would have added another dependency (`IEnvironmentService`) to `getExtensionKind`. Instead of adding another parameter, I thought it's better to extract `getExtensionKind` and friends to it's own class: the `ExtensionKindController`

I ended up not changing `getExtensionKind`, but I think the change makes sense. Have a look and decide for yourself if you want to take it.
