### PR TITLE
Better action hover feedback

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.css
+++ b/src/vs/base/browser/ui/actionbar/actionbar.css
@@ -6,12 +6,14 @@
 .monaco-action-bar {
 	text-align: right;
 	white-space: nowrap;
+	height: 100%;
 }
 
 .monaco-action-bar .actions-container {
 	display: flex;
 	margin: 0 auto;
 	padding: 0;
+	height: 100%;
 	width: 100%;
 	justify-content: flex-end;
 }
@@ -21,18 +23,21 @@
 }
 
 .monaco-action-bar .action-item {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	cursor: pointer;
-	display: inline-block;
-	transition: transform 50ms ease;
 	position: relative;  /* DO NOT REMOVE - this is the key to preventing the ghosting icon bug in Chrome 42 */
+	min-width: 24px;
+}
+
+.monaco-action-bar:not(.vertical) .action-item {
+	margin-right: 4px;
 }
 
 .monaco-action-bar .action-item.disabled {
 	cursor: default;
-}
-
-.monaco-action-bar.animated .action-item.active {
-	transform: scale(1.272019649, 1.272019649); /* 1.272019649 = √φ */
+	min-width: 0;
 }
 
 .monaco-action-bar .action-item .icon,
@@ -47,7 +52,8 @@
 
 .monaco-action-bar .action-label {
 	font-size: 11px;
-	margin-right: 4px;
+	padding: 3px;
+	border-radius: 5px;
 }
 
 .monaco-action-bar .action-item.disabled .action-label,
@@ -72,10 +78,6 @@
 	padding-top: 1px;
 	margin-left: .8em;
 	margin-right: .8em;
