### PR TITLE
Listen on local interface only

### DIFF
--- a/src/vs/platform/remote/node/tunnelService.ts
+++ b/src/vs/platform/remote/node/tunnelService.ts
@@ -76,12 +76,12 @@ class NodeRemoteTunnel extends Disposable implements RemoteTunnel {
 
 		// if that fails, the method above returns 0, which works out fine below...
 		let address: string | net.AddressInfo | null = null;
-		address = (<net.AddressInfo>this._server.listen(localPort).address());
+		address = (<net.AddressInfo>this._server.listen(localPort, '127.0.0.1').address());
 
 		// It is possible for findFreePortFaster to return a port that there is already a server listening on. This causes the previous listen call to error out.
 		if (!address) {
 			localPort = 0;
-			address = (<net.AddressInfo>this._server.listen(localPort).address());
+			address = (<net.AddressInfo>this._server.listen(localPort, '127.0.0.1').address());
 		}
 
 		this.tunnelLocalPort = address.port;


### PR DESCRIPTION
#124350

@alexr00 Seeing that you are OOF, I might merge this to give it some test exposure before endgame.

@alexdima I think you have worked with @alexr00 in this area, can you think of a case where listening on other interfaces than the local one is needed? If there is one, we might need a setting to be safe by default.