### PR TITLE
Disable non syntax errors in files that don't have semantic capabilities

### DIFF
--- a/extensions/typescript-language-features/src/languageProvider.ts
+++ b/extensions/typescript-language-features/src/languageProvider.ts
@@ -9,6 +9,7 @@ import { CommandManager } from './commands/commandManager';
 import { DiagnosticKind } from './languageFeatures/diagnostics';
 import FileConfigurationManager from './languageFeatures/fileConfigurationManager';
 import { CachedResponse } from './tsServer/cachedResponse';
+import { ClientCapability } from './typescriptService';
 import TypeScriptServiceClient from './typescriptServiceClient';
 import { Disposable } from './utils/dispose';
 import { DocumentSelector } from './utils/documentSelector';
@@ -127,6 +128,10 @@ export default class LanguageProvider extends Disposable {
 	}
 
 	public diagnosticsReceived(diagnosticsKind: DiagnosticKind, file: vscode.Uri, diagnostics: (vscode.Diagnostic & { reportUnnecessary: any, reportDeprecated: any })[]): void {
+		if (diagnosticsKind !== DiagnosticKind.Syntax && !this.client.hasCapabilityForResource(file, ClientCapability.Semantic)) {
+			return;
+		}
+
 		const config = vscode.workspace.getConfiguration(this.id, file);
 		const reportUnnecessary = config.get<boolean>('showUnused', true);
 		const reportDeprecated = config.get<boolean>('showDeprecated', true);


### PR DESCRIPTION
If we're on a host that supports semantic checking, but in a file that doesn't support semantic errors, we currently don't want to report semantic errors since these will likely complain about imports and other undefined symols

