### PR TITLE
Decrease opacity of execution label for accessibility contrast ratio

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -584,7 +584,7 @@
 	font-family: var(--monaco-monospace-font);
 	white-space: pre;
 	box-sizing: border-box;
-	opacity: .6;
+	opacity: .7;
 
 	/* Sizing hacks */
 	bottom: 0px;


### PR DESCRIPTION
This PR fixes #105898
