### PR TITLE
Add showDeprecated option to suggest, filters out deprecated options

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -204,6 +204,7 @@ function migrateOptions(options: IEditorOptions): void {
 		mapping['method'] = 'showMethods';
 		mapping['function'] = 'showFunctions';
 		mapping['constructor'] = 'showConstructors';
+		mapping['deprecated'] = 'showDeprecated';
 		mapping['field'] = 'showFields';
 		mapping['variable'] = 'showVariables';
 		mapping['class'] = 'showClasses';

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3187,6 +3187,10 @@ export interface ISuggestOptions {
 	 */
 	showConstructors?: boolean;
 	/**
+	 * Show deprecated-suggestions.
+	 */
+	showDeprecated?: boolean;
+	/**
 	 * Show field-suggestions.
 	 */
 	showFields?: boolean;
@@ -3301,6 +3305,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, InternalSugge
 			showMethods: true,
 			showFunctions: true,
 			showConstructors: true,
+			showDeprecated: true,
 			showFields: true,
 			showVariables: true,
 			showClasses: true,
@@ -3397,6 +3402,11 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, InternalSugge
 					type: 'boolean',
 					default: true,
 					markdownDescription: nls.localize('editor.suggest.showConstructors', "When enabled IntelliSense shows `constructor`-suggestions.")
+				},
+				'editor.suggest.showDeprecated': {
+					type: 'boolean',
+					default: true,
+					markdownDescription: nls.localize('editor.suggest.showDeprecated', "When enabled IntelliSense shows `deprecated`-suggestions.")
 				},
 				'editor.suggest.showFields': {
 					type: 'boolean',
@@ -3544,6 +3554,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, InternalSugge
 			showMethods: boolean(input.showMethods, this.defaultValue.showMethods),
 			showFunctions: boolean(input.showFunctions, this.defaultValue.showFunctions),
 			showConstructors: boolean(input.showConstructors, this.defaultValue.showConstructors),
+			showDeprecated: boolean(input.showDeprecated, this.defaultValue.showDeprecated),
 			showFields: boolean(input.showFields, this.defaultValue.showFields),
 			showVariables: boolean(input.showVariables, this.defaultValue.showVariables),
 			showClasses: boolean(input.showClasses, this.defaultValue.showClasses),

--- a/src/vs/editor/contrib/suggest/completionModel.ts
+++ b/src/vs/editor/contrib/suggest/completionModel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { fuzzyScore, fuzzyScoreGracefulAggressive, FuzzyScorer, FuzzyScore, anyScore } from 'vs/base/common/filters';
-import { CompletionItemProvider, CompletionItemKind } from 'vs/editor/common/modes';
+import { CompletionItemProvider, CompletionItemKind, CompletionItemTag } from 'vs/editor/common/modes';
 import { CompletionItem } from './suggest';
 import { InternalSuggestOptions } from 'vs/editor/common/config/editorOptions';
 import { WordDistance } from 'vs/editor/contrib/suggest/wordDistance';
@@ -159,6 +159,9 @@ export class CompletionModel {
 
 			if (item.isInvalid) {
 				continue; // SKIP invalid items
+			}
+			if (!this._options.showDeprecated && item.completion.tags?.includes(CompletionItemTag.Deprecated)) {
+				continue; // skip deprecated items
 			}
 
 			// collect all support, know if their result is incomplete

--- a/src/vs/editor/contrib/suggest/completionModel.ts
+++ b/src/vs/editor/contrib/suggest/completionModel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { fuzzyScore, fuzzyScoreGracefulAggressive, FuzzyScorer, FuzzyScore, anyScore } from 'vs/base/common/filters';
-import { CompletionItemProvider, CompletionItemKind, CompletionItemTag } from 'vs/editor/common/modes';
+import { CompletionItemProvider, CompletionItemKind } from 'vs/editor/common/modes';
 import { CompletionItem } from './suggest';
 import { InternalSuggestOptions } from 'vs/editor/common/config/editorOptions';
 import { WordDistance } from 'vs/editor/contrib/suggest/wordDistance';
@@ -159,9 +159,6 @@ export class CompletionModel {
 
 			if (item.isInvalid) {
 				continue; // SKIP invalid items
-			}
-			if (!this._options.showDeprecated && item.completion.tags?.includes(CompletionItemTag.Deprecated)) {
-				continue; // skip deprecated items
 			}
 
 			// collect all support, know if their result is incomplete

--- a/src/vs/editor/contrib/suggest/suggest.ts
+++ b/src/vs/editor/contrib/suggest/suggest.ts
@@ -155,6 +155,7 @@ export class CompletionOptions {
 		readonly snippetSortOrder = SnippetSortOrder.Bottom,
 		readonly kindFilter = new Set<modes.CompletionItemKind>(),
 		readonly providerFilter = new Set<modes.CompletionItemProvider>(),
+		readonly showDeprecated = true
 	) { }
 }
 
@@ -216,6 +217,10 @@ export async function provideSuggestionItems(
 		}
 		for (let suggestion of container.suggestions) {
 			if (!options.kindFilter.has(suggestion.kind)) {
+				// skip if not showing deprecated suggestions
+				if (!options.showDeprecated && suggestion?.tags?.includes(modes.CompletionItemTag.Deprecated)) {
+					continue;
+				}
 				// fill in default range when missing
 				if (!suggestion.range) {
 					suggestion.range = defaultRange;

--- a/src/vs/editor/contrib/suggest/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/suggestModel.ts
@@ -428,13 +428,13 @@ export class SuggestModel implements IDisposable {
 				break;
 		}
 
-		const itemKindFilter = SuggestModel._createItemKindFilter(this._editor);
+		const { itemKind: itemKindFilter, showDeprecated } = SuggestModel._createSuggestFilter(this._editor);
 		const wordDistance = WordDistance.create(this._editorWorkerService, this._editor);
 
 		const completions = provideSuggestionItems(
 			model,
 			this._editor.getPosition(),
-			new CompletionOptions(snippetSortOrder, itemKindFilter, onlyFrom),
+			new CompletionOptions(snippetSortOrder, itemKindFilter, onlyFrom, showDeprecated),
 			suggestCtx,
 			this._requestToken.token
 		);
@@ -502,7 +502,7 @@ export class SuggestModel implements IDisposable {
 		});
 	}
 
-	private static _createItemKindFilter(editor: ICodeEditor): Set<CompletionItemKind> {
+	private static _createSuggestFilter(editor: ICodeEditor): { itemKind: Set<CompletionItemKind>; showDeprecated: boolean } {
 		// kind filter and snippet sort rules
 		const result = new Set<CompletionItemKind>();
 
@@ -543,7 +543,7 @@ export class SuggestModel implements IDisposable {
 		if (!suggestOptions.showUsers) { result.add(CompletionItemKind.User); }
 		if (!suggestOptions.showIssues) { result.add(CompletionItemKind.Issue); }
 
-		return result;
+		return { itemKind: result, showDeprecated: suggestOptions.showDeprecated };
 	}
 
 	private _onNewContext(ctx: LineContext): void {

--- a/src/vs/editor/contrib/suggest/test/completionModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/completionModel.test.ts
@@ -43,6 +43,7 @@ suite('CompletionModel', function () {
 		showMethods: true,
 		showFunctions: true,
 		showConstructors: true,
+		showDeprecated: true,
 		showFields: true,
 		showVariables: true,
 		showClasses: true,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3848,6 +3848,10 @@ declare namespace monaco.editor {
 		 */
 		showConstructors?: boolean;
 		/**
+		 * Show deprecated-suggestions.
+		 */
+		showDeprecated?: boolean;
+		/**
 		 * Show field-suggestions.
 		 */
 		showFields?: boolean;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Adds an option to `showDeprecated` in the suggest list.  When false, deprecated items are not shown.  Defaults to true, same as old behavior.

Changes were mostly done by following the `showConstructors` option.

Example
![recording](https://user-images.githubusercontent.com/52075362/117527422-9c294080-af91-11eb-82bd-1c7d639db788.gif)




This PR fixes #77239.
