### PR TITLE
file working copy - let dispose unregister working copies

### DIFF
--- a/src/vs/workbench/services/textfile/browser/browserTextFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/browserTextFileService.ts
@@ -6,11 +6,52 @@
 import { AbstractTextFileService } from 'vs/workbench/services/textfile/browser/textFileService';
 import { ITextFileService, TextFileEditorModelState } from 'vs/workbench/services/textfile/common/textfiles';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
+import { IModelService } from 'vs/editor/common/services/modelService';
+import { IModeService } from 'vs/editor/common/services/modeService';
+import { ITextModelService } from 'vs/editor/common/services/resolverService';
+import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfigurationService';
+import { IDialogService, IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IFileService } from 'vs/platform/files/common/files';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { ILogService } from 'vs/platform/log/common/log';
+import { IElevatedFileService } from 'vs/workbench/services/files/common/elevatedFileService';
+import { IFilesConfigurationService } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
+import { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import { IPathService } from 'vs/workbench/services/path/common/pathService';
+import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
+import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
+import { IWorkingCopyFileService } from 'vs/workbench/services/workingCopy/common/workingCopyFileService';
 
 export class BrowserTextFileService extends AbstractTextFileService {
 
-	protected override registerListeners(): void {
-		super.registerListeners();
+	constructor(
+		@IFileService fileService: IFileService,
+		@IUntitledTextEditorService untitledTextEditorService: IUntitledTextEditorService,
+		@ILifecycleService lifecycleService: ILifecycleService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IModelService modelService: IModelService,
+		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+		@IDialogService dialogService: IDialogService,
+		@IFileDialogService fileDialogService: IFileDialogService,
+		@ITextResourceConfigurationService textResourceConfigurationService: ITextResourceConfigurationService,
+		@IFilesConfigurationService filesConfigurationService: IFilesConfigurationService,
+		@ITextModelService textModelService: ITextModelService,
+		@ICodeEditorService codeEditorService: ICodeEditorService,
+		@IPathService pathService: IPathService,
+		@IWorkingCopyFileService workingCopyFileService: IWorkingCopyFileService,
+		@IUriIdentityService uriIdentityService: IUriIdentityService,
+		@IModeService modeService: IModeService,
+		@IElevatedFileService elevatedFileService: IElevatedFileService,
+		@ILogService logService: ILogService
+	) {
+		super(fileService, untitledTextEditorService, lifecycleService, instantiationService, modelService, environmentService, dialogService, fileDialogService, textResourceConfigurationService, filesConfigurationService, textModelService, codeEditorService, pathService, workingCopyFileService, uriIdentityService, modeService, logService, elevatedFileService);
+
+		this.registerListeners();
+	}
+
+	private registerListeners(): void {
 
 		// Lifecycle
 		this.lifecycleService.onBeforeShutdown(event => event.veto(this.onBeforeShutdown(), 'veto.textFiles'));

--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -73,14 +73,6 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 		@IElevatedFileService private readonly elevatedFileService: IElevatedFileService
 	) {
 		super();
-
-		this.registerListeners();
-	}
-
-	protected registerListeners(): void {
-
-		// Lifecycle
-		this.lifecycleService.onDidShutdown(() => this.dispose());
 	}
 
 	//#region text file read / write / create

--- a/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
@@ -462,11 +462,8 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 	override dispose(): void {
 		super.dispose();
 
-		// Working copy caches
-		this.mapResourceToModel.forEach(model => model.dispose());
+		// model caches
 		this.mapResourceToModel.clear();
-
-		// Pending working copy resolves
 		this.mapResourceToPendingModelResolvers.clear();
 
 		// dispose the dispose listeners

--- a/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
@@ -467,11 +467,11 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 		this.mapResourceToPendingModelResolvers.clear();
 
 		// dispose the dispose listeners
-		this.mapResourceToDisposeListener.forEach(listener => listener.dispose());
+		dispose(this.mapResourceToDisposeListener.values());
 		this.mapResourceToDisposeListener.clear();
 
 		// dispose the model change listeners
-		this.mapResourceToModelListeners.forEach(listener => listener.dispose());
+		dispose(this.mapResourceToModelListeners.values());
 		this.mapResourceToModelListeners.clear();
 	}
 }

--- a/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
@@ -10,7 +10,6 @@ import { URI } from 'vs/base/common/uri';
 import { TextFileEditorModel } from 'vs/workbench/services/textfile/common/textFileEditorModel';
 import { dispose, IDisposable, Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { ITextFileEditorModel, ITextFileEditorModelManager, ITextFileEditorModelResolveOrCreateOptions, ITextFileResolveEvent, ITextFileSaveEvent, ITextFileSaveParticipant } from 'vs/workbench/services/textfile/common/textfiles';
-import { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ResourceMap } from 'vs/base/common/map';
 import { IFileService, FileChangesEvent, FileOperation, FileChangeType } from 'vs/platform/files/common/files';
@@ -72,7 +71,6 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 	}
 
 	constructor(
-		@ILifecycleService private readonly lifecycleService: ILifecycleService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IFileService private readonly fileService: IFileService,
 		@INotificationService private readonly notificationService: INotificationService,
@@ -93,9 +91,6 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 		this._register(this.workingCopyFileService.onWillRunWorkingCopyFileOperation(e => this.onWillRunWorkingCopyFileOperation(e)));
 		this._register(this.workingCopyFileService.onDidFailWorkingCopyFileOperation(e => this.onDidFailWorkingCopyFileOperation(e)));
 		this._register(this.workingCopyFileService.onDidRunWorkingCopyFileOperation(e => this.onDidRunWorkingCopyFileOperation(e)));
-
-		// Lifecycle
-		this.lifecycleService.onDidShutdown(() => this.dispose());
 	}
 
 	private onDidFilesChange(e: FileChangesEvent): void {
@@ -428,21 +423,6 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 
 	//#endregion
 
-	clear(): void {
-
-		// model caches
-		this.mapResourceToModel.clear();
-		this.mapResourceToPendingModelResolvers.clear();
-
-		// dispose the dispose listeners
-		this.mapResourceToDisposeListener.forEach(listener => listener.dispose());
-		this.mapResourceToDisposeListener.clear();
-
-		// dispose the model change listeners
-		this.mapResourceToModelListeners.forEach(listener => listener.dispose());
-		this.mapResourceToModelListeners.clear();
-	}
-
 	canDispose(model: TextFileEditorModel): true | Promise<true> {
 
 		// quick return if model already disposed or not dirty and not resolving
@@ -482,6 +462,19 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 	override dispose(): void {
 		super.dispose();
 
-		this.clear();
+		// Working copy caches
+		this.mapResourceToModel.forEach(model => model.dispose());
+		this.mapResourceToModel.clear();
+
+		// Pending working copy resolves
+		this.mapResourceToPendingModelResolvers.clear();
+
+		// dispose the dispose listeners
+		this.mapResourceToDisposeListener.forEach(listener => listener.dispose());
+		this.mapResourceToDisposeListener.clear();
+
+		// dispose the model change listeners
+		this.mapResourceToModelListeners.forEach(listener => listener.dispose());
+		this.mapResourceToModelListeners.clear();
 	}
 }

--- a/src/vs/workbench/services/textfile/electron-sandbox/nativeTextFileService.ts
+++ b/src/vs/workbench/services/textfile/electron-sandbox/nativeTextFileService.ts
@@ -54,10 +54,11 @@ export class NativeTextFileService extends AbstractTextFileService {
 		super(fileService, untitledTextEditorService, lifecycleService, instantiationService, modelService, environmentService, dialogService, fileDialogService, textResourceConfigurationService, filesConfigurationService, textModelService, codeEditorService, pathService, workingCopyFileService, uriIdentityService, modeService, logService, elevatedFileService);
 
 		this.environmentService = environmentService;
+
+		this.registerListeners();
 	}
 
-	protected override registerListeners(): void {
-		super.registerListeners();
+	private registerListeners(): void {
 
 		// Lifecycle
 		this.lifecycleService.onWillShutdown(event => event.join(this.onWillShutdown(), 'join.textFiles'));

--- a/src/vs/workbench/services/textfile/test/browser/textFileEditorModelManager.test.ts
+++ b/src/vs/workbench/services/textfile/test/browser/textFileEditorModelManager.test.ts
@@ -72,7 +72,7 @@ suite('Files - TextFileEditorModelManager', () => {
 		results = manager.models;
 		assert.strictEqual(2, results.length);
 
-		manager.clear();
+		manager.dispose();
 		results = manager.models;
 		assert.strictEqual(0, results.length);
 

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
@@ -227,7 +227,6 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 
 		// Lifecycle
 		this.lifecycleService.onWillShutdown(event => event.join(this.onWillShutdown(), 'join.fileWorkingCopyManager'));
-		this.lifecycleService.onDidShutdown(() => this.dispose());
 	}
 
 	private async onWillShutdown(): Promise<void> {
@@ -567,21 +566,6 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 		}
 	}
 
-	private clear(): void {
-
-		// Working copy caches
-		this.mapResourceToWorkingCopy.clear();
-		this.mapResourceToPendingWorkingCopyResolve.clear();
-
-		// Dispose the dispose listeners
-		this.mapResourceToDisposeListener.forEach(listener => listener.dispose());
-		this.mapResourceToDisposeListener.clear();
-
-		// Dispose the working copy change listeners
-		this.mapResourceToWorkingCopyListeners.forEach(listener => listener.dispose());
-		this.mapResourceToWorkingCopyListeners.clear();
-	}
-
 	//#endregion
 
 	//#region Save As...
@@ -718,7 +702,20 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 	override dispose(): void {
 		super.dispose();
 
-		this.clear();
+		// Working copy caches
+		this.mapResourceToWorkingCopy.forEach(workingCopy => workingCopy.dispose());
+		this.mapResourceToWorkingCopy.clear();
+
+		// Pending working copy resolves
+		this.mapResourceToPendingWorkingCopyResolve.clear();
+
+		// Dispose the dispose listeners
+		this.mapResourceToDisposeListener.forEach(listener => listener.dispose());
+		this.mapResourceToDisposeListener.clear();
+
+		// Dispose the working copy change listeners
+		this.mapResourceToWorkingCopyListeners.forEach(listener => listener.dispose());
+		this.mapResourceToWorkingCopyListeners.clear();
 	}
 
 	//#endregion

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
@@ -722,16 +722,16 @@ export class FileWorkingCopyManager<T extends IFileWorkingCopyModel> extends Dis
 		this.mapResourceToPendingWorkingCopyResolve.clear();
 
 		// Dispose the dispose listeners
-		dispose(Array.from(this.mapResourceToDisposeListener.values()));
+		dispose(this.mapResourceToDisposeListener.values());
 		this.mapResourceToDisposeListener.clear();
 
 		// Dispose the working copy change listeners
-		dispose(Array.from(this.mapResourceToWorkingCopyListeners.values()));
+		dispose(this.mapResourceToWorkingCopyListeners.values());
 		this.mapResourceToWorkingCopyListeners.clear();
 	}
 
 	destroyWorkingCopies(): void {
-		dispose(Array.from(this.mapResourceToWorkingCopy.values()));
+		dispose(this.mapResourceToWorkingCopy.values());
 	}
 
 	//#endregion

--- a/src/vs/workbench/services/workingCopy/test/browser/fileWorkingCopyManager.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/fileWorkingCopyManager.test.ts
@@ -242,6 +242,28 @@ suite('FileWorkingCopyManager', () => {
 		workingCopy2.dispose();
 	});
 
+	test('resolve registers as working copy and dispose clears', async () => {
+		const resource1 = URI.file('/test1.html');
+		const resource2 = URI.file('/test2.html');
+		const resource3 = URI.file('/test3.html');
+
+		assert.strictEqual(accessor.workingCopyService.workingCopies.length, 0);
+
+		const firstPromise = manager.resolve(resource1);
+		const secondPromise = manager.resolve(resource2);
+		const thirdPromise = manager.resolve(resource3);
+
+		await Promise.all([firstPromise, secondPromise, thirdPromise]);
+
+		assert.strictEqual(accessor.workingCopyService.workingCopies.length, 3);
+		assert.strictEqual(manager.workingCopies.length, 3);
+
+		manager.dispose();
+
+		assert.strictEqual(accessor.workingCopyService.workingCopies.length, 0);
+		assert.strictEqual(manager.workingCopies.length, 0);
+	});
+
 	test('file change event triggers working copy resolve', async () => {
 		const resource = URI.file('/path/index.txt');
 

--- a/src/vs/workbench/services/workingCopy/test/browser/fileWorkingCopyManager.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/fileWorkingCopyManager.test.ts
@@ -260,6 +260,30 @@ suite('FileWorkingCopyManager', () => {
 
 		manager.dispose();
 
+		assert.strictEqual(manager.workingCopies.length, 0);
+
+		// dispose does not remove from working copy service, only destroyWorkingCopies should
+		assert.strictEqual(accessor.workingCopyService.workingCopies.length, 3);
+	});
+
+	test('destroyWorkingCopies', async () => {
+		const resource1 = URI.file('/test1.html');
+		const resource2 = URI.file('/test2.html');
+		const resource3 = URI.file('/test3.html');
+
+		assert.strictEqual(accessor.workingCopyService.workingCopies.length, 0);
+
+		const firstPromise = manager.resolve(resource1);
+		const secondPromise = manager.resolve(resource2);
+		const thirdPromise = manager.resolve(resource3);
+
+		await Promise.all([firstPromise, secondPromise, thirdPromise]);
+
+		assert.strictEqual(accessor.workingCopyService.workingCopies.length, 3);
+		assert.strictEqual(manager.workingCopies.length, 3);
+
+		manager.destroyWorkingCopies();
+
 		assert.strictEqual(accessor.workingCopyService.workingCopies.length, 0);
 		assert.strictEqual(manager.workingCopies.length, 0);
 	});

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -327,8 +327,8 @@ export class TestTextFileService extends BrowserTextFileService {
 			workingCopyFileService,
 			uriIdentityService,
 			modeService,
-			logService,
-			elevatedFileService
+			elevatedFileService,
+			logService
 		);
 	}
 


### PR DESCRIPTION
On top of https://github.com/microsoft/vscode/commit/c98cc5cf81b433ebd2c85e600fbd8a19fcdec9ee updates managers to actually dispose the working copies they create. 

Disposing a working copy will unregister it from the working copy service and will:
* discard any backups
* fire a `onDidChangeDirty` event if the working copy was dirty

I am not super happy with the fact that backups get discarded though because it might be easy to accidentally call `dispose` on the manager on shutdown and then have backups discarded for no reason. I had code in the managers to call `dispose` when the `onDidShutdown` event fires which I now removed because of that.

An alternative would be not do this through `dispose` but have another method like `destroy` or `clear` to make this a bit more obvious.

@jrieken doing this from a PR so that you can test how it behaves for notebooks. 

