### PR TITLE
Simplify logic for webview resource uris

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -147,7 +147,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostNotebookKernels = rpcProtocol.set(ExtHostContext.ExtHostNotebookKernels, new ExtHostNotebookKernels(rpcProtocol, initData, extHostNotebook, extHostLogService));
 	const extHostEditors = rpcProtocol.set(ExtHostContext.ExtHostEditors, new ExtHostEditors(rpcProtocol, extHostDocumentsAndEditors));
 	const extHostTreeViews = rpcProtocol.set(ExtHostContext.ExtHostTreeViews, new ExtHostTreeViews(rpcProtocol.getProxy(MainContext.MainThreadTreeViews), extHostCommands, extHostLogService));
-	const extHostEditorInsets = rpcProtocol.set(ExtHostContext.ExtHostEditorInsets, new ExtHostEditorInsets(rpcProtocol.getProxy(MainContext.MainThreadEditorInsets), extHostEditors, { ...initData.environment, remote: initData.remote }));
+	const extHostEditorInsets = rpcProtocol.set(ExtHostContext.ExtHostEditorInsets, new ExtHostEditorInsets(rpcProtocol.getProxy(MainContext.MainThreadEditorInsets), extHostEditors, initData));
 	const extHostDiagnostics = rpcProtocol.set(ExtHostContext.ExtHostDiagnostics, new ExtHostDiagnostics(rpcProtocol, extHostLogService));
 	const extHostLanguageFeatures = rpcProtocol.set(ExtHostContext.ExtHostLanguageFeatures, new ExtHostLanguageFeatures(rpcProtocol, uriTransformer, extHostDocuments, extHostCommands, extHostDiagnostics, extHostLogService, extHostApiDeprecation));
 	const extHostFileSystem = rpcProtocol.set(ExtHostContext.ExtHostFileSystem, new ExtHostFileSystem(rpcProtocol, extHostLanguageFeatures));
@@ -160,7 +160,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostTheming = rpcProtocol.set(ExtHostContext.ExtHostTheming, new ExtHostTheming(rpcProtocol));
 	const extHostAuthentication = rpcProtocol.set(ExtHostContext.ExtHostAuthentication, new ExtHostAuthentication(rpcProtocol));
 	const extHostTimeline = rpcProtocol.set(ExtHostContext.ExtHostTimeline, new ExtHostTimeline(rpcProtocol, extHostCommands));
-	const extHostWebviews = rpcProtocol.set(ExtHostContext.ExtHostWebviews, new ExtHostWebviews(rpcProtocol, { ...initData.environment, remote: initData.remote }, extHostWorkspace, extHostLogService, extHostApiDeprecation));
+	const extHostWebviews = rpcProtocol.set(ExtHostContext.ExtHostWebviews, new ExtHostWebviews(rpcProtocol, { remote: initData.remote }, extHostWorkspace, extHostLogService, extHostApiDeprecation));
 	const extHostWebviewPanels = rpcProtocol.set(ExtHostContext.ExtHostWebviewPanels, new ExtHostWebviewPanels(rpcProtocol, extHostWebviews, extHostWorkspace));
 	const extHostCustomEditors = rpcProtocol.set(ExtHostContext.ExtHostCustomEditors, new ExtHostCustomEditors(rpcProtocol, extHostDocuments, extensionStoragePaths, extHostWebviews, extHostWebviewPanels));
 	const extHostWebviewViews = rpcProtocol.set(ExtHostContext.ExtHostWebviewViews, new ExtHostWebviewViews(rpcProtocol, extHostWebviews));

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -74,8 +74,6 @@ export interface IEnvironment {
 	extensionTestsLocationURI?: URI;
 	globalStorageHome: URI;
 	workspaceStorageHome: URI;
-	webviewResourceRoot: string;
-	webviewCspSource: string;
 	useHostProxy?: boolean;
 }
 

