### PR TITLE
Add editorID property

### DIFF
--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -305,11 +305,8 @@ export abstract class TitleControl extends Themable {
 		};
 
 		// If it's a custom editor or a notebook add the viewtype
-		if ((editor as object).hasOwnProperty('viewType')) {
-			interface EditorInputWithViewType extends IEditorInput {
-				viewType: string;
-			}
-			editorOptions = { ...editorOptions, override: (editor as EditorInputWithViewType).viewType };
+		if (editor.editorId) {
+			editorOptions = { ...editorOptions, override: editor.editorId };
 		}
 
 		this.instantiationService.invokeFunction(fillResourceDataTransfers, [resource], () => editorOptions, e);

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -290,7 +290,8 @@ export abstract class TitleControl extends Themable {
 			return false;
 		}
 
-		let editorOptions: ITextEditorOptions = {
+		const editorOptions: ITextEditorOptions = {
+			override: editor.editorId,
 			viewState: (() => {
 				if (this.group.activeEditor === editor) {
 					const activeControl = this.group.activeEditorPane?.getControl();
@@ -303,11 +304,6 @@ export abstract class TitleControl extends Themable {
 			})(),
 			sticky: this.group.isSticky(editor)
 		};
-
-		// If it's a custom editor or a notebook add the viewtype
-		if (editor.editorId) {
-			editorOptions = { ...editorOptions, override: editor.editorId };
-		}
 
 		this.instantiationService.invokeFunction(fillResourceDataTransfers, [resource], () => editorOptions, e);
 

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -543,7 +543,7 @@ export abstract class EditorInput extends Disposable implements IEditorInput {
 
 	abstract get typeId(): string;
 
-	get editorId(): string | undefined { return; }
+	get editorId(): string | undefined { return undefined; }
 
 	abstract get resource(): URI | undefined;
 

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -393,6 +393,12 @@ export interface IEditorInput extends IDisposable {
 	readonly typeId: string;
 
 	/**
+	 * Unique editor identifier. Used to identify which type of editor it is.
+	 * This is primarily used for overrides where a user wants to open a particular editor
+	 */
+	readonly editorId: string | undefined;
+
+	/**
 	 * Returns the optional associated resource of this input.
 	 *
 	 * This resource should be unique for all editors of the same
@@ -536,6 +542,8 @@ export abstract class EditorInput extends Disposable implements IEditorInput {
 	private disposed: boolean = false;
 
 	abstract get typeId(): string;
+
+	get editorId(): string | undefined { return; }
 
 	abstract get resource(): URI | undefined;
 

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -91,6 +91,10 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 		return CustomEditorInput.typeId;
 	}
 
+	public override get editorId() {
+		return this.viewType;
+	}
+
 	public override canSplit() {
 		return !!this.customEditorService.getCustomEditorCapabilities(this.viewType)?.supportsMultipleEditorsPerDocument;
 	}

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
@@ -59,6 +59,10 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 		return NotebookEditorInput.ID;
 	}
 
+	override get editorId(): string {
+		return this.editorId;
+	}
+
 	override isDirty() {
 		if (!this._editorModelReference) {
 			return this._defaultDirtyState;

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
@@ -60,7 +60,7 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 	}
 
 	override get editorId(): string {
-		return this.editorId;
+		return this.viewType;
 	}
 
 	override isDirty() {

--- a/src/vs/workbench/contrib/outline/browser/outlinePane.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePane.ts
@@ -38,8 +38,6 @@ import { Event } from 'vs/base/common/event';
 import { ITreeSorter } from 'vs/base/browser/ui/tree/tree';
 import { URI } from 'vs/base/common/uri';
 import { EditorOverride } from 'vs/platform/editor/common/editor';
-import { NotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
-import { CustomEditorInput } from 'vs/workbench/contrib/customEditor/browser/customEditorInput';
 
 const _ctxFollowsCursor = new RawContextKey('outlineFollowsCursor', false);
 const _ctxFilterOnType = new RawContextKey('outlineFiltersOnType', false);
@@ -289,8 +287,8 @@ export class OutlinePane extends ViewPane {
 		// on change -> reveal/select defining range
 		this._editorDisposables.add(tree.onDidOpen(e => {
 			let override: EditorOverride | string = EditorOverride.DISABLED;
-			if (this._editorService.activeEditor instanceof NotebookEditorInput || this._editorService.activeEditor instanceof CustomEditorInput) {
-				override = this._editorService.activeEditor.viewType;
+			if (this._editorService.activeEditor?.editorId) {
+				override = this._editorService.activeEditor?.editorId;
 			}
 			newOutline.reveal(e.element, { ...e.editorOptions, override }, e.sideBySide);
 		}));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #124354

Adds a possibly undefined `editorId` property so that all `IEditorInput`s can be checked for overrides. This is a relatively safe change and more adopters can join and dictate what they want their id to be if they want to participate. 
