### PR TITLE
Make sure terminal profiles are initialized

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -739,6 +739,9 @@ export class TerminalService implements ITerminalService {
 			this._setConnected();
 		}
 		if (this._terminalGroupService.groups.length === 0 && this.isProcessSupportRegistered) {
+			if (this._availableProfiles === undefined) {
+				await this._refreshAvailableProfilesNow();
+			}
 			this.createTerminal({ location: TerminalLocation.Panel });
 		}
 	}


### PR DESCRIPTION
It's possible that when this.createTerminal is called below the change, the profiles aren't loaded. As a result, the first terminal doesn't use data from the terminal profiles.