### PR TITLE
change seedSearchStringFromSelection to enum never, always, selectionOnly

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1356,7 +1356,7 @@ export interface IEditorFindOptions {
 	/**
 	 * Controls if we seed search string in the Find Widget with editor selection.
 	 */
-	seedSearchStringFromSelection?: boolean;
+	seedSearchStringFromSelection?: 'never' | 'always' | 'selectionOnly';
 	/**
 	 * Controls if Find in Selection flag is turned on in the editor.
 	 */
@@ -1383,7 +1383,7 @@ class EditorFind extends BaseEditorOption<EditorOption.find, EditorFindOptions> 
 	constructor() {
 		const defaults: EditorFindOptions = {
 			cursorMoveOnType: true,
-			seedSearchStringFromSelection: true,
+			seedSearchStringFromSelection: 'always',
 			autoFindInSelection: 'never',
 			globalFindClipboard: false,
 			addExtraSpaceOnTop: true,
@@ -1398,8 +1398,14 @@ class EditorFind extends BaseEditorOption<EditorOption.find, EditorFindOptions> 
 					description: nls.localize('find.cursorMoveOnType', "Controls whether the cursor should jump to find matches while typing.")
 				},
 				'editor.find.seedSearchStringFromSelection': {
-					type: 'boolean',
+					type: 'string',
+					enum: ['never', 'always', 'selectionOnly'],
 					default: defaults.seedSearchStringFromSelection,
+					enumDescriptions: [
+						nls.localize('editor.find.seedSearchStringFromSelection.never', 'Never seed search string from the editor selection.'),
+						nls.localize('editor.find.seedSearchStringFromSelection.always', 'Always seed search string from the editor selection, including word at cursor position.'),
+						nls.localize('editor.find.seedSearchStringFromSelection.selectionOnly', 'Only seed search string from the editor selection.')
+					],
 					description: nls.localize('find.seedSearchStringFromSelection', "Controls whether the search string in the Find Widget is seeded from the editor selection.")
 				},
 				'editor.find.autoFindInSelection': {
@@ -1441,7 +1447,7 @@ class EditorFind extends BaseEditorOption<EditorOption.find, EditorFindOptions> 
 		const input = _input as IEditorFindOptions;
 		return {
 			cursorMoveOnType: boolean(input.cursorMoveOnType, this.defaultValue.cursorMoveOnType),
-			seedSearchStringFromSelection: boolean(input.seedSearchStringFromSelection, this.defaultValue.seedSearchStringFromSelection),
+			seedSearchStringFromSelection: stringSet<'never' | 'always' | 'selectionOnly'>(input.seedSearchStringFromSelection, this.defaultValue.seedSearchStringFromSelection, ['never', 'always', 'selectionOnly']),
 			autoFindInSelection: typeof _input.autoFindInSelection === 'boolean'
 				? (_input.autoFindInSelection ? 'always' : 'never')
 				: stringSet<'never' | 'always' | 'multiline'>(input.autoFindInSelection, this.defaultValue.autoFindInSelection, ['never', 'always', 'multiline']),

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1356,7 +1356,7 @@ export interface IEditorFindOptions {
 	/**
 	 * Controls if we seed search string in the Find Widget with editor selection.
 	 */
-	seedSearchStringFromSelection?: 'never' | 'always' | 'selectionOnly';
+	seedSearchStringFromSelection?: 'never' | 'always' | 'selection';
 	/**
 	 * Controls if Find in Selection flag is turned on in the editor.
 	 */
@@ -1399,12 +1399,12 @@ class EditorFind extends BaseEditorOption<EditorOption.find, EditorFindOptions> 
 				},
 				'editor.find.seedSearchStringFromSelection': {
 					type: 'string',
-					enum: ['never', 'always', 'selectionOnly'],
+					enum: ['never', 'always', 'selection'],
 					default: defaults.seedSearchStringFromSelection,
 					enumDescriptions: [
 						nls.localize('editor.find.seedSearchStringFromSelection.never', 'Never seed search string from the editor selection.'),
 						nls.localize('editor.find.seedSearchStringFromSelection.always', 'Always seed search string from the editor selection, including word at cursor position.'),
-						nls.localize('editor.find.seedSearchStringFromSelection.selectionOnly', 'Only seed search string from the editor selection.')
+						nls.localize('editor.find.seedSearchStringFromSelection.selection', 'Only seed search string from the editor selection.')
 					],
 					description: nls.localize('find.seedSearchStringFromSelection', "Controls whether the search string in the Find Widget is seeded from the editor selection.")
 				},
@@ -1447,7 +1447,9 @@ class EditorFind extends BaseEditorOption<EditorOption.find, EditorFindOptions> 
 		const input = _input as IEditorFindOptions;
 		return {
 			cursorMoveOnType: boolean(input.cursorMoveOnType, this.defaultValue.cursorMoveOnType),
-			seedSearchStringFromSelection: stringSet<'never' | 'always' | 'selectionOnly'>(input.seedSearchStringFromSelection, this.defaultValue.seedSearchStringFromSelection, ['never', 'always', 'selectionOnly']),
+			seedSearchStringFromSelection: typeof _input.seedSearchStringFromSelection === 'boolean'
+				? (_input.seedSearchStringFromSelection ? 'always' : 'never')
+				: stringSet<'never' | 'always' | 'selection'>(input.seedSearchStringFromSelection, this.defaultValue.seedSearchStringFromSelection, ['never', 'always', 'selection']),
 			autoFindInSelection: typeof _input.autoFindInSelection === 'boolean'
 				? (_input.autoFindInSelection ? 'always' : 'never')
 				: stringSet<'never' | 'always' | 'multiline'>(input.autoFindInSelection, this.defaultValue.autoFindInSelection, ['never', 'always', 'multiline']),

--- a/src/vs/editor/contrib/find/test/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/findController.test.ts
@@ -284,6 +284,7 @@ suite('FindController', async () => {
 			await findController.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
+				seedSearchStringFromSelectionOnly: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.FocusFindInput,
 				shouldAnimate: false,
@@ -310,6 +311,7 @@ suite('FindController', async () => {
 			await findController.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
+				seedSearchStringFromSelectionOnly: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: false,
@@ -591,6 +593,7 @@ suite('FindController query options persistence', async () => {
 			const findConfig: IFindStartOptions = {
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
+				seedSearchStringFromSelectionOnly: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: false,
@@ -623,6 +626,7 @@ suite('FindController query options persistence', async () => {
 			await findController.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
+				seedSearchStringFromSelectionOnly: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: false,
@@ -647,6 +651,7 @@ suite('FindController query options persistence', async () => {
 			await findController.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
+				seedSearchStringFromSelectionOnly: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: false,
@@ -672,6 +677,7 @@ suite('FindController query options persistence', async () => {
 			await findController.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
+				seedSearchStringFromSelectionOnly: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: false,

--- a/src/vs/editor/contrib/find/test/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/findController.test.ts
@@ -284,7 +284,7 @@ suite('FindController', async () => {
 			await findController.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
-				seedSearchStringFromSelectionOnly: false,
+				seedSearchStringFromNonEmptySelection: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.FocusFindInput,
 				shouldAnimate: false,
@@ -311,7 +311,7 @@ suite('FindController', async () => {
 			await findController.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
-				seedSearchStringFromSelectionOnly: false,
+				seedSearchStringFromNonEmptySelection: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: false,
@@ -593,7 +593,7 @@ suite('FindController query options persistence', async () => {
 			const findConfig: IFindStartOptions = {
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
-				seedSearchStringFromSelectionOnly: false,
+				seedSearchStringFromNonEmptySelection: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: false,
@@ -626,7 +626,7 @@ suite('FindController query options persistence', async () => {
 			await findController.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
-				seedSearchStringFromSelectionOnly: false,
+				seedSearchStringFromNonEmptySelection: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: false,
@@ -651,7 +651,7 @@ suite('FindController query options persistence', async () => {
 			await findController.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
-				seedSearchStringFromSelectionOnly: false,
+				seedSearchStringFromNonEmptySelection: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: false,
@@ -677,7 +677,7 @@ suite('FindController query options persistence', async () => {
 			await findController.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: 'none',
-				seedSearchStringFromSelectionOnly: false,
+				seedSearchStringFromNonEmptySelection: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: false,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3439,7 +3439,7 @@ declare namespace monaco.editor {
 		/**
 		 * Controls if we seed search string in the Find Widget with editor selection.
 		 */
-		seedSearchStringFromSelection?: boolean;
+		seedSearchStringFromSelection?: 'never' | 'always' | 'selectionOnly';
 		/**
 		 * Controls if Find in Selection flag is turned on in the editor.
 		 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3439,7 +3439,7 @@ declare namespace monaco.editor {
 		/**
 		 * Controls if we seed search string in the Find Widget with editor selection.
 		 */
-		seedSearchStringFromSelection?: 'never' | 'always' | 'selectionOnly';
+		seedSearchStringFromSelection?: 'never' | 'always' | 'selection';
 		/**
 		 * Controls if Find in Selection flag is turned on in the editor.
 		 */


### PR DESCRIPTION
never: Never seed search string from the editor selection
always: Always seed search string from the editor selection, including word at cursor position
selectionOnly: Only seed search string from the editor selection

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #113830
