### PR TITLE
Ported some of the scripts in the scripts/ folder to the fish shell

### DIFF
--- a/.devcontainer/prepare.fish.sh
+++ b/.devcontainer/prepare.fish.sh
@@ -1,0 +1,10 @@
+#!/bin/fish
+
+# This file contains the steps that should be run when creating the intermediary image that contains
+# contents for that should be in the image by default. It will be used to build up from the base image
+# to create an image that speeds up first time use of the dev container by "caching" the results
+# of these commands. Developers can still run these commands without an issue once the container is
+# up, but only differences will be processed which also speeds up the first time these operations occur.
+
+yarn install
+yarn electron

--- a/scripts/code-cli.fish.sh
+++ b/scripts/code-cli.fish.sh
@@ -1,11 +1,11 @@
-#!/usr/bin/env bash
+#!/usr/bin/env fish
 
 if [[ "$OSTYPE" == "darwin"* ]]
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
 	ROOT=$(dirname $(dirname $(realpath "$0")))
 else
 	ROOT=$(dirname $(dirname $(readlink -f $0)))
-fi
+end
 
 function code() {
 	cd $ROOT
@@ -16,18 +16,18 @@ function code() {
 	else
 		NAME=`node -p "require('./product.json').applicationName"`
 		CODE=".build/electron/$NAME"
-	fi
+	end
 
 	# Get electron, compile, built-in extensions
-	if [[ -z "${VSCODE_SKIP_PRELAUNCH}" ]]; then
+	if [[ -z "${VSCODE_SKIP_PRELAUNCH}" ]]
 		node build/lib/preLaunch.js
-	fi
+	end
 
 	# Manage built-in extensions
-	if [[ "$1" == "--builtin" ]]; then
+	if [[ "$1" == "--builtin" ]]
 		exec "$CODE" build/builtin
 		return
-	fi
+	end
 
 	ELECTRON_RUN_AS_NODE=1 \
 	NODE_ENV=development \

--- a/scripts/npm.fish.sh
+++ b/scripts/npm.fish.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env fish
+
+yarn $argv

--- a/scripts/test-documentation.sh
+++ b/scripts/test-documentation.sh
@@ -1,14 +1,16 @@
-#!/usr/bin/env bash
+#!/usr/bin/env fish
 set -e
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if "$OSTYPE" == "darwin"
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
-	ROOT=$(dirname $(dirname $(realpath "$0")))
+	# ROOT=$(dirname $(dirname $(realpath "$0")))
+	set ROOT $(dirname $(dirname $(realpath "$0")))
 	VSCODEUSERDATADIR=`mktemp -d -t 'myuserdatadir'`
 else
-	ROOT=$(dirname $(dirname $(readlink -f $0)))
+	# ROOT=$(dirname $(dirname $(readlink -f $0)))
+	set ROOT $(dirname $(dirname $(readlink -f $0)))
 	VSCODEUSERDATADIR=`mktemp -d 2>/dev/null`
-fi
+end
 
 cd $ROOT
 


### PR DESCRIPTION
A lot of people are using the fish shell nowadays This PR converts some of the scripts inside of the `scripts/` folder to the fish shell . All files that are ported to the fish have the extension `.fish.sh`

The following scripts were ported to the fish shell:
```bash
scripts/code-cli.fish.sh
scripts/npm.fish.sh
```