### PR TITLE
Fix description for EventEmitter.fire(data: T)

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1550,7 +1550,7 @@ declare module 'vscode' {
 		 * Notify all subscribers of the {@link EventEmitter.event event}. Failure
 		 * of one or more listener will not fail this function call.
 		 *
-		 * @param data The event object.
+		 * @param data A value passed to event listeners.
 		 */
 		fire(data: T): void;
 


### PR DESCRIPTION
`data` at `EventEmitter.fire(data: T)` is a value passed to event listeners, not an event object.
https://github.com/microsoft/vscode/blob/2da60a8a4a390b1d02ba11c6f0f9a48a17ab7806/src/vs/base/common/event.ts#L556-L588