### PR TITLE
Add scopes property to login telemetry

### DIFF
--- a/extensions/github-authentication/src/github.ts
+++ b/extensions/github-authentication/src/github.ts
@@ -196,9 +196,13 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 	public async createSession(scopes: string[]): Promise<vscode.AuthenticationSession> {
 		try {
 			/* __GDPR__
-				"login" : { }
+				"login" : {
+					"scopes": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" }
+				}
 			*/
-			this.telemetryReporter?.sendTelemetryEvent('login');
+			this.telemetryReporter?.sendTelemetryEvent('login', {
+				scopes: JSON.stringify(scopes),
+			});
 
 			const token = await this._githubServer.login(scopes.join(' '));
 			this.afterTokenLoad(token);

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -30,7 +30,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				*/
 				telemetryReporter.sendTelemetryEvent('login', {
 					// Get rid of guids from telemetry.
-					scopes: JSON.stringify(scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/, '{guid}'))),
+					scopes: JSON.stringify(scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i, '{guid}'))),
 				});
 
 				const session = await loginService.createSession(scopes.sort().join(' '));

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -24,9 +24,14 @@ export async function activate(context: vscode.ExtensionContext) {
 		createSession: async (scopes: string[]) => {
 			try {
 				/* __GDPR__
-					"login" : { }
+					"login" : {
+						"scopes": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" }
+					}
 				*/
-				telemetryReporter.sendTelemetryEvent('login');
+				telemetryReporter.sendTelemetryEvent('login', {
+					// Get rid of guids from telemetry.
+					scopes: JSON.stringify(scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/, '{guid}'))),
+				});
 
 				const session = await loginService.createSession(scopes.sort().join(' '));
 				onDidChangeSessions.fire({ added: [session], removed: [], changed: [] });


### PR DESCRIPTION
The result:
```
"Properties": {
	"scopes": "[\"read:user\",\"user:email\",\"repo\"]"
},
```

Note that for Micrsoft, we scrub any guids out.

cc @lszomoru 