### PR TITLE
Clean Up Whitespace on Enter

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -492,6 +492,11 @@ const editorConfiguration: IConfigurationNode = {
 			default: EDITOR_MODEL_DEFAULTS.trimAutoWhitespace,
 			description: nls.localize('trimAutoWhitespace', "Remove trailing auto inserted whitespace.")
 		},
+		'editor.trimTrailingWhitespace': {
+			type: 'boolean',
+			default: EDITOR_MODEL_DEFAULTS.trimTrailingWhitespace,
+			description: nls.localize('trimTrailingWhitespace', "Remove any trailing whitespace.")
+		},
 		'editor.largeFileOptimizations': {
 			type: 'boolean',
 			default: EDITOR_MODEL_DEFAULTS.largeFileOptimizations,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3883,6 +3883,7 @@ export const EDITOR_MODEL_DEFAULTS = {
 	insertSpaces: true,
 	detectIndentation: true,
 	trimAutoWhitespace: true,
+	trimTrailingWhitespace: true,
 	largeFileOptimizations: true
 };
 

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -431,6 +431,7 @@ export class TextModelResolvedOptions {
 	readonly insertSpaces: boolean;
 	readonly defaultEOL: DefaultEndOfLine;
 	readonly trimAutoWhitespace: boolean;
+	readonly trimTrailingWhitespace: boolean;
 
 	/**
 	 * @internal
@@ -441,12 +442,14 @@ export class TextModelResolvedOptions {
 		insertSpaces: boolean;
 		defaultEOL: DefaultEndOfLine;
 		trimAutoWhitespace: boolean;
+		trimTrailingWhitespace: boolean;
 	}) {
 		this.tabSize = Math.max(1, src.tabSize | 0);
 		this.indentSize = src.tabSize | 0;
 		this.insertSpaces = Boolean(src.insertSpaces);
 		this.defaultEOL = src.defaultEOL | 0;
 		this.trimAutoWhitespace = Boolean(src.trimAutoWhitespace);
+		this.trimTrailingWhitespace = Boolean(src.trimTrailingWhitespace);
 	}
 
 	/**
@@ -459,6 +462,7 @@ export class TextModelResolvedOptions {
 			&& this.insertSpaces === other.insertSpaces
 			&& this.defaultEOL === other.defaultEOL
 			&& this.trimAutoWhitespace === other.trimAutoWhitespace
+			&& this.trimTrailingWhitespace === other.trimTrailingWhitespace
 		);
 	}
 
@@ -471,6 +475,7 @@ export class TextModelResolvedOptions {
 			indentSize: this.indentSize !== newOpts.indentSize,
 			insertSpaces: this.insertSpaces !== newOpts.insertSpaces,
 			trimAutoWhitespace: this.trimAutoWhitespace !== newOpts.trimAutoWhitespace,
+			trimTrailingWhitespace: this.trimTrailingWhitespace !== newOpts.trimTrailingWhitespace,
 		};
 	}
 }
@@ -484,6 +489,7 @@ export interface ITextModelCreationOptions {
 	insertSpaces: boolean;
 	detectIndentation: boolean;
 	trimAutoWhitespace: boolean;
+	trimTrailingWhitespace: boolean;
 	defaultEOL: DefaultEndOfLine;
 	isForSimpleWidget: boolean;
 	largeFileOptimizations: boolean;
@@ -494,6 +500,7 @@ export interface ITextModelUpdateOptions {
 	indentSize?: number;
 	insertSpaces?: boolean;
 	trimAutoWhitespace?: boolean;
+	trimTrailingWhitespace?: boolean;
 }
 
 export class FindMatch {

--- a/src/vs/editor/common/model/textModelEvents.ts
+++ b/src/vs/editor/common/model/textModelEvents.ts
@@ -106,6 +106,7 @@ export interface IModelOptionsChangedEvent {
 	readonly indentSize: boolean;
 	readonly insertSpaces: boolean;
 	readonly trimAutoWhitespace: boolean;
+	readonly trimTrailingWhitespace: boolean;
 }
 
 /**

--- a/src/vs/editor/common/services/modelServiceImpl.ts
+++ b/src/vs/editor/common/services/modelServiceImpl.ts
@@ -99,6 +99,7 @@ interface IRawEditorConfig {
 	insertSpaces?: any;
 	detectIndentation?: any;
 	trimAutoWhitespace?: any;
+	trimTrailingWhitespace?: any;
 	creationOptions?: any;
 	largeFileOptimizations?: any;
 }
@@ -223,6 +224,11 @@ export class ModelServiceImpl extends Disposable implements IModelService {
 			trimAutoWhitespace = (config.editor.trimAutoWhitespace === 'false' ? false : Boolean(config.editor.trimAutoWhitespace));
 		}
 
+		let trimTrailingWhitespace = EDITOR_MODEL_DEFAULTS.trimTrailingWhitespace;
+		if (config.editor && typeof config.editor.trimTrailingWhitespace !== 'undefined') {
+			trimTrailingWhitespace = (config.editor.trimTrailingWhitespace === 'false' ? false : Boolean(config.editor.trimTrailingWhitespace));
+		}
+
 		let detectIndentation = EDITOR_MODEL_DEFAULTS.detectIndentation;
 		if (config.editor && typeof config.editor.detectIndentation !== 'undefined') {
 			detectIndentation = (config.editor.detectIndentation === 'false' ? false : Boolean(config.editor.detectIndentation));
@@ -241,6 +247,7 @@ export class ModelServiceImpl extends Disposable implements IModelService {
 			detectIndentation: detectIndentation,
 			defaultEOL: newDefaultEOL,
 			trimAutoWhitespace: trimAutoWhitespace,
+			trimTrailingWhitespace: trimTrailingWhitespace,
 			largeFileOptimizations: largeFileOptimizations
 		};
 	}
@@ -303,6 +310,7 @@ export class ModelServiceImpl extends Disposable implements IModelService {
 			&& (currentOptions.tabSize === newOptions.tabSize)
 			&& (currentOptions.indentSize === newOptions.indentSize)
 			&& (currentOptions.trimAutoWhitespace === newOptions.trimAutoWhitespace)
+			&& (currentOptions.trimTrailingWhitespace === newOptions.trimTrailingWhitespace)
 		) {
 			// Same indent opts, no need to touch the model
 			return;
@@ -311,14 +319,16 @@ export class ModelServiceImpl extends Disposable implements IModelService {
 		if (newOptions.detectIndentation) {
 			model.detectIndentation(newOptions.insertSpaces, newOptions.tabSize);
 			model.updateOptions({
-				trimAutoWhitespace: newOptions.trimAutoWhitespace
+				trimAutoWhitespace: newOptions.trimAutoWhitespace,
+				trimTrailingWhitespace: newOptions.trimTrailingWhitespace
 			});
 		} else {
 			model.updateOptions({
 				insertSpaces: newOptions.insertSpaces,
 				tabSize: newOptions.tabSize,
 				indentSize: newOptions.indentSize,
-				trimAutoWhitespace: newOptions.trimAutoWhitespace
+				trimAutoWhitespace: newOptions.trimAutoWhitespace,
+				trimTrailingWhitespace: newOptions.trimTrailingWhitespace
 			});
 		}
 	}

--- a/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
@@ -109,6 +109,11 @@ export interface IGlobalEditorOptions {
 	 */
 	trimAutoWhitespace?: boolean;
 	/**
+	 * Remove any trailing whitespace.
+	 * Defaults to true.
+	 */
+	trimTrailingWhitespace?: boolean;
+	/**
 	 * Special handling for large files to disable certain memory intensive features.
 	 * Defaults to true.
 	 */

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -1339,7 +1339,8 @@ suite('Editor Controller - Regression tests', () => {
 			].join('\n'),
 			{
 				insertSpaces: false,
-				trimAutoWhitespace: false
+				trimAutoWhitespace: false,
+				trimTrailingWhitespace: false
 			},
 		);
 
@@ -2800,7 +2801,10 @@ suite('Editor Controller - Cursor Configuration', () => {
 				'    Third Line',
 				'',
 				'1'
-			]
+			],
+			modelOpts: {
+				trimTrailingWhitespace: false
+			}
 		}, (editor, model, viewModel) => {
 			CoreNavigationCommands.MoveTo.runCoreEditorCommand(viewModel, { position: new Position(1, 21), source: 'keyboard' });
 			viewModel.type('\n', 'keyboard');
@@ -2940,7 +2944,8 @@ suite('Editor Controller - Cursor Configuration', () => {
 				'    some  line abc  '
 			],
 			modelOpts: {
-				trimAutoWhitespace: false
+				trimAutoWhitespace: false,
+				trimTrailingWhitespace: false
 			}
 		}, (editor, model, viewModel) => {
 
@@ -2962,7 +2967,10 @@ suite('Editor Controller - Cursor Configuration', () => {
 		usingCursor({
 			text: [
 				'    '
-			]
+			],
+			modelOpts: {
+				trimTrailingWhitespace: false
+			}
 		}, (editor, model, viewModel) => {
 			moveTo(editor, viewModel, 1, model.getLineContent(1).length + 1);
 			viewModel.type('\n', 'keyboard');
@@ -2973,6 +2981,73 @@ suite('Editor Controller - Cursor Configuration', () => {
 			assert.strictEqual(model.getLineContent(1), '    ');
 			assert.strictEqual(model.getLineContent(2), '');
 			assert.strictEqual(model.getLineContent(3), '    ');
+		});
+	});
+
+	test('trimTrailingWhitespace on: blank lines removed: Enter at end of line', () => {
+		usingCursor({
+			text: [
+				'      '
+			]
+		}, (editor, model, viewModel) => {
+			moveTo(editor, viewModel, 1, 7);
+			viewModel.type('\n', 'keyboard');
+			assert.strictEqual(model.getLineContent(1), '');
+			assert.strictEqual(model.getLineContent(2), '      ');
+		});
+	});
+
+	test('trimTrailingWhitespace on: blank lines removed: Enter in middle of line', () => {
+		usingCursor({
+			text: [
+				'      '
+			]
+		}, (editor, model, viewModel) => {
+			moveTo(editor, viewModel, 1, 3);
+			viewModel.type('\n', 'keyboard');
+			assert.strictEqual(model.getLineContent(1), '');
+			assert.strictEqual(model.getLineContent(2), '      ');
+		});
+	});
+
+	test('trimTrailingWhitespace on: blank lines removed: Enter at start of line', () => {
+		usingCursor({
+			text: [
+				'      '
+			]
+		}, (editor, model, viewModel) => {
+			moveTo(editor, viewModel, 1, 1);
+			viewModel.type('\n', 'keyboard');
+			assert.strictEqual(model.getLineContent(1), '');
+			assert.strictEqual(model.getLineContent(2), '      ');
+		});
+	});
+
+	test('trimTrailingWhitespace on: whitespace removed at end', () => {
+		usingCursor({
+			text: [
+				'  abc '
+			]
+		}, (editor, model, viewModel) => {
+			moveTo(editor, viewModel, 1, 6);
+			viewModel.type('\n', 'keyboard');
+			assert.strictEqual(model.getLineContent(1), '  abc');
+			assert.strictEqual(model.getLineContent(2), '  ');
+		});
+	});
+
+	test('issue #61972: trimTrailingWhitespace on: whitespace removed before text', () => {
+		usingCursor({
+			text: [
+				'  [',
+				'    1, 2, 3, 4',
+				'  ]'
+			]
+		}, (editor, model, viewModel) => {
+			moveTo(editor, viewModel, 2, 10);
+			viewModel.type('\n', 'keyboard');
+			assert.strictEqual(model.getLineContent(2), '    1, 2,');
+			assert.strictEqual(model.getLineContent(3), '    3, 4');
 		});
 	});
 
@@ -3090,7 +3165,10 @@ suite('Editor Controller - Cursor Configuration', () => {
 		let model = createTextModel(
 			[
 				'    some  line abc  '
-			].join('\n')
+			].join('\n'),
+			{
+				trimTrailingWhitespace: false
+			}
 		);
 
 		withTestCodeEditor(null, { model: model }, (editor, viewModel) => {
@@ -3689,7 +3767,7 @@ suite('Editor Controller - Indentation Rules', () => {
 
 			viewModel.type('\n', 'keyboard');
 			assertCursor(viewModel, new Selection(4, 3, 4, 3));
-			assert.strictEqual(model.getLineContent(4), '\t\t true;', '001');
+			assert.strictEqual(model.getLineContent(4), '\t\ttrue;', '001');
 		});
 	});
 
@@ -3728,7 +3806,7 @@ suite('Editor Controller - Indentation Rules', () => {
 
 			viewModel.type('\n', 'keyboard');
 			assertCursor(viewModel, new Selection(4, 5, 4, 5));
-			assert.strictEqual(model.getLineContent(4), '     true;', '001');
+			assert.strictEqual(model.getLineContent(4), '    true;', '001');
 		});
 	});
 
@@ -4476,7 +4554,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				new Selection(1, 14, 1, 14),
 			]);
 			viewModel.type('\n', 'keyboard');
-			assert.strictEqual(model.getValue(), '    let a,\n\t b,\n\t c;');
+			assert.strictEqual(model.getValue(), '    let a,\n\tb,\n\tc;');
 		});
 	});
 

