### PR TITLE
Allow opening search view to the side or bottom

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -5480,6 +5480,12 @@ declare module 'vscode' {
 		 */
 		Beside = -2,
 		/**
+		 * A *symbolic* editor column representing the column below the active one. This value can be used
+		 * when opening editors, but the *resolved* {@link TextEditor.viewColumn viewColumn}-value of
+		 * editors will always be `One`, `Two`, `Three`,... or `undefined` but never `Below`.
+		 */
+		Below = -3,
+		/**
 		 * The first editor column.
 		 */
 		One = 1,

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -34,7 +34,7 @@ import * as search from 'vs/workbench/contrib/search/common/search';
 import { CoverageDetails, DetailType, ICoveredCount, IFileCoverage, ISerializedTestResults, ITestItem, ITestItemContext, ITestMessage, SerializedTestResultItem } from 'vs/workbench/contrib/testing/common/testCollection';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { EditorGroupColumn } from 'vs/workbench/services/editor/common/editorGroupColumn';
-import { ACTIVE_GROUP, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
+import { ACTIVE_GROUP, SIDE_GROUP, BELOW_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import type * as vscode from 'vscode';
 import * as types from './extHostTypes';
 
@@ -231,6 +231,9 @@ export namespace ViewColumn {
 
 		if (column === types.ViewColumn.Beside) {
 			return SIDE_GROUP;
+		}
+		if (column === types.ViewColumn.Below) {
+			return BELOW_GROUP;
 		}
 
 		return ACTIVE_GROUP; // default is always the active group

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -1549,6 +1549,7 @@ export class InlineSuggestions implements vscode.InlineCompletionList {
 export enum ViewColumn {
 	Active = -1,
 	Beside = -2,
+	Below = -3,
 	One = 1,
 	Two = 2,
 	Three = 3,

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -614,6 +614,7 @@ class ShowAllSymbolsAction extends Action {
 }
 
 const SEARCH_MODE_CONFIG = 'search.mode';
+const SEARCH_NEW_EDITOR_GROUP_CONFIG = 'search.newEditorGroup';
 
 const viewContainer = Registry.as<IViewContainersRegistry>(ViewExtensions.ViewContainersRegistry).registerViewContainer({
 	id: VIEWLET_ID,
@@ -856,6 +857,17 @@ configurationRegistry.registerConfiguration({
 				nls.localize('search.mode.view', "Search in the search view, either in the panel or sidebar."),
 				nls.localize('search.mode.reuseEditor', "Search in an existing search editor if present, otherwise in a new search editor."),
 				nls.localize('search.mode.newEditor', "Search in a new search editor."),
+			]
+		},
+		[SEARCH_NEW_EDITOR_GROUP_CONFIG]: {
+			type: 'string',
+			enum: ['active', 'side', 'bottom'],
+			default: 'active',
+			markdownDescription: nls.localize('search.newEditorGroup', "Controls group where new `Search: Find in Files` and `Find in Folder` operations occur when opening a new search editor"),
+			enumDescriptions: [
+				nls.localize('search.newEditorGroup.active', "Search in the active editor group."),
+				nls.localize('search.newEditorGroup.side', "Search in editor group to the side."),
+				nls.localize('search.newEditorGroup.beside', "Search in editor group below."),
 			]
 		},
 		'search.useRipgrep': {

--- a/src/vs/workbench/contrib/search/browser/searchActions.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActions.ts
@@ -193,6 +193,7 @@ export const FindInFilesCommand: ICommandHandler = (accessor, args: IFindInFiles
 			}
 		});
 	} else {
+		const newEditorGroup = searchConfig.newEditorGroup;
 		const convertArgs = (args: IFindInFilesArgs): OpenSearchEditorArgs => ({
 			location: mode === 'newEditor' ? 'new' : 'reuse',
 			query: args.query,
@@ -205,7 +206,12 @@ export const FindInFilesCommand: ICommandHandler = (accessor, args: IFindInFiles
 			onlyOpenEditors: args.onlyOpenEditors,
 			showIncludesExcludes: !!(args.filesToExclude || args.filesToExclude || !args.useExcludeSettingsAndIgnoreFiles),
 		});
-		accessor.get(ICommandService).executeCommand(OpenEditorCommandId, convertArgs(args));
+		let finalArgs = convertArgs(args);
+		if (newEditorGroup === 'side')
+			finalArgs.position = 'side';
+		else if (newEditorGroup === 'bottom')
+			finalArgs.position = 'below';
+		accessor.get(ICommandService).executeCommand(OpenEditorCommandId, finalArgs);
 	}
 };
 

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
@@ -24,7 +24,7 @@ import { OpenSearchEditorArgs } from 'vs/workbench/contrib/searchEditor/browser/
 import { getOrMakeSearchEditorInput, SearchEditorInput } from 'vs/workbench/contrib/searchEditor/browser/searchEditorInput';
 import { serializeSearchResultForEditor } from 'vs/workbench/contrib/searchEditor/browser/searchEditorSerialization';
 import { IConfigurationResolverService } from 'vs/workbench/services/configurationResolver/common/configurationResolver';
-import { ACTIVE_GROUP, IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
+import { ACTIVE_GROUP, BELOW_GROUP, IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
 import { ISearchConfigurationProperties } from 'vs/workbench/services/search/common/search';
 
@@ -97,7 +97,7 @@ export async function openSearchEditor(accessor: ServicesAccessor): Promise<void
 }
 
 export const openNewSearchEditor =
-	async (accessor: ServicesAccessor, _args: OpenSearchEditorArgs = {}, toSide = false) => {
+	async (accessor: ServicesAccessor, _args: OpenSearchEditorArgs = {}) => {
 		const editorService = accessor.get(IEditorService);
 		const telemetryService = accessor.get(ITelemetryService);
 		const instantiationService = accessor.get(IInstantiationService);
@@ -153,7 +153,12 @@ export const openNewSearchEditor =
 			editor.setSearchConfig(args);
 		} else {
 			const input = instantiationService.invokeFunction(getOrMakeSearchEditorInput, { config: args, resultsContents: '', from: 'rawData' });
-			editor = await editorService.openEditor(input, { pinned: true }, toSide ? SIDE_GROUP : ACTIVE_GROUP) as SearchEditor;
+			let editorGroup = ACTIVE_GROUP;
+			if (args.position === 'side')
+				editorGroup = SIDE_GROUP;
+			else if (args.position === 'below')
+				editorGroup = BELOW_GROUP;
+			editor = await editorService.openEditor(input, { pinned: true }, editorGroup) as SearchEditor;
 		}
 
 		const searchOnType = configurationService.getValue<ISearchConfigurationProperties>('search').searchOnType;

--- a/src/vs/workbench/services/editor/common/editorGroupFinder.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupFinder.ts
@@ -7,8 +7,8 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { EditorActivation } from 'vs/platform/editor/common/editor';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorInputWithOptions, isEditorInputWithOptions, IUntypedEditorInput } from 'vs/workbench/common/editor';
-import { IEditorGroup, GroupsOrder, preferredSideBySideGroupDirection, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { PreferredGroup, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
+import { IEditorGroup, GroupsOrder, preferredSideBySideGroupDirection, IEditorGroupsService, GroupDirection } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { PreferredGroup, SIDE_GROUP, BELOW_GROUP } from 'vs/workbench/services/editor/common/editorService';
 
 /**
  * Finds the target `IEditorGroup` given the instructions provided
@@ -61,6 +61,11 @@ function doFindGroup(input: IEditorInputWithOptions | IUntypedEditorInput, prefe
 	// Group: Side by Side
 	else if (preferredGroup === SIDE_GROUP) {
 		group = doFindSideBySideGroup(editorGroupService, configurationService);
+	}
+
+	// Group: Below
+	else if (preferredGroup === BELOW_GROUP) {
+		group = doFindBelowGroup(editorGroupService, configurationService);
 	}
 
 	// Group: Specific Group
@@ -121,6 +126,17 @@ function doFindGroup(input: IEditorInputWithOptions | IUntypedEditorInput, prefe
 
 function doFindSideBySideGroup(editorGroupService: IEditorGroupsService, configurationService: IConfigurationService): IEditorGroup {
 	const direction = preferredSideBySideGroupDirection(configurationService);
+
+	let neighbourGroup = editorGroupService.findGroup({ direction });
+	if (!neighbourGroup) {
+		neighbourGroup = editorGroupService.addGroup(editorGroupService.activeGroup, direction);
+	}
+
+	return neighbourGroup;
+}
+
+function doFindBelowGroup(editorGroupService: IEditorGroupsService, configurationService: IConfigurationService): IEditorGroup {
+	const direction = GroupDirection.DOWN;
 
 	let neighbourGroup = editorGroupService.findGroup({ direction });
 	if (!neighbourGroup) {

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -26,7 +26,13 @@ export type ACTIVE_GROUP_TYPE = typeof ACTIVE_GROUP;
 export const SIDE_GROUP = -2;
 export type SIDE_GROUP_TYPE = typeof SIDE_GROUP;
 
-export type PreferredGroup = IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE;
+/**
+ * Open an editor below the active group.
+ */
+export const BELOW_GROUP = -3;
+export type BELOW_GROUP_TYPE = typeof SIDE_GROUP;
+
+export type PreferredGroup = IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE | BELOW_GROUP_TYPE;
 
 export function isPreferredGroup(obj: unknown): obj is PreferredGroup {
 	const candidate = obj as PreferredGroup | undefined;

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -379,6 +379,8 @@ export interface ISearchConfigurationProperties {
 	seedWithNearestWord: boolean;
 	searchOnTypeDebouncePeriod: number;
 	mode: 'view' | 'reuseEditor' | 'newEditor';
+	newEditorGroup: 'active' | 'side' | 'bottom';
+
 	searchEditor: {
 		doubleClickBehaviour: 'selectWord' | 'goToLocation' | 'openLocationToSide',
 		reusePriorSearchConfiguration: boolean,


### PR DESCRIPTION
This PR fixes #128920.  It allows the search to open in a side or below group.  I did see `workbench.editor.openSideBySideDirection` that I might be able to use to to make `search.newEditorGroup` a boolean of active or side, but I wanted the flexibility of always opened search in the bottom, but configure `workbench.editor.openSideBySideDirection` to `right`.

To test:
1.  Set `search.mode` to `newEditor`.
2.  Use Cmd + Shift + F with the different values for the `search.newEditorGroup` setting.