### PR TITLE
fix: remove useless priority field in vscode.FileDecoration api

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2911,9 +2911,7 @@ export class FileDecoration {
 	badge?: string;
 	tooltip?: string;
 	color?: vscode.ThemeColor;
-	priority?: number;
 	propagate?: boolean;
-
 
 	constructor(badge?: string, tooltip?: string, color?: ThemeColor) {
 		this.badge = badge;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #

Remove useless `priority` field in vscode.FileDecoration api.

Because there is no usage for this field.

https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/common/extHostDecorations.ts#L103

![image](https://user-images.githubusercontent.com/6828924/127127450-12dadb4d-563b-40fa-ad0e-22bfebd28b06.png)

https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/browser/mainThreadDecorations.ts#L97

![image](https://user-images.githubusercontent.com/6828924/127132336-d6e0c3c1-9b5b-4b4a-b452-d7fb9f2a247f.png)

https://github.com/microsoft/vscode/blob/main/src/vs/vscode.d.ts#L5896

![image](https://user-images.githubusercontent.com/6828924/127127530-b804cf0d-b98e-4137-aab4-bc91d028aa4a.png)

