### PR TITLE
Fix deadlock in `IExtensionService`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.60.2",
+  "version": "1.60.3",
   "distro": "0ea9111ff3b92a2070f03c531e3af26435112451",
   "author": {
     "name": "Microsoft Corporation"

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -263,6 +263,10 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 		let lock: IDisposable | null = null;
 		try {
 			this._inHandleDeltaExtensions = true;
+
+			// wait for _initialize to finish before hanlding any delta extension events
+			await this._installedExtensionsReady.wait();
+
 			lock = await this._registryLock.acquire('handleDeltaExtensions');
 			while (this._deltaExtensionsQueue.length > 0) {
 				const item = this._deltaExtensionsQueue.shift()!;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/134276

* the problem appears when the listener for `IExtensionManagementService.onDidInstallExtensions` fires before `AbstractExtensionService._initialize` is called.
* the event listener grabs the registry lock in `_handleDeltaExtensions` but then ends up awaiting on some extension host to start in order to tell it which extensions got installed.
* the extension hosts never start because `_initialize` cannot grab the lock anymore because it is being held by `_handleDeltaExtensions`.
* the fix is to delay handling any events until `_initialize` has finished. this is done by reusing the `_installedExtensionsReady` barrier.
