### PR TITLE
Allow bracket pairs to share open tokens or close tokens in the colorizer

### DIFF
--- a/src/vs/editor/common/model/bracketPairColorizer/bracketPairColorizer.ts
+++ b/src/vs/editor/common/model/bracketPairColorizer/bracketPairColorizer.ts
@@ -120,8 +120,8 @@ class BracketPairColorizerImpl extends Disposable implements DecorationProvider 
 	private initialAstWithoutTokens: AstNode | undefined;
 	private astWithTokens: AstNode | undefined;
 
-	private readonly brackets = new LanguageAgnosticBracketTokens([]);
-	private readonly denseKeyProvider = new DenseKeyProvider<number>();
+	private readonly denseKeyProvider = new DenseKeyProvider<string>();
+	private readonly brackets = new LanguageAgnosticBracketTokens(this.denseKeyProvider);
 
 	public didLanguageChange(languageId: LanguageId): boolean {
 		return this.brackets.didLanguageChange(languageId);
@@ -159,7 +159,7 @@ class BracketPairColorizerImpl extends Disposable implements DecorationProvider 
 			// There are no token information yet
 			const brackets = this.brackets.getSingleLanguageBracketTokens(this.textModel.getLanguageIdentifier().id);
 			const tokenizer = new FastTokenizer(this.textModel.getValue(), brackets);
-			this.initialAstWithoutTokens = parseDocument(tokenizer, [], undefined, this.denseKeyProvider);
+			this.initialAstWithoutTokens = parseDocument(tokenizer, [], undefined);
 			this.astWithTokens = this.initialAstWithoutTokens.clone();
 		} else if (textModel.backgroundTokenizationState === BackgroundTokenizationState.Completed) {
 			// Skip the initial ast, as there is no flickering.
@@ -196,7 +196,7 @@ class BracketPairColorizerImpl extends Disposable implements DecorationProvider 
 		const isPure = false;
 		const previousAstClone = isPure ? previousAst?.clone() : previousAst;
 		const tokenizer = new TextBufferTokenizer(this.textModel, this.brackets);
-		const result = parseDocument(tokenizer, edits, previousAstClone, this.denseKeyProvider);
+		const result = parseDocument(tokenizer, edits, previousAstClone);
 		return result;
 	}
 

--- a/src/vs/editor/common/model/bracketPairColorizer/parser.ts
+++ b/src/vs/editor/common/model/bracketPairColorizer/parser.ts
@@ -5,14 +5,14 @@
 
 import { AstNode, AstNodeKind, BracketAstNode, InvalidBracketAstNode, ListAstNode, PairAstNode, TextAstNode } from './ast';
 import { BeforeEditPositionMapper, TextEditInfo } from './beforeEditPositionMapper';
-import { DenseKeyProvider, SmallImmutableSet } from './smallImmutableSet';
+import { SmallImmutableSet } from './smallImmutableSet';
 import { lengthGetLineCount, lengthIsZero, lengthLessThanEqual } from './length';
 import { concat23Trees } from './concat23Trees';
 import { NodeReader } from './nodeReader';
-import { Tokenizer, TokenKind } from './tokenizer';
+import { OpeningBracketId, Tokenizer, TokenKind } from './tokenizer';
 
-export function parseDocument(tokenizer: Tokenizer, edits: TextEditInfo[], oldNode: AstNode | undefined, denseKeyProvider: DenseKeyProvider<number>): AstNode {
-	const parser = new Parser(tokenizer, edits, oldNode, denseKeyProvider);
+export function parseDocument(tokenizer: Tokenizer, edits: TextEditInfo[], oldNode: AstNode | undefined): AstNode {
+	const parser = new Parser(tokenizer, edits, oldNode);
 	return parser.parseDocument();
 }
 
@@ -40,7 +40,6 @@ class Parser {
 		private readonly tokenizer: Tokenizer,
 		edits: TextEditInfo[],
 		oldNode: AstNode | undefined,
-		private readonly denseKeyProvider: DenseKeyProvider<number>,
 	) {
 		this.oldNodeReader = oldNode ? new NodeReader(oldNode) : undefined;
 		this.positionMapper = new BeforeEditPositionMapper(edits, tokenizer.length);
@@ -59,7 +58,7 @@ class Parser {
 	}
 
 	private parseList(
-		expectedClosingCategories: SmallImmutableSet<number>,
+		openedBracketIds: SmallImmutableSet<OpeningBracketId>,
 	): AstNode | null {
 		const items = new Array<AstNode>();
 
@@ -68,12 +67,12 @@ class Parser {
 			if (
 				!token ||
 				(token.kind === TokenKind.ClosingBracket &&
-					expectedClosingCategories.has(token.category, this.denseKeyProvider))
+					token.bracketIds.intersects(openedBracketIds))
 			) {
 				break;
 			}
 
-			const child = this.parseChild(expectedClosingCategories);
+			const child = this.parseChild(openedBracketIds);
 			if (child.kind === AstNodeKind.List && child.children.length === 0) {
 				continue;
 			}
@@ -86,7 +85,7 @@ class Parser {
 	}
 
 	private parseChild(
-		expectingClosingCategories: SmallImmutableSet<number>,
+		openedBracketIds: SmallImmutableSet<number>,
 	): AstNode {
 		if (this.oldNodeReader) {
 			const maxCacheableLength = this.positionMapper.getDistanceToNextChange(this.tokenizer.offset);
@@ -97,7 +96,7 @@ class Parser {
 					}
 
 					const endLineDidChange = lengthGetLineCount(curNode.length) === lengthGetLineCount(maxCacheableLength);
-					const canBeReused = curNode.canBeReused(expectingClosingCategories, endLineDidChange);
+					const canBeReused = curNode.canBeReused(openedBracketIds, endLineDidChange);
 					return canBeReused;
 				});
 
@@ -115,31 +114,29 @@ class Parser {
 
 		switch (token.kind) {
 			case TokenKind.ClosingBracket:
-				return new InvalidBracketAstNode(token.category, token.length, this.denseKeyProvider);
+				return new InvalidBracketAstNode(token.bracketIds, token.length);
 
 			case TokenKind.Text:
 				return token.astNode as TextAstNode;
 
 			case TokenKind.OpeningBracket:
-				const set = expectingClosingCategories.add(token.category, this.denseKeyProvider);
+				const set = openedBracketIds.merge(token.bracketIds);
 				const child = this.parseList(set);
 
 				const nextToken = this.tokenizer.peek();
 				if (
 					nextToken &&
 					nextToken.kind === TokenKind.ClosingBracket &&
-					nextToken.category === token.category
+					(nextToken.bracketId === token.bracketId || nextToken.bracketIds.intersects(token.bracketIds))
 				) {
 					this.tokenizer.read();
 					return PairAstNode.create(
-						token.category,
 						token.astNode as BracketAstNode,
 						child,
 						nextToken.astNode as BracketAstNode
 					);
 				} else {
 					return PairAstNode.create(
-						token.category,
 						token.astNode as BracketAstNode,
 						child,
 						null

--- a/src/vs/editor/common/model/bracketPairColorizer/smallImmutableSet.ts
+++ b/src/vs/editor/common/model/bracketPairColorizer/smallImmutableSet.ts
@@ -37,7 +37,7 @@ export class SmallImmutableSet<T> {
 	) {
 	}
 
-	public add(value: T, keyProvider: DenseKeyProvider<T>): SmallImmutableSet<T> {
+	public add(value: T, keyProvider: IDenseKeyProvider<T>): SmallImmutableSet<T> {
 		const key = keyProvider.getKey(value);
 		let idx = key >> 5; // divided by 32
 		if (idx === 0) {
@@ -59,7 +59,7 @@ export class SmallImmutableSet<T> {
 		return SmallImmutableSet.create(this.items, newItems);
 	}
 
-	public has(value: T, keyProvider: DenseKeyProvider<T>): boolean {
+	public has(value: T, keyProvider: IDenseKeyProvider<T>): boolean {
 		const key = keyProvider.getKey(value);
 		let idx = key >> 5; // divided by 32
 		if (idx === 0) {
@@ -128,6 +128,16 @@ export class SmallImmutableSet<T> {
 		return true;
 	}
 }
+
+export interface IDenseKeyProvider<T> {
+	getKey(value: T): number;
+}
+
+export const identityKeyProvider: IDenseKeyProvider<number> = {
+	getKey(value: number) {
+		return value;
+	}
+};
 
 /**
  * Assigns values a unique incrementing key.

--- a/src/vs/editor/common/model/bracketPairColorizer/tokenizer.ts
+++ b/src/vs/editor/common/model/bracketPairColorizer/tokenizer.ts
@@ -6,7 +6,8 @@
 import { NotSupportedError } from 'vs/base/common/errors';
 import { LineTokens } from 'vs/editor/common/core/lineTokens';
 import { ITextModel } from 'vs/editor/common/model';
-import { LanguageId, StandardTokenType, TokenMetadata } from 'vs/editor/common/modes';
+import { SmallImmutableSet } from 'vs/editor/common/model/bracketPairColorizer/smallImmutableSet';
+import { StandardTokenType, TokenMetadata } from 'vs/editor/common/modes';
 import { BracketAstNode, TextAstNode } from './ast';
 import { BracketTokens, LanguageAgnosticBracketTokens } from './brackets';
 import { lengthGetColumnCountIfZeroLineCount, Length, lengthAdd, lengthDiff, lengthToObj, lengthZero, toLength } from './length';
@@ -28,12 +29,24 @@ export const enum TokenKind {
 	ClosingBracket = 2,
 }
 
+export type OpeningBracketId = number;
+
 export class Token {
 	constructor(
 		readonly length: Length,
 		readonly kind: TokenKind,
-		readonly category: number,
-		readonly languageId: LanguageId,
+		/**
+		 * If this token is an opening bracket, this is the id of the opening bracket.
+		 * If this token is a closing bracket, this is the id of the first opening bracket that is closed by this bracket.
+		 * Otherwise, it is -1.
+		 */
+		readonly bracketId: OpeningBracketId,
+		/**
+		 * If this token is an opening bracket, this just contains `bracketId`.
+		 * If this token is a closing bracket, this lists all opening bracket ids, that it closes.
+		 * Otherwise, it is empty.
+		 */
+		readonly bracketIds: SmallImmutableSet<OpeningBracketId>,
 		readonly astNode: BracketAstNode | TextAstNode | undefined,
 	) { }
 }
@@ -229,7 +242,7 @@ class NonPeekableTextBufferTokenizer {
 		}
 
 		const length = lengthDiff(startLineIdx, startLineCharOffset, this.lineIdx, this.lineCharOffset);
-		return new Token(length, TokenKind.Text, -1, -1, new TextAstNode(length));
+		return new Token(length, TokenKind.Text, -1, SmallImmutableSet.getEmpty(), new TextAstNode(length));
 	}
 }
 
@@ -255,7 +268,7 @@ export class FastTokenizer implements Tokenizer {
 		for (let i = 0; i < 60; i++) {
 			smallTextTokens0Line.push(
 				new Token(
-					toLength(0, i), TokenKind.Text, -1, -1,
+					toLength(0, i), TokenKind.Text, -1, SmallImmutableSet.getEmpty(),
 					new TextAstNode(toLength(0, i))
 				)
 			);
@@ -265,7 +278,7 @@ export class FastTokenizer implements Tokenizer {
 		for (let i = 0; i < 60; i++) {
 			smallTextTokens1Line.push(
 				new Token(
-					toLength(1, i), TokenKind.Text, -1, -1,
+					toLength(1, i), TokenKind.Text, -1, SmallImmutableSet.getEmpty(),
 					new TextAstNode(toLength(1, i))
 				)
 			);
@@ -288,7 +301,7 @@ export class FastTokenizer implements Tokenizer {
 								token = smallTextTokens0Line[colCount];
 							} else {
 								const length = toLength(0, colCount);
-								token = new Token(length, TokenKind.Text, -1, -1, new TextAstNode(length));
+								token = new Token(length, TokenKind.Text, -1, SmallImmutableSet.getEmpty(), new TextAstNode(length));
 							}
 						} else {
 							const lineCount = curLineCount - lastTokenEndLine;
@@ -297,7 +310,7 @@ export class FastTokenizer implements Tokenizer {
 								token = smallTextTokens1Line[colCount];
 							} else {
 								const length = toLength(lineCount, colCount);
-								token = new Token(length, TokenKind.Text, -1, -1, new TextAstNode(length));
+								token = new Token(length, TokenKind.Text, -1, SmallImmutableSet.getEmpty(), new TextAstNode(length));
 							}
 						}
 						tokens.push(token);
@@ -318,7 +331,7 @@ export class FastTokenizer implements Tokenizer {
 			const length = (lastTokenEndLine === curLineCount)
 				? toLength(0, offset - lastTokenEndOffset)
 				: toLength(curLineCount - lastTokenEndLine, offset - lastLineBreakOffset);
-			tokens.push(new Token(length, TokenKind.Text, -1, -1, new TextAstNode(length)));
+			tokens.push(new Token(length, TokenKind.Text, -1, SmallImmutableSet.getEmpty(), new TextAstNode(length)));
 		}
 
 		this.length = toLength(curLineCount, offset - lastLineBreakOffset);

--- a/src/vs/editor/test/common/model/bracketPairColorizer/brackets.test.ts
+++ b/src/vs/editor/test/common/model/bracketPairColorizer/brackets.test.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert = require('assert');
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { LanguageAgnosticBracketTokens } from 'vs/editor/common/model/bracketPairColorizer/brackets';
+import { SmallImmutableSet, DenseKeyProvider } from 'vs/editor/common/model/bracketPairColorizer/smallImmutableSet';
+import { Token, TokenKind } from 'vs/editor/common/model/bracketPairColorizer/tokenizer';
+import { LanguageIdentifier } from 'vs/editor/common/modes';
+import { LanguageConfigurationRegistry } from 'vs/editor/common/modes/languageConfigurationRegistry';
+
+suite('Bracket Pair Colorizer - Brackets', () => {
+	test('Basic', () => {
+		const languageId = 3;
+		const mode1 = new LanguageIdentifier('testMode1', languageId);
+		const denseKeyProvider = new DenseKeyProvider<string>();
+		const getImmutableSet = (elements: string[]) => {
+			let newSet = SmallImmutableSet.getEmpty();
+			elements.forEach(x => newSet = newSet.add(`${languageId}:::${x}`, denseKeyProvider));
+			return newSet;
+		};
+		const getKey = (value: string) => {
+			return denseKeyProvider.getKey(`${languageId}:::${value}`);
+		};
+
+		const disposableStore = new DisposableStore();
+		disposableStore.add(LanguageConfigurationRegistry.register(mode1, {
+			brackets: [
+				['{', '}'], ['[', ']'], ['(', ')'],
+				['begin', 'end'], ['case', 'endcase'], ['casez', 'endcase'],					// Verilog
+				['\\left(', '\\right)'], ['\\left(', '\\right.'], ['\\left.', '\\right)'],		// LaTeX Parentheses
+				['\\left[', '\\right]'], ['\\left[', '\\right.'], ['\\left.', '\\right]']		// LaTeX Brackets
+			]
+		}));
+
+		const brackets = new LanguageAgnosticBracketTokens(denseKeyProvider);
+		const bracketsExpected = [
+			{ text: '{', length: 1, kind: 'OpeningBracket', bracketId: getKey('{'), bracketIds: getImmutableSet(['{']) },
+			{ text: '[', length: 1, kind: 'OpeningBracket', bracketId: getKey('['), bracketIds: getImmutableSet(['[']) },
+			{ text: '(', length: 1, kind: 'OpeningBracket', bracketId: getKey('('), bracketIds: getImmutableSet(['(']) },
+			{ text: 'begin', length: 5, kind: 'OpeningBracket', bracketId: getKey('begin'), bracketIds: getImmutableSet(['begin']) },
+			{ text: 'case', length: 4, kind: 'OpeningBracket', bracketId: getKey('case'), bracketIds: getImmutableSet(['case']) },
+			{ text: 'casez', length: 5, kind: 'OpeningBracket', bracketId: getKey('casez'), bracketIds: getImmutableSet(['casez']) },
+			{ text: '\\left(', length: 6, kind: 'OpeningBracket', bracketId: getKey('\\left('), bracketIds: getImmutableSet(['\\left(']) },
+			{ text: '\\left.', length: 6, kind: 'OpeningBracket', bracketId: getKey('\\left.'), bracketIds: getImmutableSet(['\\left.']) },
+			{ text: '\\left[', length: 6, kind: 'OpeningBracket', bracketId: getKey('\\left['), bracketIds: getImmutableSet(['\\left[']) },
+
+			{ text: '}', length: 1, kind: 'ClosingBracket', bracketId: getKey('{'), bracketIds: getImmutableSet(['{']) },
+			{ text: ']', length: 1, kind: 'ClosingBracket', bracketId: getKey('['), bracketIds: getImmutableSet(['[']) },
+			{ text: ')', length: 1, kind: 'ClosingBracket', bracketId: getKey('('), bracketIds: getImmutableSet(['(']) },
+			{ text: 'end', length: 3, kind: 'ClosingBracket', bracketId: getKey('begin'), bracketIds: getImmutableSet(['begin']) },
+			{ text: 'endcase', length: 7, kind: 'ClosingBracket', bracketId: getKey('case'), bracketIds: getImmutableSet(['case', 'casez']) },
+			{ text: '\\right)', length: 7, kind: 'ClosingBracket', bracketId: getKey('\\left('), bracketIds: getImmutableSet(['\\left(', '\\left.']) },
+			{ text: '\\right.', length: 7, kind: 'ClosingBracket', bracketId: getKey('\\left('), bracketIds: getImmutableSet(['\\left(', '\\left[']) },
+			{ text: '\\right]', length: 7, kind: 'ClosingBracket', bracketId: getKey('\\left['), bracketIds: getImmutableSet(['\\left[', '\\left.']) }
+		];
+		const bracketsActual = bracketsExpected.map(x => tokenToObject(brackets.getToken(x.text, 3), x.text));
+
+		assert.deepStrictEqual(bracketsActual, bracketsExpected);
+
+		disposableStore.dispose();
+	});
+});
+
+function tokenToObject(token: Token | undefined, text: string): any {
+	if (token === undefined) {
+		return undefined;
+	}
+	return {
+		text: text,
+		length: token.length,
+		bracketId: token.bracketId,
+		bracketIds: token.bracketIds,
+		kind: {
+			[TokenKind.ClosingBracket]: 'ClosingBracket',
+			[TokenKind.OpeningBracket]: 'OpeningBracket',
+			[TokenKind.Text]: 'Text',
+		}[token.kind],
+	};
+}

--- a/src/vs/editor/test/common/model/bracketPairColorizer/concat23Trees.test.ts
+++ b/src/vs/editor/test/common/model/bracketPairColorizer/concat23Trees.test.ts
@@ -33,12 +33,12 @@ suite('Bracket Pair Colorizer - mergeItems', () => {
 			}
 		}
 
-		if (!node1.unopenedBrackets.equals(node2.unopenedBrackets)) {
+		if (!node1.missingBracketIds.equals(node2.missingBracketIds)) {
 			return false;
 		}
 
 		if (node1.kind === AstNodeKind.Pair && node2.kind === AstNodeKind.Pair) {
-			return node1.category === node2.category;
+			return true;
 		} else if (node1.kind === node2.kind) {
 			return true;
 		}


### PR DESCRIPTION
This addresses issue #132209.

This change modifies the bracket pair colorizer to allow opening brackets to share the same closing bracket, and closing brackets to share the same opening bracket, which is a feature in certain languages, such as Verilog and LaTeX.

To do this, a `pairsWith: number[]` property was added to the `Token` class (from `tokenizer.ts`), used by closing brackets only, to allow them to specify multiple category numbers (used by opening brackets) to which they can match.

When loading bracket pairs from languages, new category numbers are only given to unique opening brackets, and duplicate closing brackets get the associated opening bracket's category number added to their pairsWith property.

Finally, every instance of comparing opening bracket category numbers with closing bracket category numbers was replaced with appropriate logic to check if the opening bracket category number exists within the closing bracket's pairsWith property.

The existing test within `tokenizer.test.ts` was updated to account for the new `pairsWith` property, and a very basic test for the correct `category` and `pairsWith` properties (plus all the other properties too, but especially these) of tokens loaded from languages was added to a new file `brackets.test.ts`.

This pull request doesn't address any other issues, only bracket sharing.

![image](https://user-images.githubusercontent.com/1189874/132275253-f83e7e9b-9041-48d0-bf42-9febdebacc22.png)
