### PR TITLE
Uses eslint-plugin-header to enforce license headers.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -16,3 +16,4 @@
 **/extensions/markdown-language-features/notebook-out/**
 **/extensions/typescript-basics/test/colorize-fixtures/**
 **/extensions/**/dist/**
+**/extensions/typescript-language-features/test-workspace/**

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
 	},
 	"plugins": [
 		"@typescript-eslint",
-		"jsdoc"
+		"jsdoc",
+		"header"
 	],
 	"rules": {
 		"constructor-super": "warn",
@@ -979,6 +980,16 @@
 					"xterm*"
 				]
 			}
+		],
+		"header/header": [
+			2,
+			"block",
+			[
+				"---------------------------------------------------------------------------------------------",
+				" *  Copyright (c) Microsoft Corporation. All rights reserved.",
+				" *  Licensed under the MIT License. See License.txt in the project root for license information.",
+				" *--------------------------------------------------------------------------------------------"
+			]
 		]
 	},
 	"overrides": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.59.0",
-  "distro": "4f9399b417ee98731317fbd4616d6fc287172355",
+  "distro": "74b4e453554c83bca64754d34278aff04e1d78f9",
   "author": {
     "name": "Microsoft Corporation"
   },
@@ -59,6 +59,7 @@
   "dependencies": {
     "applicationinsights": "1.0.8",
     "chokidar": "3.5.1",
+    "eslint-plugin-header": "3.1.1",
     "graceful-fs": "4.2.6",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3264,6 +3264,11 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
+eslint-plugin-header@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz#6ce512432d57675265fac47292b50d1eff11acd6"
+  integrity sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==
+
 eslint-plugin-jsdoc@^19.1.0:
   version "19.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-19.1.0.tgz#fcc17f0378fdd6ee1c847a79b7211745cb05d014"


### PR DESCRIPTION
This adds a quick fix to add license header using [eslint-plugin-header](https://github.com/Stuk/eslint-plugin-header).

This PR fixes #124891

![](https://user-images.githubusercontent.com/2931520/120067345-4bca6d80-c07b-11eb-8d58-3ab8b066e7cc.gif)

I reviewed the dependency's source code and locked the version in `package.json` to prevent accidental updates.