### PR TITLE
Implimented a max zoom level

### DIFF
--- a/src/vs/platform/windows/electron-sandbox/window.ts
+++ b/src/vs/platform/windows/electron-sandbox/window.ts
@@ -12,12 +12,15 @@ import { setZoomFactor, setZoomLevel, getZoomLevel } from 'vs/base/browser/brows
  * browser helper so that it can be accessed in non-electron layers.
  */
 export function applyZoom(zoomLevel: number): void {
-	webFrame.setZoomLevel(zoomLevel);
-	setZoomFactor(zoomLevelToZoomFactor(zoomLevel));
-	// Cannot be trusted because the webFrame might take some time
-	// until it really applies the new zoom level
-	// See https://github.com/microsoft/vscode/issues/26151
-	setZoomLevel(zoomLevel, false /* isTrusted */);
+	// Zoom levels above 8 make the user experience extremely poor.
+	if (zoomLevel <= 8) {
+		webFrame.setZoomLevel(zoomLevel);
+		setZoomFactor(zoomLevelToZoomFactor(zoomLevel));
+		// Cannot be trusted because the webFrame might take some time
+		// until it really applies the new zoom level
+		// See https://github.com/microsoft/vscode/issues/26151
+		setZoomLevel(zoomLevel, false /* isTrusted */);
+	}
 }
 
 export function zoomIn(): void {

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -211,7 +211,7 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 			'window.zoomLevel': {
 				'type': 'number',
 				'default': 0,
-				'description': localize('zoomLevel', "Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity."),
+				'description': localize('zoomLevel', "Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity. The maximum zoom level is 8."),
 				ignoreSync: true
 			},
 			'window.newWindowDimensions': {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
--> Prevents users from having a zoom level past 8, which for nearly all situations makes the IDE unusable for the user.

This PR fixes #119890