### PR TITLE
Use JS modules for kernel preloads

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1520,12 +1520,14 @@ declare module 'vscode' {
 		provides: string[];
 
 		/**
-		 * URI for the file to preload
+		 * URI of the JavaScript module to preload.
+		 *
+		 * This module must export an `activate` function that takes a context object that contains the notebook API.
 		 */
 		uri: Uri;
 
 		/**
-		 * @param uri URI for the file to preload
+		 * @param uri URI of the JavaScript module to preload
 		 * @param provides Value for the `provides` property
 		 */
 		constructor(uri: Uri, provides?: string | string[]);

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -168,8 +168,33 @@ async function webviewPreloads(ctx: PreloadContext) {
 		readonly workspace: { readonly isTrusted: boolean };
 	}
 
-	interface ScriptModule {
-		activate(ctx?: RendererContext): Promise<RendererApi | undefined | any> | RendererApi | undefined | any;
+	interface RendererModule {
+		activate(ctx: RendererContext): Promise<RendererApi | undefined | any> | RendererApi | undefined | any;
+	}
+
+	interface KernelPreloadContext {
+		getState(): { [key: string]: unknown; };
+		setState(data: { [key: string]: unknown; }): void;
+		postMessage(msg: unknown): void;
+
+		readonly onDidReceiveKernelMessage: Event<unknown>;
+		postKernelMessage(data: unknown): void;
+	}
+
+	interface KernelPreloadModule {
+		activate(ctx: KernelPreloadContext): Promise<void> | void;
+	}
+
+	function createKernelContext(): KernelPreloadContext {
+		const vscodeApi = acquireVsCodeApi();
+		return {
+			getState: vscodeApi.getState,
+			setState: vscodeApi.setState,
+			postMessage: vscodeApi.postMessage,
+
+			onDidReceiveKernelMessage: onDidReceiveKernelMessage.event,
+			postKernelMessage: (data: unknown) => postNotebookMessage('customKernelMessage', { message: data }),
+		};
 	}
 
 	const invokeSourceWithGlobals = (functionSrc: string, globals: { [name: string]: unknown }) => {
@@ -177,18 +202,20 @@ async function webviewPreloads(ctx: PreloadContext) {
 		return new Function(...args.map(([k]) => k), functionSrc)(...args.map(([, v]) => v));
 	};
 
-	const runPreload = async (url: string, originalUri: string): Promise<ScriptModule> => {
+	const runKernelPreload = async (url: string, originalUri: string): Promise<void> => {
 		const text = await loadScriptSource(url, originalUri);
-		return {
-			activate: () => {
-				try {
-					return invokeSourceWithGlobals(text, { ...kernelPreloadGlobals, scriptUrl: url });
-				} catch (e) {
-					console.error(e);
-					throw e;
-				}
+		const isModule = /\bexport\b.*\bactivate\b/.test(text);
+		try {
+			if (isModule) {
+				const module: KernelPreloadModule = await __import(url);
+				return module.activate(createKernelContext());
+			} else {
+				return invokeSourceWithGlobals(text, { ...kernelPreloadGlobals, scriptUrl: url });
 			}
-		};
+		} catch (e) {
+			console.error(e);
+			throw e;
+		}
 	};
 
 	const dimensionUpdater = new class {
@@ -759,7 +786,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 
 		/** Inner function cached in the _loadPromise(). */
 		private async _load(): Promise<RendererApi | undefined> {
-			const module = await __import(this.data.entrypoint);
+			const module: RendererModule = await __import(this.data.entrypoint);
 			if (!module) {
 				return;
 			}
@@ -795,9 +822,9 @@ async function webviewPreloads(ctx: PreloadContext) {
 		 */
 		public load(uri: string, originalUri: string) {
 			const promise = Promise.all([
-				runPreload(uri, originalUri),
+				runKernelPreload(uri, originalUri),
 				this.waitForAllCurrent(),
-			]).then(([module]) => module.activate());
+			]);
 
 			this.preloads.set(uri, promise);
 			return promise;

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -173,10 +173,6 @@ async function webviewPreloads(ctx: PreloadContext) {
 	}
 
 	interface KernelPreloadContext {
-		getState(): { [key: string]: unknown; };
-		setState(data: { [key: string]: unknown; }): void;
-		postMessage(msg: unknown): void;
-
 		readonly onDidReceiveKernelMessage: Event<unknown>;
 		postKernelMessage(data: unknown): void;
 	}
@@ -186,12 +182,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 	}
 
 	function createKernelContext(): KernelPreloadContext {
-		const vscodeApi = acquireVsCodeApi();
 		return {
-			getState: vscodeApi.getState,
-			setState: vscodeApi.setState,
-			postMessage: vscodeApi.postMessage,
-
 			onDidReceiveKernelMessage: onDidReceiveKernelMessage.event,
 			postKernelMessage: (data: unknown) => postNotebookMessage('customKernelMessage', { message: data }),
 		};


### PR DESCRIPTION
Fixes #131117

This changes kernel preloads from being global scripts to instead be JS modules. This aligns them with our existing renderer API and should make it easier for people to author preloads that depend on VS Code apis

For now, we should continue to be backwards compatible with the global style preloads but support for these will be removed once we move all consumers of the existing api to use modules instead 


