### PR TITLE
asar - introduce alternative path to circumvent drive letter casing issues

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -73,11 +73,11 @@
 
 			NODE_MODULES_ALTERNATIVE_PATH = alternativeDriveLetter + NODE_MODULES_PATH.substr(1);
 		} else {
-			NODE_MODULES_ALTERNATIVE_PATH = NODE_MODULES_PATH;
+			NODE_MODULES_ALTERNATIVE_PATH = undefined;
 		}
 
 		const NODE_MODULES_ASAR_PATH = `${NODE_MODULES_PATH}.asar`;
-		const NODE_MODULES_ASAR_ALTERNATIVE_PATH = `${NODE_MODULES_ALTERNATIVE_PATH}.asar`;
+		const NODE_MODULES_ASAR_ALTERNATIVE_PATH = NODE_MODULES_ALTERNATIVE_PATH ? `${NODE_MODULES_ALTERNATIVE_PATH}.asar` : undefined;
 
 		// @ts-ignore
 		const originalResolveLookupPaths = Module._resolveLookupPaths;
@@ -92,17 +92,16 @@
 						asarPathAdded = true;
 						paths.splice(i, 0, NODE_MODULES_ASAR_PATH);
 						break;
-					} else if (process.platform === 'win32' && paths[i] === NODE_MODULES_ALTERNATIVE_PATH) {
+					} else if (paths[i] === NODE_MODULES_ALTERNATIVE_PATH) {
 						asarPathAdded = true;
 						paths.splice(i, 0, NODE_MODULES_ASAR_ALTERNATIVE_PATH);
 						break;
 					}
 				}
 				if (!asarPathAdded && appRoot) {
+					// Assuming that adding just `NODE_MODULES_ASAR_PATH` is sufficient
+					// because nodejs should find it even if it has a different driver letter case
 					paths.push(NODE_MODULES_ASAR_PATH);
-					if (NODE_MODULES_ASAR_PATH !== NODE_MODULES_ASAR_ALTERNATIVE_PATH) {
-						paths.push(NODE_MODULES_ASAR_ALTERNATIVE_PATH);
-					}
 				}
 			}
 

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -53,23 +53,31 @@
 			return;
 		}
 
-		let NODE_MODULES_PATH = appRoot ? path.join(appRoot, 'node_modules') : undefined;
-		if (!NODE_MODULES_PATH) {
-			NODE_MODULES_PATH = path.join(__dirname, '../node_modules');
-		} else {
-			// use the drive letter casing of __dirname
-			// if it matches the drive letter of `appRoot`
-			// (https://github.com/microsoft/vscode/issues/128725)
-			if (process.platform === 'win32') {
-				const nodejsDriveLetter = __dirname.substr(0, 1);
-				const vscodeDriveLetter = appRoot.substr(0, 1);
-				if (nodejsDriveLetter.toLowerCase() === vscodeDriveLetter.toLowerCase()) {
-					NODE_MODULES_PATH = nodejsDriveLetter + NODE_MODULES_PATH.substr(1);
-				}
+		const NODE_MODULES_PATH = appRoot ? path.join(appRoot, 'node_modules') : path.join(__dirname, '../node_modules');
+
+		// Windows only:
+		// use both lowercase and uppercase drive letter
+		// as a way to ensure we do the right check on
+		// the node modules path: node.js might internally
+		// use a different case compared to what we have
+		let NODE_MODULES_ALTERNATIVE_PATH;
+		if (appRoot /* only used from renderer until `sandbox` enabled */ && process.platform === 'win32') {
+			const driveLetter = appRoot.substr(0, 1);
+
+			let alternativeDriveLetter;
+			if (driveLetter.toLowerCase() !== driveLetter) {
+				alternativeDriveLetter = driveLetter.toLowerCase();
+			} else {
+				alternativeDriveLetter = driveLetter.toUpperCase();
 			}
+
+			NODE_MODULES_ALTERNATIVE_PATH = alternativeDriveLetter + NODE_MODULES_PATH.substr(1);
+		} else {
+			NODE_MODULES_ALTERNATIVE_PATH = NODE_MODULES_PATH;
 		}
 
 		const NODE_MODULES_ASAR_PATH = `${NODE_MODULES_PATH}.asar`;
+		const NODE_MODULES_ASAR_ALTERNATIVE_PATH = `${NODE_MODULES_ALTERNATIVE_PATH}.asar`;
 
 		// @ts-ignore
 		const originalResolveLookupPaths = Module._resolveLookupPaths;
@@ -84,10 +92,17 @@
 						asarPathAdded = true;
 						paths.splice(i, 0, NODE_MODULES_ASAR_PATH);
 						break;
+					} else if (process.platform === 'win32' && paths[i] === NODE_MODULES_ALTERNATIVE_PATH) {
+						asarPathAdded = true;
+						paths.splice(i, 0, NODE_MODULES_ASAR_ALTERNATIVE_PATH);
+						break;
 					}
 				}
 				if (!asarPathAdded && appRoot) {
 					paths.push(NODE_MODULES_ASAR_PATH);
+					if (NODE_MODULES_ASAR_PATH !== NODE_MODULES_ASAR_ALTERNATIVE_PATH) {
+						paths.push(NODE_MODULES_ASAR_ALTERNATIVE_PATH);
+					}
 				}
 			}
 


### PR DESCRIPTION
My only worry with this change is that we are ending up with 2 paths being added in case we were not adding the path before:

https://github.com/microsoft/vscode/blob/13e572599f04ad08452195129f50bfd53b3f541e/src/bootstrap.js#L101-L106

This PR fixes #128725
