### PR TITLE
Add resolveCodeAction to monaco registerCodeActionProvider

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -467,7 +467,8 @@ export function registerCodeActionProvider(languageId: string, provider: CodeAct
 				return Range.areIntersectingOrTouching(m, range);
 			});
 			return provider.provideCodeActions(model, range, { markers, only: context.only }, token);
-		}
+		},
+		resolveCodeAction: provider.resolveCodeAction
 	});
 }
 
@@ -588,6 +589,11 @@ export interface CodeActionProvider {
 	 * Provide commands for the given document and range.
 	 */
 	provideCodeActions(model: model.ITextModel, range: Range, context: CodeActionContext, token: CancellationToken): modes.ProviderResult<modes.CodeActionList>;
+
+	/**
+	 * Given a code action fill in the edit. Will only invoked when missing.
+	 */
+	resolveCodeAction?(codeAction: modes.CodeAction, token: CancellationToken): modes.ProviderResult<modes.CodeAction>;
 }
 
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5460,6 +5460,10 @@ declare namespace monaco.languages {
 		 * Provide commands for the given document and range.
 		 */
 		provideCodeActions(model: editor.ITextModel, range: Range, context: CodeActionContext, token: CancellationToken): ProviderResult<CodeActionList>;
+		/**
+		 * Given a code action fill in the edit. Will only invoked when missing.
+		 */
+		resolveCodeAction?(codeAction: CodeAction, token: CancellationToken): ProviderResult<CodeAction>;
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/monaco-editor/issues/2663

The code action resolving wasn't implemented in the monaco editor api.
