### PR TITLE
Fix missing active debug line + breakpoint glyph

### DIFF
--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
@@ -166,7 +166,7 @@ export class GlyphMarginOverlay extends DedupOverlay {
 		const lineHeight = this._lineHeight.toString();
 		const left = this._glyphMarginLeft.toString();
 		const width = this._glyphMarginWidth.toString();
-		const common = (content: string = '') => `" style="left:${left}px;width:${width}px;height:${lineHeight}px;">${content}</div>`;
+		const common = '" style="left:' + left + 'px;width:' + width + 'px' + ';height:' + lineHeight + 'px;"></div>';
 
 		const output: string[] = [];
 		for (let lineNumber = visibleStartLineNumber; lineNumber <= visibleEndLineNumber; lineNumber++) {
@@ -176,8 +176,11 @@ export class GlyphMarginOverlay extends DedupOverlay {
 			if (classNames.length === 0) {
 				output[lineIndex] = '';
 			} else {
-				// Map codicons inside parent div
-				output[lineIndex] = `<div class="cgmr${common(classNames.map(className => `<div class="cgmr codicon ${className}${common()}`).join(''))}</div>`;
+				output[lineIndex] = (
+					'<div class="cgmr codicon '
+					+ classNames.join(' ')
+					+ common
+				);
 			}
 		}
 

--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
@@ -166,7 +166,7 @@ export class GlyphMarginOverlay extends DedupOverlay {
 		const lineHeight = this._lineHeight.toString();
 		const left = this._glyphMarginLeft.toString();
 		const width = this._glyphMarginWidth.toString();
-		const common = '" style="left:' + left + 'px;width:' + width + 'px' + ';height:' + lineHeight + 'px;"></div>';
+		const common = (content: string = '') => `" style="left:${left}px;width:${width}px;height:${lineHeight}px;">${content}</div>`;
 
 		const output: string[] = [];
 		for (let lineNumber = visibleStartLineNumber; lineNumber <= visibleEndLineNumber; lineNumber++) {
@@ -176,11 +176,8 @@ export class GlyphMarginOverlay extends DedupOverlay {
 			if (classNames.length === 0) {
 				output[lineIndex] = '';
 			} else {
-				output[lineIndex] = (
-					'<div class="cgmr codicon '
-					+ classNames.join(' ')
-					+ common
-				);
+				// Map codicons inside parent div
+				output[lineIndex] = `<div class="cgmr${common(classNames.map(className => `<div class="cgmr codicon ${className}${common()}`).join(''))}</div>`;
 			}
 		}
 

--- a/src/vs/workbench/contrib/debug/browser/media/debug.contribution.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debug.contribution.css
@@ -31,6 +31,12 @@
 	margin-top: -1px;
 }
 
+.codicon-debug-breakpoint.codicon-debug-stackframe-focused::after,
+.codicon-debug-breakpoint.codicon-debug-stackframe::after {
+	content: '\eb8a';
+	position: absolute;
+}
+
 .monaco-editor .debug-top-stack-frame-column {
 	font: normal normal normal 16px/1 codicon;
 	text-rendering: auto;


### PR DESCRIPTION
This patch resolves #137436.
When multiple classes (e.g. codicon-debug-breakpoint,codicon-debug-hint)
are added they would disable the ::after content for consecutive classes
for the HTML Element.

This patch adds a parent element to the overlay and adds all classes as
seperated divs, so they can be drawn on top of each other.

![2021-11-18_21-34-16](https://user-images.githubusercontent.com/10652205/142492607-d582922c-92d4-4a5b-ab62-cc21b3bbf8b0.gif)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #137436.
