### PR TITLE
handle shift+click for list that are not focused fixes #122402

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -662,21 +662,26 @@ export class MouseController<T> implements IDisposable {
 		const focus = e.index!;
 		const anchor = this.list.getAnchor();
 
-		if (this.isSelectionRangeChangeEvent(e) && typeof anchor === 'number') {
-			const min = Math.min(anchor, focus);
-			const max = Math.max(anchor, focus);
-			const rangeSelection = range(min, max + 1);
-			const selection = this.list.getSelection();
-			const contiguousRange = getContiguousRangeContaining(disjunction(selection, [anchor]), anchor);
+		if (this.isSelectionRangeChangeEvent(e)) {
+			if (typeof anchor === 'number') {
+				const min = Math.min(anchor, focus);
+				const max = Math.max(anchor, focus);
+				const rangeSelection = range(min, max + 1);
+				const selection = this.list.getSelection();
+				const contiguousRange = getContiguousRangeContaining(disjunction(selection, [anchor]), anchor);
 
-			if (contiguousRange.length === 0) {
-				return;
+				if (contiguousRange.length === 0) {
+					return;
+				}
+
+				const newSelection = disjunction(rangeSelection, relativeComplement(selection, contiguousRange));
+				this.list.setSelection(newSelection, e.browserEvent);
+				this.list.setFocus([focus], e.browserEvent);
+			} else { // shift + click when there isn't an anchor, https://github.com/microsoft/vscode/issues/122402
+				this.list.setSelection([focus], e.browserEvent);
+				this.list.setFocus([focus], e.browserEvent);
+				this.list.setAnchor(focus);
 			}
-
-			const newSelection = disjunction(rangeSelection, relativeComplement(selection, contiguousRange));
-			this.list.setSelection(newSelection, e.browserEvent);
-			this.list.setFocus([focus], e.browserEvent);
-
 		} else if (this.isSelectionSingleChangeEvent(e)) {
 			const selection = this.list.getSelection();
 			const newSelection = selection.filter(i => i !== focus);


### PR DESCRIPTION
fix list shift+click when an element isn't initially focused

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Reproduction steps, https://github.com/microsoft/vscode/issues/122402#issuecomment-828494840.  Test that doing this does focus the elements as expected.  Can test with either the terminal tabs or file explorer.

This PR fixes #122402.
