### PR TITLE
Allow text search providers to give messages with links that trigger researching.

### DIFF
--- a/src/vs/platform/opener/browser/link.ts
+++ b/src/vs/platform/opener/browser/link.ts
@@ -31,6 +31,8 @@ export class Link extends Disposable {
 		textLinkForeground: Color.fromHex('#006AB1')
 	};
 
+	private handler: (href: string) => void;
+
 	constructor(
 		link: ILinkDescriptor,
 		@IOpenerService openerService: IOpenerService
@@ -50,15 +52,22 @@ export class Link extends Disposable {
 			.event;
 		const onOpen = Event.any<EventLike>(onClick, onEnterPress);
 
+		this.handler = (href) => openerService.open(href, { allowCommands: true });
+		this._register({ dispose: () => this.handler = undefined! });
+
 		this._register(onOpen(e => {
 			EventHelper.stop(e, true);
 			if (!this.disabled) {
-				openerService.open(link.href, { allowCommands: true });
+				this.handler(link.href);
 			}
 		}));
 
 		this.disabled = false;
 		this.applyStyles();
+	}
+
+	setHandler(handler: (href: string) => void) {
+		this.handler = handler;
 	}
 
 	style(styles: ILinkStyles): void {

--- a/src/vs/platform/opener/browser/link.ts
+++ b/src/vs/platform/opener/browser/link.ts
@@ -18,6 +18,10 @@ export interface ILinkDescriptor {
 	readonly title?: string;
 }
 
+export interface ILinkOptions {
+	readonly opener?: (href: string) => void;
+}
+
 export interface ILinkStyles {
 	readonly textLinkForeground?: Color;
 	readonly disabled?: boolean;
@@ -31,10 +35,9 @@ export class Link extends Disposable {
 		textLinkForeground: Color.fromHex('#006AB1')
 	};
 
-	private handler: (href: string) => void;
-
 	constructor(
 		link: ILinkDescriptor,
+		options: ILinkOptions | undefined = undefined,
 		@IOpenerService openerService: IOpenerService
 	) {
 		super();
@@ -52,22 +55,19 @@ export class Link extends Disposable {
 			.event;
 		const onOpen = Event.any<EventLike>(onClick, onEnterPress);
 
-		this.handler = (href) => openerService.open(href, { allowCommands: true });
-		this._register({ dispose: () => this.handler = undefined! });
-
 		this._register(onOpen(e => {
 			EventHelper.stop(e, true);
 			if (!this.disabled) {
-				this.handler(link.href);
+				if (options?.opener) {
+					options.opener(link.href);
+				} else {
+					openerService.open(link.href, { allowCommands: true });
+				}
 			}
 		}));
 
 		this.disabled = false;
 		this.applyStyles();
-	}
-
-	setHandler(handler: (href: string) => void) {
-		this.handler = handler;
 	}
 
 	style(styles: ILinkStyles): void {

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -410,8 +410,9 @@ declare module 'vscode' {
 		 *
 		 * Messages with "Information" tyle support links in markdown syntax:
 		 * - Click to [run a command](command:workbench.action.OpenQuickPick)
-		 * 		- Commands may optionally return an object with a 'triggerSearch' property set `true` to signal to VS Code that the original should run be agian.
 		 * - Click to [open a website](https://aka.ms)
+		 *
+		 * Commands may optionally return { triggerSearch: true } to signal to VS Code that the original search should run be agian.
 		 */
 		message?: { text: string, type: TextSearchCompleteMessageType } | { text: string, type: TextSearchCompleteMessageType }[];
 	}

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -393,8 +393,8 @@ declare module 'vscode' {
 	}
 
 	/**
- * A message regarding a completed search.
- */
+	 * A message regarding a completed search.
+	 */
 	export interface TextSearchCompleteMessage {
 		/**
 		 * Markdown text of the message.

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -393,6 +393,24 @@ declare module 'vscode' {
 	}
 
 	/**
+ * A message regarding a completed search.
+ */
+	export interface TextSearchCompleteMessage {
+		/**
+		 * Markdown text of the message.
+		 */
+		text: string,
+		/**
+		 * Whether the source of the message is trusted, command links are disabled for untrusted message sources.
+		 */
+		trusted: boolean,
+		/**
+		 * The message type, this affects how the message will be rendered.
+		 */
+		type: TextSearchCompleteMessageType,
+	}
+
+	/**
 	 * Information collected when text search is complete.
 	 */
 	export interface TextSearchComplete {
@@ -414,7 +432,7 @@ declare module 'vscode' {
 		 *
 		 * Commands may optionally return { triggerSearch: true } to signal to VS Code that the original search should run be agian.
 		 */
-		message?: { text: string, type: TextSearchCompleteMessageType } | { text: string, type: TextSearchCompleteMessageType }[];
+		message?: TextSearchCompleteMessage | TextSearchCompleteMessage[];
 	}
 
 	/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -410,6 +410,7 @@ declare module 'vscode' {
 		 *
 		 * Messages with "Information" tyle support links in markdown syntax:
 		 * - Click to [run a command](command:workbench.action.OpenQuickPick)
+		 * 		- Commands may optionally return an object with a 'triggerSearch' property set `true` to signal to VS Code that the original should run be agian.
 		 * - Click to [open a website](https://aka.ms)
 		 */
 		message?: { text: string, type: TextSearchCompleteMessageType } | { text: string, type: TextSearchCompleteMessageType }[];

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -402,6 +402,7 @@ declare module 'vscode' {
 		text: string,
 		/**
 		 * Whether the source of the message is trusted, command links are disabled for untrusted message sources.
+		 * Messaged are untrusted by default.
 		 */
 		trusted?: boolean,
 		/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -403,7 +403,7 @@ declare module 'vscode' {
 		/**
 		 * Whether the source of the message is trusted, command links are disabled for untrusted message sources.
 		 */
-		trusted: boolean,
+		trusted?: boolean,
 		/**
 		 * The message type, this affects how the message will be rendered.
 		 */

--- a/src/vs/workbench/browser/parts/views/viewPane.ts
+++ b/src/vs/workbench/browser/parts/views/viewPane.ts
@@ -579,7 +579,7 @@ export abstract class ViewPane extends Pane implements IView {
 						if (typeof node === 'string') {
 							append(p, document.createTextNode(node));
 						} else {
-							const link = this.instantiationService.createInstance(Link, node);
+							const link = this.instantiationService.createInstance(Link, node, {});
 							append(p, link.el);
 							disposables.add(link);
 							disposables.add(attachLinkStyler(link, this.themeService));

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1662,16 +1662,17 @@ export class SearchView extends ViewPane {
 			if (typeof node === 'string') {
 				dom.append(span, document.createTextNode(node));
 			} else {
-				const link = this.instantiationService.createInstance(Link, node);
-				link.setHandler(async href => {
-					const parsed = URI.parse(href, true);
-					if (parsed.scheme === Schemas.command) {
-						const result = await this.commandService.executeCommand(parsed.path);
-						if ((result as any)?.triggerSearch) {
-							this.triggerQueryChange();
+				const link = this.instantiationService.createInstance(Link, node, {
+					opener: async href => {
+						const parsed = URI.parse(href, true);
+						if (parsed.scheme === Schemas.command) {
+							const result = await this.commandService.executeCommand(parsed.path);
+							if ((result as any)?.triggerSearch) {
+								this.triggerQueryChange();
+							}
+						} else {
+							this.openerService.open(parsed);
 						}
-					} else {
-						this.openerService.open(parsed);
 					}
 				});
 				dom.append(span, link.el);

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
@@ -597,16 +597,17 @@ export class SearchEditor extends BaseTextEditor {
 			if (typeof node === 'string') {
 				DOM.append(messageBox, document.createTextNode(node));
 			} else {
-				const link = this.instantiationService.createInstance(Link, node);
-				link.setHandler(async href => {
-					const parsed = URI.parse(href, true);
-					if (parsed.scheme === Schemas.command) {
-						const result = await this.commandService.executeCommand(parsed.path);
-						if ((result as any)?.triggerSearch) {
-							this.triggerSearch();
+				const link = this.instantiationService.createInstance(Link, node, {
+					opener: async href => {
+						const parsed = URI.parse(href, true);
+						if (parsed.scheme === Schemas.command) {
+							const result = await this.commandService.executeCommand(parsed.path);
+							if ((result as any)?.triggerSearch) {
+								this.triggerSearch();
+							}
+						} else {
+							this.openerService.open(parsed);
 						}
-					} else {
-						this.openerService.open(parsed);
 					}
 				});
 				DOM.append(messageBox, link.el);

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
@@ -902,7 +902,7 @@ export class GettingStartedPage extends EditorPane {
 					if (typeof node === 'string') {
 						append(p, renderFormattedText(node, { inline: true, renderCodeSegements: true }));
 					} else {
-						const link = this.instantiationService.createInstance(Link, node);
+						const link = this.instantiationService.createInstance(Link, node, {});
 
 						append(p, link.el);
 						this.detailsPageDisposables.add(link);

--- a/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
@@ -195,7 +195,7 @@ export class WorkspaceTrustEditor extends EditorPane {
 			if (typeof node === 'string') {
 				append(p, document.createTextNode(node));
 			} else {
-				const link = this.instantiationService.createInstance(Link, node);
+				const link = this.instantiationService.createInstance(Link, node, {});
 				append(p, link.el);
 				this.rerenderDisposables.add(link);
 				this.rerenderDisposables.add(attachLinkStyler(link, this.themeService));
@@ -399,7 +399,7 @@ export class WorkspaceTrustEditor extends EditorPane {
 				if (typeof node === 'string') {
 					append(text, document.createTextNode(node));
 				} else {
-					const link = this.instantiationService.createInstance(Link, node);
+					const link = this.instantiationService.createInstance(Link, node, {});
 					append(text, link.el);
 					this.rerenderDisposables.add(link);
 					this.rerenderDisposables.add(attachLinkStyler(link, this.themeService));

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -206,9 +206,15 @@ export function isProgressMessage(p: ISearchProgressItem | ISerializedSearchProg
 	return !!(p as IProgressMessage).message;
 }
 
+export interface ITextSearchCompleteMessage {
+	text: string;
+	type: TextSearchCompleteMessageType;
+	trusted: boolean;
+}
+
 export interface ISearchCompleteStats {
 	limitHit?: boolean;
-	messages: { text: string, type: TextSearchCompleteMessageType }[];
+	messages: ITextSearchCompleteMessage[];
 	stats?: IFileSearchStats | ITextSearchStats;
 }
 
@@ -508,13 +514,13 @@ export interface ISearchEngine<T> {
 export interface ISerializedSearchSuccess {
 	type: 'success';
 	limitHit: boolean;
-	messages: { text: string, type: TextSearchCompleteMessageType }[];
+	messages: ITextSearchCompleteMessage[];
 	stats?: IFileSearchStats | ITextSearchStats;
 }
 
 export interface ISearchEngineSuccess {
 	limitHit: boolean;
-	messages: { text: string, type: TextSearchCompleteMessageType }[];
+	messages: ITextSearchCompleteMessage[];
 	stats: ISearchEngineStats;
 }
 

--- a/src/vs/workbench/services/search/common/searchExtTypes.ts
+++ b/src/vs/workbench/services/search/common/searchExtTypes.ts
@@ -225,6 +225,24 @@ export enum TextSearchCompleteMessageType {
 }
 
 /**
+ * A message regarding a completed search.
+ */
+export interface TextSearchCompleteMessage {
+	/**
+	 * Markdown text of the message.
+	 */
+	text: string,
+	/**
+	 * Whether the source of the message is trusted, command links are disabled for untrusted message sources.
+	 */
+	trusted: boolean,
+	/**
+	 * The message type, this affects how the message will be rendered.
+	 */
+	type: TextSearchCompleteMessageType,
+}
+
+/**
  * Information collected when text search is complete.
  */
 export interface TextSearchComplete {
@@ -244,7 +262,7 @@ export interface TextSearchComplete {
 	 * - Click to [run a command](command:workbench.action.OpenQuickPick)
 	 * - Click to [open a website](https://aka.ms)
 	 */
-	message?: { text: string, type: TextSearchCompleteMessageType } | { text: string, type: TextSearchCompleteMessageType }[];
+	message?: TextSearchCompleteMessage | TextSearchCompleteMessage[];
 }
 
 /**

--- a/src/vs/workbench/services/search/common/searchService.ts
+++ b/src/vs/workbench/services/search/common/searchService.ts
@@ -153,7 +153,7 @@ export class SearchService extends Disposable implements ISearchService {
 			return {
 				limitHit: completes[0] && completes[0].limitHit,
 				stats: completes[0].stats,
-				messages: arrays.coalesce(arrays.flatten(completes.map(i => i.messages))).filter(arrays.uniqueFilter(message => message.type + message.text)),
+				messages: arrays.coalesce(arrays.flatten(completes.map(i => i.messages))).filter(arrays.uniqueFilter(message => message.type + message.text + message.trusted)),
 				results: arrays.flatten(completes.map((c: ISearchComplete) => c.results))
 			};
 		})();


### PR DESCRIPTION
cc @joaomoreno this modifies the Link class to allow setting a custom opener, to enable search to interpret the output of commands in provider messages in a way specific to the particular search UI. 