### PR TITLE
Differentiate cell unitialized and restored from cache state 

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -257,6 +257,7 @@ export interface MarkdownCellLayoutInfo {
 	readonly previewHeight: number;
 	readonly bottomToolbarOffset: number;
 	readonly totalHeight: number;
+	readonly layoutState: CodeCellLayoutState;
 }
 
 export interface MarkdownCellLayoutChangeEvent {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
@@ -146,7 +146,7 @@ export class CodeCellViewModel extends BaseCellViewModel implements ICellViewMod
 			outputTotalHeight: 0,
 			outputShowMoreContainerHeight: 0,
 			outputShowMoreContainerOffset: 0,
-			totalHeight: 0,
+			totalHeight: this.computeTotalHeight(17, 0, 0),
 			indicatorHeight: 0,
 			bottomToolbarOffset: 0,
 			layoutState: CodeCellLayoutState.Uninitialized


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes issues found during #130625. The markdown cell can be invisible if reverting a dirty notebook

* create an `ipynb` file with following content

```
{
 "cells": [
  {
   "cell_type": "markdown",
   "source": [
    "# header"
   ],
   "metadata": {}
  },
  {
   "cell_type": "code",
   "execution_count": 1,
   "source": [
    "x = 5\r\n",
    "y = 10"
   ],
   "outputs": [],
   "metadata": {}
  },
  {
   "cell_type": "code",
   "execution_count": null,
   "source": [
    "def add(a,b):\r\n",
    "    return a+b"
   ],
   "outputs": [],
   "metadata": {}
  },
  {
   "cell_type": "code",
   "execution_count": null,
   "source": [],
   "outputs": [],
   "metadata": {}
  }
 ],
 "metadata": {
  "kernelspec": {
   "display_name": "Python 3.7.1 64-bit ('base': conda)",
   "language": "python",
   "name": "python37164bitbaseconda4b1c372f534149d9bd3cb6b75fac4c2e"
  },
  "language_info": {
   "codemirror_mode": {
    "name": "ipython",
    "version": 3
   },
   "file_extension": ".py",
   "mimetype": "text/x-python",
   "name": "python",
   "nbconvert_exporter": "python",
   "pygments_lexer": "ipython3",
   "version": "3.7.6"
  },
  "orig_nbformat": 2
 },
 "nbformat": 4,
 "nbformat_minor": 2
}
```
* open in notebook editor
* turn off auto save
* scroll the markdown cell out of the viewport
* insert a new cell
* close the editor, do not save
* open it again
* scroll upwards

The markdown cell should be rendered but currently it doesn't.
