### PR TITLE
add `editor.rulers` to TextEditor options for extensions

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -634,6 +634,11 @@ declare module 'vscode' {
 		Relative = 2
 	}
 
+	export interface RulerOption {
+		readonly column: number;
+		readonly color: string | null;
+	}
+
 	/**
 	 * Represents a {@link TextEditor text editor}'s {@link TextEditor.options options}.
 	 */
@@ -669,6 +674,13 @@ declare module 'vscode' {
 		 * When setting a text editor's options, this property is optional.
 		 */
 		lineNumbers?: TextEditorLineNumbersStyle;
+
+		/**
+		 * Render rulers at the specified number of characters.
+		 * When getting a text editor's option, this property will always be present.
+		 * When setting a text editor's options, this property is optional.
+		 */
+		rulers?: (number | RulerOption)[]
 	}
 
 	/**

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -15,7 +15,7 @@ import * as performance from 'vs/base/common/performance';
 import Severity from 'vs/base/common/severity';
 import { Dto } from 'vs/base/common/types';
 import { URI, UriComponents } from 'vs/base/common/uri';
-import { RenderLineNumbersType, TextEditorCursorStyle } from 'vs/editor/common/config/editorOptions';
+import { IRulerOption, RenderLineNumbersType, TextEditorCursorStyle } from 'vs/editor/common/config/editorOptions';
 import { IPosition } from 'vs/editor/common/core/position';
 import { IRange } from 'vs/editor/common/core/range';
 import { ISelection, Selection } from 'vs/editor/common/core/selection';
@@ -232,6 +232,7 @@ export interface ITextEditorConfigurationUpdate {
 	insertSpaces?: boolean | 'auto';
 	cursorStyle?: TextEditorCursorStyle;
 	lineNumbers?: RenderLineNumbersType;
+	rulers?: (number | IRulerOption)[];
 }
 
 export interface IResolvedTextEditorConfiguration {
@@ -239,6 +240,7 @@ export interface IResolvedTextEditorConfiguration {
 	insertSpaces: boolean;
 	cursorStyle: TextEditorCursorStyle;
 	lineNumbers: RenderLineNumbersType;
+	rulers: (number | IRulerOption)[];
 }
 
 export enum TextEditorRevealType {

--- a/src/vs/workbench/test/browser/api/extHostTextEditor.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostTextEditor.test.ts
@@ -21,7 +21,7 @@ suite('ExtHostTextEditor', () => {
 	], '\n', 1, 'text', false);
 
 	setup(() => {
-		editor = new ExtHostTextEditor('fake', null!, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4 }, [], 1);
+		editor = new ExtHostTextEditor('fake', null!, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4, rulers: [] }, [], 1);
 	});
 
 	test('disposed editor', () => {
@@ -48,7 +48,7 @@ suite('ExtHostTextEditor', () => {
 					applyCount += 1;
 					return Promise.resolve(true);
 				}
-			}, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4 }, [], 1);
+			}, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4, rulers: [] }, [], 1);
 
 		await editor.value.edit(edit => { });
 		assert.strictEqual(applyCount, 0);
@@ -92,7 +92,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		}, new NullLogService());
 	});
 
@@ -106,7 +107,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: opts.value.tabSize,
 			insertSpaces: opts.value.insertSpaces,
 			cursorStyle: opts.value.cursorStyle,
-			lineNumbers: opts.value.lineNumbers
+			lineNumbers: opts.value.lineNumbers,
+			rulers: opts.value.rulers
 		};
 		assert.deepStrictEqual(actual, expected);
 	}
@@ -117,7 +119,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -128,7 +131,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 1,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 1 }]);
 	});
@@ -139,7 +143,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 2,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 2 }]);
 	});
@@ -150,7 +155,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 2,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 2 }]);
 	});
@@ -161,7 +167,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 'auto' }]);
 	});
@@ -172,7 +179,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -183,7 +191,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -194,7 +203,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -205,7 +215,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -216,7 +227,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -227,7 +239,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: true,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ insertSpaces: true }]);
 	});
@@ -238,7 +251,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -249,7 +263,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: true,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ insertSpaces: true }]);
 	});
@@ -260,7 +275,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ insertSpaces: 'auto' }]);
 	});
@@ -271,7 +287,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -282,7 +299,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Block,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ cursorStyle: TextEditorCursorStyle.Block }]);
 	});
@@ -293,7 +311,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -304,9 +323,34 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.Off
+			lineNumbers: RenderLineNumbersType.Off,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ lineNumbers: RenderLineNumbersType.Off }]);
+	});
+
+	test('can set rulers to same value', () => {
+		opts.value.rulers = [];
+		assertState(opts, {
+			tabSize: 4,
+			insertSpaces: false,
+			cursorStyle: TextEditorCursorStyle.Line,
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
+		});
+		assert.deepStrictEqual(calls, []);
+	});
+
+	test('can change rulers', () => {
+		opts.value.rulers = [100, 120];
+		assertState(opts, {
+			tabSize: 4,
+			insertSpaces: false,
+			cursorStyle: TextEditorCursorStyle.Line,
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: [100, 120]
+		});
+		assert.deepStrictEqual(calls, [{ rulers: [100, 120] }]);
 	});
 
 	test('can do bulk updates 0', () => {
@@ -320,7 +364,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -334,7 +379,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: true,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 'auto', insertSpaces: true }]);
 	});
@@ -348,7 +394,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 3,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 3, insertSpaces: 'auto' }]);
 	});
@@ -362,7 +409,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Block,
-			lineNumbers: RenderLineNumbersType.Relative
+			lineNumbers: RenderLineNumbersType.Relative,
+			rulers: []
 		});
 		assert.deepStrictEqual(calls, [{ cursorStyle: TextEditorCursorStyle.Block, lineNumbers: RenderLineNumbersType.Relative }]);
 	});


### PR DESCRIPTION
Adds `editor.rulers` to the options that an extension can update.  Allows an extension to configure the location of rulers, so that https://github.com/editorconfig/editorconfig-vscode/issues/272 can be fixed.

Can be tested by creating a simple command in an extension that updates the editor options.
```ts
export class SetRulersCommand implements Command {
	public readonly id = 'markdown.setRulers';

	public constructor(
	) { }

	public execute() {
		if (editor) { // editor is the current editor.
			editor.options.rulers = [20, 40, 60, 80];
		}
	}
}
```

This PR fixes #111251.
