### PR TITLE
Add bool objects renderer in settings editor

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -34,6 +34,10 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-list-object-input-key-checkbox .setting-value-checkbox {
 	margin-top: 3px;
 }
+.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-list-object-value .value-description {
+	font-style: italic;
+	white-space: normal;
+}
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-key {
 	margin-left: 0;
 }
@@ -53,7 +57,7 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value {
 	display: inline-block;
 	line-height: 24px;
-	height: 24px;
+	min-height: 24px;
 }
 
 /* Use monospace to display glob patterns in exclude widget */

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -27,6 +27,13 @@
 	margin-left: 4px;
 	min-width: 40%;
 }
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-key-checkbox {
+	margin-left: 4px;
+	height: 24px;
+}
+.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-list-object-input-key-checkbox .setting-value-checkbox {
+	margin-top: 3px;
+}
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-key {
 	margin-left: 0;
 }
@@ -46,6 +53,7 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value {
 	display: inline-block;
 	line-height: 24px;
+	height: 24px;
 }
 
 /* Use monospace to display glob patterns in exclude widget */
@@ -166,4 +174,11 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input select {
 	width: 100%;
 	height: 24px;
+}
+
+.settings-editor > .settings-body > .settings-tree-container .setting-list-widget .setting-list-object-list-row.select-container {
+	width: 320px;
+}
+.settings-editor > .settings-body > .settings-tree-container .setting-list-widget .setting-list-object-list-row.select-container > select {
+	width: inherit;
 }

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -38,10 +38,6 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-list-object-value {
 	cursor: pointer;
 }
-.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-list-object-value .value-description {
-	white-space: normal;
-	padding-bottom: 8px;
-}
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-key {
 	margin-left: 0;

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -27,17 +27,22 @@
 	margin-left: 4px;
 	min-width: 40%;
 }
