### PR TITLE
snap-build-linux.yml: use "snap pack" to get LZO

### DIFF
--- a/build/azure-pipelines/linux/snap-build-linux.yml
+++ b/build/azure-pipelines/linux/snap-build-linux.yml
@@ -48,7 +48,7 @@ steps:
         x64) SNAPCRAFT_TARGET_ARGS="" ;;
         *) SNAPCRAFT_TARGET_ARGS="--target-arch $(VSCODE_ARCH)" ;;
       esac
-      (cd $SNAP_ROOT/code-* && sudo --preserve-env snapcraft snap $SNAPCRAFT_TARGET_ARGS --output "$SNAP_PATH")
+      (cd $SNAP_ROOT/code-* && sudo --preserve-env snapcraft prime $SNAPCRAFT_TARGET_ARGS && snap pack prime --compression=lzo --filename="$SNAP_PATH")
 
       # Publish snap package
       AZURE_DOCUMENTDB_MASTERKEY="$(builds-docdb-key-readwrite)" \


### PR DESCRIPTION
Use `snap pack --compression=lzo` instead of letting snapcraft pack the final
snap, as the current snapcraft.yaml is not setup to use any base in it, and as
such is missing the new feature for configuring the compression of the final
snap.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #117852
