### PR TITLE
debug: fix stop on entry not working after launch.json change

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
@@ -374,10 +374,6 @@ export class ConfigurationManager implements IConfigurationManager {
 		let type = config?.type;
 		if (name && names.indexOf(name) >= 0) {
 			this.setSelectedLaunchName(name);
-			if (!config && name && launch) {
-				config = launch.getConfiguration(name);
-				type = config?.type;
-			}
 		} else if (dynamicConfig && dynamicConfig.type) {
 			// We could not find the previously used name and config is not passed. We should get all dynamic configurations from providers
 			// And potentially auto select the previously used dynamic configuration #96293
@@ -412,6 +408,11 @@ export class ConfigurationManager implements IConfigurationManager {
 			// We could not find the configuration to select, pick the first one, or reset the selection if there is no launch configuration
 			const nameToSet = names.length ? names[0] : undefined;
 			this.setSelectedLaunchName(nameToSet);
+		}
+
+		if (!config && this.selectedName) {
+			config = launch.getConfiguration(this.selectedName);
+			type = config?.type;
 		}
 
 		this.selectedType = dynamicConfig?.type || config?.type;

--- a/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
@@ -410,7 +410,7 @@ export class ConfigurationManager implements IConfigurationManager {
 			this.setSelectedLaunchName(nameToSet);
 		}
 
-		if (!config && this.selectedName) {
+		if (!config && launch && this.selectedName) {
 			config = launch.getConfiguration(this.selectedName);
 			type = config?.type;
 		}


### PR DESCRIPTION
This PR fixes #49855

I added a fix here to set the selected type and config only if a 'name' was provided. But if a launch config changes (https://github.com/microsoft/vscode/issues/49855#issuecomment-808445217) the name is undefined. We reuse the previous selectedName, but then the code path isn't hit.

Instead, set the config and type using the selected name after all selection (or lack thereof) occurs.