### PR TITLE
Remove angle brackets when checking the scheme

### DIFF
--- a/extensions/markdown-language-features/src/features/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/features/documentLinkProvider.ts
@@ -15,7 +15,9 @@ function parseLink(
 	document: vscode.TextDocument,
 	link: string,
 ): { uri: vscode.Uri, tooltip?: string } | undefined {
-	const externalSchemeUri = getUriForLinkWithKnownExternalScheme(link);
+
+	const cleanLink = stripAngleBrackets(link);
+	const externalSchemeUri = getUriForLinkWithKnownExternalScheme(cleanLink);
 	if (externalSchemeUri) {
 		// Normalize VS Code links to target currently running version
 		if (isOfScheme(Schemes.vscode, link) || isOfScheme(Schemes['vscode-insiders'], link)) {
@@ -87,6 +89,15 @@ function extractDocumentLink(
 	} catch (e) {
 		return undefined;
 	}
+}
+
+/* Used to strip brackets from the markdown link
+	<http://example.com> will be transformed to
+	http://example.com
+*/
+export function stripAngleBrackets(link: string) {
+	const bracketMatcher = /^<(.*)>$/;
+	return link.replace(bracketMatcher, '$1');
 }
 
 export default class LinkProvider implements vscode.DocumentLinkProvider {

--- a/extensions/markdown-language-features/src/util/links.ts
+++ b/extensions/markdown-language-features/src/util/links.ts
@@ -22,11 +22,27 @@ const knownSchemes = [
 ];
 
 export function getUriForLinkWithKnownExternalScheme(link: string): vscode.Uri | undefined {
-	if (knownSchemes.some(knownScheme => isOfScheme(knownScheme, link))) {
+	const cleanLink = stripAngleBrackets(link);
+	if (knownSchemes.some(knownScheme => isOfScheme(knownScheme, cleanLink))) {
 		return vscode.Uri.parse(link);
 	}
 
 	return undefined;
+}
+
+/* Used to strip brackets from the markdown link
+	<http://example.com> will be transformed to
+	http://example.com
+*/
+export function stripAngleBrackets(link: string) {
+	const bracketMatcher = /^<(.*)>$/;
+	const matches = link.match(bracketMatcher);
+
+	if (Array.isArray(matches) && matches.length > 1) {
+		return matches[1];
+	}
+
+	return link;
 }
 
 export function isOfScheme(scheme: string, link: string): boolean {

--- a/extensions/markdown-language-features/src/util/links.ts
+++ b/extensions/markdown-language-features/src/util/links.ts
@@ -22,27 +22,11 @@ const knownSchemes = [
 ];
 
 export function getUriForLinkWithKnownExternalScheme(link: string): vscode.Uri | undefined {
-	const cleanLink = stripAngleBrackets(link);
-	if (knownSchemes.some(knownScheme => isOfScheme(knownScheme, cleanLink))) {
+	if (knownSchemes.some(knownScheme => isOfScheme(knownScheme, link))) {
 		return vscode.Uri.parse(link);
 	}
 
 	return undefined;
-}
-
-/* Used to strip brackets from the markdown link
-	<http://example.com> will be transformed to
-	http://example.com
-*/
-export function stripAngleBrackets(link: string) {
-	const bracketMatcher = /^<(.*)>$/;
-	const matches = link.match(bracketMatcher);
-
-	if (Array.isArray(matches) && matches.length > 1) {
-		return matches[1];
-	}
-
-	return link;
 }
 
 export function isOfScheme(scheme: string, link: string): boolean {


### PR DESCRIPTION
# Summary
When the link is being checked for a known scheme in a markdown file, the scheme wasn't being recognized when encased inside of angle brackets < and >.  This change strips the link of beginning and ending < and > so the scheme can be properly checked.

This only removes the brackets during the scheme check if the initial link provided actually has angle brackets.  Otherwise it will just use the given link as usual.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
## Issue
This PR fixes #132974

## Testing (Currently Released Build)
Begin editing a markdown file, and enter the following text into the file.  If you attempt to `command + click` or `control + click` the link in the markdown file you are editing, it won't open in a browser.  (note it will open from the markdown preview, just not the editable markdown file)
```
[Bad - Opens file](<http://google.com>)
```

## Testing (Fixes)
With the code changes applied, you can enter the same text in a markdown file, and the link will open up as expected in the browser.  (and it will still open from the markdown preview).