### PR TITLE
Add support for more merge-conflict comparisons

### DIFF
--- a/extensions/merge-conflict/package.json
+++ b/extensions/merge-conflict/package.json
@@ -91,6 +91,18 @@
         "title": "%command.compare%",
         "original": "Compare Current Conflict",
         "command": "merge-conflict.compare"
+      },
+      {
+        "category": "%command.category%",
+        "title": "%command.compare-current-original%",
+        "original": "Compare Current Against Original",
+        "command": "merge-conflict.compare-current-original"
+      },
+      {
+        "category": "%command.category%",
+        "title": "%command.compare-original-incoming%",
+        "original": "Compare Original Against Incoming",
+        "command": "merge-conflict.compare-original-incoming"
       }
     ],
     "menus": {

--- a/extensions/merge-conflict/package.nls.json
+++ b/extensions/merge-conflict/package.nls.json
@@ -12,6 +12,8 @@
 	"command.next": "Next Conflict",
 	"command.previous": "Previous Conflict",
 	"command.compare": "Compare Current Conflict",
+	"command.compare-current-original": "Compare Current Against Original",
+	"command.compare-original-incoming": "Compare Original Against Incoming",
 	"config.title": "Merge Conflict",
 	"config.autoNavigateNextConflictEnabled": "Whether to automatically navigate to the next merge conflict after resolving a merge conflict.",
 	"config.codeLensEnabled": "Create a CodeLens for merge conflict blocks within editor.",


### PR DESCRIPTION
This allows for comparison between current/original and
original/incoming if the underlying file has 3-way merge
information in it.

Fixes #133088

There are no tests here -- I'm not sure how best to make a test for this and would be happy for guidance here.

Thanks!