### PR TITLE
Removes special character that terminates link recognition

### DIFF
--- a/src/vs/editor/common/modes/linkComputer.ts
+++ b/src/vs/editor/common/modes/linkComputer.ts
@@ -154,7 +154,7 @@ function getClassifier(): CharacterClassifier<CharacterClass> {
 	if (_classifier === null) {
 		_classifier = new CharacterClassifier<CharacterClass>(CharacterClass.None);
 
-		const FORCE_TERMINATION_CHARACTERS = ' \t<>\'\"、。｡､，．：；‘“〈《「『【〔（［｛｢｣｝］）〕】』」》〉”’｀～…';
+		const FORCE_TERMINATION_CHARACTERS = ' \t<>\'\"、。｡､，．：；‘“〈《「『〔（［｛｢｣｝］）〕』」》〉”’｀～…';
 		for (let i = 0; i < FORCE_TERMINATION_CHARACTERS.length; i++) {
 			_classifier.set(FORCE_TERMINATION_CHARACTERS.charCodeAt(i), CharacterClass.ForceTermination);
 		}

--- a/src/vs/editor/common/modes/linkComputer.ts
+++ b/src/vs/editor/common/modes/linkComputer.ts
@@ -154,7 +154,7 @@ function getClassifier(): CharacterClassifier<CharacterClass> {
 	if (_classifier === null) {
 		_classifier = new CharacterClassifier<CharacterClass>(CharacterClass.None);
 
-		const FORCE_TERMINATION_CHARACTERS = ' \t<>\'\"、。｡､，．：；‘“〈《「『〔（［｛｢｣｝］）〕』」》〉”’｀～…';
+		const FORCE_TERMINATION_CHARACTERS = ' \t<>\'\"、。｡､，．：；‘〈「『〔（［｛｢｣｝］）〕』」〉’｀～…';
 		for (let i = 0; i < FORCE_TERMINATION_CHARACTERS.length; i++) {
 			_classifier.set(FORCE_TERMINATION_CHARACTERS.charCodeAt(i), CharacterClass.ForceTermination);
 		}

--- a/src/vs/editor/test/common/modes/linkComputer.test.ts
+++ b/src/vs/editor/test/common/modes/linkComputer.test.ts
@@ -230,4 +230,11 @@ suite('Editor Modes - Link Computer', () => {
 			'    http://tree-mark.chips.jp/レーズン＆ベリーミックス    '
 		);
 	});
+
+	test('issue #121438: Link detection stops at ＆', () => {
+		assertLink(
+			'aa  https://zh.wikipedia.org/wiki/【我推的孩子】 aa',
+			'    https://zh.wikipedia.org/wiki/【我推的孩子】   '
+		);
+	});
 });

--- a/src/vs/editor/test/common/modes/linkComputer.test.ts
+++ b/src/vs/editor/test/common/modes/linkComputer.test.ts
@@ -231,10 +231,24 @@ suite('Editor Modes - Link Computer', () => {
 		);
 	});
 
-	test('issue #121438: Link detection stops at ＆', () => {
+	test('issue #121438: Link detection stops at【...】', () => {
 		assertLink(
 			'aa  https://zh.wikipedia.org/wiki/【我推的孩子】 aa',
 			'    https://zh.wikipedia.org/wiki/【我推的孩子】   '
+		);
+	});
+
+	test('issue #121438: Link detection stops at《...》', () => {
+		assertLink(
+			'aa  https://zh.wikipedia.org/wiki/《新青年》编辑部旧址 aa',
+			'    https://zh.wikipedia.org/wiki/《新青年》编辑部旧址   '
+		);
+	});
+
+	test('issue #121438: Link detection stops at “...”', () => {
+		assertLink(
+			'aa  https://zh.wikipedia.org/wiki/“常凯申”误译事件 aa',
+			'    https://zh.wikipedia.org/wiki/“常凯申”误译事件   '
 		);
 	});
 });


### PR DESCRIPTION
This special character is valid for links though.

This PR fixes #121438 
