### PR TITLE
Do not auto-trigger suggest when typing exactly the inline suggestion

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/ghostTextController.ts
@@ -19,7 +19,7 @@ import { ContextKeyExpr, IContextKeyService, RawContextKey } from 'vs/platform/c
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 export class GhostTextController extends Disposable {
-	public static readonly inlineSuggestionVisible = new RawContextKey<boolean>('inlineSuggestionVisible ', false, nls.localize('inlineSuggestionVisible', "Whether an inline suggestion is visible"));
+	public static readonly inlineSuggestionVisible = new RawContextKey<boolean>('inlineSuggestionVisible', false, nls.localize('inlineSuggestionVisible', "Whether an inline suggestion is visible"));
 	public static readonly inlineSuggestionHasIndentation = new RawContextKey<boolean>('inlineSuggestionHasIndentation', false, nls.localize('inlineSuggestionHasIndentation', "Whether the inline suggestion starts with whitespace"));
 
 	static ID = 'editor.contrib.ghostTextController';
@@ -48,6 +48,9 @@ export class GhostTextController extends Disposable {
 		}));
 		this._register(this.editor.onDidChangeConfiguration((e) => {
 			if (e.hasChanged(EditorOption.suggest)) {
+				this.updateModelController();
+			}
+			if (e.hasChanged(EditorOption.inlineSuggest)) {
 				this.updateModelController();
 			}
 		}));

--- a/src/vs/editor/contrib/suggest/test/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/suggestModel.test.ts
@@ -31,11 +31,12 @@ import { IEditorWorkerService } from 'vs/editor/common/services/editorWorkerServ
 import { ISuggestMemoryService } from 'vs/editor/contrib/suggest/suggestMemory';
 import { ITextModel } from 'vs/editor/common/model';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { MockKeybindingService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
+import { MockKeybindingService, MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
 import { createTextModel } from 'vs/editor/test/common/editorTestUtils';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { mock } from 'vs/base/test/common/mock';
 import { NullLogService } from 'vs/platform/log/common/log';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 
 
 function createMockEditor(model: TextModel): ITestCodeEditor {
@@ -204,7 +205,9 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 					}
 				},
 				NullTelemetryService,
-				new NullLogService()
+				new NullLogService(),
+				new MockContextKeyService(),
+				new TestConfigurationService()
 			);
 			disposables.push(oracle, editor);
 


### PR DESCRIPTION
#### Only when inline suggestions are visible:
- quick suggestions will no longer auto-trigger. 
  - As an emergency, there is a hidden setting `editor.inlineSuggest.allowQuickSuggestions` that can be set to `true` to get the old behavior.
- trigger characters will no longer auto-trigger.
  - As an emergency, there is a hidden setting `editor.inlineSuggest.allowSuggestOnTriggerCharacters` that can be set to `true` to get the old behavior.

#### There is no change if inline suggestions are not visible.

---

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/2208

---

* Removes errornous trailing space in `inlineSuggestionVisible` context key (not detected in tests - it is only a bug when users want to use that key). This is important if users/copilot want to check if an inline suggestion is visible / use it in keybindings.
* Activates controller when `editor.inlineSuggest.enabled` is changed. This is important when copilot sets this setting to true.