### PR TITLE
The default Monokai highlight color is displayed incorrectly

### DIFF
--- a/extensions/theme-monokai/themes/monokai-color-theme.json
+++ b/extensions/theme-monokai/themes/monokai-color-theme.json
@@ -18,7 +18,7 @@
 		"button.background": "#75715E",
 		"editor.background": "#272822",
 		"editor.foreground": "#f8f8f2",
-		"selection.background": "#ccccc7",
+		"selection.background": "#878b9180",
 		"editor.selectionHighlightBackground": "#575b6180",
 		"editor.selectionBackground": "#878b9180",
 		"minimap.selectionHighlight": "#878b9180",


### PR DESCRIPTION
1.56 fix for #123044

`selection.background` is used as selection background in text input widgets.

The Monokai `selection.background` was too bright and the fix is to change if to the same color for selection as in the editor.

Why the bright color wasn't show in previous releases is unclear to me. It looks like a fix in Electron.
But the change looks correct.

I also checked all other built-in themes that define a custom `selection.background` 
