### PR TITLE
[Markdown] Adding support for GitHub themed images

### DIFF
--- a/extensions/github/markdown.css
+++ b/extensions/github/markdown.css
@@ -1,0 +1,4 @@
+.vscode-dark img[src$=\#gh-light-mode-only],
+.vscode-light img[src$=\#gh-dark-mode-only] {
+    display: none;
+}

--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -64,6 +64,9 @@
         "contents": "%welcome.publishWorkspaceFolder%",
         "when": "config.git.enabled && git.state == initialized && workbenchState == workspace && workspaceFolderCount != 0"
       }
+    ],
+    "markdown.previewStyles": [
+      "./markdown.css"
     ]
   },
   "scripts": {


### PR DESCRIPTION
GitHub recently added support for appending `#gh-dark-mode-only` / `#gh-light-mode-only` to the end of a Markdown image's URL, in order to hide/show images based on the end-user's active color theme ([Details](https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/)). This PR simply adds the equivalent support to the VS Code markdown preview.

![Images](https://user-images.githubusercontent.com/116461/143305721-a97bc821-b4b5-489f-8313-144b0a14f2c6.gif)

Note: I added this support to the built-in `github` extension, since the URL marker is technically GitHub specific, and therefore, felt appropriate being a part of the core GitHub capabilities. That said, let me know if this seems like it should be part of a different built-in extension 👍🏼 