### PR TITLE
Fixes #124742 by ensuring that overwriteAfter is not negative.

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel.ts
@@ -151,6 +151,9 @@ function getInlineCompletion(suggestController: SuggestController, position: Pos
 	const info = suggestController.getOverwriteInfo(item, false);
 	return {
 		text: insertText,
-		range: Range.fromPositions(position.delta(0, -info.overwriteBefore), position.delta(0, info.overwriteAfter)),
+		range: Range.fromPositions(
+			position.delta(0, -info.overwriteBefore),
+			position.delta(0, Math.max(info.overwriteAfter, 0))
+		),
 	};
 }


### PR DESCRIPTION
This PR fixes #124742.
@jrieken I'm pretty sure this fix does not address the root of the issue.

Given this code:
```ts
window
```

If you place the cursor in the middle of `window`:
```
win|dow
```

And trigger the suggest window and then press arrow-right,
```
wind|ow
```

`this._lineSuffix.value.delta(this.editor.getPosition())` will report `-1` (in suggestController.ts). Since `columnDelta` is 0, `overwriteAfter` will be `-1` too.

I guess the line suffix code is not prepared for the case that the user moves the cursor when a session is active.

The line suffix logic was introduced [here](https://github.com/microsoft/vscode/commit/edcae85fd6a16807183ed2c8582c2d8cceace224).