### PR TITLE
Introducing SimpleEditorContext for simple widget editors

### DIFF
--- a/src/vs/editor/contrib/clipboard/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/clipboard.ts
@@ -61,6 +61,12 @@ export const CutAction = supportsCut ? registerCommand(new MultiCommand({
 		group: '',
 		title: nls.localize('actions.clipboard.cutLabel', "Cut"),
 		order: 1
+	}, {
+		menuId: MenuId.SimpleEditorContext,
+		group: CLIPBOARD_CONTEXT_MENU_GROUP,
+		title: nls.localize('actions.clipboard.cutLabel', "Cut"),
+		when: EditorContextKeys.writable,
+		order: 1,
 	}]
 })) : undefined;
 
@@ -91,6 +97,11 @@ export const CopyAction = supportsCopy ? registerCommand(new MultiCommand({
 		group: '',
 		title: nls.localize('actions.clipboard.copyLabel', "Copy"),
 		order: 1
+	}, {
+		menuId: MenuId.SimpleEditorContext,
+		group: CLIPBOARD_CONTEXT_MENU_GROUP,
+		title: nls.localize('actions.clipboard.copyLabel', "Copy"),
+		order: 2,
 	}]
 })) : undefined;
 
@@ -126,6 +137,12 @@ export const PasteAction = supportsPaste ? registerCommand(new MultiCommand({
 		group: '',
 		title: nls.localize('actions.clipboard.pasteLabel', "Paste"),
 		order: 1
+	}, {
+		menuId: MenuId.SimpleEditorContext,
+		group: CLIPBOARD_CONTEXT_MENU_GROUP,
+		title: nls.localize('actions.clipboard.pasteLabel', "Paste"),
+		when: EditorContextKeys.writable,
+		order: 4,
 	}]
 })) : undefined;
 

--- a/src/vs/editor/contrib/contextmenu/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/contextmenu.ts
@@ -135,7 +135,8 @@ export class ContextMenuController implements IEditorContribution {
 		}
 
 		// Find actions available for menu
-		const menuActions = this._getMenuActions(this._editor.getModel(), MenuId.EditorContext);
+		const menuActions = this._getMenuActions(this._editor.getModel(),
+			this._editor.isSimpleWidget ? MenuId.SimpleEditorContext : MenuId.EditorContext);
 
 		// Show menu if we have actions to show
 		if (menuActions.length > 0) {

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -87,6 +87,7 @@ export class MenuId {
 	static readonly DebugWatchContext = new MenuId('DebugWatchContext');
 	static readonly DebugToolBar = new MenuId('DebugToolBar');
 	static readonly EditorContext = new MenuId('EditorContext');
+	static readonly SimpleEditorContext = new MenuId('SimpleEditorContext');
 	static readonly EditorContextCopy = new MenuId('EditorContextCopy');
 	static readonly EditorContextPeek = new MenuId('EditorContextPeek');
 	static readonly EditorTitle = new MenuId('EditorTitle');


### PR DESCRIPTION
SimpleEditorContext is used instead of EditorContext for simple widget editors.
This prevents contributions from extensions to extend the context menu for simple widget editors, such as the SCM commit message editor.

This PR fixes #89459 

* [x] Discuss name: Is the name "SimpleEditorContext" ok? An alternative would be "EmbeddedEditorContext".