### PR TITLE
add an option to always search the workspace for package.json

### DIFF
--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -289,6 +289,12 @@
           "tags": [
             "usesOnlineServices"
           ]
+        },
+        "npm.alwaysPerformLookup": {
+          "type": "boolean",
+          "description": "%config.npm.alwaysPerformLookup%",
+          "default": false,
+          "scope": "application"
         }
       }
     },

--- a/extensions/npm/package.nls.json
+++ b/extensions/npm/package.nls.json
@@ -2,6 +2,7 @@
 	"description": "Extension to add task support for npm scripts.",
 	"displayName": "NPM support for VS Code",
 	"workspaceTrust": "This extension executes tasks, which require trust to run.",
+	"config.npm.alwaysPerformLookup": "Search the entire workspace for a package.json without timing out.",
 	"config.npm.autoDetect": "Controls whether npm scripts should be automatically detected.",
 	"config.npm.runSilent": "Run npm commands with the `--silent` option.",
 	"config.npm.packageManager": "The package manager used to run scripts.",

--- a/extensions/npm/src/tasks.ts
+++ b/extensions/npm/src/tasks.ts
@@ -365,11 +365,18 @@ export function getPackageJsonUriFromTask(task: Task): Uri | null {
 }
 
 export async function hasPackageJson(): Promise<boolean> {
-	const token = new CancellationTokenSource();
-	// Search for files for max 1 second.
-	const timeout = setTimeout(() => token.cancel(), 1000);
-	const files = await workspace.findFiles('**/package.json', undefined, 1, token.token);
-	clearTimeout(timeout);
+	let files: Uri[];
+	const alwaysLookup = workspace.getConfiguration().get<boolean>('npm.alwaysPerformLookup');
+	if (!alwaysLookup) {
+		const token = new CancellationTokenSource();
+		// Search for files for max 1 second.
+		const timeout = setTimeout(() => token.cancel(), 1000);
+		files = await workspace.findFiles('**/package.json', undefined, 1, token.token);
+		clearTimeout(timeout);
+		return files.length > 0;
+	} else {
+		files = await workspace.findFiles('**/package.json', undefined, 1);
+	}
 	return files.length > 0 || await hasRootPackageJson();
 }
 


### PR DESCRIPTION
add an option to always search the workspace for package.json

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #119868.

https://github.com/microsoft/vscode/pull/124803 is a similar PR for checking the existence of a `package.json`.
