### PR TITLE
Adding more auto-closing comments to other languages

### DIFF
--- a/extensions/cpp/language-configuration.json
+++ b/extensions/cpp/language-configuration.json
@@ -13,7 +13,9 @@
 		{ "open": "{", "close": "}" },
 		{ "open": "(", "close": ")" },
 		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
-		{ "open": "\"", "close": "\"", "notIn": ["string"] }
+		{ "open": "\"", "close": "\"", "notIn": ["string"] },
+		{ "open": "/**", "close": " */", "notIn": ["string"] },
+		{ "open": "/*!", "close": " */", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],

--- a/extensions/css/language-configuration.json
+++ b/extensions/css/language-configuration.json
@@ -12,7 +12,8 @@
 		{ "open": "[", "close": "]", "notIn": ["string", "comment"] },
 		{ "open": "(", "close": ")", "notIn": ["string", "comment"] },
 		{ "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
-		{ "open": "'", "close": "'", "notIn": ["string", "comment"] }
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
+		{ "open": "/**", "close": " */", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],

--- a/extensions/go/language-configuration.json
+++ b/extensions/go/language-configuration.json
@@ -14,7 +14,8 @@
 		["(", ")"],
 		{ "open": "`", "close": "`", "notIn": ["string"]},
 		{ "open": "\"", "close": "\"", "notIn": ["string"]},
-		{ "open": "'", "close": "'", "notIn": ["string", "comment"]}
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"]},
+		{ "open": "/**", "close": " */", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],

--- a/extensions/groovy/language-configuration.json
+++ b/extensions/groovy/language-configuration.json
@@ -13,7 +13,8 @@
 		["[", "]"],
 		["(", ")"],
 		{ "open": "\"", "close": "\"", "notIn": ["string"] },
-		{ "open": "'", "close": "'", "notIn": ["string"] }
+		{ "open": "'", "close": "'", "notIn": ["string"] },
+		{ "open": "/**", "close": " */", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],

--- a/extensions/less/language-configuration.json
+++ b/extensions/less/language-configuration.json
@@ -13,7 +13,8 @@
 		{ "open": "[", "close": "]", "notIn": ["string", "comment"] },
 		{ "open": "(", "close": ")", "notIn": ["string", "comment"] },
 		{ "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
-		{ "open": "'", "close": "'", "notIn": ["string", "comment"] }
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
+		{ "open": "/**", "close": " */", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],

--- a/extensions/objective-c/language-configuration.json
+++ b/extensions/objective-c/language-configuration.json
@@ -13,7 +13,8 @@
 		["[", "]"],
 		["(", ")"],
 		{ "open": "\"", "close": "\"", "notIn": ["string"] },
-		{ "open": "'", "close": "'", "notIn": ["string"] }
+		{ "open": "'", "close": "'", "notIn": ["string"] },
+		{ "open": "/**", "close": " */", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],

--- a/extensions/rust/language-configuration.json
+++ b/extensions/rust/language-configuration.json
@@ -12,7 +12,8 @@
 		["{", "}"],
 		["[", "]"],
 		["(", ")"],
-		{ "open": "\"", "close": "\"", "notIn": ["string"] }
+		{ "open": "\"", "close": "\"", "notIn": ["string"] },
+		{ "open": "/**", "close": " */", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],

--- a/extensions/scss/language-configuration.json
+++ b/extensions/scss/language-configuration.json
@@ -13,7 +13,8 @@
 		{ "open": "[", "close": "]", "notIn": ["string", "comment"] },
 		{ "open": "(", "close": ")", "notIn": ["string", "comment"] },
 		{ "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
-		{ "open": "'", "close": "'", "notIn": ["string", "comment"] }
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
+		{ "open": "/**", "close": " */", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],

--- a/extensions/swift/language-configuration.json
+++ b/extensions/swift/language-configuration.json
@@ -14,7 +14,8 @@
 		["(", ")"],
 		{ "open": "\"", "close": "\"", "notIn": ["string"] },
 		{ "open": "'", "close": "'", "notIn": ["string"] },
-		{ "open": "`", "close": "`", "notIn": ["string"] }
+		{ "open": "`", "close": "`", "notIn": ["string"] },
+		{ "open": "/**", "close": " */", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Some languages in vscode have a self closing comment, eg php, java, javascript and typescript - this PR adds the same autocompletion to other languages that use a similar comment syntax, as per: https://github.com/kevb34ns/auto-comment-blocks/tree/master/language-configuration.

This CL should mean that in the languages added, eg C++, typing `/**` will result in the comment being automatically closed by `*/`.

Added languages are the ones supported by the auto comment blocks extension, but it should be trivial to add others.

This PR is part of #127779
