### PR TITLE
1.62: `Invalid regular expression` from JSON validation

### DIFF
--- a/extensions/json-language-features/server/package.json
+++ b/extensions/json-language-features/server/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "jsonc-parser": "^3.0.0",
     "request-light": "^0.5.4",
-    "vscode-json-languageservice": "^4.1.9",
+    "vscode-json-languageservice": "^4.1.10",
     "vscode-languageserver": "^7.0.0",
     "vscode-uri": "^3.0.2"
   },

--- a/extensions/json-language-features/server/yarn.lock
+++ b/extensions/json-language-features/server/yarn.lock
@@ -22,10 +22,10 @@ request-light@^0.5.4:
   resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.5.4.tgz#497a98c6d8ae49536417a5e2d7f383b934f3e38c"
   integrity sha512-t3566CMweOFlUk7Y1DJMu5OrtpoZEb6aSTsLQVT3wtrIEJ5NhcY9G/Oqxvjllzl4a15zXfFlcr9q40LbLVQJqw==
 
-vscode-json-languageservice@^4.1.9:
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-4.1.9.tgz#fb48edc69e37167c3cafd447c3fa898052d87b61"
-  integrity sha512-kxNHitUy2fCxmP6vAp0SRLrUSuecUYzzxlC+85cC3jJlFHWmvtCJOzikC+kcUnIdls9fQSB8n0yHs8Sl6taxJw==
+vscode-json-languageservice@^4.1.10:
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-4.1.10.tgz#5d5729fc4f3e02f41599e0104523a1877c25f0fb"
+  integrity sha512-IHliMEEYSY0tJjJt0ECb8ESx/nRXpoy9kN42WVQXgaqGyizFAf3jibSiezDQTrrY7f3kywXggCU+kkJEM+OLZQ==
   dependencies:
     jsonc-parser "^3.0.0"
     vscode-languageserver-textdocument "^1.0.1"


### PR DESCRIPTION
Fixes #137054

updates the service.

Actual fix is in the JSON language service: https://github.com/microsoft/vscode-json-languageservice/commit/de73b8b67e3c125b3d249ae53ff046b8411c0d2d