### PR TITLE
Fix notebook diff editor dispose

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookDiffEditorInput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookDiffEditorInput.ts
@@ -117,12 +117,4 @@ export class NotebookDiffEditorInput extends DiffEditorInput {
 		}
 		return false;
 	}
-
-	override dispose() {
-		this._modifiedTextModel?.dispose();
-		this._modifiedTextModel = null;
-		this._originalTextModel?.dispose();
-		this._originalTextModel = null;
-		super.dispose();
-	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/127738#issuecomment-873216177

`NotebookDiffEditorInput` now inherits from base `DiffEditorInput`, it should not dispose the editor models resolved by original and modified editor inputs explicitly. The original and modified editor inputs know how to dispose the `ref` of the text models correctly.
