### PR TITLE
Add telemetry for notifications

### DIFF
--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -220,7 +220,7 @@ export class SimpleNotificationService implements INotificationService {
 
 	readonly onDidAddNotification: Event<INotification> = Event.None;
 
-	onDidRemoveNotification: Event<INotification> = Event.None;
+	readonly onDidRemoveNotification: Event<INotification> = Event.None;
 
 	public _serviceBrand: undefined;
 

--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -218,6 +218,10 @@ export class SimpleDialogService implements IDialogService {
 
 export class SimpleNotificationService implements INotificationService {
 
+	onDidAddNotification: Event<INotification> = Event.None;
+
+	onDidRemoveNotification: Event<INotification> = Event.None;
+
 	public _serviceBrand: undefined;
 
 	private static readonly NO_OP: INotificationHandle = new NoOpNotification();

--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -218,7 +218,7 @@ export class SimpleDialogService implements IDialogService {
 
 export class SimpleNotificationService implements INotificationService {
 
-	onDidAddNotification: Event<INotification> = Event.None;
+	readonly onDidAddNotification: Event<INotification> = Event.None;
 
 	onDidRemoveNotification: Event<INotification> = Event.None;
 

--- a/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
+++ b/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
@@ -140,6 +140,8 @@ suite('AbstractKeybindingService', () => {
 
 			let notificationService: INotificationService = {
 				_serviceBrand: undefined,
+				onDidAddNotification: undefined!,
+				onDidRemoveNotification: undefined!,
 				notify: (notification: INotification) => {
 					showMessageCalls.push({ sev: notification.severity, message: notification.message });
 					return new NoOpNotification();

--- a/src/vs/platform/notification/common/notification.ts
+++ b/src/vs/platform/notification/common/notification.ts
@@ -305,6 +305,16 @@ export interface INotificationService {
 	readonly _serviceBrand: undefined;
 
 	/**
+	 * Emitted when a new notification is added.
+	 */
+	readonly onDidAddNotification: Event<INotification>;
+
+	/**
+	 * Emitted when a notification is removed.
+	 */
+	readonly onDidRemoveNotification: Event<INotification>;
+
+	/**
 	 * Show the provided notification to the user. The returned `INotificationHandle`
 	 * can be used to control the notification afterwards.
 	 *

--- a/src/vs/platform/notification/common/notification.ts
+++ b/src/vs/platform/notification/common/notification.ts
@@ -86,7 +86,7 @@ export interface INotification extends INotificationProperties {
 	/**
 	 * The source of the notification appears as additional information.
 	 */
-	readonly source?: string;
+	readonly source?: string | { label: string; id: string; };
 
 	/**
 	 * Actions to show as part of the notification. Primary actions show up as

--- a/src/vs/platform/notification/test/common/testNotificationService.ts
+++ b/src/vs/platform/notification/test/common/testNotificationService.ts
@@ -9,7 +9,7 @@ import { Event } from 'vs/base/common/event';
 
 export class TestNotificationService implements INotificationService {
 
-	onDidAddNotification: Event<INotification> = Event.None;
+	readonly onDidAddNotification: Event<INotification> = Event.None;
 
 	readonly onDidRemoveNotification: Event<INotification> = Event.None;
 

--- a/src/vs/platform/notification/test/common/testNotificationService.ts
+++ b/src/vs/platform/notification/test/common/testNotificationService.ts
@@ -11,7 +11,7 @@ export class TestNotificationService implements INotificationService {
 
 	onDidAddNotification: Event<INotification> = Event.None;
 
-	onDidRemoveNotification: Event<INotification> = Event.None;
+	readonly onDidRemoveNotification: Event<INotification> = Event.None;
 
 	declare readonly _serviceBrand: undefined;
 

--- a/src/vs/platform/notification/test/common/testNotificationService.ts
+++ b/src/vs/platform/notification/test/common/testNotificationService.ts
@@ -5,8 +5,13 @@
 
 import { INotificationService, INotificationHandle, NoOpNotification, Severity, INotification, IPromptChoice, IPromptOptions, IStatusMessageOptions, NotificationsFilter } from 'vs/platform/notification/common/notification';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Event } from 'vs/base/common/event';
 
 export class TestNotificationService implements INotificationService {
+
+	onDidAddNotification: Event<INotification> = Event.None;
+
+	onDidRemoveNotification: Event<INotification> = Event.None;
 
 	declare readonly _serviceBrand: undefined;
 

--- a/src/vs/workbench/api/browser/mainThreadMessageService.ts
+++ b/src/vs/workbench/api/browser/mainThreadMessageService.ts
@@ -66,9 +66,12 @@ export class MainThreadMessageService implements MainThreadMessageServiceShape {
 				primaryActions.push(new MessageItemAction('_extension_message_handle_' + command.handle, command.title, command.handle));
 			});
 
-			let source: string | undefined;
+			let source: string | { label: string, id: string } | undefined;
 			if (extension) {
-				source = nls.localize('extensionSource', "{0} (Extension)", extension.displayName || extension.name);
+				source = {
+					label: nls.localize('extensionSource', "{0} (Extension)", extension.displayName || extension.name),
+					id: extension.identifier.value
+				};
 			}
 
 			if (!source) {

--- a/src/vs/workbench/browser/parts/notifications/notificationsActions.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsActions.ts
@@ -15,6 +15,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { Codicon } from 'vs/base/common/codicons';
 import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
+import { hash } from 'vs/base/common/hash';
 
 const clearIcon = registerIcon('notifications-clear', Codicon.close, localize('clearIcon', 'Icon for the clear action in notifications.'));
 const clearAllIcon = registerIcon('notifications-clear-all', Codicon.clearAll, localize('clearAllIcon', 'Icon for the clear all action in notifications.'));
@@ -145,6 +146,15 @@ export class CopyNotificationMessageAction extends Action {
 	}
 }
 
+interface NotificationActionMetrics {
+	id: number;
+	actionId: string;
+}
+type NotificationActionMetricsClassification = {
+	id: { classification: 'SystemMetaData', purpose: 'FeatureInsight' };
+	actionId: { classification: 'SystemMetaData', purpose: 'FeatureInsight' }
+};
+
 export class NotificationActionRunner extends ActionRunner {
 
 	constructor(
@@ -156,6 +166,7 @@ export class NotificationActionRunner extends ActionRunner {
 
 	protected async runAction(action: IAction, context: INotificationViewItem): Promise<void> {
 		this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: action.id, from: 'message' });
+		this.telemetryService.publicLog2<NotificationActionMetrics, NotificationActionMetricsClassification>('notification:actionExecuted', { id: hash(context.message.original.toString()), actionId: action.id });
 
 		// Run and make sure to notify on any error again
 		try {

--- a/src/vs/workbench/browser/parts/notifications/notificationsActions.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsActions.ts
@@ -148,11 +148,13 @@ export class CopyNotificationMessageAction extends Action {
 
 interface NotificationActionMetrics {
 	id: number;
-	actionId: string;
+	actionLabel: string;
+	source: string | undefined;
 }
 type NotificationActionMetricsClassification = {
 	id: { classification: 'SystemMetaData', purpose: 'FeatureInsight' };
-	actionId: { classification: 'SystemMetaData', purpose: 'FeatureInsight' }
+	actionLabel: { classification: 'SystemMetaData', purpose: 'FeatureInsight' };
+	source: { classification: 'SystemMetaData', purpose: 'FeatureInsight' };
 };
 
 export class NotificationActionRunner extends ActionRunner {
@@ -166,7 +168,7 @@ export class NotificationActionRunner extends ActionRunner {
 
 	protected async runAction(action: IAction, context: INotificationViewItem): Promise<void> {
 		this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: action.id, from: 'message' });
-		this.telemetryService.publicLog2<NotificationActionMetrics, NotificationActionMetricsClassification>('notification:actionExecuted', { id: hash(context.message.original.toString()), actionId: action.id });
+		this.telemetryService.publicLog2<NotificationActionMetrics, NotificationActionMetricsClassification>('notification:actionExecuted', { id: hash(context.message.original.toString()), actionLabel: action.label, source: context.sourceId });
 
 		// Run and make sure to notify on any error again
 		try {

--- a/src/vs/workbench/browser/parts/notifications/notificationsTelemetry.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsTelemetry.ts
@@ -19,7 +19,7 @@ type NotificationMetricsClassification = {
 	source?: { classification: 'SystemMetaData', purpose: 'FeatureInsight' }
 };
 
-export class NotificationsTelemetryContribution extends Disposable implements IWorkbenchContribution {
+export class NotificationsTelemetry extends Disposable implements IWorkbenchContribution {
 
 	constructor(
 		@ITelemetryService private readonly telemetryService: ITelemetryService,

--- a/src/vs/workbench/browser/parts/notifications/notificationsTelemetry.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsTelemetry.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions } from 'vs/workbench/common/contributions';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import { hash } from 'vs/base/common/hash';
+
+interface NotificationMetrics {
+	id: number;
+	source?: string;
+}
+
+type NotificationMetricsClassification = {
+	id: { classification: 'SystemMetaData', purpose: 'FeatureInsight' };
+	source?: { classification: 'SystemMetaData', purpose: 'FeatureInsight' }
+};
+
+class NotificationsTelemetryContribution extends Disposable implements IWorkbenchContribution {
+
+	constructor(
+		@ITelemetryService telemetryService: ITelemetryService,
+		@INotificationService notificationService: INotificationService
+	) {
+		super();
+		this._register(notificationService.onDidAddNotification(notification => {
+			if (!notification.silent) {
+				telemetryService.publicLog2<NotificationMetrics, NotificationMetricsClassification>('notification:show', {
+					id: hash(notification.message.toString()),
+					source: notification.source
+				});
+			}
+		}));
+
+		this._register(notificationService.onDidRemoveNotification(notification => {
+			if (!notification.silent) {
+				telemetryService.publicLog2<NotificationMetrics, NotificationMetricsClassification>('notification:close', {
+					id: hash(notification.message.toString()),
+					source: notification.source
+				});
+			}
+		}));
+	}
+}
+
+export function registerNotificationTelemetry() {
+	Registry.as<IWorkbenchContributionsRegistry>(Extensions.Workbench).registerWorkbenchContribution(NotificationsTelemetryContribution, LifecyclePhase.Restored);
+}
+
+

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -38,7 +38,7 @@ import { coalesce } from 'vs/base/common/arrays';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { Layout } from 'vs/workbench/browser/layout';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
-import { NotificationsTelemetryContribution } from 'vs/workbench/browser/parts/notifications/notificationsTelemetry';
+import { NotificationsTelemetry } from 'vs/workbench/browser/parts/notifications/notificationsTelemetry';
 
 export class Workbench extends Layout {
 
@@ -379,6 +379,7 @@ export class Workbench extends Layout {
 		const notificationsToasts = this._register(instantiationService.createInstance(NotificationsToasts, this.container, notificationService.model));
 		this._register(instantiationService.createInstance(NotificationsAlerts, notificationService.model));
 		const notificationsStatus = instantiationService.createInstance(NotificationsStatus, notificationService.model);
+		this._register(instantiationService.createInstance(NotificationsTelemetry));
 
 		// Visibility
 		this._register(notificationsCenter.onDidChangeVisibility(() => {
@@ -392,9 +393,6 @@ export class Workbench extends Layout {
 
 		// Register Commands
 		registerNotificationCommands(notificationsCenter, notificationsToasts);
-
-		// Register Notification Telemetry
-		this._register(instantiationService.createInstance(NotificationsTelemetryContribution));
 
 		// Register with Layout
 		this.registerNotifications({

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -38,7 +38,7 @@ import { coalesce } from 'vs/base/common/arrays';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { Layout } from 'vs/workbench/browser/layout';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
-import { registerNotificationTelemetry } from 'vs/workbench/browser/parts/notifications/notificationsTelemetry';
+import { NotificationsTelemetryContribution } from 'vs/workbench/browser/parts/notifications/notificationsTelemetry';
 
 export class Workbench extends Layout {
 
@@ -394,7 +394,7 @@ export class Workbench extends Layout {
 		registerNotificationCommands(notificationsCenter, notificationsToasts);
 
 		// Register Notification Telemetry
-		registerNotificationTelemetry();
+		this._register(instantiationService.createInstance(NotificationsTelemetryContribution));
 
 		// Register with Layout
 		this.registerNotifications({

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -38,6 +38,7 @@ import { coalesce } from 'vs/base/common/arrays';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { Layout } from 'vs/workbench/browser/layout';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
+import { registerNotificationTelemetry } from 'vs/workbench/browser/parts/notifications/notificationsTelemetry';
 
 export class Workbench extends Layout {
 
@@ -391,6 +392,9 @@ export class Workbench extends Layout {
 
 		// Register Commands
 		registerNotificationCommands(notificationsCenter, notificationsToasts);
+
+		// Register Notification Telemetry
+		registerNotificationTelemetry();
 
 		// Register with Layout
 		this.registerNotifications({

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -26,6 +26,7 @@ import { NotificationService } from 'vs/workbench/services/notification/common/n
 import { NotificationsCenter } from 'vs/workbench/browser/parts/notifications/notificationsCenter';
 import { NotificationsAlerts } from 'vs/workbench/browser/parts/notifications/notificationsAlerts';
 import { NotificationsStatus } from 'vs/workbench/browser/parts/notifications/notificationsStatus';
+import { NotificationsTelemetry } from 'vs/workbench/browser/parts/notifications/notificationsTelemetry';
 import { registerNotificationCommands } from 'vs/workbench/browser/parts/notifications/notificationsCommands';
 import { NotificationsToasts } from 'vs/workbench/browser/parts/notifications/notificationsToasts';
 import { setARIAContainer } from 'vs/base/browser/ui/aria/aria';
@@ -38,7 +39,6 @@ import { coalesce } from 'vs/base/common/arrays';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { Layout } from 'vs/workbench/browser/layout';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
-import { NotificationsTelemetry } from 'vs/workbench/browser/parts/notifications/notificationsTelemetry';
 
 export class Workbench extends Layout {
 

--- a/src/vs/workbench/common/notifications.ts
+++ b/src/vs/workbench/common/notifications.ts
@@ -280,6 +280,7 @@ export interface INotificationViewItem {
 	readonly silent: boolean;
 	readonly message: INotificationMessage;
 	readonly source: string | undefined;
+	readonly sourceId: string | undefined;
 	readonly actions: INotificationActions | undefined;
 	readonly progress: INotificationViewItemProgress;
 
@@ -502,7 +503,7 @@ export class NotificationViewItem extends Disposable implements INotificationVie
 		private _sticky: boolean | undefined,
 		private _silent: boolean | undefined,
 		private _message: INotificationMessage,
-		private _source: string | undefined,
+		private _source: string | { label: string, id: string } | undefined,
 		progress: INotificationProgressProperties | undefined,
 		actions?: INotificationActions
 	) {
@@ -599,7 +600,11 @@ export class NotificationViewItem extends Disposable implements INotificationVie
 	}
 
 	get source(): string | undefined {
-		return this._source;
+		return typeof this._source === 'string' ? this._source : (this._source ? this._source.label : undefined);
+	}
+
+	get sourceId(): string | undefined {
+		return (this._source && typeof this._source !== 'string' && 'id' in this._source) ? this._source.id : undefined;
 	}
 
 	get actions(): INotificationActions | undefined {

--- a/src/vs/workbench/services/configuration/test/browser/configurationEditingService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationEditingService.test.ts
@@ -163,7 +163,7 @@ suite('ConfigurationEditingService', () => {
 	test('do not notify error', async () => {
 		instantiationService.stub(ITextFileService, 'isDirty', true);
 		const target = sinon.stub();
-		instantiationService.stub(INotificationService, <INotificationService>{ prompt: target, _serviceBrand: undefined, notify: null!, error: null!, info: null!, warn: null!, status: null!, setFilter: null! });
+		instantiationService.stub(INotificationService, <INotificationService>{ prompt: target, _serviceBrand: undefined, onDidAddNotification: undefined!, onDidRemoveNotification: undefined!, notify: null!, error: null!, info: null!, warn: null!, status: null!, setFilter: null! });
 		try {
 			await testObject.writeConfiguration(EditableConfigurationTarget.USER_LOCAL, { key: 'configurationEditing.service.testSetting', value: 'value' }, { donotNotifyError: true });
 			assert.fail('Should fail with ERROR_CONFIGURATION_FILE_DIRTY error.');

--- a/src/vs/workbench/services/notification/common/notificationService.ts
+++ b/src/vs/workbench/services/notification/common/notificationService.ts
@@ -17,13 +17,19 @@ export class NotificationService extends Disposable implements INotificationServ
 	declare readonly _serviceBrand: undefined;
 
 	readonly model = this._register(new NotificationsModel());
-	private readonly _onDidAddNotification = new Emitter<INotification>();
-	private readonly _onDidRemoveNotification = new Emitter<INotification>();
+	private readonly _onDidAddNotification = this._register(new Emitter<INotification>());
+	readonly onDidAddNotification = this._onDidAddNotification.event;
+	private readonly _onDidRemoveNotification = this._register(new Emitter<INotification>());
+	readonly onDidRemoveNotification = this._onDidRemoveNotification.event;
 
 	constructor(
 		@IStorageService private readonly storageService: IStorageService
 	) {
 		super();
+		this.registerListeners();
+	}
+
+	private registerListeners(): void {
 		this._register(this.model.onDidChangeNotification(e => {
 			const event = {
 				message: e.item.message.original,
@@ -39,14 +45,6 @@ export class NotificationService extends Disposable implements INotificationServ
 				this._onDidRemoveNotification.fire(event);
 			}
 		}));
-	}
-
-	get onDidAddNotification(): Event<INotification> {
-		return this._onDidAddNotification.event;
-	}
-
-	get onDidRemoveNotification(): Event<INotification> {
-		return this._onDidRemoveNotification.event;
 	}
 
 	setFilter(filter: NotificationsFilter): void {

--- a/src/vs/workbench/test/browser/api/extHostMessagerService.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostMessagerService.test.ts
@@ -11,6 +11,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { mock } from 'vs/base/test/common/mock';
 import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
 import * as platform from 'vs/base/common/platform';
+import { Event } from 'vs/base/common/event';
 
 const emptyDialogService = new class implements IDialogService {
 	declare readonly _serviceBrand: undefined;
@@ -42,6 +43,8 @@ const emptyCommandService: ICommandService = {
 
 const emptyNotificationService = new class implements INotificationService {
 	declare readonly _serviceBrand: undefined;
+	onDidAddNotification: Event<INotification> = Event.None;
+	onDidRemoveNotification: Event<INotification> = Event.None;
 	notify(...args: any[]): never {
 		throw new Error('not implemented');
 	}
@@ -71,6 +74,8 @@ class EmptyNotificationService implements INotificationService {
 	constructor(private withNotify: (notification: INotification) => void) {
 	}
 
+	onDidAddNotification: Event<INotification> = Event.None;
+	onDidRemoveNotification: Event<INotification> = Event.None;
 	notify(notification: INotification): INotificationHandle {
 		this.withNotify(notification);
 


### PR DESCRIPTION
This PR does the following:
* Adds the `onDidAddNotification` and `onDidRemoveNotification` events to the `notificationService`
* Introduces `notificationsTelemetry` a workbench contribution that reports telemetry based on these new events
* Reports telemetry when a notification action is executed

When a new notification is shown we fire an event `notification:show`
When a new notification is closed we fire an event `notification:close`. 
Both of these events contain the following data:
```
{
 id: number; // hash of the message
 source?: string; // for example "Remote - Containers (Extension)", or `undefined` if coming from vscode
}
```

When a notification action is executed we fire an event `notification:actionExecuted` with the following data:
```
{
 id: number; // id of the notification to match with the other events
 actionId: string;
}
```

Polish questions:
1. Let me know if you would like me to use other telemetry log event names. Or if additional data might be needed.
2. Also maybe when notification is coming from internal we can set source to "VS Code" or "internal" and not be `undefined`?
3. When user presses `Esc` we do not get the event, since that makes all the notifications be hidden and not closed. Not sure if we should also capture this one
4. Should `notification:actionExecuted` be merged with the existing `workbenchActionExecuted`? This would require that the `workbenchActionExecuted` gets enriched with the `notificationId` field which I found weird.

I believe we now have enough enough data for some initial findings: do some notification appear too many times, do some extensions use too many notifications. I am open to adding more data to the data object if it will help with the data manipulation.

fyi @digitarald, @egamma since you expressed interest in standup