### PR TITLE
Add notebook output border color token

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2804,7 +2804,7 @@ registerThemingParticipant((theme, collector) => {
 
 	const containerBorder = theme.getColor(notebookOutputContainerBorderColor);
 	if (containerBorder) {
-		collector.addRule(`.notebookOverlay .output-element { border: 1px solid transparent; border-color: ${containerBorder} !important; }`);
+		collector.addRule(`.notebookOverlay .output-element { border-top: none !important; border: 1px solid transparent; border-color: ${containerBorder} !important; }`);
 	}
 
 	const notebookBackground = theme.getColor(editorBackground);

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2646,11 +2646,17 @@ export const cellStatusIconRunning = registerColor('notebookStatusRunningIcon.fo
 	hc: foreground
 }, nls.localize('notebookStatusRunningIcon.foreground', "The running icon color of notebook cells in the cell status bar."));
 
+export const notebookOutputContainerBorderColor = registerColor('notebook.outputContainerBorderColor', {
+	dark: null,
+	light: null,
+	hc: null
+}, nls.localize('notebook.outputContainerBorderColor', "The border color of the notebook output container."));
+
 export const notebookOutputContainerColor = registerColor('notebook.outputContainerBackgroundColor', {
 	dark: null,
 	light: null,
 	hc: null
-}, nls.localize('notebook.outputContainerBackgroundColor', "The Color of the notebook output container background."));
+}, nls.localize('notebook.outputContainerBackgroundColor', "The color of the notebook output container background."));
 
 // TODO@rebornix currently also used for toolbar border, if we keep all of this, pick a generic name
 export const CELL_TOOLBAR_SEPERATOR = registerColor('notebook.cellToolbarSeparator', {
@@ -2794,6 +2800,11 @@ registerThemingParticipant((theme, collector) => {
 		collector.addRule(`.notebookOverlay .output { background-color: ${containerBackground}; }`);
 		collector.addRule(`.notebookOverlay .output-element { background-color: ${containerBackground}; }`);
 		collector.addRule(`.notebookOverlay .output-show-more-container { background-color: ${containerBackground}; }`);
+	}
+
+	const containerBorder = theme.getColor(notebookOutputContainerBorderColor);
+	if (containerBorder) {
+		collector.addRule(`.notebookOverlay .output-element { border: 1px solid transparent; border-color: ${containerBorder} !important; }`);
 	}
 
 	const notebookBackground = theme.getColor(editorBackground);

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -235,6 +235,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Disposable {
 						padding-bottom: var(--notebook-output-node-padding);
 						padding-left: var(--notebook-output-node-left-padding);
 						box-sizing: border-box;
+						border: 1px solid var(--theme-notebook-output-border);
 						background-color: var(--theme-notebook-output-background);
 					}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -235,6 +235,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Disposable {
 						padding-bottom: var(--notebook-output-node-padding);
 						padding-left: var(--notebook-output-node-left-padding);
 						box-sizing: border-box;
+						border-top: none !important;
 						border: 1px solid var(--theme-notebook-output-border);
 						background-color: var(--theme-notebook-output-background);
 					}

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewThemeMapping.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewThemeMapping.ts
@@ -56,6 +56,7 @@ const mapping: ReadonlyMap<string, string> = new Map([
 	['theme-info-foreground', 'vscode-foreground'],
 	// Notebook:
 	['theme-notebook-output-background', 'vscode-notebook-outputContainerBackgroundColor'],
+	['theme-notebook-output-border', 'vscode-notebook-outputContainerBorderColor'],
 	['theme-notebook-cell-selected-background', 'vscode-notebook-selectedCellBackground'],
 	['theme-notebook-symbol-highlight-background', 'vscode-notebook-symbolHighlightBackground'],
 	['theme-notebook-diff-removed-background', 'vscode-diffEditor-removedTextBackground'],


### PR DESCRIPTION
This PR fixes #125462 and adds the color token `notebook.outputContainerBorderColor` for theming the output container:

<img width="722" alt="CleanShot 2021-09-13 at 11 42 58@2x" src="https://user-images.githubusercontent.com/35271042/133139115-6e3a6b98-16bd-479d-a131-d838635b6f53.png">

One thing that needs to be decided is if this should apply a border around the entire container, like so:

<img width="712" alt="CleanShot 2021-09-13 at 11 44 23@2x" src="https://user-images.githubusercontent.com/35271042/133139296-8b4f8cd0-b66a-477d-b58a-8b086c2e4623.png">

Or only around the left/right/bottom so as to not create a "stacking" of borders and make it look more visually appealing if you're trying to match the cell border colors :

<img width="712" alt="CleanShot 2021-09-13 at 11 45 09@2x" src="https://user-images.githubusercontent.com/35271042/133139391-b42fd8f2-c83d-4f32-b87b-467763dfa963.png">

<img width="709" alt="CleanShot 2021-09-13 at 11 51 00@2x" src="https://user-images.githubusercontent.com/35271042/133140147-d439ab8d-9ae8-4af3-8768-0c9682845b10.png">

cc @JacksonKearl for feedback since you requested this
