### PR TITLE
update breadcrumbs editor binding on control change (#133975)

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsModel.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsModel.ts
@@ -67,6 +67,7 @@ export class BreadcrumbsModel {
 		if (editor) {
 			this._bindToEditor(editor);
 			this._disposables.add(_outlineService.onDidChange(() => this._bindToEditor(editor)));
+			this._disposables.add(editor.onDidChangeControl(() => this._bindToEditor(editor)));
 		}
 		this._onDidUpdate.fire(this);
 	}


### PR DESCRIPTION
For split editors I had to introduce a new event `onDidChangeControl` to signal when focus changes to left or right side. Anytime a component asks for `IEditorPane.getControl()` the currently focused side will be returned for split editors. The editor status selection indication is using this too to indicate the selection of the focussed side.

For breadcrumbs I want to bind the editor whenever the side changes and found a relatively simple change that seems to work.