### PR TITLE
debug: update js-debug

### DIFF
--- a/product.json
+++ b/product.json
@@ -93,7 +93,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.55.1",
+			"version": "1.55.2",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
This fixes https://github.com/microsoft/vscode/issues/120227 and contains the following change: https://github.com/microsoft/vscode-js-debug/commit/2994e0576d17a54e11132f92945039dd827e0d78

On WSL, calling `listen(x)` preferentially listened on ipv6 loopback. Interestingly, while listening on `::` and connecting on ipv4 loopback seem to work if everything is in Windows, if the server is running in WSL you can  _only_ connect via `::`, where the companion tries to attach on `127.0.0.1`.

```
# wsl:

> net.createServer().listen(0).address()
{ address: '::', family: 'IPv6', port: 10556 }
> net.connect(36715, '127.0.0.1', l => console.log("ok"))
ok

# windows:

> net.connect(36715, '127.0.0.1', l => console.log("ok"))
Error: connect ECONNREFUSED 127.0.0.1:36715
> net.connect(36715, '::', l => console.log("ok"))
ok
```

So the change was to go back to the old behavior (before I refactored things for the port listener) to explicitly listen on 127.0.0.1. More secure anyway in the event that `listen(x)` binds to anycast.