### PR TITLE
fix mime => metadata for renderOutputItem

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -575,7 +575,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 					} else {
 						const rendererApi = preloadsAndErrors[0] as RendererApi;
 						try {
-							rendererApi.renderOutputItem(new OutputItem(outputId, outputNode, content.mimeType, content.mimeType, content.valueBytes), outputNode);
+							rendererApi.renderOutputItem(new OutputItem(outputId, outputNode, content.mimeType, content.metadata, content.valueBytes), outputNode);
 						} catch (e) {
 							showPreloadErrors(outputNode, e);
 						}


### PR DESCRIPTION
Just looks like a small issue from this commit here: https://github.com/microsoft/vscode/commit/e410db3dfe45292183ad106fe4bc6efb72803f2f#diff-c782cacbe379d1a57c8e6490a813998561065c89f9c39662ef7a8b544a69e8fcR576
