### PR TITLE
Move OpenIssueReporter api command registration out of extHostApiCommands

### DIFF
--- a/src/vs/workbench/api/common/apiCommands.ts
+++ b/src/vs/workbench/api/common/apiCommands.ts
@@ -78,23 +78,6 @@ export class RemoveFromRecentlyOpenedAPICommand {
 }
 CommandsRegistry.registerCommand(RemoveFromRecentlyOpenedAPICommand.ID, adjustHandler(RemoveFromRecentlyOpenedAPICommand.execute));
 
-export interface OpenIssueReporterArgs {
-	readonly extensionId: string;
-	readonly issueTitle?: string;
-	readonly issueBody?: string;
-}
-
-export class OpenIssueReporter {
-	public static readonly ID = 'vscode.openIssueReporter';
-
-	public static execute(executor: ICommandsExecutor, args: string | OpenIssueReporterArgs): Promise<void> {
-		const commandArgs = typeof args === 'string'
-			? { extensionId: args }
-			: args;
-		return executor.executeCommand('workbench.action.openIssueReporter', commandArgs);
-	}
-}
-
 interface RecentEntry {
 	uri: URI;
 	type: 'workspace' | 'folder' | 'file';

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -14,7 +14,7 @@ import * as search from 'vs/workbench/contrib/search/common/search';
 import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
 import { ApiCommand, ApiCommandArgument, ApiCommandResult, ExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
 import { CustomCodeAction } from 'vs/workbench/api/common/extHostLanguageFeatures';
-import { ICommandsExecutor, RemoveFromRecentlyOpenedAPICommand, OpenIssueReporter, OpenIssueReporterArgs } from './apiCommands';
+import { ICommandsExecutor, RemoveFromRecentlyOpenedAPICommand } from './apiCommands';
 import { isFalsyOrEmpty } from 'vs/base/common/arrays';
 import { IRange } from 'vs/editor/common/core/range';
 import { IPosition } from 'vs/editor/common/core/position';
@@ -454,13 +454,6 @@ export class ExtHostApiCommands {
 			description: 'Removes an entry with the given path from the recently opened list.',
 			args: [
 				{ name: 'path', description: 'Path to remove from recently opened.', constraint: (value: any) => typeof value === 'string' }
-			]
-		});
-
-		this._register(OpenIssueReporter.ID, adjustHandler(OpenIssueReporter.execute), {
-			description: 'Opens the issue reporter with the provided extension id as the selected source',
-			args: [
-				{ name: 'extensionId', description: 'extensionId to report an issue on', constraint: (value: unknown) => typeof value === 'string' || (typeof value === 'object' && typeof (value as OpenIssueReporterArgs).extensionId === 'string') }
 			]
 		});
 	}

