### PR TITLE
Initial file working copies

### DIFF
--- a/src/vs/workbench/services/filesConfiguration/common/filesConfigurationService.ts
+++ b/src/vs/workbench/services/filesConfiguration/common/filesConfigurationService.ts
@@ -54,7 +54,7 @@ export interface IFilesConfigurationService {
 
 	readonly hotExitConfiguration: string | undefined;
 
-	preventSaveConflicts(resource: URI, language: string): boolean;
+	preventSaveConflicts(resource: URI, language?: string): boolean;
 }
 
 export class FilesConfigurationService extends Disposable implements IFilesConfigurationService {
@@ -203,7 +203,7 @@ export class FilesConfigurationService extends Disposable implements IFilesConfi
 		return this.currentHotExitConfig;
 	}
 
-	preventSaveConflicts(resource: URI, language: string): boolean {
+	preventSaveConflicts(resource: URI, language?: string): boolean {
 		return this.configurationService.getValue('files.saveConflictResolution', { resource, overrideIdentifier: language }) !== 'overwriteFileOnDisk';
 	}
 }

--- a/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
@@ -373,7 +373,7 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 		modelListeners.add(model.onDidLoad(reason => this._onDidLoad.fire({ model, reason })));
 		modelListeners.add(model.onDidChangeDirty(() => this._onDidChangeDirty.fire(model)));
 		modelListeners.add(model.onDidSaveError(() => this._onDidSaveError.fire(model)));
-		modelListeners.add(model.onDidSave(reason => this._onDidSave.fire({ model: model, reason })));
+		modelListeners.add(model.onDidSave(reason => this._onDidSave.fire({ model, reason })));
 		modelListeners.add(model.onDidRevert(() => this._onDidRevert.fire(model)));
 		modelListeners.add(model.onDidChangeEncoding(() => this._onDidChangeEncoding.fire(model)));
 

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
@@ -958,12 +958,18 @@ export class FileWorkingCopy<T extends IFileWorkingCopyModel> extends Disposable
 		}
 
 		// Delegate to save error handler
+		let throwError = true;
 		if (this.isTextFileModel(this.model)) {
 			this.textFileService.files.saveErrorHandler.onSaveError(error, this.model);
+			throwError = false;
 		}
 
 		// Emit as event
 		this._onDidSaveError.fire();
