### PR TITLE
Add `getContext` command

### DIFF
--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -580,6 +580,17 @@ CommandsRegistry.registerCommand(SET_CONTEXT_COMMAND_ID, function (accessor, con
 });
 
 CommandsRegistry.registerCommand({
+	id: 'getContext',
+	handler(accessor, contextKey: any) {
+		return accessor.get(IContextKeyService).getContextKeyValue(String(contextKey));
+	},
+	description: {
+		description: localize('getContext', "Returns the value of a context key"),
+		args: [{ name: 'key', description: "The context key to look up" }]
+	}
+});
+
+CommandsRegistry.registerCommand({
 	id: 'getContextKeyInfo',
 	handler() {
 		return [...RawContextKey.all()].sort((a, b) => a.key.localeCompare(b.key));


### PR DESCRIPTION
In parallel to `setContext`.  Can be tested by running eg

```js
vscode.commands.executeCommand("getContext", "terminalFocus")
```

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR partially fixes #10471
