### PR TITLE
labels - relative path separator not used when no formatting available

### DIFF
--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -148,10 +148,7 @@ export class LabelService extends Disposable implements ILabelService {
 		// Without formatting we still need to support the separator
 		// as provided in options (https://github.com/microsoft/vscode/issues/130019)
 		if (!formatting && options.separator) {
-			switch (options.separator) {
-				case paths.win32.sep: return paths.win32.normalize(label);
-				case paths.posix.sep: return paths.posix.normalize(label);
-			}
+			return label.replace(sepRegexp, options.separator);
 		}
 
 		return label;

--- a/src/vs/workbench/services/label/test/browser/label.test.ts
+++ b/src/vs/workbench/services/label/test/browser/label.test.ts
@@ -303,4 +303,12 @@ suite('workspace at FSP root', () => {
 			assert.strictEqual(generated, label);
 		});
 	});
+
+	test('relative label with explicit path separator', () => {
+		let generated = labelService.getUriLabel(URI.parse('myscheme://myauthority/some/folder/test.txt'), { relative: true, separator: '/' });
+		assert.strictEqual(generated, 'some/folder/test.txt');
+
+		generated = labelService.getUriLabel(URI.parse('myscheme://myauthority/some/folder/test.txt'), { relative: true, separator: '\\' });
+		assert.strictEqual(generated, 'some\\folder\\test.txt');
+	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #130019
