### PR TITLE
Allow text search providers to give messages

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -396,6 +396,15 @@ declare module 'vscode' {
 		 * - If search hits an internal limit which is less than `maxResults`, this should be true.
 		 */
 		limitHit?: boolean;
+
+		/**
+		 * Additional information regarding the state of the completed search.
+		 *
+		 * Supports links in markdown syntax:
+		 * - Click to [run a command](command:workbench.action.OpenQuickPick)
+		 * - Click to [open a website](https://aka.ms)
+		 */
+		message?: string;
 	}
 
 	/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -385,6 +385,14 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * Represents the severiry of a TextSearchComplete message.
+	 */
+	export enum TextSearchCompleteMessageType {
+		Information = 1,
+		Warning = 2,
+	}
+
+	/**
 	 * Information collected when text search is complete.
 	 */
 	export interface TextSearchComplete {
@@ -400,11 +408,11 @@ declare module 'vscode' {
 		/**
 		 * Additional information regarding the state of the completed search.
 		 *
-		 * Supports links in markdown syntax:
+		 * Messages with "Information" tyle support links in markdown syntax:
 		 * - Click to [run a command](command:workbench.action.OpenQuickPick)
 		 * - Click to [open a website](https://aka.ms)
 		 */
-		message?: string;
+		message?: { text: string, type: TextSearchCompleteMessageType } | { text: string, type: TextSearchCompleteMessageType }[];
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/mainThreadSearch.ts
+++ b/src/vs/workbench/api/browser/mainThreadSearch.ts
@@ -138,7 +138,7 @@ class RemoteSearchProvider implements ISearchResultProvider, IDisposable {
 
 		return Promise.resolve(searchP).then((result: ISearchCompleteStats) => {
 			this._searches.delete(search.id);
-			return { results: Array.from(search.matches.values()), stats: result.stats, limitHit: result.limitHit };
+			return { results: Array.from(search.matches.values()), stats: result.stats, limitHit: result.limitHit, messages: result.messages };
 		}, err => {
 			this._searches.delete(search.id);
 			return Promise.reject(err);

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -86,6 +86,7 @@ import { ExtHostEditorTabs } from 'vs/workbench/api/common/extHostEditorTabs';
 import { IExtHostTelemetry } from 'vs/workbench/api/common/extHostTelemetry';
 import { ExtHostNotebookKernels } from 'vs/workbench/api/common/extHostNotebookKernels';
 import { RemoteTrustOption } from 'vs/platform/remote/common/remoteAuthorityResolver';
+import { TextSearchCompleteMessageType } from 'vs/workbench/services/search/common/searchExtTypes';
 
 export interface IExtensionApiFactory {
 	(extension: IExtensionDescription, registry: ExtensionDescriptionRegistry, configProvider: ExtHostConfigProvider): typeof vscode;
@@ -1262,6 +1263,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			TestItem: extHostTypes.TestItem,
 			TestResultState: extHostTypes.TestResultState,
 			TestMessage: extHostTypes.TestMessage,
+			TextSearchCompleteMessageType: TextSearchCompleteMessageType,
 			TestMessageSeverity: extHostTypes.TestMessageSeverity,
 			WorkspaceTrustState: extHostTypes.WorkspaceTrustState
 		};

--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -156,6 +156,11 @@
 	padding: 0 22px 8px;
 }
 
+.search-view .messages .message .providerMessage {
+	display: inline-block;
+	margin-left: 4px;
+}
+
 .search-view .message p:first-child {
 	margin-top: 0px;
 	margin-bottom: 0px;

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -150,7 +150,6 @@ export class SearchView extends ViewPane {
 	private pauseSearching = false;
 
 	private treeAccessibilityProvider: SearchAccessibilityProvider;
-	messages: any;
 
 	constructor(
 		options: IViewPaneOptions,
@@ -1418,7 +1417,6 @@ export class SearchView extends ViewPane {
 		});
 
 		this.searchWidget.searchInput.clearMessage();
-		this.messages = [];
 		this.state = SearchUIState.Searching;
 		this.showEmptyStage();
 
@@ -1457,12 +1455,11 @@ export class SearchView extends ViewPane {
 					type: MessageType.WARNING
 				});
 			}
-			console.log({ completed });
+
 			if (completed && completed.messages) {
 				for (const message of completed.messages) {
 					this.addMessage(message);
 				}
-
 			}
 
 			if (!hasResults) {

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1649,16 +1649,18 @@ export class SearchView extends ViewPane {
 			return;
 		}
 
+		const span = dom.append(messageBox, $('span.providerMessage'));
+
 		if (messageBox.innerText) {
-			dom.append(messageBox, document.createTextNode(' - '));
+			dom.append(span, document.createTextNode(' - '));
 		}
 
 		for (const node of linkedText.nodes) {
 			if (typeof node === 'string') {
-				dom.append(messageBox, document.createTextNode(node));
+				dom.append(span, document.createTextNode(node));
 			} else {
 				const link = this.instantiationService.createInstance(Link, node);
-				dom.append(messageBox, link.el);
+				dom.append(span, link.el);
 				this.messageDisposables.add(link);
 				this.messageDisposables.add(attachLinkStyler(link, this.themeService));
 			}

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -1142,7 +1142,7 @@ export class SearchModel extends Disposable {
 		if (errors.isPromiseCanceledError(e)) {
 			this.onSearchCompleted(
 				this.searchCancelledForNewSearch
-					? { exit: SearchCompletionExitCode.NewSearchStarted, results: [] }
+					? { exit: SearchCompletionExitCode.NewSearchStarted, results: [], messages: [] }
 					: null,
 				duration);
 			this.searchCancelledForNewSearch = false;

--- a/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
@@ -202,7 +202,7 @@ suite('SearchModel', () => {
 
 		instantiationService.stub(ISearchService, searchServiceWithResults(
 			[aRawMatch('file://c:/1', new TextSearchMatch('some preview', lineOneRange))],
-			{ results: [], stats: testSearchStats }));
+			{ results: [], stats: testSearchStats, messages: [] }));
 
 		const testObject = instantiationService.createInstance(SearchModel);
 		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
@@ -9,7 +9,7 @@ import { alert } from 'vs/base/browser/ui/aria/aria';
 import { Delayer } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
-import { dispose, IDisposable } from 'vs/base/common/lifecycle';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { assertIsDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import 'vs/css!./media/searchEditor';
@@ -33,7 +33,7 @@ import { IEditorProgressService, LongRunningOperation } from 'vs/platform/progre
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { inputBorder, registerColor, searchEditorFindMatch, searchEditorFindMatchBorder } from 'vs/platform/theme/common/colorRegistry';
-import { attachInputBoxStyler } from 'vs/platform/theme/common/styler';
+import { attachInputBoxStyler, attachLinkStyler } from 'vs/platform/theme/common/styler';
 import { IThemeService, registerThemingParticipant, ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { BaseTextEditor } from 'vs/workbench/browser/parts/editor/textEditor';
@@ -52,6 +52,8 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { IPatternInfo, ISearchConfigurationProperties, ITextQuery, SearchSortOrder } from 'vs/workbench/services/search/common/search';
 import { searchDetailsIcon } from 'vs/workbench/contrib/search/browser/searchIcons';
 import { IFileService } from 'vs/platform/files/common/files';
+import { parseLinkedText } from 'vs/base/common/linkedText';
+import { Link } from 'vs/platform/opener/browser/link';
 
 const RESULT_LINE_REGEX = /^(\s+)(\d+)(:| )(\s+)(.*)$/;
 const FILE_LINE_REGEX = /^(\S.*):$/;
@@ -80,7 +82,7 @@ export class SearchEditor extends BaseTextEditor {
 	private inputFocusContextKey: IContextKey<boolean>;
 	private searchOperation: LongRunningOperation;
 	private searchHistoryDelayer: Delayer<void>;
-	private messageDisposables: IDisposable[] = [];
+	private messageDisposables: DisposableStore;
 	private container: HTMLElement;
 	private searchModel: SearchModel;
 	private ongoingOperations: number = 0;
@@ -114,6 +116,8 @@ export class SearchEditor extends BaseTextEditor {
 		this.inSearchEditorContextKey.set(true);
 		this.inputFocusContextKey = InputBoxFocusedKey.bindTo(scopedContextKeyService);
 		this.searchOperation = this._register(new LongRunningOperation(progressService));
+		this._register(this.messageDisposables = new DisposableStore());
+
 		this.searchHistoryDelayer = new Delayer<void>(2000);
 
 		this.searchModel = this._register(this.instantiationService.createInstance(SearchModel));
@@ -193,15 +197,13 @@ export class SearchEditor extends BaseTextEditor {
 
 	private toggleRunAgainMessage(show: boolean) {
 		DOM.clearNode(this.messageBox);
-		dispose(this.messageDisposables);
-		this.messageDisposables = [];
+		this.messageDisposables.clear();
 
 		if (show) {
 			const runAgainLink = DOM.append(this.messageBox, DOM.$('a.pointer.prominent.message', {}, localize('runSearch', "Run Search")));
-			this.messageDisposables.push(DOM.addDisposableListener(runAgainLink, DOM.EventType.CLICK, async () => {
+			this.messageDisposables.add(DOM.addDisposableListener(runAgainLink, DOM.EventType.CLICK, async () => {
 				await this.triggerSearch();
 				this.searchResultEditor.focus();
-				this.toggleRunAgainMessage(false);
 			}));
 		}
 	}
@@ -427,8 +429,8 @@ export class SearchEditor extends BaseTextEditor {
 
 		if (!this.pauseSearching) {
 			await this.runSearchDelayer.trigger(async () => {
-				await this.doRunSearch();
 				this.toggleRunAgainMessage(false);
+				await this.doRunSearch();
 				if (options.resetCursor) {
 					this.searchResultEditor.setPosition(new Position(1, 1));
 					this.searchResultEditor.setScrollPosition({ scrollTop: 0, scrollLeft: 0 });
@@ -533,10 +535,41 @@ export class SearchEditor extends BaseTextEditor {
 		const results = serializeSearchResultForEditor(this.searchModel.searchResult, config.filesToInclude, config.filesToExclude, config.contextLines, labelFormatter, sortOrder, exit?.limitHit);
 		const { body } = await input.getModels();
 		this.modelService.updateModel(body, results.text);
+		if (exit.messages) {
+			for (const message of exit.messages) {
+				this.addMessage(message);
+			}
+		}
 		input.config = config;
 
 		input.setDirty(!input.isUntitled());
 		input.setMatchRanges(results.matchRanges);
+	}
+
+	private addMessage(message: string) {
+		const linkedText = parseLinkedText(message);
+
+		let messageBox: HTMLElement;
+		if (this.messageBox.firstChild) {
+			messageBox = this.messageBox.firstChild as HTMLElement;
+		} else {
+			messageBox = DOM.append(this.messageBox, DOM.$('.message'));
+		}
+
+		if (messageBox.innerText) {
+			DOM.append(messageBox, document.createTextNode(' - '));
+		}
+
+		for (const node of linkedText.nodes) {
+			if (typeof node === 'string') {
+				DOM.append(messageBox, document.createTextNode(node));
+			} else {
+				const link = this.instantiationService.createInstance(Link, node);
+				DOM.append(messageBox, link.el);
+				this.messageDisposables.add(link);
+				this.messageDisposables.add(attachLinkStyler(link, this.themeService));
+			}
+		}
 	}
 
 	private async retrieveFileStats(searchResult: SearchResult): Promise<void> {

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -205,6 +205,7 @@ export function isProgressMessage(p: ISearchProgressItem | ISerializedSearchProg
 
 export interface ISearchCompleteStats {
 	limitHit?: boolean;
+	messages: string[];
 	stats?: IFileSearchStats | ITextSearchStats;
 }
 
@@ -504,11 +505,13 @@ export interface ISearchEngine<T> {
 export interface ISerializedSearchSuccess {
 	type: 'success';
 	limitHit: boolean;
+	messages: string[];
 	stats?: IFileSearchStats | ITextSearchStats;
 }
 
 export interface ISearchEngineSuccess {
 	limitHit: boolean;
+	messages: string[];
 	stats: ISearchEngineStats;
 }
 

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -17,6 +17,9 @@ import { ITelemetryData } from 'vs/platform/telemetry/common/telemetry';
 import { Event } from 'vs/base/common/event';
 import * as paths from 'vs/base/common/path';
 import { isPromiseCanceledError } from 'vs/base/common/errors';
+import { TextSearchCompleteMessageType } from 'vs/workbench/services/search/common/searchExtTypes';
+
+export { TextSearchCompleteMessageType };
 
 export const VIEWLET_ID = 'workbench.view.search';
 export const PANEL_ID = 'workbench.panel.search';
@@ -205,7 +208,7 @@ export function isProgressMessage(p: ISearchProgressItem | ISerializedSearchProg
 
 export interface ISearchCompleteStats {
 	limitHit?: boolean;
-	messages: string[];
+	messages: { text: string, type: TextSearchCompleteMessageType }[];
 	stats?: IFileSearchStats | ITextSearchStats;
 }
 
@@ -505,13 +508,13 @@ export interface ISearchEngine<T> {
 export interface ISerializedSearchSuccess {
 	type: 'success';
 	limitHit: boolean;
-	messages: string[];
+	messages: { text: string, type: TextSearchCompleteMessageType }[];
 	stats?: IFileSearchStats | ITextSearchStats;
 }
 
 export interface ISearchEngineSuccess {
 	limitHit: boolean;
-	messages: string[];
+	messages: { text: string, type: TextSearchCompleteMessageType }[];
 	stats: ISearchEngineStats;
 }
 

--- a/src/vs/workbench/services/search/common/searchExtTypes.ts
+++ b/src/vs/workbench/services/search/common/searchExtTypes.ts
@@ -217,6 +217,14 @@ export interface TextSearchOptions extends SearchOptions {
 }
 
 /**
+ * Represents the severiry of a TextSearchComplete message.
+ */
+export enum TextSearchCompleteMessageType {
+	Information = 1,
+	Warning = 2,
+}
+
+/**
  * Information collected when text search is complete.
  */
 export interface TextSearchComplete {
@@ -236,7 +244,7 @@ export interface TextSearchComplete {
 	 * - Click to [run a command](command:workbench.action.OpenQuickPick)
 	 * - Click to [open a website](https://aka.ms)
 	 */
-	message?: string;
+	message?: { text: string, type: TextSearchCompleteMessageType } | { text: string, type: TextSearchCompleteMessageType }[];
 }
 
 /**

--- a/src/vs/workbench/services/search/common/searchExtTypes.ts
+++ b/src/vs/workbench/services/search/common/searchExtTypes.ts
@@ -228,6 +228,15 @@ export interface TextSearchComplete {
 	 * - If search hits an internal limit which is less than `maxResults`, this should be true.
 	 */
 	limitHit?: boolean;
+
+	/**
+	 * Additional information regarding the state of the completed search.
+	 *
+	 * Supports links in markdown syntax:
+	 * - Click to [run a command](command:workbench.action.OpenQuickPick)
+	 * - Click to [open a website](https://aka.ms)
+	 */
+	message?: string;
 }
 
 /**

--- a/src/vs/workbench/services/search/common/searchService.ts
+++ b/src/vs/workbench/services/search/common/searchService.ts
@@ -153,7 +153,7 @@ export class SearchService extends Disposable implements ISearchService {
 			return {
 				limitHit: completes[0] && completes[0].limitHit,
 				stats: completes[0].stats,
-				messages: arrays.coalesce(arrays.flatten(completes.map(i => i.messages))),
+				messages: arrays.coalesce(arrays.flatten(completes.map(i => i.messages))).filter(arrays.uniqueFilter(message => message)),
 				results: arrays.flatten(completes.map((c: ISearchComplete) => c.results))
 			};
 		})();

--- a/src/vs/workbench/services/search/common/searchService.ts
+++ b/src/vs/workbench/services/search/common/searchService.ts
@@ -145,13 +145,15 @@ export class SearchService extends Disposable implements ISearchService {
 			if (!completes.length) {
 				return {
 					limitHit: false,
-					results: []
+					results: [],
+					messages: [],
 				};
 			}
 
-			return <ISearchComplete>{
+			return {
 				limitHit: completes[0] && completes[0].limitHit,
 				stats: completes[0].stats,
+				messages: arrays.coalesce(arrays.flatten(completes.map(i => i.messages))),
 				results: arrays.flatten(completes.map((c: ISearchComplete) => c.results))
 			};
 		})();

--- a/src/vs/workbench/services/search/common/searchService.ts
+++ b/src/vs/workbench/services/search/common/searchService.ts
@@ -153,7 +153,7 @@ export class SearchService extends Disposable implements ISearchService {
 			return {
 				limitHit: completes[0] && completes[0].limitHit,
 				stats: completes[0].stats,
-				messages: arrays.coalesce(arrays.flatten(completes.map(i => i.messages))).filter(arrays.uniqueFilter(message => message)),
+				messages: arrays.coalesce(arrays.flatten(completes.map(i => i.messages))).filter(arrays.uniqueFilter(message => message.type + message.text)),
 				results: arrays.flatten(completes.map((c: ISearchComplete) => c.results))
 			};
 		})();

--- a/src/vs/workbench/services/search/common/textSearchManager.ts
+++ b/src/vs/workbench/services/search/common/textSearchManager.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'vs/base/common/path';
-import { mapArrayOrNot } from 'vs/base/common/arrays';
+import { coalesce, mapArrayOrNot } from 'vs/base/common/arrays';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
 import * as resources from 'vs/base/common/resources';
@@ -70,6 +70,7 @@ export class TextSearchManager {
 				const someFolderHitLImit = results.some(result => !!result && !!result.limitHit);
 				resolve({
 					limitHit: this.isLimitHit || someFolderHitLImit,
+					messages: coalesce(results.map(result => result?.message)),
 					stats: {
 						type: 'textSearchProvider'
 					}

--- a/src/vs/workbench/services/search/common/textSearchManager.ts
+++ b/src/vs/workbench/services/search/common/textSearchManager.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'vs/base/common/path';
-import { coalesce, mapArrayOrNot } from 'vs/base/common/arrays';
+import { flatten, mapArrayOrNot } from 'vs/base/common/arrays';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
 import * as resources from 'vs/base/common/resources';
@@ -13,6 +13,7 @@ import { URI } from 'vs/base/common/uri';
 import { IExtendedExtensionSearchOptions, IFileMatch, IFolderQuery, IPatternInfo, ISearchCompleteStats, ITextQuery, ITextSearchContext, ITextSearchMatch, ITextSearchResult, QueryGlobTester, resolvePatternsForProvider } from 'vs/workbench/services/search/common/search';
 import { TextSearchProvider, TextSearchResult, TextSearchMatch, TextSearchComplete, Range, TextSearchOptions, TextSearchQuery } from 'vs/workbench/services/search/common/searchExtTypes';
 import { Schemas } from 'vs/base/common/network';
+import { isArray } from 'vs/base/common/types';
 
 export interface IFileUtils {
 	readdir: (resource: URI) => Promise<string[]>;
@@ -70,7 +71,11 @@ export class TextSearchManager {
 				const someFolderHitLImit = results.some(result => !!result && !!result.limitHit);
 				resolve({
 					limitHit: this.isLimitHit || someFolderHitLImit,
-					messages: coalesce(results.map(result => result?.message)),
+					messages: flatten(results.map(result => {
+						if (!result?.message) { return []; }
+						if (isArray(result.message)) { return result.message; }
+						else { return [result.message]; }
+					})),
 					stats: {
 						type: 'textSearchProvider'
 					}

--- a/src/vs/workbench/services/search/electron-browser/searchService.ts
+++ b/src/vs/workbench/services/search/electron-browser/searchService.ts
@@ -138,7 +138,8 @@ export class DiskSearch implements ISearchResultProvider {
 						c({
 							limitHit: ev.limitHit,
 							results: result,
-							stats: ev.stats
+							stats: ev.stats,
+							messages: ev.messages,
 						});
 					} else {
 						e(ev.error);

--- a/src/vs/workbench/services/search/node/fileSearch.ts
+++ b/src/vs/workbench/services/search/node/fileSearch.ts
@@ -640,7 +640,8 @@ export class Engine implements ISearchEngine<IRawFileMatch> {
 		this.walker.walk(this.folderQueries, this.extraFiles, onResult, onProgress, (err: Error | null, isLimitHit: boolean) => {
 			done(err, {
 				limitHit: isLimitHit,
-				stats: this.walker.getStats()
+				stats: this.walker.getStats(),
+				messages: [],
 			});
 		});
 	}

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -195,6 +195,7 @@ export class SearchService implements IRawSearchService {
 							workspaceFolderCount: config.folderQueries.length,
 							resultCount: sortedResults.length
 						},
+						messages: result.messages,
 						limitHit: result.limitHit || typeof config.maxResults === 'number' && results.length > config.maxResults
 					} as ISerializedSearchSuccess, sortedResults];
 				});

--- a/src/vs/workbench/services/search/test/electron-browser/rawSearchService.test.ts
+++ b/src/vs/workbench/services/search/test/electron-browser/rawSearchService.test.ts
@@ -47,7 +47,8 @@ class TestSearchEngine implements ISearchEngine<IRawFileMatch> {
 				if (self.isCanceled) {
 					done(null!, {
 						limitHit: false,
-						stats: stats
+						stats: stats,
+						messages: [],
 					});
 					return;
 				}
@@ -55,7 +56,8 @@ class TestSearchEngine implements ISearchEngine<IRawFileMatch> {
 				if (!result) {
 					done(null!, {
 						limitHit: false,
-						stats: stats
+						stats: stats,
+						messages: [],
 					});
 				} else {
 					onResult(result);

--- a/src/vs/workbench/test/electron-browser/api/mainThreadWorkspace.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/mainThreadWorkspace.test.ts
@@ -34,7 +34,7 @@ suite('MainThreadWorkspace', () => {
 				assert.deepEqual(query.includePattern, { 'foo': true });
 				assert.strictEqual(query.maxResults, 10);
 
-				return Promise.resolve({ results: [] });
+				return Promise.resolve({ results: [], messages: [] });
 			}
 		});
 
@@ -56,7 +56,7 @@ suite('MainThreadWorkspace', () => {
 				assert.strictEqual(query.folderQueries[0].disregardIgnoreFiles, true);
 				assert.deepStrictEqual(query.folderQueries[0].excludePattern, { 'filesExclude': true });
 
-				return Promise.resolve({ results: [] });
+				return Promise.resolve({ results: [], messages: [] });
 			}
 		});
 
@@ -77,7 +77,7 @@ suite('MainThreadWorkspace', () => {
 				assert.strictEqual(query.folderQueries[0].excludePattern, undefined);
 				assert.deepStrictEqual(query.excludePattern, undefined);
 
-				return Promise.resolve({ results: [] });
+				return Promise.resolve({ results: [], messages: [] });
 			}
 		});
 
@@ -91,7 +91,7 @@ suite('MainThreadWorkspace', () => {
 				assert.strictEqual(query.folderQueries[0].excludePattern, undefined);
 				assert.deepEqual(query.excludePattern, { 'exclude/**': true });
 
-				return Promise.resolve({ results: [] });
+				return Promise.resolve({ results: [], messages: [] });
 			}
 		});
 


### PR DESCRIPTION
Allow a text search provider to give a message with additional information regarding a completed search:

![image](https://user-images.githubusercontent.com/8586769/115099274-c7b49000-9ee9-11eb-990d-af0ee5882804.png)
![image](https://user-images.githubusercontent.com/8586769/115116591-28c27f00-9f4f-11eb-9a34-c44b465ba72a.png)
