### PR TITLE
Make sure we layout editors in sideBySideEditor after they are created

### DIFF
--- a/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
@@ -219,6 +219,8 @@ export class SideBySideEditor extends EditorPane {
 			this.secondaryEditorPane.setInput(secondaryInput, undefined, context, token),
 			this.primaryEditorPane.setInput(primaryInput, options, context, token)]
 		);
+
+		this.layout(this.dimension);
 	}
 
 	override updateStyles(): void {


### PR DESCRIPTION
Fixes #125202

This make sure we always invoke `layout` when a new editor is created in a split view. Due to the caching added in 0449a18b7bb1d8b3cf7138df63e03126ba47c21d, the `WebviewEditor` created by the split view never had `layout` called on it

Not sure if this is best fix for this issue. If not, I suggest we revert 0449a18b7bb1d8b3cf7138df63e03126ba47c21d and then revisit it next iteration
