### PR TITLE
Fix object widget tooltips, fixes #129059

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -145,12 +145,6 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 			schema
 		}));
 
-	const additionalValueEnums = getEnumOptionsFromSchema(
-		typeof objectAdditionalProperties === 'boolean'
-			? {}
-			: objectAdditionalProperties ?? {}
-	);
-
 	const wellDefinedKeyEnumOptions = Object.entries(objectProperties ?? {}).map(
 		([key, schema]) => ({ value: key, description: schema.description })
 	);
@@ -167,15 +161,14 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 					},
 					value: {
 						type: 'boolean',
-						data: data[key],
-						description: objectProperties[key].description
+						data: data[key]
 					},
+					keyDescription: objectProperties[key].description,
 					removable: false
 				} as IObjectDataItem;
 			}
 
 			const valueEnumOptions = getEnumOptionsFromSchema(objectProperties[key]);
-
 			return {
 				key: {
 					type: 'enum',
@@ -187,6 +180,7 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 					data: data[key],
 					options: valueEnumOptions,
 				},
+				keyDescription: objectProperties[key].description,
 				removable: isUndefinedOrNull(defaultValue),
 			} as IObjectDataItem;
 		}
@@ -201,9 +195,16 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 					data: data[key],
 					options: valueEnumOptions,
 				},
+				keyDescription: schema.description,
 				removable: true,
 			} as IObjectDataItem;
 		}
+
+		const additionalValueEnums = getEnumOptionsFromSchema(
+			typeof objectAdditionalProperties === 'boolean'
+				? {}
+				: objectAdditionalProperties ?? {}
+		);
 
 		return {
 			key: { type: 'string', data: key },
@@ -212,6 +213,7 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 				data: data[key],
 				options: additionalValueEnums,
 			},
+			keyDescription: typeof objectAdditionalProperties === 'object' ? objectAdditionalProperties.description : undefined,
 			removable: true,
 		} as IObjectDataItem;
 	});

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -1259,13 +1259,15 @@ export class ObjectSettingDropdownWidget extends AbstractListSettingWidget<IObje
 	protected addTooltipsToRow(rowElement: HTMLElement, item: IObjectDataItem): void {
 		const keyElement = rowElement.getElementsByClassName('setting-list-object-key')[0] as HTMLElement;
 		const valueElement = rowElement.getElementsByClassName('setting-list-object-value')[0] as HTMLElement;
-		const defaultDescription = localize('objectPairHintLabel', "The property `{0}` is set to `{1}`.", item.key.data, item.value.data);
+		const accessibleDescription = localize('objectPairHintLabel', "The property `{0}` is set to `{1}`.", item.key.data, item.value.data);
 
-		const keyDescription = this.getEnumDescription(item.key) ?? item.keyDescription ?? defaultDescription;
-		this.addTooltipToElement(keyElement, keyDescription);
+		const keyDescription = this.getEnumDescription(item.key) ?? item.keyDescription ?? accessibleDescription;
+		keyElement.title = keyDescription;
 
-		const valueDescription = this.getEnumDescription(item.value) ?? defaultDescription;
-		this.addTooltipToElement(valueElement, valueDescription);
+		const valueDescription = this.getEnumDescription(item.value) ?? accessibleDescription;
+		valueElement.title = valueDescription;
+
+		rowElement.setAttribute('aria-label', accessibleDescription);
 	}
 
 	private getEnumDescription(keyOrValue: ObjectKey | ObjectValue): string | undefined {
@@ -1273,11 +1275,6 @@ export class ObjectSettingDropdownWidget extends AbstractListSettingWidget<IObje
 			? keyOrValue.options.find(({ value }) => keyOrValue.data === value)?.description
 			: undefined;
 		return enumDescription;
-	}
-
-	private addTooltipToElement(element: HTMLElement, description: string) {
-		element.title = description;
-		element.setAttribute('aria-label', description);
 	}
 
 	protected getLocalizedStrings() {
@@ -1406,11 +1403,11 @@ export class ObjectSettingCheckboxWidget extends AbstractListSettingWidget<IObje
 	}
 
 	protected addTooltipsToRow(rowElement: HTMLElement, item: IObjectDataItem): void {
-		const title = item.keyDescription ??
-			localize('objectPairHintLabel', "The property `{0}` is set to `{1}`.", item.key.data, item.value.data);
+		const accessibleDescription = localize('objectPairHintLabel', "The property `{0}` is set to `{1}`.", item.key.data, item.value.data);
+		const title = item.keyDescription ?? accessibleDescription;
 
 		rowElement.title = title;
-		rowElement.setAttribute('aria-label', rowElement.title);
+		rowElement.setAttribute('aria-label', accessibleDescription);
 	}
 
 	protected getLocalizedStrings() {


### PR DESCRIPTION
This PR fixes #129059 

For object widgets, hovering over the key now displays the key enumDescription or description, and hovering over the value displays the value enumDescription. In both cases, if none of those descriptions are provided, there is still the fallback to the default description saying "property X is set to Y".

The default description is still used for the aria-label to help with accessibility.

![Demo](https://user-images.githubusercontent.com/7199958/126570957-78ff496f-8f12-4b64-940d-e595a6773f28.gif)

I tested the issue with the following settings:

```json
"emmet.hmm": {
  "type": "object",
  "properties": {
	"property": {
	  "type": "string",
	  "enum": ["a", "b", "c"],
	  "enumDescriptions": ["Item a", "Item b", "Item c"],
	  "description": "propertiesDescription"
	}
  },
  "patternProperties": {
	"^pattern-": {
	  "type": "string",
	  "enum": ["d", "e", "f"],
	  "enumDescriptions": ["Item d", "Item e", "Item f"],
	  "description": "patternDescription"
	}
  },
  "additionalProperties": {
	"type": "string",
	"enum": ["g", "h", "i"],
	"enumDescriptions": ["Item g", "Item h", "Item i"],
	"description": "additionalPropertiesDescription"
  },
  "default": {
	"property": "a",
	"pattern-here": "e",
	"additional": "h"
  }
},
"emmet.boolhmm": {
  "type": "object",
  "properties": {
	"property": {
	  "type": "boolean",
	  "description": "propertiesDescription"
	}
  },
  "default": {
	"property": true
  }
}
```