### PR TITLE
Exclude any selections that intersect with the selection of find next.

### DIFF
--- a/src/vs/editor/contrib/multicursor/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/multicursor.ts
@@ -341,7 +341,9 @@ export class MultiCursorSession {
 		}
 
 		const allSelections = this._editor.getSelections();
-		return new MultiCursorSessionResult(allSelections.concat(nextMatch), nextMatch, ScrollType.Smooth);
+		// Even if `editor.multiCursorMergeOverlapping` is set to false, we want to merge the selections.
+		const selections = allSelections.filter(s => !s.intersectRanges(nextMatch)).concat(nextMatch);
+		return new MultiCursorSessionResult(selections, nextMatch, ScrollType.Smooth);
 	}
 
 	public moveSelectionToNextFindMatch(): MultiCursorSessionResult | null {

--- a/src/vs/editor/contrib/multicursor/test/multicursor.test.ts
+++ b/src/vs/editor/contrib/multicursor/test/multicursor.test.ts
@@ -49,7 +49,6 @@ suite('Multicursor', () => {
 			assert.strictEqual(viewModel.getSelections().length, 1);
 		});
 	});
-
 });
 
 function fromRange(rng: Range): number[] {
@@ -75,6 +74,18 @@ suite('Multicursor selection', () => {
 		isNew: () => true,
 		keys: () => []
 	} as IStorageService);
+
+	test('issue #123303: Cursors should be merged on select next', () => {
+		withTestCodeEditor([
+			'abc',
+		], { multiCursorMergeOverlapping: false, serviceCollection }, (editor, viewModel) => {
+			editor.registerAndInstantiateContribution(MultiCursorSelectionController.ID, MultiCursorSelectionController);
+			editor.registerAndInstantiateContribution(CommonFindController.ID, CommonFindController);
+			editor.setSelection(new Selection(1, 2, 1, 2));
+			new AddSelectionToNextFindMatchAction().run(null!, editor);
+			assert.deepStrictEqual(viewModel.getSelections(), [new Selection(1, 1, 1, 4)]);
+		});
+	});
 
 	test('issue #8817: Cursor position changes when you cancel multicursor', () => {
 		withTestCodeEditor([


### PR DESCRIPTION
This PR fixes #123303.