### PR TITLE
Add a problem matcher for cuda-cpp based on nvcc output

### DIFF
--- a/extensions/cpp/package.json
+++ b/extensions/cpp/package.json
@@ -73,6 +73,28 @@
         "path": "./syntaxes/platform.tmLanguage.json"
       }
     ],
+    "problemPatterns": [
+      {
+        "name": "nvcc-location",
+        "regexp": "^(.*)\\((\\d+)\\):\\s+(warning|error):\\s+(.*)",
+        "kind": "location",
+        "file": 1,
+        "location": 2,
+        "severity": 3,
+        "message": 4
+      }
+    ],
+    "problemMatchers": [
+        {
+            "name": "nvcc",
+            "owner": "cuda-cpp",
+            "fileLocation": [
+                "relative",
+                "${workspaceFolder}"
+            ],
+            "pattern": "$nvcc-location"
+        }
+    ],
     "snippets": [
       {
         "language": "c",


### PR DESCRIPTION
This change adds a new problem matcher to the cpp extension to parse the output from the nvcc compiler for cuda-cpp.

Related PR: [PR #119285](https://github.com/microsoft/vscode/pull/119287)
