### PR TITLE
Add changesLoop option to stop loop at last change

### DIFF
--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -986,6 +986,11 @@ export interface IDiffEditor extends editorCommon.IEditor {
 	 * @internal
 	 */
 	readonly maxComputationTime: number;
+	/**
+	 * Controls whether the changes movement automatically restarts from the beginning (or the end) when no further changes can be found.
+	 * @internal
+	 */
+	readonly changesLoop: boolean;
 
 	/**
 	 * @see {@link ICodeEditor.getDomNode}

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -20,6 +20,7 @@ import { IEditorWhitespace } from 'vs/editor/common/viewLayout/linesLayout';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IDiffComputationResult } from 'vs/editor/common/services/editorWorkerService';
 import { IViewModel } from 'vs/editor/common/viewModel/viewModel';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 /**
  * A view zone is a full horizontal rectangle that 'pushes' text down.
@@ -991,6 +992,10 @@ export interface IDiffEditor extends editorCommon.IEditor {
 	 * @internal
 	 */
 	readonly changesLoop: boolean;
+	/**
+	 * @internal
+	 */
+	readonly contextKeyService: IContextKeyService;
 
 	/**
 	 * @see {@link ICodeEditor.getDomNode}

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -380,6 +380,10 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		return this._options.changesLoop;
 	}
 
+	public get contextKeyService(): IContextKeyService {
+		return this._contextKeyService;
+	}
+
 	public getContentHeight(): number {
 		return this._modifiedEditor.getContentHeight();
 	}

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -266,7 +266,8 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 			originalEditable: false,
 			diffCodeLens: false,
 			renderOverviewRuler: true,
-			diffWordWrap: 'inherit'
+			diffWordWrap: 'inherit',
+			changesLoop: true
 		});
 
 		if (typeof options.isInEmbeddedEditor !== 'undefined') {
@@ -373,6 +374,10 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 
 	public get maxComputationTime(): number {
 		return this._options.maxComputationTime;
+	}
+
+	public get changesLoop(): boolean {
+		return this._options.changesLoop;
 	}
 
 	public getContentHeight(): number {
@@ -2500,6 +2505,7 @@ function validateDiffEditorOptions(options: Readonly<IDiffEditorOptions>, defaul
 		diffCodeLens: validateBooleanOption(options.diffCodeLens, defaults.diffCodeLens),
 		renderOverviewRuler: validateBooleanOption(options.renderOverviewRuler, defaults.renderOverviewRuler),
 		diffWordWrap: validateDiffWordWrap(options.diffWordWrap, defaults.diffWordWrap),
+		changesLoop: validateBooleanOption(options.changesLoop, defaults.changesLoop),
 	};
 }
 
@@ -2515,6 +2521,7 @@ function changedDiffEditorOptions(a: ValidDiffEditorBaseOptions, b: ValidDiffEdi
 		diffCodeLens: (a.diffCodeLens !== b.diffCodeLens),
 		renderOverviewRuler: (a.renderOverviewRuler !== b.renderOverviewRuler),
 		diffWordWrap: (a.diffWordWrap !== b.diffWordWrap),
+		changesLoop: (a.changesLoop !== b.changesLoop),
 	};
 }
 

--- a/src/vs/editor/browser/widget/diffNavigator.ts
+++ b/src/vs/editor/browser/widget/diffNavigator.ts
@@ -210,16 +210,32 @@ export class DiffNavigator extends Disposable implements IDiffNavigator {
 		}
 	}
 
+	private _canNavigateInLoop(): boolean {
+		return this.canNavigate() && this._editor.changesLoop;
+	}
+
+	private _canNavigateBack(): boolean {
+		return this._canNavigateInLoop() || (this.nextIdx !== 0);
+	}
+
+	private _canNavigateForward(): boolean {
+		return this._canNavigateInLoop() || (this.nextIdx !== this.ranges.length - 1);
+	}
+
 	canNavigate(): boolean {
 		return this.ranges && this.ranges.length > 0;
 	}
 
 	next(scrollType: ScrollType = ScrollType.Smooth): void {
-		this._move(true, scrollType);
+		if (this._canNavigateForward()) {
+			this._move(true, scrollType);
+		}
 	}
 
 	previous(scrollType: ScrollType = ScrollType.Smooth): void {
-		this._move(false, scrollType);
+		if (this._canNavigateBack()) {
+			this._move(false, scrollType);
+		}
 	}
 
 	override dispose(): void {

--- a/src/vs/editor/browser/widget/diffNavigator.ts
+++ b/src/vs/editor/browser/widget/diffNavigator.ts
@@ -11,6 +11,7 @@ import { IDiffEditor } from 'vs/editor/browser/editorBrowser';
 import { ICursorPositionChangedEvent } from 'vs/editor/common/controller/cursorEvents';
 import { Range } from 'vs/editor/common/core/range';
 import { ILineChange, ScrollType } from 'vs/editor/common/editorCommon';
+import { IContextKey } from 'vs/platform/contextkey/common/contextkey';
 
 
 interface IDiffRange {
@@ -45,6 +46,8 @@ export class DiffNavigator extends Disposable implements IDiffNavigator {
 	private readonly _editor: IDiffEditor;
 	private readonly _options: Options;
 	private readonly _onDidUpdate = this._register(new Emitter<this>());
+	private readonly _canNavigateBackKey: IContextKey<boolean>;
+	private readonly _canNavigateForwardKey: IContextKey<boolean>;
 
 	readonly onDidUpdate: Event<this> = this._onDidUpdate.event;
 
@@ -58,6 +61,9 @@ export class DiffNavigator extends Disposable implements IDiffNavigator {
 		super();
 		this._editor = editor;
 		this._options = objects.mixin(options, defaultOptions, false);
+
+		this._canNavigateBackKey = this._editor.contextKeyService.createKey('canNavigateDiffBack', true);
+		this._canNavigateForwardKey = this._editor.contextKeyService.createKey('canNavigateDiffForward', true);
 
 		this.disposed = false;
 
@@ -208,6 +214,9 @@ export class DiffNavigator extends Disposable implements IDiffNavigator {
 		} finally {
 			this.ignoreSelectionChange = false;
 		}
+
+		this._canNavigateBackKey.set(this._canNavigateBack());
+		this._canNavigateForwardKey.set(this._canNavigateForward());
 	}
 
 	private _canNavigateInLoop(): boolean {

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -622,7 +622,12 @@ const editorConfiguration: IConfigurationNode = {
 				nls.localize('wordWrap.on', "Lines will wrap at the viewport width."),
 				nls.localize('wordWrap.inherit', "Lines will wrap according to the `#editor.wordWrap#` setting."),
 			]
-		}
+		},
+		'diffEditor.changesLoop': {
+			type: 'boolean',
+			default: true,
+			description: nls.localize('changesLoop', "Controls whether the changes movement automatically restarts from the beginning (or the end) when no further changes can be found.")
+		},
 	}
 };
 

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -700,6 +700,10 @@ export interface IDiffEditorBaseOptions {
 	 * Control the wrapping of the diff editor.
 	 */
 	diffWordWrap?: 'off' | 'on' | 'inherit';
+	/**
+	 * Controls whether the changes movement automatically restarts from the beginning (or the end) when no further changes can be found.
+	 */
+	changesLoop?: boolean;
 }
 
 /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3346,6 +3346,10 @@ declare namespace monaco.editor {
 		 * Control the wrapping of the diff editor.
 		 */
 		diffWordWrap?: 'off' | 'on' | 'inherit';
+		/**
+		 * Controls whether the changes movement automatically restarts from the beginning (or the end) when no further changes can be found.
+		 */
+		changesLoop?: boolean;
 	}
 
 	/**

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -489,25 +489,47 @@ const previousChangeIcon = registerIcon('diff-editor-previous-change', Codicon.a
 const nextChangeIcon = registerIcon('diff-editor-next-change', Codicon.arrowDown, localize('nextChangeIcon', 'Icon for the next change action in the diff editor.'));
 const toggleWhitespace = registerIcon('diff-editor-toggle-whitespace', Codicon.whitespace, localize('toggleWhitespace', 'Icon for the toggle whitespace action in the diff editor.'));
 
-// Diff Editor Title Menu: Previous Change
+// Diff Editor Title Menu: Previous Change (Enabled)
 appendEditorToolItem(
 	{
 		id: GOTO_PREVIOUS_CHANGE,
 		title: localize('navigate.prev.label', "Previous Change"),
 		icon: previousChangeIcon
 	},
-	TextCompareEditorActiveContext,
+	ContextKeyExpr.and(TextCompareEditorActiveContext, ContextKeyExpr.equals('canNavigateDiffBack', true)),
 	10
 );
 
-// Diff Editor Title Menu: Next Change
+// Diff Editor Title Menu: Previous Change (Disabled)
+appendEditorToolItem(
+	{
+		id: GOTO_PREVIOUS_CHANGE,
+		title: localize('navigate.prev.label', "Previous Change"),
+		icon: ThemeIcon.modify(previousChangeIcon, 'disabled')
+	},
+	ContextKeyExpr.and(TextCompareEditorActiveContext, ContextKeyExpr.equals('canNavigateDiffBack', false)),
+	10
+);
+
+// Diff Editor Title Menu: Next Change (Enabled)
 appendEditorToolItem(
 	{
 		id: GOTO_NEXT_CHANGE,
 		title: localize('navigate.next.label', "Next Change"),
 		icon: nextChangeIcon
 	},
-	TextCompareEditorActiveContext,
+	ContextKeyExpr.and(TextCompareEditorActiveContext, ContextKeyExpr.equals('canNavigateDiffForward', true)),
+	11
+);
+
+// Diff Editor Title Menu: Next Change (Disabled)
+appendEditorToolItem(
+	{
+		id: GOTO_NEXT_CHANGE,
+		title: localize('navigate.next.label', "Next Change"),
+		icon: ThemeIcon.modify(nextChangeIcon, 'disabled')
+	},
+	ContextKeyExpr.and(TextCompareEditorActiveContext, ContextKeyExpr.equals('canNavigateDiffForward', false)),
 	11
 );
 


### PR DESCRIPTION
I have added an option named `diffEditor.changesLoop` and implemented the navigation logic as described in the related issue:


https://user-images.githubusercontent.com/17585121/138835308-ec3fea04-162b-4dbd-84e5-744e971b25a9.mov

Fixes #120709