### PR TITLE
Add flag for "simple" debug UI

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -13083,6 +13083,13 @@ declare module 'vscode' {
 		 * If compact is true, debug sessions with a single child are hidden in the CALL STACK view to make the tree more compact.
 		 */
 		compact?: boolean;
+
+		/**
+		 * When true, the debug toolbar will not be shown for this session, the window statusbar color will not be changed, and the debug viewlet will not be automatically revealed.
+		 */
+		debugUI?: {
+			simple?: boolean;
+		}
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -13083,13 +13083,6 @@ declare module 'vscode' {
 		 * If compact is true, debug sessions with a single child are hidden in the CALL STACK view to make the tree more compact.
 		 */
 		compact?: boolean;
-
-		/**
-		 * When true, the debug toolbar will not be shown for this session, the window statusbar color will not be changed, and the debug viewlet will not be automatically revealed.
-		 */
-		debugUI?: {
-			simple?: boolean;
-		}
 	}
 
 	/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -697,6 +697,13 @@ declare module 'vscode' {
 		 * This property is ignored if the session has no parent session.
 		 */
 		lifecycleManagedByParent?: boolean;
+
+		debugUI?: {
+			/**
+			 * When true, the debug toolbar will not be shown for this session, the window statusbar color will not be changed, and the debug viewlet will not be automatically revealed.
+			 */
+			simple?: boolean;
+		}
 	}
 
 	//#endregion

--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -228,6 +228,7 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 			parentSession,
 			repl: options.repl,
 			compact: options.compact,
+			simpleUI: options.simpleUI,
 			compoundRoot: parentSession?.compoundRoot
 		};
 		return this.debugService.startDebugging(launch, nameOrConfig, debugOptions).then(success => {

--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -228,7 +228,7 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 			parentSession,
 			repl: options.repl,
 			compact: options.compact,
-			simpleUI: options.simpleUI,
+			debugUI: options.debugUI,
 			compoundRoot: parentSession?.compoundRoot
 		};
 		return this.debugService.startDebugging(launch, nameOrConfig, debugOptions).then(success => {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1097,6 +1097,7 @@ export interface IStartDebuggingOptions {
 	repl?: IDebugSessionReplMode;
 	noDebug?: boolean;
 	compact?: boolean;
+	simpleUI?: boolean;
 }
 
 export interface MainThreadDebugServiceShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1097,7 +1097,9 @@ export interface IStartDebuggingOptions {
 	repl?: IDebugSessionReplMode;
 	noDebug?: boolean;
 	compact?: boolean;
-	simpleUI?: boolean;
+	debugUI?: {
+		simple?: boolean;
+	};
 }
 
 export interface MainThreadDebugServiceShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -291,7 +291,8 @@ export abstract class ExtHostDebugServiceBase implements IExtHostDebugService, E
 			parentSessionID: options.parentSession ? options.parentSession.id : undefined,
 			repl: options.consoleMode === DebugConsoleMode.MergeWithParent ? 'mergeWithParent' : 'separate',
 			noDebug: options.noDebug,
-			compact: options.compact
+			compact: options.compact,
+			simpleUI: options.debugUI?.simple
 		});
 	}
 

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -292,7 +292,7 @@ export abstract class ExtHostDebugServiceBase implements IExtHostDebugService, E
 			repl: options.consoleMode === DebugConsoleMode.MergeWithParent ? 'mergeWithParent' : 'separate',
 			noDebug: options.noDebug,
 			compact: options.compact,
