### PR TITLE
Fix race condition in showing and hiding suggestWidget

### DIFF
--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -490,8 +490,10 @@ export class SuggestWidget implements IDisposable {
 		this._ctxSuggestWidgetVisible.set(true);
 
 		this._showTimeout.cancelAndSet(() => {
-			this.element.domNode.classList.add('visible');
-			this._onDidShow.fire(this);
+			if (this._state !== State.Hidden) {
+				this.element.domNode.classList.add('visible');
+				this._onDidShow.fire(this);
+			}
 		}, 100);
 	}
 

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -440,6 +440,7 @@ export class SuggestWidget implements IDisposable {
 				this._contentWidget.hide();
 				this._ctxSuggestWidgetVisible.reset();
 				this._ctxSuggestWidgetMultipleSuggestions.reset();
+				this._showTimeout.cancel();
 				this.element.domNode.classList.remove('visible');
 				this._list.splice(0, this._list.length);
 				this._focusedItem = undefined;
@@ -490,10 +491,8 @@ export class SuggestWidget implements IDisposable {
 		this._ctxSuggestWidgetVisible.set(true);
 
 		this._showTimeout.cancelAndSet(() => {
-			if (this._state !== State.Hidden) {
-				this.element.domNode.classList.add('visible');
-				this._onDidShow.fire(this);
-			}
+			this.element.domNode.classList.add('visible');
+			this._onDidShow.fire(this);
 		}, 100);
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/monaco-editor/issues/2437

If suggestions are triggered by typing, typing causes the suggest widget be shown and then hidden as the typing initially matches some suggestions but then no suggestions. However, a race condition might happen because [there is a 100ms timeout for showing the widget](https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/suggest/suggestWidget.ts#L493), but [hiding is immediate](https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/suggest/suggestWidget.ts#L443). This change fixes the issue by cancelling the show timeout when hiding the widget.