### PR TITLE
Fix: Path of files with '#' is cut in Markers resource (Problems) #136588

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -302,6 +302,10 @@ export class URI implements UriComponents {
 	 */
 	static file(path: string): URI {
 
+		if (path.startsWith('file:///')) {
+			path = path.replace('file:///', '');
+		}
+
 		let authority = _empty;
 
 		// normalize to fwd-slashes on windows,
@@ -324,7 +328,7 @@ export class URI implements UriComponents {
 			}
 		}
 
-		return new Uri('file', authority, path, _empty, _empty);
+		return new Uri('file', authority, percentDecode(path), _empty, _empty);
 	}
 
 	static from(components: { scheme: string; authority?: string; path?: string; query?: string; fragment?: string }): URI {

--- a/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
@@ -316,7 +316,7 @@ export abstract class AbstractProblemCollector implements IDisposable {
 		if (markers.size !== reported.get(resource)) {
 			let toSet: IMarkerData[] = [];
 			markers.forEach(value => toSet.push(value));
-			this.markerService.changeOne(owner, URI.parse(resource), toSet);
+			this.markerService.changeOne(owner, URI.file(resource), toSet);
 			reported.set(resource, markers.size);
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #136588.

problemCollectors use URI.parse(resource) to get the path of the "error" but it's a file.
➡️ Replaced by URI.file(resource).

What I checked:
- Reproduce the "error" of #136588 => the "error" points to `C:\Code\C#\tools\main.cpp`
- Removed the "error" => the program is executed correctly
- Debugging other projects  in JS, and C++ => works