### PR TITLE
support any HTMLElement has hover content, rename from text to conten…

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconHoverDelegate.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconHoverDelegate.ts
@@ -13,7 +13,7 @@ export interface IHoverDelegateTarget extends IDisposable {
 }
 
 export interface IHoverDelegateOptions {
-	text: IMarkdownString | string;
+	content: IMarkdownString | string | HTMLElement;
 	target: IHoverDelegateTarget | HTMLElement;
 	hoverPosition?: HoverPosition;
 	showPointer?: boolean;

--- a/src/vs/base/browser/ui/iconLabel/iconLabelHover.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabelHover.ts
@@ -72,7 +72,7 @@ export function setupCustomHover(hoverDelegate: IHoverDelegate, htmlElement: HTM
 			if (hoverPreparation) {
 
 				const hoverOptions = {
-					text: localize('iconLabel.loading', "Loading..."),
+					content: localize('iconLabel.loading', "Loading..."),
 					target,
 					hoverPosition: HoverPosition.BELOW
 				};
@@ -87,7 +87,7 @@ export function setupCustomHover(hoverDelegate: IHoverDelegate, htmlElement: HTM
 				// awaiting the tooltip could take a while. Make sure we're still preparing to hover.
 				if (resolvedTooltip && hoverPreparation) {
 					const hoverOptions = {
-						text: resolvedTooltip,
+						content: resolvedTooltip,
 						target,
 						showPointer: hoverDelegate.placement === 'element',
 						hoverPosition: HoverPosition.BELOW

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -417,7 +417,7 @@ export class ActivityActionViewItem extends BaseActionViewItem {
 		this.hover.value = this.hoverService.showHover({
 			target: this.container,
 			hoverPosition,
-			text: this.computeTitle(),
+			content: this.computeTitle(),
 			showPointer: true,
 			compact: true,
 			skipFadeInAnimation

--- a/src/vs/workbench/contrib/terminal/browser/widgets/environmentVariableInfoWidget.ts
+++ b/src/vs/workbench/contrib/terminal/browser/widgets/environmentVariableInfoWidget.ts
@@ -83,7 +83,7 @@ export class EnvironmentVariableInfoWidget extends Widget implements ITerminalWi
 			const actions = this._info.getActions ? this._info.getActions() : undefined;
 			this._hoverOptions = {
 				target: this._domNode,
-				text: new MarkdownString(this._info.getInfo()),
+				content: new MarkdownString(this._info.getInfo()),
 				actions
 			};
 		}

--- a/src/vs/workbench/contrib/terminal/browser/widgets/terminalHoverWidget.ts
+++ b/src/vs/workbench/contrib/terminal/browser/widgets/terminalHoverWidget.ts
@@ -50,7 +50,7 @@ export class TerminalHover extends Disposable implements ITerminalWidget {
 		const target = new CellHoverTarget(container, this._targetOptions);
 		const hover = this._hoverService.showHover({
 			target,
-			text: this._text,
+			content: this._text,
 			linkHandler: this._linkHandler,
 			// .xterm-hover lets xterm know that the hover is part of a link
 			additionalClasses: ['xterm-hover']

--- a/src/vs/workbench/services/hover/browser/hover.ts
+++ b/src/vs/workbench/services/hover/browser/hover.ts
@@ -40,10 +40,10 @@ export interface IHoverService {
 
 export interface IHoverOptions {
 	/**
-	 * The text to display in the primary section of the hover. The type of text determines the
+	 * The content to display in the primary section of the hover. The type of text determines the
 	 * default `hideOnHover` behavior.
 	 */
-	text: IMarkdownString | string;
+	content: IMarkdownString | string | HTMLElement;
 
 	/**
 	 * The target for the hover. This determines the position of the hover and it will only be


### PR DESCRIPTION
This PR helps with https://github.com/microsoft/vscode/issues/129037 and allows to show any html element as hover contents