### PR TITLE
Escape unicode directional formatting characters when rendering control characters

### DIFF
--- a/src/vs/editor/browser/viewParts/lines/viewLines.css
+++ b/src/vs/editor/browser/viewParts/lines/viewLines.css
@@ -14,6 +14,11 @@
 	100% { background-color: none }
 }*/
 
+.mtkcontrol {
+	color: rgb(255, 255, 255) !important;
+	background: rgb(150, 0, 0) !important;
+}
+
 .monaco-editor.no-user-select .lines-content,
 .monaco-editor.no-user-select .view-line,
 .monaco-editor.no-user-select .view-lines {

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -575,7 +575,7 @@ export interface IEditorOptions {
 	renderWhitespace?: 'none' | 'boundary' | 'selection' | 'trailing' | 'all';
 	/**
 	 * Enable rendering of control characters.
-	 * Defaults to false.
+	 * Defaults to true.
 	 */
 	renderControlCharacters?: boolean;
 	/**
@@ -4637,8 +4637,8 @@ export const EditorOptions = {
 		{ description: nls.localize('renameOnType', "Controls whether the editor auto renames on type."), markdownDeprecationMessage: nls.localize('renameOnTypeDeprecate', "Deprecated, use `editor.linkedEditing` instead.") }
 	)),
 	renderControlCharacters: register(new EditorBooleanOption(
-		EditorOption.renderControlCharacters, 'renderControlCharacters', false,
-		{ description: nls.localize('renderControlCharacters', "Controls whether the editor should render control characters.") }
+		EditorOption.renderControlCharacters, 'renderControlCharacters', true,
+		{ description: nls.localize('renderControlCharacters', "Controls whether the editor should render control characters."), restricted: true }
 	)),
 	renderFinalNewline: register(new EditorBooleanOption(
 		EditorOption.renderFinalNewline, 'renderFinalNewline', true,

--- a/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
+++ b/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
@@ -2114,6 +2114,38 @@ suite('viewLineRenderer.renderLine 2', () => {
 		assert.deepStrictEqual(actual.html, expected);
 	});
 
+	test('issue #116939: Important control characters aren\'t rendered', () => {
+		const actual = renderViewLine(new RenderLineInput(
+			false,
+			false,
+			`transferBalance(5678,${String.fromCharCode(0x202E)}6776,4321${String.fromCharCode(0x202C)},"USD");`,
+			false,
+			false,
+			false,
+			0,
+			createViewLineTokens([createPart(42, 3)]),
+			[],
+			4,
+			0,
+			10,
+			10,
+			10,
+			10000,
+			'none',
+			true,
+			false,
+			null
+		));
+
+		const expected = [
+			'<span>',
+			'<span class="mtk3">transferBalance(5678,</span><span class="mtkcontrol">[U+202E]</span><span class="mtk3">6776,4321</span><span class="mtkcontrol">[U+202C]</span><span class="mtk3">,"USD");</span>',
+			'</span>'
+		].join('');
+
+		assert.deepStrictEqual(actual.html, expected);
+	});
+
 	test('issue #124038: Multiple end-of-line text decorations get merged', () => {
 		const actual = renderViewLine(new RenderLineInput(
 			true,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3226,7 +3226,7 @@ declare namespace monaco.editor {
 		renderWhitespace?: 'none' | 'boundary' | 'selection' | 'trailing' | 'all';
 		/**
 		 * Enable rendering of control characters.
-		 * Defaults to false.
+		 * Defaults to true.
 		 */
 		renderControlCharacters?: boolean;
 		/**


### PR DESCRIPTION
Fixes #116939

This also changes the default for `editor.renderControlCharacters` to be `true` by default. Here is how things will look by default for the directional formatting characters:

```

transferBalance(5678,‮6776,4321‬,"USD");

```

![image](https://user-images.githubusercontent.com/5047891/140066829-b9cb6290-3c80-46af-8eec-8cf23e6621ed.png)
