### PR TITLE
Adopt injected text for ghost text

### DIFF
--- a/src/vs/editor/common/viewModel/splitLinesCollection.ts
+++ b/src/vs/editor/common/viewModel/splitLinesCollection.ts
@@ -1246,7 +1246,7 @@ export class SplitLine implements ISplitLine {
 
 		let r: string;
 		if (this._lineBreakData.injectionOffsets !== null) {
-			const injectedTexts = this._lineBreakData.injectionOffsets.map((offset, idx) => new LineInjectedText(0, 0, offset, this._lineBreakData.injectionOptions![idx], 0));
+			const injectedTexts = this._lineBreakData.injectionOffsets.map((offset, idx) => new LineInjectedText(0, 0, offset + 1, this._lineBreakData.injectionOptions![idx], 0));
 			r = LineInjectedText.applyInjectedText(model.getLineContent(modelLineNumber), injectedTexts).substring(startOffset, endOffset);
 		} else {
 			r = model.getValueInRange({

--- a/src/vs/editor/contrib/inlineCompletions/test/inlineCompletionsProvider.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/inlineCompletionsProvider.test.ts
@@ -75,6 +75,12 @@ suite('Inline Completions', () => {
 		test('Multi Part Diffing', () => {
 			assert.deepStrictEqual(getOutput('foo[()]', '(x);'), { prefix: undefined, subword: 'foo([x])[;]' });
 			assert.deepStrictEqual(getOutput('[\tfoo]', '\t\tfoobar'), { prefix: undefined, subword: '\t[\t]foo[bar]' });
+			assert.deepStrictEqual(getOutput('[(y ===)]', '(y === 1) { f(); }'), { prefix: undefined, subword: '(y ===[ 1])[ { f(); }]' });
+			assert.deepStrictEqual(getOutput('[(y ==)]', '(y === 1) { f(); }'), { prefix: undefined, subword: '(y ==[= 1])[ { f(); }]' });
+		});
+
+		test('Multi Part Diffing 1', () => {
+			assert.deepStrictEqual(getOutput('[if () ()]', 'if (1 == f()) ()'), { prefix: undefined, subword: 'if ([1 == f()]) ()' });
 		});
 	});
 

--- a/src/vs/editor/test/common/viewModel/splitLinesCollection.test.ts
+++ b/src/vs/editor/test/common/viewModel/splitLinesCollection.test.ts
@@ -408,6 +408,10 @@ suite('SplitLinesCollection', () => {
 
 	function assertAllMinimapLinesRenderingData(splitLinesCollection: SplitLinesCollection, all: ITestMinimapLineRenderingData[]): void {
 		let lineCount = all.length;
+		for (let line = 1; line <= lineCount; line++) {
+			assert.strictEqual(splitLinesCollection.getViewLineData(line).content, splitLinesCollection.getViewLineContent(line));
+		}
+
 		for (let start = 1; start <= lineCount; start++) {
 			for (let end = start; end <= lineCount; end++) {
 				let count = end - start + 1;
@@ -419,6 +423,7 @@ suite('SplitLinesCollection', () => {
 						expected[i] = (needed[i] ? all[start - 1 + i] : null);
 					}
 					let actual = splitLinesCollection.getViewLinesData(start, end, needed);
+
 					assertMinimapLinesRenderingData(actual, expected);
 					// Comment out next line to test all possible combinations
 					break;


### PR DESCRIPTION
This PR switches the implementation of ghost from before/after css classes to injected text.

Use `editor.useInjectedText: false` to go back to before/after css classes.

Fixes #125742, #126537, #125324 and #125123.