### PR TITLE
Fix env passing with open cmd

### DIFF
--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -357,7 +357,7 @@ export async function main(argv: string[]): Promise<any> {
 
 		const options: SpawnOptions = {
 			detached: true,
-			env
+			env: {}
 		};
 
 		if (!verbose) {
@@ -367,7 +367,7 @@ export async function main(argv: string[]): Promise<any> {
 		let child: ChildProcess;
 		if (!isMacOSBigSurOrNewer) {
 			// We spawn process.execPath directly
-			child = spawn(process.execPath, argv.slice(2), options);
+			child = spawn(process.execPath, argv.slice(2), { ...options, env });
 		} else {
 			// On Big Sur, we spawn using the open command to obtain behavior
 			// similar to if the app was launched from the dock
@@ -428,13 +428,7 @@ export async function main(argv: string[]): Promise<any> {
 				}
 			}
 
-			const truncatedOptions = {
-				detached: options.detached,
-				stdio: options['stdio'],
-				env: {}
-			};
-
-			child = spawn('open', spawnArgs, truncatedOptions);
+			child = spawn('open', spawnArgs, options);
 		}
 
 		return Promise.all(processCallbacks.map(callback => callback(child)));

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -428,15 +428,10 @@ export async function main(argv: string[]): Promise<any> {
 				}
 			}
 
-			// Keep just the _ env var here,
-			// because it's still needed to open Code,
-			// even though the open command doesn't understand it.
 			const truncatedOptions = {
 				detached: options.detached,
 				stdio: options['stdio'],
-				env: {
-					'_': options.env?.['_']
-				}
+				env: {}
 			};
 
 			child = spawn('open', spawnArgs, truncatedOptions);

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -357,7 +357,7 @@ export async function main(argv: string[]): Promise<any> {
 
 		const options: SpawnOptions = {
 			detached: true,
-			env: {}
+			env
 		};
 
 		if (!verbose) {
@@ -367,7 +367,7 @@ export async function main(argv: string[]): Promise<any> {
 		let child: ChildProcess;
 		if (!isMacOSBigSurOrNewer) {
 			// We spawn process.execPath directly
-			child = spawn(process.execPath, argv.slice(2), { ...options, env });
+			child = spawn(process.execPath, argv.slice(2), options);
 		} else {
 			// On Big Sur, we spawn using the open command to obtain behavior
 			// similar to if the app was launched from the dock
@@ -428,7 +428,10 @@ export async function main(argv: string[]): Promise<any> {
 				}
 			}
 
-			child = spawn('open', spawnArgs, options);
+			// We already passed over the env variables
+			// using the --env flags, so we can leave them out here.
+			// Also, we don't need to pass env._, which is different from argv._
+			child = spawn('open', spawnArgs, { ...options, env: {} });
 		}
 
 		return Promise.all(processCallbacks.map(callback => callback(child)));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #134696

This PR adds the following changes:
1. It passes in all env vars except for `_` to the open command using `--env` flags.
2. It passes in the `_` env var using the original path, still. I created a `truncatedOptions` object so we don't pass in the same env vars twice (which doesn't break anything, but is more confusing).
3. It adds a polish fix to the `launchDirIndex` (which only showed up while I was debugging this issue with a custom `code-cli.sh`, anyway).
