### PR TITLE
Prototype side by side commands for getting started

### DIFF
--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
@@ -264,7 +264,14 @@ export class GettingStartedPage extends EditorPane {
 							}
 							const taskToRun = assertIsDefined(this.currentCategory?.content.items.find(task => task.id === argument));
 							if (taskToRun.button.command) {
-								this.commandService.executeCommand(taskToRun.button.command);
+								if (taskToRun.button.sideBySide) {
+									// todo: Only split when current layout is 1-column
+									this.commandService.executeCommand('workbench.action.editorLayoutTwoColumns')
+										.then(() => this.commandService.executeCommand('workbench.action.focusNextGroup'))
+										.then(() => this.commandService.executeCommand(taskToRun.button.command));
+								} else {
+									this.commandService.executeCommand(taskToRun.button.command);
+								}
 							} else if (taskToRun.button.link) {
 								this.openerService.open(taskToRun.button.link);
 								this.gettingStartedService.progressByEvent('linkOpened:' + taskToRun.button.link);

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedService.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedService.ts
@@ -48,7 +48,7 @@ export interface IGettingStartedTask {
 	order: number
 	button:
 	| { title: string, command?: never, link: string }
-	| { title: string, command: string, link?: never },
+	| { title: string, command: string, link?: never, sideBySide?: boolean }
 	doneOn: { commandExecuted: string, eventFired?: never } | { eventFired: string, commandExecuted?: never }
 	media: { type: 'image', path: { hc: URI, light: URI, dark: URI }, altText: string }
 }

--- a/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
@@ -20,7 +20,7 @@ export type BuiltinGettingStartedItem = {
 	description: string,
 	button:
 	| { title: string, command?: never, link: string }
-	| { title: string, command: string, link?: never },
+	| { title: string, command: string, link?: never, sideBySide?: boolean },
 	doneOn: { commandExecuted: string, eventFired?: never } | { eventFired: string, commandExecuted?: never, }
 	when?: string,
 	media: { type: 'image', path: string | { hc: string, light: string, dark: string }, altText: string },
@@ -290,7 +290,8 @@ export const content: GettingStartedContent = [
 					when: 'workspaceFolderCount != 0',
 					button: {
 						title: localize('gettingStarted.quickOpen.button', "Quick Open a File"),
-						command: 'workbench.action.quickOpen'
+						command: 'workbench.action.quickOpen',
+						sideBySide: true
 					},
 					doneOn: { commandExecuted: 'workbench.action.quickOpen' },
 					media: {
@@ -371,7 +372,8 @@ export const content: GettingStartedContent = [
 					description: localize('gettingStarted.settings.description', "Tweak every aspect of VS Code and your extensions to your liking. Commonly used settings are listed first to get you started."),
 					button: {
 						title: localize('gettingStarted.settings.button', "Tweak my Settings"),
-						command: 'workbench.action.openSettings'
+						command: 'workbench.action.openSettings',
+						sideBySide: true
 					},
 					doneOn: { commandExecuted: 'workbench.action.openSettings' },
 					media: {


### PR DESCRIPTION
Scaffolding out a basic implementation for opening new tabs from Getting Started in split view. Works best for commands that directly open a tab (like Settings), but I also added it to quick open just to try it out.

![recording (3)](https://user-images.githubusercontent.com/8599/113442028-23d4cb80-93a4-11eb-9ff0-9c634f857558.gif)

One todo is to not reset the split layout if a user is already in split mode, but there might be more ideas to avoid surprises.

To further learn, we could put this behind an experiment flag to see if this helps users complete more of getting started, but also use it for extension walkthroughs that have more content to open.

cc @misolori