### PR TITLE
Update spdlog, use lazy initialization in extension host

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "native-watchdog": "1.3.0",
     "node-pty": "0.10.1",
     "nsfw": "2.1.2",
-    "spdlog": "^0.11.1",
+    "spdlog": "0.13.0",
     "sudo-prompt": "9.2.1",
     "tas-client-umd": "0.1.4",
     "v8-inspect-profiler": "^0.0.20",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "native-watchdog": "1.3.0",
     "node-pty": "0.10.1",
     "nsfw": "2.1.2",
-    "spdlog": "0.13.0",
+    "spdlog": "0.13.1",
     "sudo-prompt": "9.2.1",
     "tas-client-umd": "0.1.4",
     "v8-inspect-profiler": "^0.0.20",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "native-watchdog": "1.3.0",
     "node-pty": "0.10.1",
     "nsfw": "2.1.2",
-    "spdlog": "0.13.1",
+    "spdlog": "^0.13.0",
     "sudo-prompt": "9.2.1",
     "tas-client-umd": "0.1.4",
     "v8-inspect-profiler": "^0.0.20",

--- a/remote/package.json
+++ b/remote/package.json
@@ -15,7 +15,7 @@
     "native-watchdog": "1.3.0",
     "node-pty": "0.10.1",
     "nsfw": "2.1.2",
-    "spdlog": "0.13.1",
+    "spdlog": "^0.13.0",
     "tas-client-umd": "0.1.4",
     "vscode-oniguruma": "1.5.1",
     "vscode-proxy-agent": "^0.11.0",

--- a/remote/package.json
+++ b/remote/package.json
@@ -15,7 +15,7 @@
     "native-watchdog": "1.3.0",
     "node-pty": "0.10.1",
     "nsfw": "2.1.2",
-    "spdlog": "^0.11.1",
+    "spdlog": "0.13.1",
     "tas-client-umd": "0.1.4",
     "vscode-oniguruma": "1.5.1",
     "vscode-proxy-agent": "^0.11.0",

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -441,10 +441,10 @@ socks@^2.3.3:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
-spdlog@0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.1.tgz#bb33c7e4b4b11925962a6048f0cf24379803a5b8"
-  integrity sha512-pgOmpBTRaWCm0oEoN2pyeGGYbLk4hcw2R2TU0nkz6m1++e/SBw1xWKzofe7sneFBC3xudhqmQkjm+doFXQtq2w==
+spdlog@^0.13.0:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.3.tgz#8e11c1a24f5a47c7e6651b30659ed70f74d91a0c"
+  integrity sha512-eCG0MzQMnzei31gso8HDgaypeHTd/woAwxwsEEBEmY+tt4hkDGA/3YJgsS4z6BY+ps4JY7NzvmFUhOOdQL7Xgw==
   dependencies:
     bindings "^1.5.0"
     mkdirp "^0.5.5"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -338,15 +338,10 @@ ms@2.1.2, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nan@^2.13.2:
+nan@^2.13.2, nan@^2.14.0:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
-
-nan@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 native-watchdog@1.3.0:
   version "1.3.0"
@@ -442,9 +437,9 @@ socks@^2.3.3:
     smart-buffer "^4.1.0"
 
 spdlog@^0.13.0:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.3.tgz#8e11c1a24f5a47c7e6651b30659ed70f74d91a0c"
-  integrity sha512-eCG0MzQMnzei31gso8HDgaypeHTd/woAwxwsEEBEmY+tt4hkDGA/3YJgsS4z6BY+ps4JY7NzvmFUhOOdQL7Xgw==
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.4.tgz#7393d436f077fca1d07500741e50cbf8928a838a"
+  integrity sha512-tdzk9ysc640emskx+pE/A2JdJ5IAr440ZIsNjRlD9aPK6U6IQ94VUGpl7u0NHamAB8O1H7RxLgtHyXT32V+RaA==
   dependencies:
     bindings "^1.5.0"
     mkdirp "^0.5.5"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -321,7 +321,7 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mkdirp@^0.5.1:
+mkdirp@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -441,13 +441,13 @@ socks@^2.3.3:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
-spdlog@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.11.1.tgz#29721b31018a5fe6a3ce2531f9d8d43e0bd6b825"
-  integrity sha512-M+sg9/Tnr0lrfnW2/hqgpoc4Z8Jzq7W8NUn35iiSslj+1uj1pgutI60MCpulDP2QyFzOpC8VsJmYD6Fub7wHoA==
+spdlog@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.1.tgz#bb33c7e4b4b11925962a6048f0cf24379803a5b8"
+  integrity sha512-pgOmpBTRaWCm0oEoN2pyeGGYbLk4hcw2R2TU0nkz6m1++e/SBw1xWKzofe7sneFBC3xudhqmQkjm+doFXQtq2w==
   dependencies:
     bindings "^1.5.0"
-    mkdirp "^0.5.1"
+    mkdirp "^0.5.5"
     nan "^2.14.0"
 
 string_decoder@~0.10.x:

