### PR TITLE
Improve debian control description

### DIFF
--- a/resources/linux/debian/control.template
+++ b/resources/linux/debian/control.template
@@ -11,4 +11,7 @@ Provides: visual-studio-@@NAME@@
 Conflicts: visual-studio-@@NAME@@
 Replaces: visual-studio-@@NAME@@
 Description: Code editing. Redefined.
- Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle. See https://code.visualstudio.com/docs/setup/linux for installation instructions and FAQ.
+ Visual Studio Code is a new choice of tool that combines the simplicity of a
+	code editor with what developers need for the core edit-build-debug cycle.
+	See https://code.visualstudio.com/docs/setup/linux for installation
+	instructions and FAQ.


### PR DESCRIPTION
This should not be longer than 80 characters/line. The last two lines belong to /usr/share/doc/code/README.Debian

Also it should not start with "Visual Studio Code is" but rather with "This is" 
Please refer to the Debian Developer Manual.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #feel free to create this one, but that's the problem:

```
apt-cache show code
---8<---snip-snap
Description: Code editing. Redefined.
 Visual Studio Code is a new choice of tool that combines the simplicity of a co
de editor with what developers need for the core edit-build-debug cycle. See htt
ps://code.visualstudio.com/docs/setup/linux for installation instructions and FA
Q.
---snip-snap--->8---
>>>