### PR TITLE
platform/configuration: fix empty keys being ignored by configuration parser

### DIFF
--- a/src/vs/platform/configuration/common/configurationModels.ts
+++ b/src/vs/platform/configuration/common/configurationModels.ts
@@ -270,7 +270,7 @@ export class ConfigurationModelParser {
 		function onValue(value: any) {
 			if (Array.isArray(currentParent)) {
 				(<any[]>currentParent).push(value);
-			} else if (currentProperty) {
+			} else if (currentProperty !== null) {
 				currentParent[currentProperty] = value;
 			}
 		}

--- a/src/vs/platform/configuration/test/common/configurationModels.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationModels.test.ts
@@ -334,6 +334,16 @@ suite('CustomConfigurationModel', () => {
 		assert.deepStrictEqual(testObject.configurationModel.keys, []);
 	});
 
+	test('Test empty property is not ignored', () => {
+		const testObject = new ConfigurationModelParser('test');
+		testObject.parse(JSON.stringify({ '': 1 }));
+
+		// deepStrictEqual seems to ignore empty properties, fall back
+		// to comparing the output of JSON.stringify
+		assert.strictEqual(JSON.stringify(testObject.configurationModel.contents), JSON.stringify({ '': 1 }));
+		assert.deepStrictEqual(testObject.configurationModel.keys, ['']);
+	});
+
 	test('Test registering the same property again', () => {
 		Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
 			'id': 'a',


### PR DESCRIPTION
This PR fixes #126972.

I tested the change locally with my own extension (since I encountered #126972 in https://github.com/71/dance/issues/184), and it did fix it.