### PR TITLE
 Enlarge small markdown text size - trivial change

### DIFF
--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -54,16 +54,24 @@ export const activate: ActivationFunction<void> = (ctx) => {
 		}
 
 		h1 {
-			font-size: 26px;
-			line-height: 31px;
+			font-size: 1.8rem;
+			line-height: 34px;
 			margin: 0;
-			margin-bottom: 13px;
+			margin-bottom: 22px;
 		}
 
 		h2 {
-			font-size: 19px;
+			font-size: 1.5rem;
 			margin: 0;
-			margin-bottom: 10px;
+			margin-bottom: 2px;
+		}
+
+		h3 {
+			font-size: 1.25rem;
+		}
+
+		p {
+			font-size: 1.1em;
 		}
 
 		h1,

--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -54,20 +54,15 @@ export const activate: ActivationFunction<void> = (ctx) => {
 		}
 
 		h1 {
-			font-size: 1.8rem;
-			line-height: 31px;
-			margin: 0;
-			margin-bottom: 22px;
+			font-size: 2.25em;
 		}
 
 		h2 {
-			font-size: 1.5rem;
-			margin: 0;
-			margin-bottom: 2px;
+			font-size: 1.9em;
 		}
 
 		h3 {
-			font-size: 1.25rem;
+			font-size: 1.6em;
 		}
 
 		p {

--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -55,7 +55,7 @@ export const activate: ActivationFunction<void> = (ctx) => {
 
 		h1 {
 			font-size: 1.8rem;
-			line-height: 34px;
+			line-height: 31px;
 			margin: 0;
 			margin-bottom: 22px;
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR partially and trivially addresses #126294. It's a simple modification of default markdown font sizes for h1, h2, h3, and p, as there have been many complaints about the small size of regular text (p) elements. 

On Windows, these changes result in very similar sizing for affected elements as is displayed in Jupyter. Not sure how these changes perform on Mac/Linux yet.
