### PR TITLE
semantic highlighting no longer works for js/jsx files

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "jsonc-parser": "^2.2.1",
     "semver": "5.5.1",
-    "typescript-vscode-sh-plugin": "^0.7.1",
+    "typescript-vscode-sh-plugin": "^0.7.3",
     "vscode-extension-telemetry": "0.1.7",
     "vscode-nls": "^4.1.1"
   },

--- a/extensions/typescript-language-features/yarn.lock
+++ b/extensions/typescript-language-features/yarn.lock
@@ -98,10 +98,10 @@ stack-chain@^1.3.7:
   resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
   integrity sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
 
-typescript-vscode-sh-plugin@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/typescript-vscode-sh-plugin/-/typescript-vscode-sh-plugin-0.7.1.tgz#0be744032aa7fdcb764497342fd0fd2d093ed7ca"
-  integrity sha512-upXxgeI21tEMJxRVxF4PekQBM+eF0cRp0GgD2sblQkEm43NR+Fcbusa+FKAekUgwkbjVq1Loq+vKCCUbxM6R8A==
+typescript-vscode-sh-plugin@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/typescript-vscode-sh-plugin/-/typescript-vscode-sh-plugin-0.7.3.tgz#acdc223e5baf2cd43b8e9cf21775fba162b05029"
+  integrity sha512-IAjOX1fE35G6DiNCJv6oq7JmYkPV7KI/g1SGX6i8Cgauv7hsXbS94fboSZNM2Dai+m3xNGARHG5V6Ka7YcZRgQ==
 
 vscode-extension-telemetry@0.1.7:
   version "0.1.7"


### PR DESCRIPTION
Fixes #120103

typescript-vscode-sh-plugin@0.7.3 brings back the plugin for js and jsx files in all TypeScript versions.