### PR TITLE
Allow extension authors to set the title of a QuickPick/InputBox in Options

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1406,6 +1406,7 @@ export class QuickInputController extends Disposable {
 					resolve(undefined);
 				}),
 			];
+			input.title = options.title;
 			input.canSelectMany = !!options.canPickMany;
 			input.placeholder = options.placeHolder;
 			input.ignoreFocusOut = !!options.ignoreFocusLost;
@@ -1499,6 +1500,8 @@ export class QuickInputController extends Disposable {
 					resolve(undefined);
 				}),
 			];
+
+			input.title = options.title;
 			input.value = options.value || '';
 			input.valueSelection = options.valueSelection;
 			input.prompt = options.prompt;

--- a/src/vs/base/parts/quickinput/common/quickInput.ts
+++ b/src/vs/base/parts/quickinput/common/quickInput.ts
@@ -60,6 +60,11 @@ export interface IQuickNavigateConfiguration {
 export interface IPickOptions<T extends IQuickPickItem> {
 
 	/**
+	 * an optional string to show as the title of the quick input
+	 */
+	title?: string;
+
+	/**
 	 * an optional string to show as placeholder in the input box to guide the user what she picks on
 	 */
 	placeHolder?: string;
@@ -115,6 +120,11 @@ export interface IPickOptions<T extends IQuickPickItem> {
 }
 
 export interface IInputOptions {
+
+	/**
+	 * an optional string to show as the title of the quick input
+	 */
+	title?: string;
 
 	/**
 	 * the value to prefill in the input box

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -924,6 +924,24 @@ declare module 'vscode' {
 
 	//#endregion
 
+	//#region allow title property to QuickPickOptions/InputBoxOptions: https://github.com/microsoft/vscode/issues/77423
+
+	interface QuickPickOptions {
+		/**
+		 * An optional string that represents the tile of the quick pick.
+		 */
+		title?: string;
+	}
+
+	interface InputBoxOptions {
+		/**
+		 * An optional string that represents the tile of the input box.
+		 */
+		title?: string;
+	}
+
+	//#endregion
+
 	//#region Provide a way for custom editors to process untitled files without relying on textDocument https://github.com/microsoft/vscode/issues/115631
 	/**
 	 * Additional information about the opening custom document.

--- a/src/vs/workbench/api/browser/mainThreadQuickOpen.ts
+++ b/src/vs/workbench/api/browser/mainThreadQuickOpen.ts
@@ -89,6 +89,7 @@ export class MainThreadQuickOpen implements MainThreadQuickOpenShape {
 		const inputOptions: IInputOptions = Object.create(null);
 
 		if (options) {
+			inputOptions.title = options.title;
 			inputOptions.password = options.password;
 			inputOptions.placeHolder = options.placeHolder;
 			inputOptions.valueSelection = options.valueSelection;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -559,6 +559,7 @@ export interface TransferInputBox extends BaseTransferQuickInput {
 }
 
 export interface IInputBoxOptions {
+	title?: string;
 	value?: string;
 	valueSelection?: [number, number];
 	prompt?: string;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -505,6 +505,8 @@ export interface BaseTransferQuickInput {
 
 	id: number;
 
+	title?: string;
+
 	type?: 'quickPick' | 'inputBox';
 
 	enabled?: boolean;

--- a/src/vs/workbench/api/common/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/common/extHostQuickOpen.ts
@@ -68,11 +68,12 @@ export function createExtHostQuickOpen(mainContext: IMainContext, workspace: IEx
 			const instance = ++this._instances;
 
 			const quickPickWidget = proxy.$show(instance, {
-				placeHolder: options && options.placeHolder,
-				matchOnDescription: options && options.matchOnDescription,
-				matchOnDetail: options && options.matchOnDetail,
-				ignoreFocusLost: options && options.ignoreFocusOut,
-				canPickMany: options && options.canPickMany
+				title: options?.title,
+				placeHolder: options?.placeHolder,
+				matchOnDescription: options?.matchOnDescription,
+				matchOnDetail: options?.matchOnDetail,
+				ignoreFocusLost: options?.ignoreFocusOut,
+				canPickMany: options?.canPickMany,
 			}, token);
 
 			const widgetClosedMarker = {};


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #77423

```ts
        await window.showQuickPick(['eins', 'zwei', 'drei'], {
		title: 'Hallo',
		placeHolder: 'eins, zwei or drei',
		onDidSelectItem: (item: any) => window.showInformationMessage(`Focus ${++i}: ${item}`)
	}

// and

        await window.showInputBox({
		title: 'Hallo',
		value: 'abcdef',
		valueSelection: [2, 4],
		placeHolder: 'For example: fedcba. But not: 123',
		validateInput: (text: any) => {
			window.showInformationMessage(`Validating: ${text}`);
			return text === '123' ? 'Not 123!' : null;
		}
	});
```

![image](https://user-images.githubusercontent.com/2644648/111395429-13211780-867a-11eb-9076-59bf4b45a739.png)

naturally if you don't specify a title, then no title bar shows up.

I was looking for an opportunity to write tests for this where I call the showInputBox or whatever and then check if the created input box behind the scenes has the title set... but that looks pretty convoluted so I'm not sure that test is worth it. Please let me know if there's a good way to write a test for this.