### PR TITLE
Migrate profile setting and fallback properly

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -46,7 +46,7 @@ import { TypeAheadAddon } from 'vs/workbench/contrib/terminal/browser/terminalTy
 import { BrowserFeatures } from 'vs/base/browser/canIUse';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 import { IEnvironmentVariableInfo } from 'vs/workbench/contrib/terminal/common/environmentVariable';
-import { IProcessDataEvent, IShellLaunchConfig, ITerminalDimensionsOverride, ITerminalLaunchError, TerminalShellType, TerminalSettingId, TitleEventSource, TerminalIcon, TerminalSettingPrefix } from 'vs/platform/terminal/common/terminal';
+import { IProcessDataEvent, IShellLaunchConfig, ITerminalDimensionsOverride, ITerminalLaunchError, TerminalShellType, TerminalSettingId, TitleEventSource, TerminalIcon, TerminalSettingPrefix, ITerminalProfileObject } from 'vs/platform/terminal/common/terminal';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { formatMessageForTerminal } from 'vs/workbench/contrib/terminal/common/terminalStrings';
 import { AutoOpenBarrier } from 'vs/base/common/async';
@@ -373,14 +373,22 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 							const shell = this._configurationService.getValue(TerminalSettingPrefix.Shell + platform);
 							const shellArgs = this._configurationService.getValue(TerminalSettingPrefix.ShellArgs + platform);
 							const profile = await this._terminalProfileResolverService.createProfileFromShellAndShellArgs(shell, shellArgs);
-							if (profile) {
-								this._configurationService.updateValue(TerminalSettingPrefix.DefaultProfile + platform, profile.profileName);
-								this._configurationService.updateValue(TerminalSettingPrefix.Shell + platform, undefined);
-								this._configurationService.updateValue(TerminalSettingPrefix.ShellArgs + platform, undefined);
-								this._logService.trace(`migrated from shell/shellArgs, ${shell} ${shellArgs} to profile ${JSON.stringify(profile)}`);
+							if (typeof profile === 'string') {
+								await this._configurationService.updateValue(TerminalSettingPrefix.DefaultProfile + platform, profile);
+								this._logService.trace(`migrated from shell/shellArgs, using existing profile ${profile}`);
 							} else {
-								this._logService.trace('migration from shell/shellArgs to profile did not occur bc created profile was an exact match for existing one', shell, shellArgs);
+								const profiles = this._configurationService.inspect<{ [key: string]: ITerminalProfileObject }>(TerminalSettingPrefix.Profiles + platform).userValue || {};
+								const profileConfig: ITerminalProfileObject = { path: profile.path };
+								if (profile.args) {
+									profileConfig.args = profile.args;
+								}
+								profiles[profile.profileName] = profileConfig;
+								await this._configurationService.updateValue(TerminalSettingPrefix.Profiles + platform, profiles);
+								await this._configurationService.updateValue(TerminalSettingPrefix.DefaultProfile + platform, profile.profileName);
+								this._logService.trace(`migrated from shell/shellArgs, ${shell} ${shellArgs} to profile ${JSON.stringify(profile)}`);
 							}
+							await this._configurationService.updateValue(TerminalSettingPrefix.Shell + platform, undefined);
+							await this._configurationService.updateValue(TerminalSettingPrefix.ShellArgs + platform, undefined);
 						}
 					} as IPromptChoice,
 				],

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -376,7 +376,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 							if (typeof profile === 'string') {
 								await this._configurationService.updateValue(TerminalSettingPrefix.DefaultProfile + platform, profile);
 								this._logService.trace(`migrated from shell/shellArgs, using existing profile ${profile}`);
-							} else if (profile) {
+							} else {
 								const profiles = this._configurationService.inspect<{ [key: string]: ITerminalProfileObject }>(TerminalSettingPrefix.Profiles + platform).userValue || {};
 								const profileConfig: ITerminalProfileObject = { path: profile.path };
 								if (profile.args) {
@@ -386,9 +386,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 								await this._configurationService.updateValue(TerminalSettingPrefix.Profiles + platform, profiles);
 								await this._configurationService.updateValue(TerminalSettingPrefix.DefaultProfile + platform, profile.profileName);
 								this._logService.trace(`migrated from shell/shellArgs, ${shell} ${shellArgs} to profile ${JSON.stringify(profile)}`);
-							} else {
-								this._logService.trace(`couldn't migrate because profile was undefined`);
-								return;
 							}
 							await this._configurationService.updateValue(TerminalSettingPrefix.Shell + platform, undefined);
 							await this._configurationService.updateValue(TerminalSettingPrefix.ShellArgs + platform, undefined);

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -376,7 +376,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 							if (typeof profile === 'string') {
 								await this._configurationService.updateValue(TerminalSettingPrefix.DefaultProfile + platform, profile);
 								this._logService.trace(`migrated from shell/shellArgs, using existing profile ${profile}`);
-							} else {
+							} else if (profile) {
 								const profiles = this._configurationService.inspect<{ [key: string]: ITerminalProfileObject }>(TerminalSettingPrefix.Profiles + platform).userValue || {};
 								const profileConfig: ITerminalProfileObject = { path: profile.path };
 								if (profile.args) {
@@ -386,6 +386,9 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 								await this._configurationService.updateValue(TerminalSettingPrefix.Profiles + platform, profiles);
 								await this._configurationService.updateValue(TerminalSettingPrefix.DefaultProfile + platform, profile.profileName);
 								this._logService.trace(`migrated from shell/shellArgs, ${shell} ${shellArgs} to profile ${JSON.stringify(profile)}`);
+							} else {
+								this._logService.trace(`couldn't migrate because profile was undefined`);
+								return;
 							}
 							await this._configurationService.updateValue(TerminalSettingPrefix.Shell + platform, undefined);
 							await this._configurationService.updateValue(TerminalSettingPrefix.ShellArgs + platform, undefined);

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -112,7 +112,7 @@ export interface ITerminalProfileResolverService {
 	getDefaultShell(options: IShellLaunchConfigResolveOptions): Promise<string>;
 	getDefaultShellArgs(options: IShellLaunchConfigResolveOptions): Promise<string | string[]>;
 	getEnvironment(remoteAuthority: string | undefined): Promise<IProcessEnvironment>;
-	createProfileFromShellAndShellArgs(shell?: unknown, shellArgs?: unknown): Promise<ITerminalProfile | undefined>;
+	createProfileFromShellAndShellArgs(shell?: unknown, shellArgs?: unknown): Promise<ITerminalProfile | string>;
 }
 
 export interface IShellLaunchConfigResolveOptions {

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1602,7 +1602,7 @@ export class TestTerminalProfileResolverService implements ITerminalProfileResol
 	async getEnvironment(): Promise<IProcessEnvironment> { return process.env; }
 	getSafeConfigValue(key: string, os: OperatingSystem): unknown | undefined { return undefined; }
 	getSafeConfigValueFullKey(key: string): unknown | undefined { return undefined; }
-	createProfileFromShellAndShellArgs(shell?: unknown, shellArgs?: unknown): Promise<ITerminalProfile | undefined> { throw new Error('Method not implemented.'); }
+	createProfileFromShellAndShellArgs(shell?: unknown, shellArgs?: unknown): Promise<string | ITerminalProfile> { throw new Error('Method not implemented.'); }
 }
 
 export class TestLocalTerminalService implements ILocalTerminalService {


### PR DESCRIPTION
Fixes #125177

Tested with:

```json
{
    "terminal.integrated.defaultProfile.osx": "tmux",
    "terminal.integrated.shell.osx": "zsh",
    "terminal.integrated.shellArgs.osx": ["-l"]
}
```

Which migrates to:

```json
{
    "terminal.integrated.defaultProfile.osx": "zsh"
}
```

And

```json
{
    "terminal.integrated.defaultProfile.osx": "tmux",
    "terminal.integrated.shell.osx": "zsh",
    "terminal.integrated.shellArgs.osx": ["-l", "-a"]
}
```

Which migrates to:

```json
{
    "terminal.integrated.defaultProfile.osx": "zsh (migrated)",
    "terminal.integrated.profiles.osx": {
        "zsh (migrated)": {
            "path": "zsh",
            "args": [
                "-l",
                "-a"
            ]
        }
    }
}
```