### PR TITLE
Try to block webviews from cancelling unloads

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -187,6 +187,35 @@ function getVsCodeApiScript(allowMultipleAPIAcquire, useParentPostMessage, state
 			delete window.parent;
 			delete window.top;
 			delete window.frameElement;
+
+			// Try to block webviews from cancelling unloads.
+			// This blocking is not perfect but should block common patterns
+			(function() {
+				const createUnloadEventProxy = (e) => {
+					return new Proxy(e, {
+						set: (target, prop, receiver) => {
+							if (prop === 'returnValue') {
+								// Don't allow setting return value to block window unload
+								return;
+							}
+							target[prop] = value;
+						}
+					});
+				};
+
+				Object.defineProperty(window, 'onbeforeunload', { value: null, writable: false });
+
+				const originalAddEventListener = window.addEventListener.bind(window);
+				window.addEventListener = (type, listener, ...args) => {
+					if (type === 'beforeunload') {
+						return originalAddEventListener(type, (e) => {
+							return createUnloadEventProxy(listener);
+						}, ...args);
+					} else {
+						return originalAddEventListener(type, listener, ...args);
+					}
+				}
+			})();
 		`;
 }
 


### PR DESCRIPTION
Fixes #122736

With iframe based webviews on desktop, if a script inside the webview cancels an unload by setting `returnValue`, it can prevents the entire window from being unloaded

This change attempts to block webviews from cancelling unloads by overwriting the `onbeforeunload` event and `beforeunload` events. This blocking is not supposed to be perfect, just to prevent the most common patterns
