### PR TITLE
Add support for `"log": "<level>"` to the argv.json

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -163,7 +163,7 @@ function configureCommandlineSwitchesSync(cliArgs) {
 		'enable-browser-code-loading',
 
 		// Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'.
-		'log',
+		'log-level',
 	];
 
 	// Read argv config
@@ -209,7 +209,7 @@ function configureCommandlineSwitchesSync(cliArgs) {
 					}
 					break;
 
-				case 'log':
+				case 'log-level':
 					if (typeof argvValue === 'string') {
 						process.argv.push('--log', argvValue);
 					}

--- a/src/main.js
+++ b/src/main.js
@@ -160,7 +160,10 @@ function configureCommandlineSwitchesSync(cliArgs) {
 
 		// TODO@sandbox remove me once testing is done on `vscode-file` protocol
 		// (all traces of `enable-browser-code-loading` and `ENABLE_VSCODE_BROWSER_CODE_LOADING`)
-		'enable-browser-code-loading'
+		'enable-browser-code-loading',
+
+		// Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'.
+		'log',
 	];
 
 	// Read argv config
@@ -203,6 +206,12 @@ function configureCommandlineSwitchesSync(cliArgs) {
 				case 'enable-browser-code-loading':
 					if (typeof argvValue === 'string') {
 						process.env['ENABLE_VSCODE_BROWSER_CODE_LOADING'] = argvValue;
+					}
+					break;
+
+				case 'log':
+					if (typeof argvValue === 'string') {
+						process.argv.push('--log', argvValue);
 					}
 					break;
 			}

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -361,6 +361,10 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 				items: {
 					type: 'string'
 				}
+			},
+			'log': {
+				type: 'string',
+				description: localize('argv.log', "Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'.")
 			}
 		}
 	};

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -362,9 +362,9 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 					type: 'string'
 				}
 			},
-			'log': {
+			'log-level': {
 				type: 'string',
-				description: localize('argv.log', "Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'.")
+				description: localize('argv.logLevel', "Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'.")
 			}
 		}
 	};


### PR DESCRIPTION
Fixes #118824

Realized this is easy to implement and went ahead since this will improve serviceability of env (e.g., PATH) issues on Mac when starting from the dock.