### PR TITLE
Remove illegal top level export from web worker script

### DIFF
--- a/src/vs/editor/editor.worker.ts
+++ b/src/vs/editor/editor.worker.ts
@@ -9,7 +9,7 @@ import { EditorWorkerHost } from 'vs/editor/common/services/editorWorkerServiceI
 
 let initialized = false;
 
-export function initialize(foreignModule: any) {
+function initialize(foreignModule: any) {
 	if (initialized) {
 		return;
 	}


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/124095

This PR fixes an issue I've been having with Monaco, where loading the editor would throw an error about tap level exports not allowed.
I was less worried about this, but I recently added error tracking to my site, and figured if the fix is easy, I may as well fix it 🙃 

Details: 
 - This is how I prepare the workers for use in Monaco, using ESBuild: https://github.com/NullVoxPopuli/limber/blob/main/packages/monaco/build.js#L33
    - I'm using `esm` as a target, but it shouldn't matter as `bundle: true` is set (so everything is one file)
 - Compiled file deployed here: https://limber.glimdown.com/monaco/editor/editor.worker.js
    - problem: ![image](https://user-images.githubusercontent.com/199018/118122494-ef9bf400-b3c0-11eb-8e9f-2243e115e1ae.png)
