### PR TITLE
Fix #126178

### DIFF
--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -531,7 +531,7 @@ export class StaticMarkdownPreview extends Disposable implements ManagedMarkdown
 		}));
 
 		this._register(this.preview.onScroll((scrollInfo) => {
-			topmostLineMonitor.setPreviousEditorLine(scrollInfo);
+			topmostLineMonitor.setPreviousStaticEditorLine(scrollInfo);
 		}));
 
 		this._register(topmostLineMonitor.onDidChanged(event => {

--- a/extensions/markdown-language-features/src/features/previewManager.ts
+++ b/extensions/markdown-language-features/src/features/previewManager.ts
@@ -81,7 +81,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 
 			// When at a markdown file, apply existing scroll settings
 			if (textEditor && textEditor.document && isMarkdownFile(textEditor.document)) {
-				const line = this._topmostLineMonitor.getPreviousEditorLineByUri(textEditor.document.uri);
+				const line = this._topmostLineMonitor.getPreviousStaticEditorLineByUri(textEditor.document.uri);
 				if (line) {
 					scrollEditorToLine(line, textEditor);
 				}
@@ -172,7 +172,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 		document: vscode.TextDocument,
 		webview: vscode.WebviewPanel
 	): Promise<void> {
-		const lineNumber = this._topmostLineMonitor.getPreviousEditorLineByUri(document.uri);
+		const lineNumber = this._topmostLineMonitor.getPreviousTextEditorLineByUri(document.uri);
 		const preview = StaticMarkdownPreview.revive(
 			document.uri,
 			webview,

--- a/extensions/markdown-language-features/src/util/topmostLineMonitor.ts
+++ b/extensions/markdown-language-features/src/util/topmostLineMonitor.ts
@@ -16,15 +16,15 @@ export class TopmostLineMonitor extends Disposable {
 
 	private readonly pendingUpdates = new Map<string, number>();
 	private readonly throttle = 50;
-	private previousEditorInfo = new Map<string, LastScrollLocation>();
-	public isPrevEditorCustom = false;
+	private previousTextEditorInfo = new Map<string, LastScrollLocation>();
+	private previousStaticEditorInfo = new Map<string, LastScrollLocation>();
 
 	constructor() {
 		super();
 
 		if (vscode.window.activeTextEditor) {
 			const line = getVisibleLine(vscode.window.activeTextEditor);
-			this.setPreviousEditorLine({ uri: vscode.window.activeTextEditor.document.uri, line: line ?? 0 });
+			this.setPreviousTextEditorLine({ uri: vscode.window.activeTextEditor.document.uri, line: line ?? 0 });
 		}
 
 		this._register(vscode.window.onDidChangeTextEditorVisibleRanges(event => {
@@ -32,7 +32,7 @@ export class TopmostLineMonitor extends Disposable {
 				const line = getVisibleLine(event.textEditor);
 				if (typeof line === 'number') {
 					this.updateLine(event.textEditor.document.uri, line);
-					this.setPreviousEditorLine({ uri: event.textEditor.document.uri, line: line });
+					this.setPreviousTextEditorLine({ uri: event.textEditor.document.uri, line: line });
 				}
 			}
 		}));
@@ -41,12 +41,24 @@ export class TopmostLineMonitor extends Disposable {
 	private readonly _onChanged = this._register(new vscode.EventEmitter<{ readonly resource: vscode.Uri, readonly line: number }>());
 	public readonly onDidChanged = this._onChanged.event;
 
-	public setPreviousEditorLine(scrollLocation: LastScrollLocation): void {
-		this.previousEditorInfo.set(scrollLocation.uri.toString(), scrollLocation);
+	public setPreviousStaticEditorLine(scrollLocation: LastScrollLocation): void {
+		this.previousStaticEditorInfo.set(scrollLocation.uri.toString(), scrollLocation);
 	}
 
-	public getPreviousEditorLineByUri(resource: vscode.Uri): number | undefined {
-		const scrollLoc = this.previousEditorInfo.get(resource.toString());
+	public getPreviousStaticEditorLineByUri(resource: vscode.Uri): number | undefined {
+		const scrollLoc = this.previousStaticEditorInfo.get(resource.toString());
+		this.previousStaticEditorInfo.delete(resource.toString());
+		return scrollLoc?.line;
+	}
+
+
+	public setPreviousTextEditorLine(scrollLocation: LastScrollLocation): void {
+		this.previousTextEditorInfo.set(scrollLocation.uri.toString(), scrollLocation);
+	}
+
+	public getPreviousTextEditorLineByUri(resource: vscode.Uri): number | undefined {
+		const scrollLoc = this.previousTextEditorInfo.get(resource.toString());
+		this.previousTextEditorInfo.delete(resource.toString());
 		return scrollLoc?.line;
 	}
 


### PR DESCRIPTION
Previously, opening two markdown files side-by-side caused unexpected scrolling. This was due to a bug introduced in #123727, which was fixed by separating the last scroll locations of static/text editors and consuming the info entry upon access.

This PR fixes #126178
