### PR TITLE
fix(122003): set "tabindex" to all activity bar items so that :focus selector works

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -328,9 +328,9 @@ export class ActionBar extends Disposable implements IActionRunner {
 			item.setActionContext(this.context);
 			item.render(actionViewItemElement);
 
-			if (this.focusable && item instanceof BaseActionViewItem && this.viewItems.length === 0) {
+			if (this.focusable && item instanceof BaseActionViewItem) {
 				// We need to allow for the first enabled item to be focused on using tab navigation #106441
-				item.setFocusable(true);
+				item.setFocusable(this.viewItems.length === 0);
 			}
 
 			if (index === null || index < 0 || index >= this.actionsList.children.length) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/122003, but I'm not completely sure if this change is aligned with the accessibility feature of vscode. I noticed that there have been some non trivial changes happening around `setFocusable` regarding the behaviour of tab/arrow navigation. For example, I found these old issues after digging through `git blame`:

- https://github.com/microsoft/vscode/issues/106441
- https://github.com/microsoft/vscode/issues/116559
- https://github.com/microsoft/vscode/issues/116722

To explain my understanding of the current code and the intention of my change:

- In the current version of vscode, only the first action bar item (which, I believe, is always "file explorer" tab) has `tabindex="0"` initially. Therefore `:focus` style was applied only to the "file explorer" tab and not others. Other items will get `tabindex="-1"` only after some tab/arrow navigation reached the action bar via `ActionBar.setFocusable`, so it looks like the behaviour is a bit random.

- This PR will simply initialize all items with `tabindex="-1"` except the first item having `tabindex="0"`. So, `:focus` style will work for all items and as far as I can tell, it keeps the same tab/arrow navigation behaviour as before.

Since I'm very new to the code base, it's highly possible that I'm missing some important aspects of the current implementation.
I hope, at least, this PR demonstrates the reason why the bug happens, but if my (tiny) change creates new problems, please feel free to close the PR.
Thanks a lot for the code review!