### PR TITLE
Properly fix #133687

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -435,7 +435,7 @@ export class TerminalService implements ITerminalService {
 							}
 						} else {
 							// add split terminals to this group
-							await this.createTerminal({ config: { attachPersistentProcess: terminalLayout.terminal! }, location: { parentTerminal: terminalInstance } });
+							terminalInstance = await this.createTerminal({ config: { attachPersistentProcess: terminalLayout.terminal! }, location: { parentTerminal: terminalInstance } });
 						}
 					}
 					const activeInstance = this.instances.find(t => {
@@ -1371,10 +1371,6 @@ export class TerminalService implements ITerminalService {
 	}
 
 	private _getSplitParent(location?: ITerminalLocationOptions): ITerminalInstance | undefined {
-		if (this._connectionState === TerminalConnectionState.Connecting && this.activeInstance) {
-			const group = this._terminalGroupService.getGroupForInstance(this.activeInstance);
-			return group?.terminalInstances[group.terminalInstances.length - 1];
-		}
 		if (location && typeof location === 'object' && 'parentTerminal' in location) {
 			return location.parentTerminal;
 		} else if (location && typeof location === 'object' && 'splitActiveTerminal' in location) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #133687

@meganrogge sorry for bothering you again but 54ab46f01667f8e1a2f094c73890b24312cc4b44 caused a regression when creating terminals using the location API `location: {parentTerminal}` from an extension
```
const terminal1 = vscode.window.createTerminal({ name: `Term 1` });
terminal1.show();

const terminal2 = vscode.window.createTerminal({ name: `Term 2` });
terminal2.show();

const terminal3 = vscode.window.createTerminal({ name: `Term 3`, location: {parentTerminal: terminal2} });
terminal3.show();
```
Running this will create all three terminal in a single group (the panel must be hidden initially)

