### PR TITLE
Take first, not last, binding as primary

### DIFF
--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -255,7 +255,7 @@ export class KeybindingResolver {
 
 		const itemMatchingContext = context &&
 			Array.from(items).reverse().find(item => context.contextMatchesRules(item.when));
-		return itemMatchingContext ?? items[items.length - 1];
+		return itemMatchingContext ?? items[0];
 	}
 
 	public resolve(context: IContext, currentChord: string | null, keypress: string): IResolveResult | null {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #126306

Also fixes the display bug mentioned in #126742.

When no contect match is found the last looked up binding was used. This made the wrong command shortcut keybinding sometimes display in places like the command palette when there are os specific bindings. Picking the first item fixes this.

I don't know, however, why the wrong bindings are in the list to begin with, so this might be just fixing the symptoms of something else that is wrong.