### PR TITLE
Call `extractControlCharacters` before introducing empty line parts for line decorations

### DIFF
--- a/src/vs/editor/common/viewLayout/viewLineRenderer.ts
+++ b/src/vs/editor/common/viewLayout/viewLineRenderer.ts
@@ -474,6 +474,11 @@ function resolveRenderLineInput(input: RenderLineInput): ResolvedRenderLineInput
 	}
 
 	let tokens = transformAndRemoveOverflowing(input.lineTokens, input.fauxIndentLength, len);
+	if (input.renderControlCharacters && !input.isBasicASCII) {
+		// Calling `extractControlCharacters` before adding (possibly empty) line parts
+		// for inline decorations. `extractControlCharacters` removes empty line parts.
+		tokens = extractControlCharacters(lineContent, tokens);
+	}
 	if (input.renderWhitespace === RenderWhitespace.All ||
 		input.renderWhitespace === RenderWhitespace.Boundary ||
 		(input.renderWhitespace === RenderWhitespace.Selection && !!input.selectionsOnLine) ||
@@ -499,9 +504,6 @@ function resolveRenderLineInput(input: RenderLineInput): ResolvedRenderLineInput
 	if (!input.containsRTL) {
 		// We can never split RTL text, as it ruins the rendering
 		tokens = splitLargeTokens(lineContent, tokens, !input.isBasicASCII || input.fontLigatures);
-	}
-	if (input.renderControlCharacters && !input.isBasicASCII) {
-		tokens = extractControlCharacters(lineContent, tokens);
 	}
 
 	return new ResolvedRenderLineInput(

--- a/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
+++ b/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
@@ -1722,6 +1722,46 @@ suite('viewLineRenderer.renderLine 2', () => {
 		assert.deepStrictEqual(actual.html, expected);
 	});
 
+	test('issue #136622: Inline decorations are not rendering on non-ASCII lines when renderControlCharacters is on', () => {
+
+		let actual = renderViewLine(new RenderLineInput(
+			true,
+			true,
+			'some text £',
+			false,
+			false,
+			false,
+			0,
+			createViewLineTokens([createPart(11, 3)]),
+			[
+				new LineDecoration(5, 5, 'inlineDec1', InlineDecorationType.After),
+				new LineDecoration(6, 6, 'inlineDec2', InlineDecorationType.Before),
+			],
+			4,
+			0,
+			10,
+			10,
+			10,
+			10000,
+			'none',
+			true,
+			false,
+			null
+		));
+
+		let expected = [
+			'<span>',
+			'<span class="mtk3">some</span>',
+			'<span class="mtk3 inlineDec1"></span>',
+			'<span class="mtk3">\u00a0</span>',
+			'<span class="mtk3 inlineDec2"></span>',
+			'<span class="mtk3">text\u00a0£</span>',
+			'</span>'
+		].join('');
+
+		assert.deepStrictEqual(actual.html, expected);
+	});
+
 	test('issue #22832: Consider fullwidth characters when rendering tabs', () => {
 
 		let actual = renderViewLine(new RenderLineInput(


### PR DESCRIPTION
Fixes #136622

Thank you @hediet for tracking this down!