### PR TITLE
Make easy adoptions of async configuation resolver service

### DIFF
--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -384,7 +384,7 @@ export abstract class ExtHostDebugServiceBase implements IExtHostDebugService, E
 				}
 			};
 		}
-		return this._variableResolver.resolveAny(ws, config);
+		return this._variableResolver.resolveAnyAsync(ws, config);
 	}
 
 	protected createDebugAdapter(adapter: IAdapterDescriptor, session: ExtHostDebugSession): AbstractDebugAdapter | undefined {

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
@@ -137,11 +137,13 @@ export const openNewSearchEditor =
 
 		const seedSearchStringFromSelection = _args.location === 'new' || configurationService.getValue<IEditorOptions>('editor').find!.seedSearchStringFromSelection;
 		const args: OpenSearchEditorArgs = { query: seedSearchStringFromSelection ? selected : undefined };
-		Object.entries(_args).forEach(([name, value]) => {
+		for (const entry of Object.entries(_args)) {
+			const name = entry[0];
+			const value = entry[1];
 			if (value !== undefined) {
-				(args as any)[name as any] = (typeof value === 'string') ? configurationResolverService.resolve(lastActiveWorkspaceRoot, value) : value;
+				(args as any)[name as any] = (typeof value === 'string') ? await configurationResolverService.resolveAsync(lastActiveWorkspaceRoot, value) : value;
 			}
-		});
+		}
 		const existing = editorService.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE).find(id => id.editor.getTypeId() === SearchEditorInput.ID);
 		let editor: SearchEditor;
 		if (existing && args.location === 'reuse') {

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -76,7 +76,7 @@ async function getCwdForSplit(configHelper: ITerminalConfigHelper, instance: ITe
 }
 
 export const terminalSendSequenceCommand = (accessor: ServicesAccessor, args: { text?: string } | undefined) => {
-	accessor.get(ITerminalService).doWithActiveInstance(t => {
+	accessor.get(ITerminalService).doWithActiveInstance(async t => {
 		if (!args?.text) {
 			return;
 		}
@@ -85,7 +85,7 @@ export const terminalSendSequenceCommand = (accessor: ServicesAccessor, args: { 
 		const historyService = accessor.get(IHistoryService);
 		const activeWorkspaceRootUri = historyService.getLastActiveWorkspaceRoot(Schemas.file);
 		const lastActiveWorkspaceRoot = activeWorkspaceRootUri ? withNullAsUndefined(workspaceContextService.getWorkspaceFolder(activeWorkspaceRootUri)) : undefined;
-		const resolvedText = configurationResolverService.resolve(lastActiveWorkspaceRoot, args.text);
+		const resolvedText = await configurationResolverService.resolveAsync(lastActiveWorkspaceRoot, args.text);
 		t.sendText(resolvedText, false);
 	});
 };

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -376,16 +376,16 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 			shellLaunchConfig.executable = defaultConfig.shell;
 			shellLaunchConfig.args = defaultConfig.args;
 		} else {
-			shellLaunchConfig.executable = this._configurationResolverService.resolve(lastActiveWorkspace, shellLaunchConfig.executable);
+			shellLaunchConfig.executable = await this._configurationResolverService.resolveAsync(lastActiveWorkspace, shellLaunchConfig.executable);
 			if (shellLaunchConfig.args) {
 				if (Array.isArray(shellLaunchConfig.args)) {
 					const resolvedArgs: string[] = [];
 					for (const arg of shellLaunchConfig.args) {
-						resolvedArgs.push(this._configurationResolverService.resolve(lastActiveWorkspace, arg));
+						resolvedArgs.push(await this._configurationResolverService.resolveAsync(lastActiveWorkspace, arg));
 					}
 					shellLaunchConfig.args = resolvedArgs;
 				} else {
-					shellLaunchConfig.args = this._configurationResolverService.resolve(lastActiveWorkspace, shellLaunchConfig.args);
+					shellLaunchConfig.args = await this._configurationResolverService.resolveAsync(lastActiveWorkspace, shellLaunchConfig.args);
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/terminal/node/terminalProfiles.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalProfiles.ts
@@ -100,7 +100,7 @@ async function transformToTerminalProfiles(entries: IterableIterator<[string, IT
 		const paths = originalPaths.slice();
 
 		for (let i = 0; i < paths.length; i++) {
-			paths[i] = variableResolver?.resolve(workspaceFolder, paths[i]) || paths[i];
+			paths[i] = await variableResolver?.resolveAsync(workspaceFolder, paths[i]) || paths[i];
 		}
 		const validatedProfile = await validateProfilePaths(profileName, paths, statProvider, args, profile.overrideName, profile.isAutoDetected, logService);
 		if (validatedProfile) {


### PR DESCRIPTION
As part of #108804, the configuration resolver service's methods must be async to accomadate the new async way of getting the process environment. This PR makes the easy adoptions in search and terminal.
