### PR TITLE
Improve visibility of interactive window input editor

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -255,7 +255,7 @@ registerAction2(class extends Action2 {
 			if (editors.length) {
 				const editorInput = editors[0].editor as InteractiveEditorInput;
 				const currentGroup = editors[0].groupId;
-				await editorService.openEditor(editorInput, undefined, currentGroup);
+				await editorService.openEditor(editorInput, { preserveFocus: true }, currentGroup);
 				return {
 					notebookUri: editorInput.resource!,
 					inputUri: editorInput.inputResource

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -16,8 +16,8 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { editorForeground, resolveColorValue } from 'vs/platform/theme/common/colorRegistry';
-import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { editorForeground, registerColor, resolveColorValue } from 'vs/platform/theme/common/colorRegistry';
+import { IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { EditorPane } from 'vs/workbench/browser/parts/editor/editorPane';
 import { IEditorOpenContext } from 'vs/workbench/common/editor';
 import { getSimpleCodeEditorWidgetOptions, getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/simpleEditorOptions';
@@ -36,6 +36,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { INTERACTIVE_INPUT_CURSOR_BOUNDARY } from 'vs/workbench/contrib/interactive/browser/interactiveCommon';
 import { IInteractiveHistoryService } from 'vs/workbench/contrib/interactive/browser/interactiveHistoryService';
 import { IInteractiveDocumentService } from 'vs/workbench/contrib/interactive/browser/interactiveDocumentService';
+import { peekViewEditorBackground } from 'vs/editor/contrib/peekView/peekView';
 
 const DECORATION_KEY = 'interactiveInputDecoration';
 
@@ -346,3 +347,17 @@ export class InteractiveEditor extends EditorPane {
 		};
 	}
 }
+
+export const interactiveInputEditorBackground = registerColor('interactive.inputEditorBackground', {
+	dark: peekViewEditorBackground,
+	light: peekViewEditorBackground,
+	hc: peekViewEditorBackground
+}, nls.localize('interactive.inputEditorBackground', "The background color of the input editor."));
+
+registerThemingParticipant((theme, collector) => {
+	const editorBackgroundColor = theme.getColor(interactiveInputEditorBackground) ?? theme.getColor(interactiveInputEditorBackground);
+	if (editorBackgroundColor) {
+		collector.addRule(`.interactive-editor .input-editor-container,
+		.interactive-editor .input-editor-container .monaco-editor-background { background: ${editorBackgroundColor}; }`);
+	}
+});

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -299,6 +299,7 @@ export class InteractiveEditor extends EditorPane {
 				},
 				renderOptions: {
 					after: {
+						fontStyle: 'italic',
 						contentText: text,
 						color: transparentForeground ? transparentForeground.toString() : undefined
 					}

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -289,7 +289,7 @@ export class InteractiveEditor extends EditorPane {
 		if (model?.getValueLength() === 0) {
 			const transparentForeground = resolveColorValue(editorForeground, this.themeService.getColorTheme())?.transparent(0.4);
 			const keybinding = this.#keybindingService.lookupKeybinding('interactive.execute')?.getLabel();
-			const text = nls.localize('interactiveInputPlaceHolder', "Type code here and press {0} to run", keybinding ?? 'ctrl+enter');
+			const text = nls.localize('interactiveInputPlaceHolder', "Type code here and press {0} to run", keybinding ?? 'Ctrl+Enter');
 			decorations.push({
 				range: {
 					startLineNumber: 0,

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -39,7 +39,9 @@ import { IInteractiveDocumentService } from 'vs/workbench/contrib/interactive/br
 import { peekViewEditorBackground } from 'vs/editor/contrib/peekView/peekView';
 
 const DECORATION_KEY = 'interactiveInputDecoration';
-
+const INPUT_CONTAINER_PADDING = 10;
+const INPUT_WIDGET_HEIGHT = 19;
+const INPUT_CONTAINER_HEIGHT = INPUT_WIDGET_HEIGHT + 2 * INPUT_CONTAINER_PADDING;
 
 export class InteractiveEditor extends EditorPane {
 	static readonly ID: string = 'workbench.editor.interactive';
@@ -102,7 +104,7 @@ export class InteractiveEditor extends EditorPane {
 		this.#notebookEditorContainer = DOM.append(this.#rootElement, DOM.$('.notebook-editor-container'));
 		this.#inputEditorContainer = DOM.append(this.#rootElement, DOM.$('.input-editor-container'));
 		this.#inputEditorContainer.style.position = 'absolute';
-		this.#inputEditorContainer.style.height = `${19}px`;
+		this.#inputEditorContainer.style.height = `${INPUT_WIDGET_HEIGHT}px`;
 	}
 
 	override async setInput(input: InteractiveEditorInput, options: INotebookEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
@@ -145,10 +147,12 @@ export class InteractiveEditor extends EditorPane {
 		});
 
 		if (this.#dimension) {
-			this.#notebookWidget.value!.layout(this.#dimension.with(this.#dimension.width, this.#dimension.height - 19), this.#rootElement);
-			this.#codeEditorWidget.layout(new DOM.Dimension(this.#dimension.width, 19));
-			this.#inputEditorContainer.style.top = `${this.#dimension.height - 19}px`;
+			this.#notebookWidget.value!.layout(this.#dimension.with(this.#dimension.width, this.#dimension.height - INPUT_CONTAINER_HEIGHT), this.#rootElement);
+			this.#codeEditorWidget.layout(new DOM.Dimension(this.#dimension.width, INPUT_WIDGET_HEIGHT));
+			this.#inputEditorContainer.style.top = `${this.#dimension.height - INPUT_CONTAINER_HEIGHT}px`;
 			this.#inputEditorContainer.style.width = `${this.#dimension.width}px`;
+			this.#inputEditorContainer.style.paddingTop = `${INPUT_CONTAINER_PADDING}px`;
+			this.#inputEditorContainer.style.paddingBottom = `${INPUT_CONTAINER_PADDING}px`;
 		}
 
 		await super.setInput(input, options, context, token);
@@ -181,10 +185,13 @@ export class InteractiveEditor extends EditorPane {
 			const contentHeight = this.#codeEditorWidget.getContentHeight();
 
 			if (this.#dimension) {
-				this.#notebookWidget.value!.layout(this.#dimension.with(this.#dimension.width, this.#dimension.height - contentHeight), this.#rootElement);
+				this.#notebookWidget.value!.layout(this.#dimension.with(this.#dimension.width, this.#dimension.height - contentHeight - 2 * INPUT_CONTAINER_PADDING), this.#rootElement);
 				this.#codeEditorWidget.layout(new DOM.Dimension(this.#dimension.width, contentHeight));
-				this.#inputEditorContainer.style.top = `${this.#dimension.height - contentHeight}px`;
+				this.#inputEditorContainer.style.top = `${this.#dimension.height - contentHeight - 2 * INPUT_CONTAINER_PADDING}px`;
 				this.#inputEditorContainer.style.width = `${this.#dimension.width}px`;
+				this.#inputEditorContainer.style.height = `${contentHeight}px`;
+				this.#inputEditorContainer.style.paddingTop = `${INPUT_CONTAINER_PADDING}px`;
+				this.#inputEditorContainer.style.paddingBottom = `${INPUT_CONTAINER_PADDING}px`;
 			}
 		}));
 
@@ -266,12 +273,14 @@ export class InteractiveEditor extends EditorPane {
 			return;
 		}
 
-		this.#notebookEditorContainer.style.height = `${this.#dimension.height - 19}px`;
-		this.#inputEditorContainer.style.top = `${this.#dimension.height - 19}px`;
+		this.#notebookEditorContainer.style.height = `${this.#dimension.height - INPUT_CONTAINER_HEIGHT}px`;
+		this.#inputEditorContainer.style.top = `${this.#dimension.height - INPUT_CONTAINER_HEIGHT}px`;
 		this.#inputEditorContainer.style.width = `${this.#dimension.width}px`;
+		this.#inputEditorContainer.style.paddingTop = `${INPUT_CONTAINER_PADDING}px`;
+		this.#inputEditorContainer.style.paddingBottom = `${INPUT_CONTAINER_PADDING}px`;
 
-		this.#codeEditorWidget.layout(new DOM.Dimension(this.#dimension.width, 19));
-		this.#notebookWidget.value!.layout(this.#dimension.with(this.#dimension.width, this.#dimension.height - 19), this.#rootElement);
+		this.#codeEditorWidget.layout(new DOM.Dimension(this.#dimension.width, INPUT_WIDGET_HEIGHT));
+		this.#notebookWidget.value!.layout(this.#dimension.with(this.#dimension.width, this.#dimension.height - INPUT_CONTAINER_HEIGHT), this.#rootElement);
 	}
 
 	#updateInputDecoration(): void {


### PR DESCRIPTION
![recording (10)](https://user-images.githubusercontent.com/30305945/123504400-e59b2100-d60d-11eb-8b8a-55e79432273c.gif)

- Match the built-in interactive input editor background color to the token that the Jupyter extension currently uses and add 10px padding to the top and bottom of the editor. In the early days of the original interactive window, the Jupyter extension devs found that users struggled to locate the input box, and increasing its vertical size somewhat and using a different background color for the input editor helped.
- Introduce a themeable input box token in case users dislike the interactive input editor background color.
- Ensure that the interactive window input box never steals focus from an associated interactive file, in order to avoid breaking users' flow when shift+enter-ing through an interactive Python file.