### PR TITLE
Adopts injected text for inlay text.

### DIFF
--- a/src/vs/editor/browser/services/codeEditorServiceImpl.ts
+++ b/src/vs/editor/browser/services/codeEditorServiceImpl.ts
@@ -251,6 +251,7 @@ export class DecorationTypeOptionsProvider implements IModelDecorationOptionsPro
 	public overviewRuler: IModelDecorationOverviewRulerOptions | undefined;
 	public stickiness: TrackedRangeStickiness | undefined;
 	public beforeInjectedText: InjectedTextOptions | undefined;
+	public afterInjectedText: InjectedTextOptions | undefined;
 
 	constructor(description: string, themeService: IThemeService, styleSheet: GlobalStyleSheet | RefCountedStyleSheet, providerArgs: ProviderArguments) {
 		this.description = description;
@@ -291,6 +292,15 @@ export class DecorationTypeOptionsProvider implements IModelDecorationOptionsPro
 				content: providerArgs.options.beforeInjectedText.contentText,
 				inlineClassName: beforeInlineData?.className,
 				inlineClassNameAffectsLetterSpacing: beforeInlineData?.hasLetterSpacing || providerArgs.options.beforeInjectedText.affectsLetterSpacing
+			};
+		}
+
+		if (providerArgs.options.afterInjectedText && providerArgs.options.afterInjectedText.contentText) {
+			const afterInlineData = createInlineCSSRules(ModelDecorationCSSRuleType.AfterInjectedTextClassName);
+			this.afterInjectedText = {
+				content: providerArgs.options.afterInjectedText.contentText,
+				inlineClassName: afterInlineData?.className,
+				inlineClassNameAffectsLetterSpacing: afterInlineData?.hasLetterSpacing || providerArgs.options.afterInjectedText.affectsLetterSpacing
 			};
 		}
 
@@ -479,6 +489,11 @@ class DecorationCSSRules {
 				lightCSS = this.getCSSTextForModelDecorationContentClassName(options.light && options.light.beforeInjectedText);
 				darkCSS = this.getCSSTextForModelDecorationContentClassName(options.dark && options.dark.beforeInjectedText);
 				break;
+			case ModelDecorationCSSRuleType.AfterInjectedTextClassName:
+				unthemedCSS = this.getCSSTextForModelDecorationContentClassName(options.afterInjectedText);
+				lightCSS = this.getCSSTextForModelDecorationContentClassName(options.light && options.light.afterInjectedText);
+				darkCSS = this.getCSSTextForModelDecorationContentClassName(options.dark && options.dark.afterInjectedText);
+				break;
 			default:
 				throw new Error('Unknown rule type: ' + this._ruleType);
 		}
@@ -620,6 +635,7 @@ const enum ModelDecorationCSSRuleType {
 	BeforeContentClassName = 3,
 	AfterContentClassName = 4,
 	BeforeInjectedTextClassName = 5,
+	AfterInjectedTextClassName = 6,
 }
 
 class CSSNameHelper {

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -622,6 +622,7 @@ export interface IThemeDecorationRenderOptions {
 	after?: IContentDecorationRenderOptions;
 
 	beforeInjectedText?: IContentDecorationRenderOptions & { affectsLetterSpacing?: boolean };
+	afterInjectedText?: IContentDecorationRenderOptions & { affectsLetterSpacing?: boolean };
 }
 
 /**

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -620,6 +620,8 @@ export interface IThemeDecorationRenderOptions {
 
 	before?: IContentDecorationRenderOptions;
 	after?: IContentDecorationRenderOptions;
+
+	beforeInjectedText?: IContentDecorationRenderOptions & { affectsLetterSpacing?: boolean };
 }
 
 /**

--- a/src/vs/editor/contrib/inlayHints/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/inlayHintsController.ts
@@ -26,7 +26,7 @@ import { IRange } from 'vs/base/common/range';
 import { assertType } from 'vs/base/common/types';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { Position } from 'vs/editor/common/core/position';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 const MAX_DECORATORS = 500;
 
@@ -66,7 +66,7 @@ export class InlayHintsController implements IEditorContribution {
 		private readonly _editor: ICodeEditor,
 		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService,
 		@IThemeService private readonly _themeService: IThemeService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		this._disposables.add(InlayHintsProviderRegistry.onDidChange(() => this._update()));
 		this._disposables.add(_themeService.onDidColorThemeChange(() => this._update()));
@@ -147,7 +147,7 @@ export class InlayHintsController implements IEditorContribution {
 		const fontFamilyVar = '--inlayHintsFontFamily';
 		this._editor.getContainerDomNode().style.setProperty(fontFamilyVar, fontFamily);
 
-		const key = this._contextKeyService.getContextKeyValue('config.editor.useInjectedText');
+		const key = this._configurationService.getValue('editor.useInjectedText');
 		const shouldUseInjectedText = key === undefined ? true : !!key;
 
 		for (const { list: hints } of hintsData) {

--- a/src/vs/editor/contrib/inlayHints/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/inlayHintsController.ts
@@ -26,6 +26,7 @@ import { IRange } from 'vs/base/common/range';
 import { assertType } from 'vs/base/common/types';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { Position } from 'vs/editor/common/core/position';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 const MAX_DECORATORS = 500;
 
@@ -65,6 +66,7 @@ export class InlayHintsController implements IEditorContribution {
 		private readonly _editor: ICodeEditor,
 		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService,
 		@IThemeService private readonly _themeService: IThemeService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService
 	) {
 		this._disposables.add(InlayHintsProviderRegistry.onDidChange(() => this._update()));
 		this._disposables.add(_themeService.onDidColorThemeChange(() => this._update()));
@@ -145,6 +147,9 @@ export class InlayHintsController implements IEditorContribution {
 		const fontFamilyVar = '--inlayHintsFontFamily';
 		this._editor.getContainerDomNode().style.setProperty(fontFamilyVar, fontFamily);
 
+		const key = this._contextKeyService.getContextKeyValue('config.editor.useInjectedText');
+		const shouldUseInjectedText = key === undefined ? true : !!key;
+
 		for (const { list: hints } of hintsData) {
 
 			for (let j = 0; j < hints.length && newDecorationsData.length < MAX_DECORATORS; j++) {
@@ -163,7 +168,8 @@ export class InlayHintsController implements IEditorContribution {
 					borderRadius: `${(fontSize / 4) | 0}px`,
 				};
 				const key = 'inlayHints-' + hash(before).toString(16);
-				this._codeEditorService.registerDecorationType('inlay-hints-controller', key, { before }, undefined, this._editor);
+				this._codeEditorService.registerDecorationType('inlay-hints-controller', key,
+					shouldUseInjectedText ? { beforeInjectedText: { ...before, affectsLetterSpacing: true } } : { before }, undefined, this._editor);
 
 				// decoration types are ref-counted which means we only need to
 				// call register und remove equally often


### PR DESCRIPTION
* Extends CodeEditorService to register rich decorations for injected text.
* Adopts injected text for inlay text.

FYI @jrieken @mjbvz @Kingwl

At some point, `beforeInjectedText`/`afterInjectedText` should replace `before`/`after`.
However, that is a breaking change, as you can insert css decorations (e.g. symbols) with `before` (without any text), but this is not possible with injected text. By design, injected text has no effect if the injected text is empty.

Use `editor.useInjectedText: false` to go back to before/after css decorations.