### PR TITLE
add the git.fetch action to the first header menu

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -969,6 +969,11 @@
           "when": "scmProvider == git"
         },
         {
+          "command": "git.fetch",
+          "group": "1_header@5",
+          "when": "scmProvider == git"
+        },
+        {
           "submenu": "git.commit",
           "group": "2_main@1",
           "when": "scmProvider == git"


### PR DESCRIPTION
add the git.fetch action to the frist header menu in scm in order to be easier to fetch the repo immediately and directly

![image](https://user-images.githubusercontent.com/1876302/143589889-7a68671e-b77e-44fe-990c-01f35e27d659.png)
