### PR TITLE
Pass cwd directly in options to fallback to default profile

### DIFF
--- a/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
+++ b/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
@@ -67,7 +67,7 @@ CommandsRegistry.registerCommand({
 						return;
 					}
 					opened[cwd.path] = true;
-					const instance = await integratedTerminalService.createTerminal({ config: { cwd } });
+					const instance = await integratedTerminalService.createTerminal({ cwd });
 					if (instance && instance.target !== TerminalLocation.Editor && (resources.length === 1 || !resource || cwd.path === resource.path || cwd.path === dirname(resource.path))) {
 						integratedTerminalService.setActiveInstance(instance);
 						terminalGroupService.showPanel(true);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #132718 

This is workaround for issue but doesn't fix root cause and other related issues (tasks, terminals from extensions (probably #132766 wont be fixed in recovery etc.).

#132718 has easysteps to reproduce and not duplicate of #132150
It avoids using almost empty `config` object in terminal that would prevent `createTerminal` method to use default profile selected by user.

@meganrogge @Tyriar 
Root cause in line
https://github.com/microsoft/vscode/blob/72bbe2e7484cf332ad10781dc36498904b7be0b2/src/vs/workbench/contrib/terminal/browser/terminalService.ts#L1161
and there are a lot of cases when `options.config` has only 1-2 fields, but don't define profile to use and also prevents usage of user selected default profile.
Probably there should be more precise check of `options.config` before ignoring default profile.

UPD. There is no expectation that this one will be merged as more work needed to fix root cause.
