### PR TITLE
Commit message

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
@@ -247,16 +247,25 @@ class FormatOnSaveParticipant implements ITextFileSaveParticipant {
 		}
 
 		const editorOrModel = findEditor(textEditorModel, this.codeEditorService) || textEditorModel;
-		const mode = this.configurationService.getValue<'file' | 'modifications'>('editor.formatOnSaveMode', overrides);
-		if (mode === 'modifications') {
-			// format modifications
+		const mode = this.configurationService.getValue<'file' | 'modifications' | 'modificationsIfAvailable'>('editor.formatOnSaveMode', overrides);
+
+		// keeping things DRY :)
+		const formatWholeFile = async () => {
+			await this.instantiationService.invokeFunction(formatDocumentWithSelectedProvider, editorOrModel, FormattingMode.Silent, nestedProgress, token);
+		}
+
+		if (mode === 'modifications' || mode === 'modificationsIfAvailable') {
+			// try formatting modifications
 			const ranges = await this.instantiationService.invokeFunction(getModifiedRanges, isCodeEditor(editorOrModel) ? editorOrModel.getModel() : editorOrModel);
 			if (ranges) {
+				// version control reports changes
 				await this.instantiationService.invokeFunction(formatDocumentRangesWithSelectedProvider, editorOrModel, ranges, FormattingMode.Silent, nestedProgress, token);
+			} else if (ranges === null) {
+				// version control not found
+				formatWholeFile();
 			}
 		} else {
-			// format the whole file
-			await this.instantiationService.invokeFunction(formatDocumentWithSelectedProvider, editorOrModel, FormattingMode.Silent, nestedProgress, token);
+			formatWholeFile();
 		}
 	}
 }

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -294,11 +294,13 @@ configurationRegistry.registerConfiguration({
 			'default': 'file',
 			'enum': [
 				'file',
-				'modifications'
+				'modifications',
+				'modificationsIfAvailable'
 			],
 			'enumDescriptions': [
 				nls.localize({ key: 'everything', comment: ['This is the description of an option'] }, "Format the whole file."),
 				nls.localize({ key: 'modification', comment: ['This is the description of an option'] }, "Format modifications (requires source control)."),
+				nls.localize({ key: 'modificationIfAvailable', comment: ['This is the description of an option'] }, "Will attempt to format modifications only (requires source control). If source control can't be used, then the whole file will be formatted."),
 			],
 			'markdownDescription': nls.localize('formatOnSaveMode', "Controls if format on save formats the whole file or only modifications. Only applies when `#editor.formatOnSave#` is enabled."),
 			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE,

--- a/src/vs/workbench/contrib/format/browser/formatModified.ts
+++ b/src/vs/workbench/contrib/format/browser/formatModified.ts
@@ -49,14 +49,14 @@ registerEditorAction(class FormatModifiedAction extends EditorAction {
 });
 
 
-export async function getModifiedRanges(accessor: ServicesAccessor, modified: ITextModel): Promise<Range[] | undefined> {
+export async function getModifiedRanges(accessor: ServicesAccessor, modified: ITextModel): Promise<Range[] | undefined | null> {
 	const scmService = accessor.get(ISCMService);
 	const workerService = accessor.get(IEditorWorkerService);
 	const modelService = accessor.get(ITextModelService);
 
 	const original = await getOriginalResource(scmService, modified.uri);
 	if (!original) {
-		return undefined;
+		return null; // let undefined signify no changes, null represents no source control (there's probably a better way, but I can't think of one rn)
 	}
 
 	const ranges: Range[] = [];


### PR DESCRIPTION
This PR fixes #127838

Adds "modificationsIfAvailable" option to editor.formatOnSave. Editor will try to use modifications, and if source control is unavailable then it will format the entire file instead.

Not really sure how to test tbh, it just kinda works