### PR TITLE
Fix regression cannot preview image with special characters '#', '%' or '?'

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/baseWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/baseWebviewElement.ts
@@ -212,10 +212,16 @@ export abstract class BaseWebview<T extends HTMLElement> extends Disposable {
 
 		this._register(this.on(WebviewMessageChannels.loadResource, (entry: { id: number, path: string, query: string, ifNoneMatch?: string }) => {
 			const rawPath = entry.path;
-			const normalizedPath = decodeURIComponent(rawPath);
-			const uri = URI.parse(normalizedPath.replace(/^\/([\w\-]+)\/(.+)$/, (_, scheme, path) => scheme + ':/' + path)).with({
+			const uri = URI.parse(rawPath.replace(/^\/([\w\-]+)(\/{1,2})/, (_: string, scheme: string, sep: string) => {
+				if (sep.length === 1) {
+					return `${scheme}:///`; // Add empty authority.
+				} else {
+					return `${scheme}://`; // Url has own authority.
+				}
+			})).with({
 				query: decodeURIComponent(entry.query),
 			});
+
 			this.loadResource(entry.id, rawPath, uri, entry.ifNoneMatch);
 		}));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #121873
cc @mjbvz 
