### PR TITLE
Register .mak extension for the Make language

### DIFF
--- a/extensions/make/package.json
+++ b/extensions/make/package.json
@@ -20,6 +20,7 @@
           "makefile"
         ],
         "extensions": [
+          ".mak",
           ".mk"
         ],
         "filenames": [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Associate the `.mak` extension with the Make language. This extension is commonly used for files included by `Makefile`s, and is recognized by GitHub's language detection: https://github.com/github/linguist/blob/32ec19c013a7f81ffaeead25e6e8f9668c7ed574/lib/linguist/languages.yml#L3282.

This PR fixes #122613.

Tested change by created a file with the `.mak` extension, and opening it in VS Code. The Language Mode was automatically set to 'Makefile'.
