### PR TITLE
[extensions/git] Faster git with "untrackedChanges=hidden"

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1816,10 +1816,7 @@ export class Repository {
 		return new Promise<{ status: IFileStatus[]; didHitLimit: boolean; }>((c, e) => {
 			const parser = new GitStatusParser();
 			const env = { GIT_OPTIONAL_LOCKS: '0' };
-			const args = ['status', '-z'];
-			if (untrackedChanges !== 'hidden') {
-				args.push('-u');
-			}
+			const args = ['status', '-z', untrackedChanges === 'hidden' ? '-uno' : '-u'];
 
 			if (opts?.ignoreSubmodules) {
 				args.push('--ignore-submodules');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #131020
This PR relates to #128800

As pointed out in the issue above: when untrackedChanges is set to "hidden", there's no value in passing the `-u` arg to `git status`.  In large repositories, enumerating untracked files can also be costly.

This change allows VS Code users to get the performance benefit of omitting untracked files from their status panel.