### PR TITLE
Avoid handling an extension installation event too early

### DIFF
--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -490,7 +490,14 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 	protected async _initialize(): Promise<void> {
 		perf.mark('code/willLoadExtensions');
 		this._startExtensionHosts(true, []);
-		await this._scanAndHandleExtensions();
+
+		const lock = await this._registryLock.acquire('_initialize');
+		try {
+			await this._scanAndHandleExtensions();
+		} finally {
+			lock.dispose();
+		}
+
 		this._releaseBarrier();
 		perf.mark('code/didLoadExtensions');
 		await this._handleExtensionTests();


### PR DESCRIPTION
This PR fixes #133434

Hold the registry lock during initialization. This will make it that any events that lead to the delta extension logic (installation events, enablement events, etc.) which come in before initialization will only be handled once initialization completes.

To understand the PR, look for other users of `this._registryLock`.