### PR TITLE
Update aria label to include codicon names and wrap in spaces

### DIFF
--- a/src/vs/base/common/codicons.ts
+++ b/src/vs/base/common/codicons.ts
@@ -49,6 +49,16 @@ export function registerCodicon(id: string, def: Codicon): Codicon {
 	return new Codicon(id, def);
 }
 
+// Selects all codicon names encapsulated in the `$()` syntax and wraps the
+// results with spaces so that screen readers can read the text better.
+export function getCodiconAriaLabel(text: string | undefined) {
+	if (!text) {
+		return '';
+	}
+
+	return text.replace(/\$\((.*?)\)/g, (_match, codiconName) => ` ${codiconName} `).trim();
+}
+
 export class Codicon implements CSSIcon {
 	constructor(public readonly id: string, public readonly definition: Codicon | IconDefinition, public description?: string) {
 		_registry.add(this);

--- a/src/vs/base/parts/quickinput/browser/quickInputList.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInputList.ts
@@ -27,6 +27,7 @@ import { IQuickInputOptions } from 'vs/base/parts/quickinput/browser/quickInput'
 import { IListOptions, List, IListStyles, IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
 import { KeybindingLabel } from 'vs/base/browser/ui/keybindingLabel/keybindingLabel';
 import { localize } from 'vs/nls';
+import { getCodiconAriaLabel } from 'vs/base/common/codicons';
 
 const $ = dom.$;
 
@@ -240,7 +241,6 @@ export enum QuickInputListFocus {
 
 export class QuickInputList {
 
-	private static readonly CODICON_REGEXP = /\$\((.*?)\)/g;
 	readonly id: string;
 	private container: HTMLElement;
 	private list: List<ListElement>;
@@ -428,7 +428,7 @@ export class QuickInputList {
 				const saneDescription = item.description && item.description.replace(/\r?\n/g, ' ');
 				const saneDetail = item.detail && item.detail.replace(/\r?\n/g, ' ');
 				const saneAriaLabel = item.ariaLabel || [saneLabel, saneDescription, saneDetail]
-					.map(s => s && s.replace(QuickInputList.CODICON_REGEXP, (_match, codiconName) => ` ${codiconName} `))
+					.map(s => getCodiconAriaLabel(s))
 					.filter(s => !!s)
 					.join(', ');
 

--- a/src/vs/base/parts/quickinput/browser/quickInputList.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInputList.ts
@@ -240,6 +240,7 @@ export enum QuickInputListFocus {
 
 export class QuickInputList {
 
+	private static readonly CODICON_REGEXP = /\$\((.*?)\)/g;
 	readonly id: string;
 	private container: HTMLElement;
 	private list: List<ListElement>;
@@ -427,7 +428,7 @@ export class QuickInputList {
 				const saneDescription = item.description && item.description.replace(/\r?\n/g, ' ');
 				const saneDetail = item.detail && item.detail.replace(/\r?\n/g, ' ');
 				const saneAriaLabel = item.ariaLabel || [saneLabel, saneDescription, saneDetail]
-					.map(s => s && parseLabelWithIcons(s).text)
+					.map(s => s && s.replace(QuickInputList.CODICON_REGEXP, (_match, codiconName) => ` ${codiconName} `))
 					.filter(s => !!s)
 					.join(', ');
 

--- a/src/vs/base/test/common/codicons.test.ts
+++ b/src/vs/base/test/common/codicons.test.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { getCodiconAriaLabel } from 'vs/base/common/codicons';
+
+suite('Codicon', () => {
+	test('Can get proper aria labels', () => {
+		// note, the spaces in the results are important
+		const testCases = new Map<string, string>([
+			['', ''],
+			['asdf', 'asdf'],
+			['asdf$(squirrel)asdf', 'asdf squirrel asdf'],
+			['asdf $(squirrel) asdf', 'asdf  squirrel  asdf'],
+			['$(rocket)asdf', 'rocket asdf'],
+			['$(rocket) asdf', 'rocket  asdf'],
+			['$(rocket)$(rocket)$(rocket)asdf', 'rocket  rocket  rocket asdf'],
+			['$(rocket) asdf $(rocket)', 'rocket  asdf  rocket'],
+			['$(rocket)asdf$(rocket)', 'rocket asdf rocket'],
+		]);
+
+		for (const [input, expected] of testCases) {
+			assert.strictEqual(getCodiconAriaLabel(input), expected);
+		}
+	});
+});

--- a/src/vs/workbench/api/browser/mainThreadStatusBar.ts
+++ b/src/vs/workbench/api/browser/mainThreadStatusBar.ts
@@ -35,7 +35,7 @@ export class MainThreadStatusBar implements MainThreadStatusBarShape {
 			ariaLabel = accessibilityInformation.label;
 			role = accessibilityInformation.role;
 		} else {
-			ariaLabel = text ? text.replace(MainThreadStatusBar.CODICON_REGEXP, (_match, codiconName) => codiconName) : '';
+			ariaLabel = text ? text.replace(MainThreadStatusBar.CODICON_REGEXP, (_match, codiconName) => ` ${codiconName} `) : '';
 		}
 		const entry: IStatusbarEntry = { text, tooltip, command, color, backgroundColor, ariaLabel, role };
 

--- a/src/vs/workbench/api/browser/mainThreadStatusBar.ts
+++ b/src/vs/workbench/api/browser/mainThreadStatusBar.ts
@@ -10,12 +10,12 @@ import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { dispose } from 'vs/base/common/lifecycle';
 import { Command } from 'vs/editor/common/modes';
 import { IAccessibilityInformation } from 'vs/platform/accessibility/common/accessibility';
+import { getCodiconAriaLabel } from 'vs/base/common/codicons';
 
 @extHostNamedCustomer(MainContext.MainThreadStatusBar)
 export class MainThreadStatusBar implements MainThreadStatusBarShape {
 
 	private readonly entries: Map<number, { accessor: IStatusbarEntryAccessor, alignment: MainThreadStatusBarAlignment, priority: number }> = new Map();
-	private static readonly CODICON_REGEXP = /\$\((.*?)\)/g;
 
 	constructor(
 		_extHostContext: IExtHostContext,
@@ -35,7 +35,7 @@ export class MainThreadStatusBar implements MainThreadStatusBarShape {
 			ariaLabel = accessibilityInformation.label;
 			role = accessibilityInformation.role;
 		} else {
-			ariaLabel = text ? text.replace(MainThreadStatusBar.CODICON_REGEXP, (_match, codiconName) => ` ${codiconName} `) : '';
+			ariaLabel = getCodiconAriaLabel(text);
 		}
 		const entry: IStatusbarEntry = { text, tooltip, command, color, backgroundColor, ariaLabel, role };
 

--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -261,7 +261,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 			command = RemoteStatusIndicator.REMOTE_ACTIONS_COMMAND_ID;
 		}
 
-		const ariaLabel = text.replace(RemoteStatusIndicator.CODICON_REGEXP, (_match, codiconName) => codiconName);
+		const ariaLabel = text.replace(RemoteStatusIndicator.CODICON_REGEXP, (_match, codiconName) => ` ${codiconName} `);
 		const properties: IStatusbarEntry = {
 			backgroundColor: themeColorFromId(STATUS_BAR_HOST_NAME_BACKGROUND),
 			color: themeColorFromId(STATUS_BAR_HOST_NAME_FOREGROUND),

--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -26,6 +26,7 @@ import { once } from 'vs/base/common/functional';
 import { truncate } from 'vs/base/common/strings';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { getVirtualWorkspaceLocation } from 'vs/platform/remote/common/remoteHosts';
+import { getCodiconAriaLabel } from 'vs/base/common/codicons';
 
 export class RemoteStatusIndicator extends Disposable implements IWorkbenchContribution {
 
@@ -34,7 +35,6 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 	private static readonly SHOW_CLOSE_REMOTE_COMMAND_ID = !isWeb; // web does not have a "Close Remote" command
 
 	private static readonly REMOTE_STATUS_LABEL_MAX_LENGTH = 40;
-	private static readonly CODICON_REGEXP = /\$\((.*?)\)/g;
 
 	private remoteStatusEntry: IStatusbarEntryAccessor | undefined;
 
@@ -261,7 +261,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 			command = RemoteStatusIndicator.REMOTE_ACTIONS_COMMAND_ID;
 		}
 
-		const ariaLabel = text.replace(RemoteStatusIndicator.CODICON_REGEXP, (_match, codiconName) => ` ${codiconName} `);
+		const ariaLabel = getCodiconAriaLabel(text);
 		const properties: IStatusbarEntry = {
 			backgroundColor: themeColorFromId(STATUS_BAR_HOST_NAME_BACKGROUND),
 			color: themeColorFromId(STATUS_BAR_HOST_NAME_FOREGROUND),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #120992

This PR does two things:

1. Follows the StatusBar's example by including codicon names in the aria label for QuickInputList
2. Updates all "replaces" to include wrapping them in spaces so that the screen reader can read it better (`squirrel squirrel squirrel` instead of `squirrelsquirrelsquirrel`)

Note, this does mean that there are extra spaces in the aria label, but the screen reader doesn't seem to care.

![image](https://user-images.githubusercontent.com/2644648/115071632-5bb33700-9eab-11eb-81da-c9c586b5e709.png)
