### PR TITLE
Find in current file command

### DIFF
--- a/src/vs/editor/contrib/find/findController.ts
+++ b/src/vs/editor/contrib/find/findController.ts
@@ -26,6 +26,9 @@ import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storag
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
+import { FindInFilesCommand, IFindInFilesArgs } from 'vs/workbench/contrib/search/browser/searchActions';
+import { resolveResourcesForSearchIncludes } from 'vs/workbench/contrib/search/common/queryBuilder';
+import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 
 const SEARCH_STRING_MAX_LENGTH = 524288;
 
@@ -757,6 +760,46 @@ StartFindReplaceAction.addImplementation(0, (accessor: ServicesAccessor, editor:
 	});
 });
 
+export class FindAllInCurrentFileAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: FIND_IDS.FindAllInCurrentFileAction,
+			label: nls.localize('findAllInCurrentFile', "Find All in Current File"),
+			alias: 'Find All in Current File',
+			precondition: ContextKeyExpr.or(EditorContextKeys.focus, ContextKeyExpr.has('editorIsOpen'), CONTEXT_FIND_WIDGET_VISIBLE),
+			kbOpts: {
+				kbExpr: EditorContextKeys.focus,
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyMod.Shift | KeyCode.KEY_F,
+				mac: {
+					primary: KeyMod.CtrlCmd | KeyMod.WinCtrl | KeyMod.Shift | KeyCode.KEY_F
+				},
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor | null, editor: ICodeEditor): void {
+		const model = editor.getModel();
+		if (accessor && model !== null) {
+			// Get query from selection or find widget if open
+			let query = getSelectionSearchString(editor, "single") || "";
+			if (CONTEXT_FIND_WIDGET_VISIBLE.getValue(accessor.get(IContextKeyService))) {
+				let controller = CommonFindController.get(editor);
+				if (controller)
+					query = controller.getState().searchString
+			}
+
+			// Open find in files scoped to resource
+			let opts: IFindInFilesArgs = {
+				query: query,
+				filesToInclude: resolveResourcesForSearchIncludes([model.uri], accessor.get(IWorkspaceContextService))[0]
+			};
+			FindInFilesCommand(accessor, opts);
+		}
+	}
+}
+
 registerEditorContribution(CommonFindController.ID, FindController);
 
 registerEditorAction(StartFindWithSelectionAction);
@@ -764,6 +807,7 @@ registerEditorAction(NextMatchFindAction);
 registerEditorAction(PreviousMatchFindAction);
 registerEditorAction(NextSelectionMatchFindAction);
 registerEditorAction(PreviousSelectionMatchFindAction);
+registerEditorAction(FindAllInCurrentFileAction);
 
 const FindCommand = EditorCommand.bindToContribution<CommonFindController>(CommonFindController.get);
 

--- a/src/vs/editor/contrib/find/findModel.ts
+++ b/src/vs/editor/contrib/find/findModel.ts
@@ -68,7 +68,8 @@ export const FIND_IDS = {
 	TogglePreserveCaseCommand: 'togglePreserveCase',
 	ReplaceOneAction: 'editor.action.replaceOne',
 	ReplaceAllAction: 'editor.action.replaceAll',
-	SelectAllMatchesAction: 'editor.action.selectAllMatches'
+	SelectAllMatchesAction: 'editor.action.selectAllMatches',
+	FindAllInCurrentFileAction: 'editor.action.findAllInCurrentFile',
 };
 
 export const MATCHES_LIMIT = 19999;

--- a/src/vs/editor/contrib/find/findWidget.ts
+++ b/src/vs/editor/contrib/find/findWidget.ts
@@ -47,6 +47,7 @@ export const findReplaceIcon = registerIcon('find-replace', Codicon.replace, nls
 export const findReplaceAllIcon = registerIcon('find-replace-all', Codicon.replaceAll, nls.localize('findReplaceAllIcon', 'Icon for \'Replace All\' in the editor find widget.'));
 export const findPreviousMatchIcon = registerIcon('find-previous-match', Codicon.arrowUp, nls.localize('findPreviousMatchIcon', 'Icon for \'Find Previous\' in the editor find widget.'));
 export const findNextMatchIcon = registerIcon('find-next-match', Codicon.arrowDown, nls.localize('findNextMatchIcon', 'Icon for \'Find Next\' in the editor find widget.'));
+export const findAllMatchesIcon = registerIcon('find-all-in-current-file', Codicon.file, nls.localize('findAllMatchesIcon', 'Icon for \'Find All in Current File\' in the editor find widget.'));
 
 export interface IFindController {
 	replace(): void;
@@ -65,6 +66,7 @@ const NLS_REPLACE_INPUT_PLACEHOLDER = nls.localize('placeholder.replace', "Repla
 const NLS_REPLACE_BTN_LABEL = nls.localize('label.replaceButton', "Replace");
 const NLS_REPLACE_ALL_BTN_LABEL = nls.localize('label.replaceAllButton', "Replace All");
 const NLS_TOGGLE_REPLACE_MODE_BTN_LABEL = nls.localize('label.toggleReplaceButton', "Toggle Replace mode");
+const NLS_FIND_ALL_BTN_LABEL = nls.localize('label.findAllInCurrentFile', "Find all in the current file");
 const NLS_MATCHES_COUNT_LIMIT_TITLE = nls.localize('title.matchesCountLimit', "Only the first {0} results are highlighted, but all find operations work on the entire text.", MATCHES_LIMIT);
 export const NLS_MATCHES_LOCATION = nls.localize('label.matchesLocation', "{0} of {1}");
 export const NLS_NO_RESULTS = nls.localize('label.noResults', "No results");
@@ -132,6 +134,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 	private _matchesCount!: HTMLElement;
 	private _prevBtn!: SimpleButton;
 	private _nextBtn!: SimpleButton;
+	private _findAllBtn!: SimpleButton;
 	private _toggleSelectionFind!: Checkbox;
 	private _closeBtn!: SimpleButton;
 	private _replaceBtn!: SimpleButton;
@@ -474,6 +477,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		let matchesCount = this._state.matchesCount ? true : false;
 		this._prevBtn.setEnabled(this._isVisible && findInputIsNonEmpty && matchesCount && this._state.canNavigateBack());
 		this._nextBtn.setEnabled(this._isVisible && findInputIsNonEmpty && matchesCount && this._state.canNavigateForward());
+		this._findAllBtn.setEnabled(this._isVisible && findInputIsNonEmpty);
 		this._replaceBtn.setEnabled(this._isVisible && this._isReplaceVisible && findInputIsNonEmpty);
 		this._replaceAllBtn.setEnabled(this._isVisible && this._isReplaceVisible && findInputIsNonEmpty);
 
@@ -1032,6 +1036,15 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			}
 		}));
 
