### PR TITLE
Add explorer.autorevealExclude setting

### DIFF
--- a/extensions/configuration-editing/src/settingsDocumentHelper.ts
+++ b/extensions/configuration-editing/src/settingsDocumentHelper.ts
@@ -26,8 +26,8 @@ export class SettingsDocument {
 			return this.provideFilesAssociationsCompletionItems(location, position);
 		}
 
-		// files.exclude, search.exclude
-		if (location.path[0] === 'files.exclude' || location.path[0] === 'search.exclude') {
+		// files.exclude, search.exclude, explorer.autorevealExclude
+		if (location.path[0] === 'files.exclude' || location.path[0] === 'search.exclude' || location.path[0] === 'explorer.autorevealExclude') {
 			return this.provideExcludeCompletionItems(location, position);
 		}
 

--- a/extensions/configuration-editing/src/settingsDocumentHelper.ts
+++ b/extensions/configuration-editing/src/settingsDocumentHelper.ts
@@ -26,8 +26,8 @@ export class SettingsDocument {
 			return this.provideFilesAssociationsCompletionItems(location, position);
 		}
 
-		// files.exclude, search.exclude, explorer.autorevealExclude
-		if (location.path[0] === 'files.exclude' || location.path[0] === 'search.exclude' || location.path[0] === 'explorer.autorevealExclude') {
+		// files.exclude, search.exclude, explorer.autoRevealExclude
+		if (location.path[0] === 'files.exclude' || location.path[0] === 'search.exclude' || location.path[0] === 'explorer.autoRevealExclude') {
 			return this.provideExcludeCompletionItems(location, position);
 		}
 

--- a/src/vs/workbench/common/resources.ts
+++ b/src/vs/workbench/common/resources.ts
@@ -87,7 +87,10 @@ export class ResourceGlobMatcher extends Disposable {
 		}
 	}
 
-	matches(resource: URI): boolean {
+	matches(
+		resource: URI,
+		hasSibling?: (name: string) => boolean | Promise<boolean>
+	): boolean {
 		const folder = this.contextService.getWorkspaceFolder(resource);
 
 		let expressionForRoot: ParsedExpression | undefined;
@@ -108,6 +111,6 @@ export class ResourceGlobMatcher extends Disposable {
 			resourcePathToMatch = resource.fsPath; // TODO@isidor: support non-file URIs
 		}
 
-		return !!expressionForRoot && typeof resourcePathToMatch === 'string' && !!expressionForRoot(resourcePathToMatch);
+		return !!expressionForRoot && typeof resourcePathToMatch === 'string' && !!expressionForRoot(resourcePathToMatch, undefined, hasSibling);
 	}
 }

--- a/src/vs/workbench/common/resources.ts
+++ b/src/vs/workbench/common/resources.ts
@@ -89,7 +89,7 @@ export class ResourceGlobMatcher extends Disposable {
 
 	matches(
 		resource: URI,
-		hasSibling?: (name: string) => boolean | Promise<boolean>
+		hasSibling?: (name: string) => boolean
 	): boolean {
 		const folder = this.contextService.getWorkspaceFolder(resource);
 

--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -263,13 +263,8 @@ export class ExplorerService implements IExplorerService {
 			return;
 		}
 
-		// If file or parent matches exclude patterns, do not reveal nless reveal argument is 'force'
-		// However selectResource expects only a boolean to be passed even if accepts bool | string
-		let ignoreRevealExcludes = false;
-		if (reveal === 'force') {
-			ignoreRevealExcludes = true;
-			reveal = true;
-		}
+		// If file or parent matches exclude patterns, do not reveal unless reveal argument is 'force'
+		const ignoreRevealExcludes = reveal === 'force';
 
 		const fileStat = this.findClosest(resource);
 		if (fileStat) {

--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -482,21 +482,11 @@ function doesFileEventAffect(item: ExplorerItem, view: IExplorerView, events: Fi
 }
 
 function getRevealExcludes(configuration: IFilesConfiguration): IExpression {
-	const fileExcludes = configuration && configuration.files && configuration.files.exclude;
 	const revealExcludes = configuration && configuration.explorer && configuration.explorer.autoRevealExclude;
 
-	if (!fileExcludes && !revealExcludes) {
+	if (!revealExcludes) {
 		return {};
 	}
 
-	if (!fileExcludes || !revealExcludes) {
-		return fileExcludes || revealExcludes;
-	}
-
-	let allExcludes: IExpression = Object.create(null);
-	// clone the config as it could be frozen
-	allExcludes = mixin(allExcludes, deepClone(fileExcludes));
-	allExcludes = mixin(allExcludes, deepClone(revealExcludes), true);
-
-	return allExcludes;
+	return revealExcludes;
 }

--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -139,7 +139,6 @@ export class ExplorerService implements IExplorerService {
 			(event) => event.affectsConfiguration('explorer.autoRevealExclude'),
 			contextService, configurationService);
 		this.disposables.add(this.revealExcludeMatcher);
-		this.disposables.add(this.revealExcludeMatcher.onExpressionChange(() => this.refresh()));
 	}
 
 	get roots(): ExplorerItem[] {
@@ -266,7 +265,7 @@ export class ExplorerService implements IExplorerService {
 
 		const fileStat = this.findClosest(resource);
 		// If file or parent matches exclude patterns, do not reveal
-		if (fileStat && !this.matchesUpToRoot(fileStat)) {
+		if (fileStat && !this.shouldAutoRevealItem(fileStat)) {
 			await this.view.selectResource(fileStat.resource, reveal);
 			return Promise.resolve(undefined);
 		}
@@ -288,8 +287,8 @@ export class ExplorerService implements IExplorerService {
 			const item = root.find(resource);
 			await this.view.refresh(true, root);
 
-			// Select and Reveal, unless matching exclude patterns
-			if (item && reveal && this.matchesUpToRoot(item)) {
+			//
+			if (item && !this.shouldAutoRevealItem(item)) {
 				return;
 			}
 			await this.view.selectResource(item ? item.resource : undefined, reveal);
@@ -410,18 +409,21 @@ export class ExplorerService implements IExplorerService {
 	}
 
 	// Reveal excludes
-	private matchesUpToRoot(item: ExplorerItem | undefined): boolean {
+	private shouldAutoRevealItem(item: ExplorerItem | undefined): boolean {
 		if (item === undefined) {
 			return false;
 		}
+		if (this.revealExcludeMatcher.matches(item.resource, name => !!(item.parent && item.parent.getChild(name)))) {
+			return true;
+		}
 		const root = item.root;
-		let currentItem = item;
+		let currentItem = item.parent;
 		while (currentItem !== root) {
-			if (this.revealExcludeMatcher.matches(currentItem.resource, name => !!(currentItem.parent && currentItem.parent.getChild(name)))) {
-				return true;
+			if (currentItem === undefined) {
+				return false
 			}
-			if (currentItem.parent === undefined) {
-				return false;
+			if (this.revealExcludeMatcher.matches(currentItem.resource)) {
+				return true;
 			}
 			currentItem = currentItem.parent;
 		}

--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -420,7 +420,7 @@ export class ExplorerService implements IExplorerService {
 		let currentItem = item.parent;
 		while (currentItem !== root) {
 			if (currentItem === undefined) {
-				return false
+				return false;
 			}
 			if (this.revealExcludeMatcher.matches(currentItem.resource)) {
 				return true;

--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -24,7 +24,6 @@ import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IExpression } from 'vs/base/common/glob';
-import { mixin, deepClone } from 'vs/base/common/objects';
 import { ResourceGlobMatcher } from 'vs/workbench/common/resources';
 
 export const UNDO_REDO_SOURCE = new UndoRedoSource();

--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -330,7 +330,7 @@ CommandsRegistry.registerCommand({
 			const explorerView = viewlet.getExplorerView();
 			if (explorerView) {
 				explorerView.setExpanded(true);
-				await explorerService.select(uri, true);
+				await explorerService.select(uri, 'force');
 				explorerView.focus();
 			}
 		} else {

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -373,8 +373,8 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.autoRevealExclude': {
 			'type': 'object',
-			'markdownDescription': nls.localize('autoRevealExclude', "Configure glob patterns for excluding files and folders from being revealed and selected in the explorer when they are opened. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)."),
-			'default': { '**/node_modules': true, '**/bower_components': true, '**/*.code-search': true },
+			'markdownDescription': nls.localize('autoRevealExclude', "Configure glob patterns for excluding files and folders from being revealed and selected in the explorer when they are opened. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)."),
+			'default': { '**/node_modules': true, '**/bower_components': true },
 			'additionalProperties': {
 				'anyOf': [
 					{

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -371,6 +371,30 @@ configurationRegistry.registerConfiguration({
 			],
 			'description': nls.localize('autoReveal', "Controls whether the explorer should automatically reveal and select files when opening them.")
 		},
+		'explorer.autoRevealExclude': {
+			'type': 'object',
+			'markdownDescription': nls.localize('autoRevealExclude', "Configure glob patterns for excluding files and folders from being revealed and selected in the explorer when they are opened. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)."),
+			'default': { '**/node_modules': true, '**/bower_components': true, '**/*.code-search': true },
+			'additionalProperties': {
+				'anyOf': [
+					{
+						'type': 'boolean',
+						'description': nls.localize('explorer.autoRevealExclude.boolean', "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."),
+					},
+					{
+						type: 'object',
+						properties: {
+							when: {
+								type: 'string', // expression ({ "**/*.js": { "when": "$(basename).js" } })
+								pattern: '\\w*\\$\\(basename\\)\\w*',
+								default: '$(basename).ext',
+								description: nls.localize('explorer.autoRevealExclude.when', 'Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.')
+							}
+						}
+					}
+				]
+			}
+		},
 		'explorer.enableDragAndDrop': {
 			'type': 'boolean',
 			'description': nls.localize('enableDragAndDrop', "Controls whether the explorer should allow to move files and folders via drag and drop. This setting only effects drag and drop from inside the explorer."),

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -725,7 +725,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 	}
 
 	public async selectResource(resource: URI | undefined, reveal = this.autoReveal, retry = 0): Promise<void> {
-		// do no retry more than once to prevent inifinite loops in cases of inconsistent model
+		// do no retry more than once to prevent infinite loops in cases of inconsistent model
 		if (retry === 2) {
 			return;
 		}

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -181,7 +181,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 	private horizontalScrolling: boolean | undefined;
 
 	private dragHandler!: DelayedDragHandler;
-	private autoReveal: boolean | 'focusNoScroll' = false;
+	private autoReveal: boolean | 'force' | 'focusNoScroll' = false;
 	private decorationsProvider: ExplorerDecorationsProvider | undefined;
 
 	constructor(
@@ -766,7 +766,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 					await this.tree.expand(item.nestedParent);
 				}
 
-				if (reveal === true && this.tree.getRelativeTop(item) === null) {
+				if ((reveal === true || reveal === 'force') && this.tree.getRelativeTop(item) === null) {
 					// Don't scroll to the item if it's already visible, or if set not to.
 					this.tree.reveal(item, 0.5);
 				}

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -598,7 +598,7 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 	}
 }
 
-export interface CachedParsedExpression {
+interface CachedParsedExpression {
 	original: glob.IExpression;
 	parsed: glob.ParsedExpression;
 }

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -598,13 +598,13 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 	}
 }
 
-interface CachedParsedExpression {
+export interface CachedParsedExpression {
 	original: glob.IExpression;
 	parsed: glob.ParsedExpression;
 }
 
 /**
- * Respectes files.exclude setting in filtering out content from the explorer.
+ * Respects files.exclude setting in filtering out content from the explorer.
  * Makes sure that visible editors are always shown in the explorer even if they are filtered out by settings.
  */
 export class FilesFilter implements ITreeFilter<ExplorerItem, FuzzyScore> {

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -21,6 +21,7 @@ import { once } from 'vs/base/common/functional';
 import { ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { localize } from 'vs/nls';
+import { IExpression } from 'vs/base/common/glob';
 
 /**
  * Explorer viewlet id.
@@ -88,6 +89,7 @@ export interface IFilesConfiguration extends PlatformIFilesConfiguration, IWorkb
 			sortOrder: 'editorOrder' | 'alphabetical' | 'fullPath';
 		};
 		autoReveal: boolean | 'focusNoScroll';
+		autoRevealExclude: IExpression;
 		enableDragAndDrop: boolean;
 		confirmDelete: boolean;
 		enableUndo: boolean;

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -739,6 +739,7 @@ export function isExcludeSetting(setting: ISetting): boolean {
 	return setting.key === 'files.exclude' ||
 		setting.key === 'search.exclude' ||
 		setting.key === 'workbench.localHistory.exclude' ||
+		setting.key === 'explorer.autoRevealExclude' ||
 		setting.key === 'files.watcherExclude';
 }
 


### PR DESCRIPTION
This PR fixes #87956

Loosely based on the original PR by @joelday and the `FilesFilter` class, using the suggestion of @JacksonKearl to be in the `ExplorerService` file. 

- Inherits from `files.exclude`
- Defaults to same values as `search.exclude`: `**/node_modules`, `**/bower_components`, `**/*.code-search`
- Calls to `refresh`, `selectResource` and calls from `ExplorerView` are all routed to `ExplorerService.select()`, where the reveal check occurs
- Recursively checks from the file up to the first root child, if any of them match a pattern then the file is not revealed.

Example of glob matching nested folder:
![lx4QuzvqPP](https://user-images.githubusercontent.com/20613660/141199536-da5da6ce-b94d-4d07-9472-c61ab3fe0638.gif)

Example of using when clause to hide .js files:
![RZ9Ji13Xmh](https://user-images.githubusercontent.com/20613660/141199588-ee4b90a3-d13e-4567-ac9d-40de6ba1da3b.gif)

Some things to consider:

- Tests: I wasn't sure if there is support for testing whether the reveal correctly shows or not. `files.exclude` only has tests for the find files function, and not for `FilesFilter`. I suppose you could create a `RevealFilter` manually and check the boolean function, but I didn't see other tests having support for mocking `contextService` etc
  - Edit: Could be added to integration tests?
- Behaviour if folder is already open:
  - Should the file still be revealed?
  - Should it be ignored? (<- current behaviour)
- Behaviour if an open folder is added to the setting:
  - Should the tree close the folder?
  - Should it be left as is? (<- current behaviour)
- Performance:
  - Should the check run on each selection? How much does iterating through the parent tree of an item each time matter (No initial cost, each call only iterates up it's own parent(s))
  - Or should it mirror the `files.exclude` setting, which runs top-down each time files are updated and sets a cached boolean for each folder/file. (Bigger initial cost as has to check all folder/files, no cost after)