### PR TITLE
use title for terminal selection

### DIFF
--- a/src/vs/workbench/api/node/extHostDebugService.ts
+++ b/src/vs/workbench/api/node/extHostDebugService.ts
@@ -82,7 +82,7 @@ export class ExtHostDebugService extends ExtHostDebugServiceBase {
 			const shell = this._terminalService.getDefaultShell(true, configProvider);
 			const shellArgs = this._terminalService.getDefaultShellArgs(true, configProvider);
 
-			const terminalName = args.title || nls.localize('debug.terminal.title', "debuggee");
+			const terminalName = args.title || nls.localize('debug.terminal.title', "Debug Process");
 
 			const shellConfig = JSON.stringify({ shell, shellArgs });
 			let terminal = await this._integratedTerminalInstances.checkout(shellConfig, terminalName);

--- a/src/vs/workbench/api/node/extHostDebugService.ts
+++ b/src/vs/workbench/api/node/extHostDebugService.ts
@@ -82,8 +82,10 @@ export class ExtHostDebugService extends ExtHostDebugServiceBase {
 			const shell = this._terminalService.getDefaultShell(true, configProvider);
 			const shellArgs = this._terminalService.getDefaultShellArgs(true, configProvider);
 
+			const terminalName = args.title || nls.localize('debug.terminal.title', "debuggee");
+
 			const shellConfig = JSON.stringify({ shell, shellArgs });
-			let terminal = await this._integratedTerminalInstances.checkout(shellConfig);
+			let terminal = await this._integratedTerminalInstances.checkout(shellConfig, terminalName);
 
 			let cwdForPrepareCommand: string | undefined;
 			let giveShellTimeToInitialize = false;
@@ -93,7 +95,7 @@ export class ExtHostDebugService extends ExtHostDebugServiceBase {
 					shellPath: shell,
 					shellArgs: shellArgs,
 					cwd: args.cwd,
-					name: args.title || nls.localize('debug.terminal.title', "debuggee"),
+					name: terminalName,
 				};
 				giveShellTimeToInitialize = true;
 				terminal = this._terminalService.createTerminalFromOptions(options, true);
@@ -157,9 +159,15 @@ class DebugTerminalCollection {
 
 	private _terminalInstances = new Map<vscode.Terminal, { lastUsedAt: number, config: string }>();
 
-	public async checkout(config: string) {
+	public async checkout(config: string, name: string) {
 		const entries = [...this._terminalInstances.entries()];
 		const promises = entries.map(([terminal, termInfo]) => createCancelablePromise(async ct => {
+
+			// Only allow terminals that match the title.  See #123189
+			if (terminal.name !== name) {
+				return null;
+			}
+
 			if (termInfo.lastUsedAt !== -1 && await hasChildProcesses(await terminal.processId)) {
 				return null;
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #123189

This should guarantee that all launch configurations that use integrated terminal should always receive a terminal with their name.  It should also help fix issues related to vscode opening multiple terminals for the same launch process.

