### PR TITLE
Add python On Enter Rules

### DIFF
--- a/extensions/python/language-configuration.json
+++ b/extensions/python/language-configuration.json
@@ -49,7 +49,7 @@
 	},
 	"onEnterRules": [
 		{
-			"beforeText": "^\\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|async).*?:\\s*$",
+			"beforeText": "^\\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|async|match|case|as).*?:\\s*$",
 			"action": { "indent": "indent" }
 		}
 	]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR added three `On Enter Rules` keywords. Python 3.10 added a new syntax features: `Structural Pattern Matching`, so I added `match` and `case`, `as` is added BTW.
