### PR TITLE
Changing port "privacy" to "visibility" to address Codespaces user confusion

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/tunnelView.ts
+++ b/src/vs/workbench/contrib/remote/browser/tunnelView.ts
@@ -295,7 +295,7 @@ class OriginColumn implements ITableColumn<ITunnelItem, ActionBarCell> {
 }
 
 class PrivacyColumn implements ITableColumn<ITunnelItem, ActionBarCell> {
-	readonly label: string = nls.localize('tunnel.privacyColumn.label', "Privacy");
+	readonly label: string = nls.localize('tunnel.privacyColumn.label', "Visibility");
 	readonly tooltip: string = nls.localize('tunnel.privacyColumn.tooltip', "The availability of the forwarded port.");
 	readonly weight: number = 1;
 	readonly templateId: string = 'actionbar';

--- a/src/vs/workbench/contrib/remote/browser/tunnelView.ts
+++ b/src/vs/workbench/contrib/remote/browser/tunnelView.ts
@@ -1579,7 +1579,7 @@ MenuRegistry.appendMenuItem(MenuId.TunnelContext, ({
 	group: '2_localaddress',
 	order: 2,
 	submenu: MenuId.TunnelPrivacy,
-	title: nls.localize('tunnelContext.privacyMenu', "Port Privacy"),
+	title: nls.localize('tunnelContext.privacyMenu', "Port Visibility"),
 	when: ContextKeyExpr.and(isForwardedExpr, TunnelPrivacyEnabledContextKey)
 }));
 MenuRegistry.appendMenuItem(MenuId.TunnelContext, ({


### PR DESCRIPTION
The Codespaces product team has gotten some user feedback that the term
`privacy` field of port forwarding is confusing. Some quick user feedback has
indicated that a term like `visibility` is more clear, e.g. "port 3000 is publicly
visible" rather than "port 3000's privacy setting is public."

We believe that Codespaces is the only user of this term as we're not aware
of it showing up anywhere else (e.g. `devcontainer.json`). Please let me know
if this isn't the case.

This PR is what I believe the minimal change required to change the UI
to show "Visibility" vs "Privacy", though I don't claim that it's
complete (e.g. I am not sure how we handle localization), rather, a
place to start the conversation.

@alexr00, I've been told you are the right person to direct this to, and
would love to chat about this change in more detail.

cc @lostintangent

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
