### PR TITLE
Quick pick icons vertical alignment fix.

### DIFF
--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -218,7 +218,7 @@
 }
 
 .quick-input-list .quick-input-list-rows > .quick-input-list-row .codicon[class*='codicon-'] {
-	vertical-align: sub;
+	vertical-align: text-bottom;
 }
 
 .quick-input-list .quick-input-list-rows .monaco-highlighted-label span {

--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -260,7 +260,7 @@
 
 .quick-input-list .quick-input-list-entry-action-bar .action-label.codicon {
 	margin-right: 4px;
-	padding: 2px;
+	padding: 0px 2px 2px 2px;
 }
 
 .quick-input-list .quick-input-list-entry-action-bar {


### PR DESCRIPTION
Vertical alignment of right icons fixed by removing an extra 2px top
padding.

Before:

<img width="546" alt="before_icon" src="https://user-images.githubusercontent.com/30214183/126067739-905b482a-7339-4065-8114-1af79d11f03a.png">

After:

<img width="534" alt="after_icon" src="https://user-images.githubusercontent.com/30214183/126067742-b3ca47ac-00a4-49c4-8db4-62d5b3be4a49.png">


This PR fixes #124382