### PR TITLE
Add icon for deprecated messages in the settings ui

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -377,7 +377,11 @@
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item-contents.is-deprecated .setting-item-deprecation-message {
-	display: block;
+	display: flex;
+}
+
+.settings-editor > .settings-body > .settings-tree-container .setting-item-contents.is-deprecated .setting-item-deprecation-message .codicon {
+	margin-right: 4px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item-contents .setting-item-description {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -868,6 +868,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		} else {
 			template.deprecationWarningElement.innerText = deprecationText;
 		}
+		template.deprecationWarningElement.prepend($('.codicon.codicon-error'));
 		template.containerElement.classList.toggle('is-deprecated', !!deprecationText);
 
 		this.renderValue(element, <ISettingItemTemplate>template, onChange);


### PR DESCRIPTION
This PR fixes #135043 and adds an error icon to the deprecated message:

<img width="607" src="https://user-images.githubusercontent.com/35271042/137218297-f196ed19-26bc-4c0e-9757-2ad5d5378b07.png">

<img width="607" alt="CleanShot 2021-10-13 at 14 58 38@2x" src="https://user-images.githubusercontent.com/35271042/137218331-e2eb0752-9a83-48d6-89ab-1db036875645.png">