+
+		if (throwError) {
+			throw error;
+		}
 	}
 
 	private updateSavedVersionId(): void {

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
@@ -47,6 +47,11 @@ export interface IFileWorkingCopyModel {
 	readonly onDidChangeContent: Event<IFileWorkingCopyModelContentChangedEvent>;
 
 	/**
+	 * An event that fires whenever the model is disposed.
+	 */
+	readonly onDispose: Event<void>;
+
+	/**
 	 * Snapshots the model's current content for writing.
 	 *
 	 * @param token support for cancellation

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
@@ -1,0 +1,366 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableStore, dispose, IDisposable } from 'vs/base/common/lifecycle';
+import { Event, Emitter } from 'vs/base/common/event';
+import { IFileWorkingCopy, IFileWorkingCopyModel } from 'vs/workbench/services/workingCopy/common/fileWorkingCopy';
+import { SaveReason } from 'vs/workbench/common/editor';
+import { ResourceMap } from 'vs/base/common/map';
+import { ResourceQueue } from 'vs/base/common/async';
+import { FileChangesEvent, FileChangeType, IFileService } from 'vs/platform/files/common/files';
+import { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import { onUnexpectedError } from 'vs/base/common/errors';
+import { URI } from 'vs/base/common/uri';
+import { VSBufferReadableStream } from 'vs/base/common/buffer';
+
+/**
+ * The only one that should be dealing with `IFileWorkingCopy` and handle all
+ * operations that are working copy related, such as save/revert, backup
+ * and loading.
+ */
+export interface IFileWorkingCopyManager<T extends IFileWorkingCopyModel> {
+	readonly onDidCreate: Event<IFileWorkingCopy<T>>;
+	readonly onDidLoad: Event<IFileWorkingCopy<T>>;
+	readonly onDidChangeDirty: Event<IFileWorkingCopy<T>>;
+	readonly onDidSaveError: Event<IFileWorkingCopy<T>>;
+	readonly onDidSave: Event<IFileWorkingCopySaveEvent<T>>;
+	readonly onDidRevert: Event<IFileWorkingCopy<T>>;
+
+	readonly fileWorkingCopies: IFileWorkingCopy<T>[];
+}
+
+export interface IFileWorkingCopySaveEvent<T extends IFileWorkingCopyModel> {
+	workingCopy: IFileWorkingCopy<T>;
+	reason: SaveReason;
+}
+
+export interface IFileWorkingCopyLoadOrCreateOptions {
+
+	/**
+	 * The contents to use for the file working copy if known.
+	 * If not provided, the contents will be retrieved from the
+	 * underlying resource or backup if present.
+	 */
+	contents?: VSBufferReadableStream;
+
+	/**
+	 * If the file working copy was already loaded before,
+	 * allows to trigger a reload of it to fetch the latest contents:
+	 * - async: resolve() will return immediately and trigger
+	 * a reload that will run in the background.
+	 * - sync: resolve() will only return resolved when the
+	 * file working copy has finished reloading.
+	 */
+	reload?: {
+		async: boolean
+	};
+}
+
+export interface IFileWorkingCopyManagerDelegate<T extends IFileWorkingCopyModel> {
+
+	createFileWorkingCopy(resource: URI): IFileWorkingCopy<T>;
+}
+
+export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Disposable {
+
+	//#region Events
+
+	private readonly _onDidCreate = this._register(new Emitter<IFileWorkingCopy<T>>());
+	readonly onDidCreate = this._onDidCreate.event;
+
+	private readonly _onDidLoad = this._register(new Emitter<IFileWorkingCopy<T>>());
+	readonly onDidLoad = this._onDidLoad.event;
+
+	private readonly _onDidChangeDirty = this._register(new Emitter<IFileWorkingCopy<T>>());
+	readonly onDidChangeDirty = this._onDidChangeDirty.event;
+
+	private readonly _onDidSaveError = this._register(new Emitter<IFileWorkingCopy<T>>());
+	readonly onDidSaveError = this._onDidSaveError.event;
+
+	private readonly _onDidSave = this._register(new Emitter<IFileWorkingCopySaveEvent<T>>());
+	readonly onDidSave = this._onDidSave.event;
+
+	private readonly _onDidRevert = this._register(new Emitter<IFileWorkingCopy<T>>());
+	readonly onDidRevert = this._onDidRevert.event;
+
+	//#endregion
+
+	private readonly mapResourceToFileWorkingCopy = new ResourceMap<IFileWorkingCopy<T>>();
+	private readonly mapResourceToFileWorkingCopyListeners = new ResourceMap<IDisposable>();
+	private readonly mapResourceToDisposeListener = new ResourceMap<IDisposable>();
+	private readonly mapResourceToPendingFileWorkingCopyLoaders = new ResourceMap<Promise<IFileWorkingCopy<T>>>();
+
+	private readonly fileWorkingCopyLoadQueue = this._register(new ResourceQueue());
+
+	get fileWorkingCopies(): IFileWorkingCopy<T>[] {
+		return [...this.mapResourceToFileWorkingCopy.values()];
+	}
+
+	constructor(
+		private readonly delegate: IFileWorkingCopyManagerDelegate<T>,
+		@IFileService private readonly fileService: IFileService,
+		@ILifecycleService private readonly lifecycleService: ILifecycleService
+	) {
+		super();
+
+		this.registerListeners();
+	}
+
+	private registerListeners(): void {
+
+		// Update file working copies from file change events
+		this._register(this.fileService.onDidFilesChange(e => this.onDidFilesChange(e)));
+
+		// Lifecycle
+		this.lifecycleService.onShutdown(() => this.dispose);
+	}
+
+	private onDidFilesChange(e: FileChangesEvent): void {
+		for (const fileWorkingCopy of this.fileWorkingCopies) {
+			if (fileWorkingCopy.isDirty() || !fileWorkingCopy.isResolved()) {
+				continue; // require a resolved, saved file working copy to continue
+			}
+
+			// Trigger a load for any update or add event that impacts
+			// the file working copy. We also consider the added event
+			// because it could be that a file was added and updated
+			// right after.
+			if (e.contains(fileWorkingCopy.resource, FileChangeType.UPDATED, FileChangeType.ADDED)) {
+				this.queueFileWorkingCopyLoad(fileWorkingCopy);
+			}
+		}
+	}
+
+	private queueFileWorkingCopyLoad(fileWorkingCopy: IFileWorkingCopy<T>): void {
+
+		// Load file working copy to update (use a queue to prevent accumulation of
+		// loads when the load actually takes long. At most we only want the queue
+		// to have a size of 2 (1 running load and 1 queued load).
+		const queue = this.fileWorkingCopyLoadQueue.queueFor(fileWorkingCopy.resource);
+		if (queue.size <= 1) {
+			queue.queue(async () => {
+				try {
+					await fileWorkingCopy.load();
+				} catch (error) {
+					onUnexpectedError(error);
+				}
+			});
+		}
+	}
+
+	get(resource: URI): IFileWorkingCopy<T> | undefined {
+		return this.mapResourceToFileWorkingCopy.get(resource);
+	}
+
+	async resolve(resource: URI, options?: IFileWorkingCopyLoadOrCreateOptions): Promise<IFileWorkingCopy<T>> {
+
+		// Await a pending file working copy load first before proceeding
+		// to ensure that we never load a file working copy more than once
+		// in parallel
+		const pendingResolve = this.joinPendingResolve(resource);
+		if (pendingResolve) {
+			await pendingResolve;
+		}
+
+		let fileWorkingCopyPromise: Promise<IFileWorkingCopy<T>>;
+		let fileWorkingCopy = this.get(resource);
+		let didCreateFileWorkingCopy = false;
+
+		// File working copy exists
+		if (fileWorkingCopy) {
+
+			// Always reload if contents are provided
+			if (options?.contents) {
+				fileWorkingCopyPromise = fileWorkingCopy.load(options);
+			}
+
+			// Reload async or sync based on options
+			else if (options?.reload) {
+
+				// async reload: trigger a reload but return immediately
+				if (options.reload.async) {
+					fileWorkingCopyPromise = Promise.resolve(fileWorkingCopy);
+					fileWorkingCopy.load(options);
+				}
+
+				// sync reload: do not return until file working copy reloaded
+				else {
+					fileWorkingCopyPromise = fileWorkingCopy.load(options);
+				}
+			}
+
+			// Do not reload
+			else {
+				fileWorkingCopyPromise = Promise.resolve(fileWorkingCopy);
+			}
+		}
+
+		// File working copy does not exist
+		else {
+			didCreateFileWorkingCopy = true;
+
+			const newFileWorkingCopy = fileWorkingCopy = this.delegate.createFileWorkingCopy(resource);
+			fileWorkingCopyPromise = fileWorkingCopy.load(options);
+
+			this.registerFileWorkingCopy(newFileWorkingCopy);
+		}
+
+		// Store pending loads to avoid race conditions
+		this.mapResourceToPendingFileWorkingCopyLoaders.set(resource, fileWorkingCopyPromise);
+
+		// Make known to manager (if not already known)
+		this.add(resource, fileWorkingCopy);
+
+		// Emit some events if we created the file working copy
+		if (didCreateFileWorkingCopy) {
+			this._onDidCreate.fire(fileWorkingCopy);
+
+			// If the file working copy is dirty right from the beginning,
+			// make sure to emit this as an event
+			if (fileWorkingCopy.isDirty()) {
+				this._onDidChangeDirty.fire(fileWorkingCopy);
+			}
+		}
+
+		try {
+			const resolvedFileWorkingCopy = await fileWorkingCopyPromise;
+
+			// Remove from pending loads
+			this.mapResourceToPendingFileWorkingCopyLoaders.delete(resource);
+
+			// File working copy can be dirty if a backup was restored, so we make sure to
+			// have this event delivered if we created the file working copy here
+			if (didCreateFileWorkingCopy && resolvedFileWorkingCopy.isDirty()) {
+				this._onDidChangeDirty.fire(resolvedFileWorkingCopy);
+			}
+
+			return resolvedFileWorkingCopy;
+		} catch (error) {
+
+			// Free resources of this invalid file working copy
+			if (fileWorkingCopy) {
+				fileWorkingCopy.dispose();
+			}
+
+			// Remove from pending loads
+			this.mapResourceToPendingFileWorkingCopyLoaders.delete(resource);
+
+			throw error;
+		}
+	}
+
+	private joinPendingResolve(resource: URI): Promise<void> | undefined {
+		const pendingFileWorkingCopyLoad = this.mapResourceToPendingFileWorkingCopyLoaders.get(resource);
+		if (pendingFileWorkingCopyLoad) {
+			return pendingFileWorkingCopyLoad.then(undefined, error => {/* ignore any error here, it will bubble to the original requestor*/ });
+		}
+
+		return undefined;
+	}
+
+	private registerFileWorkingCopy(fileWorkingCopy: IFileWorkingCopy<T>): void {
+
+		// Install file working copy listeners
+		const fileWorkingCopyListeners = new DisposableStore();
+		fileWorkingCopyListeners.add(fileWorkingCopy.onDidLoad(reason => this._onDidLoad.fire(fileWorkingCopy)));
+		fileWorkingCopyListeners.add(fileWorkingCopy.onDidChangeDirty(() => this._onDidChangeDirty.fire(fileWorkingCopy)));
+		fileWorkingCopyListeners.add(fileWorkingCopy.onDidSaveError(() => this._onDidSaveError.fire(fileWorkingCopy)));
+		fileWorkingCopyListeners.add(fileWorkingCopy.onDidSave(reason => this._onDidSave.fire({ workingCopy: fileWorkingCopy, reason })));
+		fileWorkingCopyListeners.add(fileWorkingCopy.onDidRevert(() => this._onDidRevert.fire(fileWorkingCopy)));
+
+		// Keep for disposal
+		this.mapResourceToFileWorkingCopyListeners.set(fileWorkingCopy.resource, fileWorkingCopyListeners);
+	}
+
+	protected add(resource: URI, fileWorkingCopy: IFileWorkingCopy<T>): void {
+		const knownFileWorkingCopy = this.mapResourceToFileWorkingCopy.get(resource);
+		if (knownFileWorkingCopy === fileWorkingCopy) {
+			return; // already cached
+		}
+
+		// dispose any previously stored dispose listener for this resource
+		const disposeListener = this.mapResourceToDisposeListener.get(resource);
+		if (disposeListener) {
+			disposeListener.dispose();
+		}
+
+		// store in cache but remove when file working copy gets disposed
+		this.mapResourceToFileWorkingCopy.set(resource, fileWorkingCopy);
+		this.mapResourceToDisposeListener.set(resource, fileWorkingCopy.onDispose(() => this.remove(resource)));
+	}
+
+	protected remove(resource: URI): void {
+		this.mapResourceToFileWorkingCopy.delete(resource);
+
+		const disposeListener = this.mapResourceToDisposeListener.get(resource);
+		if (disposeListener) {
+			dispose(disposeListener);
+			this.mapResourceToDisposeListener.delete(resource);
+		}
+
+		const fileWorkingCopyListener = this.mapResourceToFileWorkingCopyListeners.get(resource);
+		if (fileWorkingCopyListener) {
+			dispose(fileWorkingCopyListener);
+			this.mapResourceToFileWorkingCopyListeners.delete(resource);
+		}
+	}
+
+	clear(): void {
+
+		// file working copy caches
+		this.mapResourceToFileWorkingCopy.clear();
+		this.mapResourceToPendingFileWorkingCopyLoaders.clear();
+
+		// dispose the dispose listeners
+		this.mapResourceToDisposeListener.forEach(listener => listener.dispose());
+		this.mapResourceToDisposeListener.clear();
+
+		// dispose the file working copy change listeners
+		this.mapResourceToFileWorkingCopyListeners.forEach(listener => listener.dispose());
+		this.mapResourceToFileWorkingCopyListeners.clear();
+	}
+
+	canDispose(fileWorkingCopy: IFileWorkingCopy<T>): true | Promise<true> {
+
+		// quick return if file working copy already disposed or not dirty and not loading
+		if (
+			fileWorkingCopy.isDisposed() ||
+			(!this.mapResourceToPendingFileWorkingCopyLoaders.has(fileWorkingCopy.resource) && !fileWorkingCopy.isDirty())
+		) {
+			return true;
+		}
+
+		// promise based return in all other cases
+		return this.doCanDispose(fileWorkingCopy);
+	}
+
+	private async doCanDispose(fileWorkingCopy: IFileWorkingCopy<T>): Promise<true> {
+
+		// if we have a pending file working copy load, await it first and then try again
+		const pendingResolve = this.joinPendingResolve(fileWorkingCopy.resource);
+		if (pendingResolve) {
+			await pendingResolve;
+
+			return this.canDispose(fileWorkingCopy);
+		}
+
+		// dirty file working copy: we do not allow to dispose dirty file working copys
+		// to prevent data loss cases. dirty file working copys can only be disposed when
+		// they are either saved or reverted
+		if (fileWorkingCopy.isDirty()) {
+			await Event.toPromise(fileWorkingCopy.onDidChangeDirty);
+
+			return this.canDispose(fileWorkingCopy);
+		}
+
+		return true;
+	}
+
+	dispose(): void {
+		super.dispose();
+
+		this.clear();
+	}
+}

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
@@ -5,7 +5,7 @@
 
 import { Disposable, DisposableStore, dispose, IDisposable } from 'vs/base/common/lifecycle';
 import { Event, Emitter } from 'vs/base/common/event';
-import { IFileWorkingCopy, IFileWorkingCopyModel } from 'vs/workbench/services/workingCopy/common/fileWorkingCopy';
+import { FileWorkingCopy, IFileWorkingCopy, IFileWorkingCopyModel, IFileWorkingCopyModelFactory } from 'vs/workbench/services/workingCopy/common/fileWorkingCopy';
 import { SaveReason } from 'vs/workbench/common/editor';
 import { ResourceMap } from 'vs/base/common/map';
 import { ResourceQueue } from 'vs/base/common/async';
@@ -14,39 +14,97 @@ import { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecy
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { URI } from 'vs/base/common/uri';
 import { VSBufferReadableStream } from 'vs/base/common/buffer';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 /**
  * The only one that should be dealing with `IFileWorkingCopy` and handle all
  * operations that are working copy related, such as save/revert, backup
- * and loading.
+ * and resolving.
  */
 export interface IFileWorkingCopyManager<T extends IFileWorkingCopyModel> {
+
+	/**
+	 * An event for when a file working copy was created.
+	 */
 	readonly onDidCreate: Event<IFileWorkingCopy<T>>;
-	readonly onDidLoad: Event<IFileWorkingCopy<T>>;
+
+	/**
+	 * An event for when a file working copy was resolved.
+	 */
+	readonly onDidResolve: Event<IFileWorkingCopy<T>>;
+
+	/**
+	 * An event for when a file working copy changed it's dirty state.
+	 */
 	readonly onDidChangeDirty: Event<IFileWorkingCopy<T>>;
+
+	/**
+	 * An event for when a file working copy failed to save.
+	 */
 	readonly onDidSaveError: Event<IFileWorkingCopy<T>>;
+
+	/**
+	 * An event for when a file working copy successfully saved.
+	 */
 	readonly onDidSave: Event<IFileWorkingCopySaveEvent<T>>;
+
+	/**
+	 * An event for when a file working copy was reverted.
+	 */
 	readonly onDidRevert: Event<IFileWorkingCopy<T>>;
 
-	readonly fileWorkingCopies: IFileWorkingCopy<T>[];
+	/**
+	 * Access to all known file working copies within the manager.
+	 */
+	readonly workingCopies: IFileWorkingCopy<T>[];
+
+	/**
+	 * Returns the file working copy for the provided resource
+	 * or undefined if none.
+	 */
+	get(resource: URI): IFileWorkingCopy<T> | undefined;
+
+	/**
+	 * Allows to resolve a file working copy.
+	 */
+	resolve(resource: URI, options?: IFileWorkingCopyResolveOptions): Promise<IFileWorkingCopy<T>>;
+
+	/**
+	 * Waits for the file working copy to be ready to be disposed. There may be
+	 * conditions under which the file working copy cannot be disposed, e.g. when
+	 * it is dirty. Once the promise is settled, it is safe to dispose.
+	 */
+	canDispose(workingCopy: IFileWorkingCopy<T>): true | Promise<true>;
 }
 
 export interface IFileWorkingCopySaveEvent<T extends IFileWorkingCopyModel> {
+
+	/**
+	 * The file working copy that was successfully saved.
+	 */
 	workingCopy: IFileWorkingCopy<T>;
+
+	/**
+	 * The reason why the file working copy was saved.
+	 */
 	reason: SaveReason;
 }
 
-export interface IFileWorkingCopyLoadOrCreateOptions {
+export interface IFileWorkingCopyResolveOptions {
 
 	/**
 	 * The contents to use for the file working copy if known.
 	 * If not provided, the contents will be retrieved from the
 	 * underlying resource or backup if present.
+	 *
+	 * If contents are provided, the file working copy will be marked
+	 * as dirty right from the beginning.
 	 */
 	contents?: VSBufferReadableStream;
 
 	/**
-	 * If the file working copy was already loaded before,
+	 * If the file working copy was already resolved before,
 	 * allows to trigger a reload of it to fetch the latest contents:
 	 * - async: resolve() will return immediately and trigger
 	 * a reload that will run in the background.
@@ -58,20 +116,15 @@ export interface IFileWorkingCopyLoadOrCreateOptions {
 	};
 }
 
-export interface IFileWorkingCopyManagerDelegate<T extends IFileWorkingCopyModel> {
-
-	createFileWorkingCopy(resource: URI): IFileWorkingCopy<T>;
-}
-
-export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Disposable {
+export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Disposable implements IFileWorkingCopyManager<T> {
 
 	//#region Events
 
 	private readonly _onDidCreate = this._register(new Emitter<IFileWorkingCopy<T>>());
 	readonly onDidCreate = this._onDidCreate.event;
 
-	private readonly _onDidLoad = this._register(new Emitter<IFileWorkingCopy<T>>());
-	readonly onDidLoad = this._onDidLoad.event;
+	private readonly _onDidResolve = this._register(new Emitter<IFileWorkingCopy<T>>());
+	readonly onDidResolve = this._onDidResolve.event;
 
 	private readonly _onDidChangeDirty = this._register(new Emitter<IFileWorkingCopy<T>>());
 	readonly onDidChangeDirty = this._onDidChangeDirty.event;
@@ -87,21 +140,23 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 
 	//#endregion
 
-	private readonly mapResourceToFileWorkingCopy = new ResourceMap<IFileWorkingCopy<T>>();
-	private readonly mapResourceToFileWorkingCopyListeners = new ResourceMap<IDisposable>();
+	private readonly mapResourceToWorkingCopy = new ResourceMap<IFileWorkingCopy<T>>();
+	private readonly mapResourceToWorkingCopyListeners = new ResourceMap<IDisposable>();
 	private readonly mapResourceToDisposeListener = new ResourceMap<IDisposable>();
-	private readonly mapResourceToPendingFileWorkingCopyLoaders = new ResourceMap<Promise<IFileWorkingCopy<T>>>();
+	private readonly mapResourceToPendingWorkingCopyResolve = new ResourceMap<Promise<IFileWorkingCopy<T>>>();
 
-	private readonly fileWorkingCopyLoadQueue = this._register(new ResourceQueue());
+	private readonly workingCopyResolveQueue = this._register(new ResourceQueue());
 
-	get fileWorkingCopies(): IFileWorkingCopy<T>[] {
-		return [...this.mapResourceToFileWorkingCopy.values()];
+	get workingCopies(): IFileWorkingCopy<T>[] {
+		return [...this.mapResourceToWorkingCopy.values()];
 	}
 
 	constructor(
-		private readonly delegate: IFileWorkingCopyManagerDelegate<T>,
+		private readonly modelFactory: IFileWorkingCopyModelFactory<T>,
 		@IFileService private readonly fileService: IFileService,
-		@ILifecycleService private readonly lifecycleService: ILifecycleService
+		@ILifecycleService private readonly lifecycleService: ILifecycleService,
+		@ILabelService private readonly labelService: ILabelService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) {
 		super();
 
@@ -110,7 +165,7 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 
 	private registerListeners(): void {
 
-		// Update file working copies from file change events
+		// Update working copies from file change events
 		this._register(this.fileService.onDidFilesChange(e => this.onDidFilesChange(e)));
 
 		// Lifecycle
@@ -118,31 +173,31 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 	}
 
 	private onDidFilesChange(e: FileChangesEvent): void {
-		for (const fileWorkingCopy of this.fileWorkingCopies) {
-			if (fileWorkingCopy.isDirty() || !fileWorkingCopy.isResolved()) {
-				continue; // require a resolved, saved file working copy to continue
+		for (const workingCopy of this.workingCopies) {
+			if (workingCopy.isDirty() || !workingCopy.isResolved()) {
+				continue; // require a resolved, saved working copy to continue
 			}
 
-			// Trigger a load for any update or add event that impacts
-			// the file working copy. We also consider the added event
+			// Trigger a resolve for any update or add event that impacts
+			// the working copy. We also consider the added event
 			// because it could be that a file was added and updated
 			// right after.
-			if (e.contains(fileWorkingCopy.resource, FileChangeType.UPDATED, FileChangeType.ADDED)) {
-				this.queueFileWorkingCopyLoad(fileWorkingCopy);
+			if (e.contains(workingCopy.resource, FileChangeType.UPDATED, FileChangeType.ADDED)) {
+				this.queueWorkingCopyResolve(workingCopy);
 			}
 		}
 	}
 
-	private queueFileWorkingCopyLoad(fileWorkingCopy: IFileWorkingCopy<T>): void {
+	private queueWorkingCopyResolve(workingCopy: IFileWorkingCopy<T>): void {
 
-		// Load file working copy to update (use a queue to prevent accumulation of
-		// loads when the load actually takes long. At most we only want the queue
-		// to have a size of 2 (1 running load and 1 queued load).
-		const queue = this.fileWorkingCopyLoadQueue.queueFor(fileWorkingCopy.resource);
+		// Resolves a working copy to update (use a queue to prevent accumulation of
+		// resolve when the resolving actually takes long. At most we only want the
+		// queue to have a size of 2 (1 running resolve and 1 queued resolve).
+		const queue = this.workingCopyResolveQueue.queueFor(workingCopy.resource);
 		if (queue.size <= 1) {
 			queue.queue(async () => {
 				try {
-					await fileWorkingCopy.load();
+					await workingCopy.resolve();
 				} catch (error) {
 					onUnexpectedError(error);
 				}
@@ -151,29 +206,29 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 	}
 
 	get(resource: URI): IFileWorkingCopy<T> | undefined {
-		return this.mapResourceToFileWorkingCopy.get(resource);
+		return this.mapResourceToWorkingCopy.get(resource);
 	}
 
-	async resolve(resource: URI, options?: IFileWorkingCopyLoadOrCreateOptions): Promise<IFileWorkingCopy<T>> {
+	async resolve(resource: URI, options?: IFileWorkingCopyResolveOptions): Promise<IFileWorkingCopy<T>> {
 
-		// Await a pending file working copy load first before proceeding
-		// to ensure that we never load a file working copy more than once
+		// Await a pending working copy resolve first before proceeding
+		// to ensure that we never resolve a working copy more than once
 		// in parallel
 		const pendingResolve = this.joinPendingResolve(resource);
 		if (pendingResolve) {
 			await pendingResolve;
 		}
 
-		let fileWorkingCopyPromise: Promise<IFileWorkingCopy<T>>;
-		let fileWorkingCopy = this.get(resource);
-		let didCreateFileWorkingCopy = false;
+		let workingCopyPromise: Promise<IFileWorkingCopy<T>>;
+		let workingCopy = this.get(resource);
+		let didCreateWorkingCopy = false;
 
-		// File working copy exists
-		if (fileWorkingCopy) {
+		// Working copy exists
+		if (workingCopy) {
 
 			// Always reload if contents are provided
 			if (options?.contents) {
-				fileWorkingCopyPromise = fileWorkingCopy.load(options);
+				workingCopyPromise = workingCopy.resolve(options);
 			}
 
 			// Reload async or sync based on options
@@ -181,102 +236,102 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 
 				// async reload: trigger a reload but return immediately
 				if (options.reload.async) {
-					fileWorkingCopyPromise = Promise.resolve(fileWorkingCopy);
-					fileWorkingCopy.load(options);
+					workingCopyPromise = Promise.resolve(workingCopy);
+					workingCopy.resolve(options);
 				}
 
-				// sync reload: do not return until file working copy reloaded
+				// sync reload: do not return until working copy reloaded
 				else {
-					fileWorkingCopyPromise = fileWorkingCopy.load(options);
+					workingCopyPromise = workingCopy.resolve(options);
 				}
 			}
 
 			// Do not reload
 			else {
-				fileWorkingCopyPromise = Promise.resolve(fileWorkingCopy);
+				workingCopyPromise = Promise.resolve(workingCopy);
 			}
 		}
 
 		// File working copy does not exist
 		else {
-			didCreateFileWorkingCopy = true;
+			didCreateWorkingCopy = true;
 
-			const newFileWorkingCopy = fileWorkingCopy = this.delegate.createFileWorkingCopy(resource);
-			fileWorkingCopyPromise = fileWorkingCopy.load(options);
+			const newWorkingCopy = workingCopy = this.instantiationService.createInstance(FileWorkingCopy, resource, this.labelService.getUriBasenameLabel(resource), this.modelFactory) as unknown as IFileWorkingCopy<T>;
+			workingCopyPromise = workingCopy.resolve(options);
 
-			this.registerFileWorkingCopy(newFileWorkingCopy);
+			this.registerWorkingCopy(newWorkingCopy);
 		}
 
-		// Store pending loads to avoid race conditions
-		this.mapResourceToPendingFileWorkingCopyLoaders.set(resource, fileWorkingCopyPromise);
+		// Store pending resolve to avoid race conditions
+		this.mapResourceToPendingWorkingCopyResolve.set(resource, workingCopyPromise);
 
 		// Make known to manager (if not already known)
-		this.add(resource, fileWorkingCopy);
+		this.add(resource, workingCopy);
 
-		// Emit some events if we created the file working copy
-		if (didCreateFileWorkingCopy) {
-			this._onDidCreate.fire(fileWorkingCopy);
+		// Emit some events if we created the working copy
+		if (didCreateWorkingCopy) {
+			this._onDidCreate.fire(workingCopy);
 
-			// If the file working copy is dirty right from the beginning,
+			// If the working copy is dirty right from the beginning,
 			// make sure to emit this as an event
-			if (fileWorkingCopy.isDirty()) {
-				this._onDidChangeDirty.fire(fileWorkingCopy);
+			if (workingCopy.isDirty()) {
+				this._onDidChangeDirty.fire(workingCopy);
 			}
 		}
 
 		try {
-			const resolvedFileWorkingCopy = await fileWorkingCopyPromise;
+			const resolvedWorkingCopy = await workingCopyPromise;
 
-			// Remove from pending loads
-			this.mapResourceToPendingFileWorkingCopyLoaders.delete(resource);
+			// Remove from pending resolves
+			this.mapResourceToPendingWorkingCopyResolve.delete(resource);
 
 			// File working copy can be dirty if a backup was restored, so we make sure to
-			// have this event delivered if we created the file working copy here
-			if (didCreateFileWorkingCopy && resolvedFileWorkingCopy.isDirty()) {
-				this._onDidChangeDirty.fire(resolvedFileWorkingCopy);
+			// have this event delivered if we created the working copy here
+			if (didCreateWorkingCopy && resolvedWorkingCopy.isDirty()) {
+				this._onDidChangeDirty.fire(resolvedWorkingCopy);
 			}
 
-			return resolvedFileWorkingCopy;
+			return resolvedWorkingCopy;
 		} catch (error) {
 
-			// Free resources of this invalid file working copy
-			if (fileWorkingCopy) {
-				fileWorkingCopy.dispose();
+			// Free resources of this invalid working copy
+			if (workingCopy) {
+				workingCopy.dispose();
 			}
 
-			// Remove from pending loads
-			this.mapResourceToPendingFileWorkingCopyLoaders.delete(resource);
+			// Remove from pending resolves
+			this.mapResourceToPendingWorkingCopyResolve.delete(resource);
 
 			throw error;
 		}
 	}
 
 	private joinPendingResolve(resource: URI): Promise<void> | undefined {
-		const pendingFileWorkingCopyLoad = this.mapResourceToPendingFileWorkingCopyLoaders.get(resource);
-		if (pendingFileWorkingCopyLoad) {
-			return pendingFileWorkingCopyLoad.then(undefined, error => {/* ignore any error here, it will bubble to the original requestor*/ });
+		const pendingWorkingCopyResolve = this.mapResourceToPendingWorkingCopyResolve.get(resource);
+		if (pendingWorkingCopyResolve) {
+			return pendingWorkingCopyResolve.then(undefined, error => {/* ignore any error here, it will bubble to the original requestor*/ });
 		}
 
 		return undefined;
 	}
 
-	private registerFileWorkingCopy(fileWorkingCopy: IFileWorkingCopy<T>): void {
+	private registerWorkingCopy(workingCopy: IFileWorkingCopy<T>): void {
 
-		// Install file working copy listeners
-		const fileWorkingCopyListeners = new DisposableStore();
-		fileWorkingCopyListeners.add(fileWorkingCopy.onDidLoad(reason => this._onDidLoad.fire(fileWorkingCopy)));
-		fileWorkingCopyListeners.add(fileWorkingCopy.onDidChangeDirty(() => this._onDidChangeDirty.fire(fileWorkingCopy)));
-		fileWorkingCopyListeners.add(fileWorkingCopy.onDidSaveError(() => this._onDidSaveError.fire(fileWorkingCopy)));
-		fileWorkingCopyListeners.add(fileWorkingCopy.onDidSave(reason => this._onDidSave.fire({ workingCopy: fileWorkingCopy, reason })));
-		fileWorkingCopyListeners.add(fileWorkingCopy.onDidRevert(() => this._onDidRevert.fire(fileWorkingCopy)));
+		// Install working copy listeners
+		const workingCopyListeners = new DisposableStore();
+		workingCopyListeners.add(workingCopy.onDidResolve(() => this._onDidResolve.fire(workingCopy)));
+		workingCopyListeners.add(workingCopy.onDidChangeDirty(() => this._onDidChangeDirty.fire(workingCopy)));
+		workingCopyListeners.add(workingCopy.onDidSaveError(() => this._onDidSaveError.fire(workingCopy)));
+		workingCopyListeners.add(workingCopy.onDidSave(reason => this._onDidSave.fire({ workingCopy: workingCopy, reason })));
+		workingCopyListeners.add(workingCopy.onDidRevert(() => this._onDidRevert.fire(workingCopy)));
 
 		// Keep for disposal
-		this.mapResourceToFileWorkingCopyListeners.set(fileWorkingCopy.resource, fileWorkingCopyListeners);
+		this.mapResourceToWorkingCopyListeners.set(workingCopy.resource, workingCopyListeners);
 	}
 
-	protected add(resource: URI, fileWorkingCopy: IFileWorkingCopy<T>): void {
-		const knownFileWorkingCopy = this.mapResourceToFileWorkingCopy.get(resource);
-		if (knownFileWorkingCopy === fileWorkingCopy) {
+	protected add(resource: URI, workingCopy: IFileWorkingCopy<T>): void {
+		const knownWorkingCopy = this.mapResourceToWorkingCopy.get(resource);
+		if (knownWorkingCopy === workingCopy) {
 			return; // already cached
 		}
 
@@ -286,13 +341,13 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 			disposeListener.dispose();
 		}
 
-		// store in cache but remove when file working copy gets disposed
-		this.mapResourceToFileWorkingCopy.set(resource, fileWorkingCopy);
-		this.mapResourceToDisposeListener.set(resource, fileWorkingCopy.onDispose(() => this.remove(resource)));
+		// store in cache but remove when working copy gets disposed
+		this.mapResourceToWorkingCopy.set(resource, workingCopy);
+		this.mapResourceToDisposeListener.set(resource, workingCopy.onDispose(() => this.remove(resource)));
 	}
 
 	protected remove(resource: URI): void {
-		this.mapResourceToFileWorkingCopy.delete(resource);
+		this.mapResourceToWorkingCopy.delete(resource);
 
 		const disposeListener = this.mapResourceToDisposeListener.get(resource);
 		if (disposeListener) {
@@ -300,59 +355,59 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 			this.mapResourceToDisposeListener.delete(resource);
 		}
 
-		const fileWorkingCopyListener = this.mapResourceToFileWorkingCopyListeners.get(resource);
-		if (fileWorkingCopyListener) {
-			dispose(fileWorkingCopyListener);
-			this.mapResourceToFileWorkingCopyListeners.delete(resource);
+		const workingCopyListener = this.mapResourceToWorkingCopyListeners.get(resource);
+		if (workingCopyListener) {
+			dispose(workingCopyListener);
+			this.mapResourceToWorkingCopyListeners.delete(resource);
 		}
 	}
 
 	clear(): void {
 
-		// file working copy caches
-		this.mapResourceToFileWorkingCopy.clear();
-		this.mapResourceToPendingFileWorkingCopyLoaders.clear();
+		// working copy caches
+		this.mapResourceToWorkingCopy.clear();
+		this.mapResourceToPendingWorkingCopyResolve.clear();
 
 		// dispose the dispose listeners
 		this.mapResourceToDisposeListener.forEach(listener => listener.dispose());
 		this.mapResourceToDisposeListener.clear();
 
-		// dispose the file working copy change listeners
-		this.mapResourceToFileWorkingCopyListeners.forEach(listener => listener.dispose());
-		this.mapResourceToFileWorkingCopyListeners.clear();
+		// dispose the working copy change listeners
+		this.mapResourceToWorkingCopyListeners.forEach(listener => listener.dispose());
+		this.mapResourceToWorkingCopyListeners.clear();
 	}
 
-	canDispose(fileWorkingCopy: IFileWorkingCopy<T>): true | Promise<true> {
+	canDispose(workingCopy: IFileWorkingCopy<T>): true | Promise<true> {
 
-		// quick return if file working copy already disposed or not dirty and not loading
+		// quick return if working copy already disposed or not dirty and not resolving
 		if (
-			fileWorkingCopy.isDisposed() ||
-			(!this.mapResourceToPendingFileWorkingCopyLoaders.has(fileWorkingCopy.resource) && !fileWorkingCopy.isDirty())
+			workingCopy.isDisposed() ||
+			(!this.mapResourceToPendingWorkingCopyResolve.has(workingCopy.resource) && !workingCopy.isDirty())
 		) {
 			return true;
 		}
 
 		// promise based return in all other cases
-		return this.doCanDispose(fileWorkingCopy);
+		return this.doCanDispose(workingCopy);
 	}
 
-	private async doCanDispose(fileWorkingCopy: IFileWorkingCopy<T>): Promise<true> {
+	private async doCanDispose(workingCopy: IFileWorkingCopy<T>): Promise<true> {
 
-		// if we have a pending file working copy load, await it first and then try again
-		const pendingResolve = this.joinPendingResolve(fileWorkingCopy.resource);
+		// if we have a pending working copy resolve, await it first and then try again
+		const pendingResolve = this.joinPendingResolve(workingCopy.resource);
 		if (pendingResolve) {
 			await pendingResolve;
 
-			return this.canDispose(fileWorkingCopy);
+			return this.canDispose(workingCopy);
 		}
 
-		// dirty file working copy: we do not allow to dispose dirty file working copys
-		// to prevent data loss cases. dirty file working copys can only be disposed when
+		// dirty working copy: we do not allow to dispose dirty working copys
+		// to prevent data loss cases. dirty working copys can only be disposed when
 		// they are either saved or reverted
-		if (fileWorkingCopy.isDirty()) {
-			await Event.toPromise(fileWorkingCopy.onDidChangeDirty);
+		if (workingCopy.isDirty()) {
+			await Event.toPromise(workingCopy.onDidChangeDirty);
 
-			return this.canDispose(fileWorkingCopy);
+			return this.canDispose(workingCopy);
 		}
 
 		return true;


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/117873

Usage pseudo code:

```ts
class NotebookModel implements IFileWorkingCopyModel {
	/* Implementation */
}

class NotebookModelFactory implements IFileWorkingCopyModelFactory<NotebookModel> {

	async createModel(resource: URI, contents: VSBufferReadableStream, token: CancellationToken): Promise<NotebookModel> {
		return new NotebookModel(resource, contents, token);
	}
}

// Should be a singleton!
const notebookWorkingCopyManager = instantiationService.createInstance(FileWorkingCopyManager, new NotebookModelFactory());

// the working copy will be registered to the working copy service automatically
const workingCopy = notebookWorkingCopyManager.resolve(resource);
const model = workingCopy.model;
```

The only requirement for a file working copy is that the `resource` has an associated file system provider to work. I still did not relax the requirement that you can only have 1 working copy per resource because that needs more thinking: what does it mean if backups are created for the same resource from different working copies, I wonder if that causes more trouble than helps.

//cc @jrieken 