### PR TITLE
npm extension - check for root package.json before findFiles

### DIFF
--- a/extensions/npm/src/tasks.ts
+++ b/extensions/npm/src/tasks.ts
@@ -365,12 +365,16 @@ export function getPackageJsonUriFromTask(task: Task): Uri | null {
 }
 
 export async function hasPackageJson(): Promise<boolean> {
+	// Faster than `findFiles` for workspaces with a root package.json.
+	if (await hasRootPackageJson()) {
+		return true;
+	}
 	const token = new CancellationTokenSource();
 	// Search for files for max 1 second.
 	const timeout = setTimeout(() => token.cancel(), 1000);
 	const files = await workspace.findFiles('**/package.json', undefined, 1, token.token);
 	clearTimeout(timeout);
-	return files.length > 0 || await hasRootPackageJson();
+	return files.length > 0;
 }
 
 async function hasRootPackageJson(): Promise<boolean> {


### PR DESCRIPTION
Searching the workspace root for a `package.json` before triggering the `findFiles` call decreases the extension activation time for workspaces that have a root `package.json`.