### PR TITLE
chore: use bundled node-gyp

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -115,9 +115,6 @@ steps:
       export SDKROOT=/Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk
       ls /Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/
       yarn electron-rebuild
-      # remove once https://github.com/prebuild/prebuild-install/pull/140 is merged and found in keytar
-      cd ./node_modules/keytar
-      node-gyp rebuild
     displayName: Rebuild native modules for ARM64
     condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'arm64'))
 

--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -61,13 +61,6 @@ steps:
 
   - script: |
       set -e
-      npm install -g node-gyp@latest
-      node-gyp --version
-    displayName: Update node-gyp
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), eq(variables['VSCODE_ARCH'], 'x64'))
-
-  - script: |
-      set -e
       npx https://aka.ms/enablesecurefeed standAlone
     timeoutInMinutes: 5
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), eq(variables['ENABLE_TERRAPIN'], 'true'))
@@ -86,7 +79,6 @@ steps:
       if [ "$VSCODE_ARCH" == "x64" ]; then
         export VSCODE_REMOTE_CC=$(which gcc-4.8)
         export VSCODE_REMOTE_CXX=$(which g++-4.8)
-        export VSCODE_REMOTE_NODE_GYP=$(which node-gyp)
       fi
 
       for i in {1..3}; do # try 3 times, for Terrapin


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode/pull/120673

Only the mac ci needs latest node-gyp to recompile modules for arm64, elsewhere the node-gyp bundled with npm is sufficient.