### PR TITLE
Fix webview views not updating correctly on scroll

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -16,6 +16,7 @@ import { isFirefox } from 'vs/base/browser/browser';
 import { DataTransfers } from 'vs/base/browser/dnd';
 import { Orientation } from 'vs/base/browser/ui/sash/sash';
 import { localize } from 'vs/nls';
+import { ScrollEvent } from 'vs/base/common/scrollable';
 
 export interface IPaneOptions {
 	minimumBodySize?: number;
@@ -444,6 +445,7 @@ export class PaneView extends Disposable {
 
 	orientation: Orientation;
 	readonly onDidSashChange: Event<number>;
+	readonly onScroll: Event<ScrollEvent>;
 
 	constructor(container: HTMLElement, options: IPaneViewOptions = {}) {
 		super();
@@ -453,6 +455,7 @@ export class PaneView extends Disposable {
 		this.element = append(container, $('.monaco-pane-view'));
 		this.splitview = this._register(new SplitView(this.element, { orientation: this.orientation }));
 		this.onDidSashChange = this.splitview.onDidSashChange;
+		this.onScroll = this.splitview.onScroll;
 	}
 
 	addPane(pane: Pane, size: number, index = this.splitview.length): void {

--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -14,7 +14,7 @@ import { Color } from 'vs/base/common/color';
 import { domEvent } from 'vs/base/browser/event';
 import { $, append, scheduleAtNextAnimationFrame } from 'vs/base/browser/dom';
 import { SmoothScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElement';
-import { Scrollable, ScrollbarVisibility } from 'vs/base/common/scrollable';
+import { Scrollable, ScrollbarVisibility, ScrollEvent } from 'vs/base/common/scrollable';
 export { Orientation } from 'vs/base/browser/ui/sash/sash';
 
 export interface ISplitViewStyles {
@@ -237,6 +237,8 @@ export class SplitView<TLayoutContext = undefined> extends Disposable {
 	private _onDidSashReset = this._register(new Emitter<number>());
 	readonly onDidSashReset = this._onDidSashReset.event;
 
+	readonly onScroll: Event<ScrollEvent>;
+
 	get length(): number {
 		return this.viewItems.length;
 	}
@@ -317,7 +319,8 @@ export class SplitView<TLayoutContext = undefined> extends Disposable {
 			horizontal: this.orientation === Orientation.HORIZONTAL ? (options.scrollbarVisibility ?? ScrollbarVisibility.Auto) : ScrollbarVisibility.Hidden
 		}, this.scrollable));
 
-		this._register(this.scrollableElement.onScroll(e => {
+		this.onScroll = this.scrollableElement.onScroll;
+		this._register(this.onScroll(e => {
 			this.viewContainer.scrollTop = e.scrollTop;
 			this.viewContainer.scrollLeft = e.scrollLeft;
 		}));

--- a/src/vs/workbench/browser/parts/views/viewPane.ts
+++ b/src/vs/workbench/browser/parts/views/viewPane.ts
@@ -445,6 +445,10 @@ export abstract class ViewPane extends Pane implements IView {
 		this.scrollableElement.scanDomNode();
 	}
 
+	onRootScroll() {
+		// noop
+	}
+
 	getProgressIndicator() {
 		if (this.progressBar === undefined) {
 			// Progress bar

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -38,6 +38,7 @@ import { ViewPane } from 'vs/workbench/browser/parts/views/viewPane';
 import { CompositeMenuActions } from 'vs/workbench/browser/menuActions';
 import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
+import { ScrollEvent } from 'vs/base/common/scrollable';
 
 export const ViewsSubMenu = new MenuId('Views');
 MenuRegistry.appendMenuItem(MenuId.ViewContainerTitle, <ISubmenuItem>{
@@ -407,6 +408,7 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 		options.orientation = this.orientation;
 		this.paneview = this._register(new PaneView(parent, this.options));
 		this._register(this.paneview.onDidDrop(({ from, to }) => this.movePane(from as ViewPane, to as ViewPane)));
+		this._register(this.paneview.onScroll(e => this.onPaneScroll(e)));
 		this._register(addDisposableListener(parent, EventType.CONTEXT_MENU, (e: MouseEvent) => this.showContextMenu(new StandardMouseEvent(e))));
 
 		this._menuActions = this._register(this.instantiationService.createInstance(ViewContainerMenuActions, this.paneview.element, this.viewContainer));
@@ -1062,6 +1064,12 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 			return this.visibleViewsCountFromCache === 1;
 		}
 		return true;
+	}
+
+	private onPaneScroll(e: ScrollEvent) {
+		for (const pane of this.panes) {
+			pane.onRootScroll();
+		}
 	}
 
 	override dispose(): void {


### PR DESCRIPTION
Fixes #110450

This fixes two issues with webview views that are inside view pane containers that are overflowing:

- When a container with webview views is scrolled, we need to update the positon of the webview

- If the webview is then scrolled outside of the container, we need to make sure it is clipped so it does not draw on top of other interface elements

Both of these are required since the webview is not part of the normal editor dom. Instead it is a top level element that is absolutely positioned in the slot it needs to me

