### PR TITLE
Allow empty extension location for internal notebook contribution

### DIFF
--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -668,7 +668,7 @@ export interface WebviewExtensionDescription {
 
 export interface NotebookExtensionDescription {
 	readonly id: ExtensionIdentifier;
-	readonly location: UriComponents;
+	readonly location: UriComponents | undefined;
 }
 
 export enum WebviewEditorCapabilities {

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -164,7 +164,7 @@ export class InteractiveDocumentContribution extends Disposable implements IWork
 		};
 		this._register(notebookService.registerNotebookController('interactive', {
 			id: new ExtensionIdentifier('interactive.builtin'),
-			location: URI.parse('interactive://test')
+			location: undefined
 		}, controller));
 
 		const info = notebookService.getContributedNotebookType('interactive');

--- a/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
@@ -661,7 +661,9 @@ export class NotebookService extends Disposable implements INotebookService {
 	getNotebookProviderResourceRoots(): URI[] {
 		const ret: URI[] = [];
 		this._notebookProviders.forEach(val => {
-			ret.push(URI.revive(val.extensionData.location));
+			if (val.extensionData.location) {
+				ret.push(URI.revive(val.extensionData.location));
+			}
 		});
 
 		return ret;


### PR DESCRIPTION
No need to specify a fake location for interactive notebooks

