### PR TITLE
Uses EventType.MOUSE_DOWN instead of EventType.CLICK

### DIFF
--- a/src/vs/base/browser/ui/hover/hoverWidget.ts
+++ b/src/vs/base/browser/ui/hover/hoverWidget.ts
@@ -63,7 +63,7 @@ export class HoverAction extends Disposable {
 		const label = dom.append(this.action, $('span'));
 		label.textContent = keybindingLabel ? `${actionOptions.label} (${keybindingLabel})` : actionOptions.label;
 
-		this._register(dom.addDisposableListener(this.actionContainer, dom.EventType.CLICK, e => {
+		this._register(dom.addDisposableListener(this.actionContainer, dom.EventType.MOUSE_DOWN, e => {
 			e.stopPropagation();
 			e.preventDefault();
 			actionOptions.run(this.actionContainer);


### PR DESCRIPTION
…so that high frequent clicks work properly. Fixes #133517.
