### PR TITLE
Tyler leonhardt/quick access highlight fix

### DIFF
--- a/src/vs/base/common/fuzzyScorer.ts
+++ b/src/vs/base/common/fuzzyScorer.ts
@@ -112,7 +112,7 @@ function doScoreFuzzy(query: string, queryLower: string, queryLength: number, ta
 				// found out this is contiguous otherwise there wouldn't have been a score
 				queryIndexGtNull ||
 				// lastly check if the query is completely contiguous at this index in the target
-				target.startsWith(query, targetIndex)
+				targetLower.startsWith(queryLower, targetIndex)
 			)) {
 				matches[currentIndex] = matchesSequenceLength + 1;
 				scores[currentIndex] = diagScore + score;

--- a/src/vs/base/common/fuzzyScorer.ts
+++ b/src/vs/base/common/fuzzyScorer.ts
@@ -42,13 +42,30 @@ export function scoreFuzzy(target: string, query: string, queryLower: string, fu
 	// When not searching fuzzy, we require the query to be contained fully
 	// in the target string contiguously.
 	if (!fuzzy) {
-		if (!targetLower.includes(queryLower)) {
+		const matchIndex = targetLower.indexOf(queryLower);
+		if (matchIndex === -1) {
+
 			// if (DEBUG) {
 			// 	console.log(`Characters not matching consecutively ${queryLower} within ${targetLower}`);
 			// }
 
 			return NO_SCORE;
 		}
+
+		const indexesArray: number[] = [];
+		for (let i = 0; i < queryLower.length; i++) {
+			indexesArray.push(i + matchIndex);
+		}
+
+		// TODO: what's a better value for the score?
+		const res: FuzzyScore = [100, indexesArray];
+
+		// if (DEBUG) {
+		// 	console.log(`%cFinal Score: ${res[0]}`, 'font-weight: bold');
+		// 	console.groupEnd();
+		// }
+
+		return res;
 	}
 
 	const res = doScoreFuzzy(query, queryLower, queryLength, target, targetLower, targetLength);

--- a/src/vs/base/common/fuzzyScorer.ts
+++ b/src/vs/base/common/fuzzyScorer.ts
@@ -389,9 +389,9 @@ export function scoreItemFuzzy<T>(item: T, query: IPreparedQuery, allowNonContig
 	// - whether fuzzy matching is enabled or not
 	let cacheHash: string;
 	if (description) {
-		cacheHash = `${label}${description}${query.normalized}${Array.isArray(query.values) ? query.values.length : ''}${allowNonContiguousMatches}${query.expectExactMatch}`;
+		cacheHash = `${label}${description}${query.normalized}${Array.isArray(query.values) ? query.values.length : ''}${allowNonContiguousMatches}${query.expectContiguousMatch}`;
 	} else {
-		cacheHash = `${label}${query.normalized}${Array.isArray(query.values) ? query.values.length : ''}${allowNonContiguousMatches}${query.expectExactMatch}`;
+		cacheHash = `${label}${query.normalized}${Array.isArray(query.values) ? query.values.length : ''}${allowNonContiguousMatches}${query.expectContiguousMatch}`;
 	}
 
 	const cached = cache[cacheHash];
@@ -462,7 +462,7 @@ function doScoreItemFuzzySingle(label: string, description: string | undefined, 
 			label,
 			query.normalized,
 			query.normalizedLowercase,
-			allowNonContiguousMatches && !query.expectExactMatch);
+			allowNonContiguousMatches && !query.expectContiguousMatch);
 		if (labelScore) {
 
 			// If we have a prefix match on the label, we give a much
@@ -504,7 +504,7 @@ function doScoreItemFuzzySingle(label: string, description: string | undefined, 
 			descriptionAndLabel,
 			query.normalized,
 			query.normalizedLowercase,
-			allowNonContiguousMatches && !query.expectExactMatch);
+			allowNonContiguousMatches && !query.expectContiguousMatch);
 		if (labelDescriptionScore) {
 			const labelDescriptionMatches = createMatches(labelDescriptionPositions);
 			const labelMatch: IMatch[] = [];
@@ -804,7 +804,7 @@ export interface IPreparedQueryPiece {
 	 * this query must be a substring of the input.
 	 * In other words, no fuzzy matching is used.
 	 */
-	expectExactMatch: boolean;
+	expectContiguousMatch: boolean;
 }
 
 export interface IPreparedQuery extends IPreparedQueryPiece {
@@ -866,13 +866,13 @@ export function prepareQuery(original: string): IPreparedQuery {
 					pathNormalized: pathNormalizedPiece,
 					normalized: normalizedPiece,
 					normalizedLowercase: normalizedLowercasePiece,
-					expectExactMatch: expectExactMatchPiece
+					expectContiguousMatch: expectExactMatchPiece
 				});
 			}
 		}
 	}
 
-	return { original, originalLowercase, pathNormalized, normalized, normalizedLowercase, values, containsPathSeparator, expectExactMatch };
+	return { original, originalLowercase, pathNormalized, normalized, normalizedLowercase, values, containsPathSeparator, expectContiguousMatch: expectExactMatch };
 }
 
 function normalizeQuery(original: string): { pathNormalized: string, normalized: string, normalizedLowercase: string } {

--- a/src/vs/base/test/common/fuzzyScorer.test.ts
+++ b/src/vs/base/test/common/fuzzyScorer.test.ts
@@ -76,10 +76,10 @@ class NullAccessorClass implements IItemAccessor<URI> {
 	}
 }
 
-function _doScore(target: string, query: string, allowNonContiguousMatches: boolean): FuzzyScore {
+function _doScore(target: string, query: string, allowNonContiguousMatches?: boolean): FuzzyScore {
 	const preparedQuery = prepareQuery(query);
 
-	return scoreFuzzy(target, preparedQuery.normalized, preparedQuery.normalizedLowercase, allowNonContiguousMatches);
+	return scoreFuzzy(target, preparedQuery.normalized, preparedQuery.normalizedLowercase, allowNonContiguousMatches ?? !preparedQuery.expectContiguousMatch);
 }
 
 function _doScore2(target: string, query: string, matchOffset: number = 0): FuzzyScore2 {
@@ -1082,11 +1082,11 @@ suite('Fuzzy Scorer', () => {
 		assert.strictEqual(prepareQuery('model Tester.ts').original, 'model Tester.ts');
 		assert.strictEqual(prepareQuery('model Tester.ts').originalLowercase, 'model Tester.ts'.toLowerCase());
 		assert.strictEqual(prepareQuery('model Tester.ts').normalized, 'modelTester.ts');
-		assert.strictEqual(prepareQuery('model Tester.ts').expectExactMatch, false); // doesn't have quotes in it
+		assert.strictEqual(prepareQuery('model Tester.ts').expectContiguousMatch, false); // doesn't have quotes in it
 		assert.strictEqual(prepareQuery('Model Tester.ts').normalizedLowercase, 'modeltester.ts');
 		assert.strictEqual(prepareQuery('ModelTester.ts').containsPathSeparator, false);
 		assert.strictEqual(prepareQuery('Model' + sep + 'Tester.ts').containsPathSeparator, true);
-		assert.strictEqual(prepareQuery('"hello"').expectExactMatch, true);
+		assert.strictEqual(prepareQuery('"hello"').expectContiguousMatch, true);
 		assert.strictEqual(prepareQuery('"hello"').normalized, 'hello');
 
 		// with spaces
@@ -1214,5 +1214,22 @@ suite('Fuzzy Scorer', () => {
 		assert.ok(score);
 		assert.ok(typeof score[0] === 'number');
 		assert.ok(score[1].length > 0);
+	});
+
+	test('Using quotes should expect contiguous matches match', function () {
+		// missing the "i" in the query
+		assert.strictEqual(_doScore('contiguous', '"contguous"')[0], 0);
+
+		const score = _doScore('contiguous', '"contiguous"');
+		assert.strictEqual(score[0], 253);
+	});
+
+	test('Using quotes should highlight contiguous indexes', function () {
+		const score = _doScore('2021-7-26.md', '"26"');
+		assert.strictEqual(score[0], 13);
+
+		// The indexes of the 2 and 6 of "26"
+		assert.strictEqual(score[1][0], 7);
+		assert.strictEqual(score[1][1], 8);
 	});
 });

--- a/src/vs/base/test/common/fuzzyScorer.test.ts
+++ b/src/vs/base/test/common/fuzzyScorer.test.ts
@@ -76,10 +76,10 @@ class NullAccessorClass implements IItemAccessor<URI> {
 	}
 }
 
-function _doScore(target: string, query: string, fuzzy: boolean): FuzzyScore {
+function _doScore(target: string, query: string, allowNonContiguousMatches: boolean): FuzzyScore {
 	const preparedQuery = prepareQuery(query);
 
-	return scoreFuzzy(target, preparedQuery.normalized, preparedQuery.normalizedLowercase, fuzzy);
+	return scoreFuzzy(target, preparedQuery.normalized, preparedQuery.normalizedLowercase, allowNonContiguousMatches);
 }
 
 function _doScore2(target: string, query: string, matchOffset: number = 0): FuzzyScore2 {
@@ -88,12 +88,12 @@ function _doScore2(target: string, query: string, matchOffset: number = 0): Fuzz
 	return scoreFuzzy2(target, preparedQuery, 0, matchOffset);
 }
 
-function scoreItem<T>(item: T, query: string, fuzzy: boolean, accessor: IItemAccessor<T>): IItemScore {
-	return scoreItemFuzzy(item, prepareQuery(query), fuzzy, accessor, Object.create(null));
+function scoreItem<T>(item: T, query: string, allowNonContiguousMatches: boolean, accessor: IItemAccessor<T>): IItemScore {
+	return scoreItemFuzzy(item, prepareQuery(query), allowNonContiguousMatches, accessor, Object.create(null));
 }
 
-function compareItemsByScore<T>(itemA: T, itemB: T, query: string, fuzzy: boolean, accessor: IItemAccessor<T>): number {
-	return compareItemsByFuzzyScore(itemA, itemB, prepareQuery(query), fuzzy, accessor, Object.create(null));
+function compareItemsByScore<T>(itemA: T, itemB: T, query: string, allowNonContiguousMatches: boolean, accessor: IItemAccessor<T>): number {
+	return compareItemsByFuzzyScore(itemA, itemB, prepareQuery(query), allowNonContiguousMatches, accessor, Object.create(null));
 }
 
 const NullAccessor = new NullAccessorClass();


### PR DESCRIPTION
Just the "quotes" support from #131215 fixing the highlighting problem so typing:

`"26"` will actually highlight 2020-7-`26` and not `2`020-7-2`6`.
