### PR TITLE
Fix #122741: Change vertical positions of the walkthrough titles and close-icons to center

### DIFF
--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.css
@@ -624,7 +624,7 @@
 	top: 0;
 }
 
-.codicon-getting-started-setup::before, .codicon-getting-started-beginner::before, .codicon-getting-started-intermediate::before, .codicon-close::before {
+.monaco-workbench .part.editor > .content .getting-started-category .codicon::before{
 	vertical-align: middle;
 }
 

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.css
@@ -243,7 +243,7 @@
 	box-sizing: border-box;
 	line-height: normal;
 	margin: 8px 8px 12px;
-	padding: 6px 12px 6px;
+	padding: 3px 12px 6px;
 	left: 1px;
 	text-align: left;
 	display: flex;

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.css
@@ -624,6 +624,10 @@
 	top: 0;
 }
 
+.codicon-getting-started-setup::before, .codicon-getting-started-beginner::before, .codicon-getting-started-intermediate::before, .codicon-close::before {
+	vertical-align: middle;
+}
+
 .monaco-workbench .part.editor > .content .gettingStartedContainer .codicon-close {
 	visibility: hidden;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/122741
<img width="1262" alt="スクリーンショット 2021-05-01 16 11 32" src="https://user-images.githubusercontent.com/42561234/116774629-e6458a00-aa98-11eb-8c53-e4502f32a799.png">
<img width="1262" alt="スクリーンショット 2021-05-01 16 22 47" src="https://user-images.githubusercontent.com/42561234/116774759-b8147a00-aa99-11eb-831b-856d71da9e66.png">


