### PR TITLE
Fix: find next match selection regex

### DIFF
--- a/src/vs/editor/common/model/textModelSearch.ts
+++ b/src/vs/editor/common/model/textModelSearch.ts
@@ -89,6 +89,9 @@ export function isMultilineRegexSource(searchString: string): boolean {
 				return true;
 			}
 		}
+		if (chCode === CharCode.LineFeed) {
+			return true;
+		}
 	}
 
 	return false;

--- a/src/vs/editor/contrib/multicursor/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/multicursor.ts
@@ -379,7 +379,8 @@ export class MultiCursorSession {
 
 		const allSelections = this._editor.getSelections();
 		const lastAddedSelection = allSelections[allSelections.length - 1];
-		const nextMatch = this._editor.getModel().findNextMatch(this.searchText, lastAddedSelection.getEndPosition(), false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
+		const isRegex = this.findController.getState().isRegex;
+		const nextMatch = this._editor.getModel().findNextMatch(this.searchText, lastAddedSelection.getEndPosition(), isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
 
 		if (!nextMatch) {
 			return null;

--- a/src/vs/editor/test/common/model/textModelSearch.test.ts
+++ b/src/vs/editor/test/common/model/textModelSearch.test.ts
@@ -743,6 +743,7 @@ suite('TextModelSearch', () => {
 		assert(!isMultilineRegexSource('\\\\notnewline'));
 
 		assert(isMultilineRegexSource('foo\\nbar'));
+		assert(isMultilineRegexSource('foo\nbar'));
 		assert(isMultilineRegexSource('foo\\nbar\\s'));
 		assert(isMultilineRegexSource('foo\\r\\n'));
 		assert(isMultilineRegexSource('\\n'));


### PR DESCRIPTION
This PR fixes #107090

The problem was that the boolean `isRegex` to find the next match was always set to false.

I didn't add a new test for this case because I didn't succeed to set up the `findController` with the `multiCursorSelectController`. If anyone knows how to do it, I can add the test.