### PR TITLE
Fix Initial Scroll Position on Markdown Dynamic Preview

### DIFF
--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -500,8 +500,9 @@ export class StaticMarkdownPreview extends Disposable implements ManagedMarkdown
 		logger: Logger,
 		contributionProvider: MarkdownContributionProvider,
 		engine: MarkdownEngine,
+		scrollLocation?: number,
 	): StaticMarkdownPreview {
-		return new StaticMarkdownPreview(webview, resource, contentProvider, previewConfigurations, logger, contributionProvider, engine);
+		return new StaticMarkdownPreview(webview, resource, contentProvider, previewConfigurations, logger, contributionProvider, engine, scrollLocation);
 	}
 
 	private readonly preview: MarkdownPreview;
@@ -514,10 +515,12 @@ export class StaticMarkdownPreview extends Disposable implements ManagedMarkdown
 		logger: Logger,
 		contributionProvider: MarkdownContributionProvider,
 		engine: MarkdownEngine,
+		scrollLocation?: number,
 	) {
 		super();
 
-		this.preview = this._register(new MarkdownPreview(this._webviewPanel, resource, undefined, {
+		const startingScroll = scrollLocation ? new StartingScrollLine(scrollLocation) : undefined;
+		this.preview = this._register(new MarkdownPreview(this._webviewPanel, resource, startingScroll, {
 			getAdditionalState: () => { return {}; },
 			openPreviewLinkToMarkdownFile: () => { /* todo */ }
 		}, engine, contentProvider, _previewConfigurations, logger, contributionProvider));

--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -500,9 +500,8 @@ export class StaticMarkdownPreview extends Disposable implements ManagedMarkdown
 		logger: Logger,
 		contributionProvider: MarkdownContributionProvider,
 		engine: MarkdownEngine,
-		scrollLocation?: number,
 	): StaticMarkdownPreview {
-		return new StaticMarkdownPreview(webview, resource, contentProvider, previewConfigurations, logger, contributionProvider, engine, scrollLocation);
+		return new StaticMarkdownPreview(webview, resource, contentProvider, previewConfigurations, logger, contributionProvider, engine);
 	}
 
 	private readonly preview: MarkdownPreview;
@@ -515,12 +514,10 @@ export class StaticMarkdownPreview extends Disposable implements ManagedMarkdown
 		logger: Logger,
 		contributionProvider: MarkdownContributionProvider,
 		engine: MarkdownEngine,
-		scrollLocation?: number,
 	) {
 		super();
 
-		const startingScroll = scrollLocation ? new StartingScrollLine(scrollLocation) : undefined;
-		this.preview = this._register(new MarkdownPreview(this._webviewPanel, resource, startingScroll, {
+		this.preview = this._register(new MarkdownPreview(this._webviewPanel, resource, undefined, {
 			getAdditionalState: () => { return {}; },
 			openPreviewLinkToMarkdownFile: () => { /* todo */ }
 		}, engine, contentProvider, _previewConfigurations, logger, contributionProvider));

--- a/extensions/markdown-language-features/src/features/previewManager.ts
+++ b/extensions/markdown-language-features/src/features/previewManager.ts
@@ -175,7 +175,6 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 		resource: vscode.Uri,
 		previewSettings: DynamicPreviewSettings
 	): DynamicMarkdownPreview {
-
 		const activeTextEditorURI = vscode.window.activeTextEditor?.document.uri;
 		const scrollLine = (activeTextEditorURI?.toString() === resource.toString()) ? vscode.window.activeTextEditor?.visibleRanges[0].start.line : undefined;
 		const preview = DynamicMarkdownPreview.create(
@@ -183,7 +182,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 				resource,
 				resourceColumn: previewSettings.resourceColumn,
 				locked: previewSettings.locked,
-				line: scrollLine, // Get the first visible line number from the most recent
+				line: scrollLine,
 			},
 			previewSettings.previewColumn,
 			this._contentProvider,

--- a/extensions/markdown-language-features/src/features/previewManager.ts
+++ b/extensions/markdown-language-features/src/features/previewManager.ts
@@ -160,7 +160,6 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 		document: vscode.TextDocument,
 		webview: vscode.WebviewPanel
 	): Promise<void> {
-		const scrollLocation = vscode.window.activeTextEditor?.visibleRanges[0].start.line;
 		const preview = StaticMarkdownPreview.revive(
 			document.uri,
 			webview,
@@ -168,8 +167,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 			this._previewConfigurations,
 			this._logger,
 			this._contributions,
-			this._engine,
-			scrollLocation);
+			this._engine);
 		this.registerStaticPreview(preview);
 	}
 

--- a/extensions/markdown-language-features/src/features/previewManager.ts
+++ b/extensions/markdown-language-features/src/features/previewManager.ts
@@ -160,6 +160,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 		document: vscode.TextDocument,
 		webview: vscode.WebviewPanel
 	): Promise<void> {
+		const scrollLocation = vscode.window.activeTextEditor?.visibleRanges[0].start.line;
 		const preview = StaticMarkdownPreview.revive(
 			document.uri,
 			webview,
@@ -167,7 +168,8 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 			this._previewConfigurations,
 			this._logger,
 			this._contributions,
-			this._engine);
+			this._engine,
+			scrollLocation);
 		this.registerStaticPreview(preview);
 	}
 
@@ -175,11 +177,15 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 		resource: vscode.Uri,
 		previewSettings: DynamicPreviewSettings
 	): DynamicMarkdownPreview {
+
+		const activeTextEditorURI = vscode.window.activeTextEditor?.document.uri;
+		const scrollLine = (activeTextEditorURI?.toString() === resource.toString()) ? vscode.window.activeTextEditor?.visibleRanges[0].start.line : undefined;
 		const preview = DynamicMarkdownPreview.create(
 			{
 				resource,
 				resourceColumn: previewSettings.resourceColumn,
 				locked: previewSettings.locked,
+				line: scrollLine, // Get the first visible line number from the most recent
 			},
 			previewSettings.previewColumn,
 			this._contentProvider,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Currently, the dynamic preview for markdown files does not open at the correct initial scroll position (without resizing or scrolling on the text-based markdown file). Currently, the preview opens at the top of the file regardless of where the user is scrolled on the text editor. This small PR should fix this.

This PR fixes #123612
