### PR TITLE
Limit forced Get Started page by product config

### DIFF
--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -114,7 +114,7 @@ export interface IProductConfiguration {
 	readonly reportMarketplaceIssueUrl?: string;
 	readonly licenseUrl?: string;
 	readonly privacyStatementUrl?: string;
-	readonly telemetryOptOutUrl?: string;
+	readonly showTelemetryOptOut?: boolean;
 
 	readonly npsSurveyUrl?: string;
 	readonly cesSurveyUrl?: string;

--- a/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -52,6 +52,7 @@ export class WelcomePageContribution implements IWorkbenchContribution {
 		// Always open Welcome page for first-launch, no matter what is open or which startupEditor is set.
 		if (
 			product.enableTelemetry
+			&& product.showTelemetryOptOut
 			&& getTelemetryLevel(this.configurationService) !== TelemetryLevel.NONE
 			&& !this.environmentService.skipWelcome
 			&& !this.storageService.get(telemetryOptOutStorageKey, StorageScope.GLOBAL)


### PR DESCRIPTION
New product config replaces the optout url to fix the unwelcome welcome pages on web.