### PR TITLE
Pass profiles, defaultProfile, isWorkspaceTrusted from renderer to shared process

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,23 +53,6 @@
 	"emmet.excludeLanguages": [],
 	"typescript.preferences.importModuleSpecifier": "non-relative",
 	"typescript.preferences.quoteStyle": "single",
-	"terminal.integrated.profiles.windows": {
-		"PowerShell": {
-			"source": "PowerShell",
-			"icon": "terminal-powershell"
-		},
-		"Command Prompt workspace": {
-			"path": [
-				"${env:windir}\\Sysnative\\cmd.exe",
-				"${env:windir}\\System32\\cmd.exe"
-			],
-			"args": [],
-			"icon": "terminal-cmd"
-		},
-		"Git Bash": {
-			"source": "Git Bash"
-		}
-	},
 	"json.schemas": [
 		{
 			"fileMatch": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,6 +53,23 @@
 	"emmet.excludeLanguages": [],
 	"typescript.preferences.importModuleSpecifier": "non-relative",
 	"typescript.preferences.quoteStyle": "single",
+	"terminal.integrated.profiles.windows": {
+		"PowerShell": {
+			"source": "PowerShell",
+			"icon": "terminal-powershell"
+		},
+		"Command Prompt workspace": {
+			"path": [
+				"${env:windir}\\Sysnative\\cmd.exe",
+				"${env:windir}\\System32\\cmd.exe"
+			],
+			"args": [],
+			"icon": "terminal-cmd"
+		},
+		"Git Bash": {
+			"source": "Git Bash"
+		}
+	},
 	"json.schemas": [
 		{
 			"fileMatch": [

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -184,7 +184,7 @@ export interface IOffProcessTerminalService {
 	attachToProcess(id: number): Promise<ITerminalChildProcess | undefined>;
 	listProcesses(): Promise<IProcessDetails[]>;
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string>;
-	getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
+	getProfiles(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getWslPath(original: string): Promise<string>;
 	getEnvironment(): Promise<IProcessEnvironment>;
 	getShellEnvironment(): Promise<IProcessEnvironment | undefined>;
@@ -258,7 +258,7 @@ export interface IPtyService {
 	updateTitle(id: number, title: string, titleSource: TitleEventSource): Promise<void>;
 	updateIcon(id: number, icon: TerminalIcon, color?: string): Promise<void>;
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string>;
-	getProfiles?(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
+	getProfiles?(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getEnvironment(): Promise<IProcessEnvironment>;
 	getWslPath(original: string): Promise<string>;
 	setTerminalLayoutInfo(args: ISetTerminalLayoutInfoArgs): Promise<void>;

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -184,7 +184,7 @@ export interface IOffProcessTerminalService {
 	attachToProcess(id: number): Promise<ITerminalChildProcess | undefined>;
 	listProcesses(): Promise<IProcessDetails[]>;
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string>;
-	getProfiles(includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
+	getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getWslPath(original: string): Promise<string>;
 	getEnvironment(): Promise<IProcessEnvironment>;
 	getShellEnvironment(): Promise<IProcessEnvironment | undefined>;
@@ -258,7 +258,7 @@ export interface IPtyService {
 	updateTitle(id: number, title: string, titleSource: TitleEventSource): Promise<void>;
 	updateIcon(id: number, icon: TerminalIcon, color?: string): Promise<void>;
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string>;
-	getProfiles?(includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
+	getProfiles?(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getEnvironment(): Promise<IProcessEnvironment>;
 	getWslPath(original: string): Promise<string>;
 	setTerminalLayoutInfo(args: ISetTerminalLayoutInfoArgs): Promise<void>;

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -184,7 +184,7 @@ export interface IOffProcessTerminalService {
 	attachToProcess(id: number): Promise<ITerminalChildProcess | undefined>;
 	listProcesses(): Promise<IProcessDetails[]>;
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string>;
-	getProfiles(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
+	getProfiles(profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getWslPath(original: string): Promise<string>;
 	getEnvironment(): Promise<IProcessEnvironment>;
 	getShellEnvironment(): Promise<IProcessEnvironment | undefined>;
@@ -258,7 +258,7 @@ export interface IPtyService {
 	updateTitle(id: number, title: string, titleSource: TitleEventSource): Promise<void>;
 	updateIcon(id: number, icon: TerminalIcon, color?: string): Promise<void>;
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string>;
-	getProfiles?(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
+	getProfiles?(profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getEnvironment(): Promise<IProcessEnvironment>;
 	getWslPath(original: string): Promise<string>;
 	setTerminalLayoutInfo(args: ISetTerminalLayoutInfoArgs): Promise<void>;

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -222,8 +222,8 @@ export class PtyHostService extends Disposable implements IPtyService {
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string> {
 		return this._proxy.getDefaultSystemShell(osOverride);
 	}
-	async getProfiles(includeDetectedProfiles: boolean = false): Promise<ITerminalProfile[]> {
-		return detectAvailableProfiles(includeDetectedProfiles, this._configurationService, undefined, this._logService, this._resolveVariables.bind(this));
+	async getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles: boolean = false): Promise<ITerminalProfile[]> {
+		return detectAvailableProfiles(isWorkspaceTrusted, includeDetectedProfiles, this._configurationService, undefined, this._logService, this._resolveVariables.bind(this));
 	}
 	getEnvironment(): Promise<IProcessEnvironment> {
 		return this._proxy.getEnvironment();

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -222,8 +222,8 @@ export class PtyHostService extends Disposable implements IPtyService {
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string> {
 		return this._proxy.getDefaultSystemShell(osOverride);
 	}
-	async getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles: boolean = false): Promise<ITerminalProfile[]> {
-		return detectAvailableProfiles(isWorkspaceTrusted, includeDetectedProfiles, this._configurationService, undefined, this._logService, this._resolveVariables.bind(this));
+	async getProfiles(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles: boolean = false): Promise<ITerminalProfile[]> {
+		return detectAvailableProfiles(isWorkspaceTrusted, profiles, defaultProfile, includeDetectedProfiles, this._configurationService, undefined, this._logService, this._resolveVariables.bind(this));
 	}
 	getEnvironment(): Promise<IProcessEnvironment> {
 		return this._proxy.getEnvironment();

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -222,8 +222,8 @@ export class PtyHostService extends Disposable implements IPtyService {
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string> {
 		return this._proxy.getDefaultSystemShell(osOverride);
 	}
-	async getProfiles(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles: boolean = false): Promise<ITerminalProfile[]> {
-		return detectAvailableProfiles(isWorkspaceTrusted, profiles, defaultProfile, includeDetectedProfiles, this._configurationService, undefined, this._logService, this._resolveVariables.bind(this));
+	async getProfiles(profiles: unknown, defaultProfile: unknown, includeDetectedProfiles: boolean = false): Promise<ITerminalProfile[]> {
+		return detectAvailableProfiles(profiles, defaultProfile, includeDetectedProfiles, this._configurationService, undefined, this._logService, this._resolveVariables.bind(this));
 	}
 	getEnvironment(): Promise<IProcessEnvironment> {
 		return this._proxy.getEnvironment();

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalService.ts
@@ -226,8 +226,8 @@ export class RemoteTerminalService extends Disposable implements IRemoteTerminal
 		return this._remoteTerminalChannel?.getDefaultSystemShell(osOverride) || '';
 	}
 
-	async getProfiles(includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
-		return this._remoteTerminalChannel?.getProfiles(includeDetectedProfiles) || [];
+	async getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
+		return this._remoteTerminalChannel?.getProfiles(isWorkspaceTrusted, includeDetectedProfiles) || [];
 	}
 
 	async getEnvironment(): Promise<IProcessEnvironment> {

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalService.ts
@@ -226,8 +226,8 @@ export class RemoteTerminalService extends Disposable implements IRemoteTerminal
 		return this._remoteTerminalChannel?.getDefaultSystemShell(osOverride) || '';
 	}
 
-	async getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
-		return this._remoteTerminalChannel?.getProfiles(isWorkspaceTrusted, includeDetectedProfiles) || [];
+	async getProfiles(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
+		return this._remoteTerminalChannel?.getProfiles(isWorkspaceTrusted, profiles, defaultProfile, includeDetectedProfiles) || [];
 	}
 
 	async getEnvironment(): Promise<IProcessEnvironment> {

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalService.ts
@@ -226,8 +226,8 @@ export class RemoteTerminalService extends Disposable implements IRemoteTerminal
 		return this._remoteTerminalChannel?.getDefaultSystemShell(osOverride) || '';
 	}
 
-	async getProfiles(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
-		return this._remoteTerminalChannel?.getProfiles(isWorkspaceTrusted, profiles, defaultProfile, includeDetectedProfiles) || [];
+	async getProfiles(profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
+		return this._remoteTerminalChannel?.getProfiles(profiles, defaultProfile, includeDetectedProfiles) || [];
 	}
 
 	async getEnvironment(): Promise<IProcessEnvironment> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -43,6 +43,7 @@ import { Orientation } from 'vs/base/browser/ui/sash/sash';
 import { registerTerminalDefaultProfileConfiguration } from 'vs/platform/terminal/common/terminalPlatformConfiguration';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 
 export class TerminalService implements ITerminalService {
 	declare _serviceBrand: undefined;
@@ -151,6 +152,7 @@ export class TerminalService implements ITerminalService {
 		@ICommandService private readonly _commandService: ICommandService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@INotificationService private readonly _notificationService: INotificationService,
+		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@optional(ILocalTerminalService) localTerminalService: ILocalTerminalService
 	) {
 		this._localTerminalService = localTerminalService;
@@ -380,7 +382,7 @@ export class TerminalService implements ITerminalService {
 		if (!offProcService) {
 			return this._availableProfiles || [];
 		}
-		return offProcService?.getProfiles(includeDetectedProfiles);
+		return offProcService?.getProfiles(this._workspaceTrustManagementService.isWorkpaceTrusted(), includeDetectedProfiles);
 	}
 
 	private _onBeforeShutdown(reason: ShutdownReason): boolean | Promise<boolean> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -43,7 +43,6 @@ import { Orientation } from 'vs/base/browser/ui/sash/sash';
 import { registerTerminalDefaultProfileConfiguration } from 'vs/platform/terminal/common/terminalPlatformConfiguration';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { INotificationService } from 'vs/platform/notification/common/notification';
-import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 
 export class TerminalService implements ITerminalService {
 	declare _serviceBrand: undefined;
@@ -152,7 +151,6 @@ export class TerminalService implements ITerminalService {
 		@ICommandService private readonly _commandService: ICommandService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@INotificationService private readonly _notificationService: INotificationService,
-		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@optional(ILocalTerminalService) localTerminalService: ILocalTerminalService
 	) {
 		this._localTerminalService = localTerminalService;
@@ -383,7 +381,7 @@ export class TerminalService implements ITerminalService {
 			return this._availableProfiles || [];
 		}
 		const platform = await this._getPlatformKey();
-		return offProcService?.getProfiles(this._workspaceTrustManagementService.isWorkpaceTrusted(), this._configurationService.getValue(`${TerminalSettingPrefix.Profiles}${platform}`), this._configurationService.getValue(`${TerminalSettingPrefix.DefaultProfile}${platform}`), includeDetectedProfiles);
+		return offProcService?.getProfiles(this._configurationService.getValue(`${TerminalSettingPrefix.Profiles}${platform}`), this._configurationService.getValue(`${TerminalSettingPrefix.DefaultProfile}${platform}`), includeDetectedProfiles);
 	}
 
 	private _onBeforeShutdown(reason: ShutdownReason): boolean | Promise<boolean> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -382,7 +382,8 @@ export class TerminalService implements ITerminalService {
 		if (!offProcService) {
 			return this._availableProfiles || [];
 		}
-		return offProcService?.getProfiles(this._workspaceTrustManagementService.isWorkpaceTrusted(), includeDetectedProfiles);
+		const platform = await this._getPlatformKey();
+		return offProcService?.getProfiles(this._workspaceTrustManagementService.isWorkpaceTrusted(), this._configurationService.getValue(`${TerminalSettingPrefix.Profiles}${platform}`), this._configurationService.getValue(`${TerminalSettingPrefix.DefaultProfile}${platform}`), includeDetectedProfiles);
 	}
 
 	private _onBeforeShutdown(reason: ShutdownReason): boolean | Promise<boolean> {

--- a/src/vs/workbench/contrib/terminal/common/remoteTerminalChannel.ts
+++ b/src/vs/workbench/contrib/terminal/common/remoteTerminalChannel.ts
@@ -238,8 +238,8 @@ export class RemoteTerminalChannelClient {
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string> {
 		return this._channel.call('$getDefaultSystemShell', [osOverride]);
 	}
-	getProfiles(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
-		return this._channel.call('$getProfiles', [isWorkspaceTrusted, profiles, defaultProfile, includeDetectedProfiles]);
+	getProfiles(profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
+		return this._channel.call('$getProfiles', [profiles, defaultProfile, includeDetectedProfiles]);
 	}
 	acceptPtyHostResolvedVariables(id: number, resolved: string[]) {
 		return this._channel.call('$acceptPtyHostResolvedVariables', [id, resolved]);

--- a/src/vs/workbench/contrib/terminal/common/remoteTerminalChannel.ts
+++ b/src/vs/workbench/contrib/terminal/common/remoteTerminalChannel.ts
@@ -238,8 +238,8 @@ export class RemoteTerminalChannelClient {
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string> {
 		return this._channel.call('$getDefaultSystemShell', [osOverride]);
 	}
-	getProfiles(includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
-		return this._channel.call('$getProfiles', [includeDetectedProfiles]);
+	getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
+		return this._channel.call('$getProfiles', [isWorkspaceTrusted, includeDetectedProfiles]);
 	}
 	acceptPtyHostResolvedVariables(id: number, resolved: string[]) {
 		return this._channel.call('$acceptPtyHostResolvedVariables', [id, resolved]);

--- a/src/vs/workbench/contrib/terminal/common/remoteTerminalChannel.ts
+++ b/src/vs/workbench/contrib/terminal/common/remoteTerminalChannel.ts
@@ -238,8 +238,8 @@ export class RemoteTerminalChannelClient {
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string> {
 		return this._channel.call('$getDefaultSystemShell', [osOverride]);
 	}
-	getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
-		return this._channel.call('$getProfiles', [isWorkspaceTrusted, includeDetectedProfiles]);
+	getProfiles(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
+		return this._channel.call('$getProfiles', [isWorkspaceTrusted, profiles, defaultProfile, includeDetectedProfiles]);
 	}
 	acceptPtyHostResolvedVariables(id: number, resolved: string[]) {
 		return this._channel.call('$acceptPtyHostResolvedVariables', [id, resolved]);

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalService.ts
@@ -155,8 +155,8 @@ export class LocalTerminalService extends Disposable implements ILocalTerminalSe
 		return this._localPtyService.getDefaultSystemShell(osOverride);
 	}
 
-	async getProfiles(includeDetectedProfiles?: boolean) {
-		return this._localPtyService.getProfiles?.(includeDetectedProfiles) || [];
+	async getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean) {
+		return this._localPtyService.getProfiles?.(isWorkspaceTrusted, includeDetectedProfiles) || [];
 	}
 
 	async getEnvironment(): Promise<IProcessEnvironment> {

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalService.ts
@@ -155,8 +155,8 @@ export class LocalTerminalService extends Disposable implements ILocalTerminalSe
 		return this._localPtyService.getDefaultSystemShell(osOverride);
 	}
 
-	async getProfiles(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean) {
-		return this._localPtyService.getProfiles?.(isWorkspaceTrusted, profiles, defaultProfile, includeDetectedProfiles) || [];
+	async getProfiles(profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean) {
+		return this._localPtyService.getProfiles?.(profiles, defaultProfile, includeDetectedProfiles) || [];
 	}
 
 	async getEnvironment(): Promise<IProcessEnvironment> {

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalService.ts
@@ -155,8 +155,8 @@ export class LocalTerminalService extends Disposable implements ILocalTerminalSe
 		return this._localPtyService.getDefaultSystemShell(osOverride);
 	}
 
-	async getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean) {
-		return this._localPtyService.getProfiles?.(isWorkspaceTrusted, includeDetectedProfiles) || [];
+	async getProfiles(isWorkspaceTrusted: boolean, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean) {
+		return this._localPtyService.getProfiles?.(isWorkspaceTrusted, profiles, defaultProfile, includeDetectedProfiles) || [];
 	}
 
 	async getEnvironment(): Promise<IProcessEnvironment> {

--- a/src/vs/workbench/contrib/terminal/test/node/terminalProfiles.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/node/terminalProfiles.test.ts
@@ -45,7 +45,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [
 					{ profileName: 'Git Bash', path: 'C:\\Program Files\\Git\\bin\\bash.exe', args: ['--login'], isDefault: true }
 				];
@@ -66,7 +66,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [
 					{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', overrideName: true, args: ['-NoProfile'], isDefault: true }
 				];
@@ -87,7 +87,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [{ profileName: 'Git Bash', path: 'C:\\Program Files\\Git\\bin\\bash.exe', args: [], isAutoDetected: undefined, overrideName: undefined, isDefault: true }];
 				profilesEqual(profiles, expected);
 			});
@@ -110,7 +110,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					const expected = [
 						{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', isDefault: true }
 					];
@@ -124,7 +124,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					const expected = [
 						{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', isDefault: true }
 					];
@@ -136,7 +136,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					strictEqual(profiles.length, 1);
 					strictEqual(profiles[0].profileName, 'PowerShell');
 				});
@@ -181,7 +181,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell3'
 				]);
 				const configurationService = new TestConfigurationService({ terminal: { integrated: absoluteConfig } });
-				const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: '/bin/fakeshell1', isDefault: true },
 					{ profileName: 'fakeshell3', path: '/bin/fakeshell3', isDefault: true }
@@ -194,7 +194,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell3'
 				], '/bin/fakeshell1\n/bin/fakeshell3');
 				const configurationService = new TestConfigurationService({ terminal: { integrated: onPathConfig } });
-				const profiles = await detectAvailableProfiles(true, undefined, undefined, true, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(false, undefined, undefined, true, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: 'fakeshell1', isDefault: true },
 					{ profileName: 'fakeshell3', path: 'fakeshell3', isDefault: true }
@@ -207,7 +207,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell1'
 				], '/bin/fakeshell1\n/bin/fakeshell3');
 				const configurationService = new TestConfigurationService({ terminal: { integrated: onPathConfig } });
-				const profiles = await detectAvailableProfiles(true, undefined, undefined, true, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(false, undefined, undefined, true, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: 'fakeshell1', isDefault: true }
 				];

--- a/src/vs/workbench/contrib/terminal/test/node/terminalProfiles.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/node/terminalProfiles.test.ts
@@ -45,7 +45,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [
 					{ profileName: 'Git Bash', path: 'C:\\Program Files\\Git\\bin\\bash.exe', args: ['--login'], isDefault: true }
 				];
@@ -66,7 +66,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [
 					{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', overrideName: true, args: ['-NoProfile'], isDefault: true }
 				];
@@ -87,7 +87,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [{ profileName: 'Git Bash', path: 'C:\\Program Files\\Git\\bin\\bash.exe', args: [], isAutoDetected: undefined, overrideName: undefined, isDefault: true }];
 				profilesEqual(profiles, expected);
 			});
@@ -110,7 +110,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(true, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					const expected = [
 						{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', isDefault: true }
 					];
@@ -124,7 +124,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(true, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					const expected = [
 						{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', isDefault: true }
 					];
@@ -136,7 +136,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(true, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					strictEqual(profiles.length, 1);
 					strictEqual(profiles[0].profileName, 'PowerShell');
 				});
@@ -181,7 +181,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell3'
 				]);
 				const configurationService = new TestConfigurationService({ terminal: { integrated: absoluteConfig } });
-				const profiles = await detectAvailableProfiles(false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: '/bin/fakeshell1', isDefault: true },
 					{ profileName: 'fakeshell3', path: '/bin/fakeshell3', isDefault: true }
@@ -194,7 +194,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell3'
 				], '/bin/fakeshell1\n/bin/fakeshell3');
 				const configurationService = new TestConfigurationService({ terminal: { integrated: onPathConfig } });
-				const profiles = await detectAvailableProfiles(true, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, true, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: 'fakeshell1', isDefault: true },
 					{ profileName: 'fakeshell3', path: 'fakeshell3', isDefault: true }
@@ -207,7 +207,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell1'
 				], '/bin/fakeshell1\n/bin/fakeshell3');
 				const configurationService = new TestConfigurationService({ terminal: { integrated: onPathConfig } });
-				const profiles = await detectAvailableProfiles(true, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, true, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: 'fakeshell1', isDefault: true }
 				];

--- a/src/vs/workbench/contrib/terminal/test/node/terminalProfiles.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/node/terminalProfiles.test.ts
@@ -45,7 +45,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [
 					{ profileName: 'Git Bash', path: 'C:\\Program Files\\Git\\bin\\bash.exe', args: ['--login'], isDefault: true }
 				];
@@ -66,7 +66,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [
 					{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', overrideName: true, args: ['-NoProfile'], isDefault: true }
 				];
@@ -87,7 +87,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [{ profileName: 'Git Bash', path: 'C:\\Program Files\\Git\\bin\\bash.exe', args: [], isAutoDetected: undefined, overrideName: undefined, isDefault: true }];
 				profilesEqual(profiles, expected);
 			});
@@ -110,7 +110,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					const expected = [
 						{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', isDefault: true }
 					];
@@ -124,7 +124,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					const expected = [
 						{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', isDefault: true }
 					];
@@ -136,7 +136,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					strictEqual(profiles.length, 1);
 					strictEqual(profiles[0].profileName, 'PowerShell');
 				});
@@ -181,7 +181,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell3'
 				]);
 				const configurationService = new TestConfigurationService({ terminal: { integrated: absoluteConfig } });
-				const profiles = await detectAvailableProfiles(false, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: '/bin/fakeshell1', isDefault: true },
 					{ profileName: 'fakeshell3', path: '/bin/fakeshell3', isDefault: true }
@@ -194,7 +194,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell3'
 				], '/bin/fakeshell1\n/bin/fakeshell3');
 				const configurationService = new TestConfigurationService({ terminal: { integrated: onPathConfig } });
-				const profiles = await detectAvailableProfiles(false, undefined, undefined, true, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(undefined, undefined, true, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: 'fakeshell1', isDefault: true },
 					{ profileName: 'fakeshell3', path: 'fakeshell3', isDefault: true }
@@ -207,7 +207,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell1'
 				], '/bin/fakeshell1\n/bin/fakeshell3');
 				const configurationService = new TestConfigurationService({ terminal: { integrated: onPathConfig } });
-				const profiles = await detectAvailableProfiles(false, undefined, undefined, true, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(undefined, undefined, true, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: 'fakeshell1', isDefault: true }
 				];

--- a/src/vs/workbench/contrib/terminal/test/node/terminalProfiles.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/node/terminalProfiles.test.ts
@@ -45,7 +45,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(true, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [
 					{ profileName: 'Git Bash', path: 'C:\\Program Files\\Git\\bin\\bash.exe', args: ['--login'], isDefault: true }
 				];
@@ -66,7 +66,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(true, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [
 					{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', overrideName: true, args: ['-NoProfile'], isDefault: true }
 				];
@@ -87,7 +87,7 @@ suite('Workbench - TerminalProfiles', () => {
 					useWslProfiles: false
 				};
 				const configurationService = new TestConfigurationService({ terminal: { integrated: config } });
-				const profiles = await detectAvailableProfiles(true, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected = [{ profileName: 'Git Bash', path: 'C:\\Program Files\\Git\\bin\\bash.exe', args: [], isAutoDetected: undefined, overrideName: undefined, isDefault: true }];
 				profilesEqual(profiles, expected);
 			});
@@ -110,7 +110,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(true, false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					const expected = [
 						{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', isDefault: true }
 					];
@@ -124,7 +124,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(true, false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					const expected = [
 						{ profileName: 'PowerShell', path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe', isDefault: true }
 					];
@@ -136,7 +136,7 @@ suite('Workbench - TerminalProfiles', () => {
 						'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 					];
 					const configurationService = new TestConfigurationService({ terminal: { integrated: pwshSourceConfig } });
-					const profiles = await detectAvailableProfiles(true, false, configurationService, undefined, undefined, undefined, expectedPaths);
+					const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, undefined, undefined, undefined, expectedPaths);
 					strictEqual(profiles.length, 1);
 					strictEqual(profiles[0].profileName, 'PowerShell');
 				});
@@ -181,7 +181,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell3'
 				]);
 				const configurationService = new TestConfigurationService({ terminal: { integrated: absoluteConfig } });
-				const profiles = await detectAvailableProfiles(true, false, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, undefined, undefined, false, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: '/bin/fakeshell1', isDefault: true },
 					{ profileName: 'fakeshell3', path: '/bin/fakeshell3', isDefault: true }
@@ -194,7 +194,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell3'
 				], '/bin/fakeshell1\n/bin/fakeshell3');
 				const configurationService = new TestConfigurationService({ terminal: { integrated: onPathConfig } });
-				const profiles = await detectAvailableProfiles(true, true, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, undefined, undefined, true, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: 'fakeshell1', isDefault: true },
 					{ profileName: 'fakeshell3', path: 'fakeshell3', isDefault: true }
@@ -207,7 +207,7 @@ suite('Workbench - TerminalProfiles', () => {
 					'/bin/fakeshell1'
 				], '/bin/fakeshell1\n/bin/fakeshell3');
 				const configurationService = new TestConfigurationService({ terminal: { integrated: onPathConfig } });
-				const profiles = await detectAvailableProfiles(true, true, configurationService, fsProvider, undefined, undefined, undefined);
+				const profiles = await detectAvailableProfiles(true, undefined, undefined, true, configurationService, fsProvider, undefined, undefined, undefined);
 				const expected: ITerminalProfile[] = [
 					{ profileName: 'fakeshell1', path: 'fakeshell1', isDefault: true }
 				];

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1619,7 +1619,7 @@ export class TestLocalTerminalService implements ILocalTerminalService {
 	async attachToProcess(id: number): Promise<ITerminalChildProcess | undefined> { throw new Error('Method not implemented.'); }
 	async listProcesses(): Promise<IProcessDetails[]> { throw new Error('Method not implemented.'); }
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string> { throw new Error('Method not implemented.'); }
-	getProfiles(includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> { throw new Error('Method not implemented.'); }
+	getProfiles(isWorkspaceTrusted: boolean, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> { throw new Error('Method not implemented.'); }
 	getEnvironment(): Promise<IProcessEnvironment> { throw new Error('Method not implemented.'); }
 	getShellEnvironment(): Promise<IProcessEnvironment | undefined> { throw new Error('Method not implemented.'); }
 	getWslPath(original: string): Promise<string> { throw new Error('Method not implemented.'); }


### PR DESCRIPTION
This PR fixes #125440
