### PR TITLE
Transfer notebook output as VSBuffer

### DIFF
--- a/src/vs/base/common/marshalling.ts
+++ b/src/vs/base/common/marshalling.ts
@@ -51,6 +51,7 @@ function replacer(key: string, value: any): any {
 
 
 type Deserialize<T> = T extends UriComponents ? URI
+	: T extends VSBuffer ? VSBuffer
 	: T extends object
 	? Revived<T>
 	: T;

--- a/src/vs/workbench/api/browser/mainThreadNotebook.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebook.ts
@@ -58,7 +58,7 @@ export class MainThreadNotebooks implements MainThreadNotebookShape {
 			open: async (uri: URI, backupId: string | undefined, untitledDocumentData: VSBuffer | undefined, token: CancellationToken) => {
 				const data = await this._proxy.$openNotebook(viewType, uri, backupId, untitledDocumentData, token);
 				return {
-					data: NotebookDto.fromNotebookDataDto(data),
+					data: NotebookDto.fromNotebookDataDto(data.value),
 					transientOptions: contentOptions
 				};
 			},

--- a/src/vs/workbench/api/browser/mainThreadNotebook.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebook.ts
@@ -13,6 +13,7 @@ import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { INotebookCellStatusBarService } from 'vs/workbench/contrib/notebook/common/notebookCellStatusBarService';
 import { INotebookCellStatusBarItemProvider, INotebookContributionData, NotebookData as NotebookData, TransientCellMetadata, TransientDocumentMetadata, TransientOptions } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookContentProvider, INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { ExtHostContext, ExtHostNotebookShape, IExtHostContext, MainContext, MainThreadNotebookShape, NotebookExtensionDescription } from '../common/extHost.protocol';
 
 @extHostNamedCustomer(MainContext.MainThreadNotebook)
@@ -107,10 +108,10 @@ export class MainThreadNotebooks implements MainThreadNotebookShape {
 			options,
 			dataToNotebook: async (data: VSBuffer): Promise<NotebookData> => {
 				const dto = await this._proxy.$dataToNotebook(handle, data, CancellationToken.None);
-				return NotebookDto.fromNotebookDataDto(dto);
+				return NotebookDto.fromNotebookDataDto(dto.value);
 			},
 			notebookToData: (data: NotebookData): Promise<VSBuffer> => {
-				return this._proxy.$notebookToData(handle, NotebookDto.toNotebookDataDto(data), CancellationToken.None);
+				return this._proxy.$notebookToData(handle, new SerializableObjectWithBuffers(NotebookDto.toNotebookDataDto(data)), CancellationToken.None);
 			}
 		});
 		const disposables = new DisposableStore();

--- a/src/vs/workbench/api/browser/mainThreadNotebookDocuments.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookDocuments.ts
@@ -15,6 +15,7 @@ import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/ur
 import { ExtHostContext, ExtHostNotebookDocumentsShape, IExtHostContext, MainThreadNotebookDocumentsShape, NotebookCellDto, NotebookCellsChangedEventDto, NotebookDataDto } from '../common/extHost.protocol';
 import { MainThreadNotebooksAndEditors } from 'vs/workbench/api/browser/mainThreadNotebookDocumentsAndEditors';
 import { NotebookDto } from 'vs/workbench/api/browser/mainThreadNotebookDto';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 export class MainThreadNotebookDocuments implements MainThreadNotebookDocumentsShape {
 
@@ -104,7 +105,7 @@ export class MainThreadNotebookDocuments implements MainThreadNotebookDocumentsS
 				// is marked as dirty and that another event is fired
 				this._proxy.$acceptModelChanged(
 					textModel.uri,
-					eventDto,
+					new SerializableObjectWithBuffers(eventDto),
 					this._notebookEditorModelResolverService.isDirty(textModel.uri)
 				);
 

--- a/src/vs/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -20,6 +20,7 @@ import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookS
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { ExtHostContext, ExtHostNotebookShape, IExtHostContext, INotebookDocumentsAndEditorsDelta, INotebookEditorAddData, INotebookModelAddedData, MainContext } from '../common/extHost.protocol';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 interface INotebookAndEditorDelta {
 	removedDocuments: URI[];
@@ -190,7 +191,7 @@ export class MainThreadNotebooksAndEditors {
 		};
 
 		// send to extension FIRST
-		this._proxy.$acceptDocumentAndEditorsDelta(dto);
+		this._proxy.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers(dto));
 
 		// handle internally
 		this._onDidRemoveEditors.fire(delta.removedEditors);

--- a/src/vs/workbench/api/browser/mainThreadNotebookDto.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookDto.ts
@@ -13,7 +13,7 @@ export namespace NotebookDto {
 	export function toNotebookOutputItemDto(item: notebookCommon.IOutputItemDto): extHostProtocol.NotebookOutputItemDto {
 		return {
 			mime: item.mime,
-			valueBytes: Array.from(item.data)
+			valueBytes: item.data
 		};
 	}
 
@@ -47,7 +47,7 @@ export namespace NotebookDto {
 	export function fromNotebookOutputItemDto(item: extHostProtocol.NotebookOutputItemDto): notebookCommon.IOutputItemDto {
 		return {
 			mime: item.mime,
-			data: new Uint8Array(item.valueBytes)
+			data: item.valueBytes
 		};
 	}
 

--- a/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
@@ -16,6 +16,7 @@ import { INotebookEditor } from 'vs/workbench/contrib/notebook/browser/notebookB
 import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/notebookEditorService';
 import { INotebookCellExecution, INotebookExecutionService } from 'vs/workbench/contrib/notebook/common/notebookExecutionService';
 import { INotebookKernel, INotebookKernelChangeEvent, INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { ExtHostContext, ExtHostNotebookKernelsShape, ICellExecuteUpdateDto, IExtHostContext, INotebookKernelDto2, MainContext, MainThreadNotebookKernelsShape } from '../common/extHost.protocol';
 
 abstract class MainThreadKernel implements INotebookKernel {
@@ -233,7 +234,8 @@ export class MainThreadNotebookKernels implements MainThreadNotebookKernelsShape
 		this._executions.set(handle, execution);
 	}
 
-	$updateExecutions(updates: ICellExecuteUpdateDto[]): void {
+	$updateExecutions(data: SerializableObjectWithBuffers<ICellExecuteUpdateDto[]>): void {
+		const updates = data.value;
 		const groupedUpdates = groupBy(updates, (a, b) => a.executionHandle - b.executionHandle);
 		groupedUpdates.forEach(datas => {
 			const first = datas[0];

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1993,7 +1993,7 @@ export interface ExtHostNotebookShape extends ExtHostNotebookDocumentsAndEditors
 	$provideNotebookCellStatusBarItems(handle: number, uri: UriComponents, index: number, token: CancellationToken): Promise<INotebookCellStatusBarListDto | undefined>;
 	$releaseNotebookCellStatusBarItems(id: number): void;
 
-	$openNotebook(viewType: string, uri: UriComponents, backupId: string | undefined, untitledDocumentData: VSBuffer | undefined, token: CancellationToken): Promise<NotebookDataDto>;
+	$openNotebook(viewType: string, uri: UriComponents, backupId: string | undefined, untitledDocumentData: VSBuffer | undefined, token: CancellationToken): Promise<SerializableObjectWithBuffers<NotebookDataDto>>;
 	$saveNotebook(viewType: string, uri: UriComponents, token: CancellationToken): Promise<boolean>;
 	$saveNotebookAs(viewType: string, uri: UriComponents, target: UriComponents, token: CancellationToken): Promise<boolean>;
 	$backupNotebook(viewType: string, uri: UriComponents, cancellation: CancellationToken): Promise<string>;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -65,7 +65,7 @@ import { InternalTimelineOptions, Timeline, TimelineChangeEvent, TimelineOptions
 import { TypeHierarchyItem } from 'vs/workbench/contrib/typeHierarchy/common/typeHierarchy';
 import { EditorGroupColumn } from 'vs/workbench/services/editor/common/editorGroupColumn';
 import { ActivationKind, ExtensionHostKind, MissingExtensionDependency } from 'vs/workbench/services/extensions/common/extensions';
-import { createExtHostContextProxyIdentifier as createExtId, createMainContextProxyIdentifier as createMainId, IRPCProtocol } from 'vs/workbench/services/extensions/common/proxyIdentifier';
+import { createExtHostContextProxyIdentifier as createExtId, createMainContextProxyIdentifier as createMainId, IRPCProtocol, SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { CandidatePort } from 'vs/workbench/services/remote/common/remoteExplorerService';
 import * as search from 'vs/workbench/services/search/common/search';
 import * as statusbar from 'vs/workbench/services/statusbar/common/statusbar';
@@ -944,7 +944,7 @@ export interface MainThreadNotebookKernelsShape extends IDisposable {
 	$updateNotebookPriority(handle: number, uri: UriComponents, value: number | undefined): void;
 
 	$addExecution(handle: number, uri: UriComponents, cellHandle: number): void;
-	$updateExecutions(data: ICellExecuteUpdateDto[]): void;
+	$updateExecutions(data: SerializableObjectWithBuffers<ICellExecuteUpdateDto[]>): void;
 	$removeExecution(handle: number): void;
 }
 
@@ -1952,7 +1952,7 @@ export interface INotebookDocumentsAndEditorsDelta {
 
 export interface NotebookOutputItemDto {
 	readonly mime: string;
-	readonly valueBytes: number[]; // todo@jrieken ugly, should be VSBuffer
+	readonly valueBytes: VSBuffer;
 }
 
 export interface NotebookOutputDto {
@@ -1998,8 +1998,8 @@ export interface ExtHostNotebookShape extends ExtHostNotebookDocumentsAndEditors
 	$saveNotebookAs(viewType: string, uri: UriComponents, target: UriComponents, token: CancellationToken): Promise<boolean>;
 	$backupNotebook(viewType: string, uri: UriComponents, cancellation: CancellationToken): Promise<string>;
 
-	$dataToNotebook(handle: number, data: VSBuffer, token: CancellationToken): Promise<NotebookDataDto>;
-	$notebookToData(handle: number, data: NotebookDataDto, token: CancellationToken): Promise<VSBuffer>;
+	$dataToNotebook(handle: number, data: VSBuffer, token: CancellationToken): Promise<SerializableObjectWithBuffers<NotebookDataDto>>;
+	$notebookToData(handle: number, data: SerializableObjectWithBuffers<NotebookDataDto>, token: CancellationToken): Promise<VSBuffer>;
 }
 
 export interface ExtHostNotebookRenderersShape {
@@ -2007,7 +2007,7 @@ export interface ExtHostNotebookRenderersShape {
 }
 
 export interface ExtHostNotebookDocumentsAndEditorsShape {
-	$acceptDocumentAndEditorsDelta(delta: INotebookDocumentsAndEditorsDelta): void;
+	$acceptDocumentAndEditorsDelta(delta: SerializableObjectWithBuffers<INotebookDocumentsAndEditorsDelta>): void;
 }
 
 export type NotebookRawContentEventDto =
@@ -2050,7 +2050,7 @@ export type NotebookCellsChangedEventDto = {
 };
 
 export interface ExtHostNotebookDocumentsShape {
-	$acceptModelChanged(uriComponents: UriComponents, event: NotebookCellsChangedEventDto, isDirty: boolean): void;
+	$acceptModelChanged(uriComponents: UriComponents, event: SerializableObjectWithBuffers<NotebookCellsChangedEventDto>, isDirty: boolean): void;
 	$acceptDirtyStateChanged(uriComponents: UriComponents, isDirty: boolean): void;
 	$acceptModelSaved(uriComponents: UriComponents): void;
 	$acceptDocumentPropertiesChanged(uriComponents: UriComponents, data: INotebookDocumentPropertiesChangeData): void;

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -24,6 +24,7 @@ import { IExtensionStoragePaths } from 'vs/workbench/api/common/extHostStoragePa
 import * as typeConverters from 'vs/workbench/api/common/extHostTypeConverters';
 import * as extHostTypes from 'vs/workbench/api/common/extHostTypes';
 import { INotebookExclusiveDocumentFilter, INotebookContributionData } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import type * as vscode from 'vscode';
 import { ExtHostCell, ExtHostNotebookDocument } from './extHostNotebookDocument';
 import { ExtHostNotebookEditor } from './extHostNotebookEditor';
@@ -334,21 +335,21 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 		});
 	}
 
-	async $dataToNotebook(handle: number, bytes: VSBuffer, token: CancellationToken): Promise<NotebookDataDto> {
+	async $dataToNotebook(handle: number, bytes: VSBuffer, token: CancellationToken): Promise<SerializableObjectWithBuffers<NotebookDataDto>> {
 		const serializer = this._notebookSerializer.get(handle);
 		if (!serializer) {
 			throw new Error('NO serializer found');
 		}
 		const data = await serializer.deserializeNotebook(bytes.buffer, token);
-		return typeConverters.NotebookData.from(data);
+		return new SerializableObjectWithBuffers(typeConverters.NotebookData.from(data));
 	}
 
-	async $notebookToData(handle: number, data: NotebookDataDto, token: CancellationToken): Promise<VSBuffer> {
+	async $notebookToData(handle: number, data: SerializableObjectWithBuffers<NotebookDataDto>, token: CancellationToken): Promise<VSBuffer> {
 		const serializer = this._notebookSerializer.get(handle);
 		if (!serializer) {
 			throw new Error('NO serializer found');
 		}
-		const bytes = await serializer.serializeNotebook(typeConverters.NotebookData.to(data), token);
+		const bytes = await serializer.serializeNotebook(typeConverters.NotebookData.to(data.value), token);
 		return VSBuffer.wrap(bytes);
 	}
 
@@ -411,10 +412,10 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 		this._editors.set(editorId, editor);
 	}
 
-	$acceptDocumentAndEditorsDelta(delta: INotebookDocumentsAndEditorsDelta): void {
+	$acceptDocumentAndEditorsDelta(delta: SerializableObjectWithBuffers<INotebookDocumentsAndEditorsDelta>): void {
 
-		if (delta.removedDocuments) {
-			for (const uri of delta.removedDocuments) {
+		if (delta.value.removedDocuments) {
+			for (const uri of delta.value.removedDocuments) {
 				const revivedUri = URI.revive(uri);
 				const document = this._documents.get(revivedUri);
 
@@ -433,11 +434,11 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 			}
 		}
 
-		if (delta.addedDocuments) {
+		if (delta.value.addedDocuments) {
 
 			const addedCellDocuments: IModelAddedData[] = [];
 
-			for (const modelData of delta.addedDocuments) {
+			for (const modelData of delta.value.addedDocuments) {
 				const uri = URI.revive(modelData.uri);
 
 				if (this._documents.has(uri)) {
@@ -478,8 +479,8 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 			}
 		}
 
-		if (delta.addedEditors) {
-			for (const editorModelData of delta.addedEditors) {
+		if (delta.value.addedEditors) {
+			for (const editorModelData of delta.value.addedEditors) {
 				if (this._editors.has(editorModelData.id)) {
 					return;
 				}
@@ -495,8 +496,8 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 
 		const removedEditors: ExtHostNotebookEditor[] = [];
 
-		if (delta.removedEditors) {
-			for (const editorid of delta.removedEditors) {
+		if (delta.value.removedEditors) {
+			for (const editorid of delta.value.removedEditors) {
 				const editor = this._editors.get(editorid);
 
 				if (editor) {
@@ -511,8 +512,8 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 			}
 		}
 
-		if (delta.visibleEditors) {
-			this._visibleNotebookEditors = delta.visibleEditors.map(id => this._editors.get(id)!).filter(editor => !!editor) as ExtHostNotebookEditor[];
+		if (delta.value.visibleEditors) {
+			this._visibleNotebookEditors = delta.value.visibleEditors.map(id => this._editors.get(id)!).filter(editor => !!editor) as ExtHostNotebookEditor[];
 			const visibleEditorsSet = new Set<string>();
 			this._visibleNotebookEditors.forEach(editor => visibleEditorsSet.add(editor.id));
 
@@ -525,13 +526,13 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 			this._onDidChangeVisibleNotebookEditors.fire(this.visibleNotebookEditors);
 		}
 
-		if (delta.newActiveEditor === null) {
+		if (delta.value.newActiveEditor === null) {
 			// clear active notebook as current active editor is non-notebook editor
 			this._activeNotebookEditor = undefined;
-		} else if (delta.newActiveEditor) {
-			this._activeNotebookEditor = this._editors.get(delta.newActiveEditor);
+		} else if (delta.value.newActiveEditor) {
+			this._activeNotebookEditor = this._editors.get(delta.value.newActiveEditor);
 		}
-		if (delta.newActiveEditor !== undefined) {
+		if (delta.value.newActiveEditor !== undefined) {
 			this._onDidChangeActiveNotebookEditor.fire(this._activeNotebookEditor?.apiEditor);
 		}
 	}

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -355,13 +355,13 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 
 	// --- open, save, saveAs, backup
 
-	async $openNotebook(viewType: string, uri: UriComponents, backupId: string | undefined, untitledDocumentData: VSBuffer | undefined, token: CancellationToken): Promise<NotebookDataDto> {
+	async $openNotebook(viewType: string, uri: UriComponents, backupId: string | undefined, untitledDocumentData: VSBuffer | undefined, token: CancellationToken): Promise<SerializableObjectWithBuffers<NotebookDataDto>> {
 		const { provider } = this._getProviderData(viewType);
 		const data = await provider.openNotebook(URI.revive(uri), { backupId, untitledDocumentData: untitledDocumentData?.buffer }, token);
-		return {
+		return new SerializableObjectWithBuffers({
 			metadata: data.metadata ?? Object.create(null),
 			cells: data.cells.map(typeConverters.NotebookCellData.from),
-		};
+		});
 	}
 
 	async $saveNotebook(viewType: string, uri: UriComponents, token: CancellationToken): Promise<boolean> {

--- a/src/vs/workbench/api/common/extHostNotebookDocuments.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocuments.ts
@@ -8,6 +8,7 @@ import { URI, UriComponents } from 'vs/base/common/uri';
 import { ILogService } from 'vs/platform/log/common/log';
 import * as extHostProtocol from 'vs/workbench/api/common/extHost.protocol';
 import { ExtHostNotebookController } from 'vs/workbench/api/common/extHostNotebook';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import type * as vscode from 'vscode';
 
 export class ExtHostNotebookDocuments implements extHostProtocol.ExtHostNotebookDocumentsShape {
@@ -23,9 +24,9 @@ export class ExtHostNotebookDocuments implements extHostProtocol.ExtHostNotebook
 		private readonly _notebooksAndEditors: ExtHostNotebookController,
 	) { }
 
-	$acceptModelChanged(uri: UriComponents, event: extHostProtocol.NotebookCellsChangedEventDto, isDirty: boolean): void {
+	$acceptModelChanged(uri: UriComponents, event: SerializableObjectWithBuffers<extHostProtocol.NotebookCellsChangedEventDto>, isDirty: boolean): void {
 		const document = this._notebooksAndEditors.getNotebookDocument(URI.revive(uri));
-		document.acceptModelChanged(event, isDirty);
+		document.acceptModelChanged(event.value, isDirty);
 	}
 
 	$acceptDirtyStateChanged(uri: UriComponents, isDirty: boolean): void {

--- a/src/vs/workbench/api/common/extHostNotebookKernels.ts
+++ b/src/vs/workbench/api/common/extHostNotebookKernels.ts
@@ -21,6 +21,7 @@ import { NotebookCellOutput } from 'vs/workbench/api/common/extHostTypes';
 import { asWebviewUri } from 'vs/workbench/api/common/shared/webview';
 import { CellExecutionUpdateType } from 'vs/workbench/contrib/notebook/common/notebookExecutionService';
 import { checkProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import * as vscode from 'vscode';
 
 interface IKernelData {
@@ -362,7 +363,7 @@ class NotebookCellExecutionTask extends Disposable {
 
 	private async update(update: ICellExecuteUpdateDto | ICellExecuteUpdateDto[]): Promise<void> {
 		const updates = Array.isArray(update) ? update : [update];
-		return this._proxy.$updateExecutions(updates);
+		return this._proxy.$updateExecutions(new SerializableObjectWithBuffers(updates));
 	}
 
 	private verifyStateForOutput() {

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { coalesce, isNonEmptyArray } from 'vs/base/common/arrays';
+import { VSBuffer } from 'vs/base/common/buffer';
 import * as htmlContent from 'vs/base/common/htmlContent';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import * as marked from 'vs/base/common/marked/marked';
@@ -1494,12 +1495,12 @@ export namespace NotebookCellOutputItem {
 	export function from(item: types.NotebookCellOutputItem): extHostProtocol.NotebookOutputItemDto {
 		return {
 			mime: item.mime,
-			valueBytes: Array.from(item.data), //todo@jrieken this HACKY and SLOW... hoist VSBuffer instead
+			valueBytes: VSBuffer.wrap(item.data),
 		};
 	}
 
 	export function to(item: extHostProtocol.NotebookOutputItemDto): types.NotebookCellOutputItem {
-		return new types.NotebookCellOutputItem(new Uint8Array(item.valueBytes), item.mime);
+		return new types.NotebookCellOutputItem(item.valueBytes.buffer, item.mime);
 	}
 }
 

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -104,7 +104,7 @@ export class InteractiveDocumentContribution extends Disposable implements IWork
 											outputId: output.outputId,
 											outputs: output.outputs.map(ot => ({
 												mime: ot.mime,
-												data: Uint8Array.from(ot.data)
+												data: ot.data
 											}))
 										}))
 										: [],
@@ -145,7 +145,7 @@ export class InteractiveDocumentContribution extends Disposable implements IWork
 								outputId: output.outputId,
 								outputs: output.outputs.map(ot => ({
 									mime: ot.mime,
-									data: Array.from(ot.data)
+									data: ot.data
 								}))
 							};
 						}),

--- a/src/vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/codeRenderer/codeRenderer.ts
@@ -95,7 +95,7 @@ export class NotebookCodeRendererContribution extends Disposable {
 				}
 
 				render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement): IRenderOutput {
-					const str = getStringValue(item);
+					const str = item.data.toString();
 					return this._render(output, container, str, languageId);
 				}
 			});
@@ -121,10 +121,6 @@ workbenchContributionsRegistry.registerWorkbenchContribution(NotebookCodeRendere
 
 
 // --- utils ---
-function getStringValue(item: IOutputItemDto): string {
-	// todo@jrieken NOT proper, should be VSBuffer
-	return new TextDecoder().decode(item.data);
-}
 
 function getOutputSimpleEditorOptions(): IEditorConstructionOptions {
 	return {

--- a/src/vs/workbench/contrib/notebook/browser/diff/diffElementViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/diffElementViewModel.ts
@@ -515,12 +515,12 @@ function outputsEqual(original: ICellOutput[], modified: ICellOutput[]) {
 				return false;
 			}
 
-			if (aOutputItem.data.length !== bOutputItem.data.length) {
+			if (aOutputItem.data.buffer.length !== bOutputItem.data.buffer.length) {
 				return false;
 			}
 
-			for (let k = 0; k < aOutputItem.data.length; k++) {
-				if (aOutputItem.data[k] !== bOutputItem.data[k]) {
+			for (let k = 0; k < aOutputItem.data.buffer.length; k++) {
+				if (aOutputItem.data.buffer[k] !== bOutputItem.data.buffer[k]) {
 					return false;
 				}
 			}

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -372,7 +372,7 @@ class CellInfoContentProvider {
 		const sameStream = !outputs.find(op => op.mime !== mime);
 
 		if (sameStream) {
-			return outputs.map(opit => new TextDecoder().decode(opit.data)).join('');
+			return outputs.map(opit => opit.data.toString()).join('');
 		} else {
 			return null;
 		}
@@ -413,7 +413,7 @@ class CellInfoContentProvider {
 					metadata: output.metadata,
 					outputItems: output.outputs.map(opit => ({
 						mimeType: opit.mime,
-						data: new TextDecoder().decode(opit.data)
+						data: opit.data.toString()
 					}))
 				})));
 				const edits = format(content, undefined, {});

--- a/src/vs/workbench/contrib/notebook/browser/view/output/transforms/richTransform.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/output/transforms/richTransform.ts
@@ -254,7 +254,7 @@ class ImgRendererContrib extends Disposable implements IOutputRendererContributi
 	render(output: ICellOutputViewModel, item: IOutputItemDto, container: HTMLElement, notebookUri: URI): IRenderOutput {
 		const disposable = new DisposableStore();
 
-		const blob = new Blob([item.data], { type: item.mime });
+		const blob = new Blob([item.data.buffer], { type: item.mime });
 		const src = URL.createObjectURL(blob);
 		disposable.add(toDisposable(() => URL.revokeObjectURL(src)));
 
@@ -281,6 +281,5 @@ OutputRendererRegistry.registerOutputTransform(StderrRendererContrib);
 
 // --- utils ---
 export function getStringValue(item: IOutputItemDto): string {
-	// todo@jrieken NOT proper, should be VSBuffer
-	return new TextDecoder().decode(item.data);
+	return item.data.toString();
 }

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -980,7 +980,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Disposable {
 					type: RenderOutputType.Extension,
 					outputId: output.outputId,
 					mimeType: first.mime,
-					valueBytes: first.data,
+					valueBytes: first.data.buffer,
 					metadata: output.metadata,
 				},
 			};

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -1017,7 +1017,7 @@ class OutputSequence implements ISequence {
 		return this.outputs.map(output => {
 			return hash(output.outputs.map(output => ({
 				mime: output.mime,
-				data: Array.from(output.data)
+				data: output.data
 			})));
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { VSBuffer } from 'vs/base/common/buffer';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IDiffResult, ISequence } from 'vs/base/common/diff/diff';
 import { Event } from 'vs/base/common/event';
@@ -157,7 +158,7 @@ export interface IOrderedMimeType {
 
 export interface IOutputItemDto {
 	readonly mime: string;
-	readonly data: Uint8Array;
+	readonly data: VSBuffer;
 }
 
 export interface IOutputDto {

--- a/src/vs/workbench/contrib/notebook/common/services/notebookSimpleWorker.ts
+++ b/src/vs/workbench/contrib/notebook/common/services/notebookSimpleWorker.ts
@@ -74,7 +74,7 @@ class MirrorCell {
 		this._hash = hash([hash(this.language), hash(this.getValue()), this.metadata, this.internalMetadata, this.outputs.map(op => ({
 			outputs: op.outputs.map(output => ({
 				mime: output.mime,
-				data: Array.from(output.data)
+				data: output.data
 			})),
 			metadata: op.metadata
 		}))]);

--- a/src/vs/workbench/contrib/notebook/test/notebookDiff.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/notebookDiff.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { VSBuffer } from 'vs/base/common/buffer';
 import { LcsDiff } from 'vs/base/common/diff/diff';
 import { Mimes } from 'vs/base/common/mime';
 import { NotebookDiffEditorEventDispatcher } from 'vs/workbench/contrib/notebook/browser/diff/eventDispatcher';
@@ -15,9 +16,9 @@ suite('NotebookCommon', () => {
 
 	test('diff different source', async () => {
 		await withTestNotebookDiffModel([
-			['x', 'javascript', CellKind.Code, [{ outputId: 'someOtherId', outputs: [{ mime: Mimes.text, data: new Uint8Array([3]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 3 }],
+			['x', 'javascript', CellKind.Code, [{ outputId: 'someOtherId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([3])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 3 }],
 		], [
-			['y', 'javascript', CellKind.Code, [{ outputId: 'someOtherId', outputs: [{ mime: Mimes.text, data: new Uint8Array([3]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 3 }],
+			['y', 'javascript', CellKind.Code, [{ outputId: 'someOtherId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([3])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 3 }],
 		], (model, accessor) => {
 			const diff = new LcsDiff(new CellSequence(model.original.notebook), new CellSequence(model.modified.notebook));
 			const diffResult = diff.ComputeDiff(false);
@@ -45,10 +46,10 @@ suite('NotebookCommon', () => {
 
 	test('diff different output', async () => {
 		await withTestNotebookDiffModel([
-			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([5]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 5 }],
+			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([5])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 5 }],
 			['', 'javascript', CellKind.Code, [], {}]
 		], [
-			['x', 'javascript', CellKind.Code, [{ outputId: 'someOtherId', outputs: [{ mime: Mimes.text, data: new Uint8Array([3]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 3 }],
+			['x', 'javascript', CellKind.Code, [{ outputId: 'someOtherId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([3])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 3 }],
 			['', 'javascript', CellKind.Code, [], {}]
 		], (model, accessor) => {
 			const diff = new LcsDiff(new CellSequence(model.original.notebook), new CellSequence(model.modified.notebook));
@@ -146,12 +147,12 @@ suite('NotebookCommon', () => {
 
 	test('diff foo/foe', async () => {
 		await withTestNotebookDiffModel([
-			[['def foe(x, y):\n', '    return x + y\n', 'foe(3, 2)'].join(''), 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([6]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 5 }],
-			[['def foo(x, y):\n', '    return x * y\n', 'foo(1, 2)'].join(''), 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([2]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 6 }],
+			[['def foe(x, y):\n', '    return x + y\n', 'foe(3, 2)'].join(''), 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([6])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 5 }],
+			[['def foo(x, y):\n', '    return x * y\n', 'foo(1, 2)'].join(''), 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([2])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 6 }],
 			['', 'javascript', CellKind.Code, [], {}]
 		], [
-			[['def foo(x, y):\n', '    return x * y\n', 'foo(1, 2)'].join(''), 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([6]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 5 }],
-			[['def foe(x, y):\n', '    return x + y\n', 'foe(3, 2)'].join(''), 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([2]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 6 }],
+			[['def foo(x, y):\n', '    return x * y\n', 'foo(1, 2)'].join(''), 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([6])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 5 }],
+			[['def foe(x, y):\n', '    return x + y\n', 'foe(3, 2)'].join(''), 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([2])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 6 }],
 			['', 'javascript', CellKind.Code, [], {}]
 		], (model, accessor) => {
 			const diff = new LcsDiff(new CellSequence(model.original.notebook), new CellSequence(model.modified.notebook));
@@ -273,13 +274,13 @@ suite('NotebookCommon', () => {
 		await withTestNotebookDiffModel([
 			['# Description', 'markdown', CellKind.Markup, [], { custom: { metadata: {} } }],
 			['x = 3', 'javascript', CellKind.Code, [], { custom: { metadata: { collapsed: true } }, executionOrder: 1 }],
-			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([3]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 1 }],
+			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([3])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 1 }],
 			['x', 'javascript', CellKind.Code, [], { custom: { metadata: { collapsed: false } } }]
 		], [
 			['# Description', 'markdown', CellKind.Markup, [], { custom: { metadata: {} } }],
 			['x = 3', 'javascript', CellKind.Code, [], { custom: { metadata: { collapsed: true } }, executionOrder: 1 }],
 			['x', 'javascript', CellKind.Code, [], { custom: { metadata: { collapsed: false } } }],
-			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([3]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 1 }]
+			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([3])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 1 }]
 		], async (model) => {
 			const diff = new LcsDiff(new CellSequence(model.original.notebook), new CellSequence(model.modified.notebook));
 			const diffResult = diff.ComputeDiff(false);
@@ -306,18 +307,18 @@ suite('NotebookCommon', () => {
 		await withTestNotebookDiffModel([
 			['# Description', 'markdown', CellKind.Markup, [], { custom: { metadata: {} } }],
 			['x = 3', 'javascript', CellKind.Code, [], { custom: { metadata: { collapsed: true } }, executionOrder: 1 }],
-			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([3]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 1 }],
+			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([3])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 1 }],
 			['x', 'javascript', CellKind.Code, [], { custom: { metadata: { collapsed: false } } }],
 			['x = 5', 'javascript', CellKind.Code, [], {}],
 			['x', 'javascript', CellKind.Code, [], {}],
-			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([5]) }] }], {}],
+			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([5])) }] }], {}],
 		], [
 			['# Description', 'markdown', CellKind.Markup, [], { custom: { metadata: {} } }],
 			['x = 3', 'javascript', CellKind.Code, [], { custom: { metadata: { collapsed: true } }, executionOrder: 1 }],
 			['x', 'javascript', CellKind.Code, [], { custom: { metadata: { collapsed: false } } }],
-			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([3]) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 1 }],
+			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([3])) }] }], { custom: { metadata: { collapsed: false } }, executionOrder: 1 }],
 			['x = 5', 'javascript', CellKind.Code, [], {}],
-			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: new Uint8Array([5]) }] }], {}],
+			['x', 'javascript', CellKind.Code, [{ outputId: 'someId', outputs: [{ mime: Mimes.text, data: VSBuffer.wrap(new Uint8Array([5])) }] }], {}],
 			['x', 'javascript', CellKind.Code, [], {}],
 		], async (model) => {
 			const diff = new LcsDiff(new CellSequence(model.original.notebook), new CellSequence(model.modified.notebook));

--- a/src/vs/workbench/contrib/notebook/test/notebookTextModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/notebookTextModel.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { VSBuffer } from 'vs/base/common/buffer';
 import { Mimes } from 'vs/base/common/mime';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
@@ -426,7 +427,7 @@ suite('NotebookTextModel', () => {
 			const success1 = model.applyEdits(
 				[{
 					editType: CellEditType.Output, index: 0, outputs: [
-						{ outputId: 'out1', outputs: [{ mime: 'application/x.notebook.stream', data: new Uint8Array([1]) }] }
+						{ outputId: 'out1', outputs: [{ mime: 'application/x.notebook.stream', data: VSBuffer.wrap(new Uint8Array([1])) }] }
 					],
 					append: false
 				}], true, undefined, () => undefined, undefined, false
@@ -438,7 +439,7 @@ suite('NotebookTextModel', () => {
 			const success2 = model.applyEdits(
 				[{
 					editType: CellEditType.Output, index: 0, outputs: [
-						{ outputId: 'out2', outputs: [{ mime: 'application/x.notebook.stream', data: new Uint8Array([1]) }] }
+						{ outputId: 'out2', outputs: [{ mime: 'application/x.notebook.stream', data: VSBuffer.wrap(new Uint8Array([1])) }] }
 					],
 					append: true
 				}], true, undefined, () => undefined, undefined, false
@@ -465,7 +466,7 @@ suite('NotebookTextModel', () => {
 				const success = model.applyEdits(
 					[{
 						editType: CellEditType.Output, index: 0, outputs: [
-							{ outputId: 'out1', outputs: [{ mime: 'application/x.notebook.stream', data: new Uint8Array([1]) }] }
+							{ outputId: 'out1', outputs: [{ mime: 'application/x.notebook.stream', data: VSBuffer.wrap(new Uint8Array([1])) }] }
 						],
 						append: false
 					}], true, undefined, () => undefined, undefined, false

--- a/src/vs/workbench/contrib/notebook/test/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/testNotebookEditor.ts
@@ -47,6 +47,7 @@ import { NotebookOptions } from 'vs/workbench/contrib/notebook/common/notebookOp
 import { ViewContext } from 'vs/workbench/contrib/notebook/browser/viewModel/viewContext';
 import { OutputRenderer } from 'vs/workbench/contrib/notebook/browser/view/output/outputRenderer';
 import { Mimes } from 'vs/base/common/mime';
+import { VSBuffer } from 'vs/base/common/buffer';
 
 export class TestCell extends NotebookCellTextModel {
 	constructor(
@@ -345,6 +346,6 @@ export function createNotebookCellList(instantiationService: TestInstantiationSe
 	return cellList;
 }
 
-export function valueBytesFromString(value: string) {
-	return new TextEncoder().encode(value);
+export function valueBytesFromString(value: string): VSBuffer {
+	return VSBuffer.fromString(value);
 }

--- a/src/vs/workbench/services/extensions/common/proxyIdentifier.ts
+++ b/src/vs/workbench/services/extensions/common/proxyIdentifier.ts
@@ -57,3 +57,12 @@ export function createExtHostContextProxyIdentifier<T>(identifier: string): Prox
 export function getStringIdentifierForProxy(nid: number): string {
 	return identifiers[nid].sid;
 }
+
+/**
+ * Marks the object as containing buffers that should be serialized more efficently.
+ */
+export class SerializableObjectWithBuffers<T> {
+	constructor(
+		public readonly value: T
+	) { }
+}

--- a/src/vs/workbench/test/browser/api/extHostNotebook.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostNotebook.test.ts
@@ -23,6 +23,7 @@ import { IExtensionStoragePaths } from 'vs/workbench/api/common/extHostStoragePa
 import { generateUuid } from 'vs/base/common/uuid';
 import { Event } from 'vs/base/common/event';
 import { ExtHostNotebookDocuments } from 'vs/workbench/api/common/extHostNotebookDocuments';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 suite('NotebookCell#Document', function () {
 
@@ -63,7 +64,7 @@ suite('NotebookCell#Document', function () {
 		let reg = extHostNotebooks.registerNotebookContentProvider(nullExtensionDescription, 'test', new class extends mock<vscode.NotebookContentProvider>() {
 			// async openNotebook() { }
 		});
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({
 			addedDocuments: [{
 				uri: notebookUri,
 				viewType: 'test',
@@ -92,8 +93,8 @@ suite('NotebookCell#Document', function () {
 				selections: [{ start: 0, end: 1 }],
 				visibleRanges: []
 			}]
-		});
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({ newActiveEditor: '_notebook_editor_0' });
+		}));
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({ newActiveEditor: '_notebook_editor_0' }));
 
 		notebook = extHostNotebooks.notebookDocuments[0]!;
 
@@ -134,7 +135,7 @@ suite('NotebookCell#Document', function () {
 			removedCellUris.push(doc.uri.toString());
 		});
 
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({ removedDocuments: [notebook.uri] });
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({ removedDocuments: [notebook.uri] }));
 		reg.dispose();
 
 		assert.strictEqual(removedCellUris.length, 2);
@@ -167,7 +168,7 @@ suite('NotebookCell#Document', function () {
 			});
 		});
 
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -191,7 +192,7 @@ suite('NotebookCell#Document', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 
 		await p;
 
@@ -229,7 +230,7 @@ suite('NotebookCell#Document', function () {
 		}
 
 		// close notebook -> docs are closed
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({ removedDocuments: [notebook.uri] });
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({ removedDocuments: [notebook.uri] }));
 		for (let cell of notebook.apiNotebook.getCells()) {
 			assert.throws(() => extHostDocuments.getDocument(cell.document.uri));
 		}
@@ -243,7 +244,7 @@ suite('NotebookCell#Document', function () {
 		assert.strictEqual(notebook.apiNotebook.cellCount, 2);
 		const [cell1, cell2] = notebook.apiNotebook.getCells();
 
-		extHostNotebookDocuments.$acceptModelChanged(notebook.uri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebook.uri, new SerializableObjectWithBuffers({
 			versionId: 2,
 			rawEvents: [
 				{
@@ -251,7 +252,7 @@ suite('NotebookCell#Document', function () {
 					changes: [[0, 1, []]]
 				}
 			]
-		}, false);
+		}), false);
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1);
 		assert.strictEqual(cell1.document.isClosed, true); // ref still alive!
@@ -274,18 +275,18 @@ suite('NotebookCell#Document', function () {
 		assert.strictEqual(second.index, 1);
 
 		// remove first cell
-		extHostNotebookDocuments.$acceptModelChanged(notebook.uri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebook.uri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [{
 				kind: NotebookCellsChangeType.ModelChange,
 				changes: [[0, 1, []]]
 			}]
-		}, false);
+		}), false);
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1);
 		assert.strictEqual(second.index, 0);
 
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [{
 				kind: NotebookCellsChangeType.ModelChange,
@@ -307,7 +308,7 @@ suite('NotebookCell#Document', function () {
 					outputs: [],
 				}]]]
 			}]
-		}, false);
+		}), false);
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 3);
 		assert.strictEqual(second.index, 2);
@@ -320,7 +321,7 @@ suite('NotebookCell#Document', function () {
 		// DON'T call this, make sure the cell-documents have not been created yet
 		// assert.strictEqual(notebook.notebookDocument.cellCount, 2);
 
-		extHostNotebookDocuments.$acceptModelChanged(notebook.uri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebook.uri, new SerializableObjectWithBuffers({
 			versionId: 100,
 			rawEvents: [{
 				kind: NotebookCellsChangeType.ModelChange,
@@ -342,7 +343,7 @@ suite('NotebookCell#Document', function () {
 					outputs: [],
 				}]]]
 			}]
-		}, false);
+		}), false);
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 2);
 
@@ -363,18 +364,18 @@ suite('NotebookCell#Document', function () {
 		let count = 0;
 		extHostNotebooks.onDidChangeActiveNotebookEditor(() => count += 1);
 
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({
 			addedEditors: [{
 				documentUri: notebookUri,
 				id: '_notebook_editor_2',
 				selections: [{ start: 0, end: 1 }],
 				visibleRanges: []
 			}]
-		});
+		}));
 
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({
 			newActiveEditor: '_notebook_editor_2'
-		});
+		}));
 
 		assert.strictEqual(count, 1);
 	});
@@ -384,13 +385,13 @@ suite('NotebookCell#Document', function () {
 		const editor = extHostNotebooks.activeNotebookEditor;
 		assert.ok(editor !== undefined);
 
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({ newActiveEditor: undefined });
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({ newActiveEditor: undefined }));
 		assert.ok(extHostNotebooks.activeNotebookEditor === editor);
 
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({});
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({}));
 		assert.ok(extHostNotebooks.activeNotebookEditor === editor);
 
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({ newActiveEditor: null });
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({ newActiveEditor: null }));
 		assert.ok(extHostNotebooks.activeNotebookEditor === undefined);
 	});
 
@@ -403,13 +404,13 @@ suite('NotebookCell#Document', function () {
 		const removed = Event.toPromise(extHostDocuments.onDidRemoveDocument);
 		const added = Event.toPromise(extHostDocuments.onDidAddDocument);
 
-		extHostNotebookDocuments.$acceptModelChanged(notebook.uri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebook.uri, new SerializableObjectWithBuffers({
 			versionId: 12, rawEvents: [{
 				kind: NotebookCellsChangeType.ChangeLanguage,
 				index: 0,
 				language: 'fooLang'
 			}]
-		}, false);
+		}), false);
 
 		const removedDoc = await removed;
 		const addedDoc = await added;

--- a/src/vs/workbench/test/browser/api/extHostNotebookConcatDocument.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostNotebookConcatDocument.test.ts
@@ -23,6 +23,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { IExtensionStoragePaths } from 'vs/workbench/api/common/extHostStoragePaths';
 import { generateUuid } from 'vs/base/common/uuid';
 import { ExtHostNotebookDocuments } from 'vs/workbench/api/common/extHostNotebookDocuments';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 suite('NotebookConcatDocument', function () {
 
@@ -60,7 +61,7 @@ suite('NotebookConcatDocument', function () {
 		let reg = extHostNotebooks.registerNotebookContentProvider(nullExtensionDescription, 'test', new class extends mock<vscode.NotebookContentProvider>() {
 			// async openNotebook() { }
 		});
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({
 			addedDocuments: [{
 				uri: notebookUri,
 				viewType: 'test',
@@ -81,8 +82,8 @@ suite('NotebookConcatDocument', function () {
 				selections: [{ start: 0, end: 1 }],
 				visibleRanges: []
 			}]
-		});
-		extHostNotebooks.$acceptDocumentAndEditorsDelta({ newActiveEditor: '_notebook_editor_0' });
+		}));
+		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({ newActiveEditor: '_notebook_editor_0' }));
 
 		notebook = extHostNotebooks.notebookDocuments[0]!;
 
@@ -127,7 +128,7 @@ suite('NotebookConcatDocument', function () {
 		const cellUri1 = CellUri.generate(notebook.uri, 1);
 		const cellUri2 = CellUri.generate(notebook.uri, 2);
 
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [{
 				kind: NotebookCellsChangeType.ModelChange,
@@ -150,7 +151,7 @@ suite('NotebookConcatDocument', function () {
 				}]]
 				]
 			}]
-		}, false);
+		}), false);
 
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2); // markdown and code
@@ -164,7 +165,7 @@ suite('NotebookConcatDocument', function () {
 
 	test('location, position mapping', function () {
 
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -188,7 +189,7 @@ suite('NotebookConcatDocument', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2); // markdown and code
@@ -209,7 +210,7 @@ suite('NotebookConcatDocument', function () {
 		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
 
 		// UPDATE 1
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -225,7 +226,7 @@ suite('NotebookConcatDocument', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 1);
 		assert.strictEqual(doc.version, 1);
 		assertLines(doc, 'Hello', 'World', 'Hello World!');
@@ -236,7 +237,7 @@ suite('NotebookConcatDocument', function () {
 
 
 		// UPDATE 2
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -252,7 +253,7 @@ suite('NotebookConcatDocument', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2);
 		assert.strictEqual(doc.version, 2);
@@ -264,7 +265,7 @@ suite('NotebookConcatDocument', function () {
 		assertLocation(doc, new Position(5, 12), new Location(notebook.apiNotebook.cellAt(1).document.uri, new Position(2, 11)), false); // don't check identity because position will be clamped
 
 		// UPDATE 3 (remove cell #2 again)
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -272,7 +273,7 @@ suite('NotebookConcatDocument', function () {
 					changes: [[1, 1, []]]
 				}
 			]
-		}, false);
+		}), false);
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 1);
 		assert.strictEqual(doc.version, 3);
 		assertLines(doc, 'Hello', 'World', 'Hello World!');
@@ -286,7 +287,7 @@ suite('NotebookConcatDocument', function () {
 		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
 
 		// UPDATE 1
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -311,7 +312,7 @@ suite('NotebookConcatDocument', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2);
 		assert.strictEqual(doc.version, 1);
 
@@ -347,7 +348,7 @@ suite('NotebookConcatDocument', function () {
 
 	test('selector', function () {
 
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -371,7 +372,7 @@ suite('NotebookConcatDocument', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 
 		const mixedDoc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
 		const fooLangDoc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, 'fooLang');
@@ -381,7 +382,7 @@ suite('NotebookConcatDocument', function () {
 		assertLines(fooLangDoc, 'fooLang-document');
 		assertLines(barLangDoc, 'barLang-document');
 
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -397,7 +398,7 @@ suite('NotebookConcatDocument', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 
 		assertLines(mixedDoc, 'fooLang-document', 'barLang-document', 'barLang-document2');
 		assertLines(fooLangDoc, 'fooLang-document');
@@ -419,7 +420,7 @@ suite('NotebookConcatDocument', function () {
 
 	test('offsetAt(position) <-> positionAt(offset)', function () {
 
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -443,7 +444,7 @@ suite('NotebookConcatDocument', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2); // markdown and code
 
@@ -476,7 +477,7 @@ suite('NotebookConcatDocument', function () {
 
 	test('locationAt(position) <-> positionAt(location)', function () {
 
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -500,7 +501,7 @@ suite('NotebookConcatDocument', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2); // markdown and code
 
@@ -517,7 +518,7 @@ suite('NotebookConcatDocument', function () {
 
 	test('getText(range)', function () {
 
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -549,7 +550,7 @@ suite('NotebookConcatDocument', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 3); // markdown and code
 
@@ -564,7 +565,7 @@ suite('NotebookConcatDocument', function () {
 
 	test('validateRange/Position', function () {
 
-		extHostNotebookDocuments.$acceptModelChanged(notebookUri, {
+		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
 			versionId: notebook.apiNotebook.version + 1,
 			rawEvents: [
 				{
@@ -588,7 +589,7 @@ suite('NotebookConcatDocument', function () {
 					}]]]
 				}
 			]
-		}, false);
+		}), false);
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2); // markdown and code
 

--- a/src/vs/workbench/test/browser/api/extHostTypeConverter.test.ts
+++ b/src/vs/workbench/test/browser/api/extHostTypeConverter.test.ts
@@ -104,11 +104,11 @@ suite('ExtHostTypeConverter', function () {
 		const dto = NotebookCellOutputItem.from(item);
 
 		assert.strictEqual(dto.mime, 'foo/bar');
-		assert.deepStrictEqual(dto.valueBytes, Array.from(new TextEncoder().encode('Hello')));
+		assert.deepStrictEqual(Array.from(dto.valueBytes.buffer), Array.from(new TextEncoder().encode('Hello')));
 
 		const item2 = NotebookCellOutputItem.to(dto);
 
 		assert.strictEqual(item2.mime, item.mime);
-		assert.deepStrictEqual(item2.data, item.data);
+		assert.deepStrictEqual(Array.from(item2.data), Array.from(item.data));
 	});
 });


### PR DESCRIPTION
Fixes #125819

This PR lets us transfer the notebook output as a VSBuffer instead of as an array of numbers. This should significantly reduce the rpc message size when talking about notebook outputs and also speed up serialization and deserialization of notebook outputs.

# Problem
Right now, our RPC implementation can only serialize `VSBuffers` that appear as top level arguments. The issue is that the notebook outputs appear inside deeply nested objects, and we cannot extract them to top level arguments without adding a lot of complexity to rpc calls involving outputs.

# Fix 
This PR adds a new `SerializableObjectWithBuffers` class that indicates to our rpc implementation that an object should have its buffers extracted and efficiently serialized for transfer. This lets us keep any `VSBuffers` that appear inside the arguments as binary data, and also lets us avoid overhead of parsing them as JSON.

`SerializableObjectWithBuffers` can appear both rpc arguments and be used as an rpc return value.