### PR TITLE
allowed characters: string -> record

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -854,8 +854,8 @@ export class ApplyUpdateResult<T> {
 }
 
 function applyUpdate<T>(value: T, update: T): ApplyUpdateResult<T> {
-	if (typeof value !== 'object' || typeof update !== 'object') {
-		return new ApplyUpdateResult(update, value === update);
+	if (typeof value !== 'object' || typeof update !== 'object' || !value || !update) {
+		return new ApplyUpdateResult(update, value !== update);
 	}
 	if (Array.isArray(value) || Array.isArray(update)) {
 		const arrayEquals = Array.isArray(value) && Array.isArray(update) && arrays.equals(value, update);
@@ -863,7 +863,7 @@ function applyUpdate<T>(value: T, update: T): ApplyUpdateResult<T> {
 	}
 	let didChange = false;
 	for (let key in update) {
-		if ((value as T & object).hasOwnProperty(key)) {
+		if ((update as T & object).hasOwnProperty(key)) {
 			const result = applyUpdate(value[key], update[key]);
 			if (result.didChange) {
 				value[key] = result.newValue;

--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -10,7 +10,7 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { OpenerService } from 'vs/editor/browser/services/openerService';
 import { DiffNavigator, IDiffNavigator } from 'vs/editor/browser/widget/diffNavigator';
-import { EditorOptions, ConfigurationChangedEvent } from 'vs/editor/common/config/editorOptions';
+import { EditorOptions, ConfigurationChangedEvent, ApplyUpdateResult } from 'vs/editor/common/config/editorOptions';
 import { BareFontInfo, FontInfo } from 'vs/editor/common/config/fontInfo';
 import { Token } from 'vs/editor/common/core/token';
 import { IEditor, EditorType } from 'vs/editor/common/editorCommon';
@@ -393,6 +393,7 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 		FontInfo: <any>FontInfo,
 		TextModelResolvedOptions: <any>TextModelResolvedOptions,
 		FindMatch: <any>FindMatch,
+		ApplyUpdateResult: <any>ApplyUpdateResult,
 
 		// vars
 		EditorType: EditorType,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3378,6 +3378,16 @@ declare namespace monaco.editor {
 		readonly id: K1;
 		readonly name: string;
 		defaultValue: V;
+		/**
+		 * Might modify `value`.
+		*/
+		applyUpdate(value: V, update: V): ApplyUpdateResult<V>;
+	}
+
+	export class ApplyUpdateResult<T> {
+		readonly newValue: T;
+		readonly didChange: boolean;
+		constructor(newValue: T, didChange: boolean);
 	}
 
 	/**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3884,9 +3884,9 @@ declare namespace monaco.editor {
 		ambiguousCharacters?: boolean;
 		includeComments?: boolean | InUntrustedWorkspace;
 		/**
-		 * A list of allowed code points in a single string.
+		 * A map of allowed characters (true: allowed).
 		*/
-		allowedCharacters?: string;
+		allowedCharacters?: Record<string, true>;
 	}
 
 	export interface IInlineSuggestOptions {


### PR DESCRIPTION
Please only review https://github.com/microsoft/vscode/pull/138042/commits/093aa3c433320e9aaa32ca55fe8fc54e6fbe8336

This PR enables this scenario, which is already supported by the config system:

```json5
// user
"editor.unicodeHighlight.allowedCharacters": {
    "ο": true
}

// workspace
"[typescript]": {
    "editor.unicodeHighlight.allowedCharacters": {
        "γ": true
    }
},
"editor.unicodeHighlight.allowedCharacters": {
    "α": true
}
```

-> Resolved settings for `foo.ts`:
```json5
"editor.unicodeHighlight.allowedCharacters": {
    "ο": true,
    "γ": true
    "α": true,
}
```