### PR TITLE
feat: custom configurations for hover widgets

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1766,6 +1766,27 @@ export interface IEditorHoverOptions {
 	 * Defaults to true.
 	 */
 	sticky?: boolean;
+	/**
+	 * The font size for the hover widget.
+	 * Defaults to the editor font size.
+	 */
+	fontSize?: number;
+	/**
+	 * The line height for the hover widget.
+	 * Defaults to the editor line height.
+	 */
+	lineHeight?: number;
+	/**
+	 * The max width for the hover widget.
+	 * Defaults to the editor configuration.
+	 */
+	maxWidth?: number;
+	/**
+	 * The max height for the hover widget.
+	 * Defaults to the editor configuration.
+	 */
+	maxHeight?: number;
+
 }
 
 export type EditorHoverOptions = Readonly<Required<IEditorHoverOptions>>;
@@ -1776,7 +1797,11 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, EditorHoverOption
 		const defaults: EditorHoverOptions = {
 			enabled: true,
 			delay: 300,
-			sticky: true
+			sticky: true,
+			fontSize: 0,
+			lineHeight: 0,
+			maxWidth: 0,
+			maxHeight: 0,
 		};
 		super(
 			EditorOption.hover, 'hover', defaults,
@@ -1796,6 +1821,26 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, EditorHoverOption
 					default: defaults.sticky,
 					description: nls.localize('hover.sticky', "Controls whether the hover should remain visible when mouse is moved over it.")
 				},
+				'editor.hover.fontSize': {
+					type: 'number',
+					default: defaults.fontSize,
+					description: nls.localize('hover.fontSize', "Controls the font size which the hover is shown.")
+				},
+				'editor.hover.lineHeight': {
+					type: 'number',
+					default: defaults.lineHeight,
+					description: nls.localize('hover.lineHeight', "Controls the line height which the hover is shown.")
+				},
+				'editor.hover.maxWidth': {
+					type: 'number',
+					default: defaults.maxWidth,
+					description: nls.localize('hover.maxWidth', "Controls the widget max width which the hover is shown.")
+				},
+				'editor.hover.maxHeight': {
+					type: 'number',
+					default: defaults.maxHeight,
+					description: nls.localize('hover.maxHeight', "Controls widget max height which the hover is shown.")
+				},
 			}
 		);
 	}
@@ -1808,7 +1853,11 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, EditorHoverOption
 		return {
 			enabled: boolean(input.enabled, this.defaultValue.enabled),
 			delay: EditorIntOption.clampedInt(input.delay, this.defaultValue.delay, 0, 10000),
-			sticky: boolean(input.sticky, this.defaultValue.sticky)
+			sticky: boolean(input.sticky, this.defaultValue.sticky),
+			fontSize: EditorIntOption.clampedInt(input.fontSize, this.defaultValue.fontSize, 0, 1000),
+			lineHeight: EditorIntOption.clampedInt(input.lineHeight, this.defaultValue.lineHeight, 0, 1000),
+			maxWidth: EditorIntOption.clampedInt(input.maxWidth, this.defaultValue.maxWidth, 0, 10000),
+			maxHeight: EditorIntOption.clampedInt(input.maxHeight, this.defaultValue.maxHeight, 0, 10000),
 		};
 	}
 }

--- a/src/vs/editor/contrib/hover/hoverWidgets.ts
+++ b/src/vs/editor/contrib/hover/hoverWidgets.ts
@@ -29,7 +29,7 @@ export class GlyphHoverWidget extends Widget implements IOverlayWidget {
 		this._showAtLineNumber = -1;
 
 		this._register(this._editor.onDidChangeConfiguration((e: ConfigurationChangedEvent) => {
-			if (e.hasChanged(EditorOption.fontInfo)) {
+			if (e.hasChanged(EditorOption.fontInfo) || e.hasChanged(EditorOption.hover)) {
 				this.updateFont();
 			}
 		}));
@@ -92,7 +92,28 @@ export class GlyphHoverWidget extends Widget implements IOverlayWidget {
 		const codeTags: HTMLElement[] = Array.prototype.slice.call(this._domNode.getElementsByTagName('code'));
 		const codeClasses: HTMLElement[] = Array.prototype.slice.call(this._domNode.getElementsByClassName('code'));
 
-		[...codeTags, ...codeClasses].forEach(node => this._editor.applyFontInfo(node));
+		const fontInfo = this._editor.getOption(EditorOption.fontInfo);
+		const fontFamily = fontInfo.getMassagedFontFamily();
+		const fontFeatureSettings = fontInfo.fontFeatureSettings;
+		const HoverInfo = this._editor.getOption(EditorOption.hover);
+		const fontSize = HoverInfo.fontSize || fontInfo.fontSize;
+		const lineHeight = HoverInfo.lineHeight || fontInfo.lineHeight;
+		const letterSpacing = fontInfo.letterSpacing;
+		const fontWeight = fontInfo.fontWeight;
+		const fontSizePx = `${fontSize}px`;
+		const lineHeightPx = `${lineHeight}px`;
+		const letterSpacingPx = `${letterSpacing}px`;
+
+		[...codeTags, ...codeClasses].forEach(domNode => {
+			domNode.style.fontFamily = fontFamily;
+			domNode.style.fontWeight = fontWeight;
+			domNode.style.fontSize = fontSizePx;
+			domNode.style.fontFeatureSettings = fontFeatureSettings;
+			domNode.style.lineHeight = lineHeightPx;
+			domNode.style.letterSpacing = letterSpacingPx;
+		});
+
+
 	}
 
 	protected updateContents(node: Node): void {

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -230,7 +230,7 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 		});
 
 		this._register(this._editor.onDidChangeConfiguration((e: ConfigurationChangedEvent) => {
-			if (e.hasChanged(EditorOption.fontInfo)) {
+			if (e.hasChanged(EditorOption.fontInfo) || e.hasChanged(EditorOption.hover)) {
 				this._updateFont();
 			}
 		}));
@@ -379,7 +379,27 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 
 	private _updateFont(): void {
 		const codeClasses: HTMLElement[] = Array.prototype.slice.call(this._hover.contentsDomNode.getElementsByClassName('code'));
-		codeClasses.forEach(node => this._editor.applyFontInfo(node));
+
+		const fontInfo = this._editor.getOption(EditorOption.fontInfo);
+		const fontFamily = fontInfo.getMassagedFontFamily();
+		const fontFeatureSettings = fontInfo.fontFeatureSettings;
+		const HoverInfo = this._editor.getOption(EditorOption.hover);
+		const fontSize = HoverInfo.fontSize || fontInfo.fontSize;
+		const lineHeight = HoverInfo.lineHeight || fontInfo.lineHeight;
+		const letterSpacing = fontInfo.letterSpacing;
+		const fontWeight = fontInfo.fontWeight;
+		const fontSizePx = `${fontSize}px`;
+		const lineHeightPx = `${lineHeight}px`;
+		const letterSpacingPx = `${letterSpacing}px`;
+
+		codeClasses.forEach(domNode => {
+			domNode.style.fontFamily = fontFamily;
+			domNode.style.fontWeight = fontWeight;
+			domNode.style.fontSize = fontSizePx;
+			domNode.style.fontFeatureSettings = fontFeatureSettings;
+			domNode.style.lineHeight = lineHeightPx;
+			domNode.style.letterSpacing = letterSpacingPx;
+		});
 	}
 
 	private _updateContents(node: Node): void {
@@ -392,13 +412,19 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 	}
 
 	private layout(): void {
-		const height = Math.max(this._editor.getLayoutInfo().height / 4, 250);
-		const { fontSize, lineHeight } = this._editor.getOption(EditorOption.fontInfo);
+
+		const fontInfo = this._editor.getOption(EditorOption.fontInfo);
+		const HoverInfo = this._editor.getOption(EditorOption.hover);
+		const fontSize = HoverInfo.fontSize || fontInfo.fontSize;
+		const lineHeight = HoverInfo.lineHeight || fontInfo.lineHeight;
+		const maxWidth = HoverInfo.maxWidth || Math.max(this._editor.getLayoutInfo().width * 0.66, 500);
+		const maxHeight = HoverInfo.maxHeight || Math.max(this._editor.getLayoutInfo().height / 4, 250);
 
 		this._hover.contentsDomNode.style.fontSize = `${fontSize}px`;
 		this._hover.contentsDomNode.style.lineHeight = `${lineHeight}px`;
-		this._hover.contentsDomNode.style.maxHeight = `${height}px`;
-		this._hover.contentsDomNode.style.maxWidth = `${Math.max(this._editor.getLayoutInfo().width * 0.66, 500)}px`;
+		this._hover.contentsDomNode.style.maxHeight = `${maxHeight}px`;
+		this._hover.contentsDomNode.style.maxWidth = `${maxWidth}px`;
+
 	}
 
 	public onModelDecorationsChanged(): void {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3498,6 +3498,26 @@ declare namespace monaco.editor {
 		 * Defaults to true.
 		 */
 		sticky?: boolean;
+		/**
+		 * The font size for the hover widget.
+		 * Defaults to the editor font size.
+		 */
+		fontSize?: number;
+		/**
+		 * The line height for the hover widget.
+		 * Defaults to the editor line height.
+		 */
+		lineHeight?: number;
+		/**
+		 * The max width for the hover widget.
+		 * Defaults to the editor configuration.
+		 */
+		maxWidth?: number;
+		/**
+		 * The max height for the hover widget.
+		 * Defaults to the editor configuration.
+		 */
+		maxHeight?: number;
 	}
 
 	export type EditorHoverOptions = Readonly<Required<IEditorHoverOptions>>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## This PR is for new featre:

* Custom the font size for the hover widget.
* Custom line height for the hover widget.
* Custom max width for the hover widget.
* Custom max height for the hover widget.

## Advantage

* Could change the font size and line height different from editor's configuration.
* Custom the max size for hover widget and could see something more without scroll bar.

## Configuration

* `editor.hover.fontSize` 0 is defaults to the editor font size.
* `editor.hover.lineHeight` 0 is defaults to the editor line height.
* `editor.hover.maxWidth` 0 is defaults to the editor configuration.
* `editor.hover.maxHeight` 0 is defaults to the editor configuration.

