### PR TITLE
Adding support for negated test tag filtering to the testingExplorerView

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -869,11 +869,13 @@ class TestsFilter implements ITreeFilter<TestExplorerTreeElement> {
 	}
 
 	private testTags(element: TestItemTreeElement): FilterResult {
-		if (!this.state.onlyTags.size) {
+		if (!this.state.includeTags.size && !this.state.excludeTags.size) {
 			return FilterResult.Include;
 		}
 
-		return element.test.item.tags.some(t => this.state.onlyTags.has(t))
+		return (this.state.includeTags.size ?
+			element.test.item.tags.some(t => this.state.includeTags.has(t)) :
+			true) && element.test.item.tags.every(t => !this.state.excludeTags.has(t))
 			? FilterResult.Include
 			: FilterResult.Inherit;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Add support for negated tags when computing filters for test items.

This PR fixes #133350