--- a/src/vs/editor/test/common/editorTestUtils.ts
+++ b/src/vs/editor/test/common/editorTestUtils.ts
@@ -23,6 +23,7 @@ export interface IRelaxedTextModelCreationOptions {
 	insertSpaces?: boolean;
 	detectIndentation?: boolean;
 	trimAutoWhitespace?: boolean;
+	trimTrailingWhitespace?: boolean;
 	defaultEOL?: DefaultEndOfLine;
 	isForSimpleWidget?: boolean;
 	largeFileOptimizations?: boolean;
@@ -35,6 +36,7 @@ export function createTextModel(text: string, _options: IRelaxedTextModelCreatio
 		insertSpaces: (typeof _options.insertSpaces === 'undefined' ? TextModel.DEFAULT_CREATION_OPTIONS.insertSpaces : _options.insertSpaces),
 		detectIndentation: (typeof _options.detectIndentation === 'undefined' ? TextModel.DEFAULT_CREATION_OPTIONS.detectIndentation : _options.detectIndentation),
 		trimAutoWhitespace: (typeof _options.trimAutoWhitespace === 'undefined' ? TextModel.DEFAULT_CREATION_OPTIONS.trimAutoWhitespace : _options.trimAutoWhitespace),
+		trimTrailingWhitespace: (typeof _options.trimTrailingWhitespace === 'undefined' ? TextModel.DEFAULT_CREATION_OPTIONS.trimTrailingWhitespace : _options.trimTrailingWhitespace),
 		defaultEOL: (typeof _options.defaultEOL === 'undefined' ? TextModel.DEFAULT_CREATION_OPTIONS.defaultEOL : _options.defaultEOL),
 		isForSimpleWidget: (typeof _options.isForSimpleWidget === 'undefined' ? TextModel.DEFAULT_CREATION_OPTIONS.isForSimpleWidget : _options.isForSimpleWidget),
 		largeFileOptimizations: (typeof _options.largeFileOptimizations === 'undefined' ? TextModel.DEFAULT_CREATION_OPTIONS.largeFileOptimizations : _options.largeFileOptimizations),

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1119,6 +1119,11 @@ declare namespace monaco.editor {
 		 */
 		trimAutoWhitespace?: boolean;
 		/**
+		 * Remove any trailing whitespace.
+		 * Defaults to true.
+		 */
+		trimTrailingWhitespace?: boolean;
+		/**
 		 * Special handling for large files to disable certain memory intensive features.
 		 * Defaults to true.
 		 */
@@ -1634,6 +1639,7 @@ declare namespace monaco.editor {
 		readonly insertSpaces: boolean;
 		readonly defaultEOL: DefaultEndOfLine;
 		readonly trimAutoWhitespace: boolean;
+		readonly trimTrailingWhitespace: boolean;
 	}
 
 	export interface ITextModelUpdateOptions {
@@ -1641,6 +1647,7 @@ declare namespace monaco.editor {
 		indentSize?: number;
 		insertSpaces?: boolean;
 		trimAutoWhitespace?: boolean;
+		trimTrailingWhitespace?: boolean;
 	}
 
 	export class FindMatch {
@@ -2532,6 +2539,7 @@ declare namespace monaco.editor {
 		readonly indentSize: boolean;
 		readonly insertSpaces: boolean;
 		readonly trimAutoWhitespace: boolean;
+		readonly trimTrailingWhitespace: boolean;
 	}
 
 	/**


### PR DESCRIPTION
Clean up whitespace when Enter key is pressed.  This will:
1.  Remove all whitespace lines when you hit Enter.
2. Remove whitespace from the end of something like `"abc"; ` when you hit Enter.
3. Remove the space before the 2 if you hit Enter after the comma in `1, 2`. (This also works for multi-cursor mode)

This PR fixes #61972.
It might also be a workaround for #13157 because it will remove whitespace on the lines you modify, not the whole file.

To test, you can run this:
```bash
./scripts/test.sh --glob **/cursor.test.js --grep trimTrailingWhitespace
```
You can also manually test by adding whitespace at the end of lines and clicking Enter.
