### PR TITLE
Try erroring when passing invalid types to rpc calls

### DIFF
--- a/src/vs/workbench/api/common/extHostCustomEditors.ts
+++ b/src/vs/workbench/api/common/extHostCustomEditors.ts
@@ -17,6 +17,7 @@ import * as typeConverters from 'vs/workbench/api/common/extHostTypeConverters';
 import { ExtHostWebviews, shouldSerializeBuffersForPostMessage, toExtensionData } from 'vs/workbench/api/common/extHostWebview';
 import { ExtHostWebviewPanels } from 'vs/workbench/api/common/extHostWebviewPanels';
 import { EditorGroupColumn } from 'vs/workbench/services/editor/common/editorGroupColumn';
+import { RpcProxy } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import type * as vscode from 'vscode';
 import { Cache } from './cache';
 import * as extHostProtocol from './extHost.protocol';
@@ -156,7 +157,7 @@ class EditorProviderStore {
 
 export class ExtHostCustomEditors implements extHostProtocol.ExtHostCustomEditorsShape {
 
-	private readonly _proxy: extHostProtocol.MainThreadCustomEditorsShape;
+	private readonly _proxy: RpcProxy<extHostProtocol.MainThreadCustomEditorsShape>;
 
 	private readonly _editorProviders = new EditorProviderStore();
 

--- a/src/vs/workbench/api/common/extHostRpcService.ts
+++ b/src/vs/workbench/api/common/extHostRpcService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ProxyIdentifier, IRPCProtocol } from 'vs/workbench/services/extensions/common/proxyIdentifier';
+import { ProxyIdentifier, IRPCProtocol, RpcProxy } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
 export const IExtHostRpcService = createDecorator<IExtHostRpcService>('IExtHostRpcService');
@@ -15,7 +15,7 @@ export interface IExtHostRpcService extends IRPCProtocol {
 export class ExtHostRpcService implements IExtHostRpcService {
 	readonly _serviceBrand: undefined;
 
-	readonly getProxy: <T>(identifier: ProxyIdentifier<T>) => T;
+	readonly getProxy: <T>(identifier: ProxyIdentifier<T>) => RpcProxy<T>;
 	readonly set: <T, R extends T> (identifier: ProxyIdentifier<T>, instance: R) => R;
 	readonly assertRegistered: (identifiers: ProxyIdentifier<any>[]) => void;
 	readonly drain: () => Promise<void>;

--- a/src/vs/workbench/api/common/extHostWebview.ts
+++ b/src/vs/workbench/api/common/extHostWebview.ts
@@ -13,13 +13,14 @@ import { IExtHostApiDeprecationService } from 'vs/workbench/api/common/extHostAp
 import { serializeWebviewMessage, deserializeWebviewMessage } from 'vs/workbench/api/common/extHostWebviewMessaging';
 import { IExtHostWorkspace } from 'vs/workbench/api/common/extHostWorkspace';
 import { asWebviewUri, webviewGenericCspSource, WebviewInitData } from 'vs/workbench/api/common/shared/webview';
+import { RpcProxy } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import type * as vscode from 'vscode';
 import * as extHostProtocol from './extHost.protocol';
 
 export class ExtHostWebview implements vscode.Webview {
 
 	readonly #handle: extHostProtocol.WebviewHandle;
-	readonly #proxy: extHostProtocol.MainThreadWebviewsShape;
+	readonly #proxy: RpcProxy<extHostProtocol.MainThreadWebviewsShape>;
 	readonly #deprecationService: IExtHostApiDeprecationService;
 
 	readonly #initData: WebviewInitData;
@@ -35,7 +36,7 @@ export class ExtHostWebview implements vscode.Webview {
 
 	constructor(
 		handle: extHostProtocol.WebviewHandle,
-		proxy: extHostProtocol.MainThreadWebviewsShape,
+		proxy: RpcProxy<extHostProtocol.MainThreadWebviewsShape>,
 		options: vscode.WebviewOptions,
 		initData: WebviewInitData,
 		workspace: IExtHostWorkspace | undefined,
@@ -131,7 +132,7 @@ export function shouldSerializeBuffersForPostMessage(extension: IExtensionDescri
 
 export class ExtHostWebviews implements extHostProtocol.ExtHostWebviewsShape {
 
-	private readonly _webviewProxy: extHostProtocol.MainThreadWebviewsShape;
+	private readonly _webviewProxy: RpcProxy<extHostProtocol.MainThreadWebviewsShape>;
 
 	private readonly _webviews = new Map<extHostProtocol.WebviewHandle, ExtHostWebview>();
 

--- a/src/vs/workbench/services/extensions/common/extensionHostManager.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostManager.ts
@@ -189,7 +189,7 @@ export class ExtensionHostManager extends Disposable {
 		const extHostContext: IExtHostContext = {
 			remoteAuthority: this._extensionHost.remoteAuthority,
 			extensionHostKind: this.kind,
-			getProxy: <T>(identifier: ProxyIdentifier<T>): T => this._rpcProtocol!.getProxy(identifier),
+			getProxy: <T>(identifier: ProxyIdentifier<T>) => this._rpcProtocol!.getProxy(identifier),
 			set: <T, R extends T>(identifier: ProxyIdentifier<T>, instance: R): R => this._rpcProtocol!.set(identifier, instance),
 			assertRegistered: (identifiers: ProxyIdentifier<any>[]): void => this._rpcProtocol!.assertRegistered(identifiers),
 			drain: (): Promise<void> => this._rpcProtocol!.drain(),

--- a/src/vs/workbench/services/extensions/common/rpcProtocol.ts
+++ b/src/vs/workbench/services/extensions/common/rpcProtocol.ts
@@ -4,17 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RunOnceScheduler } from 'vs/base/common/async';
+import { VSBuffer } from 'vs/base/common/buffer';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { CharCode } from 'vs/base/common/charCode';
 import * as errors from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { MarshalledId } from 'vs/base/common/marshalling';
 import { IURITransformer, transformIncomingURIs } from 'vs/base/common/uriIpc';
 import { IMessagePassingProtocol } from 'vs/base/parts/ipc/common/ipc';
 import { LazyPromise } from 'vs/workbench/services/extensions/common/lazyPromise';
-import { IRPCProtocol, ProxyIdentifier, getStringIdentifierForProxy } from 'vs/workbench/services/extensions/common/proxyIdentifier';
-import { VSBuffer } from 'vs/base/common/buffer';
-import { MarshalledId } from 'vs/base/common/marshalling';
+import { getStringIdentifierForProxy, IRPCProtocol, ProxyIdentifier, RpcProxy } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 export interface JSONStringifyReplacer {
 	(key: string, value: any): any;
@@ -187,7 +187,7 @@ export class RPCProtocol extends Disposable implements IRPCProtocol {
 		return transformIncomingURIs(obj, this._uriTransformer);
 	}
 
-	public getProxy<T>(identifier: ProxyIdentifier<T>): T {
+	public getProxy<T>(identifier: ProxyIdentifier<T>): RpcProxy<T> {
 		const { nid: rpcId, sid } = identifier;
 		if (!this._proxies[rpcId]) {
 			this._proxies[rpcId] = this._createProxy(rpcId, sid);

--- a/src/vs/workbench/test/browser/api/testRPCProtocol.ts
+++ b/src/vs/workbench/test/browser/api/testRPCProtocol.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ProxyIdentifier } from 'vs/workbench/services/extensions/common/proxyIdentifier';
+import { isThenable } from 'vs/base/common/async';
 import { CharCode } from 'vs/base/common/charCode';
 import { IExtHostContext } from 'vs/workbench/api/common/extHost.protocol';
-import { isThenable } from 'vs/base/common/async';
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
 import { ExtensionHostKind } from 'vs/workbench/services/extensions/common/extensions';
+import { ProxyIdentifier, RpcProxy } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 export function SingleProxyRPCProtocol(thing: any): IExtHostContext & IExtHostRpcService {
 	return {
@@ -78,7 +78,7 @@ export class TestRPCProtocol implements IExtHostContext, IExtHostRpcService {
 		});
 	}
 
-	public getProxy<T>(identifier: ProxyIdentifier<T>): T {
+	public getProxy<T>(identifier: ProxyIdentifier<T>): RpcProxy<T> {
 		if (!this._proxies[identifier.sid]) {
 			this._proxies[identifier.sid] = this._createProxy(identifier.sid);
 		}


### PR DESCRIPTION
This draft PR attempts to restrict the type of values that can be passed to rpc calls. This should help catch cases were objects containing VSBuffers or functions or other, non-serializable types are being passed to an RPC call

The current approach requires all callers of `getProxy` to start using the `RpcProxy` object. I'm seeing if there is a better way to do this

The PR also currently errors in a few places where we are passing in odd types. Some of these may be actual bugs but a few look more like oversights with my implementation


@alexdima I split this off from my other rpc related PR. Let me know if you think this makes sense and if I should continue looking into it. Also let me know you have ideas on how we could improve this type checking. The main issue with the draft is that is requires updating all code that calls `getProxy`