### PR TITLE
Fix a few typos in doc comments

### DIFF
--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -760,7 +760,7 @@ export interface ITextModel {
 	getLineLastNonWhitespaceColumn(lineNumber: number): number;
 
 	/**
-	 * Create a valid position,
+	 * Create a valid position.
 	 */
 	validatePosition(position: IPosition): Position;
 
@@ -800,7 +800,7 @@ export interface ITextModel {
 	getPositionAt(offset: number): Position;
 
 	/**
-	 * Get a range covering the entire model
+	 * Get a range covering the entire model.
 	 */
 	getFullModelRange(): Range;
 

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -539,11 +539,10 @@ export interface CompletionItem {
 	/**
 	 * A string or snippet that should be inserted in a document when selecting
 	 * this completion.
-	 * is used.
 	 */
 	insertText: string;
 	/**
-	 * Addition rules (as bitmask) that should be applied when inserting
+	 * Additional rules (as bitmask) that should be applied when inserting
 	 * this completion.
 	 */
 	insertTextRules?: CompletionItemInsertTextRule;


### PR DESCRIPTION
I noticed these while looking at [Monaco's API](https://microsoft.github.io/monaco-editor/api/).