### PR TITLE
vscode.git - jschardet 2.2.1 -> 2.3.0

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -2369,7 +2369,7 @@
     "byline": "^5.0.0",
     "file-type": "^7.2.0",
     "iconv-lite-umd": "0.6.8",
-    "jschardet": "2.2.1",
+    "jschardet": "2.3.0",
     "vscode-extension-telemetry": "0.1.7",
     "vscode-nls": "^4.0.0",
     "vscode-uri": "^2.0.0",

--- a/extensions/git/yarn.lock
+++ b/extensions/git/yarn.lock
@@ -117,10 +117,10 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-jschardet@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-2.2.1.tgz#03b0264669a90c7a5c436a68c5a7d4e4cb0c9823"
-  integrity sha512-Ks2JNuUJoc7PGaZ7bVFtSEvOcr0rBq6Q1J5/7+zKWLT+g+4zziL63O0jg7y2jxhzIa1LVsHUbPXrbaWmz9iwDw==
+jschardet@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-2.3.0.tgz#06e2636e16c8ada36feebbdc08aa34e6a9b3ff75"
+  integrity sha512-6I6xT7XN/7sBB7q8ObzKbmv5vN+blzLcboDE1BNEsEfmRXJValMxO6OIRT69ylPBRemS3rw6US+CMCar0OBc9g==
 
 semver@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
Upgrade jschardet to 2.3.0 as that is the version used across the product.