### PR TITLE
Add a cache to the editor override service to allow awaiting ext host

### DIFF
--- a/src/vs/workbench/services/editor/browser/editorOverrideService.ts
+++ b/src/vs/workbench/services/editor/browser/editorOverrideService.ts
@@ -21,6 +21,9 @@ import { Codicon } from 'vs/base/common/codicons';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 
 interface IContributedEditorInput extends IEditorInput {
 	viewType?: string;
@@ -40,6 +43,8 @@ export class EditorOverrideService extends Disposable implements IEditorOverride
 	readonly _serviceBrand: undefined;
 
 	private _contributionPoints: Map<string | glob.IRelativePattern, ContributionPoints> = new Map<string | glob.IRelativePattern, ContributionPoints>();
+	private static readonly overrideCacheStorageID = 'editorOverrideService.cache';
+	private cache: Set<string> | undefined;
 
 	constructor(
 		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
@@ -47,11 +52,28 @@ export class EditorOverrideService extends Disposable implements IEditorOverride
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@INotificationService private readonly notificationService: INotificationService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@ILifecycleService private readonly lifeCycleService: ILifecycleService,
+		@IStorageService private readonly storageService: IStorageService,
+		@IExtensionService private readonly extensionService: IExtensionService
 	) {
 		super();
+		// Read in the cache on statup
+		this.cache = new Set<string>(JSON.parse(this.storageService.get(EditorOverrideService.overrideCacheStorageID, StorageScope.GLOBAL, JSON.stringify([]))));
+		this.storageService.remove(EditorOverrideService.overrideCacheStorageID, StorageScope.GLOBAL);
+
+		this._register(this.lifeCycleService.onWillShutdown(() => {
+			// We want to store the glob patterns we would activate on, this allows us to know if we need to await the ext host on startup for opening a resource
+			this.cacheContributionPoints();
+		}));
 	}
 
 	async resolveEditorOverride(editor: IEditorInput, options: IEditorOptions | ITextEditorOptions | undefined, group: IEditorGroup): Promise<IEditorInputWithOptionsAndGroup | undefined> {
+		// If it was an override before we await for the extensions to activate and then proceed with overriding or else they won't be registered
+		if (this.cache && editor.resource && this.resourceMatchesCache(editor.resource)) {
+			await this.extensionService.whenInstalledExtensionsRegistered();
+			this.cache = undefined;
+		}
+
 		if (options?.override === EditorOverride.DISABLED) {
 			throw new Error(`Calling resolve editor override when override is explicitly disabled!`);
 		}
@@ -471,6 +493,48 @@ export class EditorOverrideService extends Disposable implements IEditorOverride
 		if (chosenInput.viewType) {
 			this.telemetryService.publicLog2<editorOverrideEvent, editorOverrideClassification>('override.viewType', { viewType: chosenInput.viewType });
 		}
+	}
+
+	private cacheContributionPoints() {
+		// Create a set to store contributed glob patterns
+		const cacheStorage: Set<string> = new Set<string>();
+
+		// Store just the relative pattern pieces without any path info
+		for (const globPattern of this._contributionPoints.keys()) {
+			const contribPoint = this._contributionPoints.get(globPattern)!;
+			const nonOptional = !!contribPoint.find(c => c.editorInfo.priority !== ContributedEditorPriority.option);
+			// Don't keep a cache of the optional ones as those wouldn't be opened on start anyways
+			if (!nonOptional) {
+				continue;
+			}
+			if (glob.isRelativePattern(globPattern)) {
+				cacheStorage.add(`${globPattern.pattern}`);
+			} else {
+				cacheStorage.add(globPattern);
+			}
+		}
+
+		// Also store the users settings as those would have to activate on startup as well
+		const userAssociations = this.configurationService.getValue<EditorAssociations>(editorsAssociationsSettingId) || [];
+		for (const association of userAssociations) {
+			if (association.filenamePattern) {
+				cacheStorage.add(association.filenamePattern);
+			}
+		}
+		this.storageService.store(EditorOverrideService.overrideCacheStorageID, JSON.stringify(Array.from(cacheStorage)), StorageScope.GLOBAL, StorageTarget.MACHINE);
+	}
+
+	private resourceMatchesCache(resource: URI): boolean {
+		if (!this.cache) {
+			return false;
+		}
+
+		for (const cacheEntry of this.cache) {
+			if (globMatchesResource(cacheEntry, resource)) {
+				return true;
+			}
+		}
+		return false;
 	}
 }
 

--- a/src/vs/workbench/services/editor/browser/editorOverrideService.ts
+++ b/src/vs/workbench/services/editor/browser/editorOverrideService.ts
@@ -74,7 +74,6 @@ export class EditorOverrideService extends Disposable implements IEditorOverride
 		// If it was an override before we await for the extensions to activate and then proceed with overriding or else they won't be registered
 		if (this.cache && editor.resource && this.resourceMatchesCache(editor.resource)) {
 			await this.extensionService.whenInstalledExtensionsRegistered();
-			this.cache = undefined;
 		}
 
 		if (options?.override === EditorOverride.DISABLED) {


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #116259

Using @jrieken's suggestion we will cache the registered contributions and then if it previously matched we will await the extension registration to allow for the extension to be ready to handle the request.