### PR TITLE
reset scroll position core

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -455,7 +455,7 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 	private _matchOnLabel = true;
 	private _sortByLabel = true;
 	private _autoFocusOnList = true;
-	private _resetScrollPosition = true;
+	private _keepScrollPosition = false;
 	private _itemActivation = this.ui.isScreenReaderOptimized() ? ItemActivation.NONE /* https://github.com/microsoft/vscode/issues/57501 */ : ItemActivation.FIRST;
 	private _activeItems: T[] = [];
 	private activeItemsUpdated = false;
@@ -604,12 +604,12 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 		this.update();
 	}
 
-	get resetScrollPosition() {
-		return this._resetScrollPosition;
+	get keepScrollPosition() {
+		return this._keepScrollPosition;
 	}
 
-	set resetScrollPosition(resetScrollPosition: boolean) {
-		this._resetScrollPosition = resetScrollPosition;
+	set keepScrollPosition(keepScrollPosition: boolean) {
+		this._keepScrollPosition = keepScrollPosition;
 	}
 
 	get itemActivation() {
@@ -940,7 +940,7 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 			return;
 		}
 		// store the scrollTop before it is reset
-		const scrollTopBefore = this.resetScrollPosition ? 0 : this.scrollTop;
+		const scrollTopBefore = this.keepScrollPosition ? this.scrollTop : 0;
 		const hideInput = !!this._hideInput && this._items.length > 0;
 		this.ui.container.classList.toggle('hidden-input', hideInput && !this.description);
 		const visibilities: Visibilities = {
@@ -1043,7 +1043,7 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 		}
 
 		// Set the scroll position to what it was before updating the items
-		if (!this.resetScrollPosition) {
+		if (this.keepScrollPosition) {
 			this.scrollTop = scrollTopBefore;
 		}
 	}
@@ -1434,14 +1434,14 @@ export class QuickInputController extends Disposable {
 						if (index !== -1) {
 							const items = input.items.slice();
 							const removed = items.splice(index, 1);
-							const activeItems = input.activeItems.filter((ai) => ai !== removed[0]);
-							const resetScrollPositionBefore = input.resetScrollPosition;
-							input.resetScrollPosition = false;
+							const activeItems = input.activeItems.filter(activeItem => activeItem !== removed[0]);
+							const keepScrollPositionBefore = input.keepScrollPosition;
+							input.keepScrollPosition = true;
 							input.items = items;
 							if (activeItems) {
 								input.activeItems = activeItems;
 							}
-							input.resetScrollPosition = resetScrollPositionBefore;
+							input.keepScrollPosition = keepScrollPositionBefore;
 						}
 					}
 				})),

--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -455,6 +455,7 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 	private _matchOnLabel = true;
 	private _sortByLabel = true;
 	private _autoFocusOnList = true;
+	private _resetScrollPosition = true;
 	private _itemActivation = this.ui.isScreenReaderOptimized() ? ItemActivation.NONE /* https://github.com/microsoft/vscode/issues/57501 */ : ItemActivation.FIRST;
 	private _activeItems: T[] = [];
 	private activeItemsUpdated = false;
@@ -527,6 +528,14 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 		return this._items;
 	}
 
+	private get scrollTop() {
+		return this.ui.list.scrollTop;
+	}
+
+	private set scrollTop(scrollTop: number) {
+		this.ui.list.scrollTop = scrollTop;
+	}
+
 	set items(items: Array<T | IQuickPickSeparator>) {
 		this._items = items;
 		this.itemsUpdated = true;
@@ -593,6 +602,14 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 	set autoFocusOnList(autoFocusOnList: boolean) {
 		this._autoFocusOnList = autoFocusOnList;
 		this.update();
+	}
+
+	get resetScrollPosition() {
+		return this._resetScrollPosition;
+	}
+
+	set resetScrollPosition(resetScrollPosition: boolean) {
+		this._resetScrollPosition = resetScrollPosition;
 	}
 
 	get itemActivation() {
@@ -922,6 +939,8 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 		if (!this.visible) {
 			return;
 		}
+		// store the scrollTop before it is reset
+		const scrollTopBefore = this.resetScrollPosition ? 0 : this.scrollTop;
 		const hideInput = !!this._hideInput && this._items.length > 0;
 		this.ui.container.classList.toggle('hidden-input', hideInput && !this.description);
 		const visibilities: Visibilities = {
@@ -1021,6 +1040,11 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 			if (this.canSelectMany) {
 				this.ui.list.focus(QuickInputListFocus.First);
 			}
+		}
+
+		// Set the scroll position to what it was before updating the items
+		if (!this.resetScrollPosition) {
+			this.scrollTop = scrollTopBefore;
 		}
 	}
 }
@@ -1411,10 +1435,13 @@ export class QuickInputController extends Disposable {
 							const items = input.items.slice();
 							const removed = items.splice(index, 1);
 							const activeItems = input.activeItems.filter((ai) => ai !== removed[0]);
+							const resetScrollPositionBefore = input.resetScrollPosition;
+							input.resetScrollPosition = false;
 							input.items = items;
 							if (activeItems) {
 								input.activeItems = activeItems;
 							}
+							input.resetScrollPosition = resetScrollPositionBefore;
 						}
 					}
 				})),

--- a/src/vs/base/parts/quickinput/browser/quickInputList.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInputList.ts
@@ -362,6 +362,14 @@ export class QuickInputList {
 		return Event.map(this.list.onDidChangeSelection, e => ({ items: e.elements.map(e => e.item), event: e.browserEvent }));
 	}
 
+	get scrollTop() {
+		return this.list.scrollTop;
+	}
+
+	set scrollTop(scrollTop: number) {
+		this.list.scrollTop = scrollTop;
+	}
+
 	getAllVisibleChecked() {
 		return this.allVisibleChecked(this.elements, false);
 	}

--- a/src/vs/base/parts/quickinput/common/quickInput.ts
+++ b/src/vs/base/parts/quickinput/common/quickInput.ts
@@ -289,6 +289,8 @@ export interface IQuickPick<T extends IQuickPickItem> extends IQuickInput {
 
 	autoFocusOnList: boolean;
 
+	resetScrollPosition: boolean;
+
 	quickNavigate: IQuickNavigateConfiguration | undefined;
 
 	activeItems: ReadonlyArray<T>;

--- a/src/vs/base/parts/quickinput/common/quickInput.ts
+++ b/src/vs/base/parts/quickinput/common/quickInput.ts
@@ -289,7 +289,7 @@ export interface IQuickPick<T extends IQuickPickItem> extends IQuickInput {
 
 	autoFocusOnList: boolean;
 
-	resetScrollPosition: boolean;
+	keepScrollPosition: boolean;
 
 	quickNavigate: IQuickNavigateConfiguration | undefined;
 

--- a/src/vs/base/test/parts/quickinput/browser/quickinput.test.ts
+++ b/src/vs/base/test/parts/quickinput/browser/quickinput.test.ts
@@ -82,7 +82,7 @@ suite('QuickInput', () => {
 		}
 	});
 
-	test('resetScrollPosition works with activeItems', async () => {
+	test('keepScrollPosition works with activeItems', async () => {
 		quickpick = controller.createQuickPick();
 
 		const items = [];
@@ -98,16 +98,16 @@ suite('QuickInput', () => {
 
 		assert.notStrictEqual(cursorTop, 0);
 
-		quickpick.resetScrollPosition = false;
+		quickpick.keepScrollPosition = true;
 		quickpick.activeItems = [items[0]];
 		assert.strictEqual(cursorTop, getScrollTop());
 
-		quickpick.resetScrollPosition = true;
+		quickpick.keepScrollPosition = false;
 		quickpick.activeItems = [items[0]];
 		assert.strictEqual(getScrollTop(), 0);
 	});
 
-	test('resetScrollPosition works with items', async () => {
+	test('keepScrollPosition works with items', async () => {
 		quickpick = controller.createQuickPick();
 
 		const items = [];
@@ -122,11 +122,11 @@ suite('QuickInput', () => {
 		let cursorTop = getScrollTop();
 		assert.notStrictEqual(cursorTop, 0);
 
-		quickpick.resetScrollPosition = false;
+		quickpick.keepScrollPosition = true;
 		quickpick.items = items;
 		assert.strictEqual(cursorTop, getScrollTop());
 
-		quickpick.resetScrollPosition = true;
+		quickpick.keepScrollPosition = false;
 		quickpick.items = items;
 		assert.strictEqual(getScrollTop(), 0);
 	});

--- a/src/vs/base/test/parts/quickinput/browser/quickinput.test.ts
+++ b/src/vs/base/test/parts/quickinput/browser/quickinput.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert';
 import { IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { List } from 'vs/base/browser/ui/list/listWidget';
 import { QuickInputController } from 'vs/base/parts/quickinput/browser/quickInput';
+import { IQuickPick, IQuickPickItem } from 'vs/base/parts/quickinput/common/quickInput';
 import { IWorkbenchListOptions } from 'vs/platform/list/browser/listService';
 
 // Simple promisify of setTimeout
@@ -17,7 +18,11 @@ function wait(delayMS: number) {
 }
 
 suite('QuickInput', () => {
-	let fixture: HTMLElement, controller: QuickInputController;
+	let fixture: HTMLElement, controller: QuickInputController, quickpick: IQuickPick<IQuickPickItem>;
+
+	function getScrollTop(): number {
+		return (quickpick as any).scrollTop;
+	}
 
 	setup(() => {
 		fixture = document.createElement('div');
@@ -48,15 +53,19 @@ suite('QuickInput', () => {
 				widget: {}
 			}
 		});
+
+		// initial layout
+		controller.layout({ height: 20, width: 40 }, 0);
 	});
 
 	teardown(() => {
+		quickpick.dispose();
 		controller.dispose();
 		document.body.removeChild(fixture);
 	});
 
 	test('onDidChangeValue gets triggered when .value is set', async () => {
-		const quickpick = controller.createQuickPick();
+		quickpick = controller.createQuickPick();
 
 		let value: string | undefined = undefined;
 		quickpick.onDidChangeValue((e) => value = e);
@@ -71,5 +80,54 @@ suite('QuickInput', () => {
 		} finally {
 			quickpick.dispose();
 		}
+	});
+
+	test('resetScrollPosition works with activeItems', async () => {
+		quickpick = controller.createQuickPick();
+
+		const items = [];
+		for (let i = 0; i < 1000; i++) {
+			items.push({ label: `item ${i}` });
+		}
+		quickpick.items = items;
+		// setting the active item should cause the quick pick to scroll to the bottom
+		quickpick.activeItems = [items[items.length - 1]];
+		quickpick.show();
+
+		let cursorTop = getScrollTop();
+
+		assert.notStrictEqual(cursorTop, 0);
+
+		quickpick.resetScrollPosition = false;
+		quickpick.activeItems = [items[0]];
+		assert.strictEqual(cursorTop, getScrollTop());
+
+		quickpick.resetScrollPosition = true;
+		quickpick.activeItems = [items[0]];
+		assert.strictEqual(getScrollTop(), 0);
+	});
+
+	test('resetScrollPosition works with items', async () => {
+		quickpick = controller.createQuickPick();
+
+		const items = [];
+		for (let i = 0; i < 1000; i++) {
+			items.push({ label: `item ${i}` });
+		}
+		quickpick.items = items;
+		// setting the active item should cause the quick pick to scroll to the bottom
+		quickpick.activeItems = [items[items.length - 1]];
+		quickpick.show();
+
+		let cursorTop = getScrollTop();
+		assert.notStrictEqual(cursorTop, 0);
+
+		quickpick.resetScrollPosition = false;
+		quickpick.items = items;
+		assert.strictEqual(cursorTop, getScrollTop());
+
+		quickpick.resetScrollPosition = true;
+		quickpick.items = items;
+		assert.strictEqual(getScrollTop(), 0);
 	});
 });

--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -302,8 +302,15 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 							const index = picker.items.indexOf(item);
 							if (index !== -1) {
 								const items = picker.items.slice();
-								items.splice(index, 1);
+								const removed = items.splice(index, 1);
+								const activeItems = picker.activeItems.filter((ai) => ai !== removed[0]);
+								const resetScrollPositionBefore = picker.resetScrollPosition;
+								picker.resetScrollPosition = false;
 								picker.items = items;
+								if (activeItems) {
+									picker.activeItems = activeItems;
+								}
+								picker.resetScrollPosition = resetScrollPositionBefore;
 							}
 							break;
 					}

--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -303,14 +303,14 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 							if (index !== -1) {
 								const items = picker.items.slice();
 								const removed = items.splice(index, 1);
-								const activeItems = picker.activeItems.filter((ai) => ai !== removed[0]);
-								const resetScrollPositionBefore = picker.resetScrollPosition;
-								picker.resetScrollPosition = false;
+								const activeItems = picker.activeItems.filter(activeItem => activeItem !== removed[0]);
+								const keepScrollPositionBefore = picker.keepScrollPosition;
+								picker.keepScrollPosition = true;
 								picker.items = items;
 								if (activeItems) {
 									picker.activeItems = activeItems;
 								}
-								picker.resetScrollPosition = resetScrollPositionBefore;
+								picker.keepScrollPosition = keepScrollPositionBefore;
 							}
 							break;
 					}

--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -207,6 +207,7 @@ class InsertSnippetAction extends EditorAction {
 		picker.placeholder = nls.localize('pick.placeholder', "Select a snippet");
 		picker.matchOnDetail = true;
 		picker.ignoreFocusOut = false;
+		picker.resetScrollPosition = false;
 		picker.onDidTriggerItemButton(ctx => {
 			const isEnabled = snippetService.isEnabled(ctx.item.snippet);
 			snippetService.updateEnablement(ctx.item.snippet, !isEnabled);

--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -207,7 +207,7 @@ class InsertSnippetAction extends EditorAction {
 		picker.placeholder = nls.localize('pick.placeholder', "Select a snippet");
 		picker.matchOnDetail = true;
 		picker.ignoreFocusOut = false;
-		picker.resetScrollPosition = false;
+		picker.keepScrollPosition = true;
 		picker.onDidTriggerItemButton(ctx => {
 			const isEnabled = snippetService.isEnabled(ctx.item.snippet);
 			snippetService.updateEnablement(ctx.item.snippet, !isEnabled);


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Adds a new property to quick picks called:

```ts
resetScrollPosition: boolean
```

which defaults to `true`

that controls whether or not the cursor position will be reset to the top when either `items` or `activeItems` are changed.

This PR fixes #109969
