### PR TITLE
Reverse the initialization sequence for web worker ext host

### DIFF
--- a/src/vs/workbench/services/extensions/common/polyfillNestedWorker.protocol.ts
+++ b/src/vs/workbench/services/extensions/common/polyfillNestedWorker.protocol.ts
@@ -3,9 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+export const enum WorkerMessageType {
+	Ready = '_workerReady',
+	NewWorker = '_newWorker',
+	TerminateWorker = '_terminateWorker'
+}
+
+export interface WorkerReadyMessage {
+	type: WorkerMessageType.Ready;
+}
 
 export interface NewWorkerMessage {
-	type: '_newWorker';
+	type: WorkerMessageType.NewWorker;
 	id: string;
 	port: any /* MessagePort */;
 	url: string;
@@ -13,6 +22,8 @@ export interface NewWorkerMessage {
 }
 
 export interface TerminateWorkerMessage {
-	type: '_terminateWorker';
+	type: WorkerMessageType.TerminateWorker;
 	id: string;
 }
+
+export type WorkerMessage = WorkerReadyMessage | NewWorkerMessage | TerminateWorkerMessage;

--- a/src/vs/workbench/services/extensions/common/polyfillNestedWorker.protocol.ts
+++ b/src/vs/workbench/services/extensions/common/polyfillNestedWorker.protocol.ts
@@ -4,9 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const enum WorkerMessageType {
+	Initialized = '_workerInitialized',
 	Ready = '_workerReady',
 	NewWorker = '_newWorker',
 	TerminateWorker = '_terminateWorker'
+}
+
+export interface WorkerInitializedMessage {
+	type: WorkerMessageType.Initialized;
 }
 
 export interface WorkerReadyMessage {
@@ -26,4 +31,4 @@ export interface TerminateWorkerMessage {
 	id: string;
 }
 
-export type WorkerMessage = WorkerReadyMessage | NewWorkerMessage | TerminateWorkerMessage;
+export type WorkerMessage = WorkerInitializedMessage | WorkerReadyMessage | NewWorkerMessage | TerminateWorkerMessage;

--- a/src/vs/workbench/services/extensions/worker/httpWebWorkerExtensionHostIframe.html
+++ b/src/vs/workbench/services/extensions/worker/httpWebWorkerExtensionHostIframe.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src 'self' data: blob:; script-src 'unsafe-eval' 'sha256-K1g7FCERTTCfRLLmc8iHekkF33UnX2QZNtYpH4uQo0E=' http: https:; connect-src http: https: ws: wss:" />
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src 'self' data: blob:; script-src 'unsafe-eval' 'sha256-AP+gj0d1iSVAToqLVFR2WlQ7mpa5plNk+C9suFFFJgM=' http: https:; connect-src http: https: ws: wss:" />
 	</head>
 	<body>
 	<script>
@@ -42,12 +42,16 @@
 					nestedWorkers.get(id).terminate();
 					nestedWorkers.delete(id);
 				}
-			} else {
+
+			} else if (data?.type === '_workerInitialized') {
+				window.parent.postMessage({ vscodeWebWorkerExtHostId, type: '_workerInitialized' }, '*');
+
+			} else if (data?.type === '_workerReady') {
 				worker.onerror = console.error.bind(console);
-				window.parent.postMessage({
-					vscodeWebWorkerExtHostId,
-					data
-				}, '*');
+				window.parent.postMessage({ vscodeWebWorkerExtHostId, type: '_workerReady' }, '*');
+
+			} else {
+				window.parent.postMessage({ vscodeWebWorkerExtHostId, data }, '*');
 			}
 		};
 

--- a/src/vs/workbench/services/extensions/worker/httpWebWorkerExtensionHostIframe.html
+++ b/src/vs/workbench/services/extensions/worker/httpWebWorkerExtensionHostIframe.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src 'self' data: blob:; script-src 'unsafe-eval' 'sha256-cb2sg39EJV8ABaSNFfWu/ou8o1xVXYK7jp90oZ9vpcg=' http: https:; connect-src http: https: ws: wss:" />
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src 'self' data: blob:; script-src 'unsafe-eval' 'sha256-K1g7FCERTTCfRLLmc8iHekkF33UnX2QZNtYpH4uQo0E=' http: https:; connect-src http: https: ws: wss:" />
 	</head>
 	<body>
 	<script>
@@ -47,7 +47,7 @@
 				window.parent.postMessage({
 					vscodeWebWorkerExtHostId,
 					data
-				}, '*', [data]);
+				}, '*');
 			}
 		};
 
@@ -55,6 +55,8 @@
 			console.error(event.message, event.error);
 			sendError(event.error);
 		};
