### PR TITLE
Make generic code renderer output contributions in notebooks for all the languages the user has installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "spdlog": "^0.13.0",
     "sudo-prompt": "9.2.1",
     "tas-client-umd": "0.1.4",
-    "v8-inspect-profiler": "^0.0.20",
+    "v8-inspect-profiler": "^0.0.21",
     "vscode-oniguruma": "1.5.1",
     "vscode-proxy-agent": "^0.11.0",
     "vscode-regexpp": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.58.0",
-  "distro": "f9acd3d731fc630bf6b665d551d5fa12ce0560e6",
+  "distro": "73e1e7693059d649a1da9ac38c494c1f52931426",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/vs/base/browser/ui/actionbar/actionViewItems.ts
+++ b/src/vs/base/browser/ui/actionbar/actionViewItems.ts
@@ -112,7 +112,7 @@ export class BaseActionViewItem extends Disposable implements IActionViewItem {
 			}
 		}
 
-		this._register(addDisposableListener(element, TouchEventType.Tap, e => this.onClick(e)));
+		this._register(addDisposableListener(element, TouchEventType.Tap, e => this.onClick(e, true))); // Preserve focus on tap #125470
 
 		this._register(addDisposableListener(element, EventType.MOUSE_DOWN, e => {
 			if (!enableDragging) {
@@ -157,10 +157,10 @@ export class BaseActionViewItem extends Disposable implements IActionViewItem {
 		});
 	}
 
-	onClick(event: EventLike): void {
+	onClick(event: EventLike, preserveFocus = false): void {
 		EventHelper.stop(event, true);
 
-		const context = types.isUndefinedOrNull(this._context) ? this.options?.useEventAsContext ? event : undefined : this._context;
+		const context = types.isUndefinedOrNull(this._context) ? this.options?.useEventAsContext ? event : { preserveFocus } : this._context;
 		this.actionRunner.run(this._action, context);
 	}
 

--- a/src/vs/base/browser/ui/hover/hover.css
+++ b/src/vs/base/browser/ui/hover/hover.css
@@ -143,3 +143,9 @@
 	-webkit-user-select: none;
 	user-select: none;
 }
+
+.monaco-hover-content .action-container.disabled {
+	pointer-events: none;
+	opacity: 0.4;
+	cursor: default;
+}

--- a/src/vs/base/browser/ui/hover/hoverWidget.ts
+++ b/src/vs/base/browser/ui/hover/hoverWidget.ts
@@ -5,7 +5,7 @@
 
 import 'vs/css!./hover';
 import * as dom from 'vs/base/browser/dom';
-import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
+import { Disposable } from 'vs/base/common/lifecycle';
 import { DomScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElement';
 
 const $ = dom.$;
@@ -42,19 +42,43 @@ export class HoverWidget extends Disposable {
 	}
 }
 
-export function renderHoverAction(parent: HTMLElement, actionOptions: { label: string, iconClass?: string, run: (target: HTMLElement) => void, commandId: string }, keybindingLabel: string | null): IDisposable {
-	const actionContainer = dom.append(parent, $('div.action-container'));
-	const action = dom.append(actionContainer, $('a.action'));
-	action.setAttribute('href', '#');
-	action.setAttribute('role', 'button');
-	if (actionOptions.iconClass) {
-		dom.append(action, $(`span.icon.${actionOptions.iconClass}`));
+export class HoverAction extends Disposable {
+	public static render(parent: HTMLElement, actionOptions: { label: string, iconClass?: string, run: (target: HTMLElement) => void, commandId: string }, keybindingLabel: string | null) {
+		return new HoverAction(parent, actionOptions, keybindingLabel);
 	}
-	const label = dom.append(action, $('span'));
-	label.textContent = keybindingLabel ? `${actionOptions.label} (${keybindingLabel})` : actionOptions.label;
-	return dom.addDisposableListener(actionContainer, dom.EventType.CLICK, e => {
-		e.stopPropagation();
-		e.preventDefault();
-		actionOptions.run(actionContainer);
-	});
+
+	private readonly actionContainer: HTMLElement;
+	private readonly action: HTMLElement;
+
+	private constructor(parent: HTMLElement, actionOptions: { label: string, iconClass?: string, run: (target: HTMLElement) => void, commandId: string }, keybindingLabel: string | null) {
+		super();
+
+		this.actionContainer = dom.append(parent, $('div.action-container'));
+		this.action = dom.append(this.actionContainer, $('a.action'));
+		this.action.setAttribute('href', '#');
+		this.action.setAttribute('role', 'button');
+		if (actionOptions.iconClass) {
+			dom.append(this.action, $(`span.icon.${actionOptions.iconClass}`));
+		}
+		const label = dom.append(this.action, $('span'));
+		label.textContent = keybindingLabel ? `${actionOptions.label} (${keybindingLabel})` : actionOptions.label;
+
+		this._register(dom.addDisposableListener(this.actionContainer, dom.EventType.CLICK, e => {
+			e.stopPropagation();
+			e.preventDefault();
+			actionOptions.run(this.actionContainer);
+		}));
+
+		this.setEnabled(true);
+	}
+
+	public setEnabled(enabled: boolean): void {
+		if (enabled) {
+			this.actionContainer.classList.remove('disabled');
+			this.actionContainer.removeAttribute('aria-disabled');
+		} else {
+			this.actionContainer.classList.add('disabled');
+			this.actionContainer.setAttribute('aria-disabled', 'true');
+		}
+	}
 }

--- a/src/vs/editor/contrib/hover/hoverTypes.ts
+++ b/src/vs/editor/contrib/hover/hoverTypes.ts
@@ -74,8 +74,12 @@ export class HoverForeignElementAnchor {
 export type HoverAnchor = HoverRangeAnchor | HoverForeignElementAnchor;
 
 export interface IEditorHoverStatusBar {
-	addAction(actionOptions: { label: string, iconClass?: string, run: (target: HTMLElement) => void, commandId: string }): void;
+	addAction(actionOptions: { label: string, iconClass?: string, run: (target: HTMLElement) => void, commandId: string }): IEditorHoverAction;
 	append(element: HTMLElement): HTMLElement;
+}
+
+export interface IEditorHoverAction {
+	setEnabled(enabled: boolean): void;
 }
 
 export interface IEditorHoverParticipant<T extends IHoverPart = IHoverPart> {

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -23,7 +23,7 @@ import { IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { Widget } from 'vs/base/browser/ui/widget';
 import { KeyCode } from 'vs/base/common/keyCodes';
-import { HoverWidget, renderHoverAction } from 'vs/base/browser/ui/hover/hoverWidget';
+import { HoverWidget, HoverAction } from 'vs/base/browser/ui/hover/hoverWidget';
 import { MarkerHoverParticipant } from 'vs/editor/contrib/hover/markerHoverParticipant';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { MarkdownHoverParticipant } from 'vs/editor/contrib/hover/markdownHoverParticipant';
@@ -31,7 +31,7 @@ import { InlineCompletionsHoverParticipant } from 'vs/editor/contrib/inlineCompl
 import { ColorHoverParticipant } from 'vs/editor/contrib/hover/colorHoverParticipant';
 import { IEmptyContentData } from 'vs/editor/browser/controller/mouseTarget';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { IEditorHoverStatusBar, IHoverPart, HoverAnchor, IEditorHoverParticipant, HoverAnchorType, IEditorHover, HoverRangeAnchor } from 'vs/editor/contrib/hover/hoverTypes';
+import { IEditorHoverStatusBar, IHoverPart, HoverAnchor, IEditorHoverParticipant, HoverAnchorType, IEditorHover, HoverRangeAnchor, IEditorHoverAction } from 'vs/editor/contrib/hover/hoverTypes';
 
 const $ = dom.$;
 
@@ -53,11 +53,11 @@ class EditorHoverStatusBar extends Disposable implements IEditorHoverStatusBar {
 		this.actionsElement = dom.append(this.hoverElement, $('div.actions'));
 	}
 
-	public addAction(actionOptions: { label: string, iconClass?: string, run: (target: HTMLElement) => void, commandId: string }): void {
+	public addAction(actionOptions: { label: string, iconClass?: string, run: (target: HTMLElement) => void, commandId: string }): IEditorHoverAction {
 		const keybinding = this._keybindingService.lookupKeybinding(actionOptions.commandId);
 		const keybindingLabel = keybinding ? keybinding.getLabel() : null;
-		this._register(renderHoverAction(this.actionsElement, actionOptions, keybindingLabel));
 		this._hasContent = true;
+		return this._register(HoverAction.render(this.actionsElement, actionOptions, keybindingLabel));
 	}
 
 	public append(element: HTMLElement): HTMLElement {

--- a/src/vs/editor/contrib/inlineCompletions/ghostText.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostText.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from 'vs/base/common/event';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { IActiveCodeEditor } from 'vs/editor/browser/editorBrowser';
+import { EditorOption } from 'vs/editor/common/config/editorOptions';
+
+export class GhostText {
+	constructor(
+		public readonly lineNumber: number,
+		public readonly parts: GhostTextPart[],
+		public readonly additionalLines: string[],
+		public readonly additionalReservedLineCount: number = 0
+	) {
+	}
+
+	public get isMultiLine(): boolean {
+		return this.additionalLines.length > 0;
+	}
+}
+
+export interface GhostTextPart {
+	/**
+	 * Single line text.
+	*/
+	readonly text: string;
+	readonly column: number;
+}
+
+
+export interface GhostTextWidgetModel {
+	readonly onDidChange: Event<void>;
+	readonly ghostText: GhostText | undefined;
+
+	setExpanded(expanded: boolean): void;
+	readonly expanded: boolean;
+
+	readonly minReservedLineCount: number;
+}
+
+export abstract class BaseGhostTextWidgetModel extends Disposable implements GhostTextWidgetModel {
+	public abstract readonly ghostText: GhostText | undefined;
+
+	private _expanded: boolean | undefined = undefined;
+
+	protected readonly onDidChangeEmitter = new Emitter<void>();
+	public readonly onDidChange = this.onDidChangeEmitter.event;
+
+	public abstract readonly minReservedLineCount: number;
+
+	public get expanded() {
+		if (this._expanded === undefined) {
+			// TODO this should use a global hidden setting.
+			// See https://github.com/microsoft/vscode/issues/125037.
+			return true;
+		}
+		return this._expanded;
+	}
+
+	constructor(protected readonly editor: IActiveCodeEditor) {
+		super();
+
+		this._register(editor.onDidChangeConfiguration((e) => {
+			if (e.hasChanged(EditorOption.suggest) && this._expanded === undefined) {
+				this.onDidChangeEmitter.fire();
+			}
+		}));
+	}
+
+	public setExpanded(expanded: boolean): void {
+		this._expanded = true;
+		this.onDidChangeEmitter.fire();
+	}
+}

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
@@ -103,6 +103,11 @@ export class GhostTextController extends Disposable {
 	public showPreviousInlineCompletion(): void {
 		this.activeController.value?.showPreviousInlineCompletion();
 	}
+
+	public async hasMultipleInlineCompletions(): Promise<boolean> {
+		const result = await this.activeController.value?.hasMultipleInlineCompletions();
+		return result !== undefined ? result : false;
+	}
 }
 
 // TODO: This should be local state to the editor.
@@ -227,6 +232,11 @@ export class ActiveGhostTextController extends Disposable {
 
 	public showPreviousInlineCompletion(): void {
 		this.activeInlineCompletionsModel?.showPrevious();
+	}
+
+	public async hasMultipleInlineCompletions(): Promise<boolean> {
+		const result = await this.activeInlineCompletionsModel?.hasMultipleInlineCompletions();
+		return result !== undefined ? result : false;
 	}
 
 	private updateModel() {

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
@@ -110,33 +110,11 @@ export class GhostTextController extends Disposable {
 	}
 }
 
-// TODO: This should be local state to the editor.
-// The global state should depend on the local state of the currently focused editor.
-// Currently the global state is updated directly, which may lead to conflicts if multiple ghost texts are active.
 class GhostTextContextKeys {
-	private lastInlineCompletionVisibleValue = false;
-	private readonly inlineCompletionVisible = GhostTextController.inlineSuggestionVisible.bindTo(this.contextKeyService);
-
-	private lastInlineCompletionSuggestsIndentationValue = false;
-	private readonly inlineCompletionSuggestsIndentation = GhostTextController.inlineSuggestionHasIndentation.bindTo(this.contextKeyService);
+	public readonly inlineCompletionVisible = GhostTextController.inlineSuggestionVisible.bindTo(this.contextKeyService);
+	public readonly inlineCompletionSuggestsIndentation = GhostTextController.inlineSuggestionHasIndentation.bindTo(this.contextKeyService);
 
 	constructor(private readonly contextKeyService: IContextKeyService) {
-	}
-
-	public setInlineCompletionVisible(value: boolean): void {
-		// Only modify the context key if we actually changed it.
-		// Thus, we don't overwrite values set by someone else.
-		if (value !== this.lastInlineCompletionVisibleValue) {
-			this.inlineCompletionVisible.set(value);
-			this.lastInlineCompletionVisibleValue = value;
-		}
-	}
-
-	public setInlineCompletionSuggestsIndentation(value: boolean): void {
-		if (value !== this.lastInlineCompletionSuggestsIndentationValue) {
-			this.inlineCompletionSuggestsIndentation.set(value);
-			this.lastInlineCompletionSuggestsIndentationValue = value;
-		}
 	}
 }
 
@@ -174,8 +152,8 @@ export class ActiveGhostTextController extends Disposable {
 			if (widget.model === this.suggestWidgetAdapterModel || widget.model === this.inlineCompletionsModel) {
 				widget.setModel(undefined);
 			}
-			this.contextKeys.setInlineCompletionVisible(false);
-			this.contextKeys.setInlineCompletionSuggestsIndentation(false);
+			this.contextKeys.inlineCompletionVisible.set(false);
+			this.contextKeys.inlineCompletionSuggestsIndentation.set(false);
 		}));
 
 		if (this.inlineCompletionsModel) {
@@ -186,7 +164,7 @@ export class ActiveGhostTextController extends Disposable {
 	}
 
 	private updateContextKeys(): void {
-		this.contextKeys.setInlineCompletionVisible(
+		this.contextKeys.inlineCompletionVisible.set(
 			this.activeInlineCompletionsModel?.ghostText !== undefined
 		);
 
@@ -197,12 +175,12 @@ export class ActiveGhostTextController extends Disposable {
 			const indentationEndColumn = this.editor.getModel().getLineIndentColumn(p.lineNumber);
 			const inIndentation = p.column <= indentationEndColumn;
 
-			this.contextKeys.setInlineCompletionSuggestsIndentation(
+			this.contextKeys.inlineCompletionSuggestsIndentation.set(
 				this.widget.model === this.inlineCompletionsModel
 				&& suggestionStartsWithWs && inIndentation
 			);
 		} else {
-			this.contextKeys.setInlineCompletionSuggestsIndentation(false);
+			this.contextKeys.inlineCompletionSuggestsIndentation.set(false);
 		}
 	}
 

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
@@ -28,8 +28,8 @@ export class GhostTextController extends Disposable {
 		return editor.getContribution<GhostTextController>(GhostTextController.ID);
 	}
 
-	private readonly widget: GhostTextWidget;
-	private readonly activeController = this._register(new MutableDisposable<ActiveGhostTextController>());
+	protected readonly widget: GhostTextWidget;
+	protected readonly activeController = this._register(new MutableDisposable<ActiveGhostTextController>());
 	private readonly contextKeys: GhostTextContextKeys;
 	private triggeredExplicitly = false;
 
@@ -142,7 +142,7 @@ export class ActiveGhostTextController extends Disposable {
 	private readonly suggestWidgetAdapterModel = this._register(new SuggestWidgetAdapterModel(this.editor));
 	private readonly inlineCompletionsModel = this._register(new InlineCompletionsModel(this.editor, this.commandService));
 
-	private get activeInlineCompletionsModel(): InlineCompletionsModel | undefined {
+	public get activeInlineCompletionsModel(): InlineCompletionsModel | undefined {
 		if (this.widget.model === this.inlineCompletionsModel) {
 			return this.inlineCompletionsModel;
 		}
@@ -210,7 +210,7 @@ export class ActiveGhostTextController extends Disposable {
 	}
 
 	public triggerInlineCompletion(): void {
-		this.activeInlineCompletionsModel?.startSession();
+		this.activeInlineCompletionsModel?.trigger();
 	}
 
 	public commitInlineCompletion(): void {

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
@@ -144,12 +144,12 @@ export class ActiveGhostTextController extends Disposable {
 		);
 
 		const ghostText = this.model.inlineCompletionsModel.ghostText;
-		if (ghostText) {
-			const firstLine = ghostText.lines[0] || '';
-			const suggestionStartsWithWs = firstLine.startsWith(' ') || firstLine.startsWith('\t');
-			const pos = ghostText.position;
-			const indentationEndColumn = this.editor.getModel().getLineIndentColumn(pos.lineNumber);
-			const inIndentation = pos.column <= indentationEndColumn;
+		if (ghostText && ghostText.parts.length > 0) {
+			const { column, text } = ghostText.parts[0];
+			const suggestionStartsWithWs = text.startsWith(' ') || text.startsWith('\t');
+
+			const indentationEndColumn = this.editor.getModel().getLineIndentColumn(ghostText.lineNumber);
+			const inIndentation = column <= indentationEndColumn;
 
 			this.contextKeys.inlineCompletionSuggestsIndentation.set(
 				!!this.model.activeInlineCompletionsModel

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextModel.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IReference, MutableDisposable } from 'vs/base/common/lifecycle';
+import { IActiveCodeEditor } from 'vs/editor/browser/editorBrowser';
+import { GhostText, GhostTextWidgetModel } from 'vs/editor/contrib/inlineCompletions/ghostTextWidget';
+import { InlineCompletionsModel } from 'vs/editor/contrib/inlineCompletions/inlineCompletionsModel';
+import { SuggestWidgetAdapterModel } from 'vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { Emitter } from 'vs/base/common/event';
+import { Range } from 'vs/editor/common/core/range';
+import { createDisposableRef } from 'vs/editor/contrib/inlineCompletions/utils';
+
+export abstract class DelegatingModel extends Disposable implements GhostTextWidgetModel {
+	private readonly onDidChangeEmitter = new Emitter<void>();
+	public readonly onDidChange = this.onDidChangeEmitter.event;
+
+	private readonly currentModelRef = this._register(new MutableDisposable<IReference<GhostTextWidgetModel>>());
+	protected get targetModel(): GhostTextWidgetModel | undefined {
+		return this.currentModelRef.value?.object;
+	}
+
+	protected setTargetModel(model: GhostTextWidgetModel | undefined): void {
+		this.currentModelRef.value = model ? createDisposableRef(model, model.onDidChange(() => {
+			this.onDidChangeEmitter.fire();
+		})) : undefined;
+
+		this.onDidChangeEmitter.fire();
+	}
+
+	public get ghostText(): GhostText | undefined {
+		return this.targetModel?.ghostText;
+	}
+
+	public setExpanded(expanded: boolean): void {
+		this.targetModel?.setExpanded(expanded);
+	}
+
+	public get expanded(): boolean {
+		return this.targetModel ? this.targetModel.expanded : false;
+	}
+
+	public get minReservedLineCount(): number {
+		return this.targetModel ? this.targetModel.minReservedLineCount : 0;
+	}
+}
+
+/**
+ * A ghost text model that is both driven by inline completions and the suggest widget.
+*/
+export class GhostTextModel extends DelegatingModel implements GhostTextWidgetModel {
+	public readonly suggestWidgetAdapterModel = this._register(new SuggestWidgetAdapterModel(this.editor));
+	public readonly inlineCompletionsModel = this._register(new InlineCompletionsModel(this.editor, this.commandService));
+
+	public get activeInlineCompletionsModel(): InlineCompletionsModel | undefined {
+		if (this.targetModel === this.inlineCompletionsModel) {
+			return this.inlineCompletionsModel;
+		}
+		return undefined;
+	}
+
+	constructor(
+		private readonly editor: IActiveCodeEditor,
+		@ICommandService private readonly commandService: ICommandService
+	) {
+		super();
+
+		this._register(this.suggestWidgetAdapterModel.onDidChange(() => {
+			this.updateModel();
+		}));
+		this.updateModel();
+	}
+
+	private updateModel(): void {
+		this.setTargetModel(
+			this.suggestWidgetAdapterModel.isActive
+				? this.suggestWidgetAdapterModel
+				: this.inlineCompletionsModel
+		);
+		this.inlineCompletionsModel.setActive(this.targetModel === this.inlineCompletionsModel);
+	}
+
+	public shouldShowHoverAt(hoverRange: Range): boolean {
+		const ghostText = this.activeInlineCompletionsModel?.ghostText;
+		if (ghostText) {
+			return hoverRange.containsPosition(ghostText.position);
+		}
+		return false;
+	}
+
+	public triggerInlineCompletion(): void {
+		this.activeInlineCompletionsModel?.trigger();
+	}
+
+	public commitInlineCompletion(): void {
+		this.activeInlineCompletionsModel?.commitCurrentSuggestion();
+	}
+
+	public hideInlineCompletion(): void {
+		this.activeInlineCompletionsModel?.hide();
+	}
+
+	public showNextInlineCompletion(): void {
+		this.activeInlineCompletionsModel?.showNext();
+	}
+
+	public showPreviousInlineCompletion(): void {
+		this.activeInlineCompletionsModel?.showPrevious();
+	}
+
+	public async hasMultipleInlineCompletions(): Promise<boolean> {
+		const result = await this.activeInlineCompletionsModel?.hasMultipleInlineCompletions();
+		return result !== undefined ? result : false;
+	}
+}

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextModel.ts
@@ -5,13 +5,14 @@
 
 import { Disposable, IReference, MutableDisposable } from 'vs/base/common/lifecycle';
 import { IActiveCodeEditor } from 'vs/editor/browser/editorBrowser';
-import { GhostText, GhostTextWidgetModel } from 'vs/editor/contrib/inlineCompletions/ghostTextWidget';
 import { InlineCompletionsModel } from 'vs/editor/contrib/inlineCompletions/inlineCompletionsModel';
 import { SuggestWidgetAdapterModel } from 'vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { Emitter } from 'vs/base/common/event';
 import { Range } from 'vs/editor/common/core/range';
+import { Position } from 'vs/editor/common/core/position';
 import { createDisposableRef } from 'vs/editor/contrib/inlineCompletions/utils';
+import { GhostTextWidgetModel, GhostText } from 'vs/editor/contrib/inlineCompletions/ghostText';
 
 export abstract class DelegatingModel extends Disposable implements GhostTextWidgetModel {
 	private readonly onDidChangeEmitter = new Emitter<void>();
@@ -85,7 +86,7 @@ export class GhostTextModel extends DelegatingModel implements GhostTextWidgetMo
 	public shouldShowHoverAt(hoverRange: Range): boolean {
 		const ghostText = this.activeInlineCompletionsModel?.ghostText;
 		if (ghostText) {
-			return hoverRange.containsPosition(ghostText.position);
+			return ghostText.parts.some(p => hoverRange.containsPosition(new Position(ghostText.lineNumber, p.column)));
 		}
 		return false;
 	}

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextWidget.ts
@@ -84,6 +84,13 @@ export class GhostTextWidget extends Disposable {
 	private viewZoneId: string | null = null;
 	private viewMoreContentWidget: ViewMoreLinesContentWidget | null = null;
 
+	private readonly onWillRenderEmitter = new Emitter<void>();
+
+	/**
+	 * @deprecated Only use this for testing. This will get removed after the GhostTextController is refactored to use a single model.
+	*/
+	public readonly onWillRender = this.onWillRenderEmitter.event;
+
 	constructor(
 		private readonly editor: ICodeEditor,
 		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService,
@@ -147,6 +154,8 @@ export class GhostTextWidget extends Disposable {
 	}
 
 	private render(): void {
+		this.onWillRenderEmitter.fire();
+
 		const renderData = this.getRenderData();
 
 		if (this.codeEditorDecorationTypeKey) {

--- a/src/vs/editor/contrib/inlineCompletions/ghostTextWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextWidget.ts
@@ -22,6 +22,7 @@ import { IThemeService, registerThemingParticipant } from 'vs/platform/theme/com
 import { ghostTextBorder, ghostTextForeground } from 'vs/editor/common/view/editorColorRegistry';
 import { RGBA, Color } from 'vs/base/common/color';
 import { CursorColumns } from 'vs/editor/common/controller/cursorCommon';
+import { createDisposableRef } from 'vs/editor/contrib/inlineCompletions/utils';
 
 const ttPolicy = window.trustedTypes?.createPolicy('editorGhostText', { createHTML: value => value });
 
@@ -427,10 +428,3 @@ registerThemingParticipant((theme, collector) => {
 		collector.addRule(`.monaco-editor .suggest-preview-text .mtk1 { border: 2px dashed ${border}; }`);
 	}
 });
-
-function createDisposableRef<T>(object: T, disposable: IDisposable): IReference<T> {
-	return {
-		object,
-		dispose: () => disposable.dispose(),
-	};
-}

--- a/src/vs/editor/contrib/inlineCompletions/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/inlineCompletionsModel.ts
@@ -140,6 +140,11 @@ export class InlineCompletionsModel extends Disposable implements GhostTextWidge
 	public showPrevious(): void {
 		this.session?.showPreviousInlineCompletion();
 	}
+
+	public async hasMultipleInlineCompletions(): Promise<boolean> {
+		const result = await this.session?.hasMultipleInlineCompletions();
+		return result !== undefined ? result : false;
+	}
 }
 
 export class InlineCompletionsSession extends BaseGhostTextWidgetModel {
@@ -265,6 +270,11 @@ export class InlineCompletionsSession extends BaseGhostTextWidgetModel {
 			// Refresh cache
 			await this.update(InlineCompletionTriggerKind.Explicit);
 		}
+	}
+
+	public async hasMultipleInlineCompletions(): Promise<boolean> {
+		await this.ensureUpdateWithExplicitContext();
+		return (this.cache.value?.completions.length || 0) > 1;
 	}
 
 	//#endregion

--- a/src/vs/editor/contrib/inlineCompletions/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/inlineCompletionsModel.ts
@@ -14,13 +14,14 @@ import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
 import { ITextModel } from 'vs/editor/common/model';
 import { InlineCompletion, InlineCompletionContext, InlineCompletions, InlineCompletionsProvider, InlineCompletionsProviderRegistry, InlineCompletionTriggerKind } from 'vs/editor/common/modes';
-import { BaseGhostTextWidgetModel, GhostText, GhostTextWidgetModel } from 'vs/editor/contrib/inlineCompletions/ghostTextWidget';
 import { EditOperation } from 'vs/editor/common/core/editOperation';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { MutableDisposable } from 'vs/editor/contrib/inlineCompletions/utils';
 import { RedoCommand, UndoCommand } from 'vs/editor/browser/editorExtensions';
 import { CoreEditingCommands } from 'vs/editor/browser/controller/coreCommands';
+import { stringDiff } from 'vs/base/common/diff/diff';
+import { GhostTextWidgetModel, GhostText, BaseGhostTextWidgetModel, GhostTextPart } from 'vs/editor/contrib/inlineCompletions/ghostText';
 
 export class InlineCompletionsModel extends Disposable implements GhostTextWidgetModel {
 	protected readonly onDidChangeEmitter = new Emitter<void>();
@@ -478,52 +479,53 @@ export interface NormalizedInlineCompletion extends InlineCompletion {
 	range: Range;
 }
 
-function leftTrim(str: string): string {
-	return str.replace(/^\s+/, '');
-}
-
 export function inlineCompletionToGhostText(inlineCompletion: NormalizedInlineCompletion, textModel: ITextModel): GhostText | undefined {
+	if (inlineCompletion.range.startLineNumber !== inlineCompletion.range.endLineNumber) {
+		// Only single line replacements are supported.
+		return undefined;
+	}
+
 	// This is a single line string
 	const valueToBeReplaced = textModel.getValueInRange(inlineCompletion.range);
 
-	let remainingInsertText: string;
+	const changes = stringDiff(valueToBeReplaced, inlineCompletion.text, false);
 
-	// Consider these cases
-	// valueToBeReplaced -> inlineCompletion.text
-	// "\t\tfoo" -> "\t\tfoobar" (+"bar")
-	// "\t" -> "\t\tfoobar" (+"\tfoobar")
-	// "\t\tfoo" -> "\t\t\tfoobar" (+"\t", +"bar")
-	// "\t\tfoo" -> "\tfoobar" (-"\t", +"\bar")
+	const lineNumber = inlineCompletion.range.startLineNumber;
 
-	const firstNonWsCol = textModel.getLineFirstNonWhitespaceColumn(inlineCompletion.range.startLineNumber);
+	const parts = new Array<GhostTextPart>();
+	let additionalLines = new Array<string>();
 
-	if (inlineCompletion.text.startsWith(valueToBeReplaced)) {
-		remainingInsertText = inlineCompletion.text.substr(valueToBeReplaced.length);
-	} else if (firstNonWsCol === 0 || inlineCompletion.range.startColumn < firstNonWsCol) {
-		// Only allow ignoring leading whitespace in indentation.
-		const valueToBeReplacedTrimmed = leftTrim(valueToBeReplaced);
-		const insertTextTrimmed = leftTrim(inlineCompletion.text);
-		if (!insertTextTrimmed.startsWith(valueToBeReplacedTrimmed)) {
-			return undefined;
+	for (const c of changes) {
+		const insertColumn = inlineCompletion.range.startColumn + c.originalStart + c.originalLength;
+
+		if (c.originalLength > 0) {
+			const originalText = valueToBeReplaced.substr(c.originalStart, c.originalLength);
+			const firstNonWsCol = textModel.getLineFirstNonWhitespaceColumn(lineNumber);
+			if (!(/^(\t| )*$/.test(originalText) && (firstNonWsCol === 0 || insertColumn <= firstNonWsCol))) {
+				return undefined;
+			}
 		}
-		remainingInsertText = insertTextTrimmed.substr(valueToBeReplacedTrimmed.length);
-	} else {
-		return undefined;
+
+		if (c.modifiedLength === 0) {
+			continue;
+		}
+
+		const text = inlineCompletion.text.substr(c.modifiedStart, c.modifiedLength);
+		const isEndOfLine = insertColumn === textModel.getLineMaxColumn(lineNumber);
+		if (!isEndOfLine) {
+			if (text.indexOf('\n') !== -1) {
+				// no line breaks inside the text
+				return undefined;
+			}
+			parts.push({ column: insertColumn, text });
+		} else {
+			const lines = strings.splitLines(text);
+			additionalLines = lines.slice(1);
+			parts.push({ column: insertColumn, text: lines[0] });
+		}
 	}
 
-	const position = inlineCompletion.range.getEndPosition();
-
-	const lines = strings.splitLines(remainingInsertText);
-
-	if (lines.length > 1 && textModel.getLineMaxColumn(position.lineNumber) !== position.column) {
-		// Such ghost text is not supported.
-		return undefined;
-	}
-
-	return {
-		lines,
-		position
-	};
+	return new GhostText(lineNumber, parts, additionalLines, 0);
 }
 
 export interface LiveInlineCompletion extends NormalizedInlineCompletion {

--- a/src/vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel.ts
@@ -11,7 +11,7 @@ import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
 import { CompletionItemInsertTextRule } from 'vs/editor/common/modes';
-import { BaseGhostTextWidgetModel, GhostText } from 'vs/editor/contrib/inlineCompletions/ghostTextWidget';
+import { BaseGhostTextWidgetModel, GhostText } from 'vs/editor/contrib/inlineCompletions/ghostText';
 import { inlineCompletionToGhostText, NormalizedInlineCompletion } from 'vs/editor/contrib/inlineCompletions/inlineCompletionsModel';
 import { SnippetParser } from 'vs/editor/contrib/snippet/snippetParser';
 import { SnippetSession } from 'vs/editor/contrib/snippet/snippetSession';
@@ -124,14 +124,11 @@ export class SuggestWidgetAdapterModel extends BaseGhostTextWidgetModel {
 			? (
 				inlineCompletionToGhostText(completion, this.editor.getModel()) ||
 				// Show an invisible ghost text to reserve space
-				{
-					lines: [],
-					position: completion.range.getEndPosition(),
-				}
+				new GhostText(completion.range.endLineNumber, [], [], this.minReservedLineCount)
 			) : undefined;
 
 		if (this.currentGhostText && this.expanded) {
-			this.minReservedLineCount = Math.max(this.minReservedLineCount, this.currentGhostText.lines.length - 1);
+			this.minReservedLineCount = Math.max(this.minReservedLineCount, this.currentGhostText.additionalLines.length);
 		}
 
 		const suggestController = SuggestController.get(this.editor);

--- a/src/vs/editor/contrib/inlineCompletions/test/inlineCompletionsProvider.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/inlineCompletionsProvider.test.ts
@@ -1,0 +1,461 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { timeout } from 'vs/base/common/async';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { CoreEditingCommands } from 'vs/editor/browser/controller/coreCommands';
+import { Range } from 'vs/editor/common/core/range';
+import { InlineCompletionsProvider, InlineCompletionsProviderRegistry } from 'vs/editor/common/modes';
+import { ViewModel } from 'vs/editor/common/viewModel/viewModelImpl';
+import { GhostTextController } from 'vs/editor/contrib/inlineCompletions/ghostTextController';
+import { GhostTextWidget } from 'vs/editor/contrib/inlineCompletions/ghostTextWidget';
+import { InlineCompletionsModel, InlineCompletionsSession, inlineCompletionToGhostText } from 'vs/editor/contrib/inlineCompletions/inlineCompletionsModel';
+import { GhostTextContext, MockInlineCompletionsProvider } from 'vs/editor/contrib/inlineCompletions/test/utils';
+import { ITestCodeEditor, TestCodeEditorCreationOptions, withAsyncTestCodeEditor } from 'vs/editor/test/browser/testCodeEditor';
+import { createTextModel } from 'vs/editor/test/common/editorTestUtils';
+import sinon = require('sinon');
+
+test('inlineCompletionToGhostText', function () {
+	function getOutput(text: string, suggestion: string): unknown {
+		const range = new Range(1, text.indexOf('[') + 1, 1, text.indexOf(']'));
+		const tempModel = createTextModel(text.replace('[', '').replace(']', ''));
+		const ghostText = inlineCompletionToGhostText({ text: suggestion, range }, tempModel);
+		if (!ghostText) {
+			return undefined;
+		}
+		return {
+			text: ghostText.lines.join('\n'),
+			column: ghostText.position.column,
+		};
+	}
+
+	assert.deepStrictEqual(getOutput('[foo]baz', 'foobar'), { text: 'bar', column: 4 });
+	assert.deepStrictEqual(getOutput('[foo]baz', 'boobar'), undefined);
+
+	// Empty ghost text
+	assert.deepStrictEqual(getOutput('[foo]', 'foo'), { text: '', column: 4 });
+
+	// Whitespace (in indentation)
+	assert.deepStrictEqual(getOutput('[ foo]', 'foobar'), { text: 'bar', column: 5 });
+	assert.deepStrictEqual(getOutput('[\tfoo]', 'foobar'), { text: 'bar', column: 5 });
+	assert.deepStrictEqual(getOutput('[\t foo]', '\tfoobar'), { text: 'bar', column: 6 });
+	assert.deepStrictEqual(getOutput('[\tfoo]', '\t\tfoobar'), { text: 'bar', column: 5 });
+	assert.deepStrictEqual(getOutput('[\t]', '\t\tfoobar'), { text: '\tfoobar', column: 2 });
+
+	// (outside of indentation)
+	assert.deepStrictEqual(getOutput('bar[ foo]', 'foobar'), undefined);
+	assert.deepStrictEqual(getOutput('bar[\tfoo]', 'foobar'), undefined);
+
+});
+
+test('Does not trigger automatically by default', async function () {
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+
+			context.keyboardType('foo');
+			await timeout(1000);
+
+			// Provider is not called, no ghost text is shown.
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), []);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['']);
+		}
+	);
+});
+
+test('Ghost text is shown after trigger', async function () {
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+
+			context.keyboardType('foo');
+			provider.setReturnValue({ text: 'foobar', range: new Range(1, 1, 1, 4) });
+			model.trigger();
+			await timeout(1000);
+
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,4)', text: 'foo', triggerKind: 0, }
+			]);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['', 'foo[bar]']);
+		}
+	);
+});
+
+test('Ghost text is shown automatically when configured', async function () {
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider, inlineSuggest: { enabled: true } },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+			context.keyboardType('foo');
+
+			provider.setReturnValue({ text: 'foobar', range: new Range(1, 1, 1, 4) });
+			await timeout(1000);
+
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,4)', text: 'foo', triggerKind: 0, }
+			]);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['', 'foo[bar]']);
+		}
+	);
+});
+
+test('Ghost text is updated automatically', async function () {
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+
+			context.keyboardType('foo');
+			provider.setReturnValue({ text: 'foobar', range: new Range(1, 1, 1, 4) });
+			model.trigger();
+			await timeout(1000);
+
+			provider.setReturnValue({ text: 'foobizz', range: new Range(1, 1, 1, 6) });
+			context.keyboardType('bi');
+			await timeout(1000);
+
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,4)', text: 'foo', triggerKind: 0, },
+				{ position: '(1,6)', text: 'foobi', triggerKind: 0, }
+			]);
+			assert.deepStrictEqual(
+				context.getAndClearViewStates(),
+				['', 'foo[bar]', 'foob[ar]', 'foobi', 'foobi[zz]']
+			);
+		}
+	);
+});
+
+test('Unindent whitespace', async function () {
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+
+			context.keyboardType('  ');
+			provider.setReturnValue({ text: 'foo', range: new Range(1, 2, 1, 3) });
+			model.trigger();
+			await timeout(1000);
+
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['', '  [foo]']);
+
+			model.commitCurrentSuggestion();
+
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,3)', text: '  ', triggerKind: 0, },
+			]);
+
+			assert.deepStrictEqual(context.getAndClearViewStates(), [' foo']);
+		}
+	);
+});
+
+test('Unindent tab', async function () {
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+
+			context.keyboardType('\t\t');
+			provider.setReturnValue({ text: 'foo', range: new Range(1, 2, 1, 3) });
+			model.trigger();
+			await timeout(1000);
+
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['', '\t\t[foo]']);
+
+			model.commitCurrentSuggestion();
+
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,3)', text: '\t\t', triggerKind: 0, },
+			]);
+
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['\tfoo']);
+		}
+	);
+});
+
+test('No unindent after indentation', async function () {
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+
+			context.keyboardType('buzz  ');
+			provider.setReturnValue({ text: 'foo', range: new Range(1, 6, 1, 7) });
+			model.trigger();
+			await timeout(1000);
+
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['', 'buzz  ']);
+
+			model.commitCurrentSuggestion();
+
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,7)', text: 'buzz  ', triggerKind: 0, },
+			]);
+
+			assert.deepStrictEqual(context.getAndClearViewStates(), []);
+		}
+	);
+});
+
+test('Next/previous', async function () {
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+
+			context.keyboardType('foo');
+			provider.setReturnValue({ text: 'foobar1', range: new Range(1, 1, 1, 4) });
+			model.trigger();
+			await timeout(1000);
+
+			assert.deepStrictEqual(
+				context.getAndClearViewStates(),
+				['', 'foo[bar1]']
+			);
+
+			provider.setReturnValues([
+				{ text: 'foobar1', range: new Range(1, 1, 1, 4) },
+				{ text: 'foobizz2', range: new Range(1, 1, 1, 4) },
+				{ text: 'foobuzz3', range: new Range(1, 1, 1, 4) }
+			]);
+
+			model.showNext();
+			await timeout(1000);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['foo[bizz2]']);
+
+			model.showNext();
+			await timeout(1000);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['foo[buzz3]']);
+
+			model.showNext();
+			await timeout(1000);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['foo[bar1]']);
+
+			model.showPrevious();
+			await timeout(1000);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['foo[buzz3]']);
+
+			model.showPrevious();
+			await timeout(1000);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['foo[bizz2]']);
+
+			model.showPrevious();
+			await timeout(1000);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['foo[bar1]']);
+
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,4)', text: 'foo', triggerKind: 0, },
+				{ position: '(1,4)', text: 'foo', triggerKind: 1, },
+			]);
+
+		}
+	);
+});
+
+test('Calling the provider is debounced', async function () {
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+			model.trigger();
+
+			context.keyboardType('f');
+			await timeout(40);
+			context.keyboardType('o');
+			await timeout(40);
+			context.keyboardType('o');
+			await timeout(40);
+
+			// The provider is not called
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), []);
+
+			await timeout(400);
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,4)', text: 'foo', triggerKind: 0, }
+			]);
+		}
+	);
+});
+
+test('Forward stability', async function () {
+	// The user types the text as suggested and the provider is forward-stable
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+
+			provider.setReturnValue({ text: 'foobar', range: new Range(1, 1, 1, 4) });
+			context.keyboardType('foo');
+			model.trigger();
+			await timeout(1000);
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,4)', text: 'foo', triggerKind: 0, }
+			]);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['', 'foo[bar]']);
+
+			provider.setReturnValue({ text: 'foobar', range: new Range(1, 1, 1, 5) });
+			context.keyboardType('b');
+			assert.deepStrictEqual(context.currentPrettyViewState, 'foob[ar]');
+			await timeout(1000);
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,5)', text: 'foob', triggerKind: 0, }
+			]);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['foob[ar]']);
+
+			provider.setReturnValue({ text: 'foobar', range: new Range(1, 1, 1, 6) });
+			context.keyboardType('a');
+			assert.deepStrictEqual(context.currentPrettyViewState, 'fooba[r]');
+			await timeout(1000);
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,6)', text: 'fooba', triggerKind: 0, }
+			]);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['fooba[r]']);
+		}
+	);
+});
+
+test('Support forward instability', async function () {
+	// The user types the text as suggested and the provider reports a different suggestion.
+
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+			provider.setReturnValue({ text: 'foobar', range: new Range(1, 1, 1, 4) });
+			context.keyboardType('foo');
+			model.trigger();
+			await timeout(100);
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,4)', text: 'foo', triggerKind: 0, }
+			]);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['', 'foo[bar]']);
+
+			provider.setReturnValue({ text: 'foobaz', range: new Range(1, 1, 1, 5) });
+			context.keyboardType('b');
+			assert.deepStrictEqual(context.currentPrettyViewState, 'foob[ar]');
+			await timeout(100);
+			// This behavior might change!
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,5)', text: 'foob', triggerKind: 0, }
+			]);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['foob[ar]', 'foob[az]']);
+		}
+	);
+});
+
+test('Support backward instability', async function () {
+	// The user deletes text and the suggestion changes
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+
+			context.keyboardType('fooba');
+
+			provider.setReturnValue({ text: 'foobar', range: new Range(1, 1, 1, 6) });
+
+			model.trigger();
+			await timeout(1000);
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,6)', text: 'fooba', triggerKind: 0, }
+			]);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['', 'fooba[r]']);
+
+			provider.setReturnValue({ text: 'foobaz', range: new Range(1, 1, 1, 5) });
+			CoreEditingCommands.DeleteLeft.runEditorCommand(null, editor, null);
+			await timeout(1000);
+			assert.deepStrictEqual(provider.getAndClearCallHistory(), [
+				{ position: '(1,5)', text: 'foob', triggerKind: 0, }
+			]);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['foob[ar]', 'foob[az]']);
+		}
+	);
+});
+
+test('No race conditions', async function () {
+	const provider = new MockInlineCompletionsProvider();
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider, },
+		async ({ editor, editorViewModel, model, context }) => {
+			model.setActive(true);
+			context.keyboardType('h');
+			provider.setReturnValue({ text: 'helloworld', range: new Range(1, 1, 1, 2) }, 1000);
+
+			model.trigger();
+
+			await timeout(1030);
+			context.keyboardType('ello');
+			provider.setReturnValue({ text: 'helloworld', range: new Range(1, 1, 1, 6) }, 1000);
+
+			// after 20ms: Inline completion provider answers back
+			// after 50ms: Debounce is triggered
+			await timeout(2000);
+
+			assert.deepStrictEqual(context.getAndClearViewStates(), [
+				'',
+				'hello[world]',
+			]);
+		});
+});
+
+async function withAsyncTestCodeEditorAndInlineCompletionsModel(
+	text: string,
+	options: TestCodeEditorCreationOptions & { provider?: InlineCompletionsProvider, fakeClock?: boolean },
+	callback: (args: { editor: ITestCodeEditor, editorViewModel: ViewModel, model: InlineCompletionsModel, context: GhostTextContext }) => Promise<void>
+): Promise<void> {
+	const disposableStore = new DisposableStore();
+
+	if (options.provider) {
+		const d = InlineCompletionsProviderRegistry.register({ pattern: '**' }, options.provider);
+		disposableStore.add(d);
+	}
+
+	let clock: sinon.SinonFakeTimers | undefined;
+	if (options.fakeClock) {
+		clock = sinon.useFakeTimers();
+	}
+	try {
+		const p = clock?.runAllAsync();
+
+		await withAsyncTestCodeEditor(text, options, async (editor, editorViewModel, instantiationService) => {
+			const model = instantiationService.createInstance(InlineCompletionsModel, editor);
+			const context = new GhostTextContext(model, editor);
+			await callback({ editor, editorViewModel, model, context });
+		});
+
+		await p;
+	} finally {
+		clock?.restore();
+		disposableStore.dispose();
+	}
+}
+
+
+
+export class MockedGhostTextController extends GhostTextController {
+	public getInlineCompletionSession(): InlineCompletionsSession | undefined {
+		return this.activeController.value?.activeInlineCompletionsModel?.completionSession.value;
+	}
+
+	public get ghostTextWidget(): GhostTextWidget {
+		return this.widget;
+	}
+}

