### PR TITLE
Add Fold Jumping (Parent and Next/Previous at Same Level)

### DIFF
--- a/src/vs/editor/contrib/folding/folding.ts
+++ b/src/vs/editor/contrib/folding/folding.ts
@@ -947,7 +947,6 @@ class JumpToParentFoldAction extends FoldingAction<void> {
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.WinCtrl | KeyCode.KEY_F, KeyCode.KEY_P),
 				weight: KeybindingWeight.EditorContrib
 			}
 		});
@@ -979,7 +978,6 @@ class JumpToPreviousFoldAction extends FoldingAction<void> {
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.WinCtrl | KeyCode.KEY_F, KeyCode.UpArrow),
 				weight: KeybindingWeight.EditorContrib
 			}
 		});
@@ -1011,7 +1009,6 @@ class JumpToNextFoldAction extends FoldingAction<void> {
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.WinCtrl | KeyCode.KEY_F, KeyCode.DownArrow),
 				weight: KeybindingWeight.EditorContrib
 			}
 		});


### PR DESCRIPTION
This adds 3 keyboard shortcuts to jump between folds.
- Current line to parent fold (Ctrl-F, P). "P" for parent.
- Current line to previous fold at the same level. (Ctrl-F, Up)
- Current line to next fold at the same level. (Ctrl-F, Down)

By restricting the previous and next folds to the current level.  It makes it easy to navigate the different cases of `if`/`else` statements.

This PR fixes #91023.

I updated the unit test for this.  You can also test by opening a file with folds and try out the keyboard shortcuts.