### PR TITLE
Update blockCommentCommand

### DIFF
--- a/src/vs/editor/contrib/comment/blockCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/blockCommentCommand.ts
@@ -62,7 +62,9 @@ export class BlockCommentCommand implements ICommand {
 		const endColumn = selection.endColumn;
 
 		const startLineText = model.getLineContent(startLineNumber);
+		const startLineMinColumn = startLineText.search(/[\S]/) + 1;
 		const endLineText = model.getLineContent(endLineNumber);
+		const endLineTextLength = endLineText.length + 1;
 
 		let startTokenIndex = startLineText.lastIndexOf(startToken, startColumn - 1 + startToken.length);
 		let endTokenIndex = endLineText.indexOf(endToken, endColumn - 1 - endToken.length);
@@ -107,7 +109,7 @@ export class BlockCommentCommand implements ICommand {
 				new Range(startLineNumber, startTokenIndex + startToken.length + 1, endLineNumber, endTokenIndex + 1), startToken, endToken
 			);
 		} else {
-			ops = BlockCommentCommand._createAddBlockCommentOperations(selection, startToken, endToken, this._insertSpace);
+			ops = BlockCommentCommand._createAddBlockCommentOperations(selection, startToken, endToken, this._insertSpace, startLineMinColumn, endLineTextLength, model);
 			this._usedEndToken = ops.length === 1 ? endToken : null;
 		}
 
@@ -142,21 +144,40 @@ export class BlockCommentCommand implements ICommand {
 		return res;
 	}
 
-	public static _createAddBlockCommentOperations(r: Range, startToken: string, endToken: string, insertSpace: boolean): IIdentifiedSingleEditOperation[] {
+	public static _createAddBlockCommentOperations(r: Range, startToken: string, endToken: string, insertSpace: boolean, startLineMinColumn: number, endLineTextLength: number, model: ITextModel): IIdentifiedSingleEditOperation[] {
 		let res: IIdentifiedSingleEditOperation[] = [];
 
 		if (!Range.isEmpty(r)) {
 			// Insert block comment start
-			res.push(EditOperation.insert(new Position(r.startLineNumber, r.startColumn), startToken + (insertSpace ? ' ' : '')));
+			res.push(EditOperation.insert(new Position(r.startLineNumber, startLineMinColumn), startToken + (insertSpace ? ' ' : '')));
 
 			// Insert block comment end
-			res.push(EditOperation.insert(new Position(r.endLineNumber, r.endColumn), (insertSpace ? ' ' : '') + endToken));
+			res.push(EditOperation.insert(new Position(r.endLineNumber, endLineTextLength), (insertSpace ? ' ' : '') + endToken));
 		} else {
-			// Insert both continuously
-			res.push(EditOperation.replace(new Range(
-				r.startLineNumber, r.startColumn,
-				r.endLineNumber, r.endColumn
-			), startToken + '  ' + endToken));
+			const startLineText = model.getLineContent(r.startLineNumber);
+			const startblockColumn = startLineText.search(/[{]/) + 2;
+			const cursorPosition = new Position(r.startLineNumber, startblockColumn);
+			const matchedBrackets = model.matchBracket(cursorPosition);
+
+			if (matchedBrackets) {
+				let newStartBracketPosition: Position;
+				let newEndBracketPosition: Position;
+				if (matchedBrackets[0].containsPosition(cursorPosition)) {
+					newStartBracketPosition = matchedBrackets[0].getStartPosition();
+					newEndBracketPosition = matchedBrackets[1].getStartPosition();
+				} else {
+					newStartBracketPosition = matchedBrackets[1].getStartPosition();
+					newEndBracketPosition = matchedBrackets[0].getStartPosition();
+				}
+				res.push(EditOperation.insert(new Position(newStartBracketPosition.lineNumber, startLineMinColumn), startToken + (insertSpace ? ' ' : '')));
+				res.push(EditOperation.insert(new Position(newEndBracketPosition.lineNumber, newEndBracketPosition.column + 1), (insertSpace ? ' ' : '') + endToken));
+			} else {
+				// Insert both continuously
+				res.push(EditOperation.replace(new Range(
+					r.startLineNumber, r.startColumn,
+					r.endLineNumber, r.endColumn
+				), startToken + '  ' + endToken));
+			}
 		}
 
 		return res;

--- a/src/vs/editor/contrib/comment/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/lineCommentCommand.ts
@@ -305,14 +305,20 @@ export class LineCommentCommand implements ICommand {
 					new Range(s.startLineNumber, firstNonWhitespaceIndex + 1, s.startLineNumber, lineContent.length + 1),
 					startToken,
 					endToken,
-					this._insertSpace
+					this._insertSpace,
+					s.startColumn,
+					s.endColumn,
+					model
 				);
 			} else {
 				ops = BlockCommentCommand._createAddBlockCommentOperations(
 					new Range(s.startLineNumber, model.getLineFirstNonWhitespaceColumn(s.startLineNumber), s.endLineNumber, model.getLineMaxColumn(s.endLineNumber)),
 					startToken,
 					endToken,
-					this._insertSpace
+					this._insertSpace,
+					s.startColumn,
+					s.endColumn,
+					model
 				);
 			}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

# Summary
This PR fixes #135532.
We have overridden ``blockCommentCommand`` so that the first character of the first line to the last character of the last line in the selected range are commented out. So even if you select from the middle of the text, the first character of the first line to the last character of the last line in the selected range will be commented out.
![inTheMiddle](https://user-images.githubusercontent.com/55349055/138231852-98bbaa30-5ea1-4180-8707-7de620c3e7f5.gif)


Also added the feature to comment out the entire block by pressing the shortcut key(``cmd + shift + A``) while the cursor is on the top line of the block.
![topLevel](https://user-images.githubusercontent.com/55349055/138231873-7294a209-e372-41a2-815c-50d9399a35b6.gif)

# Things to be considered
- Should we separate this PR into two?
- Should we allocate another shortcut key to this new feature?

After the discussion, we'll write the test code!
Thanks!
