### PR TITLE
Settings description typos

### DIFF
--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -169,7 +169,7 @@
 	"config.useForcePushWithLease": "Controls whether force pushing uses the safer force-with-lease variant.",
 	"config.confirmForcePush": "Controls whether to ask for confirmation before force-pushing.",
 	"config.allowNoVerifyCommit": "Controls whether commits without running pre-commit and commit-msg hooks are allowed.",
-	"config.confirmNoVerifyCommit": "Controls whether to ask for confirmation before commiting without verification.",
+	"config.confirmNoVerifyCommit": "Controls whether to ask for confirmation before committing without verification.",
 	"config.openDiffOnClick": "Controls whether the diff editor should be opened when clicking a change. Otherwise the regular editor will be opened.",
 	"config.supportCancellation": "Controls whether a notification comes up when running the Sync action, which allows the user to cancel the operation.",
 	"config.branchSortOrder": "Controls the sort order for branches.",

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -15,7 +15,7 @@
 	"markdown.previewSide.title": "Open Preview to the Side",
 	"markdown.showLockedPreviewToSide.title": "Open Locked Preview to the Side",
 	"markdown.showSource.title": "Show Source",
-	"markdown.styles.dec": "A list of URLs or local paths to CSS style sheets to use from the Markdown preview. Relative paths are interpreted relative to the folder open in the explorer. If there is no open folder, they are interpreted relative to the location of the Markdown file. All '\\' need to be written as '\\\\'.",
+	"markdown.styles.dec": "A list of URLs or local paths to CSS style sheets to use from the Markdown preview. Relative paths are interpreted relative to the folder open in the Explorer. If there is no open folder, they are interpreted relative to the location of the Markdown file. All '\\' need to be written as '\\\\'.",
 	"markdown.showPreviewSecuritySelector.title": "Change Preview Security Settings",
 	"markdown.trace.desc": "Enable debug logging for the Markdown extension.",
 	"markdown.preview.refresh.title": "Refresh Preview",

--- a/extensions/markdown-math/package.nls.json
+++ b/extensions/markdown-math/package.nls.json
@@ -1,5 +1,5 @@
 {
 	"displayName": "Markdown Math",
-	"description": "Adds math support to markdown in notebooks.",
-	"config.markdown.math.enabled": "Enable/disable rendering math in the built-in markdown preview."
+	"description": "Adds math support to Markdown in notebooks.",
+	"config.markdown.math.enabled": "Enable/disable rendering math in the built-in Markdown preview."
 }

--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -356,7 +356,7 @@ const terminalPlatformConfiguration: IConfigurationNode = {
 		},
 		[TerminalSettingId.InheritEnv]: {
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('terminal.integrated.inheritEnv', "Whether new shells should inherit their environment from VS Code which may source a login shell to ensure $PATH and other development variables are initialized. This has no effect on Windows."),
+			description: localize('terminal.integrated.inheritEnv', "Whether new shells should inherit their environment from VS Code, which may source a login shell to ensure $PATH and other development variables are initialized. This has no effect on Windows."),
 			type: 'boolean',
 			default: true
 		},

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -378,7 +378,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize('sortOrderLexicographicOptions.lower', 'Lowercase names are grouped together before uppercase names.'),
 				nls.localize('sortOrderLexicographicOptions.unicode', 'Names are sorted in unicode order.')
 			],
-			'description': nls.localize('sortOrderLexicographicOptions', "Controls the lexicographic sorting of file and folder names in the explorer.")
+			'description': nls.localize('sortOrderLexicographicOptions', "Controls the lexicographic sorting of file and folder names in the Explorer.")
 		},
 		'explorer.decorations.colors': {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -646,9 +646,9 @@ configurationRegistry.registerConfiguration({
 			type: 'string',
 			enum: ['hidden', 'visible', 'visibleAfterExecute'],
 			enumDescriptions: [
-				nls.localize('notebook.showCellStatusbar.hidden.description', "The cell status bar is always hidden."),
-				nls.localize('notebook.showCellStatusbar.visible.description', "The cell status bar is always visible."),
-				nls.localize('notebook.showCellStatusbar.visibleAfterExecute.description', "The cell status bar is hidden until the cell has executed. Then it becomes visible to show the execution status.")],
+				nls.localize('notebook.showCellStatusbar.hidden.description', "The cell Status bar is always hidden."),
+				nls.localize('notebook.showCellStatusbar.visible.description', "The cell Status bar is always visible."),
+				nls.localize('notebook.showCellStatusbar.visibleAfterExecute.description', "The cell Status bar is hidden until the cell has executed. Then it becomes visible to show the execution status.")],
 			default: 'visible',
 			tags: ['notebookLayout']
 		},
@@ -708,7 +708,7 @@ configurationRegistry.registerConfiguration({
 			tags: ['notebookLayout']
 		},
 		[ShowFoldingControls]: {
-			description: nls.localize('notebook.showFoldingControls.description', "Controls when the markdown header folding arrow is shown."),
+			description: nls.localize('notebook.showFoldingControls.description', "Controls when the Markdown header folding arrow is shown."),
 			type: 'string',
 			enum: ['always', 'mouseover'],
 			enumDescriptions: [

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -390,8 +390,8 @@ const terminalConfiguration: IConfigurationNode = {
 			type: 'string',
 			enum: ['executable', 'sequence'],
 			markdownEnumDescriptions: [
-				localize('titleMode.executable', "The title is set by the _terminal_, the name of the detected foreground process will be used."),
-				localize('titleMode.sequence', "The title is set by the _process_ via an escape sequence, this is useful if your shell dynamically sets the title.")
+				localize('titleMode.executable', "The title is set by the terminal, the name of the detected foreground process will be used."),
+				localize('titleMode.sequence', "The title is set by the process via an escape sequence, this is useful if your shell dynamically sets the title.")
 			],
 			default: 'executable'
 		},

--- a/src/vs/workbench/services/themes/common/themeConfiguration.ts
+++ b/src/vs/workbench/services/themes/common/themeConfiguration.ts
@@ -70,7 +70,7 @@ const preferredHCThemeSettingSchema: IConfigurationPropertySchema = {
 };
 const detectColorSchemeSettingSchema: IConfigurationPropertySchema = {
 	type: 'boolean',
-	markdownDescription: nls.localize('detectColorScheme', 'If set, automatically switch to the preferred color theme based on the OS appearance. If the OS appearance is dark, the theme specified at `#{0}#` is used, for light `#{1}#`', ThemeSettings.PREFERRED_DARK_THEME, ThemeSettings.PREFERRED_LIGHT_THEME),
+	markdownDescription: nls.localize('detectColorScheme', 'If set, automatically switch to the preferred color theme based on the OS appearance. If the OS appearance is dark, the theme specified at `#{0}#` is used, for light `#{1}#`.', ThemeSettings.PREFERRED_DARK_THEME, ThemeSettings.PREFERRED_LIGHT_THEME),
 	default: false
 };
 


### PR DESCRIPTION
Some small settings description typos noticed during the 1.58 settings.md update.
Cleaning up before 1.59 release.