### PR TITLE
KeyBindings: Remove default Ctrl-W shortcut for close window

### DIFF
--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -44,7 +44,6 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 			id: CloseCurrentWindowAction.ID, // close the window when the last editor is closed by reusing the same keybinding
 			weight: KeybindingWeight.WorkbenchContrib,
 			when: ContextKeyExpr.and(EditorsVisibleContext.toNegated(), SingleEditorGroupsContext),
-			primary: KeyMod.CtrlCmd | KeyCode.KEY_W,
 			handler: accessor => {
 				const nativeHostService = accessor.get(INativeHostService);
 				nativeHostService.closeWindow();


### PR DESCRIPTION
... when no editor is open.

This is easily triggered by mistake when closing multiple editors,
and many users complain about it.

Fixes #54492
