### PR TITLE
Add extraClasses to editor input

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts
+++ b/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts
@@ -156,7 +156,7 @@ export abstract class BaseEditorQuickAccessProvider extends PickerQuickAccessPro
 					return isDirty ? localize('entryAriaLabelDirty', "{0}, dirty", nameAndDescription) : nameAndDescription;
 				})(),
 				description: editor.getDescription(),
-				iconClasses: getIconClasses(this.modelService, this.modeService, resource),
+				iconClasses: getIconClasses(this.modelService, this.modeService, resource).concat(editor.getLabelExtraClasses()),
 				italic: !this.editorGroupService.getGroup(groupId)?.isPinned(editor),
 				buttons: (() => {
 					return [

--- a/src/vs/workbench/browser/parts/editor/noTabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/noTabsTitleControl.ts
@@ -299,7 +299,7 @@ export class NoTabsTitleControl extends TitleControl {
 				{
 					title,
 					italic: !isEditorPinned,
-					extraClasses: coalesce((['no-tabs', 'title-label'] as (string | undefined)[]).concat(editor.getLabelExtraClasses())),
+					extraClasses: ['no-tabs', 'title-label'].concat(editor.getLabelExtraClasses()),
 					fileDecorations: {
 						colors: Boolean(options.decorations?.colors),
 						badges: Boolean(options.decorations?.badges)

--- a/src/vs/workbench/browser/parts/editor/noTabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/noTabsTitleControl.ts
@@ -17,6 +17,7 @@ import { withNullAsUndefined, assertIsDefined, assertAllDefined } from 'vs/base/
 import { IEditorGroupTitleHeight } from 'vs/workbench/browser/parts/editor/editor';
 import { equals } from 'vs/base/common/objects';
 import { toDisposable } from 'vs/base/common/lifecycle';
+import { coalesce } from 'vs/base/common/arrays';
 
 interface IRenderedEditorLabel {
 	editor?: IEditorInput;
@@ -298,7 +299,7 @@ export class NoTabsTitleControl extends TitleControl {
 				{
 					title,
 					italic: !isEditorPinned,
-					extraClasses: ['no-tabs', 'title-label'],
+					extraClasses: coalesce((['no-tabs', 'title-label'] as (string | undefined)[]).concat(editor.getLabelExtraClasses())),
 					fileDecorations: {
 						colors: Boolean(options.decorations?.colors),
 						badges: Boolean(options.decorations?.badges)

--- a/src/vs/workbench/browser/parts/editor/noTabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/noTabsTitleControl.ts
@@ -17,7 +17,6 @@ import { withNullAsUndefined, assertIsDefined, assertAllDefined } from 'vs/base/
 import { IEditorGroupTitleHeight } from 'vs/workbench/browser/parts/editor/editor';
 import { equals } from 'vs/base/common/objects';
 import { toDisposable } from 'vs/base/common/lifecycle';
-import { coalesce } from 'vs/base/common/arrays';
 
 interface IRenderedEditorLabel {
 	editor?: IEditorInput;

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -1154,7 +1154,7 @@ export class TabsTitleControl extends TitleControl {
 			{ name, description, resource: EditorResourceAccessor.getOriginalUri(editor, { supportSideBySide: SideBySideEditor.BOTH }) },
 			{
 				title,
-				extraClasses: coalesce(['tab-label', fileDecorationBadges ? 'tab-label-has-badge' : undefined]),
+				extraClasses: coalesce(['tab-label', fileDecorationBadges ? 'tab-label-has-badge' : undefined].concat(editor.getLabelExtraClasses())),
 				italic: !this.group.isPinned(editor),
 				forceLabel,
 				fileDecorations: {

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -505,7 +505,7 @@ export interface IEditorInput extends IDisposable {
 	/**
 	 * Returns the extra classes to apply to the label of this input.
 	 */
-	getLabelExtraClasses(): string[] | undefined;
+	getLabelExtraClasses(): string[];
 
 	/**
 	 * Returns the display description of this input.

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -503,6 +503,11 @@ export interface IEditorInput extends IDisposable {
 	getName(): string;
 
 	/**
+	 * Returns the extra classes to apply to the label of this input.
+	 */
+	getLabelExtraClasses(): string[] | undefined;
+
+	/**
 	 * Returns the display description of this input.
 	 */
 	getDescription(verbosity?: Verbosity): string | undefined;

--- a/src/vs/workbench/common/editor/editorInput.ts
+++ b/src/vs/workbench/common/editor/editorInput.ts
@@ -55,6 +55,10 @@ export abstract class EditorInput extends Disposable implements IEditorInput {
 		return `Editor ${this.typeId}`;
 	}
 
+	getLabelExtraClasses(): string[] | undefined {
+		return undefined;
+	}
+
 	getDescription(verbosity?: Verbosity): string | undefined {
 		return undefined;
 	}

--- a/src/vs/workbench/common/editor/editorInput.ts
+++ b/src/vs/workbench/common/editor/editorInput.ts
@@ -55,8 +55,8 @@ export abstract class EditorInput extends Disposable implements IEditorInput {
 		return `Editor ${this.typeId}`;
 	}
 
-	getLabelExtraClasses(): string[] | undefined {
-		return undefined;
+	getLabelExtraClasses(): string[] {
+		return [];
 	}
 
 	getDescription(verbosity?: Verbosity): string | undefined {

--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -52,6 +52,7 @@ import { Codicon } from 'vs/base/common/codicons';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { coalesce } from 'vs/base/common/arrays';
 
 const $ = dom.$;
 
@@ -601,7 +602,7 @@ class OpenEditorRenderer implements IListRenderer<OpenEditor, IOpenEditorTemplat
 			description: editor.getDescription(Verbosity.MEDIUM)
 		}, {
 			italic: openedEditor.isPreview(),
-			extraClasses: ['open-editor'],
+			extraClasses: coalesce((['open-editor'] as (string | undefined)[]).concat(openedEditor.editor.getLabelExtraClasses())),
 			fileDecorations: this.configurationService.getValue<IFilesConfiguration>().explorer.decorations,
 			title: editor.getTitle(Verbosity.LONG)
 		});

--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -602,7 +602,7 @@ class OpenEditorRenderer implements IListRenderer<OpenEditor, IOpenEditorTemplat
 			description: editor.getDescription(Verbosity.MEDIUM)
 		}, {
 			italic: openedEditor.isPreview(),
-			extraClasses: coalesce((['open-editor'] as (string | undefined)[]).concat(openedEditor.editor.getLabelExtraClasses())),
+			extraClasses: ['open-editor'].concat(openedEditor.editor.getLabelExtraClasses()),
 			fileDecorations: this.configurationService.getValue<IFilesConfiguration>().explorer.decorations,
 			title: editor.getTitle(Verbosity.LONG)
 		});

--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -52,7 +52,6 @@ import { Codicon } from 'vs/base/common/codicons';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { coalesce } from 'vs/base/common/arrays';
 
 const $ = dom.$;
 

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -872,17 +872,20 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		let label: string;
 		let description: string | undefined = undefined;
 		let isDirty: boolean | undefined = undefined;
+		let extraClasses: string[];
 
 		if (resourceOrEditor instanceof EditorInput) {
 			resource = EditorResourceAccessor.getOriginalUri(resourceOrEditor);
 			label = resourceOrEditor.getName();
 			description = resourceOrEditor.getDescription();
 			isDirty = resourceOrEditor.isDirty() && !resourceOrEditor.isSaving();
+			extraClasses = resourceOrEditor.getLabelExtraClasses();
 		} else {
 			resource = URI.isUri(resourceOrEditor) ? resourceOrEditor : (resourceOrEditor as IResourceEditorInput).resource;
 			label = basenameOrAuthority(resource);
 			description = this.labelService.getUriLabel(dirname(resource), { relative: true });
 			isDirty = this.workingCopyService.isDirty(resource) && !configuration.shortAutoSaveDelay;
+			extraClasses = [];
 		}
 
 		const labelAndDescription = description ? `${label} ${description}` : label;
@@ -891,7 +894,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			label,
 			ariaLabel: isDirty ? localize('filePickAriaLabelDirty', "{0} dirty", labelAndDescription) : labelAndDescription,
 			description,
-			iconClasses: getIconClasses(this.modelService, this.modeService, resource),
+			iconClasses: getIconClasses(this.modelService, this.modeService, resource).concat(extraClasses),
 			buttons: (() => {
 				const openSideBySideDirection = configuration.openSideBySideDirection;
 				const buttons: IQuickInputButton[] = [];


### PR DESCRIPTION
This enables consumers to style the tab without misappropriating the file icon system.

Part of #126689

---

`extraClasses` on labels is how icons workin the tabs list as well so this will be able to reuse most of the style code.