### PR TITLE
Fix updating notebook metadata through editor api

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -658,17 +658,6 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		this._notebookSpecificAlternativeId = Number(newAlternativeVersionId.substr(0, newAlternativeVersionId.indexOf('_')));
 	}
 
-	private _isDocumentMetadataChangeTransient(a: NotebookDocumentMetadata, b: NotebookDocumentMetadata) {
-		const keys = new Set([...Object.keys(a || {}), ...Object.keys(b || {})]);
-		for (let key of keys) {
-			if (key !== 'trusted') {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
 	private _updateNotebookMetadata(metadata: NotebookDocumentMetadata, computeUndoRedo: boolean) {
 		const oldMetadata = this.metadata;
 		const triggerDirtyChange = this._isDocumentMetadataChanged(this.metadata, metadata);
@@ -694,7 +683,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 
 		this.metadata = metadata;
 		this._pauseableEmitter.fire({
-			rawEvents: [{ kind: NotebookCellsChangeType.ChangeDocumentMetadata, metadata: this.metadata, transient: this._isDocumentMetadataChangeTransient(oldMetadata, metadata) }],
+			rawEvents: [{ kind: NotebookCellsChangeType.ChangeDocumentMetadata, metadata: this.metadata, transient: !triggerDirtyChange }],
 			versionId: this.versionId,
 			synchronous: true,
 			endSelectionState: undefined


### PR DESCRIPTION
`_isDocumentMetadataChangeTransient` currently seems to return true for every metadata object except `{ trusted: boolean }`. This causes all metadata updates to be considered transient, which means that the notebook is never marked dirty

This PR updates `_isDocumentMetadataChangeTransient` to return true if there are any changes to properties that are not marked transient


For #130602