### PR TITLE
Add colorized bracket highlighting colours

### DIFF
--- a/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
+++ b/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
@@ -391,6 +391,11 @@
 		"editor.wordHighlightBackground": "#004454AA",
 		"editor.wordHighlightStrongBackground": "#005A6FAA",
 
+		// Editor: Colorized Bracket Highlighting
+		"editorBracketHighlight.foreground1": "#cdcdcdff",
+		"editorBracketHighlight.foreground2": "#b58900ff",
+		"editorBracketHighlight.foreground3": "#d33682ff",
+
 		// Editor: Suggest
 		// "editorSuggestWidget.background": "",
 		// "editorSuggestWidget.border": "",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #132493

As suggested in [this comment](https://github.com/microsoft/vscode/issues/130989#issuecomment-913493291) by @hediet.

This shows an preview of what these colours would look like (generated from adding these settings to my local settings.json file.

![image](https://user-images.githubusercontent.com/3467306/132258128-ba22e6fd-750b-4349-87a7-f2789638d2e9.png)

edit by @hediet:

With default colors:
![](https://user-images.githubusercontent.com/3467306/132257586-85f977b6-9e92-4c3d-9d0e-f61abea0a79e.png)

Without bracket pair colorization:
![](https://user-images.githubusercontent.com/3467306/132257763-5bb038db-81f9-41e9-a0bb-c3d5ca4a63d5.png)