### PR TITLE
Terminate in case of ext host IPC timeout

### DIFF
--- a/src/vs/workbench/services/extensions/node/extensionHostProcessSetup.ts
+++ b/src/vs/workbench/services/extensions/node/extensionHostProcessSetup.ts
@@ -105,7 +105,7 @@ function _createExtHostProtocol(): Promise<PersistentProtocol> {
 			let protocol: PersistentProtocol | null = null;
 
 			let timer = setTimeout(() => {
-				reject(new Error('VSCODE_EXTHOST_IPC_SOCKET timeout'));
+				onTerminate('VSCODE_EXTHOST_IPC_SOCKET timeout');
 			}, 60000);
 
 			const reconnectionGraceTime = ProtocolConstants.ReconnectionGraceTime;


### PR DESCRIPTION
This fixes a potential ext. host leak

The scenario is the following:
- ext host starts
- some listener, say timer, is started during the startup process
- in 60s we don't receive IPC socket, and reject
- rejection goes up to the main function
- we have a timer, and it keeps the process alive
- as a result we have a process leak