--- a/src/vs/workbench/contrib/issue/browser/issue.web.contribution.ts
+++ b/src/vs/workbench/contrib/issue/browser/issue.web.contribution.ts
@@ -13,7 +13,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { CATEGORIES } from 'vs/workbench/common/actions';
 import { Extensions as WorkbenchExtensions, IWorkbenchContribution, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
 import { IWebIssueService, WebIssueService } from 'vs/workbench/contrib/issue/browser/issueService';
-import { OpenIssueReporterArgs, OpenIssueReporterActionId } from 'vs/workbench/contrib/issue/common/commands';
+import { OpenIssueReporterArgs, OpenIssueReporterActionId, OpenIssueReporterApiCommandId } from 'vs/workbench/contrib/issue/common/commands';
 
 class RegisterIssueContribution implements IWorkbenchContribution {
 
@@ -32,6 +32,53 @@ class RegisterIssueContribution implements IWorkbenchContribution {
 				}
 
 				return accessor.get(IWebIssueService).openReporter({ extensionId });
+			});
+
+			CommandsRegistry.registerCommand({
+				id: OpenIssueReporterApiCommandId,
+				handler: function (accessor, args?: [string] | OpenIssueReporterArgs) {
+					let extensionId: string | undefined;
+					if (args) {
+						if (Array.isArray(args)) {
+							[extensionId] = args;
+						} else {
+							extensionId = args.extensionId;
+						}
+					}
+
+					if (!!extensionId && typeof extensionId !== 'string') {
+						throw new Error(`Invalid argument when running '${OpenIssueReporterApiCommandId}: 'extensionId' must be of type string `);
+					}
+
+					return accessor.get(IWebIssueService).openReporter({ extensionId });
+				},
+				description: {
+					description: 'Open the issue reporter and optionally prefill part of the form.',
+					args: [
+						{
+							name: 'options',
+							description: 'Data to use to prefill the issue reporter with.',
+							isOptional: true,
+							schema: {
+								oneOf: [
+									{
+										type: 'string',
+										description: 'The extension id to preselect.'
+									},
+									{
+										type: 'object',
+										properties: {
+											extensionId: {
+												type: 'string'
+											},
+										}
+
+									}
+								]
+							}
+						},
+					]
+				}
 			});
 
 			const command: ICommandAction = {

--- a/src/vs/workbench/contrib/issue/common/commands.ts
+++ b/src/vs/workbench/contrib/issue/common/commands.ts
@@ -5,6 +5,8 @@
 
 export const OpenIssueReporterActionId = 'workbench.action.openIssueReporter';
 
+export const OpenIssueReporterApiCommandId = 'vscode.openIssueReporter';
+
 export interface OpenIssueReporterArgs {
 	readonly extensionId?: string;
 	readonly issueTitle?: string;

--- a/src/vs/workbench/contrib/issue/electron-sandbox/issue.contribution.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/issue.contribution.ts
@@ -14,7 +14,7 @@ import { WorkbenchIssueService } from 'vs/workbench/services/issue/electron-sand
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IssueReporterData } from 'vs/platform/issue/common/issue';
 import { IIssueService } from 'vs/platform/issue/electron-sandbox/issue';
-import { OpenIssueReporterArgs, OpenIssueReporterActionId } from 'vs/workbench/contrib/issue/common/commands';
+import { OpenIssueReporterArgs, OpenIssueReporterActionId, OpenIssueReporterApiCommandId } from 'vs/workbench/contrib/issue/common/commands';
 
 if (!!product.reportIssueUrl) {
 	registerAction2(ReportPerformanceIssueUsingReporterAction);
@@ -25,6 +25,50 @@ if (!!product.reportIssueUrl) {
 			: args || {};
 
 		return accessor.get(IWorkbenchIssueService).openReporter(data);
+	});
+
+	CommandsRegistry.registerCommand({
+		id: OpenIssueReporterApiCommandId,
+		handler: function (accessor, args?: [string] | OpenIssueReporterArgs) {
+			const data: Partial<IssueReporterData> = Array.isArray(args)
+				? { extensionId: args[0] }
+				: args || {};
+
+			return accessor.get(IWorkbenchIssueService).openReporter(data);
+		},
+		description: {
+			description: 'Open the issue reporter and optionally prefill part of the form.',
+			args: [
+				{
+					name: 'options',
+					description: 'Data to use to prefill the issue reporter with.',
+					isOptional: true,
+					schema: {
+						oneOf: [
+							{
+								type: 'string',
+								description: 'The extension id to preselect.'
+							},
+							{
+								type: 'object',
+								properties: {
+									extensionId: {
+										type: 'string'
+									},
+									issueTitle: {
+										type: 'string'
+									},
+									issueBody: {
+										type: 'string'
+									}
+								}
+
+							}
+						]
+					}
+				},
+			]
+		}
 	});
 
 	const reportIssue: ICommandAction = {


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/110583

Since this command doesn't have any API return types and is just an alias for a workbench command, moved it over to the renderer. Let me know if I missed anything.