### PR TITLE
[debugService #113742] variable display on debug session ending

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -657,8 +657,8 @@ export class DebugService implements IDebugService {
 
 			const focusedSession = this.viewModel.focusedSession;
 			if (focusedSession && focusedSession.getId() === session.getId()) {
-				const { session } = getStackFrameThreadAndSessionToFocus(this.model, undefined, undefined, undefined, focusedSession);
-				this.viewModel.setFocus(undefined, undefined, session, false);
+				const { session, thread, stackFrame } = getStackFrameThreadAndSessionToFocus(this.model, undefined, undefined, undefined, focusedSession);
+				this.viewModel.setFocus(stackFrame, thread, session, false);
 			}
 
 			if (this.model.getSessions().length === 0) {


### PR DESCRIPTION
- When a session ends, it should focus another session and correctly display variables
- Here, focus the first session and the Thread 1
- Should display variables accordingly

Fix https://github.com/microsoft/vscode/issues/113742

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #113742

Thanks @isidorn 