### PR TITLE
Flatten document/cell custom metadata

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -997,16 +997,21 @@ declare module 'vscode' {
 		 */
 		readonly inputCollapsed?: boolean;
 		/**
+		 * @deprecated
 		 * Additional attributes of a cell metadata.
 		 */
 		readonly custom?: Record<string, any>;
 
 		// todo@API duplicates status bar API
 		readonly statusMessage?: string;
+		/**
+		 * Additional attributes of a cell metadata.
+		 */
+		readonly [key: string]: any;
 
-		constructor(editable?: boolean, breakpointMargin?: boolean, statusMessage?: string, lastRunDuration?: number, inputCollapsed?: boolean, outputCollapsed?: boolean, custom?: Record<string, any>)
+		constructor(editable?: boolean, breakpointMargin?: boolean, statusMessage?: string, lastRunDuration?: number, inputCollapsed?: boolean, outputCollapsed?: boolean, additionalMetadata?: Record<string, any>)
 
-		with(change: { editable?: boolean | null, breakpointMargin?: boolean | null, statusMessage?: string | null, lastRunDuration?: number | null, inputCollapsed?: boolean | null, outputCollapsed?: boolean | null, custom?: Record<string, any> | null, }): NotebookCellMetadata;
+		with(change: { editable?: boolean | null, breakpointMargin?: boolean | null, statusMessage?: string | null, lastRunDuration?: number | null, inputCollapsed?: boolean | null, outputCollapsed?: boolean | null, additionalMetadata?: Record<string, any> | null }): NotebookCellMetadata;
 	}
 
 	export interface NotebookCellExecutionSummary {
@@ -1039,6 +1044,7 @@ declare module 'vscode' {
 		 */
 		readonly cellEditable: boolean;
 		/**
+		 * @deprecated
 		 * Additional attributes of the document metadata.
 		 */
 		readonly custom: { [key: string]: any; };
@@ -1047,10 +1053,14 @@ declare module 'vscode' {
 		 * When false, insecure outputs like HTML, JavaScript, SVG will not be rendered.
 		 */
 		readonly trusted: boolean;
+		/**
+		 * Additional attributes of a cell metadata.
+		 */
+		readonly [key: string]: any;
 
-		constructor(editable?: boolean, cellEditable?: boolean, custom?: { [key: string]: any; }, trusted?: boolean);
+		constructor(editable?: boolean, cellEditable?: boolean, trusted?: boolean, additionalMetadata?: { [key: string]: any; });
 
-		with(change: { editable?: boolean | null, cellEditable?: boolean | null, custom?: { [key: string]: any; } | null, trusted?: boolean | null, }): NotebookDocumentMetadata
+		with(change: { editable?: boolean | null, cellEditable?: boolean | null, trusted?: boolean | null, additionalMetadata?: Record<string, any> | null }): NotebookDocumentMetadata
 	}
 
 	export interface NotebookDocumentContentOptions {

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2941,6 +2941,7 @@ export class NotebookCellRange {
 }
 
 export class NotebookCellMetadata {
+	readonly [key: string]: any;
 
 	constructor(
 		readonly editable?: boolean,
@@ -2949,7 +2950,11 @@ export class NotebookCellMetadata {
 		readonly inputCollapsed?: boolean,
 		readonly outputCollapsed?: boolean,
 		readonly custom?: Record<string, any>,
-	) { }
+	) {
+		if (custom) {
+			Object.assign(this, custom);
+		}
+	}
 
 	with(change: {
 		editable?: boolean | null,
@@ -2957,10 +2962,10 @@ export class NotebookCellMetadata {
 		statusMessage?: string | null,
 		inputCollapsed?: boolean | null,
 		outputCollapsed?: boolean | null,
-		custom?: Record<string, any> | null,
+		additionalMetadata?: Record<string, any> | null,
 	}): NotebookCellMetadata {
 
-		let { editable, breakpointMargin, statusMessage, inputCollapsed, outputCollapsed, custom } = change;
+		let { editable, breakpointMargin, statusMessage, inputCollapsed, outputCollapsed, additionalMetadata } = change;
 
 		if (editable === undefined) {
 			editable = this.editable;
@@ -2987,10 +2992,10 @@ export class NotebookCellMetadata {
 		} else if (outputCollapsed === null) {
 			outputCollapsed = undefined;
 		}
-		if (custom === undefined) {
-			custom = this.custom;
-		} else if (custom === null) {
-			custom = undefined;
+		if (additionalMetadata === undefined) {
+			additionalMetadata = this.custom;
+		} else if (additionalMetadata === null) {
+			additionalMetadata = undefined;
 		}
 
 		if (editable === this.editable &&
@@ -2998,7 +3003,7 @@ export class NotebookCellMetadata {
 			statusMessage === this.statusMessage &&
 			inputCollapsed === this.inputCollapsed &&
 			outputCollapsed === this.outputCollapsed &&
-			custom === this.custom
+			additionalMetadata === this.custom
 		) {
 			return this;
 		}
@@ -3009,28 +3014,33 @@ export class NotebookCellMetadata {
 			statusMessage,
 			inputCollapsed,
 			outputCollapsed,
-			custom,
+			additionalMetadata,
 		);
 	}
 }
 
 export class NotebookDocumentMetadata {
+	readonly [key: string]: any;
 
 	constructor(
 		readonly editable: boolean = true,
 		readonly cellEditable: boolean = true,
-		readonly custom: { [key: string]: any; } = {},
 		readonly trusted: boolean = true,
-	) { }
+		readonly custom: { [key: string]: any; } = {}
+	) {
+		if (custom) {
+			Object.assign(this, custom);
+		}
+	}
 
 	with(change: {
 		editable?: boolean | null,
 		cellEditable?: boolean | null,
-		custom?: { [key: string]: any; } | null,
 		trusted?: boolean | null,
+		additionalMetadata?: { [key: string]: any; } | null,
 	}): NotebookDocumentMetadata {
 
-		let { editable, cellEditable, custom, trusted } = change;
+		let { editable, cellEditable, additionalMetadata, trusted } = change;
 
 		if (editable === undefined) {
 			editable = this.editable;
@@ -3042,10 +3052,10 @@ export class NotebookDocumentMetadata {
 		} else if (cellEditable === null) {
 			cellEditable = undefined;
 		}
-		if (custom === undefined) {
-			custom = this.custom;
-		} else if (custom === null) {
-			custom = undefined;
+		if (additionalMetadata === undefined) {
+			additionalMetadata = this.custom;
+		} else if (additionalMetadata === null) {
+			additionalMetadata = undefined;
 		}
 		if (trusted === undefined) {
 			trusted = this.trusted;
@@ -3055,7 +3065,7 @@ export class NotebookDocumentMetadata {
 
 		if (editable === this.editable &&
 			cellEditable === this.cellEditable &&
-			custom === this.custom &&
+			additionalMetadata === this.custom &&
 			trusted === this.trusted
 		) {
 			return this;
@@ -3065,8 +3075,8 @@ export class NotebookDocumentMetadata {
 		return new NotebookDocumentMetadata(
 			editable,
 			cellEditable,
-			custom,
-			trusted
+			trusted,
+			additionalMetadata
 		);
 	}
 }

--- a/src/vs/workbench/test/browser/api/extHostTypes.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostTypes.test.ts
@@ -667,6 +667,13 @@ suite('ExtHostTypes', function () {
 		assert.strictEqual(newObj.trusted, false);
 	});
 
+	test('NotebookMetadata - additionalMetadata', function () {
+		const obj = new types.NotebookDocumentMetadata();
+		const newObj = obj.with({ additionalMetadata: { displayId: 'first' } });
+		assert.ok(obj !== newObj);
+		assert.strictEqual(newObj.displayId, 'first');
+	});
+
 	test('NotebookCellMetadata - with', function () {
 		const obj = new types.NotebookCellMetadata(true, true);
 
@@ -680,5 +687,12 @@ suite('ExtHostTypes', function () {
 		assert.strictEqual(newObj.editable, true);
 		assert.strictEqual(newObj.custom, undefined);
 
+	});
+
+	test('NotebookCellMetadata - additionalMetadata', function () {
+		const obj = new types.NotebookCellMetadata(true, true);
+		const newObj = obj.with({ additionalMetadata: { displayId: 'first' } });
+		assert.ok(obj !== newObj);
+		assert.strictEqual(newObj.displayId, 'first');
 	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This is an idea we discussed before about dropping `custom` property from `NotebookDocumentMetadata` and `NotebookCellMetadata` and have custom metadata as properties of the metadata object. Transient metadata option `transientMetadata?: { [K in keyof NotebookCellMetadata]?: boolean };` will then allow content providers to handle every individual custom metadata's persistence.

The catch now is `NotebookCellMetadata` is now a class and the way we handle custom/additional metadata in `ctor` or `with` method is weird.
