### PR TITLE
Fix keys used to resolve terminal settings

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -209,7 +209,7 @@ export abstract class BaseTerminalProfileResolverService implements ITerminalPro
 	}
 
 	private _getUnresolvedRealDefaultProfile(os: OperatingSystem): ITerminalProfile | undefined {
-		const defaultProfileName = this._configurationService.getValue(`${TerminalSettingPrefix.DefaultProfile}.${this._getOsKey(os)}`);
+		const defaultProfileName = this._configurationService.getValue(`${TerminalSettingPrefix.DefaultProfile}${this._getOsKey(os)}`);
 		if (defaultProfileName && typeof defaultProfileName === 'string') {
 			return this._terminalService.availableProfiles.find(e => e.profileName === defaultProfileName);
 		}
@@ -217,9 +217,9 @@ export abstract class BaseTerminalProfileResolverService implements ITerminalPro
 	}
 
 	private async _getUnresolvedShellSettingDefaultProfile(options: IShellLaunchConfigResolveOptions): Promise<ITerminalProfile | undefined> {
-		let executable = this._configurationService.getValue<string>(`${TerminalSettingPrefix.Shell}.${this._getOsKey(options.os)}`);
+		let executable = this._configurationService.getValue<string>(`${TerminalSettingPrefix.Shell}${this._getOsKey(options.os)}`);
 		if (!this._isValidShell(executable)) {
-			const shellArgs = this._configurationService.inspect(`${TerminalSettingPrefix.ShellArgs}.${this._getOsKey(options.os)}`);
+			const shellArgs = this._configurationService.inspect(`${TerminalSettingPrefix.ShellArgs}${this._getOsKey(options.os)}`);
 			//  && !this.getSafeConfigValue('shellArgs', options.os, false)) {
 			if (!shellArgs.userValue && !shellArgs.workspaceValue) {
 				return undefined;
@@ -231,7 +231,7 @@ export abstract class BaseTerminalProfileResolverService implements ITerminalPro
 		}
 
 		let args: string | string[] | undefined;
-		const shellArgsSetting = this._configurationService.getValue(`${TerminalSettingPrefix.ShellArgs}.${this._getOsKey(options.os)}`);
+		const shellArgsSetting = this._configurationService.getValue(`${TerminalSettingPrefix.ShellArgs}${this._getOsKey(options.os)}`);
 		if (this._isValidShellArgs(shellArgsSetting, options.os)) {
 			args = shellArgsSetting;
 		}

--- a/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
@@ -326,7 +326,7 @@ export function getDefaultShellArgs(
 	}
 
 	const platformKey = platformOverride === Platform.Windows ? 'windows' : platformOverride === Platform.Mac ? 'osx' : 'linux';
-	let args = fetchSetting(<TerminalShellArgsSetting>`${TerminalSettingPrefix.ShellArgs}.${platformKey}`);
+	let args = fetchSetting(<TerminalShellArgsSetting>`${TerminalSettingPrefix.ShellArgs}${platformKey}`);
 	if (!args) {
 		return [];
 	}
@@ -339,7 +339,7 @@ export function getDefaultShellArgs(
 			try {
 				resolvedArgs.push(variableResolver(arg));
 			} catch (e) {
-				logService.error(`Could not resolve ${TerminalSettingPrefix.ShellArgs}.${platformKey}`, e);
+				logService.error(`Could not resolve ${TerminalSettingPrefix.ShellArgs}${platformKey}`, e);
 				resolvedArgs.push(arg);
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #132718 ("open in integrated terminal") and most likely #132824 (npm scripts, etc.)

Also this one looks like resolving infamous #132150 as well.

`TerminalSettingPrefix.*` enum members already have `.` in the end (e.g `'terminal.integrated.shell.'`) and initially used in simple string concatenation `perfix + platform` but in some template literal values has additional `.` added which results in `undefined` instead of user configured settings.

@meganrogge @Tyriar it would be nice to consider this for recovery as well.