### PR TITLE
Update debug theme styles

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -682,7 +682,7 @@ registerThemingParticipant((theme, collector) => {
 	if (debugIconBreakpointDisabledColor) {
 		collector.addRule(`
 		${icons.allBreakpoints.map(b => `.monaco-workbench ${ThemeIcon.asCSSSelector(b.disabled)}`).join(',\n		')} {
-			color: ${debugIconBreakpointDisabledColor} !important;
+			color: ${debugIconBreakpointDisabledColor};
 		}
 		`);
 	}

--- a/src/vs/workbench/contrib/debug/browser/debugColors.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugColors.ts
@@ -271,52 +271,52 @@ export function registerColors() {
 
 		const debugIconStartColor = theme.getColor(debugIconStartForeground);
 		if (debugIconStartColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStart)} { color: ${debugIconStartColor} !important; }`);
+			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStart)} { color: ${debugIconStartColor}; }`);
 		}
 
 		const debugIconPauseColor = theme.getColor(debugIconPauseForeground);
 		if (debugIconPauseColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugPause)} { color: ${debugIconPauseColor} !important; }`);
+			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugPause)} { color: ${debugIconPauseColor}; }`);
 		}
 
 		const debugIconStopColor = theme.getColor(debugIconStopForeground);
 		if (debugIconStopColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStop)} { color: ${debugIconStopColor} !important; }`);
+			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStop)} { color: ${debugIconStopColor}; }`);
 		}
 
 		const debugIconDisconnectColor = theme.getColor(debugIconDisconnectForeground);
 		if (debugIconDisconnectColor) {
-			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugDisconnect)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugDisconnect)} { color: ${debugIconDisconnectColor} !important; }`);
+			collector.addRule(`.monaco-workbench .debug-view-content ${ThemeIcon.asCSSSelector(icons.debugDisconnect)}, .monaco-workbench .debug-toolbar ${ThemeIcon.asCSSSelector(icons.debugDisconnect)} { color: ${debugIconDisconnectColor}; }`);
 		}
 
 		const debugIconRestartColor = theme.getColor(debugIconRestartForeground);
 		if (debugIconRestartColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugRestart)}, .monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugRestartFrame)} { color: ${debugIconRestartColor} !important; }`);
+			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugRestart)}, .monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugRestartFrame)} { color: ${debugIconRestartColor}; }`);
 		}
 
 		const debugIconStepOverColor = theme.getColor(debugIconStepOverForeground);
 		if (debugIconStepOverColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepOver)} { color: ${debugIconStepOverColor} !important; }`);
+			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepOver)} { color: ${debugIconStepOverColor}; }`);
 		}
 
 		const debugIconStepIntoColor = theme.getColor(debugIconStepIntoForeground);
 		if (debugIconStepIntoColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepInto)} { color: ${debugIconStepIntoColor} !important; }`);
+			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepInto)} { color: ${debugIconStepIntoColor}; }`);
 		}
 
 		const debugIconStepOutColor = theme.getColor(debugIconStepOutForeground);
 		if (debugIconStepOutColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepOut)} { color: ${debugIconStepOutColor} !important; }`);
+			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepOut)} { color: ${debugIconStepOutColor}; }`);
 		}
 
 		const debugIconContinueColor = theme.getColor(debugIconContinueForeground);
 		if (debugIconContinueColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugContinue)}, .monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugReverseContinue)} { color: ${debugIconContinueColor} !important; }`);
+			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugContinue)}, .monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugReverseContinue)} { color: ${debugIconContinueColor}; }`);
 		}
 
 		const debugIconStepBackColor = theme.getColor(debugIconStepBackForeground);
 		if (debugIconStepBackColor) {
-			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepBack)} { color: ${debugIconStepBackColor} !important; }`);
+			collector.addRule(`.monaco-workbench ${ThemeIcon.asCSSSelector(icons.debugStepBack)} { color: ${debugIconStepBackColor}; }`);
 		}
 	});
 }

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -73,6 +73,12 @@
 	cursor: initial;
 }
 
+.debug-pane .monaco-list:focus .monaco-list-row.selected .state.label,
+.debug-pane .monaco-list:focus .monaco-list-row.selected .load-all,
+.debug-pane .monaco-list:focus .monaco-list-row.selected.focused .state.label {
+	color: inherit;
+}
+
 /* Call stack */
 
 .debug-pane .call-stack-state-message {


### PR DESCRIPTION
This PR fixes #127034 and removes a lot of `!important` styles that are not needed and allows for out list widget to properly theme the icons when in focus.

**Default state**
<img width="338" alt="CleanShot 2021-06-23 at 20 17 46@2x" src="https://user-images.githubusercontent.com/35271042/123197232-15a4c180-d460-11eb-9ad2-28ab9ab10fc0.png">

**Focus state**
<img width="330" alt="CleanShot 2021-06-23 at 20 19 47@2x" src="https://user-images.githubusercontent.com/35271042/123197446-5e5c7a80-d460-11eb-87d4-49ef8d8c52fe.png">


Please check that:
- Debug icons appear normal in dark/light themes
- Debug icons are inverted on the focus state in our default dark/light themes
- Debug icons appear normal in other themes for all states (GitHub Dark/Light, for example, should not invert the icons)
  <img width="324" alt="CleanShot 2021-06-23 at 20 19 21@2x" src="https://user-images.githubusercontent.com/35271042/123197391-4f75c800-d460-11eb-8481-99fa6dddcf28.png">

Please do a vigorous test and ensure I did not miss other areas.