### PR TITLE
Share common code for the ExtensionResourceLoaderService

### DIFF
--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -30,6 +30,7 @@ import { Codicon } from 'vs/base/common/codicons';
 import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { Emitter } from 'vs/base/common/event';
+import { IExtensionResourceLoaderService } from 'vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader';
 
 export const manageExtensionIcon = registerIcon('theme-selection-manage-extension', Codicon.gear, localize('manageExtensionIcon', 'Icon for the \'Manage\' action in the theme selection quick pick.'));
 
@@ -49,6 +50,7 @@ export class SelectColorThemeAction extends Action {
 		@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService,
 		@IPaneCompositePartService private readonly paneCompositeService: IPaneCompositePartService,
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
+		@IExtensionResourceLoaderService private readonly extensionResourceLoaderService: IExtensionResourceLoaderService,
 		@ILogService private readonly logService: ILogService,
 		@IProgressService private progressService: IProgressService
 	) {
@@ -134,7 +136,7 @@ export class SelectColorThemeAction extends Action {
 				});
 				quickpick.show();
 
-				if (this.extensionGalleryService.isEnabled()) {
+				if (this.extensionGalleryService.isEnabled() && this.extensionResourceLoaderService.supportsExtensionGalleryResources) {
 
 					const marketplaceThemes = new MarketplaceThemes(this.extensionGalleryService, this.extensionManagementService, this.themeService, this.logService);
 					marketplaceThemes.onDidChange(() => {

--- a/src/vs/workbench/services/extensionManagement/common/webExtensionsScannerService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/webExtensionsScannerService.ts
@@ -24,8 +24,6 @@ import * as semver from 'vs/base/common/semver/semver';
 import { isString } from 'vs/base/common/types';
 import { getErrorMessage } from 'vs/base/common/errors';
 import { ResourceMap } from 'vs/base/common/map';
-import { IProductService } from 'vs/platform/product/common/productService';
-import { format2 } from 'vs/base/common/strings';
 import { IExtensionManifestPropertiesService } from 'vs/workbench/services/extensions/common/extensionManifestPropertiesService';
 import { IStringDictionary } from 'vs/base/common/collections';
 import { IExtensionResourceLoaderService } from 'vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader';
@@ -74,7 +72,6 @@ export class WebExtensionsScannerService extends Disposable implements IWebExten
 		@IFileService private readonly fileService: IFileService,
 		@ILogService private readonly logService: ILogService,
 		@IExtensionGalleryService private readonly galleryService: IExtensionGalleryService,
-		@IProductService private readonly productService: IProductService,
 		@IExtensionManifestPropertiesService private readonly extensionManifestPropertiesService: IExtensionManifestPropertiesService,
 		@IExtensionResourceLoaderService private readonly extensionResourceLoaderService: IExtensionResourceLoaderService,
 	) {
@@ -334,10 +331,10 @@ export class WebExtensionsScannerService extends Disposable implements IWebExten
 	}
 
 	private async toWebExtensionFromGallery(galleryExtension: IGalleryExtension, metadata?: IStringDictionary<any>): Promise<IWebExtension> {
-		if (!this.productService.extensionsGallery) {
+		let extensionLocation = this.extensionResourceLoaderService.getExtensionGalleryResourceURL(galleryExtension, 'extension');
+		if (!extensionLocation) {
 			throw new Error('No extension gallery service configured.');
 		}
-		let extensionLocation = URI.parse(format2(this.productService.extensionsGallery.resourceUrlTemplate, { publisher: galleryExtension.publisher, name: galleryExtension.name, version: galleryExtension.version, path: 'extension' }));
 		extensionLocation = galleryExtension.properties.targetPlatform === TargetPlatform.WEB ? extensionLocation.with({ query: `${extensionLocation.query ? `${extensionLocation.query}&` : ''}target=${galleryExtension.properties.targetPlatform}` }) : extensionLocation;
 		const extensionResources = await this.listExtensionResources(extensionLocation);
 		const packageNLSResource = extensionResources.find(e => basename(e) === 'package.nls.json');

--- a/src/vs/workbench/services/extensionResourceLoader/browser/extensionResourceLoaderService.ts
+++ b/src/vs/workbench/services/extensionResourceLoader/browser/extensionResourceLoaderService.ts
@@ -6,35 +6,27 @@
 import { URI } from 'vs/base/common/uri';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IFileService } from 'vs/platform/files/common/files';
-import { IExtensionResourceLoaderService } from 'vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader';
+import { AbstractExtensionResourceLoaderService, IExtensionResourceLoaderService } from 'vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader';
 import { FileAccess, Schemas } from 'vs/base/common/network';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { IStorageService } from 'vs/platform/storage/common/storage';
-import { getServiceMachineId } from 'vs/platform/serviceMachineId/common/serviceMachineId';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
-import { isWeb } from 'vs/base/common/platform';
 import { ILogService } from 'vs/platform/log/common/log';
-import { getTelemetryLevel, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
 
-class ExtensionResourceLoaderService implements IExtensionResourceLoaderService {
+class ExtensionResourceLoaderService extends AbstractExtensionResourceLoaderService {
 
 	declare readonly _serviceBrand: undefined;
 
-	private readonly _extensionGalleryResourceAuthority: string | undefined;
-
 	constructor(
-		@IFileService private readonly _fileService: IFileService,
-		@IProductService private readonly _productService: IProductService,
-		@IStorageService private readonly _storageService: IStorageService,
-		@IEnvironmentService private readonly _environmentService: IEnvironmentService,
-		@ILogService private readonly _logService: ILogService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService
+		@IFileService fileService: IFileService,
+		@IStorageService storageService: IStorageService,
+		@IProductService productService: IProductService,
+		@IEnvironmentService environmentService: IEnvironmentService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@ILogService readonly _logService: ILogService,
 	) {
-		if (_productService.extensionsGallery) {
-			this._extensionGalleryResourceAuthority = this._getExtensionResourceAuthority(URI.parse(_productService.extensionsGallery.resourceUrlTemplate));
-		}
+		super(fileService, storageService, productService, environmentService, configurationService);
 	}
 
 	async readExtensionResource(uri: URI): Promise<string> {
@@ -46,18 +38,8 @@ class ExtensionResourceLoaderService implements IExtensionResourceLoaderService 
 		}
 
 		const requestInit: RequestInit = {};
-		if (this._extensionGalleryResourceAuthority && this._extensionGalleryResourceAuthority === this._getExtensionResourceAuthority(uri)) {
-			const machineId = await this._getServiceMachineId();
-			requestInit.headers = {
-				'X-Client-Name': `${this._productService.applicationName}${isWeb ? '-web' : ''}`,
-				'X-Client-Version': this._productService.version
-			};
-			if (supportsTelemetry(this._productService, this._environmentService) && getTelemetryLevel(this._configurationService) === TelemetryLevel.USAGE) {
-				requestInit.headers['X-Machine-Id'] = machineId;
-			}
-			if (this._productService.commit) {
-				requestInit.headers['X-Client-Commit'] = this._productService.commit;
-			}
+		if (this.isExtensionGalleryResource(uri)) {
+			requestInit.headers = await this.getExtensionGalleryRequestHeaders();
 			requestInit.mode = 'cors'; /* set mode to cors so that above headers are always passed */
 		}
 
@@ -67,20 +49,6 @@ class ExtensionResourceLoaderService implements IExtensionResourceLoaderService 
 			throw new Error(response.statusText);
 		}
 		return response.text();
-
-	}
-
-	private _serviceMachineIdPromise: Promise<string> | undefined;
-	private _getServiceMachineId(): Promise<string> {
-		if (!this._serviceMachineIdPromise) {
-			this._serviceMachineIdPromise = getServiceMachineId(this._environmentService, this._fileService, this._storageService);
-		}
-		return this._serviceMachineIdPromise;
-	}
-
-	private _getExtensionResourceAuthority(uri: URI): string | undefined {
-		const index = uri.authority.indexOf('.');
-		return index !== -1 ? uri.authority.substring(index + 1) : undefined;
 	}
 }
 

--- a/src/vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader.ts
+++ b/src/vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader.ts
@@ -3,8 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { isWeb } from 'vs/base/common/platform';
+import { format2 } from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
+import { IHeaders } from 'vs/base/parts/request/common/request';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { IFileService } from 'vs/platform/files/common/files';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { IProductService } from 'vs/platform/product/common/productService';
+import { getServiceMachineId } from 'vs/platform/serviceMachineId/common/serviceMachineId';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
+import { getTelemetryLevel, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 
 export const IExtensionResourceLoaderService = createDecorator<IExtensionResourceLoaderService>('extensionResourceLoaderService');
 
@@ -18,4 +29,82 @@ export interface IExtensionResourceLoaderService {
 	 * Read a certain resource within an extension.
 	 */
 	readExtensionResource(uri: URI): Promise<string>;
+
+	/**
+	 * Returns whether the gallery provides extension resources.
+	 */
+	supportsExtensionGalleryResources: boolean;
+
+	/**
+	 * Computes the URL of a extension gallery resource. Returns `undefined` if gallery does not provide extension resources.
+	 */
+	 getExtensionGalleryResourceURL(galleryExtension: { publisher: string, name: string, version: string }, path?: string): URI | undefined;
+}
+
+
+export abstract class AbstractExtensionResourceLoaderService implements IExtensionResourceLoaderService {
+
+	readonly _serviceBrand: undefined;
+
+	private readonly _extensionGalleryResourceUrlTemplate: string | undefined;
+	private readonly _extensionGalleryAuthority: string | undefined;
+
+	constructor(
+		readonly _fileService: IFileService,
+		readonly _storageService: IStorageService,
+		readonly _productService: IProductService,
+		readonly _environmentService: IEnvironmentService,
+		readonly _configurationService: IConfigurationService,
+	) {
+		if (_productService.extensionsGallery) {
+			this._extensionGalleryResourceUrlTemplate = _productService.extensionsGallery.resourceUrlTemplate;
+			this._extensionGalleryAuthority = this._getExtensionGalleryAuthority(URI.parse(this._extensionGalleryResourceUrlTemplate));
+		}
+	}
+
+	public get supportsExtensionGalleryResources(): boolean {
+		return this._extensionGalleryResourceUrlTemplate !== undefined;
+	}
+
+	public getExtensionGalleryResourceURL(galleryExtension: { publisher: string, name: string, version: string }, path?: string): URI | undefined {
+		if (this._extensionGalleryResourceUrlTemplate) {
+			return URI.parse(format2(this._extensionGalleryResourceUrlTemplate, { publisher: galleryExtension.publisher, name: galleryExtension.name, version: galleryExtension.version, path: 'extension' }));
+		}
+		return undefined;
+	}
+
+
+	public abstract readExtensionResource(uri: URI): Promise<string>;
+
+	protected isExtensionGalleryResource(uri: URI) {
+		return this._extensionGalleryAuthority && this._extensionGalleryAuthority === this._getExtensionGalleryAuthority(uri);
+	}
+
+	protected async getExtensionGalleryRequestHeaders(): Promise<IHeaders> {
+		const headers: IHeaders = {
+			'X-Client-Name': `${this._productService.applicationName}${isWeb ? '-web' : ''}`,
+			'X-Client-Version': this._productService.version
+		};
+		if (supportsTelemetry(this._productService, this._environmentService) && getTelemetryLevel(this._configurationService) === TelemetryLevel.USAGE) {
+			headers['X-Machine-Id'] = await this._getServiceMachineId();
+		}
+		if (this._productService.commit) {
+			headers['X-Client-Commit'] = this._productService.commit;
+		}
+		return headers;
+	}
+
+	private _serviceMachineIdPromise: Promise<string> | undefined;
+	private _getServiceMachineId(): Promise<string> {
+		if (!this._serviceMachineIdPromise) {
+			this._serviceMachineIdPromise = getServiceMachineId(this._environmentService, this._fileService, this._storageService);
+		}
+		return this._serviceMachineIdPromise;
+	}
+
+	private _getExtensionGalleryAuthority(uri: URI): string | undefined {
+		const index = uri.authority.indexOf('.');
+		return index !== -1 ? uri.authority.substring(index + 1) : undefined;
+	}
+
 }

--- a/src/vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader.ts
+++ b/src/vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader.ts
@@ -38,7 +38,7 @@ export interface IExtensionResourceLoaderService {
 	/**
 	 * Computes the URL of a extension gallery resource. Returns `undefined` if gallery does not provide extension resources.
 	 */
-	 getExtensionGalleryResourceURL(galleryExtension: { publisher: string, name: string, version: string }, path?: string): URI | undefined;
+	getExtensionGalleryResourceURL(galleryExtension: { publisher: string, name: string, version: string }, path?: string): URI | undefined;
 }
 
 
@@ -58,7 +58,7 @@ export abstract class AbstractExtensionResourceLoaderService implements IExtensi
 	) {
 		if (_productService.extensionsGallery) {
 			this._extensionGalleryResourceUrlTemplate = _productService.extensionsGallery.resourceUrlTemplate;
-			this._extensionGalleryAuthority = this._getExtensionGalleryAuthority(URI.parse(this._extensionGalleryResourceUrlTemplate));
+			this._extensionGalleryAuthority = this._extensionGalleryResourceUrlTemplate ? this._getExtensionGalleryAuthority(URI.parse(this._extensionGalleryResourceUrlTemplate)) : undefined;
 		}
 	}
 

--- a/src/vs/workbench/services/extensionResourceLoader/electron-sandbox/extensionResourceLoaderService.ts
+++ b/src/vs/workbench/services/extensionResourceLoader/electron-sandbox/extensionResourceLoaderService.ts
@@ -6,47 +6,37 @@
 import { URI } from 'vs/base/common/uri';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IFileService } from 'vs/platform/files/common/files';
-import { IExtensionResourceLoaderService } from 'vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader';
+import { AbstractExtensionResourceLoaderService, IExtensionResourceLoaderService } from 'vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { asText, IRequestService } from 'vs/platform/request/common/request';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { CancellationToken } from 'vs/base/common/cancellation';
 
-export class ExtensionResourceLoaderService implements IExtensionResourceLoaderService {
-
-	declare readonly _serviceBrand: undefined;
-
-	private readonly _extensionGalleryResourceAuthority: string | undefined;
+export class ExtensionResourceLoaderService extends AbstractExtensionResourceLoaderService {
 
 	constructor(
-		@IFileService private readonly _fileService: IFileService,
-		@IProductService _productService: IProductService,
-		@IRequestService private readonly _requestService: IRequestService,
+		@IFileService fileService: IFileService,
+		@IStorageService storageService: IStorageService,
+		@IProductService productService: IProductService,
+		@IEnvironmentService environmentService: IEnvironmentService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IRequestService readonly _requestService: IRequestService,
 	) {
-		if (_productService.extensionsGallery) {
-			this._extensionGalleryResourceAuthority = this._getExtensionResourceAuthority(URI.parse(_productService.extensionsGallery.resourceUrlTemplate));
-		}
-
-
+		super(fileService, storageService, productService, environmentService, configurationService);
 	}
 
 	async readExtensionResource(uri: URI): Promise<string> {
-
-		if (this._extensionGalleryResourceAuthority && this._extensionGalleryResourceAuthority === this._getExtensionResourceAuthority(uri)) {
-			const requestContext = await this._requestService.request({
-				url: uri.toString()
-			}, CancellationToken.None);
-
+		if (this.isExtensionGalleryResource(uri)) {
+			const headers = await this.getExtensionGalleryRequestHeaders();
+			const requestContext = await this._requestService.request({ url: uri.toString(), headers }, CancellationToken.None);
 			return (await asText(requestContext)) || '';
 		}
-
 		const result = await this._fileService.readFile(uri);
 		return result.value.toString();
 	}
 
-	private _getExtensionResourceAuthority(uri: URI): string | undefined {
-		const index = uri.authority.indexOf('.');
-		return index !== -1 ? uri.authority.substring(index + 1) : undefined;
-	}
 }
 
 registerSingleton(IExtensionResourceLoaderService, ExtensionResourceLoaderService);

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -40,8 +40,6 @@ import { RunOnceScheduler, Sequencer } from 'vs/base/common/async';
 import { IUserDataInitializationService } from 'vs/workbench/services/userData/browser/userDataInit';
 import { getIconsStyleSheet } from 'vs/platform/theme/browser/iconsStyleSheet';
 import { asCssVariableName, getColorRegistry } from 'vs/platform/theme/common/colorRegistry';
-import { IProductService } from 'vs/platform/product/common/productService';
-import { format2 } from 'vs/base/common/strings';
 
 // implementation
 
@@ -113,8 +111,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 		@IWorkbenchLayoutService readonly layoutService: IWorkbenchLayoutService,
 		@ILogService private readonly logService: ILogService,
 		@IHostColorSchemeService private readonly hostColorService: IHostColorSchemeService,
-		@IUserDataInitializationService readonly userDataInitializationService: IUserDataInitializationService,
-		@IProductService private readonly productService: IProductService
+		@IUserDataInitializationService readonly userDataInitializationService: IUserDataInitializationService
 	) {
 		this.container = layoutService.container;
 		this.settings = new ThemeConfiguration(configurationService);
@@ -412,13 +409,12 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 	}
 
 	public async getMarketplaceColorThemes(id: string, version: string): Promise<IWorkbenchColorTheme[]> {
-		const resourceUrlTemplate = this.productService.extensionsGallery?.resourceUrlTemplate;
-		if (!resourceUrlTemplate) {
+		const [publisher, name] = id.split('.');
+		const extensionLocation = this.extensionResourceLoaderService.getExtensionGalleryResourceURL({ publisher, name, version}, 'extension');
+		if (!extensionLocation) {
 			return [];
 		}
 		try {
-			const [publisher, name] = id.split('.');
-			const extensionLocation = URI.parse(format2(resourceUrlTemplate, { publisher, name, version, path: 'extension' }));
 			const manifestContent = await this.extensionResourceLoaderService.readExtensionResource(resources.joinPath(extensionLocation, 'package.json'));
 
 			const data: ExtensionData = { extensionPublisher: publisher, extensionId: id, extensionName: name, extensionIsBuiltin: false };

--- a/src/vs/workbench/services/themes/test/electron-browser/tokenStyleResolving.test.ts
+++ b/src/vs/workbench/services/themes/test/electron-browser/tokenStyleResolving.test.ts
@@ -17,6 +17,9 @@ import { ExtensionResourceLoaderService } from 'vs/workbench/services/extensionR
 import { ITokenStyle } from 'vs/platform/theme/common/themeService';
 import { mock, TestProductService } from 'vs/workbench/test/common/workbenchTestServices';
 import { IRequestService } from 'vs/platform/request/common/request';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 const undefinedStyle = { bold: undefined, underline: undefined, italic: undefined };
 const unsetStyle = { bold: false, underline: false, italic: false };
@@ -81,8 +84,11 @@ function assertTokenStyles(themeData: ColorThemeData, expected: { [qualifiedClas
 suite('Themes - TokenStyleResolving', () => {
 	const fileService = new FileService(new NullLogService());
 	const requestService = new (mock<IRequestService>())();
+	const storageService = new (mock<IStorageService>())();
+	const environmentService = new (mock<IEnvironmentService>())();
+	const configurationService = new (mock<IConfigurationService>())();
 
-	const extensionResourceLoaderService = new ExtensionResourceLoaderService(fileService, TestProductService, requestService);
+	const extensionResourceLoaderService = new ExtensionResourceLoaderService(fileService, storageService, TestProductService, environmentService, configurationService, requestService);
 
 	const diskFileSystemProvider = new DiskFileSystemProvider(new NullLogService());
 	fileService.registerProvider(Schemas.file, diskFileSystemProvider);


### PR DESCRIPTION
Adds a base class for the Browser and Electron ExtensionResourceLoaderService and shares the following code:
  - test if a resource is a extension gallery resource
  - compute the request headers

New API to computes a extension gallery resource location
 - used by the WorkbenchThemeService