### PR TITLE
Reduce editor association setting verbosity.

### DIFF
--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -21,13 +21,13 @@ import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { CONTEXT_ACTIVE_CUSTOM_EDITOR_ID, CONTEXT_FOCUSED_CUSTOM_EDITOR_IS_EDITABLE, CustomEditorCapabilities, CustomEditorInfo, CustomEditorInfoCollection, ICustomEditorService } from 'vs/workbench/contrib/customEditor/common/customEditor';
 import { CustomEditorModelManager } from 'vs/workbench/contrib/customEditor/common/customEditorModelManager';
 import { IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { ContributedEditorPriority, IEditorAssociationsRegistry, IEditorOverrideService, IEditorType, IEditorTypesHandler } from 'vs/workbench/services/editor/common/editorOverrideService';
+import { ContributedEditorPriority, IEditorOverrideService, IEditorType } from 'vs/workbench/services/editor/common/editorOverrideService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
 import { ContributedCustomEditors } from '../common/contributedCustomEditors';
 import { CustomEditorInput } from './customEditorInput';
 
-export class CustomEditorService extends Disposable implements ICustomEditorService, IEditorTypesHandler {
+export class CustomEditorService extends Disposable implements ICustomEditorService {
 	_serviceBrand: any;
 
 	private readonly _contributedEditors: ContributedCustomEditors;
@@ -67,7 +67,6 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 			this.updateContexts();
 			this._onDidChangeEditorTypes.fire();
 		}));
-		this._register(Registry.as<IEditorAssociationsRegistry>(EditorExtensions.Associations).registerEditorTypesHandler('Custom Editor', this));
 		this._register(this.editorService.onDidActiveEditorChange(() => this.updateContexts()));
 
 		this._register(fileService.onDidRunOperation(e => {

--- a/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
@@ -21,11 +21,10 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IResourceEditorInput } from 'vs/platform/editor/common/editor';
 import { IFileService } from 'vs/platform/files/common/files';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { Registry } from 'vs/platform/registry/common/platform';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 import { NotebookExtensionDescription } from 'vs/workbench/api/common/extHost.protocol';
-import { EditorExtensions, IEditorInput } from 'vs/workbench/common/editor';
+import { IEditorInput } from 'vs/workbench/common/editor';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { Memento } from 'vs/workbench/common/memento';
 import { INotebookEditorContribution, notebookMarkupRendererExtensionPoint, notebookProviderExtensionPoint, notebookRendererExtensionPoint } from 'vs/workbench/contrib/notebook/browser/extensionPoint';
@@ -39,7 +38,7 @@ import { NotebookMarkupRendererInfo as NotebookMarkupRendererInfo } from 'vs/wor
 import { NotebookOutputRendererInfo } from 'vs/workbench/contrib/notebook/common/notebookOutputRenderer';
 import { NotebookEditorDescriptor, NotebookProviderInfo } from 'vs/workbench/contrib/notebook/common/notebookProvider';
 import { ComplexNotebookProviderInfo, INotebookContentProvider, INotebookSerializer, INotebookService, SimpleNotebookProviderInfo } from 'vs/workbench/contrib/notebook/common/notebookService';
-import { ContributedEditorPriority, DiffEditorInputFactoryFunction, EditorInputFactoryFunction, IEditorAssociationsRegistry, IEditorOverrideService, IEditorType, IEditorTypesHandler } from 'vs/workbench/services/editor/common/editorOverrideService';
+import { ContributedEditorPriority, DiffEditorInputFactoryFunction, EditorInputFactoryFunction, IEditorOverrideService, IEditorType } from 'vs/workbench/services/editor/common/editorOverrideService';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IExtensionPointUser } from 'vs/workbench/services/extensions/common/extensionsRegistry';
 
@@ -284,7 +283,7 @@ class ModelData implements IDisposable {
 	}
 }
 
-export class NotebookService extends Disposable implements INotebookService, IEditorTypesHandler {
+export class NotebookService extends Disposable implements INotebookService {
 
 	declare readonly _serviceBrand: undefined;
 
@@ -385,8 +384,6 @@ export class NotebookService extends Disposable implements INotebookService, IEd
 				}
 			}
 		});
