### PR TITLE
133348 fix oom when search opened in editor

### DIFF
--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorSerialization.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorSerialization.ts
@@ -38,7 +38,8 @@ const matchToSearchResultFormat = (match: Match, longestLineNumber: number): { l
 			const prefix = `  ${paddingStr}${lineNumber}: `;
 			const prefixOffset = prefix.length;
 
-			const line = (prefix + sourceLine).replace(/\r?\n?$/, '');
+			// split instead of replace to avoid creating a new string object
+			const line = prefix + sourceLine.split(/\r?\n?$/, 1)[0];
 
 			const rangeOnThisLine = ({ start, end }: { start?: number; end?: number; }) => new Range(1, (start ?? 1) + prefixOffset, 1, (end ?? sourceLine.length + 1) + prefixOffset);
 

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorSerialization.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorSerialization.ts
@@ -79,7 +79,7 @@ function fileMatchToSearchResultFormat(fileMatch: FileMatch, labelFormatter: (x:
 	const seenLines = new Set<string>();
 	sortedMatches.forEach(match => {
 		matchToSearchResultFormat(match, longestLineNumber).forEach(match => {
-			if (!seenLines.has(match.line)) {
+			if (!seenLines.has(match.lineNumber)) {
 				while (context.length && context[0].lineNumber < +match.lineNumber) {
 					const { line, lineNumber } = context.shift()!;
 					if (lastLine !== undefined && lineNumber !== lastLine + 1) {
@@ -90,7 +90,7 @@ function fileMatchToSearchResultFormat(fileMatch: FileMatch, labelFormatter: (x:
 				}
 
 				targetLineNumberToOffset[match.lineNumber] = text.length;
-				seenLines.add(match.line);
+				seenLines.add(match.lineNumber);
 				text.push(match.line);
 				lastLine = +match.lineNumber;
 			}


### PR DESCRIPTION
This PR fixes #133348
reproduce steps: https://github.com/microsoft/vscode/issues/133348#issuecomment-962272357

I test my fixes on search in `plugins.pkgd.min.js` from https://github.com/froala/wysiwyg-editor

before my fixes `Open in editor` consumed 2671MB
![before fix](https://user-images.githubusercontent.com/1365584/140592444-51386dd4-66ba-4649-96ef-69d1b279a163.png)

after first fix consumed 220MB
![fix 1](https://user-images.githubusercontent.com/1365584/140592505-5bcddb1e-00f6-4583-9ac8-85f0722cb88e.png)

after second fix consumed ~15-30MB
![fix 2](https://user-images.githubusercontent.com/1365584/140592507-5b4a8664-f400-41a2-b785-4630c592ea5c.png)


