### PR TITLE
update outline when control changes

### DIFF
--- a/src/vs/workbench/contrib/outline/browser/outlinePane.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePane.ts
@@ -201,6 +201,7 @@ export class OutlinePane extends ViewPane {
 			return this._showMessage(localize('no-editor', "The active editor cannot provide outline information."));
 		}
 
+		// react to control changes from within pane (https://github.com/microsoft/vscode/issues/134008)
 		this._editorDisposables.add(pane.onDidChangeControl(() => this._handleEditorChanged(pane)));
 
 		let loadingMessage: IDisposable | undefined;

--- a/src/vs/workbench/contrib/outline/browser/outlinePane.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePane.ts
@@ -201,6 +201,8 @@ export class OutlinePane extends ViewPane {
 			return this._showMessage(localize('no-editor', "The active editor cannot provide outline information."));
 		}
 
+		this._editorDisposables.add(pane.onDidChangeControl(() => this._handleEditorChanged(pane)));
+
 		let loadingMessage: IDisposable | undefined;
 		if (!didCapture) {
 			loadingMessage = new TimeoutTimer(() => {


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode/issues/134008

This change feels a bit ugly though, because the `_handleEditorChanged` method is called from within based on event. 

@jrieken I wonder if a better fix would be to add the logic somewhere here: 

https://github.com/microsoft/vscode/blob/f523f65f3985eb6493cae5d219de35f1d7ba6f7a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts#L412-L427

I.e. pass the `IEditorPane` into the `DocumentSymbolsOutline` instead of the control and emit a change event from within when the control changes? I think that would fix it for breadcrumbs too because it seems to be using the same factory.