### PR TITLE
Fix typo in github-authentication/github.ts

### DIFF
--- a/extensions/github-authentication/src/github.ts
+++ b/extensions/github-authentication/src/github.ts
@@ -86,7 +86,7 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 			try {
 				await this._githubServer.getUserInfo(session.accessToken);
 				this.afterTokenLoad(session.accessToken);
-				Logger.info(`Verified sesion with the following scopes: ${session.scopes}`);
+				Logger.info(`Verified session with the following scopes: ${session.scopes}`);
 				verifiedSessions.push(session);
 			} catch (e) {
 				// Remove sessions that return unauthorized response


### PR DESCRIPTION
Fixes a tiny little typo in a log message of the github-authentication extension :)
