### PR TITLE
Do not auto-close after a substitution

### DIFF
--- a/src/vs/editor/common/controller/cursorTypeOperations.ts
+++ b/src/vs/editor/common/controller/cursorTypeOperations.ts
@@ -601,7 +601,7 @@ export class TypeOperations {
 			if (autoClosingPair.open.length === 1 && chIsQuote && autoCloseConfig !== 'always') {
 				const wordSeparators = getMapForWordSeparators(config.wordSeparators);
 				const prevChar = lineText.charCodeAt(position.column - (insertOpenCharacter ? 2 : 3));
-				const maybeSubstitution = prevChar === CharCode.CloseSquareBracket || prevChar === CharCode.CloseParen;
+				const maybeSubstitution = prevChar === CharCode.CloseCurlyBrace || prevChar === CharCode.CloseParen;
 				if (insertOpenCharacter && position.column > 1 && (wordSeparators.get(prevChar) === WordCharacterClass.Regular || maybeSubstitution)) {
 					return null;
 				}

--- a/src/vs/editor/common/controller/cursorTypeOperations.ts
+++ b/src/vs/editor/common/controller/cursorTypeOperations.ts
@@ -597,13 +597,15 @@ export class TypeOperations {
 				return null;
 			}
 
-			// Do not auto-close ' or " after a word character
+			// Do not auto-close quotes after a word character or substitution
 			if (autoClosingPair.open.length === 1 && chIsQuote && autoCloseConfig !== 'always') {
 				const wordSeparators = getMapForWordSeparators(config.wordSeparators);
-				if (insertOpenCharacter && position.column > 1 && wordSeparators.get(lineText.charCodeAt(position.column - 2)) === WordCharacterClass.Regular) {
+				const prevChar = lineText.charCodeAt(position.column - (insertOpenCharacter ? 2 : 3));
+				const maybeSubstitution = prevChar === CharCode.CloseSquareBracket || prevChar === CharCode.CloseParen;
+				if (insertOpenCharacter && position.column > 1 && (wordSeparators.get(prevChar) === WordCharacterClass.Regular || maybeSubstitution)) {
 					return null;
 				}
-				if (!insertOpenCharacter && position.column > 2 && wordSeparators.get(lineText.charCodeAt(position.column - 3)) === WordCharacterClass.Regular) {
+				if (!insertOpenCharacter && position.column > 2 && (wordSeparators.get(prevChar) === WordCharacterClass.Regular || maybeSubstitution)) {
 					return null;
 				}
 			}

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -5201,7 +5201,10 @@ suite('autoClosingPairs', () => {
 				'var c = \'asd\';',
 				'var d = "asd";',
 				'var e = /*3*/	3;',
-				'var f = /** 3 */3;'
+				'var f = /** 3 */3;',
+				'var g = ',
+				'var h = `test',
+				'var i = `test ${}'
 			],
 			languageIdentifier: mode.getLanguageIdentifier()
 		}, (editor, model, viewModel) => {
@@ -5212,7 +5215,10 @@ suite('autoClosingPairs', () => {
 				'var c |=| \'asd\'|;|',
 				'var d |=| "asd"|;|',
 				'var e |=| /*3*/|	3;|',
-				'var f |=| /**| 3 */3;|'
+				'var f |=| /**| 3 */3;|',
+				'var g |=| |',
+				'var h |=| `test`',
+				'var i |=| `test ${|}`'
 			];
 			for (let i = 0, len = autoClosePositions.length; i < len; i++) {
 				const lineNumber = i + 1;

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -5201,9 +5201,7 @@ suite('autoClosingPairs', () => {
 				'var c = \'asd\';',
 				'var d = "asd";',
 				'var e = /*3*/	3;',
-				'var f = /** 3 */3;',
-				'var g = (3+5);',
-				'var h = { a: \'value\' };',
+				'var f = /** 3 */3;'
 			],
 			languageIdentifier: mode.getLanguageIdentifier()
 		}, (editor, model, viewModel) => {
@@ -5214,9 +5212,7 @@ suite('autoClosingPairs', () => {
 				'var c |=| \'asd\'|;|',
 				'var d |=| "asd"|;|',
 				'var e |=| /*3*/|	3;|',
-				'var f |=| /**| 3 */3;|',
-				'var g |=| (3+5)|;|',
-				'var h |=| {| a:| \'value\'| |}|;|',
+				'var f |=| /**| 3 */3;|'
 			];
 			for (let i = 0, len = autoClosePositions.length; i < len; i++) {
 				const lineNumber = i + 1;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #132912.

Even though language files have autoClosingPairs values such as:

```
{ "open": "`", "close": "`", "notIn": ["string", "comment"] }
```

vscode detects whether it is in a string by looking at the previous token. The token types are:

```
export const enum StandardTokenType {
	Other = 0,
	Comment = 1,
	String = 2,
	RegEx = 4
}
```

When a substitution is at the end of a template literal, such as:

```
const n = 1;
const test = `test ${n}`;
```

The token type is "Other", not "String", because the substitution is not considered to be a string in many language implementations.

This pull request does not perfectly detect when it is in a string, but it appears to cover 99% of cases by simply checking if the previous character is "}" or ")", which covers almost every single languages interpolation syntax.