-			simpleUI: options.debugUI?.simple
+			debugUI: options.debugUI
 		});
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -140,7 +140,7 @@ export class DebugSession implements IDebugSession {
 	}
 
 	get isSimpleUI(): boolean {
-		return this._options.simpleUI ?? false;
+		return this._options.debugUI?.simple ?? false;
 	}
 
 	setConfiguration(configuration: { resolved: IConfig, unresolved: IConfig | undefined }) {

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -139,6 +139,10 @@ export class DebugSession implements IDebugSession {
 		return this._options.compoundRoot;
 	}
 
+	get isSimpleUI(): boolean {
+		return this._options.simpleUI ?? false;
+	}
+
 	setConfiguration(configuration: { resolved: IConfig, unresolved: IConfig | undefined }) {
 		this._configuration = configuration;
 	}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -840,7 +840,7 @@ export class DebugSession implements IDebugSession {
 					if (!event.body.preserveFocusHint && thread.getCallStack().length) {
 						await this.debugService.focusStackFrame(undefined, thread);
 						if (thread.stoppedDetails) {
-							if (this.configurationService.getValue<IDebugConfiguration>('debug').openDebug === 'openOnDebugBreak') {
+							if (this.configurationService.getValue<IDebugConfiguration>('debug').openDebug === 'openOnDebugBreak' && !this.isSimpleUI) {
 								this.viewletService.openViewlet(VIEWLET_ID);
 							}
 

--- a/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
@@ -87,7 +87,7 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 		this.updateScheduler = this._register(new RunOnceScheduler(() => {
 			const state = this.debugService.state;
 			const toolBarLocation = this.configurationService.getValue<IDebugConfiguration>('debug').toolBarLocation;
-			if (state === State.Inactive || toolBarLocation === 'docked' || toolBarLocation === 'hidden' || this.debugService.getViewModel().focusedSession?.isSimpleUI || (state === State.Initializing && this.debugService.initializingOptions?.simpleUI)) {
+			if (state === State.Inactive || toolBarLocation === 'docked' || toolBarLocation === 'hidden' || this.debugService.getViewModel().focusedSession?.isSimpleUI || (state === State.Initializing && this.debugService.initializingOptions?.debugUI?.simple)) {
 				return this.hide();
 			}
 

--- a/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
@@ -87,7 +87,7 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 		this.updateScheduler = this._register(new RunOnceScheduler(() => {
 			const state = this.debugService.state;
 			const toolBarLocation = this.configurationService.getValue<IDebugConfiguration>('debug').toolBarLocation;
-			if (state === State.Inactive || toolBarLocation === 'docked' || toolBarLocation === 'hidden') {
+			if (state === State.Inactive || toolBarLocation === 'docked' || toolBarLocation === 'hidden' || this.debugService.getViewModel().focusedSession?.isSimpleUI || (state === State.Initializing && this.debugService.initializingOptions?.simpleUI)) {
 				return this.hide();
 			}
 

--- a/src/vs/workbench/contrib/debug/browser/statusbarColorProvider.ts
+++ b/src/vs/workbench/contrib/debug/browser/statusbarColorProvider.ts
@@ -104,7 +104,7 @@ export class StatusBarColorProvider extends Themable implements IWorkbenchContri
 }
 
 export function isStatusbarInDebugMode(state: State, session: IDebugSession | undefined): boolean {
-	if (state === State.Inactive || state === State.Initializing) {
+	if (state === State.Inactive || state === State.Initializing || session?.isSimpleUI) {
 		return false;
 	}
 	const isRunningWithoutDebug = session?.configuration?.noDebug;

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -180,6 +180,7 @@ export interface IDebugSessionOptions {
 	repl?: IDebugSessionReplMode;
 	compoundRoot?: DebugCompoundRoot;
 	compact?: boolean;
+	simpleUI?: boolean;
 }
 
 export interface IDataBreakpointInfoResponse {
@@ -200,6 +201,7 @@ export interface IDebugSession extends ITreeElement {
 	readonly compact: boolean;
 	readonly compoundRoot: DebugCompoundRoot | undefined;
 	readonly name: string;
+	readonly isSimpleUI: boolean;
 
 	setSubId(subId: string | undefined): void;
 
@@ -788,6 +790,8 @@ export interface IDebugService {
 	 * Gets the current debug state.
 	 */
 	readonly state: State;
+
+	readonly initializingOptions?: IDebugSessionOptions | undefined;
 
 	/**
 	 * Allows to register on debug state changes.

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -180,7 +180,9 @@ export interface IDebugSessionOptions {
 	repl?: IDebugSessionReplMode;
 	compoundRoot?: DebugCompoundRoot;
 	compact?: boolean;
-	simpleUI?: boolean;
+	debugUI?: {
+		simple?: boolean;
+	};
 }
 
 export interface IDataBreakpointInfoResponse {

--- a/src/vs/workbench/contrib/debug/test/browser/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/mockDebug.ts
@@ -163,6 +163,10 @@ export class MockSession implements IDebugSession {
 		return undefined;
 	}
 
+	get isSimpleUI(): boolean {
+		return false;
+	}
+
 	stepInTargets(frameId: number): Promise<{ id: number; label: string; }[]> {
 		throw new Error('Method not implemented.');
 	}


### PR DESCRIPTION
This implements #128588 and #128582

The flag in proposed will probably change, I am already thinking about how we need something slightly different for full debugging, where I want to only show the debug toolbar when paused. So another option, something like:

```
debugUI?: {
  debugToolbarVisibility: 'always' | 'never' | 'onPause';
  simple?: boolean; // Or break out flags for 'revealDebugViewlet' and 'statusBarColor' too
}
```