### PR TITLE
Sets mightBeForeignElement to true when mouse is on injected text.

### DIFF
--- a/src/vs/editor/common/viewModel/splitLinesCollection.ts
+++ b/src/vs/editor/common/viewModel/splitLinesCollection.ts
@@ -12,7 +12,7 @@ import { EndOfLinePreference, IActiveIndentGuideInfo, IModelDecoration, IModelDe
 import { ModelDecorationOptions, ModelDecorationOverviewRulerOptions } from 'vs/editor/common/model/textModel';
 import * as viewEvents from 'vs/editor/common/view/viewEvents';
 import { PrefixSumIndexOfResult } from 'vs/editor/common/viewModel/prefixSumComputer';
-import { ICoordinatesConverter, ILineBreaksComputer, IOverviewRulerDecorations, LineBreakData, SingleLineInlineDecoration, ViewLineData } from 'vs/editor/common/viewModel/viewModel';
+import { ICoordinatesConverter, InjectedText, ILineBreaksComputer, IOverviewRulerDecorations, LineBreakData, SingleLineInlineDecoration, ViewLineData } from 'vs/editor/common/viewModel/viewModel';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { FontInfo } from 'vs/editor/common/config/fontInfo';
 import { EditorTheme } from 'vs/editor/common/view/viewContext';
@@ -48,6 +48,8 @@ export interface ISplitLine {
 	getViewPositionOfModelPosition(deltaLineNumber: number, inputColumn: number, affinity?: PositionAffinity): Position;
 	getViewLineNumberOfModelPosition(deltaLineNumber: number, inputColumn: number): number;
 	normalizePosition(model: ISimpleModel, modelLineNumber: number, outputLineIndex: number, outputPosition: Position, affinity: PositionAffinity): Position;
+
+	getInjectedTextAt(outputLineIndex: number, column: number): InjectedText | null;
 }
 
 export interface IViewModelLinesCollection extends IDisposable {
@@ -77,6 +79,8 @@ export interface IViewModelLinesCollection extends IDisposable {
 
 	getAllOverviewRulerDecorations(ownerId: number, filterOutValidation: boolean, theme: EditorTheme): IOverviewRulerDecorations;
 	getDecorationsInRange(range: Range, ownerId: number, filterOutValidation: boolean): IModelDecoration[];
+
+	getInjectedTextAt(viewPosition: Position): InjectedText | null;
 
 	normalizePosition(position: Position, affinity: PositionAffinity): Position;
 	/**
@@ -997,6 +1001,15 @@ export class SplitLinesCollection implements IViewModelLinesCollection {
 		return finalResult;
 	}
 
+	public getInjectedTextAt(position: Position): InjectedText | null {
+		const viewLineNumber = this._toValidViewLineNumber(position.lineNumber);
+		const r = this.prefixSumComputer.getIndexOf(viewLineNumber - 1);
+		const lineIndex = r.index;
+		const remainder = r.remainder;
+
+		return this.lines[lineIndex].getInjectedTextAt(remainder, position.column);
+	}
+
 	normalizePosition(position: Position, affinity: PositionAffinity): Position {
 		const viewLineNumber = this._toValidViewLineNumber(position.lineNumber);
 		const r = this.prefixSumComputer.getIndexOf(viewLineNumber - 1);
@@ -1101,6 +1114,10 @@ class VisibleIdentitySplitLine implements ISplitLine {
 	public normalizePosition(model: ISimpleModel, modelLineNumber: number, outputLineIndex: number, outputPosition: Position, affinity: PositionAffinity): Position {
 		return outputPosition;
 	}
+
+	public getInjectedTextAt(_outputLineIndex: number, _outputColumn: number): InjectedText | null {
+		return null;
+	}
 }
 
 class InvisibleIdentitySplitLine implements ISplitLine {
@@ -1165,6 +1182,10 @@ class InvisibleIdentitySplitLine implements ISplitLine {
 	}
 
 	public normalizePosition(model: ISimpleModel, modelLineNumber: number, outputLineIndex: number, outputPosition: Position, affinity: PositionAffinity): Position {
+		throw new Error('Not supported');
+	}
+
+	public getInjectedTextAt(_outputLineIndex: number, _outputColumn: number): InjectedText | null {
 		throw new Error('Not supported');
 	}
 }
@@ -1451,6 +1472,10 @@ export class SplitLine implements ISplitLine {
 
 		return outputPosition;
 	}
+
+	public getInjectedTextAt(outputLineIndex: number, outputColumn: number): InjectedText | null {
+		return this._lineBreakData.getInjectedText(outputLineIndex, outputColumn);
+	}
 }
 
 let _spaces: string[] = [''];
@@ -1693,6 +1718,11 @@ export class IdentityLinesCollection implements IViewModelLinesCollection {
 
 	public getLineIndentColumn(lineNumber: number): number {
 		return this.model.getLineIndentColumn(lineNumber);
+	}
+
+	public getInjectedTextAt(position: Position): InjectedText | null {
+		// Identity lines collection does not support injected text.
+		return null;
 	}
 }
 

--- a/src/vs/editor/common/viewModel/splitLinesCollection.ts
+++ b/src/vs/editor/common/viewModel/splitLinesCollection.ts
@@ -1474,7 +1474,7 @@ export class SplitLine implements ISplitLine {
 	}
 
 	public getInjectedTextAt(outputLineIndex: number, outputColumn: number): InjectedText | null {
-		return this._lineBreakData.getInjectedText(outputLineIndex, outputColumn);
+		return this._lineBreakData.getInjectedText(outputLineIndex, outputColumn - 1);
 	}
 }
 

--- a/src/vs/editor/common/viewModel/viewModel.ts
+++ b/src/vs/editor/common/viewModel/viewModel.ts
@@ -205,7 +205,7 @@ export class LineBreakData {
 	}
 
 	public normalizeOffsetAroundInjections(offsetInUnwrappedLine: number, affinity: PositionAffinity): number {
-		const injectedText = this.getInjectedTextAt(offsetInUnwrappedLine);
+		const injectedText = this.getInjectedTextAtOffset(offsetInUnwrappedLine);
 		if (!injectedText) {
 			return offsetInUnwrappedLine;
 		}
@@ -242,7 +242,18 @@ export class LineBreakData {
 		return result;
 	}
 
-	private getInjectedTextAt(offsetInUnwrappedLine: number): { injectedTextIndex: number, offsetInUnwrappedLine: number, length: number } | undefined {
+	public getInjectedText(outputLineIndex: number, outputOffset: number): InjectedText | null {
+		const offset = this.outputPositionToOffsetInUnwrappedLine(outputLineIndex, outputOffset);
+		const injectedText = this.getInjectedTextAtOffset(offset);
+		if (!injectedText) {
+			return null;
+		}
+		return {
+			options: this.injectionOptions![injectedText.injectedTextIndex]
+		};
+	}
+
+	private getInjectedTextAtOffset(offsetInUnwrappedLine: number): { injectedTextIndex: number, offsetInUnwrappedLine: number, length: number } | undefined {
 		const injectionOffsets = this.injectionOffsets;
 		const injectionOptions = this.injectionOptions;
 
@@ -328,6 +339,8 @@ export interface IViewModel extends ICursorSimpleModel {
 	invalidateMinimapColorCache(): void;
 	getValueInRange(range: Range, eol: EndOfLinePreference): string;
 
+	getInjectedTextAt(viewPosition: Position): InjectedText | null;
+
 	getModelLineMaxColumn(modelLineNumber: number): number;
 	validateModelPosition(modelPosition: IPosition): Position;
 	validateModelRange(range: IRange): Range;
@@ -370,6 +383,10 @@ export interface IViewModel extends ICursorSimpleModel {
 	changeWhitespace(callback: (accessor: IWhitespaceChangeAccessor) => void): void;
 	setMaxLineWidth(maxLineWidth: number): void;
 	//#endregion
+}
+
+export class InjectedText {
+	constructor(public readonly options: InjectedTextOptions) { }
 }
 
 export class MinimapLinesRenderingData {

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -21,7 +21,7 @@ import { MinimapTokensColorTracker } from 'vs/editor/common/viewModel/minimapTok
 import * as viewEvents from 'vs/editor/common/view/viewEvents';
 import { ViewLayout } from 'vs/editor/common/viewLayout/viewLayout';
 import { IViewModelLinesCollection, IdentityLinesCollection, SplitLinesCollection, ILineBreaksComputerFactory } from 'vs/editor/common/viewModel/splitLinesCollection';
-import { ICoordinatesConverter, ILineBreaksComputer, IOverviewRulerDecorations, IViewModel, MinimapLinesRenderingData, ViewLineData, ViewLineRenderingData, ViewModelDecoration } from 'vs/editor/common/viewModel/viewModel';
+import { ICoordinatesConverter, InjectedText, ILineBreaksComputer, IOverviewRulerDecorations, IViewModel, MinimapLinesRenderingData, ViewLineData, ViewLineRenderingData, ViewModelDecoration } from 'vs/editor/common/viewModel/viewModel';
 import { ViewModelDecorations } from 'vs/editor/common/viewModel/viewModelDecorations';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import * as platform from 'vs/base/common/platform';
@@ -650,6 +650,10 @@ export class ViewModel extends Disposable implements IViewModel {
 
 	public getDecorationsInViewport(visibleRange: Range): ViewModelDecoration[] {
 		return this._decorations.getDecorationsViewportData(visibleRange).decorations;
+	}
+
+	public getInjectedTextAt(viewPosition: Position): InjectedText | null {
+		return this._lines.getInjectedTextAt(viewPosition);
 	}
 
 	public getViewLineRenderingData(visibleRange: Range, lineNumber: number): ViewLineRenderingData {


### PR DESCRIPTION
Exposes `getInjectedTextAt` method in view model, so that mouse move events can report if they are on injected text.

Currently, this only sets `mightBeForeignElement` to true. In the future, it could pass the actual injected text options (decoration id).