### PR TITLE
Remove private field from constructor

### DIFF
--- a/src/vs/editor/contrib/snippet/snippetVariables.ts
+++ b/src/vs/editor/contrib/snippet/snippetVariables.ts
@@ -255,9 +255,7 @@ export class TimeBasedVariableResolver implements VariableResolver {
 	private static readonly monthNames = [nls.localize('January', "January"), nls.localize('February', "February"), nls.localize('March', "March"), nls.localize('April', "April"), nls.localize('May', "May"), nls.localize('June', "June"), nls.localize('July', "July"), nls.localize('August', "August"), nls.localize('September', "September"), nls.localize('October', "October"), nls.localize('November', "November"), nls.localize('December', "December")];
 	private static readonly monthNamesShort = [nls.localize('JanuaryShort', "Jan"), nls.localize('FebruaryShort', "Feb"), nls.localize('MarchShort', "Mar"), nls.localize('AprilShort', "Apr"), nls.localize('MayShort', "May"), nls.localize('JuneShort', "Jun"), nls.localize('JulyShort', "Jul"), nls.localize('AugustShort', "Aug"), nls.localize('SeptemberShort', "Sep"), nls.localize('OctoberShort', "Oct"), nls.localize('NovemberShort', "Nov"), nls.localize('DecemberShort', "Dec")];
 
-	constructor(private readonly _date: Date = new Date()) {
-		//
-	}
+	private readonly _date = new Date();
 
 	resolve(variable: Variable): string | undefined {
 		const { name } = variable;


### PR DESCRIPTION
Remove private field from constructor. It was incorrectly placed there by me in https://github.com/microsoft/vscode/pull/128571.

 I didn't intend for it to be there, but thought that was the only way. I'm fairly new to Typescript and thought it wasn't possible without "native" private fields, since I couldn't figure out the syntax.

Ref: https://github.com/microsoft/vscode/pull/128571#discussion_r670399005

cc @jrieken 