### PR TITLE
Replace -1 constant in keycode with enum value

### DIFF
--- a/src/vs/base/common/keyCodes.ts
+++ b/src/vs/base/common/keyCodes.ts
@@ -12,6 +12,8 @@ import { illegalArgument } from 'vs/base/common/errors';
  * But these are "more general", as they should work across browsers & OS`s.
  */
 export const enum KeyCode {
+	DependsOnKbLayout = -1,
+
 	/**
 	 * Placed first to cover the 0 value of the enum.
 	 */

--- a/src/vs/base/common/scanCode.ts
+++ b/src/vs/base/common/scanCode.ts
@@ -9,6 +9,7 @@ import { KeyCode } from 'vs/base/common/keyCodes';
  * keyboardEvent.code
  */
 export const enum ScanCode {
+	DependsOnKbLayout = -1,
 	None,
 
 	Hyper,
@@ -468,11 +469,11 @@ export class ScanCodeBinding {
 
 (function () {
 	for (let i = 0; i <= ScanCode.MAX_VALUE; i++) {
-		IMMUTABLE_CODE_TO_KEY_CODE[i] = -1;
+		IMMUTABLE_CODE_TO_KEY_CODE[i] = KeyCode.DependsOnKbLayout;
 	}
 
 	for (let i = 0; i <= KeyCode.MAX_VALUE; i++) {
-		IMMUTABLE_KEY_CODE_TO_CODE[i] = -1;
+		IMMUTABLE_KEY_CODE_TO_CODE[i] = ScanCode.DependsOnKbLayout;
 	}
 
 	function define(code: ScanCode, keyCode: KeyCode): void {

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -365,6 +365,7 @@ export enum InlineHintKind {
  * But these are "more general", as they should work across browsers & OS`s.
  */
 export enum KeyCode {
+	DependsOnKbLayout = -1,
 	/**
 	 * Placed first to cover the 0 value of the enum.
 	 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -218,6 +218,7 @@ declare namespace monaco {
 	 * But these are "more general", as they should work across browsers & OS`s.
 	 */
 	export enum KeyCode {
+		DependsOnKbLayout = -1,
 		/**
 		 * Placed first to cover the 0 value of the enum.
 		 */

--- a/src/vs/workbench/services/keybinding/common/macLinuxFallbackKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/macLinuxFallbackKeyboardMapper.ts
@@ -46,7 +46,7 @@ export class MacLinuxFallbackKeyboardMapper implements IKeyboardMapper {
 
 	private _scanCodeToKeyCode(scanCode: ScanCode): KeyCode {
 		const immutableKeyCode = IMMUTABLE_CODE_TO_KEY_CODE[scanCode];
-		if (immutableKeyCode !== -1) {
+		if (immutableKeyCode !== KeyCode.DependsOnKbLayout) {
 			return immutableKeyCode;
 		}
 

--- a/src/vs/workbench/services/keybinding/common/macLinuxKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/macLinuxKeyboardMapper.ts
@@ -49,7 +49,7 @@ export class NativeResolvedKeybinding extends BaseResolvedKeybinding<ScanCodeBin
 		if (!binding) {
 			return true;
 		}
-		if (IMMUTABLE_CODE_TO_KEY_CODE[binding.scanCode] !== -1) {
+		if (IMMUTABLE_CODE_TO_KEY_CODE[binding.scanCode] !== KeyCode.DependsOnKbLayout) {
 			return true;
 		}
 		let a = this._mapper.getAriaLabelForScanCodeBinding(binding);
@@ -327,7 +327,7 @@ class ScanCodeKeyCodeMapper {
 			}
 		}
 
-		return -1;
+		return KeyCode.DependsOnKbLayout;
 	}
 
 	private _encodeScanCodeCombo(scanCodeCombo: ScanCodeCombo): number {
@@ -419,7 +419,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 		// Handle immutable mappings
 		for (let scanCode = ScanCode.None; scanCode < ScanCode.MAX_VALUE; scanCode++) {
 			const keyCode = IMMUTABLE_CODE_TO_KEY_CODE[scanCode];
-			if (keyCode !== -1) {
+			if (keyCode !== KeyCode.DependsOnKbLayout) {
 				_registerAllCombos(0, 0, 0, scanCode, keyCode);
 				this._scanCodeToLabel[scanCode] = KeyCodeUtils.toString(keyCode);
 
@@ -443,7 +443,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 					if (scanCode === ScanCode.None) {
 						continue;
 					}
-					if (IMMUTABLE_CODE_TO_KEY_CODE[scanCode] !== -1) {
+					if (IMMUTABLE_CODE_TO_KEY_CODE[scanCode] !== KeyCode.DependsOnKbLayout) {
 						continue;
 					}
 
@@ -504,7 +504,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 				if (scanCode === ScanCode.None) {
 					continue;
 				}
-				if (IMMUTABLE_CODE_TO_KEY_CODE[scanCode] !== -1) {
+				if (IMMUTABLE_CODE_TO_KEY_CODE[scanCode] !== KeyCode.DependsOnKbLayout) {
 					continue;
 				}
 
@@ -678,7 +678,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 		result.push(`isUSStandard: ${this._isUSStandard}`);
 		result.push(`----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------`);
 		for (let scanCode = ScanCode.None; scanCode < ScanCode.MAX_VALUE; scanCode++) {
-			if (IMMUTABLE_CODE_TO_KEY_CODE[scanCode] !== -1) {
+			if (IMMUTABLE_CODE_TO_KEY_CODE[scanCode] !== KeyCode.DependsOnKbLayout) {
 				if (immutableSamples.indexOf(scanCode) === -1) {
 					continue;
 				}
@@ -703,7 +703,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 					shiftKey: scanCodeCombo.shiftKey,
 					altKey: scanCodeCombo.altKey,
 					metaKey: false,
-					keyCode: -1,
+					keyCode: KeyCode.DependsOnKbLayout,
 					code: ScanCodeUtils.toString(scanCode)
 				});
 
@@ -852,13 +852,13 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 		}
 
 		const immutableKeyCode = IMMUTABLE_CODE_TO_KEY_CODE[binding.scanCode];
-		if (immutableKeyCode !== -1) {
+		if (immutableKeyCode !== KeyCode.DependsOnKbLayout) {
 			return KeyCodeUtils.toUserSettingsUS(immutableKeyCode).toLowerCase();
 		}
 
 		// Check if this scanCode always maps to the same keyCode and back
 		let constantKeyCode: KeyCode = this._scanCodeKeyCodeMapper.guessStableKeyCode(binding.scanCode);
-		if (constantKeyCode !== -1) {
+		if (constantKeyCode !== KeyCode.DependsOnKbLayout) {
 			// Verify that this is a good key code that can be mapped back to the same scan code
 			let reverseBindings = this.simpleKeybindingToScanCodeBinding(new SimpleKeybinding(binding.ctrlKey, binding.shiftKey, binding.altKey, binding.metaKey, constantKeyCode));
 			for (let i = 0, len = reverseBindings.length; i < len; i++) {
@@ -902,7 +902,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 		}
 
 		const immutableKeyCode = IMMUTABLE_CODE_TO_KEY_CODE[binding.scanCode];
-		if (immutableKeyCode !== -1) {
+		if (immutableKeyCode !== KeyCode.DependsOnKbLayout) {
 			return this._getElectronLabelForKeyCode(immutableKeyCode);
 		}
 
@@ -935,7 +935,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 			return null;
 		}
 
-		if (constantKeyCode !== -1) {
+		if (constantKeyCode !== KeyCode.DependsOnKbLayout) {
 			return this._getElectronLabelForKeyCode(constantKeyCode);
 		}
 
@@ -997,7 +997,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 			// "Dispatch" on keyCode for these key codes to workaround issues with remote desktoping software
 			// where the scan codes appear to be incorrect (see https://github.com/microsoft/vscode/issues/24107)
 			const immutableScanCode = IMMUTABLE_KEY_CODE_TO_CODE[keyCode];
-			if (immutableScanCode !== -1) {
+			if (immutableScanCode !== ScanCode.DependsOnKbLayout) {
 				code = immutableScanCode;
 			}
 
@@ -1019,7 +1019,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 				// "Dispatch" on keyCode for all numpad keys in order for NumLock to work correctly
 				if (keyCode >= 0) {
 					const immutableScanCode = IMMUTABLE_KEY_CODE_TO_CODE[keyCode];
-					if (immutableScanCode !== -1) {
+					if (immutableScanCode !== ScanCode.DependsOnKbLayout) {
 						code = immutableScanCode;
 					}
 				}

--- a/src/vs/workbench/services/keybinding/common/windowsKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/windowsKeyboardMapper.ts
@@ -180,7 +180,7 @@ export class WindowsKeyboardMapper implements IKeyboardMapper {
 
 		for (let scanCode = ScanCode.None; scanCode < ScanCode.MAX_VALUE; scanCode++) {
 			const immutableKeyCode = IMMUTABLE_CODE_TO_KEY_CODE[scanCode];
-			if (immutableKeyCode !== -1) {
+			if (immutableKeyCode !== KeyCode.DependsOnKbLayout) {
 				this._scanCodeToKeyCode[scanCode] = immutableKeyCode;
 				this._keyCodeToLabel[immutableKeyCode] = KeyCodeUtils.toString(immutableKeyCode);
 				this._keyCodeExists[immutableKeyCode] = true;
@@ -201,7 +201,7 @@ export class WindowsKeyboardMapper implements IKeyboardMapper {
 				const rawMapping = rawMappings[strCode];
 
 				const immutableKeyCode = IMMUTABLE_CODE_TO_KEY_CODE[scanCode];
-				if (immutableKeyCode !== -1) {
+				if (immutableKeyCode !== KeyCode.DependsOnKbLayout) {
 					const keyCode = NATIVE_KEY_CODE_TO_KEY_CODE[rawMapping.vkey] || KeyCode.Unknown;
 					if (keyCode === KeyCode.Unknown || immutableKeyCode === keyCode) {
 						continue;
@@ -337,7 +337,7 @@ export class WindowsKeyboardMapper implements IKeyboardMapper {
 		let cnt = 0;
 		result.push(`-----------------------------------------------------------------------------------------------------------------------------------------`);
 		for (let scanCode = ScanCode.None; scanCode < ScanCode.MAX_VALUE; scanCode++) {
-			if (IMMUTABLE_CODE_TO_KEY_CODE[scanCode] !== -1) {
+			if (IMMUTABLE_CODE_TO_KEY_CODE[scanCode] !== KeyCode.DependsOnKbLayout) {
 				if (immutableSamples.indexOf(scanCode) === -1) {
 					continue;
 				}


### PR DESCRIPTION
Tthe key code logic uses the constant `-1` in a number of places. With the latest TS 4.3 nightly build, this causes a compile error since there is no overlap between `-1` and the `KeyCode` enum

This change adds a `-1` value to the `KeyCode` and `ScanCode` enums

https://github.com/microsoft/TypeScript/issues/43419

