### PR TITLE
make checked optional on IAction to differentiate false from never checked

### DIFF
--- a/src/vs/base/browser/ui/checkbox/checkbox.ts
+++ b/src/vs/base/browser/ui/checkbox/checkbox.ts
@@ -47,7 +47,7 @@ export class CheckboxActionViewItem extends BaseActionViewItem {
 		super(context, action, options);
 		this.checkbox = this._register(new Checkbox({
 			actionClassName: this._action.class,
-			isChecked: this._action.checked,
+			isChecked: !!this._action.checked,
 			title: (<IActionViewItemOptions>this.options).keybinding ? `${this._action.label} (${(<IActionViewItemOptions>this.options).keybinding})` : this._action.label,
 			notFocusable: true
 		}));
@@ -70,7 +70,7 @@ export class CheckboxActionViewItem extends BaseActionViewItem {
 	}
 
 	override updateChecked(): void {
-		this.checkbox.checked = this._action.checked;
+		this.checkbox.checked = !!this._action.checked;
 	}
 
 	override focus(): void {

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -679,14 +679,14 @@ class BaseMenuActionViewItem extends BaseActionViewItem {
 			return;
 		}
 
-		if (this.getAction().checked) {
-			this.item.classList.add('checked');
+		const checked = this.getAction().checked;
+		this.item.classList.toggle('checked', !!checked);
+		if (checked !== undefined) {
 			this.item.setAttribute('role', 'menuitemcheckbox');
-			this.item.setAttribute('aria-checked', 'true');
+			this.item.setAttribute('aria-checked', checked ? 'true' : 'false');
 		} else {
-			this.item.classList.remove('checked');
 			this.item.setAttribute('role', 'menuitem');
-			this.item.setAttribute('aria-checked', 'false');
+			this.item.setAttribute('aria-checked', '');
 		}
 	}
 

--- a/src/vs/base/common/actions.ts
+++ b/src/vs/base/common/actions.ts
@@ -29,7 +29,7 @@ export interface IAction extends IDisposable {
 	tooltip: string;
 	class: string | undefined;
 	enabled: boolean;
-	checked: boolean;
+	checked?: boolean;
 	run(event?: unknown): unknown;
 }
 
@@ -58,7 +58,7 @@ export class Action extends Disposable implements IAction {
 	protected _tooltip: string | undefined;
 	protected _cssClass: string | undefined;
 	protected _enabled: boolean = true;
-	protected _checked: boolean = false;
+	protected _checked?: boolean;
 	protected readonly _actionCallback?: (event?: unknown) => unknown;
 
 	constructor(id: string, label: string = '', cssClass: string = '', enabled: boolean = true, actionCallback?: (event?: unknown) => unknown) {
@@ -134,15 +134,15 @@ export class Action extends Disposable implements IAction {
 		}
 	}
 
-	get checked(): boolean {
+	get checked(): boolean | undefined {
 		return this._checked;
 	}
 
-	set checked(value: boolean) {
+	set checked(value: boolean | undefined) {
 		this._setChecked(value);
 	}
 
-	protected _setChecked(value: boolean): void {
+	protected _setChecked(value: boolean | undefined): void {
 		if (this._checked !== value) {
 			this._checked = value;
 			this._onDidChange.fire({ checked: value });

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -401,7 +401,7 @@ export class MenuItemAction implements IAction {
 	readonly tooltip: string;
 	readonly class: string | undefined;
 	readonly enabled: boolean;
-	readonly checked: boolean;
+	readonly checked?: boolean;
 
 	constructor(
 		item: ICommandAction,
@@ -416,7 +416,7 @@ export class MenuItemAction implements IAction {
 			: (typeof item.title === 'string' ? item.title : item.title.value);
 		this.tooltip = (typeof item.tooltip === 'string' ? item.tooltip : item.tooltip?.value) ?? '';
 		this.enabled = !item.precondition || contextKeyService.contextMatchesRules(item.precondition);
-		this.checked = false;
+		this.checked = undefined;
 
 		if (item.toggled) {
 			const toggled = ((item.toggled as { condition: ContextKeyExpression }).condition ? item.toggled : { condition: item.toggled }) as {


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #120597

The problem that I'm trying to solve is that menu entries are controlled by `IAction` and those only allow for `checked` to be `true` or `false`. However, when `checked` is `false`, we don't know if it could ever be `true` which makes it impossible set the appropriate aria labels.

Sending this through PR because while the solution works, I am spanning display vs model logic and this might not be the preferred approach.