### PR TITLE
Fix failure to uninstall extension that has dependencies

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -469,7 +469,7 @@ export abstract class AbstractExtensionManagementService extends Disposable impl
 		for (const extension of extensionsToUninstall) {
 			const dependents = this.getDependents(extension, installed);
 			if (dependents.length) {
-				const remainingDependents = dependents.filter(dependent => extensionsToUninstall.indexOf(dependent) === -1);
+				const remainingDependents = dependents.filter(dependent => !extensionsToUninstall.some(e => areSameExtensions(e.identifier, dependent.identifier)));
 				if (remainingDependents.length) {
 					throw new Error(this.getDependentsErrorMessage(extension, remainingDependents, extensionToUninstall));
 				}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #130310

## The issue:

Can't uninstall an extension with dependencies.

## The source of the issue:

git bisect shows 4189c23b969a33ed34a0ddcd92bea1f4c16609b6 is when the issue was introduced.

We used to convert the `extension` to the instance returned by `this.getInstalled(ExtensionType.User)`
https://github.com/microsoft/vscode/blob/4fb7b80bf03297de64a61111acd75805e309b401/src/vs/platform/extensionManagement/node/extensionManagementService.ts#L459-L460

After 4189c23b969a33ed34a0ddcd92bea1f4c16609b6, we no longer convert `extension` to the instances return by `this.getInstalled(ExtensionType.User)`.
https://github.com/microsoft/vscode/blob/4189c23b969a33ed34a0ddcd92bea1f4c16609b6/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts#L393-L394

Hence, when it gets to the filter part
https://github.com/microsoft/vscode/blob/4189c23b969a33ed34a0ddcd92bea1f4c16609b6/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts#L464
the `indexOf` didn't work as intended because the `LocalExtension` are different instances. 

## The fix

The fix in this PR is to compare using `areSameExtensions` instead just comparing the instance. Alternatively, we can convert the `extension` to the instances returned by `this.getInstalled(ExtensionType.User)` like used to.

## How to test:
1. Install vsix of vspacecode.vscode-which-key
2. Install vsix of vspacecode.vspacecode
3. Uninstall vspacecode.vspacecode

The idea is to install an extension with dependencies and try to uninstall it.