### PR TITLE
files and folders cannot end with a '.' on windows

### DIFF
--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -20,6 +20,7 @@ import { CancellationTokenSource, CancellationToken } from 'vs/base/common/cance
 import { Schemas } from 'vs/base/common/network';
 import { readFileIntoStream } from 'vs/platform/files/common/io';
 import { Iterable } from 'vs/base/common/iterator';
+import { isWindows } from 'vs/base/common/platform';
 
 export class FileService extends Disposable implements IFileService {
 
@@ -313,6 +314,9 @@ export class FileService extends Disposable implements IFileService {
 		// validate overwrite
 		if (!options?.overwrite && await this.exists(resource)) {
 			throw new FileOperationError(localize('fileExists', "Unable to create file '{0}' that already exists when overwrite flag is not set", this.resourceForError(resource)), FileOperationResult.FILE_MODIFIED_SINCE, options);
+		}
+		if (isWindows && resource.fsPath.endsWith('.')) {
+			throw new FileOperationError(localize('fileNameEndsWithPeriodError', "Unable to create file '{0}' that ends with a '.'", this.resourceForError(resource)), FileOperationResult.FILE_OTHER_ERROR, options);
 		}
 	}
 

--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -20,7 +20,6 @@ import { CancellationTokenSource, CancellationToken } from 'vs/base/common/cance
 import { Schemas } from 'vs/base/common/network';
 import { readFileIntoStream } from 'vs/platform/files/common/io';
 import { Iterable } from 'vs/base/common/iterator';
-import { isWindows } from 'vs/base/common/platform';
 
 export class FileService extends Disposable implements IFileService {
 
@@ -314,9 +313,6 @@ export class FileService extends Disposable implements IFileService {
 		// validate overwrite
 		if (!options?.overwrite && await this.exists(resource)) {
 			throw new FileOperationError(localize('fileExists', "Unable to create file '{0}' that already exists when overwrite flag is not set", this.resourceForError(resource)), FileOperationResult.FILE_MODIFIED_SINCE, options);
-		}
-		if (isWindows && resource.fsPath.endsWith('.')) {
-			throw new FileOperationError(localize('fileNameEndsWithPeriodError', "Unable to create file '{0}' that ends with a '.'", this.resourceForError(resource)), FileOperationResult.FILE_OTHER_ERROR, options);
 		}
 	}
 

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -466,6 +466,7 @@ export enum FileSystemProviderErrorCode {
 	FileNotADirectory = 'EntryNotADirectory',
 	FileIsADirectory = 'EntryIsADirectory',
 	FileExceedsMemoryLimit = 'EntryExceedsMemoryLimit',
+	FilePathInvalid = 'EntryHasInvalidCharacter',
 	FileTooLarge = 'EntryTooLarge',
 	FileWriteLocked = 'EntryWriteLocked',
 	NoPermissions = 'NoPermissions',

--- a/src/vs/platform/files/node/diskFileSystemProvider.ts
+++ b/src/vs/platform/files/node/diskFileSystemProvider.ts
@@ -188,6 +188,10 @@ export class DiskFileSystemProvider extends Disposable implements
 				}
 			}
 
+			if (isWindows && (opts.create || opts.overwrite) && filePath.endsWith('.')) {
+				throw createFileSystemProviderError(localize('entryEndsWithDot', "Entries cannot end with a '.' on Windows."), FileSystemProviderErrorCode.FilePathInvalid);
+			}
+
 			// Open
 			handle = await this.open(resource, { create: true, unlock: opts.unlock });
 
@@ -211,7 +215,7 @@ export class DiskFileSystemProvider extends Disposable implements
 		try {
 			const filePath = this.toFilePath(resource);
 
-			// Determine wether to unlock the file (write only)
+			// Determine whether to unlock the file (write only)
 			if (isFileOpenForWriteOptions(opts) && opts.unlock) {
 				try {
 					const { stat } = await SymlinkSupport.stat(filePath);

--- a/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
+++ b/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
@@ -1674,6 +1674,13 @@ flakySuite('Disk File Service', function () {
 		assert.strictEqual(event!.target!.resource.fsPath, resource.fsPath);
 	});
 
+	(isWindows ? test : test.skip)('createFile (Windows does not allow files to end with ".")', async () => {
+		const resource = URI.file(join(testDir, 'test.'));
+		await assert.rejects(async () => {
+			await service.writeFile(resource, VSBuffer.fromString(''));
+		});
+	});
+
 	test('writeFile - default', async () => {
 		return testWriteFile();
 	});

--- a/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
+++ b/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
@@ -1674,21 +1674,6 @@ flakySuite('Disk File Service', function () {
 		assert.strictEqual(event!.target!.resource.fsPath, resource.fsPath);
 	});
 
-	/* https://github.com/microsoft/vscode/issues/117426 */
-	(isWindows /* windows: cannot end a file/folder name with a '.' */ ? test : test.skip)('createFile (Windows cannot end a file/folder with ".")', async () => {
-		const resource = URI.file(join(testDir, 'test.'));
-
-		let e: Error;
-		try {
-			await service.canCreateFile(resource);
-		} catch (err) {
-			e = err;
-		}
-
-		assert.ok(e!);
-	});
-
-
 	test('writeFile - default', async () => {
 		return testWriteFile();
 	});

--- a/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
+++ b/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
@@ -1674,6 +1674,21 @@ flakySuite('Disk File Service', function () {
 		assert.strictEqual(event!.target!.resource.fsPath, resource.fsPath);
 	});
 
+	/* https://github.com/microsoft/vscode/issues/117426 */
+	(isWindows /* windows: cannot end a file/folder name with a '.' */ ? test : test.skip)('createFile (Windows cannot end a file/folder with ".")', async () => {
+		const resource = URI.file(join(testDir, 'test.'));
+
+		let e: Error;
+		try {
+			await service.canCreateFile(resource);
+		} catch (err) {
+			e = err;
+		}
+
+		assert.ok(e!);
+	});
+
+
 	test('writeFile - default', async () => {
 		return testWriteFile();
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Files and folders cannot end with a `.` on windows.  This PR throws an error when a file/folder is created that has a trailing `.`.

I created the test based off of a similar one in the file, but am on a mac and cannot actually test it.  It may need to be updated/validated on a windows computer.


The windows file explorer behavior is slightly different.  It just removes the trailing `.`, so if that is preferred I can modify the PR to do that.  I would just need a pointer to where I should be modifying the resource URI to remove the trailing `.`.


This PR fixes #117426
