### PR TITLE
source maps are off in browser dev tools

### DIFF
--- a/src/vs/workbench/api/worker/extHostExtensionService.ts
+++ b/src/vs/workbench/api/worker/extHostExtensionService.ts
@@ -29,7 +29,7 @@ namespace TrustedFunction {
 			// Malicious inputs  can escape the function body and execute immediately!
 			const fnArgs = args.slice(0, -1).join(',');
 			const fnBody = args.pop()!.toString();
-			const body = `(function anonymous(${fnArgs}) {\n${fnBody}\n})`;
+			const body = `(function anonymous(${fnArgs}) {${fnBody}\n})`;
 			return body;
 		}
 	});


### PR DESCRIPTION
- clone https://github.com/microsoft/vscode-test-web
- yarn && yarn sample
- in the browser that opens run `Hello World`
- open dev tools, navigate to `extension.ts` in `static/devextensions`
- set a breakpoint in and around the command
- notice that the breakpoints are moving down a line: source maps are off