### PR TITLE
Enable replacePattern

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindReplaceWidget.ts
@@ -22,6 +22,7 @@ import { editorWidgetBackground, editorWidgetForeground, inputActiveOptionBackgr
 import { widgetClose } from 'vs/platform/theme/common/iconRegistry';
 import { attachProgressBarStyler } from 'vs/platform/theme/common/styler';
 import { IColorTheme, IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
+import { parseReplaceString, ReplacePattern } from 'vs/editor/contrib/find/replacePattern';
 
 const NLS_FIND_INPUT_LABEL = nls.localize('label.find', "Find");
 const NLS_FIND_INPUT_PLACEHOLDER = nls.localize('placeholder.find', "Find");
@@ -267,6 +268,13 @@ export abstract class SimpleFindReplaceWidget extends Widget {
 
 	protected get replaceValue() {
 		return this._replaceInput.getValue();
+	}
+
+	protected get replacePattern() {
+		if (this._state.isRegex) {
+			return parseReplaceString(this.replaceValue);
+		}
+		return ReplacePattern.fromStaticValue(this.replaceValue);
 	}
 
 	public get focusTracker(): dom.IFocusTracker {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/findController.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/findController.ts
@@ -117,8 +117,11 @@ export class NotebookFindWidget extends SimpleFindReplaceWidget implements INote
 		const { cell, match } = this._findModel.getCurrentMatch();
 		this._progressBar.infinite().show();
 
+		const replacePattern = this.replacePattern;
+		const replaceString = replacePattern.buildReplaceString(match.matches, this._state.preserveCase);
+
 		const viewModel = this._notebookEditor._getViewModel();
-		viewModel.replaceOne(cell, match.range, this.replaceValue).then(() => {
+		viewModel.replaceOne(cell, match.range, replaceString).then(() => {
 			this._progressBar.stop();
 		});
 	}
@@ -130,8 +133,20 @@ export class NotebookFindWidget extends SimpleFindReplaceWidget implements INote
 
 		this._progressBar.infinite().show();
 
+		const replacePattern = this.replacePattern;
+
+		const cellFindMatches = this._findModel.findMatches;
+		let replaceStrings: string[] = [];
+		cellFindMatches.forEach(cellFindMatch => {
+			const findMatches = cellFindMatch.matches;
+			findMatches.forEach(findMatch => {
+				const matches = findMatch.matches;
+				replaceStrings.push(replacePattern.buildReplaceString(matches, this._state.preserveCase));
+			});
+		});
+
 		const viewModel = this._notebookEditor._getViewModel();
-		viewModel.replaceAll(this._findModel.findMatches, this.replaceValue).then(() => {
+		viewModel.replaceAll(this._findModel.findMatches, replaceStrings).then(() => {
 			this._progressBar.stop();
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
@@ -532,7 +532,7 @@ export abstract class BaseCellViewModel extends Disposable {
 				options.regex || false,
 				options.caseSensitive || false,
 				options.wholeWord ? options.wordSeparators || null : null,
-				false);
+				options.regex || false);
 		} else {
 			const lineCount = this.textBuffer.getLineCount();
 			const fullRange = new Range(1, 1, lineCount, this.textBuffer.getLineLength(lineCount) + 1);
@@ -543,7 +543,7 @@ export abstract class BaseCellViewModel extends Disposable {
 				return null;
 			}
 
-			cellMatches = this.textBuffer.findMatchesLineByLine(fullRange, searchData, false, 1000);
+			cellMatches = this.textBuffer.findMatchesLineByLine(fullRange, searchData, options.regex || false, 1000);
 		}
 
 		return cellMatches;

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModel.ts
@@ -907,7 +907,7 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 		});
 	}
 
-	async replaceAll(matches: CellFindMatch[], text: string): Promise<void> {
+	async replaceAll(matches: CellFindMatch[], texts: string[]): Promise<void> {
 		if (!matches.length) {
 			return;
 		}
@@ -916,9 +916,9 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 		this._lastNotebookEditResource.push(matches[0].cell.uri);
 
 		matches.forEach(match => {
-			match.matches.forEach(singleMatch => {
+			match.matches.forEach((singleMatch, index) => {
 				textEdits.push({
-					edit: { range: singleMatch.range, text: text },
+					edit: { range: singleMatch.range, text: texts[index] },
 					resource: match.cell.uri
 				});
 			});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #135264

By interpreting the Replace input as replacePattern when "Use Regular Expression", replacing with capturing group is enabled.
This makes the find-and-replace behavior more consistent between Jupyter and the normal editor.