### PR TITLE
Persist KaTeX macros across render calls

### DIFF
--- a/extensions/markdown-math/notebook/katex.ts
+++ b/extensions/markdown-math/notebook/katex.ts
@@ -35,6 +35,6 @@ export async function activate(ctx: {
 
 	const katex = require('@iktakahiro/markdown-it-katex');
 	markdownItRenderer.extendMarkdownIt((md: markdownIt.MarkdownIt) => {
-		return md.use(katex);
+		return md.use(katex, {'globalGroup': true});
 	});
 }

--- a/extensions/markdown-math/src/extension.ts
+++ b/extensions/markdown-math/src/extension.ts
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
 		extendMarkdownIt(md: any) {
 			if (isEnabled()) {
 				const katex = require('@iktakahiro/markdown-it-katex');
-				return md.use(katex);
+				return md.use(katex, {'globalGroup': true});
 			}
 			return md;
 		}


### PR DESCRIPTION
This PR fixes the regression identified in #125425.

Sets the ["globalGroup" option](https://katex.org/docs/options.html) in KaTeX to `true` for both markdown file previews and for notebook cell rendering.

Now, markdown such as the following should render properly:

```markdown
$\newcommand{\ra}{\rightarrow}$

$\ra$
```