### PR TITLE
Fix: PHP require()/require_once() and include()/include_once() wrong syntax

### DIFF
--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -390,7 +390,7 @@
 			}
 		},
 		{
-			"begin": "(?i)\\b((?:require|include)(?:_once)?)\\s+",
+			"begin": "(?i)\\b((?:require|include)(?:_once)?)[\\s\\(]+",
 			"beginCaptures": {
 				"1": {
 					"name": "keyword.control.import.include.php"


### PR DESCRIPTION
## Explanation
In PHP we can use these commands, like this:
```php
<?php
require 'file.ext';
require_once 'file.ext';
```

But we can also use it with the path between parentheses, like this:
```php
require('file.ext');
require_once('file.ext');
```

However, the syntax highlight were only detecting the right scope of the command that doesn't use parentheses:

<table><tr><td>
<img src="https://user-images.githubusercontent.com/49572917/112789566-bd624d00-9033-11eb-8744-d6cdc5ed3eb6.png">
</td><td>
<img src="https://user-images.githubusercontent.com/49572917/112789584-c521f180-9033-11eb-94cc-60d91d9d55ab.png">
</td></tr></table>

## Fix
This pull request resolves it by adding the **`(`** char after the **`require`**/**`require_once`** and **`include`**/**`include_once`** as a valid match to the  **`keyword.control.import.include.php`** scope.

