### PR TITLE
Larger initial view size in disassembly view

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -347,7 +347,7 @@ export class DisassemblyView extends EditorPane {
 		if (this._disassembledInstructions) {
 			this._disassembledInstructions.splice(0, this._disassembledInstructions.length);
 			this._instructionBpList = this._debugService.getModel().getInstructionBreakpoints();
-			this.loadDisassembledInstructions(targetAddress, -DisassemblyView.NUM_INSTRUCTIONS_TO_LOAD, DisassemblyView.NUM_INSTRUCTIONS_TO_LOAD * 2).then(() => {
+			this.loadDisassembledInstructions(targetAddress, -DisassemblyView.NUM_INSTRUCTIONS_TO_LOAD * 4, DisassemblyView.NUM_INSTRUCTIONS_TO_LOAD * 8).then(() => {
 				// on load, set the target instruction in the middle of the page.
 				if (this._disassembledInstructions!.length > 0) {
 					this._disassembledInstructions!.reveal(Math.floor(this._disassembledInstructions!.length / 2), 0.5);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #129534

Changed from loading 100 instructions on init to 400 instructions.
