### PR TITLE
Set wordwrap to on for testingOutputPeek

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -774,6 +774,7 @@ const commonEditorOptions: IEditorOptions = {
 	minimap: {
 		enabled: false
 	},
+	wordWrap: 'on',
 };
 
 const diffEditorOptions: IDiffEditorConstructionOptions = {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #134232.
Set [wordwrap](https://github.com/microsoft/vscode/blob/a4342f3addc29f405a5cb4aab359b0b98223411e/src/vs/editor/common/config/editorOptions.ts#L271) for testingOutputPeek to 'on'.
