### PR TITLE
Do not fold closing tag

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/folding.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/folding.ts
@@ -58,7 +58,7 @@ class TypeScriptFoldingProvider implements vscode.FoldingRangeProvider {
 		return new vscode.FoldingRange(start, end, kind);
 	}
 
-	private static readonly foldEndPairCharacters = ['}', ']', ')', '`'];
+	private static readonly foldEndPairCharacters = ['}', ']', ')', '`', '>'];
 
 	private adjustFoldingEnd(range: vscode.Range, document: vscode.TextDocument) {
 		// workaround for #47240


### PR DESCRIPTION
This PR causes the folding to **not** include the closing tag.

Previously:
![image](https://user-images.githubusercontent.com/19638700/132078924-fb6d9ab0-5bd2-41ee-9728-d37d1afe140c.png)

Now:
![image](https://user-images.githubusercontent.com/19638700/132078879-8fe9730d-b5e7-41b0-9eba-ff829aba5614.png)


Fixes #132049