+		// Find all in current file button
+		this._findAllBtn = this._register(new SimpleButton({
+			label: NLS_FIND_ALL_BTN_LABEL + this._keybindingLabelFor(FIND_IDS.FindAllInCurrentFileAction),
+			icon: findAllMatchesIcon,
+			onTrigger: () => {
+				this._codeEditor.getAction(FIND_IDS.FindAllInCurrentFileAction).run().then(undefined, onUnexpectedError);
+			}
+		}));
+
 		let findPart = document.createElement('div');
 		findPart.className = 'find-part';
 		findPart.appendChild(this._findInput.domNode);
@@ -1041,6 +1054,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		actionsContainer.appendChild(this._matchesCount);
 		actionsContainer.appendChild(this._prevBtn.domNode);
 		actionsContainer.appendChild(this._nextBtn.domNode);
+		actionsContainer.appendChild(this._findAllBtn.domNode);
 
 		// Toggle selection button
 		this._toggleSelectionFind = this._register(new Checkbox({
@@ -1128,6 +1142,8 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 					this._prevBtn.focus();
 				} else if (this._nextBtn.isEnabled()) {
 					this._nextBtn.focus();
+				} else if (this._findAllBtn.isEnabled()) {
+					this._findAllBtn.focus();
 				} else if (this._toggleSelectionFind.enabled) {
 					this._toggleSelectionFind.focus();
 				} else if (this._closeBtn.isEnabled()) {

--- a/src/vs/editor/contrib/find/findWidget.ts
+++ b/src/vs/editor/contrib/find/findWidget.ts
@@ -47,7 +47,7 @@ export const findReplaceIcon = registerIcon('find-replace', Codicon.replace, nls
 export const findReplaceAllIcon = registerIcon('find-replace-all', Codicon.replaceAll, nls.localize('findReplaceAllIcon', 'Icon for \'Replace All\' in the editor find widget.'));
 export const findPreviousMatchIcon = registerIcon('find-previous-match', Codicon.arrowUp, nls.localize('findPreviousMatchIcon', 'Icon for \'Find Previous\' in the editor find widget.'));
 export const findNextMatchIcon = registerIcon('find-next-match', Codicon.arrowDown, nls.localize('findNextMatchIcon', 'Icon for \'Find Next\' in the editor find widget.'));
-export const findAllMatchesIcon = registerIcon('find-all-in-current-file', Codicon.file, nls.localize('findAllMatchesIcon', 'Icon for \'Find All in Current File\' in the editor find widget.'));
+export const findAllMatchesIcon = registerIcon('find-all-in-current-file', Codicon.search, nls.localize('findAllMatchesIcon', 'Icon for \'Find All in Current File\' in the editor find widget.'));
 
 export interface IFindController {
 	replace(): void;


### PR DESCRIPTION
This PR fixes #14836.

I did not read all of the comments on that issue since it's extensive, but I implemented @alexdima's suggestion in https://github.com/microsoft/vscode/issues/14836#issuecomment-258781578.

This adds a way to find occurrences in the current file.  To test, you can open the find widget, then click the new icon to find in the file.  I wasn't sure what icon to use.  The two I thought fit best were `file` or `search`.
![image](https://user-images.githubusercontent.com/1426848/126043892-3b005e09-84a1-4c3c-bed4-30d00a7983d1.png)
![image](https://user-images.githubusercontent.com/1426848/126043928-fc54bb5c-26f1-4778-9fb3-59276cf8f4e6.png)

I went with `search`, but I'm open to suggestions.
