### PR TITLE
Skip acquiring workspace storage locks on the local nodejs extension host

### DIFF
--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -76,6 +76,7 @@ export interface IEnvironment {
 	globalStorageHome: URI;
 	workspaceStorageHome: URI;
 	useHostProxy?: boolean;
+	skipWorkspaceStorageLock?: boolean;
 }
 
 export interface IStaticWorkspaceData {

--- a/src/vs/workbench/api/node/extHostStoragePaths.ts
+++ b/src/vs/workbench/api/node/extHostStoragePaths.ts
@@ -22,6 +22,11 @@ export class ExtensionStoragePaths extends CommonExtensionStoragePaths {
 			return workspaceStorageURI;
 		}
 
+		if (this._environment.skipWorkspaceStorageLock) {
+			this._logService.info(`Skipping acquiring lock for ${workspaceStorageURI.fsPath}.`);
+			return workspaceStorageURI;
+		}
+
 		const workspaceStorageBase = workspaceStorageURI.fsPath;
 		let attempt = 0;
 		do {

--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -238,7 +238,7 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 				}
 
 				// Run Extension Host as fork of current process
-				this._extensionHostProcess = fork(FileAccess.asFileUri('bootstrap-fork', require).fsPath, ['--type=extensionHost'], opts);
+				this._extensionHostProcess = fork(FileAccess.asFileUri('bootstrap-fork', require).fsPath, ['--type=extensionHost', '--skipWorkspaceStorageLock'], opts);
 
 				// Catch all output coming from the extension host process
 				type Output = { data: string, format: string[] };

--- a/src/vs/workbench/services/extensions/node/extensionHostProcessSetup.ts
+++ b/src/vs/workbench/services/extensions/node/extensionHostProcessSetup.ts
@@ -22,12 +22,14 @@ import { Promises } from 'vs/base/node/pfs';
 import { realpath } from 'vs/base/node/extpath';
 import { IHostUtils } from 'vs/workbench/api/common/extHostExtensionService';
 import { RunOnceScheduler } from 'vs/base/common/async';
+import { boolean } from 'vs/editor/common/config/editorOptions';
 
 import 'vs/workbench/api/common/extHost.common.services';
 import 'vs/workbench/api/node/extHost.node.services';
 
 interface ParsedExtHostArgs {
 	uriTransformerPath?: string;
+	skipWorkspaceStorageLock?: boolean;
 	useHostProxy?: string;
 }
 
@@ -46,6 +48,9 @@ const args = minimist(process.argv.slice(2), {
 	string: [
 		'uriTransformerPath',
 		'useHostProxy'
+	],
+	boolean: [
+		'skipWorkspaceStorageLock'
 	]
 }) as ParsedExtHostArgs;
 
@@ -323,6 +328,7 @@ export async function startExtensionHostProcess(): Promise<void> {
 	// setup things
 	patchProcess(!!initData.environment.extensionTestsLocationURI); // to support other test frameworks like Jasmin that use process.exit (https://github.com/microsoft/vscode/issues/37708)
 	initData.environment.useHostProxy = args.useHostProxy !== undefined ? args.useHostProxy !== 'false' : undefined;
+	initData.environment.skipWorkspaceStorageLock = boolean(args.skipWorkspaceStorageLock, false);
 
 	// host abstraction
 	const hostUtils = new class NodeHost implements IHostUtils {


### PR DESCRIPTION
Fixes #128528

* adds a new command line flag to the extension host called `--skipWorkspaceStorageLock`.
* this is used to skip acquiring a lock for the workspace storage.
* this is then exercised by the local process extension host spawning code.