### PR TITLE
Fixes #136470 by not triggering on change when there was no change.

### DIFF
--- a/src/vs/editor/common/model/bracketPairs/bracketPairsImpl.ts
+++ b/src/vs/editor/common/model/bracketPairs/bracketPairsImpl.ts
@@ -75,8 +75,10 @@ export class BracketPairs extends Disposable implements IBracketPairs {
 				this.onDidChangeEmitter.fire();
 			}
 		} else {
-			this.cache.clear();
-			this.onDidChangeEmitter.fire();
+			if (this.cache.value) {
+				this.cache.clear();
+				this.onDidChangeEmitter.fire();
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #136470 

This was only problematic if `updateCache` is called by someone who listens to changes (thus causing an endless loop).
