### PR TITLE
Make sure terminals profiles are loaded before initializing terminals

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -733,6 +733,9 @@ export class TerminalService implements ITerminalService {
 			this._setConnected();
 		}
 		if (this._terminalGroupService.groups.length === 0 && this.isProcessSupportRegistered) {
+			if (this._availableProfiles === undefined) {
+				await this._refreshAvailableProfilesNow();
+			}
 			this.createTerminal({ location: TerminalLocation.Panel });
 		}
 	}


### PR DESCRIPTION
This fixes the following problems:
- You use terminal profiles
- Sometimes, due to timing, profiles aren't loaded before the first terminal is activated
- So to fix it, I check whether there're any profiles loaded, and if not, refresh profiles