### PR TITLE
Don't return trigger characters for ambient JS suggestions

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/completions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/completions.ts
@@ -89,7 +89,7 @@ class MyCompletionItem extends vscode.CompletionItem {
 		this.useCodeSnippet = completionContext.useCodeSnippetsOnMethodSuggest && (this.kind === vscode.CompletionItemKind.Function || this.kind === vscode.CompletionItemKind.Method);
 
 		this.range = this.getRangeFromReplacementSpan(tsEntry, completionContext);
-		this.commitCharacters = MyCompletionItem.getCommitCharacters(completionContext);
+		this.commitCharacters = MyCompletionItem.getCommitCharacters(completionContext, tsEntry);
 		this.insertText = isSnippet && tsEntry.insertText ? new vscode.SnippetString(tsEntry.insertText) : tsEntry.insertText;
 		this.filterText = this.getFilterText(completionContext.line, tsEntry.insertText);
 
@@ -489,7 +489,11 @@ class MyCompletionItem extends vscode.CompletionItem {
 		}
 	}
 
-	private static getCommitCharacters(context: CompletionContext): string[] | undefined {
+	private static getCommitCharacters(context: CompletionContext, entry: Proto.CompletionEntry): string[] | undefined {
+		if (entry.kind === PConst.Kind.warning) { // Ambient JS word based suggestion
+			return undefined;
+		}
+
 		if (context.isNewIdentifierLocation || !context.isInValidCommitCharacterContext) {
 			return undefined;
 		}


### PR DESCRIPTION
Fixes #130096

JS files include their own version of word based suggestions. These include every symbol name in the current file (even if the symbol is not in scope).

These suggestions are incorrectly being returned in cases such as:

```js
const abc = 1

({  |  })
```

When you type `.` at the `|`, TS likely should not be returning these suggestions (https://github.com/microsoft/TypeScript/issues/45436) but this is not a recent regression

What changed however is that in 76885d753d6749294ab4745e3ceccb6b352b7dfd, I simplified our logic around commit characters to make it behave more consistently. In the spread cases above, this results in typing the second `.` committing the currently selected word based suggestion

My fix is to simply disable commit characters for the word based suggestions. This is how they behaved before 76885d753d6749294ab4745e3ceccb6b352b7dfd