### PR TITLE
Fix truncation of common suffixes that overlap with the common prefix.

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/suggestWidgetPreviewModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/suggestWidgetPreviewModel.ts
@@ -172,7 +172,7 @@ function lengthOfLongestCommonSuffix(str1: string, str2: string): number {
 	return i;
 }
 
-function minimizeInlineCompletion(model: ITextModel, inlineCompletion: NormalizedInlineCompletion | undefined): NormalizedInlineCompletion | undefined {
+export function minimizeInlineCompletion(model: ITextModel, inlineCompletion: NormalizedInlineCompletion | undefined): NormalizedInlineCompletion | undefined {
 	if (!inlineCompletion) {
 		return inlineCompletion;
 	}
@@ -181,7 +181,8 @@ function minimizeInlineCompletion(model: ITextModel, inlineCompletion: Normalize
 	const startOffset = model.getOffsetAt(inlineCompletion.range.getStartPosition()) + commonPrefixLength;
 	const start = model.getPositionAt(startOffset);
 
-	const commonSuffixLength = lengthOfLongestCommonSuffix(valueToReplace, inlineCompletion.text);
+	const remainingValueToReplace = valueToReplace.substr(commonPrefixLength);
+	const commonSuffixLength = lengthOfLongestCommonSuffix(remainingValueToReplace, inlineCompletion.text);
 	const end = model.getPositionAt(Math.max(startOffset, model.getOffsetAt(inlineCompletion.range.getEndPosition()) - commonSuffixLength));
 
 	return {

--- a/src/vs/editor/contrib/inlineCompletions/test/suggestWidgetModel.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/suggestWidgetModel.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SuggestWidgetPreviewModel } from 'vs/editor/contrib/inlineCompletions/suggestWidgetPreviewModel';
+import { minimizeInlineCompletion, SuggestWidgetPreviewModel } from 'vs/editor/contrib/inlineCompletions/suggestWidgetPreviewModel';
 import { SuggestController } from 'vs/editor/contrib/suggest/suggestController';
 import { SnippetController2 } from 'vs/editor/contrib/snippet/snippetController2';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
@@ -28,6 +28,7 @@ import { GhostTextContext } from 'vs/editor/contrib/inlineCompletions/test/utils
 import { Range } from 'vs/editor/common/core/range';
 import { runWithFakedTimers } from 'vs/base/test/common/timeTravelScheduler';
 import { SharedInlineCompletionCache } from 'vs/editor/contrib/inlineCompletions/ghostTextModel';
+import { createTextModel } from 'vs/editor/test/common/editorTestUtils';
 
 suite('Suggest Widget Model', () => {
 	test('Active', async () => {
@@ -82,6 +83,19 @@ suite('Suggest Widget Model', () => {
 				assert.deepStrictEqual(context.getAndClearViewStates(), ['hello.']);
 			}
 		);
+	});
+
+	test('minimizeInlineCompletion', async () => {
+		const model = createTextModel('fun');
+		const result = minimizeInlineCompletion(model, { range: new Range(1, 1, 1, 4), text: 'function' })!;
+
+		assert.deepStrictEqual({
+			range: result.range.toString(),
+			text: result.text
+		}, {
+			range: '[1,4 -> 1,4]',
+			text: 'ction'
+		});
 	});
 });
 


### PR DESCRIPTION
This PR fixes #131942

The problem is that `fun` has a common prefix with `function` of length 3 (`fun`), but also a common suffix of length 1 (`n`).

Currently, the code blindly moves the range three to the right and one to the left.
This does not make sense, because the prefix and suffix overlap.

The fix ensures that when computing the suffix, it cannot overlap the prefix.