### PR TITLE
[codespaces] Allow readme to be displayed if defaultValue is set on workbench initialization

### DIFF
--- a/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -152,12 +152,14 @@ function isWelcomePageEnabled(configurationService: IConfigurationService, conte
 			return welcomeEnabled.value;
 		}
 	}
-	if (startupEditor.value === 'readme' && startupEditor.userValue !== 'readme') {
-		console.error('Warning: `workbench.startupEditor: readme` setting ignored due to being set somewhere other than user settings');
+
+	if (startupEditor.value === 'readme' && (startupEditor.userValue !== 'readme' || startupEditor.defaultValue !== 'readme')) {
+		console.error(`Warning: 'workbench.startupEditor: readme' setting ignored due to being set somewhere other than user or default settings (user=${startupEditor.userValue}, default=${startupEditor.defaultValue})`);
 	}
 	return startupEditor.value === 'welcomePage'
 		|| startupEditor.value === 'legacy_welcomePage'
 		|| startupEditor.userValue === 'readme'
+		|| startupEditor.defaultValue === 'readme'
 		|| (contextService.getWorkbenchState() === WorkbenchState.EMPTY && (startupEditor.value === 'legacy_welcomePageInEmptyWorkbench' || startupEditor.value === 'welcomePageInEmptyWorkbench'));
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR attempts to fix an issue seen with the Codespaces web workbench where the readme no longer pops up as the `workbench.startupEditor`, despite `readme` being passed as the a member of `configurationDefaults` when initializing the workbench (using the `IWorkbenchConstructionOptions` interface.

I don't have any setting in my personal settings/settings sync. 

The Codespaces workbench sees this error in its console logs, which led me here
![image](https://user-images.githubusercontent.com/23246594/124983151-a0132680-e005-11eb-9011-12b525fe19f8.png)

Have not been able to test this end-to-end with the Codespaces workbench. Looking for opinions on whether this is the right approach or not :)

/cc @JacksonKearl