### PR TITLE
Bulk install event for python extensions

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -185,6 +185,7 @@ export interface DidInstallExtensionEvent {
 	gallery?: IGalleryExtension;
 	local?: ILocalExtension;
 	error?: string;
+	isBulkInstall?: boolean;
 }
 
 export interface DidUninstallExtensionEvent {
@@ -213,6 +214,7 @@ export interface IExtensionManagementService {
 
 	onInstallExtension: Event<InstallExtensionEvent>;
 	onDidInstallExtension: Event<DidInstallExtensionEvent>;
+	onDidInstallExtensions: Event<DidInstallExtensionEvent[]>;
 	onUninstallExtension: Event<IExtensionIdentifier>;
 	onDidUninstallExtension: Event<DidUninstallExtensionEvent>;
 

--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -91,6 +91,9 @@ export class ExtensionManagementService extends Disposable implements IExtension
 	private readonly _onDidInstallExtension = this._register(new Emitter<DidInstallExtensionEvent>());
 	readonly onDidInstallExtension: Event<DidInstallExtensionEvent> = this._onDidInstallExtension.event;
 
+	private readonly _onDidInstallExtensions = this._register(new Emitter<DidInstallExtensionEvent[]>());
+	readonly onDidInstallExtensions = this._onDidInstallExtensions.event;
+
 	private readonly _onUninstallExtension = this._register(new Emitter<IExtensionIdentifier>());
 	readonly onUninstallExtension: Event<IExtensionIdentifier> = this._onUninstallExtension.event;
 
@@ -294,12 +297,13 @@ export class ExtensionManagementService extends Disposable implements IExtension
 			this.logService.info('Extensions is already requested to install', extension.identifier.id);
 			return (await installExtensionTask.resultPromise).local;
 		} else {
-			installExtensionTask = this.createInstallFromGalleryExtensionTask(extension, options);
-			return (await this.runInstallGalleryExtensionTask(installExtensionTask, options)).local;
+			const isBulkInstall = ['ms-python.python', 'ms-python.vscode-pylance'].includes(extension.identifier.id.toLowerCase());
+			installExtensionTask = this.createInstallFromGalleryExtensionTask(extension, options, isBulkInstall);
+			return (await this.runInstallGalleryExtensionTask(installExtensionTask, options, isBulkInstall)).local;
 		}
 	}
 
-	private createInstallFromGalleryExtensionTask(extension: IGalleryExtension, options: InstallOptions): InstallExtensionTask {
+	private createInstallFromGalleryExtensionTask(extension: IGalleryExtension, options: InstallOptions, isBulkInstall: boolean): InstallExtensionTask {
 		const key = new ExtensionIdentifierWithVersion(extension.identifier, extension.version).key();
 		this._onInstallExtension.fire({ identifier: extension.identifier, gallery: extension });
 		this.logService.info('Installing extension:', extension.identifier.id);
@@ -315,7 +319,7 @@ export class ExtensionManagementService extends Disposable implements IExtension
 						try {
 							const result = await this.installGalleryExtension(extension, options, token);
 							this.logService.info(`Extensions installed successfully:`, extension.identifier.id);
-							this._onDidInstallExtension.fire({ identifier: extension.identifier, gallery: result.gallery, local: result.local, operation: result.operation });
+							this._onDidInstallExtension.fire({ identifier: extension.identifier, gallery: result.gallery, local: result.local, operation: result.operation, isBulkInstall });
 							return result;
 						} catch (error) {
 							const errorCode = error && (<ExtensionManagementError>error).code ? (<ExtensionManagementError>error).code : ERROR_UNKNOWN;
@@ -344,7 +348,7 @@ export class ExtensionManagementService extends Disposable implements IExtension
 		return installExtensionTask;
 	}
 
-	private async runInstallGalleryExtensionTask(installExtensionTask: InstallExtensionTask, options: InstallOptions): Promise<InstallResult> {
+	private async runInstallGalleryExtensionTask(installExtensionTask: InstallExtensionTask, options: InstallOptions, isBulkInstall: boolean): Promise<InstallResult> {
 		if (options.donotIncludePackAndDependencies) {
 			this.logService.info('Installing the extension without checking dependencies and pack', installExtensionTask.extension.identifier.id);
 			return installExtensionTask.run();
@@ -369,7 +373,7 @@ export class ExtensionManagementService extends Disposable implements IExtension
 				if (this.installingExtensions.has(new ExtensionIdentifierWithVersion(gallery.identifier, gallery.version).key())) {
 					this.logService.info('Extension is already requested to install', gallery.identifier.id);
 				} else {
-					const task = this.createInstallFromGalleryExtensionTask(gallery, { ...options, donotIncludePackAndDependencies: true });
+					const task = this.createInstallFromGalleryExtensionTask(gallery, { ...options, donotIncludePackAndDependencies: true }, isBulkInstall);
 					extensionsToInstallMap.set(gallery.identifier.id.toLowerCase(), { task, manifest });
 				}
 			}
@@ -405,6 +409,10 @@ export class ExtensionManagementService extends Disposable implements IExtension
 				installExtensionTask.cancel();
 			}
 			throw error;
+		} finally {
+			if (isBulkInstall) {
+				this._onDidInstallExtensions.fire(installResults.map(({ gallery, local, operation }) => ({ identifier: local.identifier, gallery, local, operation })));
+			}
 		}
 
 	}

--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -410,7 +410,7 @@ export class ExtensionManagementService extends Disposable implements IExtension
 			}
 			throw error;
 		} finally {
-			if (isBulkInstall) {
+			if (installResults.length && isBulkInstall) {
 				this._onDidInstallExtensions.fire(installResults.map(({ gallery, local, operation }) => ({ identifier: local.identifier, gallery, local, operation })));
 			}
 		}

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -5,7 +5,7 @@
 
 import { Event, EventMultiplexer } from 'vs/base/common/event';
 import {
-	ILocalExtension, IGalleryExtension, IExtensionIdentifier, IReportedExtension, IGalleryMetadata, IExtensionGalleryService, InstallOptions, UninstallOptions, INSTALL_ERROR_NOT_SUPPORTED, InstallVSIXOptions
+	ILocalExtension, IGalleryExtension, IExtensionIdentifier, IReportedExtension, IGalleryMetadata, IExtensionGalleryService, InstallOptions, UninstallOptions, INSTALL_ERROR_NOT_SUPPORTED, InstallVSIXOptions, DidInstallExtensionEvent
 } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { DidInstallExtensionOnServerEvent, DidUninstallExtensionOnServerEvent, IExtensionManagementServer, IExtensionManagementServerService, InstallExtensionOnServerEvent, IWorkbenchExtensionManagementService, UninstallExtensionOnServerEvent } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { ExtensionType, isLanguagePackExtension, IExtensionManifest } from 'vs/platform/extensions/common/extensions';
@@ -35,6 +35,7 @@ export class ExtensionManagementService extends Disposable implements IWorkbench
 	readonly onDidInstallExtension: Event<DidInstallExtensionOnServerEvent>;
 	readonly onUninstallExtension: Event<UninstallExtensionOnServerEvent>;
 	readonly onDidUninstallExtension: Event<DidUninstallExtensionOnServerEvent>;
+	readonly onDidInstallExtensions: Event<DidInstallExtensionEvent[]>;
 
 	protected readonly servers: IExtensionManagementServer[] = [];
 
@@ -63,6 +64,7 @@ export class ExtensionManagementService extends Disposable implements IWorkbench
 
 		this.onInstallExtension = this._register(this.servers.reduce((emitter: EventMultiplexer<InstallExtensionOnServerEvent>, server) => { emitter.add(Event.map(server.extensionManagementService.onInstallExtension, e => ({ ...e, server }))); return emitter; }, new EventMultiplexer<InstallExtensionOnServerEvent>())).event;
 		this.onDidInstallExtension = this._register(this.servers.reduce((emitter: EventMultiplexer<DidInstallExtensionOnServerEvent>, server) => { emitter.add(Event.map(server.extensionManagementService.onDidInstallExtension, e => ({ ...e, server }))); return emitter; }, new EventMultiplexer<DidInstallExtensionOnServerEvent>())).event;
+		this.onDidInstallExtensions = this._register(this.servers.reduce((emitter: EventMultiplexer<DidInstallExtensionEvent[]>, server) => { emitter.add(server.extensionManagementService.onDidInstallExtensions); return emitter; }, new EventMultiplexer<DidInstallExtensionEvent[]>())).event;
 		this.onUninstallExtension = this._register(this.servers.reduce((emitter: EventMultiplexer<UninstallExtensionOnServerEvent>, server) => { emitter.add(Event.map(server.extensionManagementService.onUninstallExtension, e => ({ ...e, server }))); return emitter; }, new EventMultiplexer<UninstallExtensionOnServerEvent>())).event;
 		this.onDidUninstallExtension = this._register(this.servers.reduce((emitter: EventMultiplexer<DidUninstallExtensionOnServerEvent>, server) => { emitter.add(Event.map(server.extensionManagementService.onDidUninstallExtension, e => ({ ...e, server }))); return emitter; }, new EventMultiplexer<DidUninstallExtensionOnServerEvent>())).event;
 	}

--- a/src/vs/workbench/services/extensionManagement/common/webExtensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/webExtensionManagementService.ts
@@ -30,6 +30,9 @@ export class WebExtensionManagementService extends Disposable implements IExtens
 	private readonly _onDidInstallExtension = this._register(new Emitter<DidInstallExtensionEvent>());
 	readonly onDidInstallExtension: Event<DidInstallExtensionEvent> = this._onDidInstallExtension.event;
 
+	private readonly _onDidInstallExtensions = this._register(new Emitter<DidInstallExtensionEvent[]>());
+	readonly onDidInstallExtensions = this._onDidInstallExtensions.event;
+
 	private readonly _onUninstallExtension = this._register(new Emitter<IExtensionIdentifier>());
 	readonly onUninstallExtension: Event<IExtensionIdentifier> = this._onUninstallExtension.event;
 

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -222,11 +222,23 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 		}));
 
 		this._register(this._extensionManagementService.onDidInstallExtension((event) => {
-			if (event.local) {
+			if (event.local && !event.isBulkInstall) {
 				if (this._safeInvokeIsEnabled(event.local)) {
 					// an extension has been installed
 					this._handleDeltaExtensions(new DeltaExtensionsQueueItem([event.local], []));
 				}
+			}
+		}));
+
+		this._register(this._extensionManagementService.onDidInstallExtensions((events) => {
+			const extensions: IExtension[] = [];
+			for (const { local } of events) {
+				if (local && this._safeInvokeIsEnabled(local)) {
+					extensions.push(local);
+				}
+			}
+			if (extensions.length) {
+				this._handleDeltaExtensions(new DeltaExtensionsQueueItem(extensions, []));
 			}
 		}));
 


### PR DESCRIPTION
This PR fixes #128088 

This is temporary low risk, low impact fix for above issue. Introduced bulk install flag and event only for python extensions. 
Extension runtime will ignore singular install events with bulk install flag and react to bulk install event.

**Note**: This is to fix only when installing python or pylance extension but not when installing the packs that includes these extensions.

This is the best safe changes we can do given that we are end of the milestone . 
Going forward the proper fix will take care of all possibilities
