### PR TITLE
chore(typescript-language-features): fix spelling of deprecated

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/callHierarchy.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/callHierarchy.ts
@@ -91,7 +91,7 @@ function fromProtocolCallHierarchyItem(item: Proto.CallHierarchyItem): vscode.Ca
 	);
 
 	const kindModifiers = item.kindModifiers ? parseKindModifier(item.kindModifiers) : undefined;
-	if (kindModifiers?.has(PConst.KindModifiers.depreacted)) {
+	if (kindModifiers?.has(PConst.KindModifiers.deprecated)) {
 		result.tags = [vscode.SymbolTag.Deprecated];
 	}
 	return result;

--- a/extensions/typescript-language-features/src/languageFeatures/completions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/completions.ts
@@ -121,7 +121,7 @@ class MyCompletionItem extends vscode.CompletionItem {
 				}
 				this.label += '?';
 			}
-			if (kindModifiers.has(PConst.KindModifiers.depreacted)) {
+			if (kindModifiers.has(PConst.KindModifiers.deprecated)) {
 				this.tags = [vscode.CompletionItemTag.Deprecated];
 			}
 

--- a/extensions/typescript-language-features/src/languageFeatures/documentSymbol.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/documentSymbol.ts
@@ -109,7 +109,7 @@ class TypeScriptDocumentSymbolProvider implements vscode.DocumentSymbolProvider 
 
 
 		const kindModifiers = parseKindModifier(item.kindModifiers);
-		if (kindModifiers.has(PConst.KindModifiers.depreacted)) {
+		if (kindModifiers.has(PConst.KindModifiers.deprecated)) {
 			symbolInfo.tags = [vscode.SymbolTag.Deprecated];
 		}
 

--- a/extensions/typescript-language-features/src/languageFeatures/workspaceSymbols.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/workspaceSymbols.ts
@@ -97,7 +97,7 @@ class TypeScriptWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvide
 			item.containerName || '',
 			typeConverters.Location.fromTextSpan(this.client.toResource(item.file), item));
 		const kindModifiers = item.kindModifiers ? parseKindModifier(item.kindModifiers) : undefined;
-		if (kindModifiers?.has(PConst.KindModifiers.depreacted)) {
+		if (kindModifiers?.has(PConst.KindModifiers.deprecated)) {
 			info.tags = [vscode.SymbolTag.Deprecated];
 		}
 		return info;

--- a/extensions/typescript-language-features/src/protocol.const.ts
+++ b/extensions/typescript-language-features/src/protocol.const.ts
@@ -45,7 +45,7 @@ export class DiagnosticCategory {
 
 export class KindModifiers {
 	public static readonly optional = 'optional';
-	public static readonly depreacted = 'deprecated';
+	public static readonly deprecated = 'deprecated';
 	public static readonly color = 'color';
 
 	public static readonly dtsFile = '.d.ts';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

I noticed a misspelling. It seems like this symbol is internal to typescript-language-features, so it should be safe to rename.
