### PR TITLE
[themes] Fix JSON formatting in High Contrast Black default theme

### DIFF
--- a/extensions/theme-defaults/themes/hc_black.json
+++ b/extensions/theme-defaults/themes/hc_black.json
@@ -441,7 +441,7 @@
 			"name": "HC Search Editor context line override",
 			"scope": "meta.resultLinePrefix.contextLinePrefix.search",
 			"settings": {
-				"foreground": "#CBEDCB",
+				"foreground": "#CBEDCB"
 			}
 		}
 	],


### PR DESCRIPTION
Fixes a JSON formatting issue, a trailing comma, in the High Contrast Black default theme. No issue for this, just found it myself and wanted to quickly patch. Sorry if there's any issues with this quick random PR. Thanks!
