### PR TITLE
Update PHP grammar

### DIFF
--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/atom/language-php/commit/72739e6341b1b4bf4aa185e928932983baca449e",
+	"version": "https://github.com/atom/language-php/commit/5fae657cf989701e9594912772daff33249839b3",
 	"scopeName": "source.php",
 	"patterns": [
 		{
@@ -750,7 +750,7 @@
 			]
 		},
 		{
-			"match": "(?xi)\n((?:(?:public|private|protected|static)(?:\\s+|(?=\\?)))+)                     # At least one modifier\n(\n  (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type\n  [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type\n)?\n\\s+ ((\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)          # Variable name",
+			"match": "(?xi)\n((?:(?:public|private|protected|static)(?:\\s+|(?=\\?)))++)                     # At least one modifier\n(\n  (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ |                                        # nullable type\n  [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+ (?: \\s*\\|\\s* [a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]+)+ # union type\n)?\n\\s+ ((\\$)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)          # Variable name",
 			"captures": {
 				"1": {
 					"patterns": [
@@ -1304,6 +1304,9 @@
 		},
 		"function-parameters": {
 			"patterns": [
+				{
+					"include": "#attribute"
+				},
 				{
 					"include": "#comments"
 				},


### PR DESCRIPTION
:warning: **Important note** :warning: There is one more commit upstream, but please DO NOT merge it yet. I think that PR was merged by mistake, since was very old and not maintained anymore. It's reverting major SQL changes, however atom and vscode are using different syntax for SQL and even if they tested PR properly - which I doubt, still could be some breaking changes in vscode. We need to test this properly for now or push to revert reverted changes.

This PR is fixing 2 small issues with PHP syntax.

Assign: @roblourens 

This PR fixes #116847 #120042