### PR TITLE
html-language-features: text document provider support for customData.html

### DIFF
--- a/extensions/html-language-features/client/src/customData.ts
+++ b/extensions/html-language-features/client/src/customData.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { workspace, extensions, Uri, EventEmitter, Disposable } from 'vscode';
-import { resolvePath, joinPath } from './requests';
+import { resolvePath, joinPath, uriScheme } from './requests';
+
 
 export function getCustomDataSource(toDispose: Disposable[]) {
 	let pathsInWorkspace = getCustomDataPathsInAllWorkspaces();
@@ -57,8 +58,7 @@ function getCustomDataPathsInAllWorkspaces(): Set<string> {
 		if (Array.isArray(paths)) {
 			for (const path of paths) {
 				if (typeof path === 'string') {
-					const uri = Uri.parse(path);
-					if (uri.scheme === 'file') {
+					if (!uriScheme.test(path)) {
 						// only resolve file paths relative to extension
 						dataPaths.add(resolvePath(rootFolder, path).toString());
 					} else {
@@ -94,12 +94,11 @@ function getCustomDataPathsFromAllExtensions(): Set<string> {
 		const customData = extension.packageJSON?.contributes?.html?.customData;
 		if (Array.isArray(customData)) {
 			for (const rp of customData) {
-				const uri = Uri.parse(rp);
-				if (uri.scheme === 'file') {
-					// only resolve file paths relative to extension
+				if (!uriScheme.test(rp)) {
+					// no schame -> resolve relative to extension
 					dataPaths.add(joinPath(extension.extensionUri, rp).toString());
 				} else {
-					// others schemes
+					// actual schemes
 					dataPaths.add(rp);
 				}
 

--- a/extensions/html-language-features/client/src/htmlClient.ts
+++ b/extensions/html-language-features/client/src/htmlClient.ts
@@ -120,7 +120,7 @@ export function startClient(context: ExtensionContext, newLanguageClient: Langua
 	toDispose.push(disposable);
 	client.onReady().then(() => {
 
-		serveFileSystemRequests(client, runtime, context.subscriptions);
+		toDispose.push(serveFileSystemRequests(client, runtime));
 
 		client.sendNotification(CustomDataChangedNotification.type, customDataSource.uris);
 		customDataSource.onDidChange(() => {

--- a/extensions/html-language-features/client/src/htmlClient.ts
+++ b/extensions/html-language-features/client/src/htmlClient.ts
@@ -16,7 +16,7 @@ import {
 	DocumentRangeFormattingRequest, ProvideCompletionItemsSignature, TextDocumentIdentifier, RequestType0, Range as LspRange, NotificationType, CommonLanguageClient
 } from 'vscode-languageclient';
 import { activateTagClosing } from './tagClosing';
-import { RequestService } from './requests';
+import { RequestService, serveFileSystemRequests } from './requests';
 import { getCustomDataSource } from './customData';
 
 namespace CustomDataChangedNotification {
@@ -119,6 +119,8 @@ export function startClient(context: ExtensionContext, newLanguageClient: Langua
 	let disposable = client.start();
 	toDispose.push(disposable);
 	client.onReady().then(() => {
+
+		serveFileSystemRequests(client, runtime, context.subscriptions);
 
 		client.sendNotification(CustomDataChangedNotification.type, customDataSource.uris);
 		customDataSource.onDidChange(() => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR implements #135459
It adds the ability for for html-language-features extension to receive custom-data via [Text Document Provider](https://code.visualstudio.com/api/extension-guides/virtual-documents#textdocumentcontentprovider) and update on changes to these documents.
With the change extensions can provide contribute dynamic data via `customData.html`;
