### PR TITLE
Use better context key for the Run menu

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -42,7 +42,7 @@
     "colors": "^1.4.0",
     "commander": "^7.0.0",
     "electron-osx-sign": "^0.4.16",
-    "esbuild": "^0.12.6",
+    "esbuild": "^0.12.1",
     "fs-extra": "^9.1.0",
     "got": "11.8.1",
     "iconv-lite-umd": "0.6.8",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -992,10 +992,10 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
-esbuild@^0.12.6:
-  version "0.12.6"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.6.tgz#85bc755c7cf3005d4f34b4f10f98049ce0ee67ce"
-  integrity sha512-RDvVLvAjsq/kIZJoneMiUOH7EE7t2QaW7T3Q7EdQij14+bZbDq5sndb0tTanmHIFSqZVMBMMyqzVHkS3dJobeA==
+esbuild@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.1.tgz#f652d5b3b9432dbb42fc2c034ddd62360296e03d"
+  integrity sha512-WfQ00MKm/Y4ysz1u9PCUAsV66k5lbrcEvS6aG9jhBIavpB94FBdaWeBkaZXxCZB4w+oqh+j4ozJFWnnFprOXbg==
 
 eslint-scope@^5.0.0:
   version "5.0.0"

--- a/extensions/configuration-editing/schemas/devContainer.schema.generated.json
+++ b/extensions/configuration-editing/schemas/devContainer.schema.generated.json
@@ -357,6 +357,28 @@
 					"type": "object",
 					"additionalProperties": true,
 					"description": "Codespaces-specific configuration."
+				},
+				"hostRequirements": {
+					"type": "object",
+					"description": "Host hardware requirements.",
+					"properties": {
+						"cpus": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "Number of required CPUs."
+						},
+						"memory": {
+							"type": "string",
+							"pattern": "^\\d+([tgmk]b)?$",
+							"description": "Amount of required RAM in bytes. Supports units tb, gb, mb and kb."
+						},
+						"storage": {
+							"type": "string",
+							"pattern": "^\\d+([tgmk]b)?$",
+							"description": "Amount of required disk space in bytes. Supports units tb, gb, mb and kb."
+						}
+					},
+					"additionalProperties": false
 				}
 			},
 			"required": [
@@ -714,6 +736,28 @@
 					"type": "object",
 					"additionalProperties": true,
 					"description": "Codespaces-specific configuration."
+				},
+				"hostRequirements": {
+					"type": "object",
+					"description": "Host hardware requirements.",
+					"properties": {
+						"cpus": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "Number of required CPUs."
+						},
+						"memory": {
+							"type": "string",
+							"pattern": "^\\d+([tgmk]b)?$",
+							"description": "Amount of required RAM in bytes. Supports units tb, gb, mb and kb."
+						},
+						"storage": {
+							"type": "string",
+							"pattern": "^\\d+([tgmk]b)?$",
+							"description": "Amount of required disk space in bytes. Supports units tb, gb, mb and kb."
+						}
+					},
+					"additionalProperties": false
 				}
 			},
 			"required": [
@@ -1047,6 +1091,28 @@
 					"type": "object",
 					"additionalProperties": true,
 					"description": "Codespaces-specific configuration."
+				},
+				"hostRequirements": {
+					"type": "object",
+					"description": "Host hardware requirements.",
+					"properties": {
+						"cpus": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "Number of required CPUs."
+						},
+						"memory": {
+							"type": "string",
+							"pattern": "^\\d+([tgmk]b)?$",
+							"description": "Amount of required RAM in bytes. Supports units tb, gb, mb and kb."
+						},
+						"storage": {
+							"type": "string",
+							"pattern": "^\\d+([tgmk]b)?$",
+							"description": "Amount of required disk space in bytes. Supports units tb, gb, mb and kb."
+						}
+					},
+					"additionalProperties": false
 				}
 			},
 			"required": [
@@ -1346,6 +1412,28 @@
 					"type": "object",
 					"additionalProperties": true,
 					"description": "Codespaces-specific configuration."
+				},
+				"hostRequirements": {
+					"type": "object",
+					"description": "Host hardware requirements.",
+					"properties": {
+						"cpus": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "Number of required CPUs."
+						},
+						"memory": {
+							"type": "string",
+							"pattern": "^\\d+([tgmk]b)?$",
+							"description": "Amount of required RAM in bytes. Supports units tb, gb, mb and kb."
+						},
+						"storage": {
+							"type": "string",
+							"pattern": "^\\d+([tgmk]b)?$",
+							"description": "Amount of required disk space in bytes. Supports units tb, gb, mb and kb."
+						}
+					},
+					"additionalProperties": false
 				}
 			},
 			"required": [
@@ -1614,6 +1702,28 @@
 					"type": "object",
 					"additionalProperties": true,
 					"description": "Codespaces-specific configuration."
+				},
+				"hostRequirements": {
+					"type": "object",
+					"description": "Host hardware requirements.",
+					"properties": {
+						"cpus": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "Number of required CPUs."
+						},
+						"memory": {
+							"type": "string",
+							"pattern": "^\\d+([tgmk]b)?$",
+							"description": "Amount of required RAM in bytes. Supports units tb, gb, mb and kb."
+						},
+						"storage": {
+							"type": "string",
+							"pattern": "^\\d+([tgmk]b)?$",
+							"description": "Amount of required disk space in bytes. Supports units tb, gb, mb and kb."
+						}
+					},
+					"additionalProperties": false
 				}
 			},
 			"additionalProperties": false

