### PR TITLE
Avoid conflicting scopes and commandIds in quiet logins from Accounts (fix #137601)

### DIFF
--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -163,13 +163,13 @@ export function readAllowedExtensions(storageService: IStorageService, providerI
 	return trustedExtensions;
 }
 
-export interface SessionRequest {
+interface SessionRequest {
 	disposables: IDisposable[];
 	requestingExtensionIds: string[];
 }
 
-export interface SessionRequestInfo {
-	[scopes: string]: SessionRequest;
+interface SessionRequestInfo {
+	[scopesJSON: string]: SessionRequest;
 }
 
 CommandsRegistry.registerCommand('workbench.getCodeExchangeProxyEndpoints', function (accessor, _) {
@@ -613,19 +613,21 @@ export class AuthenticationService extends Disposable implements IAuthentication
 
 		if (provider) {
 			const providerRequests = this._signInRequestItems.get(providerId);
-			const scopesList = scopes.join('');
+			const scopesJSON = JSON.stringify(scopes);
 			const extensionHasExistingRequest = providerRequests
-				&& providerRequests[scopesList]
-				&& providerRequests[scopesList].requestingExtensionIds.includes(extensionId);
+				&& providerRequests[scopesJSON]
+				&& providerRequests[scopesJSON].requestingExtensionIds.includes(extensionId);
 
 			if (extensionHasExistingRequest) {
 				return;
 			}
 
+			// Construct a commandId that won't clash with others generated here, nor likely with an extension's command
+			const commandId = `${providerId}:${extensionId}:signIn${Object.keys(providerRequests || []).length}`;
 			const menuItem = MenuRegistry.appendMenuItem(MenuId.AccountsContext, {
 				group: '2_signInRequests',
 				command: {
-					id: `${extensionId}signIn`,
+					id: commandId,
 					title: nls.localize({
 						key: 'signInRequest',
 						comment: [`The placeholder {0} will be replaced with an authentication provider's label. {1} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count.`]
@@ -637,7 +639,7 @@ export class AuthenticationService extends Disposable implements IAuthentication
 			});
 
 			const signInCommand = CommandsRegistry.registerCommand({
-				id: `${extensionId}signIn`,
+				id: commandId,
 				handler: async (accessor) => {
 					const authenticationService = accessor.get(IAuthenticationService);
 					const storageService = accessor.get(IStorageService);
@@ -653,16 +655,16 @@ export class AuthenticationService extends Disposable implements IAuthentication
 
 
 			if (providerRequests) {
-				const existingRequest = providerRequests[scopesList] || { disposables: [], requestingExtensionIds: [] };
+				const existingRequest = providerRequests[scopesJSON] || { disposables: [], requestingExtensionIds: [] };
 
-				providerRequests[scopesList] = {
+				providerRequests[scopesJSON] = {
 					disposables: [...existingRequest.disposables, menuItem, signInCommand],
 					requestingExtensionIds: [...existingRequest.requestingExtensionIds, extensionId]
 				};
 				this._signInRequestItems.set(providerId, providerRequests);
 			} else {
 				this._signInRequestItems.set(providerId, {
-					[scopesList]: {
+					[scopesJSON]: {
 						disposables: [menuItem, signInCommand],
 						requestingExtensionIds: [extensionId]
 					}

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -163,6 +163,9 @@ export function readAllowedExtensions(storageService: IStorageService, providerI
 	return trustedExtensions;
 }
 
+// OAuth2 spec prohibits space in a scope, so use that to join them.
+const SCOPESLIST_SEPARATOR = ' ';
+
 interface SessionRequest {
 	disposables: IDisposable[];
 	requestingExtensionIds: string[];
@@ -347,7 +350,7 @@ export class AuthenticationService extends Disposable implements IAuthentication
 		}
 
 		Object.keys(existingRequestsForProvider).forEach(requestedScopes => {
-			if (addedSessions.some(session => session.scopes.slice().join('') === requestedScopes)) {
+			if (addedSessions.some(session => session.scopes.slice().join(SCOPESLIST_SEPARATOR) === requestedScopes)) {
 				const sessionRequest = existingRequestsForProvider[requestedScopes];
 				sessionRequest?.disposables.forEach(item => item.dispose());
 
@@ -614,8 +617,7 @@ export class AuthenticationService extends Disposable implements IAuthentication
 		if (provider) {
 			const providerRequests = this._signInRequestItems.get(providerId);
 
-			// OAuth2 spec prohibits space in a scope, so use that to join them.
-			const scopesList = scopes.join(' ');
+			const scopesList = scopes.join(SCOPESLIST_SEPARATOR);
 			const extensionHasExistingRequest = providerRequests
 				&& providerRequests[scopesList]
 				&& providerRequests[scopesList].requestingExtensionIds.includes(extensionId);

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -169,7 +169,7 @@ interface SessionRequest {
 }
 
 interface SessionRequestInfo {
-	[scopesJSON: string]: SessionRequest;
+	[scopesList: string]: SessionRequest;
 }
 
 CommandsRegistry.registerCommand('workbench.getCodeExchangeProxyEndpoints', function (accessor, _) {
@@ -613,10 +613,12 @@ export class AuthenticationService extends Disposable implements IAuthentication
 
 		if (provider) {
 			const providerRequests = this._signInRequestItems.get(providerId);
-			const scopesJSON = JSON.stringify(scopes);
+
+			// OAuth2 spec prohibits space in a scope, so use that to join them.
+			const scopesList = scopes.join(' ');
 			const extensionHasExistingRequest = providerRequests
-				&& providerRequests[scopesJSON]
-				&& providerRequests[scopesJSON].requestingExtensionIds.includes(extensionId);
+				&& providerRequests[scopesList]
+				&& providerRequests[scopesList].requestingExtensionIds.includes(extensionId);
 
 			if (extensionHasExistingRequest) {
 				return;
@@ -655,16 +657,16 @@ export class AuthenticationService extends Disposable implements IAuthentication
 
 
 			if (providerRequests) {
-				const existingRequest = providerRequests[scopesJSON] || { disposables: [], requestingExtensionIds: [] };
+				const existingRequest = providerRequests[scopesList] || { disposables: [], requestingExtensionIds: [] };
 
-				providerRequests[scopesJSON] = {
+				providerRequests[scopesList] = {
 					disposables: [...existingRequest.disposables, menuItem, signInCommand],
 					requestingExtensionIds: [...existingRequest.requestingExtensionIds, extensionId]
 				};
 				this._signInRequestItems.set(providerId, providerRequests);
 			} else {
 				this._signInRequestItems.set(providerId, {
-					[scopesJSON]: {
+					[scopesList]: {
 						disposables: [menuItem, signInCommand],
 						requestingExtensionIds: [extensionId]
 					}

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -616,7 +616,6 @@ export class AuthenticationService extends Disposable implements IAuthentication
 
 		if (provider) {
 			const providerRequests = this._signInRequestItems.get(providerId);
-
 			const scopesList = scopes.join(SCOPESLIST_SEPARATOR);
 			const extensionHasExistingRequest = providerRequests
 				&& providerRequests[scopesList]


### PR DESCRIPTION
This PR fixes #137601

Internal structure now uses JSON-stringify form of scopes array in place of simple join.

Variable name changed to correspond.

commandId for generated login command now uses a naming scheme that will avoid clashes.

Two interfaces that aren't being used elsewhere are no longer exported.

/assign @TylerLeonhardt
