### PR TITLE
remove the nested test suite

### DIFF
--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -297,28 +297,26 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 		});
 	}
 
-	describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
-		before(async function () {
-			const app = new Application(this.defaultOptions);
-			await app!.start(opts.web ? false : undefined);
-			this.app = app;
-		});
-
-		after(async function () {
-			await this.app.stop();
-		});
-
-		if (!opts.web) { setupDataLossTests(); }
-		if (!opts.web) { setupDataPreferencesTests(); }
-		setupDataSearchTests();
-		setupDataNotebookTests();
-		setupDataLanguagesTests();
-		setupDataEditorTests();
-		setupDataStatusbarTests(!!opts.web);
-		setupDataExtensionTests();
-		if (!opts.web) { setupDataMultirootTests(); }
-		if (!opts.web) { setupDataLocalizationTests(); }
-		if (!opts.web) { setupLaunchTests(); }
+	before(async function () {
+		const app = new Application(this.defaultOptions);
+		await app!.start(opts.web ? false : undefined);
+		this.app = app;
 	});
+
+	after(async function () {
+		await this.app.stop();
+	});
+
+	if (!opts.web) { setupDataLossTests(); }
+	if (!opts.web) { setupDataPreferencesTests(); }
+	setupDataSearchTests();
+	setupDataNotebookTests();
+	setupDataLanguagesTests();
+	setupDataEditorTests();
+	setupDataStatusbarTests(!!opts.web);
+	setupDataExtensionTests();
+	if (!opts.web) { setupDataMultirootTests(); }
+	if (!opts.web) { setupDataLocalizationTests(); }
+	if (!opts.web) { setupLaunchTests(); }
 });
 


### PR DESCRIPTION
remove the unnecessary nested test suite. the tests can run now because the --screenshot and --log options are not enabled (I checked the pipeline definition yaml file), otherwise the entire test suite won't run, because the app start logic is in the inner test suite's setup, the beforeEach and afterEach are done in the outer test suite, they don't share the same context, at runtime, you will get an error saying 'cannot read property logger of undefined', because this.app doesn't exist there.

we (Azure Data Studio) team encountered this issue because we have these 2 options enabled when running smoke tests.
