### PR TITLE
seems root requires --no-sandbox

### DIFF
--- a/resources/linux/bin/code.sh
+++ b/resources/linux/bin/code.sh
@@ -30,7 +30,7 @@ if [ "$(id -u)" = "0" ]; then
 		esac
 	done
 	if [ -z $CAN_LAUNCH_AS_ROOT ]; then
-		echo "You are trying to start @@PRODNAME@@ as a super user which isn't recommended. If this was intended, please specify an alternate user data directory using the \`--user-data-dir\` argument." 1>&2
+		echo "You are trying to start @@PRODNAME@@ as a super user which isn't recommended. If this was intended, please add the argument \`--no-sandbox\` and specify an alternate user data directory using the \`--user-data-dir\` argument." 1>&2
 		exit 1
 	fi
 fi


### PR DESCRIPTION
at least on my system (Ubuntu 20.04, uname 5.4.0-88-generic #99-Ubuntu SMP Thu Sep 23 17:29:00 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux)
the command: `sudo /usr/bin/code --user-data-dir=/root/vscode/datadir`
does seemingly _nothing_, just returns 0 immediately, while
the command: `sudo /usr/bin/code --user-data-dir=/root/vscode/datadir --no-sandbox`
starts vscode... why? i don't know, but i'm now running 1.62.2 and it's been this way since at least 1.60.x (if not earlier)
