### PR TITLE
fix #131743 add menu separator only when adding 'Run to Line'

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -397,9 +397,8 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 			));
 		}
 
-		actions.push(new Separator());
-
 		if (this.debugService.state === State.Stopped) {
+			actions.push(new Separator());
 			actions.push(new Action(
 				'runToLine',
 				nls.localize('runToLine', "Run to Line"),


### PR DESCRIPTION
This PR fixes #131743
