### PR TITLE
Don't run language detection if a default language is set

### DIFF
--- a/src/vs/workbench/common/editor/textEditorModel.ts
+++ b/src/vs/workbench/common/editor/textEditorModel.ts
@@ -34,17 +34,12 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 		@IModelService protected modelService: IModelService,
 		@IModeService protected modeService: IModeService,
 		@ILanguageDetectionService private readonly languageDetectionService: ILanguageDetectionService,
-		textEditorModelHandle?: URI,
-		preferredMode?: string
+		textEditorModelHandle?: URI
 	) {
 		super();
 
 		if (textEditorModelHandle) {
 			this.handleExistingModel(textEditorModelHandle);
-		}
-
-		if (preferredMode) {
-			this.setModeInternal(preferredMode);
 		}
 	}
 

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -141,14 +141,16 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 		super(
 			modelService,
 			modeService,
-			languageDetectionService,
-			undefined,
-			preferredMode = preferredMode === UntitledTextEditorModel.ACTIVE_EDITOR_LANGUAGE_MODE
-				? editorService.activeTextEditorMode
-				: preferredMode);
+			languageDetectionService);
 
 		// Make known to working copy service
 		this._register(this.workingCopyService.registerWorkingCopy(this));
+
+		// This is typically controlled by the setting `files.defaultLanguage`.
+		// If that setting is set, we should not detect the language.
+		if (preferredMode) {
+			this.setMode(preferredMode);
+		}
 
 		// Fetch config
 		this.onConfigurationChange(false);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

affects `files.defaultLanguage` setting & also API:
```
await vscode.languages.setTextDocumentLanguage(
  document,
  'mongodb'
);
```

This PR fixes #132431

This is already fixed in insiders and confirmed working by the customers, I'm just porting it to releases since the issue affects more than initially suspected.