### PR TITLE
Change to convert the leading tilde to home path on Windows

### DIFF
--- a/src/vs/base/common/path.ts
+++ b/src/vs/base/common/path.ts
@@ -40,6 +40,7 @@ const CHAR_FORWARD_SLASH = 47; /* / */
 const CHAR_BACKWARD_SLASH = 92; /* \ */
 const CHAR_COLON = 58; /* : */
 const CHAR_QUESTION_MARK = 63; /* ? */
+const CHAR_TILDE = 126; /* ~ */
 
 class ErrorInvalidArgType extends Error {
 	code: 'ERR_INVALID_ARG_TYPE';
@@ -231,6 +232,18 @@ export const win32: IPath = {
 			let device = '';
 			let isAbsolute = false;
 			const code = path.charCodeAt(0);
+
+			// Convert the leading tilde to home path. If the tilde is used
+			// as part of a filename or directory name, it will not be converted.
+			if (code === CHAR_TILDE &&
+				len === 1 ||
+				isPathSeparator(path.charCodeAt(1))) {
+				const userProfile = process.env['USERPROFILE'];
+				path = `${userProfile}\\${path.slice(1)}`;
+
+				rootEnd = 2;
+				isAbsolute = true;
+			}
 
 			// Try to match a root
 			if (len === 1) {


### PR DESCRIPTION
This PR Changes to convert the leading tilde to home path on Windows command line.
Until now, VSCode was inconvenient because it didn't recognize the leading tilde as home directory.

e.g.:

Then VSCode will open the file `C:\Users\<USER>\a.txt`.
```sh
code ~\a.txt
```

Then VSCode will open the directory `C:\Users\<USER>\`.
```sh
code ~
```

Then VSCode will open the directory `.\~a.txt`.
```sh
code ~a.txt
```