### PR TITLE
Allow extensions to register views which are expanded by default under Explorer, SCM and Debug view containers

### DIFF
--- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
@@ -467,7 +467,7 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 						canToggleVisibility: true,
 						canMoveView: viewContainer?.id !== REMOTE,
 						treeView: type === ViewType.Tree ? this.instantiationService.createInstance(CustomTreeView, item.id, item.name) : undefined,
-						collapsed: this.showCollapsed(container) || initialVisibility === InitialVisibility.Collapsed,
+						collapsed: (initialVisibility === undefined && this.showCollapsed(container)) || initialVisibility === InitialVisibility.Collapsed,
 						order: order,
 						extensionId: extension.description.identifier,
 						originalContainerId: entry.key,

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -66,7 +66,7 @@ viewsRegistry.registerViews([{
 	canToggleVisibility: true,
 	workspace: true,
 	canMoveView: true,
-	weight: 80,
+	weight: 20,
 	order: -999,
 	containerIcon: sourceControlViewIcon,
 	openCommandActionDescriptor: {
@@ -90,7 +90,7 @@ viewsRegistry.registerViews([{
 	hideByDefault: true,
 	workspace: true,
 	canMoveView: true,
-	weight: 20,
+	weight: 5,
 	order: -1000,
 	when: ContextKeyExpr.and(ContextKeyExpr.has('scm.providerCount'), ContextKeyExpr.notEquals('scm.providerCount', 0)),
 	// readonly when = ContextKeyExpr.or(ContextKeyExpr.equals('config.scm.alwaysShowProviders', true), ContextKeyExpr.and(ContextKeyExpr.notEquals('scm.providerCount', 0), ContextKeyExpr.notEquals('scm.providerCount', 1)));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #121189

If the initialVisibility of a view is set by the extension, then all panels will honour that.
If it is not set, the it will fall back to the current functionality where it is disabled for Explorer, SCM and Debug; but enabled for everything else.

It also updated the weights of the existing SCM views so that they are scaled the same as views contributed by extensions.