### PR TITLE
Add `open with` entry for search editor

### DIFF
--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
-import { extname } from 'vs/base/common/resources';
+import { extname, isEqual } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { Range } from 'vs/editor/common/core/range';
@@ -19,7 +19,7 @@ import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegis
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { EditorDescriptor, Extensions as EditorExtensions, IEditorRegistry } from 'vs/workbench/browser/editor';
+import { DEFAULT_EDITOR_ASSOCIATION, EditorDescriptor, Extensions as EditorExtensions, IEditorRegistry } from 'vs/workbench/browser/editor';
 import { Extensions as WorkbenchExtensions, IWorkbenchContribution, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
 import { ActiveEditorContext, Extensions as EditorInputExtensions, IEditorInputSerializer, IEditorInputFactoryRegistry } from 'vs/workbench/common/editor';
 import { IViewsService } from 'vs/workbench/common/views';
@@ -75,6 +75,14 @@ class SearchEditorContribution implements IWorkbenchContribution {
 	) {
 
 		this.editorService.overrideOpenEditor({
+			getEditorOverrides: (resource: URI) => {
+				return extname(resource) === SEARCH_EDITOR_EXT ? [{
+					id: SearchEditorInput.ID,
+					label: localize('promptOpenWith.searchEditor.displayName', "Search Editor"),
+					detail: DEFAULT_EDITOR_ASSOCIATION.providerDisplayName,
+					active: isEqual(this.editorService.activeEditor?.resource, resource) && this.editorService.activeEditor instanceof SearchEditorInput
+				}] : [];
+			},
 			open: (editor, options, group) => {
 				const resource = editor.resource;
 				if (!resource) { return undefined; }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #119185

Adds a search editor override entry which gets populated in the open with and reopen with workflows.

Currently we do not do any ordering besides placing the Text Editor on the top of the open with dialog. We may want to add extra logic for all built-in contributors to be on top.
