### PR TITLE
Add Context Menu to Disassembly View

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -85,6 +85,7 @@ export class MenuId {
 	static readonly CommandPalette = new MenuId('CommandPalette');
 	static readonly DebugBreakpointsContext = new MenuId('DebugBreakpointsContext');
 	static readonly DebugCallStackContext = new MenuId('DebugCallStackContext');
+	static readonly DebugDisassemblyViewContext = new MenuId('DebugDisassemblyViewContext');
 	static readonly DebugConsoleContext = new MenuId('DebugConsoleContext');
 	static readonly DebugVariablesContext = new MenuId('DebugVariablesContext');
 	static readonly DebugWatchContext = new MenuId('DebugWatchContext');

--- a/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
@@ -32,8 +32,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions, IQuickAccessRegistry, IQuickAccessProvider, DefaultQuickAccessFilterValue } from 'vs/platform/quickinput/common/quickAccess';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IQuickInputService, IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
-import { IDisposable } from 'vs/workbench/workbench.web.api';
-import { DisposableStore } from 'vs/base/common/lifecycle';
+import { IDisposable, DisposableStore } from 'vs/base/common/lifecycle';
 
 class ToggleBreakpointAction extends Action2 {
 	constructor() {
@@ -285,7 +284,7 @@ class DisassemblyViewCopySelectionJSONAction extends Action2 {
 }
 
 class DisassemblyGotoAddressQuickAccessProvider implements IQuickAccessProvider {
-	static PREFIX: string = "##";
+	static PREFIX: string = '##';
 	defaultFilterValue?: string | DefaultQuickAccessFilterValue | undefined = DefaultQuickAccessFilterValue.PRESERVE;
 
 	constructor(@IEditorService private readonly editorService: IEditorService) {
@@ -318,7 +317,7 @@ class DisassemblyGotoAddressQuickAccessProvider implements IQuickAccessProvider 
 Registry.as<IQuickAccessRegistry>(Extensions.Quickaccess).registerQuickAccessProvider({
 	ctor: DisassemblyGotoAddressQuickAccessProvider,
 	prefix: DisassemblyGotoAddressQuickAccessProvider.PREFIX,
-	helpEntries: [{ description: "Go to Disassembly Address...", needsEditor: false }]
+	helpEntries: [{ description: nls.localize('gotoLine', "Go to Disassembly Address..."), needsEditor: false }]
 });
 
 class DisassemblyGoToAddress extends Action2 {
@@ -328,7 +327,7 @@ class DisassemblyGoToAddress extends Action2 {
 			title: { value: nls.localize('gotoLine', "Go to Disassembly Address..."), original: 'Go to Disassembly Address...' },
 			f1: true,
 			keybinding: {
-				weight: KeybindingWeight.EditorContrib - 1,
+				weight: 1,
 				when: ContextKeyExpr.and(CONTEXT_IN_DEBUG_MODE, CONTEXT_DEBUG_STATE.isEqualTo('stopped'), CONTEXT_DISASSEMBLE_REQUEST_SUPPORTED, CONTEXT_LANGUAGE_SUPPORTS_DISASSEMBLE_REQUEST),
 				primary: KeyMod.CtrlCmd | KeyCode.KeyG,
 				mac: { primary: KeyMod.WinCtrl | KeyCode.KeyG }


### PR DESCRIPTION
Added context menu to Disassembly View to have:
 - Set Instruction Breakpoint (F9)
 - Toggle Source Code
 - Go to Disassembly Address
 - Copy Disassembly as JSON

Added QuickPicker for GoToDisassembly as '##'.  Open for discuss on a better symbol.

![image](https://user-images.githubusercontent.com/19828377/144017725-62f08035-8034-4cf4-83fb-9a1b3e322d67.png)
