### PR TITLE
Change disassembly view to use WorkbenchList

### DIFF
--- a/src/vs/editor/common/config/fontInfo.ts
+++ b/src/vs/editor/common/config/fontInfo.ts
@@ -54,8 +54,6 @@ export class BareFontInfo {
 		if (lineHeight === 0) {
 			lineHeight = GOLDEN_LINE_HEIGHT_RATIO * fontSize;
 		} else if (lineHeight < MINIMUM_LINE_HEIGHT) {
-			// Enforce integer
-			lineHeight = Math.round(lineHeight);
 			// Values too small to be line heights in pixels are probably in ems. Accept them gracefully.
 			lineHeight = lineHeight * fontSize;
 		}

--- a/src/vs/editor/common/config/fontInfo.ts
+++ b/src/vs/editor/common/config/fontInfo.ts
@@ -11,7 +11,7 @@ import { EditorZoom } from 'vs/editor/common/config/editorZoom';
  * Determined from empirical observations.
  * @internal
  */
-const GOLDEN_LINE_HEIGHT_RATIO = platform.isMacintosh ? 1.5 : 1.35;
+const GOLDEN_LINE_HEIGHT_RATIO = platform.isMacintosh ? 1.5 : 1.4;
 
 /**
  * @internal
@@ -54,12 +54,13 @@ export class BareFontInfo {
 		if (lineHeight === 0) {
 			lineHeight = GOLDEN_LINE_HEIGHT_RATIO * fontSize;
 		} else if (lineHeight < MINIMUM_LINE_HEIGHT) {
+			// Enforce integer
+			lineHeight = Math.round(lineHeight);
 			// Values too small to be line heights in pixels are probably in ems. Accept them gracefully.
 			lineHeight = lineHeight * fontSize;
 		}
 
-		// Enforce integer, minimum constraints
-		lineHeight = Math.round(lineHeight);
+		// minimum constraints
 		if (lineHeight < MINIMUM_LINE_HEIGHT) {
 			lineHeight = MINIMUM_LINE_HEIGHT;
 		}
@@ -108,7 +109,7 @@ export class BareFontInfo {
 		this.fontWeight = String(opts.fontWeight);
 		this.fontSize = opts.fontSize;
 		this.fontFeatureSettings = opts.fontFeatureSettings;
-		this.lineHeight = opts.lineHeight | 0;
+		this.lineHeight = opts.lineHeight;
 		this.letterSpacing = opts.letterSpacing;
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -1249,6 +1249,7 @@ registerAction2(class extends Action2 {
 		debugService.removeBreakpoints();
 		debugService.removeFunctionBreakpoints();
 		debugService.removeDataBreakpoints();
+		debugService.removeInstructionBreakpoints();
 	}
 });
 

--- a/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
@@ -176,8 +176,6 @@ class OpenDisassemblyViewAction extends EditorAction2 {
 	}
 }
 
-
-// Doesn't make sense to have a toggle if the toggle requires restart.  Leave this action here for the
 class ToggleDisassemblyViewSourceCodeAction extends Action2 {
 
 	public static readonly ID = 'editor.debug.action.toggleDisassemblyViewSourceCode';

--- a/src/vs/workbench/contrib/debug/browser/debugIcons.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugIcons.ts
@@ -81,5 +81,3 @@ export const breakpointsActivate = registerIcon('breakpoints-activate', Codicon.
 
 export const debugConsoleEvaluationInput = registerIcon('debug-console-evaluation-input', Codicon.arrowSmallRight, localize('debugConsoleEvaluationInput', 'Icon for the debug evaluation input marker.'));
 export const debugConsoleEvaluationPrompt = registerIcon('debug-console-evaluation-prompt', Codicon.chevronRight, localize('debugConsoleEvaluationPrompt', 'Icon for the debug evaluation prompt.'));
-
-export const openPreviewIcon = registerIcon('ports-open-preview-icon', Codicon.openPreview, localize('openPreviewIcon', 'Icon for the open preview action.'));

--- a/src/vs/workbench/contrib/debug/browser/debugIcons.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugIcons.ts
@@ -81,3 +81,5 @@ export const breakpointsActivate = registerIcon('breakpoints-activate', Codicon.
 
 export const debugConsoleEvaluationInput = registerIcon('debug-console-evaluation-input', Codicon.arrowSmallRight, localize('debugConsoleEvaluationInput', 'Icon for the debug evaluation input marker.'));
 export const debugConsoleEvaluationPrompt = registerIcon('debug-console-evaluation-prompt', Codicon.chevronRight, localize('debugConsoleEvaluationPrompt', 'Icon for the debug evaluation prompt.'));
+
+export const openPreviewIcon = registerIcon('ports-open-preview-icon', Codicon.openPreview, localize('openPreviewIcon', 'Icon for the open preview action.'));

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -506,6 +506,7 @@ class BreakpointRenderer implements ITableRenderer<IDisassembledInstructionEntry
 		icon.style.display = 'flex';
 		icon.style.alignItems = 'center';
 		icon.style.justifyContent = 'center';
+		icon.style.height = this._disassemblyView.fontInfo.lineHeight + 'px';
 
 		const currentElement: { element?: IDisassembledInstructionEntry } = { element: undefined };
 


### PR DESCRIPTION
Change disassembly to use WorkbenchList: #130438

Requires #132541 to complete first. Also need help since I'm not familiar enough with HTML/CSS:

1. Can't scroll horizontally even if `horizontalScrolling` is set to true. Didn't work like this several weeks ago, not sure what's wrong here.
2. Elements that contain source code are not indented correctly.
3. Based on my test in #130438, I wasn't able to find a way to fix the breakpoint column (elements) from scrolling horizontally.