### PR TITLE
Skip logging for high-frequency keybinding commands

### DIFF
--- a/src/vs/platform/keybinding/common/abstractKeybindingService.ts
+++ b/src/vs/platform/keybinding/common/abstractKeybindingService.ts
@@ -24,6 +24,9 @@ interface CurrentChord {
 	label: string | null;
 }
 
+// Skip logging for high-frequency text editing commands
+const HIGH_FREQ_COMMANDS = /^(cursor|delete)/;
+
 export abstract class AbstractKeybindingService extends Disposable implements IKeybindingService {
 	public _serviceBrand: undefined;
 
@@ -263,7 +266,9 @@ export abstract class AbstractKeybindingService extends Disposable implements IK
 			} else {
 				this._commandService.executeCommand(resolveResult.commandId, resolveResult.commandArgs).then(undefined, err => this._notificationService.warn(err));
 			}
-			this._telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: resolveResult.commandId, from: 'keybinding' });
+			if (!HIGH_FREQ_COMMANDS.test(resolveResult.commandId)) {
+				this._telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: resolveResult.commandId, from: 'keybinding' });
+			}
 		}
 
 		return shouldPreventDefault;


### PR DESCRIPTION
Reduces telemetry data load.