### PR TITLE
Remove assert.equal

### DIFF
--- a/src/vs/base/parts/ipc/test/common/ipc.test.ts
+++ b/src/vs/base/parts/ipc/test/common/ipc.test.ts
@@ -253,7 +253,7 @@ suite('Base IPC', function () {
 
 		test('call success', async function () {
 			const r = await ipcService.marco();
-			return assert.equal(r, 'polo');
+			return assert.strictEqual(r, 'polo');
 		});
 
 		test('call error', async function () {
@@ -261,7 +261,7 @@ suite('Base IPC', function () {
 				await ipcService.error('nice error');
 				return assert.fail('should not reach here');
 			} catch (err) {
-				return assert.equal(err.message, 'nice error');
+				return assert.strictEqual(err.message, 'nice error');
 			}
 		});
 
@@ -317,7 +317,7 @@ suite('Base IPC', function () {
 
 		test('buffers in arrays', async function () {
 			const r = await ipcService.buffersLength([VSBuffer.alloc(2), VSBuffer.alloc(3)]);
-			return assert.equal(r, 5);
+			return assert.strictEqual(r, 5);
 		});
 	});
 
@@ -345,7 +345,7 @@ suite('Base IPC', function () {
 
 		test('call success', async function () {
 			const r = await ipcService.marco();
-			return assert.equal(r, 'polo');
+			return assert.strictEqual(r, 'polo');
 		});
 
 		test('call error', async function () {
@@ -353,7 +353,7 @@ suite('Base IPC', function () {
 				await ipcService.error('nice error');
 				return assert.fail('should not reach here');
 			} catch (err) {
-				return assert.equal(err.message, 'nice error');
+				return assert.strictEqual(err.message, 'nice error');
 			}
 		});
 
@@ -383,7 +383,7 @@ suite('Base IPC', function () {
 
 		test('buffers in arrays', async function () {
 			const r = await ipcService.buffersLength([VSBuffer.alloc(2), VSBuffer.alloc(3)]);
-			return assert.equal(r, 5);
+			return assert.strictEqual(r, 5);
 		});
 	});
 
@@ -411,7 +411,7 @@ suite('Base IPC', function () {
 
 		test('call extra context', async function () {
 			const r = await ipcService.context();
-			return assert.equal(r, 'Super Context');
+			return assert.strictEqual(r, 'Super Context');
 		});
 	});
 

--- a/src/vs/base/parts/ipc/test/node/ipc.cp.test.ts
+++ b/src/vs/base/parts/ipc/test/node/ipc.cp.test.ts
@@ -22,8 +22,8 @@ suite('IPC, Child Process', () => {
 		const service = new TestServiceClient(channel);
 
 		const result = service.pong('ping').then(r => {
-			assert.equal(r.incoming, 'ping');
-			assert.equal(r.outgoing, 'pong');
+			assert.strictEqual(r.incoming, 'ping');
+			assert.strictEqual(r.outgoing, 'pong');
 		});
 
 		return result.finally(() => client.dispose());
@@ -37,7 +37,7 @@ suite('IPC, Child Process', () => {
 		const event = new Promise((c, e) => {
 			service.onMarco(({ answer }) => {
 				try {
-					assert.equal(answer, 'polo');
+					assert.strictEqual(answer, 'polo');
 					c(undefined);
 				} catch (err) {
 					e(err);
@@ -60,17 +60,17 @@ suite('IPC, Child Process', () => {
 		const disposable = service.onMarco(() => count++);
 
 		const result = service.marco().then(async answer => {
-			assert.equal(answer, 'polo');
-			assert.equal(count, 1);
+			assert.strictEqual(answer, 'polo');
+			assert.strictEqual(count, 1);
 
 			const answer_1 = await service.marco();
-			assert.equal(answer_1, 'polo');
-			assert.equal(count, 2);
+			assert.strictEqual(answer_1, 'polo');
+			assert.strictEqual(count, 2);
 			disposable.dispose();
 
 			const answer_2 = await service.marco();
-			assert.equal(answer_2, 'polo');
-			assert.equal(count, 2);
+			assert.strictEqual(answer_2, 'polo');
+			assert.strictEqual(count, 2);
 		});
 
 		return result.finally(() => client.dispose());

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -111,7 +111,7 @@ suite('MarkdownRenderer', () => {
 
 		const data = <{ script: string, documentUri: URI }>parse(decodeURIComponent(uri.query));
 		assert.ok(data);
-		assert.equal(data.script, 'echo');
+		assert.strictEqual(data.script, 'echo');
 		assert.ok(data.documentUri.toString().startsWith('file:///c%3A/'));
 	});
 

--- a/src/vs/base/test/browser/ui/grid/grid.test.ts
+++ b/src/vs/base/test/browser/ui/grid/grid.test.ts
@@ -836,7 +836,7 @@ suite('SerializableGrid', function () {
 		};
 
 		const grid = SerializableGrid.deserialize(serializedGrid, deserializer);
-		assert.equal(views.length, 3);
+		assert.strictEqual(views.length, 3);
 
 		// should not throw
 		grid.removeView(views[2]);

--- a/src/vs/base/test/browser/ui/list/listView.test.ts
+++ b/src/vs/base/test/browser/ui/list/listView.test.ts
@@ -31,10 +31,10 @@ suite('ListView', function () {
 		const listView = new ListView<number>(element, delegate, [renderer]);
 		listView.layout(200);
 
-		assert.equal(templatesCount, 0, 'no templates have been allocated');
+		assert.strictEqual(templatesCount, 0, 'no templates have been allocated');
 		listView.splice(0, 0, range(100));
-		assert.equal(templatesCount, 10, 'some templates have been allocated');
+		assert.strictEqual(templatesCount, 10, 'some templates have been allocated');
 		listView.dispose();
-		assert.equal(templatesCount, 0, 'all templates have been disposed');
+		assert.strictEqual(templatesCount, 0, 'all templates have been disposed');
 	});
 });

--- a/src/vs/base/test/browser/ui/list/rangeMap.test.ts
+++ b/src/vs/base/test/browser/ui/list/rangeMap.test.ts
@@ -141,8 +141,8 @@ suite('RangeMap', () => {
 	});
 
 	test('empty', () => {
-		assert.equal(rangeMap.size, 0);
-		assert.equal(rangeMap.count, 0);
+		assert.strictEqual(rangeMap.size, 0);
+		assert.strictEqual(rangeMap.count, 0);
 	});
 
 	const one = { size: 1 };
@@ -153,44 +153,44 @@ suite('RangeMap', () => {
 
 	test('length & count', () => {
 		rangeMap.splice(0, 0, [one]);
-		assert.equal(rangeMap.size, 1);
-		assert.equal(rangeMap.count, 1);
+		assert.strictEqual(rangeMap.size, 1);
+		assert.strictEqual(rangeMap.count, 1);
 	});
 
 	test('length & count #2', () => {
 		rangeMap.splice(0, 0, [one, one, one, one, one]);
-		assert.equal(rangeMap.size, 5);
-		assert.equal(rangeMap.count, 5);
+		assert.strictEqual(rangeMap.size, 5);
+		assert.strictEqual(rangeMap.count, 5);
 	});
 
 	test('length & count #3', () => {
 		rangeMap.splice(0, 0, [five]);
-		assert.equal(rangeMap.size, 5);
-		assert.equal(rangeMap.count, 1);
+		assert.strictEqual(rangeMap.size, 5);
+		assert.strictEqual(rangeMap.count, 1);
 	});
 
 	test('length & count #4', () => {
 		rangeMap.splice(0, 0, [five, five, five, five, five]);
-		assert.equal(rangeMap.size, 25);
-		assert.equal(rangeMap.count, 5);
+		assert.strictEqual(rangeMap.size, 25);
+		assert.strictEqual(rangeMap.count, 5);
 	});
 
 	test('insert', () => {
 		rangeMap.splice(0, 0, [five, five, five, five, five]);
-		assert.equal(rangeMap.size, 25);
-		assert.equal(rangeMap.count, 5);
+		assert.strictEqual(rangeMap.size, 25);
+		assert.strictEqual(rangeMap.count, 5);
 
 		rangeMap.splice(0, 0, [five, five, five, five, five]);
-		assert.equal(rangeMap.size, 50);
-		assert.equal(rangeMap.count, 10);
+		assert.strictEqual(rangeMap.size, 50);
+		assert.strictEqual(rangeMap.count, 10);
 
 		rangeMap.splice(5, 0, [ten, ten]);
-		assert.equal(rangeMap.size, 70);
-		assert.equal(rangeMap.count, 12);
+		assert.strictEqual(rangeMap.size, 70);
+		assert.strictEqual(rangeMap.count, 12);
 
 		rangeMap.splice(12, 0, [{ size: 200 }]);
-		assert.equal(rangeMap.size, 270);
-		assert.equal(rangeMap.count, 13);
+		assert.strictEqual(rangeMap.size, 270);
+		assert.strictEqual(rangeMap.count, 13);
 	});
 
 	test('delete', () => {
@@ -198,45 +198,45 @@ suite('RangeMap', () => {
 			five, five, five, five, five,
 			five, five, five, five, five,
 			five, five, five, five, five]);
-		assert.equal(rangeMap.size, 100);
-		assert.equal(rangeMap.count, 20);
+		assert.strictEqual(rangeMap.size, 100);
+		assert.strictEqual(rangeMap.count, 20);
 
 		rangeMap.splice(10, 5);
-		assert.equal(rangeMap.size, 75);
-		assert.equal(rangeMap.count, 15);
+		assert.strictEqual(rangeMap.size, 75);
+		assert.strictEqual(rangeMap.count, 15);
 
 		rangeMap.splice(0, 1);
-		assert.equal(rangeMap.size, 70);
-		assert.equal(rangeMap.count, 14);
+		assert.strictEqual(rangeMap.size, 70);
+		assert.strictEqual(rangeMap.count, 14);
 
 		rangeMap.splice(1, 13);
-		assert.equal(rangeMap.size, 5);
-		assert.equal(rangeMap.count, 1);
+		assert.strictEqual(rangeMap.size, 5);
+		assert.strictEqual(rangeMap.count, 1);
 
 		rangeMap.splice(1, 1);
-		assert.equal(rangeMap.size, 5);
-		assert.equal(rangeMap.count, 1);
+		assert.strictEqual(rangeMap.size, 5);
+		assert.strictEqual(rangeMap.count, 1);
 	});
 
 	test('insert & delete', () => {
-		assert.equal(rangeMap.size, 0);
-		assert.equal(rangeMap.count, 0);
+		assert.strictEqual(rangeMap.size, 0);
+		assert.strictEqual(rangeMap.count, 0);
 
 		rangeMap.splice(0, 0, [one]);
-		assert.equal(rangeMap.size, 1);
-		assert.equal(rangeMap.count, 1);
+		assert.strictEqual(rangeMap.size, 1);
+		assert.strictEqual(rangeMap.count, 1);
 
 		rangeMap.splice(0, 1);
-		assert.equal(rangeMap.size, 0);
-		assert.equal(rangeMap.count, 0);
+		assert.strictEqual(rangeMap.size, 0);
+		assert.strictEqual(rangeMap.count, 0);
 	});
 
 	test('insert & delete #2', () => {
 		rangeMap.splice(0, 0, [one, one, one, one, one,
 			one, one, one, one, one]);
 		rangeMap.splice(2, 6);
-		assert.equal(rangeMap.count, 4);
-		assert.equal(rangeMap.size, 4);
+		assert.strictEqual(rangeMap.count, 4);
+		assert.strictEqual(rangeMap.size, 4);
 	});
 
 	test('insert & delete #3', () => {
@@ -245,8 +245,8 @@ suite('RangeMap', () => {
 			two, two, two, two, two,
 			two, two, two, two, two]);
 		rangeMap.splice(8, 4);
-		assert.equal(rangeMap.count, 16);
-		assert.equal(rangeMap.size, 24);
+		assert.strictEqual(rangeMap.count, 16);
+		assert.strictEqual(rangeMap.size, 24);
 	});
 
 	test('insert & delete #3', () => {
@@ -255,91 +255,91 @@ suite('RangeMap', () => {
 			two, two, two, two, two,
 			two, two, two, two, two]);
 		rangeMap.splice(5, 0, [three, three, three, three, three]);
-		assert.equal(rangeMap.count, 25);
-		assert.equal(rangeMap.size, 45);
+		assert.strictEqual(rangeMap.count, 25);
+		assert.strictEqual(rangeMap.size, 45);
 
 		rangeMap.splice(4, 7);
-		assert.equal(rangeMap.count, 18);
-		assert.equal(rangeMap.size, 28);
+		assert.strictEqual(rangeMap.count, 18);
+		assert.strictEqual(rangeMap.size, 28);
 	});
 
 	suite('indexAt, positionAt', () => {
 		test('empty', () => {
-			assert.equal(rangeMap.indexAt(0), 0);
-			assert.equal(rangeMap.indexAt(10), 0);
-			assert.equal(rangeMap.indexAt(-1), -1);
-			assert.equal(rangeMap.positionAt(0), -1);
-			assert.equal(rangeMap.positionAt(10), -1);
-			assert.equal(rangeMap.positionAt(-1), -1);
+			assert.strictEqual(rangeMap.indexAt(0), 0);
+			assert.strictEqual(rangeMap.indexAt(10), 0);
+			assert.strictEqual(rangeMap.indexAt(-1), -1);
+			assert.strictEqual(rangeMap.positionAt(0), -1);
+			assert.strictEqual(rangeMap.positionAt(10), -1);
+			assert.strictEqual(rangeMap.positionAt(-1), -1);
 		});
 
 		test('simple', () => {
 			rangeMap.splice(0, 0, [one]);
-			assert.equal(rangeMap.indexAt(0), 0);
-			assert.equal(rangeMap.indexAt(1), 1);
-			assert.equal(rangeMap.positionAt(0), 0);
-			assert.equal(rangeMap.positionAt(1), -1);
+			assert.strictEqual(rangeMap.indexAt(0), 0);
+			assert.strictEqual(rangeMap.indexAt(1), 1);
+			assert.strictEqual(rangeMap.positionAt(0), 0);
+			assert.strictEqual(rangeMap.positionAt(1), -1);
 		});
 
 		test('simple #2', () => {
 			rangeMap.splice(0, 0, [ten]);
-			assert.equal(rangeMap.indexAt(0), 0);
-			assert.equal(rangeMap.indexAt(5), 0);
-			assert.equal(rangeMap.indexAt(9), 0);
-			assert.equal(rangeMap.indexAt(10), 1);
-			assert.equal(rangeMap.positionAt(0), 0);
-			assert.equal(rangeMap.positionAt(1), -1);
+			assert.strictEqual(rangeMap.indexAt(0), 0);
+			assert.strictEqual(rangeMap.indexAt(5), 0);
+			assert.strictEqual(rangeMap.indexAt(9), 0);
+			assert.strictEqual(rangeMap.indexAt(10), 1);
+			assert.strictEqual(rangeMap.positionAt(0), 0);
+			assert.strictEqual(rangeMap.positionAt(1), -1);
 		});
 
 		test('insert', () => {
 			rangeMap.splice(0, 0, [one, one, one, one, one, one, one, one, one, one]);
-			assert.equal(rangeMap.indexAt(0), 0);
-			assert.equal(rangeMap.indexAt(1), 1);
-			assert.equal(rangeMap.indexAt(5), 5);
-			assert.equal(rangeMap.indexAt(9), 9);
-			assert.equal(rangeMap.indexAt(10), 10);
-			assert.equal(rangeMap.indexAt(11), 10);
+			assert.strictEqual(rangeMap.indexAt(0), 0);
+			assert.strictEqual(rangeMap.indexAt(1), 1);
+			assert.strictEqual(rangeMap.indexAt(5), 5);
+			assert.strictEqual(rangeMap.indexAt(9), 9);
+			assert.strictEqual(rangeMap.indexAt(10), 10);
+			assert.strictEqual(rangeMap.indexAt(11), 10);
 
 			rangeMap.splice(10, 0, [one, one, one, one, one, one, one, one, one, one]);
-			assert.equal(rangeMap.indexAt(10), 10);
-			assert.equal(rangeMap.indexAt(19), 19);
-			assert.equal(rangeMap.indexAt(20), 20);
-			assert.equal(rangeMap.indexAt(21), 20);
-			assert.equal(rangeMap.positionAt(0), 0);
-			assert.equal(rangeMap.positionAt(1), 1);
-			assert.equal(rangeMap.positionAt(19), 19);
-			assert.equal(rangeMap.positionAt(20), -1);
+			assert.strictEqual(rangeMap.indexAt(10), 10);
+			assert.strictEqual(rangeMap.indexAt(19), 19);
+			assert.strictEqual(rangeMap.indexAt(20), 20);
+			assert.strictEqual(rangeMap.indexAt(21), 20);
+			assert.strictEqual(rangeMap.positionAt(0), 0);
+			assert.strictEqual(rangeMap.positionAt(1), 1);
+			assert.strictEqual(rangeMap.positionAt(19), 19);
+			assert.strictEqual(rangeMap.positionAt(20), -1);
 		});
 
 		test('delete', () => {
 			rangeMap.splice(0, 0, [one, one, one, one, one, one, one, one, one, one]);
 			rangeMap.splice(2, 6);
 
-			assert.equal(rangeMap.indexAt(0), 0);
-			assert.equal(rangeMap.indexAt(1), 1);
-			assert.equal(rangeMap.indexAt(3), 3);
-			assert.equal(rangeMap.indexAt(4), 4);
-			assert.equal(rangeMap.indexAt(5), 4);
-			assert.equal(rangeMap.positionAt(0), 0);
-			assert.equal(rangeMap.positionAt(1), 1);
-			assert.equal(rangeMap.positionAt(3), 3);
-			assert.equal(rangeMap.positionAt(4), -1);
+			assert.strictEqual(rangeMap.indexAt(0), 0);
+			assert.strictEqual(rangeMap.indexAt(1), 1);
+			assert.strictEqual(rangeMap.indexAt(3), 3);
+			assert.strictEqual(rangeMap.indexAt(4), 4);
+			assert.strictEqual(rangeMap.indexAt(5), 4);
+			assert.strictEqual(rangeMap.positionAt(0), 0);
+			assert.strictEqual(rangeMap.positionAt(1), 1);
+			assert.strictEqual(rangeMap.positionAt(3), 3);
+			assert.strictEqual(rangeMap.positionAt(4), -1);
 		});
 
 		test('delete #2', () => {
 			rangeMap.splice(0, 0, [ten, ten, ten, ten, ten, ten, ten, ten, ten, ten]);
 			rangeMap.splice(2, 6);
 
-			assert.equal(rangeMap.indexAt(0), 0);
-			assert.equal(rangeMap.indexAt(1), 0);
-			assert.equal(rangeMap.indexAt(30), 3);
-			assert.equal(rangeMap.indexAt(40), 4);
-			assert.equal(rangeMap.indexAt(50), 4);
-			assert.equal(rangeMap.positionAt(0), 0);
-			assert.equal(rangeMap.positionAt(1), 10);
-			assert.equal(rangeMap.positionAt(2), 20);
-			assert.equal(rangeMap.positionAt(3), 30);
-			assert.equal(rangeMap.positionAt(4), -1);
+			assert.strictEqual(rangeMap.indexAt(0), 0);
+			assert.strictEqual(rangeMap.indexAt(1), 0);
+			assert.strictEqual(rangeMap.indexAt(30), 3);
+			assert.strictEqual(rangeMap.indexAt(40), 4);
+			assert.strictEqual(rangeMap.indexAt(50), 4);
+			assert.strictEqual(rangeMap.positionAt(0), 0);
+			assert.strictEqual(rangeMap.positionAt(1), 10);
+			assert.strictEqual(rangeMap.positionAt(2), 20);
+			assert.strictEqual(rangeMap.positionAt(3), 30);
+			assert.strictEqual(rangeMap.positionAt(4), -1);
 		});
 	});
 });

--- a/src/vs/base/test/browser/ui/menu/menubar.test.ts
+++ b/src/vs/base/test/browser/ui/menu/menubar.test.ts
@@ -56,7 +56,7 @@ function validateMenuBarItem(menubar: MenuBar, menubarContainer: HTMLElement, la
 	assert(titleDiv !== null, `Title div not found for ${readableLabel} button.`);
 
 	const mnem = getMnemonicFromTitleDiv(titleDiv!);
-	assert.equal(mnem, mnemonic, 'Mnemonic not correct');
+	assert.strictEqual(mnem, mnemonic, 'Mnemonic not correct');
 }
 
 suite('Menubar', () => {

--- a/src/vs/base/test/browser/ui/splitview/splitview.test.ts
+++ b/src/vs/base/test/browser/ui/splitview/splitview.test.ts
@@ -77,7 +77,7 @@ suite('Splitview', () => {
 
 	test('empty splitview has empty DOM', () => {
 		const splitview = new SplitView(container);
-		assert.equal(container.firstElementChild!.firstElementChild!.childElementCount, 0, 'split view should be empty');
+		assert.strictEqual(container.firstElementChild!.firstElementChild!.childElementCount, 0, 'split view should be empty');
 		splitview.dispose();
 	});
 
@@ -92,34 +92,34 @@ suite('Splitview', () => {
 		splitview.addView(view3, 20);
 
 		let viewQuery = container.querySelectorAll('.monaco-split-view2 > .monaco-scrollable-element > .split-view-container > .split-view-view');
-		assert.equal(viewQuery.length, 3, 'split view should have 3 views');
+		assert.strictEqual(viewQuery.length, 3, 'split view should have 3 views');
 
 		let sashQuery = container.querySelectorAll('.monaco-split-view2 > .sash-container > .monaco-sash');
-		assert.equal(sashQuery.length, 2, 'split view should have 2 sashes');
+		assert.strictEqual(sashQuery.length, 2, 'split view should have 2 sashes');
 
 		splitview.removeView(2);
 
 		viewQuery = container.querySelectorAll('.monaco-split-view2 > .monaco-scrollable-element > .split-view-container > .split-view-view');
-		assert.equal(viewQuery.length, 2, 'split view should have 2 views');
+		assert.strictEqual(viewQuery.length, 2, 'split view should have 2 views');
 
 		sashQuery = container.querySelectorAll('.monaco-split-view2 > .sash-container > .monaco-sash');
-		assert.equal(sashQuery.length, 1, 'split view should have 1 sash');
+		assert.strictEqual(sashQuery.length, 1, 'split view should have 1 sash');
 
 		splitview.removeView(0);
 
 		viewQuery = container.querySelectorAll('.monaco-split-view2 > .monaco-scrollable-element > .split-view-container > .split-view-view');
-		assert.equal(viewQuery.length, 1, 'split view should have 1 view');
+		assert.strictEqual(viewQuery.length, 1, 'split view should have 1 view');
 
 		sashQuery = container.querySelectorAll('.monaco-split-view2 > .sash-container > .monaco-sash');
-		assert.equal(sashQuery.length, 0, 'split view should have no sashes');
+		assert.strictEqual(sashQuery.length, 0, 'split view should have no sashes');
 
 		splitview.removeView(0);
 
 		viewQuery = container.querySelectorAll('.monaco-split-view2 > .monaco-scrollable-element > .split-view-container > .split-view-view');
-		assert.equal(viewQuery.length, 0, 'split view should have no views');
+		assert.strictEqual(viewQuery.length, 0, 'split view should have no views');
 
 		sashQuery = container.querySelectorAll('.monaco-split-view2 > .sash-container > .monaco-sash');
-		assert.equal(sashQuery.length, 0, 'split view should have no sashes');
+		assert.strictEqual(sashQuery.length, 0, 'split view should have no sashes');
 
 		splitview.dispose();
 		view1.dispose();
@@ -138,7 +138,7 @@ suite('Splitview', () => {
 
 		splitview.addView(view, 20);
 
-		assert.equal(view.size, 20, 'view has right size');
+		assert.strictEqual(view.size, 20, 'view has right size');
 		assert(didLayout, 'layout is called');
 		assert(didLayout, 'render is called');
 
@@ -154,22 +154,22 @@ suite('Splitview', () => {
 		splitview.layout(200);
 
 		splitview.addView(view, 20);
-		assert.equal(view.size, 200, 'view is stretched');
+		assert.strictEqual(view.size, 200, 'view is stretched');
 
 		splitview.layout(200);
-		assert.equal(view.size, 200, 'view stayed the same');
+		assert.strictEqual(view.size, 200, 'view stayed the same');
 
 		splitview.layout(100);
-		assert.equal(view.size, 100, 'view is collapsed');
+		assert.strictEqual(view.size, 100, 'view is collapsed');
 
 		splitview.layout(20);
-		assert.equal(view.size, 20, 'view is collapsed');
+		assert.strictEqual(view.size, 20, 'view is collapsed');
 
 		splitview.layout(10);
-		assert.equal(view.size, 20, 'view is clamped');
+		assert.strictEqual(view.size, 20, 'view is clamped');
 
 		splitview.layout(200);
-		assert.equal(view.size, 200, 'view is stretched');
+		assert.strictEqual(view.size, 200, 'view is stretched');
 
 		splitview.dispose();
 		view.dispose();
@@ -186,27 +186,27 @@ suite('Splitview', () => {
 		splitview.addView(view2, 20);
 		splitview.addView(view3, 20);
 
-		assert.equal(view1.size, 160, 'view1 is stretched');
-		assert.equal(view2.size, 20, 'view2 size is 20');
-		assert.equal(view3.size, 20, 'view3 size is 20');
+		assert.strictEqual(view1.size, 160, 'view1 is stretched');
+		assert.strictEqual(view2.size, 20, 'view2 size is 20');
+		assert.strictEqual(view3.size, 20, 'view3 size is 20');
 
 		splitview.resizeView(1, 40);
 
-		assert.equal(view1.size, 140, 'view1 is collapsed');
-		assert.equal(view2.size, 40, 'view2 is stretched');
-		assert.equal(view3.size, 20, 'view3 stays the same');
+		assert.strictEqual(view1.size, 140, 'view1 is collapsed');
+		assert.strictEqual(view2.size, 40, 'view2 is stretched');
+		assert.strictEqual(view3.size, 20, 'view3 stays the same');
 
 		splitview.resizeView(0, 70);
 
-		assert.equal(view1.size, 70, 'view1 is collapsed');
-		assert.equal(view2.size, 40, 'view2 stays the same');
-		assert.equal(view3.size, 90, 'view3 is stretched');
+		assert.strictEqual(view1.size, 70, 'view1 is collapsed');
+		assert.strictEqual(view2.size, 40, 'view2 stays the same');
+		assert.strictEqual(view3.size, 90, 'view3 is stretched');
 
 		splitview.resizeView(2, 40);
 
-		assert.equal(view1.size, 70, 'view1 stays the same');
-		assert.equal(view2.size, 90, 'view2 is collapsed');
-		assert.equal(view3.size, 40, 'view3 is stretched');
+		assert.strictEqual(view1.size, 70, 'view1 stays the same');
+		assert.strictEqual(view2.size, 90, 'view2 is collapsed');
+		assert.strictEqual(view3.size, 40, 'view3 is stretched');
 
 		splitview.dispose();
 		view3.dispose();
@@ -225,34 +225,34 @@ suite('Splitview', () => {
 		splitview.addView(view2, 20);
 		splitview.addView(view3, 20);
 
-		assert.equal(view1.size, 160, 'view1 is stretched');
-		assert.equal(view2.size, 20, 'view2 size is 20');
-		assert.equal(view3.size, 20, 'view3 size is 20');
+		assert.strictEqual(view1.size, 160, 'view1 is stretched');
+		assert.strictEqual(view2.size, 20, 'view2 size is 20');
+		assert.strictEqual(view3.size, 20, 'view3 size is 20');
 
 		view1.maximumSize = 20;
 
-		assert.equal(view1.size, 20, 'view1 is collapsed');
-		assert.equal(view2.size, 20, 'view2 stays the same');
-		assert.equal(view3.size, 160, 'view3 is stretched');
+		assert.strictEqual(view1.size, 20, 'view1 is collapsed');
+		assert.strictEqual(view2.size, 20, 'view2 stays the same');
+		assert.strictEqual(view3.size, 160, 'view3 is stretched');
 
 		view3.maximumSize = 40;
 
-		assert.equal(view1.size, 20, 'view1 stays the same');
-		assert.equal(view2.size, 140, 'view2 is stretched');
-		assert.equal(view3.size, 40, 'view3 is collapsed');
+		assert.strictEqual(view1.size, 20, 'view1 stays the same');
+		assert.strictEqual(view2.size, 140, 'view2 is stretched');
+		assert.strictEqual(view3.size, 40, 'view3 is collapsed');
 
 		view2.maximumSize = 200;
 
-		assert.equal(view1.size, 20, 'view1 stays the same');
-		assert.equal(view2.size, 140, 'view2 stays the same');
-		assert.equal(view3.size, 40, 'view3 stays the same');
+		assert.strictEqual(view1.size, 20, 'view1 stays the same');
+		assert.strictEqual(view2.size, 140, 'view2 stays the same');
+		assert.strictEqual(view3.size, 40, 'view3 stays the same');
 
 		view3.maximumSize = Number.POSITIVE_INFINITY;
 		view3.minimumSize = 100;
 
-		assert.equal(view1.size, 20, 'view1 is collapsed');
-		assert.equal(view2.size, 80, 'view2 is collapsed');
-		assert.equal(view3.size, 100, 'view3 is stretched');
+		assert.strictEqual(view1.size, 20, 'view1 is collapsed');
+		assert.strictEqual(view2.size, 80, 'view2 is collapsed');
+		assert.strictEqual(view3.size, 100, 'view3 is stretched');
 
 		splitview.dispose();
 		view3.dispose();
@@ -272,41 +272,41 @@ suite('Splitview', () => {
 		splitview.addView(view3, Sizing.Distribute);
 
 		let sashes = getSashes(splitview);
-		assert.equal(sashes.length, 2, 'there are two sashes');
-		assert.equal(sashes[0].state, SashState.Enabled, 'first sash is enabled');
-		assert.equal(sashes[1].state, SashState.Enabled, 'second sash is enabled');
+		assert.strictEqual(sashes.length, 2, 'there are two sashes');
+		assert.strictEqual(sashes[0].state, SashState.Enabled, 'first sash is enabled');
+		assert.strictEqual(sashes[1].state, SashState.Enabled, 'second sash is enabled');
 
 		splitview.layout(60);
-		assert.equal(sashes[0].state, SashState.Disabled, 'first sash is disabled');
-		assert.equal(sashes[1].state, SashState.Disabled, 'second sash is disabled');
+		assert.strictEqual(sashes[0].state, SashState.Disabled, 'first sash is disabled');
+		assert.strictEqual(sashes[1].state, SashState.Disabled, 'second sash is disabled');
 
 		splitview.layout(20);
-		assert.equal(sashes[0].state, SashState.Disabled, 'first sash is disabled');
-		assert.equal(sashes[1].state, SashState.Disabled, 'second sash is disabled');
+		assert.strictEqual(sashes[0].state, SashState.Disabled, 'first sash is disabled');
+		assert.strictEqual(sashes[1].state, SashState.Disabled, 'second sash is disabled');
 
 		splitview.layout(200);
-		assert.equal(sashes[0].state, SashState.Enabled, 'first sash is enabled');
-		assert.equal(sashes[1].state, SashState.Enabled, 'second sash is enabled');
+		assert.strictEqual(sashes[0].state, SashState.Enabled, 'first sash is enabled');
+		assert.strictEqual(sashes[1].state, SashState.Enabled, 'second sash is enabled');
 
 		view1.maximumSize = 20;
-		assert.equal(sashes[0].state, SashState.Disabled, 'first sash is disabled');
-		assert.equal(sashes[1].state, SashState.Enabled, 'second sash is enabled');
+		assert.strictEqual(sashes[0].state, SashState.Disabled, 'first sash is disabled');
+		assert.strictEqual(sashes[1].state, SashState.Enabled, 'second sash is enabled');
 
 		view2.maximumSize = 20;
-		assert.equal(sashes[0].state, SashState.Disabled, 'first sash is disabled');
-		assert.equal(sashes[1].state, SashState.Disabled, 'second sash is disabled');
+		assert.strictEqual(sashes[0].state, SashState.Disabled, 'first sash is disabled');
+		assert.strictEqual(sashes[1].state, SashState.Disabled, 'second sash is disabled');
 
 		view1.maximumSize = 300;
-		assert.equal(sashes[0].state, SashState.Minimum, 'first sash is enabled');
-		assert.equal(sashes[1].state, SashState.Minimum, 'second sash is enabled');
+		assert.strictEqual(sashes[0].state, SashState.Minimum, 'first sash is enabled');
+		assert.strictEqual(sashes[1].state, SashState.Minimum, 'second sash is enabled');
 
 		view2.maximumSize = 200;
-		assert.equal(sashes[0].state, SashState.Minimum, 'first sash is enabled');
-		assert.equal(sashes[1].state, SashState.Minimum, 'second sash is enabled');
+		assert.strictEqual(sashes[0].state, SashState.Minimum, 'first sash is enabled');
+		assert.strictEqual(sashes[1].state, SashState.Minimum, 'second sash is enabled');
 
 		splitview.resizeView(0, 40);
-		assert.equal(sashes[0].state, SashState.Enabled, 'first sash is enabled');
-		assert.equal(sashes[1].state, SashState.Enabled, 'second sash is enabled');
+		assert.strictEqual(sashes[0].state, SashState.Enabled, 'first sash is enabled');
+		assert.strictEqual(sashes[1].state, SashState.Enabled, 'second sash is enabled');
 
 		splitview.dispose();
 		view3.dispose();
@@ -322,7 +322,7 @@ suite('Splitview', () => {
 		splitview.layout(986);
 
 		splitview.addView(view1, 142, 0);
-		assert.equal(view1.size, 986, 'first view is stretched');
+		assert.strictEqual(view1.size, 986, 'first view is stretched');
 
 		view2.onDidGetElement(() => {
 			assert.throws(() => splitview.resizeView(1, 922));
@@ -330,13 +330,13 @@ suite('Splitview', () => {
 		});
 
 		splitview.addView(view2, 66, 0);
-		assert.equal(view2.size, 66, 'second view is fixed');
-		assert.equal(view1.size, 986 - 66, 'first view is collapsed');
+		assert.strictEqual(view2.size, 66, 'second view is fixed');
+		assert.strictEqual(view1.size, 986 - 66, 'first view is collapsed');
 
 		const viewContainers = container.querySelectorAll('.split-view-view');
-		assert.equal(viewContainers.length, 2, 'there are two view containers');
-		assert.equal((viewContainers.item(0) as HTMLElement).style.height, '66px', 'second view container is 66px');
-		assert.equal((viewContainers.item(1) as HTMLElement).style.height, `${986 - 66}px`, 'first view container is 66px');
+		assert.strictEqual(viewContainers.length, 2, 'there are two view containers');
+		assert.strictEqual((viewContainers.item(0) as HTMLElement).style.height, '66px', 'second view container is 66px');
+		assert.strictEqual((viewContainers.item(1) as HTMLElement).style.height, `${986 - 66}px`, 'first view container is 66px');
 
 		splitview.dispose();
 		view2.dispose();
@@ -351,7 +351,7 @@ suite('Splitview', () => {
 		splitview.layout(200);
 
 		splitview.addView(view1, Sizing.Distribute);
-		assert.equal(view1.size, 200);
+		assert.strictEqual(view1.size, 200);
 
 		splitview.addView(view2, 50);
 		assert.deepEqual([view1.size, view2.size], [150, 50]);
@@ -395,7 +395,7 @@ suite('Splitview', () => {
 		splitview.layout(200);
 
 		splitview.addView(view1, Sizing.Distribute);
-		assert.equal(view1.size, 200);
+		assert.strictEqual(view1.size, 200);
 
 		splitview.addView(view2, Sizing.Split(0));
 		assert.deepEqual([view1.size, view2.size], [100, 100]);
@@ -417,7 +417,7 @@ suite('Splitview', () => {
 		splitview.layout(200);
 
 		splitview.addView(view1, Sizing.Distribute);
-		assert.equal(view1.size, 200);
+		assert.strictEqual(view1.size, 200);
 
 		splitview.addView(view2, Sizing.Split(0));
 		assert.deepEqual([view1.size, view2.size], [100, 100]);

--- a/src/vs/base/test/browser/ui/tree/asyncDataTree.test.ts
+++ b/src/vs/base/test/browser/ui/tree/asyncDataTree.test.ts
@@ -97,10 +97,10 @@ suite('AsyncDataTree', function () {
 
 		const tree = new AsyncDataTree<Element, Element>('test', container, new VirtualDelegate(), [new Renderer()], new DataSource(), { identityProvider: new IdentityProvider() });
 		tree.layout(200);
-		assert.equal(container.querySelectorAll('.monaco-list-row').length, 0);
+		assert.strictEqual(container.querySelectorAll('.monaco-list-row').length, 0);
 
 		await tree.setInput(model.root);
-		assert.equal(container.querySelectorAll('.monaco-list-row').length, 1);
+		assert.strictEqual(container.querySelectorAll('.monaco-list-row').length, 1);
 		let twistie = container.querySelector('.monaco-list-row:first-child .monaco-tl-twistie') as HTMLElement;
 		assert(!twistie.classList.contains('collapsible'));
 		assert(!twistie.classList.contains('collapsed'));
@@ -112,14 +112,14 @@ suite('AsyncDataTree', function () {
 		];
 
 		await tree.updateChildren(model.root);
-		assert.equal(container.querySelectorAll('.monaco-list-row').length, 1);
+		assert.strictEqual(container.querySelectorAll('.monaco-list-row').length, 1);
 
 		await tree.expand(model.get('a'));
-		assert.equal(container.querySelectorAll('.monaco-list-row').length, 4);
+		assert.strictEqual(container.querySelectorAll('.monaco-list-row').length, 4);
 
 		model.get('a').children = [];
 		await tree.updateChildren(model.root);
-		assert.equal(container.querySelectorAll('.monaco-list-row').length, 1);
+		assert.strictEqual(container.querySelectorAll('.monaco-list-row').length, 1);
 	});
 
 	test('issue #68648', async () => {
@@ -316,16 +316,16 @@ suite('AsyncDataTree', function () {
 
 		const pUpdateChildrenA = tree.updateChildren(model.get('a'));
 		const pExpandA = tree.expand(model.get('a'));
-		assert.equal(calls.length, 1, 'expand(a) still hasn\'t called getChildren(a)');
+		assert.strictEqual(calls.length, 1, 'expand(a) still hasn\'t called getChildren(a)');
 
 		calls.pop()!();
-		assert.equal(calls.length, 0, 'no pending getChildren calls');
+		assert.strictEqual(calls.length, 0, 'no pending getChildren calls');
 
 		await pUpdateChildrenA;
-		assert.equal(calls.length, 0, 'expand(a) should not have forced a second refresh');
+		assert.strictEqual(calls.length, 0, 'expand(a) should not have forced a second refresh');
 
 		const result = await pExpandA;
-		assert.equal(result, true, 'expand(a) should be done');
+		assert.strictEqual(result, true, 'expand(a) should be done');
 	});
 
 	test('issue #80098 - first expand should call getChildren', async () => {
@@ -358,16 +358,16 @@ suite('AsyncDataTree', function () {
 		await pSetInput;
 
 		const pExpandA = tree.expand(model.get('a'));
-		assert.equal(calls.length, 1, 'expand(a) should\'ve called getChildren(a)');
+		assert.strictEqual(calls.length, 1, 'expand(a) should\'ve called getChildren(a)');
 
 		let race = await Promise.race([pExpandA.then(() => 'expand'), timeout(1).then(() => 'timeout')]);
-		assert.equal(race, 'timeout', 'expand(a) should not be yet done');
+		assert.strictEqual(race, 'timeout', 'expand(a) should not be yet done');
 
 		calls.pop()!();
-		assert.equal(calls.length, 0, 'no pending getChildren calls');
+		assert.strictEqual(calls.length, 0, 'no pending getChildren calls');
 
 		race = await Promise.race([pExpandA.then(() => 'expand'), timeout(1).then(() => 'timeout')]);
-		assert.equal(race, 'expand', 'expand(a) should now be done');
+		assert.strictEqual(race, 'expand', 'expand(a) should now be done');
 	});
 
 	test('issue #78388 - tree should react to hasChildren toggles', async () => {
@@ -383,7 +383,7 @@ suite('AsyncDataTree', function () {
 		tree.layout(200);
 
 		await tree.setInput(model.root);
-		assert.equal(container.querySelectorAll('.monaco-list-row').length, 1);
+		assert.strictEqual(container.querySelectorAll('.monaco-list-row').length, 1);
 
 		let twistie = container.querySelector('.monaco-list-row:first-child .monaco-tl-twistie') as HTMLElement;
 		assert(!twistie.classList.contains('collapsible'));
@@ -391,14 +391,14 @@ suite('AsyncDataTree', function () {
 
 		model.get('a').children = [{ id: 'aa' }];
 		await tree.updateChildren(model.get('a'), false);
-		assert.equal(container.querySelectorAll('.monaco-list-row').length, 1);
+		assert.strictEqual(container.querySelectorAll('.monaco-list-row').length, 1);
 		twistie = container.querySelector('.monaco-list-row:first-child .monaco-tl-twistie') as HTMLElement;
 		assert(twistie.classList.contains('collapsible'));
 		assert(twistie.classList.contains('collapsed'));
 
 		model.get('a').children = [];
 		await tree.updateChildren(model.get('a'), false);
-		assert.equal(container.querySelectorAll('.monaco-list-row').length, 1);
+		assert.strictEqual(container.querySelectorAll('.monaco-list-row').length, 1);
 		twistie = container.querySelector('.monaco-list-row:first-child .monaco-tl-twistie') as HTMLElement;
 		assert(!twistie.classList.contains('collapsible'));
 		assert(!twistie.classList.contains('collapsed'));

--- a/src/vs/base/test/browser/ui/tree/compressedObjectTreeModel.test.ts
+++ b/src/vs/base/test/browser/ui/tree/compressedObjectTreeModel.test.ts
@@ -319,8 +319,8 @@ suite('CompressedObjectTree', function () {
 			const list: ITreeNode<ICompressedTreeNode<number>>[] = [];
 			const model = new CompressedObjectTreeModel<number>('test', toList(list));
 			assert(model);
-			assert.equal(list.length, 0);
-			assert.equal(model.size, 0);
+			assert.strictEqual(list.length, 0);
+			assert.strictEqual(model.size, 0);
 		});
 
 		test('flat', () => withSmartSplice(options => {
@@ -334,7 +334,7 @@ suite('CompressedObjectTree', function () {
 			], options);
 
 			assert.deepEqual(toArray(list), [[0], [1], [2]]);
-			assert.equal(model.size, 3);
+			assert.strictEqual(model.size, 3);
 
 			model.setChildren(null, [
 				{ element: 3 },
@@ -343,11 +343,11 @@ suite('CompressedObjectTree', function () {
 			], options);
 
 			assert.deepEqual(toArray(list), [[3], [4], [5]]);
-			assert.equal(model.size, 3);
+			assert.strictEqual(model.size, 3);
 
 			model.setChildren(null, [], options);
 			assert.deepEqual(toArray(list), []);
-			assert.equal(model.size, 0);
+			assert.strictEqual(model.size, 0);
 		}));
 
 		test('nested', () => withSmartSplice(options => {
@@ -367,7 +367,7 @@ suite('CompressedObjectTree', function () {
 			], options);
 
 			assert.deepEqual(toArray(list), [[0], [10], [11], [12], [1], [2]]);
-			assert.equal(model.size, 6);
+			assert.strictEqual(model.size, 6);
 
 			model.setChildren(12, [
 				{ element: 120 },
@@ -375,15 +375,15 @@ suite('CompressedObjectTree', function () {
 			], options);
 
 			assert.deepEqual(toArray(list), [[0], [10], [11], [12], [120], [121], [1], [2]]);
-			assert.equal(model.size, 8);
+			assert.strictEqual(model.size, 8);
 
 			model.setChildren(0, [], options);
 			assert.deepEqual(toArray(list), [[0], [1], [2]]);
-			assert.equal(model.size, 3);
+			assert.strictEqual(model.size, 3);
 
 			model.setChildren(null, [], options);
 			assert.deepEqual(toArray(list), []);
-			assert.equal(model.size, 0);
+			assert.strictEqual(model.size, 0);
 		}));
 
 		test('compressed', () => withSmartSplice(options => {
@@ -405,7 +405,7 @@ suite('CompressedObjectTree', function () {
 			], options);
 
 			assert.deepEqual(toArray(list), [[1, 11, 111], [1111], [1112], [1113]]);
-			assert.equal(model.size, 6);
+			assert.strictEqual(model.size, 6);
 
 			model.setChildren(11, [
 				{ element: 111 },
@@ -414,21 +414,21 @@ suite('CompressedObjectTree', function () {
 			], options);
 
 			assert.deepEqual(toArray(list), [[1, 11], [111], [112], [113]]);
-			assert.equal(model.size, 5);
+			assert.strictEqual(model.size, 5);
 
 			model.setChildren(113, [
 				{ element: 1131 }
 			], options);
 
 			assert.deepEqual(toArray(list), [[1, 11], [111], [112], [113, 1131]]);
-			assert.equal(model.size, 6);
+			assert.strictEqual(model.size, 6);
 
 			model.setChildren(1131, [
 				{ element: 1132 }
 			], options);
 
 			assert.deepEqual(toArray(list), [[1, 11], [111], [112], [113, 1131, 1132]]);
-			assert.equal(model.size, 7);
+			assert.strictEqual(model.size, 7);
 
 			model.setChildren(1131, [
 				{ element: 1132 },
@@ -436,7 +436,7 @@ suite('CompressedObjectTree', function () {
 			], options);
 
 			assert.deepEqual(toArray(list), [[1, 11], [111], [112], [113, 1131], [1132], [1133]]);
-			assert.equal(model.size, 8);
+			assert.strictEqual(model.size, 8);
 		}));
 	});
 });

--- a/src/vs/base/test/browser/ui/tree/dataTree.test.ts
+++ b/src/vs/base/test/browser/ui/tree/dataTree.test.ts
@@ -77,20 +77,20 @@ suite('DataTree', function () {
 		tree.setInput(root);
 
 		let navigator = tree.navigate();
-		assert.equal(navigator.next()!.value, 0);
-		assert.equal(navigator.next()!.value, 10);
-		assert.equal(navigator.next()!.value, 11);
-		assert.equal(navigator.next()!.value, 12);
-		assert.equal(navigator.next()!.value, 1);
-		assert.equal(navigator.next()!.value, 2);
-		assert.equal(navigator.next()!, null);
+		assert.strictEqual(navigator.next()!.value, 0);
+		assert.strictEqual(navigator.next()!.value, 10);
+		assert.strictEqual(navigator.next()!.value, 11);
+		assert.strictEqual(navigator.next()!.value, 12);
+		assert.strictEqual(navigator.next()!.value, 1);
+		assert.strictEqual(navigator.next()!.value, 2);
+		assert.strictEqual(navigator.next()!, null);
 
 		tree.collapse(root.children![0]);
 		navigator = tree.navigate();
-		assert.equal(navigator.next()!.value, 0);
-		assert.equal(navigator.next()!.value, 1);
-		assert.equal(navigator.next()!.value, 2);
-		assert.equal(navigator.next()!, null);
+		assert.strictEqual(navigator.next()!.value, 0);
+		assert.strictEqual(navigator.next()!.value, 1);
+		assert.strictEqual(navigator.next()!.value, 2);
+		assert.strictEqual(navigator.next()!, null);
 
 		tree.setSelection([root.children![1]]);
 		tree.setFocus([root.children![2]]);
@@ -98,13 +98,13 @@ suite('DataTree', function () {
 		tree.setInput(empty);
 		tree.setInput(root);
 		navigator = tree.navigate();
-		assert.equal(navigator.next()!.value, 0);
-		assert.equal(navigator.next()!.value, 10);
-		assert.equal(navigator.next()!.value, 11);
-		assert.equal(navigator.next()!.value, 12);
-		assert.equal(navigator.next()!.value, 1);
-		assert.equal(navigator.next()!.value, 2);
-		assert.equal(navigator.next()!, null);
+		assert.strictEqual(navigator.next()!.value, 0);
+		assert.strictEqual(navigator.next()!.value, 10);
+		assert.strictEqual(navigator.next()!.value, 11);
+		assert.strictEqual(navigator.next()!.value, 12);
+		assert.strictEqual(navigator.next()!.value, 1);
+		assert.strictEqual(navigator.next()!.value, 2);
+		assert.strictEqual(navigator.next()!, null);
 
 		assert.deepEqual(tree.getSelection(), []);
 		assert.deepEqual(tree.getFocus(), []);
@@ -114,20 +114,20 @@ suite('DataTree', function () {
 		tree.setInput(root);
 
 		let navigator = tree.navigate();
-		assert.equal(navigator.next()!.value, 0);
-		assert.equal(navigator.next()!.value, 10);
-		assert.equal(navigator.next()!.value, 11);
-		assert.equal(navigator.next()!.value, 12);
-		assert.equal(navigator.next()!.value, 1);
-		assert.equal(navigator.next()!.value, 2);
-		assert.equal(navigator.next()!, null);
+		assert.strictEqual(navigator.next()!.value, 0);
+		assert.strictEqual(navigator.next()!.value, 10);
+		assert.strictEqual(navigator.next()!.value, 11);
+		assert.strictEqual(navigator.next()!.value, 12);
+		assert.strictEqual(navigator.next()!.value, 1);
+		assert.strictEqual(navigator.next()!.value, 2);
+		assert.strictEqual(navigator.next()!, null);
 
 		tree.collapse(root.children![0]);
 		navigator = tree.navigate();
-		assert.equal(navigator.next()!.value, 0);
-		assert.equal(navigator.next()!.value, 1);
-		assert.equal(navigator.next()!.value, 2);
-		assert.equal(navigator.next()!, null);
+		assert.strictEqual(navigator.next()!.value, 0);
+		assert.strictEqual(navigator.next()!.value, 1);
+		assert.strictEqual(navigator.next()!.value, 2);
+		assert.strictEqual(navigator.next()!, null);
 
 		tree.setSelection([root.children![1]]);
 		tree.setFocus([root.children![2]]);
@@ -137,10 +137,10 @@ suite('DataTree', function () {
 		tree.setInput(empty);
 		tree.setInput(root, viewState);
 		navigator = tree.navigate();
-		assert.equal(navigator.next()!.value, 0);
-		assert.equal(navigator.next()!.value, 1);
-		assert.equal(navigator.next()!.value, 2);
-		assert.equal(navigator.next()!, null);
+		assert.strictEqual(navigator.next()!.value, 0);
+		assert.strictEqual(navigator.next()!.value, 1);
+		assert.strictEqual(navigator.next()!.value, 2);
+		assert.strictEqual(navigator.next()!, null);
 
 		assert.deepEqual(tree.getSelection(), [root.children![1]]);
 		assert.deepEqual(tree.getFocus(), [root.children![2]]);

--- a/src/vs/base/test/browser/ui/tree/indexTreeModel.test.ts
+++ b/src/vs/base/test/browser/ui/tree/indexTreeModel.test.ts
@@ -42,7 +42,7 @@ suite('IndexTreeModel', () => {
 		const list: ITreeNode<number>[] = [];
 		const model = new IndexTreeModel<number>('test', toList(list), -1);
 		assert(model);
-		assert.equal(list.length, 0);
+		assert.strictEqual(list.length, 0);
 	});
 
 	test('insert', () => withSmartSplice(options => {

--- a/src/vs/base/test/browser/ui/tree/objectTreeModel.test.ts
+++ b/src/vs/base/test/browser/ui/tree/objectTreeModel.test.ts
@@ -28,8 +28,8 @@ suite('ObjectTreeModel', function () {
 		const list: ITreeNode<number>[] = [];
 		const model = new ObjectTreeModel<number>('test', toList(list));
 		assert(model);
-		assert.equal(list.length, 0);
-		assert.equal(model.size, 0);
+		assert.strictEqual(list.length, 0);
+		assert.strictEqual(model.size, 0);
 	});
 
 	test('flat', () => {
@@ -43,7 +43,7 @@ suite('ObjectTreeModel', function () {
 		]);
 
 		assert.deepEqual(toArray(list), [0, 1, 2]);
-		assert.equal(model.size, 3);
+		assert.strictEqual(model.size, 3);
 
 		model.setChildren(null, [
 			{ element: 3 },
@@ -52,11 +52,11 @@ suite('ObjectTreeModel', function () {
 		]);
 
 		assert.deepEqual(toArray(list), [3, 4, 5]);
-		assert.equal(model.size, 3);
+		assert.strictEqual(model.size, 3);
 
 		model.setChildren(null);
 		assert.deepEqual(toArray(list), []);
-		assert.equal(model.size, 0);
+		assert.strictEqual(model.size, 0);
 	});
 
 	test('nested', () => {
@@ -76,7 +76,7 @@ suite('ObjectTreeModel', function () {
 		]);
 
 		assert.deepEqual(toArray(list), [0, 10, 11, 12, 1, 2]);
-		assert.equal(model.size, 6);
+		assert.strictEqual(model.size, 6);
 
 		model.setChildren(12, [
 			{ element: 120 },
@@ -84,15 +84,15 @@ suite('ObjectTreeModel', function () {
 		]);
 
 		assert.deepEqual(toArray(list), [0, 10, 11, 12, 120, 121, 1, 2]);
-		assert.equal(model.size, 8);
+		assert.strictEqual(model.size, 8);
 
 		model.setChildren(0);
 		assert.deepEqual(toArray(list), [0, 1, 2]);
-		assert.equal(model.size, 3);
+		assert.strictEqual(model.size, 3);
 
 		model.setChildren(null);
 		assert.deepEqual(toArray(list), []);
-		assert.equal(model.size, 0);
+		assert.strictEqual(model.size, 0);
 	});
 
 	test('setChildren on collapsed node', () => {

--- a/src/vs/base/test/common/cache.test.ts
+++ b/src/vs/base/test/common/cache.test.ts
@@ -14,9 +14,9 @@ suite('Cache', () => {
 		const cache = new Cache(_ => Promise.resolve(counter++));
 
 		return cache.get().promise
-			.then(c => assert.equal(c, 0), () => assert.fail('Unexpected assertion error'))
+			.then(c => assert.strictEqual(c, 0), () => assert.fail('Unexpected assertion error'))
 			.then(() => cache.get().promise)
-			.then(c => assert.equal(c, 0), () => assert.fail('Unexpected assertion error'));
+			.then(c => assert.strictEqual(c, 0), () => assert.fail('Unexpected assertion error'));
 	});
 
 	test('simple error', () => {
@@ -24,9 +24,9 @@ suite('Cache', () => {
 		const cache = new Cache(_ => Promise.reject(new Error(String(counter++))));
 
 		return cache.get().promise
-			.then(() => assert.fail('Unexpected assertion error'), err => assert.equal(err.message, 0))
+			.then(() => assert.fail('Unexpected assertion error'), err => assert.strictEqual(err.message, '0'))
 			.then(() => cache.get().promise)
-			.then(() => assert.fail('Unexpected assertion error'), err => assert.equal(err.message, 0));
+			.then(() => assert.fail('Unexpected assertion error'), err => assert.strictEqual(err.message, '0'));
 	});
 
 	test('should retry cancellations', () => {
@@ -37,29 +37,29 @@ suite('Cache', () => {
 			return Promise.resolve(timeout(2, token).then(() => counter2++));
 		});
 
-		assert.equal(counter1, 0);
-		assert.equal(counter2, 0);
+		assert.strictEqual(counter1, 0);
+		assert.strictEqual(counter2, 0);
 		let result = cache.get();
-		assert.equal(counter1, 1);
-		assert.equal(counter2, 0);
+		assert.strictEqual(counter1, 1);
+		assert.strictEqual(counter2, 0);
 		result.promise.then(undefined, () => assert(true));
 		result.dispose();
-		assert.equal(counter1, 1);
-		assert.equal(counter2, 0);
+		assert.strictEqual(counter1, 1);
+		assert.strictEqual(counter2, 0);
 
 		result = cache.get();
-		assert.equal(counter1, 2);
-		assert.equal(counter2, 0);
+		assert.strictEqual(counter1, 2);
+		assert.strictEqual(counter2, 0);
 
 		return result.promise
 			.then(c => {
-				assert.equal(counter1, 2);
-				assert.equal(counter2, 1);
+				assert.strictEqual(counter1, 2);
+				assert.strictEqual(counter2, 1);
 			})
 			.then(() => cache.get().promise)
 			.then(c => {
-				assert.equal(counter1, 2);
-				assert.equal(counter2, 1);
+				assert.strictEqual(counter1, 2);
+				assert.strictEqual(counter2, 1);
 			});
 	});
 });

--- a/src/vs/base/test/common/collections.test.ts
+++ b/src/vs/base/test/common/collections.test.ts
@@ -14,18 +14,18 @@ suite('Collections', () => {
 
 		let count = 0;
 		collections.forEach({ toString: 123 }, () => count++);
-		assert.equal(count, 1);
+		assert.strictEqual(count, 1);
 
 		count = 0;
 		let dict = Object.create(null);
 		dict['toString'] = 123;
 		collections.forEach(dict, () => count++);
-		assert.equal(count, 1);
+		assert.strictEqual(count, 1);
 
 		collections.forEach(dict, () => false);
 
 		collections.forEach(dict, (x, remove) => remove());
-		assert.equal(dict['toString'], null);
+		assert.strictEqual(dict['toString'], undefined);
 
 		// don't iterate over properties that are not on the object itself
 		let test = Object.create({ 'derived': true });
@@ -45,12 +45,12 @@ suite('Collections', () => {
 		let grouped = collections.groupBy(source, x => x.key);
 
 		// Group 1
-		assert.equal(grouped[group1].length, 2);
-		assert.equal(grouped[group1][0].value, value1);
-		assert.equal(grouped[group1][1].value, value2);
+		assert.strictEqual(grouped[group1].length, 2);
+		assert.strictEqual(grouped[group1][0].value, value1);
+		assert.strictEqual(grouped[group1][1].value, value2);
 
 		// Group 2
-		assert.equal(grouped[group2].length, 1);
-		assert.equal(grouped[group2][0].value, value3);
+		assert.strictEqual(grouped[group2].length, 1);
+		assert.strictEqual(grouped[group2][0].value, value3);
 	});
 });

--- a/src/vs/base/test/common/console.test.ts
+++ b/src/vs/base/test/common/console.test.ts
@@ -13,36 +13,36 @@ suite('Console', () => {
 		let stack = 'at vscode.commands.registerCommand (/Users/someone/Desktop/test-ts/out/src/extension.js:18:17)';
 		let frame = getFirstFrame(stack)!;
 
-		assert.equal(frame.uri.fsPath, normalize('/Users/someone/Desktop/test-ts/out/src/extension.js'));
-		assert.equal(frame.line, 18);
-		assert.equal(frame.column, 17);
+		assert.strictEqual(frame.uri.fsPath, normalize('/Users/someone/Desktop/test-ts/out/src/extension.js'));
+		assert.strictEqual(frame.line, 18);
+		assert.strictEqual(frame.column, 17);
 
 		stack = 'at /Users/someone/Desktop/test-ts/out/src/extension.js:18:17';
 		frame = getFirstFrame(stack)!;
 
-		assert.equal(frame.uri.fsPath, normalize('/Users/someone/Desktop/test-ts/out/src/extension.js'));
-		assert.equal(frame.line, 18);
-		assert.equal(frame.column, 17);
+		assert.strictEqual(frame.uri.fsPath, normalize('/Users/someone/Desktop/test-ts/out/src/extension.js'));
+		assert.strictEqual(frame.line, 18);
+		assert.strictEqual(frame.column, 17);
 
 		stack = 'at c:\\Users\\someone\\Desktop\\end-js\\extension.js:18:17';
 		frame = getFirstFrame(stack)!;
 
-		assert.equal(frame.uri.fsPath, 'c:\\Users\\someone\\Desktop\\end-js\\extension.js');
-		assert.equal(frame.line, 18);
-		assert.equal(frame.column, 17);
+		assert.strictEqual(frame.uri.fsPath, 'c:\\Users\\someone\\Desktop\\end-js\\extension.js');
+		assert.strictEqual(frame.line, 18);
+		assert.strictEqual(frame.column, 17);
 
 		stack = 'at e.$executeContributedCommand(c:\\Users\\someone\\Desktop\\end-js\\extension.js:18:17)';
 		frame = getFirstFrame(stack)!;
 
-		assert.equal(frame.uri.fsPath, 'c:\\Users\\someone\\Desktop\\end-js\\extension.js');
-		assert.equal(frame.line, 18);
-		assert.equal(frame.column, 17);
+		assert.strictEqual(frame.uri.fsPath, 'c:\\Users\\someone\\Desktop\\end-js\\extension.js');
+		assert.strictEqual(frame.line, 18);
+		assert.strictEqual(frame.column, 17);
 
 		stack = 'at /Users/someone/Desktop/test-ts/out/src/extension.js:18:17\nat /Users/someone/Desktop/test-ts/out/src/other.js:28:27\nat /Users/someone/Desktop/test-ts/out/src/more.js:38:37';
 		frame = getFirstFrame(stack)!;
 
-		assert.equal(frame.uri.fsPath, normalize('/Users/someone/Desktop/test-ts/out/src/extension.js'));
-		assert.equal(frame.line, 18);
-		assert.equal(frame.column, 17);
+		assert.strictEqual(frame.uri.fsPath, normalize('/Users/someone/Desktop/test-ts/out/src/extension.js'));
+		assert.strictEqual(frame.line, 18);
+		assert.strictEqual(frame.column, 17);
 	});
 });

--- a/src/vs/base/test/common/decorators.test.ts
+++ b/src/vs/base/test/common/decorators.test.ts
@@ -22,35 +22,35 @@ suite('Decorators', () => {
 		}
 
 		const foo = new Foo(42);
-		assert.equal(foo.count, 0);
-		assert.equal(foo.answer(), 42);
-		assert.equal(foo.count, 1);
-		assert.equal(foo.answer(), 42);
-		assert.equal(foo.count, 1);
+		assert.strictEqual(foo.count, 0);
+		assert.strictEqual(foo.answer(), 42);
+		assert.strictEqual(foo.count, 1);
+		assert.strictEqual(foo.answer(), 42);
+		assert.strictEqual(foo.count, 1);
 
 		const foo2 = new Foo(1337);
-		assert.equal(foo2.count, 0);
-		assert.equal(foo2.answer(), 1337);
-		assert.equal(foo2.count, 1);
-		assert.equal(foo2.answer(), 1337);
-		assert.equal(foo2.count, 1);
+		assert.strictEqual(foo2.count, 0);
+		assert.strictEqual(foo2.answer(), 1337);
+		assert.strictEqual(foo2.count, 1);
+		assert.strictEqual(foo2.answer(), 1337);
+		assert.strictEqual(foo2.count, 1);
 
-		assert.equal(foo.answer(), 42);
-		assert.equal(foo.count, 1);
+		assert.strictEqual(foo.answer(), 42);
+		assert.strictEqual(foo.count, 1);
 
 		const foo3 = new Foo(null);
-		assert.equal(foo3.count, 0);
-		assert.equal(foo3.answer(), null);
-		assert.equal(foo3.count, 1);
-		assert.equal(foo3.answer(), null);
-		assert.equal(foo3.count, 1);
+		assert.strictEqual(foo3.count, 0);
+		assert.strictEqual(foo3.answer(), null);
+		assert.strictEqual(foo3.count, 1);
+		assert.strictEqual(foo3.answer(), null);
+		assert.strictEqual(foo3.count, 1);
 
 		const foo4 = new Foo(undefined);
-		assert.equal(foo4.count, 0);
-		assert.equal(foo4.answer(), undefined);
-		assert.equal(foo4.count, 1);
-		assert.equal(foo4.answer(), undefined);
-		assert.equal(foo4.count, 1);
+		assert.strictEqual(foo4.count, 0);
+		assert.strictEqual(foo4.answer(), undefined);
+		assert.strictEqual(foo4.count, 1);
+		assert.strictEqual(foo4.answer(), undefined);
+		assert.strictEqual(foo4.count, 1);
 	});
 
 	test('memoize should memoize getters', () => {
@@ -67,35 +67,35 @@ suite('Decorators', () => {
 		}
 
 		const foo = new Foo(42);
-		assert.equal(foo.count, 0);
-		assert.equal(foo.answer, 42);
-		assert.equal(foo.count, 1);
-		assert.equal(foo.answer, 42);
-		assert.equal(foo.count, 1);
+		assert.strictEqual(foo.count, 0);
+		assert.strictEqual(foo.answer, 42);
+		assert.strictEqual(foo.count, 1);
+		assert.strictEqual(foo.answer, 42);
+		assert.strictEqual(foo.count, 1);
 
 		const foo2 = new Foo(1337);
-		assert.equal(foo2.count, 0);
-		assert.equal(foo2.answer, 1337);
-		assert.equal(foo2.count, 1);
-		assert.equal(foo2.answer, 1337);
-		assert.equal(foo2.count, 1);
+		assert.strictEqual(foo2.count, 0);
+		assert.strictEqual(foo2.answer, 1337);
+		assert.strictEqual(foo2.count, 1);
+		assert.strictEqual(foo2.answer, 1337);
+		assert.strictEqual(foo2.count, 1);
 
-		assert.equal(foo.answer, 42);
-		assert.equal(foo.count, 1);
+		assert.strictEqual(foo.answer, 42);
+		assert.strictEqual(foo.count, 1);
 
 		const foo3 = new Foo(null);
-		assert.equal(foo3.count, 0);
-		assert.equal(foo3.answer, null);
-		assert.equal(foo3.count, 1);
-		assert.equal(foo3.answer, null);
-		assert.equal(foo3.count, 1);
+		assert.strictEqual(foo3.count, 0);
+		assert.strictEqual(foo3.answer, null);
+		assert.strictEqual(foo3.count, 1);
+		assert.strictEqual(foo3.answer, null);
+		assert.strictEqual(foo3.count, 1);
 
 		const foo4 = new Foo(undefined);
-		assert.equal(foo4.count, 0);
-		assert.equal(foo4.answer, undefined);
-		assert.equal(foo4.count, 1);
-		assert.equal(foo4.answer, undefined);
-		assert.equal(foo4.count, 1);
+		assert.strictEqual(foo4.count, 0);
+		assert.strictEqual(foo4.answer, undefined);
+		assert.strictEqual(foo4.count, 1);
+		assert.strictEqual(foo4.answer, undefined);
+		assert.strictEqual(foo4.count, 1);
 	});
 
 	test('memoized property should not be enumerable', () => {
@@ -107,7 +107,7 @@ suite('Decorators', () => {
 		}
 
 		const foo = new Foo();
-		assert.equal(foo.answer, 42);
+		assert.strictEqual(foo.answer, 42);
 
 		assert(!Object.keys(foo).some(k => /\$memoize\$/.test(k)));
 	});
@@ -121,13 +121,13 @@ suite('Decorators', () => {
 		}
 
 		const foo = new Foo();
-		assert.equal(foo.answer, 42);
+		assert.strictEqual(foo.answer, 42);
 
 		try {
 			(foo as any)['$memoize$answer'] = 1337;
 			assert(false);
 		} catch (e) {
-			assert.equal(foo.answer, 42);
+			assert.strictEqual(foo.answer, 42);
 		}
 	});
 
@@ -142,15 +142,15 @@ suite('Decorators', () => {
 		}
 
 		const foo = new Foo();
-		assert.equal(foo.answer, 1);
-		assert.equal(foo.answer, 1);
+		assert.strictEqual(foo.answer, 1);
+		assert.strictEqual(foo.answer, 1);
 		memoizer.clear();
-		assert.equal(foo.answer, 2);
-		assert.equal(foo.answer, 2);
+		assert.strictEqual(foo.answer, 2);
+		assert.strictEqual(foo.answer, 2);
 		memoizer.clear();
-		assert.equal(foo.answer, 3);
-		assert.equal(foo.answer, 3);
-		assert.equal(foo.answer, 3);
+		assert.strictEqual(foo.answer, 3);
+		assert.strictEqual(foo.answer, 3);
+		assert.strictEqual(foo.answer, 3);
 	});
 
 	test('throttle', () => {

--- a/src/vs/base/test/common/history.test.ts
+++ b/src/vs/base/test/common/history.test.ts
@@ -16,22 +16,22 @@ suite('History Navigator', () => {
 	test('create sets the position to last', () => {
 		const testObject = new HistoryNavigator(['1', '2', '3', '4'], 100);
 
-		assert.equal(testObject.current(), null);
-		assert.equal(testObject.next(), null);
-		assert.equal(testObject.previous(), '4');
+		assert.strictEqual(testObject.current(), null);
+		assert.strictEqual(testObject.next(), null);
+		assert.strictEqual(testObject.previous(), '4');
 	});
 
 	test('last returns last element', () => {
 		const testObject = new HistoryNavigator(['1', '2', '3', '4'], 100);
 
-		assert.equal(testObject.first(), '1');
-		assert.equal(testObject.last(), '4');
+		assert.strictEqual(testObject.first(), '1');
+		assert.strictEqual(testObject.last(), '4');
 	});
 
 	test('first returns first element', () => {
 		const testObject = new HistoryNavigator(['1', '2', '3', '4'], 3);
 
-		assert.equal('2', testObject.first());
+		assert.strictEqual('2', testObject.first());
 	});
 
 	test('next returns next element', () => {
@@ -39,18 +39,18 @@ suite('History Navigator', () => {
 
 		testObject.first();
 
-		assert.equal(testObject.next(), '3');
-		assert.equal(testObject.next(), '4');
-		assert.equal(testObject.next(), null);
+		assert.strictEqual(testObject.next(), '3');
+		assert.strictEqual(testObject.next(), '4');
+		assert.strictEqual(testObject.next(), null);
 	});
 
 	test('previous returns previous element', () => {
 		const testObject = new HistoryNavigator(['1', '2', '3', '4'], 3);
 
-		assert.equal(testObject.previous(), '4');
-		assert.equal(testObject.previous(), '3');
-		assert.equal(testObject.previous(), '2');
-		assert.equal(testObject.previous(), null);
+		assert.strictEqual(testObject.previous(), '4');
+		assert.strictEqual(testObject.previous(), '3');
+		assert.strictEqual(testObject.previous(), '2');
+		assert.strictEqual(testObject.previous(), null);
 	});
 
 	test('next on last element returs null and remains on last', () => {
@@ -59,8 +59,8 @@ suite('History Navigator', () => {
 		testObject.first();
 		testObject.last();
 
-		assert.equal(testObject.current(), '4');
-		assert.equal(testObject.next(), null);
+		assert.strictEqual(testObject.current(), '4');
+		assert.strictEqual(testObject.next(), null);
 	});
 
 	test('previous on first element returs null and remains on first', () => {
@@ -68,8 +68,8 @@ suite('History Navigator', () => {
 
 		testObject.first();
 
-		assert.equal(testObject.current(), '2');
-		assert.equal(testObject.previous(), null);
+		assert.strictEqual(testObject.current(), '2');
+		assert.strictEqual(testObject.previous(), null);
 	});
 
 	test('add reduces the input to limit', () => {
@@ -94,8 +94,8 @@ suite('History Navigator', () => {
 		testObject.first();
 		testObject.add('5');
 
-		assert.equal(testObject.previous(), '5');
-		assert.equal(testObject.next(), null);
+		assert.strictEqual(testObject.previous(), '5');
+		assert.strictEqual(testObject.next(), null);
 	});
 
 	test('adding an existing item changes the order', () => {
@@ -142,9 +142,9 @@ suite('History Navigator', () => {
 
 	test('clear', () => {
 		const testObject = new HistoryNavigator(['a', 'b', 'c']);
-		assert.equal(testObject.previous(), 'c');
+		assert.strictEqual(testObject.previous(), 'c');
 		testObject.clear();
-		assert.equal(testObject.current(), undefined);
+		assert.strictEqual(testObject.current(), null);
 	});
 
 	function toArray(historyNavigator: HistoryNavigator<string>): Array<string | null> {

--- a/src/vs/base/test/common/iterator.test.ts
+++ b/src/vs/base/test/common/iterator.test.ts
@@ -19,10 +19,10 @@ suite('Iterable', function () {
 
 	test('first', function () {
 
-		assert.equal(Iterable.first([]), undefined);
-		assert.equal(Iterable.first([1]), 1);
-		assert.equal(Iterable.first(customIterable), 'one');
-		assert.equal(Iterable.first(customIterable), 'one'); // fresh
+		assert.strictEqual(Iterable.first([]), undefined);
+		assert.strictEqual(Iterable.first([1]), 1);
+		assert.strictEqual(Iterable.first(customIterable), 'one');
+		assert.strictEqual(Iterable.first(customIterable), 'one'); // fresh
 	});
 
 	test('equals', () => {

--- a/src/vs/base/test/common/json.test.ts
+++ b/src/vs/base/test/common/json.test.ts
@@ -12,15 +12,15 @@ function assertKinds(text: string, ...kinds: SyntaxKind[]): void {
 	let scanner = createScanner(text);
 	let kind: SyntaxKind;
 	while ((kind = scanner.scan()) !== SyntaxKind.EOF) {
-		assert.equal(kind, kinds.shift());
+		assert.strictEqual(kind, kinds.shift());
 	}
-	assert.equal(kinds.length, 0);
+	assert.strictEqual(kinds.length, 0);
 }
 function assertScanError(text: string, expectedKind: SyntaxKind, scanError: ScanError): void {
 	let scanner = createScanner(text);
 	scanner.scan();
-	assert.equal(scanner.getToken(), expectedKind);
-	assert.equal(scanner.getTokenError(), scanError);
+	assert.strictEqual(scanner.getToken(), expectedKind);
+	assert.strictEqual(scanner.getTokenError(), scanError);
 }
 
 function assertValidParse(input: string, expected: any, options?: ParseOptions): void {
@@ -49,7 +49,7 @@ function assertTree(input: string, expected: any, expectedErrors: number[] = [],
 	let checkParent = (node: Node) => {
 		if (node.children) {
 			for (let child of node.children) {
-				assert.equal(node, child.parent);
+				assert.strictEqual(node, child.parent);
 				delete (<any>child).parent; // delete to avoid recursion in deep equal
 				checkParent(child);
 			}

--- a/src/vs/base/test/common/jsonEdit.test.ts
+++ b/src/vs/base/test/common/jsonEdit.test.ts
@@ -19,7 +19,7 @@ suite('JSON - edits', () => {
 			lastEditOffset = edit.offset;
 			content = content.substring(0, edit.offset) + edit.content + content.substring(edit.offset + edit.length);
 		}
-		assert.equal(content, expected);
+		assert.strictEqual(content, expected);
 	}
 
 	let formatterOptions: FormattingOptions = {

--- a/src/vs/base/test/common/jsonFormatter.test.ts
+++ b/src/vs/base/test/common/jsonFormatter.test.ts
@@ -28,7 +28,7 @@ suite('JSON - formatter', () => {
 			content = content.substring(0, edit.offset) + edit.content + content.substring(edit.offset + edit.length);
 		}
 
-		assert.equal(content, expected);
+		assert.strictEqual(content, expected);
 	}
 
 	test('object - single property', () => {

--- a/src/vs/base/test/common/marshalling.test.ts
+++ b/src/vs/base/test/common/marshalling.test.ts
@@ -13,10 +13,10 @@ suite('Marshalling', () => {
 		let raw = stringify(value);
 		let clone = <RegExp>parse(raw);
 
-		assert.equal(value.source, clone.source);
-		assert.equal(value.global, clone.global);
-		assert.equal(value.ignoreCase, clone.ignoreCase);
-		assert.equal(value.multiline, clone.multiline);
+		assert.strictEqual(value.source, clone.source);
+		assert.strictEqual(value.global, clone.global);
+		assert.strictEqual(value.ignoreCase, clone.ignoreCase);
+		assert.strictEqual(value.multiline, clone.multiline);
 	});
 
 	test('URI', () => {
@@ -24,15 +24,15 @@ suite('Marshalling', () => {
 		const raw = stringify(value);
 		const clone = <URI>parse(raw);
 
-		assert.equal(value.scheme, clone.scheme);
-		assert.equal(value.authority, clone.authority);
-		assert.equal(value.path, clone.path);
-		assert.equal(value.query, clone.query);
-		assert.equal(value.fragment, clone.fragment);
+		assert.strictEqual(value.scheme, clone.scheme);
+		assert.strictEqual(value.authority, clone.authority);
+		assert.strictEqual(value.path, clone.path);
+		assert.strictEqual(value.query, clone.query);
+		assert.strictEqual(value.fragment, clone.fragment);
 	});
 
 	test('Bug 16793:# in folder name => mirror models get out of sync', () => {
 		const uri1 = URI.file('C:\\C#\\file.txt');
-		assert.equal(parse(stringify(uri1)).toString(), uri1.toString());
+		assert.strictEqual(parse(stringify(uri1)).toString(), uri1.toString());
 	});
 });

--- a/src/vs/base/test/common/normalization.test.ts
+++ b/src/vs/base/test/common/normalization.test.ts
@@ -9,57 +9,57 @@ import { removeAccents } from 'vs/base/common/normalization';
 suite('Normalization', () => {
 
 	test('removeAccents', function () {
-		assert.equal(removeAccents('joào'), 'joao');
-		assert.equal(removeAccents('joáo'), 'joao');
-		assert.equal(removeAccents('joâo'), 'joao');
-		assert.equal(removeAccents('joäo'), 'joao');
-		// assert.equal(strings.removeAccents('joæo'), 'joao'); // not an accent
-		assert.equal(removeAccents('joão'), 'joao');
-		assert.equal(removeAccents('joåo'), 'joao');
-		assert.equal(removeAccents('joåo'), 'joao');
-		assert.equal(removeAccents('joāo'), 'joao');
+		assert.strictEqual(removeAccents('joào'), 'joao');
+		assert.strictEqual(removeAccents('joáo'), 'joao');
+		assert.strictEqual(removeAccents('joâo'), 'joao');
+		assert.strictEqual(removeAccents('joäo'), 'joao');
+		// assert.strictEqual(strings.removeAccents('joæo'), 'joao'); // not an accent
+		assert.strictEqual(removeAccents('joão'), 'joao');
+		assert.strictEqual(removeAccents('joåo'), 'joao');
+		assert.strictEqual(removeAccents('joåo'), 'joao');
+		assert.strictEqual(removeAccents('joāo'), 'joao');
 
-		assert.equal(removeAccents('fôo'), 'foo');
-		assert.equal(removeAccents('föo'), 'foo');
-		assert.equal(removeAccents('fòo'), 'foo');
-		assert.equal(removeAccents('fóo'), 'foo');
-		// assert.equal(strings.removeAccents('fœo'), 'foo');
-		// assert.equal(strings.removeAccents('føo'), 'foo');
-		assert.equal(removeAccents('fōo'), 'foo');
-		assert.equal(removeAccents('fõo'), 'foo');
+		assert.strictEqual(removeAccents('fôo'), 'foo');
+		assert.strictEqual(removeAccents('föo'), 'foo');
+		assert.strictEqual(removeAccents('fòo'), 'foo');
+		assert.strictEqual(removeAccents('fóo'), 'foo');
+		// assert.strictEqual(strings.removeAccents('fœo'), 'foo');
+		// assert.strictEqual(strings.removeAccents('føo'), 'foo');
+		assert.strictEqual(removeAccents('fōo'), 'foo');
+		assert.strictEqual(removeAccents('fõo'), 'foo');
 
-		assert.equal(removeAccents('andrè'), 'andre');
-		assert.equal(removeAccents('andré'), 'andre');
-		assert.equal(removeAccents('andrê'), 'andre');
-		assert.equal(removeAccents('andrë'), 'andre');
-		assert.equal(removeAccents('andrē'), 'andre');
-		assert.equal(removeAccents('andrė'), 'andre');
-		assert.equal(removeAccents('andrę'), 'andre');
+		assert.strictEqual(removeAccents('andrè'), 'andre');
+		assert.strictEqual(removeAccents('andré'), 'andre');
+		assert.strictEqual(removeAccents('andrê'), 'andre');
+		assert.strictEqual(removeAccents('andrë'), 'andre');
+		assert.strictEqual(removeAccents('andrē'), 'andre');
+		assert.strictEqual(removeAccents('andrė'), 'andre');
+		assert.strictEqual(removeAccents('andrę'), 'andre');
 
-		assert.equal(removeAccents('hvîc'), 'hvic');
-		assert.equal(removeAccents('hvïc'), 'hvic');
-		assert.equal(removeAccents('hvíc'), 'hvic');
-		assert.equal(removeAccents('hvīc'), 'hvic');
-		assert.equal(removeAccents('hvįc'), 'hvic');
-		assert.equal(removeAccents('hvìc'), 'hvic');
+		assert.strictEqual(removeAccents('hvîc'), 'hvic');
+		assert.strictEqual(removeAccents('hvïc'), 'hvic');
+		assert.strictEqual(removeAccents('hvíc'), 'hvic');
+		assert.strictEqual(removeAccents('hvīc'), 'hvic');
+		assert.strictEqual(removeAccents('hvįc'), 'hvic');
+		assert.strictEqual(removeAccents('hvìc'), 'hvic');
 
-		assert.equal(removeAccents('ûdo'), 'udo');
-		assert.equal(removeAccents('üdo'), 'udo');
-		assert.equal(removeAccents('ùdo'), 'udo');
-		assert.equal(removeAccents('údo'), 'udo');
-		assert.equal(removeAccents('ūdo'), 'udo');
+		assert.strictEqual(removeAccents('ûdo'), 'udo');
+		assert.strictEqual(removeAccents('üdo'), 'udo');
+		assert.strictEqual(removeAccents('ùdo'), 'udo');
+		assert.strictEqual(removeAccents('údo'), 'udo');
+		assert.strictEqual(removeAccents('ūdo'), 'udo');
 
-		assert.equal(removeAccents('heÿ'), 'hey');
+		assert.strictEqual(removeAccents('heÿ'), 'hey');
 
-		// assert.equal(strings.removeAccents('gruß'), 'grus');
-		assert.equal(removeAccents('gruś'), 'grus');
-		assert.equal(removeAccents('gruš'), 'grus');
+		// assert.strictEqual(strings.removeAccents('gruß'), 'grus');
+		assert.strictEqual(removeAccents('gruś'), 'grus');
+		assert.strictEqual(removeAccents('gruš'), 'grus');
 
-		assert.equal(removeAccents('çool'), 'cool');
-		assert.equal(removeAccents('ćool'), 'cool');
-		assert.equal(removeAccents('čool'), 'cool');
+		assert.strictEqual(removeAccents('çool'), 'cool');
+		assert.strictEqual(removeAccents('ćool'), 'cool');
+		assert.strictEqual(removeAccents('čool'), 'cool');
 
-		assert.equal(removeAccents('ñice'), 'nice');
-		assert.equal(removeAccents('ńice'), 'nice');
+		assert.strictEqual(removeAccents('ñice'), 'nice');
+		assert.strictEqual(removeAccents('ńice'), 'nice');
 	});
 });

--- a/src/vs/base/test/common/objects.test.ts
+++ b/src/vs/base/test/common/objects.test.ts
@@ -60,10 +60,10 @@ suite('Objects', () => {
 
 		assert(foo.bar);
 		assert(Array.isArray(foo.bar));
-		assert.equal(foo.bar.length, 3);
-		assert.equal(foo.bar[0], 1);
-		assert.equal(foo.bar[1], 2);
-		assert.equal(foo.bar[2], 3);
+		assert.strictEqual(foo.bar.length, 3);
+		assert.strictEqual(foo.bar[0], 1);
+		assert.strictEqual(foo.bar[1], 2);
+		assert.strictEqual(foo.bar[2], 3);
 	});
 
 	test('mixin - no overwrite', function () {
@@ -77,7 +77,7 @@ suite('Objects', () => {
 
 		objects.mixin(foo, bar, false);
 
-		assert.equal(foo.bar, '123');
+		assert.strictEqual(foo.bar, '123');
 	});
 
 	test('cloneAndChange', () => {
@@ -219,10 +219,10 @@ suite('Objects', () => {
 			mIxEdCaSe: 456
 		};
 
-		assert.equal(obj1.lowercase, objects.getCaseInsensitive(obj1, 'lowercase'));
-		assert.equal(obj1.lowercase, objects.getCaseInsensitive(obj1, 'lOwErCaSe'));
+		assert.strictEqual(obj1.lowercase, objects.getCaseInsensitive(obj1, 'lowercase'));
+		assert.strictEqual(obj1.lowercase, objects.getCaseInsensitive(obj1, 'lOwErCaSe'));
 
-		assert.equal(obj1.mIxEdCaSe, objects.getCaseInsensitive(obj1, 'MIXEDCASE'));
-		assert.equal(obj1.mIxEdCaSe, objects.getCaseInsensitive(obj1, 'mixedcase'));
+		assert.strictEqual(obj1.mIxEdCaSe, objects.getCaseInsensitive(obj1, 'MIXEDCASE'));
+		assert.strictEqual(obj1.mIxEdCaSe, objects.getCaseInsensitive(obj1, 'mixedcase'));
 	});
 });

--- a/src/vs/base/test/common/paging.test.ts
+++ b/src/vs/base/test/common/paging.test.ts
@@ -148,7 +148,7 @@ suite('PagedModel', () => {
 
 		const model = new PagedModel(pager);
 
-		assert.equal(state, 'idle');
+		assert.strictEqual(state, 'idle');
 
 		const tokenSource1 = new CancellationTokenSource();
 		const promise1 = model.resolve(5, tokenSource1.token).then(
@@ -156,7 +156,7 @@ suite('PagedModel', () => {
 			err => assert(isPromiseCanceledError(err))
 		);
 
-		assert.equal(state, 'resolving');
+		assert.strictEqual(state, 'resolving');
 
 		const tokenSource2 = new CancellationTokenSource();
 		const promise2 = model.resolve(6, tokenSource2.token).then(
@@ -164,17 +164,17 @@ suite('PagedModel', () => {
 			err => assert(isPromiseCanceledError(err))
 		);
 
-		assert.equal(state, 'resolving');
+		assert.strictEqual(state, 'resolving');
 
 		setTimeout(() => {
-			assert.equal(state, 'resolving');
+			assert.strictEqual(state, 'resolving');
 			tokenSource1.cancel();
-			assert.equal(state, 'resolving');
+			assert.strictEqual(state, 'resolving');
 
 			setTimeout(() => {
-				assert.equal(state, 'resolving');
+				assert.strictEqual(state, 'resolving');
 				tokenSource2.cancel();
-				assert.equal(state, 'idle');
+				assert.strictEqual(state, 'idle');
 			}, 10);
 		}, 10);
 

--- a/src/vs/base/test/common/path.test.ts
+++ b/src/vs/base/test/common/path.test.ts
@@ -353,11 +353,11 @@ suite('Paths (Node Implementation)', () => {
 		assert.strictEqual(path.posix.extname('file.\\\\'), '.\\\\');
 
 		// Tests from VSCode
-		assert.equal(path.extname('far.boo'), '.boo');
-		assert.equal(path.extname('far.b'), '.b');
-		assert.equal(path.extname('far.'), '.');
-		assert.equal(path.extname('far.boo/boo.far'), '.far');
-		assert.equal(path.extname('far.boo/boo'), '');
+		assert.strictEqual(path.extname('far.boo'), '.boo');
+		assert.strictEqual(path.extname('far.b'), '.b');
+		assert.strictEqual(path.extname('far.'), '.');
+		assert.strictEqual(path.extname('far.boo/boo.far'), '.far');
+		assert.strictEqual(path.extname('far.boo/boo'), '');
 	});
 
 	(isWeb && isWindows ? test.skip : test)('resolve', () => { // TODO@sbatten fails on windows & browser only
@@ -501,25 +501,25 @@ suite('Paths (Node Implementation)', () => {
 			controlCharFilename);
 
 		// Tests from VSCode
-		assert.equal(path.basename('foo/bar'), 'bar');
-		assert.equal(path.posix.basename('foo\\bar'), 'foo\\bar');
-		assert.equal(path.win32.basename('foo\\bar'), 'bar');
-		assert.equal(path.basename('/foo/bar'), 'bar');
-		assert.equal(path.posix.basename('\\foo\\bar'), '\\foo\\bar');
-		assert.equal(path.win32.basename('\\foo\\bar'), 'bar');
-		assert.equal(path.basename('./bar'), 'bar');
-		assert.equal(path.posix.basename('.\\bar'), '.\\bar');
-		assert.equal(path.win32.basename('.\\bar'), 'bar');
-		assert.equal(path.basename('/bar'), 'bar');
-		assert.equal(path.posix.basename('\\bar'), '\\bar');
-		assert.equal(path.win32.basename('\\bar'), 'bar');
-		assert.equal(path.basename('bar/'), 'bar');
-		assert.equal(path.posix.basename('bar\\'), 'bar\\');
-		assert.equal(path.win32.basename('bar\\'), 'bar');
-		assert.equal(path.basename('bar'), 'bar');
-		assert.equal(path.basename('////////'), '');
-		assert.equal(path.posix.basename('\\\\\\\\'), '\\\\\\\\');
-		assert.equal(path.win32.basename('\\\\\\\\'), '');
+		assert.strictEqual(path.basename('foo/bar'), 'bar');
+		assert.strictEqual(path.posix.basename('foo\\bar'), 'foo\\bar');
+		assert.strictEqual(path.win32.basename('foo\\bar'), 'bar');
+		assert.strictEqual(path.basename('/foo/bar'), 'bar');
+		assert.strictEqual(path.posix.basename('\\foo\\bar'), '\\foo\\bar');
+		assert.strictEqual(path.win32.basename('\\foo\\bar'), 'bar');
+		assert.strictEqual(path.basename('./bar'), 'bar');
+		assert.strictEqual(path.posix.basename('.\\bar'), '.\\bar');
+		assert.strictEqual(path.win32.basename('.\\bar'), 'bar');
+		assert.strictEqual(path.basename('/bar'), 'bar');
+		assert.strictEqual(path.posix.basename('\\bar'), '\\bar');
+		assert.strictEqual(path.win32.basename('\\bar'), 'bar');
+		assert.strictEqual(path.basename('bar/'), 'bar');
+		assert.strictEqual(path.posix.basename('bar\\'), 'bar\\');
+		assert.strictEqual(path.win32.basename('bar\\'), 'bar');
+		assert.strictEqual(path.basename('bar'), 'bar');
+		assert.strictEqual(path.basename('////////'), '');
+		assert.strictEqual(path.posix.basename('\\\\\\\\'), '\\\\\\\\');
+		assert.strictEqual(path.win32.basename('\\\\\\\\'), '');
 	});
 
 	test('relative', () => {

--- a/src/vs/base/test/common/processes.test.ts
+++ b/src/vs/base/test/common/processes.test.ts
@@ -27,7 +27,7 @@ suite('Processes', () => {
 			GDK_PIXBUF_MODULEDIR: 'x',
 		};
 		processes.sanitizeProcessEnvironment(env);
-		assert.equal(env['FOO'], 'bar');
-		assert.equal(Object.keys(env).length, 1);
+		assert.strictEqual(env['FOO'], 'bar');
+		assert.strictEqual(Object.keys(env).length, 1);
 	});
 });

--- a/src/vs/base/test/common/resourceTree.test.ts
+++ b/src/vs/base/test/common/resourceTree.test.ts
@@ -10,63 +10,63 @@ import { URI } from 'vs/base/common/uri';
 suite('ResourceTree', function () {
 	test('ctor', function () {
 		const tree = new ResourceTree<string, null>(null);
-		assert.equal(tree.root.childrenCount, 0);
+		assert.strictEqual(tree.root.childrenCount, 0);
 	});
 
 	test('simple', function () {
 		const tree = new ResourceTree<string, null>(null);
 
 		tree.add(URI.file('/foo/bar.txt'), 'bar contents');
-		assert.equal(tree.root.childrenCount, 1);
+		assert.strictEqual(tree.root.childrenCount, 1);
 
 		let foo = tree.root.get('foo')!;
 		assert(foo);
-		assert.equal(foo.childrenCount, 1);
+		assert.strictEqual(foo.childrenCount, 1);
 
 		let bar = foo.get('bar.txt')!;
 		assert(bar);
-		assert.equal(bar.element, 'bar contents');
+		assert.strictEqual(bar.element, 'bar contents');
 
 		tree.add(URI.file('/hello.txt'), 'hello contents');
-		assert.equal(tree.root.childrenCount, 2);
+		assert.strictEqual(tree.root.childrenCount, 2);
 
 		let hello = tree.root.get('hello.txt')!;
 		assert(hello);
-		assert.equal(hello.element, 'hello contents');
+		assert.strictEqual(hello.element, 'hello contents');
 
 		tree.delete(URI.file('/foo/bar.txt'));
-		assert.equal(tree.root.childrenCount, 1);
+		assert.strictEqual(tree.root.childrenCount, 1);
 		hello = tree.root.get('hello.txt')!;
 		assert(hello);
-		assert.equal(hello.element, 'hello contents');
+		assert.strictEqual(hello.element, 'hello contents');
 	});
 
 	test('folders with data', function () {
 		const tree = new ResourceTree<string, null>(null);
 
-		assert.equal(tree.root.childrenCount, 0);
+		assert.strictEqual(tree.root.childrenCount, 0);
 
 		tree.add(URI.file('/foo'), 'foo');
-		assert.equal(tree.root.childrenCount, 1);
-		assert.equal(tree.root.get('foo')!.element, 'foo');
+		assert.strictEqual(tree.root.childrenCount, 1);
+		assert.strictEqual(tree.root.get('foo')!.element, 'foo');
 
 		tree.add(URI.file('/bar'), 'bar');
-		assert.equal(tree.root.childrenCount, 2);
-		assert.equal(tree.root.get('bar')!.element, 'bar');
+		assert.strictEqual(tree.root.childrenCount, 2);
+		assert.strictEqual(tree.root.get('bar')!.element, 'bar');
 
 		tree.add(URI.file('/foo/file.txt'), 'file');
-		assert.equal(tree.root.childrenCount, 2);
-		assert.equal(tree.root.get('foo')!.element, 'foo');
-		assert.equal(tree.root.get('bar')!.element, 'bar');
-		assert.equal(tree.root.get('foo')!.get('file.txt')!.element, 'file');
+		assert.strictEqual(tree.root.childrenCount, 2);
+		assert.strictEqual(tree.root.get('foo')!.element, 'foo');
+		assert.strictEqual(tree.root.get('bar')!.element, 'bar');
+		assert.strictEqual(tree.root.get('foo')!.get('file.txt')!.element, 'file');
 
 		tree.delete(URI.file('/foo'));
-		assert.equal(tree.root.childrenCount, 1);
+		assert.strictEqual(tree.root.childrenCount, 1);
 		assert(!tree.root.get('foo'));
-		assert.equal(tree.root.get('bar')!.element, 'bar');
+		assert.strictEqual(tree.root.get('bar')!.element, 'bar');
 
 		tree.delete(URI.file('/bar'));
-		assert.equal(tree.root.childrenCount, 0);
+		assert.strictEqual(tree.root.childrenCount, 0);
 		assert(!tree.root.get('foo'));
 		assert(!tree.root.get('bar'));
 	});

--- a/src/vs/base/test/node/processes/processes.test.ts
+++ b/src/vs/base/test/node/processes/processes.test.ts
@@ -46,11 +46,11 @@ suite('Processes', () => {
 				counter++;
 
 				if (counter === 1) {
-					assert.equal(msgFromChild, msg1);
+					assert.strictEqual(msgFromChild, msg1);
 				} else if (counter === 2) {
-					assert.equal(msgFromChild, msg2);
+					assert.strictEqual(msgFromChild, msg2);
 				} else if (counter === 3) {
-					assert.equal(msgFromChild, msg3);
+					assert.strictEqual(msgFromChild, msg3);
 
 					child.kill();
 					done();

--- a/src/vs/code/electron-sandbox/issue/test/testReporterModel.test.ts
+++ b/src/vs/code/electron-sandbox/issue/test/testReporterModel.test.ts
@@ -25,7 +25,7 @@ suite('IssueReporter', () => {
 
 	test('serializes model skeleton when no data is provided', () => {
 		const issueReporterModel = new IssueReporterModel({});
-		assert.equal(issueReporterModel.serialize(),
+		assert.strictEqual(issueReporterModel.serialize(),
 			`
 Issue Type: <b>Bug</b>
 
@@ -55,7 +55,7 @@ Extensions: none
 				}
 			}
 		});
-		assert.equal(issueReporterModel.serialize(),
+		assert.strictEqual(issueReporterModel.serialize(),
 			`
 Issue Type: <b>Bug</b>
 
@@ -98,7 +98,7 @@ OS version: undefined
 			},
 			experimentInfo: 'vsliv695:30137379\nvsins829:30139715'
 		});
-		assert.equal(issueReporterModel.serialize(),
+		assert.strictEqual(issueReporterModel.serialize(),
 			`
 Issue Type: <b>Bug</b>
 
@@ -152,7 +152,7 @@ vsins829:30139715
 				}
 			}
 		});
-		assert.equal(issueReporterModel.serialize(),
+		assert.strictEqual(issueReporterModel.serialize(),
 			`
 Issue Type: <b>Bug</b>
 
@@ -208,7 +208,7 @@ OS version: undefined
 				]
 			}
 		});
-		assert.equal(issueReporterModel.serialize(),
+		assert.strictEqual(issueReporterModel.serialize(),
 			`
 Issue Type: <b>Bug</b>
 
@@ -256,7 +256,7 @@ Remote OS version: Linux x64 4.18.0
 				gpuStatus: {}
 			}
 		});
-		assert.equal(issueReporterModel.serialize(),
+		assert.strictEqual(issueReporterModel.serialize(),
 			`
 Issue Type: <b>Bug</b>
 
@@ -291,7 +291,7 @@ OS version: undefined
 			'https://github.com/repo/issues/new',
 			'https://github.com/repo/issues/new/'
 		].forEach(url => {
-			assert.equal('https://github.com/repo', normalizeGitHubUrl(url));
+			assert.strictEqual('https://github.com/repo', normalizeGitHubUrl(url));
 		});
 	});
 
@@ -306,7 +306,7 @@ OS version: undefined
 				fileOnExtension: true
 			});
 
-			assert.equal(issueReporterModel.fileOnExtension(), true);
+			assert.strictEqual(issueReporterModel.fileOnExtension(), true);
 		});
 	});
 });

--- a/src/vs/editor/contrib/codeAction/test/codeAction.test.ts
+++ b/src/vs/editor/contrib/codeAction/test/codeAction.test.ts
@@ -128,7 +128,7 @@ suite('CodeAction', () => {
 		];
 
 		const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Invoke }, Progress.None, CancellationToken.None);
-		assert.equal(actions.length, 6);
+		assert.strictEqual(actions.length, 6);
 		assert.deepEqual(actions, expected);
 	});
 
@@ -143,20 +143,20 @@ suite('CodeAction', () => {
 
 		{
 			const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto, filter: { include: new CodeActionKind('a') } }, Progress.None, CancellationToken.None);
-			assert.equal(actions.length, 2);
+			assert.strictEqual(actions.length, 2);
 			assert.strictEqual(actions[0].action.title, 'a');
 			assert.strictEqual(actions[1].action.title, 'a.b');
 		}
 
 		{
 			const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto, filter: { include: new CodeActionKind('a.b') } }, Progress.None, CancellationToken.None);
-			assert.equal(actions.length, 1);
+			assert.strictEqual(actions.length, 1);
 			assert.strictEqual(actions[0].action.title, 'a.b');
 		}
 
 		{
 			const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto, filter: { include: new CodeActionKind('a.b.c') } }, Progress.None, CancellationToken.None);
-			assert.equal(actions.length, 0);
+			assert.strictEqual(actions.length, 0);
 		}
 	});
 
@@ -175,7 +175,7 @@ suite('CodeAction', () => {
 		disposables.add(modes.CodeActionProviderRegistry.register('fooLang', provider));
 
 		const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto, filter: { include: new CodeActionKind('a') } }, Progress.None, CancellationToken.None);
-		assert.equal(actions.length, 1);
+		assert.strictEqual(actions.length, 1);
 		assert.strictEqual(actions[0].action.title, 'a');
 	});
 
@@ -189,13 +189,13 @@ suite('CodeAction', () => {
 
 		{
 			const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto }, Progress.None, CancellationToken.None);
-			assert.equal(actions.length, 1);
+			assert.strictEqual(actions.length, 1);
 			assert.strictEqual(actions[0].action.title, 'b');
 		}
 
 		{
 			const { validActions: actions } = await getCodeActions(model, new Range(1, 1, 2, 1), { type: modes.CodeActionTriggerType.Auto, filter: { include: CodeActionKind.Source, includeSourceActions: true } }, Progress.None, CancellationToken.None);
-			assert.equal(actions.length, 1);
+			assert.strictEqual(actions.length, 1);
 			assert.strictEqual(actions[0].action.title, 'a');
 		}
 	});
@@ -217,7 +217,7 @@ suite('CodeAction', () => {
 					includeSourceActions: true,
 				}
 			}, Progress.None, CancellationToken.None);
-			assert.equal(actions.length, 1);
+			assert.strictEqual(actions.length, 1);
 			assert.strictEqual(actions[0].action.title, 'b');
 		}
 	});
@@ -254,7 +254,7 @@ suite('CodeAction', () => {
 				}
 			}, Progress.None, CancellationToken.None);
 			assert.strictEqual(didInvoke, false);
-			assert.equal(actions.length, 1);
+			assert.strictEqual(actions.length, 1);
 			assert.strictEqual(actions[0].action.title, 'a');
 		}
 	});

--- a/src/vs/editor/contrib/codeAction/test/codeActionKeybindingResolver.test.ts
+++ b/src/vs/editor/contrib/codeAction/test/codeActionKeybindingResolver.test.ts
@@ -35,19 +35,19 @@ suite('CodeActionKeybindingResolver', () => {
 			},
 		}).getResolver();
 
-		assert.equal(
+		assert.strictEqual(
 			resolver({ title: '' }),
 			undefined);
 
-		assert.equal(
+		assert.strictEqual(
 			resolver({ title: '', kind: CodeActionKind.Refactor.value }),
 			refactorKeybinding.resolvedKeybinding);
 
-		assert.equal(
+		assert.strictEqual(
 			resolver({ title: '', kind: CodeActionKind.Refactor.append('extract').value }),
 			refactorKeybinding.resolvedKeybinding);
 
-		assert.equal(
+		assert.strictEqual(
 			resolver({ title: '', kind: CodeActionKind.QuickFix.value }),
 			undefined);
 	});
@@ -59,11 +59,11 @@ suite('CodeActionKeybindingResolver', () => {
 			},
 		}).getResolver();
 
-		assert.equal(
+		assert.strictEqual(
 			resolver({ title: '', kind: CodeActionKind.Refactor.value }),
 			refactorKeybinding.resolvedKeybinding);
 
-		assert.equal(
+		assert.strictEqual(
 			resolver({ title: '', kind: CodeActionKind.Refactor.append('extract').value }),
 			refactorExtractKeybinding.resolvedKeybinding);
 	});
@@ -75,7 +75,7 @@ suite('CodeActionKeybindingResolver', () => {
 			},
 		}).getResolver();
 
-		assert.equal(
+		assert.strictEqual(
 			resolver({ title: '', kind: CodeActionKind.SourceOrganizeImports.value }),
 			organizeImportsKeybinding.resolvedKeybinding);
 	});

--- a/src/vs/editor/contrib/codeAction/test/codeActionModel.test.ts
+++ b/src/vs/editor/contrib/codeAction/test/codeActionModel.test.ts
@@ -65,7 +65,7 @@ suite('CodeActionModel', () => {
 
 			e.actions.then(fixes => {
 				model.dispose();
-				assert.equal(fixes.validActions.length, 1);
+				assert.strictEqual(fixes.validActions.length, 1);
 				done();
 			}, done);
 		}));
@@ -101,11 +101,11 @@ suite('CodeActionModel', () => {
 			disposables.add(model.onDidChangeState((e: CodeActionsState.State) => {
 				assertType(e.type === CodeActionsState.Type.Triggered);
 
-				assert.equal(e.trigger.type, modes.CodeActionTriggerType.Auto);
+				assert.strictEqual(e.trigger.type, modes.CodeActionTriggerType.Auto);
 				assert.ok(e.actions);
 				e.actions.then(fixes => {
 					model.dispose();
-					assert.equal(fixes.validActions.length, 1);
+					assert.strictEqual(fixes.validActions.length, 1);
 					resolve(undefined);
 				}, reject);
 			}));
@@ -139,7 +139,7 @@ suite('CodeActionModel', () => {
 			disposables.add(model.onDidChangeState((e: CodeActionsState.State) => {
 				assertType(e.type === CodeActionsState.Type.Triggered);
 
-				assert.equal(e.trigger.type, modes.CodeActionTriggerType.Auto);
+				assert.strictEqual(e.trigger.type, modes.CodeActionTriggerType.Auto);
 				const selection = <Selection>e.rangeOrSelection;
 				assert.deepEqual(selection.selectionStartLineNumber, 1);
 				assert.deepEqual(selection.selectionStartColumn, 1);
@@ -164,7 +164,7 @@ suite('CodeActionModel', () => {
 		disposables.add(model.onDidChangeState((e: CodeActionsState.State) => {
 			assertType(e.type === CodeActionsState.Type.Triggered);
 
-			assert.equal(e.trigger.type, modes.CodeActionTriggerType.Auto);
+			assert.strictEqual(e.trigger.type, modes.CodeActionTriggerType.Auto);
 			++triggerCount;
 
 			// give time for second trigger before completing test

--- a/src/vs/editor/contrib/documentSymbols/test/outlineModel.test.ts
+++ b/src/vs/editor/contrib/documentSymbols/test/outlineModel.test.ts
@@ -26,16 +26,16 @@ suite('OutlineModel', function () {
 		});
 
 		await OutlineModel.create(model, CancellationToken.None);
-		assert.equal(count, 1);
+		assert.strictEqual(count, 1);
 
 		// cached
 		await OutlineModel.create(model, CancellationToken.None);
-		assert.equal(count, 1);
+		assert.strictEqual(count, 1);
 
 		// new version
 		model.applyEdits([{ text: 'XXX', range: new Range(1, 1, 1, 1) }]);
 		await OutlineModel.create(model, CancellationToken.None);
-		assert.equal(count, 2);
+		assert.strictEqual(count, 2);
 
 		reg.dispose();
 	});
@@ -56,17 +56,17 @@ suite('OutlineModel', function () {
 			}
 		});
 
-		assert.equal(isCancelled, false);
+		assert.strictEqual(isCancelled, false);
 		let s1 = new CancellationTokenSource();
 		OutlineModel.create(model, s1.token);
 		let s2 = new CancellationTokenSource();
 		OutlineModel.create(model, s2.token);
 
 		s1.cancel();
-		assert.equal(isCancelled, false);
+		assert.strictEqual(isCancelled, false);
 
 		s2.cancel();
-		assert.equal(isCancelled, true);
+		assert.strictEqual(isCancelled, true);
 
 		reg.dispose();
 	});
@@ -101,15 +101,15 @@ suite('OutlineModel', function () {
 		data.sort(Range.compareRangesUsingStarts); // model does this
 
 		group.updateMarker(data);
-		assert.equal(data.length, 0); // all 'stolen'
-		assert.equal(e0.marker!.count, 1);
-		assert.equal(e1.marker, undefined);
-		assert.equal(e2.marker!.count, 2);
+		assert.strictEqual(data.length, 0); // all 'stolen'
+		assert.strictEqual(e0.marker!.count, 1);
+		assert.strictEqual(e1.marker, undefined);
+		assert.strictEqual(e2.marker!.count, 2);
 
 		group.updateMarker([]);
-		assert.equal(e0.marker, undefined);
-		assert.equal(e1.marker, undefined);
-		assert.equal(e2.marker, undefined);
+		assert.strictEqual(e0.marker, undefined);
+		assert.strictEqual(e1.marker, undefined);
+		assert.strictEqual(e2.marker, undefined);
 	});
 
 	test('OutlineElement - updateMarker, 2', function () {
@@ -128,9 +128,9 @@ suite('OutlineModel', function () {
 		];
 
 		group.updateMarker(data);
-		assert.equal(p.marker!.count, 0);
-		assert.equal(c1.marker!.count, 1);
-		assert.equal(c2.marker, undefined);
+		assert.strictEqual(p.marker!.count, 0);
+		assert.strictEqual(c1.marker!.count, 1);
+		assert.strictEqual(c2.marker, undefined);
 
 		data = [
 			fakeMarker(new Range(2, 4, 5, 4)),
@@ -138,18 +138,18 @@ suite('OutlineModel', function () {
 			fakeMarker(new Range(7, 6, 7, 8)),
 		];
 		group.updateMarker(data);
-		assert.equal(p.marker!.count, 0);
-		assert.equal(c1.marker!.count, 2);
-		assert.equal(c2.marker!.count, 1);
+		assert.strictEqual(p.marker!.count, 0);
+		assert.strictEqual(c1.marker!.count, 2);
+		assert.strictEqual(c2.marker!.count, 1);
 
 		data = [
 			fakeMarker(new Range(1, 4, 1, 11)),
 			fakeMarker(new Range(7, 6, 7, 8)),
 		];
 		group.updateMarker(data);
-		assert.equal(p.marker!.count, 1);
-		assert.equal(c1.marker, undefined);
-		assert.equal(c2.marker!.count, 1);
+		assert.strictEqual(p.marker!.count, 1);
+		assert.strictEqual(c1.marker, undefined);
+		assert.strictEqual(c2.marker!.count, 1);
 	});
 
 	test('OutlineElement - updateMarker/multiple groups', function () {
@@ -179,9 +179,9 @@ suite('OutlineModel', function () {
 
 		model.updateMarker(data);
 
-		assert.equal(model.children.get('g1')!.children.get('c1')!.marker!.count, 2);
-		assert.equal(model.children.get('g2')!.children.get('c2')!.children.get('c2.1')!.marker!.count, 1);
-		assert.equal(model.children.get('g2')!.children.get('c2')!.children.get('c2.2')!.marker!.count, 1);
+		assert.strictEqual(model.children.get('g1')!.children.get('c1')!.marker!.count, 2);
+		assert.strictEqual(model.children.get('g2')!.children.get('c2')!.children.get('c2.1')!.marker!.count, 1);
+		assert.strictEqual(model.children.get('g2')!.children.get('c2')!.children.get('c2.2')!.marker!.count, 1);
 	});
 
 });

--- a/src/vs/editor/contrib/folding/test/foldingModel.test.ts
+++ b/src/vs/editor/contrib/folding/test/foldingModel.test.ts
@@ -90,11 +90,11 @@ suite('Folding Model', () => {
 	}
 
 	function assertRegion(actual: FoldingRegion | null, expected: ExpectedRegion | null, message?: string) {
-		assert.equal(!!actual, !!expected, message);
+		assert.strictEqual(!!actual, !!expected, message);
 		if (actual && expected) {
-			assert.equal(actual.startLineNumber, expected.startLineNumber, message);
-			assert.equal(actual.endLineNumber, expected.endLineNumber, message);
-			assert.equal(actual.isCollapsed, expected.isCollapsed, message);
+			assert.strictEqual(actual.startLineNumber, expected.startLineNumber, message);
+			assert.strictEqual(actual.endLineNumber, expected.endLineNumber, message);
+			assert.strictEqual(actual.isCollapsed, expected.isCollapsed, message);
 		}
 	}
 

--- a/src/vs/editor/contrib/folding/test/foldingRanges.test.ts
+++ b/src/vs/editor/contrib/folding/test/foldingRanges.test.ts
@@ -28,11 +28,11 @@ suite('FoldingRanges', () => {
 		}
 		let model = createTextModel(lines.join('\n'));
 		let actual = computeRanges(model, false, markers, MAX_FOLDING_REGIONS);
-		assert.equal(actual.length, nRegions, 'len');
+		assert.strictEqual(actual.length, nRegions, 'len');
 		for (let i = 0; i < nRegions; i++) {
-			assert.equal(actual.getStartLineNumber(i), i + 1, 'start' + i);
-			assert.equal(actual.getEndLineNumber(i), nRegions * 2 - i, 'end' + i);
-			assert.equal(actual.getParentIndex(i), i - 1, 'parent' + i);
+			assert.strictEqual(actual.getStartLineNumber(i), i + 1, 'start' + i);
+			assert.strictEqual(actual.getEndLineNumber(i), nRegions * 2 - i, 'end' + i);
+			assert.strictEqual(actual.getParentIndex(i), i - 1, 'parent' + i);
 		}
 
 	});
@@ -62,19 +62,19 @@ suite('FoldingRanges', () => {
 			// let r3 = r(5, 6);
 			// let r4 = r(9, 10);
 
-			assert.equal(actual.findRange(1), 0, '1');
-			assert.equal(actual.findRange(2), 0, '2');
-			assert.equal(actual.findRange(3), 1, '3');
-			assert.equal(actual.findRange(4), 2, '4');
-			assert.equal(actual.findRange(5), 3, '5');
-			assert.equal(actual.findRange(6), 3, '6');
-			assert.equal(actual.findRange(7), 2, '7');
-			assert.equal(actual.findRange(8), 2, '8');
-			assert.equal(actual.findRange(9), 4, '9');
-			assert.equal(actual.findRange(10), 4, '10');
-			assert.equal(actual.findRange(11), 2, '11');
-			assert.equal(actual.findRange(12), 1, '12');
-			assert.equal(actual.findRange(13), -1, '13');
+			assert.strictEqual(actual.findRange(1), 0, '1');
+			assert.strictEqual(actual.findRange(2), 0, '2');
+			assert.strictEqual(actual.findRange(3), 1, '3');
+			assert.strictEqual(actual.findRange(4), 2, '4');
+			assert.strictEqual(actual.findRange(5), 3, '5');
+			assert.strictEqual(actual.findRange(6), 3, '6');
+			assert.strictEqual(actual.findRange(7), 2, '7');
+			assert.strictEqual(actual.findRange(8), 2, '8');
+			assert.strictEqual(actual.findRange(9), 4, '9');
+			assert.strictEqual(actual.findRange(10), 4, '10');
+			assert.strictEqual(actual.findRange(11), 2, '11');
+			assert.strictEqual(actual.findRange(12), 1, '12');
+			assert.strictEqual(actual.findRange(13), -1, '13');
 		} finally {
 			textModel.dispose();
 		}
@@ -93,12 +93,12 @@ suite('FoldingRanges', () => {
 		}
 		let model = createTextModel(lines.join('\n'));
 		let actual = computeRanges(model, false, markers, MAX_FOLDING_REGIONS);
-		assert.equal(actual.length, nRegions, 'len');
+		assert.strictEqual(actual.length, nRegions, 'len');
 		for (let i = 0; i < nRegions; i++) {
 			actual.setCollapsed(i, i % 3 === 0);
 		}
 		for (let i = 0; i < nRegions; i++) {
-			assert.equal(actual.isCollapsed(i), i % 3 === 0, 'line' + i);
+			assert.strictEqual(actual.isCollapsed(i), i % 3 === 0, 'line' + i);
 		}
 	});
 });

--- a/src/vs/editor/contrib/folding/test/hiddenRangeModel.test.ts
+++ b/src/vs/editor/contrib/folding/test/hiddenRangeModel.test.ts
@@ -42,7 +42,7 @@ suite('Hidden Range Model', () => {
 		let foldingModel = new FoldingModel(textModel, new TestDecorationProvider(textModel));
 		let hiddenRangeModel = new HiddenRangeModel(foldingModel);
 
-		assert.equal(hiddenRangeModel.hasRanges(), false);
+		assert.strictEqual(hiddenRangeModel.hasRanges(), false);
 
 		let ranges = computeRanges(textModel, false, undefined);
 		foldingModel.update(ranges);
@@ -50,46 +50,46 @@ suite('Hidden Range Model', () => {
 		foldingModel.toggleCollapseState([foldingModel.getRegionAtLine(1)!, foldingModel.getRegionAtLine(6)!]);
 		assertRanges(hiddenRangeModel.hiddenRanges, [r(2, 3), r(7, 7)]);
 
-		assert.equal(hiddenRangeModel.hasRanges(), true);
-		assert.equal(hiddenRangeModel.isHidden(1), false);
-		assert.equal(hiddenRangeModel.isHidden(2), true);
-		assert.equal(hiddenRangeModel.isHidden(3), true);
-		assert.equal(hiddenRangeModel.isHidden(4), false);
-		assert.equal(hiddenRangeModel.isHidden(5), false);
-		assert.equal(hiddenRangeModel.isHidden(6), false);
-		assert.equal(hiddenRangeModel.isHidden(7), true);
-		assert.equal(hiddenRangeModel.isHidden(8), false);
-		assert.equal(hiddenRangeModel.isHidden(9), false);
-		assert.equal(hiddenRangeModel.isHidden(10), false);
+		assert.strictEqual(hiddenRangeModel.hasRanges(), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(1), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(2), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(3), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(4), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(5), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(6), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(7), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(8), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(9), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(10), false);
 
 		foldingModel.toggleCollapseState([foldingModel.getRegionAtLine(4)!]);
 		assertRanges(hiddenRangeModel.hiddenRanges, [r(2, 3), r(5, 9)]);
 
-		assert.equal(hiddenRangeModel.hasRanges(), true);
-		assert.equal(hiddenRangeModel.isHidden(1), false);
-		assert.equal(hiddenRangeModel.isHidden(2), true);
-		assert.equal(hiddenRangeModel.isHidden(3), true);
-		assert.equal(hiddenRangeModel.isHidden(4), false);
-		assert.equal(hiddenRangeModel.isHidden(5), true);
-		assert.equal(hiddenRangeModel.isHidden(6), true);
-		assert.equal(hiddenRangeModel.isHidden(7), true);
-		assert.equal(hiddenRangeModel.isHidden(8), true);
-		assert.equal(hiddenRangeModel.isHidden(9), true);
-		assert.equal(hiddenRangeModel.isHidden(10), false);
+		assert.strictEqual(hiddenRangeModel.hasRanges(), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(1), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(2), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(3), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(4), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(5), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(6), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(7), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(8), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(9), true);
+		assert.strictEqual(hiddenRangeModel.isHidden(10), false);
 
 		foldingModel.toggleCollapseState([foldingModel.getRegionAtLine(1)!, foldingModel.getRegionAtLine(6)!, foldingModel.getRegionAtLine(4)!]);
 		assertRanges(hiddenRangeModel.hiddenRanges, []);
-		assert.equal(hiddenRangeModel.hasRanges(), false);
-		assert.equal(hiddenRangeModel.isHidden(1), false);
-		assert.equal(hiddenRangeModel.isHidden(2), false);
-		assert.equal(hiddenRangeModel.isHidden(3), false);
-		assert.equal(hiddenRangeModel.isHidden(4), false);
-		assert.equal(hiddenRangeModel.isHidden(5), false);
-		assert.equal(hiddenRangeModel.isHidden(6), false);
-		assert.equal(hiddenRangeModel.isHidden(7), false);
-		assert.equal(hiddenRangeModel.isHidden(8), false);
-		assert.equal(hiddenRangeModel.isHidden(9), false);
-		assert.equal(hiddenRangeModel.isHidden(10), false);
+		assert.strictEqual(hiddenRangeModel.hasRanges(), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(1), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(2), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(3), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(4), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(5), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(6), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(7), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(8), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(9), false);
+		assert.strictEqual(hiddenRangeModel.isHidden(10), false);
 
 	});
 

--- a/src/vs/editor/contrib/gotoSymbol/test/referencesModel.test.ts
+++ b/src/vs/editor/contrib/gotoSymbol/test/referencesModel.test.ts
@@ -24,16 +24,16 @@ suite('references', function () {
 		}], 'FOO');
 
 		let ref = model.nearestReference(URI.file('/src/can'), new Position(1, 1));
-		assert.equal(ref!.uri.path, '/src/can');
+		assert.strictEqual(ref!.uri.path, '/src/can');
 
 		ref = model.nearestReference(URI.file('/src/someOtherFileInSrc'), new Position(1, 1));
-		assert.equal(ref!.uri.path, '/src/can');
+		assert.strictEqual(ref!.uri.path, '/src/can');
 
 		ref = model.nearestReference(URI.file('/out/someOtherFile'), new Position(1, 1));
-		assert.equal(ref!.uri.path, '/out/obj/can');
+		assert.strictEqual(ref!.uri.path, '/out/obj/can');
 
 		ref = model.nearestReference(URI.file('/out/obj/can2222'), new Position(1, 1));
-		assert.equal(ref!.uri.path, '/out/obj/can2');
+		assert.strictEqual(ref!.uri.path, '/out/obj/can2');
 	});
 
 });

--- a/src/vs/editor/contrib/linkedEditing/test/linkedEditing.test..ts
+++ b/src/vs/editor/contrib/linkedEditing/test/linkedEditing.test..ts
@@ -111,9 +111,9 @@ suite('linked editing', () => {
 			return new Promise<void>((resolve) => {
 				setTimeout(() => {
 					if (typeof expectedEndText === 'string') {
-						assert.equal(editor.getModel()!.getValue(), expectedEndText);
+						assert.strictEqual(editor.getModel()!.getValue(), expectedEndText);
 					} else {
-						assert.equal(editor.getModel()!.getValue(), expectedEndText.join('\n'));
+						assert.strictEqual(editor.getModel()!.getValue(), expectedEndText.join('\n'));
 					}
 					resolve();
 				}, timeout);

--- a/src/vs/editor/contrib/smartSelect/test/smartSelect.test.ts
+++ b/src/vs/editor/contrib/smartSelect/test/smartSelect.test.ts
@@ -226,7 +226,7 @@ suite('SmartSelect', () => {
 
 		modelService.destroyModel(model.uri);
 
-		assert.equal(expected.length, ranges!.length);
+		assert.strictEqual(expected.length, ranges!.length);
 		for (const range of ranges!) {
 			let exp = expected.shift() || null;
 			assert.ok(Range.equalsRange(range.range, exp), `A=${range.range} <> E=${exp}`);

--- a/src/vs/editor/contrib/snippet/test/snippetParser.test.ts
+++ b/src/vs/editor/contrib/snippet/test/snippetParser.test.ts
@@ -10,88 +10,88 @@ suite('SnippetParser', () => {
 	test('Scanner', () => {
 
 		const scanner = new Scanner();
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 
 		scanner.text('abc');
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 
 		scanner.text('{{abc}}');
-		assert.equal(scanner.next().type, TokenType.CurlyOpen);
-		assert.equal(scanner.next().type, TokenType.CurlyOpen);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.CurlyClose);
-		assert.equal(scanner.next().type, TokenType.CurlyClose);
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyOpen);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyOpen);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyClose);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyClose);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 
 		scanner.text('abc() ');
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.Format);
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.Format);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 
 		scanner.text('abc 123');
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.Format);
-		assert.equal(scanner.next().type, TokenType.Int);
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.Format);
+		assert.strictEqual(scanner.next().type, TokenType.Int);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 
 		scanner.text('$foo');
-		assert.equal(scanner.next().type, TokenType.Dollar);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.Dollar);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 
 		scanner.text('$foo_bar');
-		assert.equal(scanner.next().type, TokenType.Dollar);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.Dollar);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 
 		scanner.text('$foo-bar');
-		assert.equal(scanner.next().type, TokenType.Dollar);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.Dash);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.Dollar);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.Dash);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 
 		scanner.text('${foo}');
-		assert.equal(scanner.next().type, TokenType.Dollar);
-		assert.equal(scanner.next().type, TokenType.CurlyOpen);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.CurlyClose);
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.Dollar);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyOpen);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyClose);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 
 		scanner.text('${1223:foo}');
-		assert.equal(scanner.next().type, TokenType.Dollar);
-		assert.equal(scanner.next().type, TokenType.CurlyOpen);
-		assert.equal(scanner.next().type, TokenType.Int);
-		assert.equal(scanner.next().type, TokenType.Colon);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.CurlyClose);
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.Dollar);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyOpen);
+		assert.strictEqual(scanner.next().type, TokenType.Int);
+		assert.strictEqual(scanner.next().type, TokenType.Colon);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyClose);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 
 		scanner.text('\\${}');
-		assert.equal(scanner.next().type, TokenType.Backslash);
-		assert.equal(scanner.next().type, TokenType.Dollar);
-		assert.equal(scanner.next().type, TokenType.CurlyOpen);
-		assert.equal(scanner.next().type, TokenType.CurlyClose);
+		assert.strictEqual(scanner.next().type, TokenType.Backslash);
+		assert.strictEqual(scanner.next().type, TokenType.Dollar);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyOpen);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyClose);
 
 		scanner.text('${foo/regex/format/option}');
-		assert.equal(scanner.next().type, TokenType.Dollar);
-		assert.equal(scanner.next().type, TokenType.CurlyOpen);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.Forwardslash);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.Forwardslash);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.Forwardslash);
-		assert.equal(scanner.next().type, TokenType.VariableName);
-		assert.equal(scanner.next().type, TokenType.CurlyClose);
-		assert.equal(scanner.next().type, TokenType.EOF);
+		assert.strictEqual(scanner.next().type, TokenType.Dollar);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyOpen);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.Forwardslash);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.Forwardslash);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.Forwardslash);
+		assert.strictEqual(scanner.next().type, TokenType.VariableName);
+		assert.strictEqual(scanner.next().type, TokenType.CurlyClose);
+		assert.strictEqual(scanner.next().type, TokenType.EOF);
 	});
 
 	function assertText(value: string, expected: string) {
 		const p = new SnippetParser();
 		const actual = p.text(value);
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	}
 
 	function assertMarker(input: TextmateSnippet | Marker[] | string, ...ctors: Function[]) {
@@ -109,8 +109,8 @@ suite('SnippetParser', () => {
 			let ctor = ctors.pop()!;
 			assert.ok(m instanceof ctor);
 		}
-		assert.equal(marker.length, ctors.length);
-		assert.equal(marker.length, 0);
+		assert.strictEqual(marker.length, ctors.length);
+		assert.strictEqual(marker.length, 0);
 	}
 
 	function assertTextAndMarker(value: string, escaped: string, ...ctors: Function[]) {
@@ -120,7 +120,7 @@ suite('SnippetParser', () => {
 
 	function assertEscaped(value: string, expected: string) {
 		const actual = SnippetParser.escape(value);
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	}
 
 	test('Parser, escaped', function () {
@@ -167,11 +167,11 @@ suite('SnippetParser', () => {
 		let [, placeholder] = new SnippetParser().parse('foo${1:bar\\}${2:foo}}').children;
 		let { children } = (<Placeholder>placeholder);
 
-		assert.equal((<Placeholder>placeholder).index, '1');
+		assert.strictEqual((<Placeholder>placeholder).index, 1);
 		assert.ok(children[0] instanceof Text);
-		assert.equal(children[0].toString(), 'bar}');
+		assert.strictEqual(children[0].toString(), 'bar}');
 		assert.ok(children[1] instanceof Placeholder);
-		assert.equal(children[1].toString(), 'foo');
+		assert.strictEqual(children[1].toString(), 'foo');
 	});
 
 	test('Parser, placeholder', () => {
@@ -278,7 +278,7 @@ suite('SnippetParser', () => {
 		assertMarker(snippet, Placeholder);
 		const expected = [Placeholder, Text, Text, Text];
 		snippet.walk(marker => {
-			assert.equal(marker, expected.shift());
+			assert.strictEqual(marker, expected.shift());
 			return true;
 		});
 	});
@@ -292,7 +292,7 @@ suite('SnippetParser', () => {
 		function assertTextsnippetString(input: string, expected: string): void {
 			const snippet = new SnippetParser().parse(input);
 			const actual = snippet.toTextmateString();
-			assert.equal(actual, expected);
+			assert.strictEqual(actual, expected);
 		}
 
 		assertTextsnippetString('$1', '$1');
@@ -316,8 +316,8 @@ suite('SnippetParser', () => {
 				assert.ok(marker1 instanceof Object.getPrototypeOf(marker2).constructor);
 				assert.ok(marker2 instanceof Object.getPrototypeOf(marker1).constructor);
 
-				assert.equal(marker1.children.length, marker2.children.length);
-				assert.equal(marker1.toString(), marker2.toString());
+				assert.strictEqual(marker1.children.length, marker2.children.length);
+				assert.strictEqual(marker1.toString(), marker2.toString());
 
 				for (let i = 0; i < marker1.children.length; i++) {
 					checkCheckChildren(marker1.children[i], marker2.children[i]);
@@ -340,10 +340,10 @@ suite('SnippetParser', () => {
 	test('Parser, choise marker', () => {
 		const { placeholders } = new SnippetParser().parse('${1|one,two,three|}');
 
-		assert.equal(placeholders.length, 1);
+		assert.strictEqual(placeholders.length, 1);
 		assert.ok(placeholders[0].choice instanceof Choice);
 		assert.ok(placeholders[0].children[0] instanceof Choice);
-		assert.equal((<Choice>placeholders[0].children[0]).options.length, 3);
+		assert.strictEqual((<Choice>placeholders[0].children[0]).options.length, 3);
 
 		assertText('${1|one,two,three|}', 'one');
 		assertText('\\${1|one,two,three|}', '${1|one,two,three|}');
@@ -354,7 +354,7 @@ suite('SnippetParser', () => {
 	test('Backslash character escape in choice tabstop doesn\'t work #58494', function () {
 
 		const { placeholders } = new SnippetParser().parse('${1|\\,,},$,\\|,\\\\|}');
-		assert.equal(placeholders.length, 1);
+		assert.strictEqual(placeholders.length, 1);
 		assert.ok(placeholders[0].choice instanceof Choice);
 	});
 
@@ -372,27 +372,28 @@ suite('SnippetParser', () => {
 	test('Parser, real world', () => {
 		let marker = new SnippetParser().parse('console.warn(${1: $TM_SELECTED_TEXT })').children;
 
-		assert.equal(marker[0].toString(), 'console.warn(');
+		assert.strictEqual(marker[0].toString(), 'console.warn(');
 		assert.ok(marker[1] instanceof Placeholder);
-		assert.equal(marker[2].toString(), ')');
+		assert.strictEqual(marker[2].toString(), ')');
 
 		const placeholder = <Placeholder>marker[1];
+		// TODO @jrieken Making this strict causes cricular dependency
 		assert.equal(placeholder, false);
-		assert.equal(placeholder.index, '1');
-		assert.equal(placeholder.children.length, 3);
+		assert.strictEqual(placeholder.index, 1);
+		assert.strictEqual(placeholder.children.length, 3);
 		assert.ok(placeholder.children[0] instanceof Text);
 		assert.ok(placeholder.children[1] instanceof Variable);
 		assert.ok(placeholder.children[2] instanceof Text);
-		assert.equal(placeholder.children[0].toString(), ' ');
-		assert.equal(placeholder.children[1].toString(), '');
-		assert.equal(placeholder.children[2].toString(), ' ');
+		assert.strictEqual(placeholder.children[0].toString(), ' ');
+		assert.strictEqual(placeholder.children[1].toString(), '');
+		assert.strictEqual(placeholder.children[2].toString(), ' ');
 
 		const nestedVariable = <Variable>placeholder.children[1];
-		assert.equal(nestedVariable.name, 'TM_SELECTED_TEXT');
-		assert.equal(nestedVariable.children.length, 0);
+		assert.strictEqual(nestedVariable.name, 'TM_SELECTED_TEXT');
+		assert.strictEqual(nestedVariable.children.length, 0);
 
 		marker = new SnippetParser().parse('$TM_SELECTED_TEXT').children;
-		assert.equal(marker.length, 1);
+		assert.strictEqual(marker.length, 1);
 		assert.ok(marker[0] instanceof Variable);
 	});
 
@@ -401,64 +402,66 @@ suite('SnippetParser', () => {
 
 		//${1:name}
 		assert.ok(children[0] instanceof Placeholder);
-		assert.equal(children[0].children.length, 1);
-		assert.equal(children[0].children[0].toString(), 'name');
-		assert.equal((<Placeholder>children[0]).transform, undefined);
+		assert.strictEqual(children[0].children.length, 1);
+		assert.strictEqual(children[0].children[0].toString(), 'name');
+		assert.strictEqual((<Placeholder>children[0]).transform, undefined);
 
 		// :
 		assert.ok(children[1] instanceof Text);
-		assert.equal(children[1].toString(), ' : ');
+		assert.strictEqual(children[1].toString(), ' : ');
 
 		//${2:type}
 		assert.ok(children[2] instanceof Placeholder);
-		assert.equal(children[2].children.length, 1);
-		assert.equal(children[2].children[0].toString(), 'type');
+		assert.strictEqual(children[2].children.length, 1);
+		assert.strictEqual(children[2].children[0].toString(), 'type');
 
 		//${3/\\s:=(.*)/${1:+ :=}${1}/}
 		assert.ok(children[3] instanceof Placeholder);
-		assert.equal(children[3].children.length, 0);
+		assert.strictEqual(children[3].children.length, 0);
 		assert.notEqual((<Placeholder>children[3]).transform, undefined);
 		let transform = (<Placeholder>children[3]).transform!;
-		assert.equal(transform.regexp, '/\\s:=(.*)/');
-		assert.equal(transform.children.length, 2);
+		assert.deepStrictEqual(transform.regexp, /\s:=(.*)/);
+		assert.strictEqual(transform.children.length, 2);
 		assert.ok(transform.children[0] instanceof FormatString);
-		assert.equal((<FormatString>transform.children[0]).index, 1);
-		assert.equal((<FormatString>transform.children[0]).ifValue, ' :=');
+		assert.strictEqual((<FormatString>transform.children[0]).index, 1);
+		assert.strictEqual((<FormatString>transform.children[0]).ifValue, ' :=');
 		assert.ok(transform.children[1] instanceof FormatString);
-		assert.equal((<FormatString>transform.children[1]).index, 1);
+		assert.strictEqual((<FormatString>transform.children[1]).index, 1);
 		assert.ok(children[4] instanceof Text);
-		assert.equal(children[4].toString(), ';\n');
+		assert.strictEqual(children[4].toString(), ';\n');
 
 	});
 
+	// TODO @jrieken making this strictEqul causes circular json conversion errors
 	test('Parser, default placeholder values', () => {
 
 		assertMarker('errorContext: `${1:err}`, error: $1', Text, Placeholder, Text, Placeholder);
 
 		const [, p1, , p2] = new SnippetParser().parse('errorContext: `${1:err}`, error:$1').children;
 
-		assert.equal((<Placeholder>p1).index, '1');
-		assert.equal((<Placeholder>p1).children.length, '1');
+		assert.equal((<Placeholder>p1).index, 1);
+		assert.equal((<Placeholder>p1).children.length, 1);
 		assert.equal((<Text>(<Placeholder>p1).children[0]), 'err');
 
-		assert.equal((<Placeholder>p2).index, '1');
-		assert.equal((<Placeholder>p2).children.length, '1');
+		assert.equal((<Placeholder>p2).index, 1);
+		assert.equal((<Placeholder>p2).children.length, 1);
 		assert.equal((<Text>(<Placeholder>p2).children[0]), 'err');
 	});
 
+	// TODO @jrieken making this strictEqul causes circular json conversion errors
 	test('Parser, default placeholder values and one transform', () => {
 
 		assertMarker('errorContext: `${1:err}`, error: ${1/err/ok/}', Text, Placeholder, Text, Placeholder);
 
 		const [, p3, , p4] = new SnippetParser().parse('errorContext: `${1:err}`, error:${1/err/ok/}').children;
 
-		assert.equal((<Placeholder>p3).index, '1');
-		assert.equal((<Placeholder>p3).children.length, '1');
+		assert.equal((<Placeholder>p3).index, 1);
+		assert.equal((<Placeholder>p3).children.length, 1);
 		assert.equal((<Text>(<Placeholder>p3).children[0]), 'err');
 		assert.equal((<Placeholder>p3).transform, undefined);
 
-		assert.equal((<Placeholder>p4).index, '1');
-		assert.equal((<Placeholder>p4).children.length, '1');
+		assert.equal((<Placeholder>p4).index, 1);
+		assert.equal((<Placeholder>p4).children.length, 1);
 		assert.equal((<Text>(<Placeholder>p4).children[0]), 'err');
 		assert.notEqual((<Placeholder>p4).transform, undefined);
 	});
@@ -472,15 +475,15 @@ suite('SnippetParser', () => {
 
 	test('backspace esapce in TM only, #16212', () => {
 		const actual = new SnippetParser().text('Foo \\\\${abc}bar');
-		assert.equal(actual, 'Foo \\bar');
+		assert.strictEqual(actual, 'Foo \\bar');
 	});
 
 	test('colon as variable/placeholder value, #16717', () => {
 		let actual = new SnippetParser().text('${TM_SELECTED_TEXT:foo:bar}');
-		assert.equal(actual, 'foo:bar');
+		assert.strictEqual(actual, 'foo:bar');
 
 		actual = new SnippetParser().text('${1:foo:bar}');
-		assert.equal(actual, 'foo:bar');
+		assert.strictEqual(actual, 'foo:bar');
 	});
 
 	test('incomplete placeholder', () => {
@@ -493,10 +496,10 @@ suite('SnippetParser', () => {
 			const snippet = new SnippetParser().parse(template, true);
 			snippet.walk(m => {
 				const expected = lengths.shift();
-				assert.equal(m.len(), expected);
+				assert.strictEqual(m.len(), expected);
 				return true;
 			});
-			assert.equal(lengths.length, 0);
+			assert.strictEqual(lengths.length, 0);
 		}
 
 		assertLen('text$0', 4, 0);
@@ -511,17 +514,17 @@ suite('SnippetParser', () => {
 	test('parser, parent node', function () {
 		let snippet = new SnippetParser().parse('This ${1:is ${2:nested}}$0', true);
 
-		assert.equal(snippet.placeholders.length, 3);
+		assert.strictEqual(snippet.placeholders.length, 3);
 		let [first, second] = snippet.placeholders;
-		assert.equal(first.index, '1');
-		assert.equal(second.index, '2');
+		assert.strictEqual(first.index, 1);
+		assert.strictEqual(second.index, 2);
 		assert.ok(second.parent === first);
 		assert.ok(first.parent === snippet);
 
 		snippet = new SnippetParser().parse('${VAR:default${1:value}}$0', true);
-		assert.equal(snippet.placeholders.length, 2);
+		assert.strictEqual(snippet.placeholders.length, 2);
 		[first] = snippet.placeholders;
-		assert.equal(first.index, '1');
+		assert.strictEqual(first.index, 1);
 
 		assert.ok(snippet.children[0] instanceof Variable);
 		assert.ok(first.parent === snippet.children[0]);
@@ -537,76 +540,76 @@ suite('SnippetParser', () => {
 
 	test('TextmateSnippet#offset', () => {
 		let snippet = new SnippetParser().parse('te$1xt', true);
-		assert.equal(snippet.offset(snippet.children[0]), 0);
-		assert.equal(snippet.offset(snippet.children[1]), 2);
-		assert.equal(snippet.offset(snippet.children[2]), 2);
+		assert.strictEqual(snippet.offset(snippet.children[0]), 0);
+		assert.strictEqual(snippet.offset(snippet.children[1]), 2);
+		assert.strictEqual(snippet.offset(snippet.children[2]), 2);
 
 		snippet = new SnippetParser().parse('${TM_SELECTED_TEXT:def}', true);
-		assert.equal(snippet.offset(snippet.children[0]), 0);
-		assert.equal(snippet.offset((<Variable>snippet.children[0]).children[0]), 0);
+		assert.strictEqual(snippet.offset(snippet.children[0]), 0);
+		assert.strictEqual(snippet.offset((<Variable>snippet.children[0]).children[0]), 0);
 
 		// forgein marker
-		assert.equal(snippet.offset(new Text('foo')), -1);
+		assert.strictEqual(snippet.offset(new Text('foo')), -1);
 	});
 
 	test('TextmateSnippet#placeholder', () => {
 		let snippet = new SnippetParser().parse('te$1xt$0', true);
 		let placeholders = snippet.placeholders;
-		assert.equal(placeholders.length, 2);
+		assert.strictEqual(placeholders.length, 2);
 
 		snippet = new SnippetParser().parse('te$1xt$1$0', true);
 		placeholders = snippet.placeholders;
-		assert.equal(placeholders.length, 3);
+		assert.strictEqual(placeholders.length, 3);
 
 
 		snippet = new SnippetParser().parse('te$1xt$2$0', true);
 		placeholders = snippet.placeholders;
-		assert.equal(placeholders.length, 3);
+		assert.strictEqual(placeholders.length, 3);
 
 		snippet = new SnippetParser().parse('${1:bar${2:foo}bar}$0', true);
 		placeholders = snippet.placeholders;
-		assert.equal(placeholders.length, 3);
+		assert.strictEqual(placeholders.length, 3);
 	});
 
 	test('TextmateSnippet#replace 1/2', function () {
 		let snippet = new SnippetParser().parse('aaa${1:bbb${2:ccc}}$0', true);
 
-		assert.equal(snippet.placeholders.length, 3);
+		assert.strictEqual(snippet.placeholders.length, 3);
 		const [, second] = snippet.placeholders;
-		assert.equal(second.index, '2');
+		assert.strictEqual(second.index, 2);
 
 		const enclosing = snippet.enclosingPlaceholders(second);
-		assert.equal(enclosing.length, 1);
-		assert.equal(enclosing[0].index, '1');
+		assert.strictEqual(enclosing.length, 1);
+		assert.strictEqual(enclosing[0].index, 1);
 
 		let nested = new SnippetParser().parse('ddd$1eee$0', true);
 		snippet.replace(second, nested.children);
 
-		assert.equal(snippet.toString(), 'aaabbbdddeee');
-		assert.equal(snippet.placeholders.length, 4);
-		assert.equal(snippet.placeholders[0].index, '1');
-		assert.equal(snippet.placeholders[1].index, '1');
-		assert.equal(snippet.placeholders[2].index, '0');
-		assert.equal(snippet.placeholders[3].index, '0');
+		assert.strictEqual(snippet.toString(), 'aaabbbdddeee');
+		assert.strictEqual(snippet.placeholders.length, 4);
+		assert.strictEqual(snippet.placeholders[0].index, 1);
+		assert.strictEqual(snippet.placeholders[1].index, 1);
+		assert.strictEqual(snippet.placeholders[2].index, 0);
+		assert.strictEqual(snippet.placeholders[3].index, 0);
 
 		const newEnclosing = snippet.enclosingPlaceholders(snippet.placeholders[1]);
 		assert.ok(newEnclosing[0] === snippet.placeholders[0]);
-		assert.equal(newEnclosing.length, 1);
-		assert.equal(newEnclosing[0].index, '1');
+		assert.strictEqual(newEnclosing.length, 1);
+		assert.strictEqual(newEnclosing[0].index, 1);
 	});
 
 	test('TextmateSnippet#replace 2/2', function () {
 		let snippet = new SnippetParser().parse('aaa${1:bbb${2:ccc}}$0', true);
 
-		assert.equal(snippet.placeholders.length, 3);
+		assert.strictEqual(snippet.placeholders.length, 3);
 		const [, second] = snippet.placeholders;
-		assert.equal(second.index, '2');
+		assert.strictEqual(second.index, 2);
 
 		let nested = new SnippetParser().parse('dddeee$0', true);
 		snippet.replace(second, nested.children);
 
-		assert.equal(snippet.toString(), 'aaabbbdddeee');
-		assert.equal(snippet.placeholders.length, 3);
+		assert.strictEqual(snippet.toString(), 'aaabbbdddeee');
+		assert.strictEqual(snippet.placeholders.length, 3);
 	});
 
 	test('Snippet order for placeholders, #28185', function () {
@@ -614,7 +617,7 @@ suite('SnippetParser', () => {
 		const _10 = new Placeholder(10);
 		const _2 = new Placeholder(2);
 
-		assert.equal(Placeholder.compareByIndex(_10, _2), 1);
+		assert.strictEqual(Placeholder.compareByIndex(_10, _2), 1);
 	});
 
 	test('Maximum call stack size exceeded, #28983', function () {
@@ -649,32 +652,32 @@ suite('SnippetParser', () => {
 	test('Transform -> FormatString#resolve', function () {
 
 		// shorthand functions
-		assert.equal(new FormatString(1, 'upcase').resolve('foo'), 'FOO');
-		assert.equal(new FormatString(1, 'downcase').resolve('FOO'), 'foo');
-		assert.equal(new FormatString(1, 'capitalize').resolve('bar'), 'Bar');
-		assert.equal(new FormatString(1, 'capitalize').resolve('bar no repeat'), 'Bar no repeat');
-		assert.equal(new FormatString(1, 'pascalcase').resolve('bar-foo'), 'BarFoo');
-		assert.equal(new FormatString(1, 'notKnown').resolve('input'), 'input');
+		assert.strictEqual(new FormatString(1, 'upcase').resolve('foo'), 'FOO');
+		assert.strictEqual(new FormatString(1, 'downcase').resolve('FOO'), 'foo');
+		assert.strictEqual(new FormatString(1, 'capitalize').resolve('bar'), 'Bar');
+		assert.strictEqual(new FormatString(1, 'capitalize').resolve('bar no repeat'), 'Bar no repeat');
+		assert.strictEqual(new FormatString(1, 'pascalcase').resolve('bar-foo'), 'BarFoo');
+		assert.strictEqual(new FormatString(1, 'notKnown').resolve('input'), 'input');
 
 		// if
-		assert.equal(new FormatString(1, undefined, 'foo', undefined).resolve(undefined), '');
-		assert.equal(new FormatString(1, undefined, 'foo', undefined).resolve(''), '');
-		assert.equal(new FormatString(1, undefined, 'foo', undefined).resolve('bar'), 'foo');
+		assert.strictEqual(new FormatString(1, undefined, 'foo', undefined).resolve(undefined), '');
+		assert.strictEqual(new FormatString(1, undefined, 'foo', undefined).resolve(''), '');
+		assert.strictEqual(new FormatString(1, undefined, 'foo', undefined).resolve('bar'), 'foo');
 
 		// else
-		assert.equal(new FormatString(1, undefined, undefined, 'foo').resolve(undefined), 'foo');
-		assert.equal(new FormatString(1, undefined, undefined, 'foo').resolve(''), 'foo');
-		assert.equal(new FormatString(1, undefined, undefined, 'foo').resolve('bar'), 'bar');
+		assert.strictEqual(new FormatString(1, undefined, undefined, 'foo').resolve(undefined), 'foo');
+		assert.strictEqual(new FormatString(1, undefined, undefined, 'foo').resolve(''), 'foo');
+		assert.strictEqual(new FormatString(1, undefined, undefined, 'foo').resolve('bar'), 'bar');
 
 		// if-else
-		assert.equal(new FormatString(1, undefined, 'bar', 'foo').resolve(undefined), 'foo');
-		assert.equal(new FormatString(1, undefined, 'bar', 'foo').resolve(''), 'foo');
-		assert.equal(new FormatString(1, undefined, 'bar', 'foo').resolve('baz'), 'bar');
+		assert.strictEqual(new FormatString(1, undefined, 'bar', 'foo').resolve(undefined), 'foo');
+		assert.strictEqual(new FormatString(1, undefined, 'bar', 'foo').resolve(''), 'foo');
+		assert.strictEqual(new FormatString(1, undefined, 'bar', 'foo').resolve('baz'), 'bar');
 	});
 
 	test('Snippet variable transformation doesn\'t work if regex is complicated and snippet body contains \'$$\' #55627', function () {
 		const snippet = new SnippetParser().parse('const fileName = "${TM_FILENAME/(.*)\\..+$/$1/}"');
-		assert.equal(snippet.toTextmateString(), 'const fileName = "${TM_FILENAME/(.*)\\..+$/${1}/}"');
+		assert.strictEqual(snippet.toTextmateString(), 'const fileName = "${TM_FILENAME/(.*)\\..+$/${1}/}"');
 	});
 
 	test('[BUG] HTML attribute suggestions: Snippet session does not have end-position set, #33147', function () {
@@ -682,9 +685,9 @@ suite('SnippetParser', () => {
 		const { placeholders } = new SnippetParser().parse('src="$1"', true);
 		const [first, second] = placeholders;
 
-		assert.equal(placeholders.length, 2);
-		assert.equal(first.index, 1);
-		assert.equal(second.index, 0);
+		assert.strictEqual(placeholders.length, 2);
+		assert.strictEqual(first.index, 1);
+		assert.strictEqual(second.index, 0);
 
 	});
 
@@ -695,10 +698,10 @@ suite('SnippetParser', () => {
 		transform.appendChild(new FormatString(2, 'upcase'));
 		transform.regexp = /^(.)|-(.)/g;
 
-		assert.equal(transform.resolve('my-file-name'), 'MyFileName');
+		assert.strictEqual(transform.resolve('my-file-name'), 'MyFileName');
 
 		const clone = transform.clone();
-		assert.equal(clone.resolve('my-file-name'), 'MyFileName');
+		assert.strictEqual(clone.resolve('my-file-name'), 'MyFileName');
 	});
 
 	test('problem with snippets regex #40570', function () {
@@ -711,7 +714,7 @@ suite('SnippetParser', () => {
 		let transform = new Transform();
 		transform.appendChild(new Text('bar'));
 		transform.regexp = new RegExp('foo', 'gi');
-		assert.equal(transform.toTextmateString(), '/foo/bar/ig');
+		assert.strictEqual(transform.toTextmateString(), '/foo/bar/ig');
 	});
 
 	test('Snippet parser freeze #53144', function () {
@@ -725,7 +728,7 @@ suite('SnippetParser', () => {
 
 	test('Mirroring sequence of nested placeholders not selected properly on backjumping #58736', function () {
 		let snippet = new SnippetParser().parse('${3:nest1 ${1:nest2 ${2:nest3}}} $3');
-		assert.equal(snippet.children.length, 3);
+		assert.strictEqual(snippet.children.length, 3);
 		assert.ok(snippet.children[0] instanceof Placeholder);
 		assert.ok(snippet.children[1] instanceof Text);
 		assert.ok(snippet.children[2] instanceof Placeholder);
@@ -759,25 +762,25 @@ suite('SnippetParser', () => {
 
 		let snippet = new SnippetParser().parse('${TM_DIRECTORY/(.+)/${1:+import { hello \\} from world}/}');
 		let variable = <Variable>snippet.children[0];
-		assert.equal(snippet.children.length, 1);
+		assert.strictEqual(snippet.children.length, 1);
 		assert.ok(variable instanceof Variable);
 		assert.ok(variable.transform);
-		assert.equal(variable.transform!.children.length, 1);
+		assert.strictEqual(variable.transform!.children.length, 1);
 		assert.ok(variable.transform!.children[0] instanceof FormatString);
-		assert.equal((<FormatString>variable.transform!.children[0]).ifValue, 'import { hello } from world');
-		assert.equal((<FormatString>variable.transform!.children[0]).elseValue, undefined);
+		assert.strictEqual((<FormatString>variable.transform!.children[0]).ifValue, 'import { hello } from world');
+		assert.strictEqual((<FormatString>variable.transform!.children[0]).elseValue, undefined);
 	});
 
 	test('Snippet escape backslashes inside conditional insertion variable replacement #80394', function () {
 
 		let snippet = new SnippetParser().parse('${CURRENT_YEAR/(.+)/${1:+\\\\}/}');
 		let variable = <Variable>snippet.children[0];
-		assert.equal(snippet.children.length, 1);
+		assert.strictEqual(snippet.children.length, 1);
 		assert.ok(variable instanceof Variable);
 		assert.ok(variable.transform);
-		assert.equal(variable.transform!.children.length, 1);
+		assert.strictEqual(variable.transform!.children.length, 1);
 		assert.ok(variable.transform!.children[0] instanceof FormatString);
-		assert.equal((<FormatString>variable.transform!.children[0]).ifValue, '\\');
-		assert.equal((<FormatString>variable.transform!.children[0]).elseValue, undefined);
+		assert.strictEqual((<FormatString>variable.transform!.children[0]).ifValue, '\\');
+		assert.strictEqual((<FormatString>variable.transform!.children[0]).elseValue, undefined);
 	});
 });

--- a/src/vs/editor/contrib/suggest/test/completionModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/completionModel.test.ts
@@ -101,7 +101,7 @@ suite('CompletionModel', function () {
 
 	test('complete/incomplete', () => {
 
-		assert.equal(model.incomplete.size, 0);
+		assert.strictEqual(model.incomplete.size, 0);
 
 		let incompleteModel = new CompletionModel([
 			createSuggestItem('foo', 3, undefined, true),
@@ -110,7 +110,7 @@ suite('CompletionModel', function () {
 			leadingLineContent: 'foo',
 			characterCountDelta: 0
 		}, WordDistance.None, EditorOptions.suggest.defaultValue, EditorOptions.snippetSuggestions.defaultValue, undefined);
-		assert.equal(incompleteModel.incomplete.size, 1);
+		assert.strictEqual(incompleteModel.incomplete.size, 1);
 	});
 
 	test('replaceIncomplete', () => {
@@ -119,15 +119,15 @@ suite('CompletionModel', function () {
 		const incompleteItem = createSuggestItem('foofoo', 1, undefined, true, { lineNumber: 1, column: 2 });
 
 		const model = new CompletionModel([completeItem, incompleteItem], 2, { leadingLineContent: 'f', characterCountDelta: 0 }, WordDistance.None, EditorOptions.suggest.defaultValue, EditorOptions.snippetSuggestions.defaultValue, undefined);
-		assert.equal(model.incomplete.size, 1);
-		assert.equal(model.items.length, 2);
+		assert.strictEqual(model.incomplete.size, 1);
+		assert.strictEqual(model.items.length, 2);
 
 		const { incomplete } = model;
 		const complete = model.adopt(incomplete);
 
-		assert.equal(incomplete.size, 1);
+		assert.strictEqual(incomplete.size, 1);
 		assert.ok(incomplete.has(incompleteItem.provider));
-		assert.equal(complete.length, 1);
+		assert.strictEqual(complete.length, 1);
 		assert.ok(complete[0] === completeItem);
 	});
 
@@ -149,15 +149,15 @@ suite('CompletionModel', function () {
 				incompleteItem1,
 			], 2, { leadingLineContent: 'f', characterCountDelta: 0 }, WordDistance.None, EditorOptions.suggest.defaultValue, EditorOptions.snippetSuggestions.defaultValue, undefined
 		);
-		assert.equal(model.incomplete.size, 1);
-		assert.equal(model.items.length, 6);
+		assert.strictEqual(model.incomplete.size, 1);
+		assert.strictEqual(model.items.length, 6);
 
 		const { incomplete } = model;
 		const complete = model.adopt(incomplete);
 
-		assert.equal(incomplete.size, 1);
+		assert.strictEqual(incomplete.size, 1);
 		assert.ok(incomplete.has(incompleteItem1.provider));
-		assert.equal(complete.length, 5);
+		assert.strictEqual(complete.length, 5);
 	});
 
 	test('proper current word when length=0, #16380', function () {
@@ -173,13 +173,13 @@ suite('CompletionModel', function () {
 			characterCountDelta: 0
 		}, WordDistance.None, EditorOptions.suggest.defaultValue, EditorOptions.snippetSuggestions.defaultValue, undefined);
 
-		assert.equal(model.items.length, 4);
+		assert.strictEqual(model.items.length, 4);
 
 		const [a, b, c, d] = model.items;
-		assert.equal(a.completion.label, '    </div');
-		assert.equal(b.completion.label, '    </tag');
-		assert.equal(c.completion.label, 'a');
-		assert.equal(d.completion.label, 'p');
+		assert.strictEqual(a.completion.label, '    </div');
+		assert.strictEqual(b.completion.label, '    </tag');
+		assert.strictEqual(c.completion.label, 'a');
+		assert.strictEqual(d.completion.label, 'p');
 	});
 
 	test('keep snippet sorting with prefix: top, #25495', function () {
@@ -193,10 +193,10 @@ suite('CompletionModel', function () {
 			characterCountDelta: 0
 		}, WordDistance.None, defaultOptions, 'top', undefined);
 
-		assert.equal(model.items.length, 2);
+		assert.strictEqual(model.items.length, 2);
 		const [a, b] = model.items;
-		assert.equal(a.completion.label, 'Snippet1');
-		assert.equal(b.completion.label, 'semver');
+		assert.strictEqual(a.completion.label, 'Snippet1');
+		assert.strictEqual(b.completion.label, 'semver');
 		assert.ok(a.score < b.score); // snippet really promoted
 
 	});
@@ -212,10 +212,10 @@ suite('CompletionModel', function () {
 			characterCountDelta: 0
 		}, WordDistance.None, defaultOptions, 'bottom', undefined);
 
-		assert.equal(model.items.length, 2);
+		assert.strictEqual(model.items.length, 2);
 		const [a, b] = model.items;
-		assert.equal(a.completion.label, 'Semver');
-		assert.equal(b.completion.label, 'snippet1');
+		assert.strictEqual(a.completion.label, 'Semver');
+		assert.strictEqual(b.completion.label, 'snippet1');
 		assert.ok(a.score < b.score); // snippet really demoted
 	});
 
@@ -230,10 +230,10 @@ suite('CompletionModel', function () {
 			characterCountDelta: 0
 		}, WordDistance.None, defaultOptions, 'inline', undefined);
 
-		assert.equal(model.items.length, 2);
+		assert.strictEqual(model.items.length, 2);
 		const [a, b] = model.items;
-		assert.equal(a.completion.label, 'snippet1');
-		assert.equal(b.completion.label, 'Semver');
+		assert.strictEqual(a.completion.label, 'snippet1');
+		assert.strictEqual(b.completion.label, 'Semver');
 		assert.ok(a.score > b.score); // snippet really demoted
 	});
 
@@ -247,13 +247,13 @@ suite('CompletionModel', function () {
 			characterCountDelta: 0
 		}, WordDistance.None, EditorOptions.suggest.defaultValue, EditorOptions.snippetSuggestions.defaultValue, undefined);
 
-		assert.equal(model.items.length, 2);
+		assert.strictEqual(model.items.length, 2);
 
 		model.lineContext = {
 			leadingLineContent: 'Map ',
 			characterCountDelta: 3
 		};
-		assert.equal(model.items.length, 1);
+		assert.strictEqual(model.items.length, 1);
 	});
 
 	test('Vscode 1.12 no longer obeys \'sortText\' in completion items (from language server), #26096', function () {
@@ -267,11 +267,11 @@ suite('CompletionModel', function () {
 			characterCountDelta: 0
 		}, WordDistance.None, EditorOptions.suggest.defaultValue, EditorOptions.snippetSuggestions.defaultValue, undefined);
 
-		assert.equal(model.items.length, 2);
+		assert.strictEqual(model.items.length, 2);
 
 		const [first, second] = model.items;
-		assert.equal(first.completion.label, 'source');
-		assert.equal(second.completion.label, '<- groups');
+		assert.strictEqual(first.completion.label, 'source');
+		assert.strictEqual(second.completion.label, '<- groups');
 	});
 
 	test('Score only filtered items when typing more, score all when typing less', function () {
@@ -286,19 +286,19 @@ suite('CompletionModel', function () {
 			characterCountDelta: 0
 		}, WordDistance.None, EditorOptions.suggest.defaultValue, EditorOptions.snippetSuggestions.defaultValue, undefined);
 
-		assert.equal(model.items.length, 5);
+		assert.strictEqual(model.items.length, 5);
 
 		// narrow down once
 		model.lineContext = { leadingLineContent: 'c', characterCountDelta: 1 };
-		assert.equal(model.items.length, 3);
+		assert.strictEqual(model.items.length, 3);
 
 		// query gets longer, narrow down the narrow-down'ed-set from before
 		model.lineContext = { leadingLineContent: 'cn', characterCountDelta: 2 };
-		assert.equal(model.items.length, 2);
+		assert.strictEqual(model.items.length, 2);
 
 		// query gets shorter, refilter everything
 		model.lineContext = { leadingLineContent: '', characterCountDelta: 0 };
-		assert.equal(model.items.length, 5);
+		assert.strictEqual(model.items.length, 5);
 	});
 
 	test('Have more relaxed suggest matching algorithm #15419', function () {
@@ -315,12 +315,12 @@ suite('CompletionModel', function () {
 
 		// query gets longer, narrow down the narrow-down'ed-set from before
 		model.lineContext = { leadingLineContent: 'rlut', characterCountDelta: 4 };
-		assert.equal(model.items.length, 3);
+		assert.strictEqual(model.items.length, 3);
 
 		const [first, second, third] = model.items;
-		assert.equal(first.completion.label, 'result'); // best with `rult`
-		assert.equal(second.completion.label, 'replyToUser');  // best with `rltu`
-		assert.equal(third.completion.label, 'randomLolut');  // best with `rlut`
+		assert.strictEqual(first.completion.label, 'result'); // best with `rult`
+		assert.strictEqual(second.completion.label, 'replyToUser');  // best with `rltu`
+		assert.strictEqual(third.completion.label, 'randomLolut');  // best with `rlut`
 	});
 
 	test('Emmet suggestion not appearing at the top of the list in jsx files, #39518', function () {
@@ -336,10 +336,10 @@ suite('CompletionModel', function () {
 		}, WordDistance.None, EditorOptions.suggest.defaultValue, EditorOptions.snippetSuggestions.defaultValue, undefined);
 
 		model.lineContext = { leadingLineContent: 'form', characterCountDelta: 4 };
-		assert.equal(model.items.length, 5);
+		assert.strictEqual(model.items.length, 5);
 		const [first, second, third] = model.items;
-		assert.equal(first.completion.label, 'form'); // best with `form`
-		assert.equal(second.completion.label, 'form:get');  // best with `form`
-		assert.equal(third.completion.label, 'from');  // best with `from`
+		assert.strictEqual(first.completion.label, 'form'); // best with `form`
+		assert.strictEqual(second.completion.label, 'form:get');  // best with `form`
+		assert.strictEqual(third.completion.label, 'from');  // best with `from`
 	});
 });

--- a/src/vs/editor/contrib/suggest/test/suggest.test.ts
+++ b/src/vs/editor/contrib/suggest/test/suggest.test.ts
@@ -53,32 +53,32 @@ suite('Suggest', function () {
 
 	test('sort - snippet inline', async function () {
 		const { items } = await provideSuggestionItems(model, new Position(1, 1), new CompletionOptions(SnippetSortOrder.Inline));
-		assert.equal(items.length, 3);
-		assert.equal(items[0].completion.label, 'aaa');
-		assert.equal(items[1].completion.label, 'fff');
-		assert.equal(items[2].completion.label, 'zzz');
+		assert.strictEqual(items.length, 3);
+		assert.strictEqual(items[0].completion.label, 'aaa');
+		assert.strictEqual(items[1].completion.label, 'fff');
+		assert.strictEqual(items[2].completion.label, 'zzz');
 	});
 
 	test('sort - snippet top', async function () {
 		const { items } = await provideSuggestionItems(model, new Position(1, 1), new CompletionOptions(SnippetSortOrder.Top));
-		assert.equal(items.length, 3);
-		assert.equal(items[0].completion.label, 'aaa');
-		assert.equal(items[1].completion.label, 'zzz');
-		assert.equal(items[2].completion.label, 'fff');
+		assert.strictEqual(items.length, 3);
+		assert.strictEqual(items[0].completion.label, 'aaa');
+		assert.strictEqual(items[1].completion.label, 'zzz');
+		assert.strictEqual(items[2].completion.label, 'fff');
 	});
 
 	test('sort - snippet bottom', async function () {
 		const { items } = await provideSuggestionItems(model, new Position(1, 1), new CompletionOptions(SnippetSortOrder.Bottom));
-		assert.equal(items.length, 3);
-		assert.equal(items[0].completion.label, 'fff');
-		assert.equal(items[1].completion.label, 'aaa');
-		assert.equal(items[2].completion.label, 'zzz');
+		assert.strictEqual(items.length, 3);
+		assert.strictEqual(items[0].completion.label, 'fff');
+		assert.strictEqual(items[1].completion.label, 'aaa');
+		assert.strictEqual(items[2].completion.label, 'zzz');
 	});
 
 	test('sort - snippet none', async function () {
 		const { items } = await provideSuggestionItems(model, new Position(1, 1), new CompletionOptions(undefined, new Set<CompletionItemKind>().add(CompletionItemKind.Snippet)));
-		assert.equal(items.length, 1);
-		assert.equal(items[0].completion.label, 'fff');
+		assert.strictEqual(items.length, 1);
+		assert.strictEqual(items[0].completion.label, 'fff');
 	});
 
 	test('only from', function () {
@@ -102,7 +102,7 @@ suite('Suggest', function () {
 		provideSuggestionItems(model, new Position(1, 1), new CompletionOptions(undefined, undefined, new Set<CompletionItemProvider>().add(foo))).then(({ items }) => {
 			registration.dispose();
 
-			assert.equal(items.length, 1);
+			assert.strictEqual(items.length, 1);
 			assert.ok(items[0].provider === foo);
 		});
 	});
@@ -141,12 +141,12 @@ suite('Suggest', function () {
 		const { items } = await provideSuggestionItems(model, new Position(0, 0), new CompletionOptions(undefined, undefined, new Set<CompletionItemProvider>().add(foo)));
 		registration.dispose();
 
-		assert.equal(items.length, 2);
+		assert.strictEqual(items.length, 2);
 		const [a, b] = items;
 
-		assert.equal(a.completion.label, 'one');
-		assert.equal(a.isInvalid, false);
-		assert.equal(b.completion.label, 'two');
-		assert.equal(b.isInvalid, true);
+		assert.strictEqual(a.completion.label, 'one');
+		assert.strictEqual(a.isInvalid, false);
+		assert.strictEqual(b.completion.label, 'two');
+		assert.strictEqual(b.isInvalid, true);
 	});
 });

--- a/src/vs/editor/contrib/suggest/test/suggestController.test.ts
+++ b/src/vs/editor/contrib/suggest/test/suggestController.test.ts
@@ -105,7 +105,7 @@ suite('SuggestController', function () {
 		controller.acceptSelectedSuggestion(false, false);
 		await p2;
 
-		assert.equal(editor.getValue(), '    let name = foo');
+		assert.strictEqual(editor.getValue(), '    let name = foo');
 	});
 
 	test('use additionalTextEdits sync when possible', async function () {
@@ -144,7 +144,7 @@ suite('SuggestController', function () {
 		await p2;
 
 		// insertText happens sync!
-		assert.equal(editor.getValue(), 'I came synchello\nhallohello');
+		assert.strictEqual(editor.getValue(), 'I came synchello\nhallohello');
 	});
 
 	test('resolve additionalTextEdits async when needed', async function () {
@@ -187,16 +187,16 @@ suite('SuggestController', function () {
 		await p2;
 
 		// insertText happens sync!
-		assert.equal(editor.getValue(), 'hello\nhallohello');
-		assert.equal(resolveCallCount, 1);
+		assert.strictEqual(editor.getValue(), 'hello\nhallohello');
+		assert.strictEqual(resolveCallCount, 1);
 
 		// additional edits happened after a litte wait
 		await timeout(20);
-		assert.equal(editor.getValue(), 'I came latehello\nhallohello');
+		assert.strictEqual(editor.getValue(), 'I came latehello\nhallohello');
 
 		// single undo stop
 		editor.getModel()?.undo();
-		assert.equal(editor.getValue(), 'hello\nhallo');
+		assert.strictEqual(editor.getValue(), 'hello\nhallo');
 	});
 
 	test('resolve additionalTextEdits async when needed (typing)', async function () {
@@ -239,18 +239,18 @@ suite('SuggestController', function () {
 		await p2;
 
 		// insertText happens sync!
-		assert.equal(editor.getValue(), 'hello\nhallohello');
-		assert.equal(resolveCallCount, 1);
+		assert.strictEqual(editor.getValue(), 'hello\nhallohello');
+		assert.strictEqual(resolveCallCount, 1);
 
 		// additional edits happened after a litte wait
 		assert.ok(editor.getSelection()?.equalsSelection(new Selection(2, 11, 2, 11)));
 		editor.trigger('test', 'type', { text: 'TYPING' });
 
-		assert.equal(editor.getValue(), 'hello\nhallohelloTYPING');
+		assert.strictEqual(editor.getValue(), 'hello\nhallohelloTYPING');
 
 		resolve();
 		await timeout(10);
-		assert.equal(editor.getValue(), 'I came latehello\nhallohelloTYPING');
+		assert.strictEqual(editor.getValue(), 'I came latehello\nhallohelloTYPING');
 		assert.ok(editor.getSelection()?.equalsSelection(new Selection(2, 17, 2, 17)));
 	});
 
@@ -295,12 +295,12 @@ suite('SuggestController', function () {
 		await p2;
 
 		// insertText happens sync!
-		assert.equal(editor.getValue(), 'hello');
-		assert.equal(resolveCallCount, 1);
+		assert.strictEqual(editor.getValue(), 'hello');
+		assert.strictEqual(resolveCallCount, 1);
 
 		resolve();
 		await timeout(10);
-		assert.equal(editor.getValue(), 'hello');
+		assert.strictEqual(editor.getValue(), 'hello');
 	});
 
 	// additional edit come late and are AFTER the position at which the user typed -> cancelled
@@ -344,18 +344,18 @@ suite('SuggestController', function () {
 		await p2;
 
 		// insertText happens sync!
-		assert.equal(editor.getValue(), 'hello\nhallohello');
-		assert.equal(resolveCallCount, 1);
+		assert.strictEqual(editor.getValue(), 'hello\nhallohello');
+		assert.strictEqual(resolveCallCount, 1);
 
 		// additional edits happened after a litte wait
 		editor.setSelection(new Selection(1, 1, 1, 1));
 		editor.trigger('test', 'type', { text: 'TYPING' });
 
-		assert.equal(editor.getValue(), 'TYPINGhello\nhallohello');
+		assert.strictEqual(editor.getValue(), 'TYPINGhello\nhallohello');
 
 		resolve();
 		await timeout(10);
-		assert.equal(editor.getValue(), 'TYPINGhello\nhallohello');
+		assert.strictEqual(editor.getValue(), 'TYPINGhello\nhallohello');
 		assert.ok(editor.getSelection()?.equalsSelection(new Selection(1, 7, 1, 7)));
 	});
 
@@ -402,7 +402,7 @@ suite('SuggestController', function () {
 		await p2;
 
 		// insertText happens sync!
-		assert.equal(editor.getValue(), 'helloabc');
+		assert.strictEqual(editor.getValue(), 'helloabc');
 
 		// next
 		controller.acceptNextSuggestion();
@@ -413,6 +413,6 @@ suite('SuggestController', function () {
 		await timeout(10);
 
 		// next suggestion used
-		assert.equal(editor.getValue(), 'halloabc');
+		assert.strictEqual(editor.getValue(), 'halloabc');
 	});
 });

--- a/src/vs/editor/contrib/suggest/test/suggestMemory.test.ts
+++ b/src/vs/editor/contrib/suggest/test/suggestMemory.test.ts
@@ -50,7 +50,7 @@ suite('SuggestMemories', function () {
 		item2.completion.preselect = true;
 		item3.completion.preselect = true;
 
-		assert.equal(mem.select(buffer, pos, [item1, item2, item3, item4]), 1);
+		assert.strictEqual(mem.select(buffer, pos, [item1, item2, item3, item4]), 1);
 	});
 
 	test('[No|Prefix|LRU]Memory honor selection boost', function () {
@@ -64,17 +64,17 @@ suite('SuggestMemories', function () {
 		let items = [item1, item2, item3, item4];
 
 
-		assert.equal(new NoMemory().select(buffer, pos, items), 1);
-		assert.equal(new LRUMemory().select(buffer, pos, items), 1);
-		assert.equal(new PrefixMemory().select(buffer, pos, items), 1);
+		assert.strictEqual(new NoMemory().select(buffer, pos, items), 1);
+		assert.strictEqual(new LRUMemory().select(buffer, pos, items), 1);
+		assert.strictEqual(new PrefixMemory().select(buffer, pos, items), 1);
 	});
 
 	test('NoMemory', () => {
 
 		const mem = new NoMemory();
 
-		assert.equal(mem.select(buffer, pos, items), 0);
-		assert.equal(mem.select(buffer, pos, []), 0);
+		assert.strictEqual(mem.select(buffer, pos, items), 0);
+		assert.strictEqual(mem.select(buffer, pos, []), 0);
 
 		mem.memorize(buffer, pos, items[0]);
 		mem.memorize(buffer, pos, null!);
@@ -87,18 +87,18 @@ suite('SuggestMemories', function () {
 		const mem = new LRUMemory();
 		mem.memorize(buffer, pos, items[1]);
 
-		assert.equal(mem.select(buffer, pos, items), 1);
-		assert.equal(mem.select(buffer, { lineNumber: 1, column: 3 }, items), 0);
+		assert.strictEqual(mem.select(buffer, pos, items), 1);
+		assert.strictEqual(mem.select(buffer, { lineNumber: 1, column: 3 }, items), 0);
 
 		mem.memorize(buffer, pos, items[0]);
-		assert.equal(mem.select(buffer, pos, items), 0);
+		assert.strictEqual(mem.select(buffer, pos, items), 0);
 
-		assert.equal(mem.select(buffer, pos, [
+		assert.strictEqual(mem.select(buffer, pos, [
 			createSuggestItem('new', 0),
 			createSuggestItem('bar', 0)
 		]), 1);
 
-		assert.equal(mem.select(buffer, pos, [
+		assert.strictEqual(mem.select(buffer, pos, [
 			createSuggestItem('new1', 0),
 			createSuggestItem('new2', 0)
 		]), 0);
@@ -114,16 +114,16 @@ suite('SuggestMemories', function () {
 		buffer.setValue('    foo.');
 		mem.memorize(buffer, { lineNumber: 1, column: 1 }, item2);
 
-		assert.equal(mem.select(buffer, { lineNumber: 1, column: 2 }, items), 0); // leading whitespace -> ignore recent items
+		assert.strictEqual(mem.select(buffer, { lineNumber: 1, column: 2 }, items), 0); // leading whitespace -> ignore recent items
 
 		mem.memorize(buffer, { lineNumber: 1, column: 9 }, item2);
-		assert.equal(mem.select(buffer, { lineNumber: 1, column: 9 }, items), 1); // foo.
+		assert.strictEqual(mem.select(buffer, { lineNumber: 1, column: 9 }, items), 1); // foo.
 
 		buffer.setValue('    foo.g');
-		assert.equal(mem.select(buffer, { lineNumber: 1, column: 10 }, items), 1); // foo.g, 'gamma' and 'game' have the same score
+		assert.strictEqual(mem.select(buffer, { lineNumber: 1, column: 10 }, items), 1); // foo.g, 'gamma' and 'game' have the same score
 
 		item1.score = [10, 0, 0];
-		assert.equal(mem.select(buffer, { lineNumber: 1, column: 10 }, items), 0); // foo.g, 'gamma' has higher score
+		assert.strictEqual(mem.select(buffer, { lineNumber: 1, column: 10 }, items), 0); // foo.g, 'gamma' has higher score
 
 	});
 
@@ -134,10 +134,10 @@ suite('SuggestMemories', function () {
 		const mem = new LRUMemory();
 
 		mem.memorize(buffer, pos, items[1]);
-		assert.equal(mem.select(buffer, pos, items), 1);
+		assert.strictEqual(mem.select(buffer, pos, items), 1);
 
-		assert.equal(mem.select(buffer, { lineNumber: 3, column: 5 }, items), 0); // foo: |,
-		assert.equal(mem.select(buffer, { lineNumber: 3, column: 6 }, items), 1); // foo: ,|
+		assert.strictEqual(mem.select(buffer, { lineNumber: 3, column: 5 }, items), 0); // foo: |,
+		assert.strictEqual(mem.select(buffer, { lineNumber: 3, column: 6 }, items), 1); // foo: ,|
 	});
 
 	test('PrefixMemory', () => {
@@ -154,11 +154,11 @@ suite('SuggestMemories', function () {
 		mem.memorize(buffer, { lineNumber: 1, column: 3 }, item0); // co -> console
 		mem.memorize(buffer, { lineNumber: 1, column: 4 }, item2); // con -> constructor
 
-		assert.equal(mem.select(buffer, { lineNumber: 1, column: 1 }, items), 0);
-		assert.equal(mem.select(buffer, { lineNumber: 1, column: 2 }, items), 1);
-		assert.equal(mem.select(buffer, { lineNumber: 1, column: 3 }, items), 0);
-		assert.equal(mem.select(buffer, { lineNumber: 1, column: 4 }, items), 2);
-		assert.equal(mem.select(buffer, { lineNumber: 1, column: 7 }, items), 2); // find substr
+		assert.strictEqual(mem.select(buffer, { lineNumber: 1, column: 1 }, items), 0);
+		assert.strictEqual(mem.select(buffer, { lineNumber: 1, column: 2 }, items), 1);
+		assert.strictEqual(mem.select(buffer, { lineNumber: 1, column: 3 }, items), 0);
+		assert.strictEqual(mem.select(buffer, { lineNumber: 1, column: 4 }, items), 2);
+		assert.strictEqual(mem.select(buffer, { lineNumber: 1, column: 7 }, items), 2); // find substr
 	});
 
 });

--- a/src/vs/editor/contrib/suggest/test/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/suggestModel.test.ts
@@ -104,7 +104,7 @@ suite('SuggestModel - Context', function () {
 		const pos = model.getPositionAt(offset);
 		const editor = createMockEditor(model);
 		editor.setPosition(pos);
-		assert.equal(LineContext.shouldAutoTrigger(editor), expected, message);
+		assert.strictEqual(LineContext.shouldAutoTrigger(editor), expected, message);
 		editor.dispose();
 	};
 
@@ -243,25 +243,25 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				assertEvent(model.onDidTrigger, function () {
 					model.trigger({ auto: true, shy: false });
 				}, function (event) {
-					assert.equal(event.auto, true);
+					assert.strictEqual(event.auto, true);
 
 					return assertEvent(model.onDidCancel, function () {
 						model.cancel();
 					}, function (event) {
-						assert.equal(event.retrigger, false);
+						assert.strictEqual(event.retrigger, false);
 					});
 				}),
 
 				assertEvent(model.onDidTrigger, function () {
 					model.trigger({ auto: true, shy: false });
 				}, function (event) {
-					assert.equal(event.auto, true);
+					assert.strictEqual(event.auto, true);
 				}),
 
 				assertEvent(model.onDidTrigger, function () {
 					model.trigger({ auto: false, shy: false });
 				}, function (event) {
-					assert.equal(event.auto, false);
+					assert.strictEqual(event.auto, false);
 				})
 			]);
 		});
@@ -277,14 +277,14 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				assertEvent(model.onDidCancel, function () {
 					model.trigger({ auto: true, shy: false });
 				}, function (event) {
-					assert.equal(event.retrigger, false);
+					assert.strictEqual(event.retrigger, false);
 				}),
 				assertEvent(model.onDidSuggest, function () {
 					model.trigger({ auto: false, shy: false });
 				}, function (event) {
-					assert.equal(event.auto, false);
-					assert.equal(event.isFrozen, false);
-					assert.equal(event.completionModel.items.length, 0);
+					assert.strictEqual(event.auto, false);
+					assert.strictEqual(event.isFrozen, false);
+					assert.strictEqual(event.completionModel.items.length, 0);
 				})
 			]);
 		});
@@ -300,11 +300,11 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'd' });
 
 			}, event => {
-				assert.equal(event.auto, true);
-				assert.equal(event.completionModel.items.length, 1);
+				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
 
-				assert.equal(first.provider, alwaysSomethingSupport);
+				assert.strictEqual(first.provider, alwaysSomethingSupport);
 			});
 		});
 	});
@@ -339,20 +339,20 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 					editor.trigger('keyboard', Handler.Type, { text: 'My' });
 
 				}, event => {
-					assert.equal(event.auto, true);
-					assert.equal(event.completionModel.items.length, 1);
+					assert.strictEqual(event.auto, true);
+					assert.strictEqual(event.completionModel.items.length, 1);
 					const [first] = event.completionModel.items;
-					assert.equal(first.completion.label, 'My Table');
+					assert.strictEqual(first.completion.label, 'My Table');
 
 					return assertEvent(model.onDidSuggest, () => {
 						editor.setPosition({ lineNumber: 1, column: 3 });
 						editor.trigger('keyboard', Handler.Type, { text: ' ' });
 
 					}, event => {
-						assert.equal(event.auto, true);
-						assert.equal(event.completionModel.items.length, 1);
+						assert.strictEqual(event.auto, true);
+						assert.strictEqual(event.completionModel.items.length, 1);
 						const [first] = event.completionModel.items;
-						assert.equal(first.completion.label, 'My Table');
+						assert.strictEqual(first.completion.label, 'My Table');
 					});
 				});
 			});
@@ -402,20 +402,20 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'foo' });
 
 			}, event => {
-				assert.equal(event.auto, true);
-				assert.equal(event.completionModel.items.length, 1);
+				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
-				assert.equal(first.completion.label, 'foo.bar');
+				assert.strictEqual(first.completion.label, 'foo.bar');
 
 				return assertEvent(model.onDidSuggest, () => {
 					editor.trigger('keyboard', Handler.Type, { text: '.' });
 
 				}, event => {
-					assert.equal(event.auto, true);
-					assert.equal(event.completionModel.items.length, 2);
+					assert.strictEqual(event.auto, true);
+					assert.strictEqual(event.completionModel.items.length, 2);
 					const [first, second] = event.completionModel.items;
-					assert.equal(first.completion.label, 'foo.bar');
-					assert.equal(second.completion.label, 'boom');
+					assert.strictEqual(first.completion.label, 'foo.bar');
+					assert.strictEqual(second.completion.label, 'boom');
 				});
 			});
 		});
@@ -433,14 +433,14 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			return assertEvent(model.onDidSuggest, () => {
 				model.trigger({ auto: false, shy: false });
 			}, event => {
-				assert.equal(event.auto, false);
-				assert.equal(event.isFrozen, false);
-				assert.equal(event.completionModel.items.length, 1);
+				assert.strictEqual(event.auto, false);
+				assert.strictEqual(event.isFrozen, false);
+				assert.strictEqual(event.completionModel.items.length, 1);
 
 				return assertEvent(model.onDidCancel, () => {
 					editor.trigger('keyboard', Handler.Type, { text: '+' });
 				}, event => {
-					assert.equal(event.retrigger, false);
+					assert.strictEqual(event.retrigger, false);
 				});
 			});
 		});
@@ -458,14 +458,14 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			return assertEvent(model.onDidSuggest, () => {
 				model.trigger({ auto: false, shy: false });
 			}, event => {
-				assert.equal(event.auto, false);
-				assert.equal(event.isFrozen, false);
-				assert.equal(event.completionModel.items.length, 1);
+				assert.strictEqual(event.auto, false);
+				assert.strictEqual(event.isFrozen, false);
+				assert.strictEqual(event.completionModel.items.length, 1);
 
 				return assertEvent(model.onDidCancel, () => {
 					editor.trigger('keyboard', Handler.Type, { text: ' ' });
 				}, event => {
-					assert.equal(event.retrigger, false);
+					assert.strictEqual(event.retrigger, false);
 				});
 			});
 		});
@@ -495,14 +495,14 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			return assertEvent(model.onDidSuggest, () => {
 				model.trigger({ auto: false, shy: false });
 			}, event => {
-				assert.equal(event.auto, false);
-				assert.equal(event.completionModel.incomplete.size, 1);
-				assert.equal(event.completionModel.items.length, 1);
+				assert.strictEqual(event.auto, false);
+				assert.strictEqual(event.completionModel.incomplete.size, 1);
+				assert.strictEqual(event.completionModel.items.length, 1);
 
 				return assertEvent(model.onDidCancel, () => {
 					editor.trigger('keyboard', Handler.Type, { text: ';' });
 				}, event => {
-					assert.equal(event.retrigger, false);
+					assert.strictEqual(event.retrigger, false);
 				});
 			});
 		});
@@ -532,9 +532,9 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			return assertEvent(model.onDidSuggest, () => {
 				model.trigger({ auto: false, shy: false });
 			}, event => {
-				assert.equal(event.auto, false);
-				assert.equal(event.completionModel.incomplete.size, 1);
-				assert.equal(event.completionModel.items.length, 1);
+				assert.strictEqual(event.auto, false);
+				assert.strictEqual(event.completionModel.incomplete.size, 1);
+				assert.strictEqual(event.completionModel.items.length, 1);
 
 				return assertEvent(model.onDidSuggest, () => {
 					// while we cancel incrementally enriching the set of
@@ -542,9 +542,9 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 					// until now
 					editor.trigger('keyboard', Handler.Type, { text: ';' });
 				}, event => {
-					assert.equal(event.auto, false);
-					assert.equal(event.completionModel.incomplete.size, 1);
-					assert.equal(event.completionModel.items.length, 1);
+					assert.strictEqual(event.auto, false);
+					assert.strictEqual(event.completionModel.incomplete.size, 1);
+					assert.strictEqual(event.completionModel.items.length, 1);
 
 				});
 			});
@@ -556,7 +556,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 		disposables.push(CompletionProviderRegistry.register({ scheme: 'test' }, {
 			triggerCharacters: ['.'],
 			provideCompletionItems(doc, pos, context): CompletionList {
-				assert.equal(context.triggerKind, CompletionTriggerKind.TriggerCharacter);
+				assert.strictEqual(context.triggerKind, CompletionTriggerKind.TriggerCharacter);
 				triggerCharacter = context.triggerCharacter!;
 				return {
 					incomplete: false,
@@ -580,7 +580,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.setPosition({ lineNumber: 1, column: 1 });
 				editor.trigger('keyboard', Handler.Type, { text: 'foo.' });
 			}, event => {
-				assert.equal(triggerCharacter, '.');
+				assert.strictEqual(triggerCharacter, '.');
 			});
 		});
 	});
@@ -612,16 +612,16 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.setPosition({ lineNumber: 1, column: 1 });
 				editor.trigger('keyboard', Handler.Type, { text: 'a' });
 			}, event => {
-				assert.equal(event.completionModel.items.length, 1);
-				assert.equal(event.completionModel.items[0].completion.label, 'abc');
+				assert.strictEqual(event.completionModel.items.length, 1);
+				assert.strictEqual(event.completionModel.items[0].completion.label, 'abc');
 
 				return assertEvent(model.onDidSuggest, () => {
 					editor.executeEdits('test', [EditOperation.replace(new Range(1, 1, 1, 2), 'ä')]);
 
 				}, event => {
 					// suggest model changed to äbc
-					assert.equal(event.completionModel.items.length, 1);
-					assert.equal(event.completionModel.items[0].completion.label, 'äbc');
+					assert.strictEqual(event.completionModel.items.length, 1);
+					assert.strictEqual(event.completionModel.items[0].completion.label, 'äbc');
 
 				});
 			});
@@ -637,22 +637,22 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'd' });
 
 			}, event => {
-				assert.equal(event.auto, true);
-				assert.equal(event.completionModel.items.length, 1);
+				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
 
-				assert.equal(first.provider, alwaysSomethingSupport);
+				assert.strictEqual(first.provider, alwaysSomethingSupport);
 			});
 
 			await assertEvent(model.onDidSuggest, () => {
 				CoreEditingCommands.DeleteLeft.runEditorCommand(null, editor, null);
 
 			}, event => {
-				assert.equal(event.auto, true);
-				assert.equal(event.completionModel.items.length, 1);
+				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
 
-				assert.equal(first.provider, alwaysSomethingSupport);
+				assert.strictEqual(first.provider, alwaysSomethingSupport);
 			});
 		});
 	});
@@ -692,14 +692,14 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				sugget.trigger({ auto: false, shy: false });
 			}, event => {
 
-				assert.equal(event.completionModel.items.length, 1);
+				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
-				assert.equal(first.completion.label, 'bar');
+				assert.strictEqual(first.completion.label, 'bar');
 
 				ctrl._insertSuggestion({ item: first, index: 0, model: event.completionModel });
 			});
 
-			assert.equal(
+			assert.strictEqual(
 				model.getValue(),
 				'bar; import { foo, bar } from "./b"'
 			);
@@ -717,11 +717,11 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'e' });
 
 			}, event => {
-				assert.equal(event.auto, true);
-				assert.equal(event.completionModel.items.length, 1);
+				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
 
-				assert.equal(first.provider, alwaysSomethingSupport);
+				assert.strictEqual(first.provider, alwaysSomethingSupport);
 			});
 		});
 	});
@@ -774,22 +774,22 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'c' });
 
 			}, event => {
-				assert.equal(event.auto, true);
-				assert.equal(event.completionModel.items.length, 2);
-				assert.equal(disposeA, 0);
-				assert.equal(disposeB, 0);
+				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.completionModel.items.length, 2);
+				assert.strictEqual(disposeA, 0);
+				assert.strictEqual(disposeB, 0);
 			});
 
 			await assertEvent(model.onDidSuggest, () => {
 				editor.trigger('keyboard', Handler.Type, { text: 'o' });
 			}, event => {
-				assert.equal(event.auto, true);
-				assert.equal(event.completionModel.items.length, 2);
+				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.completionModel.items.length, 2);
 
 				// clean up
 				model.clear();
-				assert.equal(disposeA, 2); // provide got called two times!
-				assert.equal(disposeB, 1);
+				assert.strictEqual(disposeA, 2); // provide got called two times!
+				assert.strictEqual(disposeB, 1);
 			});
 
 		});
@@ -841,9 +841,9 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'Z' });
 
 			}, event => {
-				assert.equal(event.auto, true);
-				assert.equal(event.completionModel.items.length, 1);
-				assert.equal(event.completionModel.items[0].textLabel, 'Z aaa');
+				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.completionModel.items.length, 1);
+				assert.strictEqual(event.completionModel.items[0].textLabel, 'Z aaa');
 			});
 
 			await assertEvent(model.onDidSuggest, () => {
@@ -851,13 +851,13 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				// item should be: Z aaa, aaa
 				editor.trigger('keyboard', Handler.Type, { text: ' a' });
 			}, event => {
-				assert.equal(event.auto, true);
-				assert.equal(event.completionModel.items.length, 2);
-				assert.equal(event.completionModel.items[0].textLabel, 'Z aaa');
-				assert.equal(event.completionModel.items[1].textLabel, 'aaa');
+				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.completionModel.items.length, 2);
+				assert.strictEqual(event.completionModel.items[0].textLabel, 'Z aaa');
+				assert.strictEqual(event.completionModel.items[1].textLabel, 'aaa');
 
-				assert.equal(countA, 1); // should we keep the suggestions from the "active" provider?, Yes! See: #106573
-				assert.equal(countB, 2);
+				assert.strictEqual(countA, 1); // should we keep the suggestions from the "active" provider?, Yes! See: #106573
+				assert.strictEqual(countB, 2);
 			});
 		});
 	});

--- a/src/vs/editor/test/browser/services/openerService.test.ts
+++ b/src/vs/editor/test/browser/services/openerService.test.ts
@@ -32,47 +32,47 @@ suite('OpenerService', function () {
 	test('delegate to editorService, scheme:///fff', async function () {
 		const openerService = new OpenerService(editorService, NullCommandService);
 		await openerService.open(URI.parse('another:///somepath'));
-		assert.equal(editorService.lastInput!.options!.selection, undefined);
+		assert.strictEqual(editorService.lastInput!.options!.selection, undefined);
 	});
 
 	test('delegate to editorService, scheme:///fff#L123', async function () {
 		const openerService = new OpenerService(editorService, NullCommandService);
 
 		await openerService.open(URI.parse('file:///somepath#L23'));
-		assert.equal(editorService.lastInput!.options!.selection!.startLineNumber, 23);
-		assert.equal(editorService.lastInput!.options!.selection!.startColumn, 1);
-		assert.equal(editorService.lastInput!.options!.selection!.endLineNumber, undefined);
-		assert.equal(editorService.lastInput!.options!.selection!.endColumn, undefined);
-		assert.equal(editorService.lastInput!.resource.fragment, '');
+		assert.strictEqual(editorService.lastInput!.options!.selection!.startLineNumber, 23);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.startColumn, 1);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.endLineNumber, undefined);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.endColumn, undefined);
+		assert.strictEqual(editorService.lastInput!.resource.fragment, '');
 
 		await openerService.open(URI.parse('another:///somepath#L23'));
-		assert.equal(editorService.lastInput!.options!.selection!.startLineNumber, 23);
-		assert.equal(editorService.lastInput!.options!.selection!.startColumn, 1);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.startLineNumber, 23);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.startColumn, 1);
 
 		await openerService.open(URI.parse('another:///somepath#L23,45'));
-		assert.equal(editorService.lastInput!.options!.selection!.startLineNumber, 23);
-		assert.equal(editorService.lastInput!.options!.selection!.startColumn, 45);
-		assert.equal(editorService.lastInput!.options!.selection!.endLineNumber, undefined);
-		assert.equal(editorService.lastInput!.options!.selection!.endColumn, undefined);
-		assert.equal(editorService.lastInput!.resource.fragment, '');
+		assert.strictEqual(editorService.lastInput!.options!.selection!.startLineNumber, 23);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.startColumn, 45);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.endLineNumber, undefined);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.endColumn, undefined);
+		assert.strictEqual(editorService.lastInput!.resource.fragment, '');
 	});
 
 	test('delegate to editorService, scheme:///fff#123,123', async function () {
 		const openerService = new OpenerService(editorService, NullCommandService);
 
 		await openerService.open(URI.parse('file:///somepath#23'));
-		assert.equal(editorService.lastInput!.options!.selection!.startLineNumber, 23);
-		assert.equal(editorService.lastInput!.options!.selection!.startColumn, 1);
-		assert.equal(editorService.lastInput!.options!.selection!.endLineNumber, undefined);
-		assert.equal(editorService.lastInput!.options!.selection!.endColumn, undefined);
-		assert.equal(editorService.lastInput!.resource.fragment, '');
+		assert.strictEqual(editorService.lastInput!.options!.selection!.startLineNumber, 23);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.startColumn, 1);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.endLineNumber, undefined);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.endColumn, undefined);
+		assert.strictEqual(editorService.lastInput!.resource.fragment, '');
 
 		await openerService.open(URI.parse('file:///somepath#23,45'));
-		assert.equal(editorService.lastInput!.options!.selection!.startLineNumber, 23);
-		assert.equal(editorService.lastInput!.options!.selection!.startColumn, 45);
-		assert.equal(editorService.lastInput!.options!.selection!.endLineNumber, undefined);
-		assert.equal(editorService.lastInput!.options!.selection!.endColumn, undefined);
-		assert.equal(editorService.lastInput!.resource.fragment, '');
+		assert.strictEqual(editorService.lastInput!.options!.selection!.startLineNumber, 23);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.startColumn, 45);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.endLineNumber, undefined);
+		assert.strictEqual(editorService.lastInput!.options!.selection!.endColumn, undefined);
+		assert.strictEqual(editorService.lastInput!.resource.fragment, '');
 	});
 
 	test('delegate to commandsService, command:someid', async function () {
@@ -82,19 +82,20 @@ suite('OpenerService', function () {
 		CommandsRegistry.registerCommand(id, function () { });
 
 		await openerService.open(URI.parse('command:' + id));
-		assert.equal(lastCommand!.id, id);
-		assert.equal(lastCommand!.args.length, 0);
+		assert.strictEqual(lastCommand!.id, id);
+		assert.strictEqual(lastCommand!.args.length, 0);
 
 		await openerService.open(URI.parse('command:' + id).with({ query: '123' }));
-		assert.equal(lastCommand!.id, id);
-		assert.equal(lastCommand!.args.length, 1);
+		assert.strictEqual(lastCommand!.id, id);
+		assert.strictEqual(lastCommand!.args.length, 1);
+		// TODO @jrieken is this ok that its converting the string to a number in the args?
 		assert.equal(lastCommand!.args[0], '123');
 
 		await openerService.open(URI.parse('command:' + id).with({ query: JSON.stringify([12, true]) }));
-		assert.equal(lastCommand!.id, id);
-		assert.equal(lastCommand!.args.length, 2);
-		assert.equal(lastCommand!.args[0], 12);
-		assert.equal(lastCommand!.args[1], true);
+		assert.strictEqual(lastCommand!.id, id);
+		assert.strictEqual(lastCommand!.args.length, 2);
+		assert.strictEqual(lastCommand!.args[0], 12);
+		assert.strictEqual(lastCommand!.args[1], true);
 	});
 
 	test('links are protected by validators', async function () {
@@ -104,8 +105,8 @@ suite('OpenerService', function () {
 
 		const httpResult = await openerService.open(URI.parse('https://www.microsoft.com'));
 		const httpsResult = await openerService.open(URI.parse('https://www.microsoft.com'));
-		assert.equal(httpResult, false);
-		assert.equal(httpsResult, false);
+		assert.strictEqual(httpResult, false);
+		assert.strictEqual(httpsResult, false);
 	});
 
 	test('links validated by validators go to openers', async function () {
@@ -122,9 +123,9 @@ suite('OpenerService', function () {
 		});
 
 		await openerService.open(URI.parse('http://microsoft.com'));
-		assert.equal(openCount, 1);
+		assert.strictEqual(openCount, 1);
 		await openerService.open(URI.parse('https://microsoft.com'));
-		assert.equal(openCount, 2);
+		assert.strictEqual(openCount, 2);
 	});
 
 	test('links aren\'t manipulated before being passed to validator: PR #118226', async function () {
@@ -169,13 +170,13 @@ suite('OpenerService', function () {
 		});
 
 		await openerService.open(URI.parse('http://microsoft.com'));
-		assert.equal(openCount, 1);
-		assert.equal(v1, 1);
-		assert.equal(v2, 1);
+		assert.strictEqual(openCount, 1);
+		assert.strictEqual(v1, 1);
+		assert.strictEqual(v2, 1);
 		await openerService.open(URI.parse('https://microsoft.com'));
-		assert.equal(openCount, 2);
-		assert.equal(v1, 2);
-		assert.equal(v2, 2);
+		assert.strictEqual(openCount, 2);
+		assert.strictEqual(v1, 2);
+		assert.strictEqual(v2, 2);
 	});
 
 	test('links invalidated by first validator do not continue validating', async function () {
@@ -206,13 +207,13 @@ suite('OpenerService', function () {
 		});
 
 		await openerService.open(URI.parse('http://microsoft.com'));
-		assert.equal(openCount, 0);
-		assert.equal(v1, 1);
-		assert.equal(v2, 0);
+		assert.strictEqual(openCount, 0);
+		assert.strictEqual(v1, 1);
+		assert.strictEqual(v2, 0);
 		await openerService.open(URI.parse('https://microsoft.com'));
-		assert.equal(openCount, 0);
-		assert.equal(v1, 2);
-		assert.equal(v2, 0);
+		assert.strictEqual(openCount, 0);
+		assert.strictEqual(v1, 2);
+		assert.strictEqual(v2, 0);
 	});
 
 	test('matchesScheme', function () {

--- a/src/vs/platform/actions/test/common/menuService.test.ts
+++ b/src/vs/platform/actions/test/common/menuService.test.ts
@@ -65,14 +65,14 @@ suite('MenuService', function () {
 
 		const groups = menuService.createMenu(testMenuId, contextKeyService).getActions();
 
-		assert.equal(groups.length, 5);
+		assert.strictEqual(groups.length, 5);
 		const [one, two, three, four, five] = groups;
 
-		assert.equal(one[0], 'navigation');
-		assert.equal(two[0], '0_hello');
-		assert.equal(three[0], 'hello');
-		assert.equal(four[0], 'Hello');
-		assert.equal(five[0], '');
+		assert.strictEqual(one[0], 'navigation');
+		assert.strictEqual(two[0], '0_hello');
+		assert.strictEqual(three[0], 'hello');
+		assert.strictEqual(four[0], 'Hello');
+		assert.strictEqual(five[0], '');
 	});
 
 	test('in group sorting, by title', function () {
@@ -94,14 +94,14 @@ suite('MenuService', function () {
 
 		const groups = menuService.createMenu(testMenuId, contextKeyService).getActions();
 
-		assert.equal(groups.length, 1);
+		assert.strictEqual(groups.length, 1);
 		const [, actions] = groups[0];
 
-		assert.equal(actions.length, 3);
+		assert.strictEqual(actions.length, 3);
 		const [one, two, three] = actions;
-		assert.equal(one.id, 'a');
-		assert.equal(two.id, 'b');
-		assert.equal(three.id, 'c');
+		assert.strictEqual(one.id, 'a');
+		assert.strictEqual(two.id, 'b');
+		assert.strictEqual(three.id, 'c');
 	});
 
 	test('in group sorting, by title and order', function () {
@@ -131,15 +131,15 @@ suite('MenuService', function () {
 
 		const groups = menuService.createMenu(testMenuId, contextKeyService).getActions();
 
-		assert.equal(groups.length, 1);
+		assert.strictEqual(groups.length, 1);
 		const [, actions] = groups[0];
 
-		assert.equal(actions.length, 4);
+		assert.strictEqual(actions.length, 4);
 		const [one, two, three, four] = actions;
-		assert.equal(one.id, 'd');
-		assert.equal(two.id, 'c');
-		assert.equal(three.id, 'b');
-		assert.equal(four.id, 'a');
+		assert.strictEqual(one.id, 'd');
+		assert.strictEqual(two.id, 'c');
+		assert.strictEqual(three.id, 'b');
+		assert.strictEqual(four.id, 'a');
 	});
 
 
@@ -165,14 +165,14 @@ suite('MenuService', function () {
 
 		const groups = menuService.createMenu(testMenuId, contextKeyService).getActions();
 
-		assert.equal(groups.length, 1);
+		assert.strictEqual(groups.length, 1);
 		const [[, actions]] = groups;
 
-		assert.equal(actions.length, 3);
+		assert.strictEqual(actions.length, 3);
 		const [one, two, three] = actions;
-		assert.equal(one.id, 'c');
-		assert.equal(two.id, 'b');
-		assert.equal(three.id, 'a');
+		assert.strictEqual(one.id, 'c');
+		assert.strictEqual(two.id, 'b');
+		assert.strictEqual(three.id, 'a');
 	});
 
 	test('special MenuId palette', function () {
@@ -188,16 +188,16 @@ suite('MenuService', function () {
 		for (const item of MenuRegistry.getMenuItems(MenuId.CommandPalette)) {
 			if (isIMenuItem(item)) {
 				if (item.command.id === 'a') {
-					assert.equal(item.command.title, 'Explicit');
+					assert.strictEqual(item.command.title, 'Explicit');
 					foundA = true;
 				}
 				if (item.command.id === 'b') {
-					assert.equal(item.command.title, 'Implicit');
+					assert.strictEqual(item.command.title, 'Implicit');
 					foundB = true;
 				}
 			}
 		}
-		assert.equal(foundA, true);
-		assert.equal(foundB, true);
+		assert.strictEqual(foundA, true);
+		assert.strictEqual(foundB, true);
 	});
 });

--- a/src/vs/platform/commands/test/common/commands.test.ts
+++ b/src/vs/platform/commands/test/common/commands.test.ts
@@ -71,7 +71,7 @@ suite('Command Tests', function () {
 		CommandsRegistry.getCommands().get('test')!.handler.apply(undefined, [undefined!, 'string']);
 		CommandsRegistry.getCommands().get('test2')!.handler.apply(undefined, [undefined!, 'string']);
 		assert.throws(() => CommandsRegistry.getCommands().get('test3')!.handler.apply(undefined, [undefined!, 'string']));
-		assert.equal(CommandsRegistry.getCommands().get('test3')!.handler.apply(undefined, [undefined!, 1]), true);
+		assert.strictEqual(CommandsRegistry.getCommands().get('test3')!.handler.apply(undefined, [undefined!, 1]), true);
 
 	});
 });

--- a/src/vs/platform/configuration/test/common/configurationModels.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationModels.test.ts
@@ -356,7 +356,7 @@ suite('CustomConfigurationModel', () => {
 				}
 			}
 		});
-		assert.equal(true, new DefaultConfigurationModel().getValue('a'));
+		assert.strictEqual(true, new DefaultConfigurationModel().getValue('a'));
 	});
 });
 
@@ -380,7 +380,7 @@ suite('Configuration', () => {
 
 		testObject.updateValue('a', 2);
 
-		assert.equal(testObject.getValue('a', {}, undefined), 2);
+		assert.strictEqual(testObject.getValue('a', {}, undefined), 2);
 	});
 
 	test('Test update value after inspect', () => {
@@ -391,7 +391,7 @@ suite('Configuration', () => {
 		testObject.inspect('a', {}, undefined);
 		testObject.updateValue('a', 2);
 
-		assert.equal(testObject.getValue('a', {}, undefined), 2);
+		assert.strictEqual(testObject.getValue('a', {}, undefined), 2);
 	});
 
 	test('Test compare and update default configuration', () => {

--- a/src/vs/platform/configuration/test/common/configurationService.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationService.test.ts
@@ -43,7 +43,7 @@ suite('ConfigurationService', () => {
 		}>();
 
 		assert.ok(config);
-		assert.equal(config.foo, 'bar');
+		assert.strictEqual(config.foo, 'bar');
 	});
 
 	test('config gets flattened', async () => {
@@ -62,7 +62,7 @@ suite('ConfigurationService', () => {
 		assert.ok(config);
 		assert.ok(config.testworkbench);
 		assert.ok(config.testworkbench.editor);
-		assert.equal(config.testworkbench.editor.tabs, true);
+		assert.strictEqual(config.testworkbench.editor.tabs, true);
 	});
 
 	test('error case does not explode', async () => {
@@ -91,7 +91,7 @@ suite('ConfigurationService', () => {
 		await testObject.initialize();
 		return new Promise<void>(async (c) => {
 			disposables.add(Event.filter(testObject.onDidChangeConfiguration, e => e.source === ConfigurationTarget.USER)(() => {
-				assert.equal(testObject.getValue('foo'), 'bar');
+				assert.strictEqual(testObject.getValue('foo'), 'bar');
 				c();
 			}));
 			await fileService.writeFile(settingsResource, VSBuffer.fromString('{ "foo": "bar" }'));
@@ -106,7 +106,7 @@ suite('ConfigurationService', () => {
 
 		return new Promise<void>((c) => {
 			disposables.add(Event.filter(testObject.onDidChangeConfiguration, e => e.source === ConfigurationTarget.USER)(async (e) => {
-				assert.equal(testObject.getValue('foo'), 'barz');
+				assert.strictEqual(testObject.getValue('foo'), 'barz');
 				c();
 			}));
 			fileService.writeFile(settingsResource, VSBuffer.fromString('{ "foo": "barz" }'));
@@ -122,7 +122,7 @@ suite('ConfigurationService', () => {
 			foo: string;
 		}>();
 		assert.ok(config);
-		assert.equal(config.foo, 'bar');
+		assert.strictEqual(config.foo, 'bar');
 		await fileService.writeFile(settingsResource, VSBuffer.fromString('{ "foo": "changed" }'));
 
 		// force a reload to get latest
@@ -131,7 +131,7 @@ suite('ConfigurationService', () => {
 			foo: string;
 		}>();
 		assert.ok(config);
-		assert.equal(config.foo, 'changed');
+		assert.strictEqual(config.foo, 'changed');
 	});
 
 	test('model defaults', async () => {
@@ -160,7 +160,7 @@ suite('ConfigurationService', () => {
 		let setting = testObject.getValue<ITestSetting>();
 
 		assert.ok(setting);
-		assert.equal(setting.configuration.service.testSetting, 'isSet');
+		assert.strictEqual(setting.configuration.service.testSetting, 'isSet');
 
 		await fileService.writeFile(settingsResource, VSBuffer.fromString('{ "testworkbench.editor.tabs": true }'));
 		testObject = disposables.add(new ConfigurationService(settingsResource, fileService));
@@ -168,14 +168,14 @@ suite('ConfigurationService', () => {
 		setting = testObject.getValue<ITestSetting>();
 
 		assert.ok(setting);
-		assert.equal(setting.configuration.service.testSetting, 'isSet');
+		assert.strictEqual(setting.configuration.service.testSetting, 'isSet');
 
 		await fileService.writeFile(settingsResource, VSBuffer.fromString('{ "configuration.service.testSetting": "isChanged" }'));
 
 		await testObject.reloadConfiguration();
 		setting = testObject.getValue<ITestSetting>();
 		assert.ok(setting);
-		assert.equal(setting.configuration.service.testSetting, 'isChanged');
+		assert.strictEqual(setting.configuration.service.testSetting, 'isChanged');
 	});
 
 	test('lookup', async () => {

--- a/src/vs/platform/extensionManagement/test/common/extensionGalleryService.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/extensionGalleryService.test.ts
@@ -43,6 +43,6 @@ suite('Extension Gallery Service', () => {
 		const headers = await resolveMarketplaceHeaders(product.version, environmentService, fileService, storageService);
 		assert.ok(isUUID(headers['X-Market-User-Id']));
 		const headers2 = await resolveMarketplaceHeaders(product.version, environmentService, fileService, storageService);
-		assert.equal(headers['X-Market-User-Id'], headers2['X-Market-User-Id']);
+		assert.strictEqual(headers['X-Market-User-Id'], headers2['X-Market-User-Id']);
 	});
 });

--- a/src/vs/platform/extensionManagement/test/common/extensionManagement.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/extensionManagement.test.ts
@@ -9,21 +9,21 @@ suite('Extension Identifier Pattern', () => {
 
 	test('extension identifier pattern', () => {
 		const regEx = new RegExp(EXTENSION_IDENTIFIER_PATTERN);
-		assert.equal(true, regEx.test('publisher.name'));
-		assert.equal(true, regEx.test('publiSher.name'));
-		assert.equal(true, regEx.test('publisher.Name'));
-		assert.equal(true, regEx.test('PUBLISHER.NAME'));
-		assert.equal(true, regEx.test('PUBLISHEr.NAMe'));
-		assert.equal(true, regEx.test('PUBLISHEr.N-AMe'));
-		assert.equal(true, regEx.test('PUB-LISHEr.NAMe'));
-		assert.equal(true, regEx.test('PUB-LISHEr.N-AMe'));
-		assert.equal(true, regEx.test('PUBLISH12Er90.N-A54Me123'));
-		assert.equal(true, regEx.test('111PUBLISH12Er90.N-1111A54Me123'));
-		assert.equal(false, regEx.test('publishername'));
-		assert.equal(false, regEx.test('-publisher.name'));
-		assert.equal(false, regEx.test('publisher.-name'));
-		assert.equal(false, regEx.test('-publisher.-name'));
-		assert.equal(false, regEx.test('publ_isher.name'));
-		assert.equal(false, regEx.test('publisher._name'));
+		assert.strictEqual(true, regEx.test('publisher.name'));
+		assert.strictEqual(true, regEx.test('publiSher.name'));
+		assert.strictEqual(true, regEx.test('publisher.Name'));
+		assert.strictEqual(true, regEx.test('PUBLISHER.NAME'));
+		assert.strictEqual(true, regEx.test('PUBLISHEr.NAMe'));
+		assert.strictEqual(true, regEx.test('PUBLISHEr.N-AMe'));
+		assert.strictEqual(true, regEx.test('PUB-LISHEr.NAMe'));
+		assert.strictEqual(true, regEx.test('PUB-LISHEr.N-AMe'));
+		assert.strictEqual(true, regEx.test('PUBLISH12Er90.N-A54Me123'));
+		assert.strictEqual(true, regEx.test('111PUBLISH12Er90.N-1111A54Me123'));
+		assert.strictEqual(false, regEx.test('publishername'));
+		assert.strictEqual(false, regEx.test('-publisher.name'));
+		assert.strictEqual(false, regEx.test('publisher.-name'));
+		assert.strictEqual(false, regEx.test('-publisher.-name'));
+		assert.strictEqual(false, regEx.test('publ_isher.name'));
+		assert.strictEqual(false, regEx.test('publisher._name'));
 	});
 });

--- a/src/vs/platform/instantiation/test/common/graph.test.ts
+++ b/src/vs/platform/instantiation/test/common/graph.test.ts
@@ -35,12 +35,12 @@ suite('Graph', () => {
 	test('root', () => {
 		graph.insertEdge('1', '2');
 		let roots = graph.roots();
-		assert.equal(roots.length, 1);
-		assert.equal(roots[0].data, '2');
+		assert.strictEqual(roots.length, 1);
+		assert.strictEqual(roots[0].data, '2');
 
 		graph.insertEdge('2', '1');
 		roots = graph.roots();
-		assert.equal(roots.length, 0);
+		assert.strictEqual(roots.length, 0);
 	});
 
 	test('root complex', function () {
@@ -49,7 +49,7 @@ suite('Graph', () => {
 		graph.insertEdge('3', '4');
 
 		let roots = graph.roots();
-		assert.equal(roots.length, 2);
+		assert.strictEqual(roots.length, 2);
 		assert(['2', '4'].every(n => roots.some(node => node.data === n)));
 	});
 });

--- a/src/vs/platform/instantiation/test/common/instantiationService.test.ts
+++ b/src/vs/platform/instantiation/test/common/instantiationService.test.ts
@@ -55,7 +55,7 @@ interface IDependentService {
 class DependentService implements IDependentService {
 	declare readonly _serviceBrand: undefined;
 	constructor(@IService1 service: IService1) {
-		assert.equal(service.c, 1);
+		assert.strictEqual(service.c, 1);
 	}
 
 	name = 'farboo';
@@ -65,7 +65,7 @@ class Service1Consumer {
 
 	constructor(@IService1 service1: IService1) {
 		assert.ok(service1);
-		assert.equal(service1.c, 1);
+		assert.strictEqual(service1.c, 1);
 	}
 }
 
@@ -81,7 +81,7 @@ class TargetWithStaticParam {
 	constructor(v: boolean, @IService1 service1: IService1) {
 		assert.ok(v);
 		assert.ok(service1);
-		assert.equal(service1.c, 1);
+		assert.strictEqual(service1.c, 1);
 	}
 }
 
@@ -93,7 +93,7 @@ class TargetNotOptional {
 class TargetOptional {
 	constructor(@IService1 service1: IService1, @optional(IService2) service2: IService2) {
 		assert.ok(service1);
-		assert.equal(service1.c, 1);
+		assert.strictEqual(service1.c, 1);
 		assert.ok(service2 === undefined);
 	}
 }
@@ -101,16 +101,16 @@ class TargetOptional {
 class DependentServiceTarget {
 	constructor(@IDependentService d: IDependentService) {
 		assert.ok(d);
-		assert.equal(d.name, 'farboo');
+		assert.strictEqual(d.name, 'farboo');
 	}
 }
 
 class DependentServiceTarget2 {
 	constructor(@IDependentService d: IDependentService, @IService1 s: IService1) {
 		assert.ok(d);
-		assert.equal(d.name, 'farboo');
+		assert.strictEqual(d.name, 'farboo');
 		assert.ok(s);
-		assert.equal(s.c, 1);
+		assert.strictEqual(s.c, 1);
 	}
 }
 
@@ -138,9 +138,9 @@ suite('Instantiation Service', () => {
 	test('service collection, cannot overwrite', function () {
 		let collection = new ServiceCollection();
 		let result = collection.set(IService1, null!);
-		assert.equal(result, undefined);
+		assert.strictEqual(result, undefined);
 		result = collection.set(IService1, new Service1());
-		assert.equal(result, null);
+		assert.strictEqual(result, null);
 	});
 
 	test('service collection, add/has', function () {
@@ -237,7 +237,7 @@ suite('Instantiation Service', () => {
 
 			let service1 = accessor.get(IService1);
 			assert.ok(service1);
-			assert.equal(service1.c, 1);
+			assert.strictEqual(service1.c, 1);
 
 			let service2 = accessor.get(IService1);
 			assert.ok(service1 === service2);
@@ -253,7 +253,7 @@ suite('Instantiation Service', () => {
 		service.invokeFunction(accessor => {
 			let d = accessor.get(IDependentService);
 			assert.ok(d);
-			assert.equal(d.name, 'farboo');
+			assert.strictEqual(d.name, 'farboo');
 		});
 	});
 
@@ -305,12 +305,12 @@ suite('Instantiation Service', () => {
 
 		function test(accessor: ServicesAccessor) {
 			assert.ok(accessor.get(IService1) instanceof Service1);
-			assert.equal(accessor.get(IService1).c, 1);
+			assert.strictEqual(accessor.get(IService1).c, 1);
 
 			return true;
 		}
 
-		assert.equal(service.invokeFunction(test), true);
+		assert.strictEqual(service.invokeFunction(test), true);
 	});
 
 	test('Invoke - get service, optional', function () {
@@ -320,10 +320,10 @@ suite('Instantiation Service', () => {
 		function test(accessor: ServicesAccessor) {
 			assert.ok(accessor.get(IService1) instanceof Service1);
 			assert.throws(() => accessor.get(IService2));
-			assert.equal(accessor.get(IService2, optional), undefined);
+			assert.strictEqual(accessor.get(IService2, optional), undefined);
 			return true;
 		}
-		assert.equal(service.invokeFunction(test), true);
+		assert.strictEqual(service.invokeFunction(test), true);
 	});
 
 	test('Invoke - keeping accessor NOT allowed', function () {
@@ -336,12 +336,12 @@ suite('Instantiation Service', () => {
 
 		function test(accessor: ServicesAccessor) {
 			assert.ok(accessor.get(IService1) instanceof Service1);
-			assert.equal(accessor.get(IService1).c, 1);
+			assert.strictEqual(accessor.get(IService1).c, 1);
 			cached = accessor;
 			return true;
 		}
 
-		assert.equal(service.invokeFunction(test), true);
+		assert.strictEqual(service.invokeFunction(test), true);
 
 		assert.throws(() => cached.get(IService2));
 	});
@@ -379,7 +379,7 @@ suite('Instantiation Service', () => {
 		let child = service.createChild(new ServiceCollection([IService2, new Service2()]));
 		child.createInstance(Service1Consumer);
 
-		assert.equal(serviceInstanceCount, 1);
+		assert.strictEqual(serviceInstanceCount, 1);
 
 		// creating the service instance AFTER the child service
 		serviceInstanceCount = 0;
@@ -390,7 +390,7 @@ suite('Instantiation Service', () => {
 		service.createInstance(Service1Consumer);
 		child.createInstance(Service1Consumer);
 
-		assert.equal(serviceInstanceCount, 1);
+		assert.strictEqual(serviceInstanceCount, 1);
 	});
 
 	test('Remote window / integration tests is broken #105562', function () {

--- a/src/vs/platform/markers/test/common/markerService.test.ts
+++ b/src/vs/platform/markers/test/common/markerService.test.ts
@@ -30,10 +30,10 @@ suite('Marker Service', () => {
 			marker: randomMarkerData(MarkerSeverity.Error)
 		}]);
 
-		assert.equal(service.read().length, 1);
-		assert.equal(service.read({ owner: 'far' }).length, 1);
-		assert.equal(service.read({ resource: URI.parse('file:///c/test/file.cs') }).length, 1);
-		assert.equal(service.read({ owner: 'far', resource: URI.parse('file:///c/test/file.cs') }).length, 1);
+		assert.strictEqual(service.read().length, 1);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 1);
+		assert.strictEqual(service.read({ resource: URI.parse('file:///c/test/file.cs') }).length, 1);
+		assert.strictEqual(service.read({ owner: 'far', resource: URI.parse('file:///c/test/file.cs') }).length, 1);
 
 
 		service.changeAll('boo', [{
@@ -41,14 +41,14 @@ suite('Marker Service', () => {
 			marker: randomMarkerData(MarkerSeverity.Warning)
 		}]);
 
-		assert.equal(service.read().length, 2);
-		assert.equal(service.read({ owner: 'far' }).length, 1);
-		assert.equal(service.read({ owner: 'boo' }).length, 1);
+		assert.strictEqual(service.read().length, 2);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 1);
+		assert.strictEqual(service.read({ owner: 'boo' }).length, 1);
 
-		assert.equal(service.read({ severities: MarkerSeverity.Error }).length, 1);
-		assert.equal(service.read({ severities: MarkerSeverity.Warning }).length, 1);
-		assert.equal(service.read({ severities: MarkerSeverity.Hint }).length, 0);
-		assert.equal(service.read({ severities: MarkerSeverity.Error | MarkerSeverity.Warning }).length, 2);
+		assert.strictEqual(service.read({ severities: MarkerSeverity.Error }).length, 1);
+		assert.strictEqual(service.read({ severities: MarkerSeverity.Warning }).length, 1);
+		assert.strictEqual(service.read({ severities: MarkerSeverity.Hint }).length, 0);
+		assert.strictEqual(service.read({ severities: MarkerSeverity.Error | MarkerSeverity.Warning }).length, 2);
 
 	});
 
@@ -57,17 +57,17 @@ suite('Marker Service', () => {
 
 		let service = new markerService.MarkerService();
 		service.changeOne('far', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
-		assert.equal(service.read().length, 1);
-		assert.equal(service.read({ owner: 'far' }).length, 1);
+		assert.strictEqual(service.read().length, 1);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 1);
 
 		service.changeOne('boo', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
-		assert.equal(service.read().length, 2);
-		assert.equal(service.read({ owner: 'far' }).length, 1);
-		assert.equal(service.read({ owner: 'boo' }).length, 1);
+		assert.strictEqual(service.read().length, 2);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 1);
+		assert.strictEqual(service.read({ owner: 'boo' }).length, 1);
 
 		service.changeOne('far', URI.parse('file:///path/only.cs'), [randomMarkerData(), randomMarkerData()]);
-		assert.equal(service.read({ owner: 'far' }).length, 2);
-		assert.equal(service.read({ owner: 'boo' }).length, 1);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 2);
+		assert.strictEqual(service.read({ owner: 'boo' }).length, 1);
 
 	});
 
@@ -76,19 +76,19 @@ suite('Marker Service', () => {
 		let service = new markerService.MarkerService();
 		service.changeOne('far', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
 		service.changeOne('boo', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
-		assert.equal(service.read({ owner: 'far' }).length, 1);
-		assert.equal(service.read({ owner: 'boo' }).length, 1);
-		assert.equal(service.read().length, 2);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 1);
+		assert.strictEqual(service.read({ owner: 'boo' }).length, 1);
+		assert.strictEqual(service.read().length, 2);
 
 		service.changeOne('far', URI.parse('file:///path/only.cs'), []);
-		assert.equal(service.read({ owner: 'far' }).length, 0);
-		assert.equal(service.read({ owner: 'boo' }).length, 1);
-		assert.equal(service.read().length, 1);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 0);
+		assert.strictEqual(service.read({ owner: 'boo' }).length, 1);
+		assert.strictEqual(service.read().length, 1);
 
 		service.changeAll('boo', []);
-		assert.equal(service.read({ owner: 'far' }).length, 0);
-		assert.equal(service.read({ owner: 'boo' }).length, 0);
-		assert.equal(service.read().length, 0);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 0);
+		assert.strictEqual(service.read({ owner: 'boo' }).length, 0);
+		assert.strictEqual(service.read().length, 0);
 	});
 
 	test('changeAll sends event for cleared', () => {
@@ -102,12 +102,12 @@ suite('Marker Service', () => {
 			marker: randomMarkerData()
 		}]);
 
-		assert.equal(service.read({ owner: 'far' }).length, 2);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 2);
 
 		service.onMarkerChanged(changedResources => {
-			assert.equal(changedResources.length, 1);
-			changedResources.forEach(u => assert.equal(u.toString(), 'file:///d/path'));
-			assert.equal(service.read({ owner: 'far' }).length, 0);
+			assert.strictEqual(changedResources.length, 1);
+			changedResources.forEach(u => assert.strictEqual(u.toString(), 'file:///d/path'));
+			assert.strictEqual(service.read({ owner: 'far' }).length, 0);
 		});
 
 		service.changeAll('far', []);
@@ -124,7 +124,7 @@ suite('Marker Service', () => {
 			marker: randomMarkerData()
 		}]);
 
-		assert.equal(service.read({ owner: 'far' }).length, 2);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 2);
 	});
 
 	test('changeAll must not break integrety, issue #12635', () => {
@@ -151,8 +151,8 @@ suite('Marker Service', () => {
 			marker: randomMarkerData()
 		}]);
 
-		assert.equal(service.read({ owner: 'far' }).length, 2);
-		assert.equal(service.read({ resource: URI.parse('scheme:path1') }).length, 2);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 2);
+		assert.strictEqual(service.read({ resource: URI.parse('scheme:path1') }).length, 2);
 	});
 
 	test('invalid marker data', () => {
@@ -162,15 +162,15 @@ suite('Marker Service', () => {
 
 		data.message = undefined!;
 		service.changeOne('far', URI.parse('some:uri/path'), [data]);
-		assert.equal(service.read({ owner: 'far' }).length, 0);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 0);
 
 		data.message = null!;
 		service.changeOne('far', URI.parse('some:uri/path'), [data]);
-		assert.equal(service.read({ owner: 'far' }).length, 0);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 0);
 
 		data.message = 'null';
 		service.changeOne('far', URI.parse('some:uri/path'), [data]);
-		assert.equal(service.read({ owner: 'far' }).length, 1);
+		assert.strictEqual(service.read({ owner: 'far' }).length, 1);
 	});
 
 	test('MapMap#remove returns bad values, https://github.com/microsoft/vscode/issues/13548', () => {
@@ -197,7 +197,7 @@ suite('Marker Service', () => {
 		service.changeOne('far', URI.parse('some:thing'), [data]);
 		let marker = service.read({ resource: URI.parse('some:thing') });
 
-		assert.equal(marker.length, 1);
-		assert.equal(marker[0].code, '0');
+		assert.strictEqual(marker.length, 1);
+		assert.strictEqual(marker[0].code, '0');
 	});
 });

--- a/src/vs/platform/registry/test/common/platform.test.ts
+++ b/src/vs/platform/registry/test/common/platform.test.ts
@@ -21,7 +21,7 @@ suite('Platform / Registry', () => {
 
 		assert.ok(Registry.knows('foo'));
 		assert.ok(Registry.as<any>('foo').bar);
-		assert.equal(Registry.as<any>('foo').bar, true);
+		assert.strictEqual(Registry.as<any>('foo').bar, true);
 	});
 
 	test('registry - knows, as', function () {

--- a/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
@@ -90,10 +90,10 @@ suite('TelemetryService', () => {
 		let service = new TelemetryService({ appender: testAppender }, undefined!);
 
 		return service.publicLog('testPrivateEvent').then(() => {
-			assert.equal(testAppender.getEventsCount(), 1);
+			assert.strictEqual(testAppender.getEventsCount(), 1);
 
 			service.dispose();
-			assert.equal(!testAppender.isDisposed, true);
+			assert.strictEqual(!testAppender.isDisposed, true);
 		});
 	}));
 
@@ -103,8 +103,8 @@ suite('TelemetryService', () => {
 		let service = new TelemetryService({ appender: testAppender }, undefined!);
 
 		return service.publicLog('testEvent').then(_ => {
-			assert.equal(testAppender.getEventsCount(), 1);
-			assert.equal(testAppender.events[0].eventName, 'testEvent');
+			assert.strictEqual(testAppender.getEventsCount(), 1);
+			assert.strictEqual(testAppender.events[0].eventName, 'testEvent');
 			assert.notEqual(testAppender.events[0].data, null);
 
 			service.dispose();
@@ -123,13 +123,13 @@ suite('TelemetryService', () => {
 				'value': 0
 			}
 		}).then(() => {
-			assert.equal(testAppender.getEventsCount(), 1);
-			assert.equal(testAppender.events[0].eventName, 'testEvent');
+			assert.strictEqual(testAppender.getEventsCount(), 1);
+			assert.strictEqual(testAppender.events[0].eventName, 'testEvent');
 			assert.notEqual(testAppender.events[0].data, null);
-			assert.equal(testAppender.events[0].data['stringProp'], 'property');
-			assert.equal(testAppender.events[0].data['numberProp'], 1);
-			assert.equal(testAppender.events[0].data['booleanProp'], true);
-			assert.equal(testAppender.events[0].data['complexProp'].value, 0);
+			assert.strictEqual(testAppender.events[0].data['stringProp'], 'property');
+			assert.strictEqual(testAppender.events[0].data['numberProp'], 1);
+			assert.strictEqual(testAppender.events[0].data['booleanProp'], true);
+			assert.strictEqual(testAppender.events[0].data['complexProp'].value, 0);
 
 			service.dispose();
 		});
@@ -146,9 +146,9 @@ suite('TelemetryService', () => {
 		return service.publicLog('testEvent').then(_ => {
 			let [first] = testAppender.events;
 
-			assert.equal(Object.keys(first.data).length, 2);
-			assert.equal(typeof first.data['foo'], 'string');
-			assert.equal(typeof first.data['bar'], 'number');
+			assert.strictEqual(Object.keys(first.data).length, 2);
+			assert.strictEqual(typeof first.data['foo'], 'string');
+			assert.strictEqual(typeof first.data['bar'], 'number');
 
 			service.dispose();
 		});
@@ -164,11 +164,11 @@ suite('TelemetryService', () => {
 		return service.publicLog('testEvent', { hightower: 'xl', price: 8000 }).then(_ => {
 			let [first] = testAppender.events;
 
-			assert.equal(Object.keys(first.data).length, 4);
-			assert.equal(typeof first.data['foo'], 'string');
-			assert.equal(typeof first.data['bar'], 'number');
-			assert.equal(typeof first.data['hightower'], 'string');
-			assert.equal(typeof first.data['price'], 'number');
+			assert.strictEqual(Object.keys(first.data).length, 4);
+			assert.strictEqual(typeof first.data['foo'], 'string');
+			assert.strictEqual(typeof first.data['bar'], 'number');
+			assert.strictEqual(typeof first.data['hightower'], 'string');
+			assert.strictEqual(typeof first.data['price'], 'number');
 
 			service.dispose();
 		});
@@ -185,9 +185,9 @@ suite('TelemetryService', () => {
 		}, undefined!);
 
 		return service.getTelemetryInfo().then(info => {
-			assert.equal(info.sessionId, 'one');
-			assert.equal(info.instanceId, 'two');
-			assert.equal(info.machineId, 'three');
+			assert.strictEqual(info.sessionId, 'one');
+			assert.strictEqual(info.instanceId, 'two');
+			assert.strictEqual(info.machineId, 'three');
 
 			service.dispose();
 		});
@@ -198,8 +198,8 @@ suite('TelemetryService', () => {
 		let service = new TelemetryService({ appender: testAppender }, undefined!);
 
 		return service.publicLog('testEvent').then(() => {
-			assert.equal(testAppender.getEventsCount(), 1);
-			assert.equal(testAppender.events[0].eventName, 'testEvent');
+			assert.strictEqual(testAppender.getEventsCount(), 1);
+			assert.strictEqual(testAppender.events[0].eventName, 'testEvent');
 
 			service.dispose();
 		});
@@ -245,9 +245,9 @@ suite('TelemetryService', () => {
 			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 			await service.join();
 
-			assert.equal(testAppender.getEventsCount(), 1);
-			assert.equal(testAppender.events[0].eventName, 'UnhandledError');
-			assert.equal(testAppender.events[0].data.msg, 'This is a test.');
+			assert.strictEqual(testAppender.getEventsCount(), 1);
+			assert.strictEqual(testAppender.events[0].eventName, 'UnhandledError');
+			assert.strictEqual(testAppender.events[0].data.msg, 'This is a test.');
 
 			errorTelemetry.dispose();
 			service.dispose();
@@ -275,9 +275,9 @@ suite('TelemetryService', () => {
 	// 			// allow for the promise to finish
 	// 			this.clock.tick(MainErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 	//
-	// 			assert.equal(testAppender.getEventsCount(), 1);
-	// 			assert.equal(testAppender.events[0].eventName, 'UnhandledError');
-	// 			assert.equal(testAppender.events[0].data.msg,  'This should get logged');
+	// 			assert.strictEqual(testAppender.getEventsCount(), 1);
+	// 			assert.strictEqual(testAppender.events[0].eventName, 'UnhandledError');
+	// 			assert.strictEqual(testAppender.events[0].data.msg,  'This should get logged');
 	//
 	// 			service.dispose();
 	// 		} finally {
@@ -298,16 +298,16 @@ suite('TelemetryService', () => {
 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 		await service.join();
 
-		assert.equal(errorStub.alwaysCalledWithExactly('Error Message', 'file.js', 2, 42, testError), true);
-		assert.equal(errorStub.callCount, 1);
+		assert.strictEqual(errorStub.alwaysCalledWithExactly('Error Message', 'file.js', 2, 42, testError), true);
+		assert.strictEqual(errorStub.callCount, 1);
 
-		assert.equal(testAppender.getEventsCount(), 1);
-		assert.equal(testAppender.events[0].eventName, 'UnhandledError');
-		assert.equal(testAppender.events[0].data.msg, 'Error Message');
-		assert.equal(testAppender.events[0].data.file, 'file.js');
-		assert.equal(testAppender.events[0].data.line, 2);
-		assert.equal(testAppender.events[0].data.column, 42);
-		assert.equal(testAppender.events[0].data.uncaught_error_msg, 'test');
+		assert.strictEqual(testAppender.getEventsCount(), 1);
+		assert.strictEqual(testAppender.events[0].eventName, 'UnhandledError');
+		assert.strictEqual(testAppender.events[0].data.msg, 'Error Message');
+		assert.strictEqual(testAppender.events[0].data.file, 'file.js');
+		assert.strictEqual(testAppender.events[0].data.line, 2);
+		assert.strictEqual(testAppender.events[0].data.column, 42);
+		assert.strictEqual(testAppender.events[0].data.uncaught_error_msg, 'test');
 
 		errorTelemetry.dispose();
 		service.dispose();
@@ -328,9 +328,9 @@ suite('TelemetryService', () => {
 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 		await service.join();
 
-		assert.equal(errorStub.callCount, 1);
-		assert.equal(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo.replace(settings.personalInfo, personInfoWithSpaces)), -1);
-		assert.equal(testAppender.events[0].data.file, settings.importantInfo + '/test.js');
+		assert.strictEqual(errorStub.callCount, 1);
+		assert.strictEqual(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo.replace(settings.personalInfo, personInfoWithSpaces)), -1);
+		assert.strictEqual(testAppender.events[0].data.file, settings.importantInfo + '/test.js');
 
 		errorTelemetry.dispose();
 		service.dispose();
@@ -350,8 +350,8 @@ suite('TelemetryService', () => {
 		(<any>window.onerror)('dangerousFilename', settings.dangerousPathWithImportantInfo + '/test.js', 2, 42, dangerousFilenameError);
 		clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 		return service.join().then(() => {
-			assert.equal(errorStub.callCount, 1);
-			assert.equal(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo), -1);
+			assert.strictEqual(errorStub.callCount, 1);
+			assert.strictEqual(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo), -1);
 
 			dangerousFilenameError = new Error('dangerousFilename');
 			dangerousFilenameError.stack = settings.stack;
@@ -359,9 +359,9 @@ suite('TelemetryService', () => {
 			clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 			return service.join();
 		}).then(() => {
-			assert.equal(errorStub.callCount, 2);
-			assert.equal(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo), -1);
-			assert.equal(testAppender.events[0].data.file, settings.importantInfo + '/test.js');
+			assert.strictEqual(errorStub.callCount, 2);
+			assert.strictEqual(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.file, settings.importantInfo + '/test.js');
 
 			errorTelemetry.dispose();
 			service.dispose();
@@ -383,13 +383,13 @@ suite('TelemetryService', () => {
 			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 			await service.join();
 
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
 
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+			assert.strictEqual(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
 
 			errorTelemetry.dispose();
 			service.dispose();
@@ -413,14 +413,14 @@ suite('TelemetryService', () => {
 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 		await service.join();
 
-		assert.equal(errorStub.callCount, 1);
+		assert.strictEqual(errorStub.callCount, 1);
 		// Test that no file information remains, esp. personal info
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+		assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+		assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+		assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+		assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+		assert.strictEqual(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
 
 		errorTelemetry.dispose();
 		service.dispose();
@@ -446,13 +446,13 @@ suite('TelemetryService', () => {
 			await service.join();
 
 			assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+			assert.strictEqual(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
 
 			errorTelemetry.dispose();
 			service.dispose();
@@ -476,16 +476,16 @@ suite('TelemetryService', () => {
 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 		await service.join();
 
-		assert.equal(errorStub.callCount, 1);
+		assert.strictEqual(errorStub.callCount, 1);
 		// Test that important information remains but personal info does not
 		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+		assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+		assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+		assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+		assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+		assert.strictEqual(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
 
 		errorTelemetry.dispose();
 		service.dispose();
@@ -537,7 +537,7 @@ suite('TelemetryService', () => {
 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 		await service.join();
 
-		assert.equal(errorStub.callCount, 1);
+		assert.strictEqual(errorStub.callCount, 1);
 
 		assert.notEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModuleAsarPathToRetain), -1);
 		assert.notEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModulePathToRetain), -1);
@@ -569,13 +569,13 @@ suite('TelemetryService', () => {
 			await service.join();
 
 			assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+			assert.strictEqual(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
 
 			errorTelemetry.dispose();
 			service.dispose();
@@ -599,16 +599,16 @@ suite('TelemetryService', () => {
 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 		await service.join();
 
-		assert.equal(errorStub.callCount, 1);
+		assert.strictEqual(errorStub.callCount, 1);
 		// Test that important information remains but personal info does not
 		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+		assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+		assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+		assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+		assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+		assert.strictEqual(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
 
 		errorTelemetry.dispose();
 		service.dispose();
@@ -635,13 +635,13 @@ suite('TelemetryService', () => {
 			await service.join();
 
 			assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.missingModelPrefix), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.missingModelPrefix), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+			assert.strictEqual(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
 
 			errorTelemetry.dispose();
 			service.dispose();
@@ -664,17 +664,17 @@ suite('TelemetryService', () => {
 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 		await service.join();
 
-		assert.equal(errorStub.callCount, 1);
+		assert.strictEqual(errorStub.callCount, 1);
 		// Test that no file information remains, but this particular
 		// error message does (Received model events for missing model)
 		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.missingModelPrefix), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+		assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+		assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.missingModelPrefix), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+		assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+		assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+		assert.strictEqual(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
 
 		errorTelemetry.dispose();
 		service.dispose();
@@ -701,13 +701,13 @@ suite('TelemetryService', () => {
 			await service.join();
 
 			assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.noSuchFilePrefix), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.noSuchFilePrefix), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+			assert.strictEqual(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
 
 			errorTelemetry.dispose();
 			service.dispose();
@@ -734,18 +734,18 @@ suite('TelemetryService', () => {
 			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 			await service.join();
 
-			assert.equal(errorStub.callCount, 1);
+			assert.strictEqual(errorStub.callCount, 1);
 			// Test that no file information remains, but this particular
 			// error message does (ENOENT: no such file or directory)
 			Errors.onUnexpectedError(noSuchFileError);
 			assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.noSuchFilePrefix), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.noSuchFilePrefix), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
 			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+			assert.strictEqual(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
 
 			errorTelemetry.dispose();
 			service.dispose();
@@ -759,7 +759,7 @@ suite('TelemetryService', () => {
 		let service = new TelemetryService({ appender: testAppender }, undefined!);
 
 		return service.publicLog('testEvent').then(() => {
-			assert.equal(testAppender.getEventsCount(), 1);
+			assert.strictEqual(testAppender.getEventsCount(), 1);
 			service.dispose();
 		});
 	}));
@@ -781,15 +781,15 @@ suite('TelemetryService', () => {
 			}
 		}());
 
-		assert.equal(service.isOptedIn, false);
+		assert.strictEqual(service.isOptedIn, false);
 
 		enableTelemetry = true;
 		emitter.fire({});
-		assert.equal(service.isOptedIn, true);
+		assert.strictEqual(service.isOptedIn, true);
 
 		enableTelemetry = false;
 		emitter.fire({});
-		assert.equal(service.isOptedIn, false);
+		assert.strictEqual(service.isOptedIn, false);
 
 		service.dispose();
 	});

--- a/src/vs/platform/telemetry/test/common/telemetryLogAppender.test.ts
+++ b/src/vs/platform/telemetry/test/common/telemetryLogAppender.test.ts
@@ -77,14 +77,14 @@ suite('TelemetryLogAdapter', () => {
 		const testLoggerService = new TestTelemetryLoggerService(DEFAULT_LOG_LEVEL);
 		const testObject = new TelemetryLogAppender(testLoggerService, new TestInstantiationService().stub(IEnvironmentService, {}));
 		testObject.log('testEvent', { hello: 'world', isTrue: true, numberBetween1And3: 2 });
-		assert.equal(testLoggerService.logger.logs.length, 2);
+		assert.strictEqual(testLoggerService.logger.logs.length, 2);
 	});
 
 	test('Log Telemetry if log level is trace', async () => {
 		const testLoggerService = new TestTelemetryLoggerService(LogLevel.Trace);
 		const testObject = new TelemetryLogAppender(testLoggerService, new TestInstantiationService().stub(IEnvironmentService, {}));
 		testObject.log('testEvent', { hello: 'world', isTrue: true, numberBetween1And3: 2 });
-		assert.equal(testLoggerService.logger.logs[2], 'telemetry/testEvent' + JSON.stringify([{
+		assert.strictEqual(testLoggerService.logger.logs[2], 'telemetry/testEvent' + JSON.stringify([{
 			properties: {
 				hello: 'world',
 			},

--- a/src/vs/platform/telemetry/test/electron-browser/appInsightsAppender.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/appInsightsAppender.test.ts
@@ -44,20 +44,20 @@ suite('AIAdapter', () => {
 	test('Simple event', () => {
 		adapter.log('testEvent');
 
-		assert.equal(appInsightsMock.events.length, 1);
-		assert.equal(appInsightsMock.events[0].name, `${prefix}/testEvent`);
+		assert.strictEqual(appInsightsMock.events.length, 1);
+		assert.strictEqual(appInsightsMock.events[0].name, `${prefix}/testEvent`);
 	});
 
 	test('addional data', () => {
 		adapter = new AppInsightsAppender(prefix, { first: '1st', second: 2, third: true }, () => appInsightsMock);
 		adapter.log('testEvent');
 
-		assert.equal(appInsightsMock.events.length, 1);
+		assert.strictEqual(appInsightsMock.events.length, 1);
 		let [first] = appInsightsMock.events;
-		assert.equal(first.name, `${prefix}/testEvent`);
-		assert.equal(first.properties!['first'], '1st');
-		assert.equal(first.measurements!['second'], '2');
-		assert.equal(first.measurements!['third'], 1);
+		assert.strictEqual(first.name, `${prefix}/testEvent`);
+		assert.strictEqual(first.properties!['first'], '1st');
+		assert.strictEqual(first.measurements!['second'], 2);
+		assert.strictEqual(first.measurements!['third'], 1);
 	});
 
 	test('property limits', () => {
@@ -78,7 +78,7 @@ suite('AIAdapter', () => {
 		data['reallyLongPropertyValue'] = reallyLongPropertyValue;
 		adapter.log('testEvent', data);
 
-		assert.equal(appInsightsMock.events.length, 1);
+		assert.strictEqual(appInsightsMock.events.length, 1);
 
 		for (let prop in appInsightsMock.events[0].properties!) {
 			assert(prop.length < 150);
@@ -90,14 +90,14 @@ suite('AIAdapter', () => {
 		let date = new Date();
 		adapter.log('testEvent', { favoriteDate: date, likeRed: false, likeBlue: true, favoriteNumber: 1, favoriteColor: 'blue', favoriteCars: ['bmw', 'audi', 'ford'] });
 
-		assert.equal(appInsightsMock.events.length, 1);
-		assert.equal(appInsightsMock.events[0].name, `${prefix}/testEvent`);
-		assert.equal(appInsightsMock.events[0].properties!['favoriteColor'], 'blue');
-		assert.equal(appInsightsMock.events[0].measurements!['likeRed'], 0);
-		assert.equal(appInsightsMock.events[0].measurements!['likeBlue'], 1);
-		assert.equal(appInsightsMock.events[0].properties!['favoriteDate'], date.toISOString());
-		assert.equal(appInsightsMock.events[0].properties!['favoriteCars'], JSON.stringify(['bmw', 'audi', 'ford']));
-		assert.equal(appInsightsMock.events[0].measurements!['favoriteNumber'], 1);
+		assert.strictEqual(appInsightsMock.events.length, 1);
+		assert.strictEqual(appInsightsMock.events[0].name, `${prefix}/testEvent`);
+		assert.strictEqual(appInsightsMock.events[0].properties!['favoriteColor'], 'blue');
+		assert.strictEqual(appInsightsMock.events[0].measurements!['likeRed'], 0);
+		assert.strictEqual(appInsightsMock.events[0].measurements!['likeBlue'], 1);
+		assert.strictEqual(appInsightsMock.events[0].properties!['favoriteDate'], date.toISOString());
+		assert.strictEqual(appInsightsMock.events[0].properties!['favoriteCars'], JSON.stringify(['bmw', 'audi', 'ford']));
+		assert.strictEqual(appInsightsMock.events[0].measurements!['favoriteNumber'], 1);
 	});
 
 	test('Nested data', () => {
@@ -119,15 +119,15 @@ suite('AIAdapter', () => {
 			}
 		});
 
-		assert.equal(appInsightsMock.events.length, 1);
-		assert.equal(appInsightsMock.events[0].name, `${prefix}/testEvent`);
+		assert.strictEqual(appInsightsMock.events.length, 1);
+		assert.strictEqual(appInsightsMock.events[0].name, `${prefix}/testEvent`);
 
-		assert.equal(appInsightsMock.events[0].properties!['window.title'], 'some title');
-		assert.equal(appInsightsMock.events[0].measurements!['window.measurements.width'], 100);
-		assert.equal(appInsightsMock.events[0].measurements!['window.measurements.height'], 200);
+		assert.strictEqual(appInsightsMock.events[0].properties!['window.title'], 'some title');
+		assert.strictEqual(appInsightsMock.events[0].measurements!['window.measurements.width'], 100);
+		assert.strictEqual(appInsightsMock.events[0].measurements!['window.measurements.height'], 200);
 
-		assert.equal(appInsightsMock.events[0].properties!['nestedObj.nestedObj2.nestedObj3'], JSON.stringify({ 'testProperty': 'test' }));
-		assert.equal(appInsightsMock.events[0].measurements!['nestedObj.testMeasurement'], 1);
+		assert.strictEqual(appInsightsMock.events[0].properties!['nestedObj.nestedObj2.nestedObj3'], JSON.stringify({ 'testProperty': 'test' }));
+		assert.strictEqual(appInsightsMock.events[0].measurements!['nestedObj.testMeasurement'], 1);
 	});
 
 });

--- a/src/vs/platform/userDataSync/test/common/extensionsMerge.test.ts
+++ b/src/vs/platform/userDataSync/test/common/extensionsMerge.test.ts
@@ -173,7 +173,7 @@ suite('ExtensionsMerge', () => {
 		assert.deepEqual(actual.added, [{ identifier: { id: 'b', uuid: 'b' }, installed: true, version: '1.0.0' }, { identifier: { id: 'c', uuid: 'c' }, installed: true, version: '1.0.0' }]);
 		assert.deepEqual(actual.removed, [{ id: 'a', uuid: 'a' }, { id: 'd', uuid: 'd' }]);
 		assert.deepEqual(actual.updated, []);
-		assert.equal(actual.remote, null);
+		assert.strictEqual(actual.remote, null);
 	});
 
 	test('merge local and remote extensions when remote is moved forwarded with disabled extension', () => {
@@ -196,7 +196,7 @@ suite('ExtensionsMerge', () => {
 		assert.deepEqual(actual.added, [{ identifier: { id: 'b', uuid: 'b' }, installed: true, version: '1.0.0' }, { identifier: { id: 'c', uuid: 'c' }, installed: true, version: '1.0.0' }]);
 		assert.deepEqual(actual.removed, [{ id: 'a', uuid: 'a' }]);
 		assert.deepEqual(actual.updated, [{ identifier: { id: 'd', uuid: 'd' }, disabled: true, installed: true, version: '1.0.0' }]);
-		assert.equal(actual.remote, null);
+		assert.strictEqual(actual.remote, null);
 	});
 
 	test('merge local and remote extensions when remote moved forwarded with ignored extensions', () => {
@@ -218,7 +218,7 @@ suite('ExtensionsMerge', () => {
 		assert.deepEqual(actual.added, [{ identifier: { id: 'b', uuid: 'b' }, installed: true, version: '1.0.0' }, { identifier: { id: 'c', uuid: 'c' }, installed: true, version: '1.0.0' }]);
 		assert.deepEqual(actual.removed, [{ id: 'd', uuid: 'd' }]);
 		assert.deepEqual(actual.updated, []);
-		assert.equal(actual.remote, null);
+		assert.strictEqual(actual.remote, null);
 	});
 
 	test('merge local and remote extensions when remote is moved forwarded with skipped extensions', () => {
@@ -242,7 +242,7 @@ suite('ExtensionsMerge', () => {
 		assert.deepEqual(actual.added, [{ identifier: { id: 'b', uuid: 'b' }, installed: true, version: '1.0.0' }, { identifier: { id: 'c', uuid: 'c' }, installed: true, version: '1.0.0' }]);
 		assert.deepEqual(actual.removed, [{ id: 'd', uuid: 'd' }]);
 		assert.deepEqual(actual.updated, []);
-		assert.equal(actual.remote, null);
+		assert.strictEqual(actual.remote, null);
 	});
 
 	test('merge local and remote extensions when remote is moved forwarded with skipped and ignored extensions', () => {
@@ -266,7 +266,7 @@ suite('ExtensionsMerge', () => {
 		assert.deepEqual(actual.added, [{ identifier: { id: 'c', uuid: 'c' }, installed: true, version: '1.0.0' }]);
 		assert.deepEqual(actual.removed, [{ id: 'd', uuid: 'd' }]);
 		assert.deepEqual(actual.updated, []);
-		assert.equal(actual.remote, null);
+		assert.strictEqual(actual.remote, null);
 	});
 
 	test('merge local and remote extensions when local is moved forwarded', () => {

--- a/src/vs/platform/userDataSync/test/common/globalStateSync.test.ts
+++ b/src/vs/platform/userDataSync/test/common/globalStateSync.test.ts
@@ -50,7 +50,7 @@ suite('GlobalStateSync', () => {
 		const remoteUserData = await testObject.getRemoteUserData(null);
 		assert.deepEqual(lastSyncUserData!.ref, remoteUserData.ref);
 		assert.deepEqual(lastSyncUserData!.syncData, remoteUserData.syncData);
-		assert.equal(lastSyncUserData!.syncData, null);
+		assert.strictEqual(lastSyncUserData!.syncData, null);
 
 		manifest = await testClient.manifest();
 		server.reset();
@@ -89,7 +89,7 @@ suite('GlobalStateSync', () => {
 		await updateLocale(testClient);
 
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const { content } = await testClient.read(testObject.resource);
@@ -104,11 +104,11 @@ suite('GlobalStateSync', () => {
 		await client2.sync();
 
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
-		assert.equal(readStorage('a', testClient), 'value1');
-		assert.equal(await readLocale(testClient), 'en');
+		assert.strictEqual(readStorage('a', testClient), 'value1');
+		assert.strictEqual(await readLocale(testClient), 'en');
 	});
 
 	test('first time sync when storage exists', async () => {
@@ -117,11 +117,11 @@ suite('GlobalStateSync', () => {
 
 		updateUserStorage('b', 'value2', testClient);
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
-		assert.equal(readStorage('a', testClient), 'value1');
-		assert.equal(readStorage('b', testClient), 'value2');
+		assert.strictEqual(readStorage('a', testClient), 'value1');
+		assert.strictEqual(readStorage('b', testClient), 'value2');
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -136,10 +136,10 @@ suite('GlobalStateSync', () => {
 		updateUserStorage('a', 'value2', client2);
 		await testObject.sync(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
-		assert.equal(readStorage('a', testClient), 'value1');
+		assert.strictEqual(readStorage('a', testClient), 'value1');
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -153,11 +153,11 @@ suite('GlobalStateSync', () => {
 
 		updateUserStorage('b', 'value2', testClient);
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
-		assert.equal(readStorage('a', testClient), 'value1');
-		assert.equal(readStorage('b', testClient), 'value2');
+		assert.strictEqual(readStorage('a', testClient), 'value1');
+		assert.strictEqual(readStorage('b', testClient), 'value2');
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -171,10 +171,10 @@ suite('GlobalStateSync', () => {
 
 		updateUserStorage('a', 'value2', testClient);
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
-		assert.equal(readStorage('a', testClient), 'value2');
+		assert.strictEqual(readStorage('a', testClient), 'value2');
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -189,11 +189,11 @@ suite('GlobalStateSync', () => {
 
 		removeStorage('b', testClient);
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
-		assert.equal(readStorage('a', testClient), 'value1');
-		assert.equal(readStorage('b', testClient), undefined);
+		assert.strictEqual(readStorage('a', testClient), 'value1');
+		assert.strictEqual(readStorage('b', testClient), undefined);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);

--- a/src/vs/platform/userDataSync/test/common/keybindingsMerge.test.ts
+++ b/src/vs/platform/userDataSync/test/common/keybindingsMerge.test.ts
@@ -15,7 +15,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(!actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when local and remote are same with similar when contexts', async () => {
@@ -24,7 +24,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(!actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when local and remote has entries in different order', async () => {
@@ -39,7 +39,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(!actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when local and remote are same with multiple entries', async () => {
@@ -56,7 +56,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(!actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when local and remote are same with different base content', async () => {
@@ -77,7 +77,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, baseContent);
 		assert.ok(!actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when local and remote are same with multiple entries in different order', async () => {
@@ -94,7 +94,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(!actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when local and remote are same when remove entry is in different order', async () => {
@@ -111,7 +111,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(!actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when a new entry is added to remote', async () => {
@@ -127,7 +127,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, remoteContent);
+		assert.strictEqual(actual.mergeContent, remoteContent);
 	});
 
 	test('merge when multiple new entries are added to remote', async () => {
@@ -144,7 +144,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, remoteContent);
+		assert.strictEqual(actual.mergeContent, remoteContent);
 	});
 
 	test('merge when multiple new entries are added to remote from base and local has not changed', async () => {
@@ -161,7 +161,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, localContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, remoteContent);
+		assert.strictEqual(actual.mergeContent, remoteContent);
 	});
 
 	test('merge when an entry is removed from remote from base and local has not changed', async () => {
@@ -177,7 +177,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, localContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, remoteContent);
+		assert.strictEqual(actual.mergeContent, remoteContent);
 	});
 
 	test('merge when an entry (same command) is removed from remote from base and local has not changed', async () => {
@@ -191,7 +191,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, localContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, remoteContent);
+		assert.strictEqual(actual.mergeContent, remoteContent);
 	});
 
 	test('merge when an entry is updated in remote from base and local has not changed', async () => {
@@ -204,7 +204,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, localContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, remoteContent);
+		assert.strictEqual(actual.mergeContent, remoteContent);
 	});
 
 	test('merge when a command with multiple entries is updated from remote from base and local has not changed', async () => {
@@ -223,7 +223,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, localContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, remoteContent);
+		assert.strictEqual(actual.mergeContent, remoteContent);
 	});
 
 	test('merge when remote has moved forwareded with multiple changes and local stays with base', async () => {
@@ -246,7 +246,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, localContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, remoteContent);
+		assert.strictEqual(actual.mergeContent, remoteContent);
 	});
 
 	test('merge when a new entry is added to local', async () => {
@@ -262,7 +262,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when multiple new entries are added to local', async () => {
@@ -279,7 +279,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when multiple new entries are added to local from base and remote is not changed', async () => {
@@ -296,7 +296,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, remoteContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when an entry is removed from local from base and remote has not changed', async () => {
@@ -312,7 +312,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, remoteContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when an entry (with same command) is removed from local from base and remote has not changed', async () => {
@@ -326,7 +326,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, remoteContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when an entry is updated in local from base and remote has not changed', async () => {
@@ -339,7 +339,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, remoteContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when a command with multiple entries is updated from local from base and remote has not changed', async () => {
@@ -358,7 +358,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, remoteContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, localContent);
+		assert.strictEqual(actual.mergeContent, localContent);
 	});
 
 	test('merge when local has moved forwareded with multiple changes and remote stays with base', async () => {
@@ -390,7 +390,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, remoteContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, expected);
+		assert.strictEqual(actual.mergeContent, expected);
 	});
 
 	test('merge when local and remote has moved forwareded with conflicts', async () => {
@@ -431,7 +431,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, baseContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(!actual.hasConflicts);
-		assert.equal(actual.mergeContent, expected);
+		assert.strictEqual(actual.mergeContent, expected);
 	});
 
 	test('merge when local and remote with one entry but different value', async () => {
@@ -440,7 +440,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(actual.hasChanges);
 		assert.ok(actual.hasConflicts);
-		assert.equal(actual.mergeContent,
+		assert.strictEqual(actual.mergeContent,
 			`[
 	{
 		"key": "alt+d",
@@ -462,7 +462,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, null);
 		assert.ok(actual.hasChanges);
 		assert.ok(actual.hasConflicts);
-		assert.equal(actual.mergeContent,
+		assert.strictEqual(actual.mergeContent,
 			`[
 	{
 		"key": "alt+d",
@@ -484,7 +484,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, baseContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(actual.hasConflicts);
-		assert.equal(actual.mergeContent,
+		assert.strictEqual(actual.mergeContent,
 			`[]`);
 	});
 
@@ -495,7 +495,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, baseContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(actual.hasConflicts);
-		assert.equal(actual.mergeContent,
+		assert.strictEqual(actual.mergeContent,
 			`[
 	{
 		"key": "alt+b",
@@ -511,7 +511,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, baseContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(actual.hasConflicts);
-		assert.equal(actual.mergeContent,
+		assert.strictEqual(actual.mergeContent,
 			`[
 	{
 		"key": "alt+c",
@@ -528,7 +528,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, baseContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(actual.hasConflicts);
-		assert.equal(actual.mergeContent,
+		assert.strictEqual(actual.mergeContent,
 			`[
 	{
 		"key": "alt+c",
@@ -571,7 +571,7 @@ suite('KeybindingsMerge - No Conflicts', () => {
 		const actual = await mergeKeybindings(localContent, remoteContent, baseContent);
 		assert.ok(actual.hasChanges);
 		assert.ok(actual.hasConflicts);
-		assert.equal(actual.mergeContent,
+		assert.strictEqual(actual.mergeContent,
 			`[
 	{
 		"key": "alt+d",

--- a/src/vs/platform/userDataSync/test/common/keybindingsSync.test.ts
+++ b/src/vs/platform/userDataSync/test/common/keybindingsSync.test.ts
@@ -48,7 +48,7 @@ suite('KeybindingsSync', () => {
 		const remoteUserData = await testObject.getRemoteUserData(null);
 		assert.deepEqual(lastSyncUserData!.ref, remoteUserData.ref);
 		assert.deepEqual(lastSyncUserData!.syncData, remoteUserData.syncData);
-		assert.equal(lastSyncUserData!.syncData, null);
+		assert.strictEqual(lastSyncUserData!.syncData, null);
 
 		manifest = await client.manifest();
 		server.reset();
@@ -70,9 +70,9 @@ suite('KeybindingsSync', () => {
 
 		const lastSyncUserData = await testObject.getLastSyncUserData();
 		const remoteUserData = await testObject.getRemoteUserData(null);
-		assert.equal(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), '[]');
-		assert.equal(getKeybindingsContentFromSyncContent(remoteUserData!.syncData!.content!, true), '[]');
-		assert.equal((await fileService.readFile(keybindingsResource)).value.toString(), '');
+		assert.strictEqual(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), '[]');
+		assert.strictEqual(getKeybindingsContentFromSyncContent(remoteUserData!.syncData!.content!, true), '[]');
+		assert.strictEqual((await fileService.readFile(keybindingsResource)).value.toString(), '');
 	});
 
 	test('when keybindings file is empty and remote has changes', async () => {
@@ -95,9 +95,9 @@ suite('KeybindingsSync', () => {
 
 		const lastSyncUserData = await testObject.getLastSyncUserData();
 		const remoteUserData = await testObject.getRemoteUserData(null);
-		assert.equal(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), content);
-		assert.equal(getKeybindingsContentFromSyncContent(remoteUserData!.syncData!.content!, true), content);
-		assert.equal((await fileService.readFile(keybindingsResource)).value.toString(), content);
+		assert.strictEqual(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), content);
+		assert.strictEqual(getKeybindingsContentFromSyncContent(remoteUserData!.syncData!.content!, true), content);
+		assert.strictEqual((await fileService.readFile(keybindingsResource)).value.toString(), content);
 	});
 
 	test('when keybindings file is empty with comment and remote has no changes', async () => {
@@ -110,9 +110,9 @@ suite('KeybindingsSync', () => {
 
 		const lastSyncUserData = await testObject.getLastSyncUserData();
 		const remoteUserData = await testObject.getRemoteUserData(null);
-		assert.equal(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), expectedContent);
-		assert.equal(getKeybindingsContentFromSyncContent(remoteUserData!.syncData!.content!, true), expectedContent);
-		assert.equal((await fileService.readFile(keybindingsResource)).value.toString(), expectedContent);
+		assert.strictEqual(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), expectedContent);
+		assert.strictEqual(getKeybindingsContentFromSyncContent(remoteUserData!.syncData!.content!, true), expectedContent);
+		assert.strictEqual((await fileService.readFile(keybindingsResource)).value.toString(), expectedContent);
 	});
 
 	test('when keybindings file is empty and remote has keybindings', async () => {
@@ -135,9 +135,9 @@ suite('KeybindingsSync', () => {
 
 		const lastSyncUserData = await testObject.getLastSyncUserData();
 		const remoteUserData = await testObject.getRemoteUserData(null);
-		assert.equal(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), content);
-		assert.equal(getKeybindingsContentFromSyncContent(remoteUserData!.syncData!.content!, true), content);
-		assert.equal((await fileService.readFile(keybindingsResource)).value.toString(), content);
+		assert.strictEqual(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), content);
+		assert.strictEqual(getKeybindingsContentFromSyncContent(remoteUserData!.syncData!.content!, true), content);
+		assert.strictEqual((await fileService.readFile(keybindingsResource)).value.toString(), content);
 	});
 
 	test('when keybindings file is empty and remote has empty array', async () => {
@@ -159,9 +159,9 @@ suite('KeybindingsSync', () => {
 
 		const lastSyncUserData = await testObject.getLastSyncUserData();
 		const remoteUserData = await testObject.getRemoteUserData(null);
-		assert.equal(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), content);
-		assert.equal(getKeybindingsContentFromSyncContent(remoteUserData!.syncData!.content!, true), content);
-		assert.equal((await fileService.readFile(keybindingsResource)).value.toString(), expectedLocalContent);
+		assert.strictEqual(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), content);
+		assert.strictEqual(getKeybindingsContentFromSyncContent(remoteUserData!.syncData!.content!, true), content);
+		assert.strictEqual((await fileService.readFile(keybindingsResource)).value.toString(), expectedLocalContent);
 	});
 
 	test('when keybindings file is created after first sync', async () => {
@@ -183,7 +183,7 @@ suite('KeybindingsSync', () => {
 		const remoteUserData = await testObject.getRemoteUserData(null);
 		assert.deepEqual(lastSyncUserData!.ref, remoteUserData.ref);
 		assert.deepEqual(lastSyncUserData!.syncData, remoteUserData.syncData);
-		assert.equal(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), '[]');
+		assert.strictEqual(getKeybindingsContentFromSyncContent(lastSyncUserData!.syncData!.content!, true), '[]');
 	});
 
 	test('test apply remote when keybindings file does not exist', async () => {

--- a/src/vs/platform/userDataSync/test/common/settingsMerge.test.ts
+++ b/src/vs/platform/userDataSync/test/common/settingsMerge.test.ts
@@ -15,9 +15,9 @@ suite('SettingsMerge - Merge', () => {
 		const localContent = stringify({ 'a': 1 });
 		const remoteContent = stringify({ 'a': 1 });
 		const actual = merge(localContent, remoteContent, null, [], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -31,9 +31,9 @@ suite('SettingsMerge - Merge', () => {
 			'b': 2
 		});
 		const actual = merge(localContent, remoteContent, null, [], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -47,10 +47,10 @@ suite('SettingsMerge - Merge', () => {
 			'b': 2
 		});
 		const actual = merge(localContent, remoteContent, null, [], [], formattingOptions);
-		assert.equal(actual.localContent, localContent);
-		assert.equal(actual.remoteContent, remoteContent);
+		assert.strictEqual(actual.localContent, localContent);
+		assert.strictEqual(actual.remoteContent, remoteContent);
 		assert.ok(actual.hasConflicts);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 	});
 
 	test('merge when local and remote are same with different base content', async () => {
@@ -67,9 +67,9 @@ suite('SettingsMerge - Merge', () => {
 			'b': 2
 		});
 		const actual = merge(localContent, remoteContent, baseContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, localContent);
-		assert.equal(actual.remoteContent, remoteContent);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, localContent);
+		assert.strictEqual(actual.remoteContent, remoteContent);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(actual.hasConflicts);
 	});
 
@@ -82,9 +82,9 @@ suite('SettingsMerge - Merge', () => {
 			'b': 2
 		});
 		const actual = merge(localContent, remoteContent, null, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -98,9 +98,9 @@ suite('SettingsMerge - Merge', () => {
 			'c': 3,
 		});
 		const actual = merge(localContent, remoteContent, null, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -114,9 +114,9 @@ suite('SettingsMerge - Merge', () => {
 			'c': 3,
 		});
 		const actual = merge(localContent, remoteContent, localContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -129,9 +129,9 @@ suite('SettingsMerge - Merge', () => {
 			'a': 1,
 		});
 		const actual = merge(localContent, remoteContent, localContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -141,9 +141,9 @@ suite('SettingsMerge - Merge', () => {
 		});
 		const remoteContent = stringify({});
 		const actual = merge(localContent, remoteContent, localContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -155,9 +155,9 @@ suite('SettingsMerge - Merge', () => {
 			'a': 2
 		});
 		const actual = merge(localContent, remoteContent, localContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -172,9 +172,9 @@ suite('SettingsMerge - Merge', () => {
 			'd': 4,
 		});
 		const actual = merge(localContent, remoteContent, localContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -191,9 +191,9 @@ suite('SettingsMerge - Merge', () => {
 			'b': 2,
 		});
 		const actual = merge(localContent, remoteContent, localContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -213,9 +213,9 @@ suite('SettingsMerge - Merge', () => {
 	"c": 1,
 }`;
 		const actual = merge(localContent, remoteContent, localContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -235,9 +235,9 @@ suite('SettingsMerge - Merge', () => {
 	"b": 2,
 }`;
 		const actual = merge(localContent, remoteContent, localContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -252,9 +252,9 @@ suite('SettingsMerge - Merge', () => {
 			'a': 1,
 		});
 		const actual = merge(localContent, remoteContent, null, [], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, localContent);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, localContent);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -269,9 +269,9 @@ suite('SettingsMerge - Merge', () => {
 			'a': 1,
 		});
 		const actual = merge(localContent, remoteContent, remoteContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, localContent);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, localContent);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -287,9 +287,9 @@ suite('SettingsMerge - Merge', () => {
 			'd': 4,
 		});
 		const actual = merge(localContent, remoteContent, remoteContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, localContent);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, localContent);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -303,9 +303,9 @@ suite('SettingsMerge - Merge', () => {
 			'c': 2,
 		});
 		const actual = merge(localContent, remoteContent, remoteContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, localContent);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, localContent);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -320,9 +320,9 @@ suite('SettingsMerge - Merge', () => {
 			'a': 1,
 		});
 		const actual = merge(localContent, remoteContent, remoteContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, localContent);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, localContent);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -338,9 +338,9 @@ suite('SettingsMerge - Merge', () => {
 	"b": 2,
 }`;
 		const actual = merge(localContent, remoteContent, remoteContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, localContent);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, localContent);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -360,9 +360,9 @@ suite('SettingsMerge - Merge', () => {
 	"c": 1,
 }`;
 		const actual = merge(localContent, remoteContent, remoteContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, localContent);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, localContent);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -382,9 +382,9 @@ suite('SettingsMerge - Merge', () => {
 	"c": 1,
 }`;
 		const actual = merge(localContent, remoteContent, remoteContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, localContent);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, localContent);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -397,8 +397,8 @@ suite('SettingsMerge - Merge', () => {
 		});
 		const expectedConflicts: IConflictSetting[] = [{ key: 'a', localValue: 1, remoteValue: 2 }];
 		const actual = merge(localContent, remoteContent, null, [], [], formattingOptions);
-		assert.equal(actual.localContent, localContent);
-		assert.equal(actual.remoteContent, remoteContent);
+		assert.strictEqual(actual.localContent, localContent);
+		assert.strictEqual(actual.remoteContent, remoteContent);
 		assert.ok(actual.hasConflicts);
 		assert.deepEqual(actual.conflictsSettings, expectedConflicts);
 	});
@@ -415,11 +415,11 @@ suite('SettingsMerge - Merge', () => {
 		});
 		const expectedConflicts: IConflictSetting[] = [{ key: 'a', localValue: 2, remoteValue: undefined }];
 		const actual = merge(localContent, remoteContent, baseContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, stringify({
+		assert.strictEqual(actual.localContent, stringify({
 			'a': 2,
 			'b': 2
 		}));
-		assert.equal(actual.remoteContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, remoteContent);
 		assert.ok(actual.hasConflicts);
 		assert.deepEqual(actual.conflictsSettings, expectedConflicts);
 	});
@@ -434,8 +434,8 @@ suite('SettingsMerge - Merge', () => {
 		});
 		const expectedConflicts: IConflictSetting[] = [{ key: 'a', localValue: undefined, remoteValue: 2 }];
 		const actual = merge(localContent, remoteContent, baseContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, localContent);
-		assert.equal(actual.remoteContent, remoteContent);
+		assert.strictEqual(actual.localContent, localContent);
+		assert.strictEqual(actual.remoteContent, remoteContent);
 		assert.ok(actual.hasConflicts);
 		assert.deepEqual(actual.conflictsSettings, expectedConflicts);
 	});
@@ -467,14 +467,14 @@ suite('SettingsMerge - Merge', () => {
 			{ key: 'e', localValue: 4, remoteValue: 5 },
 		];
 		const actual = merge(localContent, remoteContent, baseContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, stringify({
+		assert.strictEqual(actual.localContent, stringify({
 			'a': 2,
 			'c': 3,
 			'd': 5,
 			'e': 4,
 			'f': 1,
 		}));
-		assert.equal(actual.remoteContent, stringify({
+		assert.strictEqual(actual.remoteContent, stringify({
 			'b': 3,
 			'c': 3,
 			'd': 6,
@@ -505,13 +505,13 @@ suite('SettingsMerge - Merge', () => {
 			'c': 4,
 		});
 		const actual = merge(localContent, remoteContent, baseContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, stringify({
+		assert.strictEqual(actual.localContent, stringify({
 			'a': 2,
 			'c': 4,
 			'b': 2,
 			'e': 5,
 		}));
-		assert.equal(actual.remoteContent, stringify({
+		assert.strictEqual(actual.remoteContent, stringify({
 			'a': 2,
 			'b': 2,
 			'e': 5,
@@ -544,8 +544,8 @@ suite('SettingsMerge - Merge', () => {
 	"c": 1
 }`;
 		const actual = merge(localContent, remoteContent, baseContent, [], [], formattingOptions);
-		assert.equal(actual.localContent, localContent);
-		assert.equal(actual.remoteContent, remoteContent);
+		assert.strictEqual(actual.localContent, localContent);
+		assert.strictEqual(actual.remoteContent, remoteContent);
 		assert.ok(actual.hasConflicts);
 		assert.deepEqual(actual.conflictsSettings, []);
 	});
@@ -574,14 +574,14 @@ suite('SettingsMerge - Merge', () => {
 			{ key: 'd', localValue: 5, remoteValue: 6 },
 		];
 		const actual = merge(localContent, remoteContent, baseContent, [], [{ key: 'a', value: 2 }, { key: 'b', value: undefined }, { key: 'e', value: 5 }], formattingOptions);
-		assert.equal(actual.localContent, stringify({
+		assert.strictEqual(actual.localContent, stringify({
 			'a': 2,
 			'c': 3,
 			'd': 5,
 			'e': 5,
 			'f': 1,
 		}));
-		assert.equal(actual.remoteContent, stringify({
+		assert.strictEqual(actual.remoteContent, stringify({
 			'c': 3,
 			'd': 6,
 			'e': 5,
@@ -596,9 +596,9 @@ suite('SettingsMerge - Merge', () => {
 		const localContent = stringify({ 'a': 1 });
 		const remoteContent = stringify({ 'a': 2 });
 		const actual = merge(localContent, remoteContent, null, ['a'], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -607,9 +607,9 @@ suite('SettingsMerge - Merge', () => {
 		const localContent = stringify({ 'a': 1 });
 		const remoteContent = stringify({ 'a': 2 });
 		const actual = merge(localContent, remoteContent, baseContent, ['a'], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -617,9 +617,9 @@ suite('SettingsMerge - Merge', () => {
 		const localContent = stringify({});
 		const remoteContent = stringify({ 'a': 1 });
 		const actual = merge(localContent, remoteContent, null, ['a'], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -627,9 +627,9 @@ suite('SettingsMerge - Merge', () => {
 		const localContent = stringify({ 'b': 2 });
 		const remoteContent = stringify({ 'a': 1, 'b': 2 });
 		const actual = merge(localContent, remoteContent, localContent, ['a'], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -637,9 +637,9 @@ suite('SettingsMerge - Merge', () => {
 		const localContent = stringify({ 'a': 1 });
 		const remoteContent = stringify({});
 		const actual = merge(localContent, remoteContent, null, ['a'], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -647,9 +647,9 @@ suite('SettingsMerge - Merge', () => {
 		const localContent = stringify({ 'a': 2 });
 		const remoteContent = stringify({});
 		const actual = merge(localContent, remoteContent, localContent, ['a'], [], formattingOptions);
-		assert.equal(actual.localContent, null);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, null);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -673,16 +673,16 @@ suite('SettingsMerge - Merge', () => {
 			'e': 6,
 		});
 		const actual = merge(localContent, remoteContent, baseContent, ['a', 'e'], [], formattingOptions);
-		assert.equal(actual.localContent, stringify({
+		assert.strictEqual(actual.localContent, stringify({
 			'a': 1,
 			'b': 3,
 		}));
-		assert.equal(actual.remoteContent, stringify({
+		assert.strictEqual(actual.remoteContent, stringify({
 			'a': 3,
 			'b': 3,
 			'e': 6,
 		}));
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 
@@ -710,12 +710,12 @@ suite('SettingsMerge - Merge', () => {
 			{ key: 'b', localValue: 4, remoteValue: 3 },
 		];
 		const actual = merge(localContent, remoteContent, baseContent, ['a', 'e'], [], formattingOptions);
-		assert.equal(actual.localContent, stringify({
+		assert.strictEqual(actual.localContent, stringify({
 			'a': 1,
 			'b': 4,
 			'd': 5,
 		}));
-		assert.equal(actual.remoteContent, stringify({
+		assert.strictEqual(actual.remoteContent, stringify({
 			'a': 3,
 			'b': 3,
 			'e': 6,
@@ -735,9 +735,9 @@ suite('SettingsMerge - Merge', () => {
 	"a": 1,
 }`;
 		const actual = merge(localContent, remoteContent, null, [], [], formattingOptions);
-		assert.equal(actual.localContent, remoteContent);
-		assert.equal(actual.remoteContent, null);
-		assert.equal(actual.conflictsSettings.length, 0);
+		assert.strictEqual(actual.localContent, remoteContent);
+		assert.strictEqual(actual.remoteContent, null);
+		assert.strictEqual(actual.conflictsSettings.length, 0);
 		assert.ok(!actual.hasConflicts);
 	});
 });
@@ -757,7 +757,7 @@ suite('SettingsMerge - Compute Remote Content', () => {
 			'e': 6,
 		});
 		const actual = updateIgnoredSettings(localContent, remoteContent, [], formattingOptions);
-		assert.equal(actual, localContent);
+		assert.strictEqual(actual, localContent);
 	});
 
 	test('ignored settings are not updated from remote content', async () => {
@@ -778,7 +778,7 @@ suite('SettingsMerge - Compute Remote Content', () => {
 			'c': 3,
 		});
 		const actual = updateIgnoredSettings(localContent, remoteContent, ['a'], formattingOptions);
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 });
@@ -808,7 +808,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a setting without comments at the end', () => {
@@ -832,7 +832,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert between settings without comment', () => {
@@ -858,7 +858,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert between settings and there is a comment in between in source', () => {
@@ -885,7 +885,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a setting and after a comment at the end', () => {
@@ -911,7 +911,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a setting ending with comma and after a comment at the end', () => {
@@ -937,7 +937,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a comment and there are no settings', () => {
@@ -960,7 +960,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a setting and between a comment and setting', () => {
@@ -989,7 +989,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a setting between two comments and there is a setting after', () => {
@@ -1021,7 +1021,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a setting between two comments on the same line and there is a setting after', () => {
@@ -1051,7 +1051,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a setting between two line comments on the same line and there is a setting after', () => {
@@ -1081,7 +1081,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a setting between two comments and there is no setting after', () => {
@@ -1110,7 +1110,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a setting with comma and between two comments and there is no setting after', () => {
@@ -1139,7 +1139,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 	test('Insert before a setting without comments', () => {
 
@@ -1164,7 +1164,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert before a setting without comments at the end', () => {
@@ -1188,7 +1188,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert before a setting with comment', () => {
@@ -1215,7 +1215,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert before a setting and before a comment at the beginning', () => {
@@ -1241,7 +1241,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert before a setting ending with comma and before a comment at the begninning', () => {
@@ -1267,7 +1267,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert before a setting and between a setting and comment', () => {
@@ -1296,7 +1296,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert before a setting between two comments and there is a setting before', () => {
@@ -1328,7 +1328,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert before a setting between two comments on the same line and there is a setting before', () => {
@@ -1359,7 +1359,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert before a setting between two line comments on the same line and there is a setting before', () => {
@@ -1389,7 +1389,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert before a setting between two comments and there is no setting before', () => {
@@ -1418,7 +1418,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert before a setting with comma and between two comments and there is no setting before', () => {
@@ -1447,7 +1447,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a setting that is of object type', () => {
@@ -1470,7 +1470,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('a', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, sourceContent);
+		assert.strictEqual(actual, sourceContent);
 	});
 
 	test('Insert after a setting that is of array type', () => {
@@ -1493,7 +1493,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('a', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, sourceContent);
+		assert.strictEqual(actual, sourceContent);
 	});
 
 	test('Insert after a comment with comma separator of previous setting and no next nodes ', () => {
@@ -1522,7 +1522,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a comment with comma separator of previous setting and there is a setting after ', () => {
@@ -1554,7 +1554,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 	test('Insert after a comment with comma separator of previous setting and there is a comment after ', () => {
@@ -1586,7 +1586,7 @@ suite('SettingsMerge - Add Setting', () => {
 
 		const actual = addSetting('b', sourceContent, targetContent, formattingOptions);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 });
 

--- a/src/vs/platform/userDataSync/test/common/settingsSync.test.ts
+++ b/src/vs/platform/userDataSync/test/common/settingsSync.test.ts
@@ -66,7 +66,7 @@ suite('SettingsSync - Auto', () => {
 		const remoteUserData = await testObject.getRemoteUserData(null);
 		assert.deepEqual(lastSyncUserData!.ref, remoteUserData.ref);
 		assert.deepEqual(lastSyncUserData!.syncData, remoteUserData.syncData);
-		assert.equal(lastSyncUserData!.syncData, null);
+		assert.strictEqual(lastSyncUserData!.syncData, null);
 
 		manifest = await client.manifest();
 		server.reset();
@@ -88,9 +88,9 @@ suite('SettingsSync - Auto', () => {
 
 		const lastSyncUserData = await testObject.getLastSyncUserData();
 		const remoteUserData = await testObject.getRemoteUserData(null);
-		assert.equal(parseSettingsSyncContent(lastSyncUserData!.syncData!.content!)?.settings, '{}');
-		assert.equal(parseSettingsSyncContent(remoteUserData!.syncData!.content!)?.settings, '{}');
-		assert.equal((await fileService.readFile(settingsResource)).value.toString(), '');
+		assert.strictEqual(parseSettingsSyncContent(lastSyncUserData!.syncData!.content!)?.settings, '{}');
+		assert.strictEqual(parseSettingsSyncContent(remoteUserData!.syncData!.content!)?.settings, '{}');
+		assert.strictEqual((await fileService.readFile(settingsResource)).value.toString(), '');
 	});
 
 	test('when settings file is empty and remote has changes', async () => {
@@ -129,9 +129,9 @@ suite('SettingsSync - Auto', () => {
 
 		const lastSyncUserData = await testObject.getLastSyncUserData();
 		const remoteUserData = await testObject.getRemoteUserData(null);
-		assert.equal(parseSettingsSyncContent(lastSyncUserData!.syncData!.content!)?.settings, content);
-		assert.equal(parseSettingsSyncContent(remoteUserData!.syncData!.content!)?.settings, content);
-		assert.equal((await fileService.readFile(settingsResource)).value.toString(), content);
+		assert.strictEqual(parseSettingsSyncContent(lastSyncUserData!.syncData!.content!)?.settings, content);
+		assert.strictEqual(parseSettingsSyncContent(remoteUserData!.syncData!.content!)?.settings, content);
+		assert.strictEqual((await fileService.readFile(settingsResource)).value.toString(), content);
 	});
 
 	test('when settings file is created after first sync', async () => {
@@ -154,7 +154,7 @@ suite('SettingsSync - Auto', () => {
 		const remoteUserData = await testObject.getRemoteUserData(null);
 		assert.deepEqual(lastSyncUserData!.ref, remoteUserData.ref);
 		assert.deepEqual(lastSyncUserData!.syncData, remoteUserData.syncData);
-		assert.equal(parseSettingsSyncContent(lastSyncUserData!.syncData!.content!)?.settings, '{}');
+		assert.strictEqual(parseSettingsSyncContent(lastSyncUserData!.syncData!.content!)?.settings, '{}');
 	});
 
 	test('sync for first time to the server', async () => {
@@ -483,8 +483,8 @@ suite('SettingsSync - Auto', () => {
 		}), client);
 		await testObject.sync(await client.manifest());
 
-		assert.equal(testObject.status, SyncStatus.HasConflicts);
-		assert.equal(testObject.conflicts[0].localResource.toString(), testObject.localResource);
+		assert.strictEqual(testObject.status, SyncStatus.HasConflicts);
+		assert.strictEqual(testObject.conflicts[0].localResource.toString(), testObject.localResource.toString());
 
 		const fileService = client.instantiationService.get(IFileService);
 		const mergeContent = (await fileService.readFile(testObject.conflicts[0].previewResource)).value.toString();
@@ -537,7 +537,7 @@ suite('SettingsSync - Manual', () => {
 		await updateSettings(settingsContent, client);
 
 		let preview = await testObject.preview(await client.manifest());
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		preview = await testObject.accept(preview!.resourcePreviews[0].previewResource);
 		preview = await testObject.apply(false);
 

--- a/src/vs/platform/userDataSync/test/common/snippetsSync.test.ts
+++ b/src/vs/platform/userDataSync/test/common/snippetsSync.test.ts
@@ -185,7 +185,7 @@ suite('SnippetsSync', () => {
 		const remoteUserData = await testObject.getRemoteUserData(null);
 		assert.deepEqual(lastSyncUserData!.ref, remoteUserData.ref);
 		assert.deepEqual(lastSyncUserData!.syncData, remoteUserData.syncData);
-		assert.equal(lastSyncUserData!.syncData, null);
+		assert.strictEqual(lastSyncUserData!.syncData, null);
 
 		manifest = await testClient.manifest();
 		server.reset();
@@ -223,7 +223,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet1, testClient);
 
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const { content } = await testClient.read(testObject.resource);
@@ -238,13 +238,13 @@ suite('SnippetsSync', () => {
 		await client2.sync();
 
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('html.json', testClient);
-		assert.equal(actual1, htmlSnippet1);
+		assert.strictEqual(actual1, htmlSnippet1);
 		const actual2 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual2, tsSnippet1);
+		assert.strictEqual(actual2, tsSnippet1);
 	});
 
 	test('first time sync when snippets exists', async () => {
@@ -253,13 +253,13 @@ suite('SnippetsSync', () => {
 
 		await updateSnippet('typescript.json', tsSnippet1, testClient);
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('html.json', testClient);
-		assert.equal(actual1, htmlSnippet1);
+		assert.strictEqual(actual1, htmlSnippet1);
 		const actual2 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual2, tsSnippet1);
+		assert.strictEqual(actual2, tsSnippet1);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -274,7 +274,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('html.json', htmlSnippet2, testClient);
 		await testObject.sync(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.HasConflicts);
+		assert.strictEqual(testObject.status, SyncStatus.HasConflicts);
 		const environmentService = testClient.instantiationService.get(IEnvironmentService);
 		const local = joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json');
 		assertPreviews(testObject.conflicts, [local]);
@@ -290,11 +290,11 @@ suite('SnippetsSync', () => {
 		await testObject.accept(conflicts[0].previewResource, htmlSnippet1);
 		await testObject.apply(false);
 
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('html.json', testClient);
-		assert.equal(actual1, htmlSnippet1);
+		assert.strictEqual(actual1, htmlSnippet1);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -311,7 +311,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		await testObject.sync(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.HasConflicts);
+		assert.strictEqual(testObject.status, SyncStatus.HasConflicts);
 		const environmentService = testClient.instantiationService.get(IEnvironmentService);
 		const local1 = joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json');
 		const local2 = joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'typescript.json');
@@ -331,7 +331,7 @@ suite('SnippetsSync', () => {
 		await testObject.accept(conflicts[0].previewResource, htmlSnippet2);
 
 		conflicts = testObject.conflicts;
-		assert.equal(testObject.status, SyncStatus.HasConflicts);
+		assert.strictEqual(testObject.status, SyncStatus.HasConflicts);
 		const environmentService = testClient.instantiationService.get(IEnvironmentService);
 		const local = joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'typescript.json');
 		assertPreviews(testObject.conflicts, [local]);
@@ -351,13 +351,13 @@ suite('SnippetsSync', () => {
 		await testObject.accept(conflicts[1].previewResource, tsSnippet1);
 		await testObject.apply(false);
 
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('html.json', testClient);
-		assert.equal(actual1, htmlSnippet2);
+		assert.strictEqual(actual1, htmlSnippet2);
 		const actual2 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual2, tsSnippet1);
+		assert.strictEqual(actual2, tsSnippet1);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -371,13 +371,13 @@ suite('SnippetsSync', () => {
 
 		await updateSnippet('typescript.json', tsSnippet1, testClient);
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('html.json', testClient);
-		assert.equal(actual1, htmlSnippet1);
+		assert.strictEqual(actual1, htmlSnippet1);
 		const actual2 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual2, tsSnippet1);
+		assert.strictEqual(actual2, tsSnippet1);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -394,13 +394,13 @@ suite('SnippetsSync', () => {
 		await client2.sync();
 
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('html.json', testClient);
-		assert.equal(actual1, htmlSnippet1);
+		assert.strictEqual(actual1, htmlSnippet1);
 		const actual2 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual2, tsSnippet1);
+		assert.strictEqual(actual2, tsSnippet1);
 	});
 
 	test('sync updating a snippet', async () => {
@@ -409,11 +409,11 @@ suite('SnippetsSync', () => {
 
 		await updateSnippet('html.json', htmlSnippet2, testClient);
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('html.json', testClient);
-		assert.equal(actual1, htmlSnippet2);
+		assert.strictEqual(actual1, htmlSnippet2);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -430,11 +430,11 @@ suite('SnippetsSync', () => {
 		await client2.sync();
 
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('html.json', testClient);
-		assert.equal(actual1, htmlSnippet2);
+		assert.strictEqual(actual1, htmlSnippet2);
 	});
 
 	test('sync updating a snippet - conflict', async () => {
@@ -447,7 +447,7 @@ suite('SnippetsSync', () => {
 
 		await updateSnippet('html.json', htmlSnippet3, testClient);
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.HasConflicts);
+		assert.strictEqual(testObject.status, SyncStatus.HasConflicts);
 		const environmentService = testClient.instantiationService.get(IEnvironmentService);
 		const local = joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json');
 		assertPreviews(testObject.conflicts, [local]);
@@ -466,11 +466,11 @@ suite('SnippetsSync', () => {
 		await testObject.accept(testObject.conflicts[0].previewResource, htmlSnippet2);
 		await testObject.apply(false);
 
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('html.json', testClient);
-		assert.equal(actual1, htmlSnippet2);
+		assert.strictEqual(actual1, htmlSnippet2);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -485,13 +485,13 @@ suite('SnippetsSync', () => {
 
 		await removeSnippet('html.json', testClient);
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual1, tsSnippet1);
+		assert.strictEqual(actual1, tsSnippet1);
 		const actual2 = await readSnippet('html.json', testClient);
-		assert.equal(actual2, null);
+		assert.strictEqual(actual2, null);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -509,13 +509,13 @@ suite('SnippetsSync', () => {
 		await client2.sync();
 
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual1, tsSnippet1);
+		assert.strictEqual(actual1, tsSnippet1);
 		const actual2 = await readSnippet('html.json', testClient);
-		assert.equal(actual2, null);
+		assert.strictEqual(actual2, null);
 	});
 
 	test('sync removing a snippet locally and updating it remotely', async () => {
@@ -530,13 +530,13 @@ suite('SnippetsSync', () => {
 		await removeSnippet('html.json', testClient);
 		await testObject.sync(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual1, tsSnippet1);
+		assert.strictEqual(actual1, tsSnippet1);
 		const actual2 = await readSnippet('html.json', testClient);
-		assert.equal(actual2, htmlSnippet2);
+		assert.strictEqual(actual2, htmlSnippet2);
 	});
 
 	test('sync removing a snippet - conflict', async () => {
@@ -551,7 +551,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('html.json', htmlSnippet2, testClient);
 		await testObject.sync(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.HasConflicts);
+		assert.strictEqual(testObject.status, SyncStatus.HasConflicts);
 		const environmentService = testClient.instantiationService.get(IEnvironmentService);
 		const local = joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json');
 		assertPreviews(testObject.conflicts, [local]);
@@ -571,13 +571,13 @@ suite('SnippetsSync', () => {
 		await testObject.accept(testObject.conflicts[0].previewResource, htmlSnippet3);
 		await testObject.apply(false);
 
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual1, tsSnippet1);
+		assert.strictEqual(actual1, tsSnippet1);
 		const actual2 = await readSnippet('html.json', testClient);
-		assert.equal(actual2, htmlSnippet3);
+		assert.strictEqual(actual2, htmlSnippet3);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -599,13 +599,13 @@ suite('SnippetsSync', () => {
 		await testObject.accept(testObject.conflicts[0].previewResource, null);
 		await testObject.apply(false);
 
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual1, tsSnippet1);
+		assert.strictEqual(actual1, tsSnippet1);
 		const actual2 = await readSnippet('html.json', testClient);
-		assert.equal(actual2, null);
+		assert.strictEqual(actual2, null);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -619,13 +619,13 @@ suite('SnippetsSync', () => {
 		await client2.sync();
 
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('html.json', testClient);
-		assert.equal(actual1, htmlSnippet1);
+		assert.strictEqual(actual1, htmlSnippet1);
 		const actual2 = await readSnippet('global.code-snippets', testClient);
-		assert.equal(actual2, globalSnippet);
+		assert.strictEqual(actual2, globalSnippet);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -640,15 +640,15 @@ suite('SnippetsSync', () => {
 		await client2.sync();
 
 		await testObject.sync(await testClient.manifest());
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 		assert.deepEqual(testObject.conflicts, []);
 
 		const actual1 = await readSnippet('typescript.json', testClient);
-		assert.equal(actual1, tsSnippet1);
+		assert.strictEqual(actual1, tsSnippet1);
 		const actual2 = await readSnippet('global.code-snippets', testClient);
-		assert.equal(actual2, globalSnippet);
+		assert.strictEqual(actual2, globalSnippet);
 		const actual3 = await readSnippet('html.html', testClient);
-		assert.equal(actual3, null);
+		assert.strictEqual(actual3, null);
 
 		const { content } = await testClient.read(testObject.resource);
 		assert.ok(content !== null);
@@ -679,7 +679,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		let preview = await testObject.preview(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -689,7 +689,7 @@ suite('SnippetsSync', () => {
 
 		preview = await testObject.merge(preview!.resourcePreviews[0].localResource);
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -705,7 +705,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		let preview = await testObject.preview(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -716,7 +716,7 @@ suite('SnippetsSync', () => {
 		preview = await testObject.merge(preview!.resourcePreviews[0].localResource);
 		preview = await testObject.merge(preview!.resourcePreviews[1].localResource);
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -732,7 +732,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		let preview = await testObject.preview(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -744,8 +744,8 @@ suite('SnippetsSync', () => {
 		preview = await testObject.merge(preview!.resourcePreviews[1].localResource);
 		preview = await testObject.apply(false);
 
-		assert.equal(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(preview, null);
 		assert.deepEqual(testObject.conflicts, []);
 	});
 
@@ -759,7 +759,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		let preview = await testObject.preview(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'typescript.json'),
@@ -769,7 +769,7 @@ suite('SnippetsSync', () => {
 
 		preview = await testObject.merge(preview!.resourcePreviews[0].localResource);
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'typescript.json'),
@@ -788,7 +788,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		let preview = await testObject.preview(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'typescript.json'),
@@ -799,8 +799,8 @@ suite('SnippetsSync', () => {
 		preview = await testObject.merge(preview!.resourcePreviews[0].localResource);
 		preview = await testObject.apply(false);
 
-		assert.equal(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(preview, null);
 		assert.deepEqual(testObject.conflicts, []);
 	});
 
@@ -815,7 +815,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		let preview = await testObject.preview(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -825,7 +825,7 @@ suite('SnippetsSync', () => {
 
 		preview = await testObject.merge(preview!.resourcePreviews[0].previewResource);
 
-		assert.equal(testObject.status, SyncStatus.HasConflicts);
+		assert.strictEqual(testObject.status, SyncStatus.HasConflicts);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -848,7 +848,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		let preview = await testObject.preview(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -859,7 +859,7 @@ suite('SnippetsSync', () => {
 		preview = await testObject.merge(preview!.resourcePreviews[0].previewResource);
 		preview = await testObject.merge(preview!.resourcePreviews[1].previewResource);
 
-		assert.equal(testObject.status, SyncStatus.HasConflicts);
+		assert.strictEqual(testObject.status, SyncStatus.HasConflicts);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -883,7 +883,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		let preview = await testObject.preview(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -893,7 +893,7 @@ suite('SnippetsSync', () => {
 
 		preview = await testObject.accept(preview!.resourcePreviews[0].previewResource, htmlSnippet2);
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -913,7 +913,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		let preview = await testObject.preview(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -924,7 +924,7 @@ suite('SnippetsSync', () => {
 		preview = await testObject.accept(preview!.resourcePreviews[0].previewResource, htmlSnippet2);
 		preview = await testObject.accept(preview!.resourcePreviews[1].previewResource, tsSnippet2);
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -944,7 +944,7 @@ suite('SnippetsSync', () => {
 		await updateSnippet('typescript.json', tsSnippet2, testClient);
 		let preview = await testObject.preview(await testClient.manifest());
 
-		assert.equal(testObject.status, SyncStatus.Syncing);
+		assert.strictEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews,
 			[
 				joinPath(environmentService.userDataSyncHome, testObject.resource, PREVIEW_DIR_NAME, 'html.json'),
@@ -956,8 +956,8 @@ suite('SnippetsSync', () => {
 		preview = await testObject.accept(preview!.resourcePreviews[1].previewResource, tsSnippet2);
 		preview = await testObject.apply(false);
 
-		assert.equal(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(preview, null);
 		assert.deepEqual(testObject.conflicts, []);
 	});
 

--- a/src/vs/platform/userDataSync/test/common/synchronizer.test.ts
+++ b/src/vs/platform/userDataSync/test/common/synchronizer.test.ts
@@ -296,7 +296,7 @@ suite('TestSynchronizer - Auto Sync', () => {
 		await testObject.apply(false);
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
 		const fileService = client.instantiationService.get(IFileService);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, (await fileService.readFile(testObject.localResource)).value.toString());
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, (await fileService.readFile(testObject.localResource)).value.toString());
 	});
 
 	test('accept remote during conflicts', async () => {
@@ -318,8 +318,8 @@ suite('TestSynchronizer - Auto Sync', () => {
 
 		await testObject.apply(false);
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, currentRemoteContent);
-		assert.equal((await fileService.readFile(testObject.localResource)).value.toString(), currentRemoteContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, currentRemoteContent);
+		assert.strictEqual((await fileService.readFile(testObject.localResource)).value.toString(), currentRemoteContent);
 	});
 
 	test('accept local during conflicts', async () => {
@@ -340,8 +340,8 @@ suite('TestSynchronizer - Auto Sync', () => {
 
 		await testObject.apply(false);
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, newLocalContent);
-		assert.equal((await fileService.readFile(testObject.localResource)).value.toString(), newLocalContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, newLocalContent);
+		assert.strictEqual((await fileService.readFile(testObject.localResource)).value.toString(), newLocalContent);
 	});
 
 	test('accept new content during conflicts', async () => {
@@ -363,8 +363,8 @@ suite('TestSynchronizer - Auto Sync', () => {
 
 		await testObject.apply(false);
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, mergeContent);
-		assert.equal((await fileService.readFile(testObject.localResource)).value.toString(), mergeContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, mergeContent);
+		assert.strictEqual((await fileService.readFile(testObject.localResource)).value.toString(), mergeContent);
 	});
 
 	test('accept delete during conflicts', async () => {
@@ -385,7 +385,7 @@ suite('TestSynchronizer - Auto Sync', () => {
 
 		await testObject.apply(false);
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, '');
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, '');
 		assert.ok(!(await fileService.exists(testObject.localResource)));
 	});
 
@@ -406,7 +406,7 @@ suite('TestSynchronizer - Auto Sync', () => {
 
 		await testObject.apply(false);
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, '');
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, '');
 		assert.ok(!(await fileService.exists(testObject.localResource)));
 	});
 
@@ -426,7 +426,7 @@ suite('TestSynchronizer - Auto Sync', () => {
 
 		await testObject.apply(false);
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData, null);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData, null);
 		assert.ok(!(await fileService.exists(testObject.localResource)));
 	});
 
@@ -480,7 +480,7 @@ suite('TestSynchronizer - Auto Sync', () => {
 		} catch (error) {
 		}
 
-		assert.equal(testObject.status, SyncStatus.Idle);
+		assert.strictEqual(testObject.status, SyncStatus.Idle);
 	});
 });
 
@@ -523,7 +523,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -537,7 +537,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -552,7 +552,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -568,12 +568,12 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
 
 		const expectedContent = manifest!.latest![testObject.resource];
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
-		assert.equal((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 
 	test('preview -> accept -> apply', async () => {
@@ -589,11 +589,11 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
 
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
-		assert.equal((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 
 	test('preview -> merge -> accept -> apply', async () => {
@@ -609,10 +609,11 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
 
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		// TODO @sandy I don't know enough about this test to make it strictly equal
 		assert.equal(!(await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 
@@ -642,11 +643,11 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
 
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
-		assert.equal((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 
 	test('preivew -> merge -> discard', async () => {
@@ -660,7 +661,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -676,7 +677,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -691,7 +692,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -707,7 +708,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -723,7 +724,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -739,7 +740,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -757,9 +758,10 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		// TODO @sandy081 I don't know enough about this test to make it strictly equal
 		assert.equal(!(await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 
@@ -778,9 +780,10 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		// TODO @sandy081 I don't know enough about this test to make it strictly equal
 		assert.equal(!(await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 
@@ -800,11 +803,11 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
 
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
-		assert.equal((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 
 	test('conflicts: preview', async () => {
@@ -829,7 +832,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.HasConflicts);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Conflict);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Conflict);
 		assertConflicts(testObject.conflicts, [preview!.resourcePreviews[0].localResource]);
 	});
 
@@ -844,7 +847,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -879,11 +882,11 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
 
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
-		assert.equal((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 
 	test('conflicts: preview -> accept', async () => {
@@ -915,11 +918,11 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
 
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
-		assert.equal((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 
 	test('conflicts: preivew -> merge -> discard', async () => {
@@ -933,7 +936,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -949,7 +952,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -964,7 +967,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -980,7 +983,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Accepted);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -996,7 +999,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.HasConflicts);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Conflict);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Conflict);
 		assertConflicts(testObject.conflicts, [preview!.resourcePreviews[0].localResource]);
 	});
 
@@ -1012,7 +1015,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.HasConflicts);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Conflict);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Conflict);
 		assertConflicts(testObject.conflicts, [preview!.resourcePreviews[0].localResource]);
 	});
 
@@ -1028,7 +1031,7 @@ suite('TestSynchronizer - Manual Sync', () => {
 
 		assert.deepEqual(testObject.status, SyncStatus.Syncing);
 		assertPreviews(preview!.resourcePreviews, [testObject.localResource]);
-		assert.equal(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
+		assert.strictEqual(preview!.resourcePreviews[0].mergeState, MergeState.Preview);
 		assertConflicts(testObject.conflicts, []);
 	});
 
@@ -1046,9 +1049,10 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		// TODO @sandy081 I don't know enoguh about this test to understand how to make it strict
 		assert.equal(!(await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 
@@ -1067,9 +1071,10 @@ suite('TestSynchronizer - Manual Sync', () => {
 		preview = await testObject.apply(false);
 
 		assert.deepEqual(testObject.status, SyncStatus.Idle);
-		assert.equal(preview, null);
+		assert.strictEqual(preview, null);
 		assertConflicts(testObject.conflicts, []);
-		assert.equal((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		assert.strictEqual((await testObject.getRemoteUserData(null)).syncData?.content, expectedContent);
+		// TODO @sandy081 I don't know enoguh about this test to understand how to make it strict
 		assert.equal(!(await client.instantiationService.get(IFileService).readFile(testObject.localResource)).value.toString(), expectedContent);
 	});
 

--- a/src/vs/platform/userDataSync/test/common/userDataAutoSyncService.test.ts
+++ b/src/vs/platform/userDataSync/test/common/userDataAutoSyncService.test.ts
@@ -410,7 +410,7 @@ suite('UserDataAutoSyncService', () => {
 		const testObject: TestUserDataAutoSyncService = disposableStore.add(testClient.instantiationService.createInstance(TestUserDataAutoSyncService));
 
 		await testObject.triggerSync(['some reason'], true, true);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['Cache-Control'], 'no-cache');
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['Cache-Control'], 'no-cache');
 	});
 
 	test('test cache control header is not sent when triggered without disable cache option', async () => {
@@ -422,7 +422,7 @@ suite('UserDataAutoSyncService', () => {
 		const testObject: TestUserDataAutoSyncService = disposableStore.add(testClient.instantiationService.createInstance(TestUserDataAutoSyncService));
 
 		await testObject.triggerSync(['some reason'], true, false);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['Cache-Control'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['Cache-Control'], undefined);
 	});
 
 });

--- a/src/vs/platform/userDataSync/test/common/userDataSyncStoreService.test.ts
+++ b/src/vs/platform/userDataSync/test/common/userDataSyncStoreService.test.ts
@@ -61,8 +61,8 @@ suite('UserDataSyncStoreManagementService', () => {
 
 		const testObject: IUserDataSyncStoreManagementService = disposableStore.add(client.instantiationService.createInstance(UserDataSyncStoreManagementService));
 
-		assert.equal(testObject.userDataSyncStore?.url.toString(), expected.url.toString());
-		assert.equal(testObject.userDataSyncStore?.defaultUrl.toString(), expected.defaultUrl.toString());
+		assert.strictEqual(testObject.userDataSyncStore?.url.toString(), expected.url.toString());
+		assert.strictEqual(testObject.userDataSyncStore?.defaultUrl.toString(), expected.defaultUrl.toString());
 		assert.deepEqual(testObject.userDataSyncStore?.authenticationProviders, expected.authenticationProviders);
 	});
 
@@ -84,12 +84,12 @@ suite('UserDataSyncStoreService', () => {
 
 		await testObject.manifest();
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-Client-Name'], `${productService.applicationName}${isWeb ? '-web' : ''}`);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-Client-Version'], productService.version);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Client-Name'], `${productService.applicationName}${isWeb ? '-web' : ''}`);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Client-Version'], productService.version);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Id'], undefined);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
 	test('test read manifest for the second time when session is not yet created', async () => {
@@ -105,9 +105,9 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.manifest();
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
 	test('test session id header is not set in the first manifest request after session is created', async () => {
@@ -124,9 +124,9 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.manifest();
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
 	test('test session id header is set from the second manifest request after session is created', async () => {
@@ -144,8 +144,8 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.manifest();
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
@@ -165,8 +165,8 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.write(SyncResource.Settings, 'some content', null);
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
@@ -186,8 +186,8 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.read(SyncResource.Settings, null);
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
@@ -208,10 +208,10 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.manifest();
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
 	test('test old headers are sent after session is changed on server ', async () => {
@@ -239,11 +239,11 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.manifest();
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
 	});
 
 	test('test old headers are reset from second request after session is changed on server ', async () => {
@@ -272,7 +272,7 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.manifest();
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
@@ -303,11 +303,11 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.manifest();
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
 	});
 
 	test('test headers are reset after session is cleared from another server ', async () => {
@@ -334,10 +334,10 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.manifest();
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.equal(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
 	test('test headers are reset after session is cleared from another server - started syncing again', async () => {
@@ -367,7 +367,7 @@ suite('UserDataSyncStoreService', () => {
 		target.reset();
 		await testObject.manifest();
 
-		assert.equal(target.requestsWithAllHeaders.length, 1);
+		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
 		assert.notEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
@@ -421,7 +421,7 @@ suite('UserDataSyncStoreService', () => {
 		} catch (e) { }
 
 		const target = disposableStore.add(client.instantiationService.createInstance(UserDataSyncStoreService));
-		assert.equal(target.donotMakeRequestsUntil?.getTime(), testObject.donotMakeRequestsUntil?.getTime());
+		assert.strictEqual(target.donotMakeRequestsUntil?.getTime(), testObject.donotMakeRequestsUntil?.getTime());
 	});
 
 	test('test donotMakeRequestsUntil is checked and reset after retreived', async () => {
@@ -450,7 +450,7 @@ suite('UserDataSyncStoreService', () => {
 		const expected = await testObject.read(SyncResource.Settings, null);
 		const actual = await testObject.read(SyncResource.Settings, expected);
 
-		assert.equal(actual, expected);
+		assert.strictEqual(actual, expected);
 	});
 
 });
@@ -471,7 +471,7 @@ suite('UserDataSyncRequestsSession', () => {
 			await testObject.request('url', {}, CancellationToken.None);
 		} catch (error) {
 			assert.ok(error instanceof UserDataSyncStoreError);
-			assert.equal((<UserDataSyncStoreError>error).code, UserDataSyncErrorCode.LocalTooManyRequests);
+			assert.strictEqual((<UserDataSyncStoreError>error).code, UserDataSyncErrorCode.LocalTooManyRequests);
 			return;
 		}
 		assert.fail('Should fail with limit exceeded');
@@ -494,7 +494,7 @@ suite('UserDataSyncRequestsSession', () => {
 			await testObject.request('url', {}, CancellationToken.None);
 		} catch (error) {
 			assert.ok(error instanceof UserDataSyncStoreError);
-			assert.equal((<UserDataSyncStoreError>error).code, UserDataSyncErrorCode.LocalTooManyRequests);
+			assert.strictEqual((<UserDataSyncStoreError>error).code, UserDataSyncErrorCode.LocalTooManyRequests);
 			return;
 		}
 		assert.fail('Should fail with limit exceeded');

--- a/src/vs/workbench/contrib/bulkEdit/test/browser/bulkEditPreview.test.ts
+++ b/src/vs/workbench/contrib/bulkEdit/test/browser/bulkEditPreview.test.ts
@@ -53,8 +53,8 @@ suite('BulkEditPreview', function () {
 		];
 
 		const ops = await instaService.invokeFunction(BulkFileOperations.create, edits);
-		assert.equal(ops.fileOperations.length, 1);
-		assert.equal(ops.checked.isChecked(edits[0]), false);
+		assert.strictEqual(ops.fileOperations.length, 1);
+		assert.strictEqual(ops.checked.isChecked(edits[0]), false);
 	});
 
 	test('has categories', async function () {
@@ -66,9 +66,9 @@ suite('BulkEditPreview', function () {
 
 
 		const ops = await instaService.invokeFunction(BulkFileOperations.create, edits);
-		assert.equal(ops.categories.length, 2);
-		assert.equal(ops.categories[0].metadata.label, 'uri1'); // unconfirmed!
-		assert.equal(ops.categories[1].metadata.label, 'uri2');
+		assert.strictEqual(ops.categories.length, 2);
+		assert.strictEqual(ops.categories[0].metadata.label, 'uri1'); // unconfirmed!
+		assert.strictEqual(ops.categories[1].metadata.label, 'uri2');
 	});
 
 	test('has not categories', async function () {
@@ -79,9 +79,9 @@ suite('BulkEditPreview', function () {
 		];
 
 		const ops = await instaService.invokeFunction(BulkFileOperations.create, edits);
-		assert.equal(ops.categories.length, 1);
-		assert.equal(ops.categories[0].metadata.label, 'uri1'); // unconfirmed!
-		assert.equal(ops.categories[0].metadata.label, 'uri1');
+		assert.strictEqual(ops.categories.length, 1);
+		assert.strictEqual(ops.categories[0].metadata.label, 'uri1'); // unconfirmed!
+		assert.strictEqual(ops.categories[0].metadata.label, 'uri1');
 	});
 
 	test('category selection', async function () {
@@ -94,8 +94,8 @@ suite('BulkEditPreview', function () {
 
 		const ops = await instaService.invokeFunction(BulkFileOperations.create, edits);
 
-		assert.equal(ops.checked.isChecked(edits[0]), true);
-		assert.equal(ops.checked.isChecked(edits[1]), true);
+		assert.strictEqual(ops.checked.isChecked(edits[0]), true);
+		assert.strictEqual(ops.checked.isChecked(edits[1]), true);
 
 		assert.ok(edits === ops.getWorkspaceEdit());
 
@@ -105,8 +105,8 @@ suite('BulkEditPreview', function () {
 		const newEdits = ops.getWorkspaceEdit();
 		assert.ok(edits !== newEdits);
 
-		assert.equal(edits.length, 2);
-		assert.equal(newEdits.length, 1);
+		assert.strictEqual(edits.length, 2);
+		assert.strictEqual(newEdits.length, 1);
 	});
 
 	test('fix bad metadata', async function () {
@@ -120,7 +120,7 @@ suite('BulkEditPreview', function () {
 
 		const ops = await instaService.invokeFunction(BulkFileOperations.create, edits);
 
-		assert.equal(ops.checked.isChecked(edits[0]), false);
-		assert.equal(ops.checked.isChecked(edits[1]), false);
+		assert.strictEqual(ops.checked.isChecked(edits[0]), false);
+		assert.strictEqual(ops.checked.isChecked(edits[1]), false);
 	});
 });

--- a/src/vs/workbench/contrib/emmet/test/browser/emmetAction.test.ts
+++ b/src/vs/workbench/contrib/emmet/test/browser/emmetAction.test.ts
@@ -64,8 +64,8 @@ suite('Emmet', () => {
 					assert.fail('langOutput not found');
 				}
 
-				assert.equal(langOutput.language, expectedLanguage);
-				assert.equal(langOutput.parentMode, expectedParentLanguage);
+				assert.strictEqual(langOutput.language, expectedLanguage);
+				assert.strictEqual(langOutput.parentMode, expectedParentLanguage);
 			}
 
 			// syntaxes mapped using the scope name of the grammar

--- a/src/vs/workbench/contrib/experiments/test/electron-browser/experimentService.test.ts
+++ b/src/vs/workbench/contrib/experiments/test/electron-browser/experimentService.test.ts
@@ -150,25 +150,25 @@ suite('Experiment Service', () => {
 		tests.push(testObject.getExperimentById('experiment5'));
 
 		return Promise.all(tests).then(results => {
-			assert.equal(results[0].id, 'experiment1');
-			assert.equal(results[0].enabled, false);
-			assert.equal(results[0].state, ExperimentState.NoRun);
+			assert.strictEqual(results[0].id, 'experiment1');
+			assert.strictEqual(results[0].enabled, false);
+			assert.strictEqual(results[0].state, ExperimentState.NoRun);
 
-			assert.equal(results[1].id, 'experiment2');
-			assert.equal(results[1].enabled, false);
-			assert.equal(results[1].state, ExperimentState.NoRun);
+			assert.strictEqual(results[1].id, 'experiment2');
+			assert.strictEqual(results[1].enabled, false);
+			assert.strictEqual(results[1].state, ExperimentState.NoRun);
 
-			assert.equal(results[2].id, 'experiment3');
-			assert.equal(results[2].enabled, true);
-			assert.equal(results[2].state, ExperimentState.Run);
+			assert.strictEqual(results[2].id, 'experiment3');
+			assert.strictEqual(results[2].enabled, true);
+			assert.strictEqual(results[2].state, ExperimentState.Run);
 
-			assert.equal(results[3].id, 'experiment4');
-			assert.equal(results[3].enabled, true);
-			assert.equal(results[3].state, ExperimentState.Run);
+			assert.strictEqual(results[3].id, 'experiment4');
+			assert.strictEqual(results[3].enabled, true);
+			assert.strictEqual(results[3].state, ExperimentState.Run);
 
-			assert.equal(results[4].id, 'experiment5');
-			assert.equal(results[4].enabled, true);
-			assert.equal(results[4].state, ExperimentState.Run);
+			assert.strictEqual(results[4].id, 'experiment5');
+			assert.strictEqual(results[4].enabled, true);
+			assert.strictEqual(results[4].state, ExperimentState.Run);
 		});
 	});
 
@@ -197,9 +197,9 @@ suite('Experiment Service', () => {
 			testObject.getExperimentById('experiment3'),
 		]);
 
-		assert.equal(actual[0]?.id, 'experiment1');
-		assert.equal(actual[1]?.id, 'experiment2');
-		assert.equal(actual[2], undefined);
+		assert.strictEqual(actual[0]?.id, 'experiment1');
+		assert.strictEqual(actual[1]?.id, 'experiment2');
+		assert.strictEqual(actual[2], undefined);
 	});
 
 	test('Insiders only experiment shouldnt be enabled in stable', () => {
@@ -218,8 +218,8 @@ suite('Experiment Service', () => {
 		instantiationService.stub(IProductService, { quality: 'stable' });
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.NoRun);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.NoRun);
 		});
 	});
 
@@ -244,8 +244,8 @@ suite('Experiment Service', () => {
 		});
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.NoRun);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.NoRun);
 		});
 	});
 
@@ -264,8 +264,8 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.NoRun);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.NoRun);
 		});
 	});
 
@@ -288,8 +288,8 @@ suite('Experiment Service', () => {
 		});
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.Run);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.Run);
 		});
 	});
 
@@ -306,8 +306,8 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.Run);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.Run);
 		});
 	});
 
@@ -326,7 +326,7 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.state, ExperimentState.Run);
+			assert.strictEqual(result.state, ExperimentState.Run);
 		});
 	});
 
@@ -345,7 +345,7 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.state, ExperimentState.NoRun);
+			assert.strictEqual(result.state, ExperimentState.NoRun);
 		});
 	});
 
@@ -373,8 +373,8 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.Evaluating);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.Evaluating);
 		});
 	});
 
@@ -402,8 +402,8 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.Run);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.Run);
 		});
 	});
 
@@ -431,8 +431,8 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.Evaluating);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.Evaluating);
 		});
 	});
 
@@ -503,9 +503,9 @@ suite('Experiment Service', () => {
 		instantiationService.stub(IStorageService, 'store', (key: string, value: string, scope: StorageScope) => {
 			if (key.includes('experimentEventRecord')) {
 				didGetCall = true;
-				assert.equal(key, 'experimentEventRecord-my-event');
+				assert.strictEqual(key, 'experimentEventRecord-my-event');
 				assert.deepEqual(JSON.parse(value).count, [1, 0, 10, 0, 0, 0, 0]);
-				assert.equal(scope, StorageScope.GLOBAL);
+				assert.strictEqual(scope, StorageScope.GLOBAL);
 			}
 		});
 
@@ -543,14 +543,14 @@ suite('Experiment Service', () => {
 		testObject = instantiationService.createInstance(TestExperimentService);
 		testObject.onExperimentEnabled(enabledListener);
 
-		assert.equal((await testObject.getExperimentById('experiment1')).state, ExperimentState.Evaluating);
-		assert.equal((await testObject.getExperimentById('experiment1')).state, ExperimentState.Evaluating);
-		assert.equal(enabledListener.callCount, 0);
+		assert.strictEqual((await testObject.getExperimentById('experiment1')).state, ExperimentState.Evaluating);
+		assert.strictEqual((await testObject.getExperimentById('experiment1')).state, ExperimentState.Evaluating);
+		assert.strictEqual(enabledListener.callCount, 0);
 
 		activationEvent.fire({ event: 'my:event', activation: Promise.resolve() });
 		await timeout(1);
-		assert.equal(enabledListener.callCount, 1);
-		assert.equal((await testObject.getExperimentById('experiment1')).state, ExperimentState.Run);
+		assert.strictEqual(enabledListener.callCount, 1);
+		assert.strictEqual((await testObject.getExperimentById('experiment1')).state, ExperimentState.Run);
 	});
 
 	test('Experiment not matching user setting should be disabled', () => {
@@ -570,8 +570,8 @@ suite('Experiment Service', () => {
 			(key: string) => key === 'neat' ? false : undefined);
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.NoRun);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.NoRun);
 		});
 	});
 
@@ -592,8 +592,8 @@ suite('Experiment Service', () => {
 			(key: string) => key === 'neat' ? true : undefined);
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.Run);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.Run);
 		});
 	});
 
@@ -612,8 +612,8 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.NoRun);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.NoRun);
 		});
 	});
 
@@ -634,8 +634,8 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.Run);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.Run);
 		});
 	});
 
@@ -656,8 +656,8 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.NoRun);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.NoRun);
 		});
 	});
 
@@ -678,8 +678,8 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.NoRun);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.NoRun);
 		});
 	});
 
@@ -705,8 +705,8 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.Complete);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.Complete);
 		});
 	});
 
@@ -732,8 +732,8 @@ suite('Experiment Service', () => {
 		});
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.Run);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.Run);
 		});
 	});
 
@@ -769,10 +769,10 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, true);
-			assert.equal(result.state, ExperimentState.Run);
+			assert.strictEqual(result.enabled, true);
+			assert.strictEqual(result.state, ExperimentState.Run);
 			return testObject.getCuratedExtensionsList(curatedExtensionsKey).then(curatedList => {
-				assert.equal(curatedList, curatedExtensionsList);
+				assert.strictEqual(curatedList, curatedExtensionsList);
 			});
 		});
 	});
@@ -809,11 +809,11 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, false);
-			assert.equal(result.action?.type, 'Prompt');
-			assert.equal(result.state, ExperimentState.NoRun);
+			assert.strictEqual(result.enabled, false);
+			assert.strictEqual(result.action?.type, 'Prompt');
+			assert.strictEqual(result.state, ExperimentState.NoRun);
 			return testObject.getCuratedExtensionsList(curatedExtensionsKey).then(curatedList => {
-				assert.equal(curatedList.length, 0);
+				assert.strictEqual(curatedList.length, 0);
 			});
 		});
 	});
@@ -837,7 +837,7 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.action?.type, 'Prompt');
+			assert.strictEqual(result.action?.type, 'Prompt');
 		});
 	});
 
@@ -906,16 +906,16 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		const disabledExperiment = testObject.getExperimentById('experiment1').then(result => {
-			assert.equal(result.enabled, false);
-			assert.equal(!!storageDataExperiment1, false);
+			assert.strictEqual(result.enabled, false);
+			assert.strictEqual(!!storageDataExperiment1, false);
 		});
 		const deletedExperiment = testObject.getExperimentById('experiment2').then(result => {
-			assert.equal(!!result, false);
-			assert.equal(!!storageDataExperiment2, false);
+			assert.strictEqual(!!result, false);
+			assert.strictEqual(!!storageDataExperiment2, false);
 		});
 		return Promise.all([disabledExperiment, deletedExperiment]).then(() => {
-			assert.equal(storageDataAllExperiments!.length, 1);
-			assert.equal(storageDataAllExperiments![0], 'experiment3');
+			assert.strictEqual(storageDataAllExperiments!.length, 1);
+			assert.strictEqual(storageDataAllExperiments![0], 'experiment3');
 		});
 
 	});
@@ -1001,21 +1001,21 @@ suite('Experiment Service', () => {
 		tests.push(testObject.getExperimentById('experiment4'));
 
 		return Promise.all(tests).then(results => {
-			assert.equal(results[0].id, 'experiment1');
-			assert.equal(results[0].enabled, true);
-			assert.equal(results[0].state, ExperimentState.Run);
+			assert.strictEqual(results[0].id, 'experiment1');
+			assert.strictEqual(results[0].enabled, true);
+			assert.strictEqual(results[0].state, ExperimentState.Run);
 
-			assert.equal(results[1].id, 'experiment2');
-			assert.equal(results[1].enabled, true);
-			assert.equal(results[1].state, ExperimentState.NoRun);
+			assert.strictEqual(results[1].id, 'experiment2');
+			assert.strictEqual(results[1].enabled, true);
+			assert.strictEqual(results[1].state, ExperimentState.NoRun);
 
-			assert.equal(results[2].id, 'experiment3');
-			assert.equal(results[2].enabled, true);
-			assert.equal(results[2].state, ExperimentState.Evaluating);
+			assert.strictEqual(results[2].id, 'experiment3');
+			assert.strictEqual(results[2].enabled, true);
+			assert.strictEqual(results[2].state, ExperimentState.Evaluating);
 
-			assert.equal(results[3].id, 'experiment4');
-			assert.equal(results[3].enabled, true);
-			assert.equal(results[3].state, ExperimentState.Complete);
+			assert.strictEqual(results[3].id, 'experiment4');
+			assert.strictEqual(results[3].enabled, true);
+			assert.strictEqual(results[3].state, ExperimentState.Complete);
 		});
 
 	});
@@ -1075,17 +1075,17 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		const custom = testObject.getExperimentsByType(ExperimentActionType.Custom).then(result => {
-			assert.equal(result.length, 3);
-			assert.equal(result[0].id, 'simple-experiment');
-			assert.equal(result[1].id, 'custom-experiment');
-			assert.equal(result[1].action!.properties, customProperties);
-			assert.equal(result[2].id, 'custom-experiment-no-properties');
-			assert.equal(!!result[2].action!.properties, true);
+			assert.strictEqual(result.length, 3);
+			assert.strictEqual(result[0].id, 'simple-experiment');
+			assert.strictEqual(result[1].id, 'custom-experiment');
+			assert.strictEqual(result[1].action!.properties, customProperties);
+			assert.strictEqual(result[2].id, 'custom-experiment-no-properties');
+			assert.strictEqual(!!result[2].action!.properties, true);
 		});
 		const prompt = testObject.getExperimentsByType(ExperimentActionType.Prompt).then(result => {
-			assert.equal(result.length, 2);
-			assert.equal(result[0].id, 'prompt-with-no-commands');
-			assert.equal(result[1].id, 'prompt-with-commands');
+			assert.strictEqual(result.length, 2);
+			assert.strictEqual(result[0].id, 'prompt-with-no-commands');
+			assert.strictEqual(result[1].id, 'prompt-with-commands');
 		});
 		return Promise.all([custom, prompt]);
 	});
@@ -1144,13 +1144,13 @@ suite('Experiment Service', () => {
 
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentsByType(ExperimentActionType.Custom).then(result => {
-			assert.equal(result.length, 2);
-			assert.equal(result[0].id, 'experiment3');
-			assert.equal(result[0].state, ExperimentState.NoRun);
-			assert.equal(result[1].id, 'experiment4');
-			assert.equal(result[1].state, ExperimentState.Run);
-			assert.equal(storageDataExperiment3.state, ExperimentState.NoRun);
-			assert.equal(storageDataExperiment4.state, ExperimentState.Run);
+			assert.strictEqual(result.length, 2);
+			assert.strictEqual(result[0].id, 'experiment3');
+			assert.strictEqual(result[0].state, ExperimentState.NoRun);
+			assert.strictEqual(result[1].id, 'experiment4');
+			assert.strictEqual(result[1].state, ExperimentState.Run);
+			assert.strictEqual(storageDataExperiment3.state, ExperimentState.NoRun);
+			assert.strictEqual(storageDataExperiment4.state, ExperimentState.Run);
 			return Promise.resolve(null);
 		});
 	});

--- a/src/vs/workbench/contrib/experiments/test/electron-browser/experimentalPrompts.test.ts
+++ b/src/vs/workbench/contrib/experiments/test/electron-browser/experimentalPrompts.test.ts
@@ -96,8 +96,8 @@ suite('Experimental Prompts', () => {
 
 		instantiationService.stub(INotificationService, {
 			prompt: (a: Severity, b: string, c: IPromptChoice[]) => {
-				assert.equal(b, promptText);
-				assert.equal(c.length, 2);
+				assert.strictEqual(b, promptText);
+				assert.strictEqual(c.length, 2);
 				c[1].run();
 				return undefined!;
 			}
@@ -107,7 +107,7 @@ suite('Experimental Prompts', () => {
 		onExperimentEnabledEvent.fire(experiment);
 
 		return Promise.resolve(null).then(result => {
-			assert.equal(storageData['state'], ExperimentState.Complete);
+			assert.strictEqual(storageData['state'], ExperimentState.Complete);
 		});
 
 	});
@@ -146,7 +146,7 @@ suite('Experimental Prompts', () => {
 
 		return Promise.resolve(null).then(result => {
 			assert.deepStrictEqual(stub.args[0], ['greet', 'world']);
-			assert.equal(storageData['state'], ExperimentState.Complete);
+			assert.strictEqual(storageData['state'], ExperimentState.Complete);
 		});
 
 	});
@@ -160,8 +160,8 @@ suite('Experimental Prompts', () => {
 
 		instantiationService.stub(INotificationService, {
 			prompt: (a: Severity, b: string, c: IPromptChoice[], options: IPromptOptions) => {
-				assert.equal(b, promptText);
-				assert.equal(c.length, 2);
+				assert.strictEqual(b, promptText);
+				assert.strictEqual(c.length, 2);
 				options.onCancel!();
 				return undefined!;
 			}
@@ -171,7 +171,7 @@ suite('Experimental Prompts', () => {
 		onExperimentEnabledEvent.fire(experiment);
 
 		return Promise.resolve(null).then(result => {
-			assert.equal(storageData['state'], ExperimentState.Complete);
+			assert.strictEqual(storageData['state'], ExperimentState.Complete);
 		});
 
 	});
@@ -203,14 +203,14 @@ suite('Experimental Prompts', () => {
 			commands: []
 		};
 
-		assert.equal(ExperimentalPrompts.getLocalizedText(simpleTextCase.promptText, 'any-language'), simpleTextCase.promptText);
+		assert.strictEqual(ExperimentalPrompts.getLocalizedText(simpleTextCase.promptText, 'any-language'), simpleTextCase.promptText);
 		const multipleLocalePromptText = multipleLocaleCase.promptText as LocalizedPromptText;
-		assert.equal(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'en'), multipleLocalePromptText['en']);
-		assert.equal(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'de'), multipleLocalePromptText['de']);
-		assert.equal(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'en-au'), multipleLocalePromptText['en-au']);
-		assert.equal(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'en-gb'), multipleLocalePromptText['en']);
-		assert.equal(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'fr'), multipleLocalePromptText['en']);
-		assert.equal(ExperimentalPrompts.getLocalizedText(englishUSTextCase.promptText, 'fr'), (englishUSTextCase.promptText as LocalizedPromptText)['en-us']);
-		assert.equal(!!ExperimentalPrompts.getLocalizedText(noEnglishTextCase.promptText, 'fr'), false);
+		assert.strictEqual(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'en'), multipleLocalePromptText['en']);
+		assert.strictEqual(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'de'), multipleLocalePromptText['de']);
+		assert.strictEqual(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'en-au'), multipleLocalePromptText['en-au']);
+		assert.strictEqual(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'en-gb'), multipleLocalePromptText['en']);
+		assert.strictEqual(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'fr'), multipleLocalePromptText['en']);
+		assert.strictEqual(ExperimentalPrompts.getLocalizedText(englishUSTextCase.promptText, 'fr'), (englishUSTextCase.promptText as LocalizedPromptText)['en-us']);
+		assert.strictEqual(!!ExperimentalPrompts.getLocalizedText(noEnglishTextCase.promptText, 'fr'), false);
 	});
 });

--- a/src/vs/workbench/contrib/markers/test/browser/markersModel.test.ts
+++ b/src/vs/workbench/contrib/markers/test/browser/markersModel.test.ts
@@ -55,7 +55,7 @@ suite('MarkersModel Test', () => {
 
 		const actuals = testObject.resourceMarkers;
 
-		assert.equal(5, actuals.length);
+		assert.strictEqual(5, actuals.length);
 		assert.ok(compareResource(actuals[0], 'a/res2'));
 		assert.ok(compareResource(actuals[1], 'b/res3'));
 		assert.ok(compareResource(actuals[2], 'res4'));
@@ -74,7 +74,7 @@ suite('MarkersModel Test', () => {
 
 		const actuals = testObject.resourceMarkers;
 
-		assert.equal(5, actuals.length);
+		assert.strictEqual(5, actuals.length);
 		assert.ok(compareResource(actuals[0], 'a/res1'));
 		assert.ok(compareResource(actuals[1], 'a/res2'));
 		assert.ok(compareResource(actuals[2], 'b/res3'));
@@ -102,49 +102,49 @@ suite('MarkersModel Test', () => {
 
 		const actuals = testObject.resourceMarkers[0].markers;
 
-		assert.equal(actuals[0].marker, marker6);
-		assert.equal(actuals[1].marker, marker14);
-		assert.equal(actuals[2].marker, marker7);
-		assert.equal(actuals[3].marker, marker9);
-		assert.equal(actuals[4].marker, marker11);
-		assert.equal(actuals[5].marker, marker3);
-		assert.equal(actuals[6].marker, marker15);
-		assert.equal(actuals[7].marker, marker10);
-		assert.equal(actuals[8].marker, marker2);
-		assert.equal(actuals[9].marker, marker13);
-		assert.equal(actuals[10].marker, marker1);
-		assert.equal(actuals[11].marker, marker8);
-		assert.equal(actuals[12].marker, marker5);
-		assert.equal(actuals[13].marker, marker12);
-		assert.equal(actuals[14].marker, marker4);
+		assert.strictEqual(actuals[0].marker, marker6);
+		assert.strictEqual(actuals[1].marker, marker14);
+		assert.strictEqual(actuals[2].marker, marker7);
+		assert.strictEqual(actuals[3].marker, marker9);
+		assert.strictEqual(actuals[4].marker, marker11);
+		assert.strictEqual(actuals[5].marker, marker3);
+		assert.strictEqual(actuals[6].marker, marker15);
+		assert.strictEqual(actuals[7].marker, marker10);
+		assert.strictEqual(actuals[8].marker, marker2);
+		assert.strictEqual(actuals[9].marker, marker13);
+		assert.strictEqual(actuals[10].marker, marker1);
+		assert.strictEqual(actuals[11].marker, marker8);
+		assert.strictEqual(actuals[12].marker, marker5);
+		assert.strictEqual(actuals[13].marker, marker12);
+		assert.strictEqual(actuals[14].marker, marker4);
 	});
 
 	test('toString()', () => {
 		let marker = aMarker('a/res1');
 		marker.code = '1234';
-		assert.equal(JSON.stringify({ ...marker, resource: marker.resource.path }, null, '\t'), new Marker('1', marker).toString());
+		assert.strictEqual(JSON.stringify({ ...marker, resource: marker.resource.path }, null, '\t'), new Marker('1', marker).toString());
 
 		marker = aMarker('a/res2', MarkerSeverity.Warning);
-		assert.equal(JSON.stringify({ ...marker, resource: marker.resource.path }, null, '\t'), new Marker('2', marker).toString());
+		assert.strictEqual(JSON.stringify({ ...marker, resource: marker.resource.path }, null, '\t'), new Marker('2', marker).toString());
 
 		marker = aMarker('a/res2', MarkerSeverity.Info, 1, 2, 1, 8, 'Info', '');
-		assert.equal(JSON.stringify({ ...marker, resource: marker.resource.path }, null, '\t'), new Marker('3', marker).toString());
+		assert.strictEqual(JSON.stringify({ ...marker, resource: marker.resource.path }, null, '\t'), new Marker('3', marker).toString());
 
 		marker = aMarker('a/res2', MarkerSeverity.Hint, 1, 2, 1, 8, 'Ignore message', 'Ignore');
-		assert.equal(JSON.stringify({ ...marker, resource: marker.resource.path }, null, '\t'), new Marker('4', marker).toString());
+		assert.strictEqual(JSON.stringify({ ...marker, resource: marker.resource.path }, null, '\t'), new Marker('4', marker).toString());
 
 		marker = aMarker('a/res2', MarkerSeverity.Warning, 1, 2, 1, 8, 'Warning message', '', [{ startLineNumber: 2, startColumn: 5, endLineNumber: 2, endColumn: 10, message: 'some info', resource: URI.file('a/res3') }]);
 		const testObject = new Marker('5', marker, null!);
 
 		// hack
 		(testObject as any).relatedInformation = marker.relatedInformation!.map(r => new RelatedInformation('6', marker, r));
-		assert.equal(JSON.stringify({ ...marker, resource: marker.resource.path, relatedInformation: marker.relatedInformation!.map(r => ({ ...r, resource: r.resource.path })) }, null, '\t'), testObject.toString());
+		assert.strictEqual(JSON.stringify({ ...marker, resource: marker.resource.path, relatedInformation: marker.relatedInformation!.map(r => ({ ...r, resource: r.resource.path })) }, null, '\t'), testObject.toString());
 	});
 
 	test('Markers for same-document but different fragment', function () {
 		const model = new TestMarkersModel([anErrorWithRange(1)]);
 
-		assert.equal(model.total, 1);
+		assert.strictEqual(model.total, 1);
 
 		const document = URI.parse('foo://test/path/file');
 		const frag1 = URI.parse('foo://test/path/file#1');
@@ -152,7 +152,7 @@ suite('MarkersModel Test', () => {
 
 		model.setResourceMarkers([[document, [{ ...aMarker(), resource: frag1 }, { ...aMarker(), resource: frag2 }]]]);
 
-		assert.equal(model.total, 3);
+		assert.strictEqual(model.total, 3);
 		let a = model.getResourceMarkers(document);
 		let b = model.getResourceMarkers(frag1);
 		let c = model.getResourceMarkers(frag2);
@@ -160,12 +160,12 @@ suite('MarkersModel Test', () => {
 		assert.ok(a === c);
 
 		model.setResourceMarkers([[document, [{ ...aMarker(), resource: frag2 }]]]);
-		assert.equal(model.total, 2);
+		assert.strictEqual(model.total, 2);
 	});
 
 	test('Problems are no sorted correctly #99135', function () {
 		const model = new TestMarkersModel([]);
-		assert.equal(model.total, 0);
+		assert.strictEqual(model.total, 0);
 
 		const document = URI.parse('foo://test/path/file');
 		const frag1 = URI.parse('foo://test/path/file#1');
@@ -180,7 +180,7 @@ suite('MarkersModel Test', () => {
 			{ ...aMarker(), resource: frag2 }
 		]]]);
 
-		assert.equal(model.total, 3);
+		assert.strictEqual(model.total, 3);
 		const markers = model.getResourceMarkers(document)?.markers;
 		assert.deepEqual(markers?.map(m => m.marker.severity), [MarkerSeverity.Error, MarkerSeverity.Error, MarkerSeverity.Warning]);
 		assert.deepEqual(markers?.map(m => m.marker.resource.toString()), [frag1.toString(), frag2.toString(), frag1.toString()]);

--- a/src/vs/workbench/contrib/notebook/browser/contrib/fold/test/notebookFolding.test.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/fold/test/notebookFolding.test.ts
@@ -29,13 +29,13 @@ suite('Notebook Folding', () => {
 				const foldingController = new FoldingModel();
 				foldingController.attachViewModel(viewModel);
 
-				assert.equal(foldingController.regions.findRange(1), 0);
-				assert.equal(foldingController.regions.findRange(2), 0);
-				assert.equal(foldingController.regions.findRange(3), 1);
-				assert.equal(foldingController.regions.findRange(4), 1);
-				assert.equal(foldingController.regions.findRange(5), 1);
-				assert.equal(foldingController.regions.findRange(6), 2);
-				assert.equal(foldingController.regions.findRange(7), 2);
+				assert.strictEqual(foldingController.regions.findRange(1), 0);
+				assert.strictEqual(foldingController.regions.findRange(2), 0);
+				assert.strictEqual(foldingController.regions.findRange(3), 1);
+				assert.strictEqual(foldingController.regions.findRange(4), 1);
+				assert.strictEqual(foldingController.regions.findRange(5), 1);
+				assert.strictEqual(foldingController.regions.findRange(6), 2);
+				assert.strictEqual(foldingController.regions.findRange(7), 2);
 			}
 		);
 	});
@@ -56,18 +56,18 @@ suite('Notebook Folding', () => {
 				const foldingController = new FoldingModel();
 				foldingController.attachViewModel(viewModel);
 
-				assert.equal(foldingController.regions.findRange(1), 0);
-				assert.equal(foldingController.regions.findRange(2), 0);
-				assert.equal(foldingController.regions.getEndLineNumber(0), 2);
+				assert.strictEqual(foldingController.regions.findRange(1), 0);
+				assert.strictEqual(foldingController.regions.findRange(2), 0);
+				assert.strictEqual(foldingController.regions.getEndLineNumber(0), 2);
 
-				assert.equal(foldingController.regions.findRange(3), 1);
-				assert.equal(foldingController.regions.findRange(4), 1);
-				assert.equal(foldingController.regions.findRange(5), 1);
-				assert.equal(foldingController.regions.getEndLineNumber(1), 7);
+				assert.strictEqual(foldingController.regions.findRange(3), 1);
+				assert.strictEqual(foldingController.regions.findRange(4), 1);
+				assert.strictEqual(foldingController.regions.findRange(5), 1);
+				assert.strictEqual(foldingController.regions.getEndLineNumber(1), 7);
 
-				assert.equal(foldingController.regions.findRange(6), 2);
-				assert.equal(foldingController.regions.findRange(7), 2);
-				assert.equal(foldingController.regions.getEndLineNumber(2), 7);
+				assert.strictEqual(foldingController.regions.findRange(6), 2);
+				assert.strictEqual(foldingController.regions.findRange(7), 2);
+				assert.strictEqual(foldingController.regions.getEndLineNumber(2), 7);
 			}
 		);
 	});
@@ -322,13 +322,13 @@ suite('Notebook Folding', () => {
 					{ start: 3, end: 6 }
 				]);
 
-				assert.equal(viewModel.getNextVisibleCellIndex(1), 2);
-				assert.equal(viewModel.getNextVisibleCellIndex(2), 7);
-				assert.equal(viewModel.getNextVisibleCellIndex(3), 7);
-				assert.equal(viewModel.getNextVisibleCellIndex(4), 7);
-				assert.equal(viewModel.getNextVisibleCellIndex(5), 7);
-				assert.equal(viewModel.getNextVisibleCellIndex(6), 7);
-				assert.equal(viewModel.getNextVisibleCellIndex(7), 8);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(1), 2);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(2), 7);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(3), 7);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(4), 7);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(5), 7);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(6), 7);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(7), 8);
 			}
 		);
 
@@ -367,13 +367,13 @@ suite('Notebook Folding', () => {
 				// folding ranges
 				// [5, 6]
 				// [10, 11]
-				assert.equal(viewModel.getNextVisibleCellIndex(4), 5);
-				assert.equal(viewModel.getNextVisibleCellIndex(5), 7);
-				assert.equal(viewModel.getNextVisibleCellIndex(6), 7);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(4), 5);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(5), 7);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(6), 7);
 
-				assert.equal(viewModel.getNextVisibleCellIndex(9), 10);
-				assert.equal(viewModel.getNextVisibleCellIndex(10), 12);
-				assert.equal(viewModel.getNextVisibleCellIndex(11), 12);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(9), 10);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(10), 12);
+				assert.strictEqual(viewModel.getNextVisibleCellIndex(11), 12);
 			}
 		);
 	});

--- a/src/vs/workbench/contrib/notebook/test/notebookCommon.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/notebookCommon.test.ts
@@ -278,8 +278,8 @@ suite('CellUri', function () {
 		const data = CellUri.generate(nb, id);
 		const actual = CellUri.parse(data);
 		assert.ok(Boolean(actual));
-		assert.equal(actual?.handle, id);
-		assert.equal(actual?.notebook.toString(), nb.toString());
+		assert.strictEqual(actual?.handle, id);
+		assert.strictEqual(actual?.notebook.toString(), nb.toString());
 	});
 
 	test('parse, generate (foo-scheme)', function () {
@@ -290,8 +290,8 @@ suite('CellUri', function () {
 		const data = CellUri.generate(nb, id);
 		const actual = CellUri.parse(data);
 		assert.ok(Boolean(actual));
-		assert.equal(actual?.handle, id);
-		assert.equal(actual?.notebook.toString(), nb.toString());
+		assert.strictEqual(actual?.handle, id);
+		assert.strictEqual(actual?.notebook.toString(), nb.toString());
 	});
 });
 

--- a/src/vs/workbench/contrib/notebook/test/notebookTextModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/notebookTextModel.test.ts
@@ -30,10 +30,10 @@ suite('NotebookTextModel', () => {
 					{ editType: CellEditType.Replace, index: 3, count: 0, cells: [new TestCell(viewModel.viewType, 6, 'var f = 6;', 'javascript', CellKind.Code, [], textModelService)] },
 				], true, undefined, () => undefined, undefined);
 
-				assert.equal(textModel.cells.length, 6);
+				assert.strictEqual(textModel.cells.length, 6);
 
-				assert.equal(textModel.cells[1].getValue(), 'var e = 5;');
-				assert.equal(textModel.cells[4].getValue(), 'var f = 6;');
+				assert.strictEqual(textModel.cells[1].getValue(), 'var e = 5;');
+				assert.strictEqual(textModel.cells[4].getValue(), 'var f = 6;');
 			}
 		);
 	});
@@ -54,10 +54,10 @@ suite('NotebookTextModel', () => {
 					{ editType: CellEditType.Replace, index: 1, count: 0, cells: [new TestCell(viewModel.viewType, 6, 'var f = 6;', 'javascript', CellKind.Code, [], textModelService)] },
 				], true, undefined, () => undefined, undefined);
 
-				assert.equal(textModel.cells.length, 6);
+				assert.strictEqual(textModel.cells.length, 6);
 
-				assert.equal(textModel.cells[1].getValue(), 'var e = 5;');
-				assert.equal(textModel.cells[2].getValue(), 'var f = 6;');
+				assert.strictEqual(textModel.cells[1].getValue(), 'var e = 5;');
+				assert.strictEqual(textModel.cells[2].getValue(), 'var f = 6;');
 			}
 		);
 	});
@@ -77,8 +77,8 @@ suite('NotebookTextModel', () => {
 					{ editType: CellEditType.Replace, index: 3, count: 1, cells: [] },
 				], true, undefined, () => undefined, undefined);
 
-				assert.equal(textModel.cells[0].getValue(), 'var a = 1;');
-				assert.equal(textModel.cells[1].getValue(), 'var c = 3;');
+				assert.strictEqual(textModel.cells[0].getValue(), 'var a = 1;');
+				assert.strictEqual(textModel.cells[1].getValue(), 'var c = 3;');
 			}
 		);
 	});
@@ -99,10 +99,10 @@ suite('NotebookTextModel', () => {
 					{ editType: CellEditType.Replace, index: 3, count: 0, cells: [new TestCell(viewModel.viewType, 5, 'var e = 5;', 'javascript', CellKind.Code, [], textModelService)] },
 				], true, undefined, () => undefined, undefined);
 
-				assert.equal(textModel.cells.length, 4);
+				assert.strictEqual(textModel.cells.length, 4);
 
-				assert.equal(textModel.cells[0].getValue(), 'var a = 1;');
-				assert.equal(textModel.cells[2].getValue(), 'var e = 5;');
+				assert.strictEqual(textModel.cells[0].getValue(), 'var a = 1;');
+				assert.strictEqual(textModel.cells[2].getValue(), 'var e = 5;');
 			}
 		);
 	});
@@ -123,10 +123,10 @@ suite('NotebookTextModel', () => {
 					{ editType: CellEditType.Replace, index: 1, count: 0, cells: [new TestCell(viewModel.viewType, 5, 'var e = 5;', 'javascript', CellKind.Code, [], textModelService)] },
 				], true, undefined, () => undefined, undefined);
 
-				assert.equal(textModel.cells.length, 4);
-				assert.equal(textModel.cells[0].getValue(), 'var a = 1;');
-				assert.equal(textModel.cells[1].getValue(), 'var e = 5;');
-				assert.equal(textModel.cells[2].getValue(), 'var c = 3;');
+				assert.strictEqual(textModel.cells.length, 4);
+				assert.strictEqual(textModel.cells[0].getValue(), 'var a = 1;');
+				assert.strictEqual(textModel.cells[1].getValue(), 'var e = 5;');
+				assert.strictEqual(textModel.cells[2].getValue(), 'var c = 3;');
 			}
 		);
 	});
@@ -146,10 +146,10 @@ suite('NotebookTextModel', () => {
 					{ editType: CellEditType.Replace, index: 1, count: 1, cells: [new TestCell(viewModel.viewType, 5, 'var e = 5;', 'javascript', CellKind.Code, [], textModelService)] },
 				], true, undefined, () => undefined, undefined);
 
-				assert.equal(textModel.cells.length, 4);
-				assert.equal(textModel.cells[0].getValue(), 'var a = 1;');
-				assert.equal(textModel.cells[1].getValue(), 'var e = 5;');
-				assert.equal(textModel.cells[2].getValue(), 'var c = 3;');
+				assert.strictEqual(textModel.cells.length, 4);
+				assert.strictEqual(textModel.cells[0].getValue(), 'var a = 1;');
+				assert.strictEqual(textModel.cells[1].getValue(), 'var e = 5;');
+				assert.strictEqual(textModel.cells[2].getValue(), 'var c = 3;');
 			}
 		);
 	});
@@ -265,9 +265,9 @@ suite('NotebookTextModel', () => {
 					metadata: { editable: false },
 				}], true, undefined, () => undefined, undefined);
 
-				assert.equal(textModel.cells.length, 1);
-				assert.equal(textModel.cells[0].metadata?.editable, false);
-				assert.equal(textModel.cells[0].metadata?.executionOrder, undefined);
+				assert.strictEqual(textModel.cells.length, 1);
+				assert.strictEqual(textModel.cells[0].metadata?.editable, false);
+				assert.strictEqual(textModel.cells[0].metadata?.executionOrder, undefined);
 			}
 		);
 	});
@@ -321,15 +321,15 @@ suite('NotebookTextModel', () => {
 					{ editType: CellEditType.Replace, index: 1, count: 0, cells: [new TestCell(viewModel.viewType, 5, 'var e = 5;', 'javascript', CellKind.Code, [], textModelService)] },
 				], true, undefined, () => ({ kind: SelectionStateType.Index, focus: { start: 0, end: 1 }, selections: [{ start: 0, end: 1 }] }), undefined);
 
-				assert.equal(textModel.cells.length, 4);
-				assert.equal(textModel.cells[0].getValue(), 'var a = 1;');
-				assert.equal(textModel.cells[1].getValue(), 'var e = 5;');
-				assert.equal(textModel.cells[2].getValue(), 'var c = 3;');
+				assert.strictEqual(textModel.cells.length, 4);
+				assert.strictEqual(textModel.cells[0].getValue(), 'var a = 1;');
+				assert.strictEqual(textModel.cells[1].getValue(), 'var e = 5;');
+				assert.strictEqual(textModel.cells[2].getValue(), 'var c = 3;');
 
 				assert.notEqual(changeEvent, undefined);
-				assert.equal(changeEvent!.rawEvents.length, 2);
+				assert.strictEqual(changeEvent!.rawEvents.length, 2);
 				assert.deepEqual(changeEvent!.endSelectionState?.selections, [{ start: 0, end: 1 }]);
-				assert.equal(textModel.versionId, version + 1);
+				assert.strictEqual(textModel.versionId, version + 1);
 				eventListener.dispose();
 			}
 		);
@@ -361,9 +361,9 @@ suite('NotebookTextModel', () => {
 				], true, undefined, () => ({ kind: SelectionStateType.Index, focus: { start: 0, end: 1 }, selections: [{ start: 0, end: 1 }] }), undefined);
 
 				assert.notEqual(changeEvent, undefined);
-				assert.equal(changeEvent!.rawEvents.length, 2);
+				assert.strictEqual(changeEvent!.rawEvents.length, 2);
 				assert.deepEqual(changeEvent!.endSelectionState?.selections, [{ start: 0, end: 1 }]);
-				assert.equal(textModel.versionId, version + 1);
+				assert.strictEqual(textModel.versionId, version + 1);
 				eventListener.dispose();
 			}
 		);

--- a/src/vs/workbench/contrib/notebook/test/notebookViewModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/notebookViewModel.test.ts
@@ -27,7 +27,7 @@ suite('NotebookViewModel', () => {
 		const model = new NotebookEditorTestModel(notebook);
 		const eventDispatcher = new NotebookEventDispatcher();
 		const viewModel = new NotebookViewModel('notebook', model.notebook, eventDispatcher, null, instantiationService, bulkEditService, undoRedoService);
-		assert.equal(viewModel.viewType, 'notebook');
+		assert.strictEqual(viewModel.viewType, 'notebook');
 	});
 
 	test('insert/delete', async function () {
@@ -38,18 +38,18 @@ suite('NotebookViewModel', () => {
 			],
 			(editor) => {
 				const viewModel = editor.viewModel;
-				assert.equal(viewModel.viewCells[0].metadata?.editable, true);
-				assert.equal(viewModel.viewCells[1].metadata?.editable, false);
+				assert.strictEqual(viewModel.viewCells[0].metadata?.editable, true);
+				assert.strictEqual(viewModel.viewCells[1].metadata?.editable, false);
 
 				const cell = viewModel.createCell(1, 'var c = 3', 'javascript', CellKind.Code, {}, [], true, true, null, []);
-				assert.equal(viewModel.viewCells.length, 3);
-				assert.equal(viewModel.notebookDocument.cells.length, 3);
-				assert.equal(viewModel.getCellIndex(cell), 1);
+				assert.strictEqual(viewModel.viewCells.length, 3);
+				assert.strictEqual(viewModel.notebookDocument.cells.length, 3);
+				assert.strictEqual(viewModel.getCellIndex(cell), 1);
 
 				viewModel.deleteCell(1, true);
-				assert.equal(viewModel.viewCells.length, 2);
-				assert.equal(viewModel.notebookDocument.cells.length, 2);
-				assert.equal(viewModel.getCellIndex(cell), -1);
+				assert.strictEqual(viewModel.viewCells.length, 2);
+				assert.strictEqual(viewModel.notebookDocument.cells.length, 2);
+				assert.strictEqual(viewModel.getCellIndex(cell), -1);
 			}
 		);
 	});
@@ -65,20 +65,20 @@ suite('NotebookViewModel', () => {
 				const viewModel = editor.viewModel;
 				viewModel.moveCellToIdx(0, 1, 0, true);
 				// no-op
-				assert.equal(viewModel.viewCells[0].getText(), '//a');
-				assert.equal(viewModel.viewCells[1].getText(), '//b');
+				assert.strictEqual(viewModel.viewCells[0].getText(), '//a');
+				assert.strictEqual(viewModel.viewCells[1].getText(), '//b');
 
 				viewModel.moveCellToIdx(0, 1, 1, true);
 				// b, a, c
-				assert.equal(viewModel.viewCells[0].getText(), '//b');
-				assert.equal(viewModel.viewCells[1].getText(), '//a');
-				assert.equal(viewModel.viewCells[2].getText(), '//c');
+				assert.strictEqual(viewModel.viewCells[0].getText(), '//b');
+				assert.strictEqual(viewModel.viewCells[1].getText(), '//a');
+				assert.strictEqual(viewModel.viewCells[2].getText(), '//c');
 
 				viewModel.moveCellToIdx(0, 1, 2, true);
 				// a, c, b
-				assert.equal(viewModel.viewCells[0].getText(), '//a');
-				assert.equal(viewModel.viewCells[1].getText(), '//c');
-				assert.equal(viewModel.viewCells[2].getText(), '//b');
+				assert.strictEqual(viewModel.viewCells[0].getText(), '//a');
+				assert.strictEqual(viewModel.viewCells[1].getText(), '//c');
+				assert.strictEqual(viewModel.viewCells[2].getText(), '//b');
 			}
 		);
 	});
@@ -94,14 +94,14 @@ suite('NotebookViewModel', () => {
 				const viewModel = editor.viewModel;
 				viewModel.moveCellToIdx(1, 1, 0, true);
 				// b, a, c
-				assert.equal(viewModel.viewCells[0].getText(), '//b');
-				assert.equal(viewModel.viewCells[1].getText(), '//a');
+				assert.strictEqual(viewModel.viewCells[0].getText(), '//b');
+				assert.strictEqual(viewModel.viewCells[1].getText(), '//a');
 
 				viewModel.moveCellToIdx(2, 1, 0, true);
 				// c, b, a
-				assert.equal(viewModel.viewCells[0].getText(), '//c');
-				assert.equal(viewModel.viewCells[1].getText(), '//b');
-				assert.equal(viewModel.viewCells[2].getText(), '//a');
+				assert.strictEqual(viewModel.viewCells[0].getText(), '//c');
+				assert.strictEqual(viewModel.viewCells[1].getText(), '//b');
+				assert.strictEqual(viewModel.viewCells[2].getText(), '//a');
 			}
 		);
 	});
@@ -126,9 +126,9 @@ suite('NotebookViewModel', () => {
 				const secondInsertIndex = viewModel.getCellIndex(lastViewCell) + 1;
 				const cell2 = viewModel.createCell(secondInsertIndex, 'var d = 4;', 'javascript', CellKind.Code, {}, [], true);
 
-				assert.equal(viewModel.viewCells.length, 3);
-				assert.equal(viewModel.notebookDocument.cells.length, 3);
-				assert.equal(viewModel.getCellIndex(cell2), 2);
+				assert.strictEqual(viewModel.viewCells.length, 3);
+				assert.strictEqual(viewModel.notebookDocument.cells.length, 3);
+				assert.strictEqual(viewModel.getCellIndex(cell2), 2);
 			}
 		);
 	});

--- a/src/vs/workbench/contrib/preferences/test/browser/keybindingsEditorContribution.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/keybindingsEditorContribution.test.ts
@@ -11,7 +11,7 @@ suite('KeybindingsEditorContribution', () => {
 	function assertUserSettingsFuzzyEquals(a: string, b: string, expected: boolean): void {
 		const actual = KeybindingEditorDecorationsRenderer._userSettingsFuzzyEquals(a, b);
 		const message = expected ? `${a} == ${b}` : `${a} != ${b}`;
-		assert.equal(actual, expected, 'fuzzy: ' + message);
+		assert.strictEqual(actual, expected, 'fuzzy: ' + message);
 	}
 
 	function assertEqual(a: string, b: string): void {

--- a/src/vs/workbench/contrib/search/test/browser/queryBuilder.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/queryBuilder.test.ts
@@ -978,8 +978,8 @@ suite('QueryBuilder', () => {
 				},
 			);
 
-			assert.equal(query.folderQueries.length, 1);
-			assert.equal(query.cacheKey, cacheKey);
+			assert.strictEqual(query.folderQueries.length, 1);
+			assert.strictEqual(query.cacheKey, cacheKey);
 			assert(query.sortByScore);
 		});
 	});
@@ -1034,12 +1034,12 @@ export function assertEqualSearchPathResults(actual: ISearchPathsInfo, expected:
 	cleanUndefinedQueryValues(actual);
 	assert.deepEqual(actual.pattern, expected.pattern, message);
 
-	assert.equal(actual.searchPaths && actual.searchPaths.length, expected.searchPaths && expected.searchPaths.length);
+	assert.strictEqual(actual.searchPaths && actual.searchPaths.length, expected.searchPaths && expected.searchPaths.length);
 	if (actual.searchPaths) {
 		actual.searchPaths.forEach((searchPath, i) => {
 			const expectedSearchPath = expected.searchPaths![i];
 			assert.deepEqual(searchPath.pattern, expectedSearchPath.pattern);
-			assert.equal(searchPath.searchPath.toString(), expectedSearchPath.searchPath.toString());
+			assert.strictEqual(searchPath.searchPath.toString(), expectedSearchPath.searchPath.toString());
 		});
 	}
 }

--- a/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
@@ -44,7 +44,7 @@ suite('Search Actions', () => {
 		const testObject: ReplaceAction = instantiationService.createInstance(ReplaceAction, tree, target, null);
 
 		const actual = testObject.getElementToFocusAfterRemoved(tree, target);
-		assert.equal(data[4], actual);
+		assert.strictEqual(data[4], actual);
 	});
 
 	test('get next element to focus after removing a match when it does not have next sibling match', function () {
@@ -56,7 +56,7 @@ suite('Search Actions', () => {
 		const testObject: ReplaceAction = instantiationService.createInstance(ReplaceAction, tree, target, null);
 
 		const actual = testObject.getElementToFocusAfterRemoved(tree, target);
-		assert.equal(data[4], actual);
+		assert.strictEqual(data[4], actual);
 	});
 
 	test('get next element to focus after removing a match when it does not have next sibling match and previous match is file match', function () {
@@ -68,7 +68,7 @@ suite('Search Actions', () => {
 		const testObject: ReplaceAction = instantiationService.createInstance(ReplaceAction, tree, target, null);
 
 		const actual = testObject.getElementToFocusAfterRemoved(tree, target);
-		assert.equal(data[2], actual);
+		assert.strictEqual(data[2], actual);
 	});
 
 	test('get next element to focus after removing a match when it is the only match', function () {
@@ -79,7 +79,7 @@ suite('Search Actions', () => {
 		const testObject: ReplaceAction = instantiationService.createInstance(ReplaceAction, tree, target, null);
 
 		const actual = testObject.getElementToFocusAfterRemoved(tree, target);
-		assert.equal(undefined, actual);
+		assert.strictEqual(undefined, actual);
 	});
 
 	test('get next element to focus after removing a file match when it has next sibling', function () {
@@ -92,7 +92,7 @@ suite('Search Actions', () => {
 		const testObject: ReplaceAction = instantiationService.createInstance(ReplaceAction, tree, target, null);
 
 		const actual = testObject.getElementToFocusAfterRemoved(tree, target);
-		assert.equal(data[4], actual);
+		assert.strictEqual(data[4], actual);
 	});
 
 	test('get next element to focus after removing a file match when it has no next sibling', function () {
@@ -105,7 +105,7 @@ suite('Search Actions', () => {
 		const testObject: ReplaceAction = instantiationService.createInstance(ReplaceAction, tree, target, null);
 
 		const actual = testObject.getElementToFocusAfterRemoved(tree, target);
-		assert.equal(data[3], actual);
+		assert.strictEqual(data[3], actual);
 	});
 
 	test('get next element to focus after removing a file match when it is only match', function () {
@@ -116,7 +116,7 @@ suite('Search Actions', () => {
 		const testObject: ReplaceAction = instantiationService.createInstance(ReplaceAction, tree, target, null);
 
 		const actual = testObject.getElementToFocusAfterRemoved(tree, target);
-		assert.equal(undefined, actual);
+		assert.strictEqual(undefined, actual);
 	});
 
 	function aFileMatch(): FileMatch {

--- a/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
@@ -66,8 +66,8 @@ suite('Search - Viewlet', () => {
 		const fileMatch = result.matches()[0];
 		const lineMatch = fileMatch.matches()[0];
 
-		assert.equal(fileMatch.id(), 'file:///c%3A/foo');
-		assert.equal(lineMatch.id(), 'file:///c%3A/foo>[2,1 -> 2,2]b');
+		assert.strictEqual(fileMatch.id(), 'file:///c%3A/foo');
+		assert.strictEqual(lineMatch.id(), 'file:///c%3A/foo>[2,1 -> 2,2]b');
 	});
 
 	test('Comparer', () => {

--- a/src/vs/workbench/contrib/search/test/common/extractRange.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/extractRange.test.ts
@@ -18,19 +18,19 @@ suite('extractRangeFromFilter', () => {
 				const base = '/some/path/file.txt';
 
 				let res = extractRangeFromFilter(`${base}${lineSep}20`);
-				assert.equal(res?.filter, base);
-				assert.equal(res?.range.startLineNumber, 20);
-				assert.equal(res?.range.startColumn, 1);
+				assert.strictEqual(res?.filter, base);
+				assert.strictEqual(res?.range.startLineNumber, 20);
+				assert.strictEqual(res?.range.startColumn, 1);
 
 				res = extractRangeFromFilter(`${base}${lineSep}20${colSep}`);
-				assert.equal(res?.filter, base);
-				assert.equal(res?.range.startLineNumber, 20);
-				assert.equal(res?.range.startColumn, 1);
+				assert.strictEqual(res?.filter, base);
+				assert.strictEqual(res?.range.startLineNumber, 20);
+				assert.strictEqual(res?.range.startColumn, 1);
 
 				res = extractRangeFromFilter(`${base}${lineSep}20${colSep}3`);
-				assert.equal(res?.filter, base);
-				assert.equal(res?.range.startLineNumber, 20);
-				assert.equal(res?.range.startColumn, 3);
+				assert.strictEqual(res?.filter, base);
+				assert.strictEqual(res?.range.startLineNumber, 20);
+				assert.strictEqual(res?.range.startColumn, 3);
 			}
 		}
 	});
@@ -38,9 +38,9 @@ suite('extractRangeFromFilter', () => {
 	test('allow space after path', async function () {
 		const res = extractRangeFromFilter('/some/path/file.txt (19,20)');
 
-		assert.equal(res?.filter, '/some/path/file.txt');
-		assert.equal(res?.range.startLineNumber, 19);
-		assert.equal(res?.range.startColumn, 20);
+		assert.strictEqual(res?.filter, '/some/path/file.txt');
+		assert.strictEqual(res?.range.startLineNumber, 19);
+		assert.strictEqual(res?.range.startColumn, 20);
 	});
 
 	test('unless', async function () {

--- a/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
@@ -140,19 +140,19 @@ suite('SearchModel', () => {
 
 		const actual = testObject.searchResult.matches();
 
-		assert.equal(2, actual.length);
-		assert.equal('file://c:/1', actual[0].resource.toString());
+		assert.strictEqual(2, actual.length);
+		assert.strictEqual('file://c:/1', actual[0].resource.toString());
 
 		let actuaMatches = actual[0].matches();
-		assert.equal(2, actuaMatches.length);
-		assert.equal('preview 1', actuaMatches[0].text());
+		assert.strictEqual(2, actuaMatches.length);
+		assert.strictEqual('preview 1', actuaMatches[0].text());
 		assert.ok(new Range(2, 2, 2, 5).equalsRange(actuaMatches[0].range()));
-		assert.equal('preview 1', actuaMatches[1].text());
+		assert.strictEqual('preview 1', actuaMatches[1].text());
 		assert.ok(new Range(2, 5, 2, 12).equalsRange(actuaMatches[1].range()));
 
 		actuaMatches = actual[1].matches();
-		assert.equal(1, actuaMatches.length);
-		assert.equal('preview 2', actuaMatches[0].text());
+		assert.strictEqual(1, actuaMatches.length);
+		assert.strictEqual('preview 2', actuaMatches[0].text());
 		assert.ok(new Range(2, 1, 2, 2).equalsRange(actuaMatches[0].range()));
 	});
 
@@ -213,7 +213,7 @@ suite('SearchModel', () => {
 				// are fired at some point.
 				assert.ok(target1.calledWith('searchResultsFirstRender'));
 				assert.ok(target1.calledWith('searchResultsFinished'));
-				// assert.equal(1, target2.callCount);
+				// assert.strictEqual(1, target2.callCount);
 			});
 		});
 	});
@@ -302,24 +302,24 @@ suite('SearchModel', () => {
 		await testObject.search({ contentPattern: { pattern: 're' }, type: 1, folderQueries });
 		testObject.replaceString = 'hello';
 		let match = testObject.searchResult.matches()[0].matches()[0];
-		assert.equal('hello', match.replaceString);
+		assert.strictEqual('hello', match.replaceString);
 
 		await testObject.search({ contentPattern: { pattern: 're', isRegExp: true }, type: 1, folderQueries });
 		match = testObject.searchResult.matches()[0].matches()[0];
-		assert.equal('hello', match.replaceString);
+		assert.strictEqual('hello', match.replaceString);
 
 		await testObject.search({ contentPattern: { pattern: 're(?:vi)', isRegExp: true }, type: 1, folderQueries });
 		match = testObject.searchResult.matches()[0].matches()[0];
-		assert.equal('hello', match.replaceString);
+		assert.strictEqual('hello', match.replaceString);
 
 		await testObject.search({ contentPattern: { pattern: 'r(e)(?:vi)', isRegExp: true }, type: 1, folderQueries });
 		match = testObject.searchResult.matches()[0].matches()[0];
-		assert.equal('hello', match.replaceString);
+		assert.strictEqual('hello', match.replaceString);
 
 		await testObject.search({ contentPattern: { pattern: 'r(e)(?:vi)', isRegExp: true }, type: 1, folderQueries });
 		testObject.replaceString = 'hello$1';
 		match = testObject.searchResult.matches()[0].matches()[0];
-		assert.equal('helloe', match.replaceString);
+		assert.strictEqual('helloe', match.replaceString);
 	});
 
 	function aRawMatch(resource: string, ...results: ITextSearchMatch[]): IFileMatch {

--- a/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
@@ -41,34 +41,34 @@ suite('SearchResult', () => {
 	test('Line Match', function () {
 		const fileMatch = aFileMatch('folder/file.txt', null!);
 		const lineMatch = new Match(fileMatch, ['0 foo bar'], new OneLineRange(0, 2, 5), new OneLineRange(1, 0, 5));
-		assert.equal(lineMatch.text(), '0 foo bar');
-		assert.equal(lineMatch.range().startLineNumber, 2);
-		assert.equal(lineMatch.range().endLineNumber, 2);
-		assert.equal(lineMatch.range().startColumn, 1);
-		assert.equal(lineMatch.range().endColumn, 6);
-		assert.equal(lineMatch.id(), 'file:///folder/file.txt>[2,1 -> 2,6]foo');
+		assert.strictEqual(lineMatch.text(), '0 foo bar');
+		assert.strictEqual(lineMatch.range().startLineNumber, 2);
+		assert.strictEqual(lineMatch.range().endLineNumber, 2);
+		assert.strictEqual(lineMatch.range().startColumn, 1);
+		assert.strictEqual(lineMatch.range().endColumn, 6);
+		assert.strictEqual(lineMatch.id(), 'file:///folder/file.txt>[2,1 -> 2,6]foo');
 
-		assert.equal(lineMatch.fullMatchText(), 'foo');
-		assert.equal(lineMatch.fullMatchText(true), '0 foo bar');
+		assert.strictEqual(lineMatch.fullMatchText(), 'foo');
+		assert.strictEqual(lineMatch.fullMatchText(true), '0 foo bar');
 	});
 
 	test('Line Match - Remove', function () {
 		const fileMatch = aFileMatch('folder/file.txt', aSearchResult(), new TextSearchMatch('foo bar', new OneLineRange(1, 0, 3)));
 		const lineMatch = fileMatch.matches()[0];
 		fileMatch.remove(lineMatch);
-		assert.equal(fileMatch.matches().length, 0);
+		assert.strictEqual(fileMatch.matches().length, 0);
 	});
 
 	test('File Match', function () {
 		let fileMatch = aFileMatch('folder/file.txt');
-		assert.equal(fileMatch.matches(), 0);
-		assert.equal(fileMatch.resource.toString(), 'file:///folder/file.txt');
-		assert.equal(fileMatch.name(), 'file.txt');
+		assert.strictEqual(fileMatch.matches().length, 0);
+		assert.strictEqual(fileMatch.resource.toString(), 'file:///folder/file.txt');
+		assert.strictEqual(fileMatch.name(), 'file.txt');
 
 		fileMatch = aFileMatch('file.txt');
-		assert.equal(fileMatch.matches(), 0);
-		assert.equal(fileMatch.resource.toString(), 'file:///file.txt');
-		assert.equal(fileMatch.name(), 'file.txt');
+		assert.strictEqual(fileMatch.matches().length, 0);
+		assert.strictEqual(fileMatch.resource.toString(), 'file:///file.txt');
+		assert.strictEqual(fileMatch.name(), 'file.txt');
 	});
 
 	test('File Match: Select an existing match', function () {
@@ -80,7 +80,7 @@ suite('SearchResult', () => {
 
 		testObject.setSelectedMatch(testObject.matches()[0]);
 
-		assert.equal(testObject.matches()[0], testObject.getSelectedMatch());
+		assert.strictEqual(testObject.matches()[0], testObject.getSelectedMatch());
 	});
 
 	test('File Match: Select non existing match', function () {
@@ -94,7 +94,7 @@ suite('SearchResult', () => {
 
 		testObject.setSelectedMatch(target);
 
-		assert.equal(undefined, testObject.getSelectedMatch());
+		assert.strictEqual(testObject.getSelectedMatch(), null);
 	});
 
 	test('File Match: isSelected return true for selected match', function () {
@@ -127,7 +127,7 @@ suite('SearchResult', () => {
 		testObject.setSelectedMatch(testObject.matches()[0]);
 		testObject.setSelectedMatch(null);
 
-		assert.equal(null, testObject.getSelectedMatch());
+		assert.strictEqual(null, testObject.getSelectedMatch());
 	});
 
 	test('File Match: unselect when not selected', function () {
@@ -138,7 +138,7 @@ suite('SearchResult', () => {
 			new TextSearchMatch('bar', new OneLineRange(1, 5, 3)));
 		testObject.setSelectedMatch(null);
 
-		assert.equal(null, testObject.getSelectedMatch());
+		assert.strictEqual(null, testObject.getSelectedMatch());
 	});
 
 	test('Alle Drei Zusammen', function () {
@@ -159,22 +159,22 @@ suite('SearchResult', () => {
 
 		testObject.add(target);
 
-		assert.equal(3, testObject.count());
+		assert.strictEqual(3, testObject.count());
 
 		const actual = testObject.matches();
-		assert.equal(1, actual.length);
-		assert.equal('file://c:/', actual[0].resource.toString());
+		assert.strictEqual(1, actual.length);
+		assert.strictEqual('file://c:/', actual[0].resource.toString());
 
 		const actuaMatches = actual[0].matches();
-		assert.equal(3, actuaMatches.length);
+		assert.strictEqual(3, actuaMatches.length);
 
-		assert.equal('preview 1', actuaMatches[0].text());
+		assert.strictEqual('preview 1', actuaMatches[0].text());
 		assert.ok(new Range(2, 2, 2, 5).equalsRange(actuaMatches[0].range()));
 
-		assert.equal('preview 1', actuaMatches[1].text());
+		assert.strictEqual('preview 1', actuaMatches[1].text());
 		assert.ok(new Range(2, 5, 2, 12).equalsRange(actuaMatches[1].range()));
 
-		assert.equal('preview 2', actuaMatches[2].text());
+		assert.strictEqual('preview 2', actuaMatches[2].text());
 		assert.ok(new Range(2, 1, 2, 2).equalsRange(actuaMatches[2].range()));
 	});
 
@@ -189,22 +189,22 @@ suite('SearchResult', () => {
 
 		testObject.add(target);
 
-		assert.equal(3, testObject.count());
+		assert.strictEqual(3, testObject.count());
 
 		const actual = testObject.matches();
-		assert.equal(2, actual.length);
-		assert.equal('file://c:/1', actual[0].resource.toString());
+		assert.strictEqual(2, actual.length);
+		assert.strictEqual('file://c:/1', actual[0].resource.toString());
 
 		let actuaMatches = actual[0].matches();
-		assert.equal(2, actuaMatches.length);
-		assert.equal('preview 1', actuaMatches[0].text());
+		assert.strictEqual(2, actuaMatches.length);
+		assert.strictEqual('preview 1', actuaMatches[0].text());
 		assert.ok(new Range(2, 2, 2, 5).equalsRange(actuaMatches[0].range()));
-		assert.equal('preview 1', actuaMatches[1].text());
+		assert.strictEqual('preview 1', actuaMatches[1].text());
 		assert.ok(new Range(2, 5, 2, 12).equalsRange(actuaMatches[1].range()));
 
 		actuaMatches = actual[1].matches();
-		assert.equal(1, actuaMatches.length);
-		assert.equal('preview 2', actuaMatches[0].text());
+		assert.strictEqual(1, actuaMatches.length);
+		assert.strictEqual('preview 2', actuaMatches[0].text());
 		assert.ok(new Range(2, 1, 2, 2).equalsRange(actuaMatches[0].range()));
 	});
 
@@ -288,8 +288,8 @@ suite('SearchResult', () => {
 		assert.ok(testObject.isEmpty());
 		target.add(matchToRemove, true);
 
-		assert.equal(1, testObject.fileCount());
-		assert.equal(target, testObject.matches()[0]);
+		assert.strictEqual(1, testObject.fileCount());
+		assert.strictEqual(target, testObject.matches()[0]);
 	});
 
 	test('replace should remove the file match', function () {

--- a/src/vs/workbench/contrib/tasks/test/common/configuration.test.ts
+++ b/src/vs/workbench/contrib/tasks/test/common/configuration.test.ts
@@ -556,7 +556,7 @@ function assertProblemPatterns(actual: ProblemPattern | ProblemPattern[], expect
 }
 
 function assertProblemPattern(actual: ProblemPattern, expected: ProblemPattern) {
-	assert.equal(actual.regexp.toString(), expected.regexp.toString());
+	assert.strictEqual(actual.regexp.toString(), expected.regexp.toString());
 	assert.strictEqual(actual.file, expected.file);
 	assert.strictEqual(actual.message, expected.message);
 	if (typeof expected.location !== 'undefined') {

--- a/src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts
+++ b/src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts
@@ -152,8 +152,8 @@ suite('ProblemPatternParser', () => {
 				{ regexp: 'test1', line: 4 }
 			];
 			let parsed = parser.parse(problemPattern);
-			assert.equal(null, parsed);
-			assert.equal(ValidationState.Error, reporter.state);
+			assert.strictEqual(null, parsed);
+			assert.strictEqual(ValidationState.Error, reporter.state);
 			assert(reporter.hasMessage('The loop property is only supported on the last line matcher.'));
 		});
 		test('forbids setting the kind outside of the first element of the array', () => {
@@ -162,8 +162,8 @@ suite('ProblemPatternParser', () => {
 				{ regexp: 'test1', kind: 'file', line: 4 }
 			];
 			let parsed = parser.parse(problemPattern);
-			assert.equal(null, parsed);
-			assert.equal(ValidationState.Error, reporter.state);
+			assert.strictEqual(null, parsed);
+			assert.strictEqual(ValidationState.Error, reporter.state);
 			assert(reporter.hasMessage('The problem pattern is invalid. The kind property must be provided only in the first element'));
 		});
 
@@ -172,8 +172,8 @@ suite('ProblemPatternParser', () => {
 				{ file: 0, line: 1, column: 20, message: 0 }
 			];
 			let parsed = parser.parse(problemPattern);
-			assert.equal(null, parsed);
-			assert.equal(ValidationState.Error, reporter.state);
+			assert.strictEqual(null, parsed);
+			assert.strictEqual(ValidationState.Error, reporter.state);
 			assert(reporter.hasMessage('The problem pattern is missing a regular expression.'));
 		});
 		test('kind: Location requires a regexp on every entry', () => {
@@ -184,8 +184,8 @@ suite('ProblemPatternParser', () => {
 				{ regexp: 'test3', message: 6 }
 			];
 			let parsed = parser.parse(problemPattern);
-			assert.equal(null, parsed);
-			assert.equal(ValidationState.Error, reporter.state);
+			assert.strictEqual(null, parsed);
+			assert.strictEqual(ValidationState.Error, reporter.state);
 			assert(reporter.hasMessage('The problem pattern is missing a regular expression.'));
 		});
 		test('kind: Location requires a message', () => {
@@ -193,8 +193,8 @@ suite('ProblemPatternParser', () => {
 				{ regexp: 'test', file: 0, line: 1, column: 20 }
 			];
 			let parsed = parser.parse(problemPattern);
-			assert.equal(null, parsed);
-			assert.equal(ValidationState.Error, reporter.state);
+			assert.strictEqual(null, parsed);
+			assert.strictEqual(ValidationState.Error, reporter.state);
 			assert(reporter.hasMessage('The problem pattern is invalid. It must have at least have a file and a message.'));
 		});
 
@@ -203,8 +203,8 @@ suite('ProblemPatternParser', () => {
 				{ regexp: 'test', line: 1, column: 20, message: 0 }
 			];
 			let parsed = parser.parse(problemPattern);
-			assert.equal(null, parsed);
-			assert.equal(ValidationState.Error, reporter.state);
+			assert.strictEqual(null, parsed);
+			assert.strictEqual(ValidationState.Error, reporter.state);
 			assert(reporter.hasMessage('The problem pattern is invalid. It must either have kind: "file" or have a line or location match group.'));
 		});
 
@@ -213,8 +213,8 @@ suite('ProblemPatternParser', () => {
 				{ regexp: 'test', file: 1, column: 20, message: 0 }
 			];
 			let parsed = parser.parse(problemPattern);
-			assert.equal(null, parsed);
-			assert.equal(ValidationState.Error, reporter.state);
+			assert.strictEqual(null, parsed);
+			assert.strictEqual(ValidationState.Error, reporter.state);
 			assert(reporter.hasMessage('The problem pattern is invalid. It must either have kind: "file" or have a line or location match group.'));
 		});
 
@@ -239,8 +239,8 @@ suite('ProblemPatternParser', () => {
 				{ regexp: 'test', kind: 'file', message: 6 }
 			];
 			let parsed = parser.parse(problemPattern);
-			assert.equal(null, parsed);
-			assert.equal(ValidationState.Error, reporter.state);
+			assert.strictEqual(null, parsed);
+			assert.strictEqual(ValidationState.Error, reporter.state);
 			assert(reporter.hasMessage('The problem pattern is invalid. It must have at least have a file and a message.'));
 		});
 
@@ -249,8 +249,8 @@ suite('ProblemPatternParser', () => {
 				{ regexp: 'test', kind: 'file', file: 6 }
 			];
 			let parsed = parser.parse(problemPattern);
-			assert.equal(null, parsed);
-			assert.equal(ValidationState.Error, reporter.state);
+			assert.strictEqual(null, parsed);
+			assert.strictEqual(ValidationState.Error, reporter.state);
 			assert(reporter.hasMessage('The problem pattern is invalid. It must have at least have a file and a message.'));
 		});
 	});

--- a/src/vs/workbench/contrib/terminal/test/browser/links/terminalProtocolLinkProvider.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/links/terminalProtocolLinkProvider.test.ts
@@ -27,7 +27,7 @@ suite('Workbench - TerminalWebLinkProvider', () => {
 
 		// Ensure all links are provided
 		const links = (await new Promise<ILink[] | undefined>(r => provider.provideLinks(1, r)))!;
-		assert.equal(links.length, expected.length);
+		assert.strictEqual(links.length, expected.length);
 		const actual = links.map(e => ({
 			text: e.text,
 			range: e.range

--- a/src/vs/workbench/contrib/terminal/test/browser/links/terminalValidatedLocalLinkProvider.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/links/terminalValidatedLocalLinkProvider.test.ts
@@ -89,7 +89,7 @@ suite('Workbench - TerminalValidatedLocalLinkProvider', () => {
 
 		// Ensure all links are provided
 		const links = (await new Promise<ILink[] | undefined>(r => provider.provideLinks(1, r)))!;
-		assert.equal(links.length, expected.length);
+		assert.strictEqual(links.length, expected.length);
 		const actual = links.map(e => ({
 			text: e.text,
 			range: e.range

--- a/src/vs/workbench/contrib/terminal/test/browser/links/terminalWordLinkProvider.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/links/terminalWordLinkProvider.test.ts
@@ -30,7 +30,7 @@ suite('Workbench - TerminalWordLinkProvider', () => {
 
 		// Ensure all links are provided
 		const links = (await new Promise<ILink[] | undefined>(r => provider.provideLinks(1, r)))!;
-		assert.equal(links.length, expected.length);
+		assert.strictEqual(links.length, expected.length);
 		const actual = links.map(e => ({
 			text: e.text,
 			range: e.range

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalCommandTracker.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalCommandTracker.test.ts
@@ -35,16 +35,16 @@ suite('Workbench - TerminalCommandTracker', () => {
 
 	suite('Command tracking', () => {
 		test('should track commands when the prompt is of sufficient size', () => {
-			assert.equal(xterm.markers.length, 0);
+			assert.strictEqual(xterm.markers.length, 0);
 			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' });
-			assert.equal(xterm.markers.length, 1);
+			assert.strictEqual(xterm.markers.length, 1);
 		});
 		test('should not track commands when the prompt is too small', () => {
-			assert.equal(xterm.markers.length, 0);
+			assert.strictEqual(xterm.markers.length, 0);
 			xterm._core.writeSync('\x1b[2G'); // Move cursor to column 2
 			xterm._core._onKey.fire({ key: '\x0d' });
-			assert.equal(xterm.markers.length, 0);
+			assert.strictEqual(xterm.markers.length, 0);
 		});
 	});
 
@@ -64,84 +64,84 @@ suite('Workbench - TerminalCommandTracker', () => {
 		test('should scroll to the next and previous commands', () => {
 			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' }); // Mark line #10
-			assert.equal(xterm.markers[0].line, 9);
+			assert.strictEqual(xterm.markers[0].line, 9);
 
 			for (let i = 0; i < 20; i++) {
 				xterm._core.writeSync(`\r\n`);
 			}
-			assert.equal(xterm.buffer.active.baseY, 20);
-			assert.equal(xterm.buffer.active.viewportY, 20);
+			assert.strictEqual(xterm.buffer.active.baseY, 20);
+			assert.strictEqual(xterm.buffer.active.viewportY, 20);
 
 			// Scroll to marker
 			commandTracker.scrollToPreviousCommand();
-			assert.equal(xterm.buffer.active.viewportY, 9);
+			assert.strictEqual(xterm.buffer.active.viewportY, 9);
 
 			// Scroll to top boundary
 			commandTracker.scrollToPreviousCommand();
-			assert.equal(xterm.buffer.active.viewportY, 0);
+			assert.strictEqual(xterm.buffer.active.viewportY, 0);
 
 			// Scroll to marker
 			commandTracker.scrollToNextCommand();
-			assert.equal(xterm.buffer.active.viewportY, 9);
+			assert.strictEqual(xterm.buffer.active.viewportY, 9);
 
 			// Scroll to bottom boundary
 			commandTracker.scrollToNextCommand();
-			assert.equal(xterm.buffer.active.viewportY, 20);
+			assert.strictEqual(xterm.buffer.active.viewportY, 20);
 		});
 		test('should select to the next and previous commands', () => {
 			xterm._core.writeSync('\r0');
 			xterm._core.writeSync('\n\r1');
 			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' }); // Mark line
-			assert.equal(xterm.markers[0].line, 10);
+			assert.strictEqual(xterm.markers[0].line, 10);
 			xterm._core.writeSync('\n\r2');
 			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' }); // Mark line
-			assert.equal(xterm.markers[1].line, 11);
+			assert.strictEqual(xterm.markers[1].line, 11);
 			xterm._core.writeSync('\n\r3');
 
-			assert.equal(xterm.buffer.active.baseY, 3);
-			assert.equal(xterm.buffer.active.viewportY, 3);
+			assert.strictEqual(xterm.buffer.active.baseY, 3);
+			assert.strictEqual(xterm.buffer.active.viewportY, 3);
 
-			assert.equal(xterm.getSelection(), '');
+			assert.strictEqual(xterm.getSelection(), '');
 			commandTracker.selectToPreviousCommand();
-			assert.equal(xterm.getSelection(), '2');
+			assert.strictEqual(xterm.getSelection(), '2');
 			commandTracker.selectToPreviousCommand();
-			assert.equal(xterm.getSelection(), isWindows ? '1\r\n2' : '1\n2');
+			assert.strictEqual(xterm.getSelection(), isWindows ? '1\r\n2' : '1\n2');
 			commandTracker.selectToNextCommand();
-			assert.equal(xterm.getSelection(), '2');
+			assert.strictEqual(xterm.getSelection(), '2');
 			commandTracker.selectToNextCommand();
-			assert.equal(xterm.getSelection(), isWindows ? '\r\n' : '\n');
+			assert.strictEqual(xterm.getSelection(), isWindows ? '\r\n' : '\n');
 		});
 		test('should select to the next and previous lines & commands', () => {
 			xterm._core.writeSync('\r0');
 			xterm._core.writeSync('\n\r1');
 			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' }); // Mark line
-			assert.equal(xterm.markers[0].line, 10);
+			assert.strictEqual(xterm.markers[0].line, 10);
 			xterm._core.writeSync('\n\r2');
 			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' }); // Mark line
-			assert.equal(xterm.markers[1].line, 11);
+			assert.strictEqual(xterm.markers[1].line, 11);
 			xterm._core.writeSync('\n\r3');
 
-			assert.equal(xterm.buffer.active.baseY, 3);
-			assert.equal(xterm.buffer.active.viewportY, 3);
+			assert.strictEqual(xterm.buffer.active.baseY, 3);
+			assert.strictEqual(xterm.buffer.active.viewportY, 3);
 
-			assert.equal(xterm.getSelection(), '');
+			assert.strictEqual(xterm.getSelection(), '');
 			commandTracker.selectToPreviousLine();
-			assert.equal(xterm.getSelection(), '2');
+			assert.strictEqual(xterm.getSelection(), '2');
 			commandTracker.selectToNextLine();
 			commandTracker.selectToNextLine();
-			assert.equal(xterm.getSelection(), '3');
+			assert.strictEqual(xterm.getSelection(), '3');
 			commandTracker.selectToPreviousCommand();
 			commandTracker.selectToPreviousCommand();
 			commandTracker.selectToNextLine();
-			assert.equal(xterm.getSelection(), '2');
+			assert.strictEqual(xterm.getSelection(), '2');
 			commandTracker.selectToPreviousCommand();
-			assert.equal(xterm.getSelection(), isWindows ? '1\r\n2' : '1\n2');
+			assert.strictEqual(xterm.getSelection(), isWindows ? '1\r\n2' : '1\n2');
 			commandTracker.selectToPreviousLine();
-			assert.equal(xterm.getSelection(), isWindows ? '0\r\n1\r\n2' : '0\n1\n2');
+			assert.strictEqual(xterm.getSelection(), isWindows ? '0\r\n1\r\n2' : '0\n1\n2');
 		});
 	});
 });

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalConfigHelper.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalConfigHelper.test.ts
@@ -22,7 +22,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		await configurationService.setUserConfiguration('terminal', { integrated: { fontFamily: 'bar' } });
 		const configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().fontFamily, 'bar', 'terminal.integrated.fontFamily should be selected over editor.fontFamily');
+		assert.strictEqual(configHelper.getFont().fontFamily, 'bar', 'terminal.integrated.fontFamily should be selected over editor.fontFamily');
 	});
 
 	test('TerminalConfigHelper - getFont fontFamily (Linux Fedora)', async () => {
@@ -32,7 +32,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		const configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.setLinuxDistro(LinuxDistro.Fedora);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().fontFamily, '\'DejaVu Sans Mono\', monospace', 'Fedora should have its font overridden when terminal.integrated.fontFamily not set');
+		assert.strictEqual(configHelper.getFont().fontFamily, '\'DejaVu Sans Mono\', monospace', 'Fedora should have its font overridden when terminal.integrated.fontFamily not set');
 	});
 
 	test('TerminalConfigHelper - getFont fontFamily (Linux Ubuntu)', async () => {
@@ -42,7 +42,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		const configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.setLinuxDistro(LinuxDistro.Ubuntu);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().fontFamily, '\'Ubuntu Mono\', monospace', 'Ubuntu should have its font overridden when terminal.integrated.fontFamily not set');
+		assert.strictEqual(configHelper.getFont().fontFamily, '\'Ubuntu Mono\', monospace', 'Ubuntu should have its font overridden when terminal.integrated.fontFamily not set');
 	});
 
 	test('TerminalConfigHelper - getFont fontFamily (Linux Unknown)', async () => {
@@ -51,7 +51,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		await configurationService.setUserConfiguration('terminal', { integrated: { fontFamily: null } });
 		const configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().fontFamily, 'foo', 'editor.fontFamily should be the fallback when terminal.integrated.fontFamily not set');
+		assert.strictEqual(configHelper.getFont().fontFamily, 'foo', 'editor.fontFamily should be the fallback when terminal.integrated.fontFamily not set');
 	});
 
 	test('TerminalConfigHelper - getFont fontSize', async () => {
@@ -69,7 +69,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		});
 		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().fontSize, 10, 'terminal.integrated.fontSize should be selected over editor.fontSize');
+		assert.strictEqual(configHelper.getFont().fontSize, 10, 'terminal.integrated.fontSize should be selected over editor.fontSize');
 
 		await configurationService.setUserConfiguration('editor', {
 			fontFamily: 'foo'
@@ -83,11 +83,11 @@ suite('Workbench - TerminalConfigHelper', () => {
 		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.setLinuxDistro(LinuxDistro.Ubuntu);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().fontSize, 8, 'The minimum terminal font size (with adjustment) should be used when terminal.integrated.fontSize less than it');
+		assert.strictEqual(configHelper.getFont().fontSize, 8, 'The minimum terminal font size (with adjustment) should be used when terminal.integrated.fontSize less than it');
 
 		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().fontSize, 6, 'The minimum terminal font size should be used when terminal.integrated.fontSize less than it');
+		assert.strictEqual(configHelper.getFont().fontSize, 6, 'The minimum terminal font size should be used when terminal.integrated.fontSize less than it');
 
 		await configurationService.setUserConfiguration('editor', {
 			fontFamily: 'foo'
@@ -100,7 +100,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		});
 		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().fontSize, 25, 'The maximum terminal font size should be used when terminal.integrated.fontSize more than it');
+		assert.strictEqual(configHelper.getFont().fontSize, 25, 'The maximum terminal font size should be used when terminal.integrated.fontSize more than it');
 
 		await configurationService.setUserConfiguration('editor', {
 			fontFamily: 'foo'
@@ -114,11 +114,11 @@ suite('Workbench - TerminalConfigHelper', () => {
 		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.setLinuxDistro(LinuxDistro.Ubuntu);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().fontSize, EDITOR_FONT_DEFAULTS.fontSize + 2, 'The default editor font size (with adjustment) should be used when terminal.integrated.fontSize is not set');
+		assert.strictEqual(configHelper.getFont().fontSize, EDITOR_FONT_DEFAULTS.fontSize + 2, 'The default editor font size (with adjustment) should be used when terminal.integrated.fontSize is not set');
 
 		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().fontSize, EDITOR_FONT_DEFAULTS.fontSize, 'The default editor font size should be used when terminal.integrated.fontSize is not set');
+		assert.strictEqual(configHelper.getFont().fontSize, EDITOR_FONT_DEFAULTS.fontSize, 'The default editor font size should be used when terminal.integrated.fontSize is not set');
 	});
 
 	test('TerminalConfigHelper - getFont lineHeight', async () => {
@@ -136,7 +136,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		});
 		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().lineHeight, 2, 'terminal.integrated.lineHeight should be selected over editor.lineHeight');
+		assert.strictEqual(configHelper.getFont().lineHeight, 2, 'terminal.integrated.lineHeight should be selected over editor.lineHeight');
 
 		await configurationService.setUserConfiguration('editor', {
 			fontFamily: 'foo',
@@ -150,7 +150,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		});
 		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.getFont().lineHeight, 1, 'editor.lineHeight should be 1 when terminal.integrated.lineHeight not set');
+		assert.strictEqual(configHelper.getFont().lineHeight, 1, 'editor.lineHeight should be 1 when terminal.integrated.lineHeight not set');
 	});
 
 	test('TerminalConfigHelper - isMonospace monospace', async function () {
@@ -163,7 +163,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 
 		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.configFontIsMonospace(), true, 'monospace is monospaced');
+		assert.strictEqual(configHelper.configFontIsMonospace(), true, 'monospace is monospaced');
 	});
 
 	test('TerminalConfigHelper - isMonospace sans-serif', async () => {
@@ -175,7 +175,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		});
 		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.configFontIsMonospace(), false, 'sans-serif is not monospaced');
+		assert.strictEqual(configHelper.configFontIsMonospace(), false, 'sans-serif is not monospaced');
 	});
 
 	test('TerminalConfigHelper - isMonospace serif', async () => {
@@ -187,7 +187,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		});
 		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.configFontIsMonospace(), false, 'serif is not monospaced');
+		assert.strictEqual(configHelper.configFontIsMonospace(), false, 'serif is not monospaced');
 	});
 
 	test('TerminalConfigHelper - isMonospace monospace falls back to editor.fontFamily', async () => {
@@ -203,7 +203,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 
 		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.configFontIsMonospace(), true, 'monospace is monospaced');
+		assert.strictEqual(configHelper.configFontIsMonospace(), true, 'monospace is monospaced');
 	});
 
 	test('TerminalConfigHelper - isMonospace sans-serif falls back to editor.fontFamily', async () => {
@@ -219,7 +219,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 
 		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.configFontIsMonospace(), false, 'sans-serif is not monospaced');
+		assert.strictEqual(configHelper.configFontIsMonospace(), false, 'sans-serif is not monospaced');
 	});
 
 	test('TerminalConfigHelper - isMonospace serif falls back to editor.fontFamily', async () => {
@@ -235,6 +235,6 @@ suite('Workbench - TerminalConfigHelper', () => {
 
 		let configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!, null!, null!);
 		configHelper.panelContainer = fixture;
-		assert.equal(configHelper.configFontIsMonospace(), false, 'serif is not monospaced');
+		assert.strictEqual(configHelper.configFontIsMonospace(), false, 'serif is not monospaced');
 	});
 });

--- a/src/vs/workbench/contrib/terminal/test/common/terminalDataBuffering.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/common/terminalDataBuffering.test.ts
@@ -42,13 +42,13 @@ suite('Workbench - TerminalDataBufferer', () => {
 
 		terminalOnData.fire('4');
 
-		assert.equal(counter[1], 1);
-		assert.equal(data[1], '123');
+		assert.strictEqual(counter[1], 1);
+		assert.strictEqual(data[1], '123');
 
 		await wait(0);
 
-		assert.equal(counter[1], 2);
-		assert.equal(data[1], '4');
+		assert.strictEqual(counter[1], 2);
+		assert.strictEqual(data[1], '4');
 	});
 
 	test('start 2', async () => {
@@ -66,17 +66,17 @@ suite('Workbench - TerminalDataBufferer', () => {
 		terminal2OnData.fire('6');
 		terminal2OnData.fire('7');
 
-		assert.equal(counter[1], undefined);
-		assert.equal(data[1], undefined);
-		assert.equal(counter[2], undefined);
-		assert.equal(data[2], undefined);
+		assert.strictEqual(counter[1], undefined);
+		assert.strictEqual(data[1], undefined);
+		assert.strictEqual(counter[2], undefined);
+		assert.strictEqual(data[2], undefined);
 
 		await wait(0);
 
-		assert.equal(counter[1], 1);
-		assert.equal(data[1], '123');
-		assert.equal(counter[2], 1);
-		assert.equal(data[2], '4567');
+		assert.strictEqual(counter[1], 1);
+		assert.strictEqual(data[1], '123');
+		assert.strictEqual(counter[2], 1);
+		assert.strictEqual(data[2], '4567');
 	});
 
 	test('stop', async () => {
@@ -91,8 +91,8 @@ suite('Workbench - TerminalDataBufferer', () => {
 		bufferer.stopBuffering(1);
 		await wait(0);
 
-		assert.equal(counter[1], 1);
-		assert.equal(data[1], '123');
+		assert.strictEqual(counter[1], 1);
+		assert.strictEqual(data[1], '123');
 	});
 
 	test('start 2 stop 1', async () => {
@@ -110,18 +110,18 @@ suite('Workbench - TerminalDataBufferer', () => {
 		terminal2OnData.fire('6');
 		terminal2OnData.fire('7');
 
-		assert.equal(counter[1], undefined);
-		assert.equal(data[1], undefined);
-		assert.equal(counter[2], undefined);
-		assert.equal(data[2], undefined);
+		assert.strictEqual(counter[1], undefined);
+		assert.strictEqual(data[1], undefined);
+		assert.strictEqual(counter[2], undefined);
+		assert.strictEqual(data[2], undefined);
 
 		bufferer.stopBuffering(1);
 		await wait(0);
 
-		assert.equal(counter[1], 1);
-		assert.equal(data[1], '123');
-		assert.equal(counter[2], 1);
-		assert.equal(data[2], '4567');
+		assert.strictEqual(counter[1], 1);
+		assert.strictEqual(data[1], '123');
+		assert.strictEqual(counter[2], 1);
+		assert.strictEqual(data[2], '4567');
 	});
 
 	test('dispose should flush remaining data events', async () => {
@@ -139,17 +139,17 @@ suite('Workbench - TerminalDataBufferer', () => {
 		terminal2OnData.fire('6');
 		terminal2OnData.fire('7');
 
-		assert.equal(counter[1], undefined);
-		assert.equal(data[1], undefined);
-		assert.equal(counter[2], undefined);
-		assert.equal(data[2], undefined);
+		assert.strictEqual(counter[1], undefined);
+		assert.strictEqual(data[1], undefined);
+		assert.strictEqual(counter[2], undefined);
+		assert.strictEqual(data[2], undefined);
 
 		bufferer.dispose();
 		await wait(0);
 
-		assert.equal(counter[1], 1);
-		assert.equal(data[1], '123');
-		assert.equal(counter[2], 1);
-		assert.equal(data[2], '4567');
+		assert.strictEqual(counter[1], 1);
+		assert.strictEqual(data[1], '123');
+		assert.strictEqual(counter[2], 1);
+		assert.strictEqual(data[2], '4567');
 	});
 });

--- a/src/vs/workbench/contrib/terminal/test/common/terminalEnvironment.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/common/terminalEnvironment.test.ts
@@ -14,106 +14,106 @@ suite('Workbench - TerminalEnvironment', () => {
 		test('should set expected variables', () => {
 			const env: { [key: string]: any } = {};
 			addTerminalEnvironmentKeys(env, '1.2.3', 'en', 'on');
-			assert.equal(env['TERM_PROGRAM'], 'vscode');
-			assert.equal(env['TERM_PROGRAM_VERSION'], '1.2.3');
-			assert.equal(env['COLORTERM'], 'truecolor');
-			assert.equal(env['LANG'], 'en_US.UTF-8');
+			assert.strictEqual(env['TERM_PROGRAM'], 'vscode');
+			assert.strictEqual(env['TERM_PROGRAM_VERSION'], '1.2.3');
+			assert.strictEqual(env['COLORTERM'], 'truecolor');
+			assert.strictEqual(env['LANG'], 'en_US.UTF-8');
 		});
 		test('should use language variant for LANG that is provided in locale', () => {
 			const env: { [key: string]: any } = {};
 			addTerminalEnvironmentKeys(env, '1.2.3', 'en-au', 'on');
-			assert.equal(env['LANG'], 'en_AU.UTF-8', 'LANG is equal to the requested locale with UTF-8');
+			assert.strictEqual(env['LANG'], 'en_AU.UTF-8', 'LANG is equal to the requested locale with UTF-8');
 		});
 		test('should fallback to en_US when no locale is provided', () => {
 			const env2: { [key: string]: any } = { FOO: 'bar' };
 			addTerminalEnvironmentKeys(env2, '1.2.3', undefined, 'on');
-			assert.equal(env2['LANG'], 'en_US.UTF-8', 'LANG is equal to en_US.UTF-8 as fallback.'); // More info on issue #14586
+			assert.strictEqual(env2['LANG'], 'en_US.UTF-8', 'LANG is equal to en_US.UTF-8 as fallback.'); // More info on issue #14586
 		});
 		test('should fallback to en_US when an invalid locale is provided', () => {
 			const env3 = { LANG: 'replace' };
 			addTerminalEnvironmentKeys(env3, '1.2.3', undefined, 'on');
-			assert.equal(env3['LANG'], 'en_US.UTF-8', 'LANG is set to the fallback LANG');
+			assert.strictEqual(env3['LANG'], 'en_US.UTF-8', 'LANG is set to the fallback LANG');
 		});
 		test('should override existing LANG', () => {
 			const env4 = { LANG: 'en_AU.UTF-8' };
 			addTerminalEnvironmentKeys(env4, '1.2.3', undefined, 'on');
-			assert.equal(env4['LANG'], 'en_US.UTF-8', 'LANG is equal to the parent environment\'s LANG');
+			assert.strictEqual(env4['LANG'], 'en_US.UTF-8', 'LANG is equal to the parent environment\'s LANG');
 		});
 	});
 
 	suite('shouldSetLangEnvVariable', () => {
 		test('auto', () => {
-			assert.equal(shouldSetLangEnvVariable({}, 'auto'), true);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US' }, 'auto'), true);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US.utf' }, 'auto'), true);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US.utf8' }, 'auto'), false);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US.UTF-8' }, 'auto'), false);
+			assert.strictEqual(shouldSetLangEnvVariable({}, 'auto'), true);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US' }, 'auto'), true);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US.utf' }, 'auto'), true);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US.utf8' }, 'auto'), false);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US.UTF-8' }, 'auto'), false);
 		});
 		test('off', () => {
-			assert.equal(shouldSetLangEnvVariable({}, 'off'), false);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US' }, 'off'), false);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US.utf' }, 'off'), false);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US.utf8' }, 'off'), false);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US.UTF-8' }, 'off'), false);
+			assert.strictEqual(shouldSetLangEnvVariable({}, 'off'), false);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US' }, 'off'), false);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US.utf' }, 'off'), false);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US.utf8' }, 'off'), false);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US.UTF-8' }, 'off'), false);
 		});
 		test('on', () => {
-			assert.equal(shouldSetLangEnvVariable({}, 'on'), true);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US' }, 'on'), true);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US.utf' }, 'on'), true);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US.utf8' }, 'on'), true);
-			assert.equal(shouldSetLangEnvVariable({ LANG: 'en-US.UTF-8' }, 'on'), true);
+			assert.strictEqual(shouldSetLangEnvVariable({}, 'on'), true);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US' }, 'on'), true);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US.utf' }, 'on'), true);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US.utf8' }, 'on'), true);
+			assert.strictEqual(shouldSetLangEnvVariable({ LANG: 'en-US.UTF-8' }, 'on'), true);
 		});
 	});
 
 	suite('getLangEnvVariable', () => {
 		test('should fallback to en_US when no locale is provided', () => {
-			assert.equal(getLangEnvVariable(undefined), 'en_US.UTF-8');
-			assert.equal(getLangEnvVariable(''), 'en_US.UTF-8');
+			assert.strictEqual(getLangEnvVariable(undefined), 'en_US.UTF-8');
+			assert.strictEqual(getLangEnvVariable(''), 'en_US.UTF-8');
 		});
 		test('should fallback to default language variants when variant isn\'t provided', () => {
-			assert.equal(getLangEnvVariable('af'), 'af_ZA.UTF-8');
-			assert.equal(getLangEnvVariable('am'), 'am_ET.UTF-8');
-			assert.equal(getLangEnvVariable('be'), 'be_BY.UTF-8');
-			assert.equal(getLangEnvVariable('bg'), 'bg_BG.UTF-8');
-			assert.equal(getLangEnvVariable('ca'), 'ca_ES.UTF-8');
-			assert.equal(getLangEnvVariable('cs'), 'cs_CZ.UTF-8');
-			assert.equal(getLangEnvVariable('da'), 'da_DK.UTF-8');
-			assert.equal(getLangEnvVariable('de'), 'de_DE.UTF-8');
-			assert.equal(getLangEnvVariable('el'), 'el_GR.UTF-8');
-			assert.equal(getLangEnvVariable('en'), 'en_US.UTF-8');
-			assert.equal(getLangEnvVariable('es'), 'es_ES.UTF-8');
-			assert.equal(getLangEnvVariable('et'), 'et_EE.UTF-8');
-			assert.equal(getLangEnvVariable('eu'), 'eu_ES.UTF-8');
-			assert.equal(getLangEnvVariable('fi'), 'fi_FI.UTF-8');
-			assert.equal(getLangEnvVariable('fr'), 'fr_FR.UTF-8');
-			assert.equal(getLangEnvVariable('he'), 'he_IL.UTF-8');
-			assert.equal(getLangEnvVariable('hr'), 'hr_HR.UTF-8');
-			assert.equal(getLangEnvVariable('hu'), 'hu_HU.UTF-8');
-			assert.equal(getLangEnvVariable('hy'), 'hy_AM.UTF-8');
-			assert.equal(getLangEnvVariable('is'), 'is_IS.UTF-8');
-			assert.equal(getLangEnvVariable('it'), 'it_IT.UTF-8');
-			assert.equal(getLangEnvVariable('ja'), 'ja_JP.UTF-8');
-			assert.equal(getLangEnvVariable('kk'), 'kk_KZ.UTF-8');
-			assert.equal(getLangEnvVariable('ko'), 'ko_KR.UTF-8');
-			assert.equal(getLangEnvVariable('lt'), 'lt_LT.UTF-8');
-			assert.equal(getLangEnvVariable('nl'), 'nl_NL.UTF-8');
-			assert.equal(getLangEnvVariable('no'), 'no_NO.UTF-8');
-			assert.equal(getLangEnvVariable('pl'), 'pl_PL.UTF-8');
-			assert.equal(getLangEnvVariable('pt'), 'pt_BR.UTF-8');
-			assert.equal(getLangEnvVariable('ro'), 'ro_RO.UTF-8');
-			assert.equal(getLangEnvVariable('ru'), 'ru_RU.UTF-8');
-			assert.equal(getLangEnvVariable('sk'), 'sk_SK.UTF-8');
-			assert.equal(getLangEnvVariable('sl'), 'sl_SI.UTF-8');
-			assert.equal(getLangEnvVariable('sr'), 'sr_YU.UTF-8');
-			assert.equal(getLangEnvVariable('sv'), 'sv_SE.UTF-8');
-			assert.equal(getLangEnvVariable('tr'), 'tr_TR.UTF-8');
-			assert.equal(getLangEnvVariable('uk'), 'uk_UA.UTF-8');
-			assert.equal(getLangEnvVariable('zh'), 'zh_CN.UTF-8');
+			assert.strictEqual(getLangEnvVariable('af'), 'af_ZA.UTF-8');
+			assert.strictEqual(getLangEnvVariable('am'), 'am_ET.UTF-8');
+			assert.strictEqual(getLangEnvVariable('be'), 'be_BY.UTF-8');
+			assert.strictEqual(getLangEnvVariable('bg'), 'bg_BG.UTF-8');
+			assert.strictEqual(getLangEnvVariable('ca'), 'ca_ES.UTF-8');
+			assert.strictEqual(getLangEnvVariable('cs'), 'cs_CZ.UTF-8');
+			assert.strictEqual(getLangEnvVariable('da'), 'da_DK.UTF-8');
+			assert.strictEqual(getLangEnvVariable('de'), 'de_DE.UTF-8');
+			assert.strictEqual(getLangEnvVariable('el'), 'el_GR.UTF-8');
+			assert.strictEqual(getLangEnvVariable('en'), 'en_US.UTF-8');
+			assert.strictEqual(getLangEnvVariable('es'), 'es_ES.UTF-8');
+			assert.strictEqual(getLangEnvVariable('et'), 'et_EE.UTF-8');
+			assert.strictEqual(getLangEnvVariable('eu'), 'eu_ES.UTF-8');
+			assert.strictEqual(getLangEnvVariable('fi'), 'fi_FI.UTF-8');
+			assert.strictEqual(getLangEnvVariable('fr'), 'fr_FR.UTF-8');
+			assert.strictEqual(getLangEnvVariable('he'), 'he_IL.UTF-8');
+			assert.strictEqual(getLangEnvVariable('hr'), 'hr_HR.UTF-8');
+			assert.strictEqual(getLangEnvVariable('hu'), 'hu_HU.UTF-8');
+			assert.strictEqual(getLangEnvVariable('hy'), 'hy_AM.UTF-8');
+			assert.strictEqual(getLangEnvVariable('is'), 'is_IS.UTF-8');
+			assert.strictEqual(getLangEnvVariable('it'), 'it_IT.UTF-8');
+			assert.strictEqual(getLangEnvVariable('ja'), 'ja_JP.UTF-8');
+			assert.strictEqual(getLangEnvVariable('kk'), 'kk_KZ.UTF-8');
+			assert.strictEqual(getLangEnvVariable('ko'), 'ko_KR.UTF-8');
+			assert.strictEqual(getLangEnvVariable('lt'), 'lt_LT.UTF-8');
+			assert.strictEqual(getLangEnvVariable('nl'), 'nl_NL.UTF-8');
+			assert.strictEqual(getLangEnvVariable('no'), 'no_NO.UTF-8');
+			assert.strictEqual(getLangEnvVariable('pl'), 'pl_PL.UTF-8');
+			assert.strictEqual(getLangEnvVariable('pt'), 'pt_BR.UTF-8');
+			assert.strictEqual(getLangEnvVariable('ro'), 'ro_RO.UTF-8');
+			assert.strictEqual(getLangEnvVariable('ru'), 'ru_RU.UTF-8');
+			assert.strictEqual(getLangEnvVariable('sk'), 'sk_SK.UTF-8');
+			assert.strictEqual(getLangEnvVariable('sl'), 'sl_SI.UTF-8');
+			assert.strictEqual(getLangEnvVariable('sr'), 'sr_YU.UTF-8');
+			assert.strictEqual(getLangEnvVariable('sv'), 'sv_SE.UTF-8');
+			assert.strictEqual(getLangEnvVariable('tr'), 'tr_TR.UTF-8');
+			assert.strictEqual(getLangEnvVariable('uk'), 'uk_UA.UTF-8');
+			assert.strictEqual(getLangEnvVariable('zh'), 'zh_CN.UTF-8');
 		});
 		test('should set language variant based on full locale', () => {
-			assert.equal(getLangEnvVariable('en-AU'), 'en_AU.UTF-8');
-			assert.equal(getLangEnvVariable('en-au'), 'en_AU.UTF-8');
-			assert.equal(getLangEnvVariable('fa-ke'), 'fa_KE.UTF-8');
+			assert.strictEqual(getLangEnvVariable('en-AU'), 'en_AU.UTF-8');
+			assert.strictEqual(getLangEnvVariable('en-au'), 'en_AU.UTF-8');
+			assert.strictEqual(getLangEnvVariable('fa-ke'), 'fa_KE.UTF-8');
 		});
 	});
 
@@ -177,7 +177,7 @@ suite('Workbench - TerminalEnvironment', () => {
 	suite('getCwd', () => {
 		// This helper checks the paths in a cross-platform friendly manner
 		function assertPathsMatch(a: string, b: string): void {
-			assert.equal(Uri.file(a).fsPath, Uri.file(b).fsPath);
+			assert.strictEqual(Uri.file(a).fsPath, Uri.file(b).fsPath);
 		}
 
 		test('should default to userHome for an empty workspace', () => {
@@ -216,7 +216,7 @@ suite('Workbench - TerminalEnvironment', () => {
 					'terminal.integrated.shell.windows': { userValue: 'C:\\Windows\\Sysnative\\cmd.exe', value: undefined, defaultValue: undefined }
 				} as any)[key];
 			}, false, 'DEFAULT', false, 'C:\\Windows', undefined, {} as any, false, platform.Platform.Windows);
-			assert.equal(shell, 'C:\\Windows\\System32\\cmd.exe');
+			assert.strictEqual(shell, 'C:\\Windows\\System32\\cmd.exe');
 		});
 
 		test('should not change Sysnative to System32 in WoW64 systems', () => {
@@ -225,7 +225,7 @@ suite('Workbench - TerminalEnvironment', () => {
 					'terminal.integrated.shell.windows': { userValue: 'C:\\Windows\\Sysnative\\cmd.exe', value: undefined, defaultValue: undefined }
 				} as any)[key];
 			}, false, 'DEFAULT', true, 'C:\\Windows', undefined, {} as any, false, platform.Platform.Windows);
-			assert.equal(shell, 'C:\\Windows\\Sysnative\\cmd.exe');
+			assert.strictEqual(shell, 'C:\\Windows\\Sysnative\\cmd.exe');
 		});
 
 		test('should use automationShell when specified', () => {
@@ -235,21 +235,21 @@ suite('Workbench - TerminalEnvironment', () => {
 					'terminal.integrated.automationShell.windows': { userValue: undefined, value: undefined, defaultValue: undefined }
 				} as any)[key];
 			}, false, 'DEFAULT', false, 'C:\\Windows', undefined, {} as any, false, platform.Platform.Windows);
-			assert.equal(shell1, 'shell', 'automationShell was false');
+			assert.strictEqual(shell1, 'shell', 'automationShell was false');
 			const shell2 = getDefaultShell(key => {
 				return ({
 					'terminal.integrated.shell.windows': { userValue: 'shell', value: undefined, defaultValue: undefined },
 					'terminal.integrated.automationShell.windows': { userValue: undefined, value: undefined, defaultValue: undefined }
 				} as any)[key];
 			}, false, 'DEFAULT', false, 'C:\\Windows', undefined, {} as any, true, platform.Platform.Windows);
-			assert.equal(shell2, 'shell', 'automationShell was true');
+			assert.strictEqual(shell2, 'shell', 'automationShell was true');
 			const shell3 = getDefaultShell(key => {
 				return ({
 					'terminal.integrated.shell.windows': { userValue: 'shell', value: undefined, defaultValue: undefined },
 					'terminal.integrated.automationShell.windows': { userValue: 'automationShell', value: undefined, defaultValue: undefined }
 				} as any)[key];
 			}, false, 'DEFAULT', false, 'C:\\Windows', undefined, {} as any, true, platform.Platform.Windows);
-			assert.equal(shell3, 'automationShell', 'automationShell was true and specified in settings');
+			assert.strictEqual(shell3, 'automationShell', 'automationShell was true and specified in settings');
 		});
 	});
 });

--- a/src/vs/workbench/electron-sandbox/sandbox.simpleservices.ts
+++ b/src/vs/workbench/electron-sandbox/sandbox.simpleservices.ts
@@ -232,8 +232,8 @@ suite("Extension Tests", function () {
 
 	// Defines a Mocha unit test
 	test("Something 1", function() {
-		assert.equal(-1, [1, 2, 3].indexOf(5));
-		assert.equal(-1, [1, 2, 3].indexOf(0));
+		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
+		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
 	});
 });`);
 

--- a/src/vs/workbench/services/commands/test/common/commandService.test.ts
+++ b/src/vs/workbench/services/commands/test/common/commandService.test.ts
@@ -56,7 +56,7 @@ suite('CommandService', function () {
 		await extensionService.whenInstalledExtensionsRegistered();
 
 		return service.executeCommand('foo').then(() => assert.ok(false), err => {
-			assert.equal(err.message, 'bad_activate');
+			assert.strictEqual(err.message, 'bad_activate');
 		});
 	});
 
@@ -72,7 +72,7 @@ suite('CommandService', function () {
 		}, new NullLogService());
 
 		service.executeCommand('bar');
-		assert.equal(callCounter, 1);
+		assert.strictEqual(callCounter, 1);
 		reg.dispose();
 	});
 
@@ -89,14 +89,14 @@ suite('CommandService', function () {
 		}, new NullLogService());
 
 		let r = service.executeCommand('bar');
-		assert.equal(callCounter, 0);
+		assert.strictEqual(callCounter, 0);
 
 		let reg = CommandsRegistry.registerCommand('bar', () => callCounter += 1);
 		resolveFunc!(true);
 
 		return r.then(() => {
 			reg.dispose();
-			assert.equal(callCounter, 1);
+			assert.strictEqual(callCounter, 1);
 		});
 	});
 
@@ -129,7 +129,7 @@ suite('CommandService', function () {
 		}, new NullLogService());
 
 		return service.executeCommand('farboo').then(() => {
-			assert.equal(callCounter, 1);
+			assert.strictEqual(callCounter, 1);
 			assert.deepEqual(events.sort(), ['*', 'onCommand:farboo'].sort());
 		}).finally(() => {
 			disposable.dispose();

--- a/src/vs/workbench/services/configuration/test/browser/configurationEditingService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationEditingService.test.ts
@@ -110,7 +110,7 @@ suite('ConfigurationEditingService', () => {
 			await testObject.writeConfiguration(EditableConfigurationTarget.WORKSPACE, { key: 'unknown.key', value: 'value' });
 			assert.fail('Should fail with ERROR_UNKNOWN_KEY');
 		} catch (error) {
-			assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_UNKNOWN_KEY);
+			assert.strictEqual(error.code, ConfigurationEditingErrorCode.ERROR_UNKNOWN_KEY);
 		}
 	});
 
@@ -120,7 +120,7 @@ suite('ConfigurationEditingService', () => {
 			await testObject.writeConfiguration(EditableConfigurationTarget.WORKSPACE, { key: 'configurationEditing.service.testSetting', value: 'value' });
 			assert.fail('Should fail with ERROR_NO_WORKSPACE_OPENED');
 		} catch (error) {
-			assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_NO_WORKSPACE_OPENED);
+			assert.strictEqual(error.code, ConfigurationEditingErrorCode.ERROR_NO_WORKSPACE_OPENED);
 		}
 	});
 
@@ -130,7 +130,7 @@ suite('ConfigurationEditingService', () => {
 			await testObject.writeConfiguration(EditableConfigurationTarget.USER_LOCAL, { key: 'configurationEditing.service.testSetting', value: 'value' });
 			assert.fail('Should fail with ERROR_INVALID_CONFIGURATION');
 		} catch (error) {
-			assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION);
+			assert.strictEqual(error.code, ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION);
 		}
 	});
 
@@ -141,7 +141,7 @@ suite('ConfigurationEditingService', () => {
 			await testObject.writeConfiguration(EditableConfigurationTarget.USER_LOCAL, { key: 'tasks.configurationEditing.service.testSetting', value: 'value' });
 			assert.fail('Should fail with ERROR_INVALID_CONFIGURATION');
 		} catch (error) {
-			assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION);
+			assert.strictEqual(error.code, ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION);
 		}
 	});
 
@@ -151,7 +151,7 @@ suite('ConfigurationEditingService', () => {
 			await testObject.writeConfiguration(EditableConfigurationTarget.USER_LOCAL, { key: 'configurationEditing.service.testSetting', value: 'value' });
 			assert.fail('Should fail with ERROR_CONFIGURATION_FILE_DIRTY error.');
 		} catch (error) {
-			assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_CONFIGURATION_FILE_DIRTY);
+			assert.strictEqual(error.code, ConfigurationEditingErrorCode.ERROR_CONFIGURATION_FILE_DIRTY);
 		}
 	});
 
@@ -168,8 +168,8 @@ suite('ConfigurationEditingService', () => {
 			await testObject.writeConfiguration(EditableConfigurationTarget.USER_LOCAL, { key: 'configurationEditing.service.testSetting', value: 'value' }, { donotNotifyError: true });
 			assert.fail('Should fail with ERROR_CONFIGURATION_FILE_DIRTY error.');
 		} catch (error) {
-			assert.equal(false, target.calledOnce);
-			assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_CONFIGURATION_FILE_DIRTY);
+			assert.strictEqual(false, target.calledOnce);
+			assert.strictEqual(error.code, ConfigurationEditingErrorCode.ERROR_CONFIGURATION_FILE_DIRTY);
 		}
 	});
 
@@ -177,7 +177,7 @@ suite('ConfigurationEditingService', () => {
 		await testObject.writeConfiguration(EditableConfigurationTarget.USER_LOCAL, { key: 'configurationEditing.service.testSetting', value: 'value' });
 		const contents = await fileService.readFile(environmentService.settingsResource);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['configurationEditing.service.testSetting'], 'value');
+		assert.strictEqual(parsed['configurationEditing.service.testSetting'], 'value');
 	});
 
 	test('write one setting - existing file', async () => {
@@ -186,8 +186,8 @@ suite('ConfigurationEditingService', () => {
 
 		const contents = await fileService.readFile(environmentService.settingsResource);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['configurationEditing.service.testSetting'], 'value');
-		assert.equal(parsed['my.super.setting'], 'my.super.value');
+		assert.strictEqual(parsed['configurationEditing.service.testSetting'], 'value');
+		assert.strictEqual(parsed['my.super.setting'], 'my.super.value');
 	});
 
 	test('remove an existing setting - existing file', async () => {
@@ -197,7 +197,7 @@ suite('ConfigurationEditingService', () => {
 		const contents = await fileService.readFile(environmentService.settingsResource);
 		const parsed = json.parse(contents.value.toString());
 		assert.deepEqual(Object.keys(parsed), ['my.super.setting']);
-		assert.equal(parsed['my.super.setting'], 'my.super.value');
+		assert.strictEqual(parsed['my.super.setting'], 'my.super.value');
 	});
 
 	test('remove non existing setting - existing file', async () => {
@@ -207,7 +207,7 @@ suite('ConfigurationEditingService', () => {
 		const contents = await fileService.readFile(environmentService.settingsResource);
 		const parsed = json.parse(contents.value.toString());
 		assert.deepEqual(Object.keys(parsed), ['my.super.setting']);
-		assert.equal(parsed['my.super.setting'], 'my.super.value');
+		assert.strictEqual(parsed['my.super.setting'], 'my.super.value');
 	});
 
 	test('write overridable settings to user settings', async () => {
@@ -247,7 +247,7 @@ suite('ConfigurationEditingService', () => {
 
 		const contents = await fileService.readFile(target);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['service.testSetting'], 'value');
+		assert.strictEqual(parsed['service.testSetting'], 'value');
 	});
 
 	test('write user standalone setting - empty file', async () => {
@@ -256,7 +256,7 @@ suite('ConfigurationEditingService', () => {
 
 		const contents = await fileService.readFile(target);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['service.testSetting'], 'value');
+		assert.strictEqual(parsed['service.testSetting'], 'value');
 	});
 
 	test('write workspace standalone setting - existing file', async () => {
@@ -267,8 +267,8 @@ suite('ConfigurationEditingService', () => {
 
 		const contents = await fileService.readFile(target);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['service.testSetting'], 'value');
-		assert.equal(parsed['my.super.setting'], 'my.super.value');
+		assert.strictEqual(parsed['service.testSetting'], 'value');
+		assert.strictEqual(parsed['my.super.setting'], 'my.super.value');
 	});
 
 	test('write user standalone setting - existing file', async () => {
@@ -279,8 +279,8 @@ suite('ConfigurationEditingService', () => {
 
 		const contents = await fileService.readFile(target);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['service.testSetting'], 'value');
-		assert.equal(parsed['my.super.setting'], 'my.super.value');
+		assert.strictEqual(parsed['service.testSetting'], 'value');
+		assert.strictEqual(parsed['my.super.setting'], 'my.super.value');
 	});
 
 	test('write workspace standalone setting - empty file - full JSON', async () => {
@@ -289,8 +289,8 @@ suite('ConfigurationEditingService', () => {
 		const target = joinPath(workspaceService.getWorkspace().folders[0].uri, WORKSPACE_STANDALONE_CONFIGURATIONS['tasks']);
 		const contents = await fileService.readFile(target);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['version'], '1.0.0');
-		assert.equal(parsed['tasks'][0]['taskName'], 'myTask');
+		assert.strictEqual(parsed['version'], '1.0.0');
+		assert.strictEqual(parsed['tasks'][0]['taskName'], 'myTask');
 	});
 
 	test('write user standalone setting - empty file - full JSON', async () => {
@@ -299,8 +299,8 @@ suite('ConfigurationEditingService', () => {
 		const target = joinPath(environmentService.userRoamingDataHome, USER_STANDALONE_CONFIGURATIONS['tasks']);
 		const contents = await fileService.readFile(target);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['version'], '1.0.0');
-		assert.equal(parsed['tasks'][0]['taskName'], 'myTask');
+		assert.strictEqual(parsed['version'], '1.0.0');
+		assert.strictEqual(parsed['tasks'][0]['taskName'], 'myTask');
 	});
 
 	test('write workspace standalone setting - existing file - full JSON', async () => {
@@ -311,8 +311,8 @@ suite('ConfigurationEditingService', () => {
 
 		const contents = await fileService.readFile(target);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['version'], '1.0.0');
-		assert.equal(parsed['tasks'][0]['taskName'], 'myTask');
+		assert.strictEqual(parsed['version'], '1.0.0');
+		assert.strictEqual(parsed['tasks'][0]['taskName'], 'myTask');
 	});
 
 	test('write user standalone setting - existing file - full JSON', async () => {
@@ -323,8 +323,8 @@ suite('ConfigurationEditingService', () => {
 
 		const contents = await fileService.readFile(target);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['version'], '1.0.0');
-		assert.equal(parsed['tasks'][0]['taskName'], 'myTask');
+		assert.strictEqual(parsed['version'], '1.0.0');
+		assert.strictEqual(parsed['tasks'][0]['taskName'], 'myTask');
 	});
 
 	test('write workspace standalone setting - existing file with JSON errors - full JSON', async () => {
@@ -335,8 +335,8 @@ suite('ConfigurationEditingService', () => {
 
 		const contents = await fileService.readFile(target);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['version'], '1.0.0');
-		assert.equal(parsed['tasks'][0]['taskName'], 'myTask');
+		assert.strictEqual(parsed['version'], '1.0.0');
+		assert.strictEqual(parsed['tasks'][0]['taskName'], 'myTask');
 	});
 
 	test('write user standalone setting - existing file with JSON errors - full JSON', async () => {
@@ -347,8 +347,8 @@ suite('ConfigurationEditingService', () => {
 
 		const contents = await fileService.readFile(target);
 		const parsed = json.parse(contents.value.toString());
-		assert.equal(parsed['version'], '1.0.0');
-		assert.equal(parsed['tasks'][0]['taskName'], 'myTask');
+		assert.strictEqual(parsed['version'], '1.0.0');
+		assert.strictEqual(parsed['tasks'][0]['taskName'], 'myTask');
 	});
 
 	test('write workspace standalone setting should replace complete file', async () => {
@@ -369,7 +369,7 @@ suite('ConfigurationEditingService', () => {
 
 		const actual = await fileService.readFile(target);
 		const expected = JSON.stringify({ 'version': '1.0.0', tasks: [{ 'taskName': 'myTask1' }] }, null, '\t');
-		assert.equal(actual.value.toString(), expected);
+		assert.strictEqual(actual.value.toString(), expected);
 	});
 
 	test('write user standalone setting should replace complete file', async () => {
@@ -390,6 +390,6 @@ suite('ConfigurationEditingService', () => {
 
 		const actual = await fileService.readFile(target);
 		const expected = JSON.stringify({ 'version': '1.0.0', tasks: [{ 'taskName': 'myTask1' }] }, null, '\t');
-		assert.equal(actual.value.toString(), expected);
+		assert.strictEqual(actual.value.toString(), expected);
 	});
 });

--- a/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
@@ -84,23 +84,23 @@ suite('WorkspaceContextService - Folder', () => {
 	test('getWorkspace()', () => {
 		const actual = testObject.getWorkspace();
 
-		assert.equal(actual.folders.length, 1);
-		assert.equal(actual.folders[0].uri.path, folder.path);
-		assert.equal(actual.folders[0].name, folderName);
-		assert.equal(actual.folders[0].index, 0);
+		assert.strictEqual(actual.folders.length, 1);
+		assert.strictEqual(actual.folders[0].uri.path, folder.path);
+		assert.strictEqual(actual.folders[0].name, folderName);
+		assert.strictEqual(actual.folders[0].index, 0);
 		assert.ok(!actual.configuration);
 	});
 
 	test('getWorkbenchState()', () => {
 		const actual = testObject.getWorkbenchState();
 
-		assert.equal(actual, WorkbenchState.FOLDER);
+		assert.strictEqual(actual, WorkbenchState.FOLDER);
 	});
 
 	test('getWorkspaceFolder()', () => {
 		const actual = testObject.getWorkspaceFolder(joinPath(folder, 'a'));
 
-		assert.equal(actual, testObject.getWorkspace().folders[0]);
+		assert.strictEqual(actual, testObject.getWorkspace().folders[0]);
 	});
 
 	test('isCurrentWorkspace() => true', () => {
@@ -156,15 +156,15 @@ suite('WorkspaceContextService - Workspace', () => {
 	test('workspace folders', () => {
 		const actual = testObject.getWorkspace().folders;
 
-		assert.equal(actual.length, 2);
-		assert.equal(basename(actual[0].uri), 'a');
-		assert.equal(basename(actual[1].uri), 'b');
+		assert.strictEqual(actual.length, 2);
+		assert.strictEqual(basename(actual[0].uri), 'a');
+		assert.strictEqual(basename(actual[1].uri), 'b');
 	});
 
 	test('getWorkbenchState()', () => {
 		const actual = testObject.getWorkbenchState();
 
-		assert.equal(actual, WorkbenchState.WORKSPACE);
+		assert.strictEqual(actual, WorkbenchState.WORKSPACE);
 	});
 
 
@@ -218,46 +218,46 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 		await testObject.addFolders([{ uri: joinPath(ROOT, 'd') }, { uri: joinPath(ROOT, 'c') }]);
 		const actual = testObject.getWorkspace().folders;
 
-		assert.equal(actual.length, 4);
-		assert.equal(basename(actual[0].uri), 'a');
-		assert.equal(basename(actual[1].uri), 'b');
-		assert.equal(basename(actual[2].uri), 'd');
-		assert.equal(basename(actual[3].uri), 'c');
+		assert.strictEqual(actual.length, 4);
+		assert.strictEqual(basename(actual[0].uri), 'a');
+		assert.strictEqual(basename(actual[1].uri), 'b');
+		assert.strictEqual(basename(actual[2].uri), 'd');
+		assert.strictEqual(basename(actual[3].uri), 'c');
 	});
 
 	test('add folders (at specific index)', async () => {
 		await testObject.addFolders([{ uri: joinPath(ROOT, 'd') }, { uri: joinPath(ROOT, 'c') }], 0);
 		const actual = testObject.getWorkspace().folders;
 
-		assert.equal(actual.length, 4);
-		assert.equal(basename(actual[0].uri), 'd');
-		assert.equal(basename(actual[1].uri), 'c');
-		assert.equal(basename(actual[2].uri), 'a');
-		assert.equal(basename(actual[3].uri), 'b');
+		assert.strictEqual(actual.length, 4);
+		assert.strictEqual(basename(actual[0].uri), 'd');
+		assert.strictEqual(basename(actual[1].uri), 'c');
+		assert.strictEqual(basename(actual[2].uri), 'a');
+		assert.strictEqual(basename(actual[3].uri), 'b');
 	});
 
 	test('add folders (at specific wrong index)', async () => {
 		await testObject.addFolders([{ uri: joinPath(ROOT, 'd') }, { uri: joinPath(ROOT, 'c') }], 10);
 		const actual = testObject.getWorkspace().folders;
 
-		assert.equal(actual.length, 4);
-		assert.equal(basename(actual[0].uri), 'a');
-		assert.equal(basename(actual[1].uri), 'b');
-		assert.equal(basename(actual[2].uri), 'd');
-		assert.equal(basename(actual[3].uri), 'c');
+		assert.strictEqual(actual.length, 4);
+		assert.strictEqual(basename(actual[0].uri), 'a');
+		assert.strictEqual(basename(actual[1].uri), 'b');
+		assert.strictEqual(basename(actual[2].uri), 'd');
+		assert.strictEqual(basename(actual[3].uri), 'c');
 	});
 
 	test('add folders (with name)', async () => {
 		await testObject.addFolders([{ uri: joinPath(ROOT, 'd'), name: 'DDD' }, { uri: joinPath(ROOT, 'c'), name: 'CCC' }]);
 		const actual = testObject.getWorkspace().folders;
 
-		assert.equal(actual.length, 4);
-		assert.equal(basename(actual[0].uri), 'a');
-		assert.equal(basename(actual[1].uri), 'b');
-		assert.equal(basename(actual[2].uri), 'd');
-		assert.equal(basename(actual[3].uri), 'c');
-		assert.equal(actual[2].name, 'DDD');
-		assert.equal(actual[3].name, 'CCC');
+		assert.strictEqual(actual.length, 4);
+		assert.strictEqual(basename(actual[0].uri), 'a');
+		assert.strictEqual(basename(actual[1].uri), 'b');
+		assert.strictEqual(basename(actual[2].uri), 'd');
+		assert.strictEqual(basename(actual[3].uri), 'c');
+		assert.strictEqual(actual[2].name, 'DDD');
+		assert.strictEqual(actual[3].name, 'CCC');
 	});
 
 	test('add folders triggers change event', async () => {
@@ -267,7 +267,7 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 		const addedFolders = [{ uri: joinPath(ROOT, 'd') }, { uri: joinPath(ROOT, 'c') }];
 		await testObject.addFolders(addedFolders);
 
-		assert.equal(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
+		assert.strictEqual(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
 		const actual_1 = (<IWorkspaceFoldersChangeEvent>target.args[0][0]);
 		assert.deepEqual(actual_1.added.map(r => r.uri.toString()), addedFolders.map(a => a.uri.toString()));
 		assert.deepEqual(actual_1.removed, []);
@@ -278,8 +278,8 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 		await testObject.removeFolders([testObject.getWorkspace().folders[0].uri]);
 		const actual = testObject.getWorkspace().folders;
 
-		assert.equal(actual.length, 1);
-		assert.equal(basename(actual[0].uri), 'b');
+		assert.strictEqual(actual.length, 1);
+		assert.strictEqual(basename(actual[0].uri), 'b');
 	});
 
 	test('remove folders triggers change event', async () => {
@@ -288,7 +288,7 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 		const removedFolder = testObject.getWorkspace().folders[0];
 		await testObject.removeFolders([removedFolder.uri]);
 
-		assert.equal(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
+		assert.strictEqual(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
 		const actual_1 = (<IWorkspaceFoldersChangeEvent>target.args[0][0]);
 		assert.deepEqual(actual_1.added, []);
 		assert.deepEqual(actual_1.removed.map(r => r.uri.toString()), [removedFolder.uri.toString()]);
@@ -322,7 +322,7 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 		const removedFolders = [testObject.getWorkspace().folders[1]].map(f => f.uri);
 		await testObject.updateFolders(addedFolders, removedFolders);
 
-		assert.equal(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
+		assert.strictEqual(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
 		const actual_1 = (<IWorkspaceFoldersChangeEvent>target.args[0][0]);
 		assert.deepEqual(actual_1.added.map(r => r.uri.toString()), addedFolders.map(a => a.uri.toString()));
 		assert.deepEqual(actual_1.removed.map(r_1 => r_1.uri.toString()), removedFolders.map(a_1 => a_1.toString()));
@@ -336,7 +336,7 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 		const removedFolders = [testObject.getWorkspace().folders[0]].map(f => f.uri);
 		await testObject.updateFolders(addedFolders, removedFolders, 0);
 
-		assert.equal(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
+		assert.strictEqual(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
 		const actual_1 = (<IWorkspaceFoldersChangeEvent>target.args[0][0]);
 		assert.deepEqual(actual_1.added, []);
 		assert.deepEqual(actual_1.removed, []);
@@ -351,7 +351,7 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 		const changedFolders = [testObject.getWorkspace().folders[1]].map(f => f.uri);
 		await testObject.updateFolders(addedFolders, removedFolders);
 
-		assert.equal(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
+		assert.strictEqual(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
 		const actual_1 = (<IWorkspaceFoldersChangeEvent>target.args[0][0]);
 		assert.deepEqual(actual_1.added.map(r => r.uri.toString()), addedFolders.map(a => a.uri.toString()));
 		assert.deepEqual(actual_1.removed.map(r_1 => r_1.uri.toString()), removedFolders.map(a_1 => a_1.toString()));
@@ -365,7 +365,7 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 		await fileService.writeFile(testObject.getWorkspace().configuration!, VSBuffer.fromString(JSON.stringify(workspace, null, '\t')));
 		await testObject.reloadConfiguration();
 
-		assert.equal(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
+		assert.strictEqual(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
 		const actual_1 = (<IWorkspaceFoldersChangeEvent>target.args[0][0]);
 		assert.deepEqual(actual_1.added, []);
 		assert.deepEqual(actual_1.removed, []);
@@ -379,7 +379,7 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 		fileService.writeFile(testObject.getWorkspace().configuration!, VSBuffer.fromString(JSON.stringify(workspace, null, '\t')));
 		await testObject.reloadConfiguration();
 
-		assert.equal(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
+		assert.strictEqual(target.callCount, 1, `Should be called only once but called ${target.callCount} times`);
 		const actual_1 = (<IWorkspaceFoldersChangeEvent>target.args[0][0]);
 		assert.deepEqual(actual_1.added, []);
 		assert.deepEqual(actual_1.removed, []);
@@ -463,8 +463,8 @@ suite('WorkspaceService - Initialization', () => {
 		const folder = joinPath(ROOT, 'a');
 		await testObject.initialize(convertToWorkspacePayload(folder));
 
-		assert.equal(testObject.getValue('initialization.testSetting1'), 'userValue');
-		assert.equal(target.callCount, 3);
+		assert.strictEqual(testObject.getValue('initialization.testSetting1'), 'userValue');
+		assert.strictEqual(target.callCount, 3);
 		assert.deepEqual(target.args[0], [WorkbenchState.FOLDER]);
 		assert.deepEqual(target.args[1], [undefined]);
 		assert.deepEqual((<IWorkspaceFoldersChangeEvent>target.args[2][0]).added.map(f => f.uri.toString()), [folder.toString()]);
@@ -488,8 +488,8 @@ suite('WorkspaceService - Initialization', () => {
 		await fileService.writeFile(joinPath(folder, '.vscode', 'settings.json'), VSBuffer.fromString('{ "initialization.testSetting1": "workspaceValue" }'));
 		await testObject.initialize(convertToWorkspacePayload(folder));
 
-		assert.equal(testObject.getValue('initialization.testSetting1'), 'workspaceValue');
-		assert.equal(target.callCount, 4);
+		assert.strictEqual(testObject.getValue('initialization.testSetting1'), 'workspaceValue');
+		assert.strictEqual(target.callCount, 4);
 		assert.deepEqual((<IConfigurationChangeEvent>target.args[0][0]).affectedKeys, ['initialization.testSetting1']);
 		assert.deepEqual(target.args[1], [WorkbenchState.FOLDER]);
 		assert.deepEqual(target.args[2], [undefined]);
@@ -512,7 +512,7 @@ suite('WorkspaceService - Initialization', () => {
 
 		await testObject.initialize(getWorkspaceIdentifier(configResource));
 
-		assert.equal(target.callCount, 3);
+		assert.strictEqual(target.callCount, 3);
 		assert.deepEqual(target.args[0], [WorkbenchState.WORKSPACE]);
 		assert.deepEqual(target.args[1], [undefined]);
 		assert.deepEqual((<IWorkspaceFoldersChangeEvent>target.args[2][0]).added.map(folder => folder.uri.toString()), [joinPath(ROOT, 'a').toString(), joinPath(ROOT, 'b').toString()]);
@@ -536,7 +536,7 @@ suite('WorkspaceService - Initialization', () => {
 		await fileService.writeFile(joinPath(ROOT, 'b', '.vscode', 'settings.json'), VSBuffer.fromString('{ "initialization.testSetting2": "workspaceValue2" }'));
 		await testObject.initialize(getWorkspaceIdentifier(configResource));
 
-		assert.equal(target.callCount, 4);
+		assert.strictEqual(target.callCount, 4);
 		assert.deepEqual((<IConfigurationChangeEvent>target.args[0][0]).affectedKeys, ['initialization.testSetting1', 'initialization.testSetting2']);
 		assert.deepEqual(target.args[1], [WorkbenchState.WORKSPACE]);
 		assert.deepEqual(target.args[2], [undefined]);
@@ -559,8 +559,8 @@ suite('WorkspaceService - Initialization', () => {
 
 		await testObject.initialize(convertToWorkspacePayload(joinPath(ROOT, 'b')));
 
-		assert.equal(testObject.getValue('initialization.testSetting1'), 'userValue');
-		assert.equal(target.callCount, 1);
+		assert.strictEqual(testObject.getValue('initialization.testSetting1'), 'userValue');
+		assert.strictEqual(target.callCount, 1);
 		assert.deepEqual((<IWorkspaceFoldersChangeEvent>target.args[0][0]).added.map(folder_1 => folder_1.uri.toString()), [joinPath(ROOT, 'b').toString()]);
 		assert.deepEqual((<IWorkspaceFoldersChangeEvent>target.args[0][0]).removed.map(folder_2 => folder_2.uri.toString()), [joinPath(ROOT, 'a').toString()]);
 		assert.deepEqual((<IWorkspaceFoldersChangeEvent>target.args[0][0]).changed, []);
@@ -579,8 +579,8 @@ suite('WorkspaceService - Initialization', () => {
 		await fileService.writeFile(joinPath(ROOT, 'b', '.vscode', 'settings.json'), VSBuffer.fromString('{ "initialization.testSetting1": "workspaceValue2" }'));
 		await testObject.initialize(convertToWorkspacePayload(joinPath(ROOT, 'b')));
 
-		assert.equal(testObject.getValue('initialization.testSetting1'), 'workspaceValue2');
-		assert.equal(target.callCount, 2);
+		assert.strictEqual(testObject.getValue('initialization.testSetting1'), 'workspaceValue2');
+		assert.strictEqual(target.callCount, 2);
 		assert.deepEqual((<IConfigurationChangeEvent>target.args[0][0]).affectedKeys, ['initialization.testSetting1']);
 		assert.deepEqual((<IWorkspaceFoldersChangeEvent>target.args[1][0]).added.map(folder_1 => folder_1.uri.toString()), [joinPath(ROOT, 'b').toString()]);
 		assert.deepEqual((<IWorkspaceFoldersChangeEvent>target.args[1][0]).removed.map(folder_2 => folder_2.uri.toString()), [joinPath(ROOT, 'a').toString()]);
@@ -599,7 +599,7 @@ suite('WorkspaceService - Initialization', () => {
 		await fileService.writeFile(joinPath(ROOT, 'a', '.vscode', 'settings.json'), VSBuffer.fromString('{ "initialization.testSetting1": "workspaceValue2" }'));
 		await testObject.initialize(getWorkspaceIdentifier(configResource));
 
-		assert.equal(target.callCount, 4);
+		assert.strictEqual(target.callCount, 4);
 		assert.deepEqual((<IConfigurationChangeEvent>target.args[0][0]).affectedKeys, ['initialization.testSetting1']);
 		assert.deepEqual(target.args[1], [WorkbenchState.WORKSPACE]);
 		assert.deepEqual(target.args[2], [undefined]);
@@ -686,33 +686,33 @@ suite('WorkspaceConfigurationService - Folder', () => {
 	test('globals override defaults', async () => {
 		await fileService.writeFile(environmentService.settingsResource, VSBuffer.fromString('{ "configurationService.folder.testSetting": "userValue" }'));
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.testSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.testSetting'), 'userValue');
 	});
 
 	test('globals', async () => {
 		await fileService.writeFile(environmentService.settingsResource, VSBuffer.fromString('{ "testworkbench.editor.tabs": true }'));
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('testworkbench.editor.tabs'), true);
+		assert.strictEqual(testObject.getValue('testworkbench.editor.tabs'), true);
 	});
 
 	test('workspace settings', async () => {
 		await fileService.writeFile(joinPath(workspaceService.getWorkspace().folders[0].uri, '.vscode', 'settings.json'), VSBuffer.fromString('{ "testworkbench.editor.icons": true }'));
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('testworkbench.editor.icons'), true);
+		assert.strictEqual(testObject.getValue('testworkbench.editor.icons'), true);
 	});
 
 	test('workspace settings override user settings', async () => {
 		await fileService.writeFile(environmentService.settingsResource, VSBuffer.fromString('{ "configurationService.folder.testSetting": "userValue" }'));
 		await fileService.writeFile(joinPath(workspaceService.getWorkspace().folders[0].uri, '.vscode', 'settings.json'), VSBuffer.fromString('{ "configurationService.folder.testSetting": "workspaceValue" }'));
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.testSetting'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.testSetting'), 'workspaceValue');
 	});
 
 	test('machine overridable settings override user Settings', async () => {
 		await fileService.writeFile(environmentService.settingsResource, VSBuffer.fromString('{ "configurationService.folder.machineOverridableSetting": "userValue" }'));
 		await fileService.writeFile(joinPath(workspaceService.getWorkspace().folders[0].uri, '.vscode', 'settings.json'), VSBuffer.fromString('{ "configurationService.folder.machineOverridableSetting": "workspaceValue" }'));
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.machineOverridableSetting'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineOverridableSetting'), 'workspaceValue');
 	});
 
 	test('workspace settings override user settings after defaults are registered ', async () => {
@@ -729,7 +729,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 				}
 			}
 		});
-		assert.equal(testObject.getValue('configurationService.folder.newSetting'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.newSetting'), 'workspaceValue');
 	});
 
 	test('machine overridable settings override user settings after defaults are registered ', async () => {
@@ -747,7 +747,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 				}
 			}
 		});
-		assert.equal(testObject.getValue('configurationService.folder.newMachineOverridableSetting'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.newMachineOverridableSetting'), 'workspaceValue');
 	});
 
 	test('application settings are not read from workspace', async () => {
@@ -756,7 +756,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.folder.applicationSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.applicationSetting'), 'userValue');
 	});
 
 	test('application settings are not read from workspace when workspace folder uri is passed', async () => {
@@ -765,7 +765,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.folder.applicationSetting', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.applicationSetting', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('machine settings are not read from workspace', async () => {
@@ -774,7 +774,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.folder.machineSetting', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineSetting', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('machine settings are not read from workspace when workspace folder uri is passed', async () => {
@@ -783,7 +783,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.folder.machineSetting', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineSetting', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('get application scope settings are not loaded after defaults are registered', async () => {
@@ -791,7 +791,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 		await fileService.writeFile(joinPath(workspaceService.getWorkspace().folders[0].uri, '.vscode', 'settings.json'), VSBuffer.fromString('{ "configurationService.folder.applicationSetting-2": "workspaceValue" }'));
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.applicationSetting-2'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.applicationSetting-2'), 'workspaceValue');
 
 		configurationRegistry.registerConfiguration({
 			'id': '_test',
@@ -805,10 +805,10 @@ suite('WorkspaceConfigurationService - Folder', () => {
 			}
 		});
 
-		assert.equal(testObject.getValue('configurationService.folder.applicationSetting-2'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.applicationSetting-2'), 'userValue');
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.applicationSetting-2'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.applicationSetting-2'), 'userValue');
 	});
 
 	test('get application scope settings are not loaded after defaults are registered when workspace folder uri is passed', async () => {
@@ -816,7 +816,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 		await fileService.writeFile(joinPath(workspaceService.getWorkspace().folders[0].uri, '.vscode', 'settings.json'), VSBuffer.fromString('{ "configurationService.folder.applicationSetting-3": "workspaceValue" }'));
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.applicationSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.applicationSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'workspaceValue');
 
 		configurationRegistry.registerConfiguration({
 			'id': '_test',
@@ -830,10 +830,10 @@ suite('WorkspaceConfigurationService - Folder', () => {
 			}
 		});
 
-		assert.equal(testObject.getValue('configurationService.folder.applicationSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.applicationSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.applicationSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.applicationSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('get machine scope settings are not loaded after defaults are registered', async () => {
@@ -841,7 +841,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 		await fileService.writeFile(joinPath(workspaceService.getWorkspace().folders[0].uri, '.vscode', 'settings.json'), VSBuffer.fromString('{ "configurationService.folder.machineSetting-2": "workspaceValue" }'));
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.machineSetting-2'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineSetting-2'), 'workspaceValue');
 
 		configurationRegistry.registerConfiguration({
 			'id': '_test',
@@ -855,10 +855,10 @@ suite('WorkspaceConfigurationService - Folder', () => {
 			}
 		});
 
-		assert.equal(testObject.getValue('configurationService.folder.machineSetting-2'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineSetting-2'), 'userValue');
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.machineSetting-2'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineSetting-2'), 'userValue');
 	});
 
 	test('get machine scope settings are not loaded after defaults are registered when workspace folder uri is passed', async () => {
@@ -866,7 +866,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 		await fileService.writeFile(joinPath(workspaceService.getWorkspace().folders[0].uri, '.vscode', 'settings.json'), VSBuffer.fromString('{ "configurationService.folder.machineSetting-3": "workspaceValue" }'));
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.machineSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'workspaceValue');
 
 		configurationRegistry.registerConfiguration({
 			'id': '_test',
@@ -880,10 +880,10 @@ suite('WorkspaceConfigurationService - Folder', () => {
 			}
 		});
 
-		assert.equal(testObject.getValue('configurationService.folder.machineSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.folder.machineSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineSetting-3', { resource: workspaceService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('reload configuration emits events after global configuraiton changes', async () => {
@@ -914,36 +914,36 @@ suite('WorkspaceConfigurationService - Folder', () => {
 
 	test('inspect', async () => {
 		let actual = testObject.inspect('something.missing');
-		assert.equal(actual.defaultValue, undefined);
-		assert.equal(actual.userValue, undefined);
-		assert.equal(actual.workspaceValue, undefined);
-		assert.equal(actual.workspaceFolderValue, undefined);
-		assert.equal(actual.value, undefined);
+		assert.strictEqual(actual.defaultValue, undefined);
+		assert.strictEqual(actual.userValue, undefined);
+		assert.strictEqual(actual.workspaceValue, undefined);
+		assert.strictEqual(actual.workspaceFolderValue, undefined);
+		assert.strictEqual(actual.value, undefined);
 
 		actual = testObject.inspect('configurationService.folder.testSetting');
-		assert.equal(actual.defaultValue, 'isSet');
-		assert.equal(actual.userValue, undefined);
-		assert.equal(actual.workspaceValue, undefined);
-		assert.equal(actual.workspaceFolderValue, undefined);
-		assert.equal(actual.value, 'isSet');
+		assert.strictEqual(actual.defaultValue, 'isSet');
+		assert.strictEqual(actual.userValue, undefined);
+		assert.strictEqual(actual.workspaceValue, undefined);
+		assert.strictEqual(actual.workspaceFolderValue, undefined);
+		assert.strictEqual(actual.value, 'isSet');
 
 		await fileService.writeFile(environmentService.settingsResource, VSBuffer.fromString('{ "configurationService.folder.testSetting": "userValue" }'));
 		await testObject.reloadConfiguration();
 		actual = testObject.inspect('configurationService.folder.testSetting');
-		assert.equal(actual.defaultValue, 'isSet');
-		assert.equal(actual.userValue, 'userValue');
-		assert.equal(actual.workspaceValue, undefined);
-		assert.equal(actual.workspaceFolderValue, undefined);
-		assert.equal(actual.value, 'userValue');
+		assert.strictEqual(actual.defaultValue, 'isSet');
+		assert.strictEqual(actual.userValue, 'userValue');
+		assert.strictEqual(actual.workspaceValue, undefined);
+		assert.strictEqual(actual.workspaceFolderValue, undefined);
+		assert.strictEqual(actual.value, 'userValue');
 
 		await fileService.writeFile(joinPath(workspaceService.getWorkspace().folders[0].uri, '.vscode', 'settings.json'), VSBuffer.fromString('{ "configurationService.folder.testSetting": "workspaceValue" }'));
 		await testObject.reloadConfiguration();
 		actual = testObject.inspect('configurationService.folder.testSetting');
-		assert.equal(actual.defaultValue, 'isSet');
-		assert.equal(actual.userValue, 'userValue');
-		assert.equal(actual.workspaceValue, 'workspaceValue');
-		assert.equal(actual.workspaceFolderValue, undefined);
-		assert.equal(actual.value, 'workspaceValue');
+		assert.strictEqual(actual.defaultValue, 'isSet');
+		assert.strictEqual(actual.userValue, 'userValue');
+		assert.strictEqual(actual.workspaceValue, 'workspaceValue');
+		assert.strictEqual(actual.workspaceFolderValue, undefined);
+		assert.strictEqual(actual.value, 'workspaceValue');
 	});
 
 	test('keys', async () => {
@@ -972,32 +972,32 @@ suite('WorkspaceConfigurationService - Folder', () => {
 
 	test('update user configuration', () => {
 		return testObject.updateValue('configurationService.folder.testSetting', 'value', ConfigurationTarget.USER)
-			.then(() => assert.equal(testObject.getValue('configurationService.folder.testSetting'), 'value'));
+			.then(() => assert.strictEqual(testObject.getValue('configurationService.folder.testSetting'), 'value'));
 	});
 
 	test('update workspace configuration', () => {
 		return testObject.updateValue('tasks.service.testSetting', 'value', ConfigurationTarget.WORKSPACE)
-			.then(() => assert.equal(testObject.getValue('tasks.service.testSetting'), 'value'));
+			.then(() => assert.strictEqual(testObject.getValue('tasks.service.testSetting'), 'value'));
 	});
 
 	test('update resource configuration', () => {
 		return testObject.updateValue('configurationService.folder.testSetting', 'value', { resource: workspaceService.getWorkspace().folders[0].uri }, ConfigurationTarget.WORKSPACE_FOLDER)
-			.then(() => assert.equal(testObject.getValue('configurationService.folder.testSetting'), 'value'));
+			.then(() => assert.strictEqual(testObject.getValue('configurationService.folder.testSetting'), 'value'));
 	});
 
 	test('update resource language configuration', () => {
 		return testObject.updateValue('configurationService.folder.languageSetting', 'value', { resource: workspaceService.getWorkspace().folders[0].uri }, ConfigurationTarget.WORKSPACE_FOLDER)
-			.then(() => assert.equal(testObject.getValue('configurationService.folder.languageSetting'), 'value'));
+			.then(() => assert.strictEqual(testObject.getValue('configurationService.folder.languageSetting'), 'value'));
 	});
 
 	test('update application setting into workspace configuration in a workspace is not supported', () => {
 		return testObject.updateValue('configurationService.folder.applicationSetting', 'workspaceValue', {}, ConfigurationTarget.WORKSPACE, true)
-			.then(() => assert.fail('Should not be supported'), (e) => assert.equal(e.code, ConfigurationEditingErrorCode.ERROR_INVALID_WORKSPACE_CONFIGURATION_APPLICATION));
+			.then(() => assert.fail('Should not be supported'), (e) => assert.strictEqual(e.code, ConfigurationEditingErrorCode.ERROR_INVALID_WORKSPACE_CONFIGURATION_APPLICATION));
 	});
 
 	test('update machine setting into workspace configuration in a workspace is not supported', () => {
 		return testObject.updateValue('configurationService.folder.machineSetting', 'workspaceValue', {}, ConfigurationTarget.WORKSPACE, true)
-			.then(() => assert.fail('Should not be supported'), (e) => assert.equal(e.code, ConfigurationEditingErrorCode.ERROR_INVALID_WORKSPACE_CONFIGURATION_MACHINE));
+			.then(() => assert.fail('Should not be supported'), (e) => assert.strictEqual(e.code, ConfigurationEditingErrorCode.ERROR_INVALID_WORKSPACE_CONFIGURATION_MACHINE));
 	});
 
 	test('update tasks configuration', () => {
@@ -1021,7 +1021,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 
 	test('update memory configuration', () => {
 		return testObject.updateValue('configurationService.folder.testSetting', 'memoryValue', ConfigurationTarget.MEMORY)
-			.then(() => assert.equal(testObject.getValue('configurationService.folder.testSetting'), 'memoryValue'));
+			.then(() => assert.strictEqual(testObject.getValue('configurationService.folder.testSetting'), 'memoryValue'));
 	});
 
 	test('update memory configuration should trigger change event before promise is resolve', () => {
@@ -1040,21 +1040,21 @@ suite('WorkspaceConfigurationService - Folder', () => {
 		await testObject.reloadConfiguration();
 
 		const actual = testObject.inspect(key, { resource: workspaceService.getWorkspace().folders[0].uri });
-		assert.equal(actual.userValue, undefined);
-		assert.equal(actual.workspaceValue, undefined);
-		assert.equal(actual.workspaceFolderValue, undefined);
+		assert.strictEqual(actual.userValue, undefined);
+		assert.strictEqual(actual.workspaceValue, undefined);
+		assert.strictEqual(actual.workspaceFolderValue, undefined);
 	});
 
 	test('update user configuration to default value when target is not passed', async () => {
 		await testObject.updateValue('configurationService.folder.testSetting', 'value', ConfigurationTarget.USER);
 		await testObject.updateValue('configurationService.folder.testSetting', 'isSet');
-		assert.equal(testObject.inspect('configurationService.folder.testSetting').userValue, undefined);
+		assert.strictEqual(testObject.inspect('configurationService.folder.testSetting').userValue, undefined);
 	});
 
 	test('update user configuration to default value when target is passed', async () => {
 		await testObject.updateValue('configurationService.folder.testSetting', 'value', ConfigurationTarget.USER);
 		await testObject.updateValue('configurationService.folder.testSetting', 'isSet', ConfigurationTarget.USER);
-		assert.equal(testObject.inspect('configurationService.folder.testSetting').userValue, 'isSet');
+		assert.strictEqual(testObject.inspect('configurationService.folder.testSetting').userValue, 'isSet');
 	});
 
 	test('update task configuration should trigger change event before promise is resolve', () => {
@@ -1082,7 +1082,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 		await new Promise<void>(async (c) => {
 			const disposable = testObject.onDidChangeConfiguration(e => {
 				assert.ok(e.affectsConfiguration('configurationService.folder.testSetting'));
-				assert.equal(testObject.getValue('configurationService.folder.testSetting'), 'workspaceValue');
+				assert.strictEqual(testObject.getValue('configurationService.folder.testSetting'), 'workspaceValue');
 				disposable.dispose();
 				c();
 			});
@@ -1100,7 +1100,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 			await fileService.del(workspaceSettingsResource);
 		});
 		assert.ok(e.affectsConfiguration('configurationService.folder.testSetting'));
-		assert.equal(testObject.getValue('configurationService.folder.testSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.testSetting'), 'userValue');
 	});
 });
 
@@ -1197,7 +1197,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.folder.applicationSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.applicationSetting'), 'userValue');
 	});
 
 	test('application settings are not read from workspace when folder is passed', async () => {
@@ -1206,7 +1206,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.folder.applicationSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.applicationSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('machine settings are not read from workspace', async () => {
@@ -1215,7 +1215,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.folder.machineSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineSetting'), 'userValue');
 	});
 
 	test('machine settings are not read from workspace when folder is passed', async () => {
@@ -1224,7 +1224,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.folder.machineSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.folder.machineSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('get application scope settings are not loaded after defaults are registered', async () => {
@@ -1232,7 +1232,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 		await jsonEditingServce.write(workspaceContextService.getWorkspace().configuration!, [{ path: ['settings'], value: { 'configurationService.workspace.newSetting': 'workspaceValue' } }], true);
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.workspace.newSetting'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.newSetting'), 'workspaceValue');
 
 		configurationRegistry.registerConfiguration({
 			'id': '_test',
@@ -1246,10 +1246,10 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 			}
 		});
 
-		assert.equal(testObject.getValue('configurationService.workspace.newSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.newSetting'), 'userValue');
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.workspace.newSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.newSetting'), 'userValue');
 	});
 
 	test('get application scope settings are not loaded after defaults are registered when workspace folder is passed', async () => {
@@ -1257,7 +1257,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 		await jsonEditingServce.write(workspaceContextService.getWorkspace().configuration!, [{ path: ['settings'], value: { 'configurationService.workspace.newSetting-2': 'workspaceValue' } }], true);
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.workspace.newSetting-2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.newSetting-2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceValue');
 
 		configurationRegistry.registerConfiguration({
 			'id': '_test',
@@ -1271,10 +1271,10 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 			}
 		});
 
-		assert.equal(testObject.getValue('configurationService.workspace.newSetting-2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.newSetting-2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.workspace.newSetting-2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.newSetting-2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('workspace settings override user settings after defaults are registered for machine overridable settings ', async () => {
@@ -1282,7 +1282,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 		await jsonEditingServce.write(workspaceContextService.getWorkspace().configuration!, [{ path: ['settings'], value: { 'configurationService.workspace.newMachineOverridableSetting': 'workspaceValue' } }], true);
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.workspace.newMachineOverridableSetting'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.newMachineOverridableSetting'), 'workspaceValue');
 
 		configurationRegistry.registerConfiguration({
 			'id': '_test',
@@ -1296,10 +1296,10 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 			}
 		});
 
-		assert.equal(testObject.getValue('configurationService.workspace.newMachineOverridableSetting'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.newMachineOverridableSetting'), 'workspaceValue');
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.workspace.newMachineOverridableSetting'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.newMachineOverridableSetting'), 'workspaceValue');
 
 	});
 
@@ -1309,7 +1309,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.workspace.applicationSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.applicationSetting'), 'userValue');
 	});
 
 	test('application settings are not read from workspace folder when workspace folder is passed', async () => {
@@ -1318,7 +1318,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.workspace.applicationSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.applicationSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('machine settings are not read from workspace folder', async () => {
@@ -1327,7 +1327,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.workspace.machineSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.machineSetting'), 'userValue');
 	});
 
 	test('machine settings are not read from workspace folder when workspace folder is passed', async () => {
@@ -1336,7 +1336,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.workspace.machineSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.machineSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('application settings are not read from workspace folder after defaults are registered', async () => {
@@ -1344,7 +1344,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 		await fileService.writeFile(workspaceContextService.getWorkspace().folders[0].toResource('.vscode/settings.json'), VSBuffer.fromString('{ "configurationService.workspace.testNewApplicationSetting": "workspaceFolderValue" }'));
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.workspace.testNewApplicationSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceFolderValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testNewApplicationSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceFolderValue');
 
 		configurationRegistry.registerConfiguration({
 			'id': '_test',
@@ -1358,10 +1358,10 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 			}
 		});
 
-		assert.equal(testObject.getValue('configurationService.workspace.testNewApplicationSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testNewApplicationSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.workspace.testNewApplicationSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testNewApplicationSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('application settings are not read from workspace folder after defaults are registered', async () => {
@@ -1369,7 +1369,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 		await fileService.writeFile(workspaceContextService.getWorkspace().folders[0].toResource('.vscode/settings.json'), VSBuffer.fromString('{ "configurationService.workspace.testNewMachineSetting": "workspaceFolderValue" }'));
 		await testObject.reloadConfiguration();
 
-		assert.equal(testObject.getValue('configurationService.workspace.testNewMachineSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceFolderValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testNewMachineSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceFolderValue');
 
 		configurationRegistry.registerConfiguration({
 			'id': '_test',
@@ -1383,10 +1383,10 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 			}
 		});
 
-		assert.equal(testObject.getValue('configurationService.workspace.testNewMachineSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testNewMachineSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
 
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.getValue('configurationService.workspace.testNewMachineSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testNewMachineSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'userValue');
 	});
 
 	test('resource setting in folder is read after it is registered later', async () => {
@@ -1404,7 +1404,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 				}
 			}
 		});
-		assert.equal(testObject.getValue('configurationService.workspace.testNewResourceSetting2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceFolderValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testNewResourceSetting2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceFolderValue');
 	});
 
 	test('resource language setting in folder is read after it is registered later', async () => {
@@ -1422,7 +1422,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 				}
 			}
 		});
-		assert.equal(testObject.getValue('configurationService.workspace.testNewResourceLanguageSetting2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceFolderValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testNewResourceLanguageSetting2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceFolderValue');
 	});
 
 	test('machine overridable setting in folder is read after it is registered later', async () => {
@@ -1440,50 +1440,50 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 				}
 			}
 		});
-		assert.equal(testObject.getValue('configurationService.workspace.testNewMachineOverridableSetting2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceFolderValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testNewMachineOverridableSetting2', { resource: workspaceContextService.getWorkspace().folders[0].uri }), 'workspaceFolderValue');
 	});
 
 	test('inspect', async () => {
 		let actual = testObject.inspect('something.missing');
-		assert.equal(actual.defaultValue, undefined);
-		assert.equal(actual.userValue, undefined);
-		assert.equal(actual.workspaceValue, undefined);
-		assert.equal(actual.workspaceFolderValue, undefined);
-		assert.equal(actual.value, undefined);
+		assert.strictEqual(actual.defaultValue, undefined);
+		assert.strictEqual(actual.userValue, undefined);
+		assert.strictEqual(actual.workspaceValue, undefined);
+		assert.strictEqual(actual.workspaceFolderValue, undefined);
+		assert.strictEqual(actual.value, undefined);
 
 		actual = testObject.inspect('configurationService.workspace.testResourceSetting');
-		assert.equal(actual.defaultValue, 'isSet');
-		assert.equal(actual.userValue, undefined);
-		assert.equal(actual.workspaceValue, undefined);
-		assert.equal(actual.workspaceFolderValue, undefined);
-		assert.equal(actual.value, 'isSet');
+		assert.strictEqual(actual.defaultValue, 'isSet');
+		assert.strictEqual(actual.userValue, undefined);
+		assert.strictEqual(actual.workspaceValue, undefined);
+		assert.strictEqual(actual.workspaceFolderValue, undefined);
+		assert.strictEqual(actual.value, 'isSet');
 
 		await fileService.writeFile(environmentService.settingsResource, VSBuffer.fromString('{ "configurationService.workspace.testResourceSetting": "userValue" }'));
 		await testObject.reloadConfiguration();
 		actual = testObject.inspect('configurationService.workspace.testResourceSetting');
-		assert.equal(actual.defaultValue, 'isSet');
-		assert.equal(actual.userValue, 'userValue');
-		assert.equal(actual.workspaceValue, undefined);
-		assert.equal(actual.workspaceFolderValue, undefined);
-		assert.equal(actual.value, 'userValue');
+		assert.strictEqual(actual.defaultValue, 'isSet');
+		assert.strictEqual(actual.userValue, 'userValue');
+		assert.strictEqual(actual.workspaceValue, undefined);
+		assert.strictEqual(actual.workspaceFolderValue, undefined);
+		assert.strictEqual(actual.value, 'userValue');
 
 		await jsonEditingServce.write((workspaceContextService.getWorkspace().configuration!), [{ path: ['settings'], value: { 'configurationService.workspace.testResourceSetting': 'workspaceValue' } }], true);
 		await testObject.reloadConfiguration();
 		actual = testObject.inspect('configurationService.workspace.testResourceSetting');
-		assert.equal(actual.defaultValue, 'isSet');
-		assert.equal(actual.userValue, 'userValue');
-		assert.equal(actual.workspaceValue, 'workspaceValue');
-		assert.equal(actual.workspaceFolderValue, undefined);
-		assert.equal(actual.value, 'workspaceValue');
+		assert.strictEqual(actual.defaultValue, 'isSet');
+		assert.strictEqual(actual.userValue, 'userValue');
+		assert.strictEqual(actual.workspaceValue, 'workspaceValue');
+		assert.strictEqual(actual.workspaceFolderValue, undefined);
+		assert.strictEqual(actual.value, 'workspaceValue');
 
 		await fileService.writeFile(workspaceContextService.getWorkspace().folders[0].toResource('.vscode/settings.json'), VSBuffer.fromString('{ "configurationService.workspace.testResourceSetting": "workspaceFolderValue" }'));
 		await testObject.reloadConfiguration();
 		actual = testObject.inspect('configurationService.workspace.testResourceSetting', { resource: workspaceContextService.getWorkspace().folders[0].uri });
-		assert.equal(actual.defaultValue, 'isSet');
-		assert.equal(actual.userValue, 'userValue');
-		assert.equal(actual.workspaceValue, 'workspaceValue');
-		assert.equal(actual.workspaceFolderValue, 'workspaceFolderValue');
-		assert.equal(actual.value, 'workspaceFolderValue');
+		assert.strictEqual(actual.defaultValue, 'isSet');
+		assert.strictEqual(actual.userValue, 'userValue');
+		assert.strictEqual(actual.workspaceValue, 'workspaceValue');
+		assert.strictEqual(actual.workspaceFolderValue, 'workspaceFolderValue');
+		assert.strictEqual(actual.value, 'workspaceFolderValue');
 	});
 
 	test('get launch configuration', async () => {
@@ -1577,7 +1577,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 	test('update user configuration', async () => {
 		await testObject.updateValue('configurationService.workspace.testSetting', 'userValue', ConfigurationTarget.USER);
-		assert.equal(testObject.getValue('configurationService.workspace.testSetting'), 'userValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testSetting'), 'userValue');
 	});
 
 	test('update user configuration should trigger change event before promise is resolve', async () => {
@@ -1589,7 +1589,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 	test('update workspace configuration', async () => {
 		await testObject.updateValue('configurationService.workspace.testSetting', 'workspaceValue', ConfigurationTarget.WORKSPACE);
-		assert.equal(testObject.getValue('configurationService.workspace.testSetting'), 'workspaceValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testSetting'), 'workspaceValue');
 	});
 
 	test('update workspace configuration should trigger change event before promise is resolve', async () => {
@@ -1601,24 +1601,24 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 	test('update application setting into workspace configuration in a workspace is not supported', () => {
 		return testObject.updateValue('configurationService.workspace.applicationSetting', 'workspaceValue', {}, ConfigurationTarget.WORKSPACE, true)
-			.then(() => assert.fail('Should not be supported'), (e) => assert.equal(e.code, ConfigurationEditingErrorCode.ERROR_INVALID_WORKSPACE_CONFIGURATION_APPLICATION));
+			.then(() => assert.fail('Should not be supported'), (e) => assert.strictEqual(e.code, ConfigurationEditingErrorCode.ERROR_INVALID_WORKSPACE_CONFIGURATION_APPLICATION));
 	});
 
 	test('update machine setting into workspace configuration in a workspace is not supported', () => {
 		return testObject.updateValue('configurationService.workspace.machineSetting', 'workspaceValue', {}, ConfigurationTarget.WORKSPACE, true)
-			.then(() => assert.fail('Should not be supported'), (e) => assert.equal(e.code, ConfigurationEditingErrorCode.ERROR_INVALID_WORKSPACE_CONFIGURATION_MACHINE));
+			.then(() => assert.fail('Should not be supported'), (e) => assert.strictEqual(e.code, ConfigurationEditingErrorCode.ERROR_INVALID_WORKSPACE_CONFIGURATION_MACHINE));
 	});
 
 	test('update workspace folder configuration', () => {
 		const workspace = workspaceContextService.getWorkspace();
 		return testObject.updateValue('configurationService.workspace.testResourceSetting', 'workspaceFolderValue', { resource: workspace.folders[0].uri }, ConfigurationTarget.WORKSPACE_FOLDER)
-			.then(() => assert.equal(testObject.getValue('configurationService.workspace.testResourceSetting', { resource: workspace.folders[0].uri }), 'workspaceFolderValue'));
+			.then(() => assert.strictEqual(testObject.getValue('configurationService.workspace.testResourceSetting', { resource: workspace.folders[0].uri }), 'workspaceFolderValue'));
 	});
 
 	test('update resource language configuration in workspace folder', async () => {
 		const workspace = workspaceContextService.getWorkspace();
 		await testObject.updateValue('configurationService.workspace.testLanguageSetting', 'workspaceFolderValue', { resource: workspace.folders[0].uri }, ConfigurationTarget.WORKSPACE_FOLDER);
-		assert.equal(testObject.getValue('configurationService.workspace.testLanguageSetting', { resource: workspace.folders[0].uri }), 'workspaceFolderValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testLanguageSetting', { resource: workspace.folders[0].uri }), 'workspaceFolderValue');
 	});
 
 	test('update workspace folder configuration should trigger change event before promise is resolve', async () => {
@@ -1640,7 +1640,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 
 	test('update memory configuration', async () => {
 		await testObject.updateValue('configurationService.workspace.testSetting', 'memoryValue', ConfigurationTarget.MEMORY);
-		assert.equal(testObject.getValue('configurationService.workspace.testSetting'), 'memoryValue');
+		assert.strictEqual(testObject.getValue('configurationService.workspace.testSetting'), 'memoryValue');
 	});
 
 	test('update memory configuration should trigger change event before promise is resolve', async () => {
@@ -1661,9 +1661,9 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 		await testObject.reloadConfiguration();
 
 		const actual = testObject.inspect(key, { resource: workspace.folders[0].uri });
-		assert.equal(actual.userValue, undefined);
-		assert.equal(actual.workspaceValue, undefined);
-		assert.equal(actual.workspaceFolderValue, undefined);
+		assert.strictEqual(actual.userValue, undefined);
+		assert.strictEqual(actual.workspaceValue, undefined);
+		assert.strictEqual(actual.workspaceFolderValue, undefined);
 	});
 
 	test('update tasks configuration in a folder', async () => {
@@ -1694,7 +1694,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 		return new Promise<void>((c, e) => {
 			testObject.onDidChangeConfiguration(() => {
 				try {
-					assert.equal(testObject.getValue('configurationService.workspace.testResourceSetting', { resource: uri }), 'workspaceFolderValue');
+					assert.strictEqual(testObject.getValue('configurationService.workspace.testResourceSetting', { resource: uri }), 'workspaceFolderValue');
 					c();
 				} catch (error) {
 					e(error);
@@ -1796,7 +1796,7 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		registerRemoteFileSystemProvider();
 		resolveRemoteEnvironment();
 		await initialize();
-		assert.equal(testObject.getValue('configurationService.remote.machineSetting'), 'remoteValue');
+		assert.strictEqual(testObject.getValue('configurationService.remote.machineSetting'), 'remoteValue');
 	});
 
 	test('remote settings override globals after remote provider is registered on activation', async () => {
@@ -1804,7 +1804,7 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		resolveRemoteEnvironment();
 		registerRemoteFileSystemProviderOnActivation();
 		await initialize();
-		assert.equal(testObject.getValue('configurationService.remote.machineSetting'), 'remoteValue');
+		assert.strictEqual(testObject.getValue('configurationService.remote.machineSetting'), 'remoteValue');
 	});
 
 	test('remote settings override globals after remote environment is resolved', async () => {
@@ -1814,9 +1814,9 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		const promise = new Promise<void>((c, e) => {
 			testObject.onDidChangeConfiguration(event => {
 				try {
-					assert.equal(event.source, ConfigurationTarget.USER);
+					assert.strictEqual(event.source, ConfigurationTarget.USER);
 					assert.deepEqual(event.affectedKeys, ['configurationService.remote.machineSetting']);
-					assert.equal(testObject.getValue('configurationService.remote.machineSetting'), 'remoteValue');
+					assert.strictEqual(testObject.getValue('configurationService.remote.machineSetting'), 'remoteValue');
 					c();
 				} catch (error) {
 					e(error);
@@ -1834,9 +1834,9 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		const promise = new Promise<void>((c, e) => {
 			testObject.onDidChangeConfiguration(event => {
 				try {
-					assert.equal(event.source, ConfigurationTarget.USER);
+					assert.strictEqual(event.source, ConfigurationTarget.USER);
 					assert.deepEqual(event.affectedKeys, ['configurationService.remote.machineSetting']);
-					assert.equal(testObject.getValue('configurationService.remote.machineSetting'), 'remoteValue');
+					assert.strictEqual(testObject.getValue('configurationService.remote.machineSetting'), 'remoteValue');
 					c();
 				} catch (error) {
 					e(error);
@@ -1852,7 +1852,7 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		registerRemoteFileSystemProvider();
 		resolveRemoteEnvironment();
 		await initialize();
-		assert.equal(testObject.getValue('configurationService.remote.machineSetting'), 'isSet');
+		assert.strictEqual(testObject.getValue('configurationService.remote.machineSetting'), 'isSet');
 	});
 
 	test('machine overridable settings in local user settings does not override defaults', async () => {
@@ -1860,7 +1860,7 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		registerRemoteFileSystemProvider();
 		resolveRemoteEnvironment();
 		await initialize();
-		assert.equal(testObject.getValue('configurationService.remote.machineOverridableSetting'), 'isSet');
+		assert.strictEqual(testObject.getValue('configurationService.remote.machineOverridableSetting'), 'isSet');
 	});
 
 	test('non machine setting is written in local settings', async () => {
@@ -1869,7 +1869,7 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		await initialize();
 		await testObject.updateValue('configurationService.remote.applicationSetting', 'applicationValue');
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.inspect('configurationService.remote.applicationSetting').userLocalValue, 'applicationValue');
+		assert.strictEqual(testObject.inspect('configurationService.remote.applicationSetting').userLocalValue, 'applicationValue');
 	});
 
 	test('machine setting is written in remote settings', async () => {
@@ -1878,7 +1878,7 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		await initialize();
 		await testObject.updateValue('configurationService.remote.machineSetting', 'machineValue');
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.inspect('configurationService.remote.machineSetting').userRemoteValue, 'machineValue');
+		assert.strictEqual(testObject.inspect('configurationService.remote.machineSetting').userRemoteValue, 'machineValue');
 	});
 
 	test('machine overridable setting is written in remote settings', async () => {
@@ -1887,7 +1887,7 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		await initialize();
 		await testObject.updateValue('configurationService.remote.machineOverridableSetting', 'machineValue');
 		await testObject.reloadConfiguration();
-		assert.equal(testObject.inspect('configurationService.remote.machineOverridableSetting').userRemoteValue, 'machineValue');
+		assert.strictEqual(testObject.inspect('configurationService.remote.machineOverridableSetting').userRemoteValue, 'machineValue');
 	});
 
 	test('machine settings in local user settings does not override defaults after defalts are registered ', async () => {
@@ -1906,7 +1906,7 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 				}
 			}
 		});
-		assert.equal(testObject.getValue('configurationService.remote.newMachineSetting'), 'isSet');
+		assert.strictEqual(testObject.getValue('configurationService.remote.newMachineSetting'), 'isSet');
 	});
 
 	test('machine overridable settings in local user settings does not override defaults after defaults are registered ', async () => {
@@ -1925,7 +1925,7 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 				}
 			}
 		});
-		assert.equal(testObject.getValue('configurationService.remote.newMachineOverridableSetting'), 'isSet');
+		assert.strictEqual(testObject.getValue('configurationService.remote.newMachineOverridableSetting'), 'isSet');
 	});
 
 });

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -371,7 +371,7 @@ suite('Configuration Resolver Service', () => {
 				'outDir': null
 			});
 
-			assert.equal(1, mockCommandService.callCount);
+			assert.strictEqual(1, mockCommandService.callCount);
 		});
 	});
 
@@ -400,7 +400,7 @@ suite('Configuration Resolver Service', () => {
 				'outDir': null
 			});
 
-			assert.equal(1, mockCommandService.callCount);
+			assert.strictEqual(1, mockCommandService.callCount);
 		});
 	});
 
@@ -436,7 +436,7 @@ suite('Configuration Resolver Service', () => {
 				}
 			});
 
-			assert.equal(2, mockCommandService.callCount);
+			assert.strictEqual(2, mockCommandService.callCount);
 		});
 	});
 
@@ -462,7 +462,7 @@ suite('Configuration Resolver Service', () => {
 				'value': 'Value for key1'
 			});
 
-			assert.equal(1, mockCommandService.callCount);
+			assert.strictEqual(1, mockCommandService.callCount);
 		});
 	});
 
@@ -490,7 +490,7 @@ suite('Configuration Resolver Service', () => {
 				'outDir': null
 			});
 
-			assert.equal(0, mockCommandService.callCount);
+			assert.strictEqual(0, mockCommandService.callCount);
 		});
 	});
 
@@ -518,7 +518,7 @@ suite('Configuration Resolver Service', () => {
 				'outDir': null
 			});
 
-			assert.equal(0, mockCommandService.callCount);
+			assert.strictEqual(0, mockCommandService.callCount);
 		});
 	});
 
@@ -546,7 +546,7 @@ suite('Configuration Resolver Service', () => {
 				'outDir': null
 			});
 
-			assert.equal(1, mockCommandService.callCount);
+			assert.strictEqual(1, mockCommandService.callCount);
 		});
 	});
 
@@ -576,7 +576,7 @@ suite('Configuration Resolver Service', () => {
 				'outDir': null
 			});
 
-			assert.equal(2, mockCommandService.callCount);
+			assert.strictEqual(2, mockCommandService.callCount);
 		});
 	});
 
@@ -604,7 +604,7 @@ suite('Configuration Resolver Service', () => {
 				'outDir': null
 			});
 
-			assert.equal(0, mockCommandService.callCount);
+			assert.strictEqual(0, mockCommandService.callCount);
 		});
 	});
 

--- a/src/vs/workbench/services/decorations/test/browser/decorationsService.test.ts
+++ b/src/vs/workbench/services/decorations/test/browser/decorationsService.test.ts
@@ -50,16 +50,16 @@ suite('DecorationsService', function () {
 		});
 
 		// trigger -> async
-		assert.equal(service.getDecoration(uri, false), undefined);
-		assert.equal(callCounter, 1);
+		assert.strictEqual(service.getDecoration(uri, false), undefined);
+		assert.strictEqual(callCounter, 1);
 
 		// event when result is computed
 		return Event.toPromise(service.onDidChangeDecorations).then(e => {
-			assert.equal(e.affectsResource(uri), true);
+			assert.strictEqual(e.affectsResource(uri), true);
 
 			// sync result
 			assert.deepEqual(service.getDecoration(uri, false)!.tooltip, 'T');
-			assert.equal(callCounter, 1);
+			assert.strictEqual(callCounter, 1);
 		});
 	});
 
@@ -79,7 +79,7 @@ suite('DecorationsService', function () {
 
 		// trigger -> sync
 		assert.deepEqual(service.getDecoration(uri, false)!.tooltip, 'Z');
-		assert.equal(callCounter, 1);
+		assert.strictEqual(callCounter, 1);
 	});
 
 	test('Clear decorations on provider dispose', async function () {
@@ -97,22 +97,22 @@ suite('DecorationsService', function () {
 
 		// trigger -> sync
 		assert.deepEqual(service.getDecoration(uri, false)!.tooltip, 'J');
-		assert.equal(callCounter, 1);
+		assert.strictEqual(callCounter, 1);
 
 		// un-register -> ensure good event
 		let didSeeEvent = false;
 		let p = new Promise<void>(resolve => {
 			service.onDidChangeDecorations(e => {
-				assert.equal(e.affectsResource(uri), true);
+				assert.strictEqual(e.affectsResource(uri), true);
 				assert.deepEqual(service.getDecoration(uri, false), undefined);
-				assert.equal(callCounter, 1);
+				assert.strictEqual(callCounter, 1);
 				didSeeEvent = true;
 				resolve();
 			});
 		});
 		reg.dispose(); // will clear all data
 		await p;
-		assert.equal(didSeeEvent, true);
+		assert.strictEqual(didSeeEvent, true);
 	});
 
 	test('No default bubbling', function () {
@@ -130,10 +130,10 @@ suite('DecorationsService', function () {
 		let childUri = URI.parse('file:///some/path/some/file.txt');
 
 		let deco = service.getDecoration(childUri, false)!;
-		assert.equal(deco.tooltip, '.txt');
+		assert.strictEqual(deco.tooltip, '.txt');
 
 		deco = service.getDecoration(childUri.with({ path: 'some/path/' }), true)!;
-		assert.equal(deco, undefined);
+		assert.strictEqual(deco, undefined);
 		reg.dispose();
 
 		// bubble
@@ -148,10 +148,10 @@ suite('DecorationsService', function () {
 		});
 
 		deco = service.getDecoration(childUri, false)!;
-		assert.equal(deco.tooltip, '.txt.bubble');
+		assert.strictEqual(deco.tooltip, '.txt.bubble');
 
 		deco = service.getDecoration(childUri.with({ path: 'some/path/' }), true)!;
-		assert.equal(typeof deco.tooltip, 'string');
+		assert.strictEqual(typeof deco.tooltip, 'string');
 	});
 
 	test('Decorations not showing up for second root folder #48502', async function () {
@@ -190,9 +190,9 @@ suite('DecorationsService', function () {
 		provider._onDidChange.fire([uri]);
 		service.getDecoration(uri, false);
 
-		assert.equal(cancelCount, 1);
-		assert.equal(winjsCancelCount, 0);
-		assert.equal(callCount, 2);
+		assert.strictEqual(cancelCount, 1);
+		assert.strictEqual(winjsCancelCount, 0);
+		assert.strictEqual(callCount, 2);
 
 		reg.dispose();
 	});
@@ -242,7 +242,7 @@ suite('DecorationsService', function () {
 		let uri = URI.parse('foo:/folder/file.ts');
 		let uri2 = URI.parse('foo:/folder/');
 		let data = service.getDecoration(uri, true)!;
-		assert.equal(data.tooltip, 'FOO');
+		assert.strictEqual(data.tooltip, 'FOO');
 
 		data = service.getDecoration(uri2, true)!;
 		assert.ok(data.tooltip); // emphazied items...
@@ -251,10 +251,10 @@ suite('DecorationsService', function () {
 		emitter.fire([uri]);
 
 		data = service.getDecoration(uri, true)!;
-		assert.equal(data, undefined);
+		assert.strictEqual(data, undefined);
 
 		data = service.getDecoration(uri2, true)!;
-		assert.equal(data, undefined);
+		assert.strictEqual(data, undefined);
 
 		reg.dispose();
 	});
@@ -277,7 +277,7 @@ suite('DecorationsService', function () {
 		let uri = URI.parse('foo:/folder/file.ts');
 		let uri2 = URI.parse('foo:/folder/');
 		let data = service.getDecoration(uri, true)!;
-		assert.equal(data.tooltip, 'FOO');
+		assert.strictEqual(data.tooltip, 'FOO');
 
 		data = service.getDecoration(uri2, true)!;
 		assert.ok(data.tooltip); // emphazied items...

--- a/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
@@ -118,7 +118,7 @@ suite('ExtensionEnablementService Test', () => {
 		const extension = aLocalExtension('pub.a');
 		await testObject.setEnablement([extension], EnablementState.DisabledGlobally);
 		assert.ok(!testObject.isEnabled(extension));
-		assert.equal(testObject.getEnablementState(extension), EnablementState.DisabledGlobally);
+		assert.strictEqual(testObject.getEnablementState(extension), EnablementState.DisabledGlobally);
 	});
 
 	test('test disable an extension globally should return truthy promise', () => {
@@ -144,20 +144,20 @@ suite('ExtensionEnablementService Test', () => {
 
 	test('test state of globally disabled extension', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledGlobally)
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledGlobally));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledGlobally));
 	});
 
 	test('test state of globally enabled extension', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledGlobally)
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.EnabledGlobally))
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.EnabledGlobally));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.EnabledGlobally));
 	});
 
 	test('test disable an extension for workspace', async () => {
 		const extension = aLocalExtension('pub.a');
 		await testObject.setEnablement([extension], EnablementState.DisabledWorkspace);
 		assert.ok(!testObject.isEnabled(extension));
-		assert.equal(testObject.getEnablementState(extension), EnablementState.DisabledWorkspace);
+		assert.strictEqual(testObject.getEnablementState(extension), EnablementState.DisabledWorkspace);
 	});
 
 	test('test disable an extension for workspace returns a truthy promise', () => {
@@ -173,59 +173,59 @@ suite('ExtensionEnablementService Test', () => {
 
 	test('test state of workspace disabled extension', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledWorkspace)
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledWorkspace));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledWorkspace));
 	});
 
 	test('test state of workspace and globally disabled extension', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledGlobally)
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledWorkspace))
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledWorkspace));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledWorkspace));
 	});
 
 	test('test state of workspace enabled extension', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledWorkspace)
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.EnabledWorkspace))
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.EnabledWorkspace));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.EnabledWorkspace));
 	});
 
 	test('test state of globally disabled and workspace enabled extension', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledGlobally)
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledWorkspace))
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.EnabledWorkspace))
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.EnabledWorkspace));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.EnabledWorkspace));
 	});
 
 	test('test state of an extension when disabled for workspace from workspace enabled', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledWorkspace)
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.EnabledWorkspace))
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledWorkspace))
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledWorkspace));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledWorkspace));
 	});
 
 	test('test state of an extension when disabled globally from workspace enabled', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledWorkspace)
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.EnabledWorkspace))
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledGlobally))
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledGlobally));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledGlobally));
 	});
 
 	test('test state of an extension when disabled globally from workspace disabled', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledWorkspace)
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledGlobally))
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledGlobally));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.DisabledGlobally));
 	});
 
 	test('test state of an extension when enabled globally from workspace enabled', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledWorkspace)
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.EnabledWorkspace))
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.EnabledGlobally))
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.EnabledGlobally));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.EnabledGlobally));
 	});
 
 	test('test state of an extension when enabled globally from workspace disabled', () => {
 		return testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.DisabledWorkspace)
 			.then(() => testObject.setEnablement([aLocalExtension('pub.a')], EnablementState.EnabledGlobally))
-			.then(() => assert.equal(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.EnabledGlobally));
+			.then(() => assert.strictEqual(testObject.getEnablementState(aLocalExtension('pub.a')), EnablementState.EnabledGlobally));
 	});
 
 	test('test disable an extension for workspace and then globally', async () => {
@@ -233,7 +233,7 @@ suite('ExtensionEnablementService Test', () => {
 		await testObject.setEnablement([extension], EnablementState.DisabledWorkspace);
 		await testObject.setEnablement([extension], EnablementState.DisabledGlobally);
 		assert.ok(!testObject.isEnabled(extension));
-		assert.equal(testObject.getEnablementState(extension), EnablementState.DisabledGlobally);
+		assert.strictEqual(testObject.getEnablementState(extension), EnablementState.DisabledGlobally);
 	});
 
 	test('test disable an extension for workspace and then globally return a truthy promise', () => {
@@ -258,7 +258,7 @@ suite('ExtensionEnablementService Test', () => {
 		await testObject.setEnablement([extension], EnablementState.DisabledGlobally);
 		await testObject.setEnablement([extension], EnablementState.DisabledWorkspace);
 		assert.ok(!testObject.isEnabled(extension));
-		assert.equal(testObject.getEnablementState(extension), EnablementState.DisabledWorkspace);
+		assert.strictEqual(testObject.getEnablementState(extension), EnablementState.DisabledWorkspace);
 	});
 
 	test('test disable an extension globally and then for workspace return a truthy promise', () => {
@@ -289,7 +289,7 @@ suite('ExtensionEnablementService Test', () => {
 		await testObject.setEnablement([extension], EnablementState.DisabledGlobally);
 		await testObject.setEnablement([extension], EnablementState.EnabledGlobally);
 		assert.ok(testObject.isEnabled(extension));
-		assert.equal(testObject.getEnablementState(extension), EnablementState.EnabledGlobally);
+		assert.strictEqual(testObject.getEnablementState(extension), EnablementState.EnabledGlobally);
 	});
 
 	test('test enable an extension globally return truthy promise', () => {
@@ -319,7 +319,7 @@ suite('ExtensionEnablementService Test', () => {
 		await testObject.setEnablement([extension], EnablementState.DisabledWorkspace);
 		await testObject.setEnablement([extension], EnablementState.EnabledWorkspace);
 		assert.ok(testObject.isEnabled(extension));
-		assert.equal(testObject.getEnablementState(extension), EnablementState.EnabledWorkspace);
+		assert.strictEqual(testObject.getEnablementState(extension), EnablementState.EnabledWorkspace);
 	});
 
 	test('test enable an extension for workspace return truthy promise', () => {
@@ -350,7 +350,7 @@ suite('ExtensionEnablementService Test', () => {
 		await testObject.setEnablement([extension], EnablementState.DisabledGlobally);
 		await testObject.setEnablement([extension], EnablementState.EnabledWorkspace);
 		assert.ok(testObject.isEnabled(extension));
-		assert.equal(testObject.getEnablementState(extension), EnablementState.EnabledWorkspace);
+		assert.strictEqual(testObject.getEnablementState(extension), EnablementState.EnabledWorkspace);
 	});
 
 	test('test enable an extension globally when disabled in workspace and gloablly', async () => {
@@ -360,7 +360,7 @@ suite('ExtensionEnablementService Test', () => {
 		await testObject.setEnablement([extension], EnablementState.DisabledGlobally);
 		await testObject.setEnablement([extension], EnablementState.EnabledGlobally);
 		assert.ok(testObject.isEnabled(extension));
-		assert.equal(testObject.getEnablementState(extension), EnablementState.EnabledGlobally);
+		assert.strictEqual(testObject.getEnablementState(extension), EnablementState.EnabledGlobally);
 	});
 
 	test('test remove an extension from disablement list when uninstalled', async () => {
@@ -369,7 +369,7 @@ suite('ExtensionEnablementService Test', () => {
 		await testObject.setEnablement([extension], EnablementState.DisabledGlobally);
 		didUninstallEvent.fire({ identifier: { id: 'pub.a' } });
 		assert.ok(testObject.isEnabled(extension));
-		assert.equal(testObject.getEnablementState(extension), EnablementState.EnabledGlobally);
+		assert.strictEqual(testObject.getEnablementState(extension), EnablementState.EnabledGlobally);
 	});
 
 	test('test isEnabled return false extension is disabled globally', () => {
@@ -389,11 +389,11 @@ suite('ExtensionEnablementService Test', () => {
 	});
 
 	test('test canChangeEnablement return false for language packs', () => {
-		assert.equal(testObject.canChangeEnablement(aLocalExtension('pub.a', { localizations: [{ languageId: 'gr', translations: [{ id: 'vscode', path: 'path' }] }] })), false);
+		assert.strictEqual(testObject.canChangeEnablement(aLocalExtension('pub.a', { localizations: [{ languageId: 'gr', translations: [{ id: 'vscode', path: 'path' }] }] })), false);
 	});
 
 	test('test canChangeEnablement return true for auth extension', () => {
-		assert.equal(testObject.canChangeEnablement(aLocalExtension('pub.a', { authentication: [{ id: 'a', label: 'a' }] })), true);
+		assert.strictEqual(testObject.canChangeEnablement(aLocalExtension('pub.a', { authentication: [{ id: 'a', label: 'a' }] })), true);
 	});
 
 	test('test canChangeEnablement return true for auth extension when user data sync account does not depends on it', () => {
@@ -401,7 +401,7 @@ suite('ExtensionEnablementService Test', () => {
 			account: { authenticationProviderId: 'b' }
 		});
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.canChangeEnablement(aLocalExtension('pub.a', { authentication: [{ id: 'a', label: 'a' }] })), true);
+		assert.strictEqual(testObject.canChangeEnablement(aLocalExtension('pub.a', { authentication: [{ id: 'a', label: 'a' }] })), true);
 	});
 
 	test('test canChangeEnablement return true for auth extension when user data sync account depends on it but auto sync is off', () => {
@@ -409,7 +409,7 @@ suite('ExtensionEnablementService Test', () => {
 			account: { authenticationProviderId: 'a' }
 		});
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.canChangeEnablement(aLocalExtension('pub.a', { authentication: [{ id: 'a', label: 'a' }] })), true);
+		assert.strictEqual(testObject.canChangeEnablement(aLocalExtension('pub.a', { authentication: [{ id: 'a', label: 'a' }] })), true);
 	});
 
 	test('test canChangeEnablement return false for auth extension and user data sync account depends on it and auto sync is on', () => {
@@ -418,39 +418,39 @@ suite('ExtensionEnablementService Test', () => {
 			account: { authenticationProviderId: 'a' }
 		});
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.canChangeEnablement(aLocalExtension('pub.a', { authentication: [{ id: 'a', label: 'a' }] })), false);
+		assert.strictEqual(testObject.canChangeEnablement(aLocalExtension('pub.a', { authentication: [{ id: 'a', label: 'a' }] })), false);
 	});
 
 	test('test canChangeWorkspaceEnablement return true', () => {
-		assert.equal(testObject.canChangeWorkspaceEnablement(aLocalExtension('pub.a')), true);
+		assert.strictEqual(testObject.canChangeWorkspaceEnablement(aLocalExtension('pub.a')), true);
 	});
 
 	test('test canChangeWorkspaceEnablement return false if there is no workspace', () => {
 		instantiationService.stub(IWorkspaceContextService, 'getWorkbenchState', WorkbenchState.EMPTY);
-		assert.equal(testObject.canChangeWorkspaceEnablement(aLocalExtension('pub.a')), false);
+		assert.strictEqual(testObject.canChangeWorkspaceEnablement(aLocalExtension('pub.a')), false);
 	});
 
 	test('test canChangeWorkspaceEnablement return false for auth extension', () => {
-		assert.equal(testObject.canChangeWorkspaceEnablement(aLocalExtension('pub.a', { authentication: [{ id: 'a', label: 'a' }] })), false);
+		assert.strictEqual(testObject.canChangeWorkspaceEnablement(aLocalExtension('pub.a', { authentication: [{ id: 'a', label: 'a' }] })), false);
 	});
 
 	test('test canChangeEnablement return false when extensions are disabled in environment', () => {
 		instantiationService.stub(IWorkbenchEnvironmentService, { disableExtensions: true } as IWorkbenchEnvironmentService);
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.canChangeEnablement(aLocalExtension('pub.a')), false);
+		assert.strictEqual(testObject.canChangeEnablement(aLocalExtension('pub.a')), false);
 	});
 
 	test('test canChangeEnablement return false when the extension is disabled in environment', () => {
 		instantiationService.stub(IWorkbenchEnvironmentService, { disableExtensions: ['pub.a'] } as IWorkbenchEnvironmentService);
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.canChangeEnablement(aLocalExtension('pub.a')), false);
+		assert.strictEqual(testObject.canChangeEnablement(aLocalExtension('pub.a')), false);
 	});
 
 	test('test canChangeEnablement return true for system extensions when extensions are disabled in environment', () => {
 		instantiationService.stub(IWorkbenchEnvironmentService, { disableExtensions: true } as IWorkbenchEnvironmentService);
 		testObject = new TestExtensionEnablementService(instantiationService);
 		const extension = aLocalExtension('pub.a', undefined, ExtensionType.System);
-		assert.equal(testObject.canChangeEnablement(extension), true);
+		assert.strictEqual(testObject.canChangeEnablement(extension), true);
 	});
 
 	test('test canChangeEnablement return false for system extension when extension is disabled in environment', () => {
@@ -501,14 +501,14 @@ suite('ExtensionEnablementService Test', () => {
 		instantiationService.stub(IExtensionManagementServerService, aMultiExtensionManagementServerService(instantiationService));
 		const localWorkspaceExtension = aLocalExtension2('pub.a', { extensionKind: ['workspace'] }, { location: URI.file(`pub.a`) });
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.canChangeEnablement(localWorkspaceExtension), false);
+		assert.strictEqual(testObject.canChangeEnablement(localWorkspaceExtension), false);
 	});
 
 	test('test canChangeEnablement return true for local ui extension', () => {
 		instantiationService.stub(IExtensionManagementServerService, aMultiExtensionManagementServerService(instantiationService));
 		const localWorkspaceExtension = aLocalExtension2('pub.a', { extensionKind: ['ui'] }, { location: URI.file(`pub.a`) });
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.canChangeEnablement(localWorkspaceExtension), true);
+		assert.strictEqual(testObject.canChangeEnablement(localWorkspaceExtension), true);
 	});
 
 	test('test remote ui extension is disabled by kind', async () => {
@@ -547,14 +547,14 @@ suite('ExtensionEnablementService Test', () => {
 		instantiationService.stub(IExtensionManagementServerService, aMultiExtensionManagementServerService(instantiationService));
 		const localWorkspaceExtension = aLocalExtension2('pub.a', { extensionKind: ['ui'] }, { location: URI.file(`pub.a`).with({ scheme: Schemas.vscodeRemote }) });
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.canChangeEnablement(localWorkspaceExtension), false);
+		assert.strictEqual(testObject.canChangeEnablement(localWorkspaceExtension), false);
 	});
 
 	test('test canChangeEnablement return true for remote workspace extension', () => {
 		instantiationService.stub(IExtensionManagementServerService, aMultiExtensionManagementServerService(instantiationService));
 		const localWorkspaceExtension = aLocalExtension2('pub.a', { extensionKind: ['workspace'] }, { location: URI.file(`pub.a`).with({ scheme: Schemas.vscodeRemote }) });
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.canChangeEnablement(localWorkspaceExtension), true);
+		assert.strictEqual(testObject.canChangeEnablement(localWorkspaceExtension), true);
 	});
 
 	test('test web extension on local server is disabled by kind when web worker is not enabled', async () => {
@@ -562,7 +562,7 @@ suite('ExtensionEnablementService Test', () => {
 		const localWorkspaceExtension = aLocalExtension2('pub.a', { extensionKind: ['web'] }, { location: URI.file(`pub.a`) });
 		(<TestConfigurationService>instantiationService.get(IConfigurationService)).setUserConfiguration('extensions', { webWorker: false });
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.isEnabled(localWorkspaceExtension), false);
+		assert.strictEqual(testObject.isEnabled(localWorkspaceExtension), false);
 		assert.deepEqual(testObject.getEnablementState(localWorkspaceExtension), EnablementState.DisabledByExtensionKind);
 	});
 
@@ -571,7 +571,7 @@ suite('ExtensionEnablementService Test', () => {
 		const localWorkspaceExtension = aLocalExtension2('pub.a', { extensionKind: ['web'] }, { location: URI.file(`pub.a`) });
 		(<TestConfigurationService>instantiationService.get(IConfigurationService)).setUserConfiguration('extensions', { webWorker: true });
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.isEnabled(localWorkspaceExtension), true);
+		assert.strictEqual(testObject.isEnabled(localWorkspaceExtension), true);
 		assert.deepEqual(testObject.getEnablementState(localWorkspaceExtension), EnablementState.EnabledGlobally);
 	});
 
@@ -580,7 +580,7 @@ suite('ExtensionEnablementService Test', () => {
 		const localWorkspaceExtension = aLocalExtension2('pub.a', { extensionKind: ['web'] }, { location: URI.file(`pub.a`).with({ scheme: 'vscode-remote' }) });
 		(<TestConfigurationService>instantiationService.get(IConfigurationService)).setUserConfiguration('extensions', { webWorker: false });
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.isEnabled(localWorkspaceExtension), false);
+		assert.strictEqual(testObject.isEnabled(localWorkspaceExtension), false);
 		assert.deepEqual(testObject.getEnablementState(localWorkspaceExtension), EnablementState.DisabledByExtensionKind);
 	});
 
@@ -589,7 +589,7 @@ suite('ExtensionEnablementService Test', () => {
 		const localWorkspaceExtension = aLocalExtension2('pub.a', { extensionKind: ['web'] }, { location: URI.file(`pub.a`).with({ scheme: 'vscode-remote' }) });
 		(<TestConfigurationService>instantiationService.get(IConfigurationService)).setUserConfiguration('extensions', { webWorker: true });
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.isEnabled(localWorkspaceExtension), false);
+		assert.strictEqual(testObject.isEnabled(localWorkspaceExtension), false);
 		assert.deepEqual(testObject.getEnablementState(localWorkspaceExtension), EnablementState.DisabledByExtensionKind);
 	});
 
@@ -597,7 +597,7 @@ suite('ExtensionEnablementService Test', () => {
 		instantiationService.stub(IExtensionManagementServerService, anExtensionManagementServerService(anExtensionManagementServer('vscode-local', instantiationService), anExtensionManagementServer('vscode-remote', instantiationService), anExtensionManagementServer('web', instantiationService)));
 		const webExtension = aLocalExtension2('pub.a', { extensionKind: ['web'] }, { location: URI.file(`pub.a`).with({ scheme: 'web' }) });
 		testObject = new TestExtensionEnablementService(instantiationService);
-		assert.equal(testObject.isEnabled(webExtension), true);
+		assert.strictEqual(testObject.isEnabled(webExtension), true);
 		assert.deepEqual(testObject.getEnablementState(webExtension), EnablementState.EnabledGlobally);
 	});
 

--- a/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
+++ b/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
@@ -129,7 +129,7 @@ suite('KeybindingsEditing', () => {
 			await testObject.editKeybinding(aResolvedKeybindingItem({ firstPart: { keyCode: KeyCode.Escape } }), 'alt+c', undefined);
 			assert.fail('Should fail with parse errors');
 		} catch (error) {
-			assert.equal(error.message, 'Unable to write to the keybindings configuration file. Please open it to correct errors/warnings in the file and try again.');
+			assert.strictEqual(error.message, 'Unable to write to the keybindings configuration file. Please open it to correct errors/warnings in the file and try again.');
 		}
 	});
 
@@ -139,7 +139,7 @@ suite('KeybindingsEditing', () => {
 			await testObject.editKeybinding(aResolvedKeybindingItem({ firstPart: { keyCode: KeyCode.Escape } }), 'alt+c', undefined);
 			assert.fail('Should fail with parse errors');
 		} catch (error) {
-			assert.equal(error.message, 'Unable to write to the keybindings configuration file. Please open it to correct errors/warnings in the file and try again.');
+			assert.strictEqual(error.message, 'Unable to write to the keybindings configuration file. Please open it to correct errors/warnings in the file and try again.');
 		}
 	});
 
@@ -147,7 +147,7 @@ suite('KeybindingsEditing', () => {
 		instantiationService.stub(ITextFileService, 'isDirty', true);
 		return testObject.editKeybinding(aResolvedKeybindingItem({ firstPart: { keyCode: KeyCode.Escape } }), 'alt+c', undefined)
 			.then(() => assert.fail('Should fail with dirty error'),
-				error => assert.equal(error.message, 'Unable to write because the keybindings configuration file is dirty. Please save it first and then try again.'));
+				error => assert.strictEqual(error.message, 'Unable to write because the keybindings configuration file is dirty. Please save it first and then try again.'));
 	});
 
 	test('errors cases - did not find an array', async () => {
@@ -156,7 +156,7 @@ suite('KeybindingsEditing', () => {
 			await testObject.editKeybinding(aResolvedKeybindingItem({ firstPart: { keyCode: KeyCode.Escape } }), 'alt+c', undefined);
 			assert.fail('Should fail');
 		} catch (error) {
-			assert.equal(error.message, 'Unable to write to the keybindings configuration file. It has an object which is not of type Array. Please open the file to clean up and try again.');
+			assert.strictEqual(error.message, 'Unable to write to the keybindings configuration file. It has an object which is not of type Array. Please open the file to clean up and try again.');
 		}
 	});
 

--- a/src/vs/workbench/services/label/test/browser/label.test.ts
+++ b/src/vs/workbench/services/label/test/browser/label.test.ts
@@ -31,8 +31,8 @@ suite('URI Label', () => {
 		});
 
 		const uri1 = URI.parse('vscode://microsoft.com/1/2/3/4/5');
-		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABEL//1/2/3/4/5/microsoft.com/END');
-		assert.equal(labelService.getUriBasenameLabel(uri1), 'END');
+		assert.strictEqual(labelService.getUriLabel(uri1, { relative: false }), 'LABEL//1/2/3/4/5/microsoft.com/END');
+		assert.strictEqual(labelService.getUriBasenameLabel(uri1), 'END');
 	});
 
 	test('separator', function () {
@@ -47,8 +47,8 @@ suite('URI Label', () => {
 		});
 
 		const uri1 = URI.parse('vscode://microsoft.com/1/2/3/4/5');
-		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABEL\\\\1\\2\\3\\4\\5\\microsoft.com\\END');
-		assert.equal(labelService.getUriBasenameLabel(uri1), 'END');
+		assert.strictEqual(labelService.getUriLabel(uri1, { relative: false }), 'LABEL\\\\1\\2\\3\\4\\5\\microsoft.com\\END');
+		assert.strictEqual(labelService.getUriBasenameLabel(uri1), 'END');
 	});
 
 	test('custom authority', function () {
@@ -62,8 +62,8 @@ suite('URI Label', () => {
 		});
 
 		const uri1 = URI.parse('vscode://microsoft.com/1/2/3/4/5');
-		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABEL//1/2/3/4/5/microsoft.com/END');
-		assert.equal(labelService.getUriBasenameLabel(uri1), 'END');
+		assert.strictEqual(labelService.getUriLabel(uri1, { relative: false }), 'LABEL//1/2/3/4/5/microsoft.com/END');
+		assert.strictEqual(labelService.getUriBasenameLabel(uri1), 'END');
 	});
 
 	test('mulitple authority', function () {
@@ -94,8 +94,8 @@ suite('URI Label', () => {
 
 		// Make sure the most specific authority is picked
 		const uri1 = URI.parse('vscode://microsoft.com/1/2/3/4/5');
-		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'second');
-		assert.equal(labelService.getUriBasenameLabel(uri1), 'second');
+		assert.strictEqual(labelService.getUriLabel(uri1, { relative: false }), 'second');
+		assert.strictEqual(labelService.getUriBasenameLabel(uri1), 'second');
 	});
 
 	test('custom query', function () {
@@ -110,7 +110,7 @@ suite('URI Label', () => {
 		});
 
 		const uri1 = URI.parse(`vscode://microsoft.com/1/2/3/4/5?${encodeURIComponent(JSON.stringify({ prefix: 'prefix', path: 'path' }))}`);
-		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABELprefix: path/END');
+		assert.strictEqual(labelService.getUriLabel(uri1, { relative: false }), 'LABELprefix: path/END');
 	});
 
 	test('custom query without value', function () {
@@ -125,7 +125,7 @@ suite('URI Label', () => {
 		});
 
 		const uri1 = URI.parse(`vscode://microsoft.com/1/2/3/4/5?${encodeURIComponent(JSON.stringify({ path: 'path' }))}`);
-		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABEL: path/END');
+		assert.strictEqual(labelService.getUriLabel(uri1, { relative: false }), 'LABEL: path/END');
 	});
 
 	test('custom query without query json', function () {
@@ -140,7 +140,7 @@ suite('URI Label', () => {
 		});
 
 		const uri1 = URI.parse('vscode://microsoft.com/1/2/3/4/5?path=foo');
-		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABEL: /END');
+		assert.strictEqual(labelService.getUriLabel(uri1, { relative: false }), 'LABEL: /END');
 	});
 
 	test('custom query without query', function () {
@@ -155,7 +155,7 @@ suite('URI Label', () => {
 		});
 
 		const uri1 = URI.parse('vscode://microsoft.com/1/2/3/4/5');
-		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABEL: /END');
+		assert.strictEqual(labelService.getUriLabel(uri1, { relative: false }), 'LABEL: /END');
 	});
 });
 
@@ -202,7 +202,7 @@ suite('multi-root workspace', () => {
 
 		Object.entries(tests).forEach(([path, label]) => {
 			const generated = labelService.getUriLabel(URI.file(path), { relative: true });
-			assert.equal(generated, label);
+			assert.strictEqual(generated, label);
 		});
 	});
 
@@ -225,7 +225,7 @@ suite('multi-root workspace', () => {
 
 		Object.entries(tests).forEach(([path, label]) => {
 			const generated = labelService.getUriLabel(URI.file(path), { relative: true });
-			assert.equal(generated, label, path);
+			assert.strictEqual(generated, label, path);
 		});
 	});
 
@@ -246,7 +246,7 @@ suite('multi-root workspace', () => {
 
 		Object.entries(tests).forEach(([path, label]) => {
 			const generated = labelService.getUriLabel(URI.file(path), { relative: true });
-			assert.equal(generated, label, path);
+			assert.strictEqual(generated, label, path);
 		});
 	});
 });
@@ -287,7 +287,7 @@ suite('workspace at FSP root', () => {
 
 		Object.entries(tests).forEach(([uriString, label]) => {
 			const generated = labelService.getUriLabel(URI.parse(uriString), { relative: false });
-			assert.equal(generated, label);
+			assert.strictEqual(generated, label);
 		});
 	});
 
@@ -300,7 +300,7 @@ suite('workspace at FSP root', () => {
 
 		Object.entries(tests).forEach(([uriString, label]) => {
 			const generated = labelService.getUriLabel(URI.parse(uriString), { relative: true });
-			assert.equal(generated, label);
+			assert.strictEqual(generated, label);
 		});
 	});
 });

--- a/src/vs/workbench/services/preferences/test/browser/keybindingsEditorModel.test.ts
+++ b/src/vs/workbench/services/preferences/test/browser/keybindingsEditorModel.test.ts
@@ -155,11 +155,11 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('')[0];
-		assert.equal(actual.keybindingItem.command, expected.command);
-		assert.equal(actual.keybindingItem.commandLabel, '');
-		assert.equal(actual.keybindingItem.commandDefaultLabel, null);
-		assert.equal(actual.keybindingItem.keybinding.getAriaLabel(), expected.resolvedKeybinding!.getAriaLabel());
-		assert.equal(actual.keybindingItem.when, expected.when!.serialize());
+		assert.strictEqual(actual.keybindingItem.command, expected.command);
+		assert.strictEqual(actual.keybindingItem.commandLabel, '');
+		assert.strictEqual(actual.keybindingItem.commandDefaultLabel, null);
+		assert.strictEqual(actual.keybindingItem.keybinding.getAriaLabel(), expected.resolvedKeybinding!.getAriaLabel());
+		assert.strictEqual(actual.keybindingItem.when, expected.when!.serialize());
 	});
 
 	test('convert keybinding with title to entry', async () => {
@@ -169,11 +169,11 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('')[0];
-		assert.equal(actual.keybindingItem.command, expected.command);
-		assert.equal(actual.keybindingItem.commandLabel, 'Some Title');
-		assert.equal(actual.keybindingItem.commandDefaultLabel, null);
-		assert.equal(actual.keybindingItem.keybinding.getAriaLabel(), expected.resolvedKeybinding!.getAriaLabel());
-		assert.equal(actual.keybindingItem.when, expected.when!.serialize());
+		assert.strictEqual(actual.keybindingItem.command, expected.command);
+		assert.strictEqual(actual.keybindingItem.commandLabel, 'Some Title');
+		assert.strictEqual(actual.keybindingItem.commandDefaultLabel, null);
+		assert.strictEqual(actual.keybindingItem.keybinding.getAriaLabel(), expected.resolvedKeybinding!.getAriaLabel());
+		assert.strictEqual(actual.keybindingItem.when, expected.when!.serialize());
 	});
 
 	test('convert without title and binding to entry', async () => {
@@ -182,11 +182,11 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('').filter(element => element.keybindingItem.command === 'command_without_keybinding')[0];
-		assert.equal(actual.keybindingItem.command, 'command_without_keybinding');
-		assert.equal(actual.keybindingItem.commandLabel, '');
-		assert.equal(actual.keybindingItem.commandDefaultLabel, null);
-		assert.equal(actual.keybindingItem.keybinding, null);
-		assert.equal(actual.keybindingItem.when, '');
+		assert.strictEqual(actual.keybindingItem.command, 'command_without_keybinding');
+		assert.strictEqual(actual.keybindingItem.commandLabel, '');
+		assert.strictEqual(actual.keybindingItem.commandDefaultLabel, null);
+		assert.strictEqual(actual.keybindingItem.keybinding, undefined);
+		assert.strictEqual(actual.keybindingItem.when, '');
 	});
 
 	test('convert with title and without binding to entry', async () => {
@@ -196,11 +196,11 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('').filter(element => element.keybindingItem.command === id)[0];
-		assert.equal(actual.keybindingItem.command, id);
-		assert.equal(actual.keybindingItem.commandLabel, 'some title');
-		assert.equal(actual.keybindingItem.commandDefaultLabel, null);
-		assert.equal(actual.keybindingItem.keybinding, null);
-		assert.equal(actual.keybindingItem.when, '');
+		assert.strictEqual(actual.keybindingItem.command, id);
+		assert.strictEqual(actual.keybindingItem.commandLabel, 'some title');
+		assert.strictEqual(actual.keybindingItem.commandDefaultLabel, null);
+		assert.strictEqual(actual.keybindingItem.keybinding, undefined);
+		assert.strictEqual(actual.keybindingItem.when, '');
 	});
 
 	test('filter by command id', async () => {
@@ -270,7 +270,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch(`@command:${command}`);
-		assert.equal(actual.length, 1);
+		assert.strictEqual(actual.length, 1);
 		assert.deepEqual(actual[0].keybindingItem.command, command);
 	});
 
@@ -281,7 +281,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch(`@command:${command}`);
-		assert.equal(actual.length, 2);
+		assert.strictEqual(actual.length, 2);
 		assert.deepEqual(actual[0].keybindingItem.command, command);
 		assert.deepEqual(actual[1].keybindingItem.command, command);
 	});
@@ -305,7 +305,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('cmd').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { metaKey: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -319,7 +319,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('meta').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { metaKey: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -333,7 +333,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('command').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { metaKey: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -347,7 +347,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('windows').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { metaKey: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -359,7 +359,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('alt').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { altKey: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -371,7 +371,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('option').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { altKey: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -383,7 +383,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('ctrl').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { ctrlKey: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -395,7 +395,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('control').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { ctrlKey: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -407,7 +407,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('shift').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { shiftKey: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -419,7 +419,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('arrow').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -431,7 +431,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('alt right').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { altKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -443,7 +443,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('right alt').filter(element => element.keybindingItem.command === command);
-		assert.equal(0, actual.length);
+		assert.strictEqual(0, actual.length);
 	});
 
 	test('filter by modifiers and key', async () => {
@@ -454,7 +454,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('alt cmd esc').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { altKey: true, metaKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -467,7 +467,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('cmd shift esc').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { metaKey: true, shiftKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -480,7 +480,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('cmd shift esc').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { metaKey: true, shiftKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -493,7 +493,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('cmd del').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { metaKey: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, { keyCode: true });
 	});
@@ -506,7 +506,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('cmd shift esc del').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { shiftKey: true, metaKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, { keyCode: true });
 	});
@@ -518,7 +518,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('"ctrl c"').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { ctrlKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -530,7 +530,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('"shift meta escape ctrl c"').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { shiftKey: true, metaKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, { ctrlKey: true, keyCode: true });
 	});
@@ -543,7 +543,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('"cmd shift esc del"').filter(element => element.keybindingItem.command === command);
-		assert.equal(0, actual.length);
+		assert.strictEqual(0, actual.length);
 	});
 
 	test('filter matches with + separator', async () => {
@@ -553,7 +553,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('"control+c"').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { ctrlKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -565,7 +565,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('@keybinding:control+c').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { ctrlKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, {});
 	});
@@ -577,7 +577,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('"shift+meta+escape ctrl+c"').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { shiftKey: true, metaKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, { keyCode: true, ctrlKey: true });
 	});
@@ -589,7 +589,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('@keybinding:"shift+meta+escape ctrl+c"').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { shiftKey: true, metaKey: true, keyCode: true });
 		assert.deepEqual(actual[0].keybindingMatches!.chordPart, { keyCode: true, ctrlKey: true });
 	});
@@ -601,7 +601,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('"ctrl+space"').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 	});
 
 	test('filter exact matches with user settings label', async () => {
@@ -612,7 +612,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('"down"').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { keyCode: true });
 	});
 
@@ -625,9 +625,9 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch(term);
-		assert.equal(1, actual.length);
-		assert.equal(command, actual[0].keybindingItem.command);
-		assert.equal(1, actual[0].commandIdMatches?.length);
+		assert.strictEqual(1, actual.length);
+		assert.strictEqual(command, actual[0].keybindingItem.command);
+		assert.strictEqual(1, actual[0].commandIdMatches?.length);
 	});
 
 	test('filter modifiers are not matched when not completely matched (includes)', async () => {
@@ -639,9 +639,9 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch(term);
-		assert.equal(1, actual.length);
-		assert.equal(command, actual[0].keybindingItem.command);
-		assert.equal(1, actual[0].commandIdMatches?.length);
+		assert.strictEqual(1, actual.length);
+		assert.strictEqual(command, actual[0].keybindingItem.command);
+		assert.strictEqual(1, actual[0].commandIdMatches?.length);
 	});
 
 	test('filter modifiers are matched with complete term', async () => {
@@ -652,7 +652,7 @@ suite('KeybindingsEditorModel', () => {
 
 		await testObject.resolve(new Map<string, string>());
 		const actual = testObject.fetch('alt').filter(element => element.keybindingItem.command === command);
-		assert.equal(1, actual.length);
+		assert.strictEqual(1, actual.length);
 		assert.deepEqual(actual[0].keybindingMatches!.firstPart, { altKey: true });
 	});
 
@@ -669,25 +669,25 @@ suite('KeybindingsEditorModel', () => {
 	}
 
 	function assertKeybindingItems(actual: ResolvedKeybindingItem[], expected: ResolvedKeybindingItem[]) {
-		assert.equal(actual.length, expected.length);
+		assert.strictEqual(actual.length, expected.length);
 		for (let i = 0; i < actual.length; i++) {
 			assertKeybindingItem(actual[i], expected[i]);
 		}
 	}
 
 	function assertKeybindingItem(actual: ResolvedKeybindingItem, expected: ResolvedKeybindingItem): void {
-		assert.equal(actual.command, expected.command);
+		assert.strictEqual(actual.command, expected.command);
 		if (actual.when) {
 			assert.ok(!!expected.when);
-			assert.equal(actual.when.serialize(), expected.when!.serialize());
+			assert.strictEqual(actual.when.serialize(), expected.when!.serialize());
 		} else {
 			assert.ok(!expected.when);
 		}
-		assert.equal(actual.isDefault, expected.isDefault);
+		assert.strictEqual(actual.isDefault, expected.isDefault);
 
 		if (actual.resolvedKeybinding) {
 			assert.ok(!!expected.resolvedKeybinding);
-			assert.equal(actual.resolvedKeybinding.getLabel(), expected.resolvedKeybinding!.getLabel());
+			assert.strictEqual(actual.resolvedKeybinding.getLabel(), expected.resolvedKeybinding!.getLabel());
 		} else {
 			assert.ok(!expected.resolvedKeybinding);
 		}

--- a/src/vs/workbench/services/preferences/test/common/preferencesValidation.test.ts
+++ b/src/vs/workbench/services/preferences/test/common/preferencesValidation.test.ts
@@ -17,7 +17,7 @@ suite('Preferences Validation', () => {
 		}
 
 		public accepts(input: string) {
-			assert.equal(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to accept \`${input}\`. Got ${this.validator(input)}.`);
+			assert.strictEqual(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to accept \`${input}\`. Got ${this.validator(input)}.`);
 		}
 
 		public rejects(input: string) {
@@ -259,7 +259,7 @@ suite('Preferences Validation', () => {
 		}
 
 		public accepts(input: string[]) {
-			assert.equal(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to accept \`${JSON.stringify(input)}\`. Got ${this.validator(input)}.`);
+			assert.strictEqual(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to accept \`${JSON.stringify(input)}\`. Got ${this.validator(input)}.`);
 		}
 
 		public rejects(input: any[]) {

--- a/src/vs/workbench/services/search/test/common/replace.test.ts
+++ b/src/vs/workbench/services/search/test/common/replace.test.ts
@@ -10,12 +10,12 @@ suite('Replace Pattern test', () => {
 	test('parse replace string', () => {
 		const testParse = (input: string, expected: string, expectedHasParameters: boolean) => {
 			let actual = new ReplacePattern(input, { pattern: 'somepattern', isRegExp: true });
-			assert.equal(expected, actual.pattern);
-			assert.equal(expectedHasParameters, actual.hasParameters);
+			assert.strictEqual(expected, actual.pattern);
+			assert.strictEqual(expectedHasParameters, actual.hasParameters);
 
 			actual = new ReplacePattern('hello' + input + 'hi', { pattern: 'sonepattern', isRegExp: true });
-			assert.equal('hello' + expected + 'hi', actual.pattern);
-			assert.equal(expectedHasParameters, actual.hasParameters);
+			assert.strictEqual('hello' + expected + 'hi', actual.pattern);
+			assert.strictEqual(expectedHasParameters, actual.hasParameters);
 		};
 
 		// no backslash => no treatment
@@ -86,155 +86,155 @@ suite('Replace Pattern test', () => {
 		assert.deepEqual(expected, actual);
 
 		let testObject = new ReplacePattern('hello$0', false, /abc/g);
-		assert.equal(false, testObject.hasParameters);
+		assert.strictEqual(false, testObject.hasParameters);
 
 		testObject = new ReplacePattern('hello$0', true, /abc/g);
-		assert.equal(true, testObject.hasParameters);
+		assert.strictEqual(true, testObject.hasParameters);
 	});
 
 	test('get replace string if given text is a complete match', () => {
 		let testObject = new ReplacePattern('hello', { pattern: 'bla', isRegExp: true });
 		let actual = testObject.getReplaceString('bla');
-		assert.equal('hello', actual);
+		assert.strictEqual('hello', actual);
 
 		testObject = new ReplacePattern('hello', { pattern: 'bla', isRegExp: false });
 		actual = testObject.getReplaceString('bla');
-		assert.equal('hello', actual);
+		assert.strictEqual('hello', actual);
 
 		testObject = new ReplacePattern('hello', { pattern: '(bla)', isRegExp: true });
 		actual = testObject.getReplaceString('bla');
-		assert.equal('hello', actual);
+		assert.strictEqual('hello', actual);
 
 		testObject = new ReplacePattern('hello$0', { pattern: '(bla)', isRegExp: true });
 		actual = testObject.getReplaceString('bla');
-		assert.equal('hellobla', actual);
+		assert.strictEqual('hellobla', actual);
 
 		testObject = new ReplacePattern('import * as $1 from \'$2\';', { pattern: 'let\\s+(\\w+)\\s*=\\s*require\\s*\\(\\s*[\'\"]([\\w.\\-/]+)\\s*[\'\"]\\s*\\)\\s*', isRegExp: true });
 		actual = testObject.getReplaceString('let fs = require(\'fs\')');
-		assert.equal('import * as fs from \'fs\';', actual);
+		assert.strictEqual('import * as fs from \'fs\';', actual);
 
 		actual = testObject.getReplaceString('let something = require(\'fs\')');
-		assert.equal('import * as something from \'fs\';', actual);
+		assert.strictEqual('import * as something from \'fs\';', actual);
 
 		actual = testObject.getReplaceString('let require(\'fs\')');
-		assert.equal(null, actual);
+		assert.strictEqual(null, actual);
 
 		testObject = new ReplacePattern('import * as $1 from \'$1\';', { pattern: 'let\\s+(\\w+)\\s*=\\s*require\\s*\\(\\s*[\'\"]([\\w.\\-/]+)\\s*[\'\"]\\s*\\)\\s*', isRegExp: true });
 		actual = testObject.getReplaceString('let something = require(\'fs\')');
-		assert.equal('import * as something from \'something\';', actual);
+		assert.strictEqual('import * as something from \'something\';', actual);
 
 		testObject = new ReplacePattern('import * as $2 from \'$1\';', { pattern: 'let\\s+(\\w+)\\s*=\\s*require\\s*\\(\\s*[\'\"]([\\w.\\-/]+)\\s*[\'\"]\\s*\\)\\s*', isRegExp: true });
 		actual = testObject.getReplaceString('let something = require(\'fs\')');
-		assert.equal('import * as fs from \'something\';', actual);
+		assert.strictEqual('import * as fs from \'something\';', actual);
 
 		testObject = new ReplacePattern('import * as $0 from \'$0\';', { pattern: 'let\\s+(\\w+)\\s*=\\s*require\\s*\\(\\s*[\'\"]([\\w.\\-/]+)\\s*[\'\"]\\s*\\)\\s*', isRegExp: true });
 		actual = testObject.getReplaceString('let something = require(\'fs\');');
-		assert.equal('import * as let something = require(\'fs\') from \'let something = require(\'fs\')\';', actual);
+		assert.strictEqual('import * as let something = require(\'fs\') from \'let something = require(\'fs\')\';', actual);
 
 		testObject = new ReplacePattern('import * as $1 from \'$2\';', { pattern: 'let\\s+(\\w+)\\s*=\\s*require\\s*\\(\\s*[\'\"]([\\w.\\-/]+)\\s*[\'\"]\\s*\\)\\s*', isRegExp: false });
 		actual = testObject.getReplaceString('let fs = require(\'fs\');');
-		assert.equal(null, actual);
+		assert.strictEqual(null, actual);
 
 		testObject = new ReplacePattern('cat$1', { pattern: 'for(.*)', isRegExp: true });
 		actual = testObject.getReplaceString('for ()');
-		assert.equal('cat ()', actual);
+		assert.strictEqual('cat ()', actual);
 	});
 
 	test('case operations', () => {
 		let testObject = new ReplacePattern('a\\u$1l\\u\\l\\U$2M$3n', { pattern: 'a(l)l(good)m(e)n', isRegExp: true });
 		let actual = testObject.getReplaceString('allgoodmen');
-		assert.equal('aLlGoODMen', actual);
+		assert.strictEqual('aLlGoODMen', actual);
 	});
 
 	test('get replace string for no matches', () => {
 		let testObject = new ReplacePattern('hello', { pattern: 'bla', isRegExp: true });
 		let actual = testObject.getReplaceString('foo');
-		assert.equal(null, actual);
+		assert.strictEqual(null, actual);
 
 		testObject = new ReplacePattern('hello', { pattern: 'bla', isRegExp: false });
 		actual = testObject.getReplaceString('foo');
-		assert.equal(null, actual);
+		assert.strictEqual(null, actual);
 	});
 
 	test('get replace string if match is sub-string of the text', () => {
 		let testObject = new ReplacePattern('hello', { pattern: 'bla', isRegExp: true });
 		let actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('hello', actual);
+		assert.strictEqual('hello', actual);
 
 		testObject = new ReplacePattern('hello', { pattern: 'bla', isRegExp: false });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('hello', actual);
+		assert.strictEqual('hello', actual);
 
 		testObject = new ReplacePattern('that', { pattern: 'this(?=.*bla)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('that', actual);
+		assert.strictEqual('that', actual);
 
 		testObject = new ReplacePattern('$1at', { pattern: '(th)is(?=.*bla)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('that', actual);
+		assert.strictEqual('that', actual);
 
 		testObject = new ReplacePattern('$1e', { pattern: '(th)is(?=.*bla)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('the', actual);
+		assert.strictEqual('the', actual);
 
 		testObject = new ReplacePattern('$1ere', { pattern: '(th)is(?=.*bla)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('there', actual);
+		assert.strictEqual('there', actual);
 
 		testObject = new ReplacePattern('$1', { pattern: '(th)is(?=.*bla)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('th', actual);
+		assert.strictEqual('th', actual);
 
 		testObject = new ReplacePattern('ma$1', { pattern: '(th)is(?=.*bla)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('math', actual);
+		assert.strictEqual('math', actual);
 
 		testObject = new ReplacePattern('ma$1s', { pattern: '(th)is(?=.*bla)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('maths', actual);
+		assert.strictEqual('maths', actual);
 
 		testObject = new ReplacePattern('ma$1s', { pattern: '(th)is(?=.*bla)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('maths', actual);
+		assert.strictEqual('maths', actual);
 
 		testObject = new ReplacePattern('$0', { pattern: '(th)is(?=.*bla)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('this', actual);
+		assert.strictEqual('this', actual);
 
 		testObject = new ReplacePattern('$0$1', { pattern: '(th)is(?=.*bla)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('thisth', actual);
+		assert.strictEqual('thisth', actual);
 
 		testObject = new ReplacePattern('foo', { pattern: 'bla(?=\\stext$)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('foo', actual);
+		assert.strictEqual('foo', actual);
 
 		testObject = new ReplacePattern('f$1', { pattern: 'b(la)(?=\\stext$)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('fla', actual);
+		assert.strictEqual('fla', actual);
 
 		testObject = new ReplacePattern('f$0', { pattern: 'b(la)(?=\\stext$)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('fbla', actual);
+		assert.strictEqual('fbla', actual);
 
 		testObject = new ReplacePattern('$0ah', { pattern: 'b(la)(?=\\stext$)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
-		assert.equal('blaah', actual);
+		assert.strictEqual('blaah', actual);
 
 		testObject = new ReplacePattern('newrege$1', true, /Testrege(\w*)/);
 		actual = testObject.getReplaceString('Testregex', true);
-		assert.equal('Newregex', actual);
+		assert.strictEqual('Newregex', actual);
 
 		testObject = new ReplacePattern('newrege$1', true, /TESTREGE(\w*)/);
 		actual = testObject.getReplaceString('TESTREGEX', true);
-		assert.equal('NEWREGEX', actual);
+		assert.strictEqual('NEWREGEX', actual);
 
 		testObject = new ReplacePattern('new_rege$1', true, /Test_Rege(\w*)/);
 		actual = testObject.getReplaceString('Test_Regex', true);
-		assert.equal('New_Regex', actual);
+		assert.strictEqual('New_Regex', actual);
 
 		testObject = new ReplacePattern('new-rege$1', true, /Test-Rege(\w*)/);
 		actual = testObject.getReplaceString('Test-Regex', true);
-		assert.equal('New-Regex', actual);
+		assert.strictEqual('New-Regex', actual);
 	});
 });

--- a/src/vs/workbench/services/search/test/common/search.test.ts
+++ b/src/vs/workbench/services/search/test/common/search.test.ts
@@ -13,7 +13,7 @@ suite('TextSearchResult', () => {
 	};
 
 	function assertOneLinePreviewRangeText(text: string, result: TextSearchMatch): void {
-		assert.equal(
+		assert.strictEqual(
 			result.preview.text.substring((<SearchRange>result.preview.matches).startColumn, (<SearchRange>result.preview.matches).endColumn),
 			text);
 	}
@@ -88,11 +88,11 @@ suite('TextSearchResult', () => {
 		const range = new SearchRange(5, 4, 6, 3);
 		const result = new TextSearchMatch('foo bar\nfoo bar', range, previewOptions);
 		assert.deepEqual(result.ranges, range);
-		assert.equal(result.preview.text, 'foo bar\nfoo bar');
-		assert.equal((<SearchRange>result.preview.matches).startLineNumber, 0);
-		assert.equal((<SearchRange>result.preview.matches).startColumn, 4);
-		assert.equal((<SearchRange>result.preview.matches).endLineNumber, 1);
-		assert.equal((<SearchRange>result.preview.matches).endColumn, 3);
+		assert.strictEqual(result.preview.text, 'foo bar\nfoo bar');
+		assert.strictEqual((<SearchRange>result.preview.matches).startLineNumber, 0);
+		assert.strictEqual((<SearchRange>result.preview.matches).startColumn, 4);
+		assert.strictEqual((<SearchRange>result.preview.matches).endLineNumber, 1);
+		assert.strictEqual((<SearchRange>result.preview.matches).endColumn, 3);
 	});
 
 	test('compacts multiple ranges on long lines', () => {
@@ -106,7 +106,7 @@ suite('TextSearchResult', () => {
 		const range3 = new SearchRange(5, 141, 5, 144);
 		const result = new TextSearchMatch('foo bar 123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 foo bar baz bar', [range1, range2, range3], previewOptions);
 		assert.deepEqual(result.preview.matches, [new SearchRange(0, 4, 0, 7), new SearchRange(0, 42, 0, 45), new SearchRange(0, 50, 0, 53)]);
-		assert.equal(result.preview.text, 'foo bar 123456⟪ 117 characters skipped ⟫o bar baz bar');
+		assert.strictEqual(result.preview.text, 'foo bar 123456⟪ 117 characters skipped ⟫o bar baz bar');
 	});
 
 	test('trims lines endings', () => {
@@ -116,8 +116,8 @@ suite('TextSearchResult', () => {
 			charsPerLine: 10000
 		};
 
-		assert.equal(new TextSearchMatch('foo bar\n', range, previewOptions).preview.text, 'foo bar');
-		assert.equal(new TextSearchMatch('foo bar\r\n', range, previewOptions).preview.text, 'foo bar');
+		assert.strictEqual(new TextSearchMatch('foo bar\n', range, previewOptions).preview.text, 'foo bar');
+		assert.strictEqual(new TextSearchMatch('foo bar\r\n', range, previewOptions).preview.text, 'foo bar');
 	});
 
 	// test('all lines of multiline match', () => {

--- a/src/vs/workbench/services/search/test/common/searchHelpers.test.ts
+++ b/src/vs/workbench/services/search/test/common/searchHelpers.test.ts
@@ -19,8 +19,8 @@ suite('SearchHelpers', () => {
 
 		test('simple', () => {
 			const results = editorMatchesToTextSearchResults([new FindMatch(new Range(6, 1, 6, 2), null)], mockTextModel);
-			assert.equal(results.length, 1);
-			assert.equal(results[0].preview.text, '6\n');
+			assert.strictEqual(results.length, 1);
+			assert.strictEqual(results[0].preview.text, '6\n');
 			assert.deepEqual(results[0].preview.matches, [new Range(0, 0, 0, 1)]);
 			assert.deepEqual(results[0].ranges, [new Range(5, 0, 5, 1)]);
 		});
@@ -33,7 +33,7 @@ suite('SearchHelpers', () => {
 					new FindMatch(new Range(9, 1, 10, 3), null),
 				],
 				mockTextModel);
-			assert.equal(results.length, 2);
+			assert.strictEqual(results.length, 2);
 			assert.deepEqual(results[0].preview.matches, [
 				new Range(0, 0, 0, 1),
 				new Range(0, 3, 2, 1),
@@ -42,7 +42,7 @@ suite('SearchHelpers', () => {
 				new Range(5, 0, 5, 1),
 				new Range(5, 3, 7, 1),
 			]);
-			assert.equal(results[0].preview.text, '6\n7\n8\n');
+			assert.strictEqual(results[0].preview.text, '6\n7\n8\n');
 
 			assert.deepEqual(results[1].preview.matches, [
 				new Range(0, 0, 1, 2),
@@ -50,7 +50,7 @@ suite('SearchHelpers', () => {
 			assert.deepEqual(results[1].ranges, [
 				new Range(8, 0, 9, 2),
 			]);
-			assert.equal(results[1].preview.text, '9\n10\n');
+			assert.strictEqual(results[1].preview.text, '9\n10\n');
 		});
 	});
 

--- a/src/vs/workbench/services/search/test/node/fileSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/fileSearch.integrationTest.ts
@@ -38,7 +38,7 @@ async function doSearchTest(query: IFileQuery, expectedResultCount: number | Fun
 		}
 	});
 
-	assert.equal(results.length, expectedResultCount, `rg ${results.length} !== ${expectedResultCount}`);
+	assert.strictEqual(results.length, expectedResultCount, `rg ${results.length} !== ${expectedResultCount}`);
 }
 
 flakySuite('FileSearch-integration', function () {

--- a/src/vs/workbench/services/search/test/node/ripgrepFileSearch.test.ts
+++ b/src/vs/workbench/services/search/test/node/ripgrepFileSearch.test.ts
@@ -10,7 +10,7 @@ import { fixDriveC, getAbsoluteGlob } from 'vs/workbench/services/search/node/ri
 suite('RipgrepFileSearch - etc', () => {
 	function testGetAbsGlob(params: string[]): void {
 		const [folder, glob, expectedResult] = params;
-		assert.equal(fixDriveC(getAbsoluteGlob(folder, glob)), expectedResult, JSON.stringify(params));
+		assert.strictEqual(fixDriveC(getAbsoluteGlob(folder, glob)), expectedResult, JSON.stringify(params));
 	}
 
 	(!platform.isWindows ? test.skip : test)('getAbsoluteGlob_win', () => {

--- a/src/vs/workbench/services/search/test/node/ripgrepTextSearchEngine.test.ts
+++ b/src/vs/workbench/services/search/test/node/ripgrepTextSearchEngine.test.ts
@@ -11,21 +11,21 @@ import { Range, TextSearchResult } from 'vs/workbench/services/search/common/sea
 
 suite('RipgrepTextSearchEngine', () => {
 	test('unicodeEscapesToPCRE2', async () => {
-		assert.equal(unicodeEscapesToPCRE2('\\u1234'), '\\x{1234}');
-		assert.equal(unicodeEscapesToPCRE2('\\u1234\\u0001'), '\\x{1234}\\x{0001}');
-		assert.equal(unicodeEscapesToPCRE2('foo\\u1234bar'), 'foo\\x{1234}bar');
-		assert.equal(unicodeEscapesToPCRE2('\\\\\\u1234'), '\\\\\\x{1234}');
-		assert.equal(unicodeEscapesToPCRE2('foo\\\\\\u1234'), 'foo\\\\\\x{1234}');
+		assert.strictEqual(unicodeEscapesToPCRE2('\\u1234'), '\\x{1234}');
+		assert.strictEqual(unicodeEscapesToPCRE2('\\u1234\\u0001'), '\\x{1234}\\x{0001}');
+		assert.strictEqual(unicodeEscapesToPCRE2('foo\\u1234bar'), 'foo\\x{1234}bar');
+		assert.strictEqual(unicodeEscapesToPCRE2('\\\\\\u1234'), '\\\\\\x{1234}');
+		assert.strictEqual(unicodeEscapesToPCRE2('foo\\\\\\u1234'), 'foo\\\\\\x{1234}');
 
-		assert.equal(unicodeEscapesToPCRE2('\\u{1234}'), '\\x{1234}');
-		assert.equal(unicodeEscapesToPCRE2('\\u{1234}\\u{0001}'), '\\x{1234}\\x{0001}');
-		assert.equal(unicodeEscapesToPCRE2('foo\\u{1234}bar'), 'foo\\x{1234}bar');
-		assert.equal(unicodeEscapesToPCRE2('[\\u00A0-\\u00FF]'), '[\\x{00A0}-\\x{00FF}]');
+		assert.strictEqual(unicodeEscapesToPCRE2('\\u{1234}'), '\\x{1234}');
+		assert.strictEqual(unicodeEscapesToPCRE2('\\u{1234}\\u{0001}'), '\\x{1234}\\x{0001}');
+		assert.strictEqual(unicodeEscapesToPCRE2('foo\\u{1234}bar'), 'foo\\x{1234}bar');
+		assert.strictEqual(unicodeEscapesToPCRE2('[\\u00A0-\\u00FF]'), '[\\x{00A0}-\\x{00FF}]');
 
-		assert.equal(unicodeEscapesToPCRE2('foo\\u{123456}7bar'), 'foo\\u{123456}7bar');
-		assert.equal(unicodeEscapesToPCRE2('\\u123'), '\\u123');
-		assert.equal(unicodeEscapesToPCRE2('foo'), 'foo');
-		assert.equal(unicodeEscapesToPCRE2(''), '');
+		assert.strictEqual(unicodeEscapesToPCRE2('foo\\u{123456}7bar'), 'foo\\u{123456}7bar');
+		assert.strictEqual(unicodeEscapesToPCRE2('\\u123'), '\\u123');
+		assert.strictEqual(unicodeEscapesToPCRE2('foo'), 'foo');
+		assert.strictEqual(unicodeEscapesToPCRE2(''), '');
 	});
 
 	test('fixRegexNewline - src', () => {
@@ -41,7 +41,7 @@ suite('RipgrepTextSearchEngine', () => {
 		];
 
 		for (const [input, expected] of ttable) {
-			assert.equal(fixRegexNewline(input), expected, `${input} -> ${expected}`);
+			assert.strictEqual(fixRegexNewline(input), expected, `${input} -> ${expected}`);
 		}
 	});
 
@@ -49,7 +49,7 @@ suite('RipgrepTextSearchEngine', () => {
 		function testFixRegexNewline([inputReg, testStr, shouldMatch]: readonly [string, string, boolean]): void {
 			const fixed = fixRegexNewline(inputReg);
 			const reg = new RegExp(fixed);
-			assert.equal(reg.test(testStr), shouldMatch, `${inputReg} => ${reg}, ${testStr}, ${shouldMatch}`);
+			assert.strictEqual(reg.test(testStr), shouldMatch, `${inputReg} => ${reg}, ${testStr}, ${shouldMatch}`);
 		}
 
 		([
@@ -74,7 +74,7 @@ suite('RipgrepTextSearchEngine', () => {
 		function testFixNewline([inputReg, testStr, shouldMatch = true]: readonly [string, string, boolean?]): void {
 			const fixed = fixNewline(inputReg);
 			const reg = new RegExp(fixed);
-			assert.equal(reg.test(testStr), shouldMatch, `${inputReg} => ${reg}, ${testStr}, ${shouldMatch}`);
+			assert.strictEqual(reg.test(testStr), shouldMatch, `${inputReg} => ${reg}, ${testStr}, ${shouldMatch}`);
 		}
 
 		([

--- a/src/vs/workbench/services/search/test/node/search.test.ts
+++ b/src/vs/workbench/services/search/test/node/search.test.ts
@@ -45,7 +45,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 4);
+			assert.strictEqual(count, 4);
 			done();
 		});
 	});
@@ -64,7 +64,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
+			assert.strictEqual(count, 1);
 			done();
 		});
 	});
@@ -83,7 +83,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
+			assert.strictEqual(count, 1);
 			done();
 		});
 	});
@@ -103,7 +103,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error, complete) => {
 			assert.ok(!error);
-			assert.equal(count, 0);
+			assert.strictEqual(count, 0);
 			assert.ok(complete.limitHit);
 			done();
 		});
@@ -124,7 +124,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error, complete) => {
 			assert.ok(!error);
-			assert.equal(count, 0);
+			assert.strictEqual(count, 0);
 			assert.ok(!complete.limitHit);
 			done();
 		});
@@ -145,7 +145,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error, complete) => {
 			assert.ok(!error);
-			assert.equal(count, 0);
+			assert.strictEqual(count, 0);
 			assert.ok(complete.limitHit);
 			done();
 		});
@@ -166,7 +166,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error, complete) => {
 			assert.ok(!error);
-			assert.equal(count, 0);
+			assert.strictEqual(count, 0);
 			assert.ok(!complete.limitHit);
 			done();
 		});
@@ -186,7 +186,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
+			assert.strictEqual(count, 1);
 			done();
 		});
 	});
@@ -205,7 +205,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 7);
+			assert.strictEqual(count, 7);
 			done();
 		});
 	});
@@ -224,7 +224,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 3);
+			assert.strictEqual(count, 3);
 			done();
 		});
 	});
@@ -247,7 +247,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error, complete) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
+			assert.strictEqual(count, 1);
 			done();
 		});
 	});
@@ -270,7 +270,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error, complete) => {
 			assert.ok(!error);
-			assert.equal(count, 0);
+			assert.strictEqual(count, 0);
 			assert.ok(complete.limitHit);
 			done();
 		});
@@ -290,7 +290,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
+			assert.strictEqual(count, 1);
 			done();
 		});
 	});
@@ -309,7 +309,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 14);
+			assert.strictEqual(count, 14);
 			done();
 		});
 	});
@@ -328,7 +328,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 0);
+			assert.strictEqual(count, 0);
 			done();
 		});
 	});
@@ -350,7 +350,7 @@ flakySuite('FileSearchEngine', () => {
 			res = result;
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
+			assert.strictEqual(count, 1);
 			assert.strictEqual(path.basename(res.relativePath), 'site.less');
 			done();
 		});
@@ -371,7 +371,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 8);
+			assert.strictEqual(count, 8);
 			done();
 		});
 	});
@@ -390,7 +390,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
+			assert.strictEqual(count, 1);
 			done();
 		});
 	});
@@ -409,7 +409,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
+			assert.strictEqual(count, 1);
 			done();
 		});
 	});
@@ -429,7 +429,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 8);
+			assert.strictEqual(count, 8);
 			done();
 		});
 	});
@@ -449,7 +449,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 8);
+			assert.strictEqual(count, 8);
 			done();
 		});
 	});
@@ -469,7 +469,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 13);
+			assert.strictEqual(count, 13);
 			done();
 		});
 	});
@@ -489,7 +489,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
+			assert.strictEqual(count, 1);
 			done();
 		});
 	});
@@ -523,7 +523,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 5);
+			assert.strictEqual(count, 5);
 			done();
 		});
 	});
@@ -544,8 +544,8 @@ flakySuite('FileSearchEngine', () => {
 			res = result;
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.equal(path.basename(res.relativePath), '汉语.txt');
+			assert.strictEqual(count, 1);
+			assert.strictEqual(path.basename(res.relativePath), '汉语.txt');
 			done();
 		});
 	});
@@ -564,7 +564,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 0);
+			assert.strictEqual(count, 0);
 			done();
 		});
 	});
@@ -585,8 +585,8 @@ flakySuite('FileSearchEngine', () => {
 			res = result;
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.equal(path.basename(res.relativePath), 'company.js');
+			assert.strictEqual(count, 1);
+			assert.strictEqual(path.basename(res.relativePath), 'company.js');
 			done();
 		});
 	});
@@ -636,8 +636,8 @@ flakySuite('FileSearchEngine', () => {
 			res = result;
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.equal(path.basename(res.relativePath), 'company.js');
+			assert.strictEqual(count, 1);
+			assert.strictEqual(path.basename(res.relativePath), 'company.js');
 			done();
 		});
 	});
@@ -664,8 +664,8 @@ flakySuite('FileSearchEngine', () => {
 			res = result;
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.equal(path.basename(res.relativePath), 'site.css');
+			assert.strictEqual(count, 1);
+			assert.strictEqual(path.basename(res.relativePath), 'site.css');
 			done();
 		});
 	});
@@ -690,7 +690,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 2);
+			assert.strictEqual(count, 2);
 			done();
 		});
 	});
@@ -712,7 +712,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.equal(count, 1);
+			assert.strictEqual(count, 1);
 			done();
 		});
 	});
@@ -731,7 +731,7 @@ flakySuite('FileWalker', () => {
 		});
 		const cmd1 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 		walker.readStdout(cmd1, 'utf8', (err1, stdout1) => {
-			assert.equal(err1, null);
+			assert.strictEqual(err1, null);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file0), -1, stdout1);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file1), -1, stdout1);
 
@@ -742,7 +742,7 @@ flakySuite('FileWalker', () => {
 			});
 			const cmd2 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 			walker.readStdout(cmd2, 'utf8', (err2, stdout2) => {
-				assert.equal(err2, null);
+				assert.strictEqual(err2, null);
 				assert.notStrictEqual(stdout1!.split('\n').indexOf(file0), -1, stdout1);
 				assert.strictEqual(stdout2!.split('\n').indexOf(file1), -1, stdout2);
 				done();
@@ -764,7 +764,7 @@ flakySuite('FileWalker', () => {
 		const walker = new FileWalker({ type: QueryType.File, folderQueries });
 		const cmd1 = walker.spawnFindCmd(folderQueries[0]);
 		walker.readStdout(cmd1, 'utf8', (err1, stdout1) => {
-			assert.equal(err1, null);
+			assert.strictEqual(err1, null);
 			assert(outputContains(stdout1!, file0), stdout1);
 			assert(!outputContains(stdout1!, file1), stdout1);
 			done();
@@ -779,7 +779,7 @@ flakySuite('FileWalker', () => {
 		const walker = new FileWalker({ type: QueryType.File, folderQueries: ROOT_FOLDER_QUERY, excludePattern: { '**/something': true } });
 		const cmd1 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 		walker.readStdout(cmd1, 'utf8', (err1, stdout1) => {
-			assert.equal(err1, null);
+			assert.strictEqual(err1, null);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file0), -1, stdout1);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file1), -1, stdout1);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file2), -1, stdout1);
@@ -787,7 +787,7 @@ flakySuite('FileWalker', () => {
 			const walker = new FileWalker({ type: QueryType.File, folderQueries: ROOT_FOLDER_QUERY, excludePattern: { '{**/examples,**/more}': true } });
 			const cmd2 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 			walker.readStdout(cmd2, 'utf8', (err2, stdout2) => {
-				assert.equal(err2, null);
+				assert.strictEqual(err2, null);
 				assert.notStrictEqual(stdout1!.split('\n').indexOf(file0), -1, stdout1);
 				assert.strictEqual(stdout2!.split('\n').indexOf(file1), -1, stdout2);
 				assert.strictEqual(stdout2!.split('\n').indexOf(file2), -1, stdout2);
@@ -803,14 +803,14 @@ flakySuite('FileWalker', () => {
 		const walker = new FileWalker({ type: QueryType.File, folderQueries: ROOT_FOLDER_QUERY, excludePattern: { '**/examples/something': true } });
 		const cmd1 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 		walker.readStdout(cmd1, 'utf8', (err1, stdout1) => {
-			assert.equal(err1, null);
+			assert.strictEqual(err1, null);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file0), -1, stdout1);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file1), -1, stdout1);
 
 			const walker = new FileWalker({ type: QueryType.File, folderQueries: ROOT_FOLDER_QUERY, excludePattern: { '**/examples/subfolder': true } });
 			const cmd2 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 			walker.readStdout(cmd2, 'utf8', (err2, stdout2) => {
-				assert.equal(err2, null);
+				assert.strictEqual(err2, null);
 				assert.notStrictEqual(stdout1!.split('\n').indexOf(file0), -1, stdout1);
 				assert.strictEqual(stdout2!.split('\n').indexOf(file1), -1, stdout2);
 				done();
@@ -825,14 +825,14 @@ flakySuite('FileWalker', () => {
 		const walker = new FileWalker({ type: QueryType.File, folderQueries: ROOT_FOLDER_QUERY, excludePattern: { '**/subfolder/something': true } });
 		const cmd1 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 		walker.readStdout(cmd1, 'utf8', (err1, stdout1) => {
-			assert.equal(err1, null);
+			assert.strictEqual(err1, null);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file0), -1, stdout1);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file1), -1, stdout1);
 
 			const walker = new FileWalker({ type: QueryType.File, folderQueries: ROOT_FOLDER_QUERY, excludePattern: { '**/subfolder/anotherfolder': true } });
 			const cmd2 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 			walker.readStdout(cmd2, 'utf8', (err2, stdout2) => {
-				assert.equal(err2, null);
+				assert.strictEqual(err2, null);
 				assert.notStrictEqual(stdout1!.split('\n').indexOf(file0), -1, stdout1);
 				assert.strictEqual(stdout2!.split('\n').indexOf(file1), -1, stdout2);
 				done();
@@ -847,14 +847,14 @@ flakySuite('FileWalker', () => {
 		const walker = new FileWalker({ type: QueryType.File, folderQueries: ROOT_FOLDER_QUERY, excludePattern: { 'examples/something': true } });
 		const cmd1 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 		walker.readStdout(cmd1, 'utf8', (err1, stdout1) => {
-			assert.equal(err1, null);
+			assert.strictEqual(err1, null);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file0), -1, stdout1);
 			assert.notStrictEqual(stdout1!.split('\n').indexOf(file1), -1, stdout1);
 
 			const walker = new FileWalker({ type: QueryType.File, folderQueries: ROOT_FOLDER_QUERY, excludePattern: { 'examples/subfolder': true } });
 			const cmd2 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 			walker.readStdout(cmd2, 'utf8', (err2, stdout2) => {
-				assert.equal(err2, null);
+				assert.strictEqual(err2, null);
 				assert.notStrictEqual(stdout1!.split('\n').indexOf(file0), -1, stdout1);
 				assert.strictEqual(stdout2!.split('\n').indexOf(file1), -1, stdout2);
 				done();
@@ -885,7 +885,7 @@ flakySuite('FileWalker', () => {
 		});
 		const cmd1 = walker.spawnFindCmd(TEST_ROOT_FOLDER);
 		walker.readStdout(cmd1, 'utf8', (err1, stdout1) => {
-			assert.equal(err1, null);
+			assert.strictEqual(err1, null);
 			for (const fileIn of filesIn) {
 				assert.notStrictEqual(stdout1!.split('\n').indexOf(fileIn), -1, stdout1);
 			}

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -39,7 +39,7 @@ function doSearchTest(query: ITextQuery, expectedResultCount: number | Function)
 		if (typeof expectedResultCount === 'function') {
 			assert(expectedResultCount(c));
 		} else {
-			assert.equal(c, expectedResultCount, `rg ${c} !== ${expectedResultCount}`);
+			assert.strictEqual(c, expectedResultCount, `rg ${c} !== ${expectedResultCount}`);
 		}
 
 		return results;
@@ -325,10 +325,10 @@ flakySuite('TextSearch-integration', function () {
 		};
 
 		return doSearchTest(config, 15).then(results => {
-			assert.equal(results.length, 3);
-			assert.equal(results[0].results!.length, 1);
+			assert.strictEqual(results.length, 3);
+			assert.strictEqual(results[0].results!.length, 1);
 			const match = <ITextSearchMatch>results[0].results![0];
-			assert.equal((<ISearchRange[]>match.ranges).length, 5);
+			assert.strictEqual((<ISearchRange[]>match.ranges).length, 5);
 		});
 	});
 
@@ -342,14 +342,14 @@ flakySuite('TextSearch-integration', function () {
 		};
 
 		return doSearchTest(config, 4).then(results => {
-			assert.equal(results.length, 4);
-			assert.equal((<ITextSearchContext>results[0].results![0]).lineNumber, 25);
-			assert.equal((<ITextSearchContext>results[0].results![0]).text, '        compiler.addUnit(prog,"input.ts");');
-			// assert.equal((<ITextSearchMatch>results[1].results[0]).preview.text, '        compiler.typeCheck();\n'); // See https://github.com/BurntSushi/ripgrep/issues/1095
-			assert.equal((<ITextSearchContext>results[2].results![0]).lineNumber, 27);
-			assert.equal((<ITextSearchContext>results[2].results![0]).text, '        compiler.emit();');
-			assert.equal((<ITextSearchContext>results[3].results![0]).lineNumber, 28);
-			assert.equal((<ITextSearchContext>results[3].results![0]).text, '');
+			assert.strictEqual(results.length, 4);
+			assert.strictEqual((<ITextSearchContext>results[0].results![0]).lineNumber, 25);
+			assert.strictEqual((<ITextSearchContext>results[0].results![0]).text, '        compiler.addUnit(prog,"input.ts");');
+			// assert.strictEqual((<ITextSearchMatch>results[1].results[0]).preview.text, '        compiler.typeCheck();\n'); // See https://github.com/BurntSushi/ripgrep/issues/1095
+			assert.strictEqual((<ITextSearchContext>results[2].results![0]).lineNumber, 27);
+			assert.strictEqual((<ITextSearchContext>results[2].results![0]).text, '        compiler.emit();');
+			assert.strictEqual((<ITextSearchContext>results[3].results![0]).lineNumber, 28);
+			assert.strictEqual((<ITextSearchContext>results[3].results![0]).text, '');
 		});
 	});
 
@@ -370,8 +370,8 @@ flakySuite('TextSearch-integration', function () {
 				throw new Error('expected fail');
 			}, err => {
 				const searchError = deserializeSearchError(err);
-				assert.equal(searchError.message, 'Unknown encoding: invalidEncoding');
-				assert.equal(searchError.code, SearchErrorCode.unknownEncoding);
+				assert.strictEqual(searchError.message, 'Unknown encoding: invalidEncoding');
+				assert.strictEqual(searchError.code, SearchErrorCode.unknownEncoding);
 			});
 		});
 
@@ -387,8 +387,8 @@ flakySuite('TextSearch-integration', function () {
 			}, err => {
 				const searchError = deserializeSearchError(err);
 				const regexParseErrorForUnclosedParenthesis = 'Regex parse error: unmatched closing parenthesis';
-				assert.equal(searchError.message, regexParseErrorForUnclosedParenthesis);
-				assert.equal(searchError.code, SearchErrorCode.regexParseError);
+				assert.strictEqual(searchError.message, regexParseErrorForUnclosedParenthesis);
+				assert.strictEqual(searchError.code, SearchErrorCode.regexParseError);
 			});
 		});
 
@@ -404,8 +404,8 @@ flakySuite('TextSearch-integration', function () {
 			}, err => {
 				const searchError = deserializeSearchError(err);
 				const regexParseErrorForLookAround = 'Regex parse error: lookbehind assertion is not fixed length';
-				assert.equal(searchError.message, regexParseErrorForLookAround);
-				assert.equal(searchError.code, SearchErrorCode.regexParseError);
+				assert.strictEqual(searchError.message, regexParseErrorForLookAround);
+				assert.strictEqual(searchError.code, SearchErrorCode.regexParseError);
 			});
 		});
 
@@ -424,8 +424,8 @@ flakySuite('TextSearch-integration', function () {
 				throw new Error('expected fail');
 			}, err => {
 				const searchError = deserializeSearchError(err);
-				assert.equal(searchError.message, 'Error parsing glob \'/{{}\': nested alternate groups are not allowed');
-				assert.equal(searchError.code, SearchErrorCode.globParseError);
+				assert.strictEqual(searchError.message, 'Error parsing glob \'/{{}\': nested alternate groups are not allowed');
+				assert.strictEqual(searchError.code, SearchErrorCode.globParseError);
 			});
 		});
 	});

--- a/src/vs/workbench/services/telemetry/test/browser/commonProperties.test.ts
+++ b/src/vs/workbench/services/telemetry/test/browser/commonProperties.test.ts
@@ -37,7 +37,7 @@ suite('Browser Telemetry - common properties', function () {
 		assert.ok('common.isNewSession' in props, 'isNewSession');
 		assert.ok('common.machineId' in props, 'machineId');
 
-		assert.equal(props['userId'], '1');
+		assert.strictEqual(props['userId'], '1');
 	});
 
 	test('mixes in additional dyanmic properties', async function () {
@@ -54,9 +54,9 @@ suite('Browser Telemetry - common properties', function () {
 		};
 
 		const props = await resolveWorkbenchCommonProperties(testStorageService, commit, version, undefined, resolveCommonTelemetryProperties);
-		assert.equal(props['userId'], '1');
+		assert.strictEqual(props['userId'], 1);
 
 		const props2 = await resolveWorkbenchCommonProperties(testStorageService, commit, version, undefined, resolveCommonTelemetryProperties);
-		assert.equal(props2['userId'], '2');
+		assert.strictEqual(props2['userId'], 2);
 	});
 });

--- a/src/vs/workbench/services/telemetry/test/electron-browser/commonProperties.test.ts
+++ b/src/vs/workbench/services/telemetry/test/electron-browser/commonProperties.test.ts
@@ -59,7 +59,7 @@ suite('Telemetry - common properties', function () {
 		// assert.ok('common.version.renderer' in first.data);
 		assert.ok('common.platformVersion' in props, 'platformVersion');
 		assert.ok('version' in props);
-		assert.equal(props['common.source'], 'my.install.source');
+		assert.strictEqual(props['common.source'], 'my.install.source');
 		assert.ok('common.firstSessionDate' in props, 'firstSessionDate');
 		assert.ok('common.lastSessionDate' in props, 'lastSessionDate'); // conditional, see below, 'lastSessionDate'ow
 		assert.ok('common.isNewSession' in props, 'isNewSession');
@@ -78,7 +78,7 @@ suite('Telemetry - common properties', function () {
 		const props = await resolveWorkbenchCommonProperties(testStorageService, testFileService, release(), commit, version, 'someMachineId', undefined, installSource);
 		assert.ok('common.lastSessionDate' in props); // conditional, see below
 		assert.ok('common.isNewSession' in props);
-		assert.equal(props['common.isNewSession'], 0);
+		assert.strictEqual(props['common.isNewSession'], '0');
 	});
 
 	test('values chance on ask', async function () {

--- a/src/vs/workbench/services/themes/test/electron-browser/tokenStyleResolving.test.ts
+++ b/src/vs/workbench/services/themes/test/electron-browser/tokenStyleResolving.test.ts
@@ -42,12 +42,12 @@ function tokenStyleAsString(ts: TokenStyle | undefined | null) {
 }
 
 function assertTokenStyle(actual: TokenStyle | undefined | null, expected: TokenStyle | undefined | null, message?: string) {
-	assert.equal(tokenStyleAsString(actual), tokenStyleAsString(expected), message);
+	assert.strictEqual(tokenStyleAsString(actual), tokenStyleAsString(expected), message);
 }
 
 function assertTokenStyleMetaData(colorIndex: string[], actual: ITokenStyle | undefined, expected: TokenStyle | undefined | null, message = '') {
 	if (expected === undefined || expected === null || actual === undefined) {
-		assert.equal(actual, expected, message);
+		assert.strictEqual(actual, expected, message);
 		return;
 	}
 	assert.strictEqual(actual.bold, expected.bold, 'bold ' + message);
@@ -56,9 +56,9 @@ function assertTokenStyleMetaData(colorIndex: string[], actual: ITokenStyle | un
 
 	const actualForegroundIndex = actual.foreground;
 	if (actualForegroundIndex && expected.foreground) {
-		assert.equal(colorIndex[actualForegroundIndex], Color.Format.CSS.formatHexA(expected.foreground, true).toUpperCase(), 'foreground ' + message);
+		assert.strictEqual(colorIndex[actualForegroundIndex], Color.Format.CSS.formatHexA(expected.foreground, true).toUpperCase(), 'foreground ' + message);
 	} else {
-		assert.equal(actualForegroundIndex, expected.foreground || 0, 'foreground ' + message);
+		assert.strictEqual(actualForegroundIndex, expected.foreground || 0, 'foreground ' + message);
 	}
 }
 
@@ -91,7 +91,7 @@ suite('Themes - TokenStyleResolving', () => {
 		themeData.location = FileAccess.asFileUri('./color-theme.json', require);
 		await themeData.ensureLoaded(extensionResourceLoaderService);
 
-		assert.equal(themeData.isLoaded, true);
+		assert.strictEqual(themeData.isLoaded, true);
 
 		assertTokenStyles(themeData, {
 			'comment': ts('#000000', undefinedStyle),
@@ -335,7 +335,7 @@ suite('Themes - TokenStyleResolving', () => {
 			registry.deregisterTokenStyleDefault(registry.parseTokenSelector('type', 'typescript1'));
 			registry.deregisterTokenStyleDefault(registry.parseTokenSelector('type:javascript1'));
 
-			assert.equal(registry.getTokenStylingDefaultRules().length, numberOfDefaultRules);
+			assert.strictEqual(registry.getTokenStylingDefaultRules().length, numberOfDefaultRules);
 		}
 	});
 });

--- a/src/vs/workbench/services/uriIdentity/test/common/uriIdentityService.test.ts
+++ b/src/vs/workbench/services/uriIdentity/test/common/uriIdentityService.test.ts
@@ -40,7 +40,7 @@ suite('URI Identity', function () {
 
 	function assertCanonical(input: URI, expected: URI, service: UriIdentityService = _service) {
 		const actual = service.asCanonicalUri(input);
-		assert.equal(actual.toString(), expected.toString());
+		assert.strictEqual(actual.toString(), expected.toString());
 		assert.ok(service.extUri.isEqual(actual, expected));
 	}
 
@@ -50,11 +50,11 @@ suite('URI Identity', function () {
 		let b = URI.parse('bar://bar/bang');
 		let b1 = URI.parse('bar://bar/BANG');
 
-		assert.equal(_service.extUri.isEqual(a, a1), true);
-		assert.equal(_service.extUri.isEqual(a1, a), true);
+		assert.strictEqual(_service.extUri.isEqual(a, a1), true);
+		assert.strictEqual(_service.extUri.isEqual(a1, a), true);
 
-		assert.equal(_service.extUri.isEqual(b, b1), false);
-		assert.equal(_service.extUri.isEqual(b1, b), false);
+		assert.strictEqual(_service.extUri.isEqual(b, b1), false);
+		assert.strictEqual(_service.extUri.isEqual(b1, b), false);
 	});
 
 	test('asCanonicalUri (casing)', function () {

--- a/src/vs/workbench/services/userData/test/browser/fileUserDataProvider.test.ts
+++ b/src/vs/workbench/services/userData/test/browser/fileUserDataProvider.test.ts
@@ -60,7 +60,7 @@ suite('FileUserDataProvider', () => {
 
 	test('exists return false when file does not exist', async () => {
 		const exists = await testObject.exists(environmentService.settingsResource);
-		assert.equal(exists, false);
+		assert.strictEqual(exists, false);
 	});
 
 	test('read file throws error if not exist', async () => {
@@ -73,39 +73,39 @@ suite('FileUserDataProvider', () => {
 	test('read existing file', async () => {
 		await testObject.writeFile(joinPath(userDataHomeOnDisk, 'settings.json'), VSBuffer.fromString('{}'));
 		const result = await testObject.readFile(environmentService.settingsResource);
-		assert.equal(result.value, '{}');
+		assert.strictEqual(result.value.toString(), '{}');
 	});
 
 	test('create file', async () => {
 		const resource = environmentService.settingsResource;
 		const actual1 = await testObject.createFile(resource, VSBuffer.fromString('{}'));
-		assert.equal(actual1.resource.toString(), resource.toString());
+		assert.strictEqual(actual1.resource.toString(), resource.toString());
 		const actual2 = await testObject.readFile(joinPath(userDataHomeOnDisk, 'settings.json'));
-		assert.equal(actual2.value.toString(), '{}');
+		assert.strictEqual(actual2.value.toString(), '{}');
 	});
 
 	test('write file creates the file if not exist', async () => {
 		const resource = environmentService.settingsResource;
 		const actual1 = await testObject.writeFile(resource, VSBuffer.fromString('{}'));
-		assert.equal(actual1.resource.toString(), resource.toString());
+		assert.strictEqual(actual1.resource.toString(), resource.toString());
 		const actual2 = await testObject.readFile(joinPath(userDataHomeOnDisk, 'settings.json'));
-		assert.equal(actual2.value.toString(), '{}');
+		assert.strictEqual(actual2.value.toString(), '{}');
 	});
 
 	test('write to existing file', async () => {
 		const resource = environmentService.settingsResource;
 		await testObject.writeFile(joinPath(userDataHomeOnDisk, 'settings.json'), VSBuffer.fromString('{}'));
 		const actual1 = await testObject.writeFile(resource, VSBuffer.fromString('{a:1}'));
-		assert.equal(actual1.resource.toString(), resource.toString());
+		assert.strictEqual(actual1.resource.toString(), resource.toString());
 		const actual2 = await testObject.readFile(joinPath(userDataHomeOnDisk, 'settings.json'));
-		assert.equal(actual2.value.toString(), '{a:1}');
+		assert.strictEqual(actual2.value.toString(), '{a:1}');
 	});
 
 	test('delete file', async () => {
 		await testObject.writeFile(joinPath(userDataHomeOnDisk, 'settings.json'), VSBuffer.fromString(''));
 		await testObject.del(environmentService.settingsResource);
 		const result = await testObject.exists(joinPath(userDataHomeOnDisk, 'settings.json'));
-		assert.equal(false, result);
+		assert.strictEqual(false, result);
 	});
 
 	test('resolve file', async () => {
@@ -117,13 +117,13 @@ suite('FileUserDataProvider', () => {
 
 	test('exists return false for folder that does not exist', async () => {
 		const exists = await testObject.exists(environmentService.snippetsHome);
-		assert.equal(exists, false);
+		assert.strictEqual(exists, false);
 	});
 
 	test('exists return true for folder that exists', async () => {
 		await testObject.createFolder(joinPath(userDataHomeOnDisk, 'snippets'));
 		const exists = await testObject.exists(environmentService.snippetsHome);
-		assert.equal(exists, true);
+		assert.strictEqual(exists, true);
 	});
 
 	test('read file throws error for folder', async () => {
@@ -139,8 +139,8 @@ suite('FileUserDataProvider', () => {
 		await testObject.writeFile(joinPath(userDataHomeOnDisk, 'snippets', 'settings.json'), VSBuffer.fromString('{}'));
 		const resource = joinPath(environmentService.snippetsHome, 'settings.json');
 		const actual = await testObject.readFile(resource);
-		assert.equal(actual.resource.toString(), resource.toString());
-		assert.equal(actual.value, '{}');
+		assert.strictEqual(actual.resource.toString(), resource.toString());
+		assert.strictEqual(actual.value.toString(), '{}');
 	});
 
 	test('read file under sub folder', async () => {
@@ -148,42 +148,42 @@ suite('FileUserDataProvider', () => {
 		await testObject.writeFile(joinPath(userDataHomeOnDisk, 'snippets', 'java', 'settings.json'), VSBuffer.fromString('{}'));
 		const resource = joinPath(environmentService.snippetsHome, 'java/settings.json');
 		const actual = await testObject.readFile(resource);
-		assert.equal(actual.resource.toString(), resource.toString());
-		assert.equal(actual.value, '{}');
+		assert.strictEqual(actual.resource.toString(), resource.toString());
+		assert.strictEqual(actual.value.toString(), '{}');
 	});
 
 	test('create file under folder that exists', async () => {
 		await testObject.createFolder(joinPath(userDataHomeOnDisk, 'snippets'));
 		const resource = joinPath(environmentService.snippetsHome, 'settings.json');
 		const actual1 = await testObject.createFile(resource, VSBuffer.fromString('{}'));
-		assert.equal(actual1.resource.toString(), resource.toString());
+		assert.strictEqual(actual1.resource.toString(), resource.toString());
 		const actual2 = await testObject.readFile(joinPath(userDataHomeOnDisk, 'snippets', 'settings.json'));
-		assert.equal(actual2.value.toString(), '{}');
+		assert.strictEqual(actual2.value.toString(), '{}');
 	});
 
 	test('create file under folder that does not exist', async () => {
 		const resource = joinPath(environmentService.snippetsHome, 'settings.json');
 		const actual1 = await testObject.createFile(resource, VSBuffer.fromString('{}'));
-		assert.equal(actual1.resource.toString(), resource.toString());
+		assert.strictEqual(actual1.resource.toString(), resource.toString());
 		const actual2 = await testObject.readFile(joinPath(userDataHomeOnDisk, 'snippets', 'settings.json'));
-		assert.equal(actual2.value.toString(), '{}');
+		assert.strictEqual(actual2.value.toString(), '{}');
 	});
 
 	test('write to not existing file under container that exists', async () => {
 		await testObject.createFolder(joinPath(userDataHomeOnDisk, 'snippets'));
 		const resource = joinPath(environmentService.snippetsHome, 'settings.json');
 		const actual1 = await testObject.writeFile(resource, VSBuffer.fromString('{}'));
-		assert.equal(actual1.resource.toString(), resource.toString());
+		assert.strictEqual(actual1.resource.toString(), resource.toString());
 		const actual = await testObject.readFile(joinPath(userDataHomeOnDisk, 'snippets', 'settings.json'));
-		assert.equal(actual.value.toString(), '{}');
+		assert.strictEqual(actual.value.toString(), '{}');
 	});
 
 	test('write to not existing file under container that does not exists', async () => {
 		const resource = joinPath(environmentService.snippetsHome, 'settings.json');
 		const actual1 = await testObject.writeFile(resource, VSBuffer.fromString('{}'));
-		assert.equal(actual1.resource.toString(), resource.toString());
+		assert.strictEqual(actual1.resource.toString(), resource.toString());
 		const actual = await testObject.readFile(joinPath(userDataHomeOnDisk, 'snippets', 'settings.json'));
-		assert.equal(actual.value.toString(), '{}');
+		assert.strictEqual(actual.value.toString(), '{}');
 	});
 
 	test('write to existing file under container', async () => {
@@ -191,17 +191,17 @@ suite('FileUserDataProvider', () => {
 		await testObject.writeFile(joinPath(userDataHomeOnDisk, 'snippets', 'settings.json'), VSBuffer.fromString('{}'));
 		const resource = joinPath(environmentService.snippetsHome, 'settings.json');
 		const actual1 = await testObject.writeFile(resource, VSBuffer.fromString('{a:1}'));
-		assert.equal(actual1.resource.toString(), resource.toString());
+		assert.strictEqual(actual1.resource.toString(), resource.toString());
 		const actual = await testObject.readFile(joinPath(userDataHomeOnDisk, 'snippets', 'settings.json'));
-		assert.equal(actual.value.toString(), '{a:1}');
+		assert.strictEqual(actual.value.toString(), '{a:1}');
 	});
 
 	test('write file under sub container', async () => {
 		const resource = joinPath(environmentService.snippetsHome, 'java/settings.json');
 		const actual1 = await testObject.writeFile(resource, VSBuffer.fromString('{}'));
-		assert.equal(actual1.resource.toString(), resource.toString());
+		assert.strictEqual(actual1.resource.toString(), resource.toString());
 		const actual = await testObject.readFile(joinPath(userDataHomeOnDisk, 'snippets', 'java', 'settings.json'));
-		assert.equal(actual.value.toString(), '{}');
+		assert.strictEqual(actual.value.toString(), '{}');
 	});
 
 	test('delete throws error for folder that does not exist', async () => {
@@ -231,7 +231,7 @@ suite('FileUserDataProvider', () => {
 		await testObject.writeFile(joinPath(userDataHomeOnDisk, 'snippets', 'settings.json'), VSBuffer.fromString('{}'));
 		await testObject.del(joinPath(environmentService.snippetsHome, 'settings.json'));
 		const exists = await testObject.exists(joinPath(userDataHomeOnDisk, 'snippets', 'settings.json'));
-		assert.equal(exists, false);
+		assert.strictEqual(exists, false);
 	});
 
 	test('resolve folder', async () => {
@@ -240,27 +240,27 @@ suite('FileUserDataProvider', () => {
 		const result = await testObject.resolve(environmentService.snippetsHome);
 		assert.ok(result.isDirectory);
 		assert.ok(result.children !== undefined);
-		assert.equal(result.children!.length, 1);
-		assert.equal(result.children![0].resource.toString(), joinPath(environmentService.snippetsHome, 'settings.json').toString());
+		assert.strictEqual(result.children!.length, 1);
+		assert.strictEqual(result.children![0].resource.toString(), joinPath(environmentService.snippetsHome, 'settings.json').toString());
 	});
 
 	test('read backup file', async () => {
 		await testObject.writeFile(joinPath(backupWorkspaceHomeOnDisk, 'backup.json'), VSBuffer.fromString('{}'));
 		const result = await testObject.readFile(joinPath(backupWorkspaceHomeOnDisk.with({ scheme: environmentService.userRoamingDataHome.scheme }), `backup.json`));
-		assert.equal(result.value, '{}');
+		assert.strictEqual(result.value.toString(), '{}');
 	});
 
 	test('create backup file', async () => {
 		await testObject.createFile(joinPath(backupWorkspaceHomeOnDisk.with({ scheme: environmentService.userRoamingDataHome.scheme }), `backup.json`), VSBuffer.fromString('{}'));
 		const result = await testObject.readFile(joinPath(backupWorkspaceHomeOnDisk, 'backup.json'));
-		assert.equal(result.value.toString(), '{}');
+		assert.strictEqual(result.value.toString(), '{}');
 	});
 
 	test('write backup file', async () => {
 		await testObject.writeFile(joinPath(backupWorkspaceHomeOnDisk, 'backup.json'), VSBuffer.fromString('{}'));
 		await testObject.writeFile(joinPath(backupWorkspaceHomeOnDisk.with({ scheme: environmentService.userRoamingDataHome.scheme }), `backup.json`), VSBuffer.fromString('{a:1}'));
 		const result = await testObject.readFile(joinPath(backupWorkspaceHomeOnDisk, 'backup.json'));
-		assert.equal(result.value.toString(), '{a:1}');
+		assert.strictEqual(result.value.toString(), '{a:1}');
 	});
 
 	test('resolve backups folder', async () => {
@@ -268,8 +268,8 @@ suite('FileUserDataProvider', () => {
 		const result = await testObject.resolve(backupWorkspaceHomeOnDisk.with({ scheme: environmentService.userRoamingDataHome.scheme }));
 		assert.ok(result.isDirectory);
 		assert.ok(result.children !== undefined);
-		assert.equal(result.children!.length, 1);
-		assert.equal(result.children![0].resource.toString(), joinPath(backupWorkspaceHomeOnDisk.with({ scheme: environmentService.userRoamingDataHome.scheme }), `backup.json`).toString());
+		assert.strictEqual(result.children!.length, 1);
+		assert.strictEqual(result.children![0].resource.toString(), joinPath(backupWorkspaceHomeOnDisk.with({ scheme: environmentService.userRoamingDataHome.scheme }), `backup.json`).toString());
 	});
 });
 

--- a/src/vs/workbench/services/views/test/browser/viewContainerModel.test.ts
+++ b/src/vs/workbench/services/views/test/browser/viewContainerModel.test.ts
@@ -63,7 +63,7 @@ suite('ViewContainerModel', () => {
 	test('empty model', function () {
 		container = ViewContainerRegistry.registerViewContainer({ id: 'test', title: 'test', ctorDescriptor: new SyncDescriptor(<any>{}) }, ViewContainerLocation.Sidebar);
 		const testObject = viewDescriptorService.getViewContainerModel(container);
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
 	});
 
 	test('register/unregister', () => {
@@ -71,8 +71,8 @@ suite('ViewContainerModel', () => {
 		const testObject = viewDescriptorService.getViewContainerModel(container);
 		const target = disposableStore.add(new ViewDescriptorSequence(testObject));
 
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 
 		const viewDescriptor: IViewDescriptor = {
 			id: 'view1',
@@ -82,23 +82,23 @@ suite('ViewContainerModel', () => {
 
 		ViewsRegistry.registerViews([viewDescriptor], container);
 
-		assert.equal(testObject.visibleViewDescriptors.length, 1);
-		assert.equal(target.elements.length, 1);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 1);
+		assert.strictEqual(target.elements.length, 1);
 		assert.deepEqual(testObject.visibleViewDescriptors[0], viewDescriptor);
 		assert.deepEqual(target.elements[0], viewDescriptor);
 
 		ViewsRegistry.deregisterViews([viewDescriptor], container);
 
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 	});
 
 	test('when contexts', async function () {
 		container = ViewContainerRegistry.registerViewContainer({ id: 'test', title: 'test', ctorDescriptor: new SyncDescriptor(<any>{}) }, ViewContainerLocation.Sidebar);
 		const testObject = viewDescriptorService.getViewContainerModel(container);
 		const target = disposableStore.add(new ViewDescriptorSequence(testObject));
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 
 		const viewDescriptor: IViewDescriptor = {
 			id: 'view1',
@@ -108,33 +108,33 @@ suite('ViewContainerModel', () => {
 		};
 
 		ViewsRegistry.registerViews([viewDescriptor], container);
-		assert.equal(testObject.visibleViewDescriptors.length, 0, 'view should not appear since context isnt in');
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0, 'view should not appear since context isnt in');
+		assert.strictEqual(target.elements.length, 0);
 
 		const key = contextKeyService.createKey('showview1', false);
-		assert.equal(testObject.visibleViewDescriptors.length, 0, 'view should still not appear since showview1 isnt true');
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0, 'view should still not appear since showview1 isnt true');
+		assert.strictEqual(target.elements.length, 0);
 
 		key.set(true);
 		await new Promise(c => setTimeout(c, 30));
-		assert.equal(testObject.visibleViewDescriptors.length, 1, 'view should appear');
-		assert.equal(target.elements.length, 1);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 1, 'view should appear');
+		assert.strictEqual(target.elements.length, 1);
 		assert.deepEqual(testObject.visibleViewDescriptors[0], viewDescriptor);
-		assert.equal(target.elements[0], viewDescriptor);
+		assert.strictEqual(target.elements[0], viewDescriptor);
 
 		key.set(false);
 		await new Promise(c => setTimeout(c, 30));
-		assert.equal(testObject.visibleViewDescriptors.length, 0, 'view should disappear');
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0, 'view should disappear');
+		assert.strictEqual(target.elements.length, 0);
 
 		ViewsRegistry.deregisterViews([viewDescriptor], container);
-		assert.equal(testObject.visibleViewDescriptors.length, 0, 'view should not be there anymore');
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0, 'view should not be there anymore');
+		assert.strictEqual(target.elements.length, 0);
 
 		key.set(true);
 		await new Promise(c => setTimeout(c, 30));
-		assert.equal(testObject.visibleViewDescriptors.length, 0, 'view should not be there anymore');
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0, 'view should not be there anymore');
+		assert.strictEqual(target.elements.length, 0);
 	});
 
 	test('when contexts - multiple', async function () {
@@ -263,8 +263,8 @@ suite('ViewContainerModel', () => {
 		const testObject = viewDescriptorService.getViewContainerModel(container);
 		const target = disposableStore.add(new ViewDescriptorSequence(testObject));
 
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 
 		const viewDescriptor: IViewDescriptor = {
 			id: 'view1',
@@ -273,8 +273,8 @@ suite('ViewContainerModel', () => {
 		};
 
 		ViewsRegistry.registerViews([viewDescriptor], container);
-		assert.equal(testObject.visibleViewDescriptors.length, 0, 'view should not appear since it was set not visible in view state');
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0, 'view should not appear since it was set not visible in view state');
+		assert.strictEqual(target.elements.length, 0);
 	});
 
 	test('view states and when contexts', async function () {
@@ -283,8 +283,8 @@ suite('ViewContainerModel', () => {
 		const testObject = viewDescriptorService.getViewContainerModel(container);
 		const target = disposableStore.add(new ViewDescriptorSequence(testObject));
 
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 
 		const viewDescriptor: IViewDescriptor = {
 			id: 'view1',
@@ -294,17 +294,17 @@ suite('ViewContainerModel', () => {
 		};
 
 		ViewsRegistry.registerViews([viewDescriptor], container);
-		assert.equal(testObject.visibleViewDescriptors.length, 0, 'view should not appear since context isnt in');
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0, 'view should not appear since context isnt in');
+		assert.strictEqual(target.elements.length, 0);
 
 		const key = contextKeyService.createKey('showview1', false);
-		assert.equal(testObject.visibleViewDescriptors.length, 0, 'view should still not appear since showview1 isnt true');
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0, 'view should still not appear since showview1 isnt true');
+		assert.strictEqual(target.elements.length, 0);
 
 		key.set(true);
 		await new Promise(c => setTimeout(c, 30));
-		assert.equal(testObject.visibleViewDescriptors.length, 0, 'view should still not appear since it was set not visible in view state');
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0, 'view should still not appear since it was set not visible in view state');
+		assert.strictEqual(target.elements.length, 0);
 	});
 
 	test('view states and when contexts multiple views', async function () {
@@ -313,8 +313,8 @@ suite('ViewContainerModel', () => {
 		const testObject = viewDescriptorService.getViewContainerModel(container);
 		const target = disposableStore.add(new ViewDescriptorSequence(testObject));
 
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 
 		const view1: IViewDescriptor = {
 			id: 'view1',
@@ -369,12 +369,12 @@ suite('ViewContainerModel', () => {
 
 		const key = contextKeyService.createKey('showview1', true);
 		await new Promise(c => setTimeout(c, 30));
-		assert.equal(testObject.visibleViewDescriptors.length, 1, 'view should appear after context is set');
-		assert.equal(target.elements.length, 1);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 1, 'view should appear after context is set');
+		assert.strictEqual(target.elements.length, 1);
 
 		testObject.setVisible('view1', false);
-		assert.equal(testObject.visibleViewDescriptors.length, 0, 'view should disappear after setting visibility to false');
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0, 'view should disappear after setting visibility to false');
+		assert.strictEqual(target.elements.length, 0);
 
 		const targetEvent = sinon.spy(testObject.onDidRemoveVisibleViewDescriptors);
 		key.set(false);
@@ -398,14 +398,14 @@ suite('ViewContainerModel', () => {
 		key.set(false);
 		ViewsRegistry.registerViews([viewDescriptor], container);
 
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 
 		const targetEvent = sinon.spy(testObject.onDidAddVisibleViewDescriptors);
 		testObject.setVisible('view1', true);
 		assert.ok(!targetEvent.called, 'add event should not be called since it is already visible');
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 	});
 
 	test('remove event is not triggered if view was hidden and not active', async function () {
@@ -424,14 +424,14 @@ suite('ViewContainerModel', () => {
 		key.set(false);
 		ViewsRegistry.registerViews([viewDescriptor], container);
 
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 
 		const targetEvent = sinon.spy(testObject.onDidAddVisibleViewDescriptors);
 		testObject.setVisible('view1', false);
 		assert.ok(!targetEvent.called, 'add event should not be called since it is disabled');
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 	});
 
 	test('add event is not triggered if view was set visible (when not visible) and not active', async function () {
@@ -450,18 +450,18 @@ suite('ViewContainerModel', () => {
 		key.set(false);
 		ViewsRegistry.registerViews([viewDescriptor], container);
 
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 
 		testObject.setVisible('view1', false);
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 
 		const targetEvent = sinon.spy(testObject.onDidAddVisibleViewDescriptors);
 		testObject.setVisible('view1', true);
 		assert.ok(!targetEvent.called, 'add event should not be called since it is disabled');
-		assert.equal(testObject.visibleViewDescriptors.length, 0);
-		assert.equal(target.elements.length, 0);
+		assert.strictEqual(testObject.visibleViewDescriptors.length, 0);
+		assert.strictEqual(target.elements.length, 0);
 	});
 
 	test('added view descriptors are in ascending order in the event', async function () {
@@ -483,9 +483,9 @@ suite('ViewContainerModel', () => {
 			order: 2
 		}], container);
 
-		assert.equal(target.elements.length, 2);
-		assert.equal(target.elements[0].id, 'view2');
-		assert.equal(target.elements[1].id, 'view5');
+		assert.strictEqual(target.elements.length, 2);
+		assert.strictEqual(target.elements[0].id, 'view2');
+		assert.strictEqual(target.elements[1].id, 'view5');
 
 		ViewsRegistry.registerViews([{
 			id: 'view4',
@@ -507,12 +507,12 @@ suite('ViewContainerModel', () => {
 			order: 1
 		}], container);
 
-		assert.equal(target.elements.length, 5);
-		assert.equal(target.elements[0].id, 'view1');
-		assert.equal(target.elements[1].id, 'view2');
-		assert.equal(target.elements[2].id, 'view3');
-		assert.equal(target.elements[3].id, 'view4');
-		assert.equal(target.elements[4].id, 'view5');
+		assert.strictEqual(target.elements.length, 5);
+		assert.strictEqual(target.elements[0].id, 'view1');
+		assert.strictEqual(target.elements[1].id, 'view2');
+		assert.strictEqual(target.elements[2].id, 'view3');
+		assert.strictEqual(target.elements[3].id, 'view4');
+		assert.strictEqual(target.elements[4].id, 'view5');
 	});
 
 });

--- a/src/vs/workbench/services/views/test/browser/viewDescriptorService.test.ts
+++ b/src/vs/workbench/services/views/test/browser/viewDescriptorService.test.ts
@@ -36,8 +36,8 @@ suite('ViewDescriptorService', () => {
 	test('Empty Containers', function () {
 		const sidebarViews = viewDescriptorService.getViewContainerModel(sidebarContainer);
 		const panelViews = viewDescriptorService.getViewContainerModel(panelContainer);
-		assert.equal(sidebarViews.allViewDescriptors.length, 0, 'The sidebar container should have no views yet.');
-		assert.equal(panelViews.allViewDescriptors.length, 0, 'The panel container should have no views yet.');
+		assert.strictEqual(sidebarViews.allViewDescriptors.length, 0, 'The sidebar container should have no views yet.');
+		assert.strictEqual(panelViews.allViewDescriptors.length, 0, 'The panel container should have no views yet.');
 	});
 
 	test('Register/Deregister', () => {
@@ -70,8 +70,8 @@ suite('ViewDescriptorService', () => {
 		let sidebarViews = viewDescriptorService.getViewContainerModel(sidebarContainer);
 		let panelViews = viewDescriptorService.getViewContainerModel(panelContainer);
 
-		assert.equal(sidebarViews.activeViewDescriptors.length, 2, 'Sidebar should have 2 views');
-		assert.equal(panelViews.activeViewDescriptors.length, 1, 'Panel should have 1 view');
+		assert.strictEqual(sidebarViews.activeViewDescriptors.length, 2, 'Sidebar should have 2 views');
+		assert.strictEqual(panelViews.activeViewDescriptors.length, 1, 'Panel should have 1 view');
 
 		ViewsRegistry.deregisterViews(viewDescriptors.slice(0, 2), sidebarContainer);
 		ViewsRegistry.deregisterViews(viewDescriptors.slice(2), panelContainer);
@@ -80,8 +80,8 @@ suite('ViewDescriptorService', () => {
 		sidebarViews = viewDescriptorService.getViewContainerModel(sidebarContainer);
 		panelViews = viewDescriptorService.getViewContainerModel(panelContainer);
 
-		assert.equal(sidebarViews.activeViewDescriptors.length, 0, 'Sidebar should have no views');
-		assert.equal(panelViews.activeViewDescriptors.length, 0, 'Panel should have no views');
+		assert.strictEqual(sidebarViews.activeViewDescriptors.length, 0, 'Sidebar should have no views');
+		assert.strictEqual(panelViews.activeViewDescriptors.length, 0, 'Panel should have no views');
 	});
 
 	test('move views to existing containers', async function () {
@@ -115,8 +115,8 @@ suite('ViewDescriptorService', () => {
 		let sidebarViews = viewDescriptorService.getViewContainerModel(sidebarContainer);
 		let panelViews = viewDescriptorService.getViewContainerModel(panelContainer);
 
-		assert.equal(sidebarViews.activeViewDescriptors.length, 1, 'Sidebar should have 2 views');
-		assert.equal(panelViews.activeViewDescriptors.length, 2, 'Panel should have 1 view');
+		assert.strictEqual(sidebarViews.activeViewDescriptors.length, 1, 'Sidebar should have 2 views');
+		assert.strictEqual(panelViews.activeViewDescriptors.length, 2, 'Panel should have 1 view');
 
 		assert.notEqual(sidebarViews.activeViewDescriptors.indexOf(viewDescriptors[2]), -1, `Sidebar should have ${viewDescriptors[2].name}`);
 		assert.notEqual(panelViews.activeViewDescriptors.indexOf(viewDescriptors[0]), -1, `Panel should have ${viewDescriptors[0].name}`);
@@ -154,20 +154,20 @@ suite('ViewDescriptorService', () => {
 		let sidebarViews = viewDescriptorService.getViewContainerModel(sidebarContainer);
 		let panelViews = viewDescriptorService.getViewContainerModel(panelContainer);
 
-		assert.equal(sidebarViews.activeViewDescriptors.length, 1, 'Sidebar container should have 1 view');
-		assert.equal(panelViews.activeViewDescriptors.length, 0, 'Panel container should have no views');
+		assert.strictEqual(sidebarViews.activeViewDescriptors.length, 1, 'Sidebar container should have 1 view');
+		assert.strictEqual(panelViews.activeViewDescriptors.length, 0, 'Panel container should have no views');
 
 		const generatedPanel = assertIsDefined(viewDescriptorService.getViewContainerByViewId(viewDescriptors[0].id));
 		const generatedSidebar = assertIsDefined(viewDescriptorService.getViewContainerByViewId(viewDescriptors[2].id));
 
-		assert.equal(viewDescriptorService.getViewContainerLocation(generatedPanel), ViewContainerLocation.Panel, 'Generated Panel should be in located in the panel');
-		assert.equal(viewDescriptorService.getViewContainerLocation(generatedSidebar), ViewContainerLocation.Sidebar, 'Generated Sidebar should be in located in the sidebar');
+		assert.strictEqual(viewDescriptorService.getViewContainerLocation(generatedPanel), ViewContainerLocation.Panel, 'Generated Panel should be in located in the panel');
+		assert.strictEqual(viewDescriptorService.getViewContainerLocation(generatedSidebar), ViewContainerLocation.Sidebar, 'Generated Sidebar should be in located in the sidebar');
 
-		assert.equal(viewDescriptorService.getViewContainerLocation(generatedPanel), viewDescriptorService.getViewLocationById(viewDescriptors[0].id), 'Panel view location and container location should match');
-		assert.equal(viewDescriptorService.getViewContainerLocation(generatedSidebar), viewDescriptorService.getViewLocationById(viewDescriptors[2].id), 'Sidebar view location and container location should match');
+		assert.strictEqual(viewDescriptorService.getViewContainerLocation(generatedPanel), viewDescriptorService.getViewLocationById(viewDescriptors[0].id), 'Panel view location and container location should match');
+		assert.strictEqual(viewDescriptorService.getViewContainerLocation(generatedSidebar), viewDescriptorService.getViewLocationById(viewDescriptors[2].id), 'Sidebar view location and container location should match');
 
-		assert.equal(viewDescriptorService.getDefaultContainerById(viewDescriptors[2].id), panelContainer, `${viewDescriptors[2].name} has wrong default container`);
-		assert.equal(viewDescriptorService.getDefaultContainerById(viewDescriptors[0].id), sidebarContainer, `${viewDescriptors[0].name} has wrong default container`);
+		assert.strictEqual(viewDescriptorService.getDefaultContainerById(viewDescriptors[2].id), panelContainer, `${viewDescriptors[2].name} has wrong default container`);
+		assert.strictEqual(viewDescriptorService.getDefaultContainerById(viewDescriptors[0].id), sidebarContainer, `${viewDescriptors[0].name} has wrong default container`);
 
 		viewDescriptorService.moveViewToLocation(viewDescriptors[0], ViewContainerLocation.Sidebar);
 		viewDescriptorService.moveViewToLocation(viewDescriptors[2], ViewContainerLocation.Panel);
@@ -175,11 +175,11 @@ suite('ViewDescriptorService', () => {
 		sidebarViews = viewDescriptorService.getViewContainerModel(sidebarContainer);
 		panelViews = viewDescriptorService.getViewContainerModel(panelContainer);
 
-		assert.equal(sidebarViews.activeViewDescriptors.length, 1, 'Sidebar should have 2 views');
-		assert.equal(panelViews.activeViewDescriptors.length, 0, 'Panel should have 1 view');
+		assert.strictEqual(sidebarViews.activeViewDescriptors.length, 1, 'Sidebar should have 2 views');
+		assert.strictEqual(panelViews.activeViewDescriptors.length, 0, 'Panel should have 1 view');
 
-		assert.equal(viewDescriptorService.getViewLocationById(viewDescriptors[0].id), ViewContainerLocation.Sidebar, 'View should be located in the sidebar');
-		assert.equal(viewDescriptorService.getViewLocationById(viewDescriptors[2].id), ViewContainerLocation.Panel, 'View should be located in the panel');
+		assert.strictEqual(viewDescriptorService.getViewLocationById(viewDescriptors[0].id), ViewContainerLocation.Sidebar, 'View should be located in the sidebar');
+		assert.strictEqual(viewDescriptorService.getViewLocationById(viewDescriptors[2].id), ViewContainerLocation.Panel, 'View should be located in the panel');
 	});
 
 	test('move view events', async function () {
@@ -262,7 +262,7 @@ suite('ViewDescriptorService', () => {
 		expectedSequence += containerMoveString(viewDescriptors[2], sidebarContainer, panelContainer);
 		viewDescriptorService.moveViewsToContainer([viewDescriptors[1], viewDescriptors[2]], panelContainer);
 
-		assert.equal(actualSequence, expectedSequence, 'Event sequence not matching expected sequence');
+		assert.strictEqual(actualSequence, expectedSequence, 'Event sequence not matching expected sequence');
 	});
 
 });

--- a/src/vs/workbench/test/browser/api/extHost.api.impl.test.ts
+++ b/src/vs/workbench/test/browser/api/extHost.api.impl.test.ts
@@ -11,11 +11,11 @@ import { isWindows } from 'vs/base/common/platform';
 suite('ExtHost API', function () {
 	test('issue #51387: originalFSPath', function () {
 		if (isWindows) {
-			assert.equal(originalFSPath(URI.file('C:\\test')).charAt(0), 'C');
-			assert.equal(originalFSPath(URI.file('c:\\test')).charAt(0), 'c');
+			assert.strictEqual(originalFSPath(URI.file('C:\\test')).charAt(0), 'C');
+			assert.strictEqual(originalFSPath(URI.file('c:\\test')).charAt(0), 'c');
 
-			assert.equal(originalFSPath(URI.revive(JSON.parse(JSON.stringify(URI.file('C:\\test'))))).charAt(0), 'C');
-			assert.equal(originalFSPath(URI.revive(JSON.parse(JSON.stringify(URI.file('c:\\test'))))).charAt(0), 'c');
+			assert.strictEqual(originalFSPath(URI.revive(JSON.parse(JSON.stringify(URI.file('C:\\test'))))).charAt(0), 'C');
+			assert.strictEqual(originalFSPath(URI.revive(JSON.parse(JSON.stringify(URI.file('c:\\test'))))).charAt(0), 'c');
 		}
 	});
 });

--- a/src/vs/workbench/test/browser/api/extHostDocumentData.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostDocumentData.test.ts
@@ -365,16 +365,16 @@ suite('ExtHostDocumentData updates line mapping', () => {
 		let line = 0, character = 0, previousIsCarriageReturn = false;
 		for (let offset = 0; offset <= allText.length; offset++) {
 			// The position coordinate system cannot express the position between \r and \n
-			const position = new Position(line, character + (previousIsCarriageReturn ? -1 : 0));
+			const position: Position = new Position(line, character + (previousIsCarriageReturn ? -1 : 0));
 
 			if (direction === AssertDocumentLineMappingDirection.OffsetToPosition) {
 				let actualPosition = doc.document.positionAt(offset);
-				assert.equal(positionToStr(actualPosition), positionToStr(position), 'positionAt mismatch for offset ' + offset);
+				assert.strictEqual(positionToStr(actualPosition), positionToStr(position), 'positionAt mismatch for offset ' + offset);
 			} else {
 				// The position coordinate system cannot express the position between \r and \n
-				let expectedOffset = offset + (previousIsCarriageReturn ? -1 : 0);
+				let expectedOffset: number = offset + (previousIsCarriageReturn ? -1 : 0);
 				let actualOffset = doc.document.offsetAt(position);
-				assert.equal(actualOffset, expectedOffset, 'offsetAt mismatch for position ' + positionToStr(position));
+				assert.strictEqual(actualOffset, expectedOffset, 'offsetAt mismatch for position ' + positionToStr(position));
 			}
 
 			if (allText.charAt(offset) === '\n') {

--- a/src/vs/workbench/test/browser/parts/editor/breadcrumbModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/breadcrumbModel.test.ts
@@ -37,14 +37,14 @@ suite('Breadcrumb Model', function () {
 		let model = new BreadcrumbsModel(URI.parse('foo:/bar/baz/ws/some/path/file.ts'), undefined, configService, workspaceService, new class extends mock<IOutlineService>() { });
 		let elements = model.getElements();
 
-		assert.equal(elements.length, 3);
+		assert.strictEqual(elements.length, 3);
 		let [one, two, three] = elements as FileElement[];
-		assert.equal(one.kind, FileKind.FOLDER);
-		assert.equal(two.kind, FileKind.FOLDER);
-		assert.equal(three.kind, FileKind.FILE);
-		assert.equal(one.uri.toString(), 'foo:/bar/baz/ws/some');
-		assert.equal(two.uri.toString(), 'foo:/bar/baz/ws/some/path');
-		assert.equal(three.uri.toString(), 'foo:/bar/baz/ws/some/path/file.ts');
+		assert.strictEqual(one.kind, FileKind.FOLDER);
+		assert.strictEqual(two.kind, FileKind.FOLDER);
+		assert.strictEqual(three.kind, FileKind.FILE);
+		assert.strictEqual(one.uri.toString(), 'foo:/bar/baz/ws/some');
+		assert.strictEqual(two.uri.toString(), 'foo:/bar/baz/ws/some/path');
+		assert.strictEqual(three.uri.toString(), 'foo:/bar/baz/ws/some/path/file.ts');
 	});
 
 	test('display uri matters for FileElement', function () {
@@ -52,14 +52,14 @@ suite('Breadcrumb Model', function () {
 		let model = new BreadcrumbsModel(URI.parse('foo:/bar/baz/ws/some/PATH/file.ts'), undefined, configService, workspaceService, new class extends mock<IOutlineService>() { });
 		let elements = model.getElements();
 
-		assert.equal(elements.length, 3);
+		assert.strictEqual(elements.length, 3);
 		let [one, two, three] = elements as FileElement[];
-		assert.equal(one.kind, FileKind.FOLDER);
-		assert.equal(two.kind, FileKind.FOLDER);
-		assert.equal(three.kind, FileKind.FILE);
-		assert.equal(one.uri.toString(), 'foo:/bar/baz/ws/some');
-		assert.equal(two.uri.toString(), 'foo:/bar/baz/ws/some/PATH');
-		assert.equal(three.uri.toString(), 'foo:/bar/baz/ws/some/PATH/file.ts');
+		assert.strictEqual(one.kind, FileKind.FOLDER);
+		assert.strictEqual(two.kind, FileKind.FOLDER);
+		assert.strictEqual(three.kind, FileKind.FILE);
+		assert.strictEqual(one.uri.toString(), 'foo:/bar/baz/ws/some');
+		assert.strictEqual(two.uri.toString(), 'foo:/bar/baz/ws/some/PATH');
+		assert.strictEqual(three.uri.toString(), 'foo:/bar/baz/ws/some/PATH/file.ts');
 	});
 
 	test('only uri, outside workspace', function () {
@@ -67,11 +67,11 @@ suite('Breadcrumb Model', function () {
 		let model = new BreadcrumbsModel(URI.parse('foo:/outside/file.ts'), undefined, configService, workspaceService, new class extends mock<IOutlineService>() { });
 		let elements = model.getElements();
 
-		assert.equal(elements.length, 2);
+		assert.strictEqual(elements.length, 2);
 		let [one, two] = elements as FileElement[];
-		assert.equal(one.kind, FileKind.FOLDER);
-		assert.equal(two.kind, FileKind.FILE);
-		assert.equal(one.uri.toString(), 'foo:/outside');
-		assert.equal(two.uri.toString(), 'foo:/outside/file.ts');
+		assert.strictEqual(one.kind, FileKind.FOLDER);
+		assert.strictEqual(two.kind, FileKind.FILE);
+		assert.strictEqual(one.uri.toString(), 'foo:/outside');
+		assert.strictEqual(two.uri.toString(), 'foo:/outside/file.ts');
 	});
 });

--- a/src/vs/workbench/test/electron-browser/api/extHostSearch.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostSearch.test.ts
@@ -215,7 +215,7 @@ suite('ExtHostSearch', () => {
 
 			const { results, stats } = await runFileSearch(getSimpleQuery());
 			assert(!stats.limitHit);
-			assert.equal(results.length, 3);
+			assert.strictEqual(results.length, 3);
 			compareURIs(results, reportedResults);
 		});
 
@@ -492,7 +492,7 @@ suite('ExtHostSearch', () => {
 
 			const { results, stats } = await runFileSearch(query);
 			assert(stats.limitHit, 'Expected to return limitHit');
-			assert.equal(results.length, 1);
+			assert.strictEqual(results.length, 1);
 			compareURIs(results, reportedResults.slice(0, 1));
 			assert(wasCanceled, 'Expected to be canceled when hitting limit');
 		});
@@ -528,7 +528,7 @@ suite('ExtHostSearch', () => {
 
 			const { results, stats } = await runFileSearch(query);
 			assert(stats.limitHit, 'Expected to return limitHit');
-			assert.equal(results.length, 2);
+			assert.strictEqual(results.length, 2);
 			compareURIs(results, reportedResults.slice(0, 2));
 			assert(wasCanceled, 'Expected to be canceled when hitting limit');
 		});
@@ -563,7 +563,7 @@ suite('ExtHostSearch', () => {
 
 			const { results, stats } = await runFileSearch(query);
 			assert(!stats.limitHit, 'Expected not to return limitHit');
-			assert.equal(results.length, 2);
+			assert.strictEqual(results.length, 2);
 			compareURIs(results, reportedResults);
 			assert(!wasCanceled, 'Expected not to be canceled when just reaching limit');
 		});
@@ -601,8 +601,8 @@ suite('ExtHostSearch', () => {
 			};
 
 			const { results } = await runFileSearch(query);
-			assert.equal(results.length, 2); // Don't care which 2 we got
-			assert.equal(cancels, 2, 'Expected all invocations to be canceled when hitting limit');
+			assert.strictEqual(results.length, 2); // Don't care which 2 we got
+			assert.strictEqual(cancels, 2, 'Expected all invocations to be canceled when hitting limit');
 		});
 
 		test('works with non-file schemes', async () => {
@@ -756,8 +756,8 @@ suite('ExtHostSearch', () => {
 		test('all provider calls get global include/excludes', async () => {
 			await registerTestTextSearchProvider({
 				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
-					assert.equal(options.includes.length, 1);
-					assert.equal(options.excludes.length, 1);
+					assert.strictEqual(options.includes.length, 1);
+					assert.strictEqual(options.excludes.length, 1);
 					return Promise.resolve(null!);
 				}
 			});
@@ -1184,8 +1184,8 @@ suite('ExtHostSearch', () => {
 			};
 
 			const { results } = await runTextSearch(query);
-			assert.equal(results.length, 2);
-			assert.equal(cancels, 2);
+			assert.strictEqual(results.length, 2);
+			assert.strictEqual(cancels, 2);
 		});
 
 		test('works with non-file schemes', async () => {

--- a/src/vs/workbench/test/electron-browser/api/mainThreadWorkspace.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/mainThreadWorkspace.test.ts
@@ -28,11 +28,11 @@ suite('MainThreadWorkspace', () => {
 	test('simple', () => {
 		instantiationService.stub(ISearchService, {
 			fileSearch(query: IFileQuery) {
-				assert.equal(query.folderQueries.length, 1);
-				assert.equal(query.folderQueries[0].disregardIgnoreFiles, true);
+				assert.strictEqual(query.folderQueries.length, 1);
+				assert.strictEqual(query.folderQueries[0].disregardIgnoreFiles, true);
 
 				assert.deepEqual(query.includePattern, { 'foo': true });
-				assert.equal(query.maxResults, 10);
+				assert.strictEqual(query.maxResults, 10);
 
 				return Promise.resolve({ results: [] });
 			}
@@ -52,8 +52,8 @@ suite('MainThreadWorkspace', () => {
 
 		instantiationService.stub(ISearchService, {
 			fileSearch(query: IFileQuery) {
-				assert.equal(query.folderQueries.length, 1);
-				assert.equal(query.folderQueries[0].disregardIgnoreFiles, true);
+				assert.strictEqual(query.folderQueries.length, 1);
+				assert.strictEqual(query.folderQueries[0].disregardIgnoreFiles, true);
 				assert.deepEqual(query.folderQueries[0].excludePattern, { 'filesExclude': true });
 
 				return Promise.resolve({ results: [] });
@@ -74,7 +74,7 @@ suite('MainThreadWorkspace', () => {
 
 		instantiationService.stub(ISearchService, {
 			fileSearch(query: IFileQuery) {
-				assert.equal(query.folderQueries[0].excludePattern, undefined);
+				assert.strictEqual(query.folderQueries[0].excludePattern, undefined);
 				assert.deepEqual(query.excludePattern, undefined);
 
 				return Promise.resolve({ results: [] });
@@ -88,7 +88,7 @@ suite('MainThreadWorkspace', () => {
 	test('exclude string', () => {
 		instantiationService.stub(ISearchService, {
 			fileSearch(query: IFileQuery) {
-				assert.equal(query.folderQueries[0].excludePattern, undefined);
+				assert.strictEqual(query.folderQueries[0].excludePattern, undefined);
 				assert.deepEqual(query.excludePattern, { 'exclude/**': true });
 
 				return Promise.resolve({ results: [] });

--- a/src/vs/workbench/test/electron-browser/textsearch.perf.integrationTest.ts
+++ b/src/vs/workbench/test/electron-browser/textsearch.perf.integrationTest.ts
@@ -105,12 +105,12 @@ suite.skip('TextSearch performance (integration)', () => {
 			function onComplete(): void {
 				try {
 					const allEvents = telemetryService.events.map(e => JSON.stringify(e)).join('\n');
-					assert.equal(telemetryService.events.length, 3, 'Expected 3 telemetry events, got:\n' + allEvents);
+					assert.strictEqual(telemetryService.events.length, 3, 'Expected 3 telemetry events, got:\n' + allEvents);
 
 					const [firstRenderEvent, resultsShownEvent, resultsFinishedEvent] = telemetryService.events;
-					assert.equal(firstRenderEvent.name, 'searchResultsFirstRender');
-					assert.equal(resultsShownEvent.name, 'searchResultsShown');
-					assert.equal(resultsFinishedEvent.name, 'searchResultsFinished');
+					assert.strictEqual(firstRenderEvent.name, 'searchResultsFirstRender');
+					assert.strictEqual(resultsShownEvent.name, 'searchResultsShown');
+					assert.strictEqual(resultsFinishedEvent.name, 'searchResultsFinished');
 
 					telemetryService.events = [];
 

--- a/test/monaco/monaco.test.ts
+++ b/test/monaco/monaco.test.ts
@@ -76,7 +76,7 @@ describe('API Integration Tests', function (): void {
 	});
 
 	it('`monaco` is not exposed as global', async function (): Promise<any> {
-		assert.equal(await page.evaluate(`typeof monaco`), 'undefined');
+		assert.strictEqual(await page.evaluate(`typeof monaco`), 'undefined');
 	});
 
 	it('Focus and Type', async function (): Promise<any> {
@@ -89,7 +89,7 @@ describe('API Integration Tests', function (): void {
 			});
 		})()
 		`);
-		assert.equal(await page.evaluate(`instance.getModel().getLineContent(1)`), 'afrom banana import *');
+		assert.strictEqual(await page.evaluate(`instance.getModel().getLineContent(1)`), 'afrom banana import *');
 	});
 
 	it('Type and Undo', async function (): Promise<any> {
@@ -103,7 +103,7 @@ describe('API Integration Tests', function (): void {
 			instance.getModel().undo();
 		})()
 		`);
-		assert.equal(await page.evaluate(`instance.getModel().getLineContent(1)`), 'from banana import *');
+		assert.strictEqual(await page.evaluate(`instance.getModel().getLineContent(1)`), 'from banana import *');
 	});
 
 	it('Multi Cursor', async function (): Promise<any> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR is part of the work for #118667

This removes `assert.equal` from the core tests and replaces it with `assert.StrictEqual`.

There are a few TODOs:
- Replace `assert.notEqual` with `assert.notStrictEqual`
- Replace `assert.deepEqual` with `assert.deepStrictEqual`
- Remove the deprecated asserts from built in extensions


@jrieken and @sandy081 There were a few tests which you two made awhile back that I couldn't make strict equal please take a look at them (I've marked them with TODO comments, you can also just search for assert.equal and look for places where it hasn't been changed)
