### PR TITLE
Fixes simple browser icons are broken in firefox

### DIFF
--- a/extensions/simple-browser/src/simpleBrowserView.ts
+++ b/extensions/simple-browser/src/simpleBrowserView.ts
@@ -90,7 +90,6 @@ export class SimpleBrowserView extends Disposable {
 		const mainJs = this.extensionResourceUrl('media', 'index.js');
 		const mainCss = this.extensionResourceUrl('media', 'main.css');
 		const codiconsUri = this.extensionResourceUrl('media', 'codicon.css');
-		const codiconsFontUri = this.extensionResourceUrl('media', 'codicon.ttf');
 
 		return /* html */ `<!DOCTYPE html>
 			<html>
@@ -99,7 +98,7 @@ export class SimpleBrowserView extends Disposable {
 
 				<meta http-equiv="Content-Security-Policy" content="
 					default-src 'none';
-					font-src ${codiconsFontUri};
+					font-src ${this._webviewPanel.webview.cspSource};
 					style-src ${this._webviewPanel.webview.cspSource};
 					script-src 'nonce-${nonce}';
 					frame-src *;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Not a CSP expert but firefox doesn't like the full URL for `font-src`
```
<meta
http-equiv="Content-Security-Policy"
content="default-src 'none';
	font-src https://55582f46-d0e8-47cd-9fee-99526b57ac58.vscode-webview-test.com/0d728c31ebdf03869d2687d9be0b017667c9ff37/vscode-resource/http//localhost%3A8080/static/extensions/simple-browser/media/codicon.ttf;
	style-src https://*.vscode-webview-test.com;
	script-src 'nonce-1617229294534534';
	frame-src *;
">
```

This PR fixes #120036
