### PR TITLE
Improve reporting of extension config schema validation errors

### DIFF
--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -213,7 +213,7 @@ function validateProperties(configuration: IConfigurationNode, extension: IExten
 			const propertyConfiguration = properties[key];
 			if (!isObject(propertyConfiguration)) {
 				delete properties[key];
-				extension.collector.error(nls.localize('invalid.property', "'configuration.property' must be an object"));
+				extension.collector.error(nls.localize('invalid.property', "configuration.properties property '{0}' must be an object", key));
 				continue;
 			}
 			if (propertyConfiguration.scope) {


### PR DESCRIPTION
In large extension configuration schemas, if a type error is present on a configuration key, an error message like the following is generated: 
![image](https://user-images.githubusercontent.com/6652840/113471287-4bfa1400-9410-11eb-92ce-42db15ae614c.png)

This requires the extension developer to go through each property and check it's the right type. I made it print out which one was bad:

![image](https://user-images.githubusercontent.com/6652840/113471337-8d8abf00-9410-11eb-98f2-8a4fa1b6368c.png)

This PR can be tested by updating the top level object of an extension `package.json` with this fragment:

```json
{
    "contributes": {
        "configuration": {
            "type": "object",
            "title": "Rust Analyzer",
            "properties": {
                "rust-analyzer.thisPropShouldBeAnObjectButIsnt": false
           }
     }
}
```