### PR TITLE
[Git watcher] ignore watchman cookies

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -545,7 +545,7 @@ class DotGitWatcher implements IFileWatcher {
 		// People might be using the watchman fsmonitor hook (https://git-scm.com/docs/githooks#_fsmonitor_watchman)
 		// on large repos. Watchman creates a cookie file inside the git directory whenever a query is run (https://facebook.github.io/watchman/docs/cookies.html)
 		// We need to ignore it to avoid an infinite loop of git operation -> watchman cookie -> git operation
-		const filteredRootWatcher = filterEvent(rootWatcher.event, uri => !/\/\.git(\/index\.lock)?$/.test(uri.path) && !/\/\.watchman-cookie.*/.test(uri.path));
+		const filteredRootWatcher = filterEvent(rootWatcher.event, uri => !/\/\.git(\/index\.lock)?$|\/\.watchman-cookie-/.test(uri.path));
 		this.event = anyEvent(filteredRootWatcher, this.emitter.event);
 
 		repository.onDidRunGitStatus(this.updateTransientWatchers, this, this.disposables);

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -542,7 +542,10 @@ class DotGitWatcher implements IFileWatcher {
 		const rootWatcher = watch(repository.dotGit);
 		this.disposables.push(rootWatcher);
 
-		const filteredRootWatcher = filterEvent(rootWatcher.event, uri => !/\/\.git(\/index\.lock)?$/.test(uri.path));
+		// People might be using the watchman fsmonitor hook (https://git-scm.com/docs/githooks#_fsmonitor_watchman)
+		// on large repos. Watchman creates a cookie file inside the git directory whenever a query is run (https://facebook.github.io/watchman/docs/cookies.html)
+		// We need to ignore it to avoid an infinite loop of git operation -> watchman cookie -> git operation
+		const filteredRootWatcher = filterEvent(rootWatcher.event, uri => !/\/\.git(\/index\.lock)?$/.test(uri.path) && !/\/\.watchman-cookie.*/.test(uri.path));
 		this.event = anyEvent(filteredRootWatcher, this.emitter.event);
 
 		repository.onDidRunGitStatus(this.updateTransientWatchers, this, this.disposables);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #112293. Git ships with a [watchman hook](https://git-scm.com/docs/githooks#_fsmonitor_watchman) to speed things up on large repos. However, watchman creates temporary files whenever a query is run (see https://facebook.github.io/watchman/docs/cookies.html), and it hides these files in VCS subdirectories. These files trigger vscode's git watcher, which causes repository status to be refreshed. The git operations from this refresh then trigger additional watchman queries, which create more files, and we wind up in an infinite loop. 

The solution is to filter these events out. Luckily, the files are created [with a consistent prefix](https://github.com/facebook/watchman/blob/544eda60323822095f9b8faed8dfaadf542cdf2e/watchman/CookieSync.h#L8) and we can filter by that. 

I verified this fix by opening a repo configured to use the watchman fsmonitor, and watching the Git output tab. 