### PR TITLE
Respect viewtype for reopen with in notebooks

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
@@ -480,15 +480,20 @@ export class NotebookService extends Disposable implements INotebookService, IEd
 		});
 	}
 
-	async withNotebookDataProvider(resource: URI): Promise<ComplexNotebookProviderInfo | SimpleNotebookProviderInfo> {
-		const [first] = this._notebookProviderInfoStore.getContributedNotebook(resource);
-		if (!first) {
+	async withNotebookDataProvider(resource: URI, viewType?: string): Promise<ComplexNotebookProviderInfo | SimpleNotebookProviderInfo> {
+		const providers = this._notebookProviderInfoStore.getContributedNotebook(resource);
+		let selected = providers[0];
+		// If we have a viewtype specified we want that data provider, as the resource won't always map correctly
+		if (viewType) {
+			selected = providers.filter(provider => provider.id === viewType)[0];
+		}
+		if (!selected) {
 			throw new Error(`NO contribution for resource: '${resource.toString()}'`);
 		}
-		await this.canResolve(first.id);
-		const result = this._notebookProviders.get(first.id);
+		await this.canResolve(selected.id);
+		const result = this._notebookProviders.get(selected.id);
 		if (!result) {
-			throw new Error(`NO provider registered for view type: '${first.id}'`);
+			throw new Error(`NO provider registered for view type: '${selected.id}'`);
 		}
 		return result;
 	}

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverService.ts
@@ -48,7 +48,7 @@ class NotebookModelReferenceCollection extends ReferenceCollection<Promise<IReso
 
 	protected async createReferencedObject(key: string, viewType: string): Promise<IResolvedNotebookEditorModel> {
 		const uri = URI.parse(key);
-		const info = await this._notebookService.withNotebookDataProvider(uri);
+		const info = await this._notebookService.withNotebookDataProvider(uri, viewType);
 
 		let result: IResolvedNotebookEditorModel;
 

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -71,7 +71,7 @@ export interface INotebookService {
 
 	registerNotebookController(viewType: string, extensionData: NotebookExtensionDescription, controller: IMainNotebookController): IDisposable;
 	registerNotebookSerializer(viewType: string, extensionData: NotebookExtensionDescription, serializer: INotebookSerializer): IDisposable;
-	withNotebookDataProvider(resource: URI): Promise<ComplexNotebookProviderInfo | SimpleNotebookProviderInfo>;
+	withNotebookDataProvider(resource: URI, viewType?: string): Promise<ComplexNotebookProviderInfo | SimpleNotebookProviderInfo>;
 
 	getMimeTypeInfo(textModel: NotebookTextModel, output: IOutputDto): readonly IOrderedMimeType[];
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #119954 

Currently when we resolve the notebook data provider using `withNotebookDataProvider` we only use the resource. This can cause issues when the resource can be mapped to multiple providers. This is especially noticeable for untitled files which map to all resources. This PR makes it so that if we know the viewType we want to open we ensure that the data provider we select is the one for that viewType. Marking this as a candidate as it would break the flow when there are two notebooks for the same glob pattern.
