### PR TITLE
Add search.maxResults setting

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -923,6 +923,11 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('search.location', "Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space."),
 			deprecationMessage: nls.localize('search.location.deprecationMessage', "This setting is deprecated. You can drag the search icon to a new location instead.")
 		},
+		'search.maxResults': {
+			type: ['number', 'null'],
+			default: 10000,
+			markdownDescription: nls.localize('search.maxResults', "Controls the maximum number of search results, this can be set to `null` (empty) to return unlimited results.")
+		},
 		'search.collapseResults': {
 			type: 'string',
 			enum: ['auto', 'alwaysCollapse', 'alwaysExpand'],

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -925,7 +925,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'search.maxResults': {
 			type: ['number', 'null'],
-			default: 10000,
+			default: 20000,
 			markdownDescription: nls.localize('search.maxResults', "Controls the maximum number of search results, this can be set to `null` (empty) to return unlimited results.")
 		},
 		'search.collapseResults': {

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -20,6 +20,7 @@ import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Disposable, DisposableStore, dispose } from 'vs/base/common/lifecycle';
 import * as env from 'vs/base/common/platform';
 import * as strings from 'vs/base/common/strings';
+import { withNullAsUndefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import 'vs/css!./media/searchview';
 import { getCodeEditor, ICodeEditor, isCodeEditor, isDiffEditor } from 'vs/editor/browser/editorBrowser';
@@ -86,8 +87,6 @@ export enum SearchViewPosition {
 
 const SEARCH_CANCELLED_MESSAGE = nls.localize('searchCanceled', "Search was canceled before any results could be found - ");
 export class SearchView extends ViewPane {
-
-	private static readonly MAX_TEXT_RESULTS = 10000;
 
 	private static readonly ACTIONS_RIGHT_CLASS_NAME = 'actions-right';
 
@@ -1340,7 +1339,7 @@ export class SearchView extends ViewPane {
 		const options: ITextQueryBuilderOptions = {
 			_reason: 'searchView',
 			extraFileResources: this.instantiationService.invokeFunction(getOutOfWorkspaceEditorResources),
-			maxResults: SearchView.MAX_TEXT_RESULTS,
+			maxResults: withNullAsUndefined(this.searchConfig.maxResults),
 			disregardIgnoreFiles: !useExcludesAndIgnoreFiles || undefined,
 			disregardExcludeSettings: !useExcludesAndIgnoreFiles || undefined,
 			onlyOpenEditors: onlySearchInOpenEditors,

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -372,6 +372,7 @@ export interface ISearchConfigurationProperties {
 	usePCRE2: boolean;
 	actionsPosition: 'auto' | 'right';
 	maintainFileSearchCache: boolean;
+	maxResults: number | null;
 	collapseResults: 'auto' | 'alwaysCollapse' | 'alwaysExpand';
 	searchOnType: boolean;
 	seedOnFocus: boolean;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes: #8563 by adding a setting `search.maxResults` which sets the maximum number of search results returned. `null` (empty) can be used to return unlimited results.

Notes:
- The default functionality is unchanged (meaning we still have a default maximum of 10000).
- The original limitation was added due to a performance issue during replace in files: #8529
- #90383 was already closed but it was never really fixed, the fix for that issue only added a warning when the maximum is reached.
- It is worth considering setting the default to unlimited, as other editors do not have this limitation and it is unexpected (there have been numerous issues opened to support this).

Related issues:
- Search only returns first 10,000 items found #90383
- Investigate removing Max results limitation for Search and replace results #8563
- search results have a limit of 10000 items #29120
- Replace in files will stop after 10000 items #51624

Preview:

Below is a preview showing the new setting functionality, and also a replace of ~240,000 lines without issue.

![vscode-max-search-results2](https://user-images.githubusercontent.com/1714804/122658233-96da1c80-d11f-11eb-9447-30c2097b4472.gif)

