### PR TITLE
fix #114381 cwd returns to os.homedir() if workspaceFolder does not resolve

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -1658,7 +1658,10 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			try {
 				cwd = await this.resolveVariable(resolver, '${workspaceFolder}');
 			} catch (e) {
-				// No workspace
+				// If we don't have a cwd, then the terminal uses the home dir.
+				let cwd_uri: URI;
+				cwd_uri = await this.pathService.userHome();
+				cwd = cwd_uri.toString();
 			}
 			return { cwd };
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #114381 

Changes:
`cwd` returns to `os.homedir()` if `workspaceFolder` does not resolve.
