### PR TITLE
Fix type ahead issue in relaunched terminals

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1167,7 +1167,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 		this._processManager.relaunch(this._shellLaunchConfig, this._cols, this._rows, this._accessibilityService.isScreenReaderOptimized(), reset);
 
-		this._xtermTypeAhead?.reset(this._processManager);
+		this._xtermTypeAhead?.reset();
 	}
 
 	@debounce(1000)

--- a/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTypeAheadAddon.ts
@@ -1330,10 +1330,8 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 		}));
 	}
 
-	public reset(processManager: ITerminalProcessManager) {
+	public reset() {
 		this.lastRow = undefined;
-		this.processManager = processManager;
-		this._register(this.processManager.onBeforeProcessData(e => this.onBeforeProcessData(e)));
 	}
 
 	private deferClearingPredictions() {


### PR DESCRIPTION
Phantom characters were showing up because type ahead was installing a
second onBeforeProcessData listener. The root cause was a refactor to
move and encapsulate the relaunching logic/concept inside TerminalProcessManager.

Fixes #118804

Co-authored-by: Megan Rogge <merogge@microsoft.com>