### PR TITLE
Remove dedicated types for notebook and cell metadata

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.document.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.document.test.ts
@@ -13,7 +13,6 @@ suite('Notebook Document', function () {
 		deserializeNotebook(_data: Uint8Array): vscode.NotebookData | Thenable<vscode.NotebookData> {
 			return new vscode.NotebookData(
 				[new vscode.NotebookCellData(vscode.NotebookCellKind.Code, '// SIMPLE', 'javascript')],
-				new vscode.NotebookDocumentMetadata()
 			);
 		}
 		serializeNotebook(_data: vscode.NotebookData): Uint8Array | Thenable<Uint8Array> {
@@ -25,7 +24,6 @@ suite('Notebook Document', function () {
 		async openNotebook(uri: vscode.Uri, _openContext: vscode.NotebookDocumentOpenContext): Promise<vscode.NotebookData> {
 			return new vscode.NotebookData(
 				[new vscode.NotebookCellData(vscode.NotebookCellKind.Code, uri.toString(), 'javascript')],
-				new vscode.NotebookDocumentMetadata()
 			);
 		}
 		async saveNotebook(_document: vscode.NotebookDocument, _cancellation: vscode.CancellationToken) {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.editor.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.editor.test.ts
@@ -13,7 +13,6 @@ suite('Notebook Editor', function () {
 		deserializeNotebook() {
 			return new vscode.NotebookData(
 				[new vscode.NotebookCellData(vscode.NotebookCellKind.Code, '// code cell', 'javascript')],
-				new vscode.NotebookDocumentMetadata()
 			);
 		}
 		serializeNotebook() {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.test.ts
@@ -108,20 +108,20 @@ suite('Notebook API tests', function () {
 			openNotebook: async (resource: vscode.Uri): Promise<vscode.NotebookData> => {
 				if (/.*empty\-.*\.vsctestnb$/.test(resource.path)) {
 					return {
-						metadata: new vscode.NotebookDocumentMetadata(),
+						metadata: {},
 						cells: []
 					};
 				}
 
 				const dto: vscode.NotebookData = {
-					metadata: new vscode.NotebookDocumentMetadata().with({ custom: { testMetadata: false } }),
+					metadata: { custom: { testMetadata: false } },
 					cells: [
 						{
 							value: 'test',
 							languageId: 'typescript',
 							kind: vscode.NotebookCellKind.Code,
 							outputs: [],
-							metadata: new vscode.NotebookCellMetadata().with({ custom: { testCellMetadata: 123 } }),
+							metadata: { custom: { testCellMetadata: 123 } },
 							executionSummary: { startTime: 10, endTime: 20 }
 						},
 						{
@@ -135,7 +135,7 @@ suite('Notebook API tests', function () {
 									{ testOutputMetadata: true })
 							],
 							executionSummary: { executionOrder: 5, success: true },
-							metadata: new vscode.NotebookCellMetadata().with({ custom: { testCellMetadata: 456 } })
+							metadata: { custom: { testCellMetadata: 456 } }
 						}
 					]
 				};
@@ -382,7 +382,7 @@ suite('Notebook API tests', function () {
 		await vscode.commands.executeCommand('vscode.openWith', resource, 'notebookCoreTest');
 
 		await vscode.window.activeNotebookEditor!.edit(editBuilder => {
-			editBuilder.replaceCellMetadata(0, new vscode.NotebookCellMetadata().with({ inputCollapsed: true }));
+			editBuilder.replaceCellMetadata(0, { inputCollapsed: true });
 		});
 
 		const document = vscode.window.activeNotebookEditor?.document!;
@@ -399,7 +399,7 @@ suite('Notebook API tests', function () {
 		const event = asPromise<vscode.NotebookCellMetadataChangeEvent>(vscode.notebook.onDidChangeCellMetadata);
 
 		await vscode.window.activeNotebookEditor!.edit(editBuilder => {
-			editBuilder.replaceCellMetadata(0, new vscode.NotebookCellMetadata().with({ inputCollapsed: true }));
+			editBuilder.replaceCellMetadata(0, { inputCollapsed: true });
 		});
 
 		const data = await event;
@@ -418,7 +418,7 @@ suite('Notebook API tests', function () {
 		const version = vscode.window.activeNotebookEditor!.document.version;
 		await vscode.window.activeNotebookEditor!.edit(editBuilder => {
 			editBuilder.replaceCells(1, 0, [{ kind: vscode.NotebookCellKind.Code, languageId: 'javascript', value: 'test 2', outputs: [], metadata: undefined }]);
-			editBuilder.replaceCellMetadata(0, new vscode.NotebookCellMetadata().with({ inputCollapsed: false }));
+			editBuilder.replaceCellMetadata(0, { inputCollapsed: false });
 		});
 
 		await cellsChangeEvent;
@@ -435,7 +435,7 @@ suite('Notebook API tests', function () {
 		const version = vscode.window.activeNotebookEditor!.document.version;
 		await vscode.window.activeNotebookEditor!.edit(editBuilder => {
 			editBuilder.replaceCells(1, 0, [{ kind: vscode.NotebookCellKind.Code, languageId: 'javascript', value: 'test 2', outputs: [], metadata: undefined }]);
-			editBuilder.replaceCellMetadata(0, new vscode.NotebookCellMetadata().with({ inputCollapsed: false }));
+			editBuilder.replaceCellMetadata(0, { inputCollapsed: false });
 		});
 
 		await cellsChangeEvent;
@@ -1246,7 +1246,7 @@ suite('Notebook API tests', function () {
 			await provideCalled;
 
 			const edit = new vscode.WorkspaceEdit();
-			edit.replaceNotebookCellMetadata(resource, 0, new vscode.NotebookCellMetadata().with({ inputCollapsed: true }));
+			edit.replaceNotebookCellMetadata(resource, 0, { inputCollapsed: true });
 			vscode.workspace.applyEdit(edit);
 			await provideCalled;
 		});

--- a/extensions/vscode-notebook-tests/src/extension.ts
+++ b/extensions/vscode-notebook-tests/src/extension.ts
@@ -23,21 +23,21 @@ export function activate(context: vscode.ExtensionContext): any {
 	context.subscriptions.push(vscode.notebook.registerNotebookContentProvider('notebookSmokeTest', {
 		openNotebook: async (_resource: vscode.Uri) => {
 			const dto: vscode.NotebookData = {
-				metadata: new vscode.NotebookDocumentMetadata(),
+				metadata: {},
 				cells: [
 					{
 						value: 'code()',
 						languageId: 'typescript',
 						kind: vscode.NotebookCellKind.Code,
 						outputs: [],
-						metadata: new vscode.NotebookCellMetadata().with({ custom: { testCellMetadata: 123 } })
+						metadata: { custom: { testCellMetadata: 123 } }
 					},
 					{
 						value: 'Markdown Cell',
 						languageId: 'markdown',
 						kind: vscode.NotebookCellKind.Markup,
 						outputs: [],
-						metadata: new vscode.NotebookCellMetadata().with({ custom: { testCellMetadata: 123 } })
+						metadata: { custom: { testCellMetadata: 123 } }
 					}
 				]
 			};

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -11340,9 +11340,9 @@ declare module 'vscode' {
 		readonly document: TextDocument;
 
 		/**
-		 * The metadata of this cell.
+		 * The metadata of this cell. Can be anything but must be JSON-stringifyable.
 		 */
-		readonly metadata: NotebookCellMetadata
+		readonly metadata: { [key: string]: any }
 
 		/**
 		 * The outputs of this cell.
@@ -11403,9 +11403,9 @@ declare module 'vscode' {
 		readonly isClosed: boolean;
 
 		/**
-		 * The {@link NotebookDocumentMetadata metadata} for this notebook.
+		 * Arbitrary metadata for this notebook. Can be anything but must be JSON-stringifyable.
 		 */
-		readonly metadata: NotebookDocumentMetadata;
+		readonly metadata: { [key: string]: any };
 
 		/**
 		 * The number of cells in the notebook.
@@ -11438,44 +11438,6 @@ declare module 'vscode' {
 		save(): Thenable<boolean>;
 	}
 
-	// todo@API jsdoc
-	export class NotebookCellMetadata {
-
-		/**
-		 * Whether a code cell's editor is collapsed
-		 */
-		// todo@API decouple from metadata? extract as dedicated field or inside an options object and leave metadata purely for extensions?
-		readonly inputCollapsed?: boolean;
-
-		/**
-		 * Whether a code cell's outputs are collapsed
-		 */
-		// todo@API decouple from metadata? extract as dedicated field or inside an options object and leave metadata purely for extensions?
-		readonly outputCollapsed?: boolean;
-
-		/**
-		 * Additional attributes of a cell metadata.
-		 */
-		readonly [key: string]: any;
-
-		/**
-		 * Create a new notebook cell metadata.
-		 *
-		 * @param inputCollapsed Whether a code cell's editor is collapsed
-		 * @param outputCollapsed Whether a code cell's outputs are collapsed
-		 */
-		constructor(inputCollapsed?: boolean, outputCollapsed?: boolean);
-
-		/**
-		 * Derived a new cell metadata from this metadata.
-		 *
-		 * @param change An object that describes a change to this NotebookCellMetadata.
-		 * @return A new NotebookCellMetadata that reflects the given change. Will return `this` NotebookCellMetadata if the change
-		 *  is not changing anything.
-		 */
-		with(change: { inputCollapsed?: boolean | null, outputCollapsed?: boolean | null, [key: string]: any }): NotebookCellMetadata;
-	}
-
 	/**
 	 * The summary of a notebook cell execution.
 	 */
@@ -11501,29 +11463,6 @@ declare module 'vscode' {
 		 * The unix timestamp at which execution ended.
 		 */
 		readonly endTime?: number;
-	}
-
-	// todo@API jsdoc
-	// todo@API remove this and use simple {}?
-	export class NotebookDocumentMetadata {
-		/**
-		 * Additional attributes of the document metadata.
-		 */
-		readonly [key: string]: any;
-
-		/**
-		 * Create a new notebook document metadata
-		 */
-		constructor();
-
-		/**
-		 * Derived a new document metadata from this metadata.
-		 *
-		 * @param change An object that describes a change to this NotebookDocumentMetadata.
-		 * @return A new NotebookDocumentMetadata that reflects the given change. Will return `this` NotebookDocumentMetadata if the change
-		 *  is not changing anything.
-		 */
-		with(change: { [key: string]: any }): NotebookDocumentMetadata
 	}
 
 	/**
@@ -11737,7 +11676,7 @@ declare module 'vscode' {
 		/**
 		 * Arbitrary metadata of this cell data. Can be anything but must be JSON-stringifyable.
 		 */
-		metadata?: NotebookCellMetadata;
+		metadata?: { [key: string]: any };
 
 		/**
 		 * The execution summary of this cell data.
@@ -11756,7 +11695,7 @@ declare module 'vscode' {
 		 * @param executionSummary Optional execution summary.
 		 */
 		// todo@API should ctors only have the args for required properties?
-		constructor(kind: NotebookCellKind, value: string, languageId: string, outputs?: NotebookCellOutput[], metadata?: NotebookCellMetadata, executionSummary?: NotebookCellExecutionSummary);
+		constructor(kind: NotebookCellKind, value: string, languageId: string, outputs?: NotebookCellOutput[], metadata?: { [key: string]: any }, executionSummary?: NotebookCellExecutionSummary);
 	}
 
 	/**
@@ -11774,17 +11713,16 @@ declare module 'vscode' {
 		cells: NotebookCellData[];
 
 		/**
-		 * The metadata of this notebook data.
+		 * Arbitrary metadata of notebook data.
 		 */
-		metadata: NotebookDocumentMetadata;
+		metadata?: { [key: string]: any };
 
 		/**
 		 * Create new notebook data.
 		 *
 		 * @param cells An array of cell data.
-		 * @param metadata Notebook metadata.
 		 */
-		constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata);
+		constructor(cells: NotebookCellData[]);
 	}
 
 	/**
@@ -11833,14 +11771,14 @@ declare module 'vscode' {
 		 * Controls if a cell metadata property change will trigger notebook document content change and if it will be used in the diff editor
 		 * Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
 		 */
-		transientCellMetadata?: { [K in keyof NotebookCellMetadata]?: boolean };
+		transientCellMetadata?: { [key: string]: boolean | undefined };
 
 		/**
 		* Controls if a document metadata property change will trigger notebook document content change and if it will be used in the diff editor
 		* Default to false. If the content provider doesn't persisit a metadata property in the file document, it should be set to true.
 		*/
-		// todo@API ...NotebookDocument... or just ...Notebook... just like...Cell... above
-		transientDocumentMetadata?: { [K in keyof NotebookDocumentMetadata]?: boolean };
+		// todo@API ...NotebookDocument... or just ...Notebook... just like...Cell... above?
+		transientDocumentMetadata?: { [key: string]: boolean | undefined };
 	}
 
 	/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1253,15 +1253,15 @@ declare module 'vscode' {
 
 	export interface WorkspaceEdit {
 		// todo@API add NotebookEdit-type which handles all these cases?
-		replaceNotebookMetadata(uri: Uri, value: NotebookDocumentMetadata): void;
+		replaceNotebookMetadata(uri: Uri, value: { [key: string]: any }): void;
 		replaceNotebookCells(uri: Uri, range: NotebookRange, cells: NotebookCellData[], metadata?: WorkspaceEditEntryMetadata): void;
-		replaceNotebookCellMetadata(uri: Uri, index: number, cellMetadata: NotebookCellMetadata, metadata?: WorkspaceEditEntryMetadata): void;
+		replaceNotebookCellMetadata(uri: Uri, index: number, cellMetadata: { [key: string]: any }, metadata?: WorkspaceEditEntryMetadata): void;
 	}
 
 	export interface NotebookEditorEdit {
-		replaceMetadata(value: NotebookDocumentMetadata): void;
+		replaceMetadata(value: { [key: string]: any }): void;
 		replaceCells(start: number, end: number, cells: NotebookCellData[]): void;
-		replaceCellMetadata(index: number, metadata: NotebookCellMetadata): void;
+		replaceCellMetadata(index: number, metadata: { [key: string]: any }): void;
 	}
 
 	export interface NotebookEditor {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1268,8 +1268,6 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			NotebookRange: extHostTypes.NotebookRange,
 			NotebookCellKind: extHostTypes.NotebookCellKind,
 			NotebookCellExecutionState: extHostTypes.NotebookCellExecutionState,
-			NotebookDocumentMetadata: extHostTypes.NotebookDocumentMetadata,
-			NotebookCellMetadata: extHostTypes.NotebookCellMetadata,
 			NotebookCellData: extHostTypes.NotebookCellData,
 			NotebookData: extHostTypes.NotebookData,
 			NotebookRendererScript: extHostTypes.NotebookRendererScript,

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -385,7 +385,7 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 		const { provider } = this._getProviderData(viewType);
 		const data = await provider.openNotebook(URI.revive(uri), { backupId, untitledDocumentData: untitledDocumentData?.buffer }, token);
 		return {
-			metadata: typeConverters.NotebookDocumentMetadata.from(data.metadata),
+			metadata: data.metadata ?? Object.create(null),
 			cells: data.cells.map(typeConverters.NotebookCellData.from),
 		};
 	}
@@ -556,7 +556,7 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 						}
 					},
 					viewType,
-					modelData.metadata ? typeConverters.NotebookDocumentMetadata.to(modelData.metadata) : new extHostTypes.NotebookDocumentMetadata(),
+					modelData.metadata ?? Object.create({}),
 					uri,
 				);
 

--- a/src/vs/workbench/api/common/extHostNotebookDocument.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocument.ts
@@ -45,7 +45,7 @@ export class ExtHostCell {
 	}
 
 	private _outputs: vscode.NotebookCellOutput[];
-	private _metadata: extHostTypes.NotebookCellMetadata;
+	private _metadata: NotebookCellMetadata;
 	private _previousResult: vscode.NotebookCellExecutionSummary | undefined;
 
 	private _internalMetadata: NotebookCellInternalMetadata;
@@ -65,7 +65,7 @@ export class ExtHostCell {
 		this.cellKind = _cellData.cellKind;
 		this._outputs = _cellData.outputs.map(extHostTypeConverters.NotebookCellOutput.to);
 		this._internalMetadata = _cellData.internalMetadata ?? {};
-		this._metadata = extHostTypeConverters.NotebookCellMetadata.to(_cellData.metadata ?? {});
+		this._metadata = _cellData.metadata ?? {};
 		this._previousResult = extHostTypeConverters.NotebookCellExecutionSummary.to(_cellData.internalMetadata ?? {});
 	}
 
@@ -109,7 +109,7 @@ export class ExtHostCell {
 	}
 
 	setMetadata(newMetadata: NotebookCellMetadata): void {
-		this._metadata = extHostTypeConverters.NotebookCellMetadata.to(newMetadata);
+		this._metadata = newMetadata;
 	}
 
 	setInternalMetadata(newInternalMetadata: NotebookCellInternalMetadata): void {
@@ -145,7 +145,7 @@ export class ExtHostNotebookDocument {
 		private readonly _textDocuments: ExtHostDocuments,
 		private readonly _emitter: INotebookEventEmitter,
 		private readonly _notebookType: string,
-		private _metadata: extHostTypes.NotebookDocumentMetadata,
+		private _metadata: Record<string, any>,
 		readonly uri: URI,
 	) { }
 
@@ -194,7 +194,7 @@ export class ExtHostNotebookDocument {
 
 	acceptDocumentPropertiesChanged(data: INotebookDocumentPropertiesChangeData) {
 		if (data.metadata) {
-			this._metadata = this._metadata.with(data.metadata);
+			this._metadata = { ...this._metadata, ...data.metadata };
 		}
 	}
 

--- a/src/vs/workbench/api/common/extHostNotebookEditor.ts
+++ b/src/vs/workbench/api/common/extHostNotebookEditor.ts
@@ -40,7 +40,7 @@ class NotebookEditorCellEditBuilder implements vscode.NotebookEditorEdit {
 		}
 	}
 
-	replaceMetadata(value: vscode.NotebookDocumentMetadata): void {
+	replaceMetadata(value: { [key: string]: any }): void {
 		this._throwIfFinalized();
 		this._collectedEdits.push({
 			editType: CellEditType.DocumentMetadata,
@@ -48,7 +48,7 @@ class NotebookEditorCellEditBuilder implements vscode.NotebookEditorEdit {
 		});
 	}
 
-	replaceCellMetadata(index: number, metadata: vscode.NotebookCellMetadata): void {
+	replaceCellMetadata(index: number, metadata: Record<string, any>): void {
 		this._throwIfFinalized();
 		this._collectedEdits.push({
 			editType: CellEditType.Metadata,

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -9,7 +9,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import * as marked from 'vs/base/common/marked/marked';
 import { parse } from 'vs/base/common/marshalling';
 import { cloneAndChange } from 'vs/base/common/objects';
-import { isDefined, isNumber, isString } from 'vs/base/common/types';
+import { isDefined, isEmptyObject, isNumber, isString } from 'vs/base/common/types';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { RenderLineNumbersType } from 'vs/editor/common/config/editorOptions';
 import { IPosition } from 'vs/editor/common/core/position';
@@ -1415,34 +1415,6 @@ export namespace NotebookRange {
 	}
 }
 
-export namespace NotebookCellMetadata {
-
-	export function to(data: notebooks.NotebookCellMetadata): types.NotebookCellMetadata {
-		return new types.NotebookCellMetadata().with({
-			...data,
-			...{
-				executionOrder: null,
-				lastRunSuccess: null,
-				runState: null,
-				runStartTime: null,
-				runStartTimeAdjustment: null,
-				runEndTime: null
-			}
-		});
-	}
-}
-
-export namespace NotebookDocumentMetadata {
-
-	export function from(data: types.NotebookDocumentMetadata): notebooks.NotebookDocumentMetadata {
-		return data;
-	}
-
-	export function to(data: notebooks.NotebookDocumentMetadata): types.NotebookDocumentMetadata {
-		return new types.NotebookDocumentMetadata().with(data);
-	}
-}
-
 export namespace NotebookCellExecutionSummary {
 	export function to(data: notebooks.NotebookCellInternalMetadata): vscode.NotebookCellExecutionSummary {
 		return {
@@ -1489,7 +1461,7 @@ export namespace NotebookData {
 
 	export function from(data: vscode.NotebookData): notebooks.NotebookDataDto {
 		const res: notebooks.NotebookDataDto = {
-			metadata: NotebookDocumentMetadata.from(data.metadata),
+			metadata: Object.create(null),
 			cells: [],
 		};
 		for (let cell of data.cells) {
@@ -1500,10 +1472,13 @@ export namespace NotebookData {
 	}
 
 	export function to(data: notebooks.NotebookDataDto): vscode.NotebookData {
-		return {
-			metadata: NotebookDocumentMetadata.to(data.metadata),
-			cells: data.cells.map(NotebookCellData.to)
-		};
+		const res = new types.NotebookData(
+			data.cells.map(NotebookCellData.to),
+		);
+		if (!isEmptyObject(data.metadata)) {
+			res.metadata = data.metadata;
+		}
+		return res;
 	}
 }
 
@@ -1526,7 +1501,7 @@ export namespace NotebookCellData {
 			data.source,
 			data.language,
 			data.outputs ? data.outputs.map(NotebookCellOutput.to) : undefined,
-			data.metadata ? NotebookCellMetadata.to(data.metadata) : undefined,
+			data.metadata,
 			data.internalMetadata ? NotebookCellExecutionSummary.to(data.internalMetadata) : undefined
 		);
 	}

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -612,7 +612,7 @@ export interface IFileCellEdit {
 	_type: FileEditType.Cell;
 	uri: URI;
 	edit?: ICellEditOperation;
-	notebookMetadata?: vscode.NotebookDocumentMetadata;
+	notebookMetadata?: Record<string, any>;
 	metadata?: vscode.WorkspaceEditEntryMetadata;
 }
 
@@ -631,7 +631,7 @@ export interface ICellOutputEdit {
 	index: number;
 	append: boolean;
 	newOutputs?: NotebookCellOutput[];
-	newMetadata?: vscode.NotebookCellMetadata;
+	newMetadata?: Record<string, any>;
 	metadata?: vscode.WorkspaceEditEntryMetadata;
 }
 
@@ -674,7 +674,7 @@ export class WorkspaceEdit implements vscode.WorkspaceEdit {
 
 	// --- notebook
 
-	replaceNotebookMetadata(uri: URI, value: vscode.NotebookDocumentMetadata, metadata?: vscode.WorkspaceEditEntryMetadata): void {
+	replaceNotebookMetadata(uri: URI, value: Record<string, any>, metadata?: vscode.WorkspaceEditEntryMetadata): void {
 		this._edits.push({ _type: FileEditType.Cell, metadata, uri, edit: { editType: CellEditType.DocumentMetadata, metadata: value }, notebookMetadata: value });
 	}
 
@@ -707,7 +707,7 @@ export class WorkspaceEdit implements vscode.WorkspaceEdit {
 		}
 	}
 
-	replaceNotebookCellMetadata(uri: URI, index: number, cellMetadata: vscode.NotebookCellMetadata, metadata?: vscode.WorkspaceEditEntryMetadata): void {
+	replaceNotebookCellMetadata(uri: URI, index: number, cellMetadata: Record<string, any>, metadata?: vscode.WorkspaceEditEntryMetadata): void {
 		this._edits.push({ _type: FileEditType.Cell, metadata, uri, edit: { editType: CellEditType.PartialMetadata, index, metadata: cellMetadata } });
 	}
 
@@ -2983,72 +2983,6 @@ export class NotebookRange {
 	}
 }
 
-export class NotebookCellMetadata {
-	readonly inputCollapsed?: boolean;
-	readonly outputCollapsed?: boolean;
-	readonly [key: string]: any;
-
-	constructor(inputCollapsed?: boolean, outputCollapsed?: boolean);
-	constructor(data: Record<string, any>);
-	constructor(inputCollapsedOrData: (boolean | undefined) | Record<string, any>, outputCollapsed?: boolean) {
-		if (typeof inputCollapsedOrData === 'object') {
-			Object.assign(this, inputCollapsedOrData);
-		} else {
-			this.inputCollapsed = inputCollapsedOrData;
-			this.outputCollapsed = outputCollapsed;
-		}
-	}
-
-	with(change: {
-		inputCollapsed?: boolean | null,
-		outputCollapsed?: boolean | null,
-		[key: string]: any
-	}): NotebookCellMetadata {
-
-		let { inputCollapsed, outputCollapsed, ...remaining } = change;
-
-		if (inputCollapsed === undefined) {
-			inputCollapsed = this.inputCollapsed;
-		} else if (inputCollapsed === null) {
-			inputCollapsed = undefined;
-		}
-		if (outputCollapsed === undefined) {
-			outputCollapsed = this.outputCollapsed;
-		} else if (outputCollapsed === null) {
-			outputCollapsed = undefined;
-		}
-
-		if (inputCollapsed === this.inputCollapsed &&
-			outputCollapsed === this.outputCollapsed &&
-			Object.keys(remaining).length === 0
-		) {
-			return this;
-		}
-
-		return new NotebookCellMetadata(
-			{
-				inputCollapsed,
-				outputCollapsed,
-				...remaining
-			}
-		);
-	}
-}
-
-export class NotebookDocumentMetadata {
-	readonly [key: string]: any;
-
-	constructor(data: Record<string, any> = {}) {
-		Object.assign(this, data);
-	}
-
-	with(change: {
-		[key: string]: any
-	}): NotebookDocumentMetadata {
-		return new NotebookDocumentMetadata(change);
-	}
-}
-
 export class NotebookCellData {
 
 	static validate(data: NotebookCellData): void {
@@ -3076,10 +3010,10 @@ export class NotebookCellData {
 	value: string;
 	languageId: string;
 	outputs?: vscode.NotebookCellOutput[];
-	metadata?: NotebookCellMetadata;
+	metadata?: Record<string, any>;
 	executionSummary?: vscode.NotebookCellExecutionSummary;
 
-	constructor(kind: NotebookCellKind, value: string, languageId: string, outputs?: vscode.NotebookCellOutput[], metadata?: NotebookCellMetadata, executionSummary?: vscode.NotebookCellExecutionSummary) {
+	constructor(kind: NotebookCellKind, value: string, languageId: string, outputs?: vscode.NotebookCellOutput[], metadata?: Record<string, any>, executionSummary?: vscode.NotebookCellExecutionSummary) {
 		this.kind = kind;
 		this.value = value;
 		this.languageId = languageId;
@@ -3094,11 +3028,10 @@ export class NotebookCellData {
 export class NotebookData {
 
 	cells: NotebookCellData[];
-	metadata: NotebookDocumentMetadata;
+	metadata?: { [key: string]: any };
 
-	constructor(cells: NotebookCellData[], metadata?: NotebookDocumentMetadata) {
+	constructor(cells: NotebookCellData[]) {
 		this.cells = cells;
-		this.metadata = metadata ?? new NotebookDocumentMetadata();
 	}
 }
 

--- a/src/vs/workbench/test/browser/api/extHostTypes.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostTypes.test.ts
@@ -648,41 +648,6 @@ suite('ExtHostTypes', function () {
 		assert.deepStrictEqual(md.value, '\n```html\n<img src=0 onerror="alert(1)">\n```\n');
 	});
 
-	test('NotebookMetadata - with custom', function () {
-		const obj = new types.NotebookDocumentMetadata();
-		const newObj = obj.with({ mycustom: { display: 'hello' } });
-		assert.ok(obj !== newObj);
-		assert.deepStrictEqual(newObj.mycustom, { display: 'hello' });
-	});
-
-	test('NotebookCellMetadata - with', function () {
-		const obj = new types.NotebookCellMetadata(true, true);
-
-		const newObj = obj.with({ inputCollapsed: false });
-		assert.ok(obj !== newObj);
-		assert.strictEqual(obj.inputCollapsed, true);
-		assert.strictEqual(obj.custom, undefined);
-
-		assert.strictEqual(newObj.inputCollapsed, false);
-		assert.strictEqual(newObj.custom, undefined);
-	});
-
-	test('NotebookCellMetadata - with custom', function () {
-		const obj = new types.NotebookCellMetadata(true, true);
-		const newObj = obj.with({ inputCollapsed: false, custom: { display: 'hello' } });
-		assert.ok(obj !== newObj);
-		const sameObj = newObj.with({ inputCollapsed: false });
-		assert.ok(newObj === sameObj);
-		assert.strictEqual(obj.inputCollapsed, true);
-		assert.strictEqual(newObj.inputCollapsed, false);
-		assert.deepStrictEqual(newObj.custom, { display: 'hello' });
-
-		const newCustom = newObj.with({ anotherCustom: { display: 'hello2' } });
-		assert.strictEqual(newCustom.inputCollapsed, false);
-		assert.deepStrictEqual(newCustom.mycustom, undefined);
-		assert.deepStrictEqual(newCustom.anotherCustom, { display: 'hello2' });
-	});
-
 	test('NotebookCellOutputItem - factories', function () {
 
 		assert.throws(() => {


### PR DESCRIPTION
Use `{ [key:string]: any}` for notebook metadata instead of dedicated types. This is because metadata is merely empty