### PR TITLE
Allow extension to set focus to selections in notebook editor

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -472,7 +472,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditor 
 		const focus = this.viewModel.getFocus();
 		this.viewModel.updateSelectionsState({
 			kind: SelectionStateType.Index,
-			focus: focus,
+			focus: selections.length === 1 ? selections[0] : focus,
 			selections: selections
 		});
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR is required to implement https://github.com/microsoft/vscode-jupyter/issues/6496

`NotebookEditor.setSelections` currently preserves the existing focus. I'd expect it to also set focus to the given range. 

Alternatively we could introduce a `NotebookEditor.setFocus` API or a `notebook.cell.focus` command. The Jupyter extension just needs some way to set focus to an arbitrary notebook cell (existing commands allow you to focus the first or last cell).
