### PR TITLE
Use insane with notebook markdown content

### DIFF
--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -4,8 +4,48 @@
  *--------------------------------------------------------------------------------------------*/
 
 const MarkdownIt = require('markdown-it');
+const insane = require('insane');
+import type { InsaneOptions } from 'insane';
 
-export function activate() {
+function _extInsaneOptions(opts: InsaneOptions, allowedAttributesForAll: string[]): InsaneOptions {
+	const allowedAttributes: Record<string, string[]> = opts.allowedAttributes ?? {};
+	if (opts.allowedTags) {
+		for (const tag of opts.allowedTags) {
+			let array = allowedAttributes[tag];
+			if (!array) {
+				array = allowedAttributesForAll;
+			} else {
+				array = array.concat(allowedAttributesForAll);
+			}
+			allowedAttributes[tag] = array;
+		}
+	}
+
+	return { ...opts, allowedAttributes };
+}
+
+const insaneOptions: InsaneOptions = _extInsaneOptions({
+	allowedTags: ['a', 'button', 'blockquote', 'code', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'img', 'input', 'label', 'li', 'p', 'pre', 'select', 'small', 'span', 'strong', 'textarea', 'ul', 'ol'],
+	allowedAttributes: {
+		'a': ['href', 'x-dispatch'],
+		'button': ['data-href', 'x-dispatch'],
+		'img': ['src'],
+		'input': ['type', 'placeholder', 'checked', 'required'],
+		'label': ['for'],
+		'select': ['required'],
+		'span': ['data-command', 'role'],
+		'textarea': ['name', 'placeholder', 'required'],
+	},
+	allowedSchemes: ['http', 'https']
+}, [
+	'align',
+	'class',
+	'id',
+	'style',
+	'aria-hidden',
+]);
+
+export function activate(ctx: { workspace: { isTrusted: boolean } }) {
 	let markdownIt = new MarkdownIt({
 		html: true
 	});
@@ -172,8 +212,10 @@ export function activate() {
 			} else {
 				previewNode.classList.remove('emptyMarkdownCell');
 
-				const rendered = markdownIt.render(text);
-				previewNode.innerHTML = rendered;
+				const unsanitizedRenderedMarkdown = markdownIt.render(text);
+				previewNode.innerHTML = ctx.workspace.isTrusted
+					? unsanitizedRenderedMarkdown
+					: insane(unsanitizedRenderedMarkdown, insaneOptions);
 			}
 		},
 		extendMarkdownIt: (f: (md: typeof markdownIt) => void) => {

--- a/extensions/markdown-language-features/notebook/insane.d.ts
+++ b/extensions/markdown-language-features/notebook/insane.d.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'insane' {
+	export interface InsaneOptions {
+		readonly allowedSchemes?: readonly string[],
+		readonly allowedTags?: readonly string[],
+		readonly allowedAttributes?: { readonly [key: string]: string[] },
+		readonly filter?: (token: { tag: string, attrs: { readonly [key: string]: string } }) => boolean,
+	}
+
+	export function insane(
+		html: string,
+		options?: InsaneOptions,
+		strict?: boolean,
+	): string;
+}

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -353,6 +353,7 @@
   },
   "dependencies": {
     "highlight.js": "^10.4.1",
+    "insane": "^2.6.2",
     "markdown-it": "^12.0.3",
     "markdown-it-front-matter": "^0.2.1",
     "vscode-extension-telemetry": "0.2.6",

--- a/extensions/markdown-language-features/yarn.lock
+++ b/extensions/markdown-language-features/yarn.lock
@@ -36,15 +36,33 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+assignment@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/assignment/-/assignment-2.0.0.tgz#ffd17b21bf5d6b22e777b989681a815456a3dd3e"
+  integrity sha1-/9F7Ib9dayLnd7mJaBqBVFaj3T4=
+
 entities@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
   integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
+he@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-0.5.0.tgz#2c05ffaef90b68e860f3fd2b54ef580989277ee2"
+  integrity sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI=
+
 highlight.js@*, highlight.js@^10.4.1:
   version "10.4.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
   integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
+
+insane@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/insane/-/insane-2.6.2.tgz#c2ab68bb3e006ab451560d1b446917329c0a8120"
+  integrity sha1-wqtouz4AarRRVg0bRGkXMpwKgSA=
+  dependencies:
+    assignment "2.0.0"
+    he "0.5.0"
 
 linkify-it@^3.0.1:
   version "3.0.2"

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -326,6 +326,11 @@ export interface INotebookOptionsMessage {
 	readonly options: PreloadOptions;
 }
 
+export interface INotebookUpdateWorkspaceTrust {
+	readonly type: 'updateWorkspaceTrust';
+	readonly isTrusted: boolean;
+}
+
 export type FromWebviewMessage = WebviewIntialized |
 	IDimensionMessage |
 	IMouseEnterMessage |
@@ -373,6 +378,7 @@ export type ToWebviewMessage = IClearMessage |
 	IUpdateSelectedMarkupCellsMessage |
 	IInitializeMarkupCells |
 	INotebookStylesMessage |
-	INotebookOptionsMessage;
+	INotebookOptionsMessage |
+	INotebookUpdateWorkspaceTrust;
 
 export type AnyMessage = FromWebviewMessage | ToWebviewMessage;


### PR DESCRIPTION
Runs insane against markdown content. Also requires back porting up a way for renderers to detect if the workspace is trusted or not

