### PR TITLE
Add telemetry to extension host startup success/fail

### DIFF
--- a/src/vs/workbench/services/extensions/common/extensions.ts
+++ b/src/vs/workbench/services/extensions/common/extensions.ts
@@ -100,6 +100,14 @@ export const enum ExtensionHostKind {
 	Remote
 }
 
+export function extensionHostKindToString(kind: ExtensionHostKind): string {
+	switch (kind) {
+		case ExtensionHostKind.LocalProcess: return 'LocalProcess';
+		case ExtensionHostKind.LocalWebWorker: return 'LocalWebWorker';
+		case ExtensionHostKind.Remote: return 'Remote';
+	}
+}
+
 export interface IExtensionHost {
 	readonly kind: ExtensionHostKind;
 	readonly remoteAuthority: string | null;

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -269,6 +269,23 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 				return;
 			}
 
+			type ExtensionHostTerminatedClassification = {
+				code: { classification: 'SystemMetaData', purpose: 'PerformanceAndHealth' };
+				signal: { classification: 'SystemMetaData', purpose: 'PerformanceAndHealth' };
+				activatedExtensions: { classification: 'SystemMetaData', purpose: 'PerformanceAndHealth' };
+				kind: { classification: 'SystemMetaData', purpose: 'PerformanceAndHealth' };
+			};
+
+			this._telemetryService.publicLog2<{
+				code: number,
+				signal: string | null,
+				activatedExtensions: ExtensionIdentifier[],
+				kind: ExtensionHostKind,
+			}, ExtensionHostTerminatedClassification>('extension-host-terminated', {
+				code, signal, activatedExtensions, kind: extensionHost.kind
+			},
+				true);
+
 			const message = `Extension host terminated unexpectedly. The following extensions were running: ${activatedExtensions.map(id => id.value).join(', ')}`;
 			this._logService.error(message);
 

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -269,23 +269,6 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 				return;
 			}
 
-			type ExtensionHostTerminatedClassification = {
-				code: { classification: 'SystemMetaData', purpose: 'PerformanceAndHealth' };
-				signal: { classification: 'SystemMetaData', purpose: 'PerformanceAndHealth' };
-				activatedExtensions: { classification: 'SystemMetaData', purpose: 'PerformanceAndHealth' };
-				kind: { classification: 'SystemMetaData', purpose: 'PerformanceAndHealth' };
-			};
-
-			this._telemetryService.publicLog2<{
-				code: number,
-				signal: string | null,
-				activatedExtensions: ExtensionIdentifier[],
-				kind: ExtensionHostKind,
-			}, ExtensionHostTerminatedClassification>('extension-host-terminated', {
-				code, signal, activatedExtensions, kind: extensionHost.kind
-			},
-				true);
-
 			const message = `Extension host terminated unexpectedly. The following extensions were running: ${activatedExtensions.map(id => id.value).join(', ')}`;
 			this._logService.error(message);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Add telemetry to note that an extensionHost is being started and then another data point at either the success or failure point.  This enables knowing the entire set of extension hosts and then the breakdown and reasoning of success/failures.

I have my own custom telemetry hook to test with, please provide guidance on how you'd like us to test with built-in telemetry hook.

This PR fixes #131916
