### PR TITLE
fix: makefile comment highlighting

### DIFF
--- a/extensions/make/syntaxes/make.tmLanguage.json
+++ b/extensions/make/syntaxes/make.tmLanguage.json
@@ -29,7 +29,7 @@
 	],
 	"repository": {
 		"comment": {
-			"begin": "(^[ ]+)?(?=#)",
+			"begin": "(^[ \t]+)?(?=#)",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.whitespace.comment.leading.makefile"


### PR DESCRIPTION
In makefiles comment lines starting with a tabulation are not highlighted, here is a fixed regex

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
