### PR TITLE
Use quotes not inline code block

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -8268,7 +8268,7 @@ declare module 'vscode' {
 		 *   }
 		 * });
 		 *
-		 * const callableUri = await vscode.env.asExternalUri(vscode.Uri.parse(`${vscode.env.uriScheme}://my.extension/did-authenticate`));
+		 * const callableUri = await vscode.env.asExternalUri(vscode.Uri.parse('${vscode.env.uriScheme}://my.extension/did-authenticate'));
 		 * await vscode.env.openExternal(callableUri);
 		 * ```
 		 *


### PR DESCRIPTION
The comment for AsExternalUri is using back ticks instead of single quotes in the TypeScript code block example.

This confuses the API generation as seen on https://code.visualstudio.com/api/references/vscode-api:

![image](https://user-images.githubusercontent.com/12818376/122330620-652b4080-cee8-11eb-9f32-797bff29f9b2.png)

With this fix, the code block renders correctly:

![image](https://user-images.githubusercontent.com/12818376/122330712-85f39600-cee8-11eb-885d-2d0b230e8465.png)

I think this has been broken for some time so we can wait until the next release when we update the vscode.d.ts commit id and publish the 1.58 API. 