### PR TITLE
Support Content-Length and Last-Modified for webview local resources

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/baseWebviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/baseWebviewElement.ts
@@ -543,6 +543,7 @@ export abstract class BaseWebview<T extends HTMLElement> extends Disposable {
 							mime: result.mimeType,
 							data: buffer,
 							etag: result.etag,
+							mtime: result.mtime
 						});
 					}
 				case WebviewResourceResponse.Type.NotModified:
@@ -552,6 +553,7 @@ export abstract class BaseWebview<T extends HTMLElement> extends Disposable {
 							status: 304, // not modified
 							path: uri.path,
 							mime: result.mimeType,
+							mtime: result.mtime
 						});
 					}
 				case WebviewResourceResponse.Type.AccessDenied:

--- a/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
+++ b/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
@@ -22,6 +22,7 @@ export namespace WebviewResourceResponse {
 		constructor(
 			public readonly stream: VSBufferReadableStream,
 			public readonly etag: string | undefined,
+			public readonly mtime: number | undefined,
 			public readonly mimeType: string,
 		) { }
 	}
@@ -34,6 +35,7 @@ export namespace WebviewResourceResponse {
 
 		constructor(
 			public readonly mimeType: string,
+			public readonly mtime: number | undefined,
 		) { }
 	}
 
@@ -50,7 +52,7 @@ export async function loadLocalResource(
 	logService: ILogService,
 	token: CancellationToken,
 ): Promise<WebviewResourceResponse.StreamResponse> {
-	logService.debug(`loadLocalResource - being. requestUri=${requestUri}`);
+	logService.debug(`loadLocalResource - begin. requestUri=${requestUri}`);
 
 	const resourceToLoad = getResourceToLoad(requestUri, options.roots);
 
@@ -64,14 +66,14 @@ export async function loadLocalResource(
 
 	try {
 		const result = await fileService.readFileStream(resourceToLoad, { etag: options.ifNoneMatch });
-		return new WebviewResourceResponse.StreamSuccess(result.value, result.etag, mime);
+		return new WebviewResourceResponse.StreamSuccess(result.value, result.etag, result.mtime, mime);
 	} catch (err) {
 		if (err instanceof FileOperationError) {
 			const result = err.fileOperationResult;
 
 			// NotModified status is expected and can be handled gracefully
 			if (result === FileOperationResult.FILE_NOT_MODIFIED_SINCE) {
-				return new WebviewResourceResponse.NotModified(mime);
+				return new WebviewResourceResponse.NotModified(mime, err.options?.mtime);
 			}
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Closes #125992

To test (steps from @mjbvz):
1. At the top of your workspace, create markdown
2. Also create an image called `img.png`
3. In markdown preview, add the content:
```js
<script>
  fetch('img.png', {
    method: 'HEAD'
}).then(async (e) => {
    console.log(e.status);
    console.log(e.headers.get('content-type'));
    console.log(e.headers.get('content-length'));
    console.log(e.headers.get('last-modified'));
})
</script> 
```
4. Open the markdown preview and make sure scripts are enabled (there should be a warning if they are not)
5. Open the developer tools, check that the header contents have been printed and are correct
6. Same steps for a `GET` request