### PR TITLE
Implement dnd for array settings

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -84,6 +84,13 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row {
 	display: flex;
 }
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row.draggable {
+	cursor: pointer;
+	user-select: none;
+}
+.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row.drag-hover * {
+	pointer-events: none;
+}
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row-header {

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -594,6 +594,11 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 		valueElement.textContent = item.value.data.toString();
 		siblingElement.textContent = item.sibling ? `when: ${item.sibling}` : null;
 
+		this.addDragAndDrop(rowElement, item, idx);
+		return rowElement;
+	}
+
+	protected addDragAndDrop(rowElement: HTMLElement, item: IListDataItem, idx: number) {
 		if (this.inReadMode) {
 			rowElement.draggable = true;
 			rowElement.classList.add('draggable');
@@ -602,7 +607,7 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 			rowElement.classList.remove('draggable');
 		}
 
-		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_START, (ev) => {
+		this.listDisposables.add(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_START, (ev) => {
 			this.dragDetails = {
 				element: rowElement,
 				item,
@@ -616,7 +621,7 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 				setTimeout(() => document.body.removeChild(dragImage), 0);
 			}
 		}));
-		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_OVER, (ev) => {
+		this.listDisposables.add(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_OVER, (ev) => {
 			if (!this.dragDetails) {
 				return false;
 			}
@@ -627,17 +632,17 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 			return true;
 		}));
 		let counter = 0;
-		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_ENTER, (ev) => {
+		this.listDisposables.add(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_ENTER, (ev) => {
 			counter++;
 			rowElement.classList.add('drag-hover');
 		}));
-		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_LEAVE, (ev) => {
+		this.listDisposables.add(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_LEAVE, (ev) => {
 			counter--;
 			if (!counter) {
 				rowElement.classList.remove('drag-hover');
 			}
 		}));
-		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DROP, (ev) => {
+		this.listDisposables.add(DOM.addDisposableListener(rowElement, DOM.EventType.DROP, (ev) => {
 			// cancel the op if we dragged to a completely different setting
 			if (!this.dragDetails) {
 				return false;
@@ -654,7 +659,7 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 			}
 			return true;
 		}));
-		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_END, (ev) => {
+		this.listDisposables.add(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_END, (ev) => {
 			counter = 0;
 			rowElement.classList.remove('drag-hover');
 			if (ev.dataTransfer) {
@@ -664,8 +669,6 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 				this.dragDetails = undefined;
 			}
 		}));
-
-		return rowElement;
 	}
 
 	protected renderEdit(item: IListDataItem, idx: number): HTMLElement {
@@ -848,6 +851,10 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 export class ExcludeSettingWidget extends ListSettingWidget {
 	protected override getContainerClasses() {
 		return ['setting-list-exclude-widget'];
+	}
+
+	protected override addDragAndDrop(rowElement: HTMLElement, item: IListDataItem, idx: number) {
+		return;
 	}
 
 	protected override getLocalizedRowTitle({ value, sibling }: IListDataItem): string {

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -23,7 +23,7 @@ import { isDefined, isUndefinedOrNull } from 'vs/base/common/types';
 import 'vs/css!./media/settingsWidgets';
 import { localize } from 'vs/nls';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
-import { editorWidgetBorder, focusBorder, foreground, inputBackground, inputBorder, inputForeground, listActiveSelectionBackground, listActiveSelectionForeground, listFocusBackground, listHoverBackground, listHoverForeground, listInactiveSelectionBackground, listInactiveSelectionForeground, registerColor, selectBackground, selectBorder, selectForeground, simpleCheckboxBackground, simpleCheckboxBorder, simpleCheckboxForeground, textLinkActiveForeground, textLinkForeground, textPreformatForeground, transparent } from 'vs/platform/theme/common/colorRegistry';
+import { editorWidgetBorder, focusBorder, foreground, inputBackground, inputBorder, inputForeground, listActiveSelectionBackground, listActiveSelectionForeground, listDropBackground, listFocusBackground, listHoverBackground, listHoverForeground, listInactiveSelectionBackground, listInactiveSelectionForeground, registerColor, selectBackground, selectBorder, selectForeground, simpleCheckboxBackground, simpleCheckboxBorder, simpleCheckboxForeground, textLinkActiveForeground, textLinkForeground, textPreformatForeground, transparent } from 'vs/platform/theme/common/colorRegistry';
 import { attachButtonStyler, attachInputBoxStyler, attachSelectBoxStyler } from 'vs/platform/theme/common/styler';
 import { IColorTheme, ICssStyleCollector, IThemeService, registerThemingParticipant, ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { settingsDiscardIcon, settingsEditIcon, settingsRemoveIcon } from 'vs/workbench/contrib/preferences/browser/preferencesIcons';
@@ -135,6 +135,11 @@ registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) =
 		collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row:hover { color: ${listHoverForegroundColor}; }`);
 	}
 
+	const listDropBackgroundColor = theme.getColor(listDropBackground);
+	if (listDropBackgroundColor) {
+		collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row.drag-hover { background-color: ${listDropBackgroundColor}; }`);
+	}
+
 	const listSelectBackgroundColor = theme.getColor(listActiveSelectionBackground);
 	if (listSelectBackgroundColor) {
 		collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row.selected:focus { background-color: ${listSelectBackgroundColor}; }`);
@@ -244,6 +249,7 @@ export interface ISettingListChangeEvent<TDataItem extends object> {
 	originalItem: TDataItem;
 	item?: TDataItem;
 	targetIndex?: number;
+	sourceIndex?: number;
 }
 
 export abstract class AbstractListSettingWidget<TDataItem extends object> extends Disposable {
@@ -262,6 +268,10 @@ export abstract class AbstractListSettingWidget<TDataItem extends object> extend
 
 	get items(): TDataItem[] {
 		return this.model.items;
+	}
+
+	get inReadMode(): boolean {
+		return this.model.items.every(item => !item.editing);
 	}
 
 	constructor(
@@ -303,7 +313,7 @@ export abstract class AbstractListSettingWidget<TDataItem extends object> extend
 	protected abstract getEmptyItem(): TDataItem;
 	protected abstract getContainerClasses(): string[];
 	protected abstract getActionsForItem(item: TDataItem, idx: number): IAction[];
-	protected abstract renderItem(item: TDataItem): HTMLElement;
+	protected abstract renderItem(item: TDataItem, idx: number): HTMLElement;
 	protected abstract renderEdit(item: TDataItem, idx: number): HTMLElement;
 	protected abstract isItemNew(item: TDataItem): boolean;
 	protected abstract getLocalizedRowTitle(item: TDataItem): string;
@@ -362,7 +372,6 @@ export abstract class AbstractListSettingWidget<TDataItem extends object> extend
 		return selectBox;
 	}
 
-
 	protected editSetting(idx: number): void {
 		this.model.setEditKey(idx);
 		this.renderList();
@@ -396,7 +405,7 @@ export abstract class AbstractListSettingWidget<TDataItem extends object> extend
 	}
 
 	private renderDataItem(item: IListViewItem<TDataItem>, idx: number, listFocused: boolean): HTMLElement {
-		const rowElement = this.renderItem(item);
+		const rowElement = this.renderItem(item, idx);
 
 		rowElement.setAttribute('data-index', idx + '');
 		rowElement.setAttribute('tabindex', item.selected ? '0' : '-1');
@@ -517,6 +526,12 @@ export interface IListDataItem {
 	sibling?: string
 }
 
+interface ListSettingWidgetDragDetails {
+	element: HTMLElement;
+	item: IListDataItem;
+	itemIndex: number;
+}
+
 export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> {
 	private keyValueSuggester: IObjectKeySuggester | undefined;
 	private showAddButton: boolean = true;
@@ -563,13 +578,92 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 		] as IAction[];
 	}
 
-	protected renderItem(item: IListDataItem): HTMLElement {
+	private dragDetails: ListSettingWidgetDragDetails | undefined;
+
+	private getDragImage(item: IListDataItem): HTMLElement {
+		const dragImage = $('.monaco-drag-image');
+		dragImage.textContent = item.value.data;
+		return dragImage;
+	}
+
+	protected renderItem(item: IListDataItem, idx: number): HTMLElement {
 		const rowElement = $('.setting-list-row');
 		const valueElement = DOM.append(rowElement, $('.setting-list-value'));
 		const siblingElement = DOM.append(rowElement, $('.setting-list-sibling'));
 
 		valueElement.textContent = item.value.data.toString();
 		siblingElement.textContent = item.sibling ? `when: ${item.sibling}` : null;
+
+		if (this.inReadMode) {
+			rowElement.draggable = true;
+			rowElement.classList.add('draggable');
+		} else {
+			rowElement.draggable = false;
+			rowElement.classList.remove('draggable');
+		}
+
+		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_START, (ev) => {
+			this.dragDetails = {
+				element: rowElement,
+				item,
+				itemIndex: idx
+			};
+			if (ev.dataTransfer) {
+				ev.dataTransfer.dropEffect = 'move';
+				const dragImage = this.getDragImage(item);
+				document.body.appendChild(dragImage);
+				ev.dataTransfer.setDragImage(dragImage, -10, -10);
+				setTimeout(() => document.body.removeChild(dragImage), 0);
+			}
+		}));
+		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_OVER, (ev) => {
+			if (!this.dragDetails) {
+				return false;
+			}
+			ev.preventDefault();
+			if (ev.dataTransfer) {
+				ev.dataTransfer.dropEffect = 'move';
+			}
+			return true;
+		}));
+		let counter = 0;
+		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_ENTER, (ev) => {
+			counter++;
+			rowElement.classList.add('drag-hover');
+		}));
+		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_LEAVE, (ev) => {
+			counter--;
+			if (!counter) {
+				rowElement.classList.remove('drag-hover');
+			}
+		}));
+		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DROP, (ev) => {
+			// cancel the op if we dragged to a completely different setting
+			if (!this.dragDetails) {
+				return false;
+			}
+			ev.preventDefault();
+			counter = 0;
+			if (this.dragDetails.element !== rowElement) {
+				this._onDidChangeList.fire({
+					originalItem: this.dragDetails.item,
+					sourceIndex: this.dragDetails.itemIndex,
+					item,
+					targetIndex: idx
+				});
+			}
+			return true;
+		}));
+		this._register(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_END, (ev) => {
+			counter = 0;
+			rowElement.classList.remove('drag-hover');
+			if (ev.dataTransfer) {
+				ev.dataTransfer.clearData();
+			}
+			if (this.dragDetails) {
+				this.dragDetails = undefined;
+			}
+		}));
 
 		return rowElement;
 	}
@@ -580,8 +674,8 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 		let currentDisplayValue: string;
 		let currentEnumOptions: IObjectEnumOption[] | undefined;
 
-		if (this.isItemNew(item) && this.keyValueSuggester) {
-			const enumData = this.keyValueSuggester(this.model.items.map(({ value: { data } }) => data));
+		if (this.keyValueSuggester) {
+			const enumData = this.keyValueSuggester(this.model.items.map(({ value: { data } }) => data), idx);
 			item = {
 				...item,
 				value: {
@@ -810,7 +904,7 @@ export interface IObjectValueSuggester {
 }
 
 export interface IObjectKeySuggester {
-	(existingKeys: string[]): IObjectEnumData | undefined;
+	(existingKeys: string[], idx?: number): IObjectEnumData | undefined;
 }
 
 interface IObjectSetValueOptions {
@@ -912,7 +1006,7 @@ export class ObjectSettingDropdownWidget extends AbstractListSettingWidget<IObje
 		return header;
 	}
 
-	protected renderItem(item: IObjectDataItem): HTMLElement {
+	protected renderItem(item: IObjectDataItem, idx: number): HTMLElement {
 		const rowElement = $('.setting-list-row');
 		rowElement.classList.add('setting-list-object-row');
 
@@ -1229,7 +1323,7 @@ export class ObjectSettingCheckboxWidget extends AbstractListSettingWidget<IObje
 		return rowElement;
 	}
 
-	protected renderItem(item: IObjectDataItem): HTMLElement {
+	protected renderItem(item: IObjectDataItem, idx: number): HTMLElement {
 		// return empty object, since we always render in edit mode
 		const rowElement = $('.setting-list-row');
 		return rowElement;


### PR DESCRIPTION
This PR fixes #127424

The PR implements drag and drop for array settings. For enum array settings, it also changes the key suggester to not recommend duplicate elements, in the case `uniqueItems` is set to true (such as for `git.checkoutType`).

I have confirmed the following:
- The recommendations are correct when the user deletes all the item, and then adds a new item
- The recommendations are correct when the user has selected all the items already, and edits one of the items
- The user is unable to drag an item from one enum array setting to a completely different enum array setting
- Drag and drop works for string array settings such as `emmet.extensionsPath`

A small glitch that still occurs is the cursor sometimes flickers to `not-allowed` when dragging an item between two items in the list. I referenced https://github.com/microsoft/vscode/issues/38753 to try and find a solution.

![A screencap showing the feature in action](https://user-images.githubusercontent.com/7199958/126013366-b992312c-7073-46ca-b189-648d30a28d93.gif)

