### PR TITLE
Fixes #136540: Do not eat up error or fall back to the next provider in case an error is thrown

### DIFF
--- a/src/vs/editor/test/common/services/getSemanticTokens.test.ts
+++ b/src/vs/editor/test/common/services/getSemanticTokens.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { canceled } from 'vs/base/common/errors';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { ITextModel } from 'vs/editor/common/model';
+import { DocumentSemanticTokensProvider, DocumentSemanticTokensProviderRegistry, ProviderResult, SemanticTokens, SemanticTokensEdits, SemanticTokensLegend } from 'vs/editor/common/modes';
+import { getDocumentSemanticTokens } from 'vs/editor/common/services/getSemanticTokens';
+import { createTextModel } from 'vs/editor/test/common/editorTestUtils';
+
+suite('getSemanticTokens', () => {
+
+	test('issue #136540: semantic highlighting flickers', async () => {
+		const disposables = new DisposableStore();
+
+		const provider = new class implements DocumentSemanticTokensProvider {
+			getLegend(): SemanticTokensLegend {
+				return { tokenTypes: ['test'], tokenModifiers: [] };
+			}
+			provideDocumentSemanticTokens(model: ITextModel, lastResultId: string | null, token: CancellationToken): ProviderResult<SemanticTokens | SemanticTokensEdits> {
+				throw canceled();
+			}
+			releaseDocumentSemanticTokens(resultId: string | undefined): void {
+			}
+		};
+
+		disposables.add(DocumentSemanticTokensProviderRegistry.register('testLang', provider));
+
+		const textModel = disposables.add(createTextModel('example', undefined, 'testLang'));
+
+		await getDocumentSemanticTokens(textModel, null, null, CancellationToken.None).then((res) => {
+			assert.fail();
+		}, (err) => {
+			assert.ok(!!err);
+		});
+
+		disposables.dispose();
+	});
+
+});


### PR DESCRIPTION
The root problem here was that we added support for having multiple semantic tokens providers. In `1.61.2`, we would just invoke the very first one, but now we invoke all of them with equal selector strength and the idea was to return the result from the first one that has a result.

But the problem is that errors are now ignored. Errors should be treated just as having a result. Errors should not be ignored, they should be passed on to the callers of `getDocumentSemanticTokens` because in the semantic documents case it is expected to use "busy" / "canceled" errors and that should not result in the semantic tokens being cleared.