### PR TITLE
Fixes pascalCase snippet formatter fails to process numbers

### DIFF
--- a/src/vs/editor/contrib/snippet/snippetParser.ts
+++ b/src/vs/editor/contrib/snippet/snippetParser.ts
@@ -388,11 +388,11 @@ export class FormatString extends Marker {
 	}
 
 	private _toPascalCase(value: string): string {
-		const match = value.match(/[a-z]+/gi);
+		const match = value.match(/[a-z0-9]+/gi);
 		if (!match) {
 			return value;
 		}
-		return match.map(function (word) {
+		return match.map(word => {
 			return word.charAt(0).toUpperCase()
 				+ word.substr(1).toLowerCase();
 		})

--- a/src/vs/editor/contrib/snippet/test/snippetParser.test.ts
+++ b/src/vs/editor/contrib/snippet/test/snippetParser.test.ts
@@ -655,6 +655,7 @@ suite('SnippetParser', () => {
 		assert.strictEqual(new FormatString(1, 'capitalize').resolve('bar'), 'Bar');
 		assert.strictEqual(new FormatString(1, 'capitalize').resolve('bar no repeat'), 'Bar no repeat');
 		assert.strictEqual(new FormatString(1, 'pascalcase').resolve('bar-foo'), 'BarFoo');
+		assert.strictEqual(new FormatString(1, 'pascalcase').resolve('bar-42-foo'), 'Bar42Foo');
 		assert.strictEqual(new FormatString(1, 'notKnown').resolve('input'), 'input');
 
 		// if


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #122255
