### PR TITLE
Add -g flag for the open command

### DIFF
--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -373,7 +373,15 @@ export async function main(argv: string[]): Promise<any> {
 			// similar to if the app was launched from the dock
 			// https://github.com/microsoft/vscode/issues/102975
 
-			const spawnArgs = ['-n'];				// -n: launches even when opened already
+			// The following args are for the open command itself, rather than for VS Code:
+			// -n creates a new instance.
+			//    Without -n, the open command re-opens the existing instance as-is.
+			// -g starts the new instance in the background.
+			//    Later, Electron brings the instance to the foreground.
+			//    This way, Mac does not automatically try to foreground the new instance, which causes
+			//    focusing issues when the new instance only sends data to a previous instance and then closes.
+			const spawnArgs = ['-n', '-g'];
+			// -a opens the given application.
 			spawnArgs.push('-a', process.execPath); // -a: opens a specific application
 
 			if (verbose) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #135291 by adding the -g flag to the open command.

It seems https://developer.apple.com/documentation/appkit/nsworkspaceopenconfiguration/3172710-createsnewapplicationinstance?language=objc corresponds to the `-n` flag for the open command, and 
https://developer.apple.com/documentation/appkit/nsworkspaceopenconfiguration/3172704-activates?language=objc corresponds to the `-g` flag.

Therefore, we have to keep the `-n` flag, otherwise Mac opens the existing instance as-is (I'm not sure how much data is passed to the existing instance, though).
But, the `-g` flag ensures that VS Code (or Electron) controls when and which VS Code window we focus on.
