### PR TITLE
notebook: reload backLayerWebView when kernels change

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1257,10 +1257,15 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 				}
 			}
 
-			await this._webview!.initializeMarkdown(requests
-				.map(request => ({ cellId: request[0].id, cellHandle: request[0].handle, content: request[0].getText(), offset: request[1] })));
+			await this._webview!.initializeMarkdown(requests.map(request => ({
+				cellId: request[0].id,
+				cellHandle: request[0].handle,
+				content: request[0].getText(),
+				offset: request[1],
+				visible: false,
+			})));
 		} else {
-			const initRequests = viewModel.viewCells.filter(cell => cell.cellKind === CellKind.Markdown).slice(0, 5).map(cell => ({ cellId: cell.id, cellHandle: cell.handle, content: cell.getText(), offset: -10000 }));
+			const initRequests = viewModel.viewCells.filter(cell => cell.cellKind === CellKind.Markdown).slice(0, 5).map(cell => ({ cellId: cell.id, cellHandle: cell.handle, content: cell.getText(), offset: -10000, visible: false }));
 			await this._webview!.initializeMarkdown(initRequests);
 
 			// no cached view state so we are rendering the first viewport
@@ -2114,6 +2119,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 			cellId: cell.id,
 			content: cell.getText(),
 			offset: cellTop,
+			visible: true,
 		});
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1691,13 +1691,10 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 			return;
 		}
 		const { selected } = this.notebookKernelService.getMatchingKernel(this.viewModel.notebookDocument);
-		if (!selected || !selected.preloadUris.length) {
-			return;
-		}
 		if (!this._webview?.isResolved()) {
 			await this._resolveWebview();
 		}
-		this._webview?.updateKernelPreloads([selected.localResourceRoot], selected.preloadUris);
+		this._webview?.updateKernelPreloads(selected);
 	}
 
 	get activeKernel() {
@@ -2112,7 +2109,12 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 		}
 
 		const cellTop = this._list.getAbsoluteTopOfElement(cell);
-		await this._webview.showMarkdownPreview(cell.id, cell.handle, cell.getText(), cellTop, cell.contentHash);
+		await this._webview.showMarkdownPreview({
+			cellHandle: cell.handle,
+			cellId: cell.id,
+			content: cell.getText(),
+			offset: cellTop,
+		});
 	}
 
 	async unhideMarkdownPreviews(cells: readonly MarkdownCellViewModel[]) {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -328,6 +328,7 @@ export interface IMarkdownCellInitialization {
 	cellHandle: number;
 	content: string;
 	offset: number;
+	visible: boolean;
 }
 
 export interface IInitializeMarkdownMessage {
@@ -411,7 +412,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Disposable {
 	element: HTMLElement;
 	webview: WebviewElement | undefined = undefined;
 	insetMapping: Map<IDisplayOutputViewModel, ICachedInset<T>> = new Map();
-	readonly markdownPreviewMapping = new Map<string, IMarkdownCellInitialization & { visible: boolean }>();
+	readonly markdownPreviewMapping = new Map<string, IMarkdownCellInitialization>();
 	hiddenInsetMapping: Set<IDisplayOutputViewModel> = new Set();
 	reversedInsetMapping: Map<string, IDisplayOutputViewModel> = new Map();
 	localResourceRootsCache: URI[] | undefined = undefined;
@@ -1182,11 +1183,7 @@ var requirejs = (function() {
 
 		const mdCells = [...this.markdownPreviewMapping.values()];
 		this.markdownPreviewMapping.clear();
-		for (const cell of mdCells) {
-			if (cell.visible) {
-				this.createMarkdownPreview(cell);
-			}
-		}
+		this.initializeMarkdown(mdCells);
 	}
 
 	private shouldUpdateInset(cell: IGenericCellViewModel, output: ICellOutputViewModel, cellTop: number, outputOffset: number): boolean {
@@ -1414,7 +1411,7 @@ var requirejs = (function() {
 
 		this._sendMessageToWebview({
 			type: 'initializeMarkdownPreview',
-			cells: cells,
+			cells,
 		});
 
 		await p;

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -491,9 +491,11 @@ async function webviewPreloads(markdownRendererModule: any, markdownDeps: any) {
 				for (const cell of event.data.cells) {
 					createMarkdownPreview(cell.cellId, cell.content, cell.offset);
 
-					const cellContainer = document.getElementById(cell.cellId);
-					if (cellContainer) {
-						cellContainer.style.visibility = 'hidden';
+					if (!cell.visible) {
+						const cellContainer = document.getElementById(cell.cellId);
+						if (cellContainer) {
+							cellContainer.style.visibility = 'hidden';
+						}
 					}
 				}
 


### PR DESCRIPTION
This reloads the webview when a kernel with a preload changes. There
were two larger reworks in here:

- The existing reload handler didn't work, since it didn't wait for
  the initialization message and would send render requests before the
  listener was ready.

  Instead, always run the reload "restore" when initialization happens.
  This means we also don't need to wait for the "loaded" promise, which
  is a good thing since that would have been a false indicator around
  reloads.

- Cache more data around markdown cells so they can be restored after
  reload. Namely, their complete content rather than just a hash.
  I assume this was avoided for memory usage -- if it's a concern, one
  alternative would be to keep a reference to the ICellViewModel so
  that `getText` can be called on-demand. Let me know your thoughts.

  I would appreciate 👀 in general here since I am less
  familiar with the markdown code.

Fixes https://github.com/microsoft/vscode/issues/120747
