### PR TITLE
Fix focus issues in disassembly view

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -164,7 +164,8 @@ export class BreakpointsView extends ViewPane {
 			}
 			if (e.element instanceof InstructionBreakpoint) {
 				const disassemblyView = await this.editorService.openEditor(DisassemblyViewInput.instance);
-				(disassemblyView as DisassemblyView).goToAddress(e.element.instructionReference);
+				// Focus on double click
+				(disassemblyView as DisassemblyView).goToAddress(e.element.instructionReference, e.browserEvent instanceof MouseEvent && e.browserEvent.detail === 2);
 			}
 			if (e.browserEvent instanceof MouseEvent && e.browserEvent.detail === 2 && e.element instanceof FunctionBreakpoint && e.element !== this.inputBoxData?.breakpoint) {
 				// double click

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -124,7 +124,8 @@ export class DisassemblyView extends EditorPane {
 				multipleSelectionSupport: false,
 				setRowLineHeight: false,
 				openOnSingleClick: false,
-				accessibilityProvider: new AccessibilityProvider()
+				accessibilityProvider: new AccessibilityProvider(),
+				mouseSupport: false
 			}
 		)) as WorkbenchTable<IDisassembledInstructionEntry>;
 
@@ -241,13 +242,6 @@ export class DisassemblyView extends EditorPane {
 			// Address is not provided or not in the table currently, clear the table
 			// and reload if we are in the state where we can load disassembly.
 			this.reloadDisassembly(address);
-			if (focus) {
-				const newIndex = this.getIndexFromAddress(address);
-				if (newIndex >= 0) {
-					this._disassembledInstructions.domFocus();
-					this._disassembledInstructions.setFocus([newIndex]);
-				}
-			}
 		}
 	}
 
@@ -361,7 +355,12 @@ export class DisassemblyView extends EditorPane {
 			this.loadDisassembledInstructions(targetAddress, -DisassemblyView.NUM_INSTRUCTIONS_TO_LOAD, DisassemblyView.NUM_INSTRUCTIONS_TO_LOAD * 2).then(() => {
 				// on load, set the target instruction in the middle of the page.
 				if (this._disassembledInstructions!.length > 0) {
-					this._disassembledInstructions!.reveal(Math.floor(this._disassembledInstructions!.length / 2), 0.5);
+					const targetIndex = Math.floor(this._disassembledInstructions!.length / 2);
+					this._disassembledInstructions!.reveal(targetIndex, 0.5);
+
+					// Always focus the target address on reload, or arrow key navigation would look terrible
+					this._disassembledInstructions!.domFocus();
+					this._disassembledInstructions!.setFocus([targetIndex]);
 				}
 			});
 		}

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -203,7 +203,7 @@ export class DisassemblyView extends EditorPane {
 	/**
 	 * Go to the address provided. If no address is provided, reveal the address of the currently focused stack frame.
 	 */
-	goToAddress(address?: string): void {
+	goToAddress(address?: string, focus?: boolean): void {
 		if (!this._disassembledInstructions) {
 			return;
 		}
@@ -222,21 +222,32 @@ export class DisassemblyView extends EditorPane {
 			const bottomElement = Math.floor((this._disassembledInstructions.scrollTop + this._disassembledInstructions.renderHeight) / this.fontInfo.lineHeight);
 			if (index > topElement && index < bottomElement) {
 				// Inside the viewport, don't do anything here
-				return;
 			} else if (index <= topElement && index > topElement - 5) {
 				// Not too far from top, review it at the top
-				return this._disassembledInstructions.reveal(index, 0);
+				this._disassembledInstructions.reveal(index, 0);
 			} else if (index >= bottomElement && index < bottomElement + 5) {
 				// Not too far from bottom, review it at the bottom
-				return this._disassembledInstructions.reveal(index, 1);
+				this._disassembledInstructions.reveal(index, 1);
 			} else {
 				// Far from the current viewport, reveal it
-				return this._disassembledInstructions.reveal(index, 0.5);
+				this._disassembledInstructions.reveal(index, 0.5);
+			}
+
+			if (focus) {
+				this._disassembledInstructions.domFocus();
+				this._disassembledInstructions.setFocus([index]);
 			}
 		} else if (this._debugService.state === State.Stopped) {
 			// Address is not provided or not in the table currently, clear the table
 			// and reload if we are in the state where we can load disassembly.
-			return this.reloadDisassembly(address);
+			this.reloadDisassembly(address);
+			if (focus) {
+				const newIndex = this.getIndexFromAddress(address);
+				if (newIndex >= 0) {
+					this._disassembledInstructions.domFocus();
+					this._disassembledInstructions.setFocus([newIndex]);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #129523 and #129535

Some changes make more sense by combining the fixes to these two issues in the same PR.

Double clicking on instruction breakpoint in breakpoints view now passes focus to disassembly view, setting the focus to the entry containing target address.

`mouseSupport` is now disabled in disassembly view to disable selection. And so need to set focus at appropriate time, or there would be weird behaviors when navigating using arrow keys.
