### PR TITLE
chore: bump node-pty@0.11.0-beta6

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -228,7 +228,14 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 			.pipe(jsFilter)
 			.pipe(util.rewriteSourceMappingURL(sourceMappingURLBase))
 			.pipe(jsFilter.restore)
-			.pipe(createAsar(path.join(process.cwd(), 'node_modules'), ['**/*.node', '**/vscode-ripgrep/bin/*', '**/node-pty/build/Release/*', '**/*.wasm'], 'node_modules.asar'));
+			.pipe(createAsar(path.join(process.cwd(), 'node_modules'), [
+				'**/*.node',
+				'**/vscode-ripgrep/bin/*',
+				'**/node-pty/build/Release/*',
+				'**/node-pty/lib/worker/conoutSocketWorker.js',
+				'**/node-pty/lib/shared/conout.js',
+				'**/*.wasm'
+			], 'node_modules.asar'));
 
 		let all = es.merge(
 			packageJsonStream,

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "native-is-elevated": "0.4.3",
     "native-keymap": "2.2.1",
     "native-watchdog": "1.3.0",
-    "node-pty": "0.10.1",
+    "node-pty": "0.11.0-beta6",
     "nsfw": "2.1.2",
     "spdlog": "^0.13.0",
     "sudo-prompt": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "native-is-elevated": "0.4.3",
     "native-keymap": "2.2.1",
     "native-watchdog": "1.3.0",
-    "node-pty": "0.11.0-beta6",
+    "node-pty": "0.11.0-beta7",
     "nsfw": "2.1.2",
     "spdlog": "^0.13.0",
     "sudo-prompt": "9.2.1",

--- a/remote/package.json
+++ b/remote/package.json
@@ -13,7 +13,7 @@
     "jschardet": "3.0.0",
     "minimist": "^1.2.5",
     "native-watchdog": "1.3.0",
-    "node-pty": "0.10.1",
+    "node-pty": "0.11.0-beta6",
     "nsfw": "2.1.2",
     "spdlog": "^0.13.0",
     "tas-client-umd": "0.1.4",

--- a/remote/package.json
+++ b/remote/package.json
@@ -13,7 +13,7 @@
     "jschardet": "3.0.0",
     "minimist": "^1.2.5",
     "native-watchdog": "1.3.0",
-    "node-pty": "0.11.0-beta6",
+    "node-pty": "0.11.0-beta7",
     "nsfw": "2.1.2",
     "spdlog": "^0.13.0",
     "tas-client-umd": "0.1.4",

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -353,10 +353,10 @@ node-addon-api@*, node-addon-api@^3.0.2:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.1.0.tgz#98b21931557466c6729e51cb77cd39c965f42239"
   integrity sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==
 
-node-pty@0.11.0-beta6:
-  version "0.11.0-beta6"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.11.0-beta6.tgz#dcf9c6550efc96bc3a949cd755850040125ea8e4"
-  integrity sha512-9zI7P2gFur9AAn0TuD83JpXQsIYMtldnPWPzm37eaEgqpBcq1V9g/zdzKxlbfZYn3ay7h7pKTRgzECmfM3izPQ==
+node-pty@0.11.0-beta7:
+  version "0.11.0-beta7"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.11.0-beta7.tgz#aed0888b5032d96c54d8473455e6adfae3bbebbe"
+  integrity sha512-uApPGLglZRiHQcUMWakbZOrBo8HVWvhzIqNnrWvBGJOvc6m/S5lCdbbg93BURyJqHFmBS0GV+4hwiMNDuGRbSA==
   dependencies:
     nan "^2.14.0"
 

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -353,10 +353,10 @@ node-addon-api@*, node-addon-api@^3.0.2:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.1.0.tgz#98b21931557466c6729e51cb77cd39c965f42239"
   integrity sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==
 
-node-pty@0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.10.1.tgz#cd05d03a2710315ec40221232ec04186f6ac2c6d"
-  integrity sha512-JTdtUS0Im/yRsWJSx7yiW9rtpfmxqxolrtnyKwPLI+6XqTAPW/O2MjS8FYL4I5TsMbH2lVgDb2VMjp+9LoQGNg==
+node-pty@0.11.0-beta6:
+  version "0.11.0-beta6"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.11.0-beta6.tgz#dcf9c6550efc96bc3a949cd755850040125ea8e4"
+  integrity sha512-9zI7P2gFur9AAn0TuD83JpXQsIYMtldnPWPzm37eaEgqpBcq1V9g/zdzKxlbfZYn3ay7h7pKTRgzECmfM3izPQ==
   dependencies:
     nan "^2.14.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6560,10 +6560,10 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pty@0.11.0-beta6:
-  version "0.11.0-beta6"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.11.0-beta6.tgz#dcf9c6550efc96bc3a949cd755850040125ea8e4"
-  integrity sha512-9zI7P2gFur9AAn0TuD83JpXQsIYMtldnPWPzm37eaEgqpBcq1V9g/zdzKxlbfZYn3ay7h7pKTRgzECmfM3izPQ==
+node-pty@0.11.0-beta7:
+  version "0.11.0-beta7"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.11.0-beta7.tgz#aed0888b5032d96c54d8473455e6adfae3bbebbe"
+  integrity sha512-uApPGLglZRiHQcUMWakbZOrBo8HVWvhzIqNnrWvBGJOvc6m/S5lCdbbg93BURyJqHFmBS0GV+4hwiMNDuGRbSA==
   dependencies:
     nan "^2.14.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6560,10 +6560,10 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pty@0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.10.1.tgz#cd05d03a2710315ec40221232ec04186f6ac2c6d"
-  integrity sha512-JTdtUS0Im/yRsWJSx7yiW9rtpfmxqxolrtnyKwPLI+6XqTAPW/O2MjS8FYL4I5TsMbH2lVgDb2VMjp+9LoQGNg==
+node-pty@0.11.0-beta6:
+  version "0.11.0-beta6"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.11.0-beta6.tgz#dcf9c6550efc96bc3a949cd755850040125ea8e4"
+  integrity sha512-9zI7P2gFur9AAn0TuD83JpXQsIYMtldnPWPzm37eaEgqpBcq1V9g/zdzKxlbfZYn3ay7h7pKTRgzECmfM3izPQ==
   dependencies:
     nan "^2.14.0"
 


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode/issues/71966

@Tyriar if you can update the module to use worker script from `node_modules.asar.unpacked` then this should be good to go, I was not sure if you want to make a generic change to the module to accept script path for the worker or you want to add a vscode specific change like below.

```js
// from
this._worker = new Worker(join(__dirname, 'worker/conoutSocketWorker.js'), { workerData });

// to
const scriptPath = __dirname.replace('node_modules.asar', 'node_modules.asar.unpacked');
this._worker = new Worker(join(scriptPath, 'worker/conoutSocketWorker.js'), { workerData });
```


Have verified with a local vscode packaged build and also sample app https://gist.github.com/deepak1556/c441a82a932a7b72ff8ae6d12e1ee622. What was causing the error previously was the missing file `lib/shared/conout.js` in the unpacked folder that is used by `conoutSocketWorker`

Fixes #71966
Fixes #117956
Fixes #121336