### PR TITLE
Suppress 'Open launch.json' command on error dialog if DA provided a command (#124020)

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -821,7 +821,8 @@ export class DebugService implements IDebugService {
 
 	private async showError(message: string, errorActions: ReadonlyArray<IAction> = []): Promise<void> {
 		const configureAction = new Action(DEBUG_CONFIGURE_COMMAND_ID, DEBUG_CONFIGURE_LABEL, undefined, true, () => this.commandService.executeCommand(DEBUG_CONFIGURE_COMMAND_ID));
-		const actions = [...errorActions, configureAction];
+		// Don't append the standard command if id of any provided action indicates it is a command
+		const actions = errorActions.filter((action) => action.id.endsWith('.command')).length > 0 ? errorActions : [...errorActions, configureAction];
 		const { choice } = await this.dialogService.show(severity.Error, message, actions.map(a => a.label).concat(nls.localize('cancel', "Cancel")), { cancelId: actions.length });
 		if (choice < actions.length) {
 			await actions[choice].run();

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -713,9 +713,12 @@ export class RawDebugSession implements IDisposable {
 		const url = error?.url;
 		if (error && url) {
 			const label = error.urlLabel ? error.urlLabel : nls.localize('moreInfo', "More Info");
+			const uri = URI.parse(url);
+			// Use a suffixed id if uri invokes a command, so default 'Open launch.json' command is suppressed on dialog
+			const actionId = uri.scheme === 'command' ? 'debug.moreInfo.command' : 'debug.moreInfo';
 			return errors.createErrorWithActions(userMessage, {
-				actions: [new Action('debug.moreInfo', label, undefined, true, async () => {
-					this.openerService.open(URI.parse(url), { allowCommands: true });
+				actions: [new Action(actionId, label, undefined, true, async () => {
+					this.openerService.open(uri, { allowCommands: true });
 				})]
 			});
 		}

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -18,6 +18,7 @@ import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { Schemas } from 'vs/base/common/network';
 
 /**
  * This interface represents a single command line argument split into a "prefix" and a "path" half.
@@ -715,7 +716,7 @@ export class RawDebugSession implements IDisposable {
 			const label = error.urlLabel ? error.urlLabel : nls.localize('moreInfo', "More Info");
 			const uri = URI.parse(url);
 			// Use a suffixed id if uri invokes a command, so default 'Open launch.json' command is suppressed on dialog
-			const actionId = uri.scheme === 'command' ? 'debug.moreInfo.command' : 'debug.moreInfo';
+			const actionId = uri.scheme === Schemas.command ? 'debug.moreInfo.command' : 'debug.moreInfo';
 			return errors.createErrorWithActions(userMessage, {
 				actions: [new Action(actionId, label, undefined, true, async () => {
 					this.openerService.open(uri, { allowCommands: true });


### PR DESCRIPTION
This PR fixes #124020
