### PR TITLE
Add detached extension host telemetry

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.net.ts
+++ b/src/vs/base/parts/ipc/common/ipc.net.ts
@@ -613,7 +613,7 @@ class LoadEstimator {
 	/**
 	 * returns an estimative number, from 0 (low load) to 1 (high load)
 	 */
-	private load(): number {
+	public load(): number {
 		const now = Date.now();
 		const historyLimit = (1 + LoadEstimator._HISTORY_LENGTH) * 1000;
 		let score = 0;
@@ -632,6 +632,7 @@ class LoadEstimator {
 
 export interface ILoadEstimator {
 	hasHighLoad(): boolean;
+	load(): number;
 }
 
 /**
@@ -745,6 +746,18 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 		const msg = new ProtocolMessage(ProtocolMessageType.Disconnect, 0, 0, getEmptyBuffer());
 		this._socketWriter.write(msg);
 		this._socketWriter.flush();
+	}
+
+	public get lastReadTime() {
+		return this._socketReader.lastReadTime;
+	}
+
+	public get load() {
+		return this._loadEstimator.load();
+	}
+
+	public get hasIncomingKeepAliveTimeout() {
+		return !!this._incomingKeepAliveTimeout;
 	}
 
 	private _sendKeepAliveCheck(): void {

--- a/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
+++ b/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
@@ -248,7 +248,8 @@ suite('PersistentProtocol reconnection', () => {
 	test('ack gets sent after a while', async () => {
 		await runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 100 }, async () => {
 			const loadEstimator: ILoadEstimator = {
-				hasHighLoad: () => false
+				hasHighLoad: () => false,
+				load: () => 1
 			};
 			const ether = new Ether();
 			const aSocket = new NodeSocket(ether.a);
@@ -293,7 +294,8 @@ suite('PersistentProtocol reconnection', () => {
 				await timeout(60 * 60 * 1000);
 
 				const loadEstimator: ILoadEstimator = {
-					hasHighLoad: () => false
+					hasHighLoad: () => false,
+					load: () => 1
 				};
 				const ether = new Ether();
 				const aSocket = new NodeSocket(ether.a);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Add telemetry for extension host state to track when it is ready, disconnected, terminated, etc.

I have my own custom telemetry hook to test with, please provide guidance on how you'd like us to test with built-in telemetry hook.

This PR fixes #132900
