### PR TITLE
Improve capabilities.untrustedWorkspaces contribution schema

### DIFF
--- a/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
@@ -427,11 +427,20 @@ export const schema: IJSONSchema = {
 				untrustedWorkspaces: {
 					description: nls.localize('vscode.extension.capabilities.untrustedWorkspaces', 'Declares how the extension should be handled in untrusted workspaces.'),
 					type: 'object',
+					required: ['supported'],
+					defaultSnippets: [
+						{ body: { supported: '${1:limited}', description: '${2}' } },
+					],
 					properties: {
 						supported: {
-							description: nls.localize('vscode.extension.capabilities.untrustedWorkspaces.supported', "Declares the level of support for untrusted workspaces by the extension. `false` indicates the extension will be disabled in untrusted workspaces. `'limited'` indicates the extension will be enabled with some functionality removed."),
+							markdownDescription: nls.localize('vscode.extension.capabilities.untrustedWorkspaces.supported', "Declares the level of support for untrusted workspaces by the extension."),
 							type: ['string', 'boolean'],
-							enum: ['limited', true, false]
+							enum: ['limited', true, false],
+							enumDescriptions: [
+								nls.localize('vscode.extension.capabilities.untrustedWorkspaces.supported.limited', "The extension will be enabled in untrusted workspaces with some functionality disabled."),
+								nls.localize('vscode.extension.capabilities.untrustedWorkspaces.supported.true', "The extension will be enabled in untrusted workspaces with all functionality enabled."),
+								nls.localize('vscode.extension.capabilities.untrustedWorkspaces.supported.false', "The extension will not be enabled in untrusted workspaces."),
+							]
 						},
 						restrictedConfigurations: {
 							description: nls.localize('vscode.extension.capabilities.untrustedWorkspaces.restrictedConfigurations', "A list of configuration keys contributed by the extension that should not use workspace values in untrusted workspaces."),
@@ -442,7 +451,7 @@ export const schema: IJSONSchema = {
 						},
 						description: {
 							type: 'string',
-							description: nls.localize('vscode.extension.capabilities.untrustedWorkspaces.description', "A description of how workspace trust affects the extensions behavior and why it is needed. This only applies when `supported` is not `true`."),
+							markdownDescription: nls.localize('vscode.extension.capabilities.untrustedWorkspaces.description', "A description of how workspace trust affects the extensions behavior and why it is needed. This only applies when `supported` is not `true`."),
 						}
 					}
 				}


### PR DESCRIPTION
Fixes #122602

- Add snippet
- Use markdown string for strings that use backticks
- Add enum descriptions for `supported`
- Mark `supported` as being required
