### PR TITLE
Allow multiple languages in settings key

### DIFF
--- a/src/vs/platform/configuration/common/configuration.ts
+++ b/src/vs/platform/configuration/common/configuration.ts
@@ -189,7 +189,9 @@ export function compare(from: IConfigurationModel | undefined, to: IConfiguratio
 		for (const key of added) {
 			const override = toOverridesByIdentifier[key];
 			if (override) {
-				overrides.push([overrideIdentifierFromKey(key), override.keys]);
+				for (let identifier of overrideIdentifierFromKey(key)) {
+					overrides.push([identifier, override.keys]);
+				}
 			}
 		}
 	}
@@ -197,7 +199,9 @@ export function compare(from: IConfigurationModel | undefined, to: IConfiguratio
 		for (const key of removed) {
 			const override = fromOverridesByIdentifier[key];
 			if (override) {
-				overrides.push([overrideIdentifierFromKey(key), override.keys]);
+				for (let identifier of overrideIdentifierFromKey(key)) {
+					overrides.push([identifier, override.keys]);
+				}
 			}
 		}
 	}
@@ -208,7 +212,10 @@ export function compare(from: IConfigurationModel | undefined, to: IConfiguratio
 			const toOverride = toOverridesByIdentifier[key];
 			if (fromOverride && toOverride) {
 				const result = compare({ contents: fromOverride.contents, keys: fromOverride.keys, overrides: [] }, { contents: toOverride.contents, keys: toOverride.keys, overrides: [] });
-				overrides.push([overrideIdentifierFromKey(key), [...result.added, ...result.removed, ...result.updated]]);
+
+				for (let identifier of overrideIdentifierFromKey(key)) {
+					overrides.push([identifier, [...result.added, ...result.removed, ...result.updated]]);
+				}
 			}
 		}
 	}
@@ -225,7 +232,7 @@ export function toOverrides(raw: any, conflictReporter: (message: string) => voi
 				overrideRaw[keyInOverrideRaw] = raw[key][keyInOverrideRaw];
 			}
 			overrides.push({
-				identifiers: [overrideIdentifierFromKey(key).trim()],
+				identifiers: overrideIdentifierFromKey(key),
 				keys: Object.keys(overrideRaw),
 				contents: toValuesTree(overrideRaw, conflictReporter)
 			});

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -259,7 +259,7 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 						description: nls.localize('defaultLanguageConfiguration.description', "Configure settings to be overridden for {0} language.", key),
 						$ref: resourceLanguageSettingsSchemaId
 					};
-					overrideIdentifiers.push(overrideIdentifierFromKey(key));
+					overrideIdentifiers.push.apply(overrideIdentifiers, overrideIdentifierFromKey(key));
 					this.configurationProperties[key] = property;
 					this.defaultLanguageConfigurationOverridesNode.properties![key] = property;
 				} else {
@@ -508,8 +508,8 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 const OVERRIDE_PROPERTY = '\\[.*\\]$';
 export const OVERRIDE_PROPERTY_PATTERN = new RegExp(OVERRIDE_PROPERTY);
 
-export function overrideIdentifierFromKey(key: string): string {
-	return key.substring(1, key.length - 1);
+export function overrideIdentifierFromKey(key: string): string[] {
+	return key.replace(/\[|\]|\s/g, '').split(',');
 }
 
 export function getDefaultValue(type: string | string[] | undefined): any {

--- a/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
@@ -76,10 +76,12 @@ export class UserSettingsRenderer extends Disposable implements IPreferencesRend
 	}
 
 	updatePreference(key: string, value: any, source: IIndexedSetting): void {
-		const overrideIdentifier = source.overrideOf ? overrideIdentifierFromKey(source.overrideOf.key) : null;
+		const overrideIdentifiers = source.overrideOf ? overrideIdentifierFromKey(source.overrideOf.key) : [];
 		const resource = this.preferencesModel.uri;
-		this.configurationService.updateValue(key, value, { overrideIdentifier, resource }, this.preferencesModel.configurationTarget)
-			.then(() => this.onSettingUpdated(source));
+
+		for (let overrideIdentifier of overrideIdentifiers)
+			this.configurationService.updateValue(key, value, { overrideIdentifier, resource }, this.preferencesModel.configurationTarget)
+				.then(() => this.onSettingUpdated(source));
 	}
 
 	private onModelChanged(): void {

--- a/src/vs/workbench/services/configuration/common/configurationModels.ts
+++ b/src/vs/workbench/services/configuration/common/configurationModels.ts
@@ -156,8 +156,11 @@ export class Configuration extends BaseConfiguration {
 		const overrides: [string, string[]][] = [];
 		for (const key of keys) {
 			if (OVERRIDE_PROPERTY_PATTERN.test(key)) {
-				const overrideIdentifier = overrideIdentifierFromKey(key);
-				overrides.push([overrideIdentifier, compare(this.getAllKeysForOverrideIdentifier(overrideIdentifier), other.getAllKeysForOverrideIdentifier(overrideIdentifier), overrideIdentifier)]);
+				const overrideIdentifiesr = overrideIdentifierFromKey(key);
+
+				for (let overrideIdentifier of overrideIdentifiesr) {
+					overrides.push([overrideIdentifier, compare(this.getAllKeysForOverrideIdentifier(overrideIdentifier), other.getAllKeysForOverrideIdentifier(overrideIdentifier), overrideIdentifier)]);
+				}
 			}
 		}
 		return { keys, overrides };

--- a/src/vs/workbench/services/configuration/common/configurationModels.ts
+++ b/src/vs/workbench/services/configuration/common/configurationModels.ts
@@ -156,9 +156,9 @@ export class Configuration extends BaseConfiguration {
 		const overrides: [string, string[]][] = [];
 		for (const key of keys) {
 			if (OVERRIDE_PROPERTY_PATTERN.test(key)) {
-				const overrideIdentifiesr = overrideIdentifierFromKey(key);
+				const overrideIdentifiers = overrideIdentifierFromKey(key);
 
-				for (let overrideIdentifier of overrideIdentifiesr) {
+				for (let overrideIdentifier of overrideIdentifiers) {
 					overrides.push([overrideIdentifier, compare(this.getAllKeysForOverrideIdentifier(overrideIdentifier), other.getAllKeysForOverrideIdentifier(overrideIdentifier), overrideIdentifier)]);
 				}
 			}

--- a/src/vs/workbench/services/configuration/test/common/configurationModels.test.ts
+++ b/src/vs/workbench/services/configuration/test/common/configurationModels.test.ts
@@ -83,6 +83,24 @@ suite('FolderSettingsModelParser', () => {
 		assert.deepStrictEqual(testObject.configurationModel.overrides, [{ 'contents': expected, 'identifiers': ['json'], 'keys': ['FolderSettingsModelParser.resource', 'FolderSettingsModelParser.resourceLanguage'] }]);
 	});
 
+	test('parse multiple resource languages settings override', () => {
+		const testObject = new ConfigurationModelParser('settings');
+
+		testObject.parse(JSON.stringify({ '[json, javascript]': { 'FolderSettingsModelParser.resource': 'resource', 'FolderSettingsModelParser.resourceLanguage': 'resourceLanguage' }, '[json]': { 'FolderSettingsModelParser.resourceLanguage': 'overrideResourceLanguage' } }), { scopes: [ConfigurationScope.RESOURCE, ConfigurationScope.LANGUAGE_OVERRIDABLE] });
+
+		const expected_json = Object.create(null);
+		expected_json['FolderSettingsModelParser'] = Object.create(null);
+		expected_json['FolderSettingsModelParser']['resource'] = 'resource';
+		expected_json['FolderSettingsModelParser']['resourceLanguage'] = 'overrideResourceLanguage';
+
+		const expected_javascript = Object.create(null);
+		expected_javascript['FolderSettingsModelParser'] = Object.create(null);
+		expected_javascript['FolderSettingsModelParser']['resource'] = 'resource';
+		expected_javascript['FolderSettingsModelParser']['resourceLanguage'] = 'resourceLanguage';
+
+		assert.deepStrictEqual(testObject.configurationModel.overrides, [{ 'contents': expected_json, 'identifiers': ['json'], 'keys': ['FolderSettingsModelParser.resource', 'FolderSettingsModelParser.resourceLanguage'] }, { 'contents': expected_javascript, 'identifiers': ['javascript'], 'keys': ['FolderSettingsModelParser.resource', 'FolderSettingsModelParser.resourceLanguage'] }]);
+	});
+
 	test('reparse folder settings excludes application and machine setting', () => {
 		const parseOptions: ConfigurationParseOptions = { scopes: [ConfigurationScope.RESOURCE, ConfigurationScope.WINDOW] };
 		const testObject = new ConfigurationModelParser('settings');


### PR DESCRIPTION
This PR fixes #51935. Allowing for a single definition for multiple different languages is going to eliminate unnecessary config duplication.

```json
{
    "[javascript, typescript]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
    }
}
```
vs
```json
{
    "[javascript]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
    },
    "[typescript]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
    }
}
```

Unfortunately, I haven't been able to do extensive testing due to having troubles getting a dev environment up and running but the unit tests in place right now are still succeeding. 

A few items that still need doing:

- [ ] Update Schema definition for settings.json to accommodate these changes
- [ ] Add additional unit tests for these new possibilities. 
- [ ] Possibly provide a warning if the same value is specified twice, once in a joined definition and once in a separate one.

Any feedback is welcome 🙂