### PR TITLE
Fix `repository` field parsing in extension editing

### DIFF
--- a/extensions/extension-editing/package.json
+++ b/extensions/extension-editing/package.json
@@ -27,6 +27,7 @@
     "watch": "gulp watch-extension:extension-editing"
   },
   "dependencies": {
+    "hosted-git-info": "^4.0.2",
     "jsonc-parser": "^2.2.1",
     "markdown-it": "^12.0.4",
     "parse5": "^3.0.2",
@@ -68,6 +69,7 @@
     ]
   },
   "devDependencies": {
+    "@types/hosted-git-info": "^3.0.2",
     "@types/markdown-it": "0.0.2",
     "@types/node": "14.x"
   },

--- a/extensions/extension-editing/src/extensionLinter.ts
+++ b/extensions/extension-editing/src/extensionLinter.ts
@@ -259,11 +259,12 @@ export class ExtensionLinter {
 
 	private readPackageJsonInfo(folder: Uri, tree: JsonNode | undefined) {
 		const engine = tree && findNodeAtLocation(tree, ['engines', 'vscode']);
-		const repo = tree && findNodeAtLocation(tree, ['repository', 'url']);
-		const uri = repo && parseUri(repo.value);
+		const repo = tree && findNodeAtLocation(tree, ['repository']);
+		const repoUrl = repo && (repo.type === 'string' ? repo : findNodeAtLocation(repo, ['url']))
+		const uri = repoUrl && repoUrl.type === 'string' && parseUri(repoUrl.value);
 		const info: PackageJsonInfo = {
 			isExtension: !!(engine && engine.type === 'string'),
-			hasHttpsRepository: !!(repo && repo.type === 'string' && repo.value && uri && uri.scheme.toLowerCase() === 'https'),
+			hasHttpsRepository: !!(uri && uri.scheme.toLowerCase() === 'https'),
 			repository: uri!
 		};
 		const str = folder.toString();

--- a/extensions/extension-editing/yarn.lock
+++ b/extensions/extension-editing/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@types/hosted-git-info@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/hosted-git-info/-/hosted-git-info-3.0.2.tgz#aa671076f5edefa4fab1189b467e6c63987be818"
+  integrity sha512-RURNTeEFUwF+ifnp7kK3WLLlTmBSlRynLNS9jeAsI6RHtSrupV0l0nO6kmpaz75EUJVexy348bR452SvmH98vQ==
+
 "@types/markdown-it@0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-0.0.2.tgz#5d9ad19e6e6508cdd2f2596df86fd0aade598660"
@@ -27,6 +32,13 @@ entities@~2.1.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
   integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
+hosted-git-info@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.0.2.tgz#5e425507eede4fea846b7262f0838456c4209961"
+  integrity sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==
+  dependencies:
+    lru-cache "^6.0.0"
+
 jsonc-parser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.2.1.tgz#db73cd59d78cce28723199466b2a03d1be1df2bc"
@@ -38,6 +50,13 @@ linkify-it@^3.0.1:
   integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
   dependencies:
     uc.micro "^1.0.1"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 markdown-it@^12.0.4:
   version "12.0.4"
@@ -76,3 +95,8 @@ vscode-nls@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
Fixes the parsing of `repository` field in extension editing, allowing `repository` shorthand, and avoids false reports of non-https relative image links.

I add a dependency `hosted-git-info`, which supports parsing repository shorthands and is developed by npm.

I only fixed the warning message when authoring extensions. Actually vsce has not supported those shorthands by now. (https://github.com/microsoft/vscode-vsce/issues/489)

This PR fixes #60669.
