### PR TITLE
fix: avoid stack overflow when loading bracket guides for large files

### DIFF
--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -1800,8 +1800,8 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 	}
 
 	public getAllDecorations(ownerId: number = 0, filterOutValidation: boolean = false): model.IModelDecoration[] {
-		const result = this._decorationsTree.getAll(this, ownerId, filterOutValidation, false);
-		result.push(...this._decorationProvider.getAllDecorations(ownerId, filterOutValidation));
+		let result = this._decorationsTree.getAll(this, ownerId, filterOutValidation, false);
+		result = result.concat(this._decorationProvider.getAllDecorations(ownerId, filterOutValidation));
 		return result;
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #133923

`a.push(...b)` will push all items of `b` onto call stack, if `b` is too large, this can cause stack overflow.

However, loading bracket info for large files can still be terribly slow.