### PR TITLE
[themes] Fix JSON formatting in High Contrast Black default theme (3)

### DIFF
--- a/extensions/theme-defaults/themes/hc_black.json
+++ b/extensions/theme-defaults/themes/hc_black.json
@@ -10,7 +10,7 @@
 		"selection.background": "#008000",
 		"editor.selectionBackground": "#FFFFFF",
 		"statusBarItem.remoteBackground": "#00000000",
-		"ports.iconRunningProcessforeground": "#FFFFFF",
+		"ports.iconRunningProcessforeground": "#FFFFFF"
 	},
 	"tokenColors": [
 		{


### PR DESCRIPTION
Continuation of #120815 + #120761, fixes trailing comma introduced in the default High Contrast Black theme by commit ffde598. Thanks!