### PR TITLE
Have scroll position in Quick input stay put in a scenario

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -520,6 +520,7 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 		let scrollTopBefore: number | undefined;
 		if (shouldKeepFocus) {
 			const newActiveItems: T[] = [];
+			// Find the new object references of the same id.
 			for (const activeItem of this._activeItems) {
 				const item = items.find(i => (i as T).id === activeItem.id);
 				if (item) {

--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -163,6 +163,7 @@ class InsertSnippetAction extends EditorAction {
 				const pick: ISnippetPick = {
 					label: snippet.prefix || snippet.name,
 					detail: snippet.description,
+					id: snippet.prefix || snippet.name,
 					snippet
 				};
 				if (!prevSnippet || prevSnippet.snippetSource !== snippet.snippetSource) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The scenario is... if you set the `.items` on a quickpick with the different items but with the same ids, the quickpick should not scroll. This would fix issues like #109969 where the ItemButtons are being used like a toggle. You would expect the scroll to stay put if you click on an eyeball.

This is the first change to fix the bug internally, then we'll expose this in the API.

Fixes #109969
