### PR TITLE
Add horizontal scroll to extension details

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -55,9 +55,14 @@
 
 .extension-editor > .header > .details {
 	padding-left: 20px;
-	overflow: hidden;
+	overflow-x: auto;
+	overflow-y: hidden;
 	user-select: text;
 	-webkit-user-select: text;
+}
+
+.extension-editor > .header > .details::-webkit-scrollbar {
+	display: none;
 }
 
 .extension-editor > .header > .details > .title {


### PR DESCRIPTION
This PR fixes #126524

Enables scrolling using the mouse wheel (<kbd>Shift</kbd> + <kbd>Scrollwheel</kbd>) when the name/details of the extension is too long and does not fit in the window horizontally.

https://user-images.githubusercontent.com/57055412/123726669-63ee0200-d85e-11eb-8414-dcddbd0fba54.mp4