-}
-
-.monaco-action-bar.animated.vertical .action-item.active {
-	transform: translate(5px, 0);
 }
 
 .secondary-actions .monaco-action-bar .action-label {

--- a/src/vs/base/browser/ui/dropdown/dropdown.css
+++ b/src/vs/base/browser/ui/dropdown/dropdown.css
@@ -11,6 +11,9 @@
 .monaco-dropdown > .dropdown-label {
 	cursor: pointer;
 	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .monaco-dropdown > .dropdown-label > .action-label.disabled {

--- a/src/vs/base/browser/ui/splitview/paneview.css
+++ b/src/vs/base/browser/ui/splitview/paneview.css
@@ -52,6 +52,10 @@
 	margin-left: auto;
 }
 
+.monaco-pane-view .pane > .pane-header > .actions .action-label {
+	padding: 2px;
+}
+
 /* TODO: actions should be part of the pane, but they aren't yet */
 .monaco-pane-view .pane:hover > .pane-header.expanded > .actions,
 .monaco-pane-view .pane:focus-within > .pane-header.expanded > .actions,

--- a/src/vs/base/browser/ui/splitview/paneview.css
+++ b/src/vs/base/browser/ui/splitview/paneview.css
@@ -60,22 +60,6 @@
 	display: initial;
 }
 
-/* TODO: actions should be part of the pane, but they aren't yet */
-.monaco-pane-view .pane > .pane-header > .actions .action-label.icon,
-.monaco-pane-view .pane > .pane-header > .actions .action-label.codicon {
-	width: 28px;
-	height: 22px;
-	background-size: 16px;
-	background-position: center center;
-	background-repeat: no-repeat;
-	margin-right: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	color: inherit;
-	outline-offset: -2px;
-}
-
 .monaco-pane-view .pane > .pane-header .monaco-action-bar .action-item.select-container {
 	cursor: default;
 }

--- a/src/vs/base/browser/ui/toolbar/toolbar.css
+++ b/src/vs/base/browser/ui/toolbar/toolbar.css
@@ -3,6 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+.monaco-toolbar {
+	height: 100%;
+}
+
 .monaco-toolbar .toolbar-toggle-more {
 	display: inline-block;
 	padding: 0;

--- a/src/vs/editor/contrib/peekView/media/peekViewWidget.css
+++ b/src/vs/editor/contrib/peekView/media/peekViewWidget.css
@@ -55,23 +55,6 @@
 	height: 100%;
 }
 
-.monaco-editor .peekview-widget .head .peekview-actions > .monaco-action-bar .action-item {
-	margin-left: 4px;
-}
-
-.monaco-editor .peekview-widget .head .peekview-actions > .monaco-action-bar .action-label {
-	width: 16px;
-	height: 100%;
-	margin: 0;
-	line-height: inherit;
-	background-repeat: no-repeat;
-	background-position: center center;
-}
-
-.monaco-editor .peekview-widget .head .peekview-actions > .monaco-action-bar .action-label.codicon {
-	margin: 0;
-}
-
 .monaco-editor .peekview-widget > .body {
 	border-top: 1px solid;
 	position: relative;

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.css
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.css
@@ -3,6 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+.monaco-action-bar .action-item.menu-entry .action-label.icon {
+	width: 16px;
+	height: 16px;
+	background-repeat: no-repeat;
+	background-position: 50%;
+}
+
 .monaco-action-bar .action-item.menu-entry .action-label {
 	background-image: var(--menu-entry-icon-light);
 }

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -405,6 +405,12 @@ export const menuSelectionBorder = registerColor('menu.selectionBorder', { dark:
 export const menuSeparatorBackground = registerColor('menu.separatorBackground', { dark: '#BBBBBB', light: '#888888', hc: contrastBorder }, nls.localize('menuSeparatorBackground', "Color of a separator menu item in menus."));
 
 /**
+ * Toolbar colors
+ */
+export const toolbarHoverBackground = registerColor('toolbar.hoverBackground', { dark: '#5a5d5e50', light: '#b8b8b850', hc: null }, nls.localize('toolbarHoverBackground', "Toolbar background when hovering over actions using the mouse"));
+export const toolbarActiveBackground = registerColor('toolbar.activeBackground', { dark: lighten(toolbarHoverBackground, 0.1), light: darken(toolbarHoverBackground, 0.1), hc: null }, nls.localize('toolbarActiveBackground', "Toolbar background when holding the mouse over actions"));
+
+/**
  * Snippet placeholder colors
  */
 export const snippetTabstopHighlightBackground = registerColor('editor.snippetTabstopHighlightBackground', { dark: new Color(new RGBA(124, 124, 124, 0.3)), light: new Color(new RGBA(10, 50, 100, 0.2)), hc: new Color(new RGBA(124, 124, 124, 0.3)) }, nls.localize('snippetTabstopHighlightBackground', "Highlight background color of a snippet tabstop."));

--- a/src/vs/workbench/browser/actions/toolbar.contribution.ts
+++ b/src/vs/workbench/browser/actions/toolbar.contribution.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { toolbarActiveBackground, toolbarHoverBackground } from 'vs/platform/theme/common/colorRegistry';
+import { IColorTheme, ICssStyleCollector, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
+
+registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {
+	collector.addRule(`
+		.monaco-action-bar:not(.vertical) .action-label:not(.disabled):hover {
+			background-color: ${theme.getColor(toolbarHoverBackground)};
+		}
+	`);
+
+	collector.addRule(`
+		.monaco-action-bar:not(.vertical) .action-item.active .action-label:not(.disabled),
+		.monaco-action-bar:not(.vertical) .monaco-dropdown.active .action-label:not(.disabled) {
+			background-color: ${theme.getColor(toolbarActiveBackground)};
+		}
+	`);
+});

--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-workbench .part {
-	box-sizing:	border-box;
+	box-sizing: border-box;
 	overflow: hidden;
 }
 
@@ -29,7 +29,7 @@
 .monaco-workbench .part > .title {
 	height: 35px;
 	display: flex;
-	box-sizing:	border-box;
+	box-sizing: border-box;
 	overflow: hidden;
 }
 
@@ -73,9 +73,6 @@
 
 .monaco-workbench .part > .title > .title-actions .action-label {
 	display: block;
-	height: 35px;
-	line-height: 35px;
-	min-width: 28px;
 	background-size: 16px;
 	background-position: center center;
 	background-repeat: no-repeat;
@@ -103,6 +100,10 @@
 }
 
 .monaco-workbench .part > .content > .monaco-progress-container .progress-bit,
-.monaco-workbench .part.editor > .content .monaco-progress-container .progress-bit {
+.monaco-workbench
+	.part.editor
+	> .content
+	.monaco-progress-container
+	.progress-bit {
 	height: 2px;
 }

--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -73,20 +73,11 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .editor-group-container-toolbar {
 	display: none;
+	height: 35px;
 }
 
 .monaco-workbench .part.editor > .content:not(.empty) .editor-group-container.empty > .editor-group-container-toolbar {
 	display: block;
-}
-
-.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-container-toolbar .action-label {
-	display: block;
-	height: 35px;
-	line-height: 35px;
-	min-width: 28px;
-	background-size: 16px;
-	background-position: center center;
-	background-repeat: no-repeat;
 }
 
 /* Editor */

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -346,13 +346,6 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab > .tab-actions .action-label {
 	opacity: 0;
-	display: block;
-	height: 16px;
-	width: 16px;
-	background-size: 16px;
-	background-position: center center;
-	background-repeat: no-repeat;
-	margin-right: 0.5em;
 }
 
 /* Tab Actions: Off */

--- a/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
@@ -37,7 +37,7 @@
 
 /* Title Actions */
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .title-actions .action-label:not(span),
+/* .monaco-workbench .part.editor > .content .editor-group-container > .title .title-actions .action-label:not(span),
 .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions .action-label:not(span) {
 	display: flex;
 	height: 35px;
@@ -66,7 +66,7 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .title-actions .action-label.disabled,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions .action-label.disabled {
 	opacity: 0.4;
-}
+} */
 
 /* Drag and Drop */
 

--- a/src/vs/workbench/browser/parts/panel/media/panelpart.css
+++ b/src/vs/workbench/browser/parts/panel/media/panelpart.css
@@ -144,8 +144,10 @@
 	opacity: 1;
 }
 
-.monaco-workbench .part.panel > .composite.title> .panel-switcher-container > .monaco-action-bar .action-item .action-label{
+.monaco-workbench .part.panel > .composite.title> .panel-switcher-container > .monaco-action-bar .action-item .action-label {
 	margin-right: 0;
+	border-radius: 0;
+	background: none !important;
 }
 
 .monaco-workbench .part.panel > .composite.title> .panel-switcher-container > .monaco-action-bar .action-item:last-child {

--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -162,6 +162,10 @@
 	display: none;
 }
 
+.customview-tree .monaco-list .monaco-list-row .custom-view-tree-node-item .actions .action-label {
+	padding: 2px;
+}
+
 .customview-tree .monaco-list .monaco-list-row:hover .custom-view-tree-node-item .actions,
 .customview-tree .monaco-list .monaco-list-row.selected .custom-view-tree-node-item .actions,
 .customview-tree .monaco-list .monaco-list-row.focused .custom-view-tree-node-item .actions {

--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -167,20 +167,3 @@
 .customview-tree .monaco-list .monaco-list-row.focused .custom-view-tree-node-item .actions {
 	display: block;
 }
-
-.customview-tree .monaco-list .custom-view-tree-node-item .actions .action-label {
-	width: 16px;
-	height: 100%;
-	background-size: 16px;
-	background-position: 50% 50%;
-	background-repeat: no-repeat;
-}
-
-.customview-tree .monaco-list .custom-view-tree-node-item .actions .action-label.codicon {
-	line-height: 22px;
-	height: 22px;
-}
-
-.customview-tree .monaco-list .custom-view-tree-node-item .actions .action-label.codicon::before {
-	vertical-align: middle;
-}

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -160,16 +160,6 @@
 	margin-right: 2px;
 }
 
-.monaco-workbench .debug-pane .monaco-action-bar .action-item > .action-label {
-	width: 16px;
-	height: 100%;
-	line-height: 22px;
-	margin-right: 8px;
-	background-size: 16px;
-	background-position: center center;
-	background-repeat: no-repeat;
-}
-
 .debug-pane .debug-call-stack .stack-frame {
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -181,6 +181,14 @@
 	flex-wrap: wrap-reverse;
 }
 
+.extension-list-item > .details > .footer > .monaco-action-bar > .actions-container .action-item {
+	margin-right: 0;
+}
+
+.extension-list-item > .details > .footer > .monaco-action-bar > .actions-container .action-label {
+	margin-right: 4px;
+}
+
 .extension-list-item > .details > .footer > .monaco-action-bar > .actions-container .extension-action.label {
 	max-width: 150px;
 }

--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -187,6 +187,7 @@
 
 .extension-list-item > .details > .footer > .monaco-action-bar > .actions-container .action-label {
 	margin-right: 4px;
+	border-radius: 0;
 }
 
 .extension-list-item > .details > .footer > .monaco-action-bar > .actions-container .extension-action.label {

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -152,8 +152,15 @@
 	justify-content: flex-start;
 }
 
-.extension-editor > .header > .details > .actions > .monaco-action-bar > .actions-container > .action-item .extension-action {
+.extension-editor > .header > .details > .actions > .monaco-action-bar > .actions-container > .action-item {
+	margin-right: 0;
+}
+
+.extension-editor > .header > .details > .actions > .monaco-action-bar > .actions-container > .action-item .extension-action:not(.manage) {
 	margin-top: 0px; /* overrides from extension actions */
+	border-radius: 0;
+	padding-top: 0;
+	padding-bottom: 0;
 }
 
 .extension-editor > .header > .details > .actions > .monaco-action-bar > .actions-container > .action-item > .extension-action,
@@ -239,11 +246,12 @@
 
 .extension-editor > .body > .navbar > .monaco-action-bar > .actions-container > .action-item > .action-label {
 	margin-right: 16px;
+	font-size: inherit;
+	opacity: 0.7;
 }
 
 .extension-editor > .body > .navbar > .monaco-action-bar > .actions-container > .action-item > .action-label {
-	font-size: inherit;
-	opacity: 0.7;
+	background: none !important;
 }
 
 .extension-editor > .body > .navbar > .monaco-action-bar > .actions-container > .action-item > .action-label.checked {

--- a/src/vs/workbench/contrib/files/browser/views/media/openeditors.css
+++ b/src/vs/workbench/contrib/files/browser/views/media/openeditors.css
@@ -12,19 +12,11 @@
 
 .open-editors .monaco-list .monaco-list-row > .monaco-action-bar .action-label {
 	display: block;
+	padding: 2px;
 }
 
 .open-editors .monaco-list .monaco-list-row > .monaco-action-bar .codicon {
 	color: inherit;
-}
-
-.open-editors .monaco-list .monaco-list-row > .monaco-action-bar .codicon-close,
-.open-editors .monaco-list .monaco-list-row > .monaco-action-bar .codicon-pinned {
-	width: 8px;
-	height: 22px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
 }
 
 .open-editors .monaco-list .monaco-list-row.dirty:not(:hover) > .monaco-action-bar .codicon-pinned::before {

--- a/src/vs/workbench/contrib/markers/browser/media/markers.css
+++ b/src/vs/workbench/contrib/markers/browser/media/markers.css
@@ -50,18 +50,7 @@
 }
 
 .markers-panel-action-filter > .markers-panel-filter-controls > .monaco-action-bar .action-item .action-label.codicon.markers-filters {
-	line-height: 20px;
-	height: 20px;
-	min-width: 22px;
-	margin-left: 4px;
-}
-
-.pane-header .markers-panel-action-filter > .markers-panel-filter-controls > .monaco-action-bar .action-item .action-label.codicon.markers-filters {
-	line-height: 18px;
-	height: 18px;
-	width: 28px;
-	margin-right: 0px;
-	justify-content: center;
+	padding: 2px;
 }
 
 .panel > .title .monaco-action-bar .action-item.markers-panel-action-filter-container {
@@ -207,10 +196,12 @@
 	display: block;
 }
 
+.markers-panel .monaco-tl-contents .actions,
 .markers-panel .monaco-tl-contents .multiline-actions .monaco-action-bar {
 	height: 22px;
 }
 
+.markers-panel .monaco-tl-contents .actions .action-label,
 .markers-panel .monaco-tl-contents .multiline-actions .monaco-action-bar .action-label {
 	padding: 2px;
 }

--- a/src/vs/workbench/contrib/markers/browser/media/markers.css
+++ b/src/vs/workbench/contrib/markers/browser/media/markers.css
@@ -85,6 +85,7 @@
 
 .markers-panel-container .monaco-action-bar.markers-panel-filter-container {
 	margin: 10px 20px;
+	height: initial;
 }
 
 .markers-panel .markers-panel-container .message-box-container {

--- a/src/vs/workbench/contrib/markers/browser/media/markers.css
+++ b/src/vs/workbench/contrib/markers/browser/media/markers.css
@@ -171,13 +171,6 @@
 	margin-left: 6px;
 }
 
-.markers-panel .monaco-tl-contents .codicon {
-	margin-right: 6px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
-
 .markers-panel .markers-panel-container .tree-container .monaco-tl-contents .marker-source,
 .markers-panel .markers-panel-container .tree-container .monaco-tl-contents .related-info-resource,
 .markers-panel .markers-panel-container .tree-container .monaco-tl-contents .related-info-resource-separator,
@@ -190,8 +183,12 @@
 	font-weight: bold;
 }
 
-.markers-panel .monaco-tl-contents .codicon {
+.markers-panel .monaco-tl-contents .marker-icon {
 	height: 22px;
+	margin: 0 6px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .markers-panel .monaco-tl-contents .actions .monaco-action-bar {
@@ -210,13 +207,16 @@
 	display: block;
 }
 
-.markers-panel .monaco-tl-contents .multiline-actions .action-label,
-.markers-panel .monaco-tl-contents .actions .action-label {
-	width: 16px;
+.markers-panel .monaco-tl-contents .multiline-actions .monaco-action-bar {
+	height: 22px;
 }
 
-.markers-panel .monaco-tl-contents .multiline-actions .action-label {
-	line-height: 22px;
+.markers-panel .monaco-tl-contents .multiline-actions .monaco-action-bar .action-label {
+	padding: 2px;
+}
+
+.markers-panel .monaco-tl-contents .actions .action-label {
+	width: 16px;
 }
 
 .markers-panel .monaco-tl-contents .multiline-actions .action-item.disabled,

--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -500,6 +500,7 @@
 
 .monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .run-button-container .monaco-toolbar {
 	visibility: hidden;
+	height: initial;
 }
 
 .monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .run-button-container .monaco-toolbar .codicon {
@@ -692,6 +693,7 @@
 	margin: 0px;
 	display: inline-flex;
 	padding: 0px 4px;
+	border-radius: 0;
 }
 
 .monaco-workbench .notebookOverlay .cell-list-top-cell-toolbar-container .monaco-toolbar .action-label .codicon,

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -286,7 +286,7 @@
 	max-width: 1000px;
 	margin: auto;
 	box-sizing: border-box;
-	padding-left: 211px;
+	padding-left: 221px;
 	padding-right: 24px;
 	overflow: visible;
 }

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -72,6 +72,7 @@
 
 .settings-editor > .settings-header > .settings-header-controls .settings-tabs-widget .action-label {
 	opacity: 0.9;
+	border-radius: 0;
 }
 
 .settings-editor > .settings-header > .settings-header-controls .last-synced-label {
@@ -177,9 +178,10 @@
 .settings-editor > .settings-body .settings-tree-container .setting-toolbar-container {
 	position: absolute;
 	left: -22px;
-	top: 11px;
+	top: 8px;
 	bottom: 0px;
-	width: 26px;
+	width: 22px;
+	height: 22px;
 }
 
 .settings-editor > .settings-body .settings-tree-container .monaco-list-row .mouseover .setting-toolbar-container > .monaco-toolbar .codicon,

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -177,17 +177,8 @@
 	display: block;
 }
 
-.scm-view .monaco-list-row .resource > .name > .monaco-icon-label > .actions .action-label,
-.scm-view .monaco-list-row .resource-group > .actions .action-label {
-	width: 16px;
-	height: 100%;
-	color: inherit;
-	background-position: 50% 50%;
-	background-repeat: no-repeat;
-}
-
-.scm-view .monaco-list-row .resource > .name > .monaco-icon-label > .actions .action-label.codicon {
-	line-height: 22px;
+.scm-view .monaco-list-row .actions .action-label {
+	padding: 2px;
 }
 
 .scm-view .scm-input {

--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -100,22 +100,8 @@
 }
 
 .search-view .search-widget .replace-container .monaco-action-bar {
-	margin-left: 0;
-}
-
-.search-view .search-widget .replace-container .monaco-action-bar {
 	height: 25px;
-}
-
-.search-view .search-widget .replace-container .monaco-action-bar .action-item .codicon {
-	background-repeat: no-repeat;
-	width: 25px;
-	height: 25px;
-	margin-right: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	color: inherit;
+	margin-left: 4px;
 }
 
 .search-view .query-details {

--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -184,6 +184,7 @@
 	position: relative;
 	line-height: 22px;
 	padding: 0;
+	height: 100%;
 }
 
 .pane-body:not(.wide) .search-view .foldermatch .monaco-icon-label,
@@ -261,13 +262,13 @@
 	display: inline-block;
 }
 
-.search-view .monaco-list .monaco-list-row .monaco-action-bar .action-label {
+.search-view .monaco-list .monaco-list-row .monaco-action-bar .action-item {
 	margin-right: 0.2em;
-	margin-top: 4px;
-	background-repeat: no-repeat;
+}
+
+.search-view .monaco-list .monaco-list-row .monaco-action-bar .action-label {
 	width: 16px;
 	height: 16px;
-	color: inherit;
 }
 
 /* Adjusts spacing in high contrast mode so that actions are vertically centered */

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -15,6 +15,7 @@ import 'vs/workbench/browser/workbench.contribution';
 
 //#region --- workbench actions
 
+import 'vs/workbench/browser/actions/toolbar.contribution';
 import 'vs/workbench/browser/actions/textInputActions';
 import 'vs/workbench/browser/actions/developerActions';
 import 'vs/workbench/browser/actions/helpActions';


### PR DESCRIPTION
This PR fixes #120226

Unsurprisingly, thanks to the magic power of CSS, this was wayyyy more work than expected, since people override CSS all the time, especially for something as popular as the action bar. Calling our owners of areas where I touched a lot of CSS (workbench actions, search, extensions) to do a good smoke test around the actions. Thanks! 🙏

This PR also makes sure the hover feedback stays visible even while the dropdown menu of the `...` toolbar action is open.