### PR TITLE
feat: Optimize completion range field

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -11,7 +11,7 @@ import * as search from 'vs/workbench/contrib/search/common/search';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Position as EditorPosition } from 'vs/editor/common/core/position';
 import { Range as EditorRange, IRange } from 'vs/editor/common/core/range';
-import { ExtHostContext, MainThreadLanguageFeaturesShape, ExtHostLanguageFeaturesShape, MainContext, IExtHostContext, ILanguageConfigurationDto, IRegExpDto, IIndentationRuleDto, IOnEnterRuleDto, ILocationDto, IWorkspaceSymbolDto, reviveWorkspaceEditDto, IDocumentFilterDto, IDefinitionLinkDto, ISignatureHelpProviderMetadataDto, ILinkDto, ICallHierarchyItemDto, ISuggestDataDto, ICodeActionDto, ISuggestDataDtoField, ISuggestResultDtoField, ICodeActionProviderMetadataDto, ILanguageWordDefinitionDto, IdentifiableInlineCompletions, IdentifiableInlineCompletion, ITypeHierarchyItemDto } from '../common/extHost.protocol';
+import { ExtHostContext, MainThreadLanguageFeaturesShape, ExtHostLanguageFeaturesShape, MainContext, IExtHostContext, ILanguageConfigurationDto, IRegExpDto, IIndentationRuleDto, IOnEnterRuleDto, ILocationDto, IWorkspaceSymbolDto, reviveWorkspaceEditDto, IDocumentFilterDto, IDefinitionLinkDto, ISignatureHelpProviderMetadataDto, ILinkDto, ICallHierarchyItemDto, ISuggestDataDto, ICodeActionDto, ISuggestDataDtoField, ISuggestResultDtoField, ICodeActionProviderMetadataDto, ILanguageWordDefinitionDto, IdentifiableInlineCompletions, IdentifiableInlineCompletion, ITypeHierarchyItemDto, RangeSuggestDataDto } from '../common/extHost.protocol';
 import { LanguageConfigurationRegistry } from 'vs/editor/common/modes/languageConfigurationRegistry';
 import { LanguageConfiguration, IndentationRule, OnEnterRule } from 'vs/editor/common/modes/languageConfiguration';
 import { IModeService } from 'vs/editor/common/services/modeService';
@@ -463,7 +463,7 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 			filterText: data[ISuggestDataDtoField.filterText],
 			preselect: data[ISuggestDataDtoField.preselect],
 			insertText: data[ISuggestDataDtoField.insertText] ?? (typeof label === 'string' ? label : label.label),
-			range: data[ISuggestDataDtoField.range] ?? defaultRange,
+			range: RangeSuggestDataDto.from(data[ISuggestDataDtoField.range]) ?? defaultRange,
 			insertTextRules: data[ISuggestDataDtoField.insertTextRules],
 			commitCharacters: data[ISuggestDataDtoField.commitCharacters],
 			additionalTextEdits: data[ISuggestDataDtoField.additionalTextEdits],

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -17,7 +17,7 @@ import { Dto } from 'vs/base/common/types';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { RenderLineNumbersType, TextEditorCursorStyle } from 'vs/editor/common/config/editorOptions';
 import { IPosition } from 'vs/editor/common/core/position';
-import { IRange } from 'vs/editor/common/core/range';
+import { IRange, Range } from 'vs/editor/common/core/range';
 import { ISelection, Selection } from 'vs/editor/common/core/selection';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import { EndOfLineSequence, ISingleEditOperation } from 'vs/editor/common/model';
@@ -1434,6 +1434,21 @@ export const enum ISuggestDataDtoField {
 	kindModifier = 'n',
 }
 
+export namespace RangeSuggestDataDto {
+	export type ISuggestRangeDto = [number, number, number, number];
+	export function to(range: IRange): ISuggestRangeDto {
+		return [range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn];
+	}
+	export function from(range: ISuggestRangeDto | { insert: IRange; replace: IRange } | undefined): IRange | { insert: IRange, replace: IRange } {
+		return (Array.isArray(range) && range.length === 4) ? Range.lift({
+			startLineNumber: range[0],
+			startColumn: range[1],
+			endLineNumber: range[2],
+			endColumn: range[3],
+		}) : range as { insert: IRange, replace: IRange };
+	}
+}
+
 export interface ISuggestDataDto {
 	[ISuggestDataDtoField.label]: string | modes.CompletionItemLabel;
 	[ISuggestDataDtoField.kind]?: modes.CompletionItemKind;
@@ -1444,7 +1459,7 @@ export interface ISuggestDataDto {
 	[ISuggestDataDtoField.preselect]?: true;
 	[ISuggestDataDtoField.insertText]?: string;
 	[ISuggestDataDtoField.insertTextRules]?: modes.CompletionItemInsertTextRule;
-	[ISuggestDataDtoField.range]?: IRange | { insert: IRange, replace: IRange; };
+	[ISuggestDataDtoField.range]?: RangeSuggestDataDto.ISuggestRangeDto | { insert: IRange, replace: IRange; };
 	[ISuggestDataDtoField.commitCharacters]?: string[];
 	[ISuggestDataDtoField.additionalTextEdits]?: ISingleEditOperation[];
 	[ISuggestDataDtoField.command]?: modes.Command;

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1009,7 +1009,7 @@ class SuggestAdapter {
 
 		if (Range.isRange(range)) {
 			// "old" range
-			result[extHostProtocol.ISuggestDataDtoField.range] = typeConvert.Range.from(range);
+			result[extHostProtocol.ISuggestDataDtoField.range] = extHostProtocol.RangeSuggestDataDto.to(typeConvert.Range.from(range));
 
 		} else if (range && (!defaultInsertRange?.isEqual(range.inserting) || !defaultReplaceRange?.isEqual(range.replacing))) {
 			// ONLY send range when it's different from the default ranges (safe bandwidth)


### PR DESCRIPTION
improve [#71060](https://github.com/microsoft/vscode/issues/71060)

The ISuggestDataDto should also be able to compress the range field？

![image](https://user-images.githubusercontent.com/20262815/137463006-1fd5011a-0b3d-4d8d-b588-a9254b29a2da.png)

```typescript
{
  startLineNumber: 1,
  startColumn: 2,
  endLineNumber: 3,  -- convert -> [1,2,3,4]
  endColumn: 4,
}
```