--- a/extensions/configuration-editing/schemas/devContainer.schema.src.json
+++ b/extensions/configuration-editing/schemas/devContainer.schema.src.json
@@ -256,6 +256,32 @@
 					"type": "object",
 					"additionalProperties": true,
 					"description": "Codespaces-specific configuration."
+				},
+				"hostRequirements": {
+					"type": "object",
+					"description": "Host hardware requirements.",
+					"allOf": [
+						{
+							"type": "object",
+							"properties": {
+								"cpus": {
+									"type": "integer",
+									"minimum": 1,
+									"description": "Number of required CPUs."
+								},
+								"memory": {
+									"type": "string",
+									"pattern": "^\\d+([tgmk]b)?$",
+									"description": "Amount of required RAM in bytes. Supports units tb, gb, mb and kb."
+								},
+								"storage": {
+									"type": "string",
+									"pattern": "^\\d+([tgmk]b)?$",
+									"description": "Amount of required disk space in bytes. Supports units tb, gb, mb and kb."
+								}
+							}
+						}
+					]
 				}
 			}
 		},

--- a/src/vs/editor/common/view/editorColorRegistry.ts
+++ b/src/vs/editor/common/view/editorColorRegistry.ts
@@ -44,7 +44,7 @@ export const editorUnnecessaryCodeBorder = registerColor('editorUnnecessaryCode.
 export const editorUnnecessaryCodeOpacity = registerColor('editorUnnecessaryCode.opacity', { dark: Color.fromHex('#000a'), light: Color.fromHex('#0007'), hc: null }, nls.localize('unnecessaryCodeOpacity', 'Opacity of unnecessary (unused) source code in the editor. For example, "#000000c0" will render the code with 75% opacity. For high contrast themes, use the  \'editorUnnecessaryCode.border\' theme color to underline unnecessary code instead of fading it out.'));
 
 export const ghostTextBorder = registerColor('editorGhostText.border', { dark: null, light: null, hc: Color.fromHex('#fff').transparent(0.8) }, nls.localize('editorGhostTextBorder', 'Border color of ghost text in the editor.'));
-export const ghostTextForeground = registerColor('editorGhostText.foreground', { dark: Color.fromHex('#FFFa'), light: Color.fromHex('#0007'), hc: null }, nls.localize('editorGhostTextForeground', 'Foreground color of the ghost text in the editor.'));
+export const ghostTextForeground = registerColor('editorGhostText.foreground', { dark: Color.fromHex('#ffffff56'), light: Color.fromHex('#0007'), hc: null }, nls.localize('editorGhostTextForeground', 'Foreground color of the ghost text in the editor.'));
 
 const rulerRangeDefault = new Color(new RGBA(0, 122, 204, 0.6));
 export const overviewRulerRangeHighlight = registerColor('editorOverviewRuler.rangeHighlightForeground', { dark: rulerRangeDefault, light: rulerRangeDefault, hc: rulerRangeDefault }, nls.localize('overviewRulerRangeHighlight', 'Overview ruler marker color for range highlights. The color must not be opaque so as not to hide underlying decorations.'), true);

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
@@ -159,6 +159,9 @@ export class ActiveGhostTextController extends Disposable {
 
 		this._register(this.suggestWidgetAdapterModel.onDidChange(() => {
 			this.updateModel();
+			// When the suggest widget becomes inactive and an inline completion
+			// becomes visible, we need to update the context keys.
+			this.updateContextKeys();
 		}));
 		this.updateModel();
 

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
@@ -34,7 +34,7 @@ export class GhostTextController extends Disposable {
 	private triggeredExplicitly = false;
 
 	constructor(
-		private readonly editor: ICodeEditor,
+		public readonly editor: ICodeEditor,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
@@ -251,6 +251,7 @@ export const commitInlineSuggestionAction = new GhostTextCommand({
 	},
 	handler(x) {
 		x.commit();
+		x.editor.focus();
 	}
 });
 registerEditorCommand(commitInlineSuggestionAction);

--- a/src/vs/editor/contrib/inlineCompletions/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/inlineCompletionsModel.ts
@@ -294,6 +294,9 @@ class InlineCompletionsSession extends BaseGhostTextWidgetModel {
 	}
 
 	public scheduleAutomaticUpdate(): void {
+		// Since updateSoon debounces, starvation can happen.
+		// To prevent stale cache, we clear the current update operation.
+		this.updateOperation.clear();
 		this.updateSoon.schedule();
 	}
 
@@ -366,6 +369,8 @@ class InlineCompletionsSession extends BaseGhostTextWidgetModel {
 					cache?.dispose();
 				})
 				.then(undefined, onUnexpectedExternalError);
+		} else {
+			cache?.dispose();
 		}
 
 		this.onDidChangeEmitter.fire();
@@ -475,15 +480,21 @@ export function inlineCompletionToGhostText(inlineCompletion: NormalizedInlineCo
 	// "\t\tfoo" -> "\t\t\tfoobar" (+"\t", +"bar")
 	// "\t\tfoo" -> "\tfoobar" (-"\t", +"\bar")
 
+	const firstNonWsCol = textModel.getLineFirstNonWhitespaceColumn(inlineCompletion.range.startLineNumber);
+
 	if (inlineCompletion.text.startsWith(valueToBeReplaced)) {
 		remainingInsertText = inlineCompletion.text.substr(valueToBeReplaced.length);
-	} else {
+	} else if (firstNonWsCol === 0 || inlineCompletion.range.startColumn < firstNonWsCol) {
+		// Only allow ignoring leading whitespace in indentation.
+		// This prevents flickering when the user types whitespace that extends an empty range.
 		const valueToBeReplacedTrimmed = leftTrim(valueToBeReplaced);
 		const insertTextTrimmed = leftTrim(inlineCompletion.text);
 		if (!insertTextTrimmed.startsWith(valueToBeReplacedTrimmed)) {
 			return undefined;
 		}
 		remainingInsertText = insertTextTrimmed.substr(valueToBeReplacedTrimmed.length);
+	} else {
+		return undefined;
 	}
 
 	const position = inlineCompletion.range.getEndPosition();

--- a/src/vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { RunOnceScheduler } from 'vs/base/common/async';
 import { Event } from 'vs/base/common/event';
 import { toDisposable } from 'vs/base/common/lifecycle';
 import { IActiveCodeEditor } from 'vs/editor/browser/editorBrowser';
@@ -20,10 +21,21 @@ import { ISelectedSuggestion } from 'vs/editor/contrib/suggest/suggestWidget';
 export class SuggestWidgetAdapterModel extends BaseGhostTextWidgetModel {
 	private isSuggestWidgetVisible: boolean = false;
 	private currentGhostText: GhostText | undefined = undefined;
+	private _isActive: boolean = false;
 
 	public override minReservedLineCount: number = 0;
 
-	public get isActive() { return this.isSuggestWidgetVisible; }
+	public get isActive() { return this._isActive; }
+
+	// This delay fixes an suggest widget issue when typing "." immediately restarts the suggestion session.
+	private setInactiveDelayed = this._register(new RunOnceScheduler(() => {
+		if (!this.isSuggestWidgetVisible) {
+			if (this.isActive) {
+				this._isActive = false;
+				this.onDidChangeEmitter.fire();
+			}
+		}
+	}, 100));
 
 	constructor(
 		editor: IActiveCodeEditor
@@ -41,15 +53,18 @@ export class SuggestWidgetAdapterModel extends BaseGhostTextWidgetModel {
 
 				this._register(suggestController.widget.value.onDidShow(() => {
 					this.isSuggestWidgetVisible = true;
+					this._isActive = true;
 					this.updateFromSuggestion();
 				}));
 				this._register(suggestController.widget.value.onDidHide(() => {
 					this.isSuggestWidgetVisible = false;
+					this.setInactiveDelayed.schedule();
 					this.minReservedLineCount = 0;
 					this.updateFromSuggestion();
 				}));
 				this._register(suggestController.widget.value.onDidFocus(() => {
 					this.isSuggestWidgetVisible = true;
+					this._isActive = true;
 					this.updateFromSuggestion();
 				}));
 			};

--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -50,7 +50,6 @@ import { registerColors } from 'vs/workbench/contrib/debug/browser/debugColors';
 import { DebugEditorContribution } from 'vs/workbench/contrib/debug/browser/debugEditorContribution';
 import { FileAccess } from 'vs/base/common/network';
 import * as icons from 'vs/workbench/contrib/debug/browser/debugIcons';
-import { IsWebContext } from 'vs/platform/contextkey/common/contextkeys';
 
 const debugCategory = nls.localize('debugCategory', "Debug");
 registerColors();
@@ -186,7 +185,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarMainMenu, {
 		original: 'Run',
 		mnemonicTitle: nls.localize({ key: 'mRun', comment: ['&& denotes a mnemonic'] }, "&&Run")
 	},
-	when: ContextKeyExpr.or(CONTEXT_DEBUGGERS_AVAILABLE, IsWebContext.toNegated()),
+	when: ContextKeyExpr.or(CONTEXT_DEBUGGERS_AVAILABLE),
 	order: 6
 });
 

--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -28,8 +28,11 @@ import { IModeService } from 'vs/editor/common/services/modeService';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import Severity from 'vs/base/common/severity';
 import { TaskDefinitionRegistry } from 'vs/workbench/contrib/tasks/common/taskDefinitionRegistry';
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 
 const jsonRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
+const DEBUGGERS_AVAILABLE_KEY = 'debug.debuggersavailable';
+
 export class AdapterManager implements IAdapterManager {
 
 	private debuggers: Debugger[];
@@ -49,12 +52,15 @@ export class AdapterManager implements IAdapterManager {
 		@IExtensionService private readonly extensionService: IExtensionService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IModeService private readonly modeService: IModeService,
-		@IDialogService private readonly dialogService: IDialogService
+		@IDialogService private readonly dialogService: IDialogService,
+		@IStorageService private readonly storageService: IStorageService
 	) {
 		this.adapterDescriptorFactories = [];
 		this.debuggers = [];
 		this.registerListeners();
+		const debuggersAvailable = this.storageService.getBoolean(DEBUGGERS_AVAILABLE_KEY, StorageScope.WORKSPACE, false);
 		this.debuggersAvailable = CONTEXT_DEBUGGERS_AVAILABLE.bindTo(contextKeyService);
+		this.debuggersAvailable.set(debuggersAvailable);
 	}
 
 	private registerListeners(): void {
@@ -158,6 +164,7 @@ export class AdapterManager implements IAdapterManager {
 	registerDebugAdapterFactory(debugTypes: string[], debugAdapterLauncher: IDebugAdapterFactory): IDisposable {
 		debugTypes.forEach(debugType => this.debugAdapterFactories.set(debugType, debugAdapterLauncher));
 		this.debuggersAvailable.set(this.debugAdapterFactories.size > 0);
+		this.storageService.store(DEBUGGERS_AVAILABLE_KEY, this.debugAdapterFactories.size > 0, StorageScope.WORKSPACE, StorageTarget.MACHINE);
 		this._onDidRegisterDebugger.fire();
 
 		return {

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -698,7 +698,7 @@ configurationRegistry.registerConfiguration({
 		[ConsolidatedRunButton]: {
 			description: nls.localize('notebook.consolidatedRunButton.description', "Control whether extra actions are shown in a dropdown next to the run button."),
 			type: 'boolean',
-			default: true,
+			default: false,
 			tags: ['notebookLayout']
 		},
 		[NotebookCellEditorOptionsCustomizations]: editorOptionsCustomizationSchema

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -181,12 +181,15 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 		}
 
 		const reference = this._data.acquire(resource.toString(), viewType);
-		const model = await reference.object;
-		return {
-			object: model,
-			dispose() {
-				reference.dispose();
-			}
-		};
+		try {
+			const model = await reference.object;
+			return {
+				object: model,
+				dispose() { reference.dispose(); }
+			};
+		} catch (err) {
+			reference.dispose();
+			throw err;
+		}
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -68,6 +68,8 @@ const NUMBER_OF_FRAMES_TO_MEASURE = 20;
 
 const SHOULD_PROMPT_FOR_PROFILE_MIGRATION_KEY = 'terminals.integrated.profile-migration';
 
+let migrationMessageShown = false;
+
 const enum Constants {
 	/**
 	 * The maximum amount of milliseconds to wait for a container before starting to create the
@@ -142,8 +144,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	private _lastLayoutDimensions: dom.Dimension | undefined;
 
 	private _hasHadInput: boolean;
-
-	messageShown: boolean = false;
 
 	readonly statusList: ITerminalStatusList = new TerminalStatusList();
 	disableLayout: boolean = false;
@@ -362,7 +362,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		const shouldMigrateToProfile = (!!this._configurationService.getValue(TerminalSettingPrefix.Shell + platform) ||
 			!!this._configurationService.inspect(TerminalSettingPrefix.ShellArgs + platform).userValue) &&
 			!!this._configurationService.getValue(TerminalSettingPrefix.DefaultProfile + platform);
-		if (shouldMigrateToProfile && this._storageService.getBoolean(SHOULD_PROMPT_FOR_PROFILE_MIGRATION_KEY, StorageScope.WORKSPACE, true) && !this.messageShown) {
+		if (shouldMigrateToProfile && this._storageService.getBoolean(SHOULD_PROMPT_FOR_PROFILE_MIGRATION_KEY, StorageScope.WORKSPACE, true) && !migrationMessageShown) {
 			this._notificationService.prompt(
 				Severity.Info,
 				nls.localize('terminalProfileMigration', "The terminal is using deprecated shell/shellArgs settings, do you want to migrate it to a profile?"),
@@ -396,7 +396,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 					neverShowAgain: { id: SHOULD_PROMPT_FOR_PROFILE_MIGRATION_KEY, scope: NeverShowAgainScope.WORKSPACE }
 				}
 			);
-			this.messageShown = true;
+			migrationMessageShown = true;
 		}
 	}
 

--- a/src/vs/workbench/contrib/workspace/browser/workspace.contribution.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspace.contribution.ts
@@ -442,7 +442,9 @@ export class WorkspaceTrustUXHandler extends Disposable implements IWorkbenchCon
 			}));
 			// TODO: Consider moving the check into setWorkspaceTrust()
 			if (this.workspaceTrustManagementService.canSetWorkspaceTrust()) {
-				this.workspaceTrustManagementService.setWorkspaceTrust(this.configurationService.getValue<boolean>(WORKSPACE_TRUST_EMPTY_WINDOW) ?? false);
+				if (this.configurationService.getValue<boolean>(WORKSPACE_TRUST_EMPTY_WINDOW)) {
+					this.workspaceTrustManagementService.setWorkspaceTrust(true);
+				}
 			}
 		}
 	}

--- a/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
+++ b/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
@@ -272,6 +272,11 @@ export class WorkspaceTrustManagementService extends Disposable implements IWork
 		// Update workspace trust
 		this._trustState.isTrusted = trusted;
 
+		// Reset acceptsOutOfWorkspaceFiles
+		if (!trusted) {
+			this._trustState.acceptsOutOfWorkspaceFiles = false;
+		}
+
 		// Run workspace trust transition participants
 		await this._trustTransitionManager.participate(trusted);
 
@@ -742,10 +747,6 @@ class WorkspaceTrustState {
 
 	set isTrusted(value: boolean | undefined) {
 		this._mementoObject[this._isTrustedKey] = value;
-		if (!value) {
-			this._mementoObject[this._acceptsOutOfWorkspaceFilesKey] = value;
-		}
-
 		this._memento.saveMemento();
 	}
 }


### PR DESCRIPTION
This PR changes the context key to be used for the run menu to be more precise.
We are using a caching strategy for the context key to not have any flashing when using this for the VS Code desktop