### PR TITLE
remove fromPromise-util and adopt single user

### DIFF
--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -364,24 +364,6 @@ export namespace Event {
 		return result.event;
 	}
 
-	export function fromPromise<T = any>(promise: Promise<T>): Event<undefined> {
-		const emitter = new Emitter<undefined>();
-		let shouldEmit = false;
-
-		promise
-			.then(undefined, () => null)
-			.then(() => {
-				if (!shouldEmit) {
-					setTimeout(() => emitter.fire(undefined), 0);
-				} else {
-					emitter.fire(undefined);
-				}
-			});
-
-		shouldEmit = true;
-		return emitter.event;
-	}
-
 	export function toPromise<T>(event: Event<T>): Promise<T> {
 		return new Promise(resolve => once(event)(resolve));
 	}

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -584,33 +584,6 @@ suite('Event utils', () => {
 		});
 	});
 
-	suite('fromPromise', () => {
-
-		test('should emit when done', async () => {
-			let count = 0;
-
-			const event = Event.fromPromise(Promise.resolve(null));
-			event(() => count++);
-
-			assert.strictEqual(count, 0);
-
-			await timeout(10);
-			assert.strictEqual(count, 1);
-		});
-
-		test('should emit when done - setTimeout', async () => {
-			let count = 0;
-
-			const promise = timeout(5);
-			const event = Event.fromPromise(promise);
-			event(() => count++);
-
-			assert.strictEqual(count, 0);
-			await promise;
-			assert.strictEqual(count, 1);
-		});
-	});
-
 	suite('stopwatch', () => {
 
 		test('should emit', () => {

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -849,14 +849,17 @@ export class SearchResult extends Disposable {
 	replaceAll(progress: IProgress<IProgressStep>): Promise<any> {
 		this.replacingAll = true;
 
+		const start = Date.now();
 		const promise = this.replaceService.replace(this.matches(), progress);
-		const onDone = Event.stopwatch(Event.fromPromise(promise));
-		/* __GDPR__
-			"replaceAll.started" : {
-				"duration" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true }
-			}
-		*/
-		onDone(duration => this.telemetryService.publicLog('replaceAll.started', { duration }));
+
+		promise.finally(() => {
+			/* __GDPR__
+				"replaceAll.started" : {
+					"duration" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true }
+				}
+			*/
+			this.telemetryService.publicLog('replaceAll.started', { duration: Date.now() - start });
+		});
 
 		return promise.then(() => {
 			this.replacingAll = false;
@@ -1073,17 +1076,17 @@ export class SearchModel extends Disposable {
 		const dispose = () => tokenSource.dispose();
 		currentRequest.then(dispose, dispose);
 
-		const onDone = Event.fromPromise(currentRequest);
-		const onFirstRender = Event.any<any>(onDone, progressEmitter.event);
-		const onFirstRenderStopwatch = Event.stopwatch(onFirstRender);
-		/* __GDPR__
-			"searchResultsFirstRender" : {
-				"duration" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true }
-			}
-		*/
-		onFirstRenderStopwatch(duration => this.telemetryService.publicLog('searchResultsFirstRender', { duration }));
-
 		const start = Date.now();
+
+		Promise.race([currentRequest, Event.toPromise(progressEmitter.event)]).finally(() => {
+			/* __GDPR__
+				"searchResultsFirstRender" : {
+					"duration" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true }
+				}
+			*/
+			this.telemetryService.publicLog('searchResultsFirstRender', { duration: Date.now() - start });
+		});
+
 		currentRequest.then(
 			value => this.onSearchCompleted(value, Date.now() - start),
 			e => this.onSearchError(e, Date.now() - start));

--- a/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
@@ -170,7 +170,7 @@ suite('SearchModel', () => {
 		await testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 
 		assert.ok(target.calledThrice);
-		const data = target.args[0];
+		const data = target.args[2];
 		data[1].duration = -1;
 		assert.deepStrictEqual(['searchResultsFirstRender', { duration: -1 }], data);
 	});


### PR DESCRIPTION
This PR part of https://github.com/microsoft/vscode/issues/123487. The `fromPromise` util is leaky and instead of fixing it we should remove it... There is only one user and that can be tweaked with easy. PR for @roblourens because for the unit test the invocation order has changed (which I believe isn't an issue in real life)
