### PR TITLE
debug: bump js-debug

### DIFF
--- a/product.json
+++ b/product.json
@@ -64,7 +64,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.60.1",
+			"version": "1.60.2",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
This PR contains this fix: https://github.com/microsoft/vscode-js-debug/compare/v1.60.1

For https://github.com/microsoft/vscode-js-debug/issues/1100