### PR TITLE
trust: serve trust from ext host if already trusted

### DIFF
--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -563,6 +563,10 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 	}
 
 	requestWorkspaceTrust(options?: vscode.WorkspaceTrustRequestOptions): Promise<boolean> {
+		if (this._trusted) {
+			return Promise.resolve(true);
+		}
+
 		return this._proxy.$requestWorkspaceTrust(options);
 	}
 


### PR DESCRIPTION
Small optimization to make. As an ext author my default behavior would
be to guard all my entry codepaths with a trust demand, which might
result in some warm paths. If the workspace is already trusted,
I don't think you need to round trip to the main thread.