### PR TITLE
Fixes cmd+click on invalid link to create new file doesn't work in markdown

### DIFF
--- a/extensions/markdown-language-features/src/commands/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/commands/openDocumentLink.ts
@@ -99,13 +99,14 @@ export class OpenDocumentLinkCommand implements Command {
 		let stat: vscode.FileStat;
 		try {
 			stat = await vscode.workspace.fs.stat(resource);
+			if (stat.type === vscode.FileType.Directory) {
+				await vscode.commands.executeCommand('revealInExplorer', resource);
+				return true;
+			}
 		} catch {
-			return false;
-		}
-
-		if (stat.type === vscode.FileType.Directory) {
-			await vscode.commands.executeCommand('revealInExplorer', resource);
-			return true;
+			// noop
+			// If resource doesn't exist, execute `vscode.open` either way so an error
+			// notification is shown to the user with a create file action #113475
 		}
 
 		try {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #113475
