### PR TITLE
Make Help menu entries more useful for exploration

### DIFF
--- a/src/vs/workbench/browser/actions/helpActions.ts
+++ b/src/vs/workbench/browser/actions/helpActions.ts
@@ -64,9 +64,9 @@ class OpenIntroductoryVideosUrlAction extends Action2 {
 		super({
 			id: OpenIntroductoryVideosUrlAction.ID,
 			title: {
-				value: localize('openIntroductoryVideosUrl', "Introductory Videos"),
-				mnemonicTitle: localize({ key: 'miIntroductoryVideos', comment: ['&& denotes a mnemonic'] }, "Introductory &&Videos"),
-				original: 'Introductory Videos'
+				value: localize('openIntroductoryVideosUrl', "Video Tutorials"),
+				mnemonicTitle: localize({ key: 'miIntroductoryVideos', comment: ['&& denotes a mnemonic'] }, "&&Video Tutorials"),
+				original: 'Video Tutorials'
 			},
 			category: CATEGORIES.Help,
 			f1: true,

--- a/src/vs/workbench/browser/actions/helpActions.ts
+++ b/src/vs/workbench/browser/actions/helpActions.ts
@@ -57,15 +57,15 @@ class KeybindingsReferenceAction extends Action2 {
 
 class OpenIntroductoryVideosUrlAction extends Action2 {
 
-	static readonly ID = 'workbench.action.openIntroductoryVideosUrl';
+	static readonly ID = 'workbench.action.openVideoTutorialsUrl';
 	static readonly AVAILABLE = !!product.introductoryVideosUrl;
 
 	constructor() {
 		super({
 			id: OpenIntroductoryVideosUrlAction.ID,
 			title: {
-				value: localize('openIntroductoryVideosUrl', "Video Tutorials"),
-				mnemonicTitle: localize({ key: 'miIntroductoryVideos', comment: ['&& denotes a mnemonic'] }, "&&Video Tutorials"),
+				value: localize('openVideoTutorialsUrl', "Video Tutorials"),
+				mnemonicTitle: localize({ key: 'miVideoTutorials', comment: ['&& denotes a mnemonic'] }, "&&Video Tutorials"),
 				original: 'Video Tutorials'
 			},
 			category: CATEGORIES.Help,

--- a/src/vs/workbench/contrib/quickaccess/browser/quickAccess.contribution.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/quickAccess.contribution.ts
@@ -57,11 +57,11 @@ MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	order: 1
 });
 
-MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
+MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {
 	group: '1_welcome',
 	command: {
 		id: ShowAllCommandsAction.ID,
-		title: localize({ key: 'miShowAllCommands', comment: ['&& denotes a mnemonic'] }, "Search All &&Commands")
+		title: localize({ key: 'miShowAllCommands', comment: ['&& denotes a mnemonic'] }, "Show All Commands")
 	},
 	order: 2
 });

--- a/src/vs/workbench/contrib/quickaccess/browser/quickAccess.contribution.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/quickAccess.contribution.ts
@@ -58,6 +58,15 @@ MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 });
 
 MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
+	group: '1_welcome',
+	command: {
+		id: ShowAllCommandsAction.ID,
+		title: localize({ key: 'miShowAllCommands', comment: ['&& denotes a mnemonic'] }, "Search All &&Commands")
+	},
+	order: 2
+});
+
+MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	group: '1_open',
 	command: {
 		id: OpenViewPickerAction.ID,

--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -37,6 +37,6 @@ if (ShowCurrentReleaseNotesAction.AVAILABE) {
 			id: ShowCurrentReleaseNotesAction.ID,
 			title: localize({ key: 'miReleaseNotes', comment: ['&& denotes a mnemonic'] }, "&&Release Notes")
 		},
-		order: 4
+		order: 5
 	});
 }

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.contribution.ts
@@ -38,7 +38,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.openWalkthrough',
-			title: localize('Welcome', "Welcome"),
+			title: localize({ key: 'miGetStarted', comment: ['&& denotes a mnemonic'] }, "&&Get Started"),
 			category: localize('help', "Help"),
 			f1: true,
 			menu: {
@@ -93,14 +93,14 @@ Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane
 	EditorPaneDescriptor.create(
 		GettingStartedPage,
 		GettingStartedPage.ID,
-		localize('welcome', "Welcome")
+		localize('getStarted', "Get Started")
 	),
 	[
 		new SyncDescriptor(GettingStartedInput)
 	]
 );
 
