### PR TITLE
Make go to next/prev folding range more intuitive

### DIFF
--- a/src/vs/editor/contrib/folding/folding.ts
+++ b/src/vs/editor/contrib/folding/folding.ts
@@ -1002,8 +1002,8 @@ class GotoPreviousFoldAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.gotoPreviousFold',
-			label: nls.localize('gotoPreviousFold.label', "Go to Previous Fold"),
-			alias: 'Go to Previous Fold',
+			label: nls.localize('gotoPreviousFold.label', "Go to Previous Folding Range"),
+			alias: 'Go to Previous Folding Range',
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1033,8 +1033,8 @@ class GotoNextFoldAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.gotoNextFold',
-			label: nls.localize('gotoNextFold.label', "Go to Next Fold"),
-			alias: 'Go to Next Fold',
+			label: nls.localize('gotoNextFold.label', "Go to Next Folding Range"),
+			alias: 'Go to Next Folding Range',
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/folding/foldingModel.ts
+++ b/src/vs/editor/contrib/folding/foldingModel.ts
@@ -454,7 +454,8 @@ export function getParentFoldLine(lineNumber: number, foldingModel: FoldingModel
  */
 export function getPreviousFoldLine(lineNumber: number, foldingModel: FoldingModel): number | null {
 	let foldingRegion = foldingModel.getRegionAtLine(lineNumber);
-	if (foldingRegion !== null) {
+	// If on the folding range start line, go to previous sibling.
+	if (foldingRegion !== null && foldingRegion.startLineNumber === lineNumber) {
 		// If current line is not the start of the current fold, go to top line of current fold. If not, go to previous fold.
 		if (lineNumber !== foldingRegion.startLineNumber) {
 			return foldingRegion.startLineNumber;
@@ -487,8 +488,8 @@ export function getPreviousFoldLine(lineNumber: number, foldingModel: FoldingMod
 		if (foldingModel.regions.length > 0) {
 			foldingRegion = foldingModel.regions.toRegion(foldingModel.regions.length - 1);
 			while (foldingRegion !== null) {
-				// Found non-parent fold before current line.
-				if (foldingRegion.parentIndex === -1 && foldingRegion.startLineNumber < lineNumber) {
+				// Found fold before current line.
+				if (foldingRegion.startLineNumber < lineNumber) {
 					return foldingRegion.startLineNumber;
 				}
 				if (foldingRegion.regionIndex > 0) {
@@ -511,7 +512,8 @@ export function getPreviousFoldLine(lineNumber: number, foldingModel: FoldingMod
  */
 export function getNextFoldLine(lineNumber: number, foldingModel: FoldingModel): number | null {
 	let foldingRegion = foldingModel.getRegionAtLine(lineNumber);
-	if (foldingRegion !== null) {
+	// If on the folding range start line, go to next sibling.
+	if (foldingRegion !== null && foldingRegion.startLineNumber === lineNumber) {
 		// Find max line number to stay within parent.
 		let expectedParentIndex = foldingRegion.parentIndex;
 		let maxLineNumber = 0;
@@ -543,8 +545,8 @@ export function getNextFoldLine(lineNumber: number, foldingModel: FoldingModel):
 		if (foldingModel.regions.length > 0) {
 			foldingRegion = foldingModel.regions.toRegion(0);
 			while (foldingRegion !== null) {
-				// Found non-parent fold after current line.
-				if (foldingRegion.parentIndex === -1 && foldingRegion.startLineNumber > lineNumber) {
+				// Found fold after current line.
+				if (foldingRegion.startLineNumber > lineNumber) {
 					return foldingRegion.startLineNumber;
 				}
 				if (foldingRegion.regionIndex < foldingModel.regions.length) {

--- a/src/vs/editor/contrib/folding/test/foldingModel.test.ts
+++ b/src/vs/editor/contrib/folding/test/foldingModel.test.ts
@@ -875,12 +875,19 @@ suite('Folding Model', () => {
 			assert.strictEqual(getPreviousFoldLine(9, foldingModel), 5);
 			assert.strictEqual(getPreviousFoldLine(5, foldingModel), 3);
 			assert.strictEqual(getPreviousFoldLine(3, foldingModel), null);
+			// Test when not on a folding region start line.
+			assert.strictEqual(getPreviousFoldLine(4, foldingModel), 3);
+			assert.strictEqual(getPreviousFoldLine(7, foldingModel), 6);
+			assert.strictEqual(getPreviousFoldLine(8, foldingModel), 6);
 
 			// Test jump to next.
 			assert.strictEqual(getNextFoldLine(3, foldingModel), 5);
-			assert.strictEqual(getNextFoldLine(4, foldingModel), 5);
 			assert.strictEqual(getNextFoldLine(5, foldingModel), 9);
 			assert.strictEqual(getNextFoldLine(9, foldingModel), null);
+			// Test when not on a folding region start line.
+			assert.strictEqual(getNextFoldLine(4, foldingModel), 5);
+			assert.strictEqual(getNextFoldLine(7, foldingModel), 9);
+			assert.strictEqual(getNextFoldLine(8, foldingModel), 9);
 
 		} finally {
 			textModel.dispose();


### PR DESCRIPTION
- Only use next/previous sibling if on the starting line of a folding region. Otherwise, just go to the nearest fold.
- Update command title in say folding region.

This PR fixes #133108

To test:
```bash
./scripts/test.sh --glob **/foldingModel.test.js
```