### PR TITLE
format modified: format lines with whitespace changes

### DIFF
--- a/src/vs/workbench/contrib/format/browser/formatModified.ts
+++ b/src/vs/workbench/contrib/format/browser/formatModified.ts
@@ -65,7 +65,7 @@ export async function getModifiedRanges(accessor: ServicesAccessor, modified: IT
 		if (!workerService.canComputeDirtyDiff(original, modified.uri)) {
 			return undefined;
 		}
-		const changes = await workerService.computeDirtyDiff(original, modified.uri, true);
+		const changes = await workerService.computeDirtyDiff(original, modified.uri, false);
 		if (!isNonEmptyArray(changes)) {
 			return undefined;
 		}


### PR DESCRIPTION
This patch makes sure all changes lines get formatted, including diffs such as this:
```diff
-    foo();
+  foo();
```
