### PR TITLE
Set tunnel factory earlier

### DIFF
--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -654,10 +654,10 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 		}
 
 		try {
+			this._disposables.add(await this._extHostTunnelService.setTunnelExtensionFunctions(resolver));
 			performance.mark(`code/extHost/willResolveAuthority/${authorityPrefix}`);
 			const result = await resolver.resolve(remoteAuthority, { resolveAttempt });
 			performance.mark(`code/extHost/didResolveAuthorityOK/${authorityPrefix}`);
-			this._disposables.add(await this._extHostTunnelService.setTunnelExtensionFunctions(resolver));
 
 			// Split merged API result into separate authority/options
 			const authority: ResolvedAuthority = {

--- a/src/vs/workbench/api/node/extHostTunnelService.ts
+++ b/src/vs/workbench/api/node/extHostTunnelService.ts
@@ -284,17 +284,19 @@ export class ExtHostTunnelService extends Disposable implements IExtHostTunnelSe
 	}
 
 	async setTunnelExtensionFunctions(provider: vscode.RemoteAuthorityResolver | undefined): Promise<IDisposable> {
+		// Do not wait for any of the proxy promises here.
+		// It will delay startup and there is nothing that needs to be waited for.
 		if (provider) {
 			if (provider.candidatePortSource !== undefined) {
-				await this._proxy.$setCandidatePortSource(provider.candidatePortSource);
+				this._proxy.$setCandidatePortSource(provider.candidatePortSource);
 			}
 			if (provider.showCandidatePort) {
 				this._showCandidatePort = provider.showCandidatePort;
-				await this._proxy.$setCandidateFilter();
+				this._proxy.$setCandidateFilter();
 			}
 			if (provider.tunnelFactory) {
 				this._forwardPortProvider = provider.tunnelFactory;
-				await this._proxy.$setTunnelProvider(provider.tunnelFeatures ?? {
+				this._proxy.$setTunnelProvider(provider.tunnelFeatures ?? {
 					elevation: false,
 					public: false
 				});


### PR DESCRIPTION
There is a bug where a Resovler can provide a tunnel factory, but then the tunnel factory isn't used. 

This is happening because:
- VS Code calls the resolver's `resolve`.
- The extension, in it's `resolve` calls `openTunnel`. There is no `tunnelFactory` set yet, so VS Code use the built-in tunneling code.
- Only after the `resolve` promise completes does VS Code notice that the extension has a `tunnelFactory`