### PR TITLE
Add setting to control hover position

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1753,6 +1753,11 @@ export interface IEditorHoverOptions {
 	 * Defaults to true.
 	 */
 	sticky?: boolean;
+	/**
+	 * Should the hover be shown below the line if possible?
+	 * Defaults to false.
+	 */
+	below?: boolean;
 }
 
 export type EditorHoverOptions = Readonly<Required<IEditorHoverOptions>>;
@@ -1763,7 +1768,8 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, EditorHoverOption
 		const defaults: EditorHoverOptions = {
 			enabled: true,
 			delay: 300,
-			sticky: true
+			sticky: true,
+			below: false,
 		};
 		super(
 			EditorOption.hover, 'hover', defaults,
@@ -1783,6 +1789,11 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, EditorHoverOption
 					default: defaults.sticky,
 					description: nls.localize('hover.sticky', "Controls whether the hover should remain visible when mouse is moved over it.")
 				},
+				'editor.hover.below': {
+					type: 'boolean',
+					default: defaults.below,
+					description: nls.localize('hover.below', "Show hovers below the line instead of above, if there's space.")
+				},
 			}
 		);
 	}
@@ -1795,7 +1806,8 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, EditorHoverOption
 		return {
 			enabled: boolean(input.enabled, this.defaultValue.enabled),
 			delay: EditorIntOption.clampedInt(input.delay, this.defaultValue.delay, 0, 10000),
-			sticky: boolean(input.sticky, this.defaultValue.sticky)
+			sticky: boolean(input.sticky, this.defaultValue.sticky),
+			below: boolean(input.below, this.defaultValue.below),
 		};
 	}
 }

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -202,6 +202,7 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 	private _shouldFocus: boolean;
 	private _colorPicker: ColorPickerWidget | null;
 	private _renderDisposable: IDisposable | null;
+	private _preferBelow: boolean;
 
 	constructor(
 		editor: ICodeEditor,
@@ -252,6 +253,7 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 		this._isChangingDecorations = false;
 		this._shouldFocus = false;
 		this._colorPicker = null;
+		this._preferBelow = this._editor.getOption(EditorOption.hover).below;
 
 		this._hoverOperation = new HoverOperation(
 			this._computer,
@@ -271,6 +273,7 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 		}));
 		this._register(editor.onDidChangeConfiguration(() => {
 			this._hoverOperation.setHoverTime(this._editor.getOption(EditorOption.hover).delay);
+			this._preferBelow = this._editor.getOption(EditorOption.hover).below;
 		}));
 		this._register(TokenizationRegistry.onDidChange(() => {
 			if (this._isVisible && this._lastAnchor && this._messages.length > 0) {
@@ -370,10 +373,13 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 			return {
 				position: this._showAtPosition,
 				range: this._showAtRange,
-				preference: [
+				preference: this._preferBelow ? [
+					ContentWidgetPositionPreference.BELOW,
 					ContentWidgetPositionPreference.ABOVE,
-					ContentWidgetPositionPreference.BELOW
-				]
+				] : [
+					ContentWidgetPositionPreference.ABOVE,
+					ContentWidgetPositionPreference.BELOW,
+				],
 			};
 		}
 		return null;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3485,6 +3485,11 @@ declare namespace monaco.editor {
 		 * Defaults to true.
 		 */
 		sticky?: boolean;
+		/**
+		 * Should the hover be shown below the line if possible?
+		 * Defaults to false.
+		 */
+		below?: boolean;
 	}
 
 	export type EditorHoverOptions = Readonly<Required<IEditorHoverOptions>>;


### PR DESCRIPTION
This adds a hover setting to control whether the user wants hovers to appear above or below the relevant line, if there's space.

Tested manually, including when the hover is near the bottom of the editor and this option is enabled.

This PR fixes #78560
