### PR TITLE
"Do you want to open it anyway?" in diff editor no-ops (fix #124222)

### DIFF
--- a/src/vs/workbench/contrib/files/browser/editors/binaryFileEditor.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/binaryFileEditor.ts
@@ -45,7 +45,9 @@ export class BinaryFileEditor extends BaseBinaryResourceEditor {
 
 			// We operate on the active editor here to support re-opening
 			// diff editors where `input` may just be one side of the
-			// diff editor
+			// diff editor.
+			// Since `openInternal` can only ever be selected from the
+			// active editor of the group, this is a safe assumption.
 			// (https://github.com/microsoft/vscode/issues/124222)
 			const editor = this.group.activeEditor;
 

--- a/src/vs/workbench/contrib/files/browser/editors/binaryFileEditor.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/binaryFileEditor.ts
@@ -41,13 +41,19 @@ export class BinaryFileEditor extends BaseBinaryResourceEditor {
 	}
 
 	private async openInternal(input: EditorInput, options: IEditorOptions | undefined): Promise<void> {
-		if (input instanceof FileEditorInput && this.group) {
+		if (input instanceof FileEditorInput && this.group && this.group.activeEditor) {
+
+			// We operate on the active editor here to support re-opening
+			// diff editors where `input` may just be one side of the
+			// diff editor
+			// (https://github.com/microsoft/vscode/issues/124222)
+			const editor = this.group.activeEditor;
 
 			// Enforce to open the input as text to enable our text based viewer
 			input.setForceOpenAsText();
 
 			// Try to let the user pick an override if there is one availabe
-			let overridenInput: ReturnedOverride | undefined = await this.editorOverrideService.resolveEditorOverride(input, { ...options, override: EditorOverride.PICK, }, this.group);
+			let overridenInput: ReturnedOverride | undefined = await this.editorOverrideService.resolveEditorOverride(editor, { ...options, override: EditorOverride.PICK, }, this.group);
 			if (overridenInput === OverrideStatus.NONE) {
 				overridenInput = undefined;
 			} else if (overridenInput === OverrideStatus.ABORT) {
@@ -56,7 +62,7 @@ export class BinaryFileEditor extends BaseBinaryResourceEditor {
 
 			// Replace the overrriden input, with the text based input
 			await this.editorService.replaceEditors([{
-				editor: input,
+				editor,
 				replacement: overridenInput?.editor ?? input,
 				options: {
 					...overridenInput?.options ?? options,


### PR DESCRIPTION
This PR fixes #124222

I wasn't actually expecting that I can pass a diff editor to `resolveEditorOverride` but it seems to work? Let me know what you think.

An alternative solution would be to leave the code as it was, but only use `group.activeEditor` in the `replaceEditors` call. This would result in the diff editor getting replaced with one of the two sides.