### PR TITLE
Fixes wrong aliases for utf8 and utf8bom

### DIFF
--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -449,14 +449,14 @@ export const SUPPORTED_ENCODINGS: { [encoding: string]: { labelLong: string; lab
 		labelLong: 'UTF-8',
 		labelShort: 'UTF-8',
 		order: 1,
-		alias: 'utf8bom'
+		alias: 'utf8'
 	},
 	utf8bom: {
 		labelLong: 'UTF-8 with BOM',
 		labelShort: 'UTF-8 with BOM',
 		encodeOnly: true,
 		order: 2,
-		alias: 'utf8'
+		alias: 'utf8bom'
 	},
 	utf16le: {
 		labelLong: 'UTF-16 LE',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
The alias for utf8 and utf8bom were mixed up.