### PR TITLE
Implements Balanced Bracket Pair Delete

### DIFF
--- a/src/vs/editor/common/controller/cursorWordOperations.ts
+++ b/src/vs/editor/common/controller/cursorWordOperations.ts
@@ -57,6 +57,7 @@ export interface DeleteWordContext {
 	autoClosingQuotes: EditorAutoClosingStrategy;
 	autoClosingPairs: AutoClosingPairs;
 	autoClosedCharacters: Range[];
+	deleteBracketPair: boolean;
 }
 
 export class WordOperations {

--- a/src/vs/editor/contrib/wordOperations/test/wordOperations.test.ts
+++ b/src/vs/editor/contrib/wordOperations/test/wordOperations.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { CoreEditingCommands } from 'vs/editor/browser/controller/coreCommands';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorCommand } from 'vs/editor/browser/editorExtensions';
@@ -870,5 +871,26 @@ suite('WordOperations', () => {
 			deleteInsideWord(editor);
 			assert.strictEqual(model.getValue(), '');
 		});
+	});
+
+	test('deleteWordLeft - brackets', () => {
+		const store = new DisposableStore();
+		try {
+			const mode = 'testMode';
+			store.add(LanguageConfigurationRegistry.register(mode, {
+				brackets: [
+					['{', '}'], ['[', ']'], ['(', ')']
+				]
+			}));
+
+			withTestCodeEditor(null, { model: createTextModel('{ text }', {}, mode) }, (editor, _) => {
+				const model = editor.getModel()!;
+				editor.setPosition(new Position(1, 9));
+				_deleteWordLeft.runEditorCommand(null, editor, { deleteBracketPair: true });
+				assert.strictEqual(model.getValue(), ' text ');
+			});
+		} finally {
+			store.dispose();
+		}
 	});
 });

--- a/src/vs/editor/contrib/wordOperations/wordOperations.ts
+++ b/src/vs/editor/contrib/wordOperations/wordOperations.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { flatten } from 'vs/base/common/arrays';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, EditorCommand, ICommandOptions, registerEditorAction, registerEditorCommand, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
@@ -330,7 +331,7 @@ export abstract class DeleteWordCommand extends EditorCommand {
 		this._wordNavigationType = opts.wordNavigationType;
 	}
 
