### PR TITLE
Language detection

### DIFF
--- a/src/vs/workbench/services/languageDetection/common/languageDetection.ts
+++ b/src/vs/workbench/services/languageDetection/common/languageDetection.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface ILanguageDetectionService {
+	readonly _serviceBrand: undefined;
+
+	detectLanguage(contet: string): Promise<string | undefined>;
+}

--- a/src/vs/workbench/services/languageDetection/node/languageDetectionService.ts
+++ b/src/vs/workbench/services/languageDetection/node/languageDetectionService.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ILanguageDetectionService } from 'vs/workbench/services/languageDetection/common/languageDetection';
+// import * as tf from '@tensorflow/tfjs-node';
+// import { TFSavedModel } from '@tensorflow/tfjs-node/dist/saved_model';
+
+enum ModelLangToLangId {
+	bat = 'bat',
+	cmd = 'bat',
+	btm = 'bat',
+	c = 'c',
+	cs = 'csharp',
+	cpp = 'cpp',
+	cc = 'cpp',
+	coffee = 'coffeescript',
+	litcoffee = 'coffeescript',
+	css = 'css',
+	erl = 'erlang',
+	hrl = 'erlang',
+	go = 'go',
+	hs = 'haskell',
+	lhs = 'haskell',
+	html = 'html',
+	java = 'java',
+	js = 'javascript',
+	es6 = 'javascript',
+	ipynb = 'jupyter',
+	lua = 'lua',
+	md = 'markdown',
+	matlab = 'matlab',
+	m = 'objective-c',
+	mm = 'objective-c',
+	pl = 'perl',
+	pm = 'perl',
+	php = 'php',
+	ps1 = 'powershell',
+	py = 'python',
+	r = 'r',
+	rdata = 'r',
+	rds = 'r',
+	rda = 'r',
+	rb = 'ruby',
+	rs = 'rust',
+	scala = 'scala',
+	sh = 'shellscript',
+	sql = 'sql',
+	swift = 'swift',
+	tex = 'tex',
+	ts = 'typescript',
+	tsx = 'typescriptreact'
+}
+
+class LanguageDetectionService implements ILanguageDetectionService {
+	declare readonly _serviceBrand: undefined;
+	private _model: TFSavedModel | undefined;
+
+	constructor() { }
+
+	async detectLanguage(content: string): Promise<string | undefined> {
+		const prediction = await this.predict(content);
+		return prediction.confidence > 0.8 ? prediction.languageId : undefined;
+	}
+
+	private async getModel(): TFSavedModel {
+		if (this._model) {
+			this._model = await tf.node.loadSavedModel('model', ['serve'], 'serving_default');
+		}
+
+		return this._model;
+	}
+
+	private async predict(content: string): Promise<{ languageId: ModelLangToLangId; confidence: number }> {
+		// call out to the model
+		const model = await this.getModel();
+		const predicted = model.predict(tf.tensor([content]));
+
+		const langs: Array<keyof typeof ModelLangToLangId> = (predicted as tf.Tensor<tf.Rank>[])[0].dataSync() as any;
+		const probabilities = (predicted as tf.Tensor<tf.Rank>[])[1].dataSync() as Float32Array;
+
+		let maxIndex = 0;
+		for (let i = 0; i < probabilities.length; i++) {
+			if (probabilities[i] > probabilities[maxIndex]) {
+				maxIndex = i;
+			}
+		}
+
+		return {
+			languageId: ModelLangToLangId[langs[maxIndex]],
+			confidence: probabilities[maxIndex]
+		};
+	}
+}
+


### PR DESCRIPTION
Creating this PR just as a sketch. After some discussions with team mates from Zurich here are some thoughts:
* It defeats the purpose to have this functionality in an extension, since nobody will discover the extension and this functionality should help new users. 
 
Here's the things which I think we need to do in order to have this in the core:

- [ ] We need to convert the model to the `tensorflow-js` model and not have a `node` dependency. We need to do this so we can run in the browser. Without this, even for VS Code desktop we would have to run the classification in the shared process, since we are moving towards node free renderers, and putting additional work in the shared process is not good.
- [ ] We should look into reducing the size of the model so we do not increase the install size too much. @TylerLeonhardt I think you already started looking into this
- [ ] I believe this work is best suited for a new service in VS Code, for example `ILanguageDetectionService`, I created a skeleton for this and I can look into this further to have it integrated on the vscode side @isidorn
- [ ] Figure out how often to call the service (after `n` characters) and what is the `confidence` we should use
- [ ] We need to measure time performance for loading the model and classification
- [ ] We need to measure memory footprint of model loading

---

If we get the above working in a good way then we need to:
- [ ] Look into supporting `JSON`, `xml` and other not supported languages
- [ ] Try to improve corner case classification - like `JS`/`TS` confusion

---

If all of this proves to be too much overhead we can look into some simpler heuristic to detect a language and not use machine learning.

@TylerLeonhardt let me know what you think, and feel free to add your name to some of the items you are interested in and also feel free to add items I might have forgot.

fixes https://github.com/microsoft/vscode/issues/118455