### PR TITLE
feat: custom configurations for hover widgets

### DIFF
--- a/src/vs/base/browser/ui/hover/hover.css
+++ b/src/vs/base/browser/ui/hover/hover.css
@@ -25,7 +25,7 @@
 }
 
 .monaco-hover .markdown-hover > .hover-contents:not(.code-hover-contents) {
-	max-width: 500px;
+	max-width: 100%;
 	word-wrap: break-word;
 }
 

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1776,6 +1776,26 @@ export interface IEditorHoverOptions {
 	 * Defaults to true.
 	 */
 	sticky?: boolean;
+	/**
+	 * The font size for the hover widget.
+	 * Defaults to the editor font size.
+	 */
+	fontSize?: number;
+	/**
+	 * The line height for the hover widget.
+	 * Defaults to the editor line height.
+	 */
+	lineHeight?: number;
+	/**
+	 * The max width for the hover widget.
+	 * Defaults to the editor configuration.
+	 */
+	maxWidth?: number;
+	/**
+	 * The max height for the hover widget.
+	 * Defaults to the editor configuration.
+	 */
+	maxHeight?: number;
 }
 
 /**
@@ -1789,7 +1809,11 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, EditorHoverOption
 		const defaults: EditorHoverOptions = {
 			enabled: true,
 			delay: 300,
-			sticky: true
+			sticky: true,
+			fontSize: 0,
+			lineHeight: 0,
+			maxWidth: 0,
+			maxHeight: 0,
 		};
 		super(
 			EditorOption.hover, 'hover', defaults,
@@ -1809,6 +1833,26 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, EditorHoverOption
 					default: defaults.sticky,
 					description: nls.localize('hover.sticky', "Controls whether the hover should remain visible when mouse is moved over it.")
 				},
+				'editor.hover.fontSize': {
+					type: 'number',
+					default: defaults.fontSize,
+					description: nls.localize('hover.fontSize', "Controls the font size which the hover is shown.")
+				},
+				'editor.hover.lineHeight': {
+					type: 'number',
+					default: defaults.lineHeight,
+					description: nls.localize('hover.lineHeight', "Controls the line height which the hover is shown.")
+				},
+				'editor.hover.maxWidth': {
+					type: 'number',
+					default: defaults.maxWidth,
+					description: nls.localize('hover.maxWidth', "Controls the widget max width which the hover is shown.")
+				},
+				'editor.hover.maxHeight': {
+					type: 'number',
+					default: defaults.maxHeight,
+					description: nls.localize('hover.maxHeight', "Controls widget max height which the hover is shown.")
+				},
 			}
 		);
 	}
@@ -1821,7 +1865,11 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, EditorHoverOption
 		return {
 			enabled: boolean(input.enabled, this.defaultValue.enabled),
 			delay: EditorIntOption.clampedInt(input.delay, this.defaultValue.delay, 0, 10000),
-			sticky: boolean(input.sticky, this.defaultValue.sticky)
+			sticky: boolean(input.sticky, this.defaultValue.sticky),
+			fontSize: EditorIntOption.clampedInt(input.fontSize, this.defaultValue.fontSize, 0, 1000),
+			lineHeight: EditorIntOption.clampedInt(input.lineHeight, this.defaultValue.lineHeight, 0, 1000),
+			maxWidth: EditorIntOption.clampedInt(input.maxWidth, this.defaultValue.maxWidth, 0, 10000),
+			maxHeight: EditorIntOption.clampedInt(input.maxHeight, this.defaultValue.maxHeight, 0, 10000),
 		};
 	}
 }

--- a/src/vs/editor/contrib/hover/modesGlyphHover.ts
+++ b/src/vs/editor/contrib/hover/modesGlyphHover.ts
@@ -9,12 +9,13 @@ import { IMarkdownString, isEmptyMarkdownString } from 'vs/base/common/htmlConte
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { MarkdownRenderer } from 'vs/editor/browser/core/markdownRenderer';
 import { ICodeEditor, IOverlayWidget, IOverlayWidgetPosition } from 'vs/editor/browser/editorBrowser';
-import { ConfigurationChangedEvent, EditorOption } from 'vs/editor/common/config/editorOptions';
+import { ConfigurationChangedEvent, EditorOption, EDITOR_FONT_DEFAULTS } from 'vs/editor/common/config/editorOptions';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { HoverOperation, HoverStartMode, IHoverComputer } from 'vs/editor/contrib/hover/hoverOperation';
 import { Widget } from 'vs/base/browser/ui/widget';
 import { IOpenerService, NullOpenerService } from 'vs/platform/opener/common/opener';
 import { HoverWidget } from 'vs/base/browser/ui/hover/hoverWidget';
+import { isSafari } from 'vs/base/browser/browser';
 
 const $ = dom.$;
 
@@ -174,7 +175,28 @@ export class ModesGlyphHoverWidget extends Widget implements IOverlayWidget {
 
 	private _updateFont(): void {
 		const codeClasses: HTMLElement[] = Array.prototype.slice.call(this._hover.contentsDomNode.getElementsByClassName('code'));
-		codeClasses.forEach(node => this._editor.applyFontInfo(node));
+		// codeClasses.forEach(node => this._editor.applyFontInfo(node));
+
+		const fontInfo = this._editor.getOption(EditorOption.fontInfo);
+		const fontFamily = fontInfo.getMassagedFontFamily(isSafari ? EDITOR_FONT_DEFAULTS.fontFamily : null);
+		const fontFeatureSettings = fontInfo.fontFeatureSettings;
+		const HoverInfo = this._editor.getOption(EditorOption.hover);
+		const fontSize = HoverInfo.fontSize || fontInfo.fontSize;
+		const lineHeight = HoverInfo.lineHeight || fontInfo.lineHeight;
+		const letterSpacing = fontInfo.letterSpacing;
+		const fontWeight = fontInfo.fontWeight;
+		const fontSizePx = `${fontSize}px`;
+		const lineHeightPx = `${lineHeight}px`;
+		const letterSpacingPx = `${letterSpacing}px`;
+
+		codeClasses.forEach(domNode => {
+			domNode.style.fontFamily = fontFamily;
+			domNode.style.fontWeight = fontWeight;
+			domNode.style.fontSize = fontSizePx;
+			domNode.style.fontFeatureSettings = fontFeatureSettings;
+			domNode.style.lineHeight = lineHeightPx;
+			domNode.style.letterSpacing = letterSpacingPx;
+		});
 	}
 
 	private _updateContents(node: Node): void {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3498,6 +3498,26 @@ declare namespace monaco.editor {
 		 * Defaults to true.
 		 */
 		sticky?: boolean;
+		/**
+		 * The font size for the hover widget.
+		 * Defaults to the editor font size.
+		 */
+		fontSize?: number;
+		/**
+		 * The line height for the hover widget.
+		 * Defaults to the editor line height.
+		 */
+		lineHeight?: number;
+		/**
+		 * The max width for the hover widget.
+		 * Defaults to the editor configuration.
+		 */
+		maxWidth?: number;
+		/**
+		 * The max height for the hover widget.
+		 * Defaults to the editor configuration.
+		 */
+		maxHeight?: number;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## This PR is for new featre:

* Custom the font size for the hover widget.
* Custom line height for the hover widget.
* Custom max width for the hover widget.
* Custom max height for the hover widget.

## Advantage

* Could change the font size and line height different from editor's configuration.
* Custom the max size for hover widget and could see something more without scroll bar.

## Configuration

* `editor.hover.fontSize` 0 is defaults to the editor font size.
* `editor.hover.lineHeight` 0 is defaults to the editor line height.
* `editor.hover.maxWidth` 0 is defaults to the editor configuration.
* `editor.hover.maxHeight` 0 is defaults to the editor configuration.

## demo

![image](https://user-images.githubusercontent.com/30247854/137462528-a64f8cef-a340-4f7e-a7a0-99211e9b2495.png)

Like this, I could see something more clearly. I have created a pull request(#130095) about three month ago. But not get any suggestions. In my opinion, it is effective.