+
+		window.addEventListener('message', event => worker.postMessage(event.data, event.ports));
 	} catch(err) {
 		console.error(err);
 		sendError(err);

--- a/src/vs/workbench/services/extensions/worker/httpsWebWorkerExtensionHostIframe.html
+++ b/src/vs/workbench/services/extensions/worker/httpsWebWorkerExtensionHostIframe.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src 'self' data: blob:; script-src 'unsafe-eval' 'sha256-K1g7FCERTTCfRLLmc8iHekkF33UnX2QZNtYpH4uQo0E=' https:; connect-src https: wss:" />
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src 'self' data: blob:; script-src 'unsafe-eval' 'sha256-AP+gj0d1iSVAToqLVFR2WlQ7mpa5plNk+C9suFFFJgM=' https:; connect-src https: wss:" />
 	</head>
 	<body>
 	<script>
@@ -42,12 +42,16 @@
 					nestedWorkers.get(id).terminate();
 					nestedWorkers.delete(id);
 				}
-			} else {
+
+			} else if (data?.type === '_workerInitialized') {
+				window.parent.postMessage({ vscodeWebWorkerExtHostId, type: '_workerInitialized' }, '*');
+
+			} else if (data?.type === '_workerReady') {
 				worker.onerror = console.error.bind(console);
-				window.parent.postMessage({
-					vscodeWebWorkerExtHostId,
-					data
-				}, '*');
+				window.parent.postMessage({ vscodeWebWorkerExtHostId, type: '_workerReady' }, '*');
+
+			} else {
+				window.parent.postMessage({ vscodeWebWorkerExtHostId, data }, '*');
 			}
 		};
 

--- a/src/vs/workbench/services/extensions/worker/httpsWebWorkerExtensionHostIframe.html
+++ b/src/vs/workbench/services/extensions/worker/httpsWebWorkerExtensionHostIframe.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src 'self' data: blob:; script-src 'unsafe-eval' 'sha256-cb2sg39EJV8ABaSNFfWu/ou8o1xVXYK7jp90oZ9vpcg=' https:; connect-src https: wss:" />
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; child-src 'self' data: blob:; script-src 'unsafe-eval' 'sha256-K1g7FCERTTCfRLLmc8iHekkF33UnX2QZNtYpH4uQo0E=' https:; connect-src https: wss:" />
 	</head>
 	<body>
 	<script>
@@ -47,7 +47,7 @@
 				window.parent.postMessage({
 					vscodeWebWorkerExtHostId,
 					data
-				}, '*', [data]);
+				}, '*');
 			}
 		};
 
@@ -55,6 +55,8 @@
 			console.error(event.message, event.error);
 			sendError(event.error);
 		};
+
+		window.addEventListener('message', event => worker.postMessage(event.data, event.ports));
 	} catch(err) {
 		console.error(err);
 		sendError(err);

--- a/src/vs/workbench/services/extensions/worker/polyfillNestedWorker.ts
+++ b/src/vs/workbench/services/extensions/worker/polyfillNestedWorker.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { NewWorkerMessage, TerminateWorkerMessage } from 'vs/workbench/services/extensions/common/polyfillNestedWorker.protocol';
+import { NewWorkerMessage, TerminateWorkerMessage, WorkerMessageType } from 'vs/workbench/services/extensions/common/polyfillNestedWorker.protocol';
 
 declare function postMessage(data: any, transferables?: Transferable[]): void;
 
@@ -75,7 +75,7 @@ export class NestedWorker extends EventTarget implements Worker {
 		const id = blobUrl; // works because blob url is unique, needs ID pool otherwise
 
 		const msg: NewWorkerMessage = {
-			type: '_newWorker',
+			type: WorkerMessageType.NewWorker,
 			id,
 			port: channel.port2,
 			url: blobUrl,
@@ -87,7 +87,7 @@ export class NestedWorker extends EventTarget implements Worker {
 		this.postMessage = channel.port1.postMessage.bind(channel.port1);
 		this.terminate = () => {
 			const msg: TerminateWorkerMessage = {
-				type: '_terminateWorker',
+				type: WorkerMessageType.TerminateWorker,
 				id
 			};
 			channel.port1.postMessage(msg);


### PR DESCRIPTION
After a brief discussion with @alexdima, we figured out a better initialization routine for the web worker extension host would be for the main thread side to create the `MessageChannel` and pass along the `MessagePort` instead of the current reverse flow.

I've tested the following scenarios:
- Electron extension host: no changes ✅
- Electron web worker extension host: works ✅
- Electron remote extension host: no changes ✅
- `yarn web` with iframe: works ✅
- `yarn web` without iframe: works ✅

Includes some drive-by improvements such as better typing as well as as waiting for the iframe to be loaded before sending out the init message.