-
-		this._register(Registry.as<IEditorAssociationsRegistry>(EditorExtensions.Associations).registerEditorTypesHandler('Notebook', this));
 
 		const updateOrder = () => {
 			const userOrder = this._configurationService.getValue<string[]>(DisplayOrderKey);

--- a/src/vs/workbench/services/editor/common/editorOverrideService.ts
+++ b/src/vs/workbench/services/editor/common/editorOverrideService.ts
@@ -43,44 +43,6 @@ export const DEFAULT_EDITOR_ASSOCIATION: IEditorType = {
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 
-// const editorTypeSchemaAddition: IJSONSchema = {
-// 	type: 'string',
-// 	enum: []
-// };
-
-// const editorAssociationsConfigurationNode: IConfigurationNode = {
-// 	...workbenchConfigurationNodeBase,
-// 	properties: {
-// 		'workbench.editorAssociations': {
-// 			type: 'array',
-// 			markdownDescription: localize('editor.editorAssociations', "Configure which editor to use for specific file types."),
-// 			items: {
-// 				type: 'object',
-// 				defaultSnippets: [{
-// 					body: {
-// 						'viewType': '$1',
-// 						'filenamePattern': '$2'
-// 					}
-// 				}],
-// 				properties: {
-// 					'viewType': {
-// 						anyOf: [
-// 							{
-// 								type: 'string',
-// 								description: localize('editor.editorAssociations.viewType', "The unique id of the editor to use."),
-// 							},
-// 							editorTypeSchemaAddition
-// 						]
-// 					},
-// 					'filenamePattern': {
-// 						type: 'string',
-// 						description: localize('editor.editorAssociations.filenamePattern', "Glob pattern specifying which files the editor should be used for."),
-// 					}
-// 				}
-// 			}
-// 		}
-// 	}
-// };
 const editorAssociationsConfigurationNode: IConfigurationNode = {
 	...workbenchConfigurationNodeBase,
 	properties: {
@@ -100,54 +62,6 @@ export interface IEditorType {
 	readonly providerDisplayName: string;
 }
 
-// class EditorAssociationsRegistry implements IEditorAssociationsRegistry {
-
-// 	private readonly editorTypesHandlers = new Map<string, IEditorTypesHandler>();
-
-// 	registerEditorTypesHandler(id: string, handler: IEditorTypesHandler): IDisposable {
-// 		if (this.editorTypesHandlers.has(id)) {
-// 			throw new Error(`An editor type handler with ${id} was already registered.`);
-// 		}
-
-// 		this.editorTypesHandlers.set(id, handler);
-// 		this.updateEditorAssociationsSchema();
-
-// 		const editorTypeChangeEvent = handler.onDidChangeEditorTypes(() => {
-// 			this.updateEditorAssociationsSchema();
-// 		});
-
-// 		return {
-// 			dispose: () => {
-// 				editorTypeChangeEvent.dispose();
-// 				this.editorTypesHandlers.delete(id);
-// 				this.updateEditorAssociationsSchema();
-// 			}
-// 		};
-// 	}
-
-// 	private updateEditorAssociationsSchema() {
-// 		const enumValues: string[] = [];
-// 		const enumDescriptions: string[] = [];
-
-// 		const editorTypes: IEditorType[] = [DEFAULT_EDITOR_ASSOCIATION];
-
-// 		for (const [, handler] of this.editorTypesHandlers) {
-// 			editorTypes.push(...handler.getEditorTypes());
-// 		}
-
-// 		for (const { id, providerDisplayName } of editorTypes) {
-// 			enumValues.push(id);
-// 			enumDescriptions.push(localize('editorAssociations.viewType.sourceDescription', "Source: {0}", providerDisplayName));
-// 		}
-
-// 		editorTypeSchemaAddition.enum = enumValues;
-// 		editorTypeSchemaAddition.enumDescriptions = enumDescriptions;
-
-// 		configurationRegistry.notifyConfigurationSchemaUpdated(editorAssociationsConfigurationNode);
-// 	}
-// }
-
-// Registry.add(EditorExtensions.Associations, new EditorAssociationsRegistry());
 configurationRegistry.registerConfiguration(editorAssociationsConfigurationNode);
 //#endregion
 

--- a/src/vs/workbench/services/editor/common/editorOverrideService.ts
+++ b/src/vs/workbench/services/editor/common/editorOverrideService.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as glob from 'vs/base/common/glob';
-import { Event } from 'vs/base/common/event';
-import { IJSONSchema } from 'vs/base/common/jsonSchema';
+// import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { posix } from 'vs/base/common/path';
@@ -17,7 +16,7 @@ import { Extensions as ConfigurationExtensions, IConfigurationNode, IConfigurati
 import { IEditorOptions, ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Registry } from 'vs/platform/registry/common/platform';
-import { EditorExtensions, IEditorInput, IEditorInputWithOptions, IEditorInputWithOptionsAndGroup } from 'vs/workbench/common/editor';
+import { IEditorInput, IEditorInputWithOptions, IEditorInputWithOptionsAndGroup } from 'vs/workbench/common/editor';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
 
@@ -44,40 +43,52 @@ export const DEFAULT_EDITOR_ASSOCIATION: IEditorType = {
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 
-const editorTypeSchemaAddition: IJSONSchema = {
-	type: 'string',
-	enum: []
-};
+// const editorTypeSchemaAddition: IJSONSchema = {
+// 	type: 'string',
+// 	enum: []
+// };
 
+// const editorAssociationsConfigurationNode: IConfigurationNode = {
+// 	...workbenchConfigurationNodeBase,
+// 	properties: {
+// 		'workbench.editorAssociations': {
+// 			type: 'array',
+// 			markdownDescription: localize('editor.editorAssociations', "Configure which editor to use for specific file types."),
+// 			items: {
+// 				type: 'object',
+// 				defaultSnippets: [{
+// 					body: {
+// 						'viewType': '$1',
+// 						'filenamePattern': '$2'
+// 					}
+// 				}],
+// 				properties: {
+// 					'viewType': {
+// 						anyOf: [
+// 							{
+// 								type: 'string',
+// 								description: localize('editor.editorAssociations.viewType', "The unique id of the editor to use."),
+// 							},
+// 							editorTypeSchemaAddition
+// 						]
+// 					},
+// 					'filenamePattern': {
+// 						type: 'string',
+// 						description: localize('editor.editorAssociations.filenamePattern', "Glob pattern specifying which files the editor should be used for."),
+// 					}
+// 				}
+// 			}
+// 		}
+// 	}
+// };
 const editorAssociationsConfigurationNode: IConfigurationNode = {
 	...workbenchConfigurationNodeBase,
 	properties: {
 		'workbench.editorAssociations': {
-			type: 'array',
+			type: 'object',
 			markdownDescription: localize('editor.editorAssociations', "Configure which editor to use for specific file types."),
-			items: {
-				type: 'object',
-				defaultSnippets: [{
-					body: {
-						'viewType': '$1',
-						'filenamePattern': '$2'
-					}
-				}],
-				properties: {
-					'viewType': {
-						anyOf: [
-							{
-								type: 'string',
-								description: localize('editor.editorAssociations.viewType', "The unique id of the editor to use."),
-							},
-							editorTypeSchemaAddition
-						]
-					},
-					'filenamePattern': {
-						type: 'string',
-						description: localize('editor.editorAssociations.filenamePattern', "Glob pattern specifying which files the editor should be used for."),
-					}
-				}
+			additionalProperties: {
+				type: 'string'
 			}
 		}
 	}
@@ -89,68 +100,54 @@ export interface IEditorType {
 	readonly providerDisplayName: string;
 }
 
-export interface IEditorTypesHandler {
-	readonly onDidChangeEditorTypes: Event<void>;
+// class EditorAssociationsRegistry implements IEditorAssociationsRegistry {
 
-	getEditorTypes(): IEditorType[];
-}
+// 	private readonly editorTypesHandlers = new Map<string, IEditorTypesHandler>();
 
-export interface IEditorAssociationsRegistry {
+// 	registerEditorTypesHandler(id: string, handler: IEditorTypesHandler): IDisposable {
+// 		if (this.editorTypesHandlers.has(id)) {
+// 			throw new Error(`An editor type handler with ${id} was already registered.`);
+// 		}
 
-	/**
-	 * Register handlers for editor types
-	 */
-	registerEditorTypesHandler(id: string, handler: IEditorTypesHandler): IDisposable;
-}
+// 		this.editorTypesHandlers.set(id, handler);
+// 		this.updateEditorAssociationsSchema();
 
-class EditorAssociationsRegistry implements IEditorAssociationsRegistry {
+// 		const editorTypeChangeEvent = handler.onDidChangeEditorTypes(() => {
+// 			this.updateEditorAssociationsSchema();
+// 		});
 
-	private readonly editorTypesHandlers = new Map<string, IEditorTypesHandler>();
+// 		return {
+// 			dispose: () => {
+// 				editorTypeChangeEvent.dispose();
+// 				this.editorTypesHandlers.delete(id);
+// 				this.updateEditorAssociationsSchema();
+// 			}
+// 		};
+// 	}
 
-	registerEditorTypesHandler(id: string, handler: IEditorTypesHandler): IDisposable {
-		if (this.editorTypesHandlers.has(id)) {
-			throw new Error(`An editor type handler with ${id} was already registered.`);
-		}
+// 	private updateEditorAssociationsSchema() {
+// 		const enumValues: string[] = [];
+// 		const enumDescriptions: string[] = [];
 
-		this.editorTypesHandlers.set(id, handler);
-		this.updateEditorAssociationsSchema();
+// 		const editorTypes: IEditorType[] = [DEFAULT_EDITOR_ASSOCIATION];
 
-		const editorTypeChangeEvent = handler.onDidChangeEditorTypes(() => {
-			this.updateEditorAssociationsSchema();
-		});
+// 		for (const [, handler] of this.editorTypesHandlers) {
+// 			editorTypes.push(...handler.getEditorTypes());
+// 		}
 
-		return {
-			dispose: () => {
-				editorTypeChangeEvent.dispose();
-				this.editorTypesHandlers.delete(id);
-				this.updateEditorAssociationsSchema();
-			}
-		};
-	}
+// 		for (const { id, providerDisplayName } of editorTypes) {
+// 			enumValues.push(id);
+// 			enumDescriptions.push(localize('editorAssociations.viewType.sourceDescription', "Source: {0}", providerDisplayName));
+// 		}
 
-	private updateEditorAssociationsSchema() {
-		const enumValues: string[] = [];
-		const enumDescriptions: string[] = [];
+// 		editorTypeSchemaAddition.enum = enumValues;
+// 		editorTypeSchemaAddition.enumDescriptions = enumDescriptions;
 
-		const editorTypes: IEditorType[] = [DEFAULT_EDITOR_ASSOCIATION];
+// 		configurationRegistry.notifyConfigurationSchemaUpdated(editorAssociationsConfigurationNode);
+// 	}
+// }
 
-		for (const [, handler] of this.editorTypesHandlers) {
-			editorTypes.push(...handler.getEditorTypes());
-		}
-
-		for (const { id, providerDisplayName } of editorTypes) {
-			enumValues.push(id);
-			enumDescriptions.push(localize('editorAssociations.viewType.sourceDescription', "Source: {0}", providerDisplayName));
-		}
-
-		editorTypeSchemaAddition.enum = enumValues;
-		editorTypeSchemaAddition.enumDescriptions = enumDescriptions;
-
-		configurationRegistry.notifyConfigurationSchemaUpdated(editorAssociationsConfigurationNode);
-	}
-}
-
-Registry.add(EditorExtensions.Associations, new EditorAssociationsRegistry());
+// Registry.add(EditorExtensions.Associations, new EditorAssociationsRegistry());
 configurationRegistry.registerConfiguration(editorAssociationsConfigurationNode);
 //#endregion
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #122365
It seemed like everyone enjoyed the way `files.associations` worked so I copied that flow.

This will read in and be able to handle the old and new format, but will only write to the new format. When I try to handle conversion I get an error saying we can't write to the user setting because there are errors. This is shown due to the fact that the types have changed from array to object, if you have any suggestions let me know.

Secondly, the biggest downside to this is we lose intellisense. The loss of intellisense does clean up a lot of code since it was dynamic, but that is still something to consider. File associations also doesn't have intellisense and the setting is often set through a picker similar to custom editors.
