### PR TITLE
Add enable-render-process-reuse flag

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,7 @@ const { getUserDataPath } = require('./vs/platform/environment/node/userDataPath
 const product = require('../product.json');
 const { app, protocol, crashReporter } = require('electron');
 
-app.allowRendererProcessReuse = true;
+app.allowRendererProcessReuse = false;
 
 // Enable portable support
 const portable = bootstrapNode.configurePortable(product);
@@ -223,8 +223,8 @@ function configureCommandlineSwitchesSync(cliArgs) {
 					break;
 
 				case 'enable-render-process-reuse':
-					if (argvValue === false) {
-						app.allowRendererProcessReuse = false;
+					if (argvValue === true) {
+						app.allowRendererProcessReuse = true;
 					}
 					break;
 			}

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,7 @@ const { getUserDataPath } = require('./vs/platform/environment/node/userDataPath
 const product = require('../product.json');
 const { app, protocol, crashReporter } = require('electron');
 
-app.allowRendererProcessReuse = false;
+app.allowRendererProcessReuse = true;
 
 // Enable portable support
 const portable = bootstrapNode.configurePortable(product);
@@ -223,9 +223,7 @@ function configureCommandlineSwitchesSync(cliArgs) {
 					break;
 
 				case 'enable-render-process-reuse':
-					if (argvValue === true) {
-						app.allowRendererProcessReuse = true;
-					} else {
+					if (argvValue === false) {
 						app.allowRendererProcessReuse = false;
 					}
 					break;

--- a/src/main.js
+++ b/src/main.js
@@ -223,10 +223,10 @@ function configureCommandlineSwitchesSync(cliArgs) {
 					break;
 
 				case 'enable-render-process-reuse':
-					if (argvValue === false) {
-						app.allowRendererProcessReuse = false;
-					} else {
+					if (argvValue === true) {
 						app.allowRendererProcessReuse = true;
+					} else {
+						app.allowRendererProcessReuse = false;
 					}
 					break;
 			}

--- a/src/main.js
+++ b/src/main.js
@@ -25,8 +25,6 @@ const { getUserDataPath } = require('./vs/platform/environment/node/userDataPath
 const product = require('../product.json');
 const { app, protocol, crashReporter } = require('electron');
 
-// Disable render process reuse, we still have
-// non-context aware native modules in the renderer.
 app.allowRendererProcessReuse = false;
 
 // Enable portable support
@@ -175,7 +173,10 @@ function configureCommandlineSwitchesSync(cliArgs) {
 		'enable-proposed-api',
 
 		// Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'.
-		'log-level'
+		'log-level',
+
+		// Enables render process reuse. Default value is 'false'. See https://github.com/electron/electron/issues/18397
+		'enable-render-process-reuse'
 	];
 
 	// Read argv config
@@ -218,6 +219,14 @@ function configureCommandlineSwitchesSync(cliArgs) {
 				case 'log-level':
 					if (typeof argvValue === 'string') {
 						process.argv.push('--log', argvValue);
+					}
+					break;
+
+				case 'enable-render-process-reuse':
+					if (argvValue === false) {
+						app.allowRendererProcessReuse = false;
+					} else {
+						app.allowRendererProcessReuse = true;
 					}
 					break;
 			}

--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -683,38 +683,30 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 		return withNullAsUndefined(this._inspectPort);
 	}
 
-	public terminate(): void {
-		if (this._terminating) {
-			return;
-		}
-		this._terminating = true;
+	public terminate(): Promise<void> {
+		return new Promise((c) => {
+			if (this._terminating) {
+				c();
+			}
+			this._terminating = true;
 
-		this._toDispose.dispose();
+			this._toDispose.dispose();
 
-		if (!this._messageProtocol) {
-			// .start() was not called
-			return;
-		}
-
-		this._messageProtocol.then((protocol) => {
-
-			// Send the extension host a request to terminate itself
-			// (graceful termination)
-			protocol.send(createMessageOfType(MessageType.Terminate));
-
-			protocol.getSocket().dispose();
-
-			protocol.dispose();
-
-			// Give the extension host 10s, after which we will
-			// try to kill the process and release any resources
-			setTimeout(() => this._cleanResources(), 10 * 1000);
-
-		}, (err) => {
-
-			// Establishing a protocol with the extension host failed, so
-			// try to kill the process and release any resources.
-			this._cleanResources();
+			if (!this._messageProtocol) {
+				// .start() was not called
+				c();
+			} else {
+				this._messageProtocol.then((protocol) => {
+					// Send the extension host a request to terminate itself
+					// (graceful termination)
+					protocol.send(createMessageOfType(MessageType.Terminate));
+					protocol.flush();
+					protocol.dispose();
+					c(this._cleanResources());
+				}).catch(() => {
+					c(this._cleanResources());
+				});
+			}
 		});
 	}
 


### PR DESCRIPTION
Affects #120431

This PR adds an `enable-render-process-reuse` flag to the runtime arguments in `argv.json` (one can access that file by running the `workbench.action.configureRuntimeArguments` command. By default, the runtime argument is `false`, but one can set it to `true` in argv.json.