### PR TITLE
Use the new loader format for web selfhost

### DIFF
--- a/build/gulpfile.compile.js
+++ b/build/gulpfile.compile.js
@@ -14,6 +14,7 @@ const compilation = require('./lib/compilation');
 const compileBuildTask = task.define('compile-build',
 	task.series(
 		util.rimraf('out-build'),
+		util.buildWebNodePaths('out-build'),
 		compilation.compileTask('src', 'out-build', true)
 	)
 );

--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -16,10 +16,10 @@ const { monacoTypecheckTask/* , monacoTypecheckWatchTask */ } = require('./gulpf
 const { compileExtensionsTask, watchExtensionsTask, compileExtensionMediaTask } = require('./gulpfile.extensions');
 
 // Fast compile for development time
-const compileClientTask = task.define('compile-client', task.series(util.rimraf('out'), util.buildWebNodePaths(), compilation.compileTask('src', 'out', false)));
+const compileClientTask = task.define('compile-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), compilation.compileTask('src', 'out', false)));
 gulp.task(compileClientTask);
 
-const watchClientTask = task.define('watch-client', task.series(util.rimraf('out'), util.buildWebNodePaths(), compilation.watchTask('out', false)));
+const watchClientTask = task.define('watch-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), compilation.watchTask('out', false)));
 gulp.task(watchClientTask);
 
 // All

--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -274,7 +274,7 @@ function getElectronVersion() {
     return target;
 }
 exports.getElectronVersion = getElectronVersion;
-function buildWebNodePaths() {
+function buildWebNodePaths(outDir) {
     const result = () => new Promise((resolve, _) => {
         var _a;
         const root = path.join(__dirname, '..', '..');
@@ -300,7 +300,7 @@ function buildWebNodePaths() {
             nodePaths[key] = entryPoint;
         }
         // Now we write the node paths to out/vs
-        const outDirectory = path.join(root, 'out', 'vs');
+        const outDirectory = path.join(root, outDir, 'vs');
         fs.mkdirSync(outDirectory, { recursive: true });
         const headerWithGeneratedFileWarning = `/*---------------------------------------------------------------------------------------------
 	 *  Copyright (c) Microsoft Corporation. All rights reserved.

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -341,30 +341,35 @@ export function getElectronVersion(): string {
 	return target;
 }
 
+export function acquireWebNodePaths() {
+	const root = path.join(__dirname, '..', '..');
+	const webPackageJSON = path.join(root, '/remote/web', 'package.json');
+	const webPackages = JSON.parse(fs.readFileSync(webPackageJSON, 'utf8')).dependencies;
+	const nodePaths: { [key: string]: string } = {};
+	for (const key of Object.keys(webPackages)) {
+		const packageJSON = path.join(root, 'node_modules', key, 'package.json');
+		const packageData = JSON.parse(fs.readFileSync(packageJSON, 'utf8'));
+		let entryPoint = packageData.browser ?? packageData.main;
+		// On rare cases a package doesn't have an entrypoint so we assume it has a dist folder with a min.js
+		if (!entryPoint) {
+			console.warn(`No entry point for ${key} assuming dist/${key}.min.js`);
+			entryPoint = `dist/${key}.min.js`;
+		}
+		// Remove any starting path information so it's all relative info
+		if (entryPoint.startsWith('./')) {
+			entryPoint = entryPoint.substr(2);
+		} else if (entryPoint.startsWith('/')) {
+			entryPoint = entryPoint.substr(1);
+		}
+		nodePaths[key] = entryPoint;
+	}
+	return nodePaths;
+}
+
 export function buildWebNodePaths(outDir: string) {
 	const result = () => new Promise<void>((resolve, _) => {
 		const root = path.join(__dirname, '..', '..');
-		const webPackageJSON = path.join(root, '/remote/web', 'package.json');
-		const webPackages = JSON.parse(fs.readFileSync(webPackageJSON, 'utf8')).dependencies;
-		const nodePaths: { [key: string]: string } = {};
-		for (const key of Object.keys(webPackages)) {
-			const packageJSON = path.join(root, 'node_modules', key, 'package.json');
-			const packageData = JSON.parse(fs.readFileSync(packageJSON, 'utf8'));
-			let entryPoint = packageData.browser ?? packageData.main;
-			// On rare cases a package doesn't have an entrypoint so we assume it has a dist folder with a min.js
-			if (!entryPoint) {
-				console.warn(`No entry point for ${key} assuming dist/${key}.min.js`);
-				entryPoint = `dist/${key}.min.js`;
-			}
-			// Remove any starting path information so it's all relative info
-			if (entryPoint.startsWith('./')) {
-				entryPoint = entryPoint.substr(2);
-			} else if (entryPoint.startsWith('/')) {
-				entryPoint = entryPoint.substr(1);
-			}
-			nodePaths[key] = entryPoint;
-		}
-
+		const nodePaths = acquireWebNodePaths();
 		// Now we write the node paths to out/vs
 		const outDirectory = path.join(root, outDir, 'vs');
 		fs.mkdirSync(outDirectory, { recursive: true });

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -341,7 +341,7 @@ export function getElectronVersion(): string {
 	return target;
 }
 
-export function buildWebNodePaths() {
+export function buildWebNodePaths(outDir: string) {
 	const result = () => new Promise<void>((resolve, _) => {
 		const root = path.join(__dirname, '..', '..');
 		const webPackageJSON = path.join(root, '/remote/web', 'package.json');
@@ -366,7 +366,7 @@ export function buildWebNodePaths() {
 		}
 
 		// Now we write the node paths to out/vs
-		const outDirectory = path.join(root, 'out', 'vs');
+		const outDirectory = path.join(root, outDir, 'vs');
 		fs.mkdirSync(outDirectory, { recursive: true });
 		const headerWithGeneratedFileWarning = `/*---------------------------------------------------------------------------------------------
 	 *  Copyright (c) Microsoft Corporation. All rights reserved.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.60.0",
-  "distro": "1a48bc9e1d4b74944a0721212e078bf24b2cbf79",
+  "distro": "0daa48b9b8ac455e8d47a401b305cbd093b8c375",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.60.0",
-  "distro": "be7a0a60b61f1de530990083d9bbf37135fe29ce",
+  "distro": "1a48bc9e1d4b74944a0721212e078bf24b2cbf79",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.60.0",
-  "distro": "1a48bc9e1d4b74944a0721212e078bf24b2cbf79",
+  "distro": "5362a5d7df38264579a8d863f8ad155da4851831",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.60.0",
-  "distro": "5362a5d7df38264579a8d863f8ad155da4851831",
+  "distro": "be7a0a60b61f1de530990083d9bbf37135fe29ce",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/vs/code/browser/workbench/workbench-dev.html
+++ b/src/vs/code/browser/workbench/workbench-dev.html
@@ -28,7 +28,11 @@
 	</body>
 
 	<!-- Startup (do not modify order of script tags!) -->
+	<script src="./static/out/vs/webPackagePaths.js"></script>
 	<script>
+		Object.keys(self.webPackagePaths).map(function (key, index) {
+			self.webPackagePaths[key] = `${window.location.origin}/static/remote/web/node_modules/${key}/${self.webPackagePaths[key]}`;
+		});
 		self.require = {
 			baseUrl: `${window.location.origin}/static/out`,
 			recordStats: true,
@@ -40,19 +44,7 @@
 					throw new Error(`Invalid script url: ${value}`)
 				}
 			}),
-			paths: {
-				'@microsoft/applicationinsights-web': `${window.location.origin}/static/remote/web/node_modules/@microsoft/applicationinsights-web/dist/applicationinsights-web.js`,
-				'@vscode/vscode-languagedetection': `${window.location.origin}/static/remote/web/node_modules/@vscode/vscode-languagedetection/dist/lib/index.js`,
-				'vscode-textmate': `${window.location.origin}/static/remote/web/node_modules/vscode-textmate/release/main`,
-				'vscode-oniguruma': `${window.location.origin}/static/remote/web/node_modules/vscode-oniguruma/release/main`,
-				'xterm': `${window.location.origin}/static/remote/web/node_modules/xterm/lib/xterm.js`,
-				'xterm-addon-search': `${window.location.origin}/static/remote/web/node_modules/xterm-addon-search/lib/xterm-addon-search.js`,
-				'xterm-addon-unicode11': `${window.location.origin}/static/remote/web/node_modules/xterm-addon-unicode11/lib/xterm-addon-unicode11.js`,
-				'xterm-addon-webgl': `${window.location.origin}/static/remote/web/node_modules/xterm-addon-webgl/lib/xterm-addon-webgl.js`,
-				'tas-client-umd': `${window.location.origin}/static/remote/web/node_modules/tas-client-umd/lib/tas-client-umd.js`,
-				'iconv-lite-umd': `${window.location.origin}/static/remote/web/node_modules/iconv-lite-umd/lib/iconv-lite-umd.js`,
-				'jschardet': `${window.location.origin}/static/remote/web/node_modules/jschardet/dist/jschardet.min.js`,
-			}
+			paths: self.webPackagePaths
 		};
 	</script>
 	<script src="./static/out/vs/loader.js"></script>

--- a/src/vs/code/browser/workbench/workbench.html
+++ b/src/vs/code/browser/workbench/workbench.html
@@ -27,7 +27,11 @@
 	</body>
 
 	<!-- Startup (do not modify order of script tags!) -->
+	<script src="./static/out/vs/webPackagePaths.js"></script>
 	<script>
+		Object.keys(self.webPackagePaths).map(function (key, index) {
+			self.webPackagePaths[key] = `${window.location.origin}/static/remote/web/node_modules/${key}/${self.webPackagePaths[key]}`;
+		});
 		self.require = {
 			baseUrl: `${window.location.origin}/static/out`,
 			recordStats: true,
@@ -39,19 +43,7 @@
 					throw new Error(`Invalid script url: ${value}`)
 				}
 			}),
-			paths: {
-				'@microsoft/applicationinsights-web': `${window.location.origin}/static/node_modules/@microsoft/applicationinsights-web/dist/applicationinsights-web.js`,
-				'@vscode/vscode-languagedetection': `${window.location.origin}/static/node_modules/@vscode/vscode-languagedetection/dist/lib/index.js`,
-				'vscode-textmate': `${window.location.origin}/static/node_modules/vscode-textmate/release/main`,
-				'vscode-oniguruma': `${window.location.origin}/static/node_modules/vscode-oniguruma/release/main`,
-				'xterm': `${window.location.origin}/static/node_modules/xterm/lib/xterm.js`,
-				'xterm-addon-search': `${window.location.origin}/static/node_modules/xterm-addon-search/lib/xterm-addon-search.js`,
-				'xterm-addon-unicode11': `${window.location.origin}/static/node_modules/xterm-addon-unicode11/lib/xterm-addon-unicode11.js`,
-				'xterm-addon-webgl': `${window.location.origin}/static/node_modules/xterm-addon-webgl/lib/xterm-addon-webgl.js`,
-				'tas-client-umd': `${window.location.origin}/static/node_modules/tas-client-umd/lib/tas-client-umd.js`,
-				'iconv-lite-umd': `${window.location.origin}/static/node_modules/iconv-lite-umd/lib/iconv-lite-umd.js`,
-				'jschardet': `${window.location.origin}/static/node_modules/jschardet/dist/jschardet.min.js`,
-			}
+			paths: self.webPackagePaths
 		};
 	</script>
 	<script src="./static/out/vs/loader.js"></script>


### PR DESCRIPTION
This updates the build scripts to properly product the new `webPackagePaths.js` which can be used in the self host setup to prevent having to manually add scripts