### PR TITLE
Fix data loss when renaming custom editors

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -147,8 +147,10 @@ export class MainThreadCustomEditors extends Disposable implements extHostProtoc
 				// This is because the backup must be ready upon model creation, and the input resolve method comes after
 				let backupID = webviewInput.backupId;
 				if (webviewInput.oldResource && !webviewInput.backupId) {
-					const backup = await this.workingCopyBackupService.resolve<CustomDocumentBackupData>({ resource: webviewInput.oldResource, typeId: NO_TYPE_ID });
+					const backupIdentifier = { resource: webviewInput.oldResource, typeId: NO_TYPE_ID };
+					const backup = await this.workingCopyBackupService.resolve<CustomDocumentBackupData>(backupIdentifier);
 					backupID = backup?.meta?.backupId;
+					this.workingCopyBackupService.discardBackup(backupIdentifier);
 				}
 
 				let modelRef: IReference<ICustomEditorModel>;

--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -145,17 +145,17 @@ export class MainThreadCustomEditors extends Disposable implements extHostProtoc
 
 				// If there's an old resource this was a move and we must resolve the backup at the same time as the webview
 				// This is because the backup must be ready upon model creation, and the input resolve method comes after
-				let backupID = webviewInput.backupId;
+				let backupId = webviewInput.backupId;
 				if (webviewInput.oldResource && !webviewInput.backupId) {
 					const backupIdentifier = { resource: webviewInput.oldResource, typeId: NO_TYPE_ID };
 					const backup = await this.workingCopyBackupService.resolve<CustomDocumentBackupData>(backupIdentifier);
-					backupID = backup?.meta?.backupId;
+					backupId = backup?.meta?.backupId;
 					this.workingCopyBackupService.discardBackup(backupIdentifier);
 				}
 
 				let modelRef: IReference<ICustomEditorModel>;
 				try {
-					modelRef = await this.getOrCreateCustomEditorModel(modelType, resource, viewType, { backupId: backupID }, cancellation);
+					modelRef = await this.getOrCreateCustomEditorModel(modelType, resource, viewType, { backupId }, cancellation);
 				} catch (error) {
 					onUnexpectedError(error);
 					webviewInput.webview.html = this.mainThreadWebview.getWebviewResolvedFailedContent(viewType);
@@ -282,7 +282,7 @@ export class MainThreadCustomEditors extends Disposable implements extHostProtoc
 				}
 			}
 			for (const model of models) {
-				if (model instanceof MainThreadCustomEditorModel) {
+				if (model instanceof MainThreadCustomEditorModel && model.isDirty()) {
 					const workingCopy = await model.backup(CancellationToken.None);
 					const identifier = { resource: model.editorResource, typeId: model.typeId };
 					await this.workingCopyBackupService.backup(identifier, workingCopy.content, undefined, workingCopy.meta);

--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -286,8 +286,6 @@ export class MainThreadCustomEditors extends Disposable implements extHostProtoc
 					const workingCopy = await model.backup(CancellationToken.None);
 					const identifier = { resource: model.editorResource, typeId: model.typeId };
 					await this.workingCopyBackupService.backup(identifier, workingCopy.content, undefined, workingCopy.meta);
-					const hasBackup = this.workingCopyBackupService.hasBackupSync(identifier);
-					console.log(hasBackup);
 				}
 			}
 		})());

--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -149,6 +149,7 @@ export class MainThreadCustomEditors extends Disposable implements extHostProtoc
 				if (webviewInput.oldResource && !webviewInput.backupId) {
 					const backup = this._editorRenameBackups.get(webviewInput.oldResource.toString());
 					backupId = backup?.backupId;
+					this._editorRenameBackups.delete(webviewInput.oldResource.toString());
 				}
 
 				let modelRef: IReference<ICustomEditorModel>;

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -57,7 +57,7 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 	public readonly oldResource?: URI;
 	private _defaultDirtyState: boolean | undefined;
 
