### PR TITLE
Add explicit dispose calls for `DiskFileSystemProvider`

### DIFF
--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -151,7 +151,6 @@ class CodeMain {
 		services.set(IFileService, fileService);
 		const diskFileSystemProvider = new DiskFileSystemProvider(logService);
 		fileService.registerProvider(Schemas.file, diskFileSystemProvider);
-		process.once('exit', () => diskFileSystemProvider.dispose());
 
 		// Logger
 		services.set(ILoggerService, new LoggerService(logService, fileService));

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -151,6 +151,7 @@ class CodeMain {
 		services.set(IFileService, fileService);
 		const diskFileSystemProvider = new DiskFileSystemProvider(logService);
 		fileService.registerProvider(Schemas.file, diskFileSystemProvider);
+		process.once('exit', () => diskFileSystemProvider.dispose());
 
 		// Logger
 		services.set(ILoggerService, new LoggerService(logService, fileService));

--- a/src/vs/platform/checksum/test/node/checksumService.test.ts
+++ b/src/vs/platform/checksum/test/node/checksumService.test.ts
@@ -15,17 +15,19 @@ import { NullLogService } from 'vs/platform/log/common/log';
 
 suite('Checksum Service', () => {
 
+	let diskFileSystemProvider: DiskFileSystemProvider;
 	let fileService: IFileService;
 
 	setup(() => {
 		const logService = new NullLogService();
 		fileService = new FileService(logService);
 
-		const diskFileSystemProvider = new DiskFileSystemProvider(logService);
+		diskFileSystemProvider = new DiskFileSystemProvider(logService);
 		fileService.registerProvider(Schemas.file, diskFileSystemProvider);
 	});
 
 	teardown(() => {
+		diskFileSystemProvider.dispose();
 		fileService.dispose();
 	});
 

--- a/src/vs/workbench/services/themes/test/electron-browser/tokenStyleResolving.test.ts
+++ b/src/vs/workbench/services/themes/test/electron-browser/tokenStyleResolving.test.ts
@@ -77,14 +77,15 @@ function assertTokenStyles(themeData: ColorThemeData, expected: { [qualifiedClas
 }
 
 suite('Themes - TokenStyleResolving', () => {
-
-
 	const fileService = new FileService(new NullLogService());
 	const extensionResourceLoaderService = new ExtensionResourceLoaderService(fileService);
 
 	const diskFileSystemProvider = new DiskFileSystemProvider(new NullLogService());
 	fileService.registerProvider(Schemas.file, diskFileSystemProvider);
 
+	teardown(() => {
+		diskFileSystemProvider.dispose();
+	});
 
 	test('color defaults', async () => {
 		const themeData = ColorThemeData.createUnloadedTheme('foo');


### PR DESCRIPTION
Affects #120431

There are some locations where the `DiskFileSystemProvider` is not explicitly disposed.