### PR TITLE
fix: handle localhost and port in asWebviewUri

### DIFF
--- a/src/vs/workbench/api/common/shared/webview.ts
+++ b/src/vs/workbench/api/common/shared/webview.ts
@@ -55,9 +55,15 @@ export function asWebviewUri(
 		});
 	}
 
+	let authority = `${resource.scheme}+${resource.authority}.${webviewRootResourceAuthority}`;
+	if (resource.authority.includes('localhost')) {
+		const authorityUrl = new URL(`http://${resource.authority}`);
+		authority = `${resource.scheme}+${authorityUrl.hostname}.${webviewRootResourceAuthority}${authorityUrl.port ? (':' + authorityUrl.port) : ''}`;
+	}
+
 	return URI.from({
+		authority,
 		scheme: Schemas.https,
-		authority: `${resource.scheme}+${resource.authority}.${webviewRootResourceAuthority}`,
 		path: resource.path,
 		fragment: resource.fragment,
 		query: resource.query,

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -278,7 +278,7 @@ async function processResourceRequest(event, requestUrl) {
 
 	const firstHostSegment = requestUrl.hostname.slice(0, requestUrl.hostname.length - (resourceBaseAuthority.length + 1));
 	const scheme = firstHostSegment.split('+', 1)[0];
-	const authority = firstHostSegment.slice(scheme.length + 1); // may be empty
+	const authority = firstHostSegment.slice(scheme.length + 1) + requestUrl.port ? (':' + requestUrl.port) : ''; // may be empty
 
 	for (const parentClient of parentClients) {
 		parentClient.postMessage({

--- a/src/vs/workbench/test/browser/api/extHostWebview.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostWebview.test.ts
@@ -119,6 +119,16 @@ suite('ExtHostWebview', () => {
 			'Unix basic'
 		);
 	});
+
+	test('asWebviewUri for localhost file paths', () => {
+		const webview = createWebview(rpcProtocol, /* remoteAuthority */ 'localhost:8080');
+
+		assert.strictEqual(
+			(webview.webview.asWebviewUri(URI.parse('file:///Users/codey/file.html')).toString()),
+			`https://vscode-remote%2Blocalhost.vscode-resource.${webviewResourceBaseHost}:8080/Users/codey/file.html`,
+			'Unix should preserve the port in'
+		);
+	});
 });
 
 function createWebview(rpcProtocol: (IExtHostRpcService & IExtHostContext) | undefined, remoteAuthority: string | undefined) {


### PR DESCRIPTION
This PR fixes #130151

We encountered this error in code-server (fix here: https://github.com/cdr/code-server/pull/3895) and noticed that resources weren't loading in webviews due to the wrong URI being returned from `asWebviewUri`. 

I don't think Codespaces has the issue because it's always running on a standard port and so it won't have a port in the url.

## Additional Context

We noticed this happening with a custom VS Code extension having issues loading resources (CSS & JS) in webviews.

I was going to try and reproduce with `vscode` by running `yarn web` but I'm not seeing the option to manually install VSIX files 🤔

![image](https://user-images.githubusercontent.com/3806031/128403846-09e5bb94-0f66-43b1-bf67-6ec92a3e1520.png)



