### PR TITLE
Properly fix #134053

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
@@ -166,9 +166,6 @@ export class TerminalGroupService extends Disposable implements ITerminalGroupSe
 	}
 
 	async showPanel(focus?: boolean): Promise<void> {
-		if (this.instances.length === 0) {
-			return;
-		}
 		const pane = this._viewsService.getActiveViewWithId(TERMINAL_VIEW_ID)
 			?? await this._viewsService.openView(TERMINAL_VIEW_ID, focus);
 		pane?.setExpanded(true);


### PR DESCRIPTION
This PR fixes #134053

@meganrogge after 0d1d04a59eb3df72828dbd84e5ea6e4ab0e3068e terminal focus is not working in the following case:
1. Open vscode and kill all the active terminals if any
2. Ensure panel is hidden
3. Open some file and focus editor
4. Run `workbench.action.terminal.toggleTerminal`
5. :bug: New terminal doesn't get focused