-	private _backupId: string | undefined;
+	private readonly _backupId: string | undefined;
 
 	private readonly _untitledDocumentData: VSBuffer | undefined;
 

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -18,15 +18,12 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
 import { GroupIdentifier, IEditorInput, IRevertOptions, ISaveOptions, Verbosity } from 'vs/workbench/common/editor';
 import { decorateFileEditorLabel } from 'vs/workbench/common/editor/resourceEditorInput';
-import { CustomDocumentBackupData } from 'vs/workbench/contrib/customEditor/browser/customEditorInputFactory';
 import { defaultCustomEditor } from 'vs/workbench/contrib/customEditor/common/contributedCustomEditors';
 import { ICustomEditorModel, ICustomEditorService } from 'vs/workbench/contrib/customEditor/common/customEditor';
 import { IWebviewService, WebviewOverlay } from 'vs/workbench/contrib/webview/browser/webview';
 import { IWebviewWorkbenchService, LazilyResolvedWebviewEditorInput } from 'vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
-import { NO_TYPE_ID } from 'vs/workbench/services/workingCopy/common/workingCopy';
-import { IWorkingCopyBackupService } from 'vs/workbench/services/workingCopy/common/workingCopyBackup';
 
 export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 
@@ -57,7 +54,7 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 	public static override readonly typeId = 'workbench.editors.webviewEditor';
 
 	private readonly _editorResource: URI;
-	private readonly _oldResource?: URI;
+	public readonly oldResource?: URI;
 	private _defaultDirtyState: boolean | undefined;
 
 	private _backupId: string | undefined;
@@ -81,11 +78,10 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IUndoRedoService private readonly undoRedoService: IUndoRedoService,
-		@IWorkingCopyBackupService private readonly workingCopyBackupService: IWorkingCopyBackupService,
 	) {
 		super(id, viewType, '', webview, webviewWorkbenchService);
 		this._editorResource = resource;
-		this._oldResource = options.oldResource;
+		this.oldResource = options.oldResource;
 		this._defaultDirtyState = options.startsDirty;
 		this._backupId = options.backupId;
 		this._untitledDocumentData = options.untitledDocumentData;
@@ -217,11 +213,6 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 
 		if (this.isDisposed()) {
 			return null;
-		}
-
-		if (this._oldResource && !this._backupId) {
-			const backup = await this.workingCopyBackupService.resolve<CustomDocumentBackupData>({ resource: this._oldResource, typeId: NO_TYPE_ID });
-			this._backupId = backup?.meta?.backupId;
 		}
 
 		if (!this._modelRef) {

--- a/src/vs/workbench/contrib/customEditor/common/customEditor.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditor.ts
@@ -41,6 +41,8 @@ export interface ICustomEditorService {
 }
 
 export interface ICustomEditorModelManager {
+	getAllModels(resource: URI): Promise<ICustomEditorModel[]>
+
 	get(resource: URI, viewType: string): Promise<ICustomEditorModel | undefined>;
 
 	tryRetain(resource: URI, viewType: string): Promise<IReference<ICustomEditorModel>> | undefined;

--- a/src/vs/workbench/contrib/customEditor/common/customEditorModelManager.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditorModelManager.ts
@@ -16,6 +16,16 @@ export class CustomEditorModelManager implements ICustomEditorModelManager {
 		counter: number
 	}>();
 
+	public async getAllModels(resource: URI): Promise<ICustomEditorModel[]> {
+		const keyStart = `${resource.toString()}@@@`;
+		const models = [];
+		for (const [key, entry] of this._references) {
+			if (key.startsWith(keyStart) && entry.model) {
+				models.push(await entry.model);
+			}
+		}
+		return models;
+	}
 	public async get(resource: URI, viewType: string): Promise<ICustomEditorModel | undefined> {
 		const key = this.key(resource, viewType);
 		const entry = this._references.get(key);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR is part of https://github.com/microsoft/vscode/issues/101370.

I don't love the solution but I believe the only perfect solution would be editor input and model reuse upon rename which would touch too many pieces for the amount of iteration left (I'm also not sure if I'm familiar enough with everything just yet to tackle that). So instead what we do here is trigger a backup on all renamed models and then notify new editor inputs that they were just renamed ones. These editor inputs then search for a backup and if there is one they restore it. There is visual sluggishness during the restore, but it's better than data loss.