### PR TITLE
fix-120429 only add color to debug codicons in specific places

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugColors.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugColors.ts
@@ -263,17 +263,17 @@ export function registerColors() {
 
 		const debugIconStartColor = theme.getColor(debugIconStartForeground);
 		if (debugIconStartColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStart)} { color: ${debugIconStartColor} !important; }`);
+			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugStart)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugStart)}, .monaco-workbench .start-debug-action-item ${ThemeIcon.asCSSSelector(icons.debugStart)} { color: ${debugIconStartColor} !important; }`);
 		}
 
 		const debugIconPauseColor = theme.getColor(debugIconPauseForeground);
 		if (debugIconPauseColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugPause)} { color: ${debugIconPauseColor} !important; }`);
+			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugPause)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugPause)} { color: ${debugIconPauseColor} !important; }`);
 		}
 
 		const debugIconStopColor = theme.getColor(debugIconStopForeground);
 		if (debugIconStopColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStop)} { color: ${debugIconStopColor} !important; }`);
+			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugStop)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugStop)} { color: ${debugIconStopColor} !important; }`);
 		}
 
 		const debugIconDisconnectColor = theme.getColor(debugIconDisconnectForeground);
@@ -283,32 +283,32 @@ export function registerColors() {
 
 		const debugIconRestartColor = theme.getColor(debugIconRestartForeground);
 		if (debugIconRestartColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugRestart)}, .monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugRestartFrame)} { color: ${debugIconRestartColor} !important; }`);
+			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugRestart)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugRestart)}, .monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugRestartFrame)} { color: ${debugIconRestartColor} !important; }`);
 		}
 
 		const debugIconStepOverColor = theme.getColor(debugIconStepOverForeground);
 		if (debugIconStepOverColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepOver)} { color: ${debugIconStepOverColor} !important; }`);
+			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugStepOver)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugStepOver)} { color: ${debugIconStepOverColor} !important; }`);
 		}
 
 		const debugIconStepIntoColor = theme.getColor(debugIconStepIntoForeground);
 		if (debugIconStepIntoColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepInto)} { color: ${debugIconStepIntoColor} !important; }`);
+			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugStepInto)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugStepInto)} { color: ${debugIconStepIntoColor} !important; }`);
 		}
 
 		const debugIconStepOutColor = theme.getColor(debugIconStepOutForeground);
 		if (debugIconStepOutColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepOut)} { color: ${debugIconStepOutColor} !important; }`);
+			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugStepOut)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugStepOut)} { color: ${debugIconStepOutColor} !important; }`);
 		}
 
 		const debugIconContinueColor = theme.getColor(debugIconContinueForeground);
 		if (debugIconContinueColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugContinue)}, .monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugReverseContinue)} { color: ${debugIconContinueColor} !important; }`);
+			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugContinue)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugContinue)}, .monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugReverseContinue)} { color: ${debugIconContinueColor} !important; }`);
 		}
 
 		const debugIconStepBackColor = theme.getColor(debugIconStepBackForeground);
 		if (debugIconStepBackColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepBack)} { color: ${debugIconStepBackColor} !important; }`);
+			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugStepBack)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugStepBack)} { color: ${debugIconStepBackColor} !important; }`);
 		}
 	});
 }


### PR DESCRIPTION
This PR fixes #120429

To test, verify that all the places where debug codicons previously displayed in color still do so.
