### PR TITLE
Reduces flickering of inline completions & fixes context key.

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
@@ -159,6 +159,9 @@ export class ActiveGhostTextController extends Disposable {
 
 		this._register(this.suggestWidgetAdapterModel.onDidChange(() => {
 			this.updateModel();
+			// When the suggest widget becomes inactive and an inline completion
+			// becomes visible, we need to update the context keys.
+			this.updateContextKeys();
 		}));
 		this.updateModel();
 

--- a/src/vs/editor/contrib/inlineCompletions/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/inlineCompletionsModel.ts
@@ -294,6 +294,9 @@ class InlineCompletionsSession extends BaseGhostTextWidgetModel {
 	}
 
 	public scheduleAutomaticUpdate(): void {
+		// Since updateSoon debounces, starvation can happen.
+		// To prevent stale cache, we clear the current update operation.
+		this.updateOperation.clear();
 		this.updateSoon.schedule();
 	}
 
@@ -366,6 +369,8 @@ class InlineCompletionsSession extends BaseGhostTextWidgetModel {
 					cache?.dispose();
 				})
 				.then(undefined, onUnexpectedExternalError);
+		} else {
+			cache?.dispose();
 		}
 
 		this.onDidChangeEmitter.fire();
@@ -475,15 +480,21 @@ export function inlineCompletionToGhostText(inlineCompletion: NormalizedInlineCo
 	// "\t\tfoo" -> "\t\t\tfoobar" (+"\t", +"bar")
 	// "\t\tfoo" -> "\tfoobar" (-"\t", +"\bar")
 
+	const firstNonWsCol = textModel.getLineFirstNonWhitespaceColumn(inlineCompletion.range.startLineNumber);
+
 	if (inlineCompletion.text.startsWith(valueToBeReplaced)) {
 		remainingInsertText = inlineCompletion.text.substr(valueToBeReplaced.length);
-	} else {
+	} else if (firstNonWsCol === 0 || inlineCompletion.range.startColumn < firstNonWsCol) {
+		// Only allow ignoring leading whitespace in indentation.
+		// This prevents flickering when the user types whitespace that extends an empty range.
 		const valueToBeReplacedTrimmed = leftTrim(valueToBeReplaced);
 		const insertTextTrimmed = leftTrim(inlineCompletion.text);
 		if (!insertTextTrimmed.startsWith(valueToBeReplacedTrimmed)) {
 			return undefined;
 		}
 		remainingInsertText = insertTextTrimmed.substr(valueToBeReplacedTrimmed.length);
+	} else {
+		return undefined;
 	}
 
 	const position = inlineCompletion.range.getEndPosition();

--- a/src/vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { RunOnceScheduler } from 'vs/base/common/async';
 import { Event } from 'vs/base/common/event';
 import { toDisposable } from 'vs/base/common/lifecycle';
 import { IActiveCodeEditor } from 'vs/editor/browser/editorBrowser';
@@ -20,10 +21,21 @@ import { ISelectedSuggestion } from 'vs/editor/contrib/suggest/suggestWidget';
 export class SuggestWidgetAdapterModel extends BaseGhostTextWidgetModel {
 	private isSuggestWidgetVisible: boolean = false;
 	private currentGhostText: GhostText | undefined = undefined;
+	private _isActive: boolean = false;
 
 	public override minReservedLineCount: number = 0;
 
-	public get isActive() { return this.isSuggestWidgetVisible; }
+	public get isActive() { return this._isActive; }
+
+	// This delay fixes an suggest widget issue when typing "." immediately restarts the suggestion session.
+	private setInactiveDelayed = this._register(new RunOnceScheduler(() => {
+		if (!this.isSuggestWidgetVisible) {
+			if (this.isActive) {
+				this._isActive = false;
+				this.onDidChangeEmitter.fire();
+			}
+		}
+	}, 100));
 
 	constructor(
 		editor: IActiveCodeEditor
@@ -41,15 +53,18 @@ export class SuggestWidgetAdapterModel extends BaseGhostTextWidgetModel {
 
 				this._register(suggestController.widget.value.onDidShow(() => {
 					this.isSuggestWidgetVisible = true;
+					this._isActive = true;
 					this.updateFromSuggestion();
 				}));
 				this._register(suggestController.widget.value.onDidHide(() => {
 					this.isSuggestWidgetVisible = false;
+					this.setInactiveDelayed.schedule();
 					this.minReservedLineCount = 0;
 					this.updateFromSuggestion();
 				}));
 				this._register(suggestController.widget.value.onDidFocus(() => {
 					this.isSuggestWidgetVisible = true;
+					this._isActive = true;
 					this.updateFromSuggestion();
 				}));
 			};


### PR DESCRIPTION
* Pending update operations are cleared immediately (and not debounced).
This prevents a stale cache when the update operation finishes.

* Context Key is updated when suggest widget becomes inactive.
This fixes that "tab" does not always work to accept a suggestion.

* Suggest Widget only becomes inactive after an 100ms timeout.
This fixes flickering when typing `window` and then `.`, which closes the suggest widget but opens it again immediately.

* Leading whitespace is only ignored when the inline completion is about indentation.
This fixes an issue when the user types a whitespace after a suggestion that has an empty replace range.

* Cache is disposed when no command is set.