### PR TITLE
Fix OnPaste Indenting after JavaDoc

### DIFF
--- a/src/vs/editor/common/modes/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/modes/languageConfigurationRegistry.ts
@@ -564,7 +564,8 @@ export class LanguageConfigurationRegistryImpl {
 						indentation = indentConverter.unshiftIndent(indentation);
 					}
 
-					if (enterResult.appendText) {
+					// Ignore " * " JavaDoc style comments (issue #119225)
+					if (enterResult.appendText && enterResult.appendText !== " * ") {
 						indentation += enterResult.appendText;
 					}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #119225.  It prevents an extra space from being inserted after JavaDoc style comments.

To test, you can paste something like this.
```typescript
/**
 * Function
 */
public func1(): number
{
	return 1;
}
```

I was trying to add an automated test to `cursor.test.ts` or `indentation.test.ts`, but wasn't able to figure it out.  Any tips on how to do that?