### PR TITLE
Add `wordPattern` for XML and XSL languages

### DIFF
--- a/extensions/xml/xml.language-configuration.json
+++ b/extensions/xml/xml.language-configuration.json
@@ -30,5 +30,9 @@
 			"start": "^\\s*<!--\\s*#region\\b.*-->",
 			"end": "^\\s*<!--\\s*#endregion\\b.*-->"
 		}
+	},
+	"wordPattern": {
+		"pattern": "[:A-Z_a-z\\u{C0}-\\u{D6}\\u{D8}-\\u{F6}\\u{F8}-\\u{2FF}\\u{370}-\\u{37D}\\u{37F}-\\u{1FFF}\\u{200C}-\\u{200D}\\u{2070}-\\u{218F}\\u{2C00}-\\u{2FEF}\\u{3001}-\\u{D7FF}\\u{F900}-\\u{FDCF}\\u{FDF0}-\\u{FFFD}\\u{10000}-\\u{EFFFF}][-:A-Z_a-z\\u{C0}-\\u{D6}\\u{D8}-\\u{F6}\\u{F8}-\\u{2FF}\\u{370}-\\u{37D}\\u{37F}-\\u{1FFF}\\u{200C}-\\u{200D}\\u{2070}-\\u{218F}\\u{2C00}-\\u{2FEF}\\u{3001}-\\u{D7FF}\\u{F900}-\\u{FDCF}\\u{FDF0}-\\u{FFFD}\\u{10000}-\\u{EFFFF}.0-9\\u{B7}\\u{0300}-\\u{036F}\\u{203F}-\\u{2040}]*",
+		"flags": "u"
 	}
 }

--- a/extensions/xml/xsl.language-configuration.json
+++ b/extensions/xml/xsl.language-configuration.json
@@ -9,7 +9,11 @@
 		["{", "}"],
 		["(", ")"],
 		["[", "]"]
-	]
+	],
+	"wordPattern": {
+		"pattern": "[:A-Z_a-z\\u{C0}-\\u{D6}\\u{D8}-\\u{F6}\\u{F8}-\\u{2FF}\\u{370}-\\u{37D}\\u{37F}-\\u{1FFF}\\u{200C}-\\u{200D}\\u{2070}-\\u{218F}\\u{2C00}-\\u{2FEF}\\u{3001}-\\u{D7FF}\\u{F900}-\\u{FDCF}\\u{FDF0}-\\u{FFFD}\\u{10000}-\\u{EFFFF}][-:A-Z_a-z\\u{C0}-\\u{D6}\\u{D8}-\\u{F6}\\u{F8}-\\u{2FF}\\u{370}-\\u{37D}\\u{37F}-\\u{1FFF}\\u{200C}-\\u{200D}\\u{2070}-\\u{218F}\\u{2C00}-\\u{2FEF}\\u{3001}-\\u{D7FF}\\u{F900}-\\u{FDCF}\\u{FDF0}-\\u{FFFD}\\u{10000}-\\u{EFFFF}.0-9\\u{B7}\\u{0300}-\\u{036F}\\u{203F}-\\u{2040}]*",
+		"flags": "u"
+	}
 
 	// enhancedBrackets: [{
 	// 	tokenType: 'tag.tag-$1.xml',


### PR DESCRIPTION
Add a `wordPattern` for XML and XSL, so that when `linkedEditing` is used, it can edit tags that have hyphens in their name.

I based the `wordPattern` off of https://www.w3.org/TR/xml/#NT-Name.

Signed-off-by: David Thompson <davthomp@redhat.com>

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #127323
