### PR TITLE
Fix terminal reconnect, remove writeSync completely

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -405,7 +405,11 @@ export const enum FlowControlConstants {
 
 export interface IProcessDataEvent {
 	data: string;
-	sync: boolean;
+	trackCommit: boolean;
+	/**
+	 * When trackCommit is set, this will be set to a promise that resolves when the data is parsed.
+	 */
+	writePromise?: Promise<void>;
 }
 
 export interface ITerminalDimensions {

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -255,7 +255,7 @@ export class PersistentTerminalProcess extends Disposable {
 	readonly onProcessShellTypeChanged = this._onProcessShellTypeChanged.event;
 	private readonly _onProcessOverrideDimensions = this._register(new Emitter<ITerminalDimensionsOverride | undefined>());
 	readonly onProcessOverrideDimensions = this._onProcessOverrideDimensions.event;
-	private readonly _onProcessData = this._register(new Emitter<IProcessDataEvent>());
+	private readonly _onProcessData = this._register(new Emitter<string>());
 	readonly onProcessData = this._onProcessData.event;
 	private readonly _onProcessOrphanQuestion = this._register(new Emitter<void>());
 	readonly onProcessOrphanQuestion = this._onProcessOrphanQuestion.event;
@@ -299,12 +299,12 @@ export class PersistentTerminalProcess extends Disposable {
 		this._register(this._terminalProcess.onProcessShellTypeChanged(e => this._onProcessShellTypeChanged.fire(e)));
 
 		// Data buffering to reduce the amount of messages going to the renderer
-		this._bufferer = new TerminalDataBufferer((_, data) => this._onProcessData.fire({ data: data, sync: true }));
+		this._bufferer = new TerminalDataBufferer((_, data) => this._onProcessData.fire(data));
 		this._register(this._bufferer.startBuffering(this._persistentProcessId, this._terminalProcess.onProcessData));
 		this._register(this._terminalProcess.onProcessExit(() => this._bufferer.stopBuffering(this._persistentProcessId)));
 
 		// Data recording for reconnect
-		this._register(this.onProcessData(e => this._recorder.recordData(e.data)));
+		this._register(this.onProcessData(e => this._recorder.recordData(e)));
 	}
 
 	attach(): void {

--- a/src/vs/workbench/contrib/terminal/browser/remotePty.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remotePty.ts
@@ -146,7 +146,7 @@ export class RemotePty extends Disposable implements ITerminalChildProcess {
 		this._onProcessResolvedShellLaunchConfig.fire(e);
 	}
 
-	handleReplay(e: IPtyHostProcessReplayEvent) {
+	async handleReplay(e: IPtyHostProcessReplayEvent) {
 		try {
 			this._inReplay = true;
 			for (const innerEvent of e.events) {
@@ -154,7 +154,9 @@ export class RemotePty extends Disposable implements ITerminalChildProcess {
 					// never override with 0x0 as that is a marker for an unknown initial size
 					this._onProcessOverrideDimensions.fire({ cols: innerEvent.cols, rows: innerEvent.rows, forceExactSize: true });
 				}
-				this._onProcessData.fire({ data: innerEvent.data, sync: true });
+				const e: IProcessDataEvent = { data: innerEvent.data, trackCommit: true };
+				this._onProcessData.fire(e);
+				await e.writePromise;
 			}
 		} finally {
 			this._inReplay = false;

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -138,11 +138,11 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 		this._dataFilter = this._instantiationService.createInstance(SeamlessRelaunchDataFilter);
 		this._dataFilter.onProcessData(ev => {
 			const data = (typeof ev === 'string' ? ev : ev.data);
-			const sync = (typeof ev === 'string' ? false : ev.sync);
+			const trackCommit = (typeof ev === 'string' ? false : ev.trackCommit);
 			const beforeProcessDataEvent: IBeforeProcessDataEvent = { data };
 			this._onBeforeProcessData.fire(beforeProcessDataEvent);
 			if (beforeProcessDataEvent.data && beforeProcessDataEvent.data.length > 0) {
-				this._onProcessData.fire({ data: beforeProcessDataEvent.data, sync });
+				this._onProcessData.fire({ data: beforeProcessDataEvent.data, trackCommit });
 			}
 		});
 	}
@@ -446,7 +446,7 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 					// For normal terminals write a message indicating what happened and relaunch
 					// using the previous shellLaunchConfig
 					let message = localize('ptyHostRelaunch', "Restarting the terminal because the connection to the shell process was lost...");
-					this._onProcessData.fire({ data: formatMessageForTerminal(message), sync: false });
+					this._onProcessData.fire({ data: formatMessageForTerminal(message), trackCommit: false });
 					await this.relaunch(this._shellLaunchConfig, this._dimensions.cols, this._dimensions.rows, this._isScreenReaderModeEnabled, false);
 				}
 			}
@@ -682,7 +682,7 @@ class SeamlessRelaunchDataFilter extends Disposable {
 		} else {
 			this._logService.trace(`Seamless terminal relaunch - resetting content`);
 			// Fire full reset (RIS) followed by the new data so the update happens in the same frame
-			this._onProcessData.fire({ data: `\x1bc${secondData}`, sync: false });
+			this._onProcessData.fire({ data: `\x1bc${secondData}`, trackCommit: false });
 		}
 
 		// Set up the new data listener

--- a/src/vs/workbench/contrib/terminal/browser/xterm-private.d.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm-private.d.ts
@@ -34,8 +34,6 @@ export interface XTermCore {
 		};
 		_onIntersectionChange: any;
 	};
-
-	writeSync(data: string | Uint8Array, maxSubsequentCalls?: number): void;
 }
 
 export interface IEventEmitter<T> {

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localPty.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localPty.ts
@@ -107,7 +107,7 @@ export class LocalPty extends Disposable implements ITerminalChildProcess {
 		this._onProcessResolvedShellLaunchConfig.fire(e);
 	}
 
-	handleReplay(e: IPtyHostProcessReplayEvent) {
+	async handleReplay(e: IPtyHostProcessReplayEvent) {
 		try {
 			this._inReplay = true;
 			for (const innerEvent of e.events) {
@@ -115,7 +115,9 @@ export class LocalPty extends Disposable implements ITerminalChildProcess {
 					// never override with 0x0 as that is a marker for an unknown initial size
 					this._onProcessOverrideDimensions.fire({ cols: innerEvent.cols, rows: innerEvent.rows, forceExactSize: true });
 				}
-				this._onProcessData.fire({ data: innerEvent.data, sync: true });
+				const e: IProcessDataEvent = { data: innerEvent.data, trackCommit: true };
+				this._onProcessData.fire(e);
+				await e.writePromise;
 			}
 		} finally {
 			this._inReplay = false;

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalCommandTracker.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalCommandTracker.test.ts
@@ -16,33 +16,37 @@ interface TestTerminal extends Terminal {
 const ROWS = 10;
 const COLS = 10;
 
+async function writeP(terminal: TestTerminal, data: string): Promise<void> {
+	return new Promise<void>(r => terminal.write(data, r));
+}
+
 suite('Workbench - TerminalCommandTracker', () => {
 	let xterm: TestTerminal;
 	let commandTracker: CommandTrackerAddon;
 
-	setup(() => {
+	setup(async () => {
 		xterm = (<TestTerminal>new Terminal({
 			cols: COLS,
 			rows: ROWS
 		}));
 		// Fill initial viewport
 		for (let i = 0; i < ROWS - 1; i++) {
-			xterm._core.writeSync(`${i}\n`);
+			await writeP(xterm, `${i}\n`);
 		}
 		commandTracker = new CommandTrackerAddon();
 		xterm.loadAddon(commandTracker);
 	});
 
 	suite('Command tracking', () => {
-		test('should track commands when the prompt is of sufficient size', () => {
+		test('should track commands when the prompt is of sufficient size', async () => {
 			assert.strictEqual(xterm.markers.length, 0);
-			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
+			await writeP(xterm, '\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' });
 			assert.strictEqual(xterm.markers.length, 1);
 		});
-		test('should not track commands when the prompt is too small', () => {
+		test('should not track commands when the prompt is too small', async () => {
 			assert.strictEqual(xterm.markers.length, 0);
-			xterm._core.writeSync('\x1b[2G'); // Move cursor to column 2
+			await writeP(xterm, '\x1b[2G'); // Move cursor to column 2
 			xterm._core._onKey.fire({ key: '\x0d' });
 			assert.strictEqual(xterm.markers.length, 0);
 		});
@@ -61,13 +65,13 @@ suite('Workbench - TerminalCommandTracker', () => {
 		teardown(() => {
 			document.body.removeChild(container);
 		});
-		test('should scroll to the next and previous commands', () => {
-			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
+		test('should scroll to the next and previous commands', async () => {
+			await writeP(xterm, '\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' }); // Mark line #10
 			assert.strictEqual(xterm.markers[0].line, 9);
 
 			for (let i = 0; i < 20; i++) {
-				xterm._core.writeSync(`\r\n`);
+				await writeP(xterm, `\r\n`);
 			}
 			assert.strictEqual(xterm.buffer.active.baseY, 20);
 			assert.strictEqual(xterm.buffer.active.viewportY, 20);
@@ -88,17 +92,17 @@ suite('Workbench - TerminalCommandTracker', () => {
 			commandTracker.scrollToNextCommand();
 			assert.strictEqual(xterm.buffer.active.viewportY, 20);
 		});
-		test('should select to the next and previous commands', () => {
-			xterm._core.writeSync('\r0');
-			xterm._core.writeSync('\n\r1');
-			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
+		test('should select to the next and previous commands', async () => {
+			await writeP(xterm, '\r0');
+			await writeP(xterm, '\n\r1');
+			await writeP(xterm, '\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' }); // Mark line
 			assert.strictEqual(xterm.markers[0].line, 10);
-			xterm._core.writeSync('\n\r2');
-			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
+			await writeP(xterm, '\n\r2');
+			await writeP(xterm, '\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' }); // Mark line
 			assert.strictEqual(xterm.markers[1].line, 11);
-			xterm._core.writeSync('\n\r3');
+			await writeP(xterm, '\n\r3');
 
 			assert.strictEqual(xterm.buffer.active.baseY, 3);
 			assert.strictEqual(xterm.buffer.active.viewportY, 3);
@@ -113,17 +117,17 @@ suite('Workbench - TerminalCommandTracker', () => {
 			commandTracker.selectToNextCommand();
 			assert.strictEqual(xterm.getSelection(), isWindows ? '\r\n' : '\n');
 		});
-		test('should select to the next and previous lines & commands', () => {
-			xterm._core.writeSync('\r0');
-			xterm._core.writeSync('\n\r1');
-			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
+		test('should select to the next and previous lines & commands', async () => {
+			await writeP(xterm, '\r0');
+			await writeP(xterm, '\n\r1');
+			await writeP(xterm, '\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' }); // Mark line
 			assert.strictEqual(xterm.markers[0].line, 10);
-			xterm._core.writeSync('\n\r2');
-			xterm._core.writeSync('\x1b[3G'); // Move cursor to column 3
+			await writeP(xterm, '\n\r2');
+			await writeP(xterm, '\x1b[3G'); // Move cursor to column 3
 			xterm._core._onKey.fire({ key: '\x0d' }); // Mark line
 			assert.strictEqual(xterm.markers[1].line, 11);
-			xterm._core.writeSync('\n\r3');
+			await writeP(xterm, '\n\r3');
 
 			assert.strictEqual(xterm.buffer.active.baseY, 3);
 			assert.strictEqual(xterm.buffer.active.viewportY, 3);


### PR DESCRIPTION
Fixes #121179

`writeSync` is deprecated in xterm.js as it is now unreliable and can cause bad bugs if used (like https://github.com/microsoft/vscode/issues/120352).