### PR TITLE
Use quick pick separator objects instead of a `kind`

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
@@ -68,7 +68,7 @@ suite('vscode API - quick input', function () {
 			},
 		}, (err?: any) => done(err));
 		quickPick.items = ['eins', 'zwei', 'drei'].map(label => ({ label }));
-		quickPick.activeItems = [quickPick.items[1]];
+		quickPick.activeItems = [quickPick.items[1]] as QuickPickItem[];
 		quickPick.show();
 
 		(async () => {
@@ -126,9 +126,9 @@ suite('vscode API - quick input', function () {
 		quickPick.items = ['eins', 'zwei', 'drei'].map(label => ({ label }));
 		quickPick.show();
 
-		quickPick.selectedItems = [quickPick.items[1]];
+		quickPick.selectedItems = [quickPick.items[1]] as QuickPickItem[];
 		setTimeout(() => {
-			quickPick.selectedItems = [quickPick.items[2]];
+			quickPick.selectedItems = [quickPick.items[2]] as QuickPickItem[];
 		}, 0);
 	});
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -8942,7 +8942,7 @@ declare module 'vscode' {
 		 * @param token A token that can be used to signal cancellation.
 		 * @return A promise that resolves to the selected items or `undefined`.
 		 */
-		export function showQuickPick<T extends QuickPickItem>(items: readonly T[] | Thenable<readonly T[]>, options: QuickPickOptions & { canPickMany: true; }, token?: CancellationToken): Thenable<T[] | undefined>;
+		export function showQuickPick<T extends QuickPickItem>(items: readonly (T | QuickPickSeparator)[] | Thenable<readonly (T | QuickPickSeparator)[]>, options: QuickPickOptions & { canPickMany: true; }, token?: CancellationToken): Thenable<T[] | undefined>;
 
 		/**
 		 * Shows a selection list.
@@ -8952,7 +8952,7 @@ declare module 'vscode' {
 		 * @param token A token that can be used to signal cancellation.
 		 * @return A promise that resolves to the selected item or `undefined`.
 		 */
-		export function showQuickPick<T extends QuickPickItem>(items: readonly T[] | Thenable<readonly T[]>, options?: QuickPickOptions, token?: CancellationToken): Thenable<T | undefined>;
+		export function showQuickPick<T extends QuickPickItem>(items: readonly (T | QuickPickSeparator)[] | Thenable<readonly (T | QuickPickSeparator)[]>, options?: QuickPickOptions, token?: CancellationToken): Thenable<T | undefined>;
 
 		/**
 		 * Shows a selection list of {@link workspace.workspaceFolders workspace folders} to pick from.
@@ -10214,7 +10214,7 @@ declare module 'vscode' {
 		/**
 		 * Items to pick from. This can be read and updated by the extension.
 		 */
-		items: readonly T[];
+		items: readonly (T | QuickPickSeparator)[];
 
 		/**
 		 * If multiple items can be selected at the same time. Defaults to false.

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -2761,10 +2761,15 @@ declare module 'vscode' {
 
 	//#endregion
 
-	//#region quickPickItemKind: https://github.com/microsoft/vscode/issues/74967
+	//#region quickPickSeparator: https://github.com/microsoft/vscode/issues/74967
+
+	export interface QuickPickSeparator {
+		type: 'separator';
+		label?: string;
+	}
 
 	export interface QuickPickItem {
-		kind?: string | { label: string; };
+		type?: 'item';
 	}
 
 	//#endregion


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

@connor4312 pointed out that the [kind proposal](https://github.com/microsoft/vscode/issues/74967#issuecomment-965671459) for quickpick separators isn’t ideal because it would not be possible to have a single blank line separating two groups. 

and @Tyriar pointed out that `kind` is ambiguous if you have a situation like this:
```
kind: ‘a’
kind: ‘b’
kind: ‘a’
```
we discussed this in the API sync as ‘doc-able’ but I do share the same feeling as he.


As such this implements:

```ts
	export interface QuickPickSeparator {
		type: 'separator';
		label?: string;
	}

	export interface QuickPickItem {
		type?: 'item';
	}
```

This is technically a compile-time break because `.items` on QuickPick needed to be updated.

Does this PR need to update vscode.d.ts? Is it possible for me to do this totally in vscode.proposed.d.ts?

cc @jrieken