### PR TITLE
editors - await closing of editor before opening to the side

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
@@ -280,7 +280,7 @@ export class MainThreadEditorTabs {
 		if (!editor) {
 			return;
 		}
-		return group.closeEditor(editor);
+		await group.closeEditor(editor);
 	}
 	//#endregion
 }

--- a/src/vs/workbench/api/browser/mainThreadEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditors.ts
@@ -177,7 +177,8 @@ export class MainThreadTextEditors implements MainThreadTextEditorsShape {
 			const editorPanes = this._editorService.visibleEditorPanes;
 			for (let editorPane of editorPanes) {
 				if (mainThreadEditor.matches(editorPane)) {
-					return editorPane.group.closeEditor(editorPane.input);
+					await editorPane.group.closeEditor(editorPane.input);
+					return;
 				}
 			}
 		}

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -460,13 +460,15 @@ export class CloseOneEditorAction extends Action {
 		if (typeof editorIndex === 'number') {
 			const editorAtIndex = group.getEditorByIndex(editorIndex);
 			if (editorAtIndex) {
-				return group.closeEditor(editorAtIndex);
+				await group.closeEditor(editorAtIndex);
+				return;
 			}
 		}
 
 		// Otherwise close active editor in group
 		if (group.activeEditor) {
-			return group.closeEditor(group.activeEditor);
+			await group.closeEditor(group.activeEditor);
+			return;
 		}
 	}
 }
@@ -501,7 +503,7 @@ export class RevertAndCloseEditorAction extends Action {
 				await this.editorService.revert({ editor, groupId: group.id }, { soft: true });
 			}
 
-			return group.closeEditor(editor);
+			await group.closeEditor(editor);
 		}
 	}
 }

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -1372,8 +1372,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 	//#region closeEditor()
 
-	async closeEditor(editor: EditorInput | undefined = this.activeEditor || undefined, options?: ICloseEditorOptions): Promise<void> {
-		await this.doCloseEditorWithDirtyHandling(editor, options);
+	async closeEditor(editor: EditorInput | undefined = this.activeEditor || undefined, options?: ICloseEditorOptions): Promise<boolean> {
+		return this.doCloseEditorWithDirtyHandling(editor, options);
 	}
 
 	private async doCloseEditorWithDirtyHandling(editor: EditorInput | undefined = this.activeEditor || undefined, options?: ICloseEditorOptions, internalOptions?: IInternalEditorCloseOptions): Promise<boolean> {

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -654,9 +654,11 @@ export interface IEditorGroup {
 	 * @param editor the editor to close, or the currently active editor
 	 * if unspecified.
 	 *
-	 * @returns a promise when the editor is closed.
+	 * @returns a promise when the editor is closed or not. If `true`, the editor
+	 * is closed and if `false` there was a veto closing the editor, e.g. when it
+	 * is dirty.
 	 */
-	closeEditor(editor?: EditorInput, options?: ICloseEditorOptions): Promise<void>;
+	closeEditor(editor?: EditorInput, options?: ICloseEditorOptions): Promise<boolean>;
 
 	/**
 	 * Closes specific editors in this group. This may trigger a confirmation dialog if

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -490,7 +490,8 @@ suite('EditorGroupsService', () => {
 		assert.strictEqual(group.activeEditor, inputInactive);
 
 		await group.openEditor(input);
-		await group.closeEditor(inputInactive);
+		const closed = await group.closeEditor(inputInactive);
+		assert.strictEqual(closed, true);
 
 		assert.strictEqual(activeEditorChangeCounter, 3);
 		assert.strictEqual(editorCloseCounter, 1);
@@ -553,12 +554,14 @@ suite('EditorGroupsService', () => {
 		await group.openEditor(input);
 
 		accessor.fileDialogService.setConfirmResult(ConfirmResult.CANCEL);
-		await group.closeEditor(input);
+		let closed = await group.closeEditor(input);
+		assert.strictEqual(closed, false);
 
 		assert.ok(!input.gotDisposed);
 
 		accessor.fileDialogService.setConfirmResult(ConfirmResult.DONT_SAVE);
-		await group.closeEditor(input);
+		closed = await group.closeEditor(input);
+		assert.strictEqual(closed, true);
 
 		assert.ok(input.gotDisposed);
 	});
@@ -576,11 +579,13 @@ suite('EditorGroupsService', () => {
 		await group.openEditors([{ editor: input, options: { pinned: true } }, { editor: inputInactive }]);
 		await rightGroup.openEditors([{ editor: input, options: { pinned: true } }, { editor: inputInactive }]);
 
-		await rightGroup.closeEditor(input);
+		let closed = await rightGroup.closeEditor(input);
+		assert.strictEqual(closed, true);
 
 		assert.ok(!input.gotDisposed);
 
-		await group.closeEditor(input);
+		closed = await group.closeEditor(input);
+		assert.strictEqual(closed, true);
 
 		assert.ok(input.gotDisposed);
 	});

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -821,7 +821,7 @@ export class TestEditorGroupView implements IEditorGroupView {
 	moveEditors(_editors: EditorInputWithOptions[], _target: IEditorGroup): void { }
 	copyEditor(_editor: EditorInput, _target: IEditorGroup, _options?: IEditorOptions): void { }
 	copyEditors(_editors: EditorInputWithOptions[], _target: IEditorGroup): void { }
-	async closeEditor(_editor?: EditorInput, options?: ICloseEditorOptions): Promise<void> { }
+	async closeEditor(_editor?: EditorInput, options?: ICloseEditorOptions): Promise<boolean> { return true; }
 	async closeEditors(_editors: EditorInput[] | ICloseEditorsFilter, options?: ICloseEditorOptions): Promise<void> { }
 	async closeAllEditors(options?: ICloseAllEditorsOptions): Promise<void> { }
 	async replaceEditors(_editors: IEditorReplacement[]): Promise<void> { }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #122363

When closing an editor because of the condition `singlePerResource`, we need to await that result before opening the editor to the side to:
* support veto
* await the saving to happen to prevent data loss
