### PR TITLE
fix #118945 validationMessage on extension InputBox lacked Severity.Error

### DIFF
--- a/src/vs/workbench/api/common/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/common/extHostQuickOpen.ts
@@ -16,6 +16,7 @@ import { ThemeIcon, QuickInputButtons } from 'vs/workbench/api/common/extHostTyp
 import { isPromiseCanceledError } from 'vs/base/common/errors';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { coalesce } from 'vs/base/common/arrays';
+import Severity from 'vs/base/common/severity';
 
 export type Item = string | QuickPickItem;
 
@@ -632,7 +633,7 @@ export function createExtHostQuickOpen(mainContext: IMainContext, workspace: IEx
 
 		set validationMessage(validationMessage: string | undefined) {
 			this._validationMessage = validationMessage;
-			this.update({ validationMessage });
+			this.update({ validationMessage, severity: validationMessage ? Severity.Error : Severity.Ignore });
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #118945, a regression in 1.55 probably caused by #118032

To repro the bug:
1. Clone [microsoft/vscode-extension-samples](https://github.com/microsoft/vscode-extension-samples)
 2. Open quickinput-sample folder
 3. Build and run it
 4. Invoke its `Quick Input Samples` command.
 5. Pick `multiStepInput`, then `vscode-data-function`
 6. In the input field type `vscode`
 7. :bug: the `Name not unique` message is not styled as an error

With this PR the 1.54 behaviour is restored.
