### PR TITLE
Fix Capitalization of sign out button

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -105,7 +105,7 @@ export class MainThreadAuthenticationProvider extends Disposable {
 				? nls.localize('signOutMessagve', "The account '{0}' has been used by: \n\n{1}\n\n Sign out from these extensions?", accountName, accountUsages.map(usage => usage.extensionName).join('\n'))
 				: nls.localize('signOutMessageSimple', "Sign out of '{0}'?", accountName),
 			[
-				nls.localize('signOut', "Sign out"),
+				nls.localize('signOut', "Sign Out"),
 				nls.localize('cancel', "Cancel")
 			],
 			{


### PR DESCRIPTION
This PR fixes #137651

![22 11 2021_13 45 36_REC](https://user-images.githubusercontent.com/46290258/142920150-0e549547-050b-4ede-aec1-36a52416229d.jpg)

Fixes typo