### PR TITLE
Enable setTextDocumentLanguage

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.test.ts
@@ -1025,6 +1025,27 @@ suite('Notebook API tests', function () {
 		await saveFileAndCloseAll(resource);
 	});
 
+	test('change cell language when notebook editor is not open', async function () {
+		const resource = await createRandomFile('', undefined, '.vsctestnb');
+		await vscode.commands.executeCommand('vscode.openWith', resource, 'notebookCoreTest');
+		const firstCell = vscode.window.activeNotebookEditor!.document.cellAt(0);
+		const cellUri = firstCell.document.uri;
+		await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+
+		let cellDoc = await vscode.workspace.openTextDocument(cellUri);
+		cellDoc = await vscode.languages.setTextDocumentLanguage(cellDoc, 'css');
+		assert.strictEqual(cellDoc.languageId, 'css');
+	});
+
+	test('change cell language when notebook editor is open', async function () {
+		const resource = await createRandomFile('', undefined, '.vsctestnb');
+		await vscode.commands.executeCommand('vscode.openWith', resource, 'notebookCoreTest');
+
+		const firstCell = vscode.window.activeNotebookEditor!.document.cellAt(0);
+		const cellDoc = await vscode.languages.setTextDocumentLanguage(firstCell.document, 'css');
+		assert.strictEqual(cellDoc.languageId, 'css');
+	});
+
 	test('multiple tabs: dirty + clean', async function () {
 		const resource = await createRandomFile('', undefined, '.vsctestnb');
 		await vscode.commands.executeCommand('vscode.openWith', resource, 'notebookCoreTest');

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/codeCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/codeCell.ts
@@ -8,7 +8,6 @@ import { raceCancellation } from 'vs/base/common/async';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import { IDimension } from 'vs/editor/common/editorCommon';
-import { IModeService } from 'vs/editor/common/services/modeService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { EDITOR_BOTTOM_PADDING } from 'vs/workbench/contrib/notebook/browser/constants';
 import { CellFocusMode, CodeCellRenderTemplate, getEditorTopPadding, IActiveNotebookEditor } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
@@ -33,8 +32,7 @@ export class CodeCell extends Disposable {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@INotebookCellStatusBarService readonly notebookCellStatusBarService: INotebookCellStatusBarService,
 		@IOpenerService readonly openerService: IOpenerService,
-		@ITextFileService readonly textFileService: ITextFileService,
-		@IModeService private readonly _modeService: IModeService,
+		@ITextFileService readonly textFileService: ITextFileService
 		// @IKeybindingService private readonly _keybindingService: IKeybindingService,
 
 	) {
@@ -105,13 +103,6 @@ export class CodeCell extends Disposable {
 				this.viewCell.layoutChange({});
 				updateForCollapseState();
 				this.relayoutCell();
-			}
-		}));
-
-		this._register(viewCell.onDidChangeState((e) => {
-			if (e.languageChanged) {
-				const mode = this._modeService.create(viewCell.language);
-				templateData.editor?.getModel()?.setMode(mode.languageIdentifier);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from 'vs/base/common/event';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable, IReference } from 'vs/base/common/lifecycle';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
@@ -17,6 +17,7 @@ import { CellEditState, CellFocusMode, CursorAtBoundary, CellViewModelStateChang
 import { CellKind, NotebookCellMetadata, NotebookDocumentMetadata, INotebookSearchOptions, ShowCellStatusBarKey } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellTextModel';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IResolvedTextEditorModel } from 'vs/editor/common/services/resolverService';
 
 export abstract class BaseCellViewModel extends Disposable {
 
@@ -102,6 +103,8 @@ export abstract class BaseCellViewModel extends Disposable {
 	set dragging(v: boolean) {
 		this._dragging = v;
 	}
+
+	protected _textModelRef: IReference<IResolvedTextEditorModel> | undefined;
 
 	constructor(
 		readonly viewType: string,
@@ -193,6 +196,11 @@ export abstract class BaseCellViewModel extends Disposable {
 		this._cursorChangeListener?.dispose();
 		this._cursorChangeListener = null;
 		this._onDidChangeEditorAttachState.fire();
+
+		if (this._textModelRef) {
+			this._textModelRef.dispose();
+			this._textModelRef = undefined;
+		}
 	}
 
 	getText(): string {
@@ -457,6 +465,10 @@ export abstract class BaseCellViewModel extends Disposable {
 
 	dispose() {
 		super.dispose();
+
+		if (this._textModelRef) {
+			this._textModelRef.dispose();
+		}
 	}
 
 	toJSON(): object {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from 'vs/base/common/event';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
@@ -17,6 +17,7 @@ import { CellEditState, CellFocusMode, CursorAtBoundary, CellViewModelStateChang
 import { CellKind, NotebookCellMetadata, NotebookDocumentMetadata, INotebookSearchOptions, ShowCellStatusBarKey } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellTextModel';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IModeService } from 'vs/editor/common/services/modeService';
 
 export abstract class BaseCellViewModel extends Disposable {
 
@@ -86,13 +87,30 @@ export abstract class BaseCellViewModel extends Disposable {
 	}>();
 	private _lastDecorationId: number = 0;
 
+	private _textModelDisposables = new DisposableStore();
 	private _textModel: model.ITextModel | undefined = undefined;
 	get textModel(): model.ITextModel | undefined {
 		return this._textModel;
 	}
 
 	set textModel(m: model.ITextModel | undefined) {
+		this._textModelDisposables.clear();
 		this._textModel = m;
+		if (this._textModel) {
+			// Init language from text model
+			const originalLanguage = this.model.language;
+			this.model.language = this._textModel.getLanguageIdentifier().language;
+			if (this.model.language !== originalLanguage) {
+				this._onDidChangeState.fire({ languageChanged: true });
+			}
+
+			// Listen to language changes on the model
+			this._textModelDisposables.add(this._textModel.onDidChangeLanguage(e => {
+				this.model.language = e.newLanguage;
+				this._onDidChangeState.fire({ languageChanged: true });
+			}));
+			this._textModelDisposables.add(this._textModel.onWillDispose(() => this.textModel = undefined));
+		}
 	}
 
 	hasModel(): this is IEditableCellViewModel {
@@ -112,12 +130,16 @@ export abstract class BaseCellViewModel extends Disposable {
 		readonly viewType: string,
 		readonly model: NotebookCellTextModel,
 		public id: string,
-		private readonly _configurationService: IConfigurationService
+		private readonly _configurationService: IConfigurationService,
+		modeService: IModeService
 	) {
 		super();
 
 		this._register(model.onDidChangeLanguage(() => {
-			this._onDidChangeState.fire({ languageChanged: true });
+			if (this.textModel) {
+				const mode = modeService.create(model.language);
+				this.textModel.setMode(mode.languageIdentifier);
+			}
 		}));
 
 		this._register(model.onDidChangeMetadata(e => {
@@ -164,7 +186,6 @@ export abstract class BaseCellViewModel extends Disposable {
 		}
 
 		this._textEditor = editor;
-		this.textModel = this._textEditor.getModel() || undefined;
 
 		if (this._editorViewStates) {
 			this._restoreViewState(this._editorViewStates);

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
@@ -23,7 +23,6 @@ export class CodeCellViewModel extends BaseCellViewModel implements ICellViewMod
 	protected readonly _onDidChangeOutputs = new Emitter<NotebookCellOutputsSplice[]>();
 	readonly onDidChangeOutputs = this._onDidChangeOutputs.event;
 	private _outputCollection: number[] = [];
-	private _hasTextModelRef = false;
 
 	private _outputsTop: PrefixSumComputer | null = null;
 
@@ -261,10 +260,8 @@ export class CodeCellViewModel extends BaseCellViewModel implements ICellViewMod
 	 * Text model is used for editing.
 	 */
 	async resolveTextModel(): Promise<model.ITextModel> {
-		if (!this._hasTextModelRef || !this.textModel) {
-			this._hasTextModelRef = true;
-			const ref = await this.model.resolveTextModelRef();
-			this._register(ref);
+		if (!this._textModelRef || !this.textModel) {
+			this._textModelRef = await this.model.resolveTextModelRef();
 			this._register(this.textModel!.onDidChangeContent(() => {
 				if (this.editState !== CellEditState.Editing) {
 					this.editState = CellEditState.Editing;

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
@@ -7,6 +7,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import * as UUID from 'vs/base/common/uuid';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import * as model from 'vs/editor/common/model';
+import { IModeService } from 'vs/editor/common/services/modeService';
 import { PrefixSumComputer } from 'vs/editor/common/viewModel/prefixSumComputer';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { BOTTOM_CELL_TOOLBAR_GAP, BOTTOM_CELL_TOOLBAR_HEIGHT, CELL_BOTTOM_MARGIN, CELL_MARGIN, CELL_RUN_GUTTER, CELL_TOP_MARGIN, CODE_CELL_LEFT_MARGIN, COLLAPSED_INDICATOR_HEIGHT, EDITOR_BOTTOM_PADDING, EDITOR_TOOLBAR_HEIGHT } from 'vs/workbench/contrib/notebook/browser/constants';
@@ -92,9 +93,10 @@ export class CodeCellViewModel extends BaseCellViewModel implements ICellViewMod
 		initialNotebookLayoutInfo: NotebookLayoutInfo | null,
 		readonly eventDispatcher: NotebookEventDispatcher,
 		@IConfigurationService configurationService: IConfigurationService,
-		@INotebookService private _notebookService: INotebookService
+		@INotebookService private _notebookService: INotebookService,
+		@IModeService modeService: IModeService,
 	) {
-		super(viewType, model, UUID.generateUuid(), configurationService);
+		super(viewType, model, UUID.generateUuid(), configurationService, modeService);
 		this._outputViewModels = this.model.outputs.map(output => new CellOutputViewModel(this, output, this._notebookService));
 
 		this._register(this.model.onDidChangeOutputs((splices) => {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel.ts
@@ -17,6 +17,7 @@ import { BaseCellViewModel } from 'vs/workbench/contrib/notebook/browser/viewMod
 import { NotebookCellStateChangedEvent, NotebookEventDispatcher } from 'vs/workbench/contrib/notebook/browser/viewModel/eventDispatcher';
 import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellTextModel';
 import { CellKind, INotebookSearchOptions } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { IModeService } from 'vs/editor/common/services/modeService';
 
 export class MarkdownCellViewModel extends BaseCellViewModel implements ICellViewModel {
 	readonly cellKind = CellKind.Markdown;
@@ -103,9 +104,10 @@ export class MarkdownCellViewModel extends BaseCellViewModel implements ICellVie
 		readonly foldingDelegate: EditorFoldingStateDelegate,
 		readonly eventDispatcher: NotebookEventDispatcher,
 		private readonly _mdRenderer: MarkdownRenderer,
-		@IConfigurationService configurationService: IConfigurationService
+		@IConfigurationService configurationService: IConfigurationService,
+		@IModeService modeService: IModeService,
 	) {
-		super(viewType, model, UUID.generateUuid(), configurationService);
+		super(viewType, model, UUID.generateUuid(), configurationService, modeService);
 
 		this._layoutInfo = {
 			editorHeight: 0,

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel.ts
@@ -22,7 +22,6 @@ export class MarkdownCellViewModel extends BaseCellViewModel implements ICellVie
 	readonly cellKind = CellKind.Markdown;
 	private _html: HTMLElement | null = null;
 	private _layoutInfo: MarkdownCellLayoutInfo;
-	private _hasTextModelRef = false;
 
 	private _version = 0;
 
@@ -226,11 +225,9 @@ export class MarkdownCellViewModel extends BaseCellViewModel implements ICellVie
 	}
 
 	async resolveTextModel(): Promise<model.ITextModel> {
-		if (!this._hasTextModelRef || !this.textModel) {
-			this._hasTextModelRef = true;
-			const ref = await this.model.resolveTextModelRef();
+		if (!!this.textModel) {
+			this._textModelRef = await this.model.resolveTextModelRef();
 			this._version = this.textModel!.getVersionId();
-			this._register(ref);
 			this._register(this.textModel!.onDidChangeContent(() => {
 				this._html = null;
 				if (this.textModel) {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel.ts
@@ -225,7 +225,7 @@ export class MarkdownCellViewModel extends BaseCellViewModel implements ICellVie
 	}
 
 	async resolveTextModel(): Promise<model.ITextModel> {
-		if (!!this.textModel) {
+		if (!this._textModelRef || !this.textModel) {
 			this._textModelRef = await this.model.resolveTextModelRef();
 			this._version = this.textModel!.getVersionId();
 			this._register(this.textModel!.onDidChangeContent(() => {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel.ts
@@ -17,12 +17,12 @@ import { BaseCellViewModel } from 'vs/workbench/contrib/notebook/browser/viewMod
 import { NotebookCellStateChangedEvent, NotebookEventDispatcher } from 'vs/workbench/contrib/notebook/browser/viewModel/eventDispatcher';
 import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellTextModel';
 import { CellKind, INotebookSearchOptions } from 'vs/workbench/contrib/notebook/common/notebookCommon';
-import { IModeService } from 'vs/editor/common/services/modeService';
 
 export class MarkdownCellViewModel extends BaseCellViewModel implements ICellViewModel {
 	readonly cellKind = CellKind.Markdown;
 	private _html: HTMLElement | null = null;
 	private _layoutInfo: MarkdownCellLayoutInfo;
+	private _hasTextModelRef = false;
 
 	private _version = 0;
 
@@ -105,9 +105,8 @@ export class MarkdownCellViewModel extends BaseCellViewModel implements ICellVie
 		readonly eventDispatcher: NotebookEventDispatcher,
 		private readonly _mdRenderer: MarkdownRenderer,
 		@IConfigurationService configurationService: IConfigurationService,
-		@IModeService modeService: IModeService,
 	) {
-		super(viewType, model, UUID.generateUuid(), configurationService, modeService);
+		super(viewType, model, UUID.generateUuid(), configurationService);
 
 		this._layoutInfo = {
 			editorHeight: 0,
@@ -227,13 +226,12 @@ export class MarkdownCellViewModel extends BaseCellViewModel implements ICellVie
 	}
 
 	async resolveTextModel(): Promise<model.ITextModel> {
-		if (!this.textModel) {
+		if (!this._hasTextModelRef || !this.textModel) {
+			this._hasTextModelRef = true;
 			const ref = await this.model.resolveTextModelRef();
-			this.textModel = ref.object.textEditorModel;
-			this._version = this.textModel.getVersionId();
-
+			this._version = this.textModel!.getVersionId();
 			this._register(ref);
-			this._register(this.textModel.onDidChangeContent(() => {
+			this._register(this.textModel!.onDidChangeContent(() => {
 				this._html = null;
 				if (this.textModel) {
 					this._version = this.textModel.getVersionId();
@@ -241,7 +239,7 @@ export class MarkdownCellViewModel extends BaseCellViewModel implements ICellVie
 				this._onDidChangeState.fire({ contentChanged: true });
 			}));
 		}
-		return this.textModel;
+		return this.textModel!;
 	}
 
 	onDeselect() {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModel.ts
@@ -24,15 +24,17 @@ import { NotebookEventDispatcher, NotebookMetadataChangedEvent } from 'vs/workbe
 import { CellFoldingState, EditorFoldingStateDelegate } from 'vs/workbench/contrib/notebook/browser/contrib/fold/foldingModel';
 import { MarkdownCellViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel';
 import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellTextModel';
-import { CellKind, NotebookCellMetadata, INotebookSearchOptions, ICellRange, NotebookCellsChangeType, ICell, NotebookCellTextModelSplice, CellEditType, IOutputDto, SelectionStateType, ISelectionState, cellIndexesToRanges, cellRangesToIndexes, reduceRanges } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { CellKind, NotebookCellMetadata, INotebookSearchOptions, ICellRange, NotebookCellsChangeType, ICell, NotebookCellTextModelSplice, CellEditType, IOutputDto, SelectionStateType, ISelectionState, cellIndexesToRanges, cellRangesToIndexes, reduceRanges, CellUri } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { FoldingRegions } from 'vs/editor/contrib/folding/foldingRanges';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { MarkdownRenderer } from 'vs/editor/browser/core/markdownRenderer';
-import { dirname } from 'vs/base/common/resources';
+import { dirname, isEqual } from 'vs/base/common/resources';
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { MultiModelEditStackElement, SingleModelEditStackElement } from 'vs/editor/common/model/editStack';
 import { ResourceNotebookCellEdit } from 'vs/workbench/contrib/bulkEdit/browser/bulkCellEdits';
 import { NotebookCellSelectionCollection } from 'vs/workbench/contrib/notebook/browser/viewModel/cellSelectionCollection';
+import { IModelService } from 'vs/editor/common/services/modelService';
+import { Schemas } from 'vs/base/common/network';
 
 export interface INotebookEditorViewState {
 	editingCells: { [key: number]: boolean };
@@ -228,13 +230,26 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 		private _layoutInfo: NotebookLayoutInfo | null,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IBulkEditService private readonly _bulkEditService: IBulkEditService,
-		@IUndoRedoService private readonly _undoService: IUndoRedoService
+		@IUndoRedoService private readonly _undoService: IUndoRedoService,
+		@IModelService modelService: IModelService,
 	) {
 		super();
 
 		MODEL_ID++;
 		this.id = '$notebookViewModel' + MODEL_ID;
 		this._instanceId = strings.singleLetterHash(MODEL_ID);
+
+		this._register(modelService.onModelAdded(e => {
+			if (e.uri.scheme === Schemas.vscodeNotebookCell) {
+				const cellUri = CellUri.parse(e.uri);
+				if (cellUri && isEqual(cellUri.notebook, this.uri)) {
+					const cell = this.getCellByHandle(cellUri.handle);
+					if (cell) {
+						cell.textModel = e;
+					}
+				}
+			}
+		}));
 
 		const compute = (changes: NotebookCellTextModelSplice<ICell>[], synchronous: boolean) => {
 			const diffs = changes.map(splice => {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModel.ts
@@ -24,17 +24,16 @@ import { NotebookEventDispatcher, NotebookMetadataChangedEvent } from 'vs/workbe
 import { CellFoldingState, EditorFoldingStateDelegate } from 'vs/workbench/contrib/notebook/browser/contrib/fold/foldingModel';
 import { MarkdownCellViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel';
 import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellTextModel';
-import { CellKind, NotebookCellMetadata, INotebookSearchOptions, ICellRange, NotebookCellsChangeType, ICell, NotebookCellTextModelSplice, CellEditType, IOutputDto, SelectionStateType, ISelectionState, cellIndexesToRanges, cellRangesToIndexes, reduceRanges, CellUri } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { CellKind, NotebookCellMetadata, INotebookSearchOptions, ICellRange, NotebookCellsChangeType, ICell, NotebookCellTextModelSplice, CellEditType, IOutputDto, SelectionStateType, ISelectionState, cellIndexesToRanges, cellRangesToIndexes, reduceRanges } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { FoldingRegions } from 'vs/editor/contrib/folding/foldingRanges';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { MarkdownRenderer } from 'vs/editor/browser/core/markdownRenderer';
-import { dirname, isEqual } from 'vs/base/common/resources';
+import { dirname } from 'vs/base/common/resources';
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { MultiModelEditStackElement, SingleModelEditStackElement } from 'vs/editor/common/model/editStack';
 import { ResourceNotebookCellEdit } from 'vs/workbench/contrib/bulkEdit/browser/bulkCellEdits';
 import { NotebookCellSelectionCollection } from 'vs/workbench/contrib/notebook/browser/viewModel/cellSelectionCollection';
 import { IModelService } from 'vs/editor/common/services/modelService';
-import { Schemas } from 'vs/base/common/network';
 
 export interface INotebookEditorViewState {
 	editingCells: { [key: number]: boolean };
@@ -239,17 +238,7 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 		this.id = '$notebookViewModel' + MODEL_ID;
 		this._instanceId = strings.singleLetterHash(MODEL_ID);
 
-		this._register(modelService.onModelAdded(e => {
-			if (e.uri.scheme === Schemas.vscodeNotebookCell) {
-				const cellUri = CellUri.parse(e.uri);
-				if (cellUri && isEqual(cellUri.notebook, this.uri)) {
-					const cell = this.getCellByHandle(cellUri.handle);
-					if (cell) {
-						cell.textModel = e;
-					}
-				}
-			}
-		}));
+
 
 		const compute = (changes: NotebookCellTextModelSplice<ICell>[], synchronous: boolean) => {
 			const diffs = changes.map(splice => {

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -14,6 +14,9 @@ import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { ISequence, LcsDiff } from 'vs/base/common/diff/diff';
 import { hash } from 'vs/base/common/hash';
 import { NotebookCellOutputTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellOutputTextModel';
+import { IModelService } from 'vs/editor/common/services/modelService';
+import { Schemas } from 'vs/base/common/network';
+import { isEqual } from 'vs/base/common/resources';
 
 
 class StackOperation implements IWorkspaceUndoRedoElement {
@@ -222,12 +225,28 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		metadata: NotebookDocumentMetadata,
 		options: TransientOptions,
 		@IUndoRedoService private _undoService: IUndoRedoService,
-		@ITextModelService private _modelService: ITextModelService,
+		@ITextModelService private _textModelService: ITextModelService,
+		@IModelService _modelService: IModelService,
 	) {
 		super();
 		this.transientOptions = options;
 		this.metadata = metadata;
 		this._initialize(cells);
+
+		this._register(_modelService.onModelAdded(e => {
+			if (e.uri.scheme === Schemas.vscodeNotebookCell) {
+				const cellUri = CellUri.parse(e.uri);
+				if (cellUri && isEqual(cellUri.notebook, this.uri)) {
+					const cellIdx = this._getCellIndexByHandle(cellUri.handle);
+					if (cellIdx >= 0) {
+						const cell = this.cells[cellIdx];
+						if (cell) {
+							cell.textModel = e;
+						}
+					}
+				}
+			}
+		}));
 
 		this._eventEmitter = new DelayedEmitter(
 			this._onDidChangeContent,
@@ -252,7 +271,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		const mainCells = cells.map(cell => {
 			const cellHandle = this._cellhandlePool++;
 			const cellUri = CellUri.generate(this.uri, cellHandle);
-			return new NotebookCellTextModel(cellUri, cellHandle, cell.source, cell.language, cell.cellKind, cell.outputs || [], cell.metadata, this.transientOptions, this._modelService);
+			return new NotebookCellTextModel(cellUri, cellHandle, cell.source, cell.language, cell.cellKind, cell.outputs || [], cell.metadata, this.transientOptions, this._textModelService);
 		});
 
 		for (let i = 0; i < mainCells.length; i++) {
@@ -412,7 +431,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 			const cell = new NotebookCellTextModel(
 				cellUri, cellHandle,
 				cellDto.source, cellDto.language, cellDto.cellKind, cellDto.outputs || [], cellDto.metadata, this.transientOptions,
-				this._modelService
+				this._textModelService
 			);
 			const dirtyStateListener = cell.onDidChangeContent(() => {
 				this._increaseVersionId();

--- a/src/vs/workbench/contrib/notebook/test/notebookViewModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/notebookViewModel.test.ts
@@ -5,16 +5,21 @@
 
 import * as assert from 'assert';
 import { URI } from 'vs/base/common/uri';
-import { NotebookViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/notebookViewModel';
-import { CellKind, NotebookCellMetadata, diff, ICellRange, notebookDocumentMetadataDefaults } from 'vs/workbench/contrib/notebook/common/notebookCommon';
-import { withTestNotebook, NotebookEditorTestModel, setupInstantiationService } from 'vs/workbench/contrib/notebook/test/testNotebookEditor';
 import { IBulkEditService } from 'vs/editor/browser/services/bulkEditService';
-import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
-import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
-import { NotebookEventDispatcher } from 'vs/workbench/contrib/notebook/browser/viewModel/eventDispatcher';
 import { TrackedRangeStickiness } from 'vs/editor/common/model';
-import { reduceCellRanges } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { ModelServiceImpl } from 'vs/editor/common/services/modelServiceImpl';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
+import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
+import { reduceCellRanges } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { NotebookEventDispatcher } from 'vs/workbench/contrib/notebook/browser/viewModel/eventDispatcher';
+import { NotebookViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/notebookViewModel';
+import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
+import { CellKind, diff, ICellRange, NotebookCellMetadata, notebookDocumentMetadataDefaults } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { NotebookEditorTestModel, setupInstantiationService, withTestNotebook } from 'vs/workbench/contrib/notebook/test/testNotebookEditor';
 
 suite('NotebookViewModel', () => {
 	const instantiationService = setupInstantiationService();
@@ -22,11 +27,15 @@ suite('NotebookViewModel', () => {
 	const bulkEditService = instantiationService.get(IBulkEditService);
 	const undoRedoService = instantiationService.get(IUndoRedoService);
 
+	instantiationService.stub(IConfigurationService, new TestConfigurationService());
+	instantiationService.stub(IThemeService, new TestThemeService());
+	const modelService = instantiationService.createInstance(ModelServiceImpl);
+
 	test('ctor', function () {
 		const notebook = new NotebookTextModel('notebook', URI.parse('test'), [], notebookDocumentMetadataDefaults, { transientMetadata: {}, transientOutputs: false }, undoRedoService, textModelService);
 		const model = new NotebookEditorTestModel(notebook);
 		const eventDispatcher = new NotebookEventDispatcher();
-		const viewModel = new NotebookViewModel('notebook', model.notebook, eventDispatcher, null, instantiationService, bulkEditService, undoRedoService);
+		const viewModel = new NotebookViewModel('notebook', model.notebook, eventDispatcher, null, instantiationService, bulkEditService, undoRedoService, modelService);
 		assert.strictEqual(viewModel.viewType, 'notebook');
 	});
 

--- a/src/vs/workbench/contrib/notebook/test/notebookViewModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/notebookViewModel.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import { URI } from 'vs/base/common/uri';
 import { IBulkEditService } from 'vs/editor/browser/services/bulkEditService';
 import { TrackedRangeStickiness } from 'vs/editor/common/model';
-import { ModelServiceImpl } from 'vs/editor/common/services/modelServiceImpl';
+import { IModelService } from 'vs/editor/common/services/modelService';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
@@ -26,13 +26,13 @@ suite('NotebookViewModel', () => {
 	const textModelService = instantiationService.get(ITextModelService);
 	const bulkEditService = instantiationService.get(IBulkEditService);
 	const undoRedoService = instantiationService.get(IUndoRedoService);
+	const modelService = instantiationService.get(IModelService);
 
 	instantiationService.stub(IConfigurationService, new TestConfigurationService());
 	instantiationService.stub(IThemeService, new TestThemeService());
-	const modelService = instantiationService.createInstance(ModelServiceImpl);
 
 	test('ctor', function () {
-		const notebook = new NotebookTextModel('notebook', URI.parse('test'), [], notebookDocumentMetadataDefaults, { transientMetadata: {}, transientOutputs: false }, undoRedoService, textModelService);
+		const notebook = new NotebookTextModel('notebook', URI.parse('test'), [], notebookDocumentMetadataDefaults, { transientMetadata: {}, transientOutputs: false }, undoRedoService, textModelService, modelService);
 		const model = new NotebookEditorTestModel(notebook);
 		const eventDispatcher = new NotebookEventDispatcher();
 		const viewModel = new NotebookViewModel('notebook', model.notebook, eventDispatcher, null, instantiationService, bulkEditService, undoRedoService, modelService);


### PR DESCRIPTION
This PR fixes #117936

When a TextModel is created, we set it on the cell VM which listens to language updates on it until it's disposed. The NotebookCellTextModel can still get a language set on it, and the TextModel will take that language when it's initialized.