### PR TITLE
Remove 'collapsed' css class for collapsed notebook cells

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/codeCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/codeCell.ts
@@ -263,7 +263,7 @@ export class CodeCell extends Disposable {
 		});
 	}
 
-	private updateInputCollaseElement(): void {
+	private updateInputCollapseElement(): void {
 		this.removeInputCollapsePreview();
 		const richEditorText = this.getRichText(this.viewCell.textBuffer, this.viewCell.language);
 		const element = DOM.$('div');
@@ -277,9 +277,8 @@ export class CodeCell extends Disposable {
 		DOM.hide(this.templateData.runButtonContainer);
 		DOM.show(this.templateData.collapsedPart);
 		DOM.show(this.templateData.outputContainer);
-		this.templateData.container.classList.toggle('collapsed', true);
 		this._outputContainerRenderer.viewUpdateShowOutputs();
-		this.updateInputCollaseElement();
+		this.updateInputCollapseElement();
 
 		this.relayoutCell();
 	}
@@ -291,7 +290,6 @@ export class CodeCell extends Disposable {
 		DOM.hide(this.templateData.outputContainer);
 		this.removeInputCollapsePreview();
 		this._outputContainerRenderer.viewUpdateHideOuputs();
-		this.templateData.container.classList.toggle('collapsed', false);
 		this.templateData.container.classList.toggle('output-collapsed', true);
 
 		this.relayoutCell();
@@ -302,10 +300,9 @@ export class CodeCell extends Disposable {
 		DOM.hide(this.templateData.runButtonContainer);
 		DOM.show(this.templateData.collapsedPart);
 		DOM.hide(this.templateData.outputContainer);
-		this.templateData.container.classList.toggle('collapsed', true);
 		this.templateData.container.classList.toggle('output-collapsed', true);
 		this._outputContainerRenderer.viewUpdateHideOuputs();
-		this.updateInputCollaseElement();
+		this.updateInputCollapseElement();
 		this.relayoutCell();
 	}
 
@@ -315,7 +312,6 @@ export class CodeCell extends Disposable {
 		DOM.hide(this.templateData.collapsedPart);
 		this.removeInputCollapsePreview();
 		DOM.show(this.templateData.outputContainer);
-		this.templateData.container.classList.toggle('collapsed', false);
 		this.templateData.container.classList.toggle('output-collapsed', false);
 		this._outputContainerRenderer.viewUpdateShowOutputs();
 		this.relayoutCell();

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/markdownCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/markdownCell.ts
@@ -180,7 +180,6 @@ export class StatefulMarkdownCell extends Disposable {
 		DOM.hide(this.editorPart);
 		this.markdownAccessibilityContainer.ariaHidden = 'true';
 
-		this.templateData.container.classList.toggle('collapsed', true);
 		this.viewCell.renderedMarkdownHeight = 0;
 		this.viewCell.layoutChange({});
 	}
@@ -195,7 +194,6 @@ export class StatefulMarkdownCell extends Disposable {
 
 		this.notebookEditor.hideMarkupPreviews([this.viewCell]);
 
-		this.templateData.container.classList.toggle('collapsed', false);
 		this.templateData.container.classList.toggle('markdown-cell-edit-mode', true);
 
 		if (this.editor && this.editor.hasModel()) {
@@ -282,7 +280,6 @@ export class StatefulMarkdownCell extends Disposable {
 		DOM.hide(this.editorPart);
 		DOM.hide(this.templateData.collapsedPart);
 		this.markdownAccessibilityContainer.ariaHidden = 'false';
-		this.templateData.container.classList.toggle('collapsed', false);
 		this.templateData.container.classList.toggle('markdown-cell-edit-mode', false);
 
 		this.renderedEditors.delete(this.viewCell);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/129090

As far as I can tell collapsing seems to work just fine without this css class.

![image](https://user-images.githubusercontent.com/30305945/126442534-6f1ab89a-8cb5-4c34-a2d1-f9f057482ac1.png)
