### PR TITLE
Fixes android screen-keyboard backspace issue.

### DIFF
--- a/src/vs/workbench/services/keybinding/common/macLinuxKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/macLinuxKeyboardMapper.ts
@@ -993,6 +993,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 			|| (keyCode === KeyCode.End)
 			|| (keyCode === KeyCode.PageDown)
 			|| (keyCode === KeyCode.PageUp)
+			|| (keyCode === KeyCode.Backspace)
 		) {
 			// "Dispatch" on keyCode for these key codes to workaround issues with remote desktoping software
 			// where the scan codes appear to be incorrect (see https://github.com/microsoft/vscode/issues/24107)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #107602.

Android screen-keyboard event's `code` field is empty, therefor it has to be set by the `keyCode` value. Reason why that one liner is enough, because the commandId later will be calculated based on the code value. In case of `Backspace` `Keydown` event `commandId` must be 'deleteLeft' in order to perform a delete.
