### PR TITLE
Prevent duplicate '(read-only)' suffix on window title (#132127)

### DIFF
--- a/src/vs/workbench/common/editor/textResourceEditorInput.ts
+++ b/src/vs/workbench/common/editor/textResourceEditorInput.ts
@@ -125,8 +125,8 @@ export class TextResourceEditorInput extends AbstractTextResourceEditorInput imp
 		super(resource, undefined, editorService, textFileService, labelService, fileService);
 	}
 
-	override getName(): string {
-		return this.name || super.getName();
+	override getName(skipDecorate?: boolean): string {
+		return this.name || super.getName(skipDecorate);
 	}
 
 	setName(name: string): void {

--- a/src/vs/workbench/contrib/files/browser/editors/fileEditorInput.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/fileEditorInput.ts
@@ -158,8 +158,8 @@ export class FileEditorInput extends AbstractTextResourceEditorInput implements 
 		}));
 	}
 
-	override getName(): string {
-		return this.preferredName || super.getName();
+	override getName(skipDecorate?: boolean): string {
+		return this.preferredName || super.getName(skipDecorate);
 	}
 
 	setPreferredName(name: string): void {


### PR DESCRIPTION
This PR fixes #132127

For repro steps, see #79240 (previous occurrence of this issue)
