### PR TITLE
Fix#122692: Hide the inline actions when the width is below a certain threshold (79 pixels)

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsWidget.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsWidget.ts
@@ -34,6 +34,7 @@ const TAB_HEIGHT = 22;
 export const MIN_TABS_WIDGET_WIDTH = 46;
 export const DEFAULT_TABS_WIDGET_WIDTH = 80;
 export const MIDPOINT_WIDGET_WIDTH = (MIN_TABS_WIDGET_WIDTH + DEFAULT_TABS_WIDGET_WIDTH) / 2;
+export const THRESHOLD_ACTIONBAR_WIDTH = 79;
 
 export class TerminalTabsWidget extends WorkbenchObjectTree<ITerminalInstance>  {
 	private _decorationsProvider: TerminalDecorationsProvider | undefined;
@@ -225,6 +226,10 @@ class TerminalTabsRenderer implements ITreeRenderer<ITerminalInstance, never, IT
 		return this._container ? this._container.clientWidth < MIDPOINT_WIDGET_WIDTH : false;
 	}
 
+	shouldHideActionBar(): boolean {
+		return this._container ? this._container.clientWidth <= THRESHOLD_ACTIONBAR_WIDTH : false;
+	}
+
 	renderElement(node: ITreeNode<ITerminalInstance>, index: number, template: ITerminalTabEntryTemplate): void {
 		let instance = node.element;
 
@@ -276,9 +281,9 @@ class TerminalTabsRenderer implements ITreeRenderer<ITerminalInstance, never, IT
 			}
 		}
 
+		const hasActionbar = !this.shouldHideActionBar();
 		let label: string;
 		if (!hasText) {
-			template.actionBar.clear();
 			const primaryStatus = instance.statusList.primary;
 			if (primaryStatus && primaryStatus.severity >= Severity.Warning) {
 				label = `${prefix}$(${primaryStatus.icon?.id || instance.icon?.id})`;
@@ -294,6 +299,9 @@ class TerminalTabsRenderer implements ITreeRenderer<ITerminalInstance, never, IT
 			if (instance.icon) {
 				label += ` ${instance.title}`;
 			}
+		}
+		if (!hasActionbar) {
+			template.actionBar.clear();
 		}
 
 		if (!template.elementDispoables) {

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.css
@@ -624,6 +624,10 @@
 	top: 0;
 }
 
+.codicon-getting-started-setup::before, .codicon-getting-started-beginner::before, .codicon-getting-started-intermediate::before, .codicon-close::before {
+	vertical-align: middle;
+}
+
 .monaco-workbench .part.editor > .content .gettingStartedContainer .codicon-close {
 	visibility: hidden;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/122692


https://user-images.githubusercontent.com/42561234/116804540-6d0e6b80-ab5a-11eb-9c44-0d22b770fd12.mov


<img width="1065" alt="122692_2" src="https://user-images.githubusercontent.com/42561234/116804226-21f35900-ab58-11eb-9b27-d81a58b597b6.png">

