### PR TITLE
Configurable global storage path via `VSCODE_GLOBAL_STORAGE`

### DIFF
--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -85,7 +85,14 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 	get machineSettingsResource(): URI { return joinPath(URI.file(join(this.userDataPath, 'Machine')), 'settings.json'); }
 
 	@memoize
-	get globalStorageHome(): URI { return URI.joinPath(this.appSettingsHome, 'globalStorage'); }
+	get globalStorageHome(): URI {
+		const globalStoragePath = env['VSCODE_GLOBAL_STORAGE'];
+		if (globalStoragePath) {
+			return URI.file(globalStoragePath);
+		}
+
+		return URI.joinPath(this.appSettingsHome, 'globalStorage');
+	}
 
 	@memoize
 	get workspaceStorageHome(): URI { return URI.joinPath(this.appSettingsHome, 'workspaceStorage'); }


### PR DESCRIPTION
This PR introduces a new environment variable `VSCODE_GLOBAL_STORAGE` which is very similar to the existing variable `VSCODE_EXTENSIONS` which allows users to set a custom path where extensions are installed (introduced in https://github.com/microsoft/vscode/pull/26849).

Extensions are generally advised to use the global storage to persist various data and our extension (similar to some others) places an executable binary there - specifically the language server.

We previously installed the binary into extension path, which didn't follow a good practice (AFAIK) and also it meant that LS had to be reinstalled whenever the extension was updated.

Our user has reported to us that they leverage `VSCODE_EXTENSIONS` to change where extensions are installed due to corporate policy and folks are allowed to run executables from that path. They are unable to run executables from the global storage however and they can't change the path to the global storage. This patch therefore addresses that.

I believe this would also help other extensions, such as [MS Remote Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) which also installs executables there.

Related discussion: https://github.com/hashicorp/vscode-terraform/pull/811#issuecomment-944349390