### PR TITLE
fix emmet issue where wrong suggestions is promoted in html file

### DIFF
--- a/extensions/emmet/src/util.ts
+++ b/extensions/emmet/src/util.ts
@@ -657,10 +657,8 @@ export function getEmbeddedCssNodeIfAny(document: vscode.TextDocument, currentNo
 	const currentHtmlNode = <HtmlFlatNode>currentNode;
 	if (currentHtmlNode && currentHtmlNode.open && currentHtmlNode.close) {
 		const offset = document.offsetAt(position);
-		if (currentHtmlNode.open.end <= offset && offset <= currentHtmlNode.close.start) {
-			if (currentHtmlNode.name === 'style'
-				&& currentHtmlNode.open.end < offset
-				&& currentHtmlNode.close.start > offset) {
+		if (currentHtmlNode.open.end < offset && offset <= currentHtmlNode.close.start) {
+			if (currentHtmlNode.name === 'style') {
 				const buffer = ' '.repeat(currentHtmlNode.open.end) + document.getText().substring(currentHtmlNode.open.end, currentHtmlNode.close.start);
 				return parseStylesheet(buffer);
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #107578

### Issue
Unwanted emmet abbreviation is shown in an HTML file containing a <style> tag.
Issue Link -- #107578

### Steps to repro
Type <style>input.</style> manually into an HTML file, after typing input. you'll notice input: .; is suggested.
The problem only occurs when typing css right before </style> close tag.
eg. `<style>   input.|   </style>` will not promote the wrong suggestion but `<style>   input.|</style>` will.

### Cause
Wrong boundary condition in `getEmbeddedCssNodeIfAny` makes getting EmbeddedCssNode for cases like `<style>input.|</style>` always fail.


cc / @rzhao271 