### PR TITLE
Make generic code renderer output contributions in notebooks for all the languages the user has installed 

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer.ts
@@ -67,9 +67,11 @@ export class NotebookCodeRendererContribution extends Disposable {
 	constructor(@IModeService _modeService: IModeService) {
 		super();
 
-		const registeredLanguages: string[] = []
+		OutputRendererRegistry.registerOutputTransform(CodeRendererContrib);
+
+		const registeredLanguages = new Map();
 		const registerCodeRendererContrib = (languageId: string) => {
-			if (registeredLanguages.includes(languageId)) { return; }
+			if (registeredLanguages.has(languageId)) { return; }
 
 			OutputRendererRegistry.registerOutputTransform(class extends CodeRendererContrib {
 				override getMimetypes() {
@@ -82,7 +84,7 @@ export class NotebookCodeRendererContribution extends Disposable {
 				}
 			});
 
-			registeredLanguages.push(languageId);
+			registeredLanguages.set(languageId, true);
 		};
 
 		_modeService.getRegisteredModes().forEach(id => {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer.ts
@@ -1,0 +1,126 @@
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { IEditorConstructionOptions } from 'vs/editor/browser/editorBrowser';
+import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
+import { IModelService } from 'vs/editor/common/services/modelService';
+import { IModeService } from 'vs/editor/common/services/modeService';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { RenderOutputType, ICommonNotebookEditor, ICellOutputViewModel, IRenderOutput, IOutputTransformContribution } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { OutputRendererRegistry } from 'vs/workbench/contrib/notebook/browser/view/output/rendererRegistry';
+import { IOutputItemDto } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+
+class CodeRendererContrib extends Disposable implements IOutputTransformContribution {
+	getType() {
+		return RenderOutputType.Mainframe;
+	}
+
+	getMimetypes() {
+		return ['text/x-javascript'];
+	}
+
+	constructor(
+		public notebookEditor: ICommonNotebookEditor,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IModelService private readonly modelService: IModelService,
+		@IModeService private readonly modeService: IModeService,
+	) {
+		super();
+	}
+
+	render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
+		const value = getStringValue(item);
+		return this._render(output, container, value, 'javascript');
+	}
+
+	protected _render(output: ICellOutputViewModel, container: HTMLElement, value: string, modeId: string): IRenderOutput {
+		const disposable = new DisposableStore();
+		const editor = this.instantiationService.createInstance(CodeEditorWidget, container, getOutputSimpleEditorOptions(), { isSimpleWidget: true });
+
+		const mode = this.modeService.create(modeId);
+		const textModel = this.modelService.createModel(value, mode, undefined, false);
+		editor.setModel(textModel);
+
+		const width = this.notebookEditor.getCellOutputLayoutInfo(output.cellViewModel).width;
+		const fontInfo = this.notebookEditor.getCellOutputLayoutInfo(output.cellViewModel).fontInfo;
+		const height = Math.min(textModel.getLineCount(), 16) * (fontInfo.lineHeight || 18);
+
+		editor.layout({ height, width });
+
+		disposable.add(editor);
+		disposable.add(textModel);
+
+		container.style.height = `${height + 8}px`;
+
+		return { type: RenderOutputType.Mainframe, initHeight: height, disposable };
+	}
+}
+
+export class NotebookCodeRendererContribution extends Disposable {
+
+	constructor(@IModeService _modeService: IModeService) {
+		super();
+
+		_modeService.getRegisteredModes().forEach(id => {
+			OutputRendererRegistry.registerOutputTransform(class extends CodeRendererContrib {
+				override getMimetypes() {
+					return [`application/${id}`];
+				}
+
+				override render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
+					const str = getStringValue(item);
+					return this._render(output, container, str, id);
+				}
+			});
+		});
+
+		this._register(_modeService.onDidCreateMode((e) => {
+			OutputRendererRegistry.registerOutputTransform(class extends CodeRendererContrib {
+				override getMimetypes() {
+					return [`application/${e.getId()}`];
+				}
+
+				override render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
+					const str = getStringValue(item);
+					return this._render(output, container, str, e.getId());
+				}
+			});
+		}));
+	}
+}
+
+const workbenchContributionsRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
+workbenchContributionsRegistry.registerWorkbenchContribution(NotebookCodeRendererContribution, LifecyclePhase.Eventually);
+
+
+// --- utils ---
+function getStringValue(item: IOutputItemDto): string {
+	// todo@jrieken NOT proper, should be VSBuffer
+	return new TextDecoder().decode(new Uint8Array(item.valueBytes));
+}
+
+function getOutputSimpleEditorOptions(): IEditorConstructionOptions {
+	return {
+		dimension: { height: 0, width: 0 },
+		readOnly: true,
+		wordWrap: 'on',
+		overviewRulerLanes: 0,
+		glyphMargin: false,
+		selectOnLineNumbers: false,
+		hideCursorInOverviewRuler: true,
+		selectionHighlight: false,
+		lineDecorationsWidth: 0,
+		overviewRulerBorder: false,
+		scrollBeyondLastLine: false,
+		renderLineHighlight: 'none',
+		minimap: {
+			enabled: false
+		},
+		lineNumbers: 'off',
+		scrollbar: {
+			alwaysConsumeMouseWheel: false
+		},
+		automaticLayout: true,
+	};
+}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer.ts
@@ -102,7 +102,7 @@ workbenchContributionsRegistry.registerWorkbenchContribution(NotebookCodeRendere
 // --- utils ---
 function getStringValue(item: IOutputItemDto): string {
 	// todo@jrieken NOT proper, should be VSBuffer
-	return new TextDecoder().decode(new Uint8Array(item.valueBytes));
+	return new TextDecoder().decode(item.data);
 }
 
 function getOutputSimpleEditorOptions(): IEditorConstructionOptions {

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -80,6 +80,7 @@ import 'vs/workbench/contrib/notebook/browser/contrib/undoRedo/notebookUndoRedo'
 import 'vs/workbench/contrib/notebook/browser/contrib/cellOperations/cellOperations';
 import 'vs/workbench/contrib/notebook/browser/contrib/viewportCustomMarkdown/viewportCustomMarkdown';
 import 'vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout';
+import 'vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer';
 
 // Diff Editor Contribution
 import 'vs/workbench/contrib/notebook/browser/diff/notebookDiffActions';

--- a/src/vs/workbench/contrib/notebook/browser/view/output/transforms/richTransform.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/output/transforms/richTransform.ts
@@ -9,10 +9,6 @@ import { Mimes } from 'vs/base/common/mime';
 import { dirname } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { MarkdownRenderer } from 'vs/editor/browser/core/markdownRenderer';
-import { IEditorConstructionOptions } from 'vs/editor/browser/editorBrowser';
-import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
-import { IModelService } from 'vs/editor/common/services/modelService';
-import { IModeService } from 'vs/editor/common/services/modeService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
@@ -50,64 +46,6 @@ class JavaScriptRendererContrib extends Disposable implements IOutputRendererCon
 			source: output,
 			htmlContent: scriptVal
 		};
-	}
-}
-
-class CodeRendererContrib extends Disposable implements IOutputRendererContribution {
-	getType() {
-		return RenderOutputType.Mainframe;
-	}
-
-	getMimetypes() {
-		return ['text/x-javascript'];
-	}
-
-	constructor(
-		public notebookEditor: ICommonNotebookEditor,
-		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IModelService private readonly modelService: IModelService,
-		@IModeService private readonly modeService: IModeService,
-	) {
-		super();
-	}
-
-	render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
-		const value = getStringValue(item);
-		return this._render(output, container, value, 'javascript');
-	}
-
-	protected _render(output: ICellOutputViewModel, container: HTMLElement, value: string, modeId: string): IRenderOutput {
-		const disposable = new DisposableStore();
-		const editor = this.instantiationService.createInstance(CodeEditorWidget, container, getOutputSimpleEditorOptions(), { isSimpleWidget: true });
-
-		const mode = this.modeService.create(modeId);
-		const textModel = this.modelService.createModel(value, mode, undefined, false);
-		editor.setModel(textModel);
-
-		const width = this.notebookEditor.getCellOutputLayoutInfo(output.cellViewModel).width;
-		const fontInfo = this.notebookEditor.getCellOutputLayoutInfo(output.cellViewModel).fontInfo;
-		const height = Math.min(textModel.getLineCount(), 16) * (fontInfo.lineHeight || 18);
-
-		editor.layout({ height, width });
-
-		disposable.add(editor);
-		disposable.add(textModel);
-
-		container.style.height = `${height + 8}px`;
-
-		return { type: RenderOutputType.Mainframe, initHeight: height, disposable };
-	}
-}
-
-class JSONRendererContrib extends CodeRendererContrib {
-
-	override getMimetypes() {
-		return ['application/json'];
-	}
-
-	override render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
-		const str = getStringValue(item);
-		return this._render(output, container, str, 'jsonc');
 	}
 }
 
@@ -326,44 +264,18 @@ class ImgRendererContrib extends Disposable implements IOutputRendererContributi
 	}
 }
 
-OutputRendererRegistry.registerOutputTransform(JSONRendererContrib);
 OutputRendererRegistry.registerOutputTransform(JavaScriptRendererContrib);
 OutputRendererRegistry.registerOutputTransform(HTMLRendererContrib);
 OutputRendererRegistry.registerOutputTransform(MdRendererContrib);
 OutputRendererRegistry.registerOutputTransform(ImgRendererContrib);
 OutputRendererRegistry.registerOutputTransform(PlainTextRendererContrib);
-OutputRendererRegistry.registerOutputTransform(CodeRendererContrib);
 OutputRendererRegistry.registerOutputTransform(JSErrorRendererContrib);
 OutputRendererRegistry.registerOutputTransform(StreamRendererContrib);
 OutputRendererRegistry.registerOutputTransform(StderrRendererContrib);
+
 
 // --- utils ---
 function getStringValue(item: IOutputItemDto): string {
 	// todo@jrieken NOT proper, should be VSBuffer
 	return new TextDecoder().decode(item.data);
-}
-
-function getOutputSimpleEditorOptions(): IEditorConstructionOptions {
-	return {
-		dimension: { height: 0, width: 0 },
-		readOnly: true,
-		wordWrap: 'on',
-		overviewRulerLanes: 0,
-		glyphMargin: false,
-		selectOnLineNumbers: false,
-		hideCursorInOverviewRuler: true,
-		selectionHighlight: false,
-		lineDecorationsWidth: 0,
-		overviewRulerBorder: false,
-		scrollBeyondLastLine: false,
-		renderLineHighlight: 'none',
-		minimap: {
-			enabled: false
-		},
-		lineNumbers: 'off',
-		scrollbar: {
-			alwaysConsumeMouseWheel: false
-		},
-		automaticLayout: true,
-	};
 }


### PR DESCRIPTION
Taking the JSON renderer from before, this PR makes it generic for all languages installed. Now notebooks can use `application/LANGUAGE_ID` for any installed language like rust or xml or whatever. 

An example of my extension using random languages:
![recording (46)](https://user-images.githubusercontent.com/12758612/121599573-16693c80-c9f8-11eb-9a12-21add22db6a5.gif)

