### PR TITLE
Make splitting respect supportMultipleDocument

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -632,8 +632,11 @@ export function splitEditor(editorGroupService: IEditorGroupsService, direction:
 		editorToCopy = withNullAsUndefined(sourceGroup.activeEditor);
 	}
 
+	// Copy the editor to the new group, else move the editor to the new group
 	if (editorToCopy && (editorToCopy as EditorInput).supportsSplitEditor()) {
 		sourceGroup.copyEditor(editorToCopy, newGroup);
+	} else if (editorToCopy) {
+		sourceGroup.moveEditor(editorToCopy, newGroup);
 	}
 
 	// Focus

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -635,12 +635,10 @@ export function splitEditor(editorGroupService: IEditorGroupsService, direction:
 	// Copy the editor to the new group, else move the editor to the new group
 	if (editorToCopy && (editorToCopy as EditorInput).supportsSplitEditor()) {
 		sourceGroup.copyEditor(editorToCopy, newGroup);
-	} else if (editorToCopy) {
-		sourceGroup.moveEditor(editorToCopy, newGroup);
+		// Focus
+		newGroup.focus();
 	}
 
-	// Focus
-	newGroup.focus();
 }
 
 function registerSplitEditorCommands() {

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -90,7 +90,7 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 	}
 
 	public supportsSplitEditor() {
-		return true;
+		return !!this.customEditorService.getCustomEditorCapabilities(this.viewType)?.supportsMultipleEditorsPerDocument;
 	}
 
 	getName(): string {

--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -199,7 +199,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		});
 	}
 
-	private getCustomEditorCapabilities(viewType: string): CustomEditorCapabilities | undefined {
+	public getCustomEditorCapabilities(viewType: string): CustomEditorCapabilities | undefined {
 		return this._editorCapabilities.get(viewType);
 	}
 

--- a/src/vs/workbench/contrib/customEditor/common/customEditor.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditor.ts
@@ -44,6 +44,7 @@ export interface ICustomEditorService {
 	openWith(resource: URI, customEditorViewType: string, options?: ITextEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined>;
 
 	registerCustomEditorCapabilities(viewType: string, options: CustomEditorCapabilities): IDisposable;
+	getCustomEditorCapabilities(viewType: string): CustomEditorCapabilities | undefined
 }
 
 export interface ICustomEditorModelManager {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #119666


When a custom editor is split that doesn't support multiple document it is left behind and a new empty group is created in the direction of split. This behavior aligns with what happens if your `supportSplitEditors` flag is false.