### PR TITLE
fix #120485 hide `Open Timeline` from Explorer context menu when there are no timeline providers

### DIFF
--- a/src/vs/workbench/contrib/timeline/browser/timeline.contribution.ts
+++ b/src/vs/workbench/contrib/timeline/browser/timeline.contribution.ts
@@ -95,7 +95,7 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerContext, ({
 		title: OpenTimelineAction.LABEL,
 		icon: timelineOpenIcon
 	},
-	when: ContextKeyExpr.and(ExplorerFolderContext.toNegated(), ResourceContextKey.HasResource)
+	when: ContextKeyExpr.and(ExplorerFolderContext.toNegated(), ResourceContextKey.HasResource, TimelineHasProviderContext)
 }));
 
 registerSingleton(ITimelineService, TimelineService, true);


### PR DESCRIPTION
This PR fixes #120485
