### PR TITLE
Walkthrough items for web

### DIFF
--- a/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
@@ -134,7 +134,7 @@ export const startEntries: GettingStartedStartEntryContent = [
 		id: 'topLevelGitOpen',
 		title: localize('gettingStarted.topLevelGitOpen.title', "Open Repository..."),
 		description: localize('gettingStarted.topLevelGitOpen.description', "Connect to a remote repository or pull request to browse, search, edit, and commit"),
-		when: 'isWeb && workspaceFolderCount == 0',
+		when: 'isWeb',
 		icon: Codicon.sourceControl,
 		content: {
 			type: 'startEntry',

--- a/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
@@ -196,7 +196,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'extensionsWeb',
 					title: localize('gettingStarted.extensions.title', "Limitless extensibility"),
-					description: localize('gettingStarted.extensions.description.interpolated', "Extensions are VS Code's power-ups. They range from handy productivity hacks, expanding out-of-the-box features, to adding completely new capabilities.\n{0}", Button(localize('browseRecommended', "Browse Recommended Extensions"), 'command:workbench.extensions.action.showPopularExtensions')),
+					description: localize('gettingStarted.extensionsWeb.description.interpolated', "Extensions are VS Code's power-ups. A growing number are becoming available in the web.\n{0}", Button(localize('browsePopular', "Browse Popular Extensions"), 'command:workbench.extensions.action.showPopularExtensions')),
 					when: 'workspacePlatform == \'webworker\'',
 					media: {
 						type: 'svg', altText: 'VS Code extension marketplace with featured language extensions', path: 'extensions.svg'
@@ -214,7 +214,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'pickAFolderTask-Web',
 					title: localize('gettingStarted.setup.OpenFolder.title', "Open up your code"),
-					description: localize('gettingStarted.setup.OpenFolderWeb.description.interpolated', "You're all set to start coding. Open a project folder to get your files into VS Code.\n{0}\n{1}", Button(localize('openFolder', "Open Folder"), 'command:workbench.action.addRootFolder'), Button(localize('openRepository', "Open Repository"), 'command:remoteHub.openRepository')),
+					description: localize('gettingStarted.setup.OpenFolderWeb.description.interpolated', "You're all set to start coding. You can open a local project or a remote repository to get your files into VS Code.\n{0}\n{1}", Button(localize('openFolder', "Open Folder"), 'command:workbench.action.addRootFolder'), Button(localize('openRepository', "Open Repository"), 'command:remoteHub.openRepository')),
 					when: 'isWeb && workspaceFolderCount == 0',
 					media: {
 						type: 'svg', altText: 'Explorer view showing buttons for opening folder and cloning repository.', path: 'openFolder.svg'

--- a/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
@@ -134,7 +134,7 @@ export const startEntries: GettingStartedStartEntryContent = [
 		id: 'topLevelGitOpen',
 		title: localize('gettingStarted.topLevelGitOpen.title', "Open Repository..."),
 		description: localize('gettingStarted.topLevelGitOpen.description', "Connect to a remote repository or pull request to browse, search, edit, and commit"),
-		when: 'isWeb',
+		when: 'workspacePlatform == \'webworker\'',
 		icon: Codicon.sourceControl,
 		content: {
 			type: 'startEntry',

--- a/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent.ts
@@ -131,6 +131,17 @@ export const startEntries: GettingStartedStartEntryContent = [
 		}
 	},
 	{
+		id: 'topLevelGitOpen',
+		title: localize('gettingStarted.topLevelGitOpen.title', "Open Repository..."),
+		description: localize('gettingStarted.topLevelGitOpen.description', "Connect to a remote repository or pull request to browse, search, edit, and commit"),
+		when: 'isWeb && workspaceFolderCount == 0',
+		icon: Codicon.sourceControl,
+		content: {
+			type: 'startEntry',
+			command: 'remoteHub.openRepository',
+		}
+	},
+	{
 		id: 'topLevelShowWalkthroughs',
 		title: localize('gettingStarted.topLevelShowWalkthroughs.title', "Open a Walkthrough..."),
 		description: localize('gettingStarted.topLevelShowWalkthroughs.description', ""),


### PR DESCRIPTION
- Adds a open remote repo on the Get Started page
- Reworded extensions entry