### PR TITLE
Allow semantic tokens to be provided by more than one provider

### DIFF
--- a/src/vs/editor/common/services/getSemanticTokens.ts
+++ b/src/vs/editor/common/services/getSemanticTokens.ts
@@ -152,14 +152,18 @@ function _getDocumentSemanticTokensProviderHighestGroup(model: ITextModel): Docu
 	return (result.length > 0 ? result[0] : null);
 }
 
-function _getDocumentRangeSemanticTokensProviderHighestGroup(model: ITextModel): DocumentRangeSemanticTokensProvider[] | null {
-	const result = DocumentRangeSemanticTokensProviderRegistry.orderedGroups(model);
-	return (result.length > 0 ? result[0] : null);
-}
-
 export function getDocumentRangeSemanticTokensProvider(model: ITextModel): DocumentRangeSemanticTokensProvider | null {
-	const highestGroup = _getDocumentRangeSemanticTokensProviderHighestGroup(model);
-	return highestGroup ? new CompositeDocumentRangeSemanticTokensProvider(highestGroup) : null;
+	const groups = DocumentRangeSemanticTokensProviderRegistry.orderedGroups(model);
+	const highestGroup = (groups.length > 0 ? groups[0] : []);
+	if (highestGroup.length === 0) {
+		// there are no providers
+		return null;
+	}
+	if (highestGroup.length === 1) {
+		// there is a single provider
+		return highestGroup[0];
+	}
+	return new CompositeDocumentRangeSemanticTokensProvider(highestGroup);
 }
 
 CommandsRegistry.registerCommand('_provideDocumentSemanticTokensLegend', async (accessor, ...args): Promise<SemanticTokensLegend | undefined> => {

--- a/src/vs/editor/common/services/getSemanticTokens.ts
+++ b/src/vs/editor/common/services/getSemanticTokens.ts
@@ -85,6 +85,7 @@ class CompositeDocumentSemanticTokensProvider implements DocumentSemanticTokensP
 }
 
 class CompositeDocumentRangeSemanticTokensProvider implements DocumentRangeSemanticTokensProvider {
+	private lastUsedProvider: DocumentRangeSemanticTokensProvider | undefined = undefined;
 	constructor(private readonly providerGroup: DocumentRangeSemanticTokensProvider[]) { }
 	public async provideDocumentRangeSemanticTokens(model: ITextModel, range: Range, token: CancellationToken): Promise<SemanticTokens | null | undefined> {
 		// Get tokens from the group all at the same time. Return the first
@@ -98,10 +99,14 @@ class CompositeDocumentRangeSemanticTokensProvider implements DocumentRangeSeman
 			return undefined;
 		}));
 
-		return list.find(l => l);
+		const hasTokensIndex = list.findIndex(l => l);
+
+		// Save last used provider. Use it for the legend if called
+		this.lastUsedProvider = this.providerGroup[hasTokensIndex];
+		return list[hasTokensIndex];
 	}
 	getLegend(): SemanticTokensLegend {
-		return this.providerGroup[0].getLegend();
+		return this.lastUsedProvider?.getLegend() || this.providerGroup[0].getLegend();
 	}
 }
 

--- a/src/vs/editor/common/services/getSemanticTokens.ts
+++ b/src/vs/editor/common/services/getSemanticTokens.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { URI } from 'vs/base/common/uri';
 import { ITextModel } from 'vs/editor/common/model';
-import { DocumentSemanticTokensProviderRegistry, DocumentSemanticTokensProvider, SemanticTokens, SemanticTokensEdits, SemanticTokensLegend, DocumentRangeSemanticTokensProviderRegistry, DocumentRangeSemanticTokensProvider, ProviderResult } from 'vs/editor/common/modes';
+import { DocumentSemanticTokensProviderRegistry, DocumentSemanticTokensProvider, SemanticTokens, SemanticTokensEdits, SemanticTokensLegend, DocumentRangeSemanticTokensProviderRegistry, DocumentRangeSemanticTokensProvider } from 'vs/editor/common/modes';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
 import { assertType } from 'vs/base/common/types';

--- a/src/vs/editor/common/services/modelServiceImpl.ts
+++ b/src/vs/editor/common/services/modelServiceImpl.ts
@@ -840,10 +840,9 @@ export class ModelSemanticColoring extends Disposable {
 			pendingChanges.push(e);
 		});
 
-		const styling = this._semanticStyling.get(provider);
-
 		request.then((res) => {
 			this._currentDocumentRequestCancellationTokenSource = null;
+			const styling = this._semanticStyling.get(provider); // Do this after the provider gets results to ensure legend matches
 			contentChangeListener.dispose();
 			this._setDocumentSemanticTokens(provider, res || null, styling, pendingChanges);
 		}, (err) => {

--- a/src/vs/editor/common/services/modelServiceImpl.ts
+++ b/src/vs/editor/common/services/modelServiceImpl.ts
@@ -29,7 +29,7 @@ import { StringSHA1 } from 'vs/base/common/hash';
 import { EditStackElement, isEditStackElement } from 'vs/editor/common/model/editStack';
 import { Schemas } from 'vs/base/common/network';
 import { SemanticTokensProviderStyling, toMultilineTokens2 } from 'vs/editor/common/services/semanticTokensProviderStyling';
-import { getDocumentSemanticTokens, isSemanticTokens, isSemanticTokensEdits } from 'vs/editor/common/services/getSemanticTokens';
+import { getDocumentSemanticTokens, hasDocumentSemanticTokensProvider, isSemanticTokens, isSemanticTokensEdits } from 'vs/editor/common/services/getSemanticTokens';
 import { equals } from 'vs/base/common/objects';
 import { ILanguageConfigurationService } from 'vs/editor/common/modes/languageConfigurationRegistry';
 
@@ -724,13 +724,13 @@ class SemanticStyling extends Disposable {
 
 class SemanticTokensResponse {
 	constructor(
-		private readonly _provider: DocumentSemanticTokensProvider,
+		public readonly provider: DocumentSemanticTokensProvider,
 		public readonly resultId: string | undefined,
 		public readonly data: Uint32Array
 	) { }
 
 	public dispose(): void {
-		this._provider.releaseDocumentSemanticTokens(this.resultId);
+		this.provider.releaseDocumentSemanticTokens(this.resultId);
 	}
 }
 
@@ -820,10 +820,7 @@ export class ModelSemanticColoring extends Disposable {
 			return;
 		}
 
-		const cancellationTokenSource = new CancellationTokenSource();
-		const lastResultId = this._currentDocumentResponse ? this._currentDocumentResponse.resultId || null : null;
-		const r = getDocumentSemanticTokens(this._model, lastResultId, cancellationTokenSource.token);
-		if (!r) {
+		if (!hasDocumentSemanticTokensProvider(this._model)) {
 			// there is no provider
 			if (this._currentDocumentResponse) {
 				// there are semantic tokens set
@@ -832,7 +829,10 @@ export class ModelSemanticColoring extends Disposable {
 			return;
 		}
 
-		const { provider, request } = r;
+		const cancellationTokenSource = new CancellationTokenSource();
+		const lastProvider = this._currentDocumentResponse ? this._currentDocumentResponse.provider : null;
+		const lastResultId = this._currentDocumentResponse ? this._currentDocumentResponse.resultId || null : null;
+		const request = getDocumentSemanticTokens(this._model, lastProvider, lastResultId, cancellationTokenSource.token);
 		this._currentDocumentRequestCancellationTokenSource = cancellationTokenSource;
 
 		const pendingChanges: IModelContentChangedEvent[] = [];
@@ -842,9 +842,15 @@ export class ModelSemanticColoring extends Disposable {
 
 		request.then((res) => {
 			this._currentDocumentRequestCancellationTokenSource = null;
-			const styling = this._semanticStyling.get(provider); // Do this after the provider gets results to ensure legend matches
 			contentChangeListener.dispose();
-			this._setDocumentSemanticTokens(provider, res || null, styling, pendingChanges);
+
+			if (!res) {
+				this._setDocumentSemanticTokens(null, null, null, pendingChanges);
+			} else {
+				const { provider, tokens } = res;
+				const styling = this._semanticStyling.get(provider);
+				this._setDocumentSemanticTokens(provider, tokens || null, styling, pendingChanges);
+			}
 		}, (err) => {
 			const isExpectedError = err && (errors.isPromiseCanceledError(err) || (typeof err.message === 'string' && err.message.indexOf('busy') !== -1));
 			if (!isExpectedError) {

--- a/src/vs/editor/contrib/viewportSemanticTokens/viewportSemanticTokens.ts
+++ b/src/vs/editor/contrib/viewportSemanticTokens/viewportSemanticTokens.ts
@@ -10,11 +10,11 @@ import { registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { Range } from 'vs/editor/common/core/range';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
 import { ITextModel } from 'vs/editor/common/model';
-import { DocumentRangeSemanticTokensProvider, DocumentRangeSemanticTokensProviderRegistry, SemanticTokens } from 'vs/editor/common/modes';
-import { getDocumentRangeSemanticTokensProvider } from 'vs/editor/common/services/getSemanticTokens';
+import { DocumentRangeSemanticTokensProviderRegistry } from 'vs/editor/common/modes';
+import { getDocumentRangeSemanticTokens, hasDocumentRangeSemanticTokensProvider } from 'vs/editor/common/services/getSemanticTokens';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { isSemanticColoringEnabled, SEMANTIC_HIGHLIGHTING_SETTING_ID } from 'vs/editor/common/services/modelServiceImpl';
-import { SemanticTokensProviderStyling, toMultilineTokens2 } from 'vs/editor/common/services/semanticTokensProviderStyling';
+import { toMultilineTokens2 } from 'vs/editor/common/services/semanticTokensProviderStyling';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 
@@ -28,7 +28,7 @@ class ViewportSemanticTokensContribution extends Disposable implements IEditorCo
 
 	private readonly _editor: ICodeEditor;
 	private readonly _tokenizeViewport: RunOnceScheduler;
-	private _outstandingRequests: CancelablePromise<SemanticTokens | null | undefined>[];
+	private _outstandingRequests: CancelablePromise<any>[];
 
 	constructor(
 		editor: ICodeEditor,
@@ -74,7 +74,7 @@ class ViewportSemanticTokensContribution extends Disposable implements IEditorCo
 		this._outstandingRequests = [];
 	}
 
-	private _removeOutstandingRequest(req: CancelablePromise<SemanticTokens | null | undefined>): void {
+	private _removeOutstandingRequest(req: CancelablePromise<any>): void {
 		for (let i = 0, len = this._outstandingRequests.length; i < len; i++) {
 			if (this._outstandingRequests[i] === req) {
 				this._outstandingRequests.splice(i, 1);
@@ -97,27 +97,27 @@ class ViewportSemanticTokensContribution extends Disposable implements IEditorCo
 			}
 			return;
 		}
-		const provider = getDocumentRangeSemanticTokensProvider(model);
-		if (!provider) {
+		if (!hasDocumentRangeSemanticTokensProvider(model)) {
 			if (model.hasSomeSemanticTokens()) {
 				model.setSemanticTokens(null, false);
 			}
 			return;
 		}
-		const styling = this._modelService.getSemanticTokensProviderStyling(provider);
 		const visibleRanges = this._editor.getVisibleRangesPlusViewportAboveBelow();
 
-		this._outstandingRequests = this._outstandingRequests.concat(visibleRanges.map(range => this._requestRange(model, range, provider, styling)));
+		this._outstandingRequests = this._outstandingRequests.concat(visibleRanges.map(range => this._requestRange(model, range)));
 	}
 
-	private _requestRange(model: ITextModel, range: Range, provider: DocumentRangeSemanticTokensProvider, styling: SemanticTokensProviderStyling): CancelablePromise<SemanticTokens | null | undefined> {
+	private _requestRange(model: ITextModel, range: Range): CancelablePromise<any> {
 		const requestVersionId = model.getVersionId();
-		const request = createCancelablePromise(token => Promise.resolve(provider.provideDocumentRangeSemanticTokens(model, range, token)));
+		const request = createCancelablePromise(token => Promise.resolve(getDocumentRangeSemanticTokens(model, range, token)));
 		request.then((r) => {
-			if (!r || model.isDisposed() || model.getVersionId() !== requestVersionId) {
+			if (!r || !r.tokens || model.isDisposed() || model.getVersionId() !== requestVersionId) {
 				return;
 			}
-			model.setPartialSemanticTokens(range, toMultilineTokens2(r, styling, model.getLanguageId()));
+			const { provider, tokens: result } = r;
+			const styling = this._modelService.getSemanticTokensProviderStyling(provider);
+			model.setPartialSemanticTokens(range, toMultilineTokens2(result, styling, model.getLanguageId()));
 		}).then(() => this._removeOutstandingRequest(request), () => this._removeOutstandingRequest(request));
 		return request;
 	}

--- a/src/vs/editor/test/common/services/modelService.test.ts
+++ b/src/vs/editor/test/common/services/modelService.test.ts
@@ -490,6 +490,7 @@ suite('ModelSemanticColoring', () => {
 
 	test('DocumentSemanticTokens should be pick the token provider with actual items', async () => {
 
+		let calledBoth = false;
 		disposables.add(ModesRegistry.registerLanguage({ id: 'testMode2' }));
 		disposables.add(DocumentSemanticTokensProviderRegistry.register('testMode2', new class implements DocumentSemanticTokensProvider {
 			getLegend(): SemanticTokensLegend {
@@ -509,6 +510,7 @@ suite('ModelSemanticColoring', () => {
 				return { tokenTypes: ['class'], tokenModifiers: [] };
 			}
 			async provideDocumentSemanticTokens(model: ITextModel, lastResultId: string | null, token: CancellationToken): Promise<SemanticTokens | SemanticTokensEdits | null> {
+				calledBoth = true;
 				return null;
 			}
 			releaseDocumentSemanticTokens(resultId: string | undefined): void {
@@ -523,6 +525,7 @@ suite('ModelSemanticColoring', () => {
 			// We should have tokens
 			assert.ok(tokens, `Tokens not found from multiple providers`);
 			assert.deepStrictEqual([...(tokens as any).data], [0, 1, 1, 1, 1, 0, 2, 1, 1, 1], `Token data not returned for multiple providers`);
+			assert.ok(calledBoth, `Did not actually call both token providers`);
 		} finally {
 			disposables.clear();
 

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -216,7 +216,7 @@ const newCommands: ApiCommand[] = [
 	),
 	new ApiCommand(
 		'vscode.provideDocumentRangeSemanticTokensLegend', '_provideDocumentRangeSemanticTokensLegend', 'Provide semantic tokens legend for a document range',
-		[ApiCommandArgument.Uri],
+		[ApiCommandArgument.Uri, ApiCommandArgument.Range.optional()],
 		new ApiCommandResult<modes.SemanticTokensLegend, types.SemanticTokensLegend | undefined>('A promise that resolves to SemanticTokensLegend.', value => {
 			if (!value) {
 				return undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #135580

Allow there to be more than one semantic token provider registered at the same time and pick the tokens from the provider that actually returns results.

This is necessary to get https://github.com/microsoft/vscode-jupyter/issues/6799 working