--- a/src/vs/workbench/api/common/extHostCodeInsets.ts
+++ b/src/vs/workbench/api/common/extHostCodeInsets.ts
@@ -10,7 +10,7 @@ import { ExtHostTextEditor } from 'vs/workbench/api/common/extHostTextEditor';
 import { ExtHostEditors } from 'vs/workbench/api/common/extHostTextEditors';
 import type * as vscode from 'vscode';
 import { ExtHostEditorInsetsShape, MainThreadEditorInsetsShape } from './extHost.protocol';
-import { asWebviewUri, WebviewInitData } from 'vs/workbench/api/common/shared/webview';
+import { asWebviewUri, webviewGenericCspSource, WebviewInitData } from 'vs/workbench/api/common/shared/webview';
 import { generateUuid } from 'vs/base/common/uuid';
 
 export class ExtHostEditorInsets implements ExtHostEditorInsetsShape {
@@ -70,7 +70,7 @@ export class ExtHostEditorInsets implements ExtHostEditorInsetsShape {
 			}
 
 			get cspSource(): string {
-				return that._initData.webviewCspSource;
+				return webviewGenericCspSource;
 			}
 
 			set options(value: vscode.WebviewOptions) {

--- a/src/vs/workbench/api/common/extHostCodeInsets.ts
+++ b/src/vs/workbench/api/common/extHostCodeInsets.ts
@@ -66,7 +66,7 @@ export class ExtHostEditorInsets implements ExtHostEditorInsetsShape {
 			private _options: vscode.WebviewOptions = Object.create(null);
 
 			asWebviewUri(resource: vscode.Uri): vscode.Uri {
-				return asWebviewUri(that._initData, this._uuid, resource);
+				return asWebviewUri(this._uuid, resource, that._initData.remote.authority);
 			}
 
 			get cspSource(): string {

--- a/src/vs/workbench/api/common/extHostNotebookKernels.ts
+++ b/src/vs/workbench/api/common/extHostNotebookKernels.ts
@@ -190,7 +190,7 @@ export class ExtHostNotebookKernels implements ExtHostNotebookKernelsShape {
 				return that._proxy.$postMessage(handle, editor && that._extHostNotebook.getIdByEditor(editor), message);
 			},
 			asWebviewUri(uri: URI) {
-				return asWebviewUri({ ...that._initData.environment, remote: that._initData.remote }, String(handle), uri);
+				return asWebviewUri(String(handle), uri, that._initData.remote.authority);
 			},
 			// --- priority
 			updateNotebookAffinity(notebook, priority) {

--- a/src/vs/workbench/api/common/extHostWebview.ts
+++ b/src/vs/workbench/api/common/extHostWebview.ts
@@ -69,7 +69,7 @@ export class ExtHostWebview implements vscode.Webview {
 
 	public asWebviewUri(resource: vscode.Uri): vscode.Uri {
 		this.#hasCalledAsWebviewUri = true;
-		return asWebviewUri(this.#initData, this.#handle, resource);
+		return asWebviewUri(this.#handle, resource, this.#initData.remote.authority);
 	}
 
 	public get cspSource(): string {

--- a/src/vs/workbench/api/common/extHostWebview.ts
+++ b/src/vs/workbench/api/common/extHostWebview.ts
@@ -12,7 +12,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IExtHostApiDeprecationService } from 'vs/workbench/api/common/extHostApiDeprecationService';
 import { serializeWebviewMessage, deserializeWebviewMessage } from 'vs/workbench/api/common/extHostWebviewMessaging';
 import { IExtHostWorkspace } from 'vs/workbench/api/common/extHostWorkspace';
-import { asWebviewUri, WebviewInitData } from 'vs/workbench/api/common/shared/webview';
+import { asWebviewUri, webviewGenericCspSource, WebviewInitData } from 'vs/workbench/api/common/shared/webview';
 import type * as vscode from 'vscode';
 import * as extHostProtocol from './extHost.protocol';
 
@@ -73,8 +73,7 @@ export class ExtHostWebview implements vscode.Webview {
 	}
 
 	public get cspSource(): string {
-		return this.#initData.webviewCspSource
-			.replace('{{uuid}}', this.#handle);
+		return webviewGenericCspSource;
 	}
 
 	public get html(): string {

--- a/src/vs/workbench/api/common/shared/webview.ts
+++ b/src/vs/workbench/api/common/shared/webview.ts
@@ -32,20 +32,24 @@ export const webviewGenericCspSource = 'https://*.vscode-webview-test.com';
  * ```txt
  * scheme/resource-authority/path...
  * ```
+ *
+ * @param uuid Unique id of the webview.
+ * @param resource Uri of the resource to load.
+ * @param fromAuthority Optional remote authority that specifies where `resource` should be resolved from.
  */
 export function asWebviewUri(
-	initData: WebviewInitData,
 	uuid: string,
 	resource: vscode.Uri,
+	fromAuthority: string | undefined
 ): vscode.Uri {
 	if (resource.scheme === Schemas.http || resource.scheme === Schemas.https) {
 		return resource;
 	}
 
-	if (initData.remote.authority && resource.scheme === Schemas.file) {
+	if (fromAuthority && resource.scheme === Schemas.file) {
 		resource = URI.from({
 			scheme: Schemas.vscodeRemote,
-			authority: initData.remote.authority,
+			authority: fromAuthority,
 			path: resource.path,
 		});
 	}

--- a/src/vs/workbench/api/common/shared/webview.ts
+++ b/src/vs/workbench/api/common/shared/webview.ts
@@ -39,7 +39,6 @@ export function asWebviewUri(
 	resource: vscode.Uri,
 ): vscode.Uri {
 	if (resource.scheme === Schemas.http || resource.scheme === Schemas.https) {
-		// No need to rewrite anything
 		return resource;
 	}
 
@@ -47,12 +46,10 @@ export function asWebviewUri(
 		resource = URI.from({
 			scheme: Schemas.vscodeRemote,
 			authority: initData.remote.authority,
-			path: '/vscode-resource',
-			query: JSON.stringify({
-				requestResourcePath: resource.path
-			})
+			path: resource.path,
 		});
 	}
+
 	const uri = webviewResourceRoot(uuid)
 		.replace('{{resource}}', resource.scheme + '/' + encodeURIComponent(resource.authority) + resource.path)
 		.replace('{{uuid}}', uuid);

--- a/src/vs/workbench/api/common/shared/webview.ts
+++ b/src/vs/workbench/api/common/shared/webview.ts
@@ -3,15 +3,25 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
 import type * as vscode from 'vscode';
 
 export interface WebviewInitData {
-	readonly isExtensionDevelopmentDebug: boolean;
-	readonly webviewResourceRoot: string;
-	readonly webviewCspSource: string;
 	readonly remote: { readonly authority: string | undefined };
 }
+
+/**
+ * Location where we load resources from
+ *
+ * There endpoints can be hardcoded because we never expect to actually hit them. Instead these requests
+ * should always go to a service worker.
+ */
+export const webviewResourceOrigin = (id: string) => `https://${id}.vscode-webview-test.com`;
+
+export const webviewResourceRoot = (id: string) => `${webviewResourceOrigin(id)}/vscode-resource/{{resource}}`;
+
+export const webviewGenericCspSource = 'https://*.vscode-webview-test.com';
 
 /**
  * Construct a uri that can load resources inside a webview
@@ -20,7 +30,7 @@ export interface WebviewInitData {
  * we know where to load the resource from (remote or truly local):
  *
  * ```txt
- * /remote-authority?/scheme/resource-authority/path...
+ * scheme/resource-authority/path...
  * ```
  */
 export function asWebviewUri(
@@ -28,8 +38,23 @@ export function asWebviewUri(
 	uuid: string,
 	resource: vscode.Uri,
 ): vscode.Uri {
-	const uri = initData.webviewResourceRoot
-		.replace('{{resource}}', (initData.remote.authority ?? '') + '/' + resource.scheme + '/' + encodeURIComponent(resource.authority) + resource.path)
+	if (resource.scheme === Schemas.http || resource.scheme === Schemas.https) {
+		// No need to rewrite anything
+		return resource;
+	}
+
+	if (initData.remote.authority && resource.scheme === Schemas.file) {
+		resource = URI.from({
+			scheme: Schemas.vscodeRemote,
+			authority: initData.remote.authority,
+			path: '/vscode-resource',
+			query: JSON.stringify({
+				requestResourcePath: resource.path
+			})
+		});
+	}
+	const uri = webviewResourceRoot(uuid)
+		.replace('{{resource}}', resource.scheme + '/' + encodeURIComponent(resource.authority) + resource.path)
 		.replace('{{uuid}}', uuid);
 	return URI.parse(uri).with({
 		fragment: resource.fragment,

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -766,9 +766,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Disposable {
 
 	private asWebviewUri(uri: URI, fromExtension: URI | undefined) {
 		const remoteAuthority = fromExtension?.scheme === Schemas.vscodeRemote ? fromExtension.authority : undefined;
-		return asWebviewUri({
-			remote: { authority: remoteAuthority }
-		}, this.id, uri);
+		return asWebviewUri(this.id, uri, remoteAuthority);
 	}
 
 	postKernelMessage(message: any) {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -767,9 +767,6 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Disposable {
 	private asWebviewUri(uri: URI, fromExtension: URI | undefined) {
 		const remoteAuthority = fromExtension?.scheme === Schemas.vscodeRemote ? fromExtension.authority : undefined;
 		return asWebviewUri({
-			isExtensionDevelopmentDebug: this.environmentService.isExtensionDevelopment,
-			webviewCspSource: this.environmentService.webviewCspSource,
-			webviewResourceRoot: this.environmentService.webviewResourceRoot,
 			remote: { authority: remoteAuthority }
 		}, this.id, uri);
 	}

--- a/src/vs/workbench/contrib/webview/browser/baseWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/baseWebviewElement.ts
@@ -380,16 +380,13 @@ export abstract class BaseWebview<T extends HTMLElement> extends Disposable {
 
 	private rewriteVsCodeResourceUrls(value: string): string {
 		const remoteAuthority = this.extension?.location.scheme === Schemas.vscodeRemote ? this.extension.location.authority : undefined;
-		const asUriContext = {
-			remote: { authority: remoteAuthority },
-		};
 		return value
 			.replace(/(["'])(?:vscode-resource):(\/\/([^\s\/'"]+?)(?=\/))?([^\s'"]+?)(["'])/gi, (_match, startQuote, _1, scheme, path, endQuote) => {
 				const uri = URI.from({
 					scheme: scheme || 'file',
 					path: path,
 				});
-				const webviewUri = asWebviewUri(asUriContext, this.id, uri).toString();
+				const webviewUri = asWebviewUri(this.id, uri, remoteAuthority).toString();
 				return `${startQuote}${webviewUri}${endQuote}`;
 			})
 			.replace(/(["'])(?:vscode-webview-resource):(\/\/[^\s\/'"]+\/([^\s\/'"]+?)(?=\/))?([^\s'"]+?)(["'])/gi, (_match, startQuote, _1, scheme, path, endQuote) => {
@@ -397,7 +394,7 @@ export abstract class BaseWebview<T extends HTMLElement> extends Disposable {
 					scheme: scheme || 'file',
 					path: path,
 				});
-				const webviewUri = asWebviewUri(asUriContext, this.id, uri).toString();
+				const webviewUri = asWebviewUri(this.id, uri, remoteAuthority).toString();
 				return `${startQuote}${webviewUri}${endQuote}`;
 			});
 	}

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -25,7 +25,7 @@ const resourceOrigin = searchParams.get('vscode-resource-origin') ?? sw.origin;
 /**
  * Root path for resources
  */
-const resourceRoot = rootPath + '/vscode-resource';
+const resourceRoot = '/vscode-resource';
 
 const serviceWorkerFetchIgnoreSubdomain = searchParams.get('serviceWorkerFetchIgnoreSubdomain') ?? false;
 
@@ -175,7 +175,6 @@ sw.addEventListener('message', async (event) => {
 
 sw.addEventListener('fetch', (event) => {
 	const requestUrl = new URL(event.request.url);
-
 	if (serviceWorkerFetchIgnoreSubdomain && requestUrl.pathname.startsWith(resourceRoot + '/')) {
 		// #121981
 		const ignoreFirstSubdomainRegex = /(.*):\/\/.*?\.(.*)/;

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -13,7 +13,6 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { ITunnelService } from 'vs/platform/remote/common/tunnel';
-import { IRequestService } from 'vs/platform/request/common/request';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { BaseWebview, WebviewMessageChannels } from 'vs/workbench/contrib/webview/browser/baseWebviewElement';
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
@@ -37,7 +36,6 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 		@IMenuService menuService: IMenuService,
 		@INotificationService notificationService: INotificationService,
 		@IRemoteAuthorityResolverService remoteAuthorityResolverService: IRemoteAuthorityResolverService,
-		@IRequestService requestService: IRequestService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@ITunnelService tunnelService: ITunnelService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
@@ -48,7 +46,6 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 			logService,
 			telemetryService,
 			environmentService,
-			requestService,
 			fileService,
 			tunnelService,
 			remoteAuthorityResolverService,
@@ -106,7 +103,8 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 			extensionId: extension?.id.value ?? '', // The extensionId and purpose in the URL are used for filtering in js-debug:
 			purpose: options.purpose,
 			serviceWorkerFetchIgnoreSubdomain: options.serviceWorkerFetchIgnoreSubdomain,
-			...extraParams
+			...extraParams,
+			'vscode-resource-origin': this.webviewResourceOrigin,
 		} as const;
 
 		const queryString = (Object.keys(params) as Array<keyof typeof params>)
@@ -122,10 +120,6 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 			return endpoint.slice(0, endpoint.length - 1);
 		}
 		return endpoint;
-	}
-
-	protected get webviewResourceEndpoint(): string {
-		return this.webviewContentEndpoint;
 	}
 
 	public mountTo(parent: HTMLElement) {

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -19,7 +19,6 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { ITunnelService } from 'vs/platform/remote/common/tunnel';
-import { IRequestService } from 'vs/platform/request/common/request';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { webviewPartitionId } from 'vs/platform/webview/common/webviewManagerService';
 import { BaseWebview, WebviewMessageChannels } from 'vs/workbench/contrib/webview/browser/baseWebviewElement';
@@ -62,7 +61,6 @@ export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> impleme
 		@IMenuService menuService: IMenuService,
 		@INotificationService notificationService: INotificationService,
 		@IFileService fileService: IFileService,
-		@IRequestService requestService: IRequestService,
 		@ITunnelService tunnelService: ITunnelService,
 		@IRemoteAuthorityResolverService remoteAuthorityResolverService: IRemoteAuthorityResolverService,
 	) {
@@ -74,7 +72,6 @@ export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> impleme
 			environmentService,
 			fileService,
 			menuService,
-			requestService,
 			tunnelService,
 			remoteAuthorityResolverService
 		});
@@ -162,7 +159,7 @@ export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> impleme
 		// and not the `vscode-file` URI because preload scripts are loaded
 		// via node.js from the main side and only allow `file:` protocol
 		this.element!.preload = FileAccess.asFileUri('./pre/electron-index.js', require).toString(true);
-		this.element!.src = `${Schemas.vscodeWebview}://${this.id}/electron-browser-index.html?platform=electron&id=${this.id}&vscode-resource-origin=${encodeURIComponent(this.webviewResourceEndpoint)}`;
+		this.element!.src = `${Schemas.vscodeWebview}://${this.id}/electron-browser-index.html?platform=electron&id=${this.id}&vscode-resource-origin=${encodeURIComponent(this.webviewResourceOrigin)}`;
 	}
 
 	protected createElement(options: WebviewOptions) {
@@ -193,10 +190,6 @@ export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> impleme
 	public override set contentOptions(options: WebviewContentOptions) {
 		this._myLogService.debug(`Webview(${this.id}): will set content options`);
 		super.contentOptions = options;
-	}
-
-	protected override get webviewResourceEndpoint(): string {
-		return `https://${this.id}.vscode-webview-test.com`;
 	}
 
 	protected readonly extraContentOptions = {};

--- a/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
@@ -13,7 +13,6 @@ import { INativeHostService } from 'vs/platform/native/electron-sandbox/native';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { ITunnelService } from 'vs/platform/remote/common/tunnel';
-import { IRequestService } from 'vs/platform/request/common/request';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { WebviewMessageChannels } from 'vs/workbench/contrib/webview/browser/baseWebviewElement';
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
@@ -38,7 +37,6 @@ export class ElectronIframeWebview extends IFrameWebview {
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@ITunnelService tunnelService: ITunnelService,
 		@IFileService fileService: IFileService,
-		@IRequestService requestService: IRequestService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 		@IRemoteAuthorityResolverService _remoteAuthorityResolverService: IRemoteAuthorityResolverService,
@@ -51,7 +49,7 @@ export class ElectronIframeWebview extends IFrameWebview {
 	) {
 		super(id, options, contentOptions, extension, webviewThemeDataProvider,
 			contextMenuService,
-			configurationService, fileService, logService, menuService, notificationService, _remoteAuthorityResolverService, requestService, telemetryService, tunnelService, environmentService);
+			configurationService, fileService, logService, menuService, notificationService, _remoteAuthorityResolverService, telemetryService, tunnelService, environmentService);
 
 		this._webviewKeyboardHandler = new WindowIgnoreMenuShortcutsManager(configurationService, mainProcessService, nativeHostService);
 
@@ -66,8 +64,7 @@ export class ElectronIframeWebview extends IFrameWebview {
 
 	protected override initElement(extension: WebviewExtensionDescription | undefined, options: WebviewOptions) {
 		super.initElement(extension, options, {
-			platform: 'electron',
-			'vscode-resource-origin': this.webviewResourceEndpoint,
+			platform: 'electron'
 		});
 	}
 
@@ -77,10 +74,6 @@ export class ElectronIframeWebview extends IFrameWebview {
 			return endpoint.slice(0, endpoint.length - 1);
 		}
 		return endpoint;
-	}
-
-	protected override get webviewResourceEndpoint(): string {
-		return `https://${this.id}.vscode-webview-test.com`;
 	}
 
 	protected override async doPostMessage(channel: string, data?: any): Promise<void> {

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
@@ -492,9 +492,7 @@ export class GettingStartedPage extends EditorPane {
 			if (src.startsWith('https://')) { return `src="${src}"`; }
 
 			const path = joinPath(base, src);
-			const transformed = asWebviewUri({
-				remote: { authority: undefined },
-			}, this.webviewID, path).toString();
+			const transformed = asWebviewUri(this.webviewID, path, undefined).toString();
 			return `src="${transformed}"`;
 		});
 

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
@@ -56,7 +56,6 @@ import { generateTokensCSSForColorMap } from 'vs/editor/common/modes/supports/to
 import { ResourceMap } from 'vs/base/common/map';
 import { IFileService } from 'vs/platform/files/common/files';
 import { joinPath } from 'vs/base/common/resources';
-import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { asWebviewUri } from 'vs/workbench/api/common/shared/webview';
 import { Schemas } from 'vs/base/common/network';
@@ -132,7 +131,6 @@ export class GettingStartedPage extends EditorPane {
 		@IExtensionService private readonly extensionService: IExtensionService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@INotificationService private readonly notificationService: INotificationService,
-		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@IEditorGroupsService private readonly groupsService: IEditorGroupsService,
 		@IContextKeyService contextService: IContextKeyService,
 		@IQuickInputService private quickInputService: IQuickInputService,
@@ -495,9 +493,6 @@ export class GettingStartedPage extends EditorPane {
 
 			const path = joinPath(base, src);
 			const transformed = asWebviewUri({
-				isExtensionDevelopmentDebug: this.environmentService.isExtensionDevelopment,
-				webviewResourceRoot: this.environmentService.webviewResourceRoot,
-				webviewCspSource: this.environmentService.webviewCspSource,
 				remote: { authority: undefined },
 			}, this.webviewID, path).toString();
 			return `src="${transformed}"`;

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -237,17 +237,6 @@ export class BrowserWorkbenchEnvironmentService implements IWorkbenchEnvironment
 	}
 
 	@memoize
-	get webviewResourceRoot(): string {
-		return `${this.webviewExternalEndpoint}/vscode-resource/{{resource}}`;
-	}
-
-	@memoize
-	get webviewCspSource(): string {
-		const uri = URI.parse(this.webviewEndpoint.replace('{{uuid}}', '*'));
-		return `${uri.scheme}://${uri.authority}`;
-	}
-
-	@memoize
 	get telemetryLogResource(): URI { return joinPath(this.options.logsPath, 'telemetry.log'); }
 	get disableTelemetry(): boolean { return false; }
 

--- a/src/vs/workbench/services/environment/common/environmentService.ts
+++ b/src/vs/workbench/services/environment/common/environmentService.ts
@@ -36,8 +36,6 @@ export interface IWorkbenchEnvironmentService extends IEnvironmentService {
 	readonly extensionEnabledProposedApi?: string[];
 
 	readonly webviewExternalEndpoint: string;
-	readonly webviewResourceRoot: string;
-	readonly webviewCspSource: string;
 
 	readonly skipReleaseNotes: boolean;
 

--- a/src/vs/workbench/services/environment/electron-sandbox/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-sandbox/environmentService.ts
@@ -69,21 +69,6 @@ export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironment
 	get webviewExternalEndpoint(): string { return `${Schemas.vscodeWebview}://{{uuid}}`; }
 
 	@memoize
-	get webviewResourceRoot(): string {
-		// On desktop, this endpoint is only used for the service worker to identify resource loads and
-		// should never actually be requested.
-		//
-		// Required due to https://github.com/electron/electron/issues/28528
-		return 'https://{{uuid}}.vscode-webview-test.com/vscode-resource/{{resource}}';
-	}
-
-	@memoize
-	get webviewCspSource(): string {
-		const uri = URI.parse(this.webviewResourceRoot.replace('{{uuid}}', '*'));
-		return `${uri.scheme}://${uri.authority}`;
-	}
-
-	@memoize
 	get skipReleaseNotes(): boolean { return !!this.args['skip-release-notes']; }
 
 	@memoize

--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -360,8 +360,6 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 				extensionTestsLocationURI: this._environmentService.extensionTestsLocationURI,
 				globalStorageHome: this._environmentService.globalStorageHome,
 				workspaceStorageHome: this._environmentService.workspaceStorageHome,
-				webviewResourceRoot: this._environmentService.webviewResourceRoot,
-				webviewCspSource: this._environmentService.webviewCspSource,
 			},
 			workspace: this._contextService.getWorkbenchState() === WorkbenchState.EMPTY ? undefined : {
 				configuration: workspace.configuration || undefined,

--- a/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
@@ -235,9 +235,7 @@ export class RemoteExtensionHost extends Disposable implements IExtensionHost {
 				extensionDevelopmentLocationURI: this._environmentService.extensionDevelopmentLocationURI,
 				extensionTestsLocationURI: this._environmentService.extensionTestsLocationURI,
 				globalStorageHome: remoteInitData.globalStorageHome,
-				workspaceStorageHome: remoteInitData.workspaceStorageHome,
-				webviewResourceRoot: this._environmentService.webviewResourceRoot,
-				webviewCspSource: this._environmentService.webviewCspSource,
+				workspaceStorageHome: remoteInitData.workspaceStorageHome
 			},
 			workspace: this._contextService.getWorkbenchState() === WorkbenchState.EMPTY ? null : {
 				configuration: workspace.configuration,

--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -476,8 +476,6 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 				extensionTestsLocationURI: this._environmentService.extensionTestsLocationURI,
 				globalStorageHome: this._environmentService.globalStorageHome,
 				workspaceStorageHome: this._environmentService.workspaceStorageHome,
-				webviewResourceRoot: this._environmentService.webviewResourceRoot,
-				webviewCspSource: this._environmentService.webviewCspSource,
 			},
 			workspace: this._contextService.getWorkbenchState() === WorkbenchState.EMPTY ? undefined : {
 				configuration: withNullAsUndefined(workspace.configuration),

--- a/src/vs/workbench/test/browser/api/extHostWebview.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostWebview.test.ts
@@ -109,12 +109,13 @@ suite('ExtHostWebview', () => {
 			'Windows C drive'
 		);
 	});
+
 	test('asWebviewUri for remote file paths', () => {
 		const webview = createWebview(rpcProtocol, /* remoteAuthority */ 'remote');
 
 		assert.strictEqual(
 			stripEndpointUuid(webview.webview.asWebviewUri(URI.parse('file:///Users/codey/file.html')).toString()),
-			'vscode-webview-test.com/vscode-resource/vscode-remote/remote/vscode-resource?%7B%22requestResourcePath%22%3A%22%2FUsers%2Fcodey%2Ffile.html%22%7D',
+			'vscode-webview-test.com/vscode-resource/vscode-remote/remote/Users/codey/file.html',
 			'Unix basic'
 		);
 	});

--- a/src/vs/workbench/test/browser/api/extHostWebview.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostWebview.test.ts
@@ -18,7 +18,7 @@ import { EditorGroupColumn } from 'vs/workbench/common/editor';
 import type * as vscode from 'vscode';
 import { SingleProxyRPCProtocol } from './testRPCProtocol';
 
-suite('ExtHostWebview', () => {
+suite.only('ExtHostWebview', () => {
 
 	let rpcProtocol: (IExtHostRpcService & IExtHostContext) | undefined;
 
@@ -30,9 +30,7 @@ suite('ExtHostWebview', () => {
 	test('Cannot register multiple serializers for the same view type', async () => {
 		const viewType = 'view.type';
 
-		const extHostWebviews = new ExtHostWebviews(rpcProtocol!, {
-			remote: { authority: undefined },
-		}, undefined, new NullLogService(), NullApiDeprecationService);
+		const extHostWebviews = new ExtHostWebviews(rpcProtocol!, { remote: { authority: undefined } }, undefined, new NullLogService(), NullApiDeprecationService);
 
 		const extHostWebviewPanels = new ExtHostWebviewPanels(rpcProtocol!, extHostWebviews, undefined);
 
@@ -130,7 +128,7 @@ function createWebview(rpcProtocol: (IExtHostRpcService & IExtHostContext) | und
 
 	const extHostWebviewPanels = new ExtHostWebviewPanels(rpcProtocol!, extHostWebviews, undefined);
 
-	const webview = extHostWebviewPanels.createWebviewPanel({} as any, 'type', 'title', 1, {});
+	const webview = extHostWebviewPanels.createWebviewPanel({} as IExtensionDescription, 'type', 'title', 1, {});
 	return webview;
 }
 

--- a/src/vs/workbench/test/browser/api/extHostWebview.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostWebview.test.ts
@@ -18,7 +18,7 @@ import { EditorGroupColumn } from 'vs/workbench/common/editor';
 import type * as vscode from 'vscode';
 import { SingleProxyRPCProtocol } from './testRPCProtocol';
 
-suite.only('ExtHostWebview', () => {
+suite('ExtHostWebview', () => {
 
 	let rpcProtocol: (IExtHostRpcService & IExtHostContext) | undefined;
 


### PR DESCRIPTION
This change attempts to simplify the logic around webview resource uris by doing the following:

- Hard code the resource origin. We always will be hitting a service worker for these paths so they don't need to be dynamic (although in the future we may want to pull them from `product.json`)

    This lets us remove these properties from the environment service

- Move remote handling from the resource loader in to `asWebviewUri`.

- Remove the handling of http and https paths from the resource loader.

    I don't think these cases can be hit any longer (although I need to confirm this with more testing for the web case). Instead I added a check to `asWebviewUri` so that we return the original uri if a http(s) uri is passed in

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
