### PR TITLE
fix: early return on cancellation

### DIFF
--- a/extensions/css-language-features/server/src/utils/runner.ts
+++ b/extensions/css-language-features/server/src/utils/runner.ts
@@ -23,6 +23,7 @@ export function runSafeAsync<T>(runtime: RuntimeEnvironment, func: () => Thenabl
 		runtime.timer.setImmediate(() => {
 			if (token.isCancellationRequested) {
 				resolve(cancelValue());
+				return;
 			}
 			return func().then(result => {
 				if (token.isCancellationRequested) {

--- a/extensions/html-language-features/server/src/utils/runner.ts
+++ b/extensions/html-language-features/server/src/utils/runner.ts
@@ -23,6 +23,7 @@ export function runSafe<T>(runtime: RuntimeEnvironment, func: () => Thenable<T>,
 		runtime.timer.setImmediate(() => {
 			if (token.isCancellationRequested) {
 				resolve(cancelValue());
+				return;
 			}
 			return func().then(result => {
 				if (token.isCancellationRequested) {

--- a/extensions/json-language-features/server/src/utils/runner.ts
+++ b/extensions/json-language-features/server/src/utils/runner.ts
@@ -23,6 +23,7 @@ export function runSafeAsync<T>(runtime: RuntimeEnvironment, func: () => Thenabl
 		runtime.timer.setImmediate(() => {
 			if (token.isCancellationRequested) {
 				resolve(cancelValue());
+				return;
 			}
 			return func().then(result => {
 				if (token.isCancellationRequested) {


### PR DESCRIPTION
This PR fixes # None

Compared the logic in `runSafe`, it might be possible to early return to save the `func()` invocation.
