### PR TITLE
only run language detection on plaintext files

### DIFF
--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -27,6 +27,7 @@ import { createTextBufferFactoryFromStream } from 'vs/editor/common/model/textMo
 import { ILanguageDetectionService } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { extUri } from 'vs/base/common/resources';
+import { PLAINTEXT_MODE_ID } from 'vs/editor/common/modes/modesRegistry';
 
 interface IBackupMetaData extends IWorkingCopyBackupMeta {
 	mtime: number;
@@ -608,8 +609,10 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 	}
 
 	protected override async autoDetectLanguage(): Promise<void> {
+		const mode = this.getMode();
 		if (
 			this.resource.scheme === this.pathService.defaultUriScheme &&	// make sure to not detect language for non-user visible documents
+			(!mode || mode === PLAINTEXT_MODE_ID) &&						// only run on files with plaintext mode set or no mode set at all
 			!this.resourceHasExtension										// only run if this particular file doesn't have an extension
 		) {
 			return super.autoDetectLanguage();


### PR DESCRIPTION
only run language detection on plaintext files

This PR fixes #132173
