### PR TITLE
Highlight substrings correctly and initial exclusion support with `-`

### DIFF
--- a/src/vs/base/common/fuzzyScorer.ts
+++ b/src/vs/base/common/fuzzyScorer.ts
@@ -42,13 +42,30 @@ export function scoreFuzzy(target: string, query: string, queryLower: string, fu
 	// When not searching fuzzy, we require the query to be contained fully
 	// in the target string contiguously.
 	if (!fuzzy) {
-		if (!targetLower.includes(queryLower)) {
+		const matchIndex = targetLower.indexOf(queryLower);
+		if (matchIndex === -1) {
+
 			// if (DEBUG) {
 			// 	console.log(`Characters not matching consecutively ${queryLower} within ${targetLower}`);
 			// }
 
 			return NO_SCORE;
 		}
+
+		const indexesArray: number[] = [];
+		for (let i = 0; i < queryLower.length; i++) {
+			indexesArray.push(i + matchIndex);
+		}
+
+		// TODO: what's a better value for the score?
+		const res: FuzzyScore = [100, indexesArray];
+
+		// if (DEBUG) {
+		// 	console.log(`%cFinal Score: ${res[0]}`, 'font-weight: bold');
+		// 	console.groupEnd();
+		// }
+
+		return res;
 	}
 
 	const res = doScoreFuzzy(query, queryLower, queryLength, target, targetLower, targetLength);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
I’ve been playing around with a few ways to hone in on the files you’re looking for in the cmd+P file search. Taking inspiration from Google & GitHub here’s what quoting and exclusion might look like:

* wrap a query piece in quotes and that substring must exist "foo"
* add a dash in front of a query piece and that substring must NOT exist -foo

The results:
| | |
|---|---|
| ![quotes-and-minuses](https://user-images.githubusercontent.com/2644648/130156500-7d761e9a-7af4-4b01-a6e5-2dafa848a7d4.gif) | ![minus-vscode-repo](https://user-images.githubusercontent.com/2644648/130156566-fdaf8088-85a1-45e6-b1f3-849620e2b929.gif) |

(exclude query pieces can only be used if there’s another piece)
(“pieces” of a query are separated by spaces so asdf bsdf has 2 pieces)

Initially I felt like the exclusion query pieces weren't needed but then I used it more and found it really nice tacking on additional exclusions.

2 commits initially:
* initial implementation that highlights consecutive maches correctly - this makes it so when searching for `"26"` the highlight is 2021-9-**26** and not **2**021-9-2**6** (if that's hard to read, the 2nd one has highlights on the first 2 instead of the 2 next to the 6)
* initial support of `-foo` exclusion query parts

I would recommend looking at the first commit first and then the 2nd.

I haven't fixed up the tests yet but I was hoping to get some feedback from @bpasero before I do that to make sure I'm on the right track generally speaking.

This PR fixes #128923