### PR TITLE
update macOS keybinding label for alt to be option

### DIFF
--- a/src/vs/base/common/keybindingLabels.ts
+++ b/src/vs/base/common/keybindingLabels.ts
@@ -89,7 +89,7 @@ export const AriaLabelProvider = new ModifierLabelProvider(
 	{
 		ctrlKey: nls.localize({ key: 'ctrlKey.long', comment: ['This is the long form for the Control key on the keyboard'] }, "Control"),
 		shiftKey: nls.localize({ key: 'shiftKey.long', comment: ['This is the long form for the Shift key on the keyboard'] }, "Shift"),
-		altKey: nls.localize({ key: 'altKey.long', comment: ['This is the long form for the Alt key on the keyboard'] }, "Alt"),
+		altKey: nls.localize({ key: 'optionKey.long', comment: ['This is the long form for the Option key on the keyboard'] }, "Option"),
 		metaKey: nls.localize({ key: 'cmdKey.long', comment: ['This is the long form for the Command key on the keyboard'] }, "Command"),
 		separator: '+',
 	},
@@ -117,7 +117,7 @@ export const ElectronAcceleratorLabelProvider = new ModifierLabelProvider(
 	{
 		ctrlKey: 'Ctrl',
 		shiftKey: 'Shift',
-		altKey: 'Alt',
+		altKey: 'Option',
 		metaKey: 'Cmd',
 		separator: '+',
 	},
@@ -137,7 +137,7 @@ export const UserSettingsLabelProvider = new ModifierLabelProvider(
 	{
 		ctrlKey: 'ctrl',
 		shiftKey: 'shift',
-		altKey: 'alt',
+		altKey: 'option',
 		metaKey: 'cmd',
 		separator: '+',
 	},

--- a/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
+++ b/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
@@ -213,13 +213,13 @@ suite('KeybindingsEditing', () => {
 	});
 
 	test('remove a default keybinding', async () => {
-		const expected: IUserFriendlyKeybinding[] = [{ key: 'alt+c', command: '-a' }];
+		const expected: IUserFriendlyKeybinding[] = [{ key: 'option+c', command: '-a' }];
 		await testObject.removeKeybinding(aResolvedKeybindingItem({ command: 'a', firstPart: { keyCode: KeyCode.KEY_C, modifiers: { altKey: true } } }));
 		assert.deepStrictEqual(await getUserKeybindings(), expected);
 	});
 
-	test('remove a default keybinding should not ad duplicate entries', async () => {
-		const expected: IUserFriendlyKeybinding[] = [{ key: 'alt+c', command: '-a' }];
+	test('remove a default keybinding should not add duplicate entries', async () => {
+		const expected: IUserFriendlyKeybinding[] = [{ key: 'option+c', command: '-a' }];
 		await testObject.removeKeybinding(aResolvedKeybindingItem({ command: 'a', firstPart: { keyCode: KeyCode.KEY_C, modifiers: { altKey: true } } }));
 		await testObject.removeKeybinding(aResolvedKeybindingItem({ command: 'a', firstPart: { keyCode: KeyCode.KEY_C, modifiers: { altKey: true } } }));
 		await testObject.removeKeybinding(aResolvedKeybindingItem({ command: 'a', firstPart: { keyCode: KeyCode.KEY_C, modifiers: { altKey: true } } }));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Updates the labels to use `Option` instead of `Alt` for macOS.  I am not super familiar with the keybinding code, but as far as I could tell this only modifies presentation values and shouldn't have any breakage.

cc @alexdima

This PR fixes https://github.com/microsoft/monaco-editor/issues/2468.
