### PR TITLE
Fix a typo in generating localised untitled editors hint.

### DIFF
--- a/src/vs/workbench/browser/parts/editor/untitledHint.ts
+++ b/src/vs/workbench/browser/parts/editor/untitledHint.ts
@@ -109,7 +109,7 @@ class UntitledHintContentWidget implements IContentWidget {
 			this.domNode.style.width = 'max-content';
 			const language = $('a.language-mode');
 			language.style.cursor = 'pointer';
-			language.innerText = localize('selectAlanguage', "Select a language");
+			language.innerText = localize('selectALanguage', "Select a language");
 			this.domNode.appendChild(language);
 			const toGetStarted = $('span');
 			toGetStarted.innerText = localize('toGetStarted', " to get started. Start typing to dismiss, or ",);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #123152. It seems that issue is caused by mistyping `selectALanguage` as `selectAlanguage` in `src/vs/workbench/browser/parts/editor/untitledHint.ts`. This PR is intended to fix it.