### PR TITLE
Cancel edit when leaving widget

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -619,6 +619,9 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 	protected readonly _onDidFocusSetting = this._register(new Emitter<SettingsTreeSettingElement>());
 	readonly onDidFocusSetting: Event<SettingsTreeSettingElement> = this._onDidFocusSetting.event;
 
+	private readonly _onDidBlurSetting = this._register(new Emitter<SettingsTreeSettingElement>());
+	readonly onDidBlurSetting: Event<SettingsTreeSettingElement> = this._onDidBlurSetting.event;
+
 	private ignoredSettings: string[];
 	private readonly _onDidChangeIgnoredSettings = this._register(new Emitter<void>());
 	readonly onDidChangeIgnoredSettings: Event<void> = this._onDidChangeIgnoredSettings.event;
@@ -718,6 +721,10 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		focusTracker.onDidBlur(() => {
 			if (template.containerElement.classList.contains('focused')) {
 				template.containerElement.classList.remove('focused');
+			}
+
+			if (template.context) {
+				this._onDidBlurSetting.fire(template.context);
 			}
 		});
 
@@ -1043,6 +1050,10 @@ export class SettingArrayRenderer extends AbstractSettingRenderer implements ITr
 			})
 		);
 
+		common.toDispose.add(this.onDidBlurSetting(() => {
+			template.listWidget.cancelEdit();
+		}));
+
 		return template;
 	}
 
@@ -1233,7 +1244,14 @@ export class SettingObjectRenderer extends AbstractSettingObjectRenderer impleme
 	renderTemplate(container: HTMLElement): ISettingObjectItemTemplate {
 		const common = this.renderCommonTemplate(null, container, 'list');
 		const widget = this._instantiationService.createInstance(ObjectSettingDropdownWidget, common.controlElement);
-		return this.renderTemplateWithWidget(common, widget);
+
+		const templateWithWidget = this.renderTemplateWithWidget(common, widget);
+
+		common.toDispose.add(this.onDidBlurSetting(() => {
+			templateWithWidget.objectDropdownWidget!.cancelEdit();
+		}));
+
+		return templateWithWidget;
 	}
 
 	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingObjectItemTemplate, onChange: (value: string) => void): void {
@@ -1306,6 +1324,10 @@ export class SettingExcludeRenderer extends AbstractSettingRenderer implements I
 		this.addSettingElementFocusHandler(template);
 
 		common.toDispose.add(excludeWidget.onDidChangeList(e => this.onDidChangeExclude(template, e)));
+
+		common.toDispose.add(this.onDidBlurSetting(() => {
+			template.excludeWidget.cancelEdit();
+		}));
 
 		return template;
 	}

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -377,7 +377,7 @@ export abstract class AbstractListSettingWidget<TDataItem extends object> extend
 		this.renderList();
 	}
 
-	protected cancelEdit(): void {
+	public cancelEdit(): void {
 		this.model.setEditKey('none');
 		this.renderList();
 	}


### PR DESCRIPTION
Fixes #125166

This PR adds a few blur handlers to the list, exclude, and object dropdown widgets, so that when the user goes back to the searchbox and types, focus doesn't accidentally go back to the widget.

The downside is that the widgets now leave edit mode more eagerly, which might result in more clicks as users go back and forth to edit settings.