### PR TITLE
Improve layout and resize events in terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -28,11 +28,11 @@
 .monaco-workbench .pane-body.integrated-terminal .terminal-wrapper {
 	display: none;
 	margin: 0 10px;
+	bottom: 2px; /* Matches padding-bottom on .terminal-outer-container */
 }
 .monaco-workbench .pane-body.integrated-terminal .terminal-wrapper.active {
 	display: block;
 	position: absolute;
-	bottom: 2px; /* Matches padding-bottom on .terminal-outer-container */
 	top: 0;
 }
 .monaco-workbench .pane-body.integrated-terminal .monaco-split-view2.horizontal .split-view-view:first-child .terminal-wrapper {

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -117,7 +117,7 @@ export interface ITerminalService {
 	/**
 	 * Creates a raw terminal instance, this should not be used outside of the terminal part.
 	 */
-	createInstance(container: HTMLElement | undefined, shellLaunchConfig: IShellLaunchConfig): ITerminalInstance;
+	createInstance(shellLaunchConfig: IShellLaunchConfig): ITerminalInstance;
 	getInstanceFromId(terminalId: number): ITerminalInstance | undefined;
 	getInstanceFromIndex(terminalIndex: number): ITerminalInstance;
 	getTabLabels(): string[];

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -519,7 +519,7 @@ export interface ITerminalInstance {
 	 *
 	 * @param container The element to attach the terminal instance to.
 	 */
-	attachToElement(container: HTMLElement): void;
+	attachToElement(container: HTMLElement): Promise<void> | void;
 
 	/**
 	 * Configure the dimensions of the terminal instance.

--- a/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
@@ -148,7 +148,6 @@ class SplitPaneContainer extends Disposable {
 	layout(width: number, height: number): void {
 		this._width = width;
 		this._height = height;
-		console.log('SplitPaneContainer.layout', width, height);
 		if (this.orientation === Orientation.HORIZONTAL) {
 			this._children.forEach(c => c.orthogonalLayout(height));
 			this._splitView.layout(width);
@@ -211,7 +210,6 @@ class SplitPane implements IView {
 	}
 
 	layout(size: number): void {
-		console.log(`SplitPane.layout (${this.instance.instanceId})`, size, this.orthogonalSize);
 		// Only layout when both sizes are known
 		if (!size || !this.orthogonalSize) {
 			return;
@@ -436,7 +434,6 @@ export class TerminalGroup extends Disposable implements ITerminalGroup {
 		if (this._groupElement) {
 			this._groupElement.style.display = visible ? '' : 'none';
 		}
-		console.log('TerminalGroup.setVisible');
 		this.terminalInstances.forEach(i => i.setVisible(visible));
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
@@ -270,7 +270,7 @@ export class TerminalGroup extends Disposable implements ITerminalGroup {
 		if ('instanceId' in shellLaunchConfigOrInstance) {
 			instance = shellLaunchConfigOrInstance;
 		} else {
-			instance = this._terminalService.createInstance(undefined, shellLaunchConfigOrInstance);
+			instance = this._terminalService.createInstance(shellLaunchConfigOrInstance);
 		}
 		this._terminalInstances.push(instance);
 		this._initInstanceListeners(instance);
@@ -438,7 +438,7 @@ export class TerminalGroup extends Disposable implements ITerminalGroup {
 	}
 
 	split(shellLaunchConfig: IShellLaunchConfig): ITerminalInstance {
-		const instance = this._terminalService.createInstance(undefined, shellLaunchConfig);
+		const instance = this._terminalService.createInstance(shellLaunchConfig);
 		this._terminalInstances.splice(this._activeInstanceIndex + 1, 0, instance);
 		this._initInstanceListeners(instance);
 		this._setActiveInstance(instance);

--- a/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
@@ -127,6 +127,7 @@ class SplitPaneContainer extends Disposable {
 		}
 
 		this._withDisabledLayout(() => this._splitView.addView(child, Sizing.Distribute, index));
+		this.layout(this._width, this._height);
 
 		this._onDidChange = Event.any(...this._children.map(c => c.onDidChange));
 	}
@@ -147,6 +148,7 @@ class SplitPaneContainer extends Disposable {
 	layout(width: number, height: number): void {
 		this._width = width;
 		this._height = height;
+		console.log('SplitPaneContainer.layout', width, height);
 		if (this.orientation === Orientation.HORIZONTAL) {
 			this._children.forEach(c => c.orthogonalLayout(height));
 			this._splitView.layout(width);
@@ -209,6 +211,7 @@ class SplitPane implements IView {
 	}
 
 	layout(size: number): void {
+		console.log(`SplitPane.layout (${this.instance.instanceId})`, size, this.orthogonalSize);
 		// Only layout when both sizes are known
 		if (!size || !this.orthogonalSize) {
 			return;
@@ -433,6 +436,7 @@ export class TerminalGroup extends Disposable implements ITerminalGroup {
 		if (this._groupElement) {
 			this._groupElement.style.display = visible ? '' : 'none';
 		}
+		console.log('TerminalGroup.setVisible');
 		this.terminalInstances.forEach(i => i.setVisible(visible));
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -103,6 +103,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	private _skipTerminalCommands: string[];
 	private _shellType: TerminalShellType;
 	private _title: string = '';
+	private _container: HTMLElement | undefined;
 	private _wrapperElement: (HTMLElement & { xterm?: XTermTerminal }) | undefined;
 	private _xterm: XTermTerminal | undefined;
 	private _xtermCore: XTermCore | undefined;
@@ -131,7 +132,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	private _commandTrackerAddon: CommandTrackerAddon | undefined;
 	private _navigationModeAddon: INavigationMode & ITerminalAddon | undefined;
 
-	private _timeoutDimension: dom.Dimension | undefined;
 	private _lastLayoutDimensions: dom.Dimension | undefined;
 
 	private _hasHadInput: boolean;
@@ -222,8 +222,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		private readonly _terminalShellTypeContextKey: IContextKey<string>,
 		private readonly _terminalAltBufferActiveContextKey: IContextKey<boolean>,
 		private readonly _configHelper: TerminalConfigHelper,
-		// TODO: Remove this, it's never set in the ctor
-		private _container: HTMLElement | undefined,
 		private _shellLaunchConfig: IShellLaunchConfig,
 		@ITerminalInstanceService private readonly _terminalInstanceService: ITerminalInstanceService,
 		@ITerminalProfileResolverService private readonly _terminalProfileResolverService: ITerminalProfileResolverService,
@@ -280,11 +278,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		this._xtermReadyPromise.then(async () => {
 			// Wait for a period to allow a container to be ready
 			await this._containerReadyBarrier.wait();
-
-			// Only attach xterm.js to the DOM if the terminal panel has been opened before.
-			if (_container) {
-				this._attachToElement(_container);
-			}
 			this._createProcess();
 		});
 
@@ -1490,8 +1483,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		if (!terminalWidth) {
 			return;
 		}
-
-		this._timeoutDimension = new dom.Dimension(dimension.width, dimension.height);
 
 		if (this._xterm && this._xterm.element) {
 			this._xterm.element.style.width = terminalWidth + 'px';

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -469,8 +469,9 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}
 
 		const xterm = new Terminal({
-			cols: this._cols || undefined,
-			rows: this._rows || undefined,
+			// TODO: Replace null with undefined when https://github.com/xtermjs/xterm.js/issues/3329 is resolved
+			cols: this._cols || null as any,
+			rows: this._rows || null as any,
 			altClickMovesCursor: config.altClickMovesCursor && editorOptions.multiCursorModifier === 'alt',
 			scrollback: config.scrollback,
 			theme: this._getXtermTheme(),

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -987,13 +987,12 @@ export class TerminalService implements ITerminalService {
 		return { label, description: profile.path, profile, buttons };
 	}
 
-	createInstance(container: HTMLElement | undefined, shellLaunchConfig: IShellLaunchConfig): ITerminalInstance {
+	createInstance(shellLaunchConfig: IShellLaunchConfig): ITerminalInstance {
 		const instance = this._instantiationService.createInstance(TerminalInstance,
 			this._terminalFocusContextKey,
 			this._terminalShellTypeContextKey,
 			this._terminalAltBufferActiveContextKey,
 			this._configHelper,
-			container,
 			shellLaunchConfig
 		);
 		this._onInstanceCreated.fire(instance);
@@ -1039,7 +1038,7 @@ export class TerminalService implements ITerminalService {
 			throw new Error('Could not create terminal when process support is not registered');
 		}
 		if (shellLaunchConfig.hideFromUser) {
-			const instance = this.createInstance(undefined, shellLaunchConfig);
+			const instance = this.createInstance(shellLaunchConfig);
 			this._backgroundedTerminalInstances.push(instance);
 			this._initInstanceListeners(instance);
 			return instance;


### PR DESCRIPTION
The hope is that this fixes a bunch of layout and rendering-related bugs by improving the number of columns and rows of the terminal and ensuring layout events are correctly passed through.

Some big things:

- `bottom: 2px` was only applied to `.active` terminals, so the height ended up sometimes coming through as `NaN` because `bottom` was set to `auto`
- Within `terminalGroup.ts` we now always layout the terminal instances after adding a split, this will trigger 3 layouts: the first to add the split pane (disableLayout), the second to resize it using the sizing strategy (disableLayout) and then a final one which will actually resize the terminal.
- Prevented race condition in `_attachToElement` by moving the xterm promise await after the elements are set on the instance

Fixes #120004
Fixes #120810
Fixes #108274