### PR TITLE
add skipSaveParticipant to model

### DIFF
--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -17,6 +17,7 @@ import { LanguageId, LanguageIdentifier, FormattingOptions } from 'vs/editor/com
 import { ThemeColor } from 'vs/platform/theme/common/themeService';
 import { MultilineTokens, MultilineTokens2 } from 'vs/editor/common/model/tokensStore';
 import { TextChange } from 'vs/editor/common/model/textChange';
+import { equals } from 'vs/base/common/arrays';
 
 /**
  * Vertical Lane in the overview ruler of the editor.
@@ -407,6 +408,7 @@ export class TextModelResolvedOptions {
 	readonly insertSpaces: boolean;
 	readonly defaultEOL: DefaultEndOfLine;
 	readonly trimAutoWhitespace: boolean;
+	readonly skipSaveParticipants: string[];
 
 	/**
 	 * @internal
@@ -417,12 +419,14 @@ export class TextModelResolvedOptions {
 		insertSpaces: boolean;
 		defaultEOL: DefaultEndOfLine;
 		trimAutoWhitespace: boolean;
+		skipSaveParticipants: string[]
 	}) {
 		this.tabSize = Math.max(1, src.tabSize | 0);
 		this.indentSize = src.tabSize | 0;
 		this.insertSpaces = Boolean(src.insertSpaces);
 		this.defaultEOL = src.defaultEOL | 0;
 		this.trimAutoWhitespace = Boolean(src.trimAutoWhitespace);
+		this.skipSaveParticipants = src.skipSaveParticipants;
 	}
 
 	/**
@@ -435,6 +439,7 @@ export class TextModelResolvedOptions {
 			&& this.insertSpaces === other.insertSpaces
 			&& this.defaultEOL === other.defaultEOL
 			&& this.trimAutoWhitespace === other.trimAutoWhitespace
+			&& equals(this.skipSaveParticipants, other.skipSaveParticipants, ((a, b) => a === b))
 		);
 	}
 
@@ -447,6 +452,7 @@ export class TextModelResolvedOptions {
 			indentSize: this.indentSize !== newOpts.indentSize,
 			insertSpaces: this.insertSpaces !== newOpts.insertSpaces,
 			trimAutoWhitespace: this.trimAutoWhitespace !== newOpts.trimAutoWhitespace,
+			skipSaveParticipants: !equals(this.skipSaveParticipants, newOpts.skipSaveParticipants, (a, b) => a === b)
 		};
 	}
 }
@@ -470,6 +476,7 @@ export interface ITextModelUpdateOptions {
 	indentSize?: number;
 	insertSpaces?: boolean;
 	trimAutoWhitespace?: boolean;
+	skipSaveParticipants?: string[];
 }
 
 export class FindMatch {

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -201,7 +201,8 @@ export class TextModel extends Disposable implements model.ITextModel {
 				indentSize: guessedIndentation.tabSize, // TODO@Alex: guess indentSize independent of tabSize
 				insertSpaces: guessedIndentation.insertSpaces,
 				trimAutoWhitespace: options.trimAutoWhitespace,
-				defaultEOL: options.defaultEOL
+				defaultEOL: options.defaultEOL,
+				skipSaveParticipants: []
 			});
 		}
 
@@ -210,7 +211,8 @@ export class TextModel extends Disposable implements model.ITextModel {
 			indentSize: options.indentSize,
 			insertSpaces: options.insertSpaces,
 			trimAutoWhitespace: options.trimAutoWhitespace,
-			defaultEOL: options.defaultEOL
+			defaultEOL: options.defaultEOL,
+			skipSaveParticipants: []
 		});
 
 	}
@@ -617,13 +619,15 @@ export class TextModel extends Disposable implements model.ITextModel {
 		let indentSize = (typeof _newOpts.indentSize !== 'undefined') ? _newOpts.indentSize : this._options.indentSize;
 		let insertSpaces = (typeof _newOpts.insertSpaces !== 'undefined') ? _newOpts.insertSpaces : this._options.insertSpaces;
 		let trimAutoWhitespace = (typeof _newOpts.trimAutoWhitespace !== 'undefined') ? _newOpts.trimAutoWhitespace : this._options.trimAutoWhitespace;
+		let skipSaveParticipants = (typeof _newOpts.skipSaveParticipants !== 'undefined') ? _newOpts.skipSaveParticipants : this._options.skipSaveParticipants;
 
 		let newOpts = new model.TextModelResolvedOptions({
 			tabSize: tabSize,
 			indentSize: indentSize,
 			insertSpaces: insertSpaces,
 			defaultEOL: this._options.defaultEOL,
-			trimAutoWhitespace: trimAutoWhitespace
+			trimAutoWhitespace: trimAutoWhitespace,
+			skipSaveParticipants
 		});
 
 		if (this._options.equals(newOpts)) {

--- a/src/vs/editor/common/model/textModelEvents.ts
+++ b/src/vs/editor/common/model/textModelEvents.ts
@@ -105,6 +105,7 @@ export interface IModelOptionsChangedEvent {
 	readonly indentSize: boolean;
 	readonly insertSpaces: boolean;
 	readonly trimAutoWhitespace: boolean;
+	readonly skipSaveParticipants: boolean;
 }
 
 /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1612,6 +1612,7 @@ declare namespace monaco.editor {
 		readonly insertSpaces: boolean;
 		readonly defaultEOL: DefaultEndOfLine;
 		readonly trimAutoWhitespace: boolean;
+		readonly skipSaveParticipants: string[];
 	}
 
 	export interface ITextModelUpdateOptions {
@@ -1619,6 +1620,7 @@ declare namespace monaco.editor {
 		indentSize?: number;
 		insertSpaces?: boolean;
 		trimAutoWhitespace?: boolean;
+		skipSaveParticipants?: string[];
 	}
 
 	export class FindMatch {
@@ -2505,6 +2507,7 @@ declare namespace monaco.editor {
 		readonly indentSize: boolean;
 		readonly insertSpaces: boolean;
 		readonly trimAutoWhitespace: boolean;
+		readonly skipSaveParticipants: boolean;
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -669,6 +669,8 @@ declare module 'vscode' {
 		 * When setting a text editor's options, this property is optional.
 		 */
 		lineNumbers?: TextEditorLineNumbersStyle;
