### PR TITLE
[Standalone editor] Add support to list provided code action kinds when registering a `CodeActionProvider`

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -459,8 +459,9 @@ export function registerCodeLensProvider(languageId: string, provider: modes.Cod
 /**
  * Register a code action provider (used by e.g. quick fix).
  */
-export function registerCodeActionProvider(languageId: string, provider: CodeActionProvider): IDisposable {
+export function registerCodeActionProvider(languageId: string, provider: CodeActionProvider, metadata?: CodeActionProviderMetadata): IDisposable {
 	return modes.CodeActionProviderRegistry.register(languageId, {
+		providedCodeActionKinds: metadata?.providedCodeActionKinds,
 		provideCodeActions: (model: model.ITextModel, range: Range, context: modes.CodeActionContext, token: CancellationToken): modes.ProviderResult<modes.CodeActionList> => {
 			let markers = StaticServices.markerService.get().read({ resource: model.uri }).filter(m => {
 				return Range.areIntersectingOrTouching(m, range);
@@ -587,6 +588,23 @@ export interface CodeActionProvider {
 	 * Provide commands for the given document and range.
 	 */
 	provideCodeActions(model: model.ITextModel, range: Range, context: CodeActionContext, token: CancellationToken): modes.ProviderResult<modes.CodeActionList>;
+}
+
+
+
+/**
+ * Metadata about the type of code actions that a {@link CodeActionProvider} provides.
+ */
+export interface CodeActionProviderMetadata {
+	/**
+	 * List of code action kinds that a {@link CodeActionProvider} may return.
+	 *
+	 * This list is used to determine if a given `CodeActionProvider` should be invoked or not.
+	 * To avoid unnecessary computation, every `CodeActionProvider` should list use `providedCodeActionKinds`. The
+	 * list of kinds may either be generic, such as `["quickfix", "refactor", "source"]`, or list out every kind provided,
+	 * such as `["quickfix.removeLine", "source.fixAll" ...]`.
+	 */
+	readonly providedCodeActionKinds?: readonly string[];
 }
 
 /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5354,7 +5354,7 @@ declare namespace monaco.languages {
 	/**
 	 * Register a code action provider (used by e.g. quick fix).
 	 */
-	export function registerCodeActionProvider(languageId: string, provider: CodeActionProvider): IDisposable;
+	export function registerCodeActionProvider(languageId: string, provider: CodeActionProvider, metadata?: CodeActionProviderMetadata): IDisposable;
 
 	/**
 	 * Register a formatter that can handle only entire models.
@@ -5445,6 +5445,21 @@ declare namespace monaco.languages {
 		 * Provide commands for the given document and range.
 		 */
 		provideCodeActions(model: editor.ITextModel, range: Range, context: CodeActionContext, token: CancellationToken): ProviderResult<CodeActionList>;
+	}
+
+	/**
+	 * Metadata about the type of code actions that a {@link CodeActionProvider} provides.
+	 */
+	export interface CodeActionProviderMetadata {
+		/**
+		 * List of code action kinds that a {@link CodeActionProvider} may return.
+		 *
+		 * This list is used to determine if a given `CodeActionProvider` should be invoked or not.
+		 * To avoid unnecessary computation, every `CodeActionProvider` should list use `providedCodeActionKinds`. The
+		 * list of kinds may either be generic, such as `["quickfix", "refactor", "source"]`, or list out every kind provided,
+		 * such as `["quickfix.removeLine", "source.fixAll" ...]`.
+		 */
+		readonly providedCodeActionKinds?: readonly string[];
 	}
 
 	/**


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/monaco-editor/issues/2625

Added a third optional parameter `metadata` on `registerCodeActionProvider` the same way the VS Code extension API does it, so that embedders of the Monaco editor can list the provided code action kinds and get support for the `editor.action.autoFix` action, as well as the "Refactor..." and "Source Action..." context menu entries. I copied over the type `CodeActionProviderMetadata` from `vscode.d.ts` into `monaco.d.ts` and just kept the `providedCodeActionKinds` property, adjusting the type and documentation wording accordingly.
