### PR TITLE
Improve defaults for dockercompose language

### DIFF
--- a/extensions/yaml/package.json
+++ b/extensions/yaml/package.json
@@ -62,6 +62,11 @@
         "editor.insertSpaces": true,
         "editor.tabSize": 2,
         "editor.autoIndent": "advanced"
+      },
+      "[dockercompose]": {
+        "editor.insertSpaces": true,
+        "editor.tabSize": 2,
+        "editor.autoIndent": "advanced"
       }
     }
   },


### PR DESCRIPTION
The Docker Compose language will benefit from the same defaults that vanilla YAML. See https://github.com/microsoft/vscode-docker/issues/3057 for an example of customer-submitted issue illustrating this.

This PR fixes https://github.com/microsoft/vscode-docker/issues/3057

@alexr00 FYI