+
+		skipSaveParticipants?: string[];
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -670,6 +670,12 @@ declare module 'vscode' {
 		 */
 		lineNumbers?: TextEditorLineNumbersStyle;
 
+		/**
+		 * An array of save participant id's that should be skipped
+		 * when the model is saved.
+		 * When getting a text editor's options, this property will always be present.
+		 * When setting a text editor's options, this property is optional.
+		 */
 		skipSaveParticipants?: string[];
 	}
 

--- a/src/vs/workbench/api/browser/mainThreadEditor.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditor.ts
@@ -80,7 +80,8 @@ export class MainThreadTextEditorProperties {
 			insertSpaces: modelOptions.insertSpaces,
 			tabSize: modelOptions.tabSize,
 			cursorStyle: cursorStyle,
-			lineNumbers: lineNumbers
+			lineNumbers: lineNumbers,
+			skipSaveParticipants: modelOptions.skipSaveParticipants
 		};
 	}
 
@@ -148,6 +149,7 @@ export class MainThreadTextEditorProperties {
 			&& a.insertSpaces === b.insertSpaces
 			&& a.cursorStyle === b.cursorStyle
 			&& a.lineNumbers === b.lineNumbers
+			&& equals(a.skipSaveParticipants, b.skipSaveParticipants, (a, b) => a === b)
 		);
 	}
 }
@@ -406,6 +408,12 @@ export class MainThreadTextEditor {
 			}
 			this._codeEditor.updateOptions({
 				lineNumbers: lineNumbers
+			});
+		}
+
+		if (typeof newConfiguration.skipSaveParticipants !== 'undefined') {
+			this._model.updateOptions({
+				skipSaveParticipants: newConfiguration.skipSaveParticipants
 			});
 		}
 	}

