### PR TITLE
Try better fix for loading mixed local/remote notebook resources

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/baseWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/baseWebviewElement.ts
@@ -514,13 +514,11 @@ export abstract class BaseWebview<T extends HTMLElement> extends Disposable {
 
 	private async loadResource(id: number, requestPath: string, uri: URI, remoteAuthority: string | undefined, ifNoneMatch: string | undefined) {
 		try {
-			const remoteAuthority = this._environmentService.remoteAuthority;
 			const remoteConnectionData = remoteAuthority ? this._remoteAuthorityResolverService.getConnectionData(remoteAuthority) : null;
 
 			const result = await loadLocalResource(uri, ifNoneMatch, {
 				roots: this.content.options.localResourceRoots || [],
 				remoteConnectionData,
-				useRootAuthority: this.content.options.useRootAuthority,
 				remoteAuthority: remoteAuthority,
 			}, this._fileService, this._requestService, this._logService, this._resourceLoadingCts.token);
 

--- a/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
+++ b/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
@@ -50,7 +50,6 @@ export async function loadLocalResource(
 		roots: ReadonlyArray<URI>;
 		remoteConnectionData?: IRemoteConnectionData | null;
 		remoteAuthority: string | undefined;
-		useRootAuthority?: boolean;
 	},
 	fileService: IFileService,
 	requestService: IRequestService,
@@ -59,7 +58,7 @@ export async function loadLocalResource(
 ): Promise<WebviewResourceResponse.StreamResponse> {
 	logService.debug(`loadLocalResource - being. requestUri=${requestUri}`);
 
-	const resourceToLoad = getResourceToLoad(requestUri, options.roots, options.remoteAuthority, options.useRootAuthority);
+	const resourceToLoad = getResourceToLoad(requestUri, options.roots, options.remoteAuthority);
 
 	logService.debug(`loadLocalResource - found resource to load. requestUri=${requestUri}, resourceToLoad=${resourceToLoad}`);
 
@@ -119,23 +118,22 @@ function getResourceToLoad(
 	requestUri: URI,
 	roots: ReadonlyArray<URI>,
 	remoteAuthority: string | undefined,
-	useRootAuthority: boolean | undefined
 ): URI | undefined {
 	for (const root of roots) {
 		if (containsResource(root, requestUri)) {
-			return normalizeResourcePath(requestUri, remoteAuthority, useRootAuthority ? root.authority : undefined);
+			return normalizeResourcePath(requestUri, remoteAuthority);
 		}
 	}
 
 	return undefined;
 }
 
-function normalizeResourcePath(resource: URI, remoteAuthority: string | undefined, useRemoteAuthority: string | undefined): URI {
+function normalizeResourcePath(resource: URI, remoteAuthority: string | undefined): URI {
 	// If the uri was from a remote authority, make we go to the remote to load it
-	if (useRemoteAuthority || (remoteAuthority && resource.scheme === Schemas.file)) {
+	if (remoteAuthority && resource.scheme === Schemas.file) {
 		return URI.from({
 			scheme: Schemas.vscodeRemote,
-			authority: useRemoteAuthority ?? remoteAuthority,
+			authority: remoteAuthority,
 			path: '/vscode-resource',
 			query: JSON.stringify({
 				requestResourcePath: resource.path

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -80,7 +80,6 @@ export interface WebviewOptions {
 }
 
 export interface WebviewContentOptions {
-	readonly useRootAuthority?: boolean;
 	readonly allowMultipleAPIAcquire?: boolean;
 	readonly allowScripts?: boolean;
 	readonly localResourceRoots?: ReadonlyArray<URI>;


### PR DESCRIPTION
This is a follow up on 19cda32aafccb88db45622e7ae9be90cb71c9744. It removes the `useRootAuthority` workaround we introduced to instead take the authority that is passed in as part of the webview resource uri