### PR TITLE
Allow extensions to disable built-in markdown preview button

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -99,7 +99,7 @@
       "editor/title": [
         {
           "command": "markdown.showPreviewToSide",
-          "when": "editorLangId == markdown && !notebookEditorFocused && !hasCustomMarkdownView",
+          "when": "editorLangId == markdown && !notebookEditorFocused && !hasCustomMarkdownPreview",
           "alt": "markdown.showPreview",
           "group": "navigation"
         },

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -99,7 +99,7 @@
       "editor/title": [
         {
           "command": "markdown.showPreviewToSide",
-          "when": "editorLangId == markdown && !notebookEditorFocused",
+          "when": "editorLangId == markdown && !notebookEditorFocused && !hasCustomMarkdownView",
           "alt": "markdown.showPreview",
           "group": "navigation"
         },


### PR DESCRIPTION
Adds a flag for the "Open Preview to the Side" button displayed for markdown files. This makes it possible for extensions to hide this button when desired by setting the flag to true. For example, extensions can now use the following line to disable the preview button:

```js
vscode.commands.executeCommand("setContext", "hasCustomMarkdownPreview", true);
```

Issue: https://github.com/microsoft/vscode/issues/136388

Regularly:
![](https://user-images.githubusercontent.com/1008124/140197297-fbd86a2f-8678-4c17-9eb2-69a7ef1afe43.png)

With the default markdown preview button disabled by an extension:
![](https://user-images.githubusercontent.com/1008124/140197295-097772aa-a941-414e-bab9-5a82ee6fbe24.png)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
