### PR TITLE
[Live Share] Fix for guest initiated debugging

### DIFF
--- a/product.json
+++ b/product.json
@@ -29,8 +29,7 @@
 		"ms-vscode.remotehub",
 		"ms-vscode.remotehub-insiders",
 		"GitHub.remotehub",
-		"GitHub.remotehub-insiders",
-		"ms-vsliveshare.vsliveshare"
+		"GitHub.remotehub-insiders"
 	],
 	"builtInExtensions": [
 		{

--- a/product.json
+++ b/product.json
@@ -29,7 +29,8 @@
 		"ms-vscode.remotehub",
 		"ms-vscode.remotehub-insiders",
 		"GitHub.remotehub",
-		"GitHub.remotehub-insiders"
+		"GitHub.remotehub-insiders",
+		"ms-vsliveshare.vsliveshare"
 	],
 	"builtInExtensions": [
 		{

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -423,7 +423,10 @@ export class DebugService implements IDebugService {
 			if (activeEditor && activeEditor.resource) {
 				type = this.chosenEnvironments[activeEditor.resource.toString()];
 			}
-			if (!type) {
+
+			if (this.configurationManager.hasDebugConfigurationProvider('*') && this.configurationManager.hasDebugConfigurationProvider('vslsJoin')) {
+				type = 'vslsJoin';
+			} else {
 				guess = await this.adapterManager.guessDebugger(false);
 				if (guess) {
 					type = guess.type;

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -424,12 +424,15 @@ export class DebugService implements IDebugService {
 				type = this.chosenEnvironments[activeEditor.resource.toString()];
 			}
 
-			if (this.configurationManager.hasDebugConfigurationProvider('*') && this.configurationManager.hasDebugConfigurationProvider('vslsJoin')) {
-				type = 'vslsJoin';
-			} else {
-				guess = await this.adapterManager.guessDebugger(false);
-				if (guess) {
-					type = guess.type;
+			if (!type) {
+				// Set the Live Share guest debug type when the user has joined a collaboration session
+				if (this.configurationManager.hasDebugConfigurationProvider('*') && this.configurationManager.hasDebugConfigurationProvider('vslsJoin')) {
+					type = 'vslsJoin';
+				} else {
+					guess = await this.adapterManager.guessDebugger(false);
+					if (guess) {
+						type = guess.type;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Issue: Live Share guest initiated debugging is currently broken due to recent changes. The guest sees:

![image](https://user-images.githubusercontent.com/8161247/135000743-4fb1ffcc-2240-4e26-961d-85dbf4e72b52.png)

Live Share currently registers two debuggers in the extension's package.json:

- "type": "vslsJoin"
- "type": "vslsShare"

When the Live Share guest joins a collaboration session we initialize our JoinDebugManager and this registers a debugConfigurationProvider:

vscode.debug.registerDebugConfigurationProvider('*', this);

This is used to intercept all possible debug types but only for the duration of the collaboration session.

@isidorn, @weinand, @roblourens: this is a possible fix for #132595. I have a more complete write-up in that issue. I'm pretty sure you won't like adding the Live Share guest debug type in this code base though. Is there a better way we can address this?
