### PR TITLE
Sets user-select: none to the hover actions so they cannot be selected anymore.

### DIFF
--- a/src/vs/base/browser/ui/hover/hover.css
+++ b/src/vs/base/browser/ui/hover/hover.css
@@ -138,3 +138,8 @@
 	margin-bottom: 4px;
 	display: inline-block;
 }
+
+.monaco-hover-content .action-container a {
+	-webkit-user-select: none;
+	user-select: none;
+}


### PR DESCRIPTION
This fixes feedback that we got for the action items, especially as they intenionally don't disappear when clicking on them.