### PR TITLE
Add terminal keybinding for cmd+. → ctrl+c to match macOS Terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
@@ -183,6 +183,10 @@ registerSendSequenceKeybinding(String.fromCharCode('A'.charCodeAt(0) - 64), {
 registerSendSequenceKeybinding(String.fromCharCode('E'.charCodeAt(0) - 64), {
 	mac: { primary: KeyMod.CtrlCmd | KeyCode.RightArrow }
 });
+// Break: ctrl+C
+registerSendSequenceKeybinding(String.fromCharCode('C'.charCodeAt(0) - 64), {
+	mac: { primary: KeyMod.CtrlCmd | KeyCode.US_DOT }
+});
 
 setupTerminalCommands();
 


### PR DESCRIPTION
- in terminal, handle cmd+. as ctrl+c(break) as like in macOS Terminal.app
- fix #130990 (thanks to @Tyriar)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

