### PR TITLE
Respect revealIfOpen setting when opening editors with Quick Open

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts
+++ b/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts
@@ -179,7 +179,13 @@ export abstract class BaseEditorQuickAccessProvider extends PickerQuickAccessPro
 
 					return TriggerAction.NO_ACTION;
 				},
-				accept: (keyMods, event) => this.editorGroupService.getGroup(groupId)?.openEditor(editor, { preserveFocus: event.inBackground }),
+				accept: (keyMods, event) => {
+					if (this.editorGroupService.partOptions.revealIfOpen) {
+						this.editorGroupService.getGroup(groupId)?.openEditor(editor, { preserveFocus: event.inBackground });
+					} else {
+						this.editorGroupService.activeGroup?.openEditor(editor, { preserveFocus: event.inBackground });
+					}
+				},
 			};
 		});
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes an issue where there is inconsistent behavior between opening file and editors when using Quick Open with respecting the `workbench.editor.revealIfOpen` setting.

#### Before this PR:
  * Using Quick Open to open a file does respect the `workbench.editor.revealIfOpen` setting.
  * Using Quick Open to open an editor ( 'edt' prefix ) **does not** respect the `workbench.editor.revealIfOpen` setting.

![Code-2021-10-06 at 01 13 05](https://user-images.githubusercontent.com/283496/136144388-5d9cea60-77a2-4c15-ac91-47c68d2d8f38.gif)

#### After this PR:
  * Using Quick Open to open a file does respect the `workbench.editor.revealIfOpen` setting.
  * Using Quick Open to open an editor ( 'edt' prefix ) **does** respect the `workbench.editor.revealIfOpen` setting

![Code - OSS-2021-10-06 at 01 01 05](https://user-images.githubusercontent.com/283496/136143477-5350bbba-28b6-430b-b604-c679c02cc72b.gif)

This PR is tangentially related to #94705 where there has been lots of discussion.

I made an alternative implementation which introduces a unique setting `workbench.editor.alwaysOpenInActiveGroupFromQuickOpen` here: https://github.com/microsoft/vscode/commit/02d4d732562d7dc36ddcae52ee822308c1ae2f90 But IMO, it is more clean to use the existing setting to create consistent behavior in this case, rather than introducing a new more granular setting.
