### PR TITLE
Workspace trust - empty workspace should not transition to restricted mode

### DIFF
--- a/src/vs/workbench/contrib/workspace/browser/workspace.contribution.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspace.contribution.ts
@@ -442,7 +442,9 @@ export class WorkspaceTrustUXHandler extends Disposable implements IWorkbenchCon
 			}));
 			// TODO: Consider moving the check into setWorkspaceTrust()
 			if (this.workspaceTrustManagementService.canSetWorkspaceTrust()) {
-				this.workspaceTrustManagementService.setWorkspaceTrust(this.configurationService.getValue<boolean>(WORKSPACE_TRUST_EMPTY_WINDOW) ?? false);
+				if (this.configurationService.getValue<boolean>(WORKSPACE_TRUST_EMPTY_WINDOW)) {
+					this.workspaceTrustManagementService.setWorkspaceTrust(true);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes #125569
