### PR TITLE
Fix font of code sections for Markdown Notebook

### DIFF
--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -136,6 +136,7 @@ export const activate: ActivationFunction<void> = (ctx) => {
 
 		code,
 		.code {
+			font-family: var(--vscode-editor-font-family, "SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace);
 			font-size: 1em;
 			line-height: 1.357em;
 		}


### PR DESCRIPTION
Code sections of Markdown Notebook extension now uses the same font of the normal Markdown code sections.
This font may be found in ~/extensions/markdown-language-features/media/markdown.css:

```css
code {
	font-family: var(--vscode-editor-font-family, "SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace);
	font-size: 1em;
	line-height: 1.357em;
}
```

This PR fixes #130647