### PR TITLE
Fix extended description

### DIFF
--- a/resources/linux/debian/control.template
+++ b/resources/linux/debian/control.template
@@ -11,7 +11,7 @@ Provides: visual-studio-@@NAME@@
 Conflicts: visual-studio-@@NAME@@
 Replaces: visual-studio-@@NAME@@
 Description: Code editing. Redefined.
- Visual Studio Code is a new choice of tool that combines the simplicity of a
-	code editor with what developers need for the core edit-build-debug cycle.
-	See https://code.visualstudio.com/docs/setup/linux for installation
-	instructions and FAQ.
+ Visual Studio Code is a new choice of tool that combines the simplicity of
+ a code editor with what developers need for the core edit-build-debug cycle.
+ See https://code.visualstudio.com/docs/setup/linux for installation
+ instructions and FAQ.


### PR DESCRIPTION
Only the first line of the extended description is visible, i.e. in `aptitude`, while the remaining ones are not.
This is due to the remaining lines starting with a tab character (`	`) instead of a space (` `).

As per [Debian Policy](https://www.debian.org/doc/debian-policy/ch-controlfields.html#description), tabs should not be used:

> Do not use tab characters. Their effect is not predictable.