### PR TITLE
fix: use addListener instead of addEventListener to to observe media query lists

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1600,3 +1600,13 @@ export function getCookieValue(name: string): string | undefined {
 
 	return match ? match.pop() : undefined;
 }
+
+export function addMatchMediaChangeListener(query: string, callback: () => void): void {
+	const mediaQueryList = window.matchMedia(query);
+	if (typeof mediaQueryList.addEventListener === 'function') {
+		mediaQueryList.addEventListener('change', callback);
+	} else {
+		// Safari 13.x
+		mediaQueryList.addListener(callback);
+	}
+}

--- a/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
@@ -233,15 +233,9 @@ export class StandaloneThemeServiceImpl extends Disposable implements IStandalon
 			this._updateCSS();
 		});
 
-		const matchForcedColors = window.matchMedia('(forced-colors: active)');
-		const matchForcedColorsListener = () => {
+		dom.addMatchMediaChangeListener('(forced-colors: active)', () => {
 			this._updateActualTheme();
-		};
-		if (typeof matchForcedColors.addEventListener === 'function') {
-			matchForcedColors.addEventListener('change', matchForcedColorsListener);
-		} else {
-			matchForcedColors.addListener(matchForcedColorsListener);
-		}
+		});
 	}
 
 	public registerEditorContainer(domNode: HTMLElement): IDisposable {

--- a/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
@@ -233,9 +233,15 @@ export class StandaloneThemeServiceImpl extends Disposable implements IStandalon
 			this._updateCSS();
 		});
 
-		window.matchMedia('(forced-colors: active)').addEventListener('change', () => {
+		const matchForcedColors = window.matchMedia('(forced-colors: active)');
+		const matchForcedColorsListener = () => {
 			this._updateActualTheme();
-		});
+		};
+		if (typeof matchForcedColors.addEventListener === 'function') {
+			matchForcedColors.addEventListener('change', matchForcedColorsListener);
+		} else {
+			matchForcedColors.addListener(matchForcedColorsListener);
+		}
 	}
 
 	public registerEditorContainer(domNode: HTMLElement): IDisposable {

--- a/src/vs/workbench/services/themes/browser/browserHostColorSchemeService.ts
+++ b/src/vs/workbench/services/themes/browser/browserHostColorSchemeService.ts
@@ -25,12 +25,18 @@ export class BrowserHostColorSchemeService extends Disposable implements IHostCo
 
 	private registerListeners(): void {
 
-		window.matchMedia('(prefers-color-scheme: dark)').addListener(() => {
+		const matchPrefersColorSchemeDark = window.matchMedia('(prefers-color-scheme: dark)');
+		const matchForcedColors = window.matchMedia('(forced-colors: active)');
+		const listener = () => {
 			this._onDidSchemeChangeEvent.fire();
-		});
-		window.matchMedia('(forced-colors: active)').addListener(() => {
-			this._onDidSchemeChangeEvent.fire();
-		});
+		};
+		if (typeof matchForcedColors.addEventListener === 'function') {
+			matchPrefersColorSchemeDark.addEventListener('change', listener);
+			matchForcedColors.addEventListener('change', listener);
+		} else {
+			matchPrefersColorSchemeDark.addListener(listener);
+			matchForcedColors.addListener(listener);
+		}
 	}
 
 	get onDidChangeColorScheme(): Event<void> {

--- a/src/vs/workbench/services/themes/browser/browserHostColorSchemeService.ts
+++ b/src/vs/workbench/services/themes/browser/browserHostColorSchemeService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from 'vs/base/common/event';
+import * as dom from 'vs/base/browser/dom';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
@@ -25,18 +26,12 @@ export class BrowserHostColorSchemeService extends Disposable implements IHostCo
 
 	private registerListeners(): void {
 
-		const matchPrefersColorSchemeDark = window.matchMedia('(prefers-color-scheme: dark)');
-		const matchForcedColors = window.matchMedia('(forced-colors: active)');
-		const listener = () => {
+		dom.addMatchMediaChangeListener('(prefers-color-scheme: dark)', () => {
 			this._onDidSchemeChangeEvent.fire();
-		};
-		if (typeof matchForcedColors.addEventListener === 'function') {
-			matchPrefersColorSchemeDark.addEventListener('change', listener);
-			matchForcedColors.addEventListener('change', listener);
-		} else {
-			matchPrefersColorSchemeDark.addListener(listener);
-			matchForcedColors.addListener(listener);
-		}
+		});
+		dom.addMatchMediaChangeListener('(forced-colors: active)', () => {
+			this._onDidSchemeChangeEvent.fire();
+		});
 	}
 
 	get onDidChangeColorScheme(): Event<void> {


### PR DESCRIPTION
Prior Safari 14, MediaQueryList does not have method addEventListener,
use addListener for backward compatibility, which is supported by all browsers.

This PR fixes https://github.com/microsoft/monaco-editor/issues/2432