-.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-key-checkbox {
+
+.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-list-object-input-key-checkbox {
 	margin-left: 4px;
 	height: 24px;
 }
 .settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-list-object-input-key-checkbox .setting-value-checkbox {
 	margin-top: 3px;
 }
-.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-list-object-value .value-description {
-	font-style: italic;
-	white-space: normal;
+.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-list-object-value {
+	cursor: pointer;
 }
+.settings-editor > .settings-body > .settings-tree-container .setting-item-bool .setting-list-object-value .value-description {
+	white-space: normal;
+	padding-bottom: 8px;
+}
+
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-key {
 	margin-left: 0;
 }

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -120,6 +120,7 @@ export class SettingsEditor2 extends EditorPane {
 		}
 		return type === SettingValueType.Enum ||
 			type === SettingValueType.StringOrEnumArray ||
+			type === SettingValueType.BooleanObject ||
 			type === SettingValueType.Complex ||
 			type === SettingValueType.Boolean ||
 			type === SettingValueType.Exclude;

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -43,7 +43,7 @@ import { ICssStyleCollector, IColorTheme, IThemeService, registerThemingParticip
 import { getIgnoredSettings } from 'vs/platform/userDataSync/common/settingsMerge';
 import { ITOCEntry } from 'vs/workbench/contrib/preferences/browser/settingsLayout';
 import { inspectSetting, ISettingsEditorViewState, settingKeyToDisplayFormat, SettingsTreeElement, SettingsTreeGroupChild, SettingsTreeGroupElement, SettingsTreeNewExtensionsElement, SettingsTreeSettingElement } from 'vs/workbench/contrib/preferences/browser/settingsTreeModels';
-import { ExcludeSettingWidget, ISettingListChangeEvent, IListDataItem, ListSettingWidget, settingsNumberInputBackground, settingsNumberInputBorder, settingsNumberInputForeground, settingsSelectBackground, settingsSelectBorder, settingsSelectForeground, settingsSelectListBorder, settingsTextInputBackground, settingsTextInputBorder, settingsTextInputForeground, ObjectSettingWidget, IObjectDataItem, IObjectEnumOption, ObjectValue, IObjectValueSuggester, IObjectKeySuggester, focusedRowBackground, focusedRowBorder, settingsHeaderForeground, rowHoverBackground } from 'vs/workbench/contrib/preferences/browser/settingsWidgets';
+import { ExcludeSettingWidget, ISettingListChangeEvent, IListDataItem, ListSettingWidget, settingsNumberInputBackground, settingsNumberInputBorder, settingsNumberInputForeground, settingsSelectBackground, settingsSelectBorder, settingsSelectForeground, settingsSelectListBorder, settingsTextInputBackground, settingsTextInputBorder, settingsTextInputForeground, ObjectSettingWidget, IObjectDataItem, IObjectEnumOption, ObjectValue, IObjectValueSuggester, IObjectKeySuggester, focusedRowBackground, focusedRowBorder, settingsHeaderForeground, rowHoverBackground, BoolObjectSettingWidget, IBoolObjectDataItem } from 'vs/workbench/contrib/preferences/browser/settingsWidgets';
 import { SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU } from 'vs/workbench/contrib/preferences/common/preferences';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { ISetting, ISettingsGroup, SettingValueType } from 'vs/workbench/services/preferences/common/preferences';
@@ -199,6 +199,27 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 			},
 			removable: true,
 		} as IObjectDataItem;
+	});
+}
+
+function getBoolObjectDisplayValue(element: SettingsTreeSettingElement): IBoolObjectDataItem[] {
+	const elementDefaultValue: Record<string, unknown> = typeof element.defaultValue === 'object'
+		? element.defaultValue ?? {}
+		: {};
+
+	const elementScopeValue: Record<string, unknown> = typeof element.scopeValue === 'object'
+		? element.scopeValue ?? {}
+		: {};
+
+	const data = element.isConfigured ?
+		{ ...elementDefaultValue, ...elementScopeValue } :
+		elementDefaultValue;
+
+	return Object.keys(data).map(key => {
+		return {
+			key,
+			value: data[key],
+		} as IBoolObjectDataItem;
 	});
 }
 
@@ -498,6 +519,10 @@ interface ISettingObjectItemTemplate extends ISettingItemTemplate<void> {
 	objectWidget: ObjectSettingWidget;
 }
 
+interface ISettingBoolObjectItemTemplate extends ISettingItemTemplate<void> {
+	objectWidget: BoolObjectSettingWidget;
+}
+
 interface ISettingNewExtensionsTemplate extends IDisposableTemplate {
 	button: Button;
 	context?: SettingsTreeNewExtensionsElement;
@@ -516,6 +541,7 @@ const SETTINGS_BOOL_TEMPLATE_ID = 'settings.bool.template';
 const SETTINGS_ARRAY_TEMPLATE_ID = 'settings.array.template';
 const SETTINGS_EXCLUDE_TEMPLATE_ID = 'settings.exclude.template';
 const SETTINGS_OBJECT_TEMPLATE_ID = 'settings.object.template';
+const SETTINGS_BOOL_OBJECT_TEMPLATE_ID = 'settings.boolObject.template';
 const SETTINGS_COMPLEX_TEMPLATE_ID = 'settings.complex.template';
 const SETTINGS_NEW_EXTENSIONS_TEMPLATE_ID = 'settings.newExtensions.template';
 const SETTINGS_ELEMENT_TEMPLATE_ID = 'settings.group.template';
@@ -590,7 +616,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 	private readonly _onDidClickSettingLink = this._register(new Emitter<ISettingLinkClickEvent>());
 	readonly onDidClickSettingLink: Event<ISettingLinkClickEvent> = this._onDidClickSettingLink.event;
 
-	private readonly _onDidFocusSetting = this._register(new Emitter<SettingsTreeSettingElement>());
+	protected readonly _onDidFocusSetting = this._register(new Emitter<SettingsTreeSettingElement>());
 	readonly onDidFocusSetting: Event<SettingsTreeSettingElement> = this._onDidFocusSetting.event;
 
 	private ignoredSettings: string[];
@@ -1198,7 +1224,90 @@ export class SettingObjectRenderer extends AbstractSettingRenderer implements IT
 				)
 				: true,
 			keySuggester: createObjectKeySuggester(dataElement),
