### PR TITLE
vscode don't include support for rendering defined lists by default so this would be a better to remove those snippet

### DIFF
--- a/extensions/markdown-basics/snippets/markdown.code-snippets
+++ b/extensions/markdown-basics/snippets/markdown.code-snippets
@@ -64,11 +64,6 @@
 		"body": ["1. ${1:first}", "2. ${2:second}", "3. ${3:third}", "$0"],
 		"description": "Insert ordered list"
 	},
-	"Insert definition list": {
-	        "prefix": "definition list",
-		"body": ["${1:term}", ": ${2:definition}", "$0"],
-		"description": "Insert definition list"
-	},
 	"Insert horizontal rule": {
 		"prefix": "horizontal rule",
 		"body": "----------\n",
@@ -88,5 +83,5 @@
 		"prefix": "strikethrough",
 		"body": "~~${1:${TM_SELECTED_TEXT}}~~",
 		"description": "Insert strikethrough"
-	},	
+	},
 }


### PR DESCRIPTION
https://github.com/microsoft/vscode/pull/131452#issuecomment-904858896

https://code.visualstudio.com/docs/languages/markdown#_does-vs-code-support-github-flavored-markdown

https://github.com/markdown-it/markdown-it#syntax-extensions