### PR TITLE
fix #127093 Update debug config list choice correctly

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugActionViewItems.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugActionViewItems.ts
@@ -238,9 +238,13 @@ export class StartDebugActionViewItem extends BaseActionViewItem {
 				handler: async () => {
 					const picked = await p.pick();
 					if (picked) {
-						await manager.selectConfiguration(picked.launch, picked.config.name, picked.config, { type: p.type });
+						// Pass alwaysFireEvent as true, otherwise the displayed list selection is wrong if the same dynamic config was selected again
+						// - part of https://github.com/microsoft/vscode/issues/127093
+						await manager.selectConfiguration(picked.launch, picked.config.name, picked.config, { type: p.type }, true);
 						return true;
 					}
+					// Ensure reselection of previous item
+					await manager.selectConfiguration(undefined, undefined, undefined, undefined, true);
 					return false;
 				}
 			});

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -690,7 +690,7 @@ export interface IConfigurationManager {
 		type: string | undefined;
 	};
 
-	selectConfiguration(launch: ILaunch | undefined, name?: string, config?: IConfig, dynamicConfigOptions?: { type?: string }): Promise<void>;
+	selectConfiguration(launch: ILaunch | undefined, name?: string, config?: IConfig, dynamicConfigOptions?: { type?: string }, alwaysFireEvent?: boolean): Promise<void>;
 
 	getLaunches(): ReadonlyArray<ILaunch>;
 	getLaunch(workspaceUri: uri | undefined): ILaunch | undefined;


### PR DESCRIPTION
This PR fixes #127093

Using vscode-mock-debug for testing, the following edge cases are now handled correctly:

- Pick 'Mock Debug...' then dismiss the dynamic config quickpick without selecting (e.g. press <kbd>Esc</kbd>)
- Pick a previously-selected dynamic config, then pick 'Mock Debug...', then select the same dynamic config.

Before this PR both of these cases would result in the collapsed dropdown continuing to display 'Mock Debug...' even though a click on the adjacent 'Start Debugging' button actually runs the config that had been selected prior to the user choosing 'Mock Debug...'