### PR TITLE
Alternative Recent Items menu in MacOS Dock

### DIFF
--- a/src/vs/platform/menubar/electron-main/macDockMenu/buildMackDockRecentSubmenu.ts
+++ b/src/vs/platform/menubar/electron-main/macDockMenu/buildMackDockRecentSubmenu.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from 'vs/nls';
+import { IMenubarMenu, IMenubarMenuItemSeparator, IMenubarMenuItemSubmenu, IMenubarMenuRecentItemAction, isMenubarMenuItemRecentAction, isMenubarMenuItemSubmenu, MenubarMenuItem } from 'vs/platform/menubar/common/menubar';
+
+const menuItemSeparator: IMenubarMenuItemSeparator = {
+	id: 'vscode.menubar.separator'
+};
+
+const menuItemTypesOrdering: Record<string, number> = {
+	'openRecentWorkspace': 0,
+	'openRecentFolder': 1,
+	'openRecentFile': 2,
+};
+
+export const buildMacDockRecentSubmenu = (menubarMenu?: IMenubarMenu | null): IMenubarMenuItemSubmenu => ({
+	id: 'Mac.Dock.RecentMenu',
+	label: localize({ key: 'miOpenRecent', comment: ['&& denotes a mnemonic'] }, "Open &&Recent"),
+	submenu: {
+		items: buildMacDockRecentMenuSubmenuItems(menubarMenu)
+	}
+});
+
+const buildMacDockRecentMenuSubmenuItems = (menubarMenu?: IMenubarMenu | null): Array<IMenubarMenuRecentItemAction | IMenubarMenuItemSeparator> => {
+	const recentMenuItems = findRecentMenuItems(menubarMenu);
+	const groupedRecentMenuItems = groupRecentMenuItemsByType(recentMenuItems);
+
+	return Object.keys(groupedRecentMenuItems)
+		.sort(byItemTypeOrder)
+		.reduce((out: Array<IMenubarMenuRecentItemAction | IMenubarMenuItemSeparator>, key: string) => {
+			const group = groupedRecentMenuItems[key];
+			return out.length === 0 ? [...group] : [...out, menuItemSeparator, ...group];
+		}, []);
+};
+
+const findRecentMenuItems = (menubarMenu?: IMenubarMenu | null): Array<IMenubarMenuRecentItemAction> =>
+	menubarMenu?.items.reduce((out: Array<IMenubarMenuRecentItemAction>, item: MenubarMenuItem) => {
+		if (isMenubarMenuItemSubmenu(item)) {
+			return [...out, ...findRecentMenuItems(item.submenu)];
+		}
+		if (isMenubarMenuItemRecentAction(item)) {
+			return [...out, item];
+		}
+
+		return out;
+	}, []) ?? [];
+
+
+const groupRecentMenuItemsByType = (recentMenuItems: Array<IMenubarMenuRecentItemAction>): Record<string, Array<IMenubarMenuRecentItemAction>> =>
+	recentMenuItems.reduce((record: Record<string, Array<IMenubarMenuRecentItemAction>>, item: IMenubarMenuRecentItemAction) => {
+		const { id } = item;
+
+		if (record[id]) {
+			record[id] = [...record[id], item];
+		} else {
+			record[id] = [item];
+		}
+
+		return record;
+	}, {});
+
+const byItemTypeOrder = (l: string, r: string): number => {
+	const lOrder = menuItemTypesOrdering[l] ?? -1;
+	const rOrder = menuItemTypesOrdering[r] ?? -1;
+
+	if (lOrder === rOrder) {
+		return 0;
+	}
+
+	if (lOrder === -1) { return -1; }
+	if (rOrder === -1) { return 1; }
+
+	return lOrder > rOrder ? 1 : -1;
+};

