### PR TITLE
Fixes horizontal scrollbar is too narrow in split settings editor JSON

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/preferences.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/preferences.css
@@ -51,6 +51,7 @@
 
 .settings-tabs-widget > .monaco-action-bar .action-item .action-label {
 	display: block;
+	padding: 0px;
 	border-radius: initial;
 	background: none !important;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #121026

Remove padding to keep size of header container same as before => `34px`
https://github.com/microsoft/vscode/blob/01466cf692c3e54f0eeb82ef0539a42391f185de/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts#L830
