### PR TITLE
Add `.ixx` as a possible C++ extension

### DIFF
--- a/extensions/cpp/package.json
+++ b/extensions/cpp/package.json
@@ -41,6 +41,7 @@
           ".ino",
           ".inl",
           ".ipp",
+          ".ixx",
           ".hpp.in",
           ".h.in"
         ],


### PR DESCRIPTION
The `.ixx` extension is used to denote a C++ module interface file, required for it to be detected as such by Visual Studio, [as seen here in the Visual Studio documentation](https://docs.microsoft.com/en-us/cpp/cpp/modules-cpp?view=msvc-160#basic-example).

Therefore, Visual Studio Code should detect files with an `.ixx` extension as C++.

To test these changes, one simply creates a file with the `.ixx` extension, and checks to see if Visual Studio Code marks it as C++ code.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #127961.
