### PR TITLE
Allow keybinding labels to be themed

### DIFF
--- a/src/vs/base/browser/ui/keybindingLabel/keybindingLabel.css
+++ b/src/vs/base/browser/ui/keybindingLabel/keybindingLabel.css
@@ -15,9 +15,7 @@
 	border-bottom-color: rgba(187, 187, 187, 0.4);
 	border-radius: 3px;
 	box-shadow: inset 0 -1px 0 rgba(187, 187, 187, 0.4);
-	background-color: rgba(221, 221, 221, 0.4);
 	vertical-align: middle;
-	color: #555;
 	font-size: 11px;
 	padding: 3px 5px;
 	margin: 0 2px;
@@ -33,8 +31,6 @@
 
 .hc-black .monaco-keybinding > .monaco-keybinding-key,
 .vs-dark .monaco-keybinding > .monaco-keybinding-key {
-	background-color: rgba(128, 128, 128, 0.17);
-	color: #ccc;
 	border: solid 1px rgba(51, 51, 51, 0.6);
 	border-bottom-color: rgba(68, 68, 68, 0.6);
 	box-shadow: inset 0 -1px 0 rgba(68, 68, 68, 0.6);

--- a/src/vs/platform/keybinding/common/keybindingLabel.ts
+++ b/src/vs/platform/keybinding/common/keybindingLabel.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { keybindingLabelBackground, keybindingLabelForeground } from 'vs/platform/theme/common/colorRegistry';
+import { IColorTheme, ICssStyleCollector, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
+
+registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {
+	const labelBackground = theme.getColor(keybindingLabelBackground);
+	if (labelBackground) {
+		collector.addRule(`
+			.monaco-keybinding > .monaco-keybinding-key {
+				background-color: ${labelBackground};
+			}
+		`);
+	}
+
+	const labelForeground = theme.getColor(keybindingLabelForeground);
+	if (labelForeground) {
+		collector.addRule(`
+			.monaco-keybinding > .monaco-keybinding-key {
+				color: ${labelForeground};
+			}
+		`);
+	}
+});

--- a/src/vs/platform/quickinput/common/quickAccess.ts
+++ b/src/vs/platform/quickinput/common/quickAccess.ts
@@ -9,6 +9,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { coalesce } from 'vs/base/common/arrays';
 import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { ItemActivation } from 'vs/base/parts/quickinput/common/quickInput';
+import 'vs/platform/keybinding/common/keybindingLabel';
 
 export interface IQuickAccessOptions {
 

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -292,6 +292,12 @@ export const pickerGroupForeground = registerColor('pickerGroup.foreground', { d
 export const pickerGroupBorder = registerColor('pickerGroup.border', { dark: '#3F3F46', light: '#CCCEDB', hc: Color.white }, nls.localize('pickerGroupBorder', "Quick picker color for grouping borders."));
 
 /**
+ * Keybinding label
+ */
+export const keybindingLabelBackground = registerColor('keybindingLabel.background', { dark: new Color(new RGBA(128, 128, 128, 0.17)), light: new Color(new RGBA(221, 221, 221, 0.4)), hc: new Color(new RGBA(128, 128, 128, 0.17)) }, nls.localize('keybindingLabelBackground', 'Keybinding label background color. The keybinding label is used in the command palette to represent a keyboard shortcut.'));
+export const keybindingLabelForeground = registerColor('keybindingLabel.foreground', { dark: Color.fromHex('#CCCCCC'), light: Color.fromHex('#555555'), hc: Color.fromHex('#CCCCCC') }, nls.localize('keybindingLabelForeground', 'Keybinding label foreground color. The keybinding label is used in the command palette to represent a keyboard shortcut.'));
+
+/**
  * Editor selection colors.
  */
 export const editorSelectionBackground = registerColor('editor.selectionBackground', { light: '#ADD6FF', dark: '#264F78', hc: '#f3f518' }, nls.localize('editorSelectionBackground', "Color of the editor selection."));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #120201

```json
"workbench.colorCustomizations": {
        "[Default Dark+]": {
            "keybindingLabel.background": "#1418ff",
            "keybindingLabel.foreground": "#ff0000"
        }
    }
```

![image](https://user-images.githubusercontent.com/2644648/113630729-33ab1480-961d-11eb-8f40-a330b49f92fb.png)
![image](https://user-images.githubusercontent.com/2644648/113630745-3a398c00-961d-11eb-9d1f-cd3ee76685ba.png)
![image](https://user-images.githubusercontent.com/2644648/113630776-46254e00-961d-11eb-8fb5-e3d4a643659a.png)


alt: #120576