### PR TITLE
Add tooltip for keybinding (#133655)

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint.ts
@@ -18,6 +18,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { ConfigurationChangedEvent, EditorOption } from 'vs/editor/common/config/editorOptions';
 import { registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { EventType as GestureEventType, Gesture } from 'vs/base/browser/touch';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 
 const $ = dom.$;
 
@@ -32,7 +33,8 @@ export class UntitledTextEditorHintContribution implements IEditorContribution {
 	constructor(
 		private editor: ICodeEditor,
 		@ICommandService private readonly commandService: ICommandService,
-		@IConfigurationService private readonly configurationService: IConfigurationService
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
 
 	) {
 		this.toDispose = [];
@@ -51,7 +53,7 @@ export class UntitledTextEditorHintContribution implements IEditorContribution {
 		const model = this.editor.getModel();
 
 		if (model && model.uri.scheme === Schemas.untitled && model.getModeId() === PLAINTEXT_MODE_ID && configValue === 'text') {
-			this.untitledTextHintContentWidget = new UntitledTextEditorHintContentWidget(this.editor, this.commandService, this.configurationService);
+			this.untitledTextHintContentWidget = new UntitledTextEditorHintContentWidget(this.editor, this.commandService, this.configurationService, this.keybindingService);
 		}
 	}
 
@@ -72,6 +74,7 @@ class UntitledTextEditorHintContentWidget implements IContentWidget {
 		private readonly editor: ICodeEditor,
 		private readonly commandService: ICommandService,
 		private readonly configurationService: IConfigurationService,
+		private readonly keybindingService: IKeybindingService,
 	) {
 		this.toDispose = [];
 		this.toDispose.push(editor.onDidChangeModelContent(() => this.onDidChangeModelContent()));
@@ -103,6 +106,11 @@ class UntitledTextEditorHintContentWidget implements IContentWidget {
 			const language = $('a.language-mode');
 			language.style.cursor = 'pointer';
 			language.innerText = localize('selectAlanguage2', "Select a language");
+			const languageKeyBinding = this.keybindingService.lookupKeybinding(ChangeModeAction.ID);
+			const languageKeybindingLabel = languageKeyBinding?.getLabel();
+			if (languageKeybindingLabel) {
+				language.title = localize('keyboardBindingTooltip', "{0}", languageKeybindingLabel);
+			}
 			this.domNode.appendChild(language);
 			const toGetStarted = $('span');
 			toGetStarted.innerText = localize('toGetStarted', " to get started. Start typing to dismiss, or ",);


### PR DESCRIPTION
This PR fixes #13365

Output with mouse cursor hidden:
With default keybinding:
![default_keybinding](https://user-images.githubusercontent.com/47393058/136012193-0e544897-06c1-4200-91cb-1ca57fd71ba5.png)

With changed keybinding:
![cutom_keybinding](https://user-images.githubusercontent.com/47393058/136012303-2135998d-e015-4752-b9ed-27adf8a8d32d.png)


