### PR TITLE
Add: "Close Other Repositories" in git scm menu

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -66,6 +66,11 @@
         "category": "Git"
       },
       {
+        "command": "git.closeOthers",
+        "title": "%command.closeOthers%",
+        "category": "Git"
+      },
+      {
         "command": "git.refresh",
         "title": "%command.refresh%",
         "category": "Git",
@@ -975,6 +980,11 @@
       "scm/sourceControl": [
         {
           "command": "git.close",
+          "group": "navigation",
+          "when": "scmProvider == git"
+        },
+        {
+          "command": "git.closeOthers",
           "group": "navigation",
           "when": "scmProvider == git"
         }

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -7,6 +7,7 @@
 	"command.init": "Initialize Repository",
 	"command.openRepository": "Open Repository",
 	"command.close": "Close Repository",
+	"command.closeOthers": "Close Other Repositories",
 	"command.refresh": "Refresh",
 	"command.openChange": "Open Changes",
 	"command.openAllChanges": "Open All Changes",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -652,6 +652,11 @@ export class CommandCenter {
 		this.model.close(repository);
 	}
 
+	@command('git.closeOthers', { repository: true })
+	async closeOthers(repository: Repository): Promise<void> {
+		this.model.closeOthers(repository);
+	}
+
 	@command('git.openFile')
 	async openFile(arg?: Resource | Uri, ...resourceStates: SourceControlResourceState[]): Promise<void> {
 		const preserveFocus = arg instanceof Resource;

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -390,6 +390,17 @@ export class Model implements IRemoteSourceProviderRegistry, IPushErrorHandlerRe
 		openRepository.dispose();
 	}
 
+	closeOthers(repository: Repository): void {
+		const otherRepositories = this.openRepositories.filter(r => r.repository !== repository);
+
+		for (const openRepository of otherRepositories) {
+			const repository = openRepository.repository;
+
+			this.outputChannel.appendLine(`Close repository: ${repository.root}`);
+			openRepository.dispose();
+		}
+	}
+
 	async pickRepository(): Promise<Repository | undefined> {
 		if (this.openRepositories.length === 0) {
 			throw new Error(localize('no repositories', "There are no available repositories"));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #130923

This adds a new command that can be called from the git scm menu to close all other repositories which is useful when working with a lot of git submodules. This is similar to how browsers provide an option to "close other tabs". 

!["Close Other Repositories" in git scm menu](https://user-images.githubusercontent.com/17804578/129612304-d7236243-cdc4-4fb6-a84c-f76c62e235a3.png)
