### PR TITLE
Cleanup service headers

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -392,7 +392,7 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 		const config = productService.extensionsGallery;
 		this.extensionsGalleryUrl = config && config.serviceUrl;
 		this.extensionsControlUrl = config && config.controlUrl;
-		this.commonHeadersPromise = resolveMarketplaceHeaders(productService.version, this.environmentService, this.fileService, storageService);
+		this.commonHeadersPromise = resolveMarketplaceHeaders(productService.version, productService, this.environmentService, this.fileService, storageService);
 	}
 
 	private api(path = ''): string {
@@ -842,7 +842,7 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 	}
 }
 
-export async function resolveMarketplaceHeaders(version: string, environmentService: IEnvironmentService, fileService: IFileService, storageService: {
+export async function resolveMarketplaceHeaders(version: string, productService: IProductService, environmentService: IEnvironmentService, fileService: IFileService, storageService: {
 	get: (key: string, scope: StorageScope) => string | undefined,
 	store: (key: string, value: string, scope: StorageScope, target: StorageTarget) => void
 } | undefined): Promise<{ [key: string]: string; }> {
@@ -850,7 +850,10 @@ export async function resolveMarketplaceHeaders(version: string, environmentServ
 		'X-Market-Client-Id': `VSCode ${version}`,
 		'User-Agent': `VSCode ${version}`
 	};
-	const uuid = await getServiceMachineId(environmentService, fileService, storageService);
-	headers['X-Market-User-Id'] = uuid;
+	// Don't send user id header if telemetry is disabled
+	if (!!productService.enableTelemetry) {
+		const uuid = await getServiceMachineId(environmentService, fileService, storageService);
+		headers['X-Market-User-Id'] = uuid;
+	}
 	return headers;
 }

--- a/src/vs/platform/extensionManagement/test/common/extensionGalleryService.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/extensionGalleryService.test.ts
@@ -16,6 +16,7 @@ import { FileService } from 'vs/platform/files/common/fileService';
 import { InMemoryFileSystemProvider } from 'vs/platform/files/common/inMemoryFilesystemProvider';
 import { NullLogService } from 'vs/platform/log/common/log';
 import product from 'vs/platform/product/common/product';
+import { IProductService } from 'vs/platform/product/common/productService';
 import { InMemoryStorageService, IStorageService } from 'vs/platform/storage/common/storage';
 
 class EnvironmentServiceMock extends mock<IEnvironmentService>() {
@@ -28,7 +29,7 @@ class EnvironmentServiceMock extends mock<IEnvironmentService>() {
 
 suite('Extension Gallery Service', () => {
 	const disposables: DisposableStore = new DisposableStore();
-	let fileService: IFileService, environmentService: IEnvironmentService, storageService: IStorageService;
+	let fileService: IFileService, environmentService: IEnvironmentService, storageService: IStorageService, productService: IProductService;
 
 	setup(() => {
 		const serviceMachineIdResource = joinPath(URI.file('tests').with({ scheme: 'vscode-tests' }), 'machineid');
@@ -37,14 +38,15 @@ suite('Extension Gallery Service', () => {
 		const fileSystemProvider = disposables.add(new InMemoryFileSystemProvider());
 		fileService.registerProvider(serviceMachineIdResource.scheme, fileSystemProvider);
 		storageService = new InMemoryStorageService();
+		productService = { _serviceBrand: undefined, ...product, enableTelemetry: true, };
 	});
 
 	teardown(() => disposables.clear());
 
 	test('marketplace machine id', async () => {
-		const headers = await resolveMarketplaceHeaders(product.version, environmentService, fileService, storageService);
+		const headers = await resolveMarketplaceHeaders(product.version, productService, environmentService, fileService, storageService);
 		assert.ok(isUUID(headers['X-Market-User-Id']));
-		const headers2 = await resolveMarketplaceHeaders(product.version, environmentService, fileService, storageService);
+		const headers2 = await resolveMarketplaceHeaders(product.version, productService, environmentService, fileService, storageService);
 		assert.strictEqual(headers['X-Market-User-Id'], headers2['X-Market-User-Id']);
 	});
 });

--- a/src/vs/platform/extensionManagement/test/common/extensionGalleryService.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/extensionGalleryService.test.ts
@@ -48,5 +48,7 @@ suite('Extension Gallery Service', () => {
 		assert.ok(isUUID(headers['X-Market-User-Id']));
 		const headers2 = await resolveMarketplaceHeaders(product.version, productService, environmentService, fileService, storageService);
 		assert.strictEqual(headers['X-Market-User-Id'], headers2['X-Market-User-Id']);
+		const headers3 = await resolveMarketplaceHeaders(product.version, { ...productService, enableTelemetry: false }, environmentService, fileService, storageService);
+		assert.ok(!headers3['X-Market-User-Id']);
 	});
 });

--- a/src/vs/platform/userDataSync/common/userDataSyncStoreService.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncStoreService.ts
@@ -174,9 +174,11 @@ export class UserDataSyncStoreClient extends Disposable implements IUserDataSync
 			.then(uuid => {
 				const headers: IHeaders = {
 					'X-Client-Name': `${productService.applicationName}${isWeb ? '-web' : ''}`,
-					'X-Client-Version': productService.version,
-					'X-Machine-Id': uuid
+					'X-Client-Version': productService.version
 				};
+				if (productService.enableTelemetry) {
+					headers['X-Machine-Id'] = uuid;
+				}
 				if (productService.commit) {
 					headers['X-Client-Commit'] = productService.commit;
 				}

--- a/src/vs/platform/userDataSync/common/userDataSyncStoreService.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncStoreService.ts
@@ -161,7 +161,7 @@ export class UserDataSyncStoreClient extends Disposable implements IUserDataSync
 
 	constructor(
 		userDataSyncStoreUrl: URI | undefined,
-		@IProductService productService: IProductService,
+		@IProductService private readonly productService: IProductService,
 		@IRequestService private readonly requestService: IRequestService,
 		@IUserDataSyncLogService private readonly logService: IUserDataSyncLogService,
 		@IEnvironmentService environmentService: IEnvironmentService,
@@ -173,14 +173,14 @@ export class UserDataSyncStoreClient extends Disposable implements IUserDataSync
 		this.commonHeadersPromise = getServiceMachineId(environmentService, fileService, storageService)
 			.then(uuid => {
 				const headers: IHeaders = {
-					'X-Client-Name': `${productService.applicationName}${isWeb ? '-web' : ''}`,
-					'X-Client-Version': productService.version
+					'X-Client-Name': `${this.productService.applicationName}${isWeb ? '-web' : ''}`,
+					'X-Client-Version': this.productService.version
 				};
-				if (productService.enableTelemetry) {
+				if (this.productService.enableTelemetry) {
 					headers['X-Machine-Id'] = uuid;
 				}
-				if (productService.commit) {
-					headers['X-Client-Commit'] = productService.commit;
+				if (this.productService.commit) {
+					headers['X-Client-Commit'] = this.productService.commit;
 				}
 				return headers;
 			});
@@ -521,6 +521,9 @@ export class UserDataSyncStoreClient extends Disposable implements IUserDataSync
 	}
 
 	private addSessionHeaders(headers: IHeaders): void {
+		if (!this.productService.enableTelemetry) {
+			return;
+		}
 		let machineSessionId = this.storageService.get(MACHINE_SESSION_ID_KEY, StorageScope.GLOBAL);
 		if (machineSessionId === undefined) {
 			machineSessionId = generateUuid();

--- a/src/vs/platform/userDataSync/test/common/userDataSyncStoreService.test.ts
+++ b/src/vs/platform/userDataSync/test/common/userDataSyncStoreService.test.ts
@@ -88,8 +88,8 @@ suite('UserDataSyncStoreService', () => {
 		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Client-Name'], `${productService.applicationName}${isWeb ? '-web' : ''}`);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Client-Version'], productService.version);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Id'], undefined);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
@@ -147,7 +147,7 @@ suite('UserDataSyncStoreService', () => {
 
 		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
 	test('test headers are send for write request', async () => {
@@ -168,7 +168,7 @@ suite('UserDataSyncStoreService', () => {
 
 		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
 	test('test headers are send for read request', async () => {
@@ -189,7 +189,7 @@ suite('UserDataSyncStoreService', () => {
 
 		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
 	test('test headers are reset after session is cleared ', async () => {
@@ -210,8 +210,8 @@ suite('UserDataSyncStoreService', () => {
 		await testObject.manifest(null);
 
 		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
@@ -241,9 +241,9 @@ suite('UserDataSyncStoreService', () => {
 		await testObject.manifest(null);
 
 		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
 	});
 
@@ -274,10 +274,10 @@ suite('UserDataSyncStoreService', () => {
 		await testObject.manifest(null);
 
 		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
 	});
 
 	test('test old headers are sent after session is cleared from another server ', async () => {
@@ -305,9 +305,9 @@ suite('UserDataSyncStoreService', () => {
 		await testObject.manifest(null);
 
 		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
 	});
 
@@ -336,8 +336,8 @@ suite('UserDataSyncStoreService', () => {
 		await testObject.manifest(null);
 
 		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
 		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
@@ -369,10 +369,10 @@ suite('UserDataSyncStoreService', () => {
 		await testObject.manifest(null);
 
 		assert.strictEqual(target.requestsWithAllHeaders.length, 1);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
-		assert.notStrictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], undefined);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-Machine-Session-Id'], machineSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], userSessionId);
+		assert.strictEqual(target.requestsWithAllHeaders[0].headers!['X-User-Session-Id'], undefined);
 	});
 
 	test('test rate limit on server with retry after', async () => {

--- a/src/vs/workbench/services/extensionResourceLoader/browser/extensionResourceLoaderService.ts
+++ b/src/vs/workbench/services/extensionResourceLoader/browser/extensionResourceLoaderService.ts
@@ -43,12 +43,16 @@ class ExtensionResourceLoaderService implements IExtensionResourceLoaderService 
 
 		const requestInit: RequestInit = {};
 		if (this._extensionGalleryResourceAuthority && this._extensionGalleryResourceAuthority === this._getExtensionResourceAuthority(uri)) {
-			const machineId = await this._getServiceMachineId();
+
 			requestInit.headers = {
 				'X-Client-Name': `${this._productService.applicationName}${isWeb ? '-web' : ''}`,
-				'X-Client-Version': this._productService.version,
-				'X-Machine-Id': machineId
+				'X-Client-Version': this._productService.version
 			};
+			// Only send machine id if telemetry is enabled
+			if (!!this._productService.enableTelemetry) {
+				const machineId = await this._getServiceMachineId();
+				requestInit.headers['X-Machine-Id'] = machineId;
+			}
 			if (this._productService.commit) {
 				requestInit.headers['X-Client-Commit'] = this._productService.commit;
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Service headers should respect the telemetry setting and not be sent. Ideally we should have an identifier just for telemetry purposes that way we don't even generate the local storage artifact if telemetry is disabled but I do not have enough context on this id to make such a large change.
