### PR TITLE
Resolves: Add security and versioning dependency alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # default location of `.github/workflows`
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    # location of package manifests
+    directory: "/"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: "daily"
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   - package-ecosystem: "npm"
     # location of package manifests
     directory: "/"
-    open-pull-requests-limit: 100
+    open-pull-requests-limit: 10
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
- add `dependabot.yml` which automatically enables Dependabot's dependency versioning scanner and dependency update PRs bot by declaring dependency ecosystems and sources in the project. For dependency security vulnerabilities scanner and vulnerable dependency update PRs bot, [enable "Dependabot alerts" and "Dependabot security updates"](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates)

Resolves #121633 
