### PR TITLE
Allow loading custom typescript.tsdk settings on web hosts

### DIFF
--- a/extensions/typescript-language-features/src/extension.browser.ts
+++ b/extensions/typescript-language-features/src/extension.browser.ts
@@ -78,7 +78,7 @@ class StaticVersionProvider implements ITypeScriptVersionProvider {
 	}
 
 	private loadVersionsFromSetting(source: TypeScriptVersionSource, tsdkPathSetting: string): TypeScriptVersion[] {
-		if (tsdkPathSetting.startsWith("https://")) {
+		if (tsdkPathSetting.startsWith('https://')) {
 			const serverPath = vscode.Uri.joinPath(vscode.Uri.parse(tsdkPathSetting), 'tsserver.js');
 			return [
 				new TypeScriptVersion(source,

--- a/extensions/typescript-language-features/src/extension.browser.ts
+++ b/extensions/typescript-language-features/src/extension.browser.ts
@@ -52,16 +52,11 @@ class StaticVersionProvider implements ITypeScriptVersionProvider {
 		if (tsdkVersions && tsdkVersions.length) {
 			return tsdkVersions[0];
 		}
-
-		const nodeVersions = this.localNodeModulesVersions;
-		if (nodeVersions && nodeVersions.length === 1) {
-			return nodeVersions[0];
-		}
 		return undefined;
 	}
 
 	public get localVersions(): TypeScriptVersion[] {
-		const allVersions = this.localTsdkVersions.concat(this.localNodeModulesVersions);
+		const allVersions = this.localTsdkVersions;
 		const paths = new Set<string>();
 		return allVersions.filter(x => {
 			if (paths.has(x.path)) {
@@ -88,10 +83,6 @@ class StaticVersionProvider implements ITypeScriptVersionProvider {
 			];
 		}
 
-		return [];
-	}
-
-	private get localNodeModulesVersions(): TypeScriptVersion[] {
 		return [];
 	}
 }

--- a/extensions/typescript-language-features/src/utils/configuration.browser.ts
+++ b/extensions/typescript-language-features/src/utils/configuration.browser.ts
@@ -8,12 +8,20 @@ import { BaseServiceConfigurationProvider } from './configuration';
 
 export class BrowserServiceConfigurationProvider extends BaseServiceConfigurationProvider {
 
-	// On browsers, we only support using the built-in TS version
-	protected extractGlobalTsdk(_configuration: vscode.WorkspaceConfiguration): string | null {
+	protected extractGlobalTsdk(configuration: vscode.WorkspaceConfiguration): string | null {
+		const inspect = configuration.inspect('typescript.tsdk');
+		if (inspect && typeof inspect.globalValue === 'string') {
+			return inspect.globalValue;
+		}
 		return null;
 	}
 
-	protected extractLocalTsdk(_configuration: vscode.WorkspaceConfiguration): string | null {
+
+	protected extractLocalTsdk(configuration: vscode.WorkspaceConfiguration): string | null {
+		const inspect = configuration.inspect('typescript.tsdk');
+		if (inspect && typeof inspect.workspaceValue === 'string') {
+			return inspect.workspaceValue;
+		}
 		return null;
 	}
 }

--- a/extensions/typescript-language-features/src/utils/configuration.browser.ts
+++ b/extensions/typescript-language-features/src/utils/configuration.browser.ts
@@ -2,26 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
-import * as vscode from 'vscode';
 import { BaseServiceConfigurationProvider } from './configuration';
 
-export class BrowserServiceConfigurationProvider extends BaseServiceConfigurationProvider {
-
-	protected extractGlobalTsdk(configuration: vscode.WorkspaceConfiguration): string | null {
-		const inspect = configuration.inspect('typescript.tsdk');
-		if (inspect && typeof inspect.globalValue === 'string') {
-			return inspect.globalValue;
-		}
-		return null;
-	}
-
-
-	protected extractLocalTsdk(configuration: vscode.WorkspaceConfiguration): string | null {
-		const inspect = configuration.inspect('typescript.tsdk');
-		if (inspect && typeof inspect.workspaceValue === 'string') {
-			return inspect.workspaceValue;
-		}
-		return null;
-	}
-}
+export class BrowserServiceConfigurationProvider extends BaseServiceConfigurationProvider { }

--- a/extensions/typescript-language-features/src/utils/configuration.electron.ts
+++ b/extensions/typescript-language-features/src/utils/configuration.electron.ts
@@ -20,19 +20,13 @@ export class ElectronServiceConfigurationProvider extends BaseServiceConfigurati
 		return inspectValue;
 	}
 
-	protected extractGlobalTsdk(configuration: vscode.WorkspaceConfiguration): string | null {
-		const inspect = configuration.inspect('typescript.tsdk');
-		if (inspect && typeof inspect.globalValue === 'string') {
-			return this.fixPathPrefixes(inspect.globalValue);
-		}
-		return null;
+	protected override extractGlobalTsdk(configuration: vscode.WorkspaceConfiguration): string | null {
+		const result = super.extractGlobalTsdk(configuration);
+		return result && this.fixPathPrefixes(result);
 	}
 
-	protected extractLocalTsdk(configuration: vscode.WorkspaceConfiguration): string | null {
-		const inspect = configuration.inspect('typescript.tsdk');
-		if (inspect && typeof inspect.workspaceValue === 'string') {
-			return this.fixPathPrefixes(inspect.workspaceValue);
-		}
-		return null;
+	protected override extractLocalTsdk(configuration: vscode.WorkspaceConfiguration): string | null {
+		const result = super.extractLocalTsdk(configuration);
+		return result && this.fixPathPrefixes(result);
 	}
 }

--- a/extensions/typescript-language-features/src/utils/configuration.ts
+++ b/extensions/typescript-language-features/src/utils/configuration.ts
@@ -136,8 +136,21 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 		};
 	}
 
-	protected abstract extractGlobalTsdk(configuration: vscode.WorkspaceConfiguration): string | null;
-	protected abstract extractLocalTsdk(configuration: vscode.WorkspaceConfiguration): string | null;
+	protected extractGlobalTsdk(configuration: vscode.WorkspaceConfiguration): string | null {
+		const inspect = configuration.inspect('typescript.tsdk');
+		if (inspect && typeof inspect.globalValue === 'string') {
+			return inspect.globalValue;
+		}
+		return null;
+	}
+
+	protected extractLocalTsdk(configuration: vscode.WorkspaceConfiguration): string | null {
+		const inspect = configuration.inspect('typescript.tsdk');
+		if (inspect && typeof inspect.workspaceValue === 'string') {
+			return inspect.workspaceValue;
+		}
+		return null;
+	}
 
 	protected readTsServerLogLevel(configuration: vscode.WorkspaceConfiguration): TsServerLogLevel {
 		const setting = configuration.get<string>('typescript.tsserver.log', 'off');


### PR DESCRIPTION
This allow you to set, eg, 
```json
{
    "typescript.tsdk": "https://unpkg.com/typescript@4.5.2/lib"
}
```
in `vscode.dev` and get a functioning custom tsdk version (for any version of TS published after https://github.com/microsoft/TypeScript/pull/39656 was pulled in) - very useful for debugging custom versions and PRs in `vscode.dev`.

cc @orta @mattbierner 

