### PR TITLE
Stop loop to next change at last change of file

### DIFF
--- a/src/vs/editor/browser/widget/diffNavigator.ts
+++ b/src/vs/editor/browser/widget/diffNavigator.ts
@@ -11,7 +11,8 @@ import { IDiffEditor } from 'vs/editor/browser/editorBrowser';
 import { ICursorPositionChangedEvent } from 'vs/editor/common/controller/cursorEvents';
 import { Range } from 'vs/editor/common/core/range';
 import { ILineChange, ScrollType } from 'vs/editor/common/editorCommon';
-
+import { alert as alertFn } from 'vs/base/browser/ui/aria/aria';
+import * as nls from 'vs/nls';
 
 interface IDiffRange {
 	rhs: boolean;
@@ -189,7 +190,8 @@ export class DiffNavigator extends Disposable implements IDiffNavigator {
 		} else if (fwd) {
 			this.nextIdx += 1;
 			if (this.nextIdx >= this.ranges.length) {
-				this.nextIdx = 0;
+				alert(nls.localize('hintnn', 'you have reached the end of the diff!'));
+				return;
 			}
 		} else {
 			this.nextIdx -= 1;


### PR DESCRIPTION

This PR fixes #120709

The line[here](https://github.com/microsoft/vscode/blob/main/src/vs/editor/browser/widget/diffNavigator.ts#L192) was making it to start from 0 index as soon as we used to reach at the end of the diff.

Approach I used to fix it -
As soon as we reach the end of the diff, we notify the users saying that they have reached the end of the diff and stopping the loop right there.

Please see the recording attached below for your ref -
https://user-images.githubusercontent.com/44888949/123504511-6e9a7280-d677-11eb-81d4-4687b6e8bfb7.mov

