### PR TITLE
Added close field in vscode.d.ts interface TaskPresntationOptions

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1034,6 +1034,11 @@ declare module 'vscode' {
 		 * Controls whether the task is executed in a specific terminal group using split panes.
 		 */
 		group?: string;
+
+		/** 
+		 * Controls whether the terminal is closed after executing the task.
+		 */
+		close?: boolean;
 	}
 	//#endregion
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Although there is an option to close terminal after task completes running in tasks.json, the option didn't exist in vscode.d.ts interface TaskPresntationOptions

Confirmed that this works as expected in a custom extension.

Please see more details in [Issue #131125](https://github.com/microsoft/vscode/issues/131125)

To test this works, create a task in a VS Code extension with vscode.Task, add the presentation option close: true, and execute the task with vscode.tasks.execute task e.g:

![image](https://user-images.githubusercontent.com/77730378/129968561-f7e59cf8-61d5-47d7-883c-0561d417159c.png)

Here is an example of it working: 

![working](https://user-images.githubusercontent.com/77730378/129968760-33f1acd0-35e7-4550-90bc-f53e4e13a0a5.gif)

This PR fixes #131125
