### PR TITLE
allow searching for publisher names with dashes

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -413,7 +413,7 @@ export class ExtensionEditor extends EditorPane {
 			this.transientDisposables.add(this.onClick(template.publisher, () => {
 				this.viewletService.openViewlet(VIEWLET_ID, true)
 					.then(viewlet => viewlet?.getViewPaneContainer() as IExtensionsViewPaneContainer)
-					.then(viewlet => viewlet.search(`publisher:"${extension.publisherDisplayName}"`));
+					.then(viewlet => viewlet.search(`publisher:${extension.publisherDisplayName}`));
 			}));
 
 			if (extension.licenseUrl) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes a bug in which the user cannot find a publisher that has a name with a dash in it by clicking on it from the extension view

**Previous behaviour:**

https://user-images.githubusercontent.com/18191750/115878801-43ae5b00-a449-11eb-966e-480d635175fa.mp4


