### PR TITLE
Add single level of categorization #126089

### DIFF
--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -25,6 +25,9 @@ export interface IConfigurationProperty {
 }
 
 export interface IConfiguration {
+	id?: string,
+	order?: number,
+	title?: string,
 	properties: { [key: string]: IConfigurationProperty; };
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -281,7 +281,7 @@
 }
 
 .settings-editor > .settings-body .settings-tree-container .monaco-list-row .monaco-tl-contents {
-	max-width: 1000px;
+	max-width: min(100%, 1000px);
 	margin: auto;
 	box-sizing: border-box;
 	padding-left: 221px;
@@ -559,17 +559,16 @@
 	padding-left: 15px;
 	width: 100%;
 	position: relative;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
-
-.settings-editor > .settings-body > .settings-tree-container .settings-group-level-1 {
+.settings-editor > .settings-body > .settings-tree-container .settings-group-title-label.settings-group-level-1 {
 	font-size: 26px;
 }
-
-.settings-editor > .settings-body > .settings-tree-container .settings-group-level-2 {
+.settings-editor > .settings-body > .settings-tree-container .settings-group-title-label.settings-group-level-2 {
 	font-size: 22px;
 }
-
-.settings-editor > .settings-body > .settings-tree-container .settings-group-level-3 {
+.settings-editor > .settings-body > .settings-tree-container .settings-group-title-label.settings-group-level-3 {
 	font-size: 18px;
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -281,12 +281,15 @@
 }
 
 .settings-editor > .settings-body .settings-tree-container .monaco-list-row .monaco-tl-contents {
-	max-width: min(100%, 1000px);
+	max-width: 1000px;
 	margin: auto;
 	box-sizing: border-box;
 	padding-left: 221px;
 	padding-right: 24px;
 	overflow: visible;
+}
+.settings-editor > .settings-body .settings-tree-container .monaco-list-row .monaco-tl-contents.group-title {
+	max-width: min(100%, 1000px); /* Cut off title if too long for window */
 }
 
 .settings-editor > .settings-body > .settings-tree-container .settings-group-title-label,

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -562,12 +562,15 @@
 }
 
 .settings-editor > .settings-body > .settings-tree-container .settings-group-level-1 {
-	font-size: 24px;
+	font-size: 26px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .settings-group-level-2 {
-	padding-top: 32px;
-	font-size: 20px;
+	font-size: 22px;
+}
+
+.settings-editor > .settings-body > .settings-tree-container .settings-group-level-3 {
+	font-size: 18px;
 }
 
 .settings-editor.search-mode > .settings-body .settings-toc-container .monaco-list-row .settings-toc-count {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -309,7 +309,7 @@ export class SettingsEditor2 extends EditorPane {
 		this.modelDisposables.clear();
 		this.modelDisposables.add(model.onDidChangeGroups(() => {
 			this.updatedConfigSchemaDelayer.trigger(() => {
-				this.onConfigUpdate(undefined, undefined, true);
+				this.onConfigUpdate(undefined, false, true);
 			});
 		}));
 		this.defaultSettingsEditorModel = model;

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -54,6 +54,7 @@ import { preferencesClearInputIcon } from 'vs/workbench/contrib/preferences/brow
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 import { IWorkbenchConfigurationService } from 'vs/workbench/services/configuration/common/configuration';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfigurationService';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 
 export const enum SettingsFocusContext {
 	Search,
@@ -199,7 +200,8 @@ export class SettingsEditor2 extends EditorPane {
 		@IEditorGroupsService protected editorGroupService: IEditorGroupsService,
 		@IUserDataSyncWorkbenchService private readonly userDataSyncWorkbenchService: IUserDataSyncWorkbenchService,
 		@IUserDataAutoSyncEnablementService private readonly userDataAutoSyncEnablementService: IUserDataAutoSyncEnablementService,
-		@IWorkspaceTrustManagementService private readonly workspaceTrustManagementService: IWorkspaceTrustManagementService
+		@IWorkspaceTrustManagementService private readonly workspaceTrustManagementService: IWorkspaceTrustManagementService,
+		@IExtensionService private readonly extensionService: IExtensionService
 	) {
 		super(SettingsEditor2.ID, telemetryService, themeService, storageService);
 		this.delayedFilterLogging = new Delayer<void>(1000);
@@ -1025,7 +1027,7 @@ export class SettingsEditor2 extends EditorPane {
 		const commonlyUsed = resolveSettingsTree(commonlyUsedData, dividedGroups.core, this.logService);
 		resolvedSettingsRoot.children!.unshift(commonlyUsed.tree);
 
-		resolvedSettingsRoot.children!.push(resolveExtensionsSettings(dividedGroups.extension || []));
+		resolvedSettingsRoot.children!.push(await resolveExtensionsSettings(this.extensionService, dividedGroups.extension || []));
 
 		if (!this.workspaceTrustManagementService.isWorkspaceTrusted() && (this.viewState.settingsTarget instanceof URI || this.viewState.settingsTarget === ConfigurationTarget.WORKSPACE)) {
 			const configuredUntrustedWorkspaceSettings = resolveConfiguredUntrustedSettings(groups, this.viewState.settingsTarget, this.configurationService);

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -7,6 +7,7 @@ import { localize } from 'vs/nls';
 export interface ITOCEntry<T> {
 	id: string;
 	label: string;
+	order?: number;
 	children?: ITOCEntry<T>[];
 	settings?: Array<T>;
 }

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -394,7 +394,16 @@ export async function resolveExtensionsSettings(extensionService: IExtensionServ
 	return Promise.all(processPromises).then(() => {
 		const extGroups: ITOCEntry<ISetting>[] = [];
 		for (const value of extGroupTree.values()) {
-			extGroups.push(value);
+			if (value.children!.length === 1) {
+				// push a flattened setting
+				extGroups.push({
+					id: value.id,
+					label: value.label,
+					settings: value.children![0].settings
+				});
+			} else {
+				extGroups.push(value);
+			}
 		}
 
 		return {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -366,12 +366,11 @@ export async function resolveExtensionsSettings(extensionService: IExtensionServ
 			const rootEntry = {
 				id: extensionId,
 				label: extensionName,
-				children: [childEntry]
+				children: []
 			};
 			extGroupTree.set(extensionId, rootEntry);
-		} else {
-			extGroupTree.get(extensionId)!.children!.push(childEntry);
 		}
+		extGroupTree.get(extensionId)!.children!.push(childEntry);
 	};
 	const processGroupEntry = async (group: ISettingsGroup) => {
 		const flatSettings = arrays.flatten(
@@ -379,16 +378,12 @@ export async function resolveExtensionsSettings(extensionService: IExtensionServ
 
 		const extensionId = group.extensionInfo!.id;
 		const extension = await extensionService.getExtension(extensionId);
-		let extensionName = group.title;
-		if (extension) {
-			extensionName = extension.displayName ?? extension.name;
-		}
-
+		const extensionName = extension!.displayName ?? extension!.name;
 		const childEntry = {
 			id: group.id,
 			label: group.title,
 			settings: flatSettings
-		} as ITOCEntry<ISetting>;
+		};
 		addEntryToTree(extensionId, extensionName, childEntry);
 	};
 
@@ -399,12 +394,7 @@ export async function resolveExtensionsSettings(extensionService: IExtensionServ
 	return Promise.all(processPromises).then(() => {
 		const extGroups: ITOCEntry<ISetting>[] = [];
 		for (const value of extGroupTree.values()) {
-			if (value.children!.length === 1) {
-				// only one child,so no need to nest it
-				extGroups.push(value.children![0]);
-			} else {
-				extGroups.push(value);
-			}
+			extGroups.push(value);
 		}
 
 		return {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -380,19 +380,10 @@ export async function resolveExtensionsSettings(extensionService: IExtensionServ
 		const extension = await extensionService.getExtension(extensionId);
 		const extensionName = extension!.displayName ?? extension!.name;
 
-		let sectionOrder = 0;
-		const extensionConfiguration = extension?.contributes?.configuration;
-		if (Array.isArray(extensionConfiguration)) {
-			const currentSection = extensionConfiguration.find((config) => config.id === group.id);
-			if (currentSection) {
-				sectionOrder = currentSection.order ?? 0;
-			}
-		}
-
 		const childEntry = {
 			id: group.id,
 			label: group.title,
-			order: sectionOrder,
+			order: group.order,
 			settings: flatSettings
 		};
 		addEntryToTree(extensionId, extensionName, childEntry);
@@ -409,7 +400,7 @@ export async function resolveExtensionsSettings(extensionService: IExtensionServ
 				// push a flattened setting
 				extGroups.push({
 					id: value.id,
-					label: value.label,
+					label: value.children![0].label,
 					settings: value.children![0].settings
 				});
 			} else {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -383,9 +383,9 @@ export async function resolveExtensionsSettings(extensionService: IExtensionServ
 		let sectionOrder = 0;
 		const extensionConfiguration = extension?.contributes?.configuration;
 		if (Array.isArray(extensionConfiguration)) {
-			const currentSection = extensionConfiguration.find((config) => (config as any)?.id === group.id);
+			const currentSection = extensionConfiguration.find((config) => config.id === group.id);
 			if (currentSection) {
-				sectionOrder = (currentSection as any)?.order ?? 0;
+				sectionOrder = currentSection.order ?? 0;
 			}
 		}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -429,9 +429,9 @@ export class SettingsTreeModel {
 	}
 
 	private createSettingsTreeGroupElement(tocEntry: ITOCEntry<ISetting>, parent?: SettingsTreeGroupElement): SettingsTreeGroupElement {
-
 		const depth = parent ? this.getDepth(parent) + 1 : 0;
 		const element = new SettingsTreeGroupElement(tocEntry.id, undefined, tocEntry.label, depth, false);
+		element.parent = parent;
 
 		const children: SettingsTreeGroupChild[] = [];
 		if (tocEntry.settings) {

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -41,6 +41,7 @@ export interface ISettingsGroup {
 	range: IRange;
 	title: string;
 	titleRange: IRange;
+	order: number;
 	sections: ISettingsSection[];
 	extensionInfo?: IConfigurationExtensionInfo;
 }

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -197,6 +197,7 @@ export class SettingsEditorModel extends AbstractSettingsModel implements ISetti
 				}],
 				title: modelGroup.title,
 				titleRange: modelGroup.titleRange,
+				order: modelGroup.order,
 				extensionInfo: modelGroup.extensionInfo
 			};
 		}
@@ -566,7 +567,7 @@ export class DefaultSettings extends Disposable {
 			if (!settingsGroup) {
 				settingsGroup = result.find(g => g.title === title && g.extensionInfo?.id === config.extensionInfo?.id);
 				if (!settingsGroup) {
-					settingsGroup = { sections: [{ settings: [] }], id: config.id || '', title: title || '', titleRange: nullRange, range: nullRange, extensionInfo: config.extensionInfo };
+					settingsGroup = { sections: [{ settings: [] }], id: config.id || '', title: title || '', titleRange: nullRange, order: config.order ?? 0, range: nullRange, extensionInfo: config.extensionInfo };
 					result.push(settingsGroup);
 				}
 			} else {
@@ -575,7 +576,7 @@ export class DefaultSettings extends Disposable {
 		}
 		if (config.properties) {
 			if (!settingsGroup) {
-				settingsGroup = { sections: [{ settings: [] }], id: config.id || '', title: config.id || '', titleRange: nullRange, range: nullRange, extensionInfo: config.extensionInfo };
+				settingsGroup = { sections: [{ settings: [] }], id: config.id || '', title: config.id || '', titleRange: nullRange, order: config.order ?? 0, range: nullRange, extensionInfo: config.extensionInfo };
 				result.push(settingsGroup);
 			}
 			const configurationSettings: ISetting[] = [];


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR affects #126089

It adds grouping to the settings editor extensions menu so that extension authors can now group their settings into multiple categories. 

The way the grouping works on the schema side is as follows:
- The contributes configuration object takes in an array of objects, rather than a single object
- Each array element can specify an `order` parameter so that the categories appear in a certain order
- This PR does **not** add support for sorting extension settings in a specific order
- See https://github.com/microsoft/vscode/blob/main/extensions/css-language-features/package.json for an example

The way the grouping works when displaying the settings is as follows:
- If there is only one category, the extension configuration title is used, rather than the extension name. For example, for https://github.com/amirmarmul/laravel-blade-vscode/blob/master/package.json, in the settings, we display "Blade Language" instead of "Laravel Blade"
- If there is more than one category, for each category, we display the category title, and for the group containing the categories, we use the extension's display name.

Here's a new picture showing how the titles look:

<img width="196" alt="Picture showing changes in this PR" src="https://user-images.githubusercontent.com/7199958/132901286-a6734f5f-25dc-4d2e-811f-53b8a947b80a.png">

