### PR TITLE
Add window duplication command to file menu

### DIFF
--- a/src/vs/workbench/browser/actions/workspaceActions.ts
+++ b/src/vs/workbench/browser/actions/workspaceActions.ts
@@ -300,7 +300,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
 	group: '3_workspace',
 	command: {
 		id: DuplicateWorkspaceInNewWindowAction.ID,
-		title: localize('duplicateWorkspace', "Duplicate Current Window as Workspace")
+		title: localize('duplicateWorkspace', "Duplicate Workspace")
 	},
 	order: 3,
 	when: EmptyWorkspaceSupportContext

--- a/src/vs/workbench/browser/actions/workspaceActions.ts
+++ b/src/vs/workbench/browser/actions/workspaceActions.ts
@@ -235,9 +235,11 @@ class SaveWorkspaceAsAction extends Action2 {
 
 class DuplicateWorkspaceInNewWindowAction extends Action2 {
 
+	static readonly ID = 'workbench.action.duplicateWorkspaceInNewWindow';
+
 	constructor() {
 		super({
-			id: 'workbench.action.duplicateWorkspaceInNewWindow',
+			id: DuplicateWorkspaceInNewWindowAction.ID,
 			title: { value: localize('duplicateWorkspaceInNewWindow', "Duplicate As Workspace in New Window"), original: 'Duplicate As Workspace in New Window' },
 			category: workspacesCategory,
 			f1: true
@@ -291,6 +293,16 @@ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
 		title: localize('miSaveWorkspaceAs', "Save Workspace As...")
 	},
 	order: 2,
+	when: EmptyWorkspaceSupportContext
+});
+
+MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
+	group: '3_workspace',
+	command: {
+		id: DuplicateWorkspaceInNewWindowAction.ID,
+		title: localize('duplicateWorkspace', "Duplicate Current Window as Workspace")
+	},
+	order: 3,
 	when: EmptyWorkspaceSupportContext
 });
 


### PR DESCRIPTION
cc @bpasero 

Opening a folder in multiple windows is one of our oldest and most popular open feature requests (https://github.com/microsoft/vscode/issues/2686), which is a bit odd because we in fact kinda-sorta-mostly support it via the `Workspaces: Duplicate as Workspace in New Window` command. However, this command is relatively unknown (even some folks on the team don't know of its existence). 

I propose we add an entry to the File menu for this command, and slightly tweak the wording to be more clear about what exactly is happening (the current wording is a bit unclear, particularly if you don't know what a workspace is). I propose: `Duplicate Current Window as Workspace`. Open to suggestions.