### PR TITLE
A run & debug dropdown with default button

### DIFF
--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -4,21 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./menuEntryActionViewItem';
-import { addDisposableListener, asCSSUrl, ModifierKeyEmitter } from 'vs/base/browser/dom';
-import { IAction, Separator, SubmenuAction } from 'vs/base/common/actions';
+import { addDisposableListener, asCSSUrl, ModifierKeyEmitter, append, EventType, $ } from 'vs/base/browser/dom';
+import { IAction, IRunEvent, Separator, SubmenuAction } from 'vs/base/common/actions';
 import { IDisposable, toDisposable, MutableDisposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { localize } from 'vs/nls';
-import { ICommandAction, IMenu, IMenuActionOptions, MenuItemAction, SubmenuItemAction, Icon } from 'vs/platform/actions/common/actions';
+import { ICommandAction, IMenu, IMenuActionOptions, MenuItemAction, SubmenuItemAction, Icon, IMenuService } from 'vs/platform/actions/common/actions';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { UILabelProvider } from 'vs/base/common/keybindingLabels';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
-import { ActionViewItem } from 'vs/base/browser/ui/actionbar/actionViewItems';
+import { ActionViewItem, BaseActionViewItem } from 'vs/base/browser/ui/actionbar/actionViewItems';
 import { DropdownMenuActionViewItem } from 'vs/base/browser/ui/dropdown/dropdownActionViewItem';
 import { isWindows, isLinux, OS } from 'vs/base/common/platform';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { Event } from 'vs/base/common/event';
+import { KeyCode } from 'vs/base/common/keyCodes';
+import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 
 export function createAndFillInContextMenuActions(menu: IMenu, options: IMenuActionOptions | undefined, target: IAction[] | { primary: IAction[]; secondary: IAction[]; }, primaryGroup?: string): IDisposable {
 	const groups = menu.getActions(options);
@@ -304,14 +308,142 @@ export class SubmenuEntryActionViewItem extends DropdownMenuActionViewItem {
 	}
 }
 
+class DropdownWithDefauktActionViewItem extends BaseActionViewItem {
+	private _defaultAction: ActionViewItem;
+	private _dropdown: DropdownMenuActionViewItem;
+	private _container: HTMLElement | null = null;
+	private _storageKey: string;
+
+	get onDidChangeDropdownVisibility(): Event<boolean> {
+		return this._dropdown.onDidChangeVisibility;
+	}
+
+	constructor(
+		submenuAction: SubmenuItemAction,
+		@IKeybindingService protected readonly _keybindingService: IKeybindingService,
+		@INotificationService protected _notificationService: INotificationService,
+		@IContextMenuService protected _contextMenuService: IContextMenuService,
+		@IMenuService protected _menuService: IMenuService,
+		@IInstantiationService protected _instaService: IInstantiationService,
+		@IStorageService protected _storageService: IStorageService
+	) {
+		super(null, submenuAction);
+
+		this._storageKey = submenuAction.item.storageKey || 'lastAction';
+
+		// determine default action
+		let defaultAction: IAction | undefined;
+		let defaultActionId = _storageService.get(this._storageKey, StorageScope.WORKSPACE);
+		if (defaultActionId) {
+			defaultAction = submenuAction.actions.find(a => defaultActionId === a.id);
+		}
+		if (!defaultAction) {
+			defaultAction = submenuAction.actions[0];
+		}
+
+		this._defaultAction = this._instaService.createInstance(MenuEntryActionViewItem, <MenuItemAction>defaultAction, undefined);
+
+		this._dropdown = new DropdownMenuActionViewItem(submenuAction, submenuAction.actions, this._contextMenuService, {
+			menuAsChild: true,
+			classNames: ['codicon', 'codicon-chevron-down']
+		});
+		this._dropdown.actionRunner.onDidRun((e: IRunEvent) => {
+			if (e.action instanceof MenuItemAction) {
+				this.update(e.action);
+			}
+		});
+	}
+
+	private update(lastAction: MenuItemAction): void {
+		this._storageService.store(this._storageKey, lastAction.id, StorageScope.WORKSPACE, StorageTarget.USER);
+
+		this._defaultAction.dispose();
+		this._defaultAction = this._instaService.createInstance(MenuEntryActionViewItem, lastAction, undefined);
+
+		if (this._container) {
+			this.render(this._container);
+		}
+	}
+
+	override setActionContext(newContext: unknown): void {
+		super.setActionContext(newContext);
+		this._defaultAction.setActionContext(newContext);
+		this._dropdown.setActionContext(newContext);
+	}
+
+	override render(container: HTMLElement): void {
+		this._container = container;
+		super.render(this._container);
+
+		this._container.classList.add('monaco-dropdown-with-primary');
+
+		const primaryContainer = $('.action-container');
+		this._defaultAction.render(append(this._container, primaryContainer));
+		this._register(addDisposableListener(primaryContainer, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			const event = new StandardKeyboardEvent(e);
+			if (event.equals(KeyCode.RightArrow)) {
+				this._defaultAction.element!.tabIndex = -1;
+				this._dropdown.focus();
+				event.stopPropagation();
+			}
+		}));
+
+		const dropdownContainer = $('.dropdown-action-container');
+		this._dropdown.render(append(this._container, dropdownContainer));
+		this._register(addDisposableListener(dropdownContainer, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			const event = new StandardKeyboardEvent(e);
+			if (event.equals(KeyCode.LeftArrow)) {
+				this._defaultAction.element!.tabIndex = 0;
+				this._dropdown.setFocusable(false);
+				this._defaultAction.element?.focus();
+				event.stopPropagation();
+			}
+		}));
+	}
+
+	override focus(fromRight?: boolean): void {
+		if (fromRight) {
+			this._dropdown.focus();
+		} else {
+			this._defaultAction.element!.tabIndex = 0;
+			this._defaultAction.element!.focus();
+		}
+	}
+
+	override blur(): void {
+		this._defaultAction.element!.tabIndex = -1;
+		this._dropdown.blur();
+		this._container!.blur();
+	}
+
+	override setFocusable(focusable: boolean): void {
+		if (focusable) {
+			this._defaultAction.element!.tabIndex = 0;
+		} else {
+			this._defaultAction.element!.tabIndex = -1;
+			this._dropdown.setFocusable(false);
+		}
+	}
+
+	override dispose() {
+		this._defaultAction.dispose();
+		this._dropdown.dispose();
+		super.dispose();
+	}
+}
+
 /**
  * Creates action view items for menu actions or submenu actions.
  */
