### PR TITLE
Short title for command contribution

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -41,6 +41,7 @@ export type Icon = { dark?: URI; light?: URI; } | ThemeIcon;
 export interface ICommandAction {
 	id: string;
 	title: string | ICommandActionTitle;
+	shortTitle?: string | ICommandActionTitle;
 	category?: string | ILocalizedString;
 	tooltip?: string;
 	icon?: Icon;
@@ -179,6 +180,7 @@ export class MenuId {
 export interface IMenuActionOptions {
 	arg?: any;
 	shouldForwardArgs?: boolean;
+	renderShortTitle?: boolean;
 }
 
 export interface IMenu extends IDisposable {
@@ -388,7 +390,9 @@ export class MenuItemAction implements IAction {
 		@ICommandService private _commandService: ICommandService
 	) {
 		this.id = item.id;
-		this.label = typeof item.title === 'string' ? item.title : item.title.value;
+		this.label = options?.renderShortTitle && item.shortTitle
+			? (typeof item.shortTitle === 'string' ? item.shortTitle : item.shortTitle.value)
+			: (typeof item.title === 'string' ? item.title : item.title.value);
 		this.tooltip = item.tooltip ?? '';
 		this.enabled = !item.precondition || contextKeyService.contextMatchesRules(item.precondition);
 		this.checked = false;

--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -438,6 +438,7 @@ namespace schema {
 	export interface IUserFriendlyCommand {
 		command: string;
 		title: string | ILocalizedString;
+		shortTitle?: string | ILocalizedString;
 		enablement?: string;
 		category?: string | ILocalizedString;
 		icon?: IUserFriendlyIcon;
@@ -455,6 +456,9 @@ namespace schema {
 			return false;
 		}
 		if (!isValidLocalizedString(command.title, collector, 'title')) {
+			return false;
+		}
+		if (command.shortTitle && !isValidLocalizedString(command.shortTitle, collector, 'shortTitle')) {
 			return false;
 		}
 		if (command.enablement && typeof command.enablement !== 'string') {
@@ -508,6 +512,10 @@ namespace schema {
 			},
 			title: {
 				description: localize('vscode.extension.contributes.commandType.title', 'Title by which the command is represented in the UI'),
+				type: 'string'
+			},
+			shortTitle: {
+				description: localize('vscode.extension.contributes.commandType.shortTitle', 'Short title by which the command is represented in the UI'),
 				type: 'string'
 			},
 			category: {
@@ -567,7 +575,7 @@ commandsExtensionPoint.setHandler(extensions => {
 			return;
 		}
 
-		const { icon, enablement, category, title, command } = userFriendlyCommand;
+		const { icon, enablement, category, title, shortTitle, command } = userFriendlyCommand;
 
 		let absoluteIcon: { dark: URI; light?: URI; } | ThemeIcon | undefined;
 		if (icon) {
@@ -588,6 +596,7 @@ commandsExtensionPoint.setHandler(extensions => {
 		bucket.push({
 			id: command,
 			title,
+			shortTitle,
 			category,
 			precondition: ContextKeyExpr.deserialize(enablement),
 			icon: absoluteIcon

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorToolbar.ts
@@ -164,7 +164,7 @@ export class NotebookEditorToolbar extends Disposable {
 			this.domNode.style.display = 'none';
 		} else {
 			this._notebookLeftToolbar.setActions([], []);
-			const groups = this._notebookGlobalActionsMenu.getActions({ shouldForwardArgs: true });
+			const groups = this._notebookGlobalActionsMenu.getActions({ shouldForwardArgs: true, renderShortTitle: true });
 			this.domNode.style.display = 'flex';
 			const primaryLeftGroups = groups.filter(group => /^navigation/.test(group[0]));
 			let primaryActions: IAction[] = [];


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

What's the intent: commands can be rendered in multiple places in VS Code workbench, e.g., command palette, editor toolbar, etc. In most places, the title of a command should be verbose enough but in some actionbar/menu bar, where the context is well defined, we want to render a short title to avoid duplicated info. 


For example, Jupyter might contribute a command called "Jupyter: Open Variables View" in both command palette and editor title bar

<img width="603" alt="image" src="https://user-images.githubusercontent.com/876920/119033868-986ac600-b962-11eb-82cc-38b6df1d458a.png">


but in notebook editor's inner toolbar, the title for this command can be as short as "Variables" 

<img width="638" alt="image" src="https://user-images.githubusercontent.com/876920/119033270-e29f7780-b961-11eb-95cf-56cebbbe5c06.png">

