### PR TITLE
adopt working copy editor handler and remove custom editor input factory

### DIFF
--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -198,22 +198,6 @@ export interface IFileEditorInputFactory {
 	isFileEditorInput(obj: unknown): obj is IFileEditorInput;
 }
 
-/**
- * @deprecated obsolete
- *
- * TODO@bpasero remove this API and users once the generic backup restorer has been removed
- */
-export interface ICustomEditorInputFactory {
-	/**
-	 * @deprecated obsolete
-	 */
-	createCustomEditorInput(resource: URI, instantiationService: IInstantiationService): Promise<IEditorInput>;
-	/**
-	 * @deprecated obsolete
-	 */
-	canResolveBackup(editorInput: IEditorInput, backupResource: URI): boolean;
-}
-
 export interface IEditorInputFactoryRegistry {
 
 	/**
@@ -225,20 +209,6 @@ export interface IEditorInputFactoryRegistry {
 	 * Returns the file editor input factory to use for file inputs.
 	 */
 	getFileEditorInputFactory(): IFileEditorInputFactory;
-
-	/**
-	 * Registers the custom editor input factory to use for custom inputs.
-	 *
-	 * @deprecated obsolete
-	 */
-	registerCustomEditorInputFactory(scheme: string, factory: ICustomEditorInputFactory): void;
-
-	/**
-	 * Returns the custom editor input factory to use for custom inputs.
-	 *
-	 * @deprecated obsolete
-	 */
-	getCustomEditorInputFactory(scheme: string): ICustomEditorInputFactory | undefined;
 
 	/**
 	 * Registers a editor input serializer for the given editor input to the registry.
@@ -1475,7 +1445,6 @@ class EditorInputFactoryRegistry implements IEditorInputFactoryRegistry {
 	private instantiationService: IInstantiationService | undefined;
 
 	private fileEditorInputFactory: IFileEditorInputFactory | undefined;
-	private readonly customEditorInputFactoryInstances: Map<string, ICustomEditorInputFactory> = new Map();
 
 	private readonly editorInputSerializerConstructors: Map<string /* Type ID */, IConstructorSignature0<IEditorInputSerializer>> = new Map();
 	private readonly editorInputSerializerInstances: Map<string /* Type ID */, IEditorInputSerializer> = new Map();
@@ -1528,14 +1497,6 @@ class EditorInputFactoryRegistry implements IEditorInputFactoryRegistry {
 	getEditorInputSerializer(editorInputTypeId: string): IEditorInputSerializer | undefined;
 	getEditorInputSerializer(arg1: string | IEditorInput): IEditorInputSerializer | undefined {
 		return this.editorInputSerializerInstances.get(typeof arg1 === 'string' ? arg1 : arg1.typeId);
-	}
-
-	registerCustomEditorInputFactory(scheme: string, factory: ICustomEditorInputFactory): void {
-		this.customEditorInputFactoryInstances.set(scheme, factory);
-	}
-
-	getCustomEditorInputFactory(scheme: string): ICustomEditorInputFactory | undefined {
-		return this.customEditorInputFactoryInstances.get(scheme);
 	}
 }
 

--- a/src/vs/workbench/contrib/customEditor/browser/customEditor.contribution.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditor.contribution.ts
@@ -3,14 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Schemas } from 'vs/base/common/network';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { EditorDescriptor, IEditorRegistry } from 'vs/workbench/browser/editor';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { EditorExtensions, IEditorInputFactoryRegistry } from 'vs/workbench/common/editor';
-import { customEditorInputFactory, CustomEditorInputSerializer } from 'vs/workbench/contrib/customEditor/browser/customEditorInputFactory';
+import { CustomEditorInputSerializer, ComplexCustomWorkingCopyEditorHandler as ComplexCustomWorkingCopyEditorHandler } from 'vs/workbench/contrib/customEditor/browser/customEditorInputFactory';
 import { ICustomEditorService } from 'vs/workbench/contrib/customEditor/common/customEditor';
 import { WebviewEditor } from 'vs/workbench/contrib/webviewPanel/browser/webviewEditor';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
@@ -34,19 +33,5 @@ Registry.as<IEditorInputFactoryRegistry>(EditorExtensions.EditorInputFactories)
 		CustomEditorInputSerializer.ID,
 		CustomEditorInputSerializer);
 
-Registry.as<IEditorInputFactoryRegistry>(EditorExtensions.EditorInputFactories)
-	.registerCustomEditorInputFactory(Schemas.vscodeCustomEditor, customEditorInputFactory);
-
-
-/**
- * Register a workbench contribution so that the custom editor service gets registered on startup.
- * This is needed for CLI opening of custom editors
- */
-class WorkbenchConfigurationContribution {
-	constructor(
-		@ICustomEditorService _customEditorService: ICustomEditorService,
-	) { }
-}
-
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
-	.registerWorkbenchContribution(WorkbenchConfigurationContribution, LifecyclePhase.Starting);
+	.registerWorkbenchContribution(ComplexCustomWorkingCopyEditorHandler, LifecyclePhase.Starting);


### PR DESCRIPTION
This PR fixes #117208

This puts an end to custom editor input factories and leverages the new `IWorkingCopyEditorHandler` infrastructure that has already been adopted for notebooks and search editors.

It is similar in some regard, so most of the code is pretty much the same. I am still not super happy that the backup needs to be resolved first before being able to create the editor input because I think that should happen rather from the `resolve` method and e.g. notebooks can resolve sync as well (and have extensions behind them).

Anyway, one issue I see with this change that I need help with: 
* open some text editors
* open a Luna paint editor
* make the paint editor dirty
* click one of the text editors
* reload
* click on paint editor

=> 🐛  `Unable to open 'Screenshot 2021-05-07 at 17.16.50.png': Webview already registered.`

**Demo:**
![recording](https://user-images.githubusercontent.com/900690/117481288-11315180-af63-11eb-97ea-90027d53ce5f.gif)

I think the second time the editor restores it works nicely because at that point the UI state did not have the previous editor in hand anymore so it was freshly opened. On the upside, this proofs that the new backup mechanism keeps backups around until they can be restored successfully 👍 
