### PR TITLE
Word-wrap text in buttons

### DIFF
--- a/src/vs/base/browser/ui/button/button.css
+++ b/src/vs/base/browser/ui/button/button.css
@@ -12,6 +12,7 @@
 	cursor: pointer;
 	justify-content: center;
 	align-items: center;
+	white-space: normal;
 }
 
 .monaco-text-button:focus {


### PR DESCRIPTION
Instead of letting too long text in buttons flow over, wrap it. This looks like this:

![image](https://user-images.githubusercontent.com/38782922/137810302-0c3b949e-d7a6-44f7-85dc-d2f8cb9a6551.png)

This PR fixes #135336.

## Reviewer Notes

Not sure whether this approach is too simple, are there any buttons that should not be word-wrapped? I could not find any counter-example at a first glance, but I am open to any suggestions and willing to try to apply them. :-)