### PR TITLE
Replaces filterSortedByKey with faster ArrayQueue.

### DIFF
--- a/src/vs/base/common/arrays.ts
+++ b/src/vs/base/common/arrays.ts
@@ -605,103 +605,35 @@ export class ArrayQueue<T> {
 	/**
 	 * Consumes elements from the beginning of the queue as long as the predicate returns true.
 	 * If no elements were consumed, `null` is returned. Has a runtime of O(result.length).
-	 *
-	 * If isPredicateMonotonous is set to `true` and predicate is monotonous on the data,
-	 * it has a runtime of O(log(result.length)) + time(slice(result.length)).
 	*/
-	takeWhile(predicate: (value: T) => boolean, isPredicateMonotonous: boolean = false): T[] | null {
+	takeWhile(predicate: (value: T) => boolean): T[] | null {
 		// P(k) := k <= this.lastIdx && predicate(this.items[k])
 		// Find s := min { k | k >= this.firstIdx && !P(k) } and return this.data[this.firstIdx...s)
 
-		if (!isPredicateMonotonous) {
-			let startIdx = this.firstIdx;
-			while (startIdx < this.items.length && predicate(this.items[startIdx])) {
-				startIdx++;
-			}
-			const result = startIdx === this.firstIdx ? null : this.items.slice(this.firstIdx, startIdx);
-			this.firstIdx = startIdx;
-			return result;
-		} else {
-			// `predicate` is monotonous, i.e. `!P(k) => !P(k + 1)`
-
-			let startIdx = this.firstIdx;
-			let delta = 1;
-			while (startIdx + delta <= this.lastIdx && predicate(this.items[startIdx + delta])) {
-				delta = delta * 2;
-			}
-			let endIdx = Math.min(startIdx + delta, this.lastIdx + 1);
-			// We have !P(startIdx + delta), thus startIdx <= s <= endIdx.
-
-			while (startIdx < endIdx) {
-				// Invariant: startIdx <= s <= endIdx.
-
-				const mid = Math.floor((startIdx + endIdx) / 2);
-				// startIdx <= mid < endIdx
-
-				if (predicate(this.items[mid])) {
-					// mid < s <= endIdx
-					startIdx = mid + 1;
-				} else {
-					// startIdx <= s <= mid
-					endIdx = mid;
-				}
-			}
-
-			const result = this.firstIdx === endIdx ? null : this.items.slice(this.firstIdx, endIdx);
-			this.firstIdx = endIdx;
-			return result;
+		let startIdx = this.firstIdx;
+		while (startIdx < this.items.length && predicate(this.items[startIdx])) {
+			startIdx++;
 		}
+		const result = startIdx === this.firstIdx ? null : this.items.slice(this.firstIdx, startIdx);
+		this.firstIdx = startIdx;
+		return result;
 	}
 
 	/**
 	 * Consumes elements from the end of the queue as long as the predicate returns true.
 	 * If no elements were consumed, `null` is returned.
 	 * The result has the same order as the underlying array!
-	 *
-	 * If isPredicateMonotonous is set to `true` and predicate is monotonous on the data,
-	 * it has a runtime of O(log(result.length)) + time(slice(result.length)).
 	*/
-	takeFromEndWhile(predicate: (value: T) => boolean, isPredicateMonotonous: boolean = false): T[] | null {
+	takeFromEndWhile(predicate: (value: T) => boolean): T[] | null {
 		// P(k) := this.firstIdx >= k && predicate(this.items[k])
 		// Find s := max { k | k <= this.lastIdx && !P(k) } and return this.data(s...this.lastIdx]
 
-		if (!isPredicateMonotonous) {
-			let endIdx = this.lastIdx;
-			while (endIdx >= 0 && predicate(this.items[endIdx])) {
-				endIdx--;
-			}
-			const result = endIdx === this.lastIdx ? null : this.items.slice(endIdx + 1, this.lastIdx + 1);
-			this.lastIdx = endIdx;
-			return result;
-		} else {
-			// `predicate` is monotonous, i.e. `!P(k) => !P(k - 1)`
-
-			let endIdx = this.lastIdx;
-			let delta = 1;
-			while (endIdx - delta >= 0 && predicate(this.items[endIdx - delta])) {
-				delta = delta * 2;
-			}
-			let startIdx = Math.max(endIdx - delta, this.firstIdx - 1);
-			// We have !P(endIdx - delta), thus startIdx <= s <= endIdx.
-
-			while (startIdx < endIdx) {
-				// Invariant: startIdx <= s <= endIdx.
-
-				const mid = Math.ceil((startIdx + endIdx) / 2);
-				// startIdx < mid <= endIdx
-
-				if (predicate(this.items[mid])) {
-					// startIdx <= s < mid
-					endIdx = mid - 1;
-				} else {
-					// mid <= s <= endIdx
-					startIdx = mid;
-				}
-			}
-
-			const result = startIdx === this.lastIdx ? null : this.items.slice(startIdx + 1, this.lastIdx + 1);
-			this.lastIdx = startIdx;
-			return result;
+		let endIdx = this.lastIdx;
+		while (endIdx >= 0 && predicate(this.items[endIdx])) {
+			endIdx--;
 		}
+		const result = endIdx === this.lastIdx ? null : this.items.slice(endIdx + 1, this.lastIdx + 1);
+		this.lastIdx = endIdx;
+		return result;
 	}
 }

--- a/src/vs/base/test/common/arrays.test.ts
+++ b/src/vs/base/test/common/arrays.test.ts
@@ -347,22 +347,10 @@ suite('Arrays', () => {
 					assert.deepStrictEqual(queue1.takeWhile(() => true), normalize(array.filter(negatedPredicate)));
 				}
 				{
-					const queue2 = new arrays.ArrayQueue(array);
-					assert.deepStrictEqual(queue2.takeWhile(predicate, true), normalize(array.filter(predicate)));
-					assert.deepStrictEqual(queue2.length, array.length - array.filter(predicate).length);
-					assert.deepStrictEqual(queue2.takeWhile(() => true, true), normalize(array.filter(negatedPredicate)));
-				}
-				{
 					const queue3 = new arrays.ArrayQueue(array);
 					assert.deepStrictEqual(queue3.takeFromEndWhile(negatedPredicate), normalize(array.filter(negatedPredicate)));
 					assert.deepStrictEqual(queue3.length, array.length - array.filter(negatedPredicate).length);
 					assert.deepStrictEqual(queue3.takeFromEndWhile(() => true), normalize(array.filter(predicate)));
-				}
-				{
-					const queue4 = new arrays.ArrayQueue(array);
-					assert.deepStrictEqual(queue4.takeFromEndWhile(negatedPredicate, true), normalize(array.filter(negatedPredicate)));
-					assert.deepStrictEqual(queue4.length, array.length - array.filter(negatedPredicate).length);
-					assert.deepStrictEqual(queue4.takeFromEndWhile(() => true, true), normalize(array.filter(predicate)));
 				}
 			}
 
@@ -381,7 +369,6 @@ suite('Arrays', () => {
 			test('TakeWhile 8', () => testMonotonous(array2, value => value < 5));
 
 			test('TakeWhile Empty', () => testMonotonous([], value => value <= 5));
-
 		});
 	});
 });

--- a/src/vs/base/test/common/arrays.test.ts
+++ b/src/vs/base/test/common/arrays.test.ts
@@ -312,12 +312,76 @@ suite('Arrays', () => {
 		assert.strictEqual(arrays.maxIndex(array, value => value === 'b' ? 5 : 0), 1);
 	});
 
-	test('filterSortedByKey', () => {
-		const array = [1, 2, 5, 5, 7, 8];
+	suite('ArrayQueue', () => {
+		suite('takeWhile/takeFromEndWhile', () => {
+			test('TakeWhile 1', () => {
+				const queue1 = new arrays.ArrayQueue([9, 8, 1, 7, 6]);
+				assert.deepStrictEqual(queue1.takeWhile(x => x > 5), [9, 8]);
+				assert.deepStrictEqual(queue1.takeWhile(x => x < 7), [1]);
+				assert.deepStrictEqual(queue1.takeWhile(x => true), [7, 6]);
+			});
 
-		assert.deepStrictEqual(arrays.filterSortedByKey(array, i => i, 3, 5), [5, 5]);
-		assert.deepStrictEqual(arrays.filterSortedByKey(array, i => i, 5, 5), [5, 5]);
-		assert.deepStrictEqual(arrays.filterSortedByKey(array, i => i, 6, 6), null);
-		assert.deepStrictEqual(arrays.filterSortedByKey(array, i => i, 8, 8), [8]);
+			test('TakeWhile 1', () => {
+				const queue1 = new arrays.ArrayQueue([9, 8, 1, 7, 6]);
+				assert.deepStrictEqual(queue1.takeFromEndWhile(x => x > 5), [7, 6]);
+				assert.deepStrictEqual(queue1.takeFromEndWhile(x => x < 2), [1]);
+				assert.deepStrictEqual(queue1.takeFromEndWhile(x => true), [9, 8]);
+			});
+		});
+
+		suite('takeWhile/takeFromEndWhile monotonous', () => {
+			function testMonotonous(array: number[], predicate: (a: number) => boolean) {
+				function normalize(arr: number[]): number[] | null {
+					if (arr.length === 0) {
+						return null;
+					}
+					return arr;
+				}
+
+				const negatedPredicate = (a: number) => !predicate(a);
+
+				{
+					const queue1 = new arrays.ArrayQueue(array);
+					assert.deepStrictEqual(queue1.takeWhile(predicate), normalize(array.filter(predicate)));
+					assert.deepStrictEqual(queue1.length, array.length - array.filter(predicate).length);
+					assert.deepStrictEqual(queue1.takeWhile(() => true), normalize(array.filter(negatedPredicate)));
+				}
+				{
+					const queue2 = new arrays.ArrayQueue(array);
+					assert.deepStrictEqual(queue2.takeWhile(predicate, true), normalize(array.filter(predicate)));
+					assert.deepStrictEqual(queue2.length, array.length - array.filter(predicate).length);
+					assert.deepStrictEqual(queue2.takeWhile(() => true, true), normalize(array.filter(negatedPredicate)));
+				}
+				{
+					const queue3 = new arrays.ArrayQueue(array);
+					assert.deepStrictEqual(queue3.takeFromEndWhile(negatedPredicate), normalize(array.filter(negatedPredicate)));
+					assert.deepStrictEqual(queue3.length, array.length - array.filter(negatedPredicate).length);
+					assert.deepStrictEqual(queue3.takeFromEndWhile(() => true), normalize(array.filter(predicate)));
+				}
+				{
+					const queue4 = new arrays.ArrayQueue(array);
+					assert.deepStrictEqual(queue4.takeFromEndWhile(negatedPredicate, true), normalize(array.filter(negatedPredicate)));
+					assert.deepStrictEqual(queue4.length, array.length - array.filter(negatedPredicate).length);
+					assert.deepStrictEqual(queue4.takeFromEndWhile(() => true, true), normalize(array.filter(predicate)));
+				}
+			}
+
+			const array = [1, 1, 1, 2, 5, 5, 7, 8, 8];
+
+			test('TakeWhile 1', () => testMonotonous(array, value => value <= 1));
+			test('TakeWhile 2', () => testMonotonous(array, value => value < 5));
+			test('TakeWhile 3', () => testMonotonous(array, value => value <= 5));
+			test('TakeWhile 4', () => testMonotonous(array, value => true));
+			test('TakeWhile 5', () => testMonotonous(array, value => false));
+
+			const array2 = [1, 1, 1, 2, 5, 5, 7, 8, 8, 9, 9, 9, 9, 10, 10];
+
+			test('TakeWhile 6', () => testMonotonous(array2, value => value < 10));
+			test('TakeWhile 7', () => testMonotonous(array2, value => value < 7));
+			test('TakeWhile 8', () => testMonotonous(array2, value => value < 5));
+
+			test('TakeWhile Empty', () => testMonotonous([], value => value <= 5));
+
+		});
 	});
 });

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -39,7 +39,7 @@ import { TextChange } from 'vs/editor/common/model/textChange';
 import { Constants } from 'vs/base/common/uint';
 import { PieceTreeTextBuffer } from 'vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer';
 import { listenStream } from 'vs/base/common/stream';
-import { filterSortedByKey } from 'vs/base/common/arrays';
+import { ArrayQueue } from 'vs/base/common/arrays';
 
 function createTextBufferBuilder() {
 	return new PieceTreeTextBufferBuilder();
@@ -1470,17 +1470,23 @@ export class TextModel extends Disposable implements model.ITextModel {
 					0,
 					0
 				));
+
+
 				const injectedTextInEditedRange = LineInjectedText.fromDecorations(decorationsWithInjectedTextInEditedRange);
+				const injectedTextInEditedRangeQueue = new ArrayQueue(injectedTextInEditedRange);
 
 				for (let j = editingLinesCnt; j >= 0; j--) {
 					const editLineNumber = startLineNumber + j;
 					const currentEditLineNumber = currentEditStartLineNumber + j;
 
+					injectedTextInEditedRangeQueue.takeFromEndWhile(r => r.lineNumber > currentEditLineNumber, true);
+					const decorationsInCurrentLine = injectedTextInEditedRangeQueue.takeFromEndWhile(r => r.lineNumber === currentEditLineNumber, true);
+
 					rawContentChanges.push(
 						new ModelRawLineChanged(
 							editLineNumber,
 							this.getLineContent(currentEditLineNumber),
-							filterSortedByKey(injectedTextInEditedRange, i => i.lineNumber, currentEditLineNumber)
+							decorationsInCurrentLine
 						));
 				}
 
@@ -1491,6 +1497,7 @@ export class TextModel extends Disposable implements model.ITextModel {
 				}
 
 				if (editingLinesCnt < insertingLinesCnt) {
+					const injectedTextInEditedRangeQueue = new ArrayQueue(injectedTextInEditedRange);
 					// Must insert some lines
 					const spliceLineNumber = startLineNumber + editingLinesCnt;
 					const cnt = insertingLinesCnt - editingLinesCnt;
@@ -1500,7 +1507,9 @@ export class TextModel extends Disposable implements model.ITextModel {
 					for (let i = 0; i < cnt; i++) {
 						let lineNumber = fromLineNumber + i;
 						newLines[i] = this.getLineContent(lineNumber);
-						injectedTexts[i] = filterSortedByKey(injectedTextInEditedRange, i => i.lineNumber, lineNumber);
+
+						injectedTextInEditedRangeQueue.takeWhile(r => r.lineNumber < lineNumber, true);
+						injectedTexts[i] = injectedTextInEditedRangeQueue.takeWhile(r => r.lineNumber === lineNumber, true);
 					}
 
 					rawContentChanges.push(

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -1479,8 +1479,8 @@ export class TextModel extends Disposable implements model.ITextModel {
 					const editLineNumber = startLineNumber + j;
 					const currentEditLineNumber = currentEditStartLineNumber + j;
 
-					injectedTextInEditedRangeQueue.takeFromEndWhile(r => r.lineNumber > currentEditLineNumber, true);
-					const decorationsInCurrentLine = injectedTextInEditedRangeQueue.takeFromEndWhile(r => r.lineNumber === currentEditLineNumber, true);
+					injectedTextInEditedRangeQueue.takeFromEndWhile(r => r.lineNumber > currentEditLineNumber);
+					const decorationsInCurrentLine = injectedTextInEditedRangeQueue.takeFromEndWhile(r => r.lineNumber === currentEditLineNumber);
 
 					rawContentChanges.push(
 						new ModelRawLineChanged(
@@ -1508,8 +1508,8 @@ export class TextModel extends Disposable implements model.ITextModel {
 						let lineNumber = fromLineNumber + i;
 						newLines[i] = this.getLineContent(lineNumber);
 
-						injectedTextInEditedRangeQueue.takeWhile(r => r.lineNumber < lineNumber, true);
-						injectedTexts[i] = injectedTextInEditedRangeQueue.takeWhile(r => r.lineNumber === lineNumber, true);
+						injectedTextInEditedRangeQueue.takeWhile(r => r.lineNumber < lineNumber);
+						injectedTexts[i] = injectedTextInEditedRangeQueue.takeWhile(r => r.lineNumber === lineNumber);
 					}
 
 					rawContentChanges.push(


### PR DESCRIPTION
This PR fixes part of #127313.

No worries, I did it in my free time yesterday 😉

Initially, for `N` being the number of lines and `M` the number of injected texts, it had runtime `O(N + M)`, then `O(N * log M)` and now something like `O(N * log (M / N))` which is better than both.

Note that `O(N + M)` is not always faster than `O(N * log M)` - consider `N = 1` or `M = N^2`.