### PR TITLE
Add Source Control View Sort to Storage

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -209,6 +209,17 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			description: localize('scm.defaultViewMode', "Controls the default Source Control repository view mode."),
 			default: 'list'
 		},
+		'scm.defaultViewSortKey': {
+			type: 'string',
+			enum: ['path', 'name', 'status'],
+			enumDescriptions: [
+				localize('scm.defaultViewSortKey.path', "Sort the repository changes by path."),
+				localize('scm.defaultViewSortKey.name', "Sort the repository changes by file name."),
+				localize('scm.defaultViewSortKey.status', "Sort the repository changes by SCM status.")
+			],
+			description: localize('scm.defaultViewSortKey', "Controls the default Source Control repository sort mode."),
+			default: 'path'
+		},
 		'scm.autoReveal': {
 			type: 'boolean',
 			description: localize('autoReveal', "Controls whether the SCM view should automatically reveal and select files when opening them."),

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1042,6 +1042,9 @@ class ViewModel {
 	private readonly _onDidChangeMode = new Emitter<ViewModelMode>();
 	readonly onDidChangeMode = this._onDidChangeMode.event;
 
+	private readonly _onDidChangeSortKey = new Emitter<ViewModelSortKey>();
+	readonly onDidChangeSortKey = this._onDidChangeSortKey.event;
+
 	private visible: boolean = false;
 
 	get mode(): ViewModelMode { return this._mode; }
@@ -1069,12 +1072,12 @@ class ViewModel {
 		this.modeContextKey.set(mode);
 	}
 
-	private _sortKey: ViewModelSortKey = ViewModelSortKey.Path;
 	get sortKey(): ViewModelSortKey { return this._sortKey; }
 	set sortKey(sortKey: ViewModelSortKey) {
 		if (sortKey !== this._sortKey) {
 			this._sortKey = sortKey;
 			this.refresh();
+			this._onDidChangeSortKey.fire(sortKey);
 		}
 		this.sortKeyContextKey.set(sortKey);
 	}
@@ -1109,6 +1112,7 @@ class ViewModel {
 		private tree: WorkbenchCompressibleObjectTree<TreeElement, FuzzyScore>,
 		private inputRenderer: InputRenderer,
 		private _mode: ViewModelMode,
+		private _sortKey: ViewModelSortKey,
 		private _treeViewState: ITreeViewState | undefined,
 		@IInstantiationService protected instantiationService: IInstantiationService,
 		@IEditorService protected editorService: IEditorService,
@@ -1120,7 +1124,7 @@ class ViewModel {
 		this.modeContextKey = ContextKeys.ViewModelMode.bindTo(contextKeyService);
 		this.modeContextKey.set(_mode);
 		this.sortKeyContextKey = ContextKeys.ViewModelSortKey.bindTo(contextKeyService);
-		this.sortKeyContextKey.set(this._sortKey);
+		this.sortKeyContextKey.set(_sortKey);
 		this.areAllRepositoriesCollapsedContextKey = ContextKeys.ViewModelAreAllRepositoriesCollapsed.bindTo(contextKeyService);
 		this.isAnyRepositoryCollapsibleContextKey = ContextKeys.ViewModelIsAnyRepositoryCollapsible.bindTo(contextKeyService);
 		this.scmProviderContextKey = ContextKeys.SCMProvider.bindTo(contextKeyService);
@@ -2143,6 +2147,21 @@ export class SCMViewPane extends ViewPane {
 			viewMode = storageMode;
 		}
 
+		let viewSortKey: ViewModelSortKey;
+		let viewSortKeyString = this.configurationService.getValue<'path' | 'name' | 'status'>('scm.defaultViewSortKey');
+		if (viewSortKeyString === 'name') {
+			viewSortKey = ViewModelSortKey.Name;
+		} else if (viewSortKeyString === 'status') {
+			viewSortKey = ViewModelSortKey.Status;
+		} else {
+			viewSortKey = ViewModelSortKey.Path;
+		}
+
+		const storageSortKey = this.storageService.get(`scm.viewSortKey`, StorageScope.WORKSPACE) as ViewModelSortKey;
+		if (typeof storageSortKey === 'string') {
+			viewSortKey = storageSortKey;
+		}
+
 		let viewState: ITreeViewState | undefined;
 
 		const storageViewState = this.storageService.get(`scm.viewState`, StorageScope.WORKSPACE);
@@ -2154,7 +2173,7 @@ export class SCMViewPane extends ViewPane {
 
 		this._register(this.instantiationService.createInstance(RepositoryVisibilityActionController));
 
-		this._viewModel = this.instantiationService.createInstance(ViewModel, this.tree, this.inputRenderer, viewMode, viewState);
+		this._viewModel = this.instantiationService.createInstance(ViewModel, this.tree, this.inputRenderer, viewMode, viewSortKey, viewState);
 		this._register(this._viewModel);
 
 		this.listContainer.classList.add('file-icon-themable-tree');
@@ -2163,6 +2182,7 @@ export class SCMViewPane extends ViewPane {
 		this.updateIndentStyles(this.themeService.getFileIconTheme());
 		this._register(this.themeService.onDidFileIconThemeChange(this.updateIndentStyles, this));
 		this._register(this._viewModel.onDidChangeMode(this.onDidChangeMode, this));
+		this._register(this._viewModel.onDidChangeSortKey(this.onDidChangeSortKey, this));
 
 		this._register(this.onDidChangeBodyVisibility(this._viewModel.setVisible, this._viewModel));
 
@@ -2186,6 +2206,10 @@ export class SCMViewPane extends ViewPane {
 	private onDidChangeMode(): void {
 		this.updateIndentStyles(this.themeService.getFileIconTheme());
 		this.storageService.store(`scm.viewMode`, this._viewModel.mode, StorageScope.WORKSPACE, StorageTarget.USER);
+	}
+
+	private onDidChangeSortKey(): void {
+		this.storageService.store(`scm.viewSortKey`, this._viewModel.sortKey, StorageScope.WORKSPACE, StorageTarget.USER);
 	}
 
 	override layoutBody(height: number | undefined = this.layoutCache.height, width: number | undefined = this.layoutCache.width): void {


### PR DESCRIPTION
Add scm view default sort setting.
Add scm view sort to workspace storage.

Test storage by changing the source control sort to a different value.  Reload vscode.  See that the previously selected sort has persisted.
Test default setting by modifying your default.  Using a terminal, create a new folder and git init inside, then open that folder with vscode.  The source control sort should use the default setting.



This PR fixes #120271
