### PR TITLE
Auth session API fix

### DIFF
--- a/extensions/github-authentication/src/github.ts
+++ b/extensions/github-authentication/src/github.ts
@@ -209,7 +209,7 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 			return session;
 		} catch (e) {
 			// If login was cancelled, do not notify user.
-			if (e.message === 'Cancelled') {
+			if (e === 'Cancelled') {
 				/* __GDPR__
 					"loginCancelled" : { }
 				*/

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -713,19 +713,19 @@ export class AuthenticationService extends Disposable implements IAuthentication
 	}
 
 	async getSessions(id: string, scopes?: string[], activateImmediate: boolean = false): Promise<ReadonlyArray<AuthenticationSession>> {
-		try {
-			const authProvider = this._authenticationProviders.get(id) || await this.tryActivateProvider(id, activateImmediate);
+		const authProvider = this._authenticationProviders.get(id) || await this.tryActivateProvider(id, activateImmediate);
+		if (authProvider) {
 			return await authProvider.getSessions(scopes);
-		} catch (_) {
+		} else {
 			throw new Error(`No authentication provider '${id}' is currently registered.`);
 		}
 	}
 
 	async createSession(id: string, scopes: string[], activateImmediate: boolean = false): Promise<AuthenticationSession> {
-		try {
-			const authProvider = this._authenticationProviders.get(id) || await this.tryActivateProvider(id, activateImmediate);
+		const authProvider = this._authenticationProviders.get(id) || await this.tryActivateProvider(id, activateImmediate);
+		if (authProvider) {
 			return await authProvider.createSession(scopes);
-		} catch (_) {
+		} else {
 			throw new Error(`No authentication provider '${id}' is currently registered.`);
 		}
 	}


### PR DESCRIPTION
This PR fixes #
https://github.com/microsoft/vscode/issues/117908

This PR aims to change the behavior of `get` and `create` auth session methods to allow users of the API distinct errors from cancellations. In the current implementation, a cancellation will be falsely reported as `No authentication provider '${id}' is currently registered.`

cc: @RMacfarlane @TylerLeonhardt 