### PR TITLE
Pass config to external terminal service

### DIFF
--- a/src/vs/platform/externalTerminal/common/externalTerminal.ts
+++ b/src/vs/platform/externalTerminal/common/externalTerminal.ts
@@ -22,7 +22,7 @@ export interface ITerminalForPlatform {
 
 export interface IExternalTerminalService {
 	readonly _serviceBrand: undefined;
-	openTerminal(path: string): Promise<void>;
+	openTerminal(configuration: IExternalTerminalSettings, path: string): Promise<void>;
 	runInTerminal(title: string, cwd: string, args: string[], env: ITerminalEnvironment, settings: IExternalTerminalSettings): Promise<number | undefined>;
 	getDefaultTerminalForPlatforms(): Promise<ITerminalForPlatform>;
 }

--- a/src/vs/platform/externalTerminal/electron-main/externalTerminalService.test.ts
+++ b/src/vs/platform/externalTerminal/electron-main/externalTerminalService.test.ts
@@ -42,7 +42,7 @@ suite('ExternalTerminalService', () => {
 				};
 			}
 		};
-		let testService = new WindowsExternalTerminalService(mockConfig);
+		let testService = new WindowsExternalTerminalService();
 		(<any>testService).spawnTerminal(
 			mockSpawner,
 			mockConfig,
@@ -67,7 +67,7 @@ suite('ExternalTerminalService', () => {
 			}
 		};
 		mockConfig.terminal.external.windowsExec = undefined;
-		let testService = new WindowsExternalTerminalService(mockConfig);
+		let testService = new WindowsExternalTerminalService();
 		(<any>testService).spawnTerminal(
 			mockSpawner,
 			mockConfig,
@@ -91,7 +91,7 @@ suite('ExternalTerminalService', () => {
 				};
 			}
 		};
-		let testService = new WindowsExternalTerminalService(mockConfig);
+		let testService = new WindowsExternalTerminalService();
 		(<any>testService).spawnTerminal(
 			mockSpawner,
 			mockConfig,
@@ -115,7 +115,7 @@ suite('ExternalTerminalService', () => {
 				return { on: (evt: any) => evt };
 			}
 		};
-		let testService = new WindowsExternalTerminalService(mockConfig);
+		let testService = new WindowsExternalTerminalService();
 		(<any>testService).spawnTerminal(
 			mockSpawner,
 			mockConfig,
@@ -137,7 +137,7 @@ suite('ExternalTerminalService', () => {
 				return { on: (evt: any) => evt };
 			}
 		};
-		let testService = new WindowsExternalTerminalService(mockConfig);
+		let testService = new WindowsExternalTerminalService();
 		(<any>testService).spawnTerminal(
 			mockSpawner,
 			mockConfig,
@@ -160,7 +160,7 @@ suite('ExternalTerminalService', () => {
 				};
 			}
 		};
-		let testService = new MacExternalTerminalService(mockConfig);
+		let testService = new MacExternalTerminalService();
 		(<any>testService).spawnTerminal(
 			mockSpawner,
 			mockConfig,
@@ -183,7 +183,7 @@ suite('ExternalTerminalService', () => {
 			}
 		};
 		mockConfig.terminal.external.osxExec = undefined;
-		let testService = new MacExternalTerminalService(mockConfig);
+		let testService = new MacExternalTerminalService();
 		(<any>testService).spawnTerminal(
 			mockSpawner,
 			mockConfig,
@@ -206,7 +206,7 @@ suite('ExternalTerminalService', () => {
 				};
 			}
 		};
-		let testService = new LinuxExternalTerminalService(mockConfig);
+		let testService = new LinuxExternalTerminalService();
 		(<any>testService).spawnTerminal(
 			mockSpawner,
 			mockConfig,
@@ -230,7 +230,7 @@ suite('ExternalTerminalService', () => {
 				}
 			};
 			mockConfig.terminal.external.linuxExec = undefined;
-			let testService = new LinuxExternalTerminalService(mockConfig);
+			let testService = new LinuxExternalTerminalService();
 			(<any>testService).spawnTerminal(
 				mockSpawner,
 				mockConfig,

--- a/src/vs/platform/externalTerminal/node/externalTerminalService.ts
+++ b/src/vs/platform/externalTerminal/node/externalTerminalService.ts
@@ -9,9 +9,7 @@ import * as processes from 'vs/base/node/processes';
 import * as nls from 'vs/nls';
 import * as pfs from 'vs/base/node/pfs';
 import * as env from 'vs/base/common/platform';
-import { IExternalTerminalConfiguration, IExternalTerminalSettings, DEFAULT_TERMINAL_OSX, ITerminalForPlatform, IExternalTerminalMainService } from 'vs/platform/externalTerminal/common/externalTerminal';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { optional } from 'vs/platform/instantiation/common/instantiation';
+import { IExternalTerminalSettings, DEFAULT_TERMINAL_OSX, ITerminalForPlatform, IExternalTerminalMainService } from 'vs/platform/externalTerminal/common/externalTerminal';
 import { FileAccess } from 'vs/base/common/network';
 import { ITerminalEnvironment } from 'vs/platform/terminal/common/terminal';
 import { sanitizeProcessEnvironment } from 'vs/base/common/processes';
@@ -31,20 +29,12 @@ export class WindowsExternalTerminalService extends ExternalTerminalService impl
 	private static readonly CMD = 'cmd.exe';
 	private static _DEFAULT_TERMINAL_WINDOWS: string;
 
-	constructor(
-		@optional(IConfigurationService) private readonly _configurationService: IConfigurationService
-	) {
-		super();
-	}
-
-	public openTerminal(cwd?: string): Promise<void> {
-		const configuration = this._configurationService.getValue<IExternalTerminalConfiguration>();
+	public openTerminal(configuration: IExternalTerminalSettings, cwd?: string): Promise<void> {
 		return this.spawnTerminal(cp, configuration, processes.getWindowsShell(), cwd);
 	}
 
-	public spawnTerminal(spawner: typeof cp, configuration: IExternalTerminalConfiguration, command: string, cwd?: string): Promise<void> {
-		const terminalConfig = configuration.terminal.external;
-		const exec = terminalConfig?.windowsExec || WindowsExternalTerminalService.getDefaultTerminalWindows();
+	public spawnTerminal(spawner: typeof cp, configuration: IExternalTerminalSettings, command: string, cwd?: string): Promise<void> {
+		const exec = configuration.windowsExec || WindowsExternalTerminalService.getDefaultTerminalWindows();
 
 		// Make the drive letter uppercase on Windows (see #9448)
 		if (cwd && cwd[1] === ':') {
@@ -124,14 +114,7 @@ export class WindowsExternalTerminalService extends ExternalTerminalService impl
 export class MacExternalTerminalService extends ExternalTerminalService implements IExternalTerminalMainService {
 	private static readonly OSASCRIPT = '/usr/bin/osascript';	// osascript is the AppleScript interpreter on OS X
 
-	constructor(
-		@optional(IConfigurationService) private readonly _configurationService: IConfigurationService
-	) {
-		super();
-	}
-
-	public openTerminal(cwd?: string): Promise<void> {
-		const configuration = this._configurationService.getValue<IExternalTerminalConfiguration>();
+	public openTerminal(configuration: IExternalTerminalSettings, cwd?: string): Promise<void> {
 		return this.spawnTerminal(cp, configuration, cwd);
 	}
 
@@ -199,9 +182,8 @@ export class MacExternalTerminalService extends ExternalTerminalService implemen
 		});
 	}
 
-	spawnTerminal(spawner: typeof cp, configuration: IExternalTerminalConfiguration, cwd?: string): Promise<void> {
-		const terminalConfig = configuration.terminal.external;
-		const terminalApp = terminalConfig?.osxExec || DEFAULT_TERMINAL_OSX;
+	spawnTerminal(spawner: typeof cp, configuration: IExternalTerminalSettings, cwd?: string): Promise<void> {
+		const terminalApp = configuration.osxExec || DEFAULT_TERMINAL_OSX;
 
 		return new Promise<void>((c, e) => {
 			const args = ['-a', terminalApp];
@@ -219,14 +201,7 @@ export class LinuxExternalTerminalService extends ExternalTerminalService implem
 
 	private static readonly WAIT_MESSAGE = nls.localize('press.any.key', "Press any key to continue...");
 
-	constructor(
-		@optional(IConfigurationService) private readonly _configurationService: IConfigurationService
-	) {
-		super();
-	}
-
-	public openTerminal(cwd?: string): Promise<void> {
-		const configuration = this._configurationService.getValue<IExternalTerminalConfiguration>();
+	public openTerminal(configuration: IExternalTerminalSettings, cwd?: string): Promise<void> {
 		return this.spawnTerminal(cp, configuration, cwd);
 	}
 
@@ -314,9 +289,8 @@ export class LinuxExternalTerminalService extends ExternalTerminalService implem
 		return LinuxExternalTerminalService._DEFAULT_TERMINAL_LINUX_READY;
 	}
 
-	spawnTerminal(spawner: typeof cp, configuration: IExternalTerminalConfiguration, cwd?: string): Promise<void> {
-		const terminalConfig = configuration.terminal.external;
-		const execPromise = terminalConfig?.linuxExec ? Promise.resolve(terminalConfig.linuxExec) : LinuxExternalTerminalService.getDefaultTerminalLinuxReady();
+	spawnTerminal(spawner: typeof cp, configuration: IExternalTerminalSettings, cwd?: string): Promise<void> {
+		const execPromise = configuration.linuxExec ? Promise.resolve(configuration.linuxExec) : LinuxExternalTerminalService.getDefaultTerminalLinuxReady();
 
 		return new Promise<void>((c, e) => {
 			execPromise.then(exec => {

--- a/src/vs/workbench/contrib/debug/node/terminals.ts
+++ b/src/vs/workbench/contrib/debug/node/terminals.ts
@@ -8,7 +8,6 @@ import * as platform from 'vs/base/common/platform';
 import { getDriveLetter } from 'vs/base/common/extpath';
 import { LinuxExternalTerminalService, MacExternalTerminalService, WindowsExternalTerminalService } from 'vs/platform/externalTerminal/node/externalTerminalService';
 import { IExternalTerminalService } from 'vs/platform/externalTerminal/common/externalTerminal';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ExtHostConfigProvider } from 'vs/workbench/api/common/extHostConfiguration';
 
 
@@ -36,11 +35,11 @@ let externalTerminalService: IExternalTerminalService | undefined = undefined;
 export function runInExternalTerminal(args: DebugProtocol.RunInTerminalRequestArguments, configProvider: ExtHostConfigProvider): Promise<number | undefined> {
 	if (!externalTerminalService) {
 		if (platform.isWindows) {
-			externalTerminalService = new WindowsExternalTerminalService(<IConfigurationService><unknown>undefined);
+			externalTerminalService = new WindowsExternalTerminalService();
 		} else if (platform.isMacintosh) {
-			externalTerminalService = new MacExternalTerminalService(<IConfigurationService><unknown>undefined);
+			externalTerminalService = new MacExternalTerminalService();
 		} else if (platform.isLinux) {
-			externalTerminalService = new LinuxExternalTerminalService(<IConfigurationService><unknown>undefined);
+			externalTerminalService = new LinuxExternalTerminalService();
 		} else {
 			throw new Error('external terminals not supported on this platform');
 		}

--- a/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
+++ b/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
@@ -42,7 +42,8 @@ CommandsRegistry.registerCommand({
 		return fileService.resolveAll(resources.map(r => ({ resource: r }))).then(async stats => {
 			const targets = distinct(stats.filter(data => data.success));
 			// Always use integrated terminal when using a remote
-			const useIntegratedTerminal = remoteAgentService.getConnection() || configurationService.getValue<IExternalTerminalConfiguration>().terminal.explorerKind === 'integrated';
+			const config = configurationService.getValue<IExternalTerminalConfiguration>();
+			const useIntegratedTerminal = remoteAgentService.getConnection() || config.terminal.explorerKind === 'integrated';
 			if (useIntegratedTerminal) {
 				// TODO: Use uri for cwd in createterminal
 				const opened: { [path: string]: boolean } = {};
@@ -71,7 +72,7 @@ CommandsRegistry.registerCommand({
 				});
 			} else {
 				distinct(targets.map(({ stat }) => stat!.isDirectory ? stat!.resource.fsPath : dirname(stat!.resource.fsPath))).forEach(cwd => {
-					terminalService!.openTerminal(cwd);
+					terminalService!.openTerminal(config.terminal.external, cwd);
 				});
 			}
 		});

--- a/src/vs/workbench/contrib/externalTerminal/electron-sandbox/externalTerminal.contribution.ts
+++ b/src/vs/workbench/contrib/externalTerminal/electron-sandbox/externalTerminal.contribution.ts
@@ -5,7 +5,7 @@
 
 import * as nls from 'vs/nls';
 import * as paths from 'vs/base/common/path';
-import { DEFAULT_TERMINAL_OSX, IExternalTerminalService } from 'vs/platform/externalTerminal/common/externalTerminal';
+import { DEFAULT_TERMINAL_OSX, IExternalTerminalService, IExternalTerminalSettings } from 'vs/platform/externalTerminal/common/externalTerminal';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { KEYBINDING_CONTEXT_TERMINAL_NOT_FOCUSED } from 'vs/workbench/contrib/terminal/common/terminal';
@@ -17,6 +17,7 @@ import { IConfigurationRegistry, Extensions, ConfigurationScope } from 'vs/platf
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { IExternalTerminalMainService } from 'vs/platform/externalTerminal/electron-sandbox/externalTerminalMainService';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 const OPEN_NATIVE_CONSOLE_COMMAND_ID = 'workbench.action.terminal.openNativeConsole';
 KeybindingsRegistry.registerCommandAndKeybindingRule({
@@ -28,18 +29,20 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const historyService = accessor.get(IHistoryService);
 		// Open external terminal in local workspaces
 		const terminalService = accessor.get(IExternalTerminalService);
+		const configurationService = accessor.get(IConfigurationService);
 		const root = historyService.getLastActiveWorkspaceRoot(Schemas.file);
+		const config = configurationService.getValue<IExternalTerminalSettings>('terminal.external');
 		if (root) {
-			terminalService.openTerminal(root.fsPath);
+			terminalService.openTerminal(config, root.fsPath);
 		} else {
 			// Opens current file's folder, if no folder is open in editor
 			const activeFile = historyService.getLastActiveFile(Schemas.file);
 			if (activeFile) {
-				terminalService.openTerminal(paths.dirname(activeFile.fsPath));
+				terminalService.openTerminal(config, paths.dirname(activeFile.fsPath));
 			} else {
 				const pathService = accessor.get(IPathService);
 				const userHome = await pathService.userHome();
-				terminalService.openTerminal(userHome.fsPath);
+				terminalService.openTerminal(config, userHome.fsPath);
 			}
 		}
 	}


### PR DESCRIPTION
The config service on the main process isn't complete which results in the terminal config being undefined if there are no user terminals settings set.

Fixes #125985
