### PR TITLE
Add `workbench.editor.alwaysOpenInActiveGroupFromQuickOpen` setting

### DIFF
--- a/src/vs/platform/editor/common/editor.ts
+++ b/src/vs/platform/editor/common/editor.ts
@@ -236,6 +236,13 @@ export interface IEditorOptions {
 	revealIfOpened?: boolean;
 
 	/**
+	 * Controls whether editors opened from Quick Open will always open in the currently active editor group.
+	 * Similar to setting the 'revealIfOpened' setting to false, this will open multiple copies of an editor in
+	 * different editor groups.
+	 */
+	alwaysOpenInActiveGroupFromQuickOpen?: boolean;
+
+	/**
 	 * An editor that is pinned remains in the editor stack even when another editor is being opened.
 	 * An editor that is not pinned will always get replaced by another editor that is not pinned.
 	 */

--- a/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts
+++ b/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts
@@ -179,7 +179,13 @@ export abstract class BaseEditorQuickAccessProvider extends PickerQuickAccessPro
 
 					return TriggerAction.NO_ACTION;
 				},
-				accept: (keyMods, event) => this.editorGroupService.getGroup(groupId)?.openEditor(editor, { preserveFocus: event.inBackground }),
+				accept: (keyMods, event) => {
+					if (this.editorGroupService.partOptions.revealIfOpen) {
+						this.editorGroupService.getGroup(groupId)?.openEditor(editor, { preserveFocus: event.inBackground });
+					} else {
+						this.editorGroupService.activeGroup?.openEditor(editor, { preserveFocus: event.inBackground });
+					}
+				},
 			};
 		});
 	}

--- a/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts
+++ b/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts
@@ -180,10 +180,10 @@ export abstract class BaseEditorQuickAccessProvider extends PickerQuickAccessPro
 					return TriggerAction.NO_ACTION;
 				},
 				accept: (keyMods, event) => {
-					if (this.editorGroupService.partOptions.revealIfOpen) {
-						this.editorGroupService.getGroup(groupId)?.openEditor(editor, { preserveFocus: event.inBackground });
-					} else {
+					if (this.editorGroupService.partOptions.alwaysOpenInActiveGroupFromQuickOpen) {
 						this.editorGroupService.activeGroup?.openEditor(editor, { preserveFocus: event.inBackground });
+					} else {
+						this.editorGroupService.getGroup(groupId)?.openEditor(editor, { preserveFocus: event.inBackground });
 					}
 				},
 			};

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -162,6 +162,11 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'markdownDescription': localize('enablePreviewFromQuickOpen', "Controls whether editors opened from Quick Open show as preview. Preview editors do not keep open and are reused until explicitly set to be kept open (e.g. via double click or editing). This value is ignored when `#workbench.editor.enablePreview#` is disabled."),
 				'default': false
 			},
+			'workbench.editor.alwaysOpenInActiveGroupFromQuickOpen': {
+				'type': 'boolean',
+				'markdownDescription': localize('alwaysOpenInActiveGroupFromQuickOpen', "Controls whether editors opened from Quick Open will always open in the currently active Editor Group."),
+				'default': false
+			},
 			'workbench.editor.enablePreviewFromCodeNavigation': {
 				'type': 'boolean',
 				'markdownDescription': localize('enablePreviewFromCodeNavigation', "Controls whether editors remain in preview when a code navigation is started from them. Preview editors do not keep open and are reused until explicitly set to be kept open (e.g. via double click or editing). This value is ignored when `#workbench.editor.enablePreview#` is disabled."),

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -850,6 +850,7 @@ interface IEditorPartConfiguration {
 	closeEmptyGroups?: boolean;
 	autoLockGroups?: Set<string>;
 	revealIfOpen?: boolean;
+	alwaysOpenInActiveGroupFromQuickOpen?: boolean;
 	mouseBackForwardToNavigate?: boolean;
 	labelFormat?: 'default' | 'short' | 'medium' | 'long';
 	restoreViewState?: boolean;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR is a follow up from #134478.
It is also tangentially related to #94705 where there has been lots of discussion.

Rather than overriding the `workbench.editor.revealIfOpen` setting and changing the default behavior, a new setting is introduced in order to make this an opt in behavior.

When enabling the `workbench.editor.alwaysOpenInActiveGroupFromQuickOpen` setting, opening editors from Quick Open will always open in the active group.

This shows the change in behavior with the setting disabled and then enabled:

![Code - OSS-2021-10-06 at 14 49 25](https://user-images.githubusercontent.com/283496/136265105-90ac6389-6a60-45de-a2c6-8f5b3d593e8d.gif)



