### PR TITLE
Add order field to the settings json schema

### DIFF
--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -152,6 +152,12 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	 * Otherwise, the presentation format defaults to `singleline`.
 	 */
 	editPresentation?: EditPresentationTypes;
+
+	/**
+	 * When specified, gives an order number for the setting
+	 * within the settings editor. Otherwise, the setting is placed at the end.
+	 */
+	order?: number;
 }
 
 export interface IConfigurationExtensionInfo {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -359,6 +359,12 @@ export function resolveConfiguredUntrustedSettings(groups: ISettingsGroup[], tar
 	return [...allSettings].filter(setting => setting.restricted && inspectSetting(setting.key, target, configurationService).isConfigured);
 }
 
+function compareNullableIntegers(a?: number, b?: number) {
+	const firstElem = a ?? Number.MAX_SAFE_INTEGER;
+	const secondElem = b ?? Number.MAX_SAFE_INTEGER;
+	return firstElem - secondElem;
+}
+
 export async function resolveExtensionsSettings(extensionService: IExtensionService, groups: ISettingsGroup[]): Promise<ITOCEntry<ISetting>> {
 	const extGroupTree = new Map<string, ITOCEntry<ISetting>>();
 	const addEntryToTree = (extensionId: string, extensionName: string, childEntry: ITOCEntry<ISetting>) => {
@@ -396,8 +402,14 @@ export async function resolveExtensionsSettings(extensionService: IExtensionServ
 	return Promise.all(processPromises).then(() => {
 		const extGroups: ITOCEntry<ISetting>[] = [];
 		for (const value of extGroupTree.values()) {
+			if (value.settings) {
+				// Sort the individual settings
+				value.settings.sort((a, b) => {
+					return compareNullableIntegers(a.order, b.order);
+				});
+			}
 			if (value.children!.length === 1) {
-				// push a flattened setting
+				// Push a flattened setting
 				extGroups.push({
 					id: value.id,
 					label: value.children![0].label,
@@ -405,12 +417,7 @@ export async function resolveExtensionsSettings(extensionService: IExtensionServ
 				});
 			} else {
 				value.children!.sort((a, b) => {
-					if (a.order !== undefined && b.order !== undefined) {
-						return a.order - b.order;
-					} else {
-						// leave things as-is
-						return 0;
-					}
+					return compareNullableIntegers(a.order, b.order);
 				});
 				extGroups.push(value);
 			}

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -402,9 +402,9 @@ export async function resolveExtensionsSettings(extensionService: IExtensionServ
 	return Promise.all(processPromises).then(() => {
 		const extGroups: ITOCEntry<ISetting>[] = [];
 		for (const value of extGroupTree.values()) {
-			if (value.settings) {
+			for (const child of value.children!) {
 				// Sort the individual settings
-				value.settings.sort((a, b) => {
+				child.settings?.sort((a, b) => {
 					return compareNullableIntegers(a.order, b.order);
 				});
 			}

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -69,6 +69,7 @@ export interface ISetting {
 
 	scope?: ConfigurationScope;
 	type?: string | string[];
+	order?: number;
 	arrayItemType?: string;
 	objectProperties?: IJSONSchemaMap,
 	objectPatternProperties?: IJSONSchemaMap,

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -677,7 +677,8 @@ export class DefaultSettings extends Disposable {
 					validator: createValidator(prop),
 					enumItemLabels: prop.enumItemLabels,
 					allKeysAreBoolean,
-					editPresentation: prop.editPresentation
+					editPresentation: prop.editPresentation,
+					order: prop.order
 				});
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #133483 and does it following:

- It adds an order field to the settings json schema so that each setting can now register its order. This order is relative (meaning instead of 1, 2, 3 you can say 2, 4, 6 and the settings are sorted the same), and the order only matters _within the category_.
- For both category and setting orders, not adding in an explicit order number now moves the category or setting to the end of the extension ToC categories list or the end of the settings for that category, respectively. This way, extension authors don't have to add order numbers to every category or setting just so unordered ones stop showing up in front of the ordered ones.

<img width="611" alt="Screen Shot 2021-09-20 at 4 36 49 PM" src="https://user-images.githubusercontent.com/7199958/134090581-8e3abaa7-7c6e-42f6-8543-f5e916d00f49.png">
