### PR TITLE
fix: the quick diff should respect `diffEditor.ignoreTrimWhitespace`

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -292,8 +292,7 @@ class DirtyDiffWidget extends PeekViewWidget {
 			fixedOverflowWidgets: true,
 			minimap: { enabled: false },
 			renderSideBySide: false,
-			readOnly: false,
-			ignoreTrimWhitespace: false
+			readOnly: false
 		};
 
 		this.diffEditor = this.instantiationService.createInstance(EmbeddedDiffEditorWidget, container, options, this.editor);


### PR DESCRIPTION
This PR fixes #130956.
