### PR TITLE
[themes] Fix JSON formatting in High Contrast Black default theme (2)

### DIFF
--- a/extensions/theme-defaults/themes/hc_black.json
+++ b/extensions/theme-defaults/themes/hc_black.json
@@ -450,6 +450,6 @@
 		"newOperator": "#FFFFFF",
 		"stringLiteral": "#ce9178",
 		"customLiteral": "#DCDCAA",
-		"numberLiteral": "#b5cea8",
+		"numberLiteral": "#b5cea8"
 	}
 }


### PR DESCRIPTION
Continuation on #120761, found another trailing comma issue in the same file I missed in the first PR. Thanks again!