### PR TITLE
Fixes #129180

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -167,12 +167,11 @@
 	width: calc(100% - 48px);
 	margin-left: 24px;
 }
-
+.settings-editor.mid-width > .settings-body > .settings-tree-container .settings-editor-tree > .monaco-scrollable-element > .shadow.top.top-left-corner {
+	width: 24px;
+	margin-left: 0px;
+}
 .settings-editor > .settings-body > .settings-tree-container .settings-editor-tree > .monaco-scrollable-element > .shadow.top {
-	left: 50%;
-	max-width: 952px;
-	/* 1000 - 24*2 padding */
-	margin-left: -476px;
 	z-index: 11;
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -162,13 +162,13 @@
 	display: none !important;
 }
 
-.settings-editor.mid-width > .settings-body > .settings-tree-container .shadow.top {
+.settings-editor.mid-width > .settings-body > .settings-tree-container .settings-editor-tree > .monaco-scrollable-element > .shadow.top {
 	left: 0;
 	width: calc(100% - 48px);
 	margin-left: 24px;
 }
 
-.settings-editor > .settings-body > .settings-tree-container .shadow.top {
+.settings-editor > .settings-body > .settings-tree-container .settings-editor-tree > .monaco-scrollable-element > .shadow.top {
 	left: 50%;
 	max-width: 952px;
 	/* 1000 - 24*2 padding */


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #129180

It changes some selectors so that only the large scrollable element (the entire list of settings) is affected by the custom shadow CSS.

![Demo](https://user-images.githubusercontent.com/7199958/126720775-0db3d999-74cb-4f13-a73b-9c6de7b351c4.png)

It seems that the shadow for the settings list fails to render properly for smaller window widths, though.

