### PR TITLE
Adds option "editor.suggest.suggestionPreviewExpanded" to toggle whether suggestion previews are expanded by default.

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3179,6 +3179,11 @@ export interface ISuggestOptions {
 	 */
 	showSuggestionPreview?: boolean;
 	/**
+	 * Enable or disable the default expansion of the suggestion preview.
+	 * Defaults to false.
+	 */
+	suggestionPreviewExpanded?: boolean;
+	/**
 	 * Show details inline with the label. Defaults to true.
 	 */
 	showInlineDetails?: boolean;
@@ -3310,6 +3315,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, InternalSugge
 			showIcons: true,
 			showStatusBar: false,
 			showSuggestionPreview: false,
+			suggestionPreviewExpanded: false,
 			showInlineDetails: true,
 			showMethods: true,
 			showFunctions: true,
@@ -3387,6 +3393,11 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, InternalSugge
 					type: 'boolean',
 					default: defaults.showSuggestionPreview,
 					description: nls.localize('suggest.showSuggestionPreview', "Controls whether to preview the suggestion outcome in the editor.")
+				},
+				'editor.suggest.suggestionPreviewExpanded': {
+					type: 'boolean',
+					default: defaults.suggestionPreviewExpanded,
+					description: nls.localize('suggest.suggestionPreviewExpanded', "Controls whether the suggestiion preview is expanded by default.")
 				},
 
 				'editor.suggest.showInlineDetails': {
@@ -3565,6 +3576,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, InternalSugge
 			showIcons: boolean(input.showIcons, this.defaultValue.showIcons),
 			showStatusBar: boolean(input.showStatusBar, this.defaultValue.showStatusBar),
 			showSuggestionPreview: boolean(input.showSuggestionPreview, this.defaultValue.showSuggestionPreview),
+			suggestionPreviewExpanded: boolean(input.suggestionPreviewExpanded, this.defaultValue.suggestionPreviewExpanded),
 			showInlineDetails: boolean(input.showInlineDetails, this.defaultValue.showInlineDetails),
 			showMethods: boolean(input.showMethods, this.defaultValue.showMethods),
 			showFunctions: boolean(input.showFunctions, this.defaultValue.showFunctions),

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextWidget.ts
@@ -20,7 +20,6 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { IModelDeltaDecoration } from 'vs/editor/common/model';
 import { IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { editorSuggestPreviewBorder, editorSuggestPreviewOpacity } from 'vs/editor/common/view/editorColorRegistry';
-import { RGBA, Color } from 'vs/base/common/color';
 
 const ttPolicy = window.trustedTypes?.createPolicy('editorGhostText', { createHTML: value => value });
 

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextWidget.ts
@@ -7,7 +7,7 @@ import 'vs/css!./ghostText';
 import * as dom from 'vs/base/browser/dom';
 import { Disposable, DisposableStore, IDisposable, IReference, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { Range } from 'vs/editor/common/core/range';
-import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
+import { ContentWidgetPositionPreference, IActiveCodeEditor, ICodeEditor, IContentWidget, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import * as strings from 'vs/base/common/strings';
 import { RenderLineInput, renderViewLine } from 'vs/editor/common/viewLayout/viewLineRenderer';
@@ -20,6 +20,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { IModelDeltaDecoration } from 'vs/editor/common/model';
 import { IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { editorSuggestPreviewBorder, editorSuggestPreviewOpacity } from 'vs/editor/common/view/editorColorRegistry';
+import { RGBA, Color } from 'vs/base/common/color';
 
 const ttPolicy = window.trustedTypes?.createPolicy('editorGhostText', { createHTML: value => value });
 
@@ -27,7 +28,7 @@ export interface GhostTextWidgetModel {
 	readonly onDidChange: Event<void>;
 	readonly ghostText: GhostText | undefined;
 
-	expand(): void;
+	setExpanded(expanded: boolean): void;
 	readonly expanded: boolean;
 
 	readonly minReservedLineCount: number;
@@ -41,7 +42,7 @@ export interface GhostText {
 export abstract class BaseGhostTextWidgetModel extends Disposable implements GhostTextWidgetModel {
 	public abstract readonly ghostText: GhostText | undefined;
 
-	private _expanded = false;
+	private _expanded: boolean | undefined = undefined;
 
 	protected readonly onDidChangeEmitter = new Emitter<void>();
 	public readonly onDidChange = this.onDidChangeEmitter.event;
@@ -49,10 +50,23 @@ export abstract class BaseGhostTextWidgetModel extends Disposable implements Gho
 	public abstract readonly minReservedLineCount: number;
 
 	public get expanded() {
+		if (this._expanded === undefined) {
+			return this.editor.getOption(EditorOption.suggest).suggestionPreviewExpanded;
+		}
 		return this._expanded;
 	}
 
-	public expand(): void {
+	constructor(protected readonly editor: IActiveCodeEditor) {
+		super();
+
+		this._register(editor.onDidChangeConfiguration((e) => {
+			if (e.hasChanged(EditorOption.suggest) && this._expanded === undefined) {
+				this.onDidChangeEmitter.fire();
+			}
+		}));
+	}
+
+	public setExpanded(expanded: boolean): void {
 		this._expanded = true;
 		this.onDidChangeEmitter.fire();
 	}
@@ -215,7 +229,7 @@ export class GhostTextWidget extends Disposable {
 		button.append(`+${remainingLinesLength} lines…`);
 
 		disposableStore.add(dom.addStandardDisposableListener(button, 'click', (e) => {
-			this.model?.expand();
+			this.model?.setExpanded(true);
 			e.preventDefault();
 			this.editor.focus();
 		}));

--- a/src/vs/editor/contrib/inlineCompletions/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/inlineCompletionsModel.ts
@@ -60,8 +60,8 @@ export class InlineCompletionsModel extends Disposable implements GhostTextWidge
 		return this.session ? this.session.expanded : false;
 	}
 
-	public expand(): void {
-		this.session?.expand();
+	public setExpanded(expanded: boolean): void {
+		this.session?.setExpanded(expanded);
 	}
 
 	public setActive(active: boolean) {
@@ -118,8 +118,8 @@ class InlineCompletionsSession extends BaseGhostTextWidgetModel {
 	private updateSoon = this._register(new RunOnceScheduler(() => this.update(), 50));
 	private readonly textModel = this.editor.getModel();
 
-	constructor(private readonly editor: IActiveCodeEditor, private readonly triggerPosition: Position, private readonly shouldUpdate: () => boolean) {
-		super();
+	constructor(editor: IActiveCodeEditor, private readonly triggerPosition: Position, private readonly shouldUpdate: () => boolean) {
+		super(editor);
 		this._register(toDisposable(() => {
 			this.clearGhostTextPromise();
 		}));

--- a/src/vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel.ts
@@ -24,9 +24,9 @@ export class SuggestWidgetAdapterModel extends BaseGhostTextWidgetModel {
 	public get isActive() { return this.isSuggestWidgetVisible; }
 
 	constructor(
-		private readonly editor: IActiveCodeEditor
+		editor: IActiveCodeEditor
 	) {
-		super();
+		super(editor);
 
 		const suggestController = SuggestController.get(this.editor);
 		if (suggestController) {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3849,6 +3849,11 @@ declare namespace monaco.editor {
 		 */
 		showSuggestionPreview?: boolean;
 		/**
+		 * Enable or disable the default expansion of the suggestion preview.
+		 * Defaults to false.
+		 */
+		suggestionPreviewExpanded?: boolean;
+		/**
 		 * Show details inline with the label. Defaults to true.
 		 */
 		showInlineDetails?: boolean;


### PR DESCRIPTION
This touches the editor config.

Maybe there is a better name for that setting?