### PR TITLE
Add triage label when notebook label is assigned

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -75,6 +75,13 @@
 	},
 	{
 		"type": "label",
+		"name": "notebook-triage",
+		"regex": "notebook.*",
+		"action": "updateLabels",
+		"addLabel": "needs-notebook-triage"
+	},
+	{
+		"type": "label",
 		"name": "L10N",
 		"assign": [
 			"csigs",


### PR DESCRIPTION
Add the 'needs-notebook-triage' label to any issue that has 'notebook' in the label added.