### PR TITLE
Add iframe search with debounce

### DIFF
--- a/product.json
+++ b/product.json
@@ -23,7 +23,6 @@
 	"reportIssueUrl": "https://github.com/microsoft/vscode/issues/new",
 	"urlProtocol": "code-oss",
 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-webview.net/{{quality}}/{{commit}}/out/vs/workbench/contrib/webview/browser/pre/",
-	"electronRepository": "microsoft/vscode-electron-prebuilt",
 	"extensionAllowedProposedApi": [
 		"ms-vscode.vscode-js-profile-flame",
 		"ms-vscode.vscode-js-profile-table",

--- a/product.json
+++ b/product.json
@@ -23,6 +23,7 @@
 	"reportIssueUrl": "https://github.com/microsoft/vscode/issues/new",
 	"urlProtocol": "code-oss",
 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-webview.net/{{quality}}/{{commit}}/out/vs/workbench/contrib/webview/browser/pre/",
+	"electronRepository": "microsoft/vscode-electron-prebuilt",
 	"extensionAllowedProposedApi": [
 		"ms-vscode.vscode-js-profile-flame",
 		"ms-vscode.vscode-js-profile-table",

--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -50,6 +50,7 @@ export class FindInput extends Widget {
 	private validation?: IInputValidator;
 	private label: string;
 	private fixFocusOnOptionClickEnabled = true;
+	private imeSessionInProgress = false;
 
 	private inputActiveOptionBorder?: Color;
 	private inputActiveOptionForeground?: Color;
@@ -252,10 +253,22 @@ export class FindInput extends Widget {
 			parent.appendChild(this.domNode);
 		}
 
+		this._register(dom.addDisposableListener(this.inputBox.inputElement, 'compositionstart', (e: CompositionEvent) => {
+			this.imeSessionInProgress = true;
+		}));
+		this._register(dom.addDisposableListener(this.inputBox.inputElement, 'compositionend', (e: CompositionEvent) => {
+			this.imeSessionInProgress = false;
+			this._onInput.fire();
+		}));
+
 		this.onkeydown(this.inputBox.inputElement, (e) => this._onKeyDown.fire(e));
 		this.onkeyup(this.inputBox.inputElement, (e) => this._onKeyUp.fire(e));
 		this.oninput(this.inputBox.inputElement, (e) => this._onInput.fire());
 		this.onmousedown(this.inputBox.inputElement, (e) => this._onMouseDown.fire(e));
+	}
+
+	public get isImeSessionInProgress(): boolean {
+		return this.imeSessionInProgress;
 	}
 
 	public get onDidChange(): Event<string> {

--- a/src/vs/platform/webview/common/webviewManagerService.ts
+++ b/src/vs/platform/webview/common/webviewManagerService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Event } from 'vs/base/common/event';
 
 export const IWebviewManagerService = createDecorator<IWebviewManagerService>('webviewManagerService');
 
@@ -23,8 +24,18 @@ export interface FindInFrameOptions {
 	matchCase?: boolean;
 }
 
+export interface FoundInFrameResult {
+	requestId: number;
+	activeMatchOrdinal: number;
+	matches: number;
+	selectionArea: any;
+	finalUpdate: boolean;
+}
+
 export interface IWebviewManagerService {
 	_serviceBrand: unknown;
+
+	onFoundInFrame: Event<FoundInFrameResult>;
 
 	setIgnoreMenuShortcuts(id: WebviewWebContentsId | WebviewWindowId, enabled: boolean): Promise<void>;
 

--- a/src/vs/platform/webview/common/webviewManagerService.ts
+++ b/src/vs/platform/webview/common/webviewManagerService.ts
@@ -28,7 +28,7 @@ export interface IWebviewManagerService {
 
 	setIgnoreMenuShortcuts(id: WebviewWebContentsId | WebviewWindowId, enabled: boolean): Promise<void>;
 
-	findInFrame(windowId: WebviewWindowId, frameName: string, text: string, options: FindInPageOptions): Promise<void>;
+	findInFrame(windowId: WebviewWindowId, frameName: string, text: string, options: FindInFrameOptions): Promise<void>;
 
 	stopFindInFrame(windowId: WebviewWindowId, frameName: string, options: { keepSelection?: boolean }): Promise<void>;
 }

--- a/src/vs/platform/webview/common/webviewManagerService.ts
+++ b/src/vs/platform/webview/common/webviewManagerService.ts
@@ -17,12 +17,18 @@ export interface WebviewWindowId {
 	readonly windowId: number;
 }
 
+export interface FindInFrameOptions {
+	forward?: boolean;
+	findNext?: boolean;
+	matchCase?: boolean;
+}
+
 export interface IWebviewManagerService {
 	_serviceBrand: unknown;
 
 	setIgnoreMenuShortcuts(id: WebviewWebContentsId | WebviewWindowId, enabled: boolean): Promise<void>;
 
-	findInFrame(windowId: WebviewWindowId, frameName: string, text: string, options: { findNext?: boolean, forward?: boolean }): Promise<void>;
+	findInFrame(windowId: WebviewWindowId, frameName: string, text: string, options: FindInPageOptions): Promise<void>;
 
 	stopFindInFrame(windowId: WebviewWindowId, frameName: string, options: { keepSelection?: boolean }): Promise<void>;
 }

--- a/src/vs/platform/webview/common/webviewManagerService.ts
+++ b/src/vs/platform/webview/common/webviewManagerService.ts
@@ -21,4 +21,8 @@ export interface IWebviewManagerService {
 	_serviceBrand: unknown;
 
 	setIgnoreMenuShortcuts(id: WebviewWebContentsId | WebviewWindowId, enabled: boolean): Promise<void>;
+
+	findInFrame(windowId: WebviewWindowId, frameName: string, text: string, options: { findNext?: boolean, forward?: boolean }): Promise<void>;
+
+	stopFindInFrame(windowId: WebviewWindowId, frameName: string, options: { keepSelection?: boolean }): Promise<void>;
 }

--- a/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
@@ -70,6 +70,7 @@ export abstract class SimpleFindWidget extends Widget {
 
 		this.oninput(this._findInput.domNode, (e) => {
 			this.foundMatch = this._onInputChanged();
+
 			this.updateButtons(this.foundMatch);
 			this._delayedUpdateHistory();
 		});
@@ -269,6 +270,8 @@ export abstract class SimpleFindWidget extends Widget {
 		const hasInput = this.inputValue.length > 0;
 		this.prevBtn.setEnabled(this._isVisible && hasInput && foundMatch);
 		this.nextBtn.setEnabled(this._isVisible && hasInput && foundMatch);
+		this.nextBtn.focus();
+		this._findInput.inputBox.focus();
 	}
 }
 

--- a/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
@@ -43,7 +43,8 @@ export abstract class SimpleFindWidget extends Widget {
 		@IContextViewService private readonly _contextViewService: IContextViewService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		private readonly _state: FindReplaceState = new FindReplaceState(),
-		showOptionButtons?: boolean
+		showOptionButtons?: boolean,
+		checkImeCompletionState?: boolean
 	) {
 		super();
 
@@ -68,12 +69,14 @@ export abstract class SimpleFindWidget extends Widget {
 		// Find History with update delayer
 		this._updateHistoryDelayer = new Delayer<void>(500);
 
-		this.oninput(this._findInput.domNode, (e) => {
-			this.foundMatch = this._onInputChanged();
+		this._register(this._findInput.onInput((e) => {
+			if (checkImeCompletionState && !this._findInput.isImeSessionInProgress) {
+				this.foundMatch = this._onInputChanged();
 
-			this.updateButtons(this.foundMatch);
-			this._delayedUpdateHistory();
-		});
+				this.updateButtons(this.foundMatch);
+				this._delayedUpdateHistory();
+			}
+		}));
 
 		this._findInput.setRegex(!!this._state.isRegex);
 		this._findInput.setCaseSensitive(!!this._state.matchCase);

--- a/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
@@ -74,6 +74,8 @@ export abstract class SimpleFindWidget extends Widget {
 				this.foundMatch = this._onInputChanged();
 
 				this.updateButtons(this.foundMatch);
+				this.focusFindBox();
+
 				this._delayedUpdateHistory();
 			}
 		}));
@@ -273,6 +275,11 @@ export abstract class SimpleFindWidget extends Widget {
 		const hasInput = this.inputValue.length > 0;
 		this.prevBtn.setEnabled(this._isVisible && hasInput && foundMatch);
 		this.nextBtn.setEnabled(this._isVisible && hasInput && foundMatch);
+	}
+
+	protected focusFindBox() {
+		// Focus back onto the find box, which
+		// requires focusing onto the next button first
 		this.nextBtn.focus();
 		this._findInput.inputBox.focus();
 	}

--- a/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
@@ -70,12 +70,10 @@ export abstract class SimpleFindWidget extends Widget {
 		this._updateHistoryDelayer = new Delayer<void>(500);
 
 		this._register(this._findInput.onInput((e) => {
-			if (checkImeCompletionState && !this._findInput.isImeSessionInProgress) {
+			if (!checkImeCompletionState || !this._findInput.isImeSessionInProgress) {
 				this.foundMatch = this._onInputChanged();
-
 				this.updateButtons(this.foundMatch);
 				this.focusFindBox();
-
 				this._delayedUpdateHistory();
 			}
 		}));

--- a/src/vs/workbench/contrib/webview/browser/baseWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/baseWebviewElement.ts
@@ -114,7 +114,7 @@ export abstract class BaseWebview<T extends HTMLElement> extends Disposable {
 		private readonly options: WebviewOptions,
 		contentOptions: WebviewContentOptions,
 		public extension: WebviewExtensionDescription | undefined,
-		private readonly webviewThemeDataProvider: WebviewThemeDataProvider,
+		protected readonly webviewThemeDataProvider: WebviewThemeDataProvider,
 		services: {
 			contextMenuService: IContextMenuService,
 			environmentService: IWorkbenchEnvironmentService,

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -80,6 +80,7 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 		// Do not start loading the webview yet.
 		// Wait the end of the ctor when all listeners have been hooked up.
 		const element = document.createElement('iframe');
+		element.name = this.id;
 		element.className = `webview ${options.customClasses || ''}`;
 		element.sandbox.add('allow-scripts', 'allow-same-origin', 'allow-forms', 'allow-pointer-lock', 'allow-downloads');
 		if (!isFirefox) {

--- a/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
@@ -46,7 +46,7 @@ export class WebviewFindWidget extends SimpleFindWidget {
 		this._delegate.focus();
 	}
 
-	public _onInputChanged() {
+	public _onInputChanged(): boolean {
 		const val = this.inputValue;
 		if (val) {
 			this._delegate.startFind(val);

--- a/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
@@ -11,6 +11,7 @@ import { Event } from 'vs/base/common/event';
 
 export interface WebviewFindDelegate {
 	readonly hasFindResult: Event<boolean>;
+	readonly checkImeCompletionState: boolean;
 	find(value: string, previous: boolean): void;
 	startFind(value: string): void;
 	stopFind(keepSelection?: boolean): void;
@@ -25,7 +26,7 @@ export class WebviewFindWidget extends SimpleFindWidget {
 		@IContextViewService contextViewService: IContextViewService,
 		@IContextKeyService contextKeyService: IContextKeyService
 	) {
-		super(contextViewService, contextKeyService);
+		super(contextViewService, contextKeyService, undefined, false, _delegate.checkImeCompletionState);
 		this._findWidgetFocused = KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_FOCUSED.bindTo(contextKeyService);
 
 		this._register(_delegate.hasFindResult(hasResult => {

--- a/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
@@ -11,6 +11,7 @@ import { Event } from 'vs/base/common/event';
 
 export interface WebviewFindDelegate {
 	readonly hasFindResult: Event<boolean>;
+	readonly onDidStopFind: Event<void>;
 	readonly checkImeCompletionState: boolean;
 	find(value: string, previous: boolean): void;
 	startFind(value: string): void;
@@ -31,6 +32,11 @@ export class WebviewFindWidget extends SimpleFindWidget {
 
 		this._register(_delegate.hasFindResult(hasResult => {
 			this.updateButtons(hasResult);
+			this.focusFindBox();
+		}));
+
+		this._register(_delegate.onDidStopFind(() => {
+			this.updateButtons(false);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -29,8 +29,9 @@ import { WebviewIgnoreMenuShortcutsManager } from 'vs/workbench/contrib/webview/
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 
 export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> implements Webview, WebviewFindDelegate {
-
 	private static _webviewKeyboardHandler: WebviewIgnoreMenuShortcutsManager | undefined;
+
+	public readonly checkImeCompletionState = false;
 
 	private static getWebviewKeyboardHandler(
 		configService: IConfigurationService,

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -223,6 +223,9 @@ export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> impleme
 	private readonly _hasFindResult = this._register(new Emitter<boolean>());
 	public readonly hasFindResult: Event<boolean> = this._hasFindResult.event;
 
+	private readonly _onDidStopFind = this._register(new Emitter<void>());
+	public readonly onDidStopFind: Event<void> = this._onDidStopFind.event;
+
 	public startFind(value: string, options?: FindInPageOptions) {
 		if (!value || !this.element) {
 			return;
@@ -275,6 +278,7 @@ export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> impleme
 		}
 		this._findStarted = false;
 		this.element.stopFindInPage(keepSelection ? 'keepSelection' : 'clearSelection');
+		this._onDidStopFind.fire();
 	}
 
 	public showFind() {

--- a/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
@@ -19,7 +19,7 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { ITunnelService } from 'vs/platform/remote/common/tunnel';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { IWebviewManagerService } from 'vs/platform/webview/common/webviewManagerService';
+import { FindInFrameOptions, IWebviewManagerService } from 'vs/platform/webview/common/webviewManagerService';
 import { WebviewMessageChannels } from 'vs/workbench/contrib/webview/browser/baseWebviewElement';
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
 import { WebviewContentOptions, WebviewExtensionDescription, WebviewOptions } from 'vs/workbench/contrib/webview/browser/webview';
@@ -129,18 +129,15 @@ export class ElectronIframeWebview extends IFrameWebview {
 			return;
 		}
 
-		// // ensure options is defined without modifying the original
-		// options = options || {};
-
-		// // FindNext must be false for a first request
-		// const findOptions: FindInPageOptions = {
-		// 	forward: options.forward,
-		// 	findNext: true,
-		// 	matchCase: options.matchCase
-		// };
+		// FindNext must be true for a first request
+		const options: FindInFrameOptions = {
+			forward: true,
+			findNext: true,
+			matchCase: false
+		};
 
 		this._findStarted = true;
-		this._webviewMainService.findInFrame({ windowId: this.nativeHostService.windowId }, this.id, value, {});
+		this._webviewMainService.findInFrame({ windowId: this.nativeHostService.windowId }, this.id, value, options);
 	}
 
 	/**
@@ -155,11 +152,12 @@ export class ElectronIframeWebview extends IFrameWebview {
 			return;
 		}
 
-		// const options = { findNext: false, forward: !previous };
 		if (!this._findStarted) {
 			this.startFind(value);
 		} else {
-			this._webviewMainService.findInFrame({ windowId: this.nativeHostService.windowId }, this.id, value, {});
+			// continuing the find, so set findNext to false
+			const options: FindInFrameOptions = { forward: !previous, findNext: false, matchCase: false };
+			this._webviewMainService.findInFrame({ windowId: this.nativeHostService.windowId }, this.id, value, options);
 		}
 	}
 

--- a/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
@@ -24,7 +24,7 @@ import { WebviewMessageChannels } from 'vs/workbench/contrib/webview/browser/bas
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
 import { WebviewContentOptions, WebviewExtensionDescription, WebviewOptions } from 'vs/workbench/contrib/webview/browser/webview';
 import { IFrameWebview } from 'vs/workbench/contrib/webview/browser/webviewElement';
-import { WebviewFindWidget } from 'vs/workbench/contrib/webview/browser/webviewFindWidget';
+import { WebviewFindDelegate, WebviewFindWidget } from 'vs/workbench/contrib/webview/browser/webviewFindWidget';
 import { WindowIgnoreMenuShortcutsManager } from 'vs/workbench/contrib/webview/electron-sandbox/windowIgnoreMenuShortcutsManager';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { Delayer } from 'vs/base/common/async';
@@ -32,7 +32,7 @@ import { Delayer } from 'vs/base/common/async';
 /**
  * Webview backed by an iframe but that uses Electron APIs to power the webview.
  */
-export class ElectronIframeWebview extends IFrameWebview {
+export class ElectronIframeWebview extends IFrameWebview implements WebviewFindDelegate {
 
 	private readonly _webviewKeyboardHandler: WindowIgnoreMenuShortcutsManager;
 
@@ -40,7 +40,7 @@ export class ElectronIframeWebview extends IFrameWebview {
 	private _findStarted: boolean = false;
 
 	private readonly _webviewMainService: IWebviewManagerService;
-	private readonly _iframeDelayer = new Delayer<void>(200);
+	private readonly _iframeDelayer = this._register(new Delayer<void>(200));
 
 	constructor(
 		id: string,

--- a/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
@@ -42,6 +42,8 @@ export class ElectronIframeWebview extends IFrameWebview implements WebviewFindD
 	private readonly _webviewMainService: IWebviewManagerService;
 	private readonly _iframeDelayer = this._register(new Delayer<void>(200));
 
+	public readonly checkImeCompletionState = true;
+
 	constructor(
 		id: string,
 		options: WebviewOptions,

--- a/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
@@ -5,9 +5,13 @@
 
 import { Schemas } from 'vs/base/common/network';
 import { IMenuService } from 'vs/platform/actions/common/actions';
+import { addDisposableListener } from 'vs/base/browser/dom';
+import { Emitter, Event } from 'vs/base/common/event';
+import { ProxyChannel } from 'vs/base/parts/ipc/common/ipc';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IFileService } from 'vs/platform/files/common/files';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IMainProcessService } from 'vs/platform/ipc/electron-sandbox/services';
 import { ILogService } from 'vs/platform/log/common/log';
 import { INativeHostService } from 'vs/platform/native/electron-sandbox/native';
@@ -15,10 +19,12 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { ITunnelService } from 'vs/platform/remote/common/tunnel';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IWebviewManagerService } from 'vs/platform/webview/common/webviewManagerService';
 import { WebviewMessageChannels } from 'vs/workbench/contrib/webview/browser/baseWebviewElement';
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
 import { WebviewContentOptions, WebviewExtensionDescription, WebviewOptions } from 'vs/workbench/contrib/webview/browser/webview';
 import { IFrameWebview } from 'vs/workbench/contrib/webview/browser/webviewElement';
+import { WebviewFindWidget } from 'vs/workbench/contrib/webview/browser/webviewFindWidget';
 import { WindowIgnoreMenuShortcutsManager } from 'vs/workbench/contrib/webview/electron-sandbox/windowIgnoreMenuShortcutsManager';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 
@@ -28,6 +34,11 @@ import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/
 export class ElectronIframeWebview extends IFrameWebview {
 
 	private readonly _webviewKeyboardHandler: WindowIgnoreMenuShortcutsManager;
+
+	private _webviewFindWidget: WebviewFindWidget | undefined;
+	private _findStarted: boolean = false;
+
+	private readonly _webviewMainService: IWebviewManagerService;
 
 	constructor(
 		id: string,
@@ -46,13 +57,16 @@ export class ElectronIframeWebview extends IFrameWebview {
 		@IConfigurationService configurationService: IConfigurationService,
 		@IMainProcessService mainProcessService: IMainProcessService,
 		@INotificationService notificationService: INotificationService,
-		@INativeHostService nativeHostService: INativeHostService,
+		@INativeHostService private readonly nativeHostService: INativeHostService,
+		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super(id, options, contentOptions, extension, webviewThemeDataProvider,
 			contextMenuService,
 			configurationService, fileService, logService, menuService, notificationService, _remoteAuthorityResolverService, telemetryService, tunnelService, environmentService);
 
 		this._webviewKeyboardHandler = new WindowIgnoreMenuShortcutsManager(configurationService, mainProcessService, nativeHostService);
+
+		this._webviewMainService = ProxyChannel.toService<IWebviewManagerService>(mainProcessService.getChannel('webview'));
 
 		this._register(this.on(WebviewMessageChannels.didFocus, () => {
 			this._webviewKeyboardHandler.didFocus();
@@ -61,6 +75,16 @@ export class ElectronIframeWebview extends IFrameWebview {
 		this._register(this.on(WebviewMessageChannels.didBlur, () => {
 			this._webviewKeyboardHandler.didBlur();
 		}));
+
+		if (options.enableFindWidget) {
+			this._webviewFindWidget = this._register(instantiationService.createInstance(WebviewFindWidget, this));
+
+			this._register(addDisposableListener(this.element!, 'found-in-page', e => {
+				this._hasFindResult.fire(e.result.matches > 0);
+			}));
+
+			this.styledFindWidget();
+		}
 	}
 
 	protected override initElement(extension: WebviewExtensionDescription | undefined, options: WebviewOptions) {
@@ -69,11 +93,96 @@ export class ElectronIframeWebview extends IFrameWebview {
 		});
 	}
 
+	public override mountTo(parent: HTMLElement) {
+		if (!this.element) {
+			return;
+		}
+
+		if (this._webviewFindWidget) {
+			parent.appendChild(this._webviewFindWidget.getDomNode()!);
+		}
+		parent.appendChild(this.element);
+	}
+
 	protected override get webviewContentEndpoint(): string {
 		return `${Schemas.vscodeWebview}://${this.id}`;
 	}
 
 	protected override async doPostMessage(channel: string, data?: any): Promise<void> {
 		this.element?.contentWindow!.postMessage({ channel, args: data }, '*');
+	}
+
+	protected override style(): void {
+		super.style();
+		this.styledFindWidget();
+	}
+
+	private styledFindWidget() {
+		this._webviewFindWidget?.updateTheme(this.webviewThemeDataProvider.getTheme());
+	}
+
+	private readonly _hasFindResult = this._register(new Emitter<boolean>());
+	public readonly hasFindResult: Event<boolean> = this._hasFindResult.event;
+
+	public startFind(value: string) {
+		if (!value || !this.element) {
+			return;
+		}
+
+		// // ensure options is defined without modifying the original
+		// options = options || {};
+
+		// // FindNext must be false for a first request
+		// const findOptions: FindInPageOptions = {
+		// 	forward: options.forward,
+		// 	findNext: true,
+		// 	matchCase: options.matchCase
+		// };
+
+		this._findStarted = true;
+		this._webviewMainService.findInFrame({ windowId: this.nativeHostService.windowId }, this.id, value, {});
+	}
+
+	/**
+	 * Webviews expose a stateful find API.
+	 * Successive calls to find will move forward or backward through onFindResults
+	 * depending on the supplied options.
+	 *
+	 * @param value The string to search for. Empty strings are ignored.
+	 */
+	public find(value: string, previous: boolean): void {
+		if (!this.element) {
+			return;
+		}
+
+		// const options = { findNext: false, forward: !previous };
+		if (!this._findStarted) {
+			this.startFind(value);
+		} else {
+			this._webviewMainService.findInFrame({ windowId: this.nativeHostService.windowId }, this.id, value, {});
+		}
+	}
+
+	public stopFind(keepSelection?: boolean): void {
+		this._hasFindResult.fire(false);
+		if (!this.element) {
+			return;
+		}
+		this._findStarted = false;
+		this._webviewMainService.stopFindInFrame({ windowId: this.nativeHostService.windowId }, this.id, {
+			keepSelection
+		});
+	}
+
+	public override showFind() {
+		this._webviewFindWidget?.reveal();
+	}
+
+	public override hideFind() {
+		this._webviewFindWidget?.hide();
+	}
+
+	public override runFindAction(previous: boolean) {
+		this._webviewFindWidget?.find(previous);
 	}
 }

--- a/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/iframeWebviewElement.ts
@@ -87,6 +87,12 @@ export class ElectronIframeWebview extends IFrameWebview implements WebviewFindD
 				this._hasFindResult.fire(e.result.matches > 0);
 			}));
 
+			this._register(this.on(WebviewMessageChannels.doUpdateState, () => {
+				if (this._findStarted) {
+					this.stopFind(false);
+				}
+			}));
+
 			this._register(this._webviewMainService.onFoundInFrame((result) => {
 				this._hasFindResult.fire(result.matches > 0);
 			}));
@@ -132,6 +138,9 @@ export class ElectronIframeWebview extends IFrameWebview implements WebviewFindD
 	private readonly _hasFindResult = this._register(new Emitter<boolean>());
 	public readonly hasFindResult: Event<boolean> = this._hasFindResult.event;
 
+	private readonly _onDidStopFind = this._register(new Emitter<void>());
+	public readonly onDidStopFind: Event<void> = this._onDidStopFind.event;
+
 	public startFind(value: string) {
 		if (!value || !this.element) {
 			return;
@@ -172,7 +181,6 @@ export class ElectronIframeWebview extends IFrameWebview implements WebviewFindD
 	}
 
 	public stopFind(keepSelection?: boolean): void {
-		this._hasFindResult.fire(false);
 		if (!this.element) {
 			return;
 		}
@@ -180,6 +188,7 @@ export class ElectronIframeWebview extends IFrameWebview implements WebviewFindD
 		this._webviewMainService.stopFindInFrame({ windowId: this.nativeHostService.windowId }, this.id, {
 			keepSelection
 		});
+		this._onDidStopFind.fire();
 	}
 
 	public override showFind() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #96307 by adding an iframe search prototype. It uses https://github.com/electron/electron/pull/28274 to search in the iframe, which results in a loss of focus during the search. Therefore, I added an event to re-focus the inputbox after find results are returned, and also added a debounce so that the focus-changing behaviour of the find call is not too obvious.

Preview:
![recording (31)](https://user-images.githubusercontent.com/7199958/121382090-1df6eb80-c8fb-11eb-920a-f3a4cb22da5a.gif)

Issues:
- The jumping search problem remains (https://github.com/microsoft/vscode/issues/96307#issuecomment-848137542). This issue can be fixed by using a BrowserView, in which case, the debounce can be taken off as well (https://github.com/microsoft/vscode/issues/96307#issuecomment-844362867).
