### PR TITLE
Logging categoryDescriptor.id instead of [object Object]

### DIFF
--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedService.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedService.ts
@@ -516,7 +516,7 @@ export class GettingStartedService extends Disposable implements IGettingStarted
 	private registerWalkthrough(categoryDescriptor: IGettingStartedWalkthroughDescriptor, items: IGettingStartedTask[]): void {
 		const oldCategory = this.gettingStartedContributions.get(categoryDescriptor.id);
 		if (oldCategory) {
-			console.error(`Skipping attempt to overwrite getting started category. (${categoryDescriptor})`);
+			console.error(`Skipping attempt to overwrite getting started category. (${categoryDescriptor.id})`);
 			return;
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
### Problem
If a getting started category is registered twice with the same id, it logs an error message.
When this error happened, instead of printing all details of the categoryDescriptor object, it was printing [object Object].

### Fix
This fixes it by printing the categoryDescriptor's id instead of '[object Object]'.
Alternatively, we can also stringify the whole object, but I assume only the ID is needed in this case.

Before:
![Screen Shot 2021-04-21 at 18 53 38](https://user-images.githubusercontent.com/3836025/115592501-96fe9d00-a2d3-11eb-9224-98e007f778f1.png)

After:
![Screen Shot 2021-04-21 at 18 54 30](https://user-images.githubusercontent.com/3836025/115592507-97973380-a2d3-11eb-86fe-23fda138a60d.png)