--- a/src/vs/platform/menubar/electron-main/macDockMenu/test/buildMacDockRecentSubmenu.test.ts
+++ b/src/vs/platform/menubar/electron-main/macDockMenu/test/buildMacDockRecentSubmenu.test.ts
@@ -1,0 +1,246 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { localize } from 'vs/nls';
+import { URI } from 'vs/base/common/uri';
+import { IMenubarMenu, IMenubarMenuItemSeparator, IMenubarMenuRecentItemAction, MenubarMenuItem } from 'vs/platform/menubar/common/menubar';
+import { buildMacDockRecentSubmenu } from 'vs/platform/menubar/electron-main/macDockMenu/buildMackDockRecentSubmenu';
+
+suite('Build Mac Dock Recent Menu', () => {
+	test('Returns empty array on null input', () => {
+		assert.deepStrictEqual(buildMacDockRecentSubmenu(null), {
+			id: 'Mac.Dock.RecentMenu',
+			label: localize({ key: 'miOpenRecent', comment: ['&& denotes a mnemonic'] }, "Open &&Recent"),
+			submenu: {
+				items: []
+			}
+		});
+	});
+
+	test('Returns empty array on undefined input', () => {
+		assert.deepStrictEqual(buildMacDockRecentSubmenu(undefined), {
+			id: 'Mac.Dock.RecentMenu',
+			label: localize({ key: 'miOpenRecent', comment: ['&& denotes a mnemonic'] }, "Open &&Recent"),
+			submenu: {
+				items: []
+			}
+		});
+	});
+
+	test('Returns empty array on empty input', () => {
+		assert.deepStrictEqual(buildMacDockRecentSubmenu({ items: [] }), {
+			id: 'Mac.Dock.RecentMenu',
+			label: localize({ key: 'miOpenRecent', comment: ['&& denotes a mnemonic'] }, "Open &&Recent"),
+			submenu: {
+				items: []
+			}
+		});
+	});
+
+	const itemProps: MenubarMenuItem = {
+		id: '',
+		uri: URI.parse(''),
+		label: ''
+	};
+
+	test('Returns all 3 types of recent menu items', () => {
+		const input: IMenubarMenu = {
+			items: [
+				{
+					...itemProps,
+					id: 'openRecentFolder',
+				},
+				{
+					id: 'with.submenu',
+					label: '',
+					submenu: {
+						items: [
+							{
+								...itemProps,
+								id: 'openRecentWorkspace',
+							},
+							{
+								...itemProps,
+								id: 'openRecentFile',
+							},
+							{
+								...itemProps,
+								id: 'openRecentFolder',
+							},
+						]
+					}
+				},
+				{
+					...itemProps,
+					id: 'openRecentFile',
+				},
+			]
+		};
+
+		const expectedSubmenuItems: Array<IMenubarMenuRecentItemAction | IMenubarMenuItemSeparator> = [
+			{
+				...itemProps,
+				id: 'openRecentWorkspace'
+			},
+			{
+				id: 'vscode.menubar.separator'
+			},
+			{
+				...itemProps,
+				id: 'openRecentFolder'
+			},
+			{
+				...itemProps,
+				id: 'openRecentFolder'
+			},
+			{
+				id: 'vscode.menubar.separator'
+			},
+			{
+				...itemProps,
+				id: 'openRecentFile'
+			},
+			{
+				...itemProps,
+				id: 'openRecentFile'
+			},
+		];
+
+		assert.deepStrictEqual(buildMacDockRecentSubmenu(input), {
+			id: 'Mac.Dock.RecentMenu',
+			label: localize({ key: 'miOpenRecent', comment: ['&& denotes a mnemonic'] }, "Open &&Recent"),
+			submenu: {
+				items: expectedSubmenuItems
+			}
+		});
+	});
+
+	test('Returns folder and file recent menu items', () => {
+		const input: IMenubarMenu = {
+			items: [
+				{
+					id: 'with.submenu',
+					label: '',
+					submenu: {
+						items: [
+							{
+								...itemProps,
+								id: 'openRecentFolder',
+							},
+							{
+								...itemProps,
+								id: 'openRecentFile',
+							},
+							{
+								...itemProps,
+								id: 'openRecentFolder',
+							},
+							{
+								...itemProps,
+								id: 'openRecentFile',
+							},
+						]
+					}
+				},
+			]
+		};
+
+		const expectedSubmenuItems: Array<IMenubarMenuRecentItemAction | IMenubarMenuItemSeparator> = [
+			{
+				...itemProps,
+				id: 'openRecentFolder'
+			},
+			{
+				...itemProps,
+				id: 'openRecentFolder'
+			},
+			{
+				id: 'vscode.menubar.separator'
+			},
+			{
+				...itemProps,
+				id: 'openRecentFile'
+			},
+			{
+				...itemProps,
+				id: 'openRecentFile'
+			},
+		];
+
+		assert.deepStrictEqual(buildMacDockRecentSubmenu(input), {
+			id: 'Mac.Dock.RecentMenu',
+			label: localize({ key: 'miOpenRecent', comment: ['&& denotes a mnemonic'] }, "Open &&Recent"),
+			submenu: {
+				items: expectedSubmenuItems
+			}
+		});
+	});
+
+	test('Returns nested folder recent menu items', () => {
+		const input: IMenubarMenu = {
+			items: [
+				{
+					id: 'with.submenu',
+					label: '',
+					submenu: {
+						items: [
+							{
+								...itemProps,
+								id: 'openRecentFolder',
+							},
+							{
+								...itemProps,
+								id: 'openRecentFolder',
+							},
+							{
+								...itemProps,
+								submenu: {
+									items: [
+										{
+											...itemProps,
+											id: 'openRecentFolder',
+										},
+									]
+								}
+							}
+						]
+					}
+				},
+				{
+					...itemProps,
+					id: 'openRecentFolder',
+				},
+			]
+		};
+
+		const expectedSubmenuItems: Array<IMenubarMenuRecentItemAction | IMenubarMenuItemSeparator> = [
+			{
+				...itemProps,
+				id: 'openRecentFolder'
+			},
+			{
+				...itemProps,
+				id: 'openRecentFolder'
+			},
+			{
+				...itemProps,
+				id: 'openRecentFolder'
+			},
+			{
+				...itemProps,
+				id: 'openRecentFolder'
+			},
+		];
+
+		assert.deepStrictEqual(buildMacDockRecentSubmenu(input), {
+			id: 'Mac.Dock.RecentMenu',
+			label: localize({ key: 'miOpenRecent', comment: ['&& denotes a mnemonic'] }, "Open &&Recent"),
+			submenu: {
+				items: expectedSubmenuItems
+			}
+		});
+	});
+});

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -282,6 +282,18 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 				'scope': ConfigurationScope.APPLICATION,
 				'description': localize('window.clickThroughInactive', "If enabled, clicking on an inactive window will both activate the window and trigger the element under the mouse if it is clickable. If disabled, clicking anywhere on an inactive window will activate it only and a second click is required on the element."),
 				'included': isMacintosh
