### PR TITLE
Fix launching Pseudoterminal-based and local terminals in remote workspaces before the connection is established

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalService.ts
@@ -140,13 +140,15 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 			isExtensionOwnedTerminal: launchConfig.isExtensionOwnedTerminal,
 			useShellEnvironment: launchConfig.useShellEnvironment,
 		};
-		this._extHostTerminals.set(extHostTerminalId, new Promise(async r => {
+		const terminal = new Promise<ITerminalInstance>(async r => {
 			const terminal = await this._terminalService.createTerminal({
 				config: shellLaunchConfig,
 				location: await this._deserializeParentTerminal(launchConfig.location)
 			});
 			r(terminal);
-		}));
+		});
+		this._extHostTerminals.set(extHostTerminalId, terminal);
+		await terminal;
 	}
 
 	private async _deserializeParentTerminal(location?: TerminalLocation | TerminalEditorLocationOptions | { parentTerminal: ExtHostTerminalIdentifier } | { splitActiveTerminal: boolean, location?: TerminalLocation }): Promise<TerminalLocation | TerminalEditorLocationOptions | { parentTerminal: ITerminalInstance } | { splitActiveTerminal: boolean } | undefined> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -1148,10 +1148,17 @@ export class TerminalService implements ITerminalService {
 
 
 	async createTerminal(options?: ICreateTerminalOptions): Promise<ITerminalInstance> {
-		const isPtyTerminal = options?.config && 'customPtyImplementation' in options.config;
-		if (!isPtyTerminal && !this._availableProfiles) {
-			await this._refreshAvailableProfilesNow();
+		// Await the initialization of available profiles as long as this is not a pty terminal or a
+		// local terminal in a remote workspace as profile won't be used in those cases and these
+		// terminals need to be launched before remote connections are established.
+		if (!this._availableProfiles) {
+			const isPtyTerminal = options?.config && 'customPtyImplementation' in options.config;
+			const isLocalInRemoteTerminal = this._remoteAgentService.getConnection() && URI.isUri(options?.cwd) && options?.cwd.scheme === Schemas.vscodeFileResource;
+			if (!isPtyTerminal && !isLocalInRemoteTerminal) {
+				await this._refreshAvailableProfilesNow();
+			}
 		}
+
 		const config = options?.config || this._availableProfiles?.find(p => p.profileName === this._defaultProfileName);
 		const shellLaunchConfig = config && 'extensionIdentifier' in config ? {} : this._convertProfileToShellLaunchConfig(config || {});
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -1148,7 +1148,8 @@ export class TerminalService implements ITerminalService {
 
 
 	async createTerminal(options?: ICreateTerminalOptions): Promise<ITerminalInstance> {
-		if (!this._availableProfiles) {
+		const isPtyTerminal = options?.config && 'customPtyImplementation' in options.config;
+		if (!isPtyTerminal && !this._availableProfiles) {
 			await this._refreshAvailableProfilesNow();
 		}
 		const config = options?.config || this._availableProfiles?.find(p => p.profileName === this._defaultProfileName);


### PR DESCRIPTION
This change ensures `Pseudoterminal`-based and local terminals (vscode-file URI as `cwd`) do not await available profiles as they will not be used:

![image](https://user-images.githubusercontent.com/2193314/132882196-29cfc231-99ee-4985-a932-721c4f9b1f2e.png)

This also ensures we await the `createTerminal` call before returning to the exthost to ensure the terminal id is ready before proceeding.

Fixes #132519
Fixes microsoft/vscode-remote-release#5556