### PR TITLE
Specific the map generics in history.ts explicitly

### DIFF
--- a/src/vs/workbench/services/history/browser/history.ts
+++ b/src/vs/workbench/services/history/browser/history.ts
@@ -113,7 +113,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 	private readonly activeEditorListeners = this._register(new DisposableStore());
 	private lastActiveEditor?: IEditorIdentifier;
 
-	private readonly editorStackListeners = new Map();
+	private readonly editorStackListeners = new Map<EditorInput, DisposableStore>();
 
 	constructor(
 		@IEditorService private readonly editorService: EditorServiceImpl,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

editorStackListeners in history.ts defines a Map(); without specifying the generics which causes issues when we compile locally.

This is a small PR to specify the generic types explicitly.
