### PR TITLE
Fixes drop indicator not shown when dragging a view over panel title

### DIFF
--- a/src/vs/workbench/browser/parts/panel/media/panelpart.css
+++ b/src/vs/workbench/browser/parts/panel/media/panelpart.css
@@ -106,8 +106,8 @@
 	padding-left: 10px;
 	padding-right: 10px;
 	font-size: 11px;
-	padding-bottom: 3px; /* puts the bottom border down */
-	padding-top: 4px;
+	padding-bottom: 1px; /* puts the bottom border down */
+	padding-top: 2px;
 	display: flex;
 }
 
@@ -115,6 +115,7 @@
 .monaco-workbench .part.panel > .composite.title> .panel-switcher-container > .monaco-action-bar .action-item::after {
 	content: '';
 	width: 2px;
+	height: 32px;
 	display: block;
 	background-color: var(--insert-border-color);
 	opacity: 0;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #125437