--- a/src/vs/platform/environment/test/node/nativeModules.test.ts
+++ b/src/vs/platform/environment/test/node/nativeModules.test.ts
@@ -34,7 +34,7 @@ suite('Native Modules (all platforms)', () => {
 
 	test('spdlog', async () => {
 		const spdlog = await import('spdlog');
-		assert.ok(typeof spdlog.createRotatingLoggerSync === 'function', testErrorMessage('spdlog'));
+		assert.ok(typeof spdlog.createRotatingLogger === 'function', testErrorMessage('spdlog'));
 	});
 
 	test('nsfw', async () => {

--- a/src/vs/platform/environment/test/node/nativeModules.test.ts
+++ b/src/vs/platform/environment/test/node/nativeModules.test.ts
@@ -34,7 +34,7 @@ suite('Native Modules (all platforms)', () => {
 
 	test('spdlog', async () => {
 		const spdlog = await import('spdlog');
-		assert.ok(typeof spdlog.createRotatingLogger === 'function', testErrorMessage('spdlog'));
+		assert.ok(typeof spdlog.createRotatingLoggerSync === 'function', testErrorMessage('spdlog'));
 	});
 
 	test('nsfw', async () => {

--- a/src/vs/platform/log/node/spdlogLog.ts
+++ b/src/vs/platform/log/node/spdlogLog.ts
@@ -18,9 +18,9 @@ async function createSpdLogLogger(name: string, logfilePath: string, filesize: n
 	return null;
 }
 
-export function createRotatingLoggerSync(name: string, filename: string, filesize: number, filecount: number): spdlog.Logger {
+export function createRotatingLogger(name: string, filename: string, filesize: number, filecount: number): Promise<spdlog.Logger> {
 	const _spdlog: typeof spdlog = require.__$__nodeRequire('spdlog');
-	return _spdlog.createRotatingLoggerSync(name, filename, filesize, filecount);
+	return _spdlog.createRotatingLogger(name, filename, filesize, filecount);
 }
 
 interface ILog {

--- a/src/vs/platform/log/node/spdlogLog.ts
+++ b/src/vs/platform/log/node/spdlogLog.ts
@@ -7,21 +7,20 @@ import { LogLevel, ILogger, AbstractMessageLogger } from 'vs/platform/log/common
 import * as spdlog from 'spdlog';
 import { ByteSize } from 'vs/platform/files/common/files';
 
-async function createSpdLogLogger(name: string, logfilePath: string, filesize: number, filecount: number): Promise<spdlog.RotatingLogger | null> {
+async function createSpdLogLogger(name: string, logfilePath: string, filesize: number, filecount: number): Promise<spdlog.Logger | null> {
 	// Do not crash if spdlog cannot be loaded
 	try {
 		const _spdlog = await import('spdlog');
-		_spdlog.setAsyncMode(8192, 500);
-		return _spdlog.createRotatingLoggerAsync(name, logfilePath, filesize, filecount);
+		return _spdlog.createAsyncRotatingLogger(name, logfilePath, filesize, filecount);
 	} catch (e) {
 		console.error(e);
 	}
 	return null;
 }
 
-export function createRotatingLogger(name: string, filename: string, filesize: number, filecount: number): spdlog.RotatingLogger {
+export function createRotatingLoggerSync(name: string, filename: string, filesize: number, filecount: number): spdlog.Logger {
 	const _spdlog: typeof spdlog = require.__$__nodeRequire('spdlog');
-	return _spdlog.createRotatingLogger(name, filename, filesize, filecount);
+	return _spdlog.createRotatingLoggerSync(name, filename, filesize, filecount);
 }
 
 interface ILog {
@@ -29,7 +28,7 @@ interface ILog {
 	message: string;
 }
 
-function log(logger: spdlog.RotatingLogger, level: LogLevel, message: string): void {
+function log(logger: spdlog.Logger, level: LogLevel, message: string): void {
 	switch (level) {
 		case LogLevel.Trace: logger.trace(message); break;
 		case LogLevel.Debug: logger.debug(message); break;
@@ -45,7 +44,7 @@ export class SpdLogLogger extends AbstractMessageLogger implements ILogger {
 
 	private buffer: ILog[] = [];
 	private readonly _loggerCreationPromise: Promise<void>;
-	private _logger: spdlog.RotatingLogger | undefined;
+	private _logger: spdlog.Logger | undefined;
 
 	constructor(
 		private readonly name: string,

--- a/src/vs/workbench/api/node/extHostOutputService.ts
+++ b/src/vs/workbench/api/node/extHostOutputService.ts
@@ -15,16 +15,15 @@ import { IExtHostInitDataService } from 'vs/workbench/api/common/extHostInitData
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
 import { MutableDisposable } from 'vs/base/common/lifecycle';
 import { ILogService } from 'vs/platform/log/common/log';
-import { createRotatingLogger } from 'vs/platform/log/node/spdlogLog';
-import { RotatingLogger } from 'spdlog';
+import { createRotatingLoggerSync } from 'vs/platform/log/node/spdlogLog';
+import { Logger } from 'spdlog';
 import { ByteSize } from 'vs/platform/files/common/files';
 
 class OutputAppender {
+	private appender: Logger;
 
-	private appender: RotatingLogger;
-
-	constructor(name: string, readonly file: string) {
-		this.appender = createRotatingLogger(name, file, 30 * ByteSize.MB, 1);
+	constructor(readonly name: string, readonly file: string) {
+		this.appender = createRotatingLoggerSync(name, file, 30 * ByteSize.MB, 1);
 		this.appender.clearFormatters();
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6442,15 +6442,10 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.12.1, nan@^2.13.2:
+nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
-
-nan@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 nanoid@3.1.12:
   version "3.1.12"
@@ -8697,9 +8692,9 @@ sparkles@^1.0.0:
   integrity sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==
 
 spdlog@^0.13.0:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.3.tgz#8e11c1a24f5a47c7e6651b30659ed70f74d91a0c"
-  integrity sha512-eCG0MzQMnzei31gso8HDgaypeHTd/woAwxwsEEBEmY+tt4hkDGA/3YJgsS4z6BY+ps4JY7NzvmFUhOOdQL7Xgw==
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.4.tgz#7393d436f077fca1d07500741e50cbf8928a838a"
+  integrity sha512-tdzk9ysc640emskx+pE/A2JdJ5IAr440ZIsNjRlD9aPK6U6IQ94VUGpl7u0NHamAB8O1H7RxLgtHyXT32V+RaA==
   dependencies:
     bindings "^1.5.0"
     mkdirp "^0.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8696,10 +8696,10 @@ sparkles@^1.0.0:
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.1.tgz#008db65edce6c50eec0c5e228e1945061dd0437c"
   integrity sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==
 
-spdlog@0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.1.tgz#bb33c7e4b4b11925962a6048f0cf24379803a5b8"
-  integrity sha512-pgOmpBTRaWCm0oEoN2pyeGGYbLk4hcw2R2TU0nkz6m1++e/SBw1xWKzofe7sneFBC3xudhqmQkjm+doFXQtq2w==
+spdlog@^0.13.0:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.3.tgz#8e11c1a24f5a47c7e6651b30659ed70f74d91a0c"
+  integrity sha512-eCG0MzQMnzei31gso8HDgaypeHTd/woAwxwsEEBEmY+tt4hkDGA/3YJgsS4z6BY+ps4JY7NzvmFUhOOdQL7Xgw==
   dependencies:
     bindings "^1.5.0"
     mkdirp "^0.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8696,10 +8696,10 @@ sparkles@^1.0.0:
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.1.tgz#008db65edce6c50eec0c5e228e1945061dd0437c"
   integrity sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==
 
-spdlog@0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.0.tgz#d9424b508928c51b233f0838e5d9f4161106d9a9"
-  integrity sha512-lz82g0f+iG4x7O9RmNpn14vzcPPzumBKx4nrvIw+ZvuGJN+ojWbDbaSPkqJuWZ+Fc1Oxdf5FTGf0iCwW3+pAOw==
+spdlog@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.1.tgz#bb33c7e4b4b11925962a6048f0cf24379803a5b8"
+  integrity sha512-pgOmpBTRaWCm0oEoN2pyeGGYbLk4hcw2R2TU0nkz6m1++e/SBw1xWKzofe7sneFBC3xudhqmQkjm+doFXQtq2w==
   dependencies:
     bindings "^1.5.0"
     mkdirp "^0.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6328,7 +6328,7 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.0, mkdirp@~0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -8696,13 +8696,13 @@ sparkles@^1.0.0:
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.1.tgz#008db65edce6c50eec0c5e228e1945061dd0437c"
   integrity sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==
 
-spdlog@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.11.1.tgz#29721b31018a5fe6a3ce2531f9d8d43e0bd6b825"
-  integrity sha512-M+sg9/Tnr0lrfnW2/hqgpoc4Z8Jzq7W8NUn35iiSslj+1uj1pgutI60MCpulDP2QyFzOpC8VsJmYD6Fub7wHoA==
+spdlog@0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/spdlog/-/spdlog-0.13.0.tgz#d9424b508928c51b233f0838e5d9f4161106d9a9"
+  integrity sha512-lz82g0f+iG4x7O9RmNpn14vzcPPzumBKx4nrvIw+ZvuGJN+ojWbDbaSPkqJuWZ+Fc1Oxdf5FTGf0iCwW3+pAOw==
   dependencies:
     bindings "^1.5.0"
-    mkdirp "^0.5.1"
+    mkdirp "^0.5.5"
     nan "^2.14.0"
 
 spdx-correct@^3.0.0:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR affects #121513

Currently, node-spdlog 0.13.1 exposes two async factory methods to construct rotating synchronous loggers and rotating async loggers.
I have changed some of the code in the extension host to initialize the async logger only when it needs to be used.

