### PR TITLE
Using Offset instead of address from disassembly

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -1249,6 +1249,7 @@ registerAction2(class extends Action2 {
 		debugService.removeBreakpoints();
 		debugService.removeFunctionBreakpoints();
 		debugService.removeDataBreakpoints();
+		debugService.removeInstructionBreakpoints();
 	}
 });
 

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -278,7 +278,6 @@ export class DisassemblyView extends EditorPane {
 	}
 
 	private async loadDisassembledInstructions(instructionOffset: number, instructionCount: number): Promise<boolean> {
-		// if address is null, then use current stack frame.
 		if (!this.currentInstructionAddress) {
 			this.ResetInstructionAddress();
 		}
@@ -286,7 +285,7 @@ export class DisassemblyView extends EditorPane {
 			return false;
 		}
 
-		console.log(`DisassemblyView: loadDisassembledInstructions ${this.currentInstructionAddress}, ${instructionOffset}, ${instructionCount}`);
+		// console.log(`DisassemblyView: loadDisassembledInstructions ${this.currentInstructionAddress}, ${instructionOffset}, ${instructionCount}`);
 		const session = this._debugService.getViewModel().focusedSession;
 		const resultEntries = await session?.disassemble(this.currentInstructionAddress, 0, instructionOffset, instructionCount);
 		if (session && resultEntries && this._disassembledInstructions) {


### PR DESCRIPTION
Refactor to use offset and a constant memoryReference from stackFrame. #129655
Fix an issue when scrolling too fast by using a "lock".  
RemoveAllBreakPoint will also remove InstructionBP. #129572

This PR fixes #129572 #129655

@isidorn @weinand 
