### PR TITLE
Philip gai/133364 file explorer copy name

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
@@ -10,7 +10,7 @@ import { revertLocalChangesCommand, acceptLocalChangesCommand, CONFLICT_RESOLUTI
 import { SyncActionDescriptor, MenuId, MenuRegistry, ILocalizedString } from 'vs/platform/actions/common/actions';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
 import { KeyMod, KeyChord, KeyCode } from 'vs/base/common/keyCodes';
-import { openWindowCommand, COPY_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_TO_SIDE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL, SAVE_FILE_AS_COMMAND_ID, SAVE_FILE_AS_LABEL, SAVE_ALL_IN_GROUP_COMMAND_ID, OpenEditorsGroupContext, COMPARE_WITH_SAVED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, OpenEditorsDirtyEditorContext, COMPARE_SELECTED_COMMAND_ID, REMOVE_ROOT_FOLDER_COMMAND_ID, REMOVE_ROOT_FOLDER_LABEL, SAVE_FILES_COMMAND_ID, COPY_RELATIVE_PATH_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_LABEL, newWindowCommand, OpenEditorsReadonlyEditorContext, OPEN_WITH_EXPLORER_COMMAND_ID, NEW_UNTITLED_FILE_COMMAND_ID, NEW_UNTITLED_FILE_LABEL, SAVE_ALL_COMMAND_ID } from 'vs/workbench/contrib/files/browser/fileCommands';
+import { openWindowCommand, COPY_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_TO_SIDE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL, SAVE_FILE_AS_COMMAND_ID, SAVE_FILE_AS_LABEL, SAVE_ALL_IN_GROUP_COMMAND_ID, OpenEditorsGroupContext, COMPARE_WITH_SAVED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, OpenEditorsDirtyEditorContext, COMPARE_SELECTED_COMMAND_ID, REMOVE_ROOT_FOLDER_COMMAND_ID, REMOVE_ROOT_FOLDER_LABEL, SAVE_FILES_COMMAND_ID, COPY_RELATIVE_PATH_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_LABEL, newWindowCommand, OpenEditorsReadonlyEditorContext, OPEN_WITH_EXPLORER_COMMAND_ID, NEW_UNTITLED_FILE_COMMAND_ID, NEW_UNTITLED_FILE_LABEL, SAVE_ALL_COMMAND_ID, COPY_NAME_COMMAND_ID } from 'vs/workbench/contrib/files/browser/fileCommands';
 import { CommandsRegistry, ICommandHandler } from 'vs/platform/commands/common/commands';
 import { ContextKeyExpr, ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
@@ -142,6 +142,11 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	handler: openFilePreserveFocusHandler
 });
 
+const copyNameCommand = {
+	id: COPY_NAME_COMMAND_ID,
+	title: nls.localize('copyName', "Copy Name")
+};
+
 const copyPathCommand = {
 	id: COPY_PATH_COMMAND_ID,
 	title: nls.localize('copyPath', "Copy Path")
@@ -153,6 +158,7 @@ const copyRelativePathCommand = {
 };
 
 // Editor Title Context Menu
+appendEditorTitleContextMenuItem(COPY_NAME_COMMAND_ID, copyNameCommand.title, ResourceContextKey.IsFileSystemResource, '1_cutcopypaste');
 appendEditorTitleContextMenuItem(COPY_PATH_COMMAND_ID, copyPathCommand.title, ResourceContextKey.IsFileSystemResource, '1_cutcopypaste');
 appendEditorTitleContextMenuItem(COPY_RELATIVE_PATH_COMMAND_ID, copyRelativePathCommand.title, ResourceContextKey.IsFileSystemResource, '1_cutcopypaste');
 appendEditorTitleContextMenuItem(REVEAL_IN_EXPLORER_COMMAND_ID, nls.localize('revealInSideBar', "Reveal in Side Bar"), ResourceContextKey.IsFileSystemResource);
@@ -198,6 +204,7 @@ export function appendToCommandPalette(id: string, title: ILocalizedString, cate
 	});
 }
 
+appendToCommandPalette(COPY_NAME_COMMAND_ID, { value: nls.localize('copyNameOfActive', "Copy Name of Active File"), original: 'Copy Name of Active File' }, category);
 appendToCommandPalette(COPY_PATH_COMMAND_ID, { value: nls.localize('copyPathOfActive', "Copy Path of Active File"), original: 'Copy Path of Active File' }, category);
 appendToCommandPalette(COPY_RELATIVE_PATH_COMMAND_ID, { value: nls.localize('copyRelativePathOfActive', "Copy Relative Path of Active File"), original: 'Copy Relative Path of Active File' }, category);
 appendToCommandPalette(SAVE_FILE_COMMAND_ID, { value: SAVE_FILE_LABEL, original: 'Save' }, category);
@@ -230,13 +237,20 @@ MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
 MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
 	group: '1_cutcopypaste',
 	order: 10,
-	command: copyPathCommand,
+	command: copyNameCommand,
 	when: ResourceContextKey.IsFileSystemResource
 });
 
 MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
 	group: '1_cutcopypaste',
 	order: 20,
+	command: copyPathCommand,
+	when: ResourceContextKey.IsFileSystemResource
+});
+
+MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
+	group: '1_cutcopypaste',
+	order: 30,
 	command: copyRelativePathCommand,
 	when: ResourceContextKey.IsFileSystemResource
 });
@@ -508,13 +522,20 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerContext, ({
 MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 	group: '6_copypath',
 	order: 10,
-	command: copyPathCommand,
+	command: copyNameCommand,
 	when: ResourceContextKey.IsFileSystemResource
 });
 
 MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 	group: '6_copypath',
 	order: 20,
+	command: copyPathCommand,
+	when: ResourceContextKey.IsFileSystemResource
+});
+
+MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
+	group: '6_copypath',
+	order: 30,
 	command: copyRelativePathCommand,
 	when: ResourceContextKey.IsFileSystemResource
 });

--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -59,6 +59,7 @@ export const SELECT_FOR_COMPARE_COMMAND_ID = 'selectForCompare';
 export const COMPARE_SELECTED_COMMAND_ID = 'compareSelected';
 export const COMPARE_RESOURCE_COMMAND_ID = 'compareFiles';
 export const COMPARE_WITH_SAVED_COMMAND_ID = 'workbench.files.action.compareWithSaved';
+export const COPY_NAME_COMMAND_ID = 'copyFileName';
 export const COPY_PATH_COMMAND_ID = 'copyFilePath';
 export const COPY_RELATIVE_PATH_COMMAND_ID = 'copyRelativeFilePath';
 
@@ -288,6 +289,25 @@ async function resourcesToClipboard(resources: URI[], relative: boolean, clipboa
 		await clipboardService.writeText(text);
 	}
 }
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: EditorContextKeys.focus.toNegated(),
+	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_N,
+	win: {
+		primary: KeyMod.Shift | KeyMod.Alt | KeyCode.KEY_N
+	},
+	id: COPY_NAME_COMMAND_ID,
+	handler: async (accessor, resource: URI | object) => {
+		const resources = getMultiSelectedResources(resource, accessor.get(IListService), accessor.get(IEditorService), accessor.get(IExplorerService));
+
+		const lineDelimiter = isWindows ? '\r\n' : '\n';
+		const labelService = accessor.get(ILabelService);
+		const clipboardService = accessor.get(IClipboardService);
+		const fileNames = resources.map(resource => labelService.getUriBasenameLabel(resource)).join(lineDelimiter);
+		clipboardService.writeText(fileNames);
+	}
+});
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	weight: KeybindingWeight.WorkbenchContrib,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #133364
- [x] code is up-to-date with the `main` branch 

This allows developers to right-click and select "Copy Name" (or use keybinding `CtrlCmd+Alt+N`) on files/folders in the Explore to get the file/base name (extension included).

This will save time in _many_ developers' workflows, as most people are currently hitting `Enter` on a single file at a time to highlight the root name, then moving the highlight over the extension, and they have to do this one file at a time and risk accidentally changing the file name.

I also did a little nit renaming of the method used for getting the full and relative paths.

## Testing
1. Open up VS Code and open any folder
2. In the Explorer:
    1. Right-click, select "Copy Name" and paste the result.
    2. Select multiple files/folders from the Explorer, right-click, "Copy Name" and paste the result.
    3. Try the keybinding! Select files/folders in the explorer and do `CtrlCmd+Alt+N` (N for name). Paste the result.

## Demo

https://user-images.githubusercontent.com/17363579/133879078-6a94988a-0ce1-40e3-8d63-62551496bb5b.mov

 
