### PR TITLE
Fixed Switch to Default Editor From Symbol Outline

### DIFF
--- a/src/vs/workbench/contrib/outline/browser/outlinePane.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePane.ts
@@ -38,6 +38,8 @@ import { Event } from 'vs/base/common/event';
 import { ITreeSorter } from 'vs/base/browser/ui/tree/tree';
 import { URI } from 'vs/base/common/uri';
 import { EditorOverride } from 'vs/platform/editor/common/editor';
+import { NotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
+import { CustomEditorInput } from 'vs/workbench/contrib/customEditor/browser/customEditorInput';
 
 const _ctxFollowsCursor = new RawContextKey('outlineFollowsCursor', false);
 const _ctxFilterOnType = new RawContextKey('outlineFiltersOnType', false);
@@ -285,8 +287,13 @@ export class OutlinePane extends ViewPane {
 
 		// feature: reveal outline selection in editor
 		// on change -> reveal/select defining range
-		this._editorDisposables.add(tree.onDidOpen(e => newOutline.reveal(e.element, { ...e.editorOptions, override: EditorOverride.DISABLED }, e.sideBySide)));
-
+		this._editorDisposables.add(tree.onDidOpen(e => {
+			let override: EditorOverride | string = EditorOverride.DISABLED;
+			if (this._editorService.activeEditor instanceof NotebookEditorInput || this._editorService.activeEditor instanceof CustomEditorInput) {
+				override = this._editorService.activeEditor.viewType;
+			}
+			newOutline.reveal(e.element, { ...e.editorOptions, override }, e.sideBySide);
+		}));
 		// feature: reveal editor selection in outline
 		const revealActiveElement = () => {
 			if (!this._outlineViewState.followCursor || !newOutline.activeElement) {

--- a/src/vs/workbench/contrib/outline/browser/outlinePane.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePane.ts
@@ -285,7 +285,7 @@ export class OutlinePane extends ViewPane {
 
 		// feature: reveal outline selection in editor
 		// on change -> reveal/select defining range
-		this._editorDisposables.add(tree.onDidOpen(e => newOutline.reveal(e.element, { ...e.editorOptions, ...{ override: EditorOverride.DISABLED } }, e.sideBySide)));
+		this._editorDisposables.add(tree.onDidOpen(e => newOutline.reveal(e.element, { ...e.editorOptions, override: EditorOverride.DISABLED }, e.sideBySide)));
 
 		// feature: reveal editor selection in outline
 		const revealActiveElement = () => {

--- a/src/vs/workbench/contrib/outline/browser/outlinePane.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePane.ts
@@ -37,6 +37,7 @@ import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { Event } from 'vs/base/common/event';
 import { ITreeSorter } from 'vs/base/browser/ui/tree/tree';
 import { URI } from 'vs/base/common/uri';
+import { EditorOverride } from 'vs/platform/editor/common/editor';
 
 const _ctxFollowsCursor = new RawContextKey('outlineFollowsCursor', false);
 const _ctxFilterOnType = new RawContextKey('outlineFiltersOnType', false);
@@ -284,7 +285,7 @@ export class OutlinePane extends ViewPane {
 
 		// feature: reveal outline selection in editor
 		// on change -> reveal/select defining range
-		this._editorDisposables.add(tree.onDidOpen(e => newOutline.reveal(e.element, e.editorOptions, e.sideBySide)));
+		this._editorDisposables.add(tree.onDidOpen(e => newOutline.reveal(e.element, { ...e.editorOptions, ...{ override: EditorOverride.DISABLED } }, e.sideBySide)));
 
 		// feature: reveal editor selection in outline
 		const revealActiveElement = () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #124122

Previously, clicking on symbols in the file outline when you had a different default editor would open your default. This editor override disable should fix it.