### PR TITLE
Reuse notebook cell statusbar helpers and dispose properly

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/statusBar/contributedStatusBarItemController.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/statusBar/contributedStatusBarItemController.ts
@@ -36,10 +36,13 @@ export class ContributedStatusBarItemController extends Disposable implements IN
 
 	private _updateEverything(): void {
 		const newCells = this._observer.visibleCells.filter(cell => !this._visibleCells.has(cell.handle));
-		this._visibleCells.forEach(helper => helper.update());
 		const visibleCellHandles = new Set(this._observer.visibleCells.map(item => item.handle));
-		const removedCells = Array.from(this._visibleCells.keys()).filter(handle => !visibleCellHandles.has(handle));
+		const currentCellHandles = Array.from(this._visibleCells.keys());
+		const removedCells = currentCellHandles.filter(handle => !visibleCellHandles.has(handle));
+		const itemsToUpdate = currentCellHandles.filter(handle => visibleCellHandles.has(handle));
+
 		this._updateVisibleCells({ added: newCells, removed: removedCells.map(handle => ({ handle })) });
+		itemsToUpdate.forEach(handle => this._visibleCells.get(handle)?.update());
 	}
 
 	private _updateVisibleCells(e: {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/statusBar/contributedStatusBarItemController.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/statusBar/contributedStatusBarItemController.ts
@@ -38,6 +38,11 @@ export class ContributedStatusBarItemController extends Disposable implements IN
 		const newCells = this._observer.visibleCells.filter(cell => !this._visibleCells.has(cell.handle));
 		this._visibleCells.forEach(helper => helper.update());
 		this._updateVisibleCells({ added: newCells, removed: [] });
+		const visibleCellHandles = new Set(this._observer.visibleCells.map(item => item.handle));
+		Array.from(this._visibleCells.keys()).filter(handle => !visibleCellHandles.has(handle)).forEach(handle => {
+			this._visibleCells.get(handle)?.dispose();
+			this._visibleCells.delete(handle);
+		});
 	}
 
 	private _updateVisibleCells(e: ICellVisibilityChangeEvent): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #125810

FYI - This isn't used in Jupyter extension, hence this fix isn't required for Jupyter (its a separate extension I have https://github.com/notebookPowerTools/vscode-notebook-linenumbers)

@rebornix @roblourens /cc