### PR TITLE
Use insiders bits when running tests

### DIFF
--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -234,9 +234,10 @@ export class BrowserWorkbenchEnvironmentService implements IWorkbenchEnvironment
 			|| this.productService.webviewContentExternalBaseUrlTemplate
 			|| 'https://{{uuid}}.vscode-webview.net/{{quality}}/{{commit}}/out/vs/workbench/contrib/webview/browser/pre/';
 
+		const webviewExternalEndpointCommit = this.payload?.get('webviewExternalEndpointCommit');
 		return endpoint
-			.replace('{{commit}}', this.payload?.get('webviewExternalEndpointCommit') ?? this.productService.commit ?? '5f19eee5dc9588ca96192f89587b5878b7d7180d')
-			.replace('{{quality}}', this.productService.quality || 'insider');
+			.replace('{{commit}}', webviewExternalEndpointCommit ?? this.productService.commit ?? '5f19eee5dc9588ca96192f89587b5878b7d7180d')
+			.replace('{{quality}}', (webviewExternalEndpointCommit ? 'insider' : this.productService.quality) ?? 'insider');
 	}
 
 	@memoize


### PR DESCRIPTION
These tests run before the content for the webview is published. To work around this while keeping the environment as close to production as possible (instead of running a local server), we use previously published bits from insiders inside the webview to run these tests. We do this by overriding  `webviewExternalEndpoint` in the tests

This change makes sure we always use the insiders bits when overriding `webviewExternalEndpoint` as the bits we are using only exist for insiders