-	public runEditorCommand(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
+	public runEditorCommand(accessor: ServicesAccessor | null, editor: ICodeEditor, args: any): void {
 		if (!editor.hasModel()) {
 			return;
 		}
@@ -342,8 +343,8 @@ export abstract class DeleteWordCommand extends EditorCommand {
 		const autoClosingPairs = LanguageConfigurationRegistry.getAutoClosingPairs(model.getLanguageId());
 		const viewModel = editor._getViewModel();
 
-		const commands = selections.map((sel) => {
-			const deleteRange = this._delete({
+		const commands = flatten(selections.map((sel) => {
+			const deleteRanges = this._delete({
 				wordSeparators,
 				model,
 				selection: sel,
@@ -352,38 +353,51 @@ export abstract class DeleteWordCommand extends EditorCommand {
 				autoClosingBrackets,
 				autoClosingQuotes,
 				autoClosingPairs,
-				autoClosedCharacters: viewModel.getCursorAutoClosedCharacters()
+				autoClosedCharacters: viewModel.getCursorAutoClosedCharacters(),
+				deleteBracketPair: Boolean(args?.deleteBracketPair)
 			}, this._wordNavigationType);
-			return new ReplaceCommand(deleteRange, '');
-		});
+			return deleteRanges.map(range => new ReplaceCommand(range, ''));
+		}));
 
 		editor.pushUndoStop();
 		editor.executeCommands(this.id, commands);
 		editor.pushUndoStop();
 	}
 
-	protected abstract _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range;
+	protected abstract _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range[];
 }
 
 export class DeleteWordLeftCommand extends DeleteWordCommand {
-	protected _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range {
+	protected _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range[] {
+		if (ctx.deleteBracketPair) {
+			const brackets = ctx.model.bracketPairs.getBracketPairsInRange(Range.fromPositions(ctx.selection.getStartPosition()));
+			const lastBracket = brackets[brackets.length - 1];
+			if (lastBracket) {
+				if (lastBracket.closingBracketRange &&
+					(lastBracket.closingBracketRange.getEndPosition().equals(ctx.selection.getStartPosition())
+						|| lastBracket.openingBracketRange.getEndPosition().equals(ctx.selection.getStartPosition()))) {
+					return [lastBracket.closingBracketRange, lastBracket.openingBracketRange];
+				}
+			}
+		}
+
 		let r = WordOperations.deleteWordLeft(ctx, wordNavigationType);
 		if (r) {
-			return r;
+			return [r];
 		}
-		return new Range(1, 1, 1, 1);
+		return [new Range(1, 1, 1, 1)];
 	}
 }
 
 export class DeleteWordRightCommand extends DeleteWordCommand {
-	protected _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range {
+	protected _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range[] {
 		let r = WordOperations.deleteWordRight(ctx, wordNavigationType);
 		if (r) {
-			return r;
+			return [r];
 		}
 		const lineCount = ctx.model.getLineCount();
 		const maxColumn = ctx.model.getLineMaxColumn(lineCount);
-		return new Range(lineCount, maxColumn, lineCount, maxColumn);
+		return [new Range(lineCount, maxColumn, lineCount, maxColumn)];
 	}
 }
 

--- a/src/vs/editor/contrib/wordPartOperations/wordPartOperations.ts
+++ b/src/vs/editor/contrib/wordPartOperations/wordPartOperations.ts
@@ -31,12 +31,12 @@ export class DeleteWordPartLeft extends DeleteWordCommand {
 		});
 	}
 
-	protected _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range {
+	protected _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range[] {
 		let r = WordPartOperations.deleteWordPartLeft(ctx);
 		if (r) {
-			return r;
+			return [r];
 		}
-		return new Range(1, 1, 1, 1);
+		return [new Range(1, 1, 1, 1)];
 	}
 }
 
@@ -56,14 +56,14 @@ export class DeleteWordPartRight extends DeleteWordCommand {
 		});
 	}
 
-	protected _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range {
+	protected _delete(ctx: DeleteWordContext, wordNavigationType: WordNavigationType): Range[] {
 		let r = WordPartOperations.deleteWordPartRight(ctx);
 		if (r) {
-			return r;
+			return [r];
 		}
 		const lineCount = ctx.model.getLineCount();
 		const maxColumn = ctx.model.getLineMaxColumn(lineCount);
-		return new Range(lineCount, maxColumn, lineCount, maxColumn);
+		return [new Range(lineCount, maxColumn, lineCount, maxColumn)];
 	}
 }
 


### PR DESCRIPTION
This PR fixes #133663

Unfortunately, this code throws when deleting a bracket pair:

```
 ERR Cannot read property 'push' of undefined: TypeError: Cannot read property 'push' of undefined
    at vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/controller/cursor.js:644:71
    at Function._computeCursorState (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/model/editStack.js:365:46)
    at EditStack.pushEditOperation (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/model/editStack.js:352:48)
    at TextModel._pushEditOperations (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/model/textModel.js:1041:41)
    at TextModel.pushEditOperations (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/model/textModel.js:963:29)
    at Function._innerExecuteCommands (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/controller/cursor.js:634:45)
    at Function.executeCommands (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/controller/cursor.js:601:33)
    at CursorsController._executeEditOperation (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/controller/cursor.js:366:44)
    at vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/controller/cursor.js:584:22
    at CursorsController._executeEdit (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/controller/cursor.js:497:17)
    at CursorsController.executeCommands (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/controller/cursor.js:583:18)
    at vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/viewModel/viewModelImpl.js:814:69
    at ViewModel._withViewEventsCollector (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/viewModel/viewModelImpl.js:863:17)
    at ViewModel._executeCursorEdit (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/viewModel/viewModelImpl.js:785:18)
    at ViewModel.executeCommands (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/common/viewModel/viewModelImpl.js:814:18)
    at CodeEditorWidget.executeCommands (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/browser/widget/codeEditorWidget.js:822:39)
    at DeleteWordLeft.runEditorCommand (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/contrib/wordOperations/wordOperations.js:304:20)
    at vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/browser/editorExtensions.js:158:29
    at InstantiationService.invokeFunction (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/platform/instantiation/common/instantiationService.js:44:24)
    at CodeEditorWidget.invokeWithinContext (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/browser/widget/codeEditorWidget.js:206:47)
    at DeleteWordLeft.runCommand (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/browser/editorExtensions.js:152:27)
    at handler (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/editor/browser/editorExtensions.js:52:51)
    at InstantiationService.invokeFunction (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/platform/instantiation/common/instantiationService.js:44:24)
    at CommandService._tryExecuteCommand (vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/workbench/services/commands/common/commandService.js:74:59)
    at vscode-file://vscode-app/c:/dev/microsoft/vscode/out/vs/workbench/services/commands/common/commandService.js:64:47
```