### PR TITLE
Use platform specific default value for separator

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -414,6 +414,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize('copyRelativePathSeparator.backslash', "Use backslash as path separation character."),
 			],
 			'description': nls.localize('copyRelativePathSeparator', "The path separation character used when copying relative file paths. Will use the operating system default unless specified."),
+			'default': isWindows ? '\\' : '/'
 		}
 	}
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #128345

This PR naively sets explicit default value that should match current behavior on Windows.

P.S. @bpasero I tried to use Copy Relative Path in web version (lauched as `yarn web` as I don't have access to Codespaces), however it always copies with `\\` independently from setting. Is it expected behavior or I should file new issue for web version?