### PR TITLE
add the ability to pause/buffer IConfigurationRegistry event and adopt in extension service

### DIFF
--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -99,8 +99,7 @@ export interface IConfigurationRegistry {
 	registerOverrideIdentifiers(identifiers: string[]): void;
 
 	/**
-	 *
-	 * @param callback
+	 * Invokes `callback`, pauses events while it runs, and sends composite events after that.
 	 */
 	withBufferedEvents<R = any>(callback: () => R): R;
 }
@@ -239,13 +238,12 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 	readonly onDidSchemaChange: Event<void> = this._onDidSchemaChange.event;
 
 	private readonly _onDidUpdateConfiguration = new PauseableEmitter<{ properties: string[], defaultsOverrides?: boolean }>({
-		merge: array => {
-
+		merge: all => {
 			const allProperties: string[][] = [];
 			let defaultsOverrides: boolean | undefined = undefined;
-			for (let e of array) {
-				allProperties.push(e.properties);
-				defaultsOverrides = defaultsOverrides || e.defaultsOverrides;
+			for (const event of all) {
+				allProperties.push(event.properties);
+				defaultsOverrides = defaultsOverrides || event.defaultsOverrides;
 			}
 			return {
 				properties: distinct(allProperties.flat()),

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -37,6 +37,8 @@ import { dedupExtensions } from 'vs/workbench/services/extensions/common/extensi
 import { ApiProposalName, allApiProposals } from 'vs/workbench/services/extensions/common/extensionsApiProposals';
 import { forEach } from 'vs/base/common/collections';
 import { ILogService } from 'vs/platform/log/common/log';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 
 const hasOwnProperty = Object.hasOwnProperty;
 const NO_OP_VOID_PROMISE = Promise.resolve<void>(undefined);
@@ -852,12 +854,15 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 		const messageHandler = (msg: IMessage) => this._handleExtensionPointMessage(msg);
 		const availableExtensions = this._registry.getAllExtensionDescriptions();
 		const extensionPoints = ExtensionsRegistry.getExtensionPoints();
+
 		perf.mark('code/willHandleExtensionPoints');
-		for (const extensionPoint of extensionPoints) {
-			if (affectedExtensionPoints[extensionPoint.name]) {
-				AbstractExtensionService._handleExtensionPoint(extensionPoint, availableExtensions, messageHandler);
+		Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).withBufferedEvents(() => {
+			for (const extensionPoint of extensionPoints) {
+				if (affectedExtensionPoints[extensionPoint.name]) {
+					AbstractExtensionService._handleExtensionPoint(extensionPoint, availableExtensions, messageHandler);
+				}
 			}
-		}
+		});
 		perf.mark('code/didHandleExtensionPoints');
 	}
 


### PR DESCRIPTION
Profiling has shown that reading contribution points updates configurations a lot <sup>1</sup>. The event of the configuration registry fire in my dev setup around 50 times. There is only 4 listeners to these events but assuming a listener takes 1ms it still makes 200ms (`50*4*1`) to fire them.

This PR adds a way to pause/resume eventing of the configuration registry and adopts that in the extension service when reading contribution points.

I measured the gains against todays insiders and things are looking pretty good. I have tested with only builtin extensions and with the 30 extensions that I have installed (using my data as real world representative, it is also pretty close to the real world average duration for this). The measurements are the times between the `willHandleExtensionPoints` and `didHandleExtensionPoints` perf-marks (F1 > Startup Performance)


|          | Insiders (`0cc0904c56`)     | PR [`7907361`](https://az764295.vo.msecnd.net/insider/790736142c236ffc44a65d2e0f0bad5a55aaa085/VSCode-darwin.zip)|  `sandy081/perf` [`c4bd3f8`](https://az764295.vo.msecnd.net/insider/c4bd3f869de30a6ebb97bcc215f652ffe66a236e/VSCode-darwin.zip)|
|--------------|-----------|------------|---|
| builtin extensions | 185.6      | 71         (**-114.6ms**) | 94.5 (**-90.2ms**)|
| builtin extensions and 30 more   | 448.8 | 148.2  (**-300.6ms**) | 163.8 (**-285ms**) |


--

<sup>1</sup> Looks like most events are triggered from custom editors and notebooks. Something to drill into further