### PR TITLE
fall back to dom if webgl loses context

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -230,7 +230,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		this._instanceId = TerminalInstance._instanceIdCounter++;
 
 		this.hasHadInput = false;
-
 		this._titleReadyPromise = new Promise<string>(c => {
 			this._titleReadyComplete = c;
 		});
@@ -1313,12 +1312,11 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		this._webglAddon = new Addon();
 		try {
 			this._xterm.loadAddon(this._webglAddon);
-			this._webglAddon.onContextLoss((e => {
-				(e as any).preventDefault();
+			this._webglAddon.onContextLoss(() => {
 				this._storageService.store(SUGGESTED_RENDERER_TYPE, 'dom', StorageScope.GLOBAL, StorageTarget.MACHINE);
-				this._safeSetOption('rendererType', 'dom');
+				this.updateConfig();
 				this._disposeOfWebglRenderer();
-			}));
+			});
 			this._storageService.store(SUGGESTED_RENDERER_TYPE, 'auto', StorageScope.GLOBAL, StorageTarget.MACHINE);
 		} catch (e) {
 			this._logService.warn(`Webgl could not be loaded. Falling back to the canvas renderer type.`, e);

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1313,6 +1313,12 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		this._webglAddon = new Addon();
 		try {
 			this._xterm.loadAddon(this._webglAddon);
+			this._webglAddon.onContextLoss((e => {
+				(e as any).preventDefault();
+				this._storageService.store(SUGGESTED_RENDERER_TYPE, 'dom', StorageScope.GLOBAL, StorageTarget.MACHINE);
+				this._safeSetOption('rendererType', 'dom');
+				this._disposeOfWebglRenderer();
+			}));
 			this._storageService.store(SUGGESTED_RENDERER_TYPE, 'auto', StorageScope.GLOBAL, StorageTarget.MACHINE);
 		} catch (e) {
 			this._logService.warn(`Webgl could not be loaded. Falling back to the canvas renderer type.`, e);

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1313,9 +1313,9 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		try {
 			this._xterm.loadAddon(this._webglAddon);
 			this._webglAddon.onContextLoss(() => {
-				this._storageService.store(SUGGESTED_RENDERER_TYPE, 'dom', StorageScope.GLOBAL, StorageTarget.MACHINE);
-				this.updateConfig();
+				this._logService.info(`Webgl lost context, disposing of webgl renderer`);
 				this._disposeOfWebglRenderer();
+				this._safeSetOption('rendererType', 'dom');
 			});
 			this._storageService.store(SUGGESTED_RENDERER_TYPE, 'auto', StorageScope.GLOBAL, StorageTarget.MACHINE);
 		} catch (e) {


### PR DESCRIPTION
This PR fixes #120393
![recording (73)](https://user-images.githubusercontent.com/29464607/113377736-019e6780-932a-11eb-9438-1a8a04a7ac4d.gif)

As you can see, it's working quite well. It goes with webgl until a context loss occurs then switches to dom (but tries again to load the webgl renderer the next time... not sure if we want this or not).