--- a/src/vs/workbench/api/browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/browser/mainThreadSaveParticipant.ts
@@ -17,6 +17,8 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 
 class ExtHostSaveParticipant implements ITextFileSaveParticipant {
 
+	id = '_extHostSave';
+
 	private readonly _proxy: ExtHostDocumentSaveParticipantShape;
 
 	constructor(extHostContext: IExtHostContext) {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -232,6 +232,7 @@ export interface ITextEditorConfigurationUpdate {
 	insertSpaces?: boolean | 'auto';
 	cursorStyle?: TextEditorCursorStyle;
 	lineNumbers?: RenderLineNumbersType;
+	skipSaveParticipants?: string[];
 }
 
 export interface IResolvedTextEditorConfiguration {
@@ -239,6 +240,7 @@ export interface IResolvedTextEditorConfiguration {
 	insertSpaces: boolean;
 	cursorStyle: TextEditorCursorStyle;
 	lineNumbers: RenderLineNumbersType;
+	skipSaveParticipants: string[];
 }
 
 export enum TextEditorRevealType {

--- a/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
@@ -34,6 +34,8 @@ import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 
 export class TrimWhitespaceParticipant implements ITextFileSaveParticipant {
 
+	id = 'trimWhitespace';
+
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ICodeEditorService private readonly codeEditorService: ICodeEditorService
@@ -42,7 +44,7 @@ export class TrimWhitespaceParticipant implements ITextFileSaveParticipant {
 	}
 
 	async participate(model: ITextFileEditorModel, env: { reason: SaveReason; }): Promise<void> {
-		if (!model.textEditorModel) {
+		if (!model.textEditorModel || !canParticipate(model, this.id)) {
 			return;
 		}
 
@@ -98,7 +100,13 @@ function findEditor(model: ITextModel, codeEditorService: ICodeEditorService): I
 	return candidate;
 }
 
+function canParticipate(model: ITextFileEditorModel, id: string) {
+	return !model.textEditorModel?.getOptions().skipSaveParticipants.includes(id);
+}
+
 export class FinalNewLineParticipant implements ITextFileSaveParticipant {
+
+	id = 'finalNewLine';
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -108,7 +116,7 @@ export class FinalNewLineParticipant implements ITextFileSaveParticipant {
 	}
 
 	async participate(model: ITextFileEditorModel, _env: { reason: SaveReason; }): Promise<void> {
-		if (!model.textEditorModel) {
+		if (!model.textEditorModel || !canParticipate(model, this.id)) {
 			return;
 		}
 
@@ -138,6 +146,8 @@ export class FinalNewLineParticipant implements ITextFileSaveParticipant {
 
 export class TrimFinalNewLinesParticipant implements ITextFileSaveParticipant {
 
+	id = 'trimFinalNewLines';
+
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ICodeEditorService private readonly codeEditorService: ICodeEditorService
@@ -146,7 +156,7 @@ export class TrimFinalNewLinesParticipant implements ITextFileSaveParticipant {
 	}
 
 	async participate(model: ITextFileEditorModel, env: { reason: SaveReason; }): Promise<void> {
-		if (!model.textEditorModel) {
+		if (!model.textEditorModel || !canParticipate(model, this.id)) {
 			return;
 		}
 
@@ -211,6 +221,8 @@ export class TrimFinalNewLinesParticipant implements ITextFileSaveParticipant {
 
 class FormatOnSaveParticipant implements ITextFileSaveParticipant {
 
+	id = 'formatOnSave';
+
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ICodeEditorService private readonly codeEditorService: ICodeEditorService,
@@ -220,7 +232,7 @@ class FormatOnSaveParticipant implements ITextFileSaveParticipant {
 	}
 
 	async participate(model: ITextFileEditorModel, env: { reason: SaveReason; }, progress: IProgress<IProgressStep>, token: CancellationToken): Promise<void> {
-		if (!model.textEditorModel) {
+		if (!model.textEditorModel || !canParticipate(model, this.id)) {
 			return;
 		}
 		if (env.reason === SaveReason.AUTO) {
@@ -262,13 +274,15 @@ class FormatOnSaveParticipant implements ITextFileSaveParticipant {
 
 class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
 
+	id = 'codeActionOnSave';
+
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) { }
 
 	async participate(model: ITextFileEditorModel, env: { reason: SaveReason; }, progress: IProgress<IProgressStep>, token: CancellationToken): Promise<void> {
-		if (!model.textEditorModel) {
+		if (!model.textEditorModel || !canParticipate(model, this.id)) {
 			return;
 		}
 

--- a/src/vs/workbench/services/textfile/common/textfiles.ts
+++ b/src/vs/workbench/services/textfile/common/textfiles.ts
@@ -318,6 +318,8 @@ export interface ITextFileResolveEvent {
 
 export interface ITextFileSaveParticipant {
 
+	id: string;
+
 	/**
 	 * Participate in a save of a model. Allows to change the model
 	 * before it is being saved to disk.

--- a/src/vs/workbench/services/textfile/test/browser/textFileEditorModel.test.ts
+++ b/src/vs/workbench/services/textfile/test/browser/textFileEditorModel.test.ts
@@ -589,6 +589,7 @@ suite('Files - TextFileEditorModel', () => {
 		});
 
 		const participant = accessor.textFileService.files.addSaveParticipant({
+			id: 'test',
 			participate: async model => {
 				assert.ok(model.isDirty());
 				(model as TextFileEditorModel).updateTextEditorModel(createTextBufferFactory('bar'));
@@ -619,6 +620,7 @@ suite('Files - TextFileEditorModel', () => {
 		const model: TextFileEditorModel = instantiationService.createInstance(TextFileEditorModel, toResource.call(this, '/path/index_async.txt'), 'utf8', undefined);
 
 		const participant = accessor.textFileService.files.addSaveParticipant({
+			id: 'test',
 			participate: async () => {
 				eventCounter++;
 			}
@@ -644,6 +646,7 @@ suite('Files - TextFileEditorModel', () => {
 		});
 
 		const participant = accessor.textFileService.files.addSaveParticipant({
+			id: 'test',
 			participate: model => {
 				assert.ok(model.isDirty());
 				(model as TextFileEditorModel).updateTextEditorModel(createTextBufferFactory('bar'));
@@ -670,6 +673,7 @@ suite('Files - TextFileEditorModel', () => {
 		const model: TextFileEditorModel = instantiationService.createInstance(TextFileEditorModel, toResource.call(this, '/path/index_async.txt'), 'utf8', undefined);
 
 		const participant = accessor.textFileService.files.addSaveParticipant({
+			id: 'test',
 			participate: async () => {
 				new Error('boom');
 			}
@@ -690,6 +694,7 @@ suite('Files - TextFileEditorModel', () => {
 		let participations: boolean[] = [];
 
 		const participant = accessor.textFileService.files.addSaveParticipant({
+			id: 'test',
 			participate: async (model, context, progress, token) => {
 				await timeout(10);
 
@@ -741,6 +746,7 @@ suite('Files - TextFileEditorModel', () => {
 		let breakLoop = false;
 
 		const participant = accessor.textFileService.files.addSaveParticipant({
+			id: 'test',
 			participate: async model => {
 				if (breakLoop) {
 					return;

--- a/src/vs/workbench/test/browser/api/extHostTextEditor.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostTextEditor.test.ts
@@ -21,7 +21,7 @@ suite('ExtHostTextEditor', () => {
 	], '\n', 1, 'text', false);
 
 	setup(() => {
-		editor = new ExtHostTextEditor('fake', null!, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4 }, [], 1);
+		editor = new ExtHostTextEditor('fake', null!, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4, skipSaveParticipants: [] }, [], 1);
 	});
 
 	test('disposed editor', () => {
@@ -48,7 +48,7 @@ suite('ExtHostTextEditor', () => {
 					applyCount += 1;
 					return Promise.resolve(true);
 				}
-			}, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4 }, [], 1);
+			}, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4, skipSaveParticipants: [] }, [], 1);
 
 		await editor.value.edit(edit => { });
 		assert.strictEqual(applyCount, 0);
@@ -92,7 +92,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		}, new NullLogService());
 	});
 
@@ -106,7 +107,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: opts.value.tabSize,
 			insertSpaces: opts.value.insertSpaces,
 			cursorStyle: opts.value.cursorStyle,
-			lineNumbers: opts.value.lineNumbers
+			lineNumbers: opts.value.lineNumbers,
+			skipSaveParticipants: opts.value.skipSaveParticipants
 		};
 		assert.deepStrictEqual(actual, expected);
 	}
@@ -117,7 +119,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -128,7 +131,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 1,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 1 }]);
 	});
@@ -139,7 +143,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 2,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 2 }]);
 	});
@@ -150,7 +155,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 2,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 2 }]);
 	});
@@ -161,7 +167,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 'auto' }]);
 	});
@@ -172,7 +179,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -183,7 +191,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -194,7 +203,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -205,7 +215,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -216,7 +227,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -227,7 +239,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: true,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ insertSpaces: true }]);
 	});
@@ -238,7 +251,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -249,7 +263,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: true,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ insertSpaces: true }]);
 	});
@@ -260,7 +275,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ insertSpaces: 'auto' }]);
 	});
@@ -271,7 +287,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -282,7 +299,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Block,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ cursorStyle: TextEditorCursorStyle.Block }]);
 	});
@@ -293,7 +311,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -304,9 +323,34 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.Off
+			lineNumbers: RenderLineNumbersType.Off,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ lineNumbers: RenderLineNumbersType.Off }]);
+	});
+
+	test('can set skipSaveParticipants to same value', () => {
+		opts.value.skipSaveParticipants = [];
+		assertState(opts, {
+			tabSize: 4,
+			insertSpaces: false,
+			cursorStyle: TextEditorCursorStyle.Line,
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
+		});
+		assert.deepStrictEqual(calls, []);
+	});
+
+	test('can change skipSaveParticipants', () => {
+		opts.value.skipSaveParticipants = ['test'];
+		assertState(opts, {
+			tabSize: 4,
+			insertSpaces: false,
+			cursorStyle: TextEditorCursorStyle.Line,
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: ['test']
+		});
+		assert.deepStrictEqual(calls, [{ skipSaveParticipants: ['test'] }]);
 	});
 
 	test('can do bulk updates 0', () => {
@@ -314,13 +358,15 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: TextEditorLineNumbersStyle.On
+			lineNumbers: TextEditorLineNumbersStyle.On,
+			skipSaveParticipants: []
 		});
 		assertState(opts, {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, []);
 	});
@@ -334,7 +380,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: true,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 'auto', insertSpaces: true }]);
 	});
@@ -348,7 +395,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 3,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Line,
-			lineNumbers: RenderLineNumbersType.On
+			lineNumbers: RenderLineNumbersType.On,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ tabSize: 3, insertSpaces: 'auto' }]);
 	});
@@ -362,7 +410,8 @@ suite('ExtHostTextEditorOptions', () => {
 			tabSize: 4,
 			insertSpaces: false,
 			cursorStyle: TextEditorCursorStyle.Block,
-			lineNumbers: RenderLineNumbersType.Relative
+			lineNumbers: RenderLineNumbersType.Relative,
+			skipSaveParticipants: []
 		});
 		assert.deepStrictEqual(calls, [{ cursorStyle: TextEditorCursorStyle.Block, lineNumbers: RenderLineNumbersType.Relative }]);
 	});


### PR DESCRIPTION
Adds an attribute to the TextModelOptions to skip which save participants should run for that model.  This allows extensions contribute to what `saveParticipants` are run or not.

One possible issue is that `skipSaveParticipants` is an array, so if 2 extensions modify the value for the model then I believe the second one to run will have priority.
Would this be better as a different data structure or functions to explicitly add/remove participant ids?  The goal would be that two extensions could still modify the same participant list, but they wouldn't completely override the other extensions changes.

This PR fixes #65663.
