### PR TITLE
Fix strange behavior when scrolling downward at low-speed with trackpad

### DIFF
--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -409,11 +409,13 @@ export abstract class AbstractScrollableElement extends Widget {
 
 			let desiredScrollPosition: INewScrollPosition = {};
 			if (deltaY) {
-				const desiredScrollTop = futureScrollPosition.scrollTop - SCROLL_WHEEL_SENSITIVITY * deltaY;
+				const deltaScrollTop = SCROLL_WHEEL_SENSITIVITY * deltaY;
+				const desiredScrollTop = futureScrollPosition.scrollTop - (deltaScrollTop < 0 ? Math.floor(deltaScrollTop) : Math.ceil(deltaScrollTop));
 				this._verticalScrollbar.writeScrollPosition(desiredScrollPosition, desiredScrollTop);
 			}
 			if (deltaX) {
-				const desiredScrollLeft = futureScrollPosition.scrollLeft - SCROLL_WHEEL_SENSITIVITY * deltaX;
+				const deltaScrollLeft = SCROLL_WHEEL_SENSITIVITY * deltaX;
+				const desiredScrollLeft = futureScrollPosition.scrollLeft - (deltaScrollLeft < 0 ? Math.floor(deltaScrollLeft) : Math.ceil(deltaScrollLeft));
 				this._horizontalScrollbar.writeScrollPosition(desiredScrollPosition, desiredScrollLeft);
 			}
 


### PR DESCRIPTION
This PR fixes microsoft/monaco-editor#2623 and similar misbehavior in VSCode up to 1.60.0-insider (i.e., editor will not respond to low-speed two-finger scrolling).

When scrolling with trackpad two-figure scrolling, or in the ending phase of an inertial scrolling, small floating pointing numbers of `deltaX/deltaY` will be fed to the handler. When the number is small enough, the `scrollTop/scrollLeft` will change by a value less than 1.

https://github.com/microsoft/vscode/blob/44129daac8b9f17ffdf741206b7f603ea082ed16/src/vs/base/browser/ui/scrollbar/scrollableElement.ts#L411-L421

Unfortunately, the `validateScrollPosition` method, which internally calls `new ScrollState()`, will simply round-down the input value.

https://github.com/microsoft/vscode/blob/8be960c60de9b445ef5fef1d9b672848d78a8d3c/src/vs/base/common/scrollable.ts#L64-L69

Therefore, for upward scrolling, users can get a smooth scrolling experience. However, for downward scrolling, VSCode/Monaco will not respond to such scrolling requests when its speed is below a certain level. With the default settings, the speed threshold is relatively high. In some cases, the difficulty of scrolling down in VSCode/Monaco is quite noticeable. For Monaco, this also means that under certain configurations such low-speed scroll events are passed to other HTML elements, causing unexpected scrolling of other elements.

This PR ensures that low-speed scrolling events from user/inertial scrolling are correctly responded to by introducing active symmetric rounding (round away from zero). The behavior is consistent with the original VSCode/Monaco upward scrolling behavior. No disruptive changes to the user experience are expected.