### PR TITLE
Fix terminal icon hover.

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconLabel.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabel.ts
@@ -147,7 +147,8 @@ export class IconLabel extends Disposable {
 		}
 
 		this.domNode.className = classes.join(' ');
-		this.setupHover(this.labelContainer, options?.title);
+		const effectiveElement = this.labelContainer.parentElement || this.labelContainer;
+		this.setupHover(effectiveElement, options?.title);
 
 		this.nameNode.setLabel(label, options);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #122427.

This change allows the Terminal status icons to show a label when hovered.
For example, in a Terminal you may execute:
```$ while true ; do sleep 5 ; tput bel ; done```
In the VS Code Settings, ensure that the Terminal Bell is enabled, and it's duration is set to a long enough time to show the hover on mouse over, such as 5000 ms.
Finally, when the Bell appears, mouse over it to show the popup.

![alt text](https://i.imgur.com/xrkPf8n.gif)