### PR TITLE
Use MarkdownRenderer for Settings editor code blocks

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -448,10 +448,11 @@
 	text-decoration: underline;
 }
 
-.settings-editor > .settings-body > .settings-tree-container .setting-item-contents .setting-item-markdown code {
+.settings-editor > .settings-body > .settings-tree-container .setting-item-contents .setting-item-markdown .code {
 	line-height: 15px;
 	/** For some reason, this is needed, otherwise <code> will take up 20px height */
 	font-family: var(--monaco-monospace-font);
+	white-space: pre;
 }
 
 .settings-editor > .settings-body > .settings-list-container .setting-item-contents .setting-item-markdown hr {


### PR DESCRIPTION
This PR fixes #129645

![An example of a code block in a setting with proper syntax highlighting](https://user-images.githubusercontent.com/7199958/128074643-459efb12-65da-4b40-94bb-0e48f91ab303.PNG)

