### PR TITLE
Re-enable webview tests on web

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
@@ -18,7 +18,7 @@ function workspaceFile(...segments: string[]) {
 const testDocument = workspaceFile('bower.json');
 
 
-suite.only('vscode API - webview', () => {
+suite('vscode API - webview', () => {
 	const disposables: vscode.Disposable[] = [];
 
 	function _register<T extends vscode.Disposable>(disposable: T) {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
@@ -339,18 +339,15 @@ suite('vscode API - webview', () => {
 		const imagePath = workspaceFile('sub', 'image.png').with({ scheme: 'vscode-resource' }).toString();
 
 		webview.webview.html = createHtmlDocumentWithBody(/*html*/`
-			<img>
+			<img src="${imagePath}">
 			<script>
 				const vscode = acquireVsCodeApi();
-				window.addEventListener('message', (message) => {
-					const img = document.getElementsByTagName('img')[0];
-					img.addEventListener('load', () => { vscode.postMessage({ value: true }); });
-					img.addEventListener('error', () => { vscode.postMessage({ value: false }); });
-					img.src = message.data.src;
-				});
 				vscode.postMessage({ type: 'ready', userAgent: window.navigator.userAgent });
-			</script>`);
 
+				const img = document.getElementsByTagName('img')[0];
+				img.addEventListener('load', () => { vscode.postMessage({ value: true }); });
+				img.addEventListener('error', () => { vscode.postMessage({ value: false }); });
+			</script>`);
 
 		const ready = getMessage(webview);
 		if ((await ready).userAgent.indexOf('Firefox') >= 0) {

--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -198,7 +198,7 @@ function getVsCodeApiScript(allowMultipleAPIAcquire, state) {
 }
 
 /** @type {Promise<void>} */
-const workerReady = new Promise(async (resolve, reject) => {
+const workerReady = new Promise((resolve, reject) => {
 	if (!areServiceWorkersEnabled()) {
 		return reject(new Error('Service Workers are not enabled. Webviews will not work. Try disabling private/incognito mode.'));
 	}
@@ -752,7 +752,6 @@ onDomReady(() => {
 	let updateId = 0;
 	hostMessaging.onMessage('content', async (_event, /** @type {ContentUpdateData} */ data) => {
 		const currentUpdateId = ++updateId;
-
 		try {
 			await workerReady;
 		} catch (e) {


### PR DESCRIPTION
This PR fixes #131622

- Disables resource loading tests on Firefox. I spent a lot of time trying to track down what is going wrong with these, but didn't make much progress
- Add extra logging to playwright to help investigate issues like these 