-export function createActionViewItem(instaService: IInstantiationService, action: IAction): undefined | MenuEntryActionViewItem | SubmenuEntryActionViewItem {
+export function createActionViewItem(instaService: IInstantiationService, action: IAction): undefined | MenuEntryActionViewItem | SubmenuEntryActionViewItem | BaseActionViewItem {
 	if (action instanceof MenuItemAction) {
 		return instaService.createInstance(MenuEntryActionViewItem, action, undefined);
 	} else if (action instanceof SubmenuItemAction) {
-		return instaService.createInstance(SubmenuEntryActionViewItem, action);
+		if (action.item.storageKey) {
+			return instaService.createInstance(DropdownWithDefauktActionViewItem, action);
+		} else {
+			return instaService.createInstance(SubmenuEntryActionViewItem, action);
+		}
 	} else {
 		return undefined;
 	}

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -308,7 +308,7 @@ export class SubmenuEntryActionViewItem extends DropdownMenuActionViewItem {
 	}
 }
 
-class DropdownWithDefauktActionViewItem extends BaseActionViewItem {
+class DropdownWithDefaultActionViewItem extends BaseActionViewItem {
 	private _defaultAction: ActionViewItem;
 	private _dropdown: DropdownMenuActionViewItem;
 	private _container: HTMLElement | null = null;
@@ -440,7 +440,7 @@ export function createActionViewItem(instaService: IInstantiationService, action
 		return instaService.createInstance(MenuEntryActionViewItem, action, undefined);
 	} else if (action instanceof SubmenuItemAction) {
 		if (action.item.storageKey) {
-			return instaService.createInstance(DropdownWithDefauktActionViewItem, action);
+			return instaService.createInstance(DropdownWithDefaultActionViewItem, action);
 		} else {
 			return instaService.createInstance(SubmenuEntryActionViewItem, action);
 		}

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -329,7 +329,7 @@ class DropdownWithDefaultActionViewItem extends BaseActionViewItem {
 	) {
 		super(null, submenuAction);
 
-		this._storageKey = submenuAction.item.storageKey || 'lastAction';
+		this._storageKey = `${submenuAction.item.submenu._debugName}_lastActionId`;
 
 		// determine default action
 		let defaultAction: IAction | undefined;
@@ -439,7 +439,7 @@ export function createActionViewItem(instaService: IInstantiationService, action
 	if (action instanceof MenuItemAction) {
 		return instaService.createInstance(MenuEntryActionViewItem, action, undefined);
 	} else if (action instanceof SubmenuItemAction) {
-		if (action.item.storageKey) {
+		if (action.item.rememberDefaultAction) {
 			return instaService.createInstance(DropdownWithDefaultActionViewItem, action);
 		} else {
 			return instaService.createInstance(SubmenuEntryActionViewItem, action);

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -66,7 +66,7 @@ export interface ISubmenuItem {
 	when?: ContextKeyExpression;
 	group?: 'navigation' | string;
 	order?: number;
-	storageKey?: string;	// for dropdown menu: if specified the last executed action is remembered as the default action under this key
+	rememberDefaultAction?: boolean;	// for dropdown menu: if true the last executed action is remembered as the default action
 }
 
 export function isIMenuItem(item: IMenuItem | ISubmenuItem): item is IMenuItem {

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -66,6 +66,7 @@ export interface ISubmenuItem {
 	when?: ContextKeyExpression;
 	group?: 'navigation' | string;
 	order?: number;
+	storageKey?: string;	// for dropdown menu: if specified the last executed action is remembered as the default action under this key
 }
 
 export function isIMenuItem(item: IMenuItem | ISubmenuItem): item is IMenuItem {

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -320,7 +320,7 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, { command: { id: SHOW_EDITORS_IN
 MenuRegistry.appendMenuItem(MenuId.EditorTitle, { command: { id: CLOSE_EDITORS_IN_GROUP_COMMAND_ID, title: localize('closeAll', "Close All") }, group: '5_close', order: 10 });
 MenuRegistry.appendMenuItem(MenuId.EditorTitle, { command: { id: CLOSE_SAVED_EDITORS_COMMAND_ID, title: localize('closeAllSaved', "Close Saved") }, group: '5_close', order: 20 });
 MenuRegistry.appendMenuItem(MenuId.EditorTitle, { command: { id: TOGGLE_KEEP_EDITORS_COMMAND_ID, title: localize('toggleKeepEditors', "Keep Editors Open"), toggled: ContextKeyExpr.not('config.workbench.editor.enablePreview') }, group: '7_settings', order: 10 });
-MenuRegistry.appendMenuItem(MenuId.EditorTitle, { submenu: MenuId.EditorTitleRun, storageKey: 'lastEditorRunAction', title: { value: localize('run', "Run or Debug..."), original: 'Run or Debug...', }, icon: Codicon.run, group: 'navigation', order: -1 });
+MenuRegistry.appendMenuItem(MenuId.EditorTitle, { submenu: MenuId.EditorTitleRun, rememberDefaultAction: true, title: { value: localize('run', "Run or Debug..."), original: 'Run or Debug...', }, icon: Codicon.run, group: 'navigation', order: -1 });
 
 interface IEditorToolItem { id: string; title: string; icon?: { dark?: URI; light?: URI; } | ThemeIcon; }
 

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -320,7 +320,7 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, { command: { id: SHOW_EDITORS_IN
 MenuRegistry.appendMenuItem(MenuId.EditorTitle, { command: { id: CLOSE_EDITORS_IN_GROUP_COMMAND_ID, title: localize('closeAll', "Close All") }, group: '5_close', order: 10 });
 MenuRegistry.appendMenuItem(MenuId.EditorTitle, { command: { id: CLOSE_SAVED_EDITORS_COMMAND_ID, title: localize('closeAllSaved', "Close Saved") }, group: '5_close', order: 20 });
 MenuRegistry.appendMenuItem(MenuId.EditorTitle, { command: { id: TOGGLE_KEEP_EDITORS_COMMAND_ID, title: localize('toggleKeepEditors', "Keep Editors Open"), toggled: ContextKeyExpr.not('config.workbench.editor.enablePreview') }, group: '7_settings', order: 10 });
-MenuRegistry.appendMenuItem(MenuId.EditorTitle, { submenu: MenuId.EditorTitleRun, title: { value: localize('run', "Run"), original: 'Run', }, icon: Codicon.run, group: 'navigation', order: -1 });
+MenuRegistry.appendMenuItem(MenuId.EditorTitle, { submenu: MenuId.EditorTitleRun, storageKey: 'lastEditorRunAction', title: { value: localize('run', "Run or Debug..."), original: 'Run or Debug...', }, icon: Codicon.run, group: 'navigation', order: -1 });
 
 interface IEditorToolItem { id: string; title: string; icon?: { dark?: URI; light?: URI; } | ThemeIcon; }
 


### PR DESCRIPTION
This PR fixes #117722

This is my first attempt for a dropdown menu that remembers a default action.

The PR introduces an alternative UI for submenus:
If a "storageKey" attribute is specified for a submenu, the submenu is shown in the UI as a dropdown menu with a button that executes the last action run from the dropdown. The default action is persisted in workspace storage under the "storageKey".

This alternate UI is generic (independent from debug's run & debug functionality).
However, this PR configures the alternate UI for the "editor/title/run" contribution point.

The UI looks like this:

![123995386-9159bd80-d9ce-11eb-8665-38e866a4536a](https://user-images.githubusercontent.com/1898161/124521550-34a43b80-ddf0-11eb-82c0-6a524d7fcfe4.gif)

