### PR TITLE
SCM: bring back focus restore

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1222,6 +1222,8 @@ class ViewModel {
 			this.scmProviderHasRootUriContextKey.set(false);
 		}
 
+		const focusedInput = this.inputRenderer.getFocusedInput();
+
 		if (!this.alwaysShowRepositories && (this.items.size === 1 && (!item || isRepositoryItem(item)))) {
 			const item = Iterable.first(this.items.values())!;
 			this.tree.setChildren(null, this.render(item, this.treeViewState).children);
@@ -1230,6 +1232,10 @@ class ViewModel {
 		} else {
 			const items = coalesce(this.scmViewService.visibleRepositories.map(r => this.items.get(r)));
 			this.tree.setChildren(null, items.map(item => this.render(item, this.treeViewState)));
+		}
+
+		if (focusedInput) {
+			this.inputRenderer.getRenderedInputWidget(focusedInput)?.focus();
 		}
 
 		this.updateRepositoryCollapseAllContextKeys();


### PR DESCRIPTION
This PR fixes #135143 for 1.61

This specific code was removed in https://github.com/microsoft/vscode/commit/fe175afdb80bd7a28caae83028e7440b45698007, when fixing https://github.com/microsoft/vscode/issues/112621, because I thought it was no longer relevant. Turns out it's still quite relevant!