### PR TITLE
Add include for ms-auth extension

### DIFF
--- a/extensions/microsoft-authentication/tsconfig.json
+++ b/extensions/microsoft-authentication/tsconfig.json
@@ -17,5 +17,6 @@
 		"strict": true,
 		"target": "es2019"
 	},
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules"],
+	"include": ["src/**/*"]
 }


### PR DESCRIPTION
Without this pattern, I see the error:

```
File '/Users/matb/projects/vscode/extensions/microsoft-authentication/dist/browser/env/browser/authServer.ts' is not under 'rootDir' '/Users/matb/projects/vscode/extensions/microsoft-authentication/src'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '**/*' in '/Users/matb/projects/vscode/extensions/microsoft-authentication/tsconfig.json'ts
 ```

I believe this is because the files under `dist` are also getting included in the tsconfig project 
