### PR TITLE
Try to clarify how we process images in md files

### DIFF
--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -11,7 +11,7 @@ import { Logger } from '../logger';
 import { MarkdownContributionProvider } from '../markdownExtensions';
 import { Disposable } from '../util/dispose';
 import { isMarkdownFile } from '../util/file';
-import { normalizeResource, WebviewResourceProvider } from '../util/resources';
+import { WebviewResourceProvider } from '../util/resources';
 import { getVisibleLine, LastScrollLocation, TopmostLineMonitor } from '../util/topmostLineMonitor';
 import { MarkdownPreviewConfigurationManager } from './previewConfig';
 import { MarkdownContentProvider, MarkdownContentProviderOutput } from './previewContentProvider';
@@ -423,7 +423,7 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			baseRoots.push(vscode.Uri.file(path.dirname(this._resource.fsPath)));
 		}
 
-		return baseRoots.map(root => normalizeResource(this._resource, root));
+		return baseRoots;
 	}
 
 
@@ -456,7 +456,7 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 	//#region WebviewResourceProvider
 
 	asWebviewUri(resource: vscode.Uri) {
-		return this._webviewPanel.webview.asWebviewUri(normalizeResource(this._resource, resource));
+		return this._webviewPanel.webview.asWebviewUri(resource);
 	}
 
 	get cspSource() {

--- a/extensions/markdown-language-features/src/features/previewContentProvider.ts
+++ b/extensions/markdown-language-features/src/features/previewContentProvider.ts
@@ -81,7 +81,7 @@ export class MarkdownContentProvider {
 		const nonce = new Date().getTime() + '' + new Date().getMilliseconds();
 		const csp = this.getCsp(resourceProvider, sourceUri, nonce);
 
-		const body = await this.engine.render(markdownDocument);
+		const body = await this.engine.render(markdownDocument, resourceProvider);
 		const html = `<!DOCTYPE html>
 			<html style="${escapeAttribute(this.getSettingsOverrideStyles(config))}">
 			<head>

--- a/extensions/markdown-language-features/src/util/resources.ts
+++ b/extensions/markdown-language-features/src/util/resources.ts
@@ -11,23 +11,3 @@ export interface WebviewResourceProvider {
 	readonly cspSource: string;
 }
 
-export function normalizeResource(
-	base: vscode.Uri,
-	resource: vscode.Uri
-): vscode.Uri {
-	// If we  have a windows path and are loading a workspace with an authority,
-	// make sure we use a unc path with an explicit localhost authority.
-	//
-	// Otherwise, the `<base>` rule will insert the authority into the resolved resource
-	// URI incorrectly.
-	if (base.authority && !resource.authority) {
-		const driveMatch = resource.path.match(/^\/(\w):\//);
-		if (driveMatch) {
-			return vscode.Uri.file(`\\\\localhost\\${driveMatch[1]}$\\${resource.fsPath.replace(/^\w:\\/, '')}`).with({
-				fragment: resource.fragment,
-				query: resource.query
-			});
-		}
-	}
-	return resource;
-}


### PR DESCRIPTION
This PR makes the following changes:

- Move logic for getting images in md files into `toResourceUri` instead of having it in `normalizeLink` (which also gets fired for plain old links)

- Update the logic to handle the new webview resource URI format

- Remove the extra normalizer. This should now be handled in `toResourceUri ` and by a call to `asWebviewUri`

- Use env instead of stateful variable in engine 