-			valueSuggester: createObjectValueSuggester(dataElement),
+			valueSuggester: createObjectValueSuggester(dataElement)
+		});
+
+		template.context = dataElement;
+	}
+}
+
+export class SettingBoolObjectRenderer extends AbstractSettingRenderer implements ITreeRenderer<SettingsTreeSettingElement, never, ISettingBoolObjectItemTemplate> {
+	templateId = SETTINGS_BOOL_OBJECT_TEMPLATE_ID;
+
+	renderTemplate(container: HTMLElement): ISettingBoolObjectItemTemplate {
+		const common = this.renderCommonTemplate(null, container, 'list');
+
+		const objectWidget = this._instantiationService.createInstance(BoolObjectSettingWidget, common.controlElement);
+		objectWidget.domNode.classList.add(AbstractSettingRenderer.CONTROL_CLASS);
+		common.toDispose.add(objectWidget);
+
+		const template: ISettingBoolObjectItemTemplate = {
+			...common,
+			objectWidget
+		};
+
+		this.addSettingElementFocusHandler(template);
+
+		common.toDispose.add(objectWidget.onDidChangeList(e => this.onDidChangeObject(template, e)));
+
+		return template;
+	}
+
+	private onDidChangeObject(template: ISettingBoolObjectItemTemplate, e: ISettingListChangeEvent<IBoolObjectDataItem>): void {
+		if (template.context) {
+			const defaultValue: Record<string, unknown> = typeof template.context.defaultValue === 'object'
+				? template.context.defaultValue ?? {}
+				: {};
+
+			const scopeValue: Record<string, unknown> = typeof template.context.scopeValue === 'object'
+				? template.context.scopeValue ?? {}
+				: {};
+
+			const newValue: Record<string, unknown> = {};
+			const newItems: IBoolObjectDataItem[] = [];
+
+			template.objectWidget.items.forEach((item, idx) => {
+				// Item was updated
+				if (isDefined(e.item) && e.targetIndex === idx) {
+					newValue[e.item.key] = e.item.value;
+					newItems.push(e.item);
+				}
+				// All remaining items, but skip the one that we just updated
+				else if (isUndefinedOrNull(e.item) || e.item.key !== item.key) {
+					newValue[item.key] = item.value;
+					newItems.push(item);
+				}
+			});
+
+			Object.entries(newValue).forEach(([key, value]) => {
+				// value from the scope has changed back to the default
+				if (scopeValue[key] !== value && defaultValue[key] === value) {
+					delete newValue[key];
+				}
+			});
+
+			this._onDidChangeSetting.fire({
+				key: template.context.setting.key,
+				value: Object.keys(newValue).length === 0 ? undefined : newValue,
+				type: template.context.valueType
+			});
+
+			this._onDidFocusSetting.fire(template.context);
+
+			template.objectWidget.setValue(newItems);
+		}
+	}
+
+	renderElement(element: ITreeNode<SettingsTreeSettingElement, never>, index: number, templateData: ISettingBoolObjectItemTemplate): void {
+		super.renderSettingElement(element, index, templateData);
+	}
+
+	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingBoolObjectItemTemplate, onChange: (value: string) => void): void {
+		const items = getBoolObjectDisplayValue(dataElement);
+		const { key } = dataElement.setting;
+
+		template.objectWidget.setValue(items, {
+			settingKey: key
 		});
 
 		template.context = dataElement;
@@ -1667,6 +1776,7 @@ export class SettingTreeRenderers {
 			this._instantiationService.createInstance(SettingExcludeRenderer, this.settingActions, actionFactory),
 			this._instantiationService.createInstance(SettingEnumRenderer, this.settingActions, actionFactory),
 			this._instantiationService.createInstance(SettingObjectRenderer, this.settingActions, actionFactory),
+			this._instantiationService.createInstance(SettingBoolObjectRenderer, this.settingActions, actionFactory),
 			this._instantiationService.createInstance(SettingUntrustedRenderer, this.settingActions, actionFactory),
 		];
 
@@ -1913,6 +2023,10 @@ class SettingsTreeDelegate extends CachedListVirtualDelegate<SettingsTreeGroupCh
 
 			if (element.valueType === SettingValueType.Object) {
 				return SETTINGS_OBJECT_TEMPLATE_ID;
+			}
+
+			if (element.valueType === SettingValueType.BooleanObject) {
+				return SETTINGS_BOOL_OBJECT_TEMPLATE_ID;
 			}
 
 			return SETTINGS_COMPLEX_TEMPLATE_ID;

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -215,7 +215,17 @@ function getBoolObjectDisplayValue(element: SettingsTreeSettingElement): IBoolOb
 		{ ...elementDefaultValue, ...elementScopeValue } :
 		elementDefaultValue;
 
+	const { objectProperties } = element.setting;
+
 	return Object.keys(data).map(key => {
+		if (objectProperties && key in objectProperties) {
+			return {
+				key,
+				value: data[key],
+				description: objectProperties[key].description
+			} as IBoolObjectDataItem;
+		}
+
 		return {
 			key,
 			value: data[key],

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1255,43 +1255,31 @@ export class SettingBoolObjectRenderer extends AbstractSettingRenderer implement
 
 	private onDidChangeObject(template: ISettingBoolObjectItemTemplate, e: ISettingListChangeEvent<IBoolObjectDataItem>): void {
 		if (template.context) {
-			const defaultValue: Record<string, unknown> = typeof template.context.defaultValue === 'object'
-				? template.context.defaultValue ?? {}
-				: {};
-
-			const scopeValue: Record<string, unknown> = typeof template.context.scopeValue === 'object'
-				? template.context.scopeValue ?? {}
-				: {};
-
-			const newValue: Record<string, unknown> = {};
+			const newValue: Record<string, boolean> = {};
 			const newItems: IBoolObjectDataItem[] = [];
 
 			template.objectWidget.items.forEach((item, idx) => {
 				// Item was updated
-				if (isDefined(e.item) && e.targetIndex === idx) {
+				if (e.targetIndex === idx && e.item) {
 					newValue[e.item.key] = e.item.value;
 					newItems.push(e.item);
 				}
 				// All remaining items, but skip the one that we just updated
-				else if (isUndefinedOrNull(e.item) || e.item.key !== item.key) {
+				else {
 					newValue[item.key] = item.value;
 					newItems.push(item);
 				}
 			});
 
-			Object.entries(newValue).forEach(([key, value]) => {
-				// value from the scope has changed back to the default
-				if (scopeValue[key] !== value && defaultValue[key] === value) {
-					delete newValue[key];
-				}
-			});
-
 			this._onDidChangeSetting.fire({
 				key: template.context.setting.key,
-				value: Object.keys(newValue).length === 0 ? undefined : newValue,
+				value: newValue,
 				type: template.context.valueType
 			});
 
+			// Focus this setting explicitly, in case we were previously
+			// focused on another setting and clicked a checkbox/value container
+			// for this setting.
 			this._onDidFocusSetting.fire(template.context);
 
 			template.objectWidget.setValue(newItems);

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1265,14 +1265,8 @@ export class SettingBoolObjectRenderer extends AbstractSettingRenderer implement
 
 	private onDidChangeObject(template: ISettingBoolObjectItemTemplate, e: ISettingListChangeEvent<IBoolObjectDataItem>): void {
 		if (template.context) {
-			const defaultValue: Record<string, boolean> = typeof template.context.defaultValue === 'object'
-				? template.context.defaultValue ?? {}
-				: {};
-
-			const scopeValue: Record<string, boolean> = typeof template.context.scopeValue === 'object'
-				? template.context.scopeValue ?? {}
-				: {};
-
+			const defaultValue: Record<string, boolean> = template.context?.defaultValue ?? {};
+			const scopeValue: Record<string, boolean> = template.context?.scopeValue ?? {};
 			const newValue: Record<string, boolean> = {};
 			const newItems: IBoolObjectDataItem[] = [];
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -248,6 +248,8 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 			}
 		} else if (isObjectSetting(this.setting)) {
 			this.valueType = SettingValueType.Object;
+		} else if (this.setting.allKeysAreBoolean) {
+			this.valueType = SettingValueType.BooleanObject;
 		} else {
 			this.valueType = SettingValueType.Complex;
 		}

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -27,7 +27,6 @@ import { editorWidgetBorder, focusBorder, foreground, inputBackground, inputBord
 import { attachButtonStyler, attachInputBoxStyler, attachSelectBoxStyler } from 'vs/platform/theme/common/styler';
 import { IColorTheme, ICssStyleCollector, IThemeService, registerThemingParticipant, ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { settingsDiscardIcon, settingsEditIcon, settingsRemoveIcon } from 'vs/workbench/contrib/preferences/browser/preferencesIcons';
-import { settingKeyToDisplayFormat } from 'vs/workbench/contrib/preferences/browser/settingsTreeModels';
 
 const $ = DOM.$;
 export const settingsHeaderForeground = registerColor('settings.headerForeground', { light: '#444444', dark: '#e7e7e7', hc: '#ffffff' }, localize('headerForeground', "The foreground color for a section header or active title."));
@@ -1247,13 +1246,8 @@ export class BoolObjectSettingWidget extends AbstractListSettingWidget<IBoolObje
 		rowElement.appendChild(element);
 
 		const valueElement = DOM.append(rowElement, $('.setting-list-object-value'));
-		const valueTitleElement = DOM.append(valueElement, $('.value-title'));
-		const { label } = settingKeyToDisplayFormat(changedItem.key);
-		valueTitleElement.textContent = label;
-		const valueDescriptionElement = DOM.append(valueElement, $('.value-description'));
-		if (item.description) {
-			valueDescriptionElement.textContent = item.description;
-		}
+		valueElement.textContent = changedItem.key;
+		valueElement.setAttribute('title', changedItem.description ?? '');
 		this._register(DOM.addDisposableListener(valueElement, DOM.EventType.MOUSE_DOWN, e => {
 			const targetElement = <HTMLElement>e.target;
 			if (targetElement.tagName.toLowerCase() !== 'a') {

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -342,16 +342,18 @@ export abstract class AbstractListSettingWidget<TDataItem extends object> extend
 		this.container.classList.toggle('setting-list-hide-add-button', !this.isAddButtonVisible() || newMode);
 
 		const header = this.renderHeader();
-		const ITEM_HEIGHT = 24;
-		let listHeight = ITEM_HEIGHT * this.model.items.length;
+		let listHeight = 0;
 
 		if (header) {
-			listHeight += ITEM_HEIGHT;
 			this.listElement.appendChild(header);
+			listHeight += header.clientHeight;
 		}
 
 		this.rowElements = this.model.items.map((item, i) => this.renderDataOrEditItem(item, i, focused));
-		this.rowElements.forEach(rowElement => this.listElement.appendChild(rowElement));
+		this.rowElements.forEach(rowElement => {
+			this.listElement.appendChild(rowElement);
+			listHeight += rowElement.clientHeight;
+		});
 
 		this.listElement.style.height = listHeight + 'px';
 	}
@@ -1183,6 +1185,7 @@ interface IBoolObjectSetValueOptions {
 export interface IBoolObjectDataItem {
 	key: string;
 	value: boolean;
+	description?: string;
 }
 
 export class BoolObjectSettingWidget extends AbstractListSettingWidget<IBoolObjectDataItem> {
@@ -1244,8 +1247,13 @@ export class BoolObjectSettingWidget extends AbstractListSettingWidget<IBoolObje
 		rowElement.appendChild(element);
 
 		const valueElement = DOM.append(rowElement, $('.setting-list-object-value'));
+		const valueTitleElement = DOM.append(valueElement, $('.value-title'));
 		const { label } = settingKeyToDisplayFormat(changedItem.key);
-		valueElement.textContent = label;
+		valueTitleElement.textContent = label;
+		const valueDescriptionElement = DOM.append(valueElement, $('.value-description'));
+		if (item.description) {
+			valueDescriptionElement.textContent = item.description;
+		}
 		this._register(DOM.addDisposableListener(valueElement, DOM.EventType.MOUSE_DOWN, e => {
 			const targetElement = <HTMLElement>e.target;
 			if (targetElement.tagName.toLowerCase() !== 'a') {

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -34,7 +34,8 @@ export enum SettingValueType {
 	Complex = 'complex',
 	NullableInteger = 'nullable-integer',
 	NullableNumber = 'nullable-number',
-	Object = 'object'
+	Object = 'object',
+	BooleanObject = 'boolean-object'
 }
 
 export interface ISettingsGroup {
@@ -82,6 +83,7 @@ export interface ISetting {
 	extensionInfo?: IConfigurationExtensionInfo;
 	validator?: (value: any) => string | null;
 	enumItemLabels?: string[];
+	allKeysAreBoolean?: boolean;
 }
 
 export interface IExtensionSetting extends ISetting {

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -634,6 +634,20 @@ export class DefaultSettings extends Disposable {
 					enumDescriptions = prop.items!.enumDescriptions || prop.items!.markdownEnumDescriptions;
 				}
 
+				let allKeysAreBoolean = false;
+				if (prop.type === 'object' && !prop.additionalProperties && prop.properties && Object.keys(prop.properties).length) {
+					allKeysAreBoolean = Object.keys(prop.properties).every(key => {
+						return prop.properties![key].type === 'boolean';
+					});
+				}
+
+				if (enumToUse && listItemType === 'enum') {
+					console.log('dbg enumArray ' + key);
+				}
+				if (allKeysAreBoolean) {
+					console.log('dbg allKeysAreBoolean ' + key);
+				}
+
 				result.push({
 					key,
 					value,
@@ -661,7 +675,8 @@ export class DefaultSettings extends Disposable {
 					deprecationMessage: prop.markdownDeprecationMessage || prop.deprecationMessage,
 					deprecationMessageIsMarkdown: !!prop.markdownDeprecationMessage,
 					validator: createValidator(prop),
-					enumItemLabels: prop.enumItemLabels
+					enumItemLabels: prop.enumItemLabels,
+					allKeysAreBoolean
 				});
 			}
 		}

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -641,13 +641,6 @@ export class DefaultSettings extends Disposable {
 					});
 				}
 
-				if (enumToUse && listItemType === 'enum') {
-					console.log('dbg enumArray ' + key);
-				}
-				if (allKeysAreBoolean) {
-					console.log('dbg allKeysAreBoolean ' + key);
-				}
-
 				result.push({
 					key,
 					value,


### PR DESCRIPTION
This PR affects #125958.

For objects that have no additional properties, where all the values are bools, we can render those objects in the settings editor as a list of checkboxes.

Current progress:

The overall look is there, but the updating is inconsistent. The interface is also not keyboard-friendly.

![recording (36)](https://user-images.githubusercontent.com/7199958/121950858-0363ae80-cd0f-11eb-9077-11f9d6956a99.gif)

