### PR TITLE
Completion in settings does not work on Linux

### DIFF
--- a/extensions/json-language-features/server/package.json
+++ b/extensions/json-language-features/server/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "jsonc-parser": "^3.0.0",
     "request-light": "^0.4.0",
-    "vscode-json-languageservice": "^4.1.2",
+    "vscode-json-languageservice": "^4.1.3",
     "vscode-languageserver": "^7.0.0",
     "vscode-uri": "^3.0.2"
   },

--- a/extensions/json-language-features/server/yarn.lock
+++ b/extensions/json-language-features/server/yarn.lock
@@ -105,10 +105,10 @@ request-light@^0.4.0:
     https-proxy-agent "^2.2.4"
     vscode-nls "^4.1.2"
 
-vscode-json-languageservice@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-4.1.2.tgz#c3873f791e23488a8b373e02c85c232bd625e27a"
-  integrity sha512-atAz6m4UZCslB7yk03Qb3/MKn1E5l07063syAEUfKRcVKTVN3t1+/KDlGu1nVCRUFAgz5+18gKidQvO4PVPLdg==
+vscode-json-languageservice@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-4.1.3.tgz#851564e529e649c13b844f10a80ea1d9095591a9"
+  integrity sha512-m/wUEt4zgCNUcvGmPr1ELo+ROQNKBgASpdOOAEpcSMwYE/6GzULZ1KfBhbX9or7qnC4E0oX+wwW+lrN3EUWCgw==
   dependencies:
     jsonc-parser "^3.0.0"
     minimatch "^3.0.4"


### PR DESCRIPTION
Fix for #122466 on 1.56

The JSON editor for settings.json and other user configurations got broken on Linux due to a change in the vscode-json-languageservice.

To associate a resource URI with a schema we now also support glob patterns and use minimatch for that.
Minimatch has a strange behaviour in that `**` does not match against folders that start with `.`  unless a certain option is set when creating a matcher: `dot: true`

On Linux our configuration files are in `vscode-userdata:/home/martin/.config/Code%20-%20Insiders/User/settings.json`.


vscode-json-languageservice@4.1.3 consist of a single commit with fix and commits

https://github.com/microsoft/vscode-json-languageservice/commit/f2f617aa60d22db6ba1566073e9b1de10b0dc58a