-const category = localize('welcome', "Welcome");
+const category = localize('getStarted', "Get Started");
 
 registerAction2(class extends Action2 {
 	constructor() {

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
@@ -821,7 +821,7 @@ export class GettingStartedPage extends EditorPane {
 
 		this.categoriesSlide = $('.gettingStartedSlideCategories.gettingStartedSlide');
 
-		const prevButton = $('button.prev-button.button-link', { 'x-dispatch': 'scrollPrev' }, $('span.scroll-button.codicon.codicon-chevron-left'), $('span.moreText', {}, localize('welcome', "Welcome")));
+		const prevButton = $('button.prev-button.button-link', { 'x-dispatch': 'scrollPrev' }, $('span.scroll-button.codicon.codicon-chevron-left'), $('span.moreText', {}, localize('getStarted', "Get Started")));
 		this.stepsSlide = $('.gettingStartedSlideDetails.gettingStartedSlide', {}, prevButton);
 
 		this.stepsContent = $('.gettingStartedDetailsContent', {});

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedInput.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedInput.ts
@@ -46,7 +46,7 @@ export class GettingStartedInput extends EditorInput {
 	}
 
 	override getName() {
-		return localize('welcome', "Welcome");
+		return localize('getStarted', "Get Started");
 	}
 
 	selectedCategory: string | undefined;

--- a/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
@@ -261,9 +261,9 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'playground',
 					title: localize('gettingStarted.playground.title', "Redefine your editing skills"),
-					description: localize('gettingStarted.playground.description.interpolated', "Want to code faster and smarter? Practice powerful code editing features in the interactive playground.\n{0}", Button(localize('openInteractivePlayground', "Open Interactive Playground"), 'command:toSide:workbench.action.showInteractivePlayground')),
+					description: localize('gettingStarted.playground.description.interpolated', "Want to code faster and smarter? Practice powerful code editing features in the interactive playground.\n{0}", Button(localize('openEditorPlayground', "Open Editor Playground"), 'command:toSide:workbench.action.showInteractivePlayground')),
 					media: {
-						type: 'svg', altText: 'Interactive Playground.', path: 'interactivePlayground.svg'
+						type: 'svg', altText: 'Editor Playground.', path: 'interactivePlayground.svg'
 					},
 				},
 				{

--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/editor/editorWalkThrough.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/editor/editorWalkThrough.ts
@@ -17,7 +17,7 @@ import { EditorResolution } from 'vs/platform/editor/common/editor';
 const typeId = 'workbench.editors.walkThroughInput';
 const inputOptions: WalkThroughInputOptions = {
 	typeId,
-	name: localize('editorWalkThrough.title', "Interactive Playground"),
+	name: localize('editorWalkThrough.title', "Editor Playground"),
 	resource: FileAccess.asBrowserUri('./vs_code_editor_walkthrough.md', require)
 		.with({
 			scheme: Schemas.walkThrough,
@@ -29,7 +29,7 @@ const inputOptions: WalkThroughInputOptions = {
 export class EditorWalkThroughAction extends Action {
 
 	public static readonly ID = 'workbench.action.showInteractivePlayground';
-	public static readonly LABEL = localize('editorWalkThrough', "Interactive Playground");
+	public static readonly LABEL = localize('editorWalkThrough', "Interactive Editor Playground");
 
 	constructor(
 		id: string,

--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution.ts
@@ -23,7 +23,7 @@ Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane)
 	.registerEditorPane(EditorPaneDescriptor.create(
 		WalkThroughPart,
 		WalkThroughPart.ID,
-		localize('walkThrough.editor.label', "Interactive Playground"),
+		localize('walkThrough.editor.label', "Playground"),
 	),
 		[new SyncDescriptor(WalkThroughInput)]);
 
@@ -49,7 +49,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {
 	group: '1_welcome',
 	command: {
 		id: 'workbench.action.showInteractivePlayground',
-		title: localize({ key: 'miInteractivePlayground', comment: ['&& denotes a mnemonic'] }, "I&&nteractive Playground")
+		title: localize({ key: 'miPlayground', comment: ['&& denotes a mnemonic'] }, "Playgrou&&nd")
 	},
-	order: 2
+	order: 3
 });

--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution.ts
@@ -30,7 +30,7 @@ Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane)
 Registry.as<IWorkbenchActionRegistry>(Extensions.WorkbenchActions)
 	.registerWorkbenchAction(
 		SyncActionDescriptor.from(EditorWalkThroughAction),
-		'Help: Interactive Playground', CATEGORIES.Help.value);
+		'Help: Interactive Editor Playground', CATEGORIES.Help.value);
 
 Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(EditorWalkThroughInputSerializer.ID, EditorWalkThroughInputSerializer);
 
@@ -49,7 +49,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {
 	group: '1_welcome',
 	command: {
 		id: 'workbench.action.showInteractivePlayground',
-		title: localize({ key: 'miPlayground', comment: ['&& denotes a mnemonic'] }, "Playgrou&&nd")
+		title: localize({ key: 'miPlayground', comment: ['&& denotes a mnemonic'] }, "Editor Playgrou&&nd")
 	},
 	order: 3
 });


### PR DESCRIPTION
Fixes #132158, see for additional background.

<img src=https://user-images.githubusercontent.com/8599/134452983-cdc75192-68c2-405b-a4af-e054ad878df1.png width=300>

_(some items not shown in screenshot as this is the OSS build)_

Help/Command/Title: `Welcome` → `Get Started`
Why: Aligned on commonly used label for beginner content.
Risk: Low, as _Welcome_ opens by default and is rarely opened via command.

➕ Added Help Menu entry: `Show All Commands`
Why: We observed frequently in user research that the Help menu was used for finding menu items for specific capabilities. Having *Show All Commands* duplicated into Help should improve discovery of the command palette.
Risk: Low, just some duplication with the `View > Command Palette …` menu, which should not affect power users.

Help Menu: `Interactive Playground` → `Editor Playground`
Command: `Help: Interactive Playground` → `Help: Editor Playground`
Why: Simplified language and more focused on the code editing capabilities it demonstrates. The other alternative considered was plain `Playground` which doesn't provide much context on its own. _Editor Playground_ is not a big change as the title on the page itself already was set to _Interactive Editor Playground_.
Risk: Low, as _Welcome_ is rarely opened via command and should not affect power users. This item was renamed before from _Walkthrough_.

Help Menu: `Introductory Videos` → `Video Tutorials`
Why: More common and simpler language ([google trends](https://trends.google.com/trends/explore?geo=US&q=Video%20Tutorials,Introductory%20Videos)).

Follow up:

- [x] Align copy on the website.
- [x] Test impact in first-time-user research