### PR TITLE
Do not show the selected or suggested kernel unless just one

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
@@ -347,7 +347,7 @@ export class KernelStatus extends Disposable implements IWorkbenchContribution {
 		this._kernelInfoElement.clear();
 
 		let { selected, suggestions, all } = this._notebookKernelService.getMatchingKernel(notebook);
-		const suggested = suggestions[0];
+		const suggested = suggestions.length === 1 ? suggestions[0] : undefined;
 		let isSuggested = false;
 
 		if (all.length === 0) {


### PR DESCRIPTION
Found that if we have more than one suggestion (or more kernels) we don't prompt user to select a kernel.