### PR TITLE
Block windows/iframes from preventing the unload (#122835)

### DIFF
--- a/src/vs/platform/windows/electron-main/window.ts
+++ b/src/vs/platform/windows/electron-main/window.ts
@@ -424,6 +424,15 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 		this._win.webContents.on('render-process-gone', (event, details) => this.onWindowError(WindowError.CRASHED, details));
 		this._win.webContents.on('did-fail-load', (event, errorCode, errorDescription) => this.onWindowError(WindowError.LOAD, errorDescription));
 
+		// Prevent windows/iframes from blocking the unload
+		// through DOM events. We have our own logic for
+		// unloading a window that should not be confused
+		// with the DOM way.
+		// (https://github.com/microsoft/vscode/issues/122736)
+		this._win.webContents.on('will-prevent-unload', event => {
+			event.preventDefault();
+		});
+
 		// Window close
 		this._win.on('closed', () => {
 			this._onDidClose.fire();

--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -187,35 +187,6 @@ function getVsCodeApiScript(allowMultipleAPIAcquire, useParentPostMessage, state
 			delete window.parent;
 			delete window.top;
 			delete window.frameElement;
-
-			// Try to block webviews from cancelling unloads.
-			// This blocking is not perfect but should block common patterns
-			(function() {
-				const createUnloadEventProxy = (e) => {
-					return new Proxy(e, {
-						set: (target, prop, receiver) => {
-							if (prop === 'returnValue') {
-								// Don't allow setting return value to block window unload
-								return;
-							}
-							target[prop] = value;
-						}
-					});
-				};
-
-				Object.defineProperty(window, 'onbeforeunload', { value: null, writable: false });
-
-				const originalAddEventListener = window.addEventListener.bind(window);
-				window.addEventListener = (type, listener, ...args) => {
-					if (type === 'beforeunload') {
-						return originalAddEventListener(type, (e) => {
-							return createUnloadEventProxy(listener);
-						}, ...args);
-					} else {
-						return originalAddEventListener(type, listener, ...args);
-					}
-				}
-			})();
 		`;
 }
 


### PR DESCRIPTION
This reverts #122758  in favor of the fix from #122835, which is less risky as we aren't modifying code inside the iframe

Fixes #122736
Fixes #122818