### PR TITLE
Allow extension to control whether interactive window editor group is activated via options

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -258,14 +258,23 @@ registerAction2(class extends Action2 {
 			f1: false,
 			category: 'Interactive',
 			description: {
-				description: localize('notebookActions.executeNotebook', "Run All"),
+				description: localize('interactive.open', "Open Interactive Window"),
 				args: [
 					{
-						name: 'column',
-						description: 'View Column',
+						name: 'showOptions',
+						description: 'Show Options',
 						schema: {
-							type: 'number',
-							default: -1
+							type: 'object',
+							properties: {
+								'viewColumn': {
+									type: 'number',
+									default: -1
+								},
+								'preserveFocus': {
+									type: 'boolean',
+									default: true
+								}
+							},
 						}
 					},
 					{
@@ -284,12 +293,16 @@ registerAction2(class extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor, column?: number, resource?: URI, id?: string): Promise<{ notebookUri: URI, inputUri: URI; }> {
+	async run(accessor: ServicesAccessor, showOptions?: { viewColumn?: number, preserveFocus?: boolean }, resource?: URI, id?: string): Promise<{ notebookUri: URI, inputUri: URI; }> {
 		const editorService = accessor.get(IEditorService);
 		const editorGroupService = accessor.get(IEditorGroupsService);
 		const historyService = accessor.get(IInteractiveHistoryService);
 		const kernelService = accessor.get(INotebookKernelService);
-		const group = columnToEditorGroup(editorGroupService, column);
+		const group = columnToEditorGroup(editorGroupService, showOptions?.viewColumn);
+		const editorOptions = {
+			activation: EditorActivation.PRESERVE,
+			preserveFocus: showOptions?.preserveFocus || true
+		};
 
 		if (resource && resource.scheme === Schemas.vscodeInteractive) {
 			const resourceUri = URI.revive(resource);
@@ -297,7 +310,7 @@ registerAction2(class extends Action2 {
 			if (editors.length) {
 				const editorInput = editors[0].editor as InteractiveEditorInput;
 				const currentGroup = editors[0].groupId;
-				await editorService.openEditor(editorInput, { activation: EditorActivation.PRESERVE, preserveFocus: true }, currentGroup);
+				await editorService.openEditor(editorInput, editorOptions, currentGroup);
 				return {
 					notebookUri: editorInput.resource!,
 					inputUri: editorInput.inputResource
@@ -332,7 +345,7 @@ registerAction2(class extends Action2 {
 
 		const editorInput = InteractiveEditorInput.create(accessor.get(IInstantiationService), notebookUri, inputUri);
 		historyService.clearHistory(notebookUri);
-		await editorService.openEditor(editorInput, undefined, group);
+		await editorService.openEditor(editorInput, editorOptions, group);
 		// Extensions must retain references to these URIs to manipulate the interactive editor
 		return { notebookUri, inputUri };
 	}

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -293,15 +293,15 @@ registerAction2(class extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor, showOptions?: { viewColumn?: number, preserveFocus?: boolean }, resource?: URI, id?: string): Promise<{ notebookUri: URI, inputUri: URI; }> {
+	async run(accessor: ServicesAccessor, showOptions?: number | { viewColumn?: number, preserveFocus?: boolean }, resource?: URI, id?: string): Promise<{ notebookUri: URI, inputUri: URI; }> {
 		const editorService = accessor.get(IEditorService);
 		const editorGroupService = accessor.get(IEditorGroupsService);
 		const historyService = accessor.get(IInteractiveHistoryService);
 		const kernelService = accessor.get(INotebookKernelService);
-		const group = columnToEditorGroup(editorGroupService, showOptions?.viewColumn);
+		const group = columnToEditorGroup(editorGroupService, typeof showOptions === 'number' ? showOptions : showOptions?.viewColumn);
 		const editorOptions = {
 			activation: EditorActivation.PRESERVE,
-			preserveFocus: showOptions?.preserveFocus || true
+			preserveFocus: typeof showOptions !== 'number' ? showOptions?.preserveFocus : true
 		};
 
 		if (resource && resource.scheme === Schemas.vscodeInteractive) {

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -301,7 +301,7 @@ registerAction2(class extends Action2 {
 		const group = columnToEditorGroup(editorGroupService, typeof showOptions === 'number' ? showOptions : showOptions?.viewColumn);
 		const editorOptions = {
 			activation: EditorActivation.PRESERVE,
-			preserveFocus: typeof showOptions !== 'number' ? showOptions?.preserveFocus : true
+			preserveFocus: typeof showOptions !== 'number' ? (showOptions?.preserveFocus ?? false) : false
 		};
 
 		if (resource && resource.scheme === Schemas.vscodeInteractive) {


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR is required to fix https://github.com/microsoft/vscode-jupyter/issues/6496

TLDR the Jupyter extension needs the ability to set focus to the interactive window, in order for the embedded NotebookDocument to show up in window.activeNotebookEditor so we can use NotebookEditor.revealRange to scroll to a specific cell