### PR TITLE
Implements horizontal guides for bracket guides.

### DIFF
--- a/src/vs/editor/browser/viewParts/indentGuides/indentGuides.css
+++ b/src/vs/editor/browser/viewParts/indentGuides/indentGuides.css
@@ -5,4 +5,5 @@
 
 .monaco-editor .lines-content .core-guide {
 	position: absolute;
+	box-sizing: border-box;
 }

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3347,8 +3347,21 @@ class BracketPairColorization extends BaseEditorOption<EditorOption.bracketPairC
 export interface IGuidesOptions {
 	/**
 	 * Enable rendering of bracket pair guides.
+	 * Defaults to 'none'.
 	*/
-	bracketPairs?: boolean;
+	bracketPairs?: 'all' | 'active' | 'none';
+
+	/**
+	 * Enable rendering of vertical bracket pair guides.
+	 * Defaults to 'active'.
+	 */
+	bracketPairsHorizontal?: 'all' | 'active' | 'none';
+
+	/**
+	 * Enable highlighting of the active bracket pair.
+	 * Defaults to true.
+	*/
+	highlightActiveBracketPair?: boolean;
 
 	/**
 	 * Enable rendering of indent guides.
@@ -3374,7 +3387,10 @@ export type InternalGuidesOptions = Readonly<Required<IGuidesOptions>>;
 class GuideOptions extends BaseEditorOption<EditorOption.guides, InternalGuidesOptions> {
 	constructor() {
 		const defaults: InternalGuidesOptions = {
-			bracketPairs: false,
+			bracketPairs: 'none',
+			bracketPairsHorizontal: 'active',
+			highlightActiveBracketPair: true,
+
 			indentation: true,
 			highlightActiveIndentation: true
 		};
@@ -3383,9 +3399,21 @@ class GuideOptions extends BaseEditorOption<EditorOption.guides, InternalGuidesO
 			EditorOption.guides, 'guides', defaults,
 			{
 				'editor.guides.bracketPairs': {
-					type: 'boolean',
+					type: 'string',
+					enum: ['all', 'active', 'none'],
 					default: defaults.bracketPairs,
 					description: nls.localize('editor.guides.bracketPairs', "Controls whether bracket pair guides are enabled or not.")
+				},
+				'editor.guides.bracketPairsHorizontal': {
+					type: 'string',
+					enum: ['all', 'active', 'none'],
+					default: defaults.bracketPairsHorizontal,
+					description: nls.localize('editor.guides.bracketPairsHorizontal', "Controls whether horizontal bracket pair guides are enabled or not.")
+				},
+				'editor.guides.highlightActiveBracketPair': {
+					type: 'boolean',
+					default: defaults.highlightActiveBracketPair,
+					description: nls.localize('editor.guides.highlightActiveBracketPair', "Controls whether bracket pair guides are enabled or not.")
 				},
 				'editor.guides.indentation': {
 					type: 'boolean',
@@ -3407,7 +3435,10 @@ class GuideOptions extends BaseEditorOption<EditorOption.guides, InternalGuidesO
 		}
 		const input = _input as IGuidesOptions;
 		return {
-			bracketPairs: boolean(input.bracketPairs, this.defaultValue.bracketPairs),
+			bracketPairs: stringSet(input.bracketPairs, this.defaultValue.bracketPairs, ['all', 'active', 'none']),
+			bracketPairsHorizontal: stringSet(input.bracketPairsHorizontal, this.defaultValue.bracketPairsHorizontal, ['all', 'active', 'none']),
+			highlightActiveBracketPair: boolean(input.highlightActiveBracketPair, this.defaultValue.highlightActiveBracketPair),
+
 			indentation: boolean(input.indentation, this.defaultValue.indentation),
 			highlightActiveIndentation: boolean(input.highlightActiveIndentation, this.defaultValue.highlightActiveIndentation),
 		};

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -1026,7 +1026,7 @@ export interface ITextModel {
 	/**
 	 * @internal
 	 */
-	getLinesBracketGuides(startLineNumber: number, endLineNumber: number, activePosition: IPosition | null, highlightActiveGuides: boolean, includeNonActiveGuides: boolean): IndentGuide[][];
+	getLinesBracketGuides(startLineNumber: number, endLineNumber: number, activePosition: IPosition | null, options: BracketGuideOptions): IndentGuide[][];
 
 	/**
 	 * Change the decorations. The callback will be called with a change accessor
@@ -1336,10 +1336,43 @@ export interface ITextModel {
 /**
  * @internal
  */
+export enum HorizontalGuidesState {
+	Disabled,
+	EnabledForActive,
+	Enabled
+}
+
+/**
+ * @internal
+ */
+export interface BracketGuideOptions {
+	includeInactive: boolean,
+	horizontalGuides: HorizontalGuidesState,
+	highlightActive: boolean,
+}
+
+/**
+ * @internal
+ */
 export class IndentGuide {
 	constructor(
 		public readonly visibleColumn: number,
-		public readonly className: string
+		public readonly className: string,
+		/**
+		 * If set, this indent guide is a horizontal guide (no vertical part).
+		 * It starts at visibleColumn and continues until endColumn.
+		*/
+		public readonly horizontalLine: IndentGuideHorizontalLine | null,
+	) { }
+}
+
+/**
+ * @internal
+ */
+export class IndentGuideHorizontalLine {
+	constructor(
+		public readonly top: boolean,
+		public readonly endColumn: number,
 	) { }
 }
 

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -3078,9 +3078,13 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 		return { startLineNumber, endLineNumber, indent };
 	}
 
-	public getLinesBracketGuides(startLineNumber: number, endLineNumber: number, activePosition: IPosition | null, highlightActiveGuides: boolean, includeNonActiveGuides: boolean): model.IndentGuide[][] {
+	public getLinesBracketGuides(
+		startLineNumber: number,
+		endLineNumber: number,
+		activePosition: IPosition | null,
+		options: model.BracketGuideOptions
+	): model.IndentGuide[][] {
 		const result: model.IndentGuide[][] = [];
-
 		const bracketPairs = this._bracketPairColorizer.getBracketPairsInRange(
 			new Range(
 				startLineNumber,
@@ -3114,48 +3118,124 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 		}
 
 		const queue = new ArrayQueue(bracketPairs);
-		const activeBracketPairs = new Array<model.BracketPair>();
+		/** Indexed by nesting level */
+		const activeGuides = new Array<{
+			nestingLevel: number,
+			guideVisibleColumn: number,
+			start: Position,
+			visibleStartColumn: number,
+			end: Position,
+			visibleEndColumn: number,
+			bracketPair: model.BracketPair,
+			renderHorizontalEndLineAtTheBottom: boolean
+		}>();
+		const nextGuides = new Array<model.IndentGuide>();
 		const colorProvider = new BracketPairGuidesClassNames();
 
 		for (let lineNumber = startLineNumber; lineNumber <= endLineNumber; lineNumber++) {
-			const guides = new Array<model.IndentGuide>();
+			let guides = new Array<model.IndentGuide>();
+			if (nextGuides.length > 0) {
+				guides = guides.concat(nextGuides);
+				nextGuides.length = 0;
+			}
 			result.push(guides);
 
-			for (const pair of queue.takeWhile(b => b.openingBracketRange.startLineNumber < lineNumber) || []) {
-				activeBracketPairs[pair.nestingLevel] = pair;
-			}
-
-			let lastVisibleColumnCount = Number.MAX_SAFE_INTEGER;
-			// Going backwards, so the last guide is before the others
-			for (let i = activeBracketPairs.length - 1; i >= 0; i--) {
-				const pair = activeBracketPairs[i];
-				if (pair.range.endLineNumber <= lineNumber) {
+			// Update activeGuides
+			for (const pair of queue.takeWhile(b => b.openingBracketRange.startLineNumber <= lineNumber) || []) {
+				if (pair.range.startLineNumber === pair.range.endLineNumber) {
+					// ignore single line brackets
 					continue;
 				}
-
-				const minIndentation = Math.min(
+				const guideVisibleColumn = Math.min(
 					this.getVisibleColumnFromPosition(pair.openingBracketRange.getStartPosition()),
 					this.getVisibleColumnFromPosition(pair.closingBracketRange?.getStartPosition() ?? pair.range.getEndPosition())
 				);
-
-				if (minIndentation > lastVisibleColumnCount) {
-					continue;
+				let renderHorizontalEndLineAtTheBottom = false;
+				if (pair.closingBracketRange) {
+					const firstNonWsIndex = strings.firstNonWhitespaceIndex(this.getLineContent(pair.closingBracketRange.startLineNumber));
+					if (firstNonWsIndex < pair.closingBracketRange.startColumn - 1) {
+						renderHorizontalEndLineAtTheBottom = true;
+					}
 				}
-				lastVisibleColumnCount = minIndentation;
+				// TODO: Consider indentation when computing guideVisibleColumn
+				const start = pair.openingBracketRange.getStartPosition();
+				const end = (pair.closingBracketRange?.getStartPosition() ?? pair.range.getEndPosition());
+				activeGuides[pair.nestingLevel] = {
+					nestingLevel: pair.nestingLevel,
+					guideVisibleColumn,
+					start,
+					visibleStartColumn: this.getVisibleColumnFromPosition(start),
+					end,
+					visibleEndColumn: this.getVisibleColumnFromPosition(end),
+					bracketPair: pair,
+					renderHorizontalEndLineAtTheBottom
+				};
+			}
 
-				const isActive = highlightActiveGuides && activeBracketPairRange &&
-					pair.range.equalsRange(activeBracketPairRange);
+			for (const line of activeGuides) {
+				const isActive = activeBracketPairRange && line.bracketPair.range.equalsRange(activeBracketPairRange);
 
 				const className =
-					colorProvider.getInlineClassNameOfLevel(pair.nestingLevel) +
-					(isActive ? ' ' + colorProvider.activeClassName : '');
+					colorProvider.getInlineClassNameOfLevel(line.nestingLevel) +
+					(options.highlightActive && isActive ? ' ' + colorProvider.activeClassName : '');
 
-				if (isActive || includeNonActiveGuides) {
-					guides.push(new model.IndentGuide(minIndentation, className));
+				if (
+					(isActive && options.horizontalGuides !== model.HorizontalGuidesState.Disabled)
+					|| (options.includeInactive && options.horizontalGuides === model.HorizontalGuidesState.Enabled)
+				) {
+					if (line.start.lineNumber === lineNumber) {
+						if (line.guideVisibleColumn < line.visibleStartColumn) {
+							guides.push(new model.IndentGuide(line.guideVisibleColumn, className,
+								new model.IndentGuideHorizontalLine(false, line.start.column)));
+						}
+					}
+					if (line.end.lineNumber === lineNumber + 1) {
+						// The next line might have horizontal guides.
+						// However, the next line might also have a new bracket pair with the same indentation,
+						// so the current bracket pair might get replaced. That's why we push the guide to nextGuides one line ahead.
+						if (line.guideVisibleColumn < line.visibleEndColumn) {
+							nextGuides.push(new model.IndentGuide(line.guideVisibleColumn, className,
+								new model.IndentGuideHorizontalLine(!line.renderHorizontalEndLineAtTheBottom, line.end.column)));
+						}
+					}
 				}
 			}
 
-			guides.reverse();
+			let lastVisibleColumnCount = Number.MAX_SAFE_INTEGER;
+			// Going backwards, so the last guide potentially replaces others
+			for (let i = activeGuides.length - 1; i >= 0; i--) {
+				const line = activeGuides[i];
+
+				const isActive = options.highlightActive && activeBracketPairRange &&
+					line.bracketPair.range.equalsRange(activeBracketPairRange);
+
+				const className =
+					colorProvider.getInlineClassNameOfLevel(line.nestingLevel) +
+					(isActive ? ' ' + colorProvider.activeClassName : '');
+
+				if (isActive || options.includeInactive) {
+					if (line.renderHorizontalEndLineAtTheBottom && line.end.lineNumber === lineNumber + 1) {
+						nextGuides.push(new model.IndentGuide(line.guideVisibleColumn, className, null));
+					}
+				}
+
+				if (line.end.lineNumber <= lineNumber
+					|| line.start.lineNumber >= lineNumber) {
+					continue;
+				}
+
+				if (line.guideVisibleColumn > lastVisibleColumnCount) {
+					continue;
+				}
+				lastVisibleColumnCount = line.guideVisibleColumn;
+
+
+				if (isActive || options.includeInactive) {
+					guides.push(new model.IndentGuide(line.guideVisibleColumn, className, null));
+				}
+			}
+
+			guides.sort((a, b) => a.visibleColumn - b.visibleColumn);
 		}
 		return result;
 	}

--- a/src/vs/editor/common/viewModel/splitLinesCollection.ts
+++ b/src/vs/editor/common/viewModel/splitLinesCollection.ts
@@ -8,7 +8,7 @@ import { WrappingIndent } from 'vs/editor/common/config/editorOptions';
 import { IViewLineTokens, LineTokens } from 'vs/editor/common/core/lineTokens';
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
-import { EndOfLinePreference, IActiveIndentGuideInfo, IModelDecoration, IModelDeltaDecoration, IndentGuide, ITextModel, PositionAffinity } from 'vs/editor/common/model';
+import { BracketGuideOptions, EndOfLinePreference, IActiveIndentGuideInfo, IModelDecoration, IModelDeltaDecoration, IndentGuide, IndentGuideHorizontalLine, ITextModel, PositionAffinity } from 'vs/editor/common/model';
 import { ModelDecorationOptions, ModelDecorationOverviewRulerOptions } from 'vs/editor/common/model/textModel';
 import * as viewEvents from 'vs/editor/common/view/viewEvents';
 import { PrefixSumIndexOfResult } from 'vs/editor/common/viewModel/prefixSumComputer';
@@ -70,7 +70,7 @@ export interface IViewModelLinesCollection extends IDisposable {
 	getViewLineCount(): number;
 	getActiveIndentGuide(viewLineNumber: number, minLineNumber: number, maxLineNumber: number): IActiveIndentGuideInfo;
 	getViewLinesIndentGuides(viewStartLineNumber: number, viewEndLineNumber: number): number[];
-	getViewLinesBracketGuides(startLineNumber: number, endLineNumber: number, activePosition: IPosition | null, highlightActiveGuides: boolean, includeNonActiveGuides: boolean): IndentGuide[][];
+	getViewLinesBracketGuides(startLineNumber: number, endLineNumber: number, activePosition: IPosition | null, options: BracketGuideOptions): IndentGuide[][];
 	getViewLineContent(viewLineNumber: number): string;
 	getViewLineLength(viewLineNumber: number): number;
 	getViewLineMinColumn(viewLineNumber: number): number;
@@ -737,7 +737,7 @@ export class SplitLinesCollection implements IViewModelLinesCollection {
 
 	// #endregion
 
-	public getViewLinesBracketGuides(viewStartLineNumber: number, viewEndLineNumber: number, activeViewPosition: IPosition | null, highlightActiveGuides: boolean, includeNonActiveGuides: boolean): IndentGuide[][] {
+	public getViewLinesBracketGuides(viewStartLineNumber: number, viewEndLineNumber: number, activeViewPosition: IPosition | null, options: BracketGuideOptions): IndentGuide[][] {
 		const modelActivePosition = activeViewPosition ? this.convertViewPositionToModelPosition(activeViewPosition.lineNumber, activeViewPosition.column) : null;
 		const resultPerViewLine: IndentGuide[][] = [];
 
@@ -748,8 +748,7 @@ export class SplitLinesCollection implements IViewModelLinesCollection {
 				modelRangeStartLineNumber,
 				group.modelRange.endLineNumber,
 				modelActivePosition,
-				highlightActiveGuides,
-				includeNonActiveGuides
+				options
 			);
 
 			for (const viewLineInfo of group.viewLines) {
@@ -757,7 +756,16 @@ export class SplitLinesCollection implements IViewModelLinesCollection {
 					// Don't add indent guides when the wrapped line continuation has no wrapping-indentation.
 					resultPerViewLine.push([]);
 				} else {
-					const bracketGuides = bracketGuidesPerModelLine[viewLineInfo.modelLineNumber - modelRangeStartLineNumber];
+					let bracketGuides = bracketGuidesPerModelLine[viewLineInfo.modelLineNumber - modelRangeStartLineNumber];
+
+					// visibleColumns stay as they are (this is a bug and needs to be fixed, but it is not a regression)
+					// model-columns must be converted to view-model columns.
+					bracketGuides = bracketGuides.map(g => g.horizontalLine ?
+						new IndentGuide(g.visibleColumn, g.className,
+							new IndentGuideHorizontalLine(g.horizontalLine.top,
+								this.convertModelPositionToViewPosition(viewLineInfo.modelLineNumber, g.horizontalLine.endColumn).column
+							)
+						) : g);
 					resultPerViewLine.push(bracketGuides);
 				}
 			}

--- a/src/vs/editor/common/viewModel/viewModel.ts
+++ b/src/vs/editor/common/viewModel/viewModel.ts
@@ -9,7 +9,7 @@ import { IViewLineTokens } from 'vs/editor/common/core/lineTokens';
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { INewScrollPosition, ScrollType } from 'vs/editor/common/editorCommon';
-import { EndOfLinePreference, IActiveIndentGuideInfo, IModelDecorationOptions, TextModelResolvedOptions, ITextModel, InjectedTextOptions, PositionAffinity, IndentGuide } from 'vs/editor/common/model';
+import { EndOfLinePreference, IActiveIndentGuideInfo, IModelDecorationOptions, TextModelResolvedOptions, ITextModel, InjectedTextOptions, PositionAffinity, IndentGuide, BracketGuideOptions } from 'vs/editor/common/model';
 import { VerticalRevealType } from 'vs/editor/common/view/viewEvents';
 import { IPartialViewLinesViewportData } from 'vs/editor/common/viewLayout/viewLinesViewportData';
 import { IEditorWhitespace, IWhitespaceChangeAccessor } from 'vs/editor/common/viewLayout/linesLayout';
@@ -333,7 +333,7 @@ export interface IViewModel extends ICursorSimpleModel {
 	getLineLength(lineNumber: number): number;
 	getActiveIndentGuide(lineNumber: number, minLineNumber: number, maxLineNumber: number): IActiveIndentGuideInfo;
 	getLinesIndentGuides(startLineNumber: number, endLineNumber: number): number[];
-	getBracketGuidesInRangeByLine(startLineNumber: number, endLineNumber: number, activePosition: IPosition | null, highlightActiveGuides: boolean, includeNonActiveGuides: boolean): IndentGuide[][];
+	getBracketGuidesInRangeByLine(startLineNumber: number, endLineNumber: number, activePosition: IPosition | null, options: BracketGuideOptions): IndentGuide[][];
 	getLineMinColumn(lineNumber: number): number;
 	getLineMaxColumn(lineNumber: number): number;
 	getLineFirstNonWhitespaceColumn(lineNumber: number): number;

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -12,7 +12,7 @@ import { IPosition, Position } from 'vs/editor/common/core/position';
 import { ISelection, Selection } from 'vs/editor/common/core/selection';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { IConfiguration, IViewState, ScrollType, ICursorState, ICommand, INewScrollPosition } from 'vs/editor/common/editorCommon';
-import { EndOfLinePreference, IActiveIndentGuideInfo, ITextModel, TrackedRangeStickiness, TextModelResolvedOptions, IIdentifiedSingleEditOperation, ICursorStateComputer, PositionAffinity, IndentGuide } from 'vs/editor/common/model';
+import { EndOfLinePreference, IActiveIndentGuideInfo, ITextModel, TrackedRangeStickiness, TextModelResolvedOptions, IIdentifiedSingleEditOperation, ICursorStateComputer, PositionAffinity, IndentGuide, BracketGuideOptions } from 'vs/editor/common/model';
 import { ModelDecorationOverviewRulerOptions, ModelDecorationMinimapOptions } from 'vs/editor/common/model/textModel';
 import * as textModelEvents from 'vs/editor/common/model/textModelEvents';
 import { ColorId, LanguageId, TokenizationRegistry } from 'vs/editor/common/modes';
@@ -614,8 +614,8 @@ export class ViewModel extends Disposable implements IViewModel {
 		return this._lines.getViewLinesIndentGuides(startLineNumber, endLineNumber);
 	}
 
-	public getBracketGuidesInRangeByLine(startLineNumber: number, endLineNumber: number, activePosition: IPosition | null, highlightActiveGuides: boolean, includeNonActiveGuides: boolean): IndentGuide[][] {
-		return this._lines.getViewLinesBracketGuides(startLineNumber, endLineNumber, activePosition, highlightActiveGuides, includeNonActiveGuides);
+	public getBracketGuidesInRangeByLine(startLineNumber: number, endLineNumber: number, activePosition: IPosition | null, options: BracketGuideOptions): IndentGuide[][] {
+		return this._lines.getViewLinesBracketGuides(startLineNumber, endLineNumber, activePosition, options);
 	}
 
 	public getLineContent(lineNumber: number): string {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3864,8 +3864,19 @@ declare namespace monaco.editor {
 	export interface IGuidesOptions {
 		/**
 		 * Enable rendering of bracket pair guides.
+		 * Defaults to 'none'.
 		*/
-		bracketPairs?: boolean;
+		bracketPairs?: 'all' | 'active' | 'none';
+		/**
+		 * Enable rendering of vertical bracket pair guides.
+		 * Defaults to 'active'.
+		 */
+		bracketPairsHorizontal?: 'all' | 'active' | 'none';
+		/**
+		 * Enable highlighting of the active bracket pair.
+		 * Defaults to true.
+		*/
+		highlightActiveBracketPair?: boolean;
 		/**
 		 * Enable rendering of indent guides.
 		 * Defaults to true.


### PR DESCRIPTION
I don't like the hack with `nextGuides`, but I thought at least 30 minutes on how to do it better.

It is for this corner-case where two bracket pairs share a common line:

![recording](https://user-images.githubusercontent.com/2931520/135582867-8124220a-adbc-4f1b-b397-e9885bd7ec31.gif)

Horizontal guides are only shown for the active bracket pair guide.
Currently, there is not setting.

When there is text before the closing bracket, the horizontal line is drawn at the bottom:
![recording](https://user-images.githubusercontent.com/2931520/135585274-ffbef426-2b6c-4c8d-aed4-8c85389a24d9.gif)

These settings are changed/introduced:
```ts
const defaults: InternalGuidesOptions = {
    bracketPairs: 'none',
    bracketPairsVertical: 'active',
    highlightActiveBracketPair: true,
};

'editor.guides.bracketPairs': {
    type: ['string', 'boolean'],
    enum: [true, false, 'active'],
    default: defaults.bracketPairs,
    description: nls.localize('editor.guides.bracketPairs', "Controls whether bracket pair guides are enabled or not.")
},
'editor.guides.bracketPairsVertical': {
    type: ['string', 'boolean'],
    enum: [true, false, 'active'],
    default: defaults.bracketPairsVertical,
    description: nls.localize('editor.guides.bracketPairsVertical', "Controls whether vertical bracket pair guides are enabled or not.")
},
'editor.guides.highlightActiveBracketPair': {
    type: 'boolean',
    default: defaults.highlightActiveBracketPair,
    description: nls.localize('editor.guides.highlightActiveBracketPair', "Controls whether bracket pair guides are enabled or not.")
},
```