### PR TITLE
fixed zsh -l error for macOS

### DIFF
--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -246,24 +246,24 @@ const terminalPlatformConfiguration: IConfigurationNode = {
 			type: 'object',
 			default: {
 				'bash': {
-					path: 'bash',
+					path: '/bin/bash',
 					args: ['-l'],
 					icon: 'terminal-bash'
 				},
 				'zsh': {
-					path: 'zsh',
+					path: '/bin/zsh',
 					args: ['-l']
 				},
 				'fish': {
-					path: 'fish',
+					path: '/bin/fish',
 					args: ['-l']
 				},
 				'tmux': {
-					path: 'tmux',
+					path: '/bin/tmux',
 					icon: 'terminal-tmux'
 				},
 				'pwsh': {
-					path: 'pwsh',
+					path: '/bin/pwsh',
 					icon: 'terminal-powershell'
 				}
 			},


### PR DESCRIPTION
"zsh -l" error: can be fixed by using absolute path instead

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
