### PR TITLE
fix: only add readonly attribute to textarea dom when editor is readonly

### DIFF
--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -132,7 +132,7 @@ export class TextAreaHandler extends ViewPart {
 		this.textArea.setAttribute('aria-haspopup', 'false');
 		this.textArea.setAttribute('aria-autocomplete', 'both');
 
-		if (options.get(EditorOption.domReadOnly)) {
+		if (options.get(EditorOption.domReadOnly) && options.get(EditorOption.readOnly)) {
 			this.textArea.setAttribute('readonly', 'true');
 		}
 
@@ -440,8 +440,8 @@ export class TextAreaHandler extends ViewPart {
 		this.textArea.setAttribute('aria-label', this._getAriaLabel(options));
 		this.textArea.setAttribute('tabindex', String(options.get(EditorOption.tabIndex)));
 
-		if (e.hasChanged(EditorOption.domReadOnly)) {
-			if (options.get(EditorOption.domReadOnly)) {
+		if (e.hasChanged(EditorOption.domReadOnly) || e.hasChanged(EditorOption.readOnly)) {
+			if (options.get(EditorOption.domReadOnly) && options.get(EditorOption.readOnly)) {
 				this.textArea.setAttribute('readonly', 'true');
 			} else {
 				this.textArea.removeAttribute('readonly');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixed #120504
The `readonly` attribute should be added to textarea dom only if the corresponding editor is readonly mode