--- a/src/vs/editor/contrib/inlineCompletions/test/inlineCompletionsProvider.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/inlineCompletionsProvider.test.ts
@@ -10,9 +10,7 @@ import { CoreEditingCommands } from 'vs/editor/browser/controller/coreCommands';
 import { Range } from 'vs/editor/common/core/range';
 import { InlineCompletionsProvider, InlineCompletionsProviderRegistry } from 'vs/editor/common/modes';
 import { ViewModel } from 'vs/editor/common/viewModel/viewModelImpl';
-import { GhostTextController } from 'vs/editor/contrib/inlineCompletions/ghostTextController';
-import { GhostTextWidget } from 'vs/editor/contrib/inlineCompletions/ghostTextWidget';
-import { InlineCompletionsModel, InlineCompletionsSession, inlineCompletionToGhostText } from 'vs/editor/contrib/inlineCompletions/inlineCompletionsModel';
+import { InlineCompletionsModel, inlineCompletionToGhostText } from 'vs/editor/contrib/inlineCompletions/inlineCompletionsModel';
 import { GhostTextContext, MockInlineCompletionsProvider } from 'vs/editor/contrib/inlineCompletions/test/utils';
 import { ITestCodeEditor, TestCodeEditorCreationOptions, withAsyncTestCodeEditor } from 'vs/editor/test/browser/testCodeEditor';
 import { createTextModel } from 'vs/editor/test/common/editorTestUtils';
@@ -445,17 +443,5 @@ async function withAsyncTestCodeEditorAndInlineCompletionsModel(
 	} finally {
 		clock?.restore();
 		disposableStore.dispose();
-	}
-}
-
-
-
-export class MockedGhostTextController extends GhostTextController {
-	public getInlineCompletionSession(): InlineCompletionsSession | undefined {
-		return this.activeController.value?.activeInlineCompletionsModel?.completionSession.value;
-	}
-
-	public get ghostTextWidget(): GhostTextWidget {
-		return this.widget;
 	}
 }

--- a/src/vs/editor/contrib/inlineCompletions/test/inlineCompletionsProvider.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/inlineCompletionsProvider.test.ts
@@ -24,6 +24,7 @@ suite('inlineCompletionToGhostText', () => {
 		const tempModel = createTextModel(cleanedText);
 		const range = Range.fromPositions(tempModel.getPositionAt(rangeStartOffset), tempModel.getPositionAt(rangeEndOffset));
 		const ghostText = inlineCompletionToGhostText({ text: suggestion, range }, tempModel);
+		tempModel.dispose();
 		if (!ghostText) {
 			return undefined;
 		}
@@ -454,6 +455,7 @@ async function withAsyncTestCodeEditorAndInlineCompletionsModel(
 			const model = instantiationService.createInstance(InlineCompletionsModel, editor);
 			const context = new GhostTextContext(model, editor);
 			await callback({ editor, editorViewModel, model, context });
+			model.dispose();
 		});
 
 		await p;

--- a/src/vs/editor/contrib/inlineCompletions/test/suggestWidgetModel.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/suggestWidgetModel.test.ts
@@ -1,0 +1,161 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SuggestWidgetAdapterModel } from 'vs/editor/contrib/inlineCompletions/suggestWidgetAdapterModel';
+import { SuggestController } from 'vs/editor/contrib/suggest/suggestController';
+import { SnippetController2 } from 'vs/editor/contrib/snippet/snippetController2';
+import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
+import { ILogService, NullLogService } from 'vs/platform/log/common/log';
+import { InMemoryStorageService, IStorageService } from 'vs/platform/storage/common/storage';
+import { MockKeybindingService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
+import { mock } from 'vs/base/test/common/mock';
+import { IEditorWorkerService } from 'vs/editor/common/services/editorWorkerService';
+import { ISuggestMemoryService } from 'vs/editor/contrib/suggest/suggestMemory';
+import { IMenuService, IMenu } from 'vs/platform/actions/common/actions';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import sinon = require('sinon');
+import { timeout } from 'vs/base/common/async';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { CompletionItemKind, CompletionItemProvider, CompletionProviderRegistry } from 'vs/editor/common/modes';
+import { ViewModel } from 'vs/editor/common/viewModel/viewModelImpl';
+import { TestCodeEditorCreationOptions, ITestCodeEditor, withAsyncTestCodeEditor } from 'vs/editor/test/browser/testCodeEditor';
+import { Event } from 'vs/base/common/event';
+import assert = require('assert');
+import { GhostTextContext } from 'vs/editor/contrib/inlineCompletions/test/utils';
+import { Range } from 'vs/editor/common/core/range';
+
+test('Active', async () => {
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider, },
+		async ({ editor, editorViewModel, context, model }) => {
+			let last: boolean | undefined = undefined;
+			const history = new Array<boolean>();
+			model.onDidChange(() => {
+				if (last !== model.isActive) {
+					last = model.isActive;
+					history.push(last);
+				}
+			});
+
+			context.keyboardType('h');
+			const suggestController = (editor.getContribution(SuggestController.ID) as SuggestController);
+			suggestController.triggerSuggest();
+			await timeout(1000);
+			assert.deepStrictEqual(history.splice(0), [true]);
+
+			context.keyboardType('.');
+			await timeout(1000);
+
+			// No flicker here
+			assert.deepStrictEqual(history.splice(0), []);
+			suggestController.cancelSuggestWidget();
+			await timeout(1000);
+
+			assert.deepStrictEqual(history.splice(0), [false]);
+		}
+	);
+});
+
+test('Ghost Text', async () => {
+	await withAsyncTestCodeEditorAndInlineCompletionsModel('',
+		{ fakeClock: true, provider, suggest: { preview: true } },
+		async ({ editor, editorViewModel, context, model }) => {
+			context.keyboardType('h');
+			const suggestController = (editor.getContribution(SuggestController.ID) as SuggestController);
+			suggestController.triggerSuggest();
+			await timeout(1000);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['', 'h[ello]']);
+
+			context.keyboardType('.');
+			await timeout(1000);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['hello', 'hello.[hello]']);
+
+			suggestController.cancelSuggestWidget();
+
+			await timeout(1000);
+			assert.deepStrictEqual(context.getAndClearViewStates(), ['hello.']);
+		}
+	);
+});
+
+const provider: CompletionItemProvider = {
+	triggerCharacters: ['.'],
+	async provideCompletionItems(model, pos) {
+		const word = model.getWordAtPosition(pos);
+		const range = word
+			? { startLineNumber: 1, startColumn: word.startColumn, endLineNumber: 1, endColumn: word.endColumn }
+			: Range.fromPositions(pos);
+
+		return {
+			suggestions: [{
+				insertText: 'hello',
+				kind: CompletionItemKind.Text,
+				label: 'hello',
+				range,
+				commitCharacters: ['.'],
+			}]
+		};
+	},
+};
+
+async function withAsyncTestCodeEditorAndInlineCompletionsModel(
+	text: string,
+	options: TestCodeEditorCreationOptions & { provider?: CompletionItemProvider, fakeClock?: boolean, serviceCollection?: never },
+	callback: (args: { editor: ITestCodeEditor, editorViewModel: ViewModel, model: SuggestWidgetAdapterModel, context: GhostTextContext }) => Promise<void>
+): Promise<void> {
+	const serviceCollection = new ServiceCollection(
+		[ITelemetryService, NullTelemetryService],
+		[ILogService, new NullLogService()],
+		[IStorageService, new InMemoryStorageService()],
+		[IKeybindingService, new MockKeybindingService()],
+		[IEditorWorkerService, new class extends mock<IEditorWorkerService>() {
+			override computeWordRanges() {
+				return Promise.resolve({});
+			}
+		}],
+		[ISuggestMemoryService, new class extends mock<ISuggestMemoryService>() {
+			override memorize(): void { }
+			override select(): number { return 0; }
+		}],
+		[IMenuService, new class extends mock<IMenuService>() {
+			override createMenu() {
+				return new class extends mock<IMenu>() {
+					override onDidChange = Event.None;
+					override dispose() { }
+				};
+			}
+		}]
+	);
+
+	const disposableStore = new DisposableStore();
+
+	if (options.provider) {
+		const d = CompletionProviderRegistry.register({ pattern: '**' }, options.provider);
+		disposableStore.add(d);
+	}
+
+	let clock: sinon.SinonFakeTimers | undefined;
+	if (options.fakeClock) {
+		clock = sinon.useFakeTimers();
+	}
+	try {
+		const p = clock?.runAllAsync();
+
+		await withAsyncTestCodeEditor(text, { ...options, serviceCollection }, async (editor, editorViewModel, instantiationService) => {
+			editor.registerAndInstantiateContribution(SnippetController2.ID, SnippetController2);
+			editor.registerAndInstantiateContribution(SuggestController.ID, SuggestController);
+			const model = instantiationService.createInstance(SuggestWidgetAdapterModel, editor);
+			const context = new GhostTextContext(model, editor);
+			await callback({ editor, editorViewModel, model, context });
+		});
+
+		await p;
+	} finally {
+		clock?.restore();
+		disposableStore.dispose();
+	}
+}

--- a/src/vs/editor/contrib/inlineCompletions/test/suggestWidgetModel.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/suggestWidgetModel.test.ts
@@ -151,6 +151,7 @@ async function withAsyncTestCodeEditorAndInlineCompletionsModel(
 			const model = instantiationService.createInstance(SuggestWidgetAdapterModel, editor);
 			const context = new GhostTextContext(model, editor);
 			await callback({ editor, editorViewModel, model, context });
+			model.dispose();
 		});
 
 		await p;

--- a/src/vs/editor/contrib/inlineCompletions/test/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/utils.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { timeout } from 'vs/base/common/async';
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { Position } from 'vs/editor/common/core/position';
+import { Range } from 'vs/editor/common/core/range';
+import { ITextModel } from 'vs/editor/common/model';
+import { InlineCompletionsProvider, InlineCompletion, InlineCompletionContext } from 'vs/editor/common/modes';
+import { GhostTextWidgetModel } from 'vs/editor/contrib/inlineCompletions/ghostTextWidget';
+import { ITestCodeEditor } from 'vs/editor/test/browser/testCodeEditor';
+import { createTextModel } from 'vs/editor/test/common/editorTestUtils';
+
+export class MockInlineCompletionsProvider implements InlineCompletionsProvider {
+	private returnValue: InlineCompletion[] = [];
+	private delayMs: number = 0;
+
+	private callHistory = new Array<unknown>();
+
+	public setReturnValue(value: InlineCompletion | undefined, delayMs: number = 0): void {
+		this.returnValue = value ? [value] : [];
+		this.delayMs = delayMs;
+	}
+
+	public setReturnValues(values: InlineCompletion[], delayMs: number = 0): void {
+		this.returnValue = values;
+		this.delayMs = delayMs;
+	}
+
+	public getAndClearCallHistory() {
+		const history = [...this.callHistory];
+		this.callHistory = [];
+		return history;
+	}
+
+	async provideInlineCompletions(model: ITextModel, position: Position, context: InlineCompletionContext, token: CancellationToken) {
+		this.callHistory.push({
+			position: position.toString(),
+			triggerKind: context.triggerKind,
+			text: model.getValue()
+		});
+		const result = new Array<InlineCompletion>();
+		result.push(...this.returnValue);
+
+		if (this.delayMs > 0) {
+			await timeout(this.delayMs);
+		}
+
+		return { items: result };
+	}
+	freeInlineCompletions() { }
+	handleItemDidShow() { }
+}
+
+export class GhostTextContext extends Disposable {
+	public readonly prettyViewStates = new Array<string | undefined>();
+	private _currentPrettyViewState: string | undefined;
+	public get currentPrettyViewState() {
+		return this._currentPrettyViewState;
+	}
+
+	constructor(private readonly model: GhostTextWidgetModel, private readonly editor: ITestCodeEditor) {
+		super();
+
+		this._register(
+			model.onDidChange(() => {
+				this.update();
+			})
+		);
+		this.update();
+	}
+
+	private update(): void {
+		const ghostText = this.model?.ghostText;
+		let view: string | undefined;
+		if (ghostText) {
+			const insertText = ghostText.lines.join('\n');
+			const tempModel = createTextModel(this.editor.getValue());
+			tempModel.applyEdits([{ range: Range.fromPositions(ghostText.position), text: `[${insertText}]` }]);
+			view = tempModel.getValue();
+		} else {
+			view = this.editor.getValue();
+		}
+
+		if (this._currentPrettyViewState !== view) {
+			this.prettyViewStates.push(view);
+		}
+		this._currentPrettyViewState = view;
+	}
+
+	public getAndClearViewStates(): (string | undefined)[] {
+		const arr = [...this.prettyViewStates];
+		this.prettyViewStates.length = 0;
+		return arr;
+	}
+
+	public keyboardType(text: string): void {
+		this.editor.trigger('keyboard', 'type', { text });
+	}
+}

--- a/src/vs/editor/contrib/inlineCompletions/test/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/utils.ts
@@ -25,7 +25,9 @@ export function renderGhostTextToText(ghostText: GhostText, text: string): strin
 			}] : [])
 		]
 	);
-	return tempModel.getValue();
+	const value = tempModel.getValue();
+	tempModel.dispose();
+	return value;
 }
 
 export class MockInlineCompletionsProvider implements InlineCompletionsProvider {

--- a/src/vs/editor/contrib/inlineCompletions/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/utils.ts
@@ -3,7 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IDisposable, trackDisposable } from 'vs/base/common/lifecycle';
+import { IDisposable, IReference, trackDisposable } from 'vs/base/common/lifecycle';
+
+export function createDisposableRef<T>(object: T, disposable?: IDisposable): IReference<T> {
+	return {
+		object,
+		dispose: () => disposable?.dispose(),
+	};
+}
 
 // TODO: merge this class into Matt's MutableDisposable.
 /**

--- a/src/vs/platform/extensionManagement/node/extensionsWatcher.ts
+++ b/src/vs/platform/extensionManagement/node/extensionsWatcher.ts
@@ -41,7 +41,7 @@ export class ExtensionsWatcher extends Disposable {
 		const extensionsResource = URI.file(environmentService.extensionsPath);
 		const extUri = new ExtUri(resource => !fileService.hasCapability(resource, FileSystemProviderCapabilities.PathCaseSensitive));
 		this._register(fileService.watch(extensionsResource));
-		this._register(Event.filter(fileService.onDidFilesChange, e => e.changes.some(change => this.doesChangeAffects(change, extensionsResource, extUri)))(() => this.onDidChange()));
+		this._register(Event.filter(fileService.onDidFilesChange, e => e.raw.some(change => this.doesChangeAffects(change, extensionsResource, extUri)))(() => this.onDidChange()));
 	}
 
 	private doesChangeAffects(change: IFileChange, extensionsResource: URI, extUri: ExtUri): boolean {

--- a/src/vs/platform/files/node/watcher/nsfw/nsfwWatcherService.ts
+++ b/src/vs/platform/files/node/watcher/nsfw/nsfwWatcherService.ts
@@ -13,7 +13,7 @@ import { IWatcherService, IWatcherRequest } from 'vs/platform/files/node/watcher
 import { ThrottledDelayer } from 'vs/base/common/async';
 import { FileChangeType } from 'vs/platform/files/common/files';
 import { normalizeNFC } from 'vs/base/common/normalization';
-import { Event, Emitter } from 'vs/base/common/event';
+import { Emitter } from 'vs/base/common/event';
 import { realcaseSync, realpathSync } from 'vs/base/node/extpath';
 import { Disposable } from 'vs/base/common/lifecycle';
 
@@ -41,7 +41,7 @@ export class NsfwWatcherService extends Disposable implements IWatcherService {
 	readonly onDidChangeFile = this._onDidChangeFile.event;
 
 	private readonly _onDidLogMessage = this._register(new Emitter<ILogMessage>());
-	readonly onDidLogMessage: Event<ILogMessage> = this._onDidLogMessage.event;
+	readonly onDidLogMessage = this._onDidLogMessage.event;
 
 	private pathWatchers: { [watchPath: string]: IPathWatcher } = {};
 	private verboseLogging: boolean | undefined;
@@ -51,17 +51,17 @@ export class NsfwWatcherService extends Disposable implements IWatcherService {
 		const normalizedRoots = this._normalizeRoots(roots);
 
 		// Gather roots that are not currently being watched
-		const rootsToStartWatching = normalizedRoots.filter(r => {
-			return !(r.path in this.pathWatchers);
+		const rootsToStartWatching = normalizedRoots.filter(root => {
+			return !(root.path in this.pathWatchers);
 		});
 
 		// Gather current roots that don't exist in the new roots array
-		const rootsToStopWatching = Object.keys(this.pathWatchers).filter(r => {
-			return normalizedRoots.every(normalizedRoot => normalizedRoot.path !== r);
+		const rootsToStopWatching = Object.keys(this.pathWatchers).filter(root => {
+			return normalizedRoots.every(normalizedRoot => normalizedRoot.path !== root);
 		});
 
 		// Logging
-		this.debug(`Start watching: [${rootsToStartWatching.map(r => r.path).join(',')}]\nStop watching: [${rootsToStopWatching.join(',')}]`);
+		this.debug(`Start watching: [${rootsToStartWatching.map(root => root.path).join(',')}]\nStop watching: [${rootsToStopWatching.join(',')}]`);
 
 		// Stop watching some roots
 		rootsToStopWatching.forEach(root => {
@@ -189,13 +189,13 @@ export class NsfwWatcherService extends Disposable implements IWatcherService {
 				}
 
 				// Broadcast to clients normalized
-				const res = normalizeFileChanges(events);
-				this._onDidChangeFile.fire(res);
+				const normalizedEvents = normalizeFileChanges(events);
+				this._onDidChangeFile.fire(normalizedEvents);
 
 				// Logging
 				if (this.verboseLogging) {
-					res.forEach(r => {
-						this.log(` >> normalized ${r.type === FileChangeType.ADDED ? '[ADDED]' : r.type === FileChangeType.DELETED ? '[DELETED]' : '[CHANGED]'} ${r.path}`);
+					normalizedEvents.forEach(e => {
+						this.log(` >> normalized ${e.type === FileChangeType.ADDED ? '[ADDED]' : e.type === FileChangeType.DELETED ? '[DELETED]' : '[CHANGED]'} ${e.path}`);
 					});
 				}
 			});
@@ -231,7 +231,7 @@ export class NsfwWatcherService extends Disposable implements IWatcherService {
 	}
 
 	private isPathIgnored(absolutePath: string, ignored: glob.ParsedPattern[]): boolean {
-		return ignored && ignored.some(i => i(absolutePath));
+		return ignored && ignored.some(ignore => ignore(absolutePath));
 	}
 
 	private log(message: string) {

--- a/src/vs/platform/files/node/watcher/nsfw/watcherService.ts
+++ b/src/vs/platform/files/node/watcher/nsfw/watcherService.ts
@@ -66,7 +66,7 @@ export class FileWatcher extends Disposable {
 		this.service.setVerboseLogging(this.verboseLogging);
 
 		this._register(this.service.onDidChangeFile(e => !this.isDisposed && this.onDidFilesChange(e)));
-		this._register(this.service.onDidLogMessage(m => this.onLogMessage(m)));
+		this._register(this.service.onDidLogMessage(e => this.onLogMessage(e)));
 
 		// Start watching
 		this.setFolders(this.folders);

--- a/src/vs/platform/files/node/watcher/unix/watcherService.ts
+++ b/src/vs/platform/files/node/watcher/unix/watcherService.ts
@@ -66,7 +66,7 @@ export class FileWatcher extends Disposable {
 		this.service.init({ ...this.watcherOptions, verboseLogging: this.verboseLogging });
 
 		this._register(this.service.onDidChangeFile(e => !this.isDisposed && this.onDidFilesChange(e)));
-		this._register(this.service.onDidLogMessage(m => this.onLogMessage(m)));
+		this._register(this.service.onDidLogMessage(e => this.onLogMessage(e)));
 
 		// Start watching
 		this.service.setRoots(this.folders);

--- a/src/vs/platform/files/node/watcher/watcher.ts
+++ b/src/vs/platform/files/node/watcher/watcher.ts
@@ -96,7 +96,7 @@ class EventNormalizer {
 		}).sort((e1, e2) => {
 			return e1.path.length - e2.path.length; // shortest path first
 		}).filter(e => {
-			if (deletedPaths.some(d => isParent(e.path, d, !isLinux /* ignorecase */))) {
+			if (deletedPaths.some(deletedPath => isParent(e.path, deletedPath, !isLinux /* ignorecase */))) {
 				return false; // DELETE is ignored if parent is deleted already
 			}
 

--- a/src/vs/platform/files/node/watcher/win32/csharpWatcherService.ts
+++ b/src/vs/platform/files/node/watcher/win32/csharpWatcherService.ts
@@ -31,7 +31,7 @@ export class OutOfProcessWin32FolderWatcher {
 		this.restartCounter = 0;
 
 		if (Array.isArray(ignored)) {
-			this.ignored = ignored.map(i => glob.parse(i));
+			this.ignored = ignored.map(ignore => glob.parse(ignore));
 		} else {
 			this.ignored = [];
 		}

--- a/src/vs/platform/files/test/common/files.test.ts
+++ b/src/vs/platform/files/test/common/files.test.ts
@@ -9,8 +9,21 @@ import { isEqual, isEqualOrParent } from 'vs/base/common/extpath';
 import { FileChangeType, FileChangesEvent, isParent } from 'vs/platform/files/common/files';
 import { isLinux, isMacintosh, isWindows } from 'vs/base/common/platform';
 import { toResource } from 'vs/base/test/common/utils';
+import { TernarySearchTree } from 'vs/base/common/map';
 
 suite('Files', () => {
+
+	function count(changes?: TernarySearchTree<unknown, unknown>): number {
+		let counter = 0;
+
+		if (changes) {
+			for (const _change of changes) {
+				counter++;
+			}
+		}
+
+		return counter;
+	}
 
 	test('FileChangesEvent - basics', function () {
 		const changes = [
@@ -57,11 +70,11 @@ suite('Files', () => {
 			}
 			assert(!event.contains(toResource.call(this, '/bar/folder2/somefile'), FileChangeType.DELETED));
 
-			assert.strictEqual(6, event.changes.length);
-			assert.strictEqual(1, event.getAdded().length);
+			assert.strictEqual(6, event.raw.length);
+			assert.strictEqual(1, count(event.rawAdded));
 			assert.strictEqual(true, event.gotAdded());
 			assert.strictEqual(true, event.gotUpdated());
-			assert.strictEqual(ignorePathCasing ? 2 : 3, event.getDeleted().length);
+			assert.strictEqual(ignorePathCasing ? 2 : 3, count(event.rawDeleted));
 			assert.strictEqual(true, event.gotDeleted());
 		}
 	});
@@ -99,10 +112,10 @@ suite('Files', () => {
 
 				switch (type) {
 					case FileChangeType.ADDED:
-						assert.strictEqual(8, event.getAdded().length);
+						assert.strictEqual(8, count(event.rawAdded));
 						break;
 					case FileChangeType.DELETED:
-						assert.strictEqual(8, event.getDeleted().length);
+						assert.strictEqual(8, count(event.rawDeleted));
 						break;
 				}
 			}

--- a/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
+++ b/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
@@ -2280,7 +2280,7 @@ flakySuite('Disk File Service', function () {
 			}
 
 			function printEvents(event: FileChangesEvent): string {
-				return event.changes.map(change => `Change: type ${toString(change.type)} path ${change.resource.toString()}`).join('\n');
+				return event.raw.map(change => `Change: type ${toString(change.type)} path ${change.resource.toString()}`).join('\n');
 			}
 
 			const listenerDisposable = service.onDidFilesChange(event => {
@@ -2288,14 +2288,14 @@ flakySuite('Disk File Service', function () {
 				listenerDisposable.dispose();
 
 				try {
-					assert.strictEqual(event.changes.length, expected.length, `Expected ${expected.length} events, but got ${event.changes.length}. Details (${printEvents(event)})`);
+					assert.strictEqual(event.raw.length, expected.length, `Expected ${expected.length} events, but got ${event.raw.length}. Details (${printEvents(event)})`);
 
 					if (expected.length === 1) {
-						assert.strictEqual(event.changes[0].type, expected[0][0], `Expected ${toString(expected[0][0])} but got ${toString(event.changes[0].type)}. Details (${printEvents(event)})`);
-						assert.strictEqual(event.changes[0].resource.fsPath, expected[0][1].fsPath);
+						assert.strictEqual(event.raw[0].type, expected[0][0], `Expected ${toString(expected[0][0])} but got ${toString(event.raw[0].type)}. Details (${printEvents(event)})`);
+						assert.strictEqual(event.raw[0].resource.fsPath, expected[0][1].fsPath);
 					} else {
 						for (const expect of expected) {
-							assert.strictEqual(hasChange(event.changes, expect[0], expect[1]), true, `Unable to find ${toString(expect[0])} for ${expect[1].fsPath}. Details (${printEvents(event)})`);
+							assert.strictEqual(hasChange(event.raw, expect[0], expect[1]), true, `Unable to find ${toString(expect[0])} for ${expect[1].fsPath}. Details (${printEvents(event)})`);
 						}
 					}
 

--- a/src/vs/platform/files/test/electron-browser/normalizer.test.ts
+++ b/src/vs/platform/files/test/electron-browser/normalizer.test.ts
@@ -64,7 +64,7 @@ suite('Normalizer', () => {
 
 		watch.onDidFilesChange(e => {
 			assert.ok(e);
-			assert.strictEqual(e.changes.length, 3);
+			assert.strictEqual(e.raw.length, 3);
 			assert.ok(e.contains(added, FileChangeType.ADDED));
 			assert.ok(e.contains(updated, FileChangeType.UPDATED));
 			assert.ok(e.contains(deleted, FileChangeType.DELETED));
@@ -103,7 +103,7 @@ suite('Normalizer', () => {
 
 			watch.onDidFilesChange(e => {
 				assert.ok(e);
-				assert.strictEqual(e.changes.length, 5);
+				assert.strictEqual(e.raw.length, 5);
 
 				assert.ok(e.contains(deletedFolderA, FileChangeType.DELETED));
 				assert.ok(e.contains(deletedFolderB, FileChangeType.DELETED));
@@ -133,7 +133,7 @@ suite('Normalizer', () => {
 
 		watch.onDidFilesChange(e => {
 			assert.ok(e);
-			assert.strictEqual(e.changes.length, 1);
+			assert.strictEqual(e.raw.length, 1);
 
 			assert.ok(e.contains(unrelated, FileChangeType.UPDATED));
 
@@ -158,7 +158,7 @@ suite('Normalizer', () => {
 
 		watch.onDidFilesChange(e => {
 			assert.ok(e);
-			assert.strictEqual(e.changes.length, 2);
+			assert.strictEqual(e.raw.length, 2);
 
 			assert.ok(e.contains(deleted, FileChangeType.UPDATED));
 			assert.ok(e.contains(unrelated, FileChangeType.UPDATED));
@@ -184,7 +184,7 @@ suite('Normalizer', () => {
 
 		watch.onDidFilesChange(e => {
 			assert.ok(e);
-			assert.strictEqual(e.changes.length, 2);
+			assert.strictEqual(e.raw.length, 2);
 
 			assert.ok(e.contains(created, FileChangeType.ADDED));
 			assert.ok(!e.contains(created, FileChangeType.UPDATED));
@@ -213,7 +213,7 @@ suite('Normalizer', () => {
 
 		watch.onDidFilesChange(e => {
 			assert.ok(e);
-			assert.strictEqual(e.changes.length, 2);
+			assert.strictEqual(e.raw.length, 2);
 
 			assert.ok(e.contains(deleted, FileChangeType.DELETED));
 			assert.ok(!e.contains(updated, FileChangeType.UPDATED));

--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -52,7 +52,7 @@ export class MainThreadFileSystemEventService {
 			deleted: []
 		};
 		this._listener.add(fileService.onDidFilesChange(event => {
-			for (let change of event.changes) {
+			for (let change of event.raw) {
 				switch (change.type) {
 					case FileChangeType.ADDED:
 						events.created.push(change.resource);

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -159,6 +159,8 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 		configurationRegistry.deregisterConfigurations(removedConfigurations);
 	}
 
+	const seenProperties = new Set<string>();
+
 	function handleConfiguration(node: IConfigurationNode, extension: IExtensionPointUser<any>): IConfigurationNode[] {
 		const configurations: IConfigurationNode[] = [];
 		let configuration = objects.deepClone(node);
@@ -174,6 +176,60 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 		configuration.title = configuration.title || extension.description.displayName || extension.description.identifier.value;
 		configurations.push(configuration);
 		return configurations;
+	}
+
+	function validateProperties(configuration: IConfigurationNode, extension: IExtensionPointUser<any>): void {
+		let properties = configuration.properties;
+		if (properties) {
+			if (typeof properties !== 'object') {
+				extension.collector.error(nls.localize('invalid.properties', "'configuration.properties' must be an object"));
+				configuration.properties = {};
+			}
+			for (let key in properties) {
+				const message = validateProperty(key);
+				if (message) {
+					delete properties[key];
+					extension.collector.warn(message);
+					continue;
+				}
+				if (seenProperties.has(key)) {
+					delete properties[key];
+					extension.collector.warn(nls.localize('config.property.duplicate', "Cannot register '{0}'. This property is already registered.", key));
+					continue;
+				}
+				const propertyConfiguration = properties[key];
+				if (!isObject(propertyConfiguration)) {
+					delete properties[key];
+					extension.collector.error(nls.localize('invalid.property', "configuration.properties property '{0}' must be an object", key));
+					continue;
+				}
+				seenProperties.add(key);
+				if (propertyConfiguration.scope) {
+					if (propertyConfiguration.scope.toString() === 'application') {
+						propertyConfiguration.scope = ConfigurationScope.APPLICATION;
+					} else if (propertyConfiguration.scope.toString() === 'machine') {
+						propertyConfiguration.scope = ConfigurationScope.MACHINE;
+					} else if (propertyConfiguration.scope.toString() === 'resource') {
+						propertyConfiguration.scope = ConfigurationScope.RESOURCE;
+					} else if (propertyConfiguration.scope.toString() === 'machine-overridable') {
+						propertyConfiguration.scope = ConfigurationScope.MACHINE_OVERRIDABLE;
+					} else if (propertyConfiguration.scope.toString() === 'language-overridable') {
+						propertyConfiguration.scope = ConfigurationScope.LANGUAGE_OVERRIDABLE;
+					} else {
+						propertyConfiguration.scope = ConfigurationScope.WINDOW;
+					}
+				} else {
+					propertyConfiguration.scope = ConfigurationScope.WINDOW;
+				}
+			}
+		}
+		let subNodes = configuration.allOf;
+		if (subNodes) {
+			extension.collector.error(nls.localize('invalid.allOf', "'configuration.allOf' is deprecated and should no longer be used. Instead, pass multiple configuration sections as an array to the 'configuration' contribution point."));
+			for (let node of subNodes) {
+				validateProperties(node, extension);
+			}
+		}
 	}
 
 	if (added.length) {
@@ -195,54 +251,6 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 
 });
 // END VSCode extension point `configuration`
-
-function validateProperties(configuration: IConfigurationNode, extension: IExtensionPointUser<any>): void {
-	let properties = configuration.properties;
-	if (properties) {
-		if (typeof properties !== 'object') {
-			extension.collector.error(nls.localize('invalid.properties', "'configuration.properties' must be an object"));
-			configuration.properties = {};
-		}
-		for (let key in properties) {
-			const message = validateProperty(key);
-			if (message) {
-				delete properties[key];
-				extension.collector.warn(message);
-				continue;
-			}
-			const propertyConfiguration = properties[key];
-			if (!isObject(propertyConfiguration)) {
-				delete properties[key];
-				extension.collector.error(nls.localize('invalid.property', "configuration.properties property '{0}' must be an object", key));
-				continue;
-			}
-			if (propertyConfiguration.scope) {
-				if (propertyConfiguration.scope.toString() === 'application') {
-					propertyConfiguration.scope = ConfigurationScope.APPLICATION;
-				} else if (propertyConfiguration.scope.toString() === 'machine') {
-					propertyConfiguration.scope = ConfigurationScope.MACHINE;
-				} else if (propertyConfiguration.scope.toString() === 'resource') {
-					propertyConfiguration.scope = ConfigurationScope.RESOURCE;
-				} else if (propertyConfiguration.scope.toString() === 'machine-overridable') {
-					propertyConfiguration.scope = ConfigurationScope.MACHINE_OVERRIDABLE;
-				} else if (propertyConfiguration.scope.toString() === 'language-overridable') {
-					propertyConfiguration.scope = ConfigurationScope.LANGUAGE_OVERRIDABLE;
-				} else {
-					propertyConfiguration.scope = ConfigurationScope.WINDOW;
-				}
-			} else {
-				propertyConfiguration.scope = ConfigurationScope.WINDOW;
-			}
-		}
-	}
-	let subNodes = configuration.allOf;
-	if (subNodes) {
-		extension.collector.error(nls.localize('invalid.allOf', "'configuration.allOf' is deprecated and should no longer be used. Instead, pass multiple configuration sections as an array to the 'configuration' contribution point."));
-		for (let node of subNodes) {
-			validateProperties(node, extension);
-		}
-	}
-}
 
 const jsonRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
 jsonRegistry.registerSchema('vscode://schemas/workspaceConfig', {

--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -58,7 +58,7 @@ export class ViewContainerActivityAction extends ActivityAction {
 		this.activity = activity;
 	}
 
-	override async run(event: unknown): Promise<void> {
+	override async run(event: any | { preserveFocus: boolean }): Promise<void> {
 		if (event instanceof MouseEvent && event.button === 2) {
 			return; // do not run on right click
 		}
@@ -74,11 +74,12 @@ export class ViewContainerActivityAction extends ActivityAction {
 		const activeViewlet = this.viewletService.getActiveViewlet();
 		const focusBehavior = this.configurationService.getValue<string>('workbench.activityBar.iconClickBehavior');
 
+		const focus = (event && 'preserveFocus' in event) ? !event.preserveFocus : true;
 		if (sideBarVisible && activeViewlet?.getId() === this.activity.id) {
 			switch (focusBehavior) {
 				case 'focus':
 					this.logAction('refocus');
-					this.viewletService.openViewlet(this.activity.id, true);
+					this.viewletService.openViewlet(this.activity.id, focus);
 					break;
 				case 'toggle':
 				default:
@@ -92,7 +93,7 @@ export class ViewContainerActivityAction extends ActivityAction {
 		}
 
 		this.logAction('show');
-		await this.viewletService.openViewlet(this.activity.id, true);
+		await this.viewletService.openViewlet(this.activity.id, focus);
 
 		return this.activate();
 	}

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -396,7 +396,7 @@ export class ActivityActionViewItem extends BaseActionViewItem {
 		if (this.useCustomHover) {
 			this.hoverDisposables.add(addDisposableListener(this.container, EventType.MOUSE_OVER, () => {
 				if (!this.showHoverScheduler.isScheduled()) {
-					this.showHoverScheduler.schedule(this.options.hoverOptions!.delay() || 150);
+					this.showHoverScheduler.schedule(this.options.hoverOptions!.delay() || 500);
 				}
 			}, true));
 			this.hoverDisposables.add(addDisposableListener(this.container, EventType.MOUSE_LEAVE, () => {

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -647,7 +647,7 @@ export class TabsTitleControl extends TitleControl {
 	private registerTabListeners(tab: HTMLElement, index: number, tabsContainer: HTMLElement, tabsScrollbar: ScrollableElement): IDisposable {
 		const disposables = new DisposableStore();
 
-		const handleClickOrTouch = (e: MouseEvent | GestureEvent): void => {
+		const handleClickOrTouch = (e: MouseEvent | GestureEvent, preserveFocus: boolean): void => {
 			tab.blur(); // prevent flicker of focus outline on tab until editor got focus
 
 			if (e instanceof MouseEvent && e.button !== 0) {
@@ -665,7 +665,7 @@ export class TabsTitleControl extends TitleControl {
 			// Open tabs editor
 			const input = this.group.getEditorByIndex(index);
 			if (input) {
-				this.group.openEditor(input);
+				this.group.openEditor(input, { preserveFocus });
 			}
 
 			return undefined;
@@ -681,8 +681,8 @@ export class TabsTitleControl extends TitleControl {
 		};
 
 		// Open on Click / Touch
-		disposables.add(addDisposableListener(tab, EventType.MOUSE_DOWN, e => handleClickOrTouch(e)));
-		disposables.add(addDisposableListener(tab, TouchEventType.Tap, (e: GestureEvent) => handleClickOrTouch(e)));
+		disposables.add(addDisposableListener(tab, EventType.MOUSE_DOWN, e => handleClickOrTouch(e, false)));
+		disposables.add(addDisposableListener(tab, TouchEventType.Tap, (e: GestureEvent) => handleClickOrTouch(e, true))); // Preserve focus on touch #125470
 
 		// Touch Scroll Support
 		disposables.add(addDisposableListener(tab, TouchEventType.Change, (e: GestureEvent) => {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -332,7 +332,7 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditorPan
 
 		// Clear view state if input is disposed or we are configured to not storing any state
 		if (input.isDisposed() || (!this.shouldRestoreTextEditorViewState(input) && (!this.group || !this.group.contains(input)))) {
-			super.clearTextEditorViewState([resource], this.group);
+			super.clearTextEditorViewState(resource, this.group);
 		}
 
 		// Otherwise save it

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -284,10 +284,8 @@ export abstract class BaseTextEditor extends EditorPane implements ITextEditorPa
 		return this.editorMemento.moveEditorState(source, target, comparer);
 	}
 
-	protected clearTextEditorViewState(resources: URI[], group?: IEditorGroup): void {
-		for (const resource of resources) {
-			this.editorMemento.clearEditorState(resource, group);
-		}
+	protected clearTextEditorViewState(resource: URI, group?: IEditorGroup): void {
+		this.editorMemento.clearEditorState(resource, group);
 	}
 
 	private updateEditorConfiguration(configuration?: IEditorConfiguration): void {

--- a/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
@@ -154,7 +154,7 @@ export class AbstractTextResourceEditor extends BaseTextEditor {
 
 		// Clear view state if input is disposed
 		if (input.isDisposed()) {
-			super.clearTextEditorViewState([resource]);
+			super.clearTextEditorViewState(resource);
 		}
 
 		// Otherwise save it

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -56,7 +56,7 @@ import { SIDE_BAR_DRAG_AND_DROP_BACKGROUND } from 'vs/workbench/common/theme';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { VirtualWorkspaceContext, WorkbenchStateContext } from 'vs/workbench/browser/contextkeys';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { isIOS, isWeb } from 'vs/base/common/platform';
+import { isWeb } from 'vs/base/common/platform';
 import { installLocalInRemoteIcon } from 'vs/workbench/contrib/extensions/browser/extensionsIcons';
 import { registerAction2, Action2, MenuId } from 'vs/platform/actions/common/actions';
 import { WorkspaceTrustContext } from 'vs/workbench/services/workspaces/common/workspaceTrust';
@@ -555,12 +555,6 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer implements IE
 
 		this._register(this.searchBox.onShouldFocusResults(() => this.focusListView(), this));
 
-		this._register(this.onDidChangeVisibility(visible => {
-			if (visible && !isIOS) {
-				this.searchBox!.focus();
-			}
-		}));
-
 		// Register DragAndDrop support
 		this._register(new DragAndDropObserver(this.root, {
 			onDragEnd: (e: DragEvent) => undefined,
@@ -608,7 +602,7 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer implements IE
 	}
 
 	override focus(): void {
-		if (this.searchBox && !isIOS) {
+		if (this.searchBox) {
 			this.searchBox.focus();
 		}
 	}

--- a/src/vs/workbench/contrib/files/browser/editors/textFileEditor.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/textFileEditor.ts
@@ -72,9 +72,11 @@ export class TextFileEditor extends BaseTextEditor {
 	}
 
 	private onDidFilesChange(e: FileChangesEvent): void {
-		const deleted = e.getDeleted();
-		if (deleted?.length) {
-			this.clearTextEditorViewState(deleted.map(({ resource }) => resource));
+		const deleted = e.rawDeleted;
+		if (deleted) {
+			for (const [resource] of deleted) {
+				this.clearTextEditorViewState(resource);
+			}
 		}
 	}
 
@@ -278,7 +280,7 @@ export class TextFileEditor extends BaseTextEditor {
 		// If the user configured to not restore view state, we clear the view
 		// state unless the editor is still opened in the group.
 		if (!this.shouldRestoreTextEditorViewState(input) && (!this.group || !this.group.contains(input))) {
-			this.clearTextEditorViewState([input.resource], this.group);
+			this.clearTextEditorViewState(input.resource, this.group);
 		}
 
 		// Otherwise we save the view state to restore it later

--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -78,13 +78,16 @@ export class ExplorerService implements IExplorerService {
 			// Or if they affect not yet resolved parts of the explorer. If that is the case we will not refresh.
 			events.forEach(e => {
 				if (!shouldRefresh) {
-					const added = e.getAdded();
-					if (added.some(a => {
-						const parent = this.model.findClosest(dirname(a.resource));
-						// Parent of the added resource is resolved and the explorer model is not aware of the added resource - we need to refresh
-						return parent && !parent.getChild(basename(a.resource));
-					})) {
-						shouldRefresh = true;
+					const added = e.rawAdded;
+					if (added) {
+						for (const [resource] of added) {
+							const parent = this.model.findClosest(dirname(resource));
+							// Parent of the added resource is resolved and the explorer model is not aware of the added resource - we need to refresh
+							if (parent && !parent.getChild(basename(resource))) {
+								shouldRefresh = true;
+								break;
+							}
+						}
 					}
 				}
 			});

--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -35,7 +35,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { WorkbenchStateContext, RemoteNameContext } from 'vs/workbench/browser/contextkeys';
-import { IsWebContext } from 'vs/platform/contextkey/common/contextkeys';
+import { IsIOSContext, IsWebContext } from 'vs/platform/contextkey/common/contextkeys';
 import { AddRootFolderAction, OpenFolderAction, OpenFileFolderAction } from 'vs/workbench/browser/actions/workspaceActions';
 import { isMacintosh, isWeb } from 'vs/base/common/platform';
 import { Codicon } from 'vs/base/common/codicons';
@@ -289,7 +289,7 @@ const viewsRegistry = Registry.as<IViewsRegistry>(Extensions.ViewsRegistry);
 viewsRegistry.registerViewWelcomeContent(EmptyView.ID, {
 	content: localize({ key: 'noWorkspaceHelp', comment: ['Please do not translate the word "commmand", it is part of our internal syntax which must not change'] },
 		"You have not yet added a folder to the workspace.\n[Add Folder](command:{0})", AddRootFolderAction.ID),
-	when: WorkbenchStateContext.isEqualTo('workspace'),
+	when: ContextKeyExpr.and(WorkbenchStateContext.isEqualTo('workspace'), IsIOSContext.toNegated()),
 	group: ViewContentGroups.Open,
 	order: 1
 });

--- a/src/vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer.ts
@@ -1,0 +1,126 @@
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { IEditorConstructionOptions } from 'vs/editor/browser/editorBrowser';
+import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
+import { IModelService } from 'vs/editor/common/services/modelService';
+import { IModeService } from 'vs/editor/common/services/modeService';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { RenderOutputType, ICommonNotebookEditor, ICellOutputViewModel, IRenderOutput, IOutputTransformContribution } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { OutputRendererRegistry } from 'vs/workbench/contrib/notebook/browser/view/output/rendererRegistry';
+import { IOutputItemDto } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+
+class CodeRendererContrib extends Disposable implements IOutputTransformContribution {
+	getType() {
+		return RenderOutputType.Mainframe;
+	}
+
+	getMimetypes() {
+		return ['text/x-javascript'];
+	}
+
+	constructor(
+		public notebookEditor: ICommonNotebookEditor,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IModelService private readonly modelService: IModelService,
+		@IModeService private readonly modeService: IModeService,
+	) {
+		super();
+	}
+
+	render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
+		const value = getStringValue(item);
+		return this._render(output, container, value, 'javascript');
+	}
+
+	protected _render(output: ICellOutputViewModel, container: HTMLElement, value: string, modeId: string): IRenderOutput {
+		const disposable = new DisposableStore();
+		const editor = this.instantiationService.createInstance(CodeEditorWidget, container, getOutputSimpleEditorOptions(), { isSimpleWidget: true });
+
+		const mode = this.modeService.create(modeId);
+		const textModel = this.modelService.createModel(value, mode, undefined, false);
+		editor.setModel(textModel);
+
+		const width = this.notebookEditor.getCellOutputLayoutInfo(output.cellViewModel).width;
+		const fontInfo = this.notebookEditor.getCellOutputLayoutInfo(output.cellViewModel).fontInfo;
+		const height = Math.min(textModel.getLineCount(), 16) * (fontInfo.lineHeight || 18);
+
+		editor.layout({ height, width });
+
+		disposable.add(editor);
+		disposable.add(textModel);
+
+		container.style.height = `${height + 8}px`;
+
+		return { type: RenderOutputType.Mainframe, initHeight: height, disposable };
+	}
+}
+
+export class NotebookCodeRendererContribution extends Disposable {
+
+	constructor(@IModeService _modeService: IModeService) {
+		super();
+
+		_modeService.getRegisteredModes().forEach(id => {
+			OutputRendererRegistry.registerOutputTransform(class extends CodeRendererContrib {
+				override getMimetypes() {
+					return [`application/${id}`];
+				}
+
+				override render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
+					const str = getStringValue(item);
+					return this._render(output, container, str, id);
+				}
+			});
+		});
+
+		this._register(_modeService.onDidCreateMode((e) => {
+			OutputRendererRegistry.registerOutputTransform(class extends CodeRendererContrib {
+				override getMimetypes() {
+					return [`application/${e.getId()}`];
+				}
+
+				override render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
+					const str = getStringValue(item);
+					return this._render(output, container, str, e.getId());
+				}
+			});
+		}));
+	}
+}
+
+const workbenchContributionsRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
+workbenchContributionsRegistry.registerWorkbenchContribution(NotebookCodeRendererContribution, LifecyclePhase.Eventually);
+
+
+// --- utils ---
+function getStringValue(item: IOutputItemDto): string {
+	// todo@jrieken NOT proper, should be VSBuffer
+	return new TextDecoder().decode(new Uint8Array(item.valueBytes));
+}
+
+function getOutputSimpleEditorOptions(): IEditorConstructionOptions {
+	return {
+		dimension: { height: 0, width: 0 },
+		readOnly: true,
+		wordWrap: 'on',
+		overviewRulerLanes: 0,
+		glyphMargin: false,
+		selectOnLineNumbers: false,
+		hideCursorInOverviewRuler: true,
+		selectionHighlight: false,
+		lineDecorationsWidth: 0,
+		overviewRulerBorder: false,
+		scrollBeyondLastLine: false,
+		renderLineHighlight: 'none',
+		minimap: {
+			enabled: false
+		},
+		lineNumbers: 'off',
+		scrollbar: {
+			alwaysConsumeMouseWheel: false
+		},
+		automaticLayout: true,
+	};
+}

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -80,6 +80,7 @@ import 'vs/workbench/contrib/notebook/browser/contrib/undoRedo/notebookUndoRedo'
 import 'vs/workbench/contrib/notebook/browser/contrib/cellOperations/cellOperations';
 import 'vs/workbench/contrib/notebook/browser/contrib/viewportCustomMarkdown/viewportCustomMarkdown';
 import 'vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout';
+import 'vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer';
 
 // Diff Editor Contribution
 import 'vs/workbench/contrib/notebook/browser/diff/notebookDiffActions';

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2635,8 +2635,8 @@ export const cellStatusIconRunning = registerColor('notebookStatusRunningIcon.fo
 }, nls.localize('notebookStatusRunningIcon.foreground', "The running icon color of notebook cells in the cell status bar."));
 
 export const notebookOutputContainerColor = registerColor('notebook.outputContainerBackgroundColor', {
-	dark: notebookCellBorder,
-	light: notebookCellBorder,
+	dark: null,
+	light: null,
 	hc: null
 }, nls.localize('notebook.outputContainerBackgroundColor', "The Color of the notebook output container background."));
 

--- a/src/vs/workbench/contrib/notebook/browser/view/output/transforms/richTransform.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/output/transforms/richTransform.ts
@@ -9,10 +9,6 @@ import { Mimes } from 'vs/base/common/mime';
 import { dirname } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { MarkdownRenderer } from 'vs/editor/browser/core/markdownRenderer';
-import { IEditorConstructionOptions } from 'vs/editor/browser/editorBrowser';
-import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
-import { IModelService } from 'vs/editor/common/services/modelService';
-import { IModeService } from 'vs/editor/common/services/modeService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
@@ -50,64 +46,6 @@ class JavaScriptRendererContrib extends Disposable implements IOutputRendererCon
 			source: output,
 			htmlContent: scriptVal
 		};
-	}
-}
-
-class CodeRendererContrib extends Disposable implements IOutputRendererContribution {
-	getType() {
-		return RenderOutputType.Mainframe;
-	}
-
-	getMimetypes() {
-		return ['text/x-javascript'];
-	}
-
-	constructor(
-		public notebookEditor: ICommonNotebookEditor,
-		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IModelService private readonly modelService: IModelService,
-		@IModeService private readonly modeService: IModeService,
-	) {
-		super();
-	}
-
-	render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
-		const value = getStringValue(item);
-		return this._render(output, container, value, 'javascript');
-	}
-
-	protected _render(output: ICellOutputViewModel, container: HTMLElement, value: string, modeId: string): IRenderOutput {
-		const disposable = new DisposableStore();
-		const editor = this.instantiationService.createInstance(CodeEditorWidget, container, getOutputSimpleEditorOptions(), { isSimpleWidget: true });
-
-		const mode = this.modeService.create(modeId);
-		const textModel = this.modelService.createModel(value, mode, undefined, false);
-		editor.setModel(textModel);
-
-		const width = this.notebookEditor.getCellOutputLayoutInfo(output.cellViewModel).width;
-		const fontInfo = this.notebookEditor.getCellOutputLayoutInfo(output.cellViewModel).fontInfo;
-		const height = Math.min(textModel.getLineCount(), 16) * (fontInfo.lineHeight || 18);
-
-		editor.layout({ height, width });
-
-		disposable.add(editor);
-		disposable.add(textModel);
-
-		container.style.height = `${height + 8}px`;
-
-		return { type: RenderOutputType.Mainframe, initHeight: height, disposable };
-	}
-}
-
-class JSONRendererContrib extends CodeRendererContrib {
-
-	override getMimetypes() {
-		return ['application/json'];
-	}
-
-	override render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
-		const str = getStringValue(item);
-		return this._render(output, container, str, 'jsonc');
 	}
 }
 
@@ -327,44 +265,18 @@ class ImgRendererContrib extends Disposable implements IOutputRendererContributi
 	}
 }
 
-OutputRendererRegistry.registerOutputTransform(JSONRendererContrib);
 OutputRendererRegistry.registerOutputTransform(JavaScriptRendererContrib);
 OutputRendererRegistry.registerOutputTransform(HTMLRendererContrib);
 OutputRendererRegistry.registerOutputTransform(MdRendererContrib);
 OutputRendererRegistry.registerOutputTransform(ImgRendererContrib);
 OutputRendererRegistry.registerOutputTransform(PlainTextRendererContrib);
-OutputRendererRegistry.registerOutputTransform(CodeRendererContrib);
 OutputRendererRegistry.registerOutputTransform(JSErrorRendererContrib);
 OutputRendererRegistry.registerOutputTransform(StreamRendererContrib);
 OutputRendererRegistry.registerOutputTransform(StderrRendererContrib);
+
 
 // --- utils ---
 function getStringValue(item: IOutputItemDto): string {
 	// todo@jrieken NOT proper, should be VSBuffer
 	return new TextDecoder().decode(new Uint8Array(item.valueBytes));
-}
-
-function getOutputSimpleEditorOptions(): IEditorConstructionOptions {
-	return {
-		dimension: { height: 0, width: 0 },
-		readOnly: true,
-		wordWrap: 'on',
-		overviewRulerLanes: 0,
-		glyphMargin: false,
-		selectOnLineNumbers: false,
-		hideCursorInOverviewRuler: true,
-		selectionHighlight: false,
-		lineDecorationsWidth: 0,
-		overviewRulerBorder: false,
-		scrollBeyondLastLine: false,
-		renderLineHighlight: 'none',
-		minimap: {
-			enabled: false
-		},
-		lineNumbers: 'off',
-		scrollbar: {
-			alwaysConsumeMouseWheel: false
-		},
-		automaticLayout: true,
-	};
 }

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -261,12 +261,9 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Disposable {
 						border-collapse: collapse;
 					}
 
-					table {
-						width: 100%;
-					}
-
 					table, th, tr {
-						text-align: left !important;
+						vertical-align: top;
+						text-align: right;
 					}
 
 					thead {

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1239,7 +1239,7 @@ class ViewModel {
 	}
 
 	focus() {
-		if (this.tree.getFocus().length === 0 && !platform.isIOS) {
+		if (this.tree.getFocus().length === 0) {
 			for (const repository of this.scmViewService.visibleRepositories) {
 				const widget = this.inputRenderer.getRenderedInputWidget(repository.input);
 

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -902,7 +902,7 @@ export class SearchView extends ViewPane {
 
 	override focus(): void {
 		super.focus();
-		if (!env.isIOS && (this.lastFocusState === 'input' || !this.hasSearchResults())) {
+		if (this.lastFocusState === 'input' || !this.hasSearchResults()) {
 			const updatedText = this.searchConfig.seedOnFocus ? this.updateTextFromSelection({ allowSearchOnType: false }) : false;
 			this.searchWidget.focus(undefined, undefined, updatedText);
 		} else {

--- a/src/vs/workbench/services/hover/browser/hoverWidget.ts
+++ b/src/vs/workbench/services/hover/browser/hoverWidget.ts
@@ -11,7 +11,7 @@ import { IHoverTarget, IHoverOptions } from 'vs/workbench/services/hover/browser
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { EDITOR_FONT_DEFAULTS, IEditorOptions } from 'vs/editor/common/config/editorOptions';
-import { HoverPosition, HoverWidget as BaseHoverWidget, renderHoverAction } from 'vs/base/browser/ui/hover/hoverWidget';
+import { HoverAction, HoverPosition, HoverWidget as BaseHoverWidget } from 'vs/base/browser/ui/hover/hoverWidget';
 import { Widget } from 'vs/base/browser/ui/widget';
 import { AnchorPosition } from 'vs/base/browser/ui/contextview/contextview';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
@@ -128,7 +128,7 @@ export class HoverWidget extends Widget {
 			options.actions.forEach(action => {
 				const keybinding = this._keybindingService.lookupKeybinding(action.commandId);
 				const keybindingLabel = keybinding ? keybinding.getLabel() : null;
-				renderHoverAction(actionsElement, {
+				HoverAction.render(actionsElement, {
 					label: action.label,
 					commandId: action.commandId,
 					run: e => {

--- a/src/vs/workbench/services/workspaces/test/browser/workspaces.test.ts
+++ b/src/vs/workbench/services/workspaces/test/browser/workspaces.test.ts
@@ -17,19 +17,3 @@ suite('Workspaces', () => {
 		assert.strictEqual(getSingleFolderWorkspaceIdentifier(URI.parse('vscode-remote:/hello/test'))?.id, '474434e4');
 	});
 });
-
-// suite('Workspace Trust', () => {
-// 	let workspaceTrustService: IWorkspaceTrustService;
-// 	setup(() => {
-// 		const instantiationService: TestInstantiationService = <TestInstantiationService>workbenchInstantiationService();
-// 		workspaceTrustService = instantiationService.createInstance(WorkspaceTrustService);
-// 	});
-
-// 	teardown(() => {
-
-// 	});
-
-// 	test('Sample Test', function () {
-// 		assert.strictEqual(workspaceTrustStateToString(workspaceTrustService.getWorkspaceTrustState()), 'Trusted');
-// 	});
-// });

--- a/src/vs/workbench/services/workspaces/test/common/workspaceTrust.test.ts
+++ b/src/vs/workbench/services/workspaces/test/common/workspaceTrust.test.ts
@@ -15,7 +15,6 @@ import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
 import { WorkspaceTrustManagementService } from 'vs/workbench/services/workspaces/common/workspaceTrust';
 import { TestContextService, TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
-import { Workspace } from 'vs/platform/workspace/test/common/testWorkspace';
 
 suite('Workspace Trust', () => {
 	let testObject: WorkspaceTrustManagementService;

--- a/src/vs/workbench/services/workspaces/test/common/workspaceTrust.test.ts
+++ b/src/vs/workbench/services/workspaces/test/common/workspaceTrust.test.ts
@@ -15,13 +15,14 @@ import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
 import { WorkspaceTrustManagementService } from 'vs/workbench/services/workspaces/common/workspaceTrust';
 import { TestContextService, TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
+import { Workspace } from 'vs/platform/workspace/test/common/testWorkspace';
 
 suite('Workspace Trust', () => {
 	let testObject: WorkspaceTrustManagementService;
 	let instantiationService: TestInstantiationService;
 	let testConfigurationService: TestConfigurationService;
 	let testStorageService: TestStorageService;
-	let testWorkspaceService: IWorkspaceContextService;
+	let testWorkspaceService: TestContextService;
 
 	setup(async () => {
 		instantiationService = new TestInstantiationService();
@@ -43,18 +44,36 @@ suite('Workspace Trust', () => {
 
 	teardown(() => testObject.dispose());
 
-	test('Initialization - workspace trust disabled (user settings)', async () => {
-		await testConfigurationService.setUserConfiguration('security', { workspace: { trust: { enabled: false } } });
+	suite('Initialization', () => {
+		test('workspace trust disabled (user settings)', async () => {
+			await testConfigurationService.setUserConfiguration('security', { workspace: { trust: { enabled: false } } });
 
-		testObject = instantiationService.createInstance(WorkspaceTrustManagementService);
-		assert.strictEqual(true, testObject.isWorkpaceTrusted());
-	});
+			testObject = instantiationService.createInstance(WorkspaceTrustManagementService);
+			assert.strictEqual(true, testObject.isWorkpaceTrusted());
+		});
 
-	test('Initialization - workspace trust disabled (--disable-workspace-trust)', () => {
-		const testEnvironmentService = { disableWorkspaceTrust: true } as IWorkbenchEnvironmentService;
-		instantiationService.stub(IWorkbenchEnvironmentService, testEnvironmentService);
+		test('workspace trust disabled (--disable-workspace-trust)', () => {
+			const testEnvironmentService = { disableWorkspaceTrust: true } as IWorkbenchEnvironmentService;
+			instantiationService.stub(IWorkbenchEnvironmentService, testEnvironmentService);
 
-		testObject = instantiationService.createInstance(WorkspaceTrustManagementService);
-		assert.strictEqual(true, testObject.isWorkpaceTrusted());
+			testObject = instantiationService.createInstance(WorkspaceTrustManagementService);
+			assert.strictEqual(true, testObject.isWorkpaceTrusted());
+		});
+
+		// test('empty workspace - trusted, no open files', () => {
+		// 	const workspace = new Workspace('empty-workspace');
+		// 	testWorkspaceService.setWorkspace(workspace);
+
+		// 	testObject = instantiationService.createInstance(WorkspaceTrustManagementService);
+		// 	assert.strictEqual(true, testObject.isWorkpaceTrusted());
+		// });
+
+		// test('empty workspace - restricted mode, no open files', () => {
+		// 	const workspace = new Workspace('empty-workspace');
+		// 	testWorkspaceService.setWorkspace(workspace);
+
+		// 	testObject = instantiationService.createInstance(WorkspaceTrustManagementService);
+		// 	assert.strictEqual(true, testObject.isWorkpaceTrusted());
+		// });
 	});
 });

--- a/src/vs/workbench/services/workspaces/test/common/workspaceTrust.test.ts
+++ b/src/vs/workbench/services/workspaces/test/common/workspaceTrust.test.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { mock } from 'vs/base/test/common/mock';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
+import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
+import { WorkspaceTrustManagementService } from 'vs/workbench/services/workspaces/common/workspaceTrust';
+import { TestContextService, TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
+
+suite('Workspace Trust', () => {
+	let testObject: WorkspaceTrustManagementService;
+	let instantiationService: TestInstantiationService;
+	let testConfigurationService: TestConfigurationService;
+	let testStorageService: TestStorageService;
+	let testWorkspaceService: IWorkspaceContextService;
+
+	setup(async () => {
+		instantiationService = new TestInstantiationService();
+
+		testConfigurationService = new TestConfigurationService();
+		instantiationService.stub(IConfigurationService, testConfigurationService);
+		await testConfigurationService.setUserConfiguration('security', { workspace: { trust: { enabled: true } } });
+
+		testStorageService = new TestStorageService();
+		instantiationService.stub(IStorageService, testStorageService);
+
+		testWorkspaceService = new TestContextService();
+		instantiationService.stub(IWorkspaceContextService, testWorkspaceService);
+
+		instantiationService.stub(IUriIdentityService, new class extends mock<IUriIdentityService>() { });
+		instantiationService.stub(IWorkbenchEnvironmentService, new class extends mock<IWorkbenchEnvironmentService>() { });
+		instantiationService.stub(IRemoteAuthorityResolverService, new class extends mock<IRemoteAuthorityResolverService>() { });
+	});
+
+	teardown(() => testObject.dispose());
+
+	test('Initialization - workspace trust disabled (user settings)', async () => {
+		await testConfigurationService.setUserConfiguration('security', { workspace: { trust: { enabled: false } } });
+
+		testObject = instantiationService.createInstance(WorkspaceTrustManagementService);
+		assert.strictEqual(true, testObject.isWorkpaceTrusted());
+	});
+
+	test('Initialization - workspace trust disabled (--disable-workspace-trust)', () => {
+		const testEnvironmentService = { disableWorkspaceTrust: true } as IWorkbenchEnvironmentService;
+		instantiationService.stub(IWorkbenchEnvironmentService, testEnvironmentService);
+
+		testObject = instantiationService.createInstance(WorkspaceTrustManagementService);
+		assert.strictEqual(true, testObject.isWorkpaceTrusted());
+	});
+});

--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -28,6 +28,7 @@ export class Application {
 	private _workbench: Workbench | undefined;
 
 	constructor(private options: ApplicationOptions) {
+		this._userDataPath = options.userDataDir;
 		this._workspacePathOrFolder = options.workspacePath;
 	}
 
@@ -64,8 +65,9 @@ export class Application {
 		return this.options.extensionsPath;
 	}
 
+	private _userDataPath: string;
 	get userDataPath(): string {
-		return this.options.userDataDir;
+		return this._userDataPath;
 	}
 
 	async start(expectWalkthroughPart = true): Promise<any> {
@@ -123,7 +125,7 @@ export class Application {
 		this._code = await spawn({
 			codePath: this.options.codePath,
 			workspacePath: this.workspacePathOrFolder,
-			userDataDir: this.options.userDataDir,
+			userDataDir: this.userDataPath,
 			extensionsPath: this.options.extensionsPath,
 			logger: this.options.logger,
 			verbose: this.options.verbose,

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -37,7 +37,10 @@ function buildDriver(browser: playwright.Browser, page: playwright.Page): IDrive
 		},
 		capturePage: () => Promise.resolve(''),
 		reloadWindow: (windowId) => Promise.resolve(),
-		exitApplication: () => browser.close(),
+		exitApplication: async () => {
+			await browser.close();
+			await teardown();
+		},
 		dispatchKeybinding: async (windowId, keybinding) => {
 			const chords = keybinding.split(' ');
 			for (let i = 0; i < chords.length; i++) {
@@ -123,9 +126,9 @@ export async function launch(userDataDir: string, _workspacePath: string, codeSe
 	endpoint = await waitForEndpoint();
 }
 
-function teardown(): void {
+async function teardown(): Promise<void> {
 	if (server) {
-		kill(server.pid);
+		await new Promise((c, e) => kill(server!.pid, error => error ? e(error) : c(null)));
 		server = undefined;
 	}
 }

--- a/test/smoke/src/areas/editor/editor.test.ts
+++ b/test/smoke/src/areas/editor/editor.test.ts
@@ -3,10 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import minimist = require('minimist');
 import { Application } from '../../../../automation';
+import { afterSuite, beforeSuite } from '../../utils';
 
-export function setup() {
+export function setup(opts: minimist.ParsedArgs) {
 	describe('Editor', () => {
+		beforeSuite(opts);
+		afterSuite();
+
 		it('shows correct quick outline', async function () {
 			const app = this.app as Application;
 			await app.workbench.quickaccess.openFile('www');

--- a/test/smoke/src/areas/extensions/extensions.test.ts
+++ b/test/smoke/src/areas/extensions/extensions.test.ts
@@ -3,10 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import minimist = require('minimist');
 import { Application, Quality } from '../../../../automation';
+import { afterSuite, beforeSuite } from '../../utils';
 
-export function setup() {
+export function setup(opts: minimist.ParsedArgs) {
 	describe('Extensions', () => {
+		beforeSuite(opts);
+		afterSuite();
+
 		it(`install and enable vscode-smoketest-check extension`, async function () {
 			const app = this.app as Application;
 

--- a/test/smoke/src/areas/languages/languages.test.ts
+++ b/test/smoke/src/areas/languages/languages.test.ts
@@ -3,10 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import minimist = require('minimist');
 import { Application, ProblemSeverity, Problems } from '../../../../automation/out';
+import { afterSuite, beforeSuite } from '../../utils';
 
-export function setup() {
+export function setup(opts: minimist.ParsedArgs) {
 	describe('Language Features', () => {
+		beforeSuite(opts);
+		afterSuite();
+
 		it('verifies quick outline', async function () {
 			const app = this.app as Application;
 			await app.workbench.quickaccess.openFile('style.css');

--- a/test/smoke/src/areas/multiroot/multiroot.test.ts
+++ b/test/smoke/src/areas/multiroot/multiroot.test.ts
@@ -4,8 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'fs';
+import minimist = require('minimist');
 import * as path from 'path';
 import { Application } from '../../../../automation';
+import { afterSuite, beforeSuite } from '../../utils';
 
 function toUri(path: string): string {
 	if (process.platform === 'win32') {
@@ -34,8 +36,9 @@ async function createWorkspaceFile(workspacePath: string): Promise<string> {
 	return workspaceFilePath;
 }
 
-export function setup() {
+export function setup(opts: minimist.ParsedArgs) {
 	describe('Multiroot', () => {
+		beforeSuite(opts);
 
 		before(async function () {
 			const app = this.app as Application;
@@ -46,6 +49,8 @@ export function setup() {
 			// to ensure the window after restart is the multi-root workspace
 			await app.restart({ workspaceOrFolder: workspaceFilePath });
 		});
+
+		afterSuite();
 
 		it('shows results from all folders', async function () {
 			const app = this.app as Application;

--- a/test/smoke/src/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/areas/notebook/notebook.test.ts
@@ -4,26 +4,32 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as cp from 'child_process';
+import minimist = require('minimist');
 import { Application } from '../../../../automation';
+import { afterSuite, beforeSuite } from '../../utils';
 
 // function wait(ms: number): Promise<void> {
 // 	return new Promise(r => setTimeout(r, ms));
 // }
 
 
-export function setup() {
+export function setup(opts: minimist.ParsedArgs) {
 	describe('Notebooks', () => {
-		after(async function () {
-			const app = this.app as Application;
-			cp.execSync('git checkout . --quiet', { cwd: app.workspacePathOrFolder });
-			cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePathOrFolder });
-		});
+		beforeSuite(opts);
 
 		afterEach(async function () {
 			const app = this.app as Application;
 			await app.workbench.quickaccess.runCommand('workbench.action.files.save');
 			await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
 		});
+
+		after(async function () {
+			const app = this.app as Application;
+			cp.execSync('git checkout . --quiet', { cwd: app.workspacePathOrFolder });
+			cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePathOrFolder });
+		});
+
+		afterSuite();
 
 		// it('inserts/edits code cell', async function () {
 		// 	const app = this.app as Application;

--- a/test/smoke/src/areas/preferences/preferences.test.ts
+++ b/test/smoke/src/areas/preferences/preferences.test.ts
@@ -3,10 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import minimist = require('minimist');
 import { Application, ActivityBarPosition } from '../../../../automation';
+import { afterSuite, beforeSuite } from '../../utils';
 
-export function setup() {
+export function setup(opts: minimist.ParsedArgs) {
 	describe('Preferences', () => {
+		beforeSuite(opts);
+		afterSuite();
+
 		it('turns off editor line numbers and verifies the live change', async function () {
 			const app = this.app as Application;
 
@@ -26,14 +31,6 @@ export function setup() {
 
 			await app.code.dispatchKeybinding('ctrl+u');
 			await app.workbench.activitybar.waitForActivityBar(ActivityBarPosition.RIGHT);
-		});
-
-		after(async function () {
-			const app = this.app as Application;
-			await app.workbench.settingsEditor.clearUserSettings();
-
-			// Wait for settings to be applied, which will happen after the settings file is empty
-			await app.workbench.activitybar.waitForActivityBar(ActivityBarPosition.LEFT);
 		});
 	});
 }

--- a/test/smoke/src/areas/search/search.test.ts
+++ b/test/smoke/src/areas/search/search.test.ts
@@ -4,16 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as cp from 'child_process';
+import minimist = require('minimist');
 import { Application } from '../../../../automation';
+import { afterSuite, beforeSuite } from '../../utils';
 
-export function setup() {
+export function setup(opts: minimist.ParsedArgs) {
 	// https://github.com/microsoft/vscode/issues/115244
 	describe('Search', () => {
+		beforeSuite(opts);
+
 		after(function () {
 			const app = this.app as Application;
 			cp.execSync('git checkout . --quiet', { cwd: app.workspacePathOrFolder });
 			cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePathOrFolder });
 		});
+
+		afterSuite();
 
 		// https://github.com/microsoft/vscode/issues/124146
 		it.skip /* https://github.com/microsoft/vscode/issues/124335 */('has a tooltp with a keybinding', async function () {
@@ -68,6 +74,9 @@ export function setup() {
 	});
 
 	describe('Quick Access', () => {
+		beforeSuite(opts);
+		afterSuite();
+
 		it('quick access search produces correct result', async function () {
 			const app = this.app as Application;
 			const expectedNames = [

--- a/test/smoke/src/areas/statusbar/statusbar.test.ts
+++ b/test/smoke/src/areas/statusbar/statusbar.test.ts
@@ -3,10 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import minimist = require('minimist');
 import { Application, Quality, StatusBarElement } from '../../../../automation';
+import { afterSuite, beforeSuite } from '../../utils';
 
-export function setup(isWeb) {
+export function setup(opts: minimist.ParsedArgs) {
 	describe('Statusbar', () => {
+		beforeSuite(opts);
+		afterSuite();
+
 		it('verifies presence of all default status bar elements', async function () {
 			const app = this.app as Application;
 
@@ -18,7 +23,7 @@ export function setup(isWeb) {
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.PROBLEMS_STATUS);
 
 			await app.workbench.quickaccess.openFile('app.js');
-			if (!isWeb) {
+			if (!opts.web) {
 				// Encoding picker currently hidden in web (only UTF-8 supported)
 				await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.ENCODING_STATUS);
 			}
@@ -39,7 +44,7 @@ export function setup(isWeb) {
 			await app.workbench.statusbar.clickOn(StatusBarElement.INDENTATION_STATUS);
 			await app.workbench.quickinput.waitForQuickInputOpened();
 			await app.workbench.quickinput.closeQuickInput();
-			if (!isWeb) {
+			if (!opts.web) {
 				// Encoding picker currently hidden in web (only UTF-8 supported)
 				await app.workbench.statusbar.clickOn(StatusBarElement.ENCODING_STATUS);
 				await app.workbench.quickinput.waitForQuickInputOpened();

--- a/test/smoke/src/areas/workbench/data-loss.test.ts
+++ b/test/smoke/src/areas/workbench/data-loss.test.ts
@@ -3,10 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import minimist = require('minimist');
 import { Application } from '../../../../automation';
+import { afterSuite, beforeSuite } from '../../utils';
 
-export function setup() {
+export function setup(opts: minimist.ParsedArgs) {
+
 	describe('Dataloss', () => {
+		beforeSuite(opts);
+		afterSuite();
+
 		it(`verifies that 'hot exit' works for dirty files`, async function () {
 			const app = this.app as Application;
 			await app.workbench.editors.newUntitledFile();

--- a/test/smoke/src/areas/workbench/localization.test.ts
+++ b/test/smoke/src/areas/workbench/localization.test.ts
@@ -3,10 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import minimist = require('minimist');
 import { Application, Quality } from '../../../../automation';
+import { afterSuite, beforeSuite } from '../../utils';
 
-export function setup() {
+export function setup(opts: minimist.ParsedArgs) {
 	describe('Localization', () => {
+		beforeSuite(opts);
+
 		before(async function () {
 			const app = this.app as Application;
 
@@ -20,6 +24,8 @@ export function setup() {
 
 			await app.restart({ extraArgs: ['--locale=DE'] });
 		});
+
+		afterSuite();
 
 		it(`starts with 'DE' locale and verifies title and viewlets text is in German`, async function () {
 			const app = this.app as Application;

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -207,7 +207,8 @@ async function setupRepository(): Promise<void> {
 			cp.spawnSync('git', ['clean', '-xdf'], { cwd: workspacePath });
 		}
 
-		// None of the test run the project
+		// None of the current smoke tests have a dependency on the packages.
+		// If new smoke tests are added that need the packages, uncomment this.
 		// console.log('*** Running yarn...');
 		// cp.execSync('yarn', { cwd: workspacePath, stdio: 'inherit' });
 	}
@@ -299,27 +300,16 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	}
 
 	describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
-		before(async function () {
-			const app = new Application(this.defaultOptions);
-			await app!.start(opts.web ? false : undefined);
-			this.app = app;
-		});
-
-		after(async function () {
-			await this.app.stop();
-		});
-
-		if (!opts.web) { setupDataLossTests(); }
-		if (!opts.web) { setupDataPreferencesTests(); }
-		setupDataSearchTests();
-		setupDataNotebookTests();
-		setupDataLanguagesTests();
-		setupDataEditorTests();
-		setupDataStatusbarTests(!!opts.web);
-		setupDataExtensionTests();
-		if (!opts.web) { setupDataMultirootTests(); }
-		if (!opts.web) { setupDataLocalizationTests(); }
+		if (!opts.web) { setupDataLossTests(opts); }
+		if (!opts.web) { setupDataPreferencesTests(opts); }
+		setupDataSearchTests(opts);
+		setupDataNotebookTests(opts);
+		setupDataLanguagesTests(opts);
+		setupDataEditorTests(opts);
+		setupDataStatusbarTests(opts);
+		setupDataExtensionTests(opts);
+		if (!opts.web) { setupDataMultirootTests(opts); }
+		if (!opts.web) { setupDataLocalizationTests(opts); }
 		if (!opts.web) { setupLaunchTests(); }
 	});
 });
-

--- a/test/smoke/src/utils.ts
+++ b/test/smoke/src/utils.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import minimist = require('minimist');
 import { Suite, Context } from 'mocha';
+import { Application, ApplicationOptions } from '../../automation';
 
 export function describeRepeat(n: number, description: string, callback: (this: Suite) => void): void {
 	for (let i = 0; i < n; i++) {
@@ -15,4 +17,26 @@ export function itRepeat(n: number, description: string, callback: (this: Contex
 	for (let i = 0; i < n; i++) {
 		it(`${description} (iteration ${i})`, callback);
 	}
+}
+
+export function beforeSuite(opts: minimist.ParsedArgs) {
+	before(async function () {
+		// https://github.com/microsoft/vscode/issues/34988
+		const options = this.defaultOptions as ApplicationOptions;
+		const userDataPathSuffix = [...Array(8)].map(() => Math.random().toString(36)[3]).join('');
+		const userDataDir = options.userDataDir.concat(`-${userDataPathSuffix}`);
+
+		const app = new Application({ ...options, userDataDir });
+		await app!.start(opts.web ? false : undefined);
+		this.app = app;
+	});
+}
+
+export function afterSuite() {
+	after(async function () {
+		const app = this.app as Application;
+		if (app) {
+			await app.stop();
+		}
+	});
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1346,11 +1346,6 @@ async-hook-jl@^1.7.6:
   dependencies:
     stack-chain "^1.3.7"
 
-async-limiter@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
-  integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
-
 async-listener@^0.6.0:
   version "0.6.10"
   resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
@@ -1977,13 +1972,13 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chrome-remote-interface@0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.26.1.tgz#6c7d4479742b6d236752d716a9bc2d322d7d8ad2"
-  integrity sha512-ela482aJK0riFu05sl+zdbnb3ezMiqzwsqf/f/27HngWds+Fat3vcZWpIoDoeQuWMid/+LfKAteAYWaWPqsweg==
+chrome-remote-interface@0.28.2:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.28.2.tgz#6be3554d2c227ff07eb74baa7e5d4911da12a5a6"
+  integrity sha512-F7mjof7rWvRNsJqhVXuiFU/HWySCxTA9tzpLxUJxVfdLkljwFJ1aMp08AnwXRmmP7r12/doTDOMwaNhFCJsacw==
   dependencies:
     commander "2.11.x"
-    ws "^3.3.3"
+    ws "^7.2.0"
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -9628,11 +9623,6 @@ typical@^4.0.0:
   resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
   integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
 
-ultron@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
-  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
-
 unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -9815,12 +9805,12 @@ v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
 
-v8-inspect-profiler@^0.0.20:
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/v8-inspect-profiler/-/v8-inspect-profiler-0.0.20.tgz#f7ad0f8178dcea2f1504334e8844ef38181792ab"
-  integrity sha512-AFLVT7GLCvTcw0HszhwxD1GCBboIeZSxqlk0myNXVLIfjelLl8rybm8KmRjoYcWH7uXqMC0qwhKk7Vj4wppiFQ==
+v8-inspect-profiler@^0.0.21:
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/v8-inspect-profiler/-/v8-inspect-profiler-0.0.21.tgz#2ded4fd59508f52d5887d3ae2bbace3e33509c41"
+  integrity sha512-6lo22vhua2Zg2Cq8Wtc2FELlTA+pmu+5epyPX65jNVAbAoKXY/XI3t33CreYiK8THKgkMeoWeviAxcJaefjyrg==
   dependencies:
-    chrome-remote-interface "0.26.1"
+    chrome-remote-interface "0.28.2"
 
 v8flags@^3.2.0:
   version "3.2.0"
@@ -10287,16 +10277,7 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-    ultron "~1.1.0"
-
-ws@^7.3.1:
+ws@^7.2.0, ws@^7.3.1:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==


### PR DESCRIPTION
Taking the JSON renderer from before, this PR makes it generic for all languages installed. Now notebooks can use `application/LANGUAGE_ID` for any installed language like rust or xml or whatever. 

An example of my extension using random languages:
![recording (46)](https://user-images.githubusercontent.com/12758612/121599573-16693c80-c9f8-11eb-9a12-21add22db6a5.gif)

