### PR TITLE
Fix --verbose flag in code-web.js

### DIFF
--- a/resources/web/code-web.js
+++ b/resources/web/code-web.js
@@ -412,7 +412,7 @@ async function handleRoot(req, res) {
 
 	if (args.verbose) {
 		fancyLog(`${ansiColors.magenta('BuiltIn extensions')}: ${dedupedBuiltInExtensions.map(e => path.basename(e.extensionPath)).join(', ')}`);
-		fancyLog(`${ansiColors.magenta('Additional extensions')}: ${additionalBuiltinExtensions.map(e => path.basename(e.extensionLocation.path)).join(', ') || 'None'}`);
+		fancyLog(`${ansiColors.magenta('Additional extensions')}: ${additionalBuiltinExtensions.map(e => path.basename(e.path)).join(', ') || 'None'}`);
 	}
 
 	const secondaryHost = (


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #128871

To test, do `--extension` with the path to an extension along with `--verbose`. Previously, this would crash on browser launch, but after, it logs correctly.
