### PR TITLE
Workspace trust - multi-root workspace file

### DIFF
--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -202,8 +202,7 @@ class BrowserMain extends Disposable {
 		]);
 
 		// Workspace Trust Service
-		// TODO @lszomoru: Following two services shall be merged into single service
-		const workspaceTrustManagementService = new WorkspaceTrustManagementService(configurationService, storageService, uriIdentityService, configurationService);
+		const workspaceTrustManagementService = new WorkspaceTrustManagementService(configurationService, environmentService, storageService, uriIdentityService, configurationService);
 		serviceCollection.set(IWorkspaceTrustManagementService, workspaceTrustManagementService);
 		configurationService.updateWorkspaceTrust(workspaceTrustManagementService.isWorkpaceTrusted());
 		this._register(workspaceTrustManagementService.onDidChangeTrust(() => configurationService.updateWorkspaceTrust(workspaceTrustManagementService.isWorkpaceTrusted())));

--- a/src/vs/workbench/electron-sandbox/shared.desktop.main.ts
+++ b/src/vs/workbench/electron-sandbox/shared.desktop.main.ts
@@ -263,7 +263,7 @@ export abstract class SharedDesktopMain extends Disposable {
 		]);
 
 		// Workspace Trust Service
-		const workspaceTrustManagementService = new WorkspaceTrustManagementService(configurationService, storageService, uriIdentityService, configurationService);
+		const workspaceTrustManagementService = new WorkspaceTrustManagementService(configurationService, environmentService, storageService, uriIdentityService, configurationService);
 		serviceCollection.set(IWorkspaceTrustManagementService, workspaceTrustManagementService);
 		configurationService.updateWorkspaceTrust(workspaceTrustManagementService.isWorkpaceTrusted());
 		this._register(workspaceTrustManagementService.onDidChangeTrust(() => configurationService.updateWorkspaceTrust(workspaceTrustManagementService.isWorkpaceTrusted())));

--- a/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
@@ -362,7 +362,7 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 		return this.jsonEditingService.write(toWorkspace.configPath, [{ path: ['settings'], value: targetWorkspaceConfiguration }], true);
 	}
 
-	private trustWorkspaceConfiguration(configPathURI: URI): void {
+	protected trustWorkspaceConfiguration(configPathURI: URI): void {
 		if (this.contextService.getWorkbenchState() !== WorkbenchState.EMPTY && this.workspaceTrustManagementService.isWorkpaceTrusted()) {
 			this.workspaceTrustManagementService.setFoldersTrust([dirname(configPathURI)], true);
 		}

--- a/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
@@ -206,9 +206,6 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 		if (path) {
 			try {
 				await this.saveWorkspaceAs(untitledWorkspace, path);
-
-				// Set trust for the workspace file
-				this.trustWorkspaceConfiguration(path);
 			} finally {
 				await this.workspacesService.deleteUntitledWorkspace(untitledWorkspace); // https://github.com/microsoft/vscode/issues/100276
 			}
@@ -238,9 +235,6 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 
 		await this.saveWorkspaceAs(workspaceIdentifier, path);
 
-		// Set trust for the workspace file
-		this.trustWorkspaceConfiguration(path);
-
 		return this.enterWorkspace(path);
 	}
 
@@ -262,6 +256,9 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 		const raw = await this.fileService.readFile(configPathURI);
 		const newRawWorkspaceContents = rewriteWorkspaceFileForNewLocation(raw.value.toString(), configPathURI, isFromUntitledWorkspace, targetConfigPathURI, this.uriIdentityService.extUri);
 		await this.textFileService.create([{ resource: targetConfigPathURI, value: newRawWorkspaceContents, options: { overwrite: true } }]);
+
+		// Set trust for the workspace file
+		this.trustWorkspaceConfiguration(targetConfigPathURI);
 	}
 
 	protected async saveWorkspace(workspace: IWorkspaceIdentifier): Promise<void> {
@@ -362,7 +359,7 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 		return this.jsonEditingService.write(toWorkspace.configPath, [{ path: ['settings'], value: targetWorkspaceConfiguration }], true);
 	}
 
-	protected trustWorkspaceConfiguration(configPathURI: URI): void {
+	private trustWorkspaceConfiguration(configPathURI: URI): void {
 		if (this.contextService.getWorkbenchState() !== WorkbenchState.EMPTY && this.workspaceTrustManagementService.isWorkpaceTrusted()) {
 			this.workspaceTrustManagementService.setFoldersTrust([dirname(configPathURI)], true);
 		}

--- a/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
@@ -14,7 +14,7 @@ import { ConfigurationScope, IConfigurationRegistry, Extensions as Configuration
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { distinct } from 'vs/base/common/arrays';
-import { isEqual, isEqualAuthority } from 'vs/base/common/resources';
+import { dirname, isEqual, isEqualAuthority } from 'vs/base/common/resources';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { IFileService } from 'vs/platform/files/common/files';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
@@ -26,6 +26,7 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { Schemas } from 'vs/base/common/network';
 import { SaveReason } from 'vs/workbench/common/editor';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
+import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 
 const UNTITLED_WORKSPACE_FILENAME = `workspace.${WORKSPACE_EXTENSION}`;
 
@@ -46,7 +47,8 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IDialogService protected readonly dialogService: IDialogService,
 		@IHostService protected readonly hostService: IHostService,
-		@IUriIdentityService protected readonly uriIdentityService: IUriIdentityService
+		@IUriIdentityService protected readonly uriIdentityService: IUriIdentityService,
+		@IWorkspaceTrustManagementService private readonly workspaceTrustManagementService: IWorkspaceTrustManagementService
 	) { }
 
 	async pickNewWorkspacePath(): Promise<URI | undefined> {
@@ -204,6 +206,9 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 		if (path) {
 			try {
 				await this.saveWorkspaceAs(untitledWorkspace, path);
+
+				// Set trust for the workspace file
+				this.trustWorkspaceConfiguration(path);
 			} finally {
 				await this.workspacesService.deleteUntitledWorkspace(untitledWorkspace); // https://github.com/microsoft/vscode/issues/100276
 			}
@@ -232,6 +237,9 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 		}
 
 		await this.saveWorkspaceAs(workspaceIdentifier, path);
+
+		// Set trust for the workspace file
+		this.trustWorkspaceConfiguration(path);
 
 		return this.enterWorkspace(path);
 	}
@@ -352,6 +360,12 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 		}
 
 		return this.jsonEditingService.write(toWorkspace.configPath, [{ path: ['settings'], value: targetWorkspaceConfiguration }], true);
+	}
+
+	private trustWorkspaceConfiguration(configPathURI: URI): void {
+		if (this.contextService.getWorkbenchState() !== WorkbenchState.EMPTY && this.workspaceTrustManagementService.isWorkpaceTrusted()) {
+			this.workspaceTrustManagementService.setFoldersTrust([dirname(configPathURI)], true);
+		}
 	}
 
 	protected getCurrentWorkspaceIdentifier(): IWorkspaceIdentifier | undefined {

--- a/src/vs/workbench/services/workspaces/browser/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/browser/workspaceEditingService.ts
@@ -20,6 +20,7 @@ import { IWorkspaceEditingService } from 'vs/workbench/services/workspaces/commo
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { URI } from 'vs/base/common/uri';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
+import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 
 export class BrowserWorkspaceEditingService extends AbstractWorkspaceEditingService {
 
@@ -36,9 +37,10 @@ export class BrowserWorkspaceEditingService extends AbstractWorkspaceEditingServ
 		@IFileDialogService fileDialogService: IFileDialogService,
 		@IDialogService dialogService: IDialogService,
 		@IHostService hostService: IHostService,
-		@IUriIdentityService uriIdentityService: IUriIdentityService
+		@IUriIdentityService uriIdentityService: IUriIdentityService,
+		@IWorkspaceTrustManagementService workspaceTrustManagementService: IWorkspaceTrustManagementService
 	) {
-		super(jsonEditingService, contextService, configurationService, notificationService, commandService, fileService, textFileService, workspacesService, environmentService, fileDialogService, dialogService, hostService, uriIdentityService);
+		super(jsonEditingService, contextService, configurationService, notificationService, commandService, fileService, textFileService, workspacesService, environmentService, fileDialogService, dialogService, hostService, uriIdentityService, workspaceTrustManagementService);
 	}
 
 	async enterWorkspace(path: URI): Promise<void> {

--- a/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
+++ b/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
@@ -51,8 +51,7 @@ export class WorkspaceTrustManagementService extends Disposable implements IWork
 		@IEnvironmentService private readonly environmentService: IEnvironmentService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
-		@IWorkspaceContextService private readonly workspaceService: IWorkspaceContextService,
-		@IEnvironmentService private readonly envService: IEnvironmentService,
+		@IWorkspaceContextService private readonly workspaceService: IWorkspaceContextService
 	) {
 		super();
 
@@ -116,7 +115,7 @@ export class WorkspaceTrustManagementService extends Disposable implements IWork
 			return true;
 		}
 
-		if (this.envService.extensionTestsLocationURI) {
+		if (this.environmentService.extensionTestsLocationURI) {
 			return true; // trust running tests with vscode-test
 		}
 

--- a/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
+++ b/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
@@ -194,7 +194,7 @@ export class WorkspaceTrustManagementService extends Disposable implements IWork
 	}
 
 	canSetWorkspaceTrust(): boolean {
-		return this.workspaceService.getWorkspace().folders.length > 0;
+		return this.workspaceService.getWorkbenchState() !== WorkbenchState.EMPTY;
 	}
 
 	canSetParentFolderTrust(): boolean {

--- a/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
@@ -31,6 +31,7 @@ import { isMacintosh } from 'vs/base/common/platform';
 import { mnemonicButtonLabel } from 'vs/base/common/labels';
 import { WorkingCopyBackupService } from 'vs/workbench/services/workingCopy/common/workingCopyBackupService';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
+import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 
 export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingService {
 
@@ -53,9 +54,10 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 		@ILifecycleService private readonly lifecycleService: ILifecycleService,
 		@ILabelService private readonly labelService: ILabelService,
 		@IHostService hostService: IHostService,
-		@IUriIdentityService uriIdentityService: IUriIdentityService
+		@IUriIdentityService uriIdentityService: IUriIdentityService,
+		@IWorkspaceTrustManagementService workspaceTrustManagementService: IWorkspaceTrustManagementService
 	) {
-		super(jsonEditingService, contextService, configurationService, notificationService, commandService, fileService, textFileService, workspacesService, environmentService, fileDialogService, dialogService, hostService, uriIdentityService);
+		super(jsonEditingService, contextService, configurationService, notificationService, commandService, fileService, textFileService, workspacesService, environmentService, fileDialogService, dialogService, hostService, uriIdentityService, workspaceTrustManagementService);
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
@@ -120,6 +120,9 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 				try {
 					await this.saveWorkspaceAs(workspaceIdentifier, newWorkspacePath);
 
+					// Set trust for the workspace file
+					this.trustWorkspaceConfiguration(newWorkspacePath);
+
 					// Make sure to add the new workspace to the history to find it again
 					const newWorkspaceIdentifier = await this.workspacesService.getWorkspaceIdentifier(newWorkspacePath);
 					await this.workspacesService.addRecentlyOpened([{

--- a/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
@@ -120,9 +120,6 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 				try {
 					await this.saveWorkspaceAs(workspaceIdentifier, newWorkspacePath);
 
-					// Set trust for the workspace file
-					this.trustWorkspaceConfiguration(newWorkspacePath);
-
 					// Make sure to add the new workspace to the history to find it again
 					const newWorkspaceIdentifier = await this.workspacesService.getWorkspaceIdentifier(newWorkspacePath);
 					await this.workspacesService.addRecentlyOpened([{


### PR DESCRIPTION
Since the multi-root workspace file contains settings/launch configs we need to factor it in workspace trust:
* Factor in the directory storing the workspace file into calculating workspace trust
* Set workspace trust when saving the workspace file if the folders are trusted