### PR TITLE
Add validation for objects, fixes #128429

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -123,6 +123,7 @@ export class SettingsEditor2 extends EditorPane {
 		return type === SettingValueType.Enum ||
 			type === SettingValueType.StringOrEnumArray ||
 			type === SettingValueType.BooleanObject ||
+			type === SettingValueType.Object ||
 			type === SettingValueType.Complex ||
 			type === SettingValueType.Boolean ||
 			type === SettingValueType.Exclude;

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1270,7 +1270,7 @@ export class SettingObjectRenderer extends AbstractSettingObjectRenderer impleme
 		template.onChange = (v: Record<string, unknown> | undefined) => {
 			renderArrayValidations(dataElement, template, v, false);
 		};
-		template.onChange(dataElement.value);
+		renderArrayValidations(dataElement, template, dataElement.value, true);
 	}
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -516,6 +516,7 @@ interface ISettingObjectItemTemplate extends ISettingItemTemplate<Record<string,
 	objectDropdownWidget?: ObjectSettingDropdownWidget,
 	objectCheckboxWidget?: ObjectSettingCheckboxWidget;
 	validationErrorMessageElement: HTMLElement;
+	renderValidations?: (value: Record<string, unknown> | undefined) => void;
 }
 
 interface ISettingNewExtensionsTemplate extends IDisposableTemplate {
@@ -1230,8 +1231,8 @@ abstract class AbstractSettingObjectRenderer extends AbstractSettingRenderer imp
 				template.objectDropdownWidget!.setValue(newItems);
 			}
 
-			if (template.onChange) {
-				template.onChange(newObject);
+			if (template.renderValidations) {
+				template.renderValidations(newObject);
 			}
 		}
 	}
@@ -1267,7 +1268,7 @@ export class SettingObjectRenderer extends AbstractSettingObjectRenderer impleme
 		});
 
 		template.context = dataElement;
-		template.onChange = (v: Record<string, unknown> | undefined) => {
+		template.renderValidations = (v: Record<string, unknown> | undefined) => {
 			renderArrayValidations(dataElement, template, v, false);
 		};
 		renderArrayValidations(dataElement, template, dataElement.value, true);

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -516,7 +516,6 @@ interface ISettingObjectItemTemplate extends ISettingItemTemplate<Record<string,
 	objectDropdownWidget?: ObjectSettingDropdownWidget,
 	objectCheckboxWidget?: ObjectSettingCheckboxWidget;
 	validationErrorMessageElement: HTMLElement;
-	renderValidations?: (value: Record<string, unknown> | undefined) => void;
 }
 
 interface ISettingNewExtensionsTemplate extends IDisposableTemplate {
@@ -1219,20 +1218,14 @@ abstract class AbstractSettingObjectRenderer extends AbstractSettingRenderer imp
 
 			const newObject = Object.keys(newValue).length === 0 ? undefined : newValue;
 
-			this._onDidChangeSetting.fire({
-				key: template.context.setting.key,
-				value: newObject,
-				type: template.context.valueType
-			});
-
 			if (template.objectCheckboxWidget) {
 				template.objectCheckboxWidget.setValue(newItems);
 			} else {
 				template.objectDropdownWidget!.setValue(newItems);
 			}
 
-			if (template.renderValidations) {
-				template.renderValidations(newObject);
+			if (template.onChange) {
+				template.onChange(newObject);
 			}
 		}
 	}
@@ -1268,7 +1261,8 @@ export class SettingObjectRenderer extends AbstractSettingObjectRenderer impleme
 		});
 
 		template.context = dataElement;
-		template.renderValidations = (v: Record<string, unknown> | undefined) => {
+		template.onChange = (v: Record<string, unknown> | undefined) => {
+			onChange(v);
 			renderArrayValidations(dataElement, template, v, false);
 		};
 		renderArrayValidations(dataElement, template, dataElement.value, true);
@@ -1304,6 +1298,9 @@ export class SettingBoolObjectRenderer extends AbstractSettingObjectRenderer imp
 		});
 
 		template.context = dataElement;
+		template.onChange = (v: Record<string, unknown> | undefined) => {
+			onChange(v);
+		};
 	}
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -512,9 +512,10 @@ interface ISettingExcludeItemTemplate extends ISettingItemTemplate<void> {
 	excludeWidget: ListSettingWidget;
 }
 
-interface ISettingObjectItemTemplate extends ISettingItemTemplate<void> {
+interface ISettingObjectItemTemplate extends ISettingItemTemplate<Record<string, unknown> | undefined> {
 	objectDropdownWidget?: ObjectSettingDropdownWidget,
 	objectCheckboxWidget?: ObjectSettingCheckboxWidget;
+	validationErrorMessageElement: HTMLElement;
 }
 
 interface ISettingNewExtensionsTemplate extends IDisposableTemplate {
@@ -1138,8 +1139,13 @@ abstract class AbstractSettingObjectRenderer extends AbstractSettingRenderer imp
 		widget.domNode.classList.add(AbstractSettingRenderer.CONTROL_CLASS);
 		common.toDispose.add(widget);
 
+		const descriptionElement = common.containerElement.querySelector('.setting-item-description')!;
+		const validationErrorMessageElement = $('.setting-item-validation-message');
+		descriptionElement.after(validationErrorMessageElement);
+
 		const template: ISettingObjectItemTemplate = {
-			...common
+			...common,
+			validationErrorMessageElement
 		};
 		if (widget instanceof ObjectSettingCheckboxWidget) {
 			template.objectCheckboxWidget = widget;
@@ -1149,7 +1155,9 @@ abstract class AbstractSettingObjectRenderer extends AbstractSettingRenderer imp
 
 		this.addSettingElementFocusHandler(template);
 
-		common.toDispose.add(widget.onDidChangeList(e => this.onDidChangeObject(template, e)));
+		common.toDispose.add(widget.onDidChangeList(e => {
+			this.onDidChangeObject(template, e);
+		}));
 
 		return template;
 	}
@@ -1208,9 +1216,11 @@ abstract class AbstractSettingObjectRenderer extends AbstractSettingRenderer imp
 				}
 			});
 
+			const newObject = Object.keys(newValue).length === 0 ? undefined : newValue;
+
 			this._onDidChangeSetting.fire({
 				key: template.context.setting.key,
-				value: Object.keys(newValue).length === 0 ? undefined : newValue,
+				value: newObject,
 				type: template.context.valueType
 			});
 
@@ -1218,6 +1228,10 @@ abstract class AbstractSettingObjectRenderer extends AbstractSettingRenderer imp
 				template.objectCheckboxWidget.setValue(newItems);
 			} else {
 				template.objectDropdownWidget!.setValue(newItems);
+			}
+
+			if (template.onChange) {
+				template.onChange(newObject);
 			}
 		}
 	}
@@ -1236,7 +1250,7 @@ export class SettingObjectRenderer extends AbstractSettingObjectRenderer impleme
 		return this.renderTemplateWithWidget(common, widget);
 	}
 
-	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingObjectItemTemplate, onChange: (value: string) => void): void {
+	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingObjectItemTemplate, onChange: (value: Record<string, unknown> | undefined) => void): void {
 		const items = getObjectDisplayValue(dataElement);
 		const { key, objectProperties, objectPatternProperties, objectAdditionalProperties } = dataElement.setting;
 
@@ -1253,6 +1267,10 @@ export class SettingObjectRenderer extends AbstractSettingObjectRenderer impleme
 		});
 
 		template.context = dataElement;
+		template.onChange = (v: Record<string, unknown> | undefined) => {
+			renderArrayValidations(dataElement, template, v, false);
+		};
+		template.onChange(dataElement.value);
 	}
 }
 
@@ -1276,7 +1294,7 @@ export class SettingBoolObjectRenderer extends AbstractSettingObjectRenderer imp
 		}
 	}
 
-	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingObjectItemTemplate, onChange: (value: string) => void): void {
+	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingObjectItemTemplate, onChange: (value: Record<string, unknown> | undefined) => void): void {
 		const items = getObjectDisplayValue(dataElement);
 		const { key } = dataElement.setting;
 
@@ -1893,8 +1911,8 @@ function renderValidations(dataElement: SettingsTreeSettingElement, template: IS
 
 function renderArrayValidations(
 	dataElement: SettingsTreeSettingElement,
-	template: ISettingListItemTemplate,
-	value: string[] | undefined,
+	template: ISettingListItemTemplate | ISettingObjectItemTemplate,
+	value: string[] | Record<string, unknown> | undefined,
 	calledOnStartup: boolean
 ) {
 	template.containerElement.classList.add('invalid-input');

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -597,7 +597,7 @@ function isObjectSetting({
 	}
 
 	// object additional properties allow it to have any shape
-	if (objectAdditionalProperties === true) {
+	if (objectAdditionalProperties === true || objectAdditionalProperties === undefined) {
 		return false;
 	}
 

--- a/src/vs/workbench/services/preferences/common/preferencesValidation.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesValidation.ts
@@ -287,8 +287,6 @@ function getArrayOfStringValidator(prop: IConfigurationPropertySchema): ((value:
 }
 
 function getObjectValidator(prop: IConfigurationPropertySchema): ((value: any) => (string | null)) | null {
-	// see if it is renderable object
-	// the only renderable values for now are strings and bools
 	if (prop.type === 'object' && !prop.additionalProperties) {
 		const { properties, patternProperties } = prop;
 		return value => {

--- a/src/vs/workbench/services/preferences/common/preferencesValidation.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesValidation.ts
@@ -301,14 +301,14 @@ function getObjectValidator(prop: IConfigurationPropertySchema): ((value: any) =
 				if (properties && key in properties) {
 					const errorMessage = getErrorsForSchema(properties[key], data);
 					if (errorMessage) {
-						errors.push(nls.localize('validations.errorsForKey', 'For key "{0}": {1}\n', key, errorMessage));
+						errors.push(nls.localize('validations.errorsForKey', "{0}: {1}", key, errorMessage) + '\n');
 					}
 				} else if (patternProperties) {
 					for (const pattern in patternProperties) {
 						if (RegExp(pattern).test(key)) {
 							const errorMessage = getErrorsForSchema(patternProperties[pattern], data);
 							if (errorMessage) {
-								errors.push(nls.localize('validations.errorsForKey', 'For key "{0}": {1}\n', key, errorMessage));
+								errors.push(nls.localize('validations.errorsForKey', "{0}: {1}", key, errorMessage) + '\n');
 							}
 							return;
 						}

--- a/src/vs/workbench/services/preferences/test/common/preferencesValidation.test.ts
+++ b/src/vs/workbench/services/preferences/test/common/preferencesValidation.test.ts
@@ -16,12 +16,12 @@ suite('Preferences Validation', () => {
 			this.validator = createValidator(settings)!;
 		}
 
-		public accepts(input: string) {
-			assert.strictEqual(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to accept \`${input}\`. Got ${this.validator(input)}.`);
+		public accepts(input: string | Record<string, unknown>) {
+			assert.strictEqual(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to accept \`${JSON.stringify(input)}\`. Got ${this.validator(input)}.`);
 		}
 
-		public rejects(input: string) {
-			assert.notStrictEqual(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to reject \`${input}\`.`);
+		public rejects(input: string | Record<string, unknown>) {
+			assert.notStrictEqual(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to reject \`${JSON.stringify(input)}\`.`);
 			return {
 				withMessage:
 					(message: string) => {
@@ -227,26 +227,23 @@ suite('Preferences Validation', () => {
 
 	test('objects work', () => {
 		{
-			const obj = new Tester({ properties: { 'a': { type: 'string', maxLength: 2 } }, additionalProperties: false });
-			obj.rejects('{ "a": "string" }');
-			obj.accepts('{ "a": "st" }');
-			obj.rejects('{ "a": null }');
-			obj.rejects('{ "a": undefined }');
-			obj.rejects('{}');
-			obj.rejects('23');
+			const obj = new Tester({ type: 'object', properties: { 'a': { type: 'string', maxLength: 2 } }, additionalProperties: false });
+			obj.rejects({ 'a': 'string' });
+			obj.accepts({ 'a': 'st' });
+			obj.rejects({ 'a': null });
+			obj.accepts({});
 		}
 		{
-			const pattern = new Tester({ patternProperties: { '^a[a-z]$': { type: 'string', minLength: 2 } }, additionalProperties: false });
-			pattern.accepts('{ "ab": "string" }');
-			pattern.accepts('{ "ab": "string", "ac": "hmm" }');
-			pattern.rejects('{ "ab": "string", "ac": "h" }');
-			pattern.rejects('{ "abc": "string" }');
-			pattern.rejects('{ "a0": "string" }');
-			pattern.rejects('{ "ab": "string", "bc": "hmm" }');
-			pattern.rejects('{ "be": "string" }');
-			pattern.rejects('{ "be": "a" }');
-			pattern.accepts('{}');
-			pattern.rejects('23');
+			const pattern = new Tester({ type: 'object', patternProperties: { '^a[a-z]$': { type: 'string', minLength: 2 } }, additionalProperties: false });
+			pattern.accepts({ 'ab': 'string' });
+			pattern.accepts({ 'ab': 'string', 'ac': 'hmm' });
+			pattern.rejects({ 'ab': 'string', 'ac': 'h' });
+			pattern.rejects({ 'abc': 'string' });
+			pattern.rejects({ 'a0': 'string' });
+			pattern.rejects({ 'ab': 'string', 'bc': 'hmm' });
+			pattern.rejects({ 'be': 'string' });
+			pattern.rejects({ 'be': 'a' });
+			pattern.accepts({});
 		}
 	});
 

--- a/src/vs/workbench/services/preferences/test/common/preferencesValidation.test.ts
+++ b/src/vs/workbench/services/preferences/test/common/preferencesValidation.test.ts
@@ -225,6 +225,31 @@ suite('Preferences Validation', () => {
 		}
 	});
 
+	test('objects work', () => {
+		{
+			const obj = new Tester({ properties: { 'a': { type: 'string', maxLength: 2 } }, additionalProperties: false });
+			obj.rejects('{ "a": "string" }');
+			obj.accepts('{ "a": "st" }');
+			obj.rejects('{ "a": null }');
+			obj.rejects('{ "a": undefined }');
+			obj.rejects('{}');
+			obj.rejects('23');
+		}
+		{
+			const pattern = new Tester({ patternProperties: { '^a[a-z]$': { type: 'string', minLength: 2 } }, additionalProperties: false });
+			pattern.accepts('{ "ab": "string" }');
+			pattern.accepts('{ "ab": "string", "ac": "hmm" }');
+			pattern.rejects('{ "ab": "string", "ac": "h" }');
+			pattern.rejects('{ "abc": "string" }');
+			pattern.rejects('{ "a0": "string" }');
+			pattern.rejects('{ "ab": "string", "bc": "hmm" }');
+			pattern.rejects('{ "be": "string" }');
+			pattern.rejects('{ "be": "a" }');
+			pattern.accepts('{}');
+			pattern.rejects('23');
+		}
+	});
+
 	test('patterns work', () => {
 		{
 			const urls = new Tester({ pattern: '^(hello)*$', type: 'string' });

--- a/src/vs/workbench/services/preferences/test/common/preferencesValidation.test.ts
+++ b/src/vs/workbench/services/preferences/test/common/preferencesValidation.test.ts
@@ -16,11 +16,11 @@ suite('Preferences Validation', () => {
 			this.validator = createValidator(settings)!;
 		}
 
-		public accepts(input: string | Record<string, unknown>) {
+		public accepts(input: any) {
 			assert.strictEqual(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to accept \`${JSON.stringify(input)}\`. Got ${this.validator(input)}.`);
 		}
 
-		public rejects(input: string | Record<string, unknown>) {
+		public rejects(input: any) {
 			assert.notStrictEqual(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to reject \`${JSON.stringify(input)}\`.`);
 			return {
 				withMessage:
@@ -33,7 +33,6 @@ suite('Preferences Validation', () => {
 			};
 		}
 
-
 		public validatesNumeric() {
 			this.accepts('3');
 			this.accepts('3.');
@@ -42,16 +41,24 @@ suite('Preferences Validation', () => {
 			this.accepts(' 3.0');
 			this.accepts(' 3.0  ');
 			this.rejects('3f');
+			this.accepts(3);
+			this.rejects('test');
 		}
 
 		public validatesNullableNumeric() {
 			this.validatesNumeric();
+			this.accepts(0);
 			this.accepts('');
+			this.accepts(null);
+			this.accepts(undefined);
 		}
 
 		public validatesNonNullableNumeric() {
 			this.validatesNumeric();
+			this.accepts(0);
 			this.rejects('');
+			this.rejects(null);
+			this.rejects(undefined);
 		}
 
 		public validatesString() {
@@ -64,6 +71,7 @@ suite('Preferences Validation', () => {
 			this.accepts('');
 			this.accepts('3f');
 			this.accepts('hello');
+			this.rejects(6);
 		}
 	}
 
@@ -231,18 +239,32 @@ suite('Preferences Validation', () => {
 			obj.rejects({ 'a': 'string' });
 			obj.accepts({ 'a': 'st' });
 			obj.rejects({ 'a': null });
+			obj.rejects({ 'a': 7 });
 			obj.accepts({});
+			obj.rejects('test');
+			obj.rejects(7);
+			obj.rejects([1, 2, 3]);
 		}
 		{
 			const pattern = new Tester({ type: 'object', patternProperties: { '^a[a-z]$': { type: 'string', minLength: 2 } }, additionalProperties: false });
 			pattern.accepts({ 'ab': 'string' });
 			pattern.accepts({ 'ab': 'string', 'ac': 'hmm' });
 			pattern.rejects({ 'ab': 'string', 'ac': 'h' });
+			pattern.rejects({ 'ab': 'string', 'ac': 99999 });
 			pattern.rejects({ 'abc': 'string' });
 			pattern.rejects({ 'a0': 'string' });
 			pattern.rejects({ 'ab': 'string', 'bc': 'hmm' });
 			pattern.rejects({ 'be': 'string' });
 			pattern.rejects({ 'be': 'a' });
+			pattern.accepts({});
+		}
+		{
+			const pattern = new Tester({ type: 'object', patternProperties: { '^#': { type: 'string', minLength: 3 } }, additionalProperties: { type: 'string', maxLength: 3 } });
+			pattern.accepts({ '#ab': 'string' });
+			pattern.accepts({ 'ab': 'str' });
+			pattern.rejects({ '#ab': 's' });
+			pattern.rejects({ 'ab': 99999 });
+			pattern.rejects({ '#ab': 99999 });
 			pattern.accepts({});
 		}
 	});
@@ -284,7 +306,7 @@ suite('Preferences Validation', () => {
 			assert.strictEqual(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to accept \`${JSON.stringify(input)}\`. Got ${this.validator(input)}.`);
 		}
 
-		public rejects(input: any[]) {
+		public rejects(input: any) {
 			assert.notStrictEqual(this.validator(input), '', `Expected ${JSON.stringify(this.settings)} to reject \`${JSON.stringify(input)}\`.`);
 			return {
 				withMessage:
@@ -304,6 +326,8 @@ suite('Preferences Validation', () => {
 			arr.accepts([]);
 			arr.accepts(['foo']);
 			arr.accepts(['foo', 'bar']);
+			arr.rejects(76);
+			arr.rejects([6, '3', 7]);
 		}
 	});
 


### PR DESCRIPTION
This PR fixes #128429

The PR adds validation messages to objects in the settings editor.

![](https://user-images.githubusercontent.com/7199958/126379793-f145aa4a-8454-4997-8b6c-972cee5300f5.PNG)
