### PR TITLE
Fixes #111814

### DIFF
--- a/src/vs/workbench/services/url/browser/urlService.ts
+++ b/src/vs/workbench/services/url/browser/urlService.ts
@@ -55,7 +55,7 @@ export class BrowserURLService extends AbstractURLService {
 		this.registerListeners();
 
 		const that = this;
-		openerService.registerOpener({
+		this._register(openerService.registerOpener({
 			async open(resource: URI | string) {
 				if (!matchesScheme(resource, productService.urlProtocol)) {
 					return false;
@@ -67,7 +67,7 @@ export class BrowserURLService extends AbstractURLService {
 
 				return that.open(resource);
 			}
-		});
+		}));
 	}
 
 	private registerListeners(): void {

--- a/src/vs/workbench/services/url/browser/urlService.ts
+++ b/src/vs/workbench/services/url/browser/urlService.ts
@@ -9,6 +9,8 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { AbstractURLService } from 'vs/platform/url/common/urlService';
 import { Event } from 'vs/base/common/event';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { IOpenerService, matchesScheme } from 'vs/platform/opener/common/opener';
+import { IProductService } from 'vs/platform/product/common/productService';
 
 export interface IURLCallbackProvider {
 
@@ -43,13 +45,29 @@ export class BrowserURLService extends AbstractURLService {
 	private provider: IURLCallbackProvider | undefined;
 
 	constructor(
-		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService
+		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+		@IOpenerService openerService: IOpenerService,
+		@IProductService productService: IProductService
 	) {
 		super();
 
 		this.provider = environmentService.options?.urlCallbackProvider;
-
 		this.registerListeners();
+
+		const that = this;
+		openerService.registerOpener({
+			async open(resource: URI | string) {
+				if (!matchesScheme(resource, productService.urlProtocol)) {
+					return false;
+				}
+
+				if (typeof resource === 'string') {
+					resource = URI.parse(resource);
+				}
+
+				return that.open(resource);
+			}
+		});
 	}
 
 	private registerListeners(): void {


### PR DESCRIPTION
I believe the problem here was the missing connection between the opener service and the URL service, when the `electron-browser` refactoring came to be. @bpasero

It works fine in `electron-browser`, so I mimic the same flow but for `browser`.

In `electron-browser` there is something strange: the `open` method is repurposed between the two interfaces. This makes the code hard to understand. @bpasero I would suggest to split the two like I did here: the `openerService` `open` method can just be an inline object which does the right forwarding.

Fixes #111814