### PR TITLE
testing: add new API `sortText` property to TestItem

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -14293,6 +14293,12 @@ declare module 'vscode' {
 		description?: string;
 
 		/**
+		 * Optional sortText to sort the test items by. If sort text exists on a
+		 * {@link TestItem} then it is used instead of {@link TestItem.label}.
+		 */
+		sortText?: string;
+
+		/**
 		 * Location of the test item in its {@link uri}.
 		 *
 		 * This is only meaningful if the `uri` points to a file.

--- a/src/vs/workbench/api/common/extHostTestingPrivateApi.ts
+++ b/src/vs/workbench/api/common/extHostTestingPrivateApi.ts
@@ -95,7 +95,7 @@ const testItemPropAccessor = <K extends keyof vscode.TestItem>(
 	};
 };
 
-type WritableProps = Pick<vscode.TestItem, 'range' | 'label' | 'description' | 'canResolveChildren' | 'busy' | 'error' | 'tags'>;
+type WritableProps = Pick<vscode.TestItem, 'range' | 'label' | 'description' | 'sortText' | 'canResolveChildren' | 'busy' | 'error' | 'tags'>;
 
 const strictEqualComparator = <T>(a: T, b: T) => a === b;
 
@@ -107,6 +107,7 @@ const propComparators: { [K in keyof Required<WritableProps>]: (a: vscode.TestIt
 	},
 	label: strictEqualComparator,
 	description: strictEqualComparator,
+	sortText: strictEqualComparator,
 	busy: strictEqualComparator,
 	error: strictEqualComparator,
 	canResolveChildren: strictEqualComparator,
@@ -129,6 +130,7 @@ const makePropDescriptors = (api: IExtHostTestItemApi, label: string): { [K in k
 	range: testItemPropAccessor(api, 'range', undefined, propComparators.range),
 	label: testItemPropAccessor(api, 'label', label, propComparators.label),
 	description: testItemPropAccessor(api, 'description', undefined, propComparators.description),
+	sortText: testItemPropAccessor(api, 'sortText', undefined, propComparators.sortText),
 	canResolveChildren: testItemPropAccessor(api, 'canResolveChildren', false, propComparators.canResolveChildren),
 	busy: testItemPropAccessor(api, 'busy', false, propComparators.busy),
 	error: testItemPropAccessor(api, 'error', undefined, propComparators.error),
@@ -268,6 +270,7 @@ export class TestItemImpl implements vscode.TestItem {
 
 	public range!: vscode.Range | undefined;
 	public description!: string | undefined;
+	public sortText!: string | undefined;
 	public label!: string;
 	public error!: string | vscode.MarkdownString;
 	public busy!: boolean;

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1685,6 +1685,7 @@ export namespace TestItem {
 			tags: item.tags.map(t => TestTag.namespace(ctrlId, t.id)),
 			range: Range.from(item.range) || null,
 			description: item.description || null,
+			sortText: item.sortText || null,
 			error: item.error ? (MarkdownString.fromStrict(item.error) || null) : null,
 		};
 	}
@@ -1703,6 +1704,7 @@ export namespace TestItem {
 			canResolveChildren: false,
 			busy: false,
 			description: item.description || undefined,
+			sortText: item.sortText || undefined,
 		};
 	}
 
@@ -1711,6 +1713,7 @@ export namespace TestItem {
 		const testItem = new TestItemImpl(testId.controllerId, testId.localId, item.label, URI.revive(item.uri));
 		testItem.range = Range.to(item.range || undefined);
 		testItem.description = item.description || undefined;
+		testItem.sortText = item.sortText || undefined;
 		return testItem;
 	}
 

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
@@ -115,6 +115,10 @@ export class TestItemTreeElement implements IActionableTestTreeElement {
 		return this.test.item.description;
 	}
 
+	public get sortText() {
+		return this.test.item.sortText;
+	}
+
 	/**
 	 * Whether the node's test result is 'retired' -- from an outdated test run.
 	 */

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -948,7 +948,7 @@ class TreeSorter implements ITreeSorter<TestExplorerTreeElement> {
 			}
 		}
 
-		return a.label.localeCompare(b.label);
+		return (a.sortText || a.label).localeCompare((b.sortText || b.label));
 	}
 }
 

--- a/src/vs/workbench/contrib/testing/common/testCollection.ts
+++ b/src/vs/workbench/contrib/testing/common/testCollection.ts
@@ -160,6 +160,7 @@ export interface ITestItem {
 	range: IRange | null;
 	description: string | null;
 	error: string | IMarkdownString | null;
+	sortText: string | null;
 }
 
 export const enum TestItemExpandState {


### PR DESCRIPTION
testing: add new API `sortText` property to TestItem; if populated will be used instead of `label` for sorting items in Test Explorer tree and list view

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #130882.

This repo may be used for testing: https://github.com/smcenlly/vscode-issue-130883. Change `sortText` and `label` to confirm `sortText` is being used instead of `label` when `sortText` exists.

**./src/extension.ts**
```
import * as vscode from 'vscode';

export async function activate(context: vscode.ExtensionContext) {
  const ctrl = vscode.tests.createTestController('duration-bug', 'duration-bug');
  const parent = ctrl.createTestItem('TestParent', 'Test Parent');
  const testItem1 = ctrl.createTestItem('A', 'A');
  const testItem2 = ctrl.createTestItem('B', 'B');
  (testItem1 as any).sortText = 'B';
  (testItem2 as any).sortText = 'A';
  parent.children.add(testItem1);
  parent.children.add(testItem2);
  ctrl.items.add(parent);
  context.subscriptions.push(ctrl);
}
```
