### PR TITLE
Change img hrefs in markdown from file to vscode-file

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -100,6 +100,22 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 	const withInnerHTML = new Promise<void>(c => signalInnerHTML = c);
 
 	const renderer = new marked.Renderer();
+
+	const htmlParser = new DOMParser();
+	renderer.html = (rawHtml: string) => {
+		const sanitizedHtml = sanitizeRenderedMarkdown(markdown, rawHtml);
+		const doc = htmlParser.parseFromString(sanitizedHtml as unknown as string, 'text/html');
+
+		doc.body.querySelectorAll('img')
+			.forEach(img => {
+				if (img.src) {
+					img.src = _href(img.src, true);
+				}
+			});
+
+		return doc.body.innerHTML;
+	};
+
 	renderer.image = (href: string, title: string, text: string) => {
 		let dimensions: string[] = [];
 		let attributes: string[] = [];

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -56,6 +56,11 @@ suite('MarkdownRenderer', () => {
 			const result: HTMLElement = renderMarkdown({ value: `![image](http://example.com/cat.gif|height=200,width=100 'caption')` }).element;
 			assertNodeEquals(result, `<div><p><img height="200" width="100" title="caption" alt="image" src="http://example.com/cat.gif"></p></div>`);
 		});
+
+		test('image with file uri should render as same origin uri', () => {
+			const result: HTMLElement = renderMarkdown({ value: `![image](file:///images/cat.gif)` }).element;
+			assertNodeEquals(result, '<div><p><img src="vscode-file://vscode-app/images/cat.gif" alt="image"></p></div>');
+		});
 	});
 
 	suite('Code block renderer', () => {
@@ -139,7 +144,7 @@ suite('MarkdownRenderer', () => {
 			mds.appendMarkdown(`[$(zap)-link](#link)`);
 
 			let result: HTMLElement = renderMarkdown(mds).element;
-			assert.strictEqual(result.innerHTML, `<p><a title="#link" data-href="#link" href="#"><span class="codicon codicon-zap"></span>-link</a></p>`);
+			assert.strictEqual(result.innerHTML, `<p><a href="#" data-href="#link" title="#link"><span class="codicon codicon-zap"></span>-link</a></p>`);
 		});
 
 		test('render icon in table', () => {
@@ -159,7 +164,7 @@ suite('MarkdownRenderer', () => {
 </thead>
 <tbody><tr>
 <td><span class="codicon codicon-zap"></span></td>
-<td><a title="#link" data-href="#link" href="#"><span class="codicon codicon-zap"></span>-link</a></td>
+<td><a href="#" data-href="#link" title="#link"><span class="codicon codicon-zap"></span>-link</a></td>
 </tr>
 </tbody></table>
 `);
@@ -250,6 +255,22 @@ suite('MarkdownRenderer', () => {
 
 			const result = renderMarkdown(mds).element;
 			assert.strictEqual(result.innerHTML, `<p>a&lt;b&gt;b&lt;/b&gt;c</p>`);
+		});
+
+		test('Should render html images', () => {
+			const mds = new MarkdownString(undefined, { supportHtml: true });
+			mds.appendMarkdown(`<img src="http://example.com/cat.gif">`);
+
+			const result = renderMarkdown(mds).element;
+			assert.strictEqual(result.innerHTML, `<img src="http://example.com/cat.gif">`);
+		});
+
+		test('Should render html images with file uri as same origin uri', () => {
+			const mds = new MarkdownString(undefined, { supportHtml: true });
+			mds.appendMarkdown(`<img src="file:///images/cat.gif">`);
+
+			const result = renderMarkdown(mds).element;
+			assert.strictEqual(result.innerHTML, `<img src="vscode-file://vscode-app/images/cat.gif">`);
 		});
 	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In markdown renderer, hrefs of images in html are transformed from `file:` to `vscode-file:` protocol.

This PR fixes #136027
