### PR TITLE
fix maximum call stack size reached issue

### DIFF
--- a/src/vs/base/browser/ui/tree/indexTreeModel.ts
+++ b/src/vs/base/browser/ui/tree/indexTreeModel.ts
@@ -5,7 +5,7 @@
 
 import { IIdentityProvider } from 'vs/base/browser/ui/list/list';
 import { ICollapseStateChangeEvent, ITreeElement, ITreeFilter, ITreeFilterDataResult, ITreeModel, ITreeNode, TreeVisibility, ITreeModelSpliceEvent, TreeError } from 'vs/base/browser/ui/tree/tree';
-import { tail2 } from 'vs/base/common/arrays';
+import { splice, tail2 } from 'vs/base/common/arrays';
 import { LcsDiff } from 'vs/base/common/diff/diff';
 import { Emitter, Event, EventBufferer } from 'vs/base/common/event';
 import { Iterable } from 'vs/base/common/iterator';
@@ -256,7 +256,7 @@ export class IndexTreeModel<T extends Exclude<any, undefined>, TFilterData = voi
 			}
 		}
 
-		const deletedNodes = parentNode.children.splice(lastIndex, deleteCount, ...nodesToInsert);
+		const deletedNodes = splice(parentNode.children, lastIndex, deleteCount, nodesToInsert);
 
 		// figure out what is the count of deleted visible children
 		let deletedVisibleChildrenCount = 0;

--- a/src/vs/base/test/common/arrays.test.ts
+++ b/src/vs/base/test/common/arrays.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
 import * as arrays from 'vs/base/common/arrays';
-import { test } from 'vscode';
 
 suite('Arrays', () => {
 	test('findFirst', () => {

--- a/src/vs/base/test/common/arrays.test.ts
+++ b/src/vs/base/test/common/arrays.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
 import * as arrays from 'vs/base/common/arrays';
+import { test } from 'vscode';
 
 suite('Arrays', () => {
 	test('findFirst', () => {
@@ -294,5 +295,47 @@ suite('Arrays', () => {
 
 		remove();
 		assert.strictEqual(array.length, 0);
+	});
+
+	test('splice', function () {
+		// negative start index, absolute value greater than the length
+		let array = [1, 2, 3, 4, 5];
+		arrays.splice(array, -6, 3, [6, 7]);
+		assert.strictEqual(array.length, 4);
+		assert.strictEqual(array[0], 6);
+		assert.strictEqual(array[1], 7);
+		assert.strictEqual(array[2], 4);
+		assert.strictEqual(array[3], 5);
+
+		// negative start index, absolute value less than the length
+		array = [1, 2, 3, 4, 5];
+		arrays.splice(array, -3, 3, [6, 7]);
+		assert.strictEqual(array.length, 4);
+		assert.strictEqual(array[0], 1);
+		assert.strictEqual(array[1], 2);
+		assert.strictEqual(array[2], 6);
+		assert.strictEqual(array[3], 7);
+
+		// Start index less than the length
+		array = [1, 2, 3, 4, 5];
+		arrays.splice(array, 3, 3, [6, 7]);
+		assert.strictEqual(array.length, 5);
+		assert.strictEqual(array[0], 1);
+		assert.strictEqual(array[1], 2);
+		assert.strictEqual(array[2], 3);
+		assert.strictEqual(array[3], 6);
+		assert.strictEqual(array[4], 7);
+
+		// Start index greater than the length
+		array = [1, 2, 3, 4, 5];
+		arrays.splice(array, 6, 3, [6, 7]);
+		assert.strictEqual(array.length, 7);
+		assert.strictEqual(array[0], 1);
+		assert.strictEqual(array[1], 2);
+		assert.strictEqual(array[2], 3);
+		assert.strictEqual(array[3], 4);
+		assert.strictEqual(array[4], 5);
+		assert.strictEqual(array[5], 6);
+		assert.strictEqual(array[6], 7);
 	});
 });


### PR DESCRIPTION
noticed this while investigating: https://github.com/microsoft/azuredatastudio/issues/14744

when there are large number of items in the array, using the spread operator might exceed the maximum call stack size as there are too many parameters, the fix is to use alternative safe ways to delete and insert.

while implementing the push/insert methods, I picked the approach of setting array length and then updating the values since it is faster comparing to other in place alternatives, it becomes more obvious as the number of items grow. here are the perf numbers, the test was done on https://jsbench.me/ 

2 array with 1000 items
![image](https://user-images.githubusercontent.com/13777222/112708598-171a1a00-8e70-11eb-9731-aef42c315d97.png)
2 array with 10,000 items
![image](https://user-images.githubusercontent.com/13777222/112708609-29945380-8e70-11eb-9a2f-51c913959dae.png)
2 array with 100,000 items
![image](https://user-images.githubusercontent.com/13777222/112708621-36b14280-8e70-11eb-97b3-726fd5cb6ce3.png)
2 array with 1,000,000 items
![image](https://user-images.githubusercontent.com/13777222/112708631-42046e00-8e70-11eb-9fae-189a62cab98e.png)

