### PR TITLE
Allow links to specific line number of any file

### DIFF
--- a/extensions/markdown-language-features/src/commands/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/commands/openDocumentLink.ts
@@ -83,7 +83,7 @@ export class OpenDocumentLinkCommand implements Command {
 
 	private static async tryOpen(engine: MarkdownEngine, resource: vscode.Uri, args: OpenDocumentLinkArgs, column: vscode.ViewColumn): Promise<boolean> {
 		const tryUpdateForActiveFile = async (): Promise<boolean> => {
-			if (vscode.window.activeTextEditor && isMarkdownFile(vscode.window.activeTextEditor.document)) {
+			if (vscode.window.activeTextEditor) {
 				if (vscode.window.activeTextEditor.document.uri.fsPath === resource.fsPath) {
 					await this.tryRevealLine(engine, vscode.window.activeTextEditor, args.fragment);
 					return true;


### PR DESCRIPTION
This PR fixes #125320

It removes the check on Markdown files when navigating to a file with a specific line number.

- `[xxx](topic.md#L5)` was working, and still works
- `[xxx](test.cpp#L3)` was not working (opening the file but without revealing any specific line) and is now fixed

