### PR TITLE
Migrate webview notebook editor backup to builtin serializer

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -13,8 +13,8 @@
 	],
 	"extensionKind": [
 		"web",
-		"ui",
-		"workspace"
+		"workspace",
+		"ui"
 	],
 	"main": "./out/ipynbMain.js",
 	"browser": "./dist/browser/ipynbMain.js",

--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -54,6 +54,7 @@
     "watch": "npx gulp watch-extension:ipynb"
   },
 	"dependencies": {
+		"@enonic/fnv-plus": "^1.3.0",
 		"detect-indent": "^6.0.0"
 	},
 	"devDependencies": {

--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { NotebookSerializer } from './serializer';
 
 export function activate(context: vscode.ExtensionContext) {
-	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('jupyter-notebook', new NotebookSerializer(), {
+	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('jupyter-notebook', new NotebookSerializer(context), {
 		transientOutputs: false,
 		transientCellMetadata: {
 			breakpointMargin: true,

--- a/extensions/ipynb/src/types.d.ts
+++ b/extensions/ipynb/src/types.d.ts
@@ -6,3 +6,5 @@
 
 /// <reference path='../../../src/vs/vscode.d.ts'/>
 /// <reference path='../../../src/vs/vscode.proposed.d.ts'/>
+
+declare module '@enonic/fnv-plus';

--- a/extensions/ipynb/yarn.lock
+++ b/extensions/ipynb/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@enonic/fnv-plus@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@enonic/fnv-plus/-/fnv-plus-1.3.0.tgz#be65a7b128a3b544f60aea3ef978d938e85869f3"
+  integrity sha512-BCN9uNWH8AmiP7BXBJqEinUY9KXalmRzo+L0cB/mQsmFfzODxwQrbvxCHXUNH2iP+qKkWYtB4vyy8N62PViMFw==
+
 "@jupyterlab/coreutils@^3.1.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz#dd4d887bdedfea4c8545d46d297531749cb13724"

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
@@ -17,6 +17,7 @@ import { IWorkingCopyEditorService } from 'vs/workbench/services/workingCopy/com
 import { ICustomEditorService } from 'vs/workbench/contrib/customEditor/common/customEditor';
 import { Schemas } from 'vs/base/common/network';
 import { isEqual } from 'vs/base/common/resources';
+import { NotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
 
 export interface CustomDocumentBackupData extends IWorkingCopyBackupMeta {
 	readonly viewType: string;
@@ -88,6 +89,10 @@ export class CustomEditorInputSerializer extends WebviewEditorInputSerializer {
 		serializedEditorInput: string
 	): CustomEditorInput {
 		const data = this.fromJson(JSON.parse(serializedEditorInput));
+		if (data.viewType === 'jupyter.notebook.ipynb') {
+			return NotebookEditorInput.create(this._instantiationService, data.editorResource, 'jupyter-notebook', { _backupId: data.backupId }) as any;
+		}
+
 		const webview = reviveWebview(this._webviewService, data);
 		const customInput = this._instantiationService.createInstance(CustomEditorInput, data.editorResource, data.viewType, data.id, webview, { startsDirty: data.dirty, backupId: data.backupId });
 		if (typeof data.group === 'number') {
@@ -149,6 +154,10 @@ export class ComplexCustomWorkingCopyEditorHandler extends Disposable implements
 				}
 
 				const backupData = backup.meta;
+				if (backupData.viewType === 'jupyter.notebook.ipynb') {
+					return NotebookEditorInput.create(this._instantiationService, URI.revive(backupData.editorResource), 'jupyter-notebook', { _backupId: backupData.backupId }) as any;
+				}
+
 				const id = backupData.webview.id;
 				const extension = reviveWebviewExtensionDescription(backupData.extension?.id, backupData.extension?.location);
 				const webview = reviveWebview(this._webviewService, {

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
@@ -130,6 +130,15 @@ export class ComplexCustomWorkingCopyEditorHandler extends Disposable implements
 		this._register(this._workingCopyEditorService.registerHandler({
 			handles: workingCopy => workingCopy.resource.scheme === Schemas.vscodeCustomEditor,
 			isOpen: (workingCopy, editor) => {
+				if (workingCopy.resource.authority === 'jupyter-notebook-ipynb' && editor instanceof NotebookEditorInput) {
+					try {
+						const data = JSON.parse(workingCopy.resource.query);
+						const workingCopyResource = URI.from(data);
+						return isEqual(workingCopyResource, editor.resource);
+					} catch {
+						return false;
+					}
+				}
 				if (!(editor instanceof CustomEditorInput)) {
 					return false;
 				}
@@ -155,7 +164,7 @@ export class ComplexCustomWorkingCopyEditorHandler extends Disposable implements
 
 				const backupData = backup.meta;
 				if (backupData.viewType === 'jupyter.notebook.ipynb') {
-					return NotebookEditorInput.create(this._instantiationService, URI.revive(backupData.editorResource), 'jupyter-notebook', { _backupId: backupData.backupId }) as any;
+					return NotebookEditorInput.create(this._instantiationService, URI.revive(backupData.editorResource), 'jupyter-notebook', { _backupId: backupData.backupId, _workingCopy: workingCopy }) as any;
 				}
 
 				const id = backupData.webview.id;

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -285,7 +285,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		);
 	}
 
-	private _initialize(cells: ICellDto2[]) {
+	_initialize(cells: ICellDto2[], triggerDirty?: boolean) {
 		this._cells = [];
 		this._versionId = 0;
 		this._notebookSpecificAlternativeId = 0;
@@ -306,6 +306,10 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 
 		this._cells.splice(0, 0, ...mainCells);
 		this._alternativeVersionId = this._generateAlternativeId();
+
+		if (triggerDirty) {
+			this._eventEmitter.emit({ kind: NotebookCellsChangeType.Unknown, transient: false }, true);
+		}
 	}
 
 	private _bindCellContentHandler(cell: NotebookCellTextModel, e: 'content' | 'language' | 'mime') {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Layer breaking code to bring webview notebook editor backups to the new serializer:

* When editor services try to restore a webview editor backup for ipynb, generate a notebook editor input
* Attach the backup id
* Pass the backup id the ipynb serializer
* ipynb serializer resolve the content based on the shape of the buffer

---

This probably doesn't work with Remote, where the Jupyter extension is in a remote extension host but the builtin serializer runs in the local extension host. @roblourens can we make the ipynb extension a workspace extension?
