### PR TITLE
Remove colorized bracket pair for plain text files

### DIFF
--- a/src/vs/base/browser/ui/countBadge/countBadge.css
+++ b/src/vs/base/browser/ui/countBadge/countBadge.css
@@ -3,11 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.count-badge-wrapper {
-	display:flex;
-	align-items:center;
-}
-
 .monaco-count-badge {
 	padding: 3px 6px;
 	border-radius: 11px;

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -317,7 +317,12 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 	public get backgroundTokenizationState(): BackgroundTokenizationState {
 		return this._backgroundTokenizationState;
 	}
-	private setBackgroundTokenizationState(newState: BackgroundTokenizationState) {
+	private handleTokenizationProgress(completed: boolean) {
+		if (this._backgroundTokenizationState === BackgroundTokenizationState.Completed) {
+			// We already did a full tokenization and don't go back to progressing.
+			return;
+		}
+		const newState = completed ? BackgroundTokenizationState.Completed : BackgroundTokenizationState.InProgress;
 		if (this._backgroundTokenizationState !== newState) {
 			this._backgroundTokenizationState = newState;
 			this._onBackgroundTokenizationStateChanged.fire();
@@ -2000,7 +2005,7 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 				});
 			}
 		}
-		this.setBackgroundTokenizationState(backgroundTokenizationCompleted ? BackgroundTokenizationState.Completed : BackgroundTokenizationState.InProgress);
+		this.handleTokenizationProgress(backgroundTokenizationCompleted);
 	}
 
 	public setSemanticTokens(tokens: MultilineTokens2[] | null, isComplete: boolean): void {

--- a/src/vs/editor/common/model/textModelTokens.ts
+++ b/src/vs/editor/common/model/textModelTokens.ts
@@ -288,13 +288,13 @@ export class TextModelTokenization extends Disposable {
 		}
 
 		this._beginBackgroundTokenization();
-		this._textModel.setTokens(builder.tokens, tokenizedLineNumber >= textModelLastLineNumber);
+		this._textModel.setTokens(builder.tokens, !this._hasLinesToTokenize());
 	}
 
 	public tokenizeViewport(startLineNumber: number, endLineNumber: number): void {
 		const builder = new MultilineTokensBuilder();
 		this._tokenizeViewport(builder, startLineNumber, endLineNumber);
-		this._textModel.setTokens(builder.tokens);
+		this._textModel.setTokens(builder.tokens, !this._hasLinesToTokenize());
 	}
 
 	public reset(): void {
@@ -305,7 +305,7 @@ export class TextModelTokenization extends Disposable {
 	public forceTokenization(lineNumber: number): void {
 		const builder = new MultilineTokensBuilder();
 		this._updateTokensUntilLine(builder, lineNumber);
-		this._textModel.setTokens(builder.tokens);
+		this._textModel.setTokens(builder.tokens, !this._hasLinesToTokenize());
 	}
 
 	public isCheapToTokenize(lineNumber: number): boolean {

--- a/src/vs/editor/common/modes/modesRegistry.ts
+++ b/src/vs/editor/common/modes/modesRegistry.ts
@@ -83,6 +83,7 @@ LanguageConfigurationRegistry.register(PLAINTEXT_LANGUAGE_IDENTIFIER, {
 		{ open: '\'', close: '\'' },
 		{ open: '`', close: '`' },
 	],
+	colorizedBracketPairs: [],
 	folding: {
 		offSide: true
 	}

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -955,7 +955,12 @@ function registerSplitEditorInGroupCommands(): void {
 				title: localize('splitEditorInGroup', "Split Active Editor in Group"),
 				category: CATEGORIES.View,
 				precondition: ActiveEditorCanSplitInGroupContext,
-				f1: true
+				f1: true,
+				keybinding: {
+					weight: KeybindingWeight.WorkbenchContrib,
+					when: ActiveEditorCanSplitInGroupContext,
+					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.US_BACKSLASH)
+				}
 			});
 		}
 		async run(accessor: ServicesAccessor): Promise<void> {
@@ -981,7 +986,12 @@ function registerSplitEditorInGroupCommands(): void {
 				title: localize('joinEditorInGroup', "Join Active Editor in Group"),
 				category: CATEGORIES.View,
 				precondition: ActiveEditorContext.isEqualTo(SideBySideEditor.ID),
-				f1: true
+				f1: true,
+				keybinding: {
+					weight: KeybindingWeight.WorkbenchContrib,
+					when: ActiveEditorContext.isEqualTo(SideBySideEditor.ID),
+					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.US_BACKSLASH)
+				}
 			});
 		}
 		async run(accessor: ServicesAccessor): Promise<void> {

--- a/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
+++ b/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/editordroptarget';
-import { LocalSelectionTransfer, DraggedEditorIdentifier, ResourcesDropHandler, DraggedEditorGroupIdentifier, DragAndDropObserver, containsDragType, CodeDataTransfers } from 'vs/workbench/browser/dnd';
+import { LocalSelectionTransfer, DraggedEditorIdentifier, ResourcesDropHandler, DraggedEditorGroupIdentifier, DragAndDropObserver, containsDragType, CodeDataTransfers, extractFilesDropData } from 'vs/workbench/browser/dnd';
 import { addDisposableListener, EventType, EventHelper, isAncestor } from 'vs/base/browser/dom';
 import { IEditorGroupsAccessor, IEditorGroupView, fillActiveEditorViewState } from 'vs/workbench/browser/parts/editor/editor';
 import { EDITOR_DRAG_AND_DROP_BACKGROUND } from 'vs/workbench/common/theme';
@@ -17,15 +17,8 @@ import { toDisposable } from 'vs/base/common/lifecycle';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { DataTransfers } from 'vs/base/browser/dnd';
-import { VSBuffer } from 'vs/base/common/buffer';
-import { IDialogService, IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { URI } from 'vs/base/common/uri';
-import { joinPath } from 'vs/base/common/resources';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { assertIsDefined, assertAllDefined } from 'vs/base/common/types';
-import Severity from 'vs/base/common/severity';
-import { localize } from 'vs/nls';
-import { ByteSize } from 'vs/platform/files/common/files';
 
 interface IDropOperation {
 	splitDirection?: GroupDirection;
@@ -34,8 +27,6 @@ interface IDropOperation {
 class DropOverlay extends Themable {
 
 	private static readonly OVERLAY_ID = 'monaco-workbench-editor-drop-overlay';
-
-	private static readonly MAX_FILE_UPLOAD_SIZE = 100 * ByteSize.MB;
 
 	private container: HTMLElement | undefined;
 	private overlay: HTMLElement | undefined;
@@ -53,9 +44,7 @@ class DropOverlay extends Themable {
 		private groupView: IEditorGroupView,
 		@IThemeService themeService: IThemeService,
 		@IInstantiationService private instantiationService: IInstantiationService,
-		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IEditorService private readonly editorService: IEditorService,
-		@IDialogService private readonly dialogService: IDialogService,
 		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService
 	) {
 		super(themeService);
@@ -307,45 +296,13 @@ class DropOverlay extends Themable {
 
 			const files = event.dataTransfer?.files;
 			if (files) {
-				for (let i = 0; i < files.length; i++) {
-					const file = files.item(i);
-					if (file) {
-
-						// Skip for very large files because this operation is unbuffered
-						if (file.size > DropOverlay.MAX_FILE_UPLOAD_SIZE) {
-							this.dialogService.show(Severity.Warning, localize('fileTooLarge', "File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."));
-							continue;
-						}
-
-						// Read file fully and open as untitled editor
-						const reader = new FileReader();
-						reader.readAsArrayBuffer(file);
-						reader.onload = async event => {
-							const name = file.name;
-							if (typeof name === 'string' && event.target?.result instanceof ArrayBuffer) {
-
-								// Try to come up with a good file path for the untitled
-								// editor by asking the file dialog service for the default
-								let proposedFilePath: URI | undefined = undefined;
-								const defaultFilePath = await this.fileDialogService.defaultFilePath();
-								if (defaultFilePath) {
-									proposedFilePath = joinPath(defaultFilePath, name);
-								}
-
-								if (!targetGroup) {
-									targetGroup = ensureTargetGroup();
-								}
-
-								// Open as untitled text file with the provided contents
-								await this.editorService.openEditor({
-									resource: proposedFilePath,
-									forceUntitled: true,
-									contents: VSBuffer.wrap(new Uint8Array(event.target.result)).toString()
-								}, targetGroup.id);
-							}
-						};
+				this.instantiationService.invokeFunction(accessor => extractFilesDropData(accessor, files, ({ resource, data }) => {
+					if (!targetGroup) {
+						targetGroup = ensureTargetGroup();
 					}
-				}
+
+					this.editorService.openEditor({ resource, forceUntitled: true, contents: data.toString() }, targetGroup.id);
+				}));
 			}
 		}
 

--- a/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
@@ -24,7 +24,7 @@ import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { IConfigurationChangeEvent, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { DEFAULT_EDITOR_MIN_DIMENSIONS } from 'vs/workbench/browser/parts/editor/editor';
 import { DisposableStore } from 'vs/base/common/lifecycle';
-import { EDITOR_GROUP_BORDER } from 'vs/workbench/common/theme';
+import { EDITOR_PANE_BORDER } from 'vs/workbench/common/theme';
 
 export class SideBySideEditor extends EditorPane {
 
@@ -278,13 +278,13 @@ export class SideBySideEditor extends EditorPane {
 			if (this.orientation === Orientation.HORIZONTAL) {
 				this.primaryEditorContainer.style.borderLeftWidth = '1px';
 				this.primaryEditorContainer.style.borderLeftStyle = 'solid';
-				this.primaryEditorContainer.style.borderLeftColor = this.getColor(EDITOR_GROUP_BORDER)?.toString() ?? '';
+				this.primaryEditorContainer.style.borderLeftColor = this.getColor(EDITOR_PANE_BORDER)?.toString() ?? '';
 
 				this.primaryEditorContainer.style.borderTopWidth = '0';
 			} else {
 				this.primaryEditorContainer.style.borderTopWidth = '1px';
 				this.primaryEditorContainer.style.borderTopStyle = 'solid';
-				this.primaryEditorContainer.style.borderTopColor = this.getColor(EDITOR_GROUP_BORDER)?.toString() ?? '';
+				this.primaryEditorContainer.style.borderTopColor = this.getColor(EDITOR_PANE_BORDER)?.toString() ?? '';
 
 				this.primaryEditorContainer.style.borderLeftWidth = '0';
 			}

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -195,12 +195,6 @@ export const EDITOR_PANE_BACKGROUND = registerColor('editorPane.background', {
 	hc: editorBackground
 }, localize('editorPaneBackground', "Background color of the editor pane visible on the left and right side of the centered editor layout."));
 
-registerColor('editorGroup.background', {
-	dark: null,
-	light: null,
-	hc: null
-}, localize('editorGroupBackground', "Deprecated background color of an editor group."), false, localize('deprecatedEditorGroupBackground', "Deprecated: Background color of an editor group is no longer being supported with the introduction of the grid editor layout. You can use editorGroup.emptyBackground to set the background color of empty editor groups."));
-
 export const EDITOR_GROUP_EMPTY_BACKGROUND = registerColor('editorGroup.emptyBackground', {
 	dark: null,
 	light: null,
@@ -242,6 +236,12 @@ export const EDITOR_GROUP_BORDER = registerColor('editorGroup.border', {
 	light: '#E7E7E7',
 	hc: contrastBorder
 }, localize('editorGroupBorder', "Color to separate multiple editor groups from each other. Editor groups are the containers of editors."));
+
+export const EDITOR_PANE_BORDER = registerColor('editorPane.border', {
+	dark: EDITOR_GROUP_BORDER,
+	light: EDITOR_GROUP_BORDER,
+	hc: EDITOR_GROUP_BORDER
+}, localize('editorPane.border', "Color to separate multiple editors from each other in an editor group."));
 
 export const EDITOR_DRAG_AND_DROP_BACKGROUND = registerColor('editorGroup.dropBackground', {
 	dark: Color.fromHex('#53595D').transparent(0.5),

--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -58,7 +58,6 @@ export class SelectColorThemeAction extends Action {
 				selectThemeTimeout = window.setTimeout(() => {
 					selectThemeTimeout = undefined;
 					const themeId = theme && theme.id !== undefined ? theme.id : currentTheme.id;
-					console.log(`setColorTheme apply: ` + applyTheme);
 					this.themeService.setColorTheme(themeId, applyTheme ? 'auto' : 'preview').then(undefined,
 						err => {
 							onUnexpectedError(err);

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -27,6 +27,8 @@ import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { Schemas } from 'vs/base/common/network';
 import { PLAINTEXT_EXTENSION } from 'vs/editor/common/modes/modesRegistry';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 export abstract class AbstractFileDialogService implements IFileDialogService {
 
@@ -46,7 +48,9 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 		@IWorkspacesService private readonly workspacesService: IWorkspacesService,
 		@ILabelService private readonly labelService: ILabelService,
 		@IPathService private readonly pathService: IPathService,
-		@ICommandService protected readonly commandService: ICommandService
+		@ICommandService protected readonly commandService: ICommandService,
+		@IEditorService protected readonly editorService: IEditorService,
+		@ICodeEditorService protected readonly codeEditorService: ICodeEditorService
 	) { }
 
 	async defaultFilePath(schemeFilter = this.getSchemeFilterForWindow()): Promise<URI> {

--- a/src/vs/workbench/services/dialogs/browser/fileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/fileDialogService.ts
@@ -13,8 +13,10 @@ import { HTMLFileSystemProvider } from 'vs/platform/files/browser/htmlFileSystem
 import { localize } from 'vs/nls';
 import { getMediaOrTextMime } from 'vs/base/common/mime';
 import { basename } from 'vs/base/common/resources';
-import { WebFileSystemAccess } from 'vs/base/browser/dom';
+import { triggerDownload, triggerUpload, WebFileSystemAccess } from 'vs/base/browser/dom';
 import Severity from 'vs/base/common/severity';
+import { VSBuffer } from 'vs/base/common/buffer';
+import { extractFilesDropData } from 'vs/workbench/browser/dnd';
 
 export class FileDialogService extends AbstractFileDialogService implements IFileDialogService {
 
@@ -54,7 +56,7 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 		}
 
 		if (!WebFileSystemAccess.supported(window)) {
-			return this.showUnsupportedBrowserWarning();
+			return this.showUnsupportedBrowserWarning('open');
 		}
 
 		let fileHandle: FileSystemHandle | undefined = undefined;
@@ -107,7 +109,7 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 		}
 
 		if (!WebFileSystemAccess.supported(window)) {
-			return this.showUnsupportedBrowserWarning();
+			return this.showUnsupportedBrowserWarning('save');
 		}
 
 		let fileHandle: FileSystemHandle | undefined = undefined;
@@ -142,7 +144,7 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 		}
 
 		if (!WebFileSystemAccess.supported(window)) {
-			return this.showUnsupportedBrowserWarning();
+			return this.showUnsupportedBrowserWarning('save');
 		}
 
 		let fileHandle: FileSystemHandle | undefined = undefined;
@@ -163,7 +165,7 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 		}
 
 		if (!WebFileSystemAccess.supported(window)) {
-			return this.showUnsupportedBrowserWarning();
+			return this.showUnsupportedBrowserWarning('open');
 		}
 
 		let uri: URI | undefined;
@@ -184,22 +186,59 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 		return uri ? [uri] : undefined;
 	}
 
-	private async showUnsupportedBrowserWarning(): Promise<undefined> {
+	private async showUnsupportedBrowserWarning(context: 'save' | 'open'): Promise<undefined> {
+
+		// When saving, try to just download the contents
+		// of the active text editor if any as a workaround
+		if (context === 'save') {
+			const activeTextModel = this.codeEditorService.getActiveCodeEditor()?.getModel();
+			if (activeTextModel) {
+				triggerDownload(VSBuffer.fromString(activeTextModel.getValue()).buffer, basename(activeTextModel.uri));
+				return;
+			}
+		}
+
+		// Otherwise inform the user about options
+
+		const buttons = context === 'open' ?
+			[localize('openRemote', "Open Remote..."), localize('upload', "Upload..."), localize('learnMore', "Learn More"), localize('cancel', "Cancel")] :
+			[localize('openRemote', "Open Remote..."), localize('learnMore', "Learn More"), localize('cancel', "Cancel")];
+
+		const cancelId = context === 'open' ? 3 : 2;
+
 		const res = await this.dialogService.show(
 			Severity.Warning,
 			localize('unsupportedBrowserMessage', "Accessing local files is unsupported in your current browser."),
-			[localize('openRemote', "Open Remote..."), localize('learnMore', "Learn More"), localize('cancel', "Cancel")],
+			buttons,
 			{
 				detail: localize('unsupportedBrowserDetail', "Click 'Learn More' to see a list of supported browsers."),
-				cancelId: 2
+				cancelId
 			}
 		);
 
 		switch (res.choice) {
+
+			// Open Remote...
 			case 0:
 				this.commandService.executeCommand('workbench.action.remote.showMenu');
 				break;
+
+			// Upload... (context === 'open')
 			case 1:
+				if (context === 'open') {
+					const files = await triggerUpload();
+					if (files) {
+						this.instantiationService.invokeFunction(accessor => extractFilesDropData(accessor, files, ({ resource, data }) => {
+							this.editorService.openEditor({ resource: resource?.with({ scheme: Schemas.untitled }), forceUntitled: true, contents: data.toString() });
+						}));
+					}
+					break;
+				} else {
+					// Fallthrough for "Learn More"
+				}
+
+			// Learn More
+			case 2:
 				this.openerService.open('https://aka.ms/VSCodeWebLocalFileSystemAccess');
 				break;
 		}

--- a/src/vs/workbench/services/dialogs/electron-sandbox/fileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-sandbox/fileDialogService.ts
@@ -23,6 +23,8 @@ import { IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 export class FileDialogService extends AbstractFileDialogService implements IFileDialogService {
 
@@ -41,10 +43,12 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 		@IWorkspacesService workspacesService: IWorkspacesService,
 		@ILabelService labelService: ILabelService,
 		@IPathService pathService: IPathService,
-		@ICommandService commandService: ICommandService
+		@ICommandService commandService: ICommandService,
+		@IEditorService editorService: IEditorService,
+		@ICodeEditorService codeEditorService: ICodeEditorService
 	) {
 		super(hostService, contextService, historyService, environmentService, instantiationService,
-			configurationService, fileService, openerService, dialogService, modeService, workspacesService, labelService, pathService, commandService);
+			configurationService, fileService, openerService, dialogService, modeService, workspacesService, labelService, pathService, commandService, editorService, codeEditorService);
 	}
 
 	private toNativeOpenDialogOptions(options: IPickAndOpenOptions): INativeOpenDialogOptions {

--- a/src/vs/workbench/services/dialogs/test/fileDialogService.test.ts
+++ b/src/vs/workbench/services/dialogs/test/fileDialogService.test.ts
@@ -30,6 +30,8 @@ import { IHistoryService } from 'vs/workbench/services/history/common/history';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { SimpleFileDialog } from 'vs/workbench/services/dialogs/browser/simpleFileDialog';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 class TestFileDialogService extends FileDialogService {
 	constructor(
@@ -48,10 +50,12 @@ class TestFileDialogService extends FileDialogService {
 		@IWorkspacesService workspacesService: IWorkspacesService,
 		@ILabelService labelService: ILabelService,
 		@IPathService pathService: IPathService,
-		@ICommandService commandService: ICommandService
+		@ICommandService commandService: ICommandService,
+		@IEditorService editorService: IEditorService,
+		@ICodeEditorService codeEditorService: ICodeEditorService
 	) {
 		super(hostService, contextService, historyService, environmentService, instantiationService, configurationService, fileService,
-			openerService, nativeHostService, dialogService, modeService, workspacesService, labelService, pathService, commandService);
+			openerService, nativeHostService, dialogService, modeService, workspacesService, labelService, pathService, commandService, editorService, codeEditorService);
 	}
 
 	protected override getSimpleFileDialog() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


This PR fixes #132432
colorizedBracketPairs for extension handling plain text files is set to empty array to prevent them from being colorized.