### PR TITLE
Notebook scrolling perf improvement

### DIFF
--- a/src/vs/base/browser/ui/list/list.ts
+++ b/src/vs/base/browser/ui/list/list.ts
@@ -11,6 +11,7 @@ export interface IListVirtualDelegate<T> {
 	getHeight(element: T): number;
 	getTemplateId(element: T): string;
 	hasDynamicHeight?(element: T): boolean;
+	getDynamicHeight?(element: T): number | null;
 	setDynamicHeight?(element: T, height: number): void;
 }
 

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1318,12 +1318,14 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 	private probeDynamicHeight(index: number): number {
 		const item = this.items[index];
 
-		if (!!this.virtualDelegate.getDynamicHeight && this.virtualDelegate.getDynamicHeight(item.element) !== null) {
-			const size = item.size;
-			let newSize = this.virtualDelegate.getDynamicHeight(item.element)!;
-			item.size = newSize;
-			item.lastDynamicHeightWidth = this.renderWidth;
-			return newSize - size;
+		if (!!this.virtualDelegate.getDynamicHeight) {
+			const newSize = this.virtualDelegate.getDynamicHeight(item.element);
+			if (newSize !== null) {
+				const size = item.size;
+				item.size = newSize;
+				item.lastDynamicHeightWidth = this.renderWidth;
+				return newSize - size;
+			}
 		}
 
 		if (!item.hasDynamicHeight || item.lastDynamicHeightWidth === this.renderWidth) {

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1318,6 +1318,14 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 	private probeDynamicHeight(index: number): number {
 		const item = this.items[index];
 
+		if (!!this.virtualDelegate.getDynamicHeight && this.virtualDelegate.getDynamicHeight(item.element) !== null) {
+			const size = item.size;
+			let newSize = this.virtualDelegate.getDynamicHeight(item.element)!;
+			item.size = newSize;
+			item.lastDynamicHeightWidth = this.renderWidth;
+			return newSize - size;
+		}
+
 		if (!item.hasDynamicHeight || item.lastDynamicHeightWidth === this.renderWidth) {
 			return 0;
 		}

--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -749,6 +749,7 @@
 .monaco-workbench .notebookOverlay .cell-list-top-cell-toolbar-container,
 .monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-bottom-toolbar-container {
 	position: absolute;
+	top: 0px;
 	display: flex;
 	height: 33px;
 	justify-content: center;

--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -235,7 +235,6 @@
 
 .monaco-workbench .notebookOverlay .output > div.foreground.output-inner-container {
 	width: 100%;
-	padding: 4px 8px;
 	box-sizing: border-box;
 }
 
@@ -384,7 +383,6 @@
 
 .monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .output-collapse-container {
 	cursor: pointer;
-	padding: 4px 8px;
 }
 
 .monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .output-collapse-container .expandOutputPlaceholder {

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -62,7 +62,7 @@ import { Webview } from 'vs/workbench/contrib/webview/browser/webview';
 import { mark } from 'vs/workbench/contrib/notebook/common/notebookPerformance';
 import { readFontInfo } from 'vs/editor/browser/config/configuration';
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
-import { NotebookOptions } from 'vs/workbench/contrib/notebook/common/notebookOptions';
+import { NotebookOptions, OutputInnerContainerTopPadding } from 'vs/workbench/contrib/notebook/common/notebookOptions';
 import { ViewContext } from 'vs/workbench/contrib/notebook/browser/viewModel/viewContext';
 import { INotebookRendererMessagingService } from 'vs/workbench/contrib/notebook/common/notebookRendererMessagingService';
 import { IAckOutputHeight, IMarkupCellInitialization } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
@@ -826,6 +826,16 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		.monaco-workbench .notebookOverlay.cell-title-toolbar-hidden > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-title-toolbar {
 			display: none;
 		}`);
+
+		// cell output innert container
+		styleSheets.push(`
+		.monaco-workbench .notebookOverlay .output > div.foreground.output-inner-container {
+			padding: ${OutputInnerContainerTopPadding}px 8px;
+		}
+		.monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .output-collapse-container {
+			padding: ${OutputInnerContainerTopPadding}px 8px;
+		}
+		`);
 
 		this._styleElement.textContent = styleSheets.join('\n');
 	}

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1320,7 +1320,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 		this._localStore.add(this._list.onWillScroll(e => {
 			if (this._webview?.isResolved()) {
-				this._webviewTransparentCover!.style.top = `${e.scrollTop}px`;
+				this._webviewTransparentCover!.style.transform = `translateY(${e.scrollTop})`;
 			}
 		}));
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -69,6 +69,7 @@ import { IAckOutputHeight, IMarkupCellInitialization } from 'vs/workbench/contri
 import { SuggestController } from 'vs/editor/contrib/suggest/suggestController';
 import { registerZIndex, ZIndex } from 'vs/platform/layout/browser/zIndexRegistry';
 import { INotebookCellList } from 'vs/workbench/contrib/notebook/browser/view/notebookRenderingCommon';
+import { notebookDebug } from 'vs/workbench/contrib/notebook/browser/notebookLogger';
 
 const $ = DOM.$;
 
@@ -456,29 +457,16 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}
 
 		this._updateForNotebookConfiguration();
-
-		if (this._debugFlag) {
-			this._domFrameLog();
-		}
 	}
 
 	private _debugFlag: boolean = false;
-	private _frameId = 0;
-	private _domFrameLog() {
-		DOM.scheduleAtNextAnimationFrame(() => {
-			this._frameId++;
-
-			this._domFrameLog();
-		}, 1000000);
-	}
 
 	private _debug(...args: any[]) {
 		if (!this._debugFlag) {
 			return;
 		}
 
-		const date = new Date();
-		console.log(`${date.getSeconds()}:${date.getMilliseconds().toString().padStart(3, '0')}`, `frame #${this._frameId}: `, ...args);
+		notebookDebug(...args);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/notebook/browser/notebookLogger.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookLogger.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from 'vs/base/browser/dom';
+
+class NotebookLogger {
+	constructor() {
+		this._domFrameLog();
+	}
+	private _frameId = 0;
+	private _domFrameLog() {
+		DOM.scheduleAtNextAnimationFrame(() => {
+			this._frameId++;
+
+			this._domFrameLog();
+		}, 1000000);
+	}
+
+	debug(...args: any[]) {
+		const date = new Date();
+		console.log(`${date.getSeconds()}:${date.getMilliseconds().toString().padStart(3, '0')}`, `frame #${this._frameId}: `, ...args);
+	}
+}
+
+const instance = new NotebookLogger();
+export function notebookDebug(...args: any[]) {
+	instance.debug(...args);
+}
+

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookRenderingCommon.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookRenderingCommon.ts
@@ -9,6 +9,7 @@ import { IListOptions, IListStyles } from 'vs/base/browser/ui/list/listWidget';
 import { ProgressBar } from 'vs/base/browser/ui/progressbar/progressbar';
 import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 import { Event } from 'vs/base/common/event';
+import { FastDomNode } from 'vs/base/browser/fastDomNode';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { ScrollEvent } from 'vs/base/common/scrollable';
 import { URI } from 'vs/base/common/uri';
@@ -97,8 +98,8 @@ export interface BaseCellRenderTemplate {
 	toolbar: ToolBar;
 	deleteToolbar: ToolBar;
 	betweenCellToolbar: ToolBar;
-	focusIndicatorLeft: HTMLElement;
-	focusIndicatorRight: HTMLElement;
+	focusIndicatorLeft: FastDomNode<HTMLElement>;
+	focusIndicatorRight: FastDomNode<HTMLElement>;
 	readonly disposables: DisposableStore;
 	readonly elementDisposables: DisposableStore;
 	bottomCellContainer: HTMLElement;
@@ -119,16 +120,16 @@ export interface CodeCellRenderTemplate extends BaseCellRenderTemplate {
 	runToolbar: ToolBar;
 	runButtonContainer: HTMLElement;
 	executionOrderLabel: HTMLElement;
-	outputContainer: HTMLElement;
+	outputContainer: FastDomNode<HTMLElement>;
 	cellOutputCollapsedContainer: HTMLElement;
-	outputShowMoreContainer: HTMLElement;
+	outputShowMoreContainer: FastDomNode<HTMLElement>;
 	focusSinkElement: HTMLElement;
 	editor: ICodeEditor;
 	progressBar: ProgressBar;
 	collapsedProgressBar: ProgressBar;
-	focusIndicatorRight: HTMLElement;
-	focusIndicatorBottom: HTMLElement;
-	dragHandle: HTMLElement;
+	focusIndicatorRight: FastDomNode<HTMLElement>;
+	focusIndicatorBottom: FastDomNode<HTMLElement>;
+	dragHandle: FastDomNode<HTMLElement>;
 }
 
 export function isCodeCellRenderTemplate(templateData: BaseCellRenderTemplate): templateData is CodeCellRenderTemplate {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellOutput.ts
@@ -208,7 +208,7 @@ export class CellOutputElement extends Disposable {
 	private _initHeightChecked = false;
 
 	probeHeight(index: number) {
-		if (!this._initHeightChecked) {
+		if (!this._initHeightChecked && this.renderResult?.type === RenderOutputType.Mainframe) {
 			// postponed DOM read
 			const offsetHeight = this.domOffsetHeight;
 			this.viewCell.updateOutputHeight(index, offsetHeight, 'CellOutputElement#renderResultInitHeight');

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellOutput.ts
@@ -286,7 +286,14 @@ export class CellOutputElement extends Disposable {
 			offsetHeight = this.renderResult.initHeight;
 			this._initHeightChecked = true;
 		} else {
-			this._initHeightChecked = false;
+			const outputIndex = this.viewCell.outputsViewModels.indexOf(this.output);
+			const oldHeight = this.viewCell.getOutputHeight(outputIndex);
+			if (oldHeight >= 0) {
+				offsetHeight = oldHeight;
+				this._initHeightChecked = true;
+			} else {
+				this._initHeightChecked = false;
+			}
 		}
 
 		const dimension = {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
@@ -74,6 +74,10 @@ export class NotebookCellListDelegate extends Disposable implements IListVirtual
 		return element.hasDynamicHeight();
 	}
 
+	getDynamicHeight(element: CellViewModel): number | null {
+		return element.getDynamicHeight();
+	}
+
 	getTemplateId(element: CellViewModel): string {
 		if (element.cellKind === CellKind.Markup) {
 			return MarkupCellRenderer.TEMPLATE_ID;
@@ -144,11 +148,11 @@ abstract class AbstractCellRenderer {
 
 		const container = templateData.bottomCellContainer;
 		const bottomToolbarOffset = element.layoutInfo.bottomToolbarOffset;
-		container.style.top = `${bottomToolbarOffset}px`;
+		container.style.transform = `translateY(${bottomToolbarOffset}px)`;
 
 		templateData.elementDisposables.add(element.onDidChangeLayout(() => {
 			const bottomToolbarOffset = element.layoutInfo.bottomToolbarOffset;
-			container.style.top = `${bottomToolbarOffset}px`;
+			container.style.transform = `translateY(${bottomToolbarOffset}px)`;
 		}));
 	}
 
@@ -192,14 +196,14 @@ abstract class AbstractCellRenderer {
 			if (actions.primary.length || actions.secondary.length) {
 				templateData.container.classList.add('cell-has-toolbar-actions');
 				if (isCodeCellRenderTemplate(templateData)) {
-					templateData.focusIndicatorLeft.style.top = `${layoutInfo.editorToolbarHeight + layoutInfo.cellTopMargin}px`;
-					templateData.focusIndicatorRight.style.top = `${layoutInfo.editorToolbarHeight + layoutInfo.cellTopMargin}px`;
+					templateData.focusIndicatorLeft.style.transform = `translateY(${layoutInfo.editorToolbarHeight + layoutInfo.cellTopMargin}px)`;
+					templateData.focusIndicatorRight.style.transform = `translateY(${layoutInfo.editorToolbarHeight + layoutInfo.cellTopMargin}px)`;
 				}
 			} else {
 				templateData.container.classList.remove('cell-has-toolbar-actions');
 				if (isCodeCellRenderTemplate(templateData)) {
-					templateData.focusIndicatorLeft.style.top = `${layoutInfo.cellTopMargin}px`;
-					templateData.focusIndicatorRight.style.top = `${layoutInfo.cellTopMargin}px`;
+					templateData.focusIndicatorLeft.style.transform = `translateY(${layoutInfo.cellTopMargin}px)`;
+					templateData.focusIndicatorRight.style.transform = `translateY(${layoutInfo.cellTopMargin}px)`;
 				}
 			}
 		};
@@ -436,7 +440,8 @@ export class MarkupCellRenderer extends AbstractCellRenderer implements IListRen
 
 	private updateForLayout(element: MarkupCellViewModel, templateData: MarkdownCellRenderTemplate): void {
 		const indicatorPostion = this.notebookEditor.notebookOptions.computeIndicatorPosition(element.layoutInfo.totalHeight, this.notebookEditor.textModel?.viewType);
-		templateData.focusIndicatorBottom.style.top = `${indicatorPostion.bottomIndicatorTop}px`;
+		templateData.focusIndicatorBottom.style.transform = `translateY(${indicatorPostion.bottomIndicatorTop}px)`;
+
 		templateData.focusIndicatorLeft.style.height = `${indicatorPostion.verticalIndicatorHeight}px`;
 		templateData.focusIndicatorRight.style.height = `${indicatorPostion.verticalIndicatorHeight}px`;
 
@@ -930,17 +935,19 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 	}
 
 	private updateForLayout(element: CodeCellViewModel, templateData: CodeCellRenderTemplate): void {
-		const layoutInfo = this.notebookEditor.notebookOptions.getLayoutConfiguration();
-		const bottomToolbarDimensions = this.notebookEditor.notebookOptions.computeBottomToolbarDimensions(this.notebookEditor.textModel?.viewType);
+		templateData.disposables.add(DOM.scheduleAtNextAnimationFrame(() => {
+			const layoutInfo = this.notebookEditor.notebookOptions.getLayoutConfiguration();
+			const bottomToolbarDimensions = this.notebookEditor.notebookOptions.computeBottomToolbarDimensions(this.notebookEditor.textModel?.viewType);
 
-		templateData.focusIndicatorLeft.style.height = `${element.layoutInfo.indicatorHeight}px`;
-		templateData.focusIndicatorRight.style.height = `${element.layoutInfo.indicatorHeight}px`;
-		templateData.focusIndicatorBottom.style.top = `${element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap - layoutInfo.cellBottomMargin}px`;
-		templateData.outputContainer.style.top = `${element.layoutInfo.outputContainerOffset}px`;
-		templateData.outputShowMoreContainer.style.top = `${element.layoutInfo.outputShowMoreContainerOffset}px`;
-		templateData.dragHandle.style.height = `${element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap}px`;
+			templateData.focusIndicatorLeft.style.height = `${element.layoutInfo.indicatorHeight}px`;
+			templateData.focusIndicatorRight.style.height = `${element.layoutInfo.indicatorHeight}px`;
+			templateData.focusIndicatorBottom.style.top = `${element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap - layoutInfo.cellBottomMargin}px`;
+			templateData.outputContainer.style.top = `${element.layoutInfo.outputContainerOffset}px`;
+			templateData.outputShowMoreContainer.style.top = `${element.layoutInfo.outputShowMoreContainerOffset}px`;
+			templateData.dragHandle.style.height = `${element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap}px`;
 
-		templateData.container.classList.toggle('cell-statusbar-hidden', this.notebookEditor.notebookOptions.computeEditorStatusbarHeight(element.internalMetadata) === 0);
+			templateData.container.classList.toggle('cell-statusbar-hidden', this.notebookEditor.notebookOptions.computeEditorStatusbarHeight(element.internalMetadata) === 0);
+		}));
 	}
 
 	renderElement(element: CodeCellViewModel, index: number, templateData: CodeCellRenderTemplate, height: number | undefined): void {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
@@ -5,6 +5,7 @@
 
 import { getPixelRatio, getZoomLevel } from 'vs/base/browser/browser';
 import * as DOM from 'vs/base/browser/dom';
+import { FastDomNode } from 'vs/base/browser/fastDomNode';
 import { IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { ProgressBar } from 'vs/base/browser/ui/progressbar/progressbar';
 import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
@@ -196,14 +197,14 @@ abstract class AbstractCellRenderer {
 			if (actions.primary.length || actions.secondary.length) {
 				templateData.container.classList.add('cell-has-toolbar-actions');
 				if (isCodeCellRenderTemplate(templateData)) {
-					templateData.focusIndicatorLeft.style.transform = `translateY(${layoutInfo.editorToolbarHeight + layoutInfo.cellTopMargin}px)`;
-					templateData.focusIndicatorRight.style.transform = `translateY(${layoutInfo.editorToolbarHeight + layoutInfo.cellTopMargin}px)`;
+					templateData.focusIndicatorLeft.domNode.style.transform = `translateY(${layoutInfo.editorToolbarHeight + layoutInfo.cellTopMargin}px)`;
+					templateData.focusIndicatorRight.domNode.style.transform = `translateY(${layoutInfo.editorToolbarHeight + layoutInfo.cellTopMargin}px)`;
 				}
 			} else {
 				templateData.container.classList.remove('cell-has-toolbar-actions');
 				if (isCodeCellRenderTemplate(templateData)) {
-					templateData.focusIndicatorLeft.style.transform = `translateY(${layoutInfo.cellTopMargin}px)`;
-					templateData.focusIndicatorRight.style.transform = `translateY(${layoutInfo.cellTopMargin}px)`;
+					templateData.focusIndicatorLeft.domNode.style.transform = `translateY(${layoutInfo.cellTopMargin}px)`;
+					templateData.focusIndicatorRight.domNode.style.transform = `translateY(${layoutInfo.cellTopMargin}px)`;
 				}
 			}
 		};
@@ -294,8 +295,8 @@ export class MarkupCellRenderer extends AbstractCellRenderer implements IListRen
 		}
 
 		DOM.append(container, $('.cell-focus-indicator.cell-focus-indicator-top'));
-		const focusIndicatorLeft = DOM.append(container, DOM.$('.cell-focus-indicator.cell-focus-indicator-side.cell-focus-indicator-left'));
-		const focusIndicatorRight = DOM.append(container, DOM.$('.cell-focus-indicator.cell-focus-indicator-side.cell-focus-indicator-right'));
+		const focusIndicatorLeft = new FastDomNode(DOM.append(container, DOM.$('.cell-focus-indicator.cell-focus-indicator-side.cell-focus-indicator-left')));
+		const focusIndicatorRight = new FastDomNode(DOM.append(container, DOM.$('.cell-focus-indicator.cell-focus-indicator-side.cell-focus-indicator-right')));
 
 		const codeInnerContent = DOM.append(container, $('.cell.code'));
 		const editorPart = DOM.append(codeInnerContent, $('.cell-editor-part'));
@@ -304,7 +305,7 @@ export class MarkupCellRenderer extends AbstractCellRenderer implements IListRen
 		editorPart.style.display = 'none';
 
 		const innerContent = DOM.append(container, $('.cell.markdown'));
-		const foldingIndicator = DOM.append(focusIndicatorLeft, DOM.$('.notebook-folding-indicator'));
+		const foldingIndicator = DOM.append(focusIndicatorLeft.domNode, DOM.$('.notebook-folding-indicator'));
 
 		const bottomCellContainer = DOM.append(container, $('.cell-bottom-toolbar-container'));
 		const betweenCellToolbar = disposables.add(this.createBetweenCellToolbar(bottomCellContainer, disposables, contextKeyService, this.notebookEditor.notebookOptions));
@@ -442,8 +443,8 @@ export class MarkupCellRenderer extends AbstractCellRenderer implements IListRen
 		const indicatorPostion = this.notebookEditor.notebookOptions.computeIndicatorPosition(element.layoutInfo.totalHeight, this.notebookEditor.textModel?.viewType);
 		templateData.focusIndicatorBottom.style.transform = `translateY(${indicatorPostion.bottomIndicatorTop}px)`;
 
-		templateData.focusIndicatorLeft.style.height = `${indicatorPostion.verticalIndicatorHeight}px`;
-		templateData.focusIndicatorRight.style.height = `${indicatorPostion.verticalIndicatorHeight}px`;
+		templateData.focusIndicatorLeft.setHeight(indicatorPostion.verticalIndicatorHeight);
+		templateData.focusIndicatorRight.setHeight(indicatorPostion.verticalIndicatorHeight);
 
 		templateData.container.classList.toggle('cell-statusbar-hidden', this.notebookEditor.notebookOptions.computeEditorStatusbarHeight(element.internalMetadata) === 0);
 	}
@@ -619,8 +620,8 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 		if (!this.notebookEditor.creationOptions.isReadOnly) {
 			deleteToolbar.setActions([this.instantiationService.createInstance(DeleteCellAction)]);
 		}
-		const focusIndicator = DOM.append(container, DOM.$('.cell-focus-indicator.cell-focus-indicator-side.cell-focus-indicator-left'));
-		const dragHandle = DOM.append(container, DOM.$('.cell-drag-handle'));
+		const focusIndicator = new FastDomNode(DOM.append(container, DOM.$('.cell-focus-indicator.cell-focus-indicator-side.cell-focus-indicator-left')));
+		const dragHandle = new FastDomNode(DOM.append(container, DOM.$('.cell-drag-handle')));
 
 		const cellContainer = DOM.append(container, $('.cell.code'));
 		const runButtonContainer = DOM.append(cellContainer, $('.run-button-container'));
@@ -660,16 +661,16 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 
 		const statusBar = disposables.add(this.instantiationService.createInstance(CellEditorStatusBar, editorPart));
 
-		const outputContainer = DOM.append(container, $('.output'));
-		const cellOutputCollapsedContainer = DOM.append(outputContainer, $('.output-collapse-container'));
-		const outputShowMoreContainer = DOM.append(container, $('.output-show-more-container'));
+		const outputContainer = new FastDomNode(DOM.append(container, $('.output')));
+		const cellOutputCollapsedContainer = DOM.append(outputContainer.domNode, $('.output-collapse-container'));
+		const outputShowMoreContainer = new FastDomNode(DOM.append(container, $('.output-show-more-container')));
 
-		const focusIndicatorRight = DOM.append(container, DOM.$('.cell-focus-indicator.cell-focus-indicator-side.cell-focus-indicator-right'));
+		const focusIndicatorRight = new FastDomNode(DOM.append(container, DOM.$('.cell-focus-indicator.cell-focus-indicator-side.cell-focus-indicator-right')));
 
 		const focusSinkElement = DOM.append(container, $('.cell-editor-focus-sink'));
 		focusSinkElement.setAttribute('tabindex', '0');
 		const bottomCellContainer = DOM.append(container, $('.cell-bottom-toolbar-container'));
-		const focusIndicatorBottom = DOM.append(container, $('.cell-focus-indicator.cell-focus-indicator-bottom'));
+		const focusIndicatorBottom = new FastDomNode(DOM.append(container, $('.cell-focus-indicator.cell-focus-indicator-bottom')));
 		const betweenCellToolbar = this.createBetweenCellToolbar(bottomCellContainer, disposables, contextKeyService, this.notebookEditor.notebookOptions);
 
 		const titleMenu = disposables.add(this.menuService.createMenu(this.notebookEditor.creationOptions.menuIds.cellTitleToolbar, contextKeyService));
@@ -707,7 +708,7 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 			toJSON: () => { return {}; }
 		};
 
-		this.dndController?.registerDragHandle(templateData, rootContainer, dragHandle, () => new CodeCellDragImageRenderer().getDragImage(templateData, templateData.editor, 'code'));
+		this.dndController?.registerDragHandle(templateData, rootContainer, dragHandle.domNode, () => new CodeCellDragImageRenderer().getDragImage(templateData, templateData.editor, 'code'));
 
 		disposables.add(this.addCollapseClickCollapseHandler(templateData));
 		disposables.add(DOM.addDisposableListener(focusSinkElement, DOM.EventType.FOCUS, () => {
@@ -762,7 +763,7 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 	}
 
 	private addCollapseClickCollapseHandler(templateData: CodeCellRenderTemplate): IDisposable {
-		const dragHandleListener = DOM.addDisposableListener(templateData.dragHandle, DOM.EventType.DBLCLICK, e => {
+		const dragHandleListener = DOM.addDisposableListener(templateData.dragHandle.domNode, DOM.EventType.DBLCLICK, e => {
 			const cell = templateData.currentRenderedCell;
 			if (!cell || !this.notebookEditor.hasModel()) {
 				return;
@@ -938,13 +939,12 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 		templateData.disposables.add(DOM.scheduleAtNextAnimationFrame(() => {
 			const layoutInfo = this.notebookEditor.notebookOptions.getLayoutConfiguration();
 			const bottomToolbarDimensions = this.notebookEditor.notebookOptions.computeBottomToolbarDimensions(this.notebookEditor.textModel?.viewType);
-
-			templateData.focusIndicatorLeft.style.height = `${element.layoutInfo.indicatorHeight}px`;
-			templateData.focusIndicatorRight.style.height = `${element.layoutInfo.indicatorHeight}px`;
-			templateData.focusIndicatorBottom.style.top = `${element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap - layoutInfo.cellBottomMargin}px`;
-			templateData.outputContainer.style.top = `${element.layoutInfo.outputContainerOffset}px`;
-			templateData.outputShowMoreContainer.style.top = `${element.layoutInfo.outputShowMoreContainerOffset}px`;
-			templateData.dragHandle.style.height = `${element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap}px`;
+			templateData.focusIndicatorLeft.setHeight(element.layoutInfo.indicatorHeight);
+			templateData.focusIndicatorRight.setHeight(element.layoutInfo.indicatorHeight);
+			templateData.focusIndicatorBottom.setTop(element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap - layoutInfo.cellBottomMargin);
+			templateData.outputContainer.setTop(element.layoutInfo.outputContainerOffset);
+			templateData.outputShowMoreContainer.setTop(element.layoutInfo.outputShowMoreContainerOffset);
+			templateData.dragHandle.setHeight(element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap);
 
 			templateData.container.classList.toggle('cell-statusbar-hidden', this.notebookEditor.notebookOptions.computeEditorStatusbarHeight(element.internalMetadata) === 0);
 		}));
@@ -976,8 +976,8 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 			return;
 		}
 
-		templateData.outputContainer.innerText = '';
-		const cellOutputCollapsedContainer = DOM.append(templateData.outputContainer, $('.output-collapse-container'));
+		templateData.outputContainer.domNode.innerText = '';
+		const cellOutputCollapsedContainer = DOM.append(templateData.outputContainer.domNode, $('.output-collapse-container'));
 		templateData.cellOutputCollapsedContainer = cellOutputCollapsedContainer;
 		this.setupOutputCollapsedPart(templateData, cellOutputCollapsedContainer, element);
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
@@ -941,7 +941,7 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 			const bottomToolbarDimensions = this.notebookEditor.notebookOptions.computeBottomToolbarDimensions(this.notebookEditor.textModel?.viewType);
 			templateData.focusIndicatorLeft.setHeight(element.layoutInfo.indicatorHeight);
 			templateData.focusIndicatorRight.setHeight(element.layoutInfo.indicatorHeight);
-			templateData.focusIndicatorBottom.setTop(element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap - layoutInfo.cellBottomMargin);
+			templateData.focusIndicatorBottom.domNode.style.transform = `translateY(${element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap - layoutInfo.cellBottomMargin}px)`;
 			templateData.outputContainer.setTop(element.layoutInfo.outputContainerOffset);
 			templateData.outputShowMoreContainer.setTop(element.layoutInfo.outputShowMoreContainerOffset);
 			templateData.dragHandle.setHeight(element.layoutInfo.totalHeight - bottomToolbarDimensions.bottomToolbarGap);

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/codeCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/codeCell.ts
@@ -250,6 +250,10 @@ export class CodeCell extends Disposable {
 			this.viewCell.layoutChange({});
 		}
 
+		this._register(this.viewCell.onLayoutInfoRead(() => {
+			this._outputContainerRenderer.probeHeight();
+		}));
+
 		this.updateForCollapseState();
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/codeCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/codeCell.ts
@@ -274,7 +274,7 @@ export class CodeCell extends Disposable {
 		if (this.viewCell.metadata.outputCollapsed) {
 			this._collapseOutput();
 		} else {
-			this._showOutput();
+			this._showOutput(false);
 		}
 
 		this.relayoutCell();
@@ -338,7 +338,7 @@ export class CodeCell extends Disposable {
 	}
 
 	private _updateOutputInnertContainer(hide: boolean) {
-		const children = this.templateData.outputContainer.children;
+		const children = this.templateData.outputContainer.domNode.children;
 		for (let i = 0; i < children.length; i++) {
 			if (children[i].classList.contains('output-inner-container')) {
 				if (hide) {
@@ -415,7 +415,7 @@ export class CodeCell extends Disposable {
 		this._removeInputCollapsePreview();
 		this._outputContainerRenderer.dispose();
 		this._untrustedStatusItem?.dispose();
-		this.templateData.focusIndicatorLeft.style.height = 'initial';
+		this.templateData.focusIndicatorLeft.setHeight(0);
 
 		super.dispose();
 	}

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/codeCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/codeCell.ts
@@ -246,7 +246,7 @@ export class CodeCell extends Disposable {
 		this._outputContainerRenderer.render(editorHeight);
 		// Need to do this after the intial renderOutput
 		if (this.viewCell.metadata.outputCollapsed === undefined && this.viewCell.metadata.outputCollapsed === undefined) {
-			this.viewUpdateExpanded();
+			this.initialViewUpdateExpanded();
 			this.viewCell.layoutChange({});
 		}
 
@@ -357,19 +357,18 @@ export class CodeCell extends Disposable {
 		this._outputContainerRenderer.viewUpdateHideOuputs();
 	}
 
-	private _showOutput() {
+	private _showOutput(initRendering: boolean) {
 		this.templateData.container.classList.toggle('output-collapsed', false);
 		DOM.hide(this.templateData.cellOutputCollapsedContainer);
 		this._updateOutputInnertContainer(false);
-		this._outputContainerRenderer.viewUpdateShowOutputs();
+		this._outputContainerRenderer.viewUpdateShowOutputs(initRendering);
 	}
 
-	private viewUpdateExpanded(): void {
-		this._showInput();
-		this._showOutput();
+	private initialViewUpdateExpanded(): void {
 		this.templateData.container.classList.toggle('input-collapsed', false);
+		this._showInput();
 		this.templateData.container.classList.toggle('output-collapsed', false);
-		this._outputContainerRenderer.viewUpdateShowOutputs();
+		this._showOutput(true);
 		this.relayoutCell();
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
@@ -23,6 +23,8 @@ import { BaseCellViewModel } from './baseCellViewModel';
 
 export class CodeCellViewModel extends BaseCellViewModel implements ICellViewModel {
 	readonly cellKind = CellKind.Code;
+	protected readonly _onLayoutInfoRead = this._register(new Emitter<void>());
+	readonly onLayoutInfoRead = this._onLayoutInfoRead.event;
 	protected readonly _onDidChangeOutputs = this._register(new Emitter<NotebookCellOutputsSplice>());
 	readonly onDidChangeOutputs = this._onDidChangeOutputs.event;
 
@@ -283,6 +285,11 @@ export class CodeCellViewModel extends BaseCellViewModel implements ICellViewMod
 	hasDynamicHeight() {
 		// CodeCellVM always measures itself and controls its cell's height
 		return false;
+	}
+
+	getDynamicHeight() {
+		this._onLayoutInfoRead.fire();
+		return this._layoutInfo.totalHeight;
 	}
 
 	firstLine(): string {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
@@ -374,6 +374,15 @@ export class CodeCellViewModel extends BaseCellViewModel implements ICellViewMod
 		}
 	}
 
+	getOutputHeight(index: number) {
+		if (index >= this._outputCollection.length) {
+			return -1;
+		}
+
+		this._ensureOutputsTop();
+		return this._outputCollection[index];
+	}
+
 	getOutputOffsetInContainer(index: number) {
 		this._ensureOutputsTop();
 

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/markupCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/markupCellViewModel.ts
@@ -250,6 +250,10 @@ export class MarkupCellViewModel extends BaseCellViewModel implements ICellViewM
 		return false;
 	}
 
+	getDynamicHeight() {
+		return null;
+	}
+
 	getHeight(lineHeight: number) {
 		if (this._layoutInfo.layoutState === CellLayoutState.Uninitialized) {
 			return 100;

--- a/src/vs/workbench/contrib/notebook/common/notebookOptions.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookOptions.ts
@@ -24,6 +24,8 @@ export function getEditorTopPadding() {
 	return EDITOR_TOP_PADDING;
 }
 
+export const OutputInnerContainerTopPadding = 4;
+
 export interface NotebookLayoutConfiguration {
 	cellRightMargin: number;
 	cellRunGutter: number;

--- a/src/vs/workbench/contrib/notebook/test/cellOutput.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/cellOutput.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import * as DOM from 'vs/base/browser/dom';
+import { FastDomNode } from 'vs/base/browser/fastDomNode';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { mock } from 'vs/base/test/common/mock';
 import { IMenuService } from 'vs/platform/actions/common/actions';
@@ -91,8 +92,8 @@ suite('NotebookViewModel Outputs', async () => {
 			],
 			(editor, viewModel, accessor) => {
 				const container = new CellOutputContainer(editor, viewModel.viewCells[0] as CodeCellViewModel, {
-					outputContainer: document.createElement('div'),
-					outputShowMoreContainer: document.createElement('div'),
+					outputContainer: new FastDomNode(document.createElement('div')),
+					outputShowMoreContainer: new FastDomNode(document.createElement('div')),
 					editor: {
 						getContentHeight: () => {
 							return 100;
@@ -170,8 +171,8 @@ suite('NotebookViewModel Outputs', async () => {
 			],
 			(editor, viewModel, accessor) => {
 				const container = new CellOutputContainer(editor, viewModel.viewCells[0] as CodeCellViewModel, {
-					outputContainer: document.createElement('div'),
-					outputShowMoreContainer: document.createElement('div'),
+					outputContainer: new FastDomNode(document.createElement('div')),
+					outputShowMoreContainer: new FastDomNode(document.createElement('div')),
 					editor: {
 						getContentHeight: () => {
 							return 100;


### PR DESCRIPTION
When scrolling a notebook, the notebook list view is creating cells, relayouting them and deleting them in a short period of time. Though we are using the same list view as the file explorer or settings editor, rendering a single notebook cell is much more costly. One typical improvement we can do is postponing rendering of costly component but it might harm the perceived experience (e.g. more flickering).

This PR tries to improvement the smoothness of scrolling by:

* Batch DOM write and read
  * When rendering the viewport, the list view will try to render all possible visible cells, insert their DOM nodes into the DOM tree
  * It will then check each one's dynamic height
  * In this PR, we will only check `offsetHeight/clientHeight` of output elements after all cells are initially rendered, to ensure that the layout is invalidated only once
* FastDomNode to avoid redundant DOM style updates
* `transfom: translateY` for updating `top` properties for focus indicator.