### PR TITLE
Fix links in ThirdPartyNotices.txt

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -743,7 +743,7 @@ Apache License
 
 Version 2.0, January 2004
 
-http://www.apache.org/licenses/
+https://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -2219,8 +2219,8 @@ END OF TypeScript-TmLanguage NOTICES AND INFORMATION
 %% Unicode NOTICES AND INFORMATION BEGIN HERE
 =========================================
 Unicode Data Files include all data files under the directories
-http://www.unicode.org/Public/, http://www.unicode.org/reports/,
-http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/, and
+https://www.unicode.org/Public/, https://www.unicode.org/reports/,
+http://www.unicode.org/cldr/data/, https://github.com/unicode-org/icu, and
 http://www.unicode.org/utility/trac/browser/.
 
 Unicode Data Files do not include PDF online code charts under the
@@ -2228,8 +2228,8 @@ directory http://www.unicode.org/Public/.
 
 Software includes any source code published in the Unicode Standard
 or under the directories
-http://www.unicode.org/Public/, http://www.unicode.org/reports/,
-http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/, and
+https://www.unicode.org/Public/, http://www.unicode.org/reports/,
+http://www.unicode.org/cldr/data/, https://github.com/unicode-org/icu, and
 http://www.unicode.org/utility/trac/browser/.
 
 NOTICE TO USER: Carefully read the following legal agreement.

--- a/src/vs/base/browser/ui/countBadge/countBadge.css
+++ b/src/vs/base/browser/ui/countBadge/countBadge.css
@@ -3,10 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.count-badge-wrapper {
-	display:flex;
-	align-items:center;
-}
+
 
 .monaco-count-badge {
 	padding: 3px 6px;
@@ -17,6 +14,7 @@
 	line-height: 11px;
 	font-weight: normal;
 	text-align: center;
+	vertical-align: text-top;
 	display: inline-block;
 	box-sizing: border-box;
 }

--- a/src/vs/base/browser/ui/countBadge/countBadge.css
+++ b/src/vs/base/browser/ui/countBadge/countBadge.css
@@ -3,7 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-
+.count-badge-wrapper {
+	display:flex;
+	align-items:center;
+}
 
 .monaco-count-badge {
 	padding: 3px 6px;
@@ -14,7 +17,6 @@
 	line-height: 11px;
 	font-weight: normal;
 	text-align: center;
-	vertical-align: text-top;
 	display: inline-block;
 	box-sizing: border-box;
 }


### PR DESCRIPTION

change url protocol from http to https 
fix broken link http://source.icu-project.org/repos/icu/ to point to Github repository instead

This PR fixes #None
