### PR TITLE
Workspace trust - extension enablement

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant.ts
@@ -20,7 +20,7 @@ export class ExtensionEnablementWorkspaceTrustTransitionParticipant extends Disp
 	) {
 		super();
 
-		if (!isWorkspaceTrustEnabled(configurationService)) {
+		if (isWorkspaceTrustEnabled(configurationService)) {
 			const workspaceTrustTransitionParticipant = new class implements IWorkspaceTrustTransitionParticipant {
 				async participate(trusted: boolean): Promise<void> {
 					if (trusted) {

--- a/src/vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant.ts
@@ -21,22 +21,30 @@ export class ExtensionEnablementWorkspaceTrustTransitionParticipant extends Disp
 		super();
 
 		if (isWorkspaceTrustEnabled(configurationService)) {
-			const workspaceTrustTransitionParticipant = new class implements IWorkspaceTrustTransitionParticipant {
-				async participate(trusted: boolean): Promise<void> {
-					if (trusted) {
-						// Untrusted -> Trusted
-						await extensionEnablementService.updateEnablementByWorkspaceTrustRequirement();
-					} else {
-						// Trusted -> Untrusted
-						extensionService.stopExtensionHosts();
-						await extensionEnablementService.updateEnablementByWorkspaceTrustRequirement();
-						extensionService.startExtensionHosts();
+			workspaceTrustManagementService.workspaceTrustInitialized.then(() => {
+				const workspaceTrustTransitionParticipant = new class implements IWorkspaceTrustTransitionParticipant {
+					async participate(trusted: boolean): Promise<void> {
+						if (trusted) {
+							// Untrusted -> Trusted
+							await extensionEnablementService.updateEnablementByWorkspaceTrustRequirement();
+						} else {
+							// Trusted -> Untrusted
+							extensionService.stopExtensionHosts();
+							await extensionEnablementService.updateEnablementByWorkspaceTrustRequirement();
+							extensionService.startExtensionHosts();
+						}
 					}
-				}
-			};
+				};
 
-			// Execute BEFORE the workspace trust transition completes
-			this._register(workspaceTrustManagementService.addWorkspaceTrustTransitionParticipant(workspaceTrustTransitionParticipant));
+				// If the workspace has already transitioned to a trusted state, we will manually run the
+				// workspace trust transition participants as they did not run when the transition happened.
+				if (workspaceTrustManagementService.isWorkpaceTrusted()) {
+					workspaceTrustTransitionParticipant.participate(true);
+				}
+
+				// Execute BEFORE the workspace trust transition completes
+				this._register(workspaceTrustManagementService.addWorkspaceTrustTransitionParticipant(workspaceTrustTransitionParticipant));
+			});
 		}
 	}
 }

--- a/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
@@ -95,7 +95,7 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 		if (this._isDisabledByExtensionKind(extension)) {
 			return EnablementState.DisabledByExtensionKind;
 		}
-		if (this._isEnabled(extension) && this._isDisabledByTrustRequirement(extension)) {
+		if (this._isEnabled(extension) && this._isDisabledByWorkspaceTrust(extension)) {
 			return EnablementState.DisabledByTrustRequirement;
 		}
 		return this._getEnablementState(extension.identifier);
@@ -160,7 +160,7 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 		}
 
 		const result = await Promises.settled(extensions.map(e => {
-			if (this._isDisabledByTrustRequirement(e)) {
+			if (this._isDisabledByWorkspaceTrust(e)) {
 				return this.workspaceTrustRequestService.requestWorkspaceTrust()
 					.then(trustState => {
 						return Promise.resolve(trustState ?? false);
@@ -268,12 +268,16 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 		return false;
 	}
 
-	private _isDisabledByTrustRequirement(extension: IExtension): boolean {
+	isDisabledByWorkspaceTrust(extension: IExtension): boolean {
+		return this.extensionManifestPropertiesService.getExtensionUntrustedWorkspaceSupportType(extension.manifest) === false;
+	}
+
+	private _isDisabledByWorkspaceTrust(extension: IExtension): boolean {
 		if (this.workspaceTrustManagementService.isWorkpaceTrusted()) {
 			return false;
 		}
 
-		return this.extensionManifestPropertiesService.getExtensionUntrustedWorkspaceSupportType(extension.manifest) === false;
+		return this.isDisabledByWorkspaceTrust(extension);
 	}
 
 	private _getEnablementState(identifier: IExtensionIdentifier): EnablementState {
@@ -412,7 +416,7 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 	}
 
 	private _onDidInstallExtension({ local, error }: DidInstallExtensionEvent): void {
-		if (local && !error && this._isDisabledByTrustRequirement(local)) {
+		if (local && !error && this._isDisabledByWorkspaceTrust(local)) {
 			this._onEnablementChanged.fire([local]);
 		}
 	}
@@ -423,15 +427,12 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 		}
 	}
 
-	private async _getExtensionsByWorkspaceTrustRequirement(): Promise<IExtension[]> {
-		const extensions = await this.extensionManagementService.getInstalled();
-		return extensions.filter(e => this.extensionManifestPropertiesService.getExtensionUntrustedWorkspaceSupportType(e.manifest) === false);
-	}
-
 	public async updateEnablementByWorkspaceTrustRequirement(): Promise<void> {
-		const extensions = await this._getExtensionsByWorkspaceTrustRequirement();
-		if (extensions.length) {
-			this._onEnablementChanged.fire(extensions);
+		const installedExtensions = await this.extensionManagementService.getInstalled();
+		const disabledExtensions = installedExtensions.filter(e => this.isDisabledByWorkspaceTrust(e));
+
+		if (disabledExtensions.length) {
+			this._onEnablementChanged.fire(disabledExtensions);
 		}
 	}
 

--- a/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
@@ -429,7 +429,7 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 
 	public async updateEnablementByWorkspaceTrustRequirement(): Promise<void> {
 		const installedExtensions = await this.extensionManagementService.getInstalled();
-		const disabledExtensions = installedExtensions.filter(e => this.isDisabledByWorkspaceTrust(e));
+		const disabledExtensions = installedExtensions.filter(e => this.isEnabled(e) && this.isDisabledByWorkspaceTrust(e));
 
 		if (disabledExtensions.length) {
 			this._onEnablementChanged.fire(disabledExtensions);

--- a/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
@@ -269,7 +269,7 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 	}
 
 	isDisabledByWorkspaceTrust(extension: IExtension): boolean {
-		return this.extensionManifestPropertiesService.getExtensionUntrustedWorkspaceSupportType(extension.manifest) === false;
+		return this._isEnabled(extension) && this.extensionManifestPropertiesService.getExtensionUntrustedWorkspaceSupportType(extension.manifest) === false;
 	}
 
 	private _isDisabledByWorkspaceTrust(extension: IExtension): boolean {

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
@@ -82,7 +82,8 @@ export interface IWorkbenchExtensionEnablementService {
 	isDisabledGlobally(extension: IExtension): boolean;
 
 	/**
-	 * Returns `true` if the given extension identifier is disabled in restricted mode.
+	 * Returns `true` if the given extension identifier is enabled by the user but it it
+	 * disabled due to the fact that the current window/folder/workspace is not trusted.
 	 */
 	isDisabledByWorkspaceTrust(extension: IExtension): boolean;
 

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
@@ -82,6 +82,11 @@ export interface IWorkbenchExtensionEnablementService {
 	isDisabledGlobally(extension: IExtension): boolean;
 
 	/**
+	 * Returns `true` if the given extension identifier is disabled in restricted mode.
+	 */
+	isDisabledByWorkspaceTrust(extension: IExtension): boolean;
+
+	/**
 	 * Enable or disable the given extension.
 	 * if `workspace` is `true` then enablement is done for workspace, otherwise globally.
 	 *

--- a/src/vs/workbench/services/extensions/browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/browser/extensionService.ts
@@ -185,8 +185,8 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 			this._remoteAgentService.getEnvironment(),
 			this._remoteAgentService.scanExtensions()
 		]);
-		localExtensions = this._checkEnabledAndProposedAPI(localExtensions);
-		remoteExtensions = this._checkEnabledAndProposedAPI(remoteExtensions);
+		localExtensions = this._checkEnabledAndProposedAPI(localExtensions, false);
+		remoteExtensions = this._checkEnabledAndProposedAPI(remoteExtensions, false);
 
 		const remoteAgentConnection = this._remoteAgentService.getConnection();
 		this._runningLocation = this._runningLocationClassifier.determineRunningLocation(localExtensions, remoteExtensions);

--- a/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
+++ b/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
@@ -156,11 +156,8 @@ export class WorkspaceTrustManagementService extends Disposable implements IWork
 					// After resolving the remote authority, if the workspace is trusted we need
 					// to execute the workspace trust transition participants and fire the event
 					if (this.calculateWorkspaceTrust()) {
-						// TODO: @lszomoru - remove after CLI flag to disable trust is added
-						if (!this.environmentService.extensionTestsLocationURI) {
-							// Run workspace trust transition participants
-							await this._trustTransitionManager.participate(true);
-						}
+						// Run workspace trust transition participants
+						await this._trustTransitionManager.participate(true);
 
 						// Fire workspace trust change event
 						this._onDidChangeTrust.fire(true);


### PR DESCRIPTION
* Extension servince improvements
* Re-enable workspace trust transition participant that enables extensions
* For remote scenario workspace trust transition happens in two phases 
  * Update trust state when canonical URI providers are available
  * Execute participant(s) and fire changed event after resolve authority