### PR TITLE
add color customizations for inline debug values

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -58,13 +58,13 @@ export const debugInlineForeground = registerColor('debugInline.decorationForegr
 	dark: '#ffffff80',
 	light: '#00000080',
 	hc: '#ffffff80'
-}, nls.localize('debug.inline.decorationForeground', "Color for the inline debug text."));
+}, nls.localize('debugInline.decorationForeground', "Color for the debug inline value text."));
 
 export const debugInlineBackground = registerColor('debugInline.decorationBackground', {
 	dark: '#ffc80033',
 	light: '#ffc80033',
 	hc: '#ffc80033'
-}, nls.localize('debug.inline.decorationBackground', "Color for the inline debug background."));
+}, nls.localize('debugInline.decorationBackground', "Color for the debug inline value background."));
 
 
 

--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -45,12 +45,28 @@ import { Event } from 'vs/base/common/event';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { Expression } from 'vs/workbench/contrib/debug/common/debugModel';
+import { themeColorFromId } from 'vs/platform/theme/common/themeService';
+import { registerColor } from 'vs/platform/theme/common/colorRegistry';
 
 const LAUNCH_JSON_REGEX = /\.vscode\/launch\.json$/;
 const INLINE_VALUE_DECORATION_KEY = 'inlinevaluedecoration';
 const MAX_NUM_INLINE_VALUES = 100; // JS Global scope can have 700+ entries. We want to limit ourselves for perf reasons
 const MAX_INLINE_DECORATOR_LENGTH = 150; // Max string length of each inline decorator when debugging. If exceeded ... is added
 const MAX_TOKENIZATION_LINE_LEN = 500; // If line is too long, then inline values for the line are skipped
+
+export const debugInlineForeground = registerColor('debugInline.decorationForeground', {
+	dark: '#ffffff80',
+	light: '#00000080',
+	hc: '#ffffff80'
+}, nls.localize('debug.inline.decorationForeground', "Color for the inline debug text."));
+
+export const debugInlineBackground = registerColor('debugInline.decorationBackground', {
+	dark: '#ffc80033',
+	light: '#ffc80033',
+	hc: '#ffc80033'
+}, nls.localize('debug.inline.decorationBackground', "Color for the inline debug background."));
+
+
 
 class InlineSegment {
 	constructor(public column: number, public text: string) {
@@ -73,18 +89,9 @@ function createInlineValueDecoration(lineNumber: number, contentText: string, co
 		renderOptions: {
 			after: {
 				contentText,
-				backgroundColor: 'rgba(255, 200, 0, 0.2)',
-				margin: '10px'
-			},
-			dark: {
-				after: {
-					color: 'rgba(255, 255, 255, 0.5)',
-				}
-			},
-			light: {
-				after: {
-					color: 'rgba(0, 0, 0, 0.5)',
-				}
+				backgroundColor: themeColorFromId(debugInlineBackground),
+				margin: '10px',
+				color: themeColorFromId(debugInlineForeground)
 			}
 		}
 	};

--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -54,17 +54,17 @@ const MAX_NUM_INLINE_VALUES = 100; // JS Global scope can have 700+ entries. We 
 const MAX_INLINE_DECORATOR_LENGTH = 150; // Max string length of each inline decorator when debugging. If exceeded ... is added
 const MAX_TOKENIZATION_LINE_LEN = 500; // If line is too long, then inline values for the line are skipped
 
-export const debugInlineForeground = registerColor('debugInline.decorationForeground', {
+export const debugInlineForeground = registerColor('editor.inlineValuesForeground', {
 	dark: '#ffffff80',
 	light: '#00000080',
 	hc: '#ffffff80'
-}, nls.localize('debugInline.decorationForeground', "Color for the debug inline value text."));
+}, nls.localize('editor.inlineValuesForeground', "Color for the debug inline value text."));
 
-export const debugInlineBackground = registerColor('debugInline.decorationBackground', {
+export const debugInlineBackground = registerColor('editor.inlineValuesBackground', {
 	dark: '#ffc80033',
 	light: '#ffc80033',
 	hc: '#ffc80033'
-}, nls.localize('debugInline.decorationBackground', "Color for the debug inline value background."));
+}, nls.localize('editor.inlineValuesBackground', "Color for the debug inline value background."));
 
 class InlineSegment {
 	constructor(public column: number, public text: string) {

--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -66,8 +66,6 @@ export const debugInlineBackground = registerColor('debugInline.decorationBackgr
 	hc: '#ffc80033'
 }, nls.localize('debugInline.decorationBackground', "Color for the debug inline value background."));
 
-
-
 class InlineSegment {
 	constructor(public column: number, public text: string) {
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Modifies inline debug values to be allow color customizations/themes.  Defaults should still be what they were previously, just converted to hex from rgba.

New color ids, `debugInline.decorationBackground` and `debugInline.decorationForeground`.  The names may need to be changed to better align with the other ids.



Example of modified colors.
<img width="289" alt="Screen Shot 2021-05-05 at 11 29 18 PM" src="https://user-images.githubusercontent.com/52075362/117241934-d364e980-adf9-11eb-811a-86d41a161498.png">


This PR fixes #120936
