### PR TITLE
fix #119261 filter also by description in Insert Snippet

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -205,7 +205,7 @@ class InsertSnippetAction extends EditorAction {
 
 		const picker = quickInputService.createQuickPick<ISnippetPick>();
 		picker.placeholder = nls.localize('pick.placeholder', "Select a snippet");
-		picker.matchOnDescription = true;
+		picker.matchOnDetail = true;
 		picker.ignoreFocusOut = false;
 		picker.onDidTriggerItemButton(ctx => {
 			const isEnabled = snippetService.isEnabled(ctx.item.snippet);


### PR DESCRIPTION
This PR fixes #119261

To test, run the `Insert Snippet` command and enter some text that you see in the secondary lines below entries. Confirm that the quickpick filtering now works on those lines.
