### PR TITLE
Fallback to 80x30 dimensions in terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1060,6 +1060,11 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			this._wrapperElement.classList.toggle('active', visible);
 		}
 		if (visible && this._xterm && this._xtermCore) {
+			// Resize to re-evaluate dimensions, this will ensure when switching to a terminal it is
+			// using the most up to date dimensions (eg. when terminal is created in the background
+			// using cached dimensions of a split terminal).
+			this._resize();
+
 			// Trigger a manual scroll event which will sync the viewport and scroll bar. This is
 			// necessary if the number of rows in the terminal has decreased while it was in the
 			// background since scrollTop changes take no effect but the terminal's position does


### PR DESCRIPTION
Fallback to 80x30 dimensions in terminal

This fixes an issue where when the terminal would be created without a container
it initializes with 0x0 dimensions which gets set to the minimum of 2x1 instead
of the expected default of 80x30 (which node-pty respects). This 80x30 is now
hardcoded in VS Code.

Fixes #128342

---

Resize terminal when it's shown

This fixes the following case:

1. Create and split the terminal
2. Hide the panel
3. Create a terminal in the background
4. Show it, the dimensions were wrong