### PR TITLE
remove .txt from stdio files so that language guessing is easier

### DIFF
--- a/src/vs/platform/environment/node/stdin.ts
+++ b/src/vs/platform/environment/node/stdin.ts
@@ -36,7 +36,7 @@ export function stdinDataListener(durationinMs: number): Promise<boolean> {
 }
 
 export function getStdinFilePath(): string {
-	return paths.join(os.tmpdir(), `code-stdin-${Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 3)}.txt`);
+	return paths.join(os.tmpdir(), `code-stdin-${Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 3)}`);
 }
 
 export async function readFromStdin(targetPath: string, verbose: boolean): Promise<void> {


### PR DESCRIPTION
Without a file extension, you can choose the `Auto Detect` option in the language picker and it will guess the language and set the mode accordingly.

This is great for a scenario like this:
```
# or any JSON REST API
curl https://raw.githubusercontent.com/microsoft/vscode/main/cgmanifest.json | code -
```
```
# review before you pipe into bash
curl https://suspicious-bash-script.com | code -
```

In the near future, the language of non-file extension files will be automatically guessed so having to click `Auto Detect` will not be needed and the scenario will be seamless.

Ideally, this should really open an untitled file... but this one-line change is good enough to see if folks like this scenario (I certainly want it!)

prereq of #41614
