### PR TITLE
Use margin instead of padding for decoration spacing

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconlabel.css
+++ b/src/vs/base/browser/ui/iconLabel/iconlabel.css
@@ -87,7 +87,7 @@
 	opacity: 0.75;
 	font-size: 90%;
 	font-weight: 600;
-	padding: 0 16px 0 5px;
+	margin: 0 16px 0 5px;
 	text-align: center;
 }
 

--- a/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
@@ -32,7 +32,7 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title.breadcrumbs .monaco-icon-label::after,
 .monaco-workbench .part.editor > .content .editor-group-container > .title.tabs .monaco-icon-label::after {
-	padding-right: 0; /* by default the icon label has a padding right and this isn't wanted when not showing tabs and not showing breadcrumbs */
+	margin-right: 0; /* by default the icon label has a padding right and this isn't wanted when not showing tabs and not showing breadcrumbs */
 }
 
 /* Drag and Drop */

--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -262,8 +262,7 @@
 }
 
 .monaco-workbench .pane-body.integrated-terminal .tabs-container.has-text .tabs-list .terminal-tabs-entry .monaco-icon-label::after {
-	padding-right: 0;
-	padding-left: 0;
+	margin-right: 0;
 }
 
 .monaco-workbench .pane-body.integrated-terminal .tabs-container:not(.has-text) .terminal-tabs-entry .codicon {

--- a/src/vs/workbench/services/decorations/browser/decorationsService.ts
+++ b/src/vs/workbench/services/decorations/browser/decorationsService.ts
@@ -127,7 +127,7 @@ class DecorationRule {
 			color: ${getColor(theme, color)};
 			font-family: codicon;
 			font-size: 16px;
-			padding-right: 14px;
+			margin-right: 14px;
 			font-weight: normal;
 			${modifier === 'spin' ? 'animation: codicon-spin 1.5s steps(30) infinite' : ''};
 			`,


### PR DESCRIPTION
This makes the spin animation work consistently as margin is not considered
part of the element.

Fixes #126819

Not sure if there's anything else to verify:

![recording (16)](https://user-images.githubusercontent.com/2193314/122937317-bb541580-d326-11eb-9437-47f8576ff78c.gif)

<img width="191" alt="Screen Shot 2021-06-22 at 6 42 16 AM" src="https://user-images.githubusercontent.com/2193314/122936820-4f71ad00-d326-11eb-874c-4f1b8bdc676b.png">
<img width="393" alt="Screen Shot 2021-06-22 at 6 42 11 AM" src="https://user-images.githubusercontent.com/2193314/122936826-513b7080-d326-11eb-9be5-0fb1f35c23fd.png">
<img width="192" alt="Screen Shot 2021-06-22 at 6 42 01 AM" src="https://user-images.githubusercontent.com/2193314/122936833-526c9d80-d326-11eb-83a0-9c067417b7f1.png">

