### PR TITLE
Remove built-in latext output rendering in nb

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -47,8 +47,7 @@
         "displayName": "Markdown it renderer",
         "entrypoint": "./notebook-out/index.js",
         "mimeTypes": [
-          "text/markdown",
-          "text/latex"
+          "text/markdown"
         ]
       }
     ],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode-jupyter/issues/7754
I added text/latex into vscode and removed text/latex from the jupyter renderers.
However since learnt that built-in renderer doesn't support a lot of latex formats, hence had to bring back text/latex into jupyter renderers.
