### PR TITLE
Focuses the editor after showing next/previous inline completion.

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
@@ -259,6 +259,7 @@ export class ShowNextInlineCompletionAction extends EditorAction {
 		const controller = GhostTextController.get(editor);
 		if (controller) {
 			controller.showNextInlineCompletion();
+			editor.focus();
 		}
 	}
 }
@@ -282,6 +283,7 @@ export class ShowPreviousInlineCompletionAction extends EditorAction {
 		const controller = GhostTextController.get(editor);
 		if (controller) {
 			controller.showPreviousInlineCompletion();
+			editor.focus();
 		}
 	}
 }


### PR DESCRIPTION
This fixes feedback from the test plan.