### PR TITLE
More effecient handling of changes

### DIFF
--- a/src/vs/workbench/api/common/extHostMemento.ts
+++ b/src/vs/workbench/api/common/extHostMemento.ts
@@ -87,7 +87,7 @@ export class ExtensionMemento implements vscode.Memento {
 		}
 
 		this._timeout = setTimeout(() => {
-			const records = { ...this._promiseRecords };
+			const records = this._promiseRecords;
 			this._promiseRecords = {};
 			(async () => {
 				try {
@@ -101,7 +101,6 @@ export class ExtensionMemento implements vscode.Memento {
 					}
 				}
 			})();
-			this._promiseRecords = {};
 		}, 0);
 
 		return promise;

--- a/src/vs/workbench/api/common/extHostMemento.ts
+++ b/src/vs/workbench/api/common/extHostMemento.ts
@@ -25,7 +25,7 @@ export class ExtensionMemento implements vscode.Memento {
 	private readonly _storageListener: IDisposable;
 
 	private _promiseRecords: { [key: string]: PromiseRecord } = {};
-	private _timeout: NodeJS.Timeout | undefined;
+	private _timeout: number | undefined;
 
 	constructor(id: string, global: boolean, storage: ExtHostStorage) {
 		this._id = id;

--- a/src/vs/workbench/api/common/extHostMemento.ts
+++ b/src/vs/workbench/api/common/extHostMemento.ts
@@ -25,7 +25,7 @@ export class ExtensionMemento implements vscode.Memento {
 	private readonly _storageListener: IDisposable;
 
 	private _promiseRecords: { [key: string]: PromiseRecord } = {};
-	private _timeout: number | undefined;
+	private _timeout: any;
 
 	constructor(id: string, global: boolean, storage: ExtHostStorage) {
 		this._id = id;

--- a/src/vs/workbench/api/common/extHostMemento.ts
+++ b/src/vs/workbench/api/common/extHostMemento.ts
@@ -79,7 +79,7 @@ export class ExtensionMemento implements vscode.Memento {
 					}
 				} catch (e) {
 					for (value of records.entries()) {
-						value.resolve();
+						value.reject();
 					}
 				}
 			})();


### PR DESCRIPTION
On each update call to the vscode.Memento, the whole value, including keys different from the one being set is sent to the main process via ext host protocol, and later update event is broadcasted for each individual key change. This event contains the whole dictionary, with all values and keys.

As a result, If you have n keys, and make n updates for each key, this leads to O(n^2) bandwidth, space, and time usage. 

In this PR, we fix it by delaying the fire event until the current tick is finished.