### PR TITLE
Remove colorized bracket pair for plain text files

### DIFF
--- a/src/vs/editor/common/modes/modesRegistry.ts
+++ b/src/vs/editor/common/modes/modesRegistry.ts
@@ -83,6 +83,7 @@ LanguageConfigurationRegistry.register(PLAINTEXT_LANGUAGE_IDENTIFIER, {
 		{ open: '\'', close: '\'' },
 		{ open: '`', close: '`' },
 	],
+	colorizedBracketPairs: [],
 	folding: {
 		offSide: true
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #132432
colorizedBracketPairs for extension handling plain text files is set to empty array to prevent them from being colorized.
