### PR TITLE
When converting an empty model range to a view range, it should prefer left view positions.

### DIFF
--- a/src/vs/editor/common/viewModel/splitLinesCollection.ts
+++ b/src/vs/editor/common/viewModel/splitLinesCollection.ts
@@ -883,13 +883,14 @@ export class SplitLinesCollection implements IViewModelLinesCollection {
 	}
 
 	public convertModelRangeToViewRange(modelRange: Range): Range {
-		const start = this.convertModelPositionToViewPosition(modelRange.startLineNumber, modelRange.startColumn, PositionAffinity.Right);
-		let end = this.convertModelPositionToViewPosition(modelRange.endLineNumber, modelRange.endColumn, PositionAffinity.Left);
-		if (end.isBefore(start)) {
-			// If the range is empty, we don't want the range to get expanded just by converting to a view range
-			end = start;
+		if (modelRange.isEmpty()) {
+			const start = this.convertModelPositionToViewPosition(modelRange.startLineNumber, modelRange.startColumn, PositionAffinity.Left);
+			return Range.fromPositions(start);
+		} else {
+			const start = this.convertModelPositionToViewPosition(modelRange.startLineNumber, modelRange.startColumn, PositionAffinity.Right);
+			const end = this.convertModelPositionToViewPosition(modelRange.endLineNumber, modelRange.endColumn, PositionAffinity.Left);
+			return new Range(start.lineNumber, start.column, end.lineNumber, end.column);
 		}
-		return new Range(start.lineNumber, start.column, end.lineNumber, end.column);
 	}
 
 	private _getViewLineNumberForModelPosition(inputLineNumber: number, inputColumn: number): number {

--- a/src/vs/editor/test/common/viewModel/viewModelDecorations.test.ts
+++ b/src/vs/editor/test/common/viewModel/viewModelDecorations.test.ts
@@ -97,13 +97,37 @@ suite('ViewModelDecorations', () => {
 				'dec14',
 			]);
 
-			let inlineDecorations1 = viewModel.getViewLineRenderingData(
+			const inlineDecorations1 = viewModel.getViewLineRenderingData(
+				new Range(1, viewModel.getLineMinColumn(1), 2, viewModel.getLineMaxColumn(2)),
+				1
+			).inlineDecorations;
+
+			// view line 1: (1,1 -> 1,14)
+			assert.deepStrictEqual(inlineDecorations1, [
+				new InlineDecoration(new Range(1, 2, 1, 3), 'i-dec1', InlineDecorationType.Regular),
+				new InlineDecoration(new Range(1, 2, 1, 2), 'b-dec1', InlineDecorationType.Before),
+				new InlineDecoration(new Range(1, 3, 1, 3), 'a-dec1', InlineDecorationType.After),
+				new InlineDecoration(new Range(1, 2, 1, 14), 'i-dec2', InlineDecorationType.Regular),
+				new InlineDecoration(new Range(1, 2, 1, 2), 'b-dec2', InlineDecorationType.Before),
+				new InlineDecoration(new Range(1, 14, 1, 14), 'a-dec2', InlineDecorationType.After),
+				new InlineDecoration(new Range(1, 2, 2, 2), 'i-dec3', InlineDecorationType.Regular),
+				new InlineDecoration(new Range(1, 2, 1, 2), 'b-dec3', InlineDecorationType.Before),
+				new InlineDecoration(new Range(1, 2, 3, 13), 'i-dec4', InlineDecorationType.Regular),
+				new InlineDecoration(new Range(1, 2, 1, 2), 'b-dec4', InlineDecorationType.Before),
+				new InlineDecoration(new Range(1, 2, 5, 8), 'i-dec5', InlineDecorationType.Regular),
+				new InlineDecoration(new Range(1, 2, 1, 2), 'b-dec5', InlineDecorationType.Before),
+				new InlineDecoration(new Range(1, 14, 1, 14), 'i-dec6', InlineDecorationType.Regular),
+				new InlineDecoration(new Range(1, 14, 1, 14), 'b-dec6', InlineDecorationType.Before),
+				new InlineDecoration(new Range(1, 14, 1, 14), 'a-dec6', InlineDecorationType.After),
+			]);
+
+			const inlineDecorations2 = viewModel.getViewLineRenderingData(
 				new Range(2, viewModel.getLineMinColumn(2), 3, viewModel.getLineMaxColumn(3)),
 				2
 			).inlineDecorations;
 
 			// view line 2: (1,14 -> 1,24)
-			assert.deepStrictEqual(inlineDecorations1, [
+			assert.deepStrictEqual(inlineDecorations2, [
 				new InlineDecoration(new Range(1, 2, 2, 2), 'i-dec3', InlineDecorationType.Regular),
 				new InlineDecoration(new Range(2, 2, 2, 2), 'a-dec3', InlineDecorationType.After),
 				new InlineDecoration(new Range(1, 2, 3, 13), 'i-dec4', InlineDecorationType.Regular),
@@ -124,13 +148,13 @@ suite('ViewModelDecorations', () => {
 				new InlineDecoration(new Range(2, 3, 2, 3), 'b-dec12', InlineDecorationType.Before),
 			]);
 
-			let inlineDecorations2 = viewModel.getViewLineRenderingData(
+			const inlineDecorations3 = viewModel.getViewLineRenderingData(
 				new Range(2, viewModel.getLineMinColumn(2), 3, viewModel.getLineMaxColumn(3)),
 				3
 			).inlineDecorations;
 
 			// view line 3 (24 -> 36)
-			assert.deepStrictEqual(inlineDecorations2, [
+			assert.deepStrictEqual(inlineDecorations3, [
 				new InlineDecoration(new Range(1, 2, 3, 13), 'i-dec4', InlineDecorationType.Regular),
 				new InlineDecoration(new Range(3, 13, 3, 13), 'a-dec4', InlineDecorationType.After),
 				new InlineDecoration(new Range(1, 2, 5, 8), 'i-dec5', InlineDecorationType.Regular),

--- a/src/vs/editor/test/common/viewModel/viewModelDecorations.test.ts
+++ b/src/vs/editor/test/common/viewModel/viewModelDecorations.test.ts
@@ -49,7 +49,7 @@ suite('ViewModelDecorations', () => {
 				// starts before viewport, ends after viewport
 				accessor.addDecoration(new Range(1, 2, 1, 51), createOpts('dec5'));
 
-				// starts at viewport start, ends at viewport start
+				// starts at viewport start, ends at viewport start (will not be visible on view line 2)
 				accessor.addDecoration(new Range(1, 14, 1, 14), createOpts('dec6'));
 				// starts at viewport start, ends inside viewport
 				accessor.addDecoration(new Range(1, 14, 1, 16), createOpts('dec7'));
@@ -108,9 +108,6 @@ suite('ViewModelDecorations', () => {
 				new InlineDecoration(new Range(2, 2, 2, 2), 'a-dec3', InlineDecorationType.After),
 				new InlineDecoration(new Range(1, 2, 3, 13), 'i-dec4', InlineDecorationType.Regular),
 				new InlineDecoration(new Range(1, 2, 5, 8), 'i-dec5', InlineDecorationType.Regular),
-				new InlineDecoration(new Range(2, 1, 2, 1), 'i-dec6', InlineDecorationType.Regular),
-				new InlineDecoration(new Range(2, 1, 2, 1), 'b-dec6', InlineDecorationType.Before),
-				new InlineDecoration(new Range(2, 1, 2, 1), 'a-dec6', InlineDecorationType.After),
 				new InlineDecoration(new Range(2, 1, 2, 3), 'i-dec7', InlineDecorationType.Regular),
 				new InlineDecoration(new Range(2, 1, 2, 1), 'b-dec7', InlineDecorationType.Before),
 				new InlineDecoration(new Range(2, 3, 2, 3), 'a-dec7', InlineDecorationType.After),
@@ -143,6 +140,9 @@ suite('ViewModelDecorations', () => {
 				new InlineDecoration(new Range(2, 3, 3, 13), 'i-dec11', InlineDecorationType.Regular),
 				new InlineDecoration(new Range(3, 13, 3, 13), 'a-dec11', InlineDecorationType.After),
 				new InlineDecoration(new Range(2, 3, 5, 8), 'i-dec12', InlineDecorationType.Regular),
+				new InlineDecoration(new Range(3, 13, 3, 13), 'i-dec13', InlineDecorationType.Regular),
+				new InlineDecoration(new Range(3, 13, 3, 13), 'b-dec13', InlineDecorationType.Before),
+				new InlineDecoration(new Range(3, 13, 3, 13), 'a-dec13', InlineDecorationType.After),
 			]);
 		});
 	});


### PR DESCRIPTION
This is important when hover ranges are translated.

Before, they were right affine. A view range spanning injected text would map to an empty model range. When translated back to the view range, the hover got positioned right of the injected text.

![image](https://user-images.githubusercontent.com/2931520/124983611-78898180-e038-11eb-982d-2ae49c6b3347.png)

This fixes that.