### PR TITLE
Fix issue reporter not closing on submit and debounce submissions

### DIFF
--- a/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
@@ -359,9 +359,7 @@ export class IssueReporter extends Disposable {
 
 		this.previewButton.onDidClick(async () => {
 			this.delayedSubmit.trigger(async () => {
-				if ((await this.createIssue())) {
-					ipcRenderer.send('vscode:closeIssueReporter');
-				}
+				this.createIssue();
 			});
 		});
 
@@ -391,7 +389,7 @@ export class IssueReporter extends Disposable {
 			// Cmd/Ctrl+Enter previews issue and closes window
 			if (cmdOrCtrlKey && e.keyCode === 13) {
 				this.delayedSubmit.trigger(async () => {
-					if ((await this.createIssue())) {
+					if (await this.createIssue()) {
 						ipcRenderer.send('vscode:closeIssueReporter');
 					}
 				});

--- a/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
@@ -355,7 +355,11 @@ export class IssueReporter extends Disposable {
 			this.searchIssues(title, fileOnExtension, fileOnMarketplace);
 		});
 
-		this.previewButton.onDidClick(() => this.createIssue());
+		this.previewButton.onDidClick(async () => {
+			if ((await this.createIssue())) {
+				ipcRenderer.send('vscode:closeIssueReporter');
+			}
+		});
 
 		function sendWorkbenchCommand(commandId: string) {
 			ipcRenderer.send('vscode:workbenchCommand', { id: commandId, from: 'issueReporter' });
@@ -382,7 +386,7 @@ export class IssueReporter extends Disposable {
 			const cmdOrCtrlKey = isMacintosh ? e.metaKey : e.ctrlKey;
 			// Cmd/Ctrl+Enter previews issue and closes window
 			if (cmdOrCtrlKey && e.keyCode === 13) {
-				if (await this.createIssue()) {
+				if ((await this.createIssue())) {
 					ipcRenderer.send('vscode:closeIssueReporter');
 				}
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Debounces the issue reporter submissions, so that a double click doesn't submit two different issues.
Fixes the issue reporter not closing when an issue has been submitted successfully.

I tried to use the debounce decorator, but couldn't get it working correctly with a return value so I went with the Delayer.


Testing
1. Open the issue reporter and fill out the required info.
2. Click the submit/preview button multiple times quickly (less than 300ms between clicks). (if you have github authenticated already, it will create multiple issues when testing this)
3. Only a single issue should be submitted.
4. The issue reporter should now close.


This PR fixes #115857


Old Behavior
![old](https://user-images.githubusercontent.com/52075362/117520744-6d01d780-af6f-11eb-912e-acfee9714e72.gif)

New Behavior
![new](https://user-images.githubusercontent.com/52075362/117520858-1943be00-af70-11eb-9ac5-ce70a4904732.gif)
