### PR TITLE
Don't sanitize `command` URLs in getting started

### DIFF
--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -182,6 +182,7 @@ function sanitize(documentContent: string): string {
 				'width', 'height', 'align', 'x-dispatch',
 				'required', 'checked', 'placeholder', 'when-checked', 'checked-on',
 			],
+			ALLOW_UNKNOWN_PROTOCOLS: true,
 		});
 	} finally {
 		dompurify.removeHook('afterSanitizeAttributes');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #135505, which is caused by #131950

This markdown document renderer is used by extension readme, release notes and getting started.

I don't think it would cause security issues because they used to support `command` URLs anyway.

If needed I can add an option to only allow `command` URLs in getting started.