### PR TITLE
[#131407] Fix service worker version check in browsers

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -233,7 +233,28 @@ const workerReady = new Promise(async (resolve, reject) => {
 				}
 			};
 			navigator.serviceWorker.addEventListener('message', versionHandler);
-			assertIsDefined(registration.active).postMessage({ channel: 'version' });
+
+			const postVersionMessage = () => {
+				assertIsDefined(navigator.serviceWorker.controller).postMessage({ channel: 'version' })
+			};
+
+			// At this point, either the service worker is ready and
+			// became our controller, or we need to wait for it.
+			// Note that navigator.serviceWorker.controller could be a
+			// controller from a previously loaded service worker.
+			const currentController = navigator.serviceWorker.controller;
+			if (currentController && currentController.scriptURL.endsWith(swPath)) {
+				// service worker already loaded & ready to receive messages
+				postVersionMessage();
+			} else {
+				// either there's no controlling service worker, or it's an old one:
+				// wait for it to change before posting the message
+				const onControllerChange = () => {
+					navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange);
+					postVersionMessage();
+				};
+				navigator.serviceWorker.addEventListener('controllerchange', onControllerChange);
+			}
 		},
 		error => {
 			reject(new Error(`Could not register service workers: ${error}.`));


### PR DESCRIPTION
This PR fixes #131407

When a service worker is started, the creator sends a message to verify its version. Sometimes this message was being sent to an older, already existing service worker. As a result, the `workerReady` promise would never resolve and the webview would stay in a loading state.

The best way I found to test this was to load a jupyter notebook ("Jupyter: Create New Blank Notebook) in a browser environment (I used https://github.com/cdr/code-server for that) in Firefox. It happens in Chrome too (~10% of the time), but it's more common in Firefox (~50% of the time). 
