### PR TITLE
Recognize .pyt files in Python extension

### DIFF
--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -24,7 +24,8 @@
           ".gyp",
           ".gypi",
           ".pyi",
-          ".ipy"
+          ".ipy",
+          ".pyt"
         ],
         "aliases": [
           "Python",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

`.pyt` files are a file type used by the ESRI ArcGIS software to describe [Python toolboxes](https://pro.arcgis.com/en/pro-app/latest/arcpy/geoprocessing_and_python/a-quick-tour-of-python-toolboxes.htm). ArcGIS is a commonly used, commercial GIS (Geographic Information Systems) software. One way of extending this software is by using custom tools, which can be contained in native (`.tbx`) or Python (`.pyt`) toolboxes. 

Python toolboxes are text files containing regular Python code, but use the `.pyt` extension to allow ArcGIS to identify them. It would be great if the `.pyt` file extension could be included as one used by the VSCode Python extension.

This PR adds the `.pyt` extension to the list of supported file types for the VS Code Python Extension.

This PR fixes #133545
