### PR TITLE
tweak api based on conversations

### DIFF
--- a/src/vs/base/common/codicons.ts
+++ b/src/vs/base/common/codicons.ts
@@ -550,7 +550,7 @@ export namespace Codicon {
 	export const debugRerun = new Codicon('debug-rerun', { fontCharacter: '\\ebc0' });
 	export const workspaceTrusted = new Codicon('workspace-trusted', { fontCharacter: '\\ebc1' });
 	export const workspaceUntrusted = new Codicon('workspace-untrusted', { fontCharacter: '\\ebc2' });
-	export const workspaceUnknown = new Codicon('workspace-unknown', { fontCharacter: '\\ebc3' });
+	export const workspaceUnspecified = new Codicon('workspace-unspecified', { fontCharacter: '\\ebc3' });
 
 	export const dropDownButton = new Codicon('drop-down-button', Codicon.chevronDown.definition);
 }

--- a/src/vs/platform/workspace/common/workspaceTrust.ts
+++ b/src/vs/platform/workspace/common/workspaceTrust.ts
@@ -16,7 +16,7 @@ export enum WorkspaceTrustScope {
 export enum WorkspaceTrustState {
 	Untrusted = 0,
 	Trusted = 1,
-	Unknown = 2
+	Unspecified = 2
 }
 
 export function workspaceTrustStateToString(trustState: WorkspaceTrustState) {
@@ -25,9 +25,9 @@ export function workspaceTrustStateToString(trustState: WorkspaceTrustState) {
 			return localize('trusted', "Trusted");
 		case WorkspaceTrustState.Untrusted:
 			return localize('untrusted', "Untrusted");
-		case WorkspaceTrustState.Unknown:
+		case WorkspaceTrustState.Unspecified:
 		default:
-			return localize('unknown', "Unknown");
+			return localize('unspecified', "Unspecified");
 	}
 }
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -2799,22 +2799,19 @@ declare module 'vscode' {
 		 *
 		 * If trust will be required, users will be prompted to make a choice.
 		 */
-		Unknown = 2
+		Unspecified = 2
 	}
 
 	/**
-	 * The event data that is fired when the trust state of the workspace changes
+	 * The event data that is fired when the trust state of the workspace changes.
+	 * When trust is revoked, the workspace will be reloaded. Therefore, extensions are
+	 * not expected to handle transitions out of a trusted state.
 	 */
 	export interface WorkspaceTrustStateChangeEvent {
 		/**
-		 * Previous trust state of the workspace
+		 * New trust state of the workspace
 		 */
-		readonly previousTrustState: WorkspaceTrustState;
-
-		/**
-		 * Current trust state of the workspace
-		 */
-		readonly currentTrustState: WorkspaceTrustState;
+		readonly newTrustState: WorkspaceTrustState;
 	}
 
 	/**

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3411,7 +3411,7 @@ export enum ExternalUriOpenerPriority {
 export enum WorkspaceTrustState {
 	Untrusted = 0,
 	Trusted = 1,
-	Unknown = 2
+	Unspecified = 2
 }
 
 export enum PortAutoForwardAction {

--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -185,7 +185,7 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 
 	private readonly _activeSearchCallbacks: ((match: IRawFileMatch2) => any)[] = [];
 
-	private _workspaceTrustState: WorkspaceTrustState = WorkspaceTrustState.Unknown;
+	private _workspaceTrustState: WorkspaceTrustState = WorkspaceTrustState.Unspecified;
 
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService,
@@ -569,7 +569,7 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 
 	$onDidChangeWorkspaceTrustState(state: WorkspaceTrustStateChangeEvent): void {
 		this._workspaceTrustState = state.currentTrustState;
-		this._onDidChangeWorkspaceTrustState.fire(Object.freeze(state));
+		this._onDidChangeWorkspaceTrustState.fire(Object.freeze({ newTrustState: state.currentTrustState }));
 	}
 }
 

--- a/src/vs/workbench/contrib/workspace/browser/workspace.contribution.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspace.contribution.ts
@@ -150,7 +150,7 @@ export class WorkspaceTrustRequestHandler extends Disposable implements IWorkben
 		}));
 
 		this._register(this.requestModel.onDidCompleteRequest(trustState => {
-			if (trustState !== undefined && trustState !== WorkspaceTrustState.Unknown) {
+			if (trustState !== undefined && trustState !== WorkspaceTrustState.Unspecified) {
 				this.toggleRequestBadge(false);
 			}
 		}));
@@ -180,7 +180,7 @@ export class WorkspaceTrustRequestHandler extends Disposable implements IWorkben
 			}
 
 			// Hide soft request badge
-			if (trustState.currentTrustState !== undefined && trustState.currentTrustState !== WorkspaceTrustState.Unknown) {
+			if (trustState.currentTrustState !== undefined && trustState.currentTrustState !== WorkspaceTrustState.Unspecified) {
 				this.toggleRequestBadge(false);
 			}
 		}));

--- a/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
@@ -47,7 +47,7 @@ import { WorkspaceTrustEditorModel } from 'vs/workbench/services/workspaces/comm
 
 const untrustedIcon = registerCodicon('workspace-untrusted-icon', Codicon.workspaceUntrusted);
 const trustedIcon = registerCodicon('workspace-trusted-icon', Codicon.workspaceTrusted);
-const unknownIcon = registerCodicon('workspace-unknown-icon', Codicon.workspaceUnknown);
+const unspecified = registerCodicon('workspace-unspecified-icon', Codicon.workspaceUnspecified);
 
 class WorkspaceTrustExtensionDelegate extends Delegate {
 	getHeight() { return super.getHeight() + 36; }
@@ -146,7 +146,7 @@ export class WorkspaceTrustEditor extends EditorPane {
 				return 'workspace-trust-header workspace-trust-trusted';
 			case WorkspaceTrustState.Untrusted:
 				return 'workspace-trust-header workspace-trust-untrusted';
-			case WorkspaceTrustState.Unknown:
+			case WorkspaceTrustState.Unspecified:
 				return 'workspace-trust-header workspace-trust-unknown';
 		}
 	}
@@ -157,8 +157,8 @@ export class WorkspaceTrustEditor extends EditorPane {
 				return localize('trustedHeader', "This workspace is trusted");
 			case WorkspaceTrustState.Untrusted:
 				return localize('untrustedHeader', "This workspace is not trusted");
-			case WorkspaceTrustState.Unknown:
-				return localize('unknownHeader', "Do you want to trust this workspace?");
+			case WorkspaceTrustState.Unspecified:
+				return localize('unspecifiedHeader', "Do you want to trust this workspace?");
 		}
 	}
 
@@ -166,8 +166,8 @@ export class WorkspaceTrustEditor extends EditorPane {
 		switch (trustState) {
 			case WorkspaceTrustState.Trusted:
 			case WorkspaceTrustState.Untrusted:
-			case WorkspaceTrustState.Unknown:
-				return localize('unknownHeaderDescription', "Trust is required for certain extensions to function in this workspace. [Learn more](https://aka.ms/vscode-workspace-trust).");
+			case WorkspaceTrustState.Unspecified:
+				return localize('unknownSpecifiedDescription', "Trust is required for certain extensions to function in this workspace. [Learn more](https://aka.ms/vscode-workspace-trust).");
 		}
 	}
 
@@ -177,8 +177,8 @@ export class WorkspaceTrustEditor extends EditorPane {
 				return trustedIcon.classNamesArray;
 			case WorkspaceTrustState.Untrusted:
 				return untrustedIcon.classNamesArray;
-			case WorkspaceTrustState.Unknown:
-				return unknownIcon.classNamesArray;
+			case WorkspaceTrustState.Unspecified:
+				return unspecified.classNamesArray;
 		}
 	}
 

--- a/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
+++ b/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
@@ -22,7 +22,7 @@ export const WORKSPACE_TRUST_STORAGE_KEY = 'content.trust.model.key';
 
 export const WorkspaceTrustContext = {
 	PendingRequest: new RawContextKey<boolean>('workspaceTrustPendingRequest', false),
-	TrustState: new RawContextKey<WorkspaceTrustState>('workspaceTrustState', WorkspaceTrustState.Unknown)
+	TrustState: new RawContextKey<WorkspaceTrustState>('workspaceTrustState', WorkspaceTrustState.Unspecified)
 };
 
 export class WorkspaceTrustEditorModel extends EditorModel {
@@ -121,7 +121,7 @@ export class WorkspaceTrustModel extends Disposable implements IWorkspaceTrustMo
 	setFolderTrustState(folder: URI, trustState: WorkspaceTrustState): void {
 		let changed = false;
 
-		if (trustState === WorkspaceTrustState.Unknown) {
+		if (trustState === WorkspaceTrustState.Unspecified) {
 			const before = this.trustStateInfo.uriTrustInfo.length;
 			this.trustStateInfo.uriTrustInfo = this.trustStateInfo.uriTrustInfo.filter(info => this.uriIdentityService.extUri.isEqual(info.uri, folder));
 
@@ -152,7 +152,7 @@ export class WorkspaceTrustModel extends Disposable implements IWorkspaceTrustMo
 	}
 
 	getFolderTrustStateInfo(folder: URI): IWorkspaceTrustUriInfo {
-		let resultState = WorkspaceTrustState.Unknown;
+		let resultState = WorkspaceTrustState.Unspecified;
 		let maxLength = -1;
 
 		let resultUri = folder;
@@ -218,7 +218,7 @@ export class WorkspaceTrustService extends Disposable implements IWorkspaceTrust
 	private readonly _onDidChangeTrustState = this._register(new Emitter<WorkspaceTrustStateChangeEvent>());
 	readonly onDidChangeTrustState = this._onDidChangeTrustState.event;
 
-	private _currentTrustState: WorkspaceTrustState = WorkspaceTrustState.Unknown;
+	private _currentTrustState: WorkspaceTrustState = WorkspaceTrustState.Unspecified;
 	private _trustRequestPromise?: Promise<WorkspaceTrustState | undefined>;
 	private _inFlightResolver?: (trustState?: WorkspaceTrustState) => void;
 	private _modalTrustRequestPromise?: Promise<WorkspaceTrustState | undefined>;
@@ -350,7 +350,7 @@ export class WorkspaceTrustService extends Disposable implements IWorkspaceTrust
 			switch (trustState) {
 				case WorkspaceTrustState.Untrusted:
 					return WorkspaceTrustState.Untrusted;
-				case WorkspaceTrustState.Unknown:
+				case WorkspaceTrustState.Unspecified:
 					state = trustState;
 					break;
 				case WorkspaceTrustState.Trusted:
@@ -362,7 +362,7 @@ export class WorkspaceTrustService extends Disposable implements IWorkspaceTrust
 			}
 		}
 
-		return state ?? WorkspaceTrustState.Unknown;
+		return state ?? WorkspaceTrustState.Unspecified;
 	}
 
 	private onTrustStateChanged(): void {


### PR DESCRIPTION
After talks this morning with @lszomoru and @mjbvz let's rename the unknown state and only provide the newTrustState in the state change event. We still use an object to allow for additional properties in the future.