### PR TITLE
Allow ThemeIcons to be used as decorations

### DIFF
--- a/src/vs/workbench/browser/labels.ts
+++ b/src/vs/workbench/browser/labels.ts
@@ -569,6 +569,7 @@ class ResourceLabelWidget extends IconLabel {
 
 				if (this.options.fileDecorations.badges) {
 					iconLabelOptions.extraClasses.push(deco.badgeClassName);
+					iconLabelOptions.extraClasses.push(deco.iconClassName);
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/terminal/browser/terminalDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalDecorationsProvider.ts
@@ -43,8 +43,7 @@ export class TerminalDecorationsProvider implements IDecorationsProvider {
 
 		return {
 			color: this.getColorForSeverity(instance.statusList.primary.severity),
-			letter: instance.statusList.statuses.length > 1 ? instance.statusList.statuses.length.toString() : '',
-			icon: instance.statusList.primary.icon
+			letter: instance.statusList.primary.icon
 		};
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalDecorationsProvider.ts
@@ -9,7 +9,6 @@ import { localize } from 'vs/nls';
 import { ITerminalService } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { IDecorationData, IDecorationsProvider } from 'vs/workbench/services/decorations/browser/decorations';
 import { Event, Emitter } from 'vs/base/common/event';
-import { Codicon } from 'vs/base/common/codicons';
 import { listErrorForeground, listWarningForeground } from 'vs/platform/theme/common/colorRegistry';
 import { TERMINAL_DECORATIONS_SCHEME } from 'vs/workbench/contrib/terminal/common/terminal';
 
@@ -34,19 +33,18 @@ export class TerminalDecorationsProvider implements IDecorationsProvider {
 
 	provideDecorations(resource: URI): IDecorationData | undefined {
 		if (resource.scheme !== TERMINAL_DECORATIONS_SCHEME || !parseInt(resource.path)) {
-			return;
+			return undefined;
 		}
 
 		const instance = this._terminalService.getInstanceFromId(parseInt(resource.path));
 		if (!instance?.statusList?.primary?.icon) {
-			return;
+			return undefined;
 		}
 
 		return {
 			color: this.getColorForSeverity(instance.statusList.primary.severity),
-			letter: this.getStatusIcon(instance.statusList.primary.icon, instance.statusList.statuses.length),
-			// Commenting out this line to unblock build
-			// tooltip: localize(instance.statusList.primary.id, '{0}', instance.statusList.primary.id)
+			letter: instance.statusList.statuses.length > 1 ? instance.statusList.statuses.length.toString() : '',
+			icon: instance.statusList.primary.icon
 		};
 	}
 
@@ -59,25 +57,6 @@ export class TerminalDecorationsProvider implements IDecorationsProvider {
 			default:
 				return '';
 		}
-	}
-
-	getStatusIcon(icon: Codicon, statusCount: number): string {
-		let statusIcon;
-		switch (icon) {
-			case Codicon.warning:
-				statusIcon = '⚠';
-				break;
-			case Codicon.bell:
-				statusIcon = 'B';
-				break;
-			case Codicon.debugDisconnect:
-				statusIcon = 'D';
-				break;
-			default:
-				statusIcon = '';
-				break;
-		}
-		return statusCount > 1 ? `${statusCount}, ${statusIcon}` : statusIcon;
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/services/decorations/browser/decorations.ts
+++ b/src/vs/workbench/services/decorations/browser/decorations.ts
@@ -9,6 +9,7 @@ import { Event } from 'vs/base/common/event';
 import { ColorIdentifier } from 'vs/platform/theme/common/colorRegistry';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { CancellationToken } from 'vs/base/common/cancellation';
+import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 
 export const IDecorationsService = createDecorator<IDecorationsService>('IFileDecorationsService');
 
@@ -16,6 +17,8 @@ export interface IDecorationData {
 	readonly weight?: number;
 	readonly color?: ColorIdentifier;
 	readonly letter?: string;
+	/** The icon to show, letter is ignored if this is specified */
+	readonly icon?: ThemeIcon;
 	readonly tooltip?: string;
 	readonly bubble?: boolean;
 }
@@ -24,6 +27,7 @@ export interface IDecoration extends IDisposable {
 	readonly tooltip: string;
 	readonly labelClassName: string;
 	readonly badgeClassName: string;
+	readonly iconClassName: string;
 }
 
 export interface IDecorationsProvider {

--- a/src/vs/workbench/services/decorations/browser/decorations.ts
+++ b/src/vs/workbench/services/decorations/browser/decorations.ts
@@ -16,9 +16,7 @@ export const IDecorationsService = createDecorator<IDecorationsService>('IFileDe
 export interface IDecorationData {
 	readonly weight?: number;
 	readonly color?: ColorIdentifier;
-	readonly letter?: string;
-	/** The icon to show, letter is ignored if this is specified */
-	readonly icon?: ThemeIcon;
+	readonly letter?: string | ThemeIcon;
 	readonly tooltip?: string;
 	readonly bubble?: boolean;
 }

--- a/src/vs/workbench/services/decorations/browser/decorationsService.ts
+++ b/src/vs/workbench/services/decorations/browser/decorationsService.ts
@@ -11,7 +11,7 @@ import { IDisposable, toDisposable, DisposableStore } from 'vs/base/common/lifec
 import { isThenable } from 'vs/base/common/async';
 import { LinkedList } from 'vs/base/common/linkedList';
 import { createStyleSheet, createCSSRule, removeCSSRulesContainingSelector } from 'vs/base/browser/dom';
-import { IThemeService, IColorTheme } from 'vs/platform/theme/common/themeService';
+import { IThemeService, IColorTheme, ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { isFalsyOrWhitespace } from 'vs/base/common/strings';
 import { localize } from 'vs/nls';
 import { isPromiseCanceledError } from 'vs/base/common/errors';
@@ -19,6 +19,7 @@ import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { hash } from 'vs/base/common/hash';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
+import { iconRegistry } from 'vs/base/common/codicons';
 
 class DecorationRule {
 
@@ -26,8 +27,8 @@ class DecorationRule {
 		if (Array.isArray(data)) {
 			return data.map(DecorationRule.keyOf).join(',');
 		} else {
-			const { color, letter } = data;
-			return `${color}/${letter}`;
+			const { color, letter, icon } = data;
+			return `${color}/${letter}/${icon?.id}`;
 		}
 	}
 
@@ -36,6 +37,7 @@ class DecorationRule {
 	readonly data: IDecorationData | IDecorationData[];
 	readonly itemColorClassName: string;
 	readonly itemBadgeClassName: string;
+	readonly iconBadgeClassName: string;
 	readonly bubbleBadgeClassName: string;
 
 	private _refCounter: number = 0;
@@ -46,6 +48,7 @@ class DecorationRule {
 		this.itemColorClassName = `${DecorationRule._classNamesPrefix}-itemColor-${suffix}`;
 		this.itemBadgeClassName = `${DecorationRule._classNamesPrefix}-itemBadge-${suffix}`;
 		this.bubbleBadgeClassName = `${DecorationRule._classNamesPrefix}-bubbleBadge-${suffix}`;
+		this.iconBadgeClassName = `${DecorationRule._classNamesPrefix}-iconBadge-${suffix}`;
 	}
 
 	acquire(): void {
@@ -65,11 +68,19 @@ class DecorationRule {
 	}
 
 	private _appendForOne(data: IDecorationData, element: HTMLStyleElement, theme: IColorTheme): void {
-		const { color, letter } = data;
+		const { color, letter, icon } = data;
 		// label
 		createCSSRule(`.${this.itemColorClassName}`, `color: ${getColor(theme, color)};`, element);
+		// icon
+		if (icon) {
+			createCSSRule(
+				`.${this.iconBadgeClassName}::after`,
+				`content: "${String.fromCharCode(charCode)}"; color: ${getColor(theme, color)}; font-family: codicon; font-size: 14px; padding-right: 14px;`,
+				element
+			);
+		}
 		// letter
-		if (letter) {
+		else if (letter) {
 			createCSSRule(`.${this.itemBadgeClassName}::after`, `content: "${letter}"; color: ${getColor(theme, color)};`, element);
 		}
 	}
@@ -79,17 +90,36 @@ class DecorationRule {
 		const { color } = data[0];
 		createCSSRule(`.${this.itemColorClassName}`, `color: ${getColor(theme, color)};`, element);
 
-		// badge
-		const letters = data.filter(d => !isFalsyOrWhitespace(d.letter)).map(d => d.letter);
-		if (letters.length) {
-			createCSSRule(`.${this.itemBadgeClassName}::after`, `content: "${letters.join(', ')}"; color: ${getColor(theme, color)};`, element);
-		}
+		// icon (only show first)
+		const icon = data.find(d => d.icon)?.icon;
+		if (icon) {
+			this.createIconCSSRule(icon, color, element, theme);
+		} else {
+			// badge
+			const letters = data.filter(d => !isFalsyOrWhitespace(d.letter)).map(d => d.letter);
+			if (letters.length) {
+				createCSSRule(`.${this.itemBadgeClassName}::after`, `content: "${letters.join(', ')}"; color: ${getColor(theme, color)};`, element);
+			}
 
-		// bubble badge
-		// TODO @misolori update bubble badge to use class name instead of unicode
+			// bubble badge
+			// TODO @misolori update bubble badge to use class name instead of unicode
+			createCSSRule(
+				`.${this.bubbleBadgeClassName}::after`,
+				`content: "\uea71"; color: ${getColor(theme, color)}; font-family: codicon; font-size: 14px; padding-right: 14px; opacity: 0.4;`,
+				element
+			);
+		}
+	}
+
+	private createIconCSSRule(icon: ThemeIcon, color: string | undefined, element: HTMLStyleElement, theme: IColorTheme) {
+		const codicon = iconRegistry.get(icon.id);
+		if (!codicon || !('fontCharacter' in codicon.definition)) {
+			return;
+		}
+		const charCode = parseInt(codicon.definition.fontCharacter.substr(1), 16);
 		createCSSRule(
-			`.${this.bubbleBadgeClassName}::after`,
-			`content: "\uea71"; color: ${getColor(theme, color)}; font-family: codicon; font-size: 14px; padding-right: 14px; opacity: 0.4;`,
+			`.${this.iconBadgeClassName}::after`,
+			`content: "${String.fromCharCode(charCode)}"; color: ${getColor(theme, color)}; font-family: codicon; font-size: 14px; padding-right: 14px;`,
 			element
 		);
 	}
@@ -98,6 +128,7 @@ class DecorationRule {
 		removeCSSRulesContainingSelector(this.itemColorClassName, element);
 		removeCSSRulesContainingSelector(this.itemBadgeClassName, element);
 		removeCSSRulesContainingSelector(this.bubbleBadgeClassName, element);
+		removeCSSRulesContainingSelector(this.iconBadgeClassName, element);
 	}
 }
 
@@ -135,6 +166,7 @@ class DecorationStyles {
 
 		let labelClassName = rule.itemColorClassName;
 		let badgeClassName = rule.itemBadgeClassName;
+		let iconClassName = rule.iconBadgeClassName;
 		let tooltip = data.filter(d => !isFalsyOrWhitespace(d.tooltip)).map(d => d.tooltip).join(' • ');
 
 		if (onlyChildren) {
@@ -146,6 +178,7 @@ class DecorationStyles {
 		return {
 			labelClassName,
 			badgeClassName,
+			iconClassName,
 			tooltip,
 			dispose: () => {
 				if (rule?.release()) {


### PR DESCRIPTION
Fixes #121483

<img width="256" alt="Screen Shot 2021-04-20 at 2 51 19 PM" src="https://user-images.githubusercontent.com/2193314/115470042-8de5d100-a1ea-11eb-884e-34b2e2841acd.png">

I worked with what I had here which was a single element that I could give a special class to, so I followed a similar approach as the hardcoded bubble badge. I allowed either a letter or an icon but not both since using multiple DOM elements would be needed for proper icon support which would be a much bigger change to manage them.

Other limitations:

- `~spin` etc. won't work
- I don't recursively check for `Codicon` definitions that are `Codicon` themselves (`definition: Codicon`)
