### PR TITLE
open editors: sort by fullPath

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -340,11 +340,12 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.openEditors.sortOrder': {
 			'type': 'string',
-			'enum': ['editorOrder', 'alphabetical'],
+			'enum': ['editorOrder', 'alphabetical', 'fullPath'],
 			'description': nls.localize({ key: 'openEditorsSortOrder', comment: ['Open is an adjective'] }, "Controls the sorting order of editors in the Open Editors pane."),
 			'enumDescriptions': [
 				nls.localize('sortOrder.editorOrder', 'Editors are ordered in the same order editor tabs are shown.'),
-				nls.localize('sortOrder.alphabetical', 'Editors are ordered in alphabetical order inside each editor group.')
+				nls.localize('sortOrder.alphabetical', 'Editors are ordered in alphabetical order inside each editor group.'),
+				nls.localize('sortOrder.fullPath', 'Editors are ordered alphabetically by full path inside each editor group.')
 			],
 			'default': 'editorOrder'
 		},

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -344,7 +344,7 @@ configurationRegistry.registerConfiguration({
 			'description': nls.localize({ key: 'openEditorsSortOrder', comment: ['Open is an adjective'] }, "Controls the sorting order of editors in the Open Editors pane."),
 			'enumDescriptions': [
 				nls.localize('sortOrder.editorOrder', 'Editors are ordered in the same order editor tabs are shown.'),
-				nls.localize('sortOrder.alphabetical', 'Editors are ordered in alphabetical order by tab name inside each editor group.'),
+				nls.localize('sortOrder.alphabetical', 'Editors are ordered in alphabetily by tab name inside each editor group.'),
 				nls.localize('sortOrder.fullPath', 'Editors are ordered alphabetically by full path inside each editor group.')
 			],
 			'default': 'editorOrder'

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -344,7 +344,7 @@ configurationRegistry.registerConfiguration({
 			'description': nls.localize({ key: 'openEditorsSortOrder', comment: ['Open is an adjective'] }, "Controls the sorting order of editors in the Open Editors pane."),
 			'enumDescriptions': [
 				nls.localize('sortOrder.editorOrder', 'Editors are ordered in the same order editor tabs are shown.'),
-				nls.localize('sortOrder.alphabetical', 'Editors are ordered in alphabetily by tab name inside each editor group.'),
+				nls.localize('sortOrder.alphabetical', 'Editors are ordered alphabetically by tab name inside each editor group.'),
 				nls.localize('sortOrder.fullPath', 'Editors are ordered alphabetically by full path inside each editor group.')
 			],
 			'default': 'editorOrder'

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -344,7 +344,7 @@ configurationRegistry.registerConfiguration({
 			'description': nls.localize({ key: 'openEditorsSortOrder', comment: ['Open is an adjective'] }, "Controls the sorting order of editors in the Open Editors pane."),
 			'enumDescriptions': [
 				nls.localize('sortOrder.editorOrder', 'Editors are ordered in the same order editor tabs are shown.'),
-				nls.localize('sortOrder.alphabetical', 'Editors are ordered in alphabetical order inside each editor group.'),
+				nls.localize('sortOrder.alphabetical', 'Editors are ordered in alphabetical order by tab name inside each editor group.'),
 				nls.localize('sortOrder.fullPath', 'Editors are ordered alphabetically by full path inside each editor group.')
 			],
 			'default': 'editorOrder'

--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -52,6 +52,8 @@ import { Codicon } from 'vs/base/common/codicons';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { Schemas } from 'vs/base/common/network';
+import { extUriIgnorePathCase } from 'vs/base/common/resources';
 
 const $ = dom.$;
 
@@ -69,7 +71,7 @@ export class OpenEditorsView extends ViewPane {
 	private contributedContextMenu!: IMenu;
 	private needsRefresh = false;
 	private elements: (OpenEditor | IEditorGroup)[] = [];
-	private sortOrder: 'editorOrder' | 'alphabetical';
+	private sortOrder: 'editorOrder' | 'alphabetical' | 'fullPath';
 	private resourceContext!: ResourceContextKey;
 	private groupFocusedContext!: IContextKey<boolean>;
 	private dirtyEditorFocusedContext!: IContextKey<boolean>;
@@ -106,7 +108,7 @@ export class OpenEditorsView extends ViewPane {
 			}
 			this.needsRefresh = false;
 
-			if (this.sortOrder === 'alphabetical') {
+			if (this.sortOrder === 'alphabetical' || this.sortOrder === 'fullPath') {
 				// We need to resort the list if the editor label changed
 				elements.forEach(e => {
 					if (e instanceof OpenEditor) {
@@ -338,6 +340,32 @@ export class OpenEditorsView extends ViewPane {
 			let editors = g.editors.map(ei => new OpenEditor(ei, g));
 			if (this.sortOrder === 'alphabetical') {
 				editors = editors.sort((first, second) => compareFileNamesDefault(first.editor.getName(), second.editor.getName()));
+			} else if (this.sortOrder === 'fullPath') {
+				editors = editors.sort((first, second) => {
+					const firstResource = first.editor.resource;
+					const secondResource = second.editor.resource;
+					//put 'system' editors before everything
+					if (firstResource === undefined && secondResource === undefined) {
+						return compareFileNamesDefault(first.editor.getName(), second.editor.getName());
+					} else if (firstResource === undefined) {
+						return -1;
+					} else if (secondResource === undefined) {
+						return 1;
+					} else {
+						const firstScheme = firstResource.scheme;
+						const secondScheme = secondResource.scheme;
+						//put non-file editors before files
+						if (firstScheme !== Schemas.file && secondScheme !== Schemas.file) {
+							return extUriIgnorePathCase.compare(firstResource, secondResource);
+						} else if (firstScheme !== Schemas.file) {
+							return -1;
+						} else if (secondScheme !== Schemas.file) {
+							return 1;
+						} else {
+							return extUriIgnorePathCase.compare(firstResource, secondResource);
+						}
+					}
+				});
 			}
 			this.elements.push(...editors);
 		});

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -83,7 +83,7 @@ export interface IFilesConfiguration extends PlatformIFilesConfiguration, IWorkb
 	explorer: {
 		openEditors: {
 			visible: number;
-			sortOrder: 'editorOrder' | 'alphabetical';
+			sortOrder: 'editorOrder' | 'alphabetical' | 'fullPath';
 		};
 		autoReveal: boolean | 'focusNoScroll';
 		enableDragAndDrop: boolean;


### PR DESCRIPTION
Issue: https://github.com/microsoft/vscode/issues/114470
I have added an option to sort editors by resource path. 
