### PR TITLE
Fix typo s/precidence/precedence/

### DIFF
--- a/extensions/ruby/syntaxes/ruby.tmLanguage.json
+++ b/extensions/ruby/syntaxes/ruby.tmLanguage.json
@@ -444,7 +444,7 @@
 			]
 		},
 		{
-			"comment": "Needs higher precidence than regular expressions.",
+			"comment": "Needs higher precedence than regular expressions.",
 			"match": "(?<!\\()/=",
 			"name": "keyword.operator.assignment.augmented.ruby"
 		},


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes just a typo, I found it in https://github.com/rubyide/vscode-ruby/pull/709
If this change is not needed, please close this PR 🙏 