### PR TITLE
Prefer non-builtin output renderers in notebooks

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
@@ -314,8 +314,8 @@ export class NotebookOutputRendererInfoStore {
 		const enum ReuseOrder {
 			PreviouslySelected = 1 << 8,
 			SameExtensionAsNotebook = 2 << 8,
-			BuiltIn = 3 << 8,
-			OtherRenderer = 4 << 8
+			OtherRenderer = 3 << 8,
+			BuiltIn = 4 << 8,
 		}
 
 		const preferred = notebookProviderInfo && this.preferredMimetype.getValue()[notebookProviderInfo.id]?.[mimeType];
@@ -333,7 +333,7 @@ export class NotebookOutputRendererInfoStore {
 					? ReuseOrder.PreviouslySelected
 					: renderer.extensionId.value === notebookProviderInfo?.extension?.value
 						? ReuseOrder.SameExtensionAsNotebook
-						: ReuseOrder.BuiltIn;
+						: renderer.isBuiltin ? ReuseOrder.BuiltIn : ReuseOrder.OtherRenderer;
 				return {
 					ordered: { mimeType, rendererId: renderer.id, isTrusted: true },
 					score: reuseScore | ownScore,


### PR DESCRIPTION
Fixes #134172

This change updates `findBestRenderers` to sort non built-in renderers higher than built-in ones

I think this does the right thing when I tested it, but am a bit concerned about causing regressions here since I'm not an expert on how notebook outputs are supposed to behave. Lets decide if this is too risky for 1.62 or not
