### PR TITLE
Improve accessibility in disassembly view

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -562,16 +562,10 @@ class AccessibilityProvider implements IListAccessibilityProvider<IDisassembledI
 	getAriaLabel(element: IDisassembledInstructionEntry): string | null {
 		let label = '';
 
-		if (element.isBreakpointSet) {
-			label += localize('breakpointIsSet', "Breakpoint is set");
-		} else if (element.allowBreakpoint) {
-			label += localize('breakpointAllowed', "Can set breakpoint");
-		}
-
 		const instruction = element.instruction;
-		label += `, ${localize('instructionAddress', "Instruction address")}: ${instruction.address}`;
+		label += `${localize('instructionAddress', "Address")}: ${instruction.address}`;
 		if (instruction.instructionBytes) {
-			label += `, ${localize('instructionBytes', "Instruction bytes")}: ${instruction.instructionBytes}`;
+			label += `, ${localize('instructionBytes', "Bytes")}: ${instruction.instructionBytes}`;
 		}
 		label += `, ${localize(`instructionText`, "Instruction")}: ${instruction.instruction}`;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #129533 

Use shorter repetitive text, and remove breakpoint text since aria label can't be updated dynamically via accessibility provider.
