### PR TITLE
Add command to delete remote tag (fix #104845)

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -341,6 +341,11 @@
         "category": "Git"
       },
       {
+        "command": "git.deleteRemoteTag",
+        "title": "%command.deleteRemoteTag%",
+        "category": "Git"
+      },
+      {
         "command": "git.fetch",
         "title": "%command.fetch%",
         "category": "Git"
@@ -781,6 +786,10 @@
         },
         {
           "command": "git.deleteTag",
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
+        },
+        {
+          "command": "git.deleteRemoteTag",
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
         },
         {
@@ -1614,6 +1623,10 @@
         {
           "command": "git.deleteTag",
           "group": "tags@2"
+        },
+        {
+          "command": "git.deleteRemoteTag",
+          "group": "tags@3"
         }
       ]
     },

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -58,6 +58,7 @@
 	"command.rebase": "Rebase Branch...",
 	"command.createTag": "Create Tag",
 	"command.deleteTag": "Delete Tag",
+	"command.deleteRemoteTag": "Delete Remote Tag",
 	"command.fetch": "Fetch",
 	"command.fetchPrune": "Fetch (Prune)",
 	"command.fetchAll": "Fetch From All Remotes",

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1485,7 +1485,12 @@ export class Repository {
 	}
 
 	async deleteTag(name: string): Promise<void> {
-		let args = ['tag', '-d', name];
+		const args = ['tag', '-d', name];
+		await this.exec(args);
+	}
+
+	async deleteRemoteTag(remoteName: string, tagName: string): Promise<void> {
+		const args = ['push', '--delete', remoteName, tagName];
 		await this.exec(args);
 	}
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -331,6 +331,7 @@ export const enum Operation {
 	Ignore = 'Ignore',
 	Tag = 'Tag',
 	DeleteTag = 'DeleteTag',
+	DeleteRemoteTag = 'DeleteRemoteTag',
 	Stash = 'Stash',
 	CheckIgnore = 'CheckIgnore',
 	GetObjectDetails = 'GetObjectDetails',
@@ -1285,6 +1286,10 @@ export class Repository implements Disposable {
 
 	async deleteTag(name: string): Promise<void> {
 		await this.run(Operation.DeleteTag, () => this.repository.deleteTag(name));
+	}
+
+	async deleteRemoteTag(remoteName: string, tagName: string): Promise<void> {
+		await this.run(Operation.DeleteRemoteTag, () => this.repository.deleteRemoteTag(remoteName, tagName));
 	}
 
 	async checkout(treeish: string, opts?: { detached?: boolean; }): Promise<void> {


### PR DESCRIPTION
This PR fixes #104845 by creating a new "Delete Remote Tag" command to Git.

The action is available through Command Palette and through the "More Actions..." menu.

1. The user selects a tag
2. The user selects the remote to delete the tag from
3. The command `git push --delete {remoteName} {tagName}` is executed