### PR TITLE
Add pattern matching 'in'

### DIFF
--- a/extensions/ruby/language-configuration.json
+++ b/extensions/ruby/language-configuration.json
@@ -25,7 +25,7 @@
 		["`", "`"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\\sdo\\b)|([^#]*=\\s*(case|if|unless)))\\b([^#\\{;]|(\"|'|\/).*\\4)*(#.*)?$",
-		"decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif|when)\\b)"
+		"increaseIndentPattern": "^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|in|while|case)|([^#]*\\sdo\\b)|([^#]*=\\s*(case|if|unless)))\\b([^#\\{;]|(\"|'|\/).*\\4)*(#.*)?$",
+		"decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif|when|in)\\b)"
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Ruby added a `case`/`in` syntax for pattern matching (see [here](https://docs.ruby-lang.org/en/3.0.0/doc/syntax/pattern_matching_rdoc.html), it is similar to the `case`/`when` syntax).

This PR makes the indenting for `in` the same as `when`:

Current behavior:

https://user-images.githubusercontent.com/7527421/115723781-51cb8100-a34e-11eb-8b71-be432ccde60c.mov

Updated behavior:

https://user-images.githubusercontent.com/7527421/115723809-57c16200-a34e-11eb-93db-4ae769ecefeb.mov