### PR TITLE
Inlay hints uses editor.fontFamily by defaults

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2437,7 +2437,7 @@ export type EditorInlayHintsOptions = Readonly<Required<IEditorInlayHintsOptions
 class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, EditorInlayHintsOptions> {
 
 	constructor() {
-		const defaults: EditorInlayHintsOptions = { enabled: true, fontSize: 0, fontFamily: EDITOR_FONT_DEFAULTS.fontFamily };
+		const defaults: EditorInlayHintsOptions = { enabled: true, fontSize: 0, fontFamily: '' };
 		super(
 			EditorOption.inlayHints, 'inlayHints', defaults,
 			{
@@ -2454,7 +2454,7 @@ class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, EditorI
 				'editor.inlayHints.fontFamily': {
 					type: 'string',
 					default: defaults.fontFamily,
-					description: nls.localize('inlayHints.fontFamily', "Controls font family of inlay hints in the editor.")
+					description: nls.localize('inlayHints.fontFamily', "Controls font family of inlay hints in the editor. When set to empty, the `#editor.fontFamily#` is used.")
 				},
 			}
 		);

--- a/src/vs/editor/contrib/inlayHints/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/inlayHintsController.ts
@@ -190,7 +190,7 @@ export class InlayHintsController implements IEditorContribution {
 		if (!fontSize || fontSize < 5 || fontSize > editorFontSize) {
 			fontSize = (editorFontSize * .9) | 0;
 		}
-		const fontFamily = options.fontFamily;
+		const fontFamily = options.fontFamily || this._editor.getOption(EditorOption.fontFamily);
 		return { fontSize, fontFamily };
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR related #https://github.com/microsoft/vscode/issues/119406 but not fix all.