+			},
+			'window.dockRecentItemsMenu': {
+				'type': 'string',
+				'enum': ['default', 'submenu'],
+				'enumDescriptions': [
+					localize('window.dockRecentItemsMenu.default', "Show recent items directly in the Dock menu."),
+					localize('window.dockRecentItemsMenu.submenu', "Use a submenu in the Dock for display of recent items.")
+				],
+				'default': 'default',
+				'scope': ConfigurationScope.APPLICATION,
+				'description': localize('window.openRecentFromDock', "Controls wheter recent items should be displayed directly in the Dock menu or as a submenu. Note that changes require a full restart to apply."),
+				'included': isMacintosh
 			}
 		}
 	});


### PR DESCRIPTION
Hi vscode team!

This PR is my proposal of an alternative "Recent Documents" menu in the Mac Dock. It is based on the recent items submenu that you can find under the "File" menu. Today I sometimes find myself a bit confused by the default recent documents menu built with the Electron api `app.addRecentDocument` as it feels different from the "File" recent items menu and I would prefer if the menu worked like in this PR. (which is basically just like the recent items menu under "File" except the other options like "Clear Recently Opened").

A screenshot of how it looks:
<img width="694" alt="Screenshot 2021-04-30 at 18 48 54" src="https://user-images.githubusercontent.com/13449288/116785495-21948880-aa9a-11eb-8cde-7f9e920d526b.png">

I make this PR as a proposal and it would be really cool to hear what your thoughts are. This is my first time looking at the vscode codebase so I might very well have missed something that needs to be done. There is also one outstanding question that have commented in the code. This change seems to work for me though and I would really like to have this behaviour in vscode.

Thanks, 
Pontus