### PR TITLE
Notebook markdown fix

### DIFF
--- a/extensions/markdown-language-features/esbuild.js
+++ b/extensions/markdown-language-features/esbuild.js
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 const path = require('path');
+const fse = require('fs-extra');
 const esbuild = require('esbuild');
 
 const args = process.argv.slice(2);
@@ -30,3 +31,7 @@ esbuild.build({
 	target: ['es2020'],
 	incremental: isWatch,
 }).catch(() => process.exit(1));
+
+fse.copySync(
+	path.join(__dirname, 'media/markdown.css'),
+	path.join(outDir, 'markdown.css'));

--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -8,6 +8,8 @@ import * as DOMPurify from 'dompurify';
 import type * as MarkdownItToken from 'markdown-it/lib/token';
 import type { ActivationFunction } from 'vscode-notebook-renderer';
 
+import '../media/markdown.css';
+
 const sanitizerOptions: DOMPurify.Config = {
 	ALLOWED_TAGS: ['a', 'button', 'blockquote', 'code', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'img', 'input', 'label', 'li', 'p', 'pre', 'select', 'small', 'span', 'strong', 'textarea', 'ul', 'ol'],
 };
@@ -144,8 +146,15 @@ export const activate: ActivationFunction<void> = (ctx) => {
 			white-space: pre-wrap;
 		}
 	`;
+	//Create a style element using "markdown.css"
+	const mdCss = document.createElement('link');
+	mdCss.rel = 'stylesheet';
+	mdCss.href = '../media/markdown.css';
+	mdCss.type = 'text/css';
+
 	const template = document.createElement('template');
 	template.classList.add('markdown-style');
+	template.content.appendChild(mdCss);
 	template.content.appendChild(style);
 	document.head.appendChild(template);
 

--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -8,11 +8,11 @@ import * as DOMPurify from 'dompurify';
 import type * as MarkdownItToken from 'markdown-it/lib/token';
 import type { ActivationFunction } from 'vscode-notebook-renderer';
 
-import '../media/markdown.css';
-
 const sanitizerOptions: DOMPurify.Config = {
 	ALLOWED_TAGS: ['a', 'button', 'blockquote', 'code', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'img', 'input', 'label', 'li', 'p', 'pre', 'select', 'small', 'span', 'strong', 'textarea', 'ul', 'ol'],
 };
+
+const mdStyleHref = import.meta.url.replace(/index.js$/, 'markdown.css');
 
 export const activate: ActivationFunction<void> = (ctx) => {
 	let markdownIt = new MarkdownIt({
@@ -27,54 +27,8 @@ export const activate: ActivationFunction<void> = (ctx) => {
 			font-style: italic;
 			opacity: 0.6;
 		}
-
-		img {
-			max-width: 100%;
-			max-height: 100%;
-		}
-
-		a {
-			text-decoration: none;
-		}
-
-		a:hover {
-			text-decoration: underline;
-		}
-
-		a:focus,
-		input:focus,
-		select:focus,
-		textarea:focus {
-			outline: 1px solid -webkit-focus-ring-color;
-			outline-offset: -1px;
-		}
-
-		hr {
-			border: 0;
-			height: 2px;
-			border-bottom: 2px solid;
-		}
-
-		h1 {
-			font-size: 2.25em;
-		}
-
-		h2 {
-			font-size: 1.9em;
-		}
-
-		h3 {
-			font-size: 1.6em;
-		}
-
-		p {
-			font-size: 1.1em;
-		}
-
-		h1,
-		h2,
-		h3 {
-			font-weight: normal;
+		body#preview {
+			padding: 0;
 		}
 
 		div {
@@ -129,46 +83,31 @@ export const activate: ActivationFunction<void> = (ctx) => {
 			border-top: 1px solid;
 		}
 
-		blockquote {
-			margin: 0 7px 0 5px;
-			padding: 0 16px 0 10px;
-			border-left-width: 5px;
-			border-left-style: solid;
-		}
-
-		code,
-		.code {
-			font-size: 1em;
-			line-height: 1.357em;
-		}
-
 		.code {
 			white-space: pre-wrap;
 		}
 	`;
-	//Create a style element using "markdown.css"
-	const mdCss = document.createElement('link');
-	mdCss.rel = 'stylesheet';
-	mdCss.href = '../media/markdown.css';
-	mdCss.type = 'text/css';
 
 	const template = document.createElement('template');
 	template.classList.add('markdown-style');
-	template.content.appendChild(mdCss);
 	template.content.appendChild(style);
 	document.head.appendChild(template);
 
+	const themeClass = document.body.classList[0];
 	return {
 		renderOutputItem: (outputInfo, element) => {
 			let previewNode: HTMLElement;
 			if (!element.shadowRoot) {
 				const previewRoot = element.attachShadow({ mode: 'open' });
-
 				// Insert styles into markdown preview shadow dom so that they are applied.
 				// First add default webview style
 				const defaultStyles = document.getElementById('_defaultStyles') as HTMLStyleElement;
 				previewRoot.appendChild(defaultStyles.cloneNode(true));
-
+				// Add default markdown styles
+				const mdCss = document.createElement('link');
+				mdCss.rel = 'stylesheet';
+				mdCss.href = mdStyleHref;
+				previewRoot.appendChild(mdCss);
 				// And then contributed styles
 				for (const element of document.getElementsByClassName('markdown-style')) {
 					if (element instanceof HTMLTemplateElement) {
@@ -178,7 +117,8 @@ export const activate: ActivationFunction<void> = (ctx) => {
 					}
 				}
 
-				previewNode = document.createElement('div');
+				previewNode = document.createElement('body');
+				previewNode.className = themeClass;
 				previewNode.id = 'preview';
 				previewRoot.appendChild(previewNode);
 			} else {

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -28,7 +28,8 @@
     "onCommand:markdown.api.render",
     "onCommand:markdown.api.reloadPlugins",
     "onWebviewPanel:markdown.preview",
-    "onCustomEditor:vscode.markdown.preview.editor"
+    "onCustomEditor:vscode.markdown.preview.editor",
+    "onRenderer:markdownItRenderer"
   ],
   "capabilities": {
     "virtualWorkspaces": true,
@@ -48,7 +49,8 @@
         "entrypoint": "./notebook-out/index.js",
         "mimeTypes": [
           "text/markdown"
-        ]
+        ],
+        "requiresMessaging": "optional"
       }
     ],
     "commands": [

--- a/extensions/markdown-language-features/src/extension.ts
+++ b/extensions/markdown-language-features/src/extension.ts
@@ -35,6 +35,17 @@ export function activate(context: vscode.ExtensionContext) {
 	const contentProvider = new MarkdownContentProvider(engine, context, cspArbiter, contributions, logger);
 	const symbolProvider = new MDDocumentSymbolProvider(engine);
 	const previewManager = new MarkdownPreviewManager(contentProvider, logger, contributions, engine);
+
+	const messageChannel = vscode.notebooks.createRendererMessaging('markdownItRenderer');
+	messageChannel.onDidReceiveMessage((e: any) => {
+		if (e.message.request === 'getMarkdownConfig') {
+			messageChannel.postMessage({
+				request: 'markdownConfig',
+				data: vscode.workspace.getConfiguration('markdown')
+			});
+		}
+	});
+
 	context.subscriptions.push(previewManager);
 
 	context.subscriptions.push(registerMarkdownLanguageFeatures(symbolProvider, engine));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The issue was caused by different styling in notebook markdown preview and original markdown preview. This doesn't really makes sense in my opinion, it should be consistent. So first of all I included a markdown.css, changed the preview root from div to body and added a theme class, to accommodate for dark and light modes. 

This fixed the issues with visual discrepancies, however the spacing and font sizes were incorrect. This was caused by missing CSS variables, which described all those properties. To access them, I needed to access vscode API, and this can't be done from client side. I used the solution described in notebook API documentation: https://code.visualstudio.com/api/extension-guides/notebook. I make a call to markdown extension, before I render the content, and retrieve all the settings I need.

You can test the fix by going into a notebook and creating a code block, it will no longer be rendered as golden text. Moreover, the headers will have an underscore just like original markdown previews.

![image](https://user-images.githubusercontent.com/17224830/139393614-e02f0404-d742-4111-949c-a2c8d9ab1dd9.png)

This PR fixes #130647
