### PR TITLE
Encode actual and expected value as JSON 

### DIFF
--- a/test/unit/electron/index.js
+++ b/test/unit/electron/index.js
@@ -79,11 +79,15 @@ function deserializeRunnable(runnable) {
 function deserializeError(err) {
 	const inspect = err.inspect;
 	err.inspect = () => inspect;
+	// Unfortunately, mocha rewrites and formats err.actual/err.expected.
+	// This formatting is hard to reverse, so err.*JSON includes the unformatted value.
 	if (err.actual) {
 		err.actual = JSON.parse(err.actual).value;
+		err.actualJSON = err.actual;
 	}
 	if (err.expected) {
 		err.expected = JSON.parse(err.expected).value;
+		err.expectedJSON = err.expected;
 	}
 	return err;
 }

--- a/test/unit/fullJsonStreamReporter.js
+++ b/test/unit/fullJsonStreamReporter.js
@@ -35,6 +35,8 @@ module.exports = class FullJsonStreamReporter extends BaseRunner {
 			test = clean(test);
 			test.actual = err.actual;
 			test.expected = err.expected;
+			test.actualJSON = err.actualJSON;
+			test.expectedJSON = err.expectedJSON;
 			test.err = err.message;
 			test.stack = err.stack || null;
 			writeEvent(['fail', test]);


### PR DESCRIPTION
...to enable https://github.com/microsoft/vscode-selfhost-test-provider/pull/2.

Only a proof of concept yet.
