### PR TITLE
Add WASM MIME type

### DIFF
--- a/src/vs/platform/webview/common/mimeTypes.ts
+++ b/src/vs/platform/webview/common/mimeTypes.ts
@@ -18,6 +18,7 @@ const webviewMimeTypes = new Map([
 	['.xhtml', 'application/xhtml+xml'],
 	['.oft', 'font/otf'],
 	['.xml', 'application/xml'],
+	['.wasm', 'application/wasm'],
 ]);
 
 export function getWebviewContentMimeType(resource: URI): string {


### PR DESCRIPTION
This PR fixes #125778 (not really in the full generality I requested there, but it fixes the specific problem I needed it for). WebAssembly local resources are now served with the proper MIME type.
