### PR TITLE
linux: use GTK_USE_PORTAL=1 to support the XDG Desktop Portal

### DIFF
--- a/resources/linux/bin/code.sh
+++ b/resources/linux/bin/code.sh
@@ -48,6 +48,11 @@ else
 	fi
 fi
 
+# if the user has GTK_USE_PORTAL defined in their environment, respect it
+if [ -z "${GTK_USE_PORTAL}" ]; then
+	GTK_USE_PORTAL=1
+fi
+
 ELECTRON="$VSCODE_PATH/@@NAME@@"
 CLI="$VSCODE_PATH/resources/app/out/cli.js"
 ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" --ms-enable-electron-run-as-node "$@"


### PR DESCRIPTION
Electron 14 will have support for file managers through the XDG Desktop
Portal Specification. In order to explicitly opt into support assuming
a user has an xdg-desktop-portal-* package installed, GTK needs to be
told to use it. This will allow for alternative file managers on KDE or
wlroots-based systems.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #50386 amongst others, once VSCode adopts Electron v14.
