### PR TITLE
make dropdown arrow larger to meet accessibility requirement

### DIFF
--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -192,17 +192,16 @@ body.web {
 .monaco-workbench .select-container:after {
 	content: "\eab4";
 	font-family: codicon;
-	font-size: 14px;
-	width: 14px;
-	height: 14px;
-	line-height: 14px;
+	font-size: 16px;
+	width: 16px;
+	height: 16px;
+	line-height: 16px;
 	position: absolute;
 	top: 0;
 	bottom: 0;
 	right: 6px;
 	margin: auto;
 	pointer-events: none;
-	font-weight: bold;
 }
 
 /* START Keyboard Focus Indication Styles */

--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -202,6 +202,7 @@ body.web {
 	right: 6px;
 	margin: auto;
 	pointer-events: none;
+	font-weight: bold;
 }
 
 /* START Keyboard Focus Indication Styles */


### PR DESCRIPTION
this is a fix for https://github.com/microsoft/azuredatastudio/issues/15767 in azure data studio, but I think this is also good for vscode.

before:
![image](https://user-images.githubusercontent.com/13777222/124214776-9fc7d800-daa7-11eb-8c9c-50c6b4a6d012.png)

after:

![image](https://user-images.githubusercontent.com/13777222/125003257-ac01e700-e00b-11eb-8843-88b86238ff8f.png)


