### PR TITLE
fix(window.ts): unresponsive window popup message [NFC]

### DIFF
--- a/src/vs/platform/windows/electron-main/window.ts
+++ b/src/vs/platform/windows/electron-main/window.ts
@@ -609,7 +609,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 					mnemonicButtonLabel(localize({ key: 'wait', comment: ['&& denotes a mnemonic'] }, "&&Keep Waiting")),
 					mnemonicButtonLabel(localize({ key: 'close', comment: ['&& denotes a mnemonic'] }, "&&Close"))
 				],
-				message: localize('appStalled', "The window is no longer responding"),
+				message: localize('appStalled', "The window is not responding"),
 				detail: localize('appStalledDetail', "You can reopen or close the window or keep waiting."),
 				noLink: true,
 				defaultId: 0,


### PR DESCRIPTION
The word `no longer` seems a bit too definitive, implying that it would not get back to be responsive again, but there is an option of waiting it to be responsive. 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
