### PR TITLE
Add Citation File Format (`.cff`) to the recognized YAML file extensions

### DIFF
--- a/extensions/yaml/package.json
+++ b/extensions/yaml/package.json
@@ -39,7 +39,8 @@
           ".yml",
           ".eyaml",
           ".eyml",
-          ".yaml"
+          ".yaml",
+          ".cff"
         ],
         "firstLine": "^#cloud-config",
         "configuration": "./language-configuration.json"


### PR DESCRIPTION
This PR adds the [Citation File Format](https://github.com/citation-file-format/citation-file-format) `.cff` to the list of YAML file extensions.

The Citation File Format is a standardized, YAML-based format for citation metadata. GitHub has [recently begun supporting](https://github.blog/2021-08-19-enhanced-support-citations-github/
) `CITATION.cff` files natively, so it would be nice to have support for them in VSCode too.