### PR TITLE
fix: areLanguageDiagnosticSettingsEqual always return true

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/diagnostics.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/diagnostics.ts
@@ -137,7 +137,7 @@ class DiagnosticSettings {
 		const currentSettings = this.get(language);
 		const newSettings = f(currentSettings);
 		this._languageSettings.set(language, newSettings);
-		return areLanguageDiagnosticSettingsEqual(currentSettings, newSettings);
+		return !areLanguageDiagnosticSettingsEqual(currentSettings, newSettings);
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #125364
