### PR TITLE
Update html-language-features documentation and tasks to yarn

### DIFF
--- a/extensions/html-language-features/.vscode/tasks.json
+++ b/extensions/html-language-features/.vscode/tasks.json
@@ -2,9 +2,9 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"label": "npm",
-			"command": "npm",
-			"args": ["run", "compile"],
+			"label": "yarn",
+			"command": "yarn",
+			"args": ["compile"],
 			"type": "shell",
 			"presentation": {
 				"reveal": "silent",

--- a/extensions/html-language-features/CONTRIBUTING.md
+++ b/extensions/html-language-features/CONTRIBUTING.md
@@ -30,7 +30,7 @@ However, within this extension, you can run a development version of `vscode-htm
 - Clone [microsoft/vscode-html-languageservice](https://github.com/microsoft/vscode-html-languageservice)
 - Run `yarn` in `vscode-html-languageservice`
 - Run `yarn link` in `vscode-html-languageservice`. This will compile and link `vscode-html-languageservice`
-- In `html-language-features/server/`, run `npm link vscode-html-languageservice`
+- In `html-language-features/server/`, run `yarn link vscode-html-languageservice`
 
 #### Testing the development version of `vscode-html-languageservice`
 

--- a/extensions/html-language-features/server/.vscode/tasks.json
+++ b/extensions/html-language-features/server/.vscode/tasks.json
@@ -2,9 +2,9 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"label": "npm watch",
-			"command": "npm",
-			"args": ["run", "watch"],
+			"label": "yarn watch",
+			"command": "yarn",
+			"args": ["watch"],
 			"type": "shell",
 			"presentation": {
 				"reveal": "silent",

--- a/extensions/html-language-features/server/package.json
+++ b/extensions/html-language-features/server/package.json
@@ -27,6 +27,6 @@
     "install-service-local": "yarn link vscode-css-languageservice && yarn link vscode-html-languageservice",
     "install-server-next": "yarn add vscode-languageserver@next",
     "install-server-local": "yarn link vscode-languageserver",
-    "test": "npm run compile && node ./test/index.js"
+    "test": "yarn compile && node ./test/index.js"
   }
 }


### PR DESCRIPTION
This PR fixes #136542

Update README to use yarn.

Also updated the launch/tasks.
npm can still be used to run them, but for consistency they should also be yarn.
