### PR TITLE
Don't activate interactive window editor group on open

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -331,7 +331,7 @@ registerAction2(class extends Action2 {
 
 		const editorInput = InteractiveEditorInput.create(accessor.get(IInstantiationService), notebookUri, inputUri);
 		historyService.clearHistory(notebookUri);
-		await editorService.openEditor(editorInput, undefined, group);
+		await editorService.openEditor(editorInput, { activation: EditorActivation.PRESERVE, preserveFocus: true }, group);
 		// Extensions must retain references to these URIs to manipulate the interactive editor
 		return { notebookUri, inputUri };
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/127834

The reason #127834 happens is because when we first open the interactive window we do activate the editor group it occupies, and subsequently the file being debugged also gets opened in the active editor group. We just need to apply https://github.com/microsoft/vscode/commit/4e1a2afb3660b35c19fb80ae55a1655a4031abc5 to the initial open as well.
