### PR TITLE
Make button hints clickable

### DIFF
--- a/src/vs/base/browser/ui/keybindingLabel/keybindingLabel.css
+++ b/src/vs/base/browser/ui/keybindingLabel/keybindingLabel.css
@@ -18,6 +18,11 @@
 	font-size: 11px;
 	padding: 3px 5px;
 	margin: 0 2px;
+	position: relative;
+}
+
+.monaco-keybinding > .monaco-keybinding-key:active {
+	top: 0.2em;
 }
 
 .monaco-keybinding > .monaco-keybinding-key:first-child {

--- a/src/vs/workbench/contrib/watermark/browser/watermark.css
+++ b/src/vs/workbench/contrib/watermark/browser/watermark.css
@@ -23,6 +23,7 @@
 	text-align: center;
 	white-space: nowrap;
 	overflow: hidden;
+	z-index: 10;
 }
 
 .monaco-workbench .part.editor > .content.empty > .watermark > .watermark-box {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR doesn't really fix any issue.

But, it adds a fun little easter egg to the editor &mdash; the button icons in keyboard hints are now clickable:

https://user-images.githubusercontent.com/43412083/135757386-7d836fea-d549-4428-843a-fbf5384f8187.mp4


I think this would be a nice, fun addition to the project. Any critique/suggestions are welcome!
