### PR TITLE
commands: allow transferring arraybuffers/uint8arrays over commands

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadCommands.ts
@@ -9,6 +9,7 @@ import { ExtHostContext, MainThreadCommandsShape, ExtHostCommandsShape, MainCont
 import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { revive } from 'vs/base/common/marshalling';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 @extHostNamedCustomer(MainContext.MainThreadCommands)
 export class MainThreadCommands implements MainThreadCommandsShape {
@@ -72,7 +73,10 @@ export class MainThreadCommands implements MainThreadCommandsShape {
 		}
 	}
 
-	async $executeCommand<T>(id: string, args: any[], retry: boolean): Promise<T | undefined> {
+	async $executeCommand<T>(id: string, args: any[] | SerializableObjectWithBuffers<any[]>, retry: boolean): Promise<T | undefined> {
+		if (args instanceof SerializableObjectWithBuffers) {
+			args = args.value;
+		}
 		for (let i = 0; i < args.length; i++) {
 			args[i] = revive(args[i]);
 		}

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -140,7 +140,7 @@ export interface MainThreadClipboardShape extends IDisposable {
 export interface MainThreadCommandsShape extends IDisposable {
 	$registerCommand(id: string): void;
 	$unregisterCommand(id: string): void;
-	$executeCommand<T>(id: string, args: any[], retry: boolean): Promise<T | undefined>;
+	$executeCommand<T>(id: string, args: any[] | SerializableObjectWithBuffers<any[]>, retry: boolean): Promise<T | undefined>;
 	$getCommands(): Promise<string[]>;
 }
 

--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -22,6 +22,8 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
 import { ISelection } from 'vs/editor/common/core/selection';
 import { TestItemImpl } from 'vs/workbench/api/common/extHostTestingPrivateApi';
+import { VSBuffer } from 'vs/base/common/buffer';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 interface CommandHandler {
 	callback: Function;
@@ -83,6 +85,9 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 						}
 						if (Range.isIRange((obj as modes.Location).range) && URI.isUri((obj as modes.Location).uri)) {
 							return extHostTypeConverter.location.to(obj);
+						}
+						if (obj instanceof VSBuffer) {
+							return obj.buffer.buffer;
 						}
 						if (!Array.isArray(obj)) {
 							return obj;
@@ -164,6 +169,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 
 		} else {
 			// automagically convert some argument types
+			let hasBuffers = false;
 			const toArgs = cloneAndChange(args, function (value) {
 				if (value instanceof extHostTypes.Position) {
 					return extHostTypeConverter.Position.from(value);
@@ -173,6 +179,12 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 					return extHostTypeConverter.location.from(value);
 				} else if (extHostTypes.NotebookRange.isNotebookRange(value)) {
 					return extHostTypeConverter.NotebookRange.from(value);
+				} else if (value instanceof ArrayBuffer) {
+					hasBuffers = true;
+					return VSBuffer.wrap(new Uint8Array(value));
+				} else if (value instanceof Uint8Array) {
+					hasBuffers = true;
+					return VSBuffer.wrap(value);
 				}
 				if (!Array.isArray(value)) {
 					return value;
@@ -180,7 +192,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 			});
 
 			try {
-				const result = await this._proxy.$executeCommand<T>(id, toArgs, retry);
+				const result = await this._proxy.$executeCommand<T>(id, hasBuffers ? new SerializableObjectWithBuffers(toArgs) : toArgs, retry);
 				return revive<any>(result);
 			} catch (e) {
 				// Rerun the command when it wasn't known, had arguments, and when retry


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/133032#issuecomment-919385497

I don't really want to deal with keeping the specific type of the binary data sent in the command, so executed commands will always receive an ArrayBuffer -- which can efficiently be turned into the TypeArray of choice.

We need to conditionally wrap the argument in `SerializableObjectWithBuffers` since the check within RPC for buffers is not recursive. As an aside, this is a leaky abstraction: it forces both the sender and the consumer to know how their data is going to be serialized, which is a lower level than the method-based RPC exposed. One way to deal with this could be to make RPC interfaces have some runtime presence, where the necessary serialization could be declared where the RPC 'binding' is created.