### PR TITLE
Workspace trust - calculate trust before extension host starts

### DIFF
--- a/src/vs/platform/workspace/common/workspaceTrust.ts
+++ b/src/vs/platform/workspace/common/workspaceTrust.ts
@@ -40,6 +40,7 @@ export interface IWorkspaceTrustManagementService {
 	onDidChangeTrust: Event<boolean>;
 	onDidChangeTrustedFolders: Event<void>;
 
+	readonly workspaceResolved: Promise<void>;
 	readonly workspaceTrustInitialized: Promise<void>;
 
 	acceptsOutOfWorkspaceFiles: boolean;

--- a/src/vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant.ts
@@ -21,6 +21,10 @@ export class ExtensionEnablementWorkspaceTrustTransitionParticipant extends Disp
 		super();
 
 		if (isWorkspaceTrustEnabled(configurationService)) {
+			// The extension enablement participant will be registered only after the
+			// workspace trust state has been initialized. There is no need to execute
+			// the participant as part of the initialization process, as the workspace
+			// trust state is initialized before starting the extension host.
 			workspaceTrustManagementService.workspaceTrustInitialized.then(() => {
 				const workspaceTrustTransitionParticipant = new class implements IWorkspaceTrustTransitionParticipant {
 					async participate(trusted: boolean): Promise<void> {
@@ -35,12 +39,6 @@ export class ExtensionEnablementWorkspaceTrustTransitionParticipant extends Disp
 						}
 					}
 				};
-
-				// If the workspace has already transitioned to a trusted state, we will manually run the
-				// workspace trust transition participants as they did not run when the transition happened.
-				if (workspaceTrustManagementService.isWorkpaceTrusted()) {
-					workspaceTrustTransitionParticipant.participate(true);
-				}
 
 				// Execute BEFORE the workspace trust transition completes
 				this._register(workspaceTrustManagementService.addWorkspaceTrustTransitionParticipant(workspaceTrustTransitionParticipant));

--- a/src/vs/workbench/contrib/workspace/browser/workspace.contribution.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspace.contribution.ts
@@ -45,8 +45,6 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IBannerItem, IBannerService } from 'vs/workbench/services/banner/browser/bannerService';
 import { isVirtualWorkspace } from 'vs/platform/remote/common/remoteHosts';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
-import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
-import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 
 const BANNER_RESTRICTED_MODE = 'workbench.banner.restrictedMode';
 const BANNER_VIRTUAL_WORKSPACE = 'workbench.banner.virtualWorkspace';
@@ -79,8 +77,6 @@ export class WorkspaceTrustRequestHandler extends Disposable implements IWorkben
 		@IStatusbarService private readonly statusbarService: IStatusbarService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
-		@IWorkbenchEnvironmentService private readonly workbenchEnvironmentService: IWorkbenchEnvironmentService,
-		@IRemoteAuthorityResolverService private readonly remoteAuthorityResolverService: IRemoteAuthorityResolverService,
 		@IBannerService private readonly bannerService: IBannerService,
 		@IHostService private readonly hostService: IHostService,
 	) {
@@ -91,11 +87,6 @@ export class WorkspaceTrustRequestHandler extends Disposable implements IWorkben
 		(async () => {
 
 			await this.workspaceTrustManagementService.workspaceTrustInitialized;
-
-			// Workaround until isTrusted from resolver is available pre-resolution
-			if (this.workbenchEnvironmentService.remoteAuthority) {
-				await this.remoteAuthorityResolverService.resolveAuthority(this.workbenchEnvironmentService.remoteAuthority);
-			}
 
 			if (isWorkspaceTrustEnabled(configurationService)) {
 				this.registerListeners();

--- a/src/vs/workbench/services/workspaces/test/common/testWorkspaceTrustService.ts
+++ b/src/vs/workbench/services/workspaces/test/common/testWorkspaceTrustService.ts
@@ -71,6 +71,10 @@ export class TestWorkspaceTrustManagementService implements IWorkspaceTrustManag
 		return this.trusted;
 	}
 
+	get workspaceResolved(): Promise<void> {
+		return Promise.resolve();
+	}
+
 	get workspaceTrustInitialized(): Promise<void> {
 		return Promise.resolve();
 	}


### PR DESCRIPTION
* Added a new semaphore - `workspaceResolved` when the workspace has been resolved with canonical URIs
* Ensure that the extension host is started only after the workspace trust has been fully initialised
* Ensure that the extension enablement participant is only registered after workspace trust has been fully initialised