### PR TITLE
Fixes #134612: Added electron flags for wayland

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -167,6 +167,9 @@ function configureCommandlineSwitchesSync(cliArgs) {
 
 		// Force enable screen readers on Linux via this flag
 		SUPPORTED_ELECTRON_SWITCHES.push('force-renderer-accessibility');
+
+		// Specify ozone platform implementation to use.
+		SUPPORTED_ELECTRON_SWITCHES.push('ozone-platform');
 	}
 
 	const SUPPORTED_MAIN_PROCESS_SWITCHES = [
@@ -194,12 +197,20 @@ function configureCommandlineSwitchesSync(cliArgs) {
 				}
 			}
 
-			// Others
+			// Other 'enabled' flags
 			else if (argvValue === true || argvValue === 'true') {
 				if (argvKey === 'disable-hardware-acceleration') {
 					app.disableHardwareAcceleration(); // needs to be called explicitly
 				} else {
 					app.commandLine.appendSwitch(argvKey);
+				}
+			}
+
+			// ozone platform
+			else if (argvKey === 'ozone-platform') {
+				if (argvValue) {
+					app.commandLine.appendSwitch(argvKey, argvValue);
+					app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform');
 				}
 			}
 		}

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -317,6 +317,10 @@ import { TELEMETRY_SETTING_ID } from 'vs/platform/telemetry/common/telemetry';
 			type: 'boolean',
 			description: localize('argv.force-renderer-accessibility', 'Forces the renderer to be accessible. ONLY change this if you are using a screen reader on Linux. On other platforms the renderer will automatically be accessible. This flag is automatically set if you have editor.accessibilitySupport: on.'),
 		};
+		schema.properties!['ozone-platform'] = {
+			type: 'string',
+			description: localize('argv.ozone-platform', "Configures the ozone platform implementation to be used by the runtime. Allowed values are 'wayland', 'x11'."),
+		};
 	}
 
 	jsonRegistry.registerSchema(argvDefinitionFileSchemaId, schema);


### PR DESCRIPTION
enable-features and the ozone-platform flag will be parsed from the runtime argv.json file.
This PR fixes #134612
