### PR TITLE
Resolve all time-based snippet variables using the same time

### DIFF
--- a/src/vs/editor/contrib/snippet/snippetVariables.ts
+++ b/src/vs/editor/contrib/snippet/snippetVariables.ts
@@ -255,33 +255,37 @@ export class TimeBasedVariableResolver implements VariableResolver {
 	private static readonly monthNames = [nls.localize('January', "January"), nls.localize('February', "February"), nls.localize('March', "March"), nls.localize('April', "April"), nls.localize('May', "May"), nls.localize('June', "June"), nls.localize('July', "July"), nls.localize('August', "August"), nls.localize('September', "September"), nls.localize('October', "October"), nls.localize('November', "November"), nls.localize('December', "December")];
 	private static readonly monthNamesShort = [nls.localize('JanuaryShort', "Jan"), nls.localize('FebruaryShort', "Feb"), nls.localize('MarchShort', "Mar"), nls.localize('AprilShort', "Apr"), nls.localize('MayShort', "May"), nls.localize('JuneShort', "Jun"), nls.localize('JulyShort', "Jul"), nls.localize('AugustShort', "Aug"), nls.localize('SeptemberShort', "Sep"), nls.localize('OctoberShort', "Oct"), nls.localize('NovemberShort', "Nov"), nls.localize('DecemberShort', "Dec")];
 
+	constructor(private readonly _date: Date = new Date()) {
+		//
+	}
+
 	resolve(variable: Variable): string | undefined {
 		const { name } = variable;
 
 		if (name === 'CURRENT_YEAR') {
-			return String(new Date().getFullYear());
+			return String(this._date.getFullYear());
 		} else if (name === 'CURRENT_YEAR_SHORT') {
-			return String(new Date().getFullYear()).slice(-2);
+			return String(this._date.getFullYear()).slice(-2);
 		} else if (name === 'CURRENT_MONTH') {
-			return String(new Date().getMonth().valueOf() + 1).padStart(2, '0');
+			return String(this._date.getMonth().valueOf() + 1).padStart(2, '0');
 		} else if (name === 'CURRENT_DATE') {
-			return String(new Date().getDate().valueOf()).padStart(2, '0');
+			return String(this._date.getDate().valueOf()).padStart(2, '0');
 		} else if (name === 'CURRENT_HOUR') {
-			return String(new Date().getHours().valueOf()).padStart(2, '0');
+			return String(this._date.getHours().valueOf()).padStart(2, '0');
 		} else if (name === 'CURRENT_MINUTE') {
-			return String(new Date().getMinutes().valueOf()).padStart(2, '0');
+			return String(this._date.getMinutes().valueOf()).padStart(2, '0');
 		} else if (name === 'CURRENT_SECOND') {
-			return String(new Date().getSeconds().valueOf()).padStart(2, '0');
+			return String(this._date.getSeconds().valueOf()).padStart(2, '0');
 		} else if (name === 'CURRENT_DAY_NAME') {
-			return TimeBasedVariableResolver.dayNames[new Date().getDay()];
+			return TimeBasedVariableResolver.dayNames[this._date.getDay()];
 		} else if (name === 'CURRENT_DAY_NAME_SHORT') {
-			return TimeBasedVariableResolver.dayNamesShort[new Date().getDay()];
+			return TimeBasedVariableResolver.dayNamesShort[this._date.getDay()];
 		} else if (name === 'CURRENT_MONTH_NAME') {
-			return TimeBasedVariableResolver.monthNames[new Date().getMonth()];
+			return TimeBasedVariableResolver.monthNames[this._date.getMonth()];
 		} else if (name === 'CURRENT_MONTH_NAME_SHORT') {
-			return TimeBasedVariableResolver.monthNamesShort[new Date().getMonth()];
+			return TimeBasedVariableResolver.monthNamesShort[this._date.getMonth()];
 		} else if (name === 'CURRENT_SECONDS_UNIX') {
-			return String(Math.floor(Date.now() / 1000));
+			return String(Math.floor(this._date.getTime() / 1000));
 		}
 
 		return undefined;

--- a/src/vs/editor/contrib/snippet/test/snippetVariables.test.ts
+++ b/src/vs/editor/contrib/snippet/test/snippetVariables.test.ts
@@ -17,6 +17,7 @@ import { Workspace } from 'vs/platform/workspace/test/common/testWorkspace';
 import { extUriBiasedIgnorePathCase } from 'vs/base/common/resources';
 import { sep } from 'vs/base/common/path';
 import { toWorkspaceFolders } from 'vs/platform/workspaces/common/workspaces';
+import * as sinon from 'sinon';
 
 suite('Snippet Variables Resolver', function () {
 
@@ -289,6 +290,36 @@ suite('Snippet Variables Resolver', function () {
 		assertVariableResolve3(resolver, 'CURRENT_MONTH_NAME');
 		assertVariableResolve3(resolver, 'CURRENT_MONTH_NAME_SHORT');
 		assertVariableResolve3(resolver, 'CURRENT_SECONDS_UNIX');
+	});
+
+	test('Time-based snippet variables resolve to the same values even as time progresses', async function () {
+		const snippetText = `
+			$CURRENT_YEAR
+			$CURRENT_YEAR_SHORT
+			$CURRENT_MONTH
+			$CURRENT_DATE
+			$CURRENT_HOUR
+			$CURRENT_MINUTE
+			$CURRENT_SECOND
+			$CURRENT_DAY_NAME
+			$CURRENT_DAY_NAME_SHORT
+			$CURRENT_MONTH_NAME
+			$CURRENT_MONTH_NAME_SHORT
+			$CURRENT_SECONDS_UNIX
+		`;
+
+		const clock = sinon.useFakeTimers();
+		try {
+			const resolver = new TimeBasedVariableResolver;
+
+			const firstResolve = new SnippetParser().parse(snippetText).resolveVariables(resolver);
+			clock.tick((365 * 24 * 3600 * 1000) + (24 * 3600 * 1000) + (3661 * 1000));  // 1 year + 1 day + 1 hour + 1 minute + 1 second
+			const secondResolve = new SnippetParser().parse(snippetText).resolveVariables(resolver);
+
+			assert.strictEqual(firstResolve.toString(), secondResolve.toString(), `Time-based snippet variables resolved differently`);
+		} finally {
+			clock.restore();
+		}
 	});
 
 	test('creating snippet - format-condition doesn\'t work #53617', function () {


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes #128570

### What approach did you choose and why?

Since `TimeBasedVariableResolver` is only used as part of `CompositeSnippetVariableResolver` and immediately used to resolve all the variables in a snippet, I added the time as a field on `TimeBasedVariableResolver` without worrying about it getting stale.

### The impact of these changes

All the time-based snippet variables in a snippet will resolve using the same time, fixing #128570

### Checklist
- [x] I have manually tested this change. 
- [x] This PR is safe to roll back.
