### PR TITLE
Enable argv.json support of enable-blink-features

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -141,6 +141,8 @@ async function onReady() {
  */
 function configureCommandlineSwitchesSync(cliArgs) {
 	const SUPPORTED_ELECTRON_SWITCHES = [
+		// Blink features: https://chromium.googlesource.com/chromium/src/+/HEAD/third_party/blink/renderer/platform/RuntimeEnabledFeatures.md
+		'enable-blink-features',
 
 		// alias from us for --disable-gpu
 		'disable-hardware-acceleration',
@@ -181,6 +183,12 @@ function configureCommandlineSwitchesSync(cliArgs) {
 
 		// Append Electron flags to Electron
 		if (SUPPORTED_ELECTRON_SWITCHES.indexOf(argvKey) !== -1) {
+			// Blink features: https://chromium.googlesource.com/chromium/src/+/HEAD/third_party/blink/renderer/platform/RuntimeEnabledFeatures.md
+			if (argvKey === 'enable-blink-features') {
+				if (argvValue) {
+					app.commandLine.appendSwitch(argvKey, argvValue);
+				}
+			}
 
 			// Color profile
 			if (argvKey === 'force-color-profile') {

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -307,6 +307,10 @@ import { EditorsVisibleContext, SingleEditorGroupsContext } from 'vs/workbench/c
 					type: 'string'
 				}
 			},
+			'enable-blink-features': {
+				type: 'string',
+				description: localize('argv.enableBlinkFeatures', 'Enables Blink features that implement new and proposed web features. https://chromium.googlesource.com/chromium/src/+/HEAD/third_party/blink/renderer/platform/RuntimeEnabledFeatures.md')
+			},
 			'log-level': {
 				type: 'string',
 				description: localize('argv.logLevel', "Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'.")


### PR DESCRIPTION
Enable argv.json support of enable-blink-features to expose features like WebCodecs, etc.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
https://github.com/microsoft/vscode/issues/127023