### PR TITLE
Fixes #125303

### DIFF
--- a/src/vs/base/browser/ui/aria/aria.css
+++ b/src/vs/base/browser/ui/aria/aria.css
@@ -6,4 +6,5 @@
 .monaco-aria-container {
 	position: absolute; /* try to hide from window but not from screen readers */
 	left:-999em;
+	top: 0; /* avoid being placed underneath a sibling element */
 }

--- a/src/vs/base/browser/ui/aria/aria.css
+++ b/src/vs/base/browser/ui/aria/aria.css
@@ -6,5 +6,4 @@
 .monaco-aria-container {
 	position: absolute; /* try to hide from window but not from screen readers */
 	left:-999em;
-	top: 0; /* avoid being placed underneath a sibling element */
 }

--- a/src/vs/editor/standalone/browser/standalone-tokens.css
+++ b/src/vs/editor/standalone/browser/standalone-tokens.css
@@ -26,6 +26,7 @@
 /* See https://github.com/microsoft/monaco-editor/issues/2168#issuecomment-780078600 */
 .monaco-aria-container {
 	position: absolute !important;
+	top: 0; /* avoid being placed underneath a sibling element */
 	height: 1px;
 	width: 1px;
 	margin: -1px;


### PR DESCRIPTION
This changes the placement of a div with this class from `top: auto` to `top: 0`, which will avoid placing this div vertically below a sibling div.

This PR fixes #125303
