### PR TITLE
Catch model errors

### DIFF
--- a/src/vs/workbench/services/languageDetection/browser/languageDetectionSimpleWorker.ts
+++ b/src/vs/workbench/services/languageDetection/browser/languageDetectionSimpleWorker.ts
@@ -90,7 +90,13 @@ export class LanguageDetectionSimpleWorker extends EditorSimpleWorker {
 			return;
 		}
 
-		const modelResults = await modelOperations.runModel(content.getValue());
+		let modelResults: ModelResult[] | undefined;
+		try {
+			modelResults = await modelOperations.runModel(content.getValue());
+		} catch (e) {
+			console.warn(e);
+		}
+
 		if (!modelResults
 			|| modelResults.length === 0
 			|| modelResults[0].confidence < LanguageDetectionSimpleWorker.expectedRelativeConfidence) {


### PR DESCRIPTION
Fixes #131717

There is a known issue that is fixed but not yet released in Tensorflow.js that causes this callstack error linked^.

When you trigger Auto Detect from the Language Picker, that error is shown in an error message to the user.

We should swollow that error instead and don't do anything if so... and act as if the model wasn't confident enough to guess the language.