### PR TITLE
remove `enableProposedApi` from extension description

### DIFF
--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -264,8 +264,6 @@ export interface IExtensionManifest {
 	readonly repository?: { url: string; };
 	readonly bugs?: { url: string; };
 	readonly enabledApiProposals?: readonly string[];
-	/** @deprecated */
-	readonly enableProposedApi?: boolean;
 	readonly api?: string;
 	readonly scripts?: { [key: string]: string; };
 	readonly capabilities?: IExtensionCapabilities;
@@ -348,9 +346,6 @@ export interface IExtensionDescription extends IExtensionManifest {
 	readonly isUserBuiltin: boolean;
 	readonly isUnderDevelopment: boolean;
 	readonly extensionLocation: URI;
-
-	/** @deprecated */
-	enableProposedApi?: boolean;
 }
 
 export function isLanguagePackExtension(manifest: IExtensionManifest): boolean {

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -1197,9 +1197,6 @@ class ProposedApiController {
 			}
 
 			extension.enabledApiProposals = productEnabledProposals;
-
-			// todo@jrieken REMOVE, legacy flag is turned on
-			extension.enableProposedApi = true;
 			return;
 		}
 
@@ -1209,11 +1206,10 @@ class ProposedApiController {
 			return;
 		}
 
-		if (!extension.isBuiltin && (extension.enableProposedApi || isNonEmptyArray(extension.enabledApiProposals))) {
+		if (!extension.isBuiltin && isNonEmptyArray(extension.enabledApiProposals)) {
 			// restrictive: extension cannot use proposed API in this context and its declaration is nulled
 			this._logService.critical(`Extension '${extension.identifier.value} CANNOT USE these API proposals '${extension.enabledApiProposals?.join(', ') ?? '*'}'. You MUST start in extension development mode or use the --enable-proposed-api command line flag`);
 			extension.enabledApiProposals = [];
-			extension.enableProposedApi = false;
 		}
 	}
 }

--- a/src/vs/workbench/services/extensions/common/extensions.ts
+++ b/src/vs/workbench/services/extensions/common/extensions.ts
@@ -19,7 +19,6 @@ export const nullExtensionDescription = Object.freeze(<IExtensionDescription>{
 	name: 'Null Extension Description',
 	version: '0.0.0',
 	publisher: 'vscode',
-	enableProposedApi: false,
 	engines: { vscode: '' },
 	extensionLocation: URI.parse('void:location'),
 	isBuiltin: false,
@@ -135,10 +134,10 @@ export interface IExtensionHost {
 }
 
 export function isProposedApiEnabled(extension: IExtensionDescription, proposal: ApiProposalName): boolean {
-	if (extension.enabledApiProposals?.includes(proposal)) {
-		return true;
+	if (!extension.enabledApiProposals) {
+		return false;
 	}
-	return Boolean(extension.enableProposedApi);
+	return extension.enabledApiProposals.includes(proposal);
 }
 
 export function checkProposedApiEnabled(extension: IExtensionDescription, proposal: ApiProposalName): void {

--- a/src/vs/workbench/services/extensions/node/extensionPoints.ts
+++ b/src/vs/workbench/services/extensions/node/extensionPoints.ts
@@ -309,7 +309,6 @@ export interface IRelaxedExtensionDescription {
 		vscode: string;
 	};
 	main?: string;
-	enableProposedApi?: boolean;
 }
 
 class ExtensionManifestValidator extends ExtensionManifestHandler {


### PR DESCRIPTION
This removes the deprecated `enableProposedApi`-flag from the extension description object and it the remainder for https://github.com/microsoft/vscode/issues/131165