### PR TITLE
Add `filenames` to `dockercompose` language to help with proper Seti icon theme mapping

### DIFF
--- a/extensions/yaml/package.json
+++ b/extensions/yaml/package.json
@@ -19,9 +19,15 @@
           "Compose",
           "compose"
         ],
-        "filenamePatterns": [
+        "filenames": [
+          "docker-compose.yml",
+          "docker-compose.yaml",
+          "docker-compose.override.yml",
+          "docker-compose.override.yaml",
           "compose.yml",
-          "compose.yaml",
+          "compose.yaml"
+        ],
+        "filenamePatterns": [
           "compose.*.yml",
           "compose.*.yaml",
           "*docker*compose*.yml",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses part of https://github.com/microsoft/vscode-docker/issues/2539. All `dockercompose` documents should now get the pink whale icon that previously only `docker-compose.y(a)ml` and `docker-compose.override.y(a)ml` received.

@alexr00 @aeschli @karolz-ms FYI

Supersedes #131650.