### PR TITLE
linux - restore `--no-sandbox` for startup scripts

### DIFF
--- a/resources/linux/code-url-handler.desktop
+++ b/resources/linux/code-url-handler.desktop
@@ -2,7 +2,7 @@
 Name=@@NAME_LONG@@ - URL Handler
 Comment=Code Editing. Redefined.
 GenericName=Text Editor
-Exec=@@EXEC@@ --open-url %U
+Exec=@@EXEC@@ --no-sandbox --open-url %U
 Icon=@@ICON@@
 Type=Application
 NoDisplay=true

--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -2,7 +2,7 @@
 Name=@@NAME_LONG@@
 Comment=Code Editing. Redefined.
 GenericName=Text Editor
-Exec=@@EXEC@@ --unity-launch %F
+Exec=@@EXEC@@ --no-sandbox --unity-launch %F
 Icon=@@ICON@@
 Type=Application
 StartupNotify=false
@@ -14,5 +14,5 @@ Keywords=vscode;
 
 [Desktop Action new-empty-window]
 Name=New Empty Window
-Exec=@@EXEC@@ --new-window %F
+Exec=@@EXEC@@ --no-sandbox --new-window %F
 Icon=@@ICON@@

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -15,7 +15,7 @@ import { isAbsolute, join } from 'vs/base/common/path';
 import { whenDeleted, writeFileSync } from 'vs/base/node/pfs';
 import { findFreePort } from 'vs/base/node/ports';
 import { randomPort } from 'vs/base/common/ports';
-import { isWindows, IProcessEnvironment } from 'vs/base/common/platform';
+import { isLinux, isWindows, IProcessEnvironment } from 'vs/base/common/platform';
 import type { ProfilingSession, Target } from 'v8-inspect-profiler';
 import { isString } from 'vs/base/common/types';
 import { hasStdinWithoutTty, stdinDataListener, getStdinFilePath, readFromStdin } from 'vs/platform/environment/node/stdin';
@@ -317,6 +317,10 @@ export async function main(argv: string[]): Promise<any> {
 
 		if (!verbose) {
 			options['stdio'] = 'ignore';
+		}
+
+		if (isLinux) {
+			addArg(argv, '--no-sandbox'); // Electron 6 introduces a chrome-sandbox that requires root to run. This can fail. Disable sandbox via --no-sandbox
 		}
 
 		const child = spawn(process.execPath, argv.slice(2), options);


### PR DESCRIPTION
Partially reverts https://github.com/microsoft/vscode/commit/e2954beb4b0fccb7c034f1444e4b76c23fa6ae0b for those files that are related to startup for our users (not tests).

This PR fixes https://github.com/microsoft/vscode/issues/126027
