### PR TITLE
Use touch-action: none

### DIFF
--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -46,7 +46,7 @@ body.web {
 }
 
 .monaco-workbench.web {
-	touch-action: initial; /* reenable touch events on workbench */
+	touch-action: none; /* Disable browser handling of all panning and zooming gestures. Removes 300ms touch delay. */
 }
 
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }


### PR DESCRIPTION
fixes #126726

I tried this out on my iPad and does not seem to break anything.
I am not sure if the touch is more snappy, that is debatable.
I played it safe and am only doing this for the web. Not sure if this might break some touch laptops, though it should not and I do not mind doing this always, not only for web.

Adding @rebornix as a reviewer since he touched that line last