### PR TITLE
Do not disable dependent if its dependency is disabled by extension kind

### DIFF
--- a/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
@@ -354,7 +354,8 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 		}
 		try {
 			for (const dependencyExtension of dependencyExtensions) {
-				if (!this._isEnabledEnablementState(this._computeEnablementState(dependencyExtension, extensions, computedEnablementStates))) {
+				const enablementState = this._computeEnablementState(dependencyExtension, extensions, computedEnablementStates);
+				if (!this._isEnabledEnablementState(enablementState) && enablementState !== EnablementState.DisabledByExtensionKind) {
 					return true;
 				}
 			}


### PR DESCRIPTION
This PR fixes #128375

Do not disable dependent if its dependency is disabled by extension kind because extension host support cross extension host dependencies
