### PR TITLE
Move the crash reporter config registration to telemetry service.

### DIFF
--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -229,3 +229,20 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		}
 	}
 });
+
+Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
+	'id': TELEMETRY_SECTION_ID,
+	'order': 110,
+	title: localize('telemetryConfigurationTitle', "Telemetry"),
+	'type': 'object',
+	'properties': {
+		'telemetry.enableCrashReporter': {
+			'type': 'boolean',
+			'description': localize('telemetry.enableCrashReporting', "Enable crash reports to be collected. This helps us improve stability. \nThis option requires restart to take effect."),
+			'default': false,
+			'restricted': true,
+			'scope': ConfigurationScope.APPLICATION,
+			'tags': ['usesOnlineServices', 'telemetry']
+		}
+	}
+});

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -222,22 +222,6 @@ import { EditorsVisibleContext, SingleEditorGroupsContext } from 'vs/workbench/c
 		}
 	});
 
-	// Telemetry
-	registry.registerConfiguration({
-		'id': 'telemetry',
-		'order': 110,
-		title: localize('telemetryConfigurationTitle', "Telemetry"),
-		'type': 'object',
-		'properties': {
-			'telemetry.enableCrashReporter': {
-				'type': 'boolean',
-				'description': localize('telemetry.enableCrashReporting', "Enable crash reports to be collected. This helps us improve stability. \nThis option requires restart to take effect."),
-				'default': true,
-				'tags': ['usesOnlineServices', 'telemetry']
-			}
-		}
-	});
-
 	// Keybinding
 	registry.registerConfiguration({
 		'id': 'keyboard',


### PR DESCRIPTION
Installation: VS Code - OSS - Electron - Desktop
This PR fixes (fresh installs): #127585, #130087, #130572

The `telemetry.enableCrashReporter` config has not yet been registered at the time it is used [1] and this causes it to always return undefined (undefined is not boolean, so it assumes true).

Due to this (and anyway, the default value true), vscode-oss ends up automatically enabling the crash reporter if it has never been configured in argv.json.

The crash reporter enabled and not correctly configured (without submitURL or directory) (with Electron >=v13) ends up causing an error [2] in the next start, only allowing to start with the parameter "--disable-crash-reporter" (or manually editing argv.json).

To fix this, I moved the `telemetry.enableCrashReporter` config registration to the telemetry service and changed the default value to false. 

Besides this, I think that vscode must follow the `telemetry.enableCrashReporter` and disable the crash reporter when this config is false. I already tested a change[3] and if it is ok  I will make a new PR with it.

[1] https://github.com/microsoft/vscode/blob/26bbfb814aed60b44419110c21dd30a21b8f9811/src/vs/code/electron-main/app.ts#L984
[2] https://github.com/electron/electron/blob/49436f298bd608aebf67ea5e676c39a943a43cd5/lib/browser/api/crash-reporter.ts#L19
[3] https://github.com/fcabralpacheco/vscode/commit/9581a5d20d41145d02b33c120dd1a77a39d293db
