### PR TITLE
Fix Emmet abbreviation for Handlebars style blocks

### DIFF
--- a/extensions/emmet/src/defaultCompletionProvider.ts
+++ b/extensions/emmet/src/defaultCompletionProvider.ts
@@ -67,7 +67,7 @@ export class DefaultCompletionItemProvider implements vscode.CompletionItemProvi
 		const lsDoc = toLSTextDocument(document);
 		position = document.validatePosition(position);
 
-		if (document.languageId === 'html') {
+		if (syntax === 'html') {
 			if (context.triggerKind === vscode.CompletionTriggerKind.TriggerForIncompleteCompletions) {
 				switch (this.lastCompletionType) {
 					case 'html':


### PR DESCRIPTION
This PR fixes #118714 

Emmet abbreviations were not working for style blocks in `Handlebars` but working in `html` because `syntax` wasn't being updated to `css` for style blocks for Handlebars. We only used to update the syntax when `document.languageId === 'html'`, we should be checking `syntax === 'html'` instead.