### PR TITLE
Copy URI authority from base when splitting terminals, fixes #127811

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -1141,6 +1141,7 @@ export class TerminalService implements ITerminalService {
 		if (options?.instanceToSplit && typeof shellLaunchConfig.cwd !== 'object' && typeof options.instanceToSplit.shellLaunchConfig.cwd === 'object') {
 			shellLaunchConfig.cwd = URI.from({
 				scheme: options.instanceToSplit.shellLaunchConfig.cwd.scheme,
+				authority: options.instanceToSplit.shellLaunchConfig.cwd.authority,
 				path: shellLaunchConfig.cwd || options.instanceToSplit.shellLaunchConfig.cwd.path
 			});
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #127811

I noticed that when splitting the terminal, the `authority` property of the URI was empty.
Thus, [this if statement](https://github.com/microsoft/vscode/blob/c2fab30adf96c36f5daad135b6ae7991f5576894/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts#L226) is false and `this._launchLocalProcess` is called instead of creating a new remote terminal.
