### PR TITLE
Fix #132139 with correct locale/language reference

### DIFF
--- a/src/vs/workbench/contrib/localizations/browser/localizations.contribution.ts
+++ b/src/vs/workbench/contrib/localizations/browser/localizations.contribution.ts
@@ -88,7 +88,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 		if (!language || !locale || locale === 'en' || locale.indexOf('en-') === 0) {
 			return;
 		}
-		if (language === locale || languagePackSuggestionIgnoreList.indexOf(language) > -1) {
+		if (language === locale || languagePackSuggestionIgnoreList.indexOf(locale) > -1) {
 			return;
 		}
 
@@ -169,7 +169,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 									label: localize('neverAgain', "Don't Show Again"),
 									isSecondary: true,
 									run: () => {
-										languagePackSuggestionIgnoreList.push(language);
+										languagePackSuggestionIgnoreList.push(locale);
 										this.storageService.store(
 											LANGUAGEPACK_SUGGESTION_IGNORE_STORAGE_KEY,
 											JSON.stringify(languagePackSuggestionIgnoreList),


### PR DESCRIPTION
I did check other potential mixups of the 2 variables, but this might be the last one.