### PR TITLE
store remoteAuthority in backup or history

### DIFF
--- a/src/vs/platform/backup/electron-main/backup.ts
+++ b/src/vs/platform/backup/electron-main/backup.ts
@@ -6,20 +6,9 @@
 import { URI } from 'vs/base/common/uri';
 import { IEmptyWindowBackupInfo } from 'vs/platform/backup/node/backup';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { isWorkspaceIdentifier, IWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IFolderBackupInfo, IWorkspaceBackupInfo, IWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 
 export const IBackupMainService = createDecorator<IBackupMainService>('backupMainService');
-
-export interface IWorkspaceBackupInfo {
-	workspace: IWorkspaceIdentifier;
-	remoteAuthority?: string;
-}
-
-export function isWorkspaceBackupInfo(obj: unknown): obj is IWorkspaceBackupInfo {
-	const candidate = obj as IWorkspaceBackupInfo;
-
-	return candidate && isWorkspaceIdentifier(candidate.workspace);
-}
 
 export interface IBackupMainService {
 	readonly _serviceBrand: undefined;
@@ -27,11 +16,11 @@ export interface IBackupMainService {
 	isHotExitEnabled(): boolean;
 
 	getWorkspaceBackups(): IWorkspaceBackupInfo[];
-	getFolderBackupPaths(): URI[];
+	getFolderBackupPaths(): IFolderBackupInfo[];
 	getEmptyWindowBackupPaths(): IEmptyWindowBackupInfo[];
 
 	registerWorkspaceBackupSync(workspace: IWorkspaceBackupInfo, migrateFrom?: string): string;
-	registerFolderBackupSync(folderUri: URI): string;
+	registerFolderBackupSync(folderUri: IFolderBackupInfo): string;
 	registerEmptyWindowBackupSync(backupFolder?: string, remoteAuthority?: string): string;
 
 	unregisterWorkspaceBackupSync(workspace: IWorkspaceIdentifier): void;
@@ -44,5 +33,5 @@ export interface IBackupMainService {
 	 * it checks for each backup location if any backups
 	 * are stored.
 	 */
-	getDirtyWorkspaces(): Promise<Array<IWorkspaceIdentifier | URI>>;
+	getDirtyWorkspaces(): Promise<Array<IWorkspaceBackupInfo | IFolderBackupInfo>>;
 }

--- a/src/vs/platform/backup/electron-main/backupMainService.ts
+++ b/src/vs/platform/backup/electron-main/backupMainService.ts
@@ -12,13 +12,13 @@ import { isLinux } from 'vs/base/common/platform';
 import { extUriBiasedIgnorePathCase } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { Promises, RimRafMode, writeFileSync } from 'vs/base/node/pfs';
-import { IBackupMainService, isWorkspaceBackupInfo, IWorkspaceBackupInfo } from 'vs/platform/backup/electron-main/backup';
-import { IBackupWorkspacesFormat, IEmptyWindowBackupInfo } from 'vs/platform/backup/node/backup';
+import { IBackupMainService } from 'vs/platform/backup/electron-main/backup';
+import { IBackupWorkspacesFormat, IDeprecatedBackupWorkspacesFormat, IEmptyWindowBackupInfo, isEmptyWindowBackupInfo } from 'vs/platform/backup/node/backup';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IEnvironmentMainService } from 'vs/platform/environment/electron-main/environmentMainService';
 import { HotExitConfiguration, IFilesConfiguration } from 'vs/platform/files/common/files';
 import { ILogService } from 'vs/platform/log/common/log';
-import { isWorkspaceIdentifier, IWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IFolderBackupInfo, isFolderBackupInfo, isWorkspaceIdentifier, IWorkspaceBackupInfo, IWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 
 export class BackupMainService implements IBackupMainService {
 
@@ -28,7 +28,7 @@ export class BackupMainService implements IBackupMainService {
 	protected workspacesJsonPath: string;
 
 	private workspaces: IWorkspaceBackupInfo[] = [];
-	private folders: URI[] = [];
+	private folders: IFolderBackupInfo[] = [];
 	private emptyWindows: IEmptyWindowBackupInfo[] = [];
 
 	// Comparers for paths and resources that will
@@ -47,7 +47,7 @@ export class BackupMainService implements IBackupMainService {
 	}
 
 	async initialize(): Promise<void> {
-		let backups: IBackupWorkspacesFormat;
+		let backups: IBackupWorkspacesFormat & IDeprecatedBackupWorkspacesFormat;
 		try {
 			backups = JSON.parse(await Promises.readFile(this.workspacesJsonPath, 'utf8')); // invalid JSON or permission issue can happen here
 		} catch (error) {
@@ -74,10 +74,12 @@ export class BackupMainService implements IBackupMainService {
 		this.workspaces = await this.validateWorkspaces(rootWorkspaces);
 
 		// read folder backups
-		let workspaceFolders: URI[] = [];
+		let workspaceFolders: IFolderBackupInfo[] = [];
 		try {
-			if (Array.isArray(backups.folderURIWorkspaces)) {
-				workspaceFolders = backups.folderURIWorkspaces.map(folder => URI.parse(folder));
+			if (Array.isArray(backups.folderWorkspaceInfos)) {
+				workspaceFolders = backups.folderWorkspaceInfos.map(folder => ({ folderUri: URI.parse(folder.folderUri), remoteAuthority: folder.remoteAuthority }));
+			} else if (Array.isArray(backups.folderURIWorkspaces)) {
+				workspaceFolders = backups.folderURIWorkspaces.map(folder => ({ folderUri: URI.parse(folder), remoteAuthority: undefined }));
 			}
 		} catch (e) {
 			// ignore URI parsing exceptions
@@ -100,7 +102,7 @@ export class BackupMainService implements IBackupMainService {
 		return this.workspaces.slice(0); // return a copy
 	}
 
-	getFolderBackupPaths(): URI[] {
+	getFolderBackupPaths(): IFolderBackupInfo[] {
 		if (this.isHotExitOnExitAndWindowClose()) {
 			// Only non-folder windows are restored on main process launch when
 			// hot exit is configured as onExitAndWindowClose.
@@ -169,17 +171,17 @@ export class BackupMainService implements IBackupMainService {
 		}
 	}
 
-	registerFolderBackupSync(folderUri: URI): string {
-		if (!this.folders.some(folder => this.backupUriComparer.isEqual(folderUri, folder))) {
-			this.folders.push(folderUri);
+	registerFolderBackupSync(folderInfo: IFolderBackupInfo): string {
+		if (!this.folders.some(folder => this.backupUriComparer.isEqual(folderInfo.folderUri, folder.folderUri))) {
+			this.folders.push(folderInfo);
 			this.saveSync();
 		}
 
-		return this.getBackupPath(this.getFolderHash(folderUri));
+		return this.getBackupPath(this.getFolderHash(folderInfo));
 	}
 
 	unregisterFolderBackupSync(folderUri: URI): void {
-		const index = this.folders.findIndex(folder => this.backupUriComparer.isEqual(folderUri, folder));
+		const index = this.folders.findIndex(folder => this.backupUriComparer.isEqual(folderUri, folder.folderUri));
 		if (index !== -1) {
 			this.folders.splice(index, 1);
 			this.saveSync();
@@ -248,25 +250,26 @@ export class BackupMainService implements IBackupMainService {
 		return result;
 	}
 
-	private async validateFolders(folderWorkspaces: URI[]): Promise<URI[]> {
+	private async validateFolders(folderWorkspaces: IFolderBackupInfo[]): Promise<IFolderBackupInfo[]> {
 		if (!Array.isArray(folderWorkspaces)) {
 			return [];
 		}
 
-		const result: URI[] = [];
+		const result: IFolderBackupInfo[] = [];
 		const seenIds: Set<string> = new Set();
-		for (let folderURI of folderWorkspaces) {
+		for (let folderInfo of folderWorkspaces) {
+			const folderURI = folderInfo.folderUri;
 			const key = this.backupUriComparer.getComparisonKey(folderURI);
 			if (!seenIds.has(key)) {
 				seenIds.add(key);
 
-				const backupPath = this.getBackupPath(this.getFolderHash(folderURI));
+				const backupPath = this.getBackupPath(this.getFolderHash(folderInfo));
 				const hasBackups = await this.doHasBackups(backupPath);
 
 				// If the folder has no backups, ignore it
 				if (hasBackups) {
 					if (folderURI.scheme !== Schemas.file || await Promises.exists(folderURI.fsPath)) {
-						result.push(folderURI);
+						result.push(folderInfo);
 					} else {
 						// If the folder has backups, but the target workspace is missing, convert backups to empty ones
 						await this.convertToEmptyWindowBackup(backupPath);
@@ -362,13 +365,13 @@ export class BackupMainService implements IBackupMainService {
 		return true;
 	}
 
-	async getDirtyWorkspaces(): Promise<Array<IWorkspaceIdentifier | URI>> {
-		const dirtyWorkspaces: Array<IWorkspaceIdentifier | URI> = [];
+	async getDirtyWorkspaces(): Promise<Array<IWorkspaceBackupInfo | IFolderBackupInfo>> {
+		const dirtyWorkspaces: Array<IWorkspaceBackupInfo | IFolderBackupInfo> = [];
 
 		// Workspaces with backups
 		for (const workspace of this.workspaces) {
 			if ((await this.hasBackups(workspace))) {
-				dirtyWorkspaces.push(workspace.workspace);
+				dirtyWorkspaces.push(workspace);
 			}
 		}
 
@@ -382,22 +385,22 @@ export class BackupMainService implements IBackupMainService {
 		return dirtyWorkspaces;
 	}
 
-	private hasBackups(backupLocation: IWorkspaceBackupInfo | IEmptyWindowBackupInfo | URI): Promise<boolean> {
+	private hasBackups(backupLocation: IWorkspaceBackupInfo | IEmptyWindowBackupInfo | IFolderBackupInfo): Promise<boolean> {
 		let backupPath: string;
 
+		// Empty
+		if (isEmptyWindowBackupInfo(backupLocation)) {
+			backupPath = backupLocation.backupFolder;
+		}
+
 		// Folder
-		if (URI.isUri(backupLocation)) {
+		else if (isFolderBackupInfo(backupLocation)) {
 			backupPath = this.getBackupPath(this.getFolderHash(backupLocation));
 		}
 
 		// Workspace
-		else if (isWorkspaceBackupInfo(backupLocation)) {
-			backupPath = this.getBackupPath(backupLocation.workspace.id);
-		}
-
-		// Empty
 		else {
-			backupPath = backupLocation.backupFolder;
+			backupPath = this.getBackupPath(backupLocation.workspace.id);
 		}
 
 		return this.doHasBackups(backupPath);
@@ -443,7 +446,7 @@ export class BackupMainService implements IBackupMainService {
 	private serializeBackups(): IBackupWorkspacesFormat {
 		return {
 			rootURIWorkspaces: this.workspaces.map(workspace => ({ id: workspace.workspace.id, configURIPath: workspace.workspace.configPath.toString(), remoteAuthority: workspace.remoteAuthority })),
-			folderURIWorkspaces: this.folders.map(folder => folder.toString()),
+			folderWorkspaceInfos: this.folders.map(folder => ({ folderUri: folder.folderUri.toString(), remoteAuthority: folder.remoteAuthority })),
 			emptyWorkspaceInfos: this.emptyWindows
 		};
 	}
@@ -452,7 +455,8 @@ export class BackupMainService implements IBackupMainService {
 		return (Date.now() + Math.round(Math.random() * 1000)).toString();
 	}
 
-	protected getFolderHash(folderUri: URI): string {
+	protected getFolderHash(folder: IFolderBackupInfo): string {
+		const folderUri = folder.folderUri;
 		let key: string;
 
 		if (folderUri.scheme === Schemas.file) {

--- a/src/vs/platform/backup/node/backup.ts
+++ b/src/vs/platform/backup/node/backup.ts
@@ -5,13 +5,25 @@
 
 export interface ISerializedWorkspace { id: string; configURIPath: string; remoteAuthority?: string; }
 
+export interface ISerializedFolder { folderUri: string; remoteAuthority?: string; }
+
 export interface IBackupWorkspacesFormat {
 	rootURIWorkspaces: ISerializedWorkspace[];
-	folderURIWorkspaces: string[];
+	folderWorkspaceInfos: ISerializedFolder[];
 	emptyWorkspaceInfos: IEmptyWindowBackupInfo[];
+}
+
+/** Deprecated since 1.64 */
+export interface IDeprecatedBackupWorkspacesFormat {
+	folderURIWorkspaces: string[]; // replaced by folderWorkspaceInfos
 }
 
 export interface IEmptyWindowBackupInfo {
 	backupFolder: string;
 	remoteAuthority?: string;
+}
+
+export function isEmptyWindowBackupInfo(obj: unknown): obj is IEmptyWindowBackupInfo {
+	const candidate = obj as IEmptyWindowBackupInfo;
+	return typeof candidate?.backupFolder === 'string';
 }

--- a/src/vs/platform/windows/electron-main/window.ts
+++ b/src/vs/platform/windows/electron-main/window.ts
@@ -689,7 +689,8 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 				},
 				urisToOpen: workspace ? [workspace] : undefined,
 				forceEmpty,
-				forceNewWindow: true
+				forceNewWindow: true,
+				remoteAuthority: this.remoteAuthority
 			});
 			window.focus();
 		}

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1184,7 +1184,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 				const extensionDevelopmentPathRemoteAuthority = getRemoteAuthority(url);
 				if (extensionDevelopmentPathRemoteAuthority) {
 					if (remoteAuthority) {
-						if (extensionDevelopmentPathRemoteAuthority !== remoteAuthority) {
+						if (!isEqualAuthority(extensionDevelopmentPathRemoteAuthority, remoteAuthority)) {
 							this.logService.error('more than one extension development path authority');
 						}
 					} else {

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1398,7 +1398,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			if (isWorkspaceIdentifier(configuration.workspace)) {
 				configuration.backupPath = this.backupMainService.registerWorkspaceBackupSync({ workspace: configuration.workspace, remoteAuthority: configuration.remoteAuthority });
 			} else if (isSingleFolderWorkspaceIdentifier(configuration.workspace)) {
-				configuration.backupPath = this.backupMainService.registerFolderBackupSync(configuration.workspace.uri);
+				configuration.backupPath = this.backupMainService.registerFolderBackupSync({ folderUri: configuration.workspace.uri, remoteAuthority: configuration.remoteAuthority });
 			} else {
 				const backupFolder = options.emptyWindowBackupInfo && options.emptyWindowBackupInfo.backupFolder;
 				configuration.backupPath = this.backupMainService.registerEmptyWindowBackupSync(backupFolder, configuration.remoteAuthority);

--- a/src/vs/platform/workspaces/common/workspaces.ts
+++ b/src/vs/platform/workspaces/common/workspaces.ts
@@ -52,7 +52,7 @@ export interface IWorkspacesService {
 	getRecentlyOpened(): Promise<IRecentlyOpened>;
 
 	// Dirty Workspaces
-	getDirtyWorkspaces(): Promise<Array<IWorkspaceIdentifier | URI>>;
+	getDirtyWorkspaces(): Promise<Array<IWorkspaceBackupInfo | IFolderBackupInfo>>;
 }
 
 //#region Workspaces Recently Opened
@@ -93,6 +93,29 @@ export function isRecentFolder(curr: IRecent): curr is IRecentFolder {
 export function isRecentFile(curr: IRecent): curr is IRecentFile {
 	return curr.hasOwnProperty('fileUri');
 }
+
+//#endregion
+
+//#region Backups
+
+export interface IWorkspaceBackupInfo {
+	workspace: IWorkspaceIdentifier;
+	remoteAuthority?: string;
+}
+
+export interface IFolderBackupInfo {
+	folderUri: URI;
+	remoteAuthority?: string;
+}
+
+export function isFolderBackupInfo(curr: IWorkspaceBackupInfo | IFolderBackupInfo): curr is IFolderBackupInfo {
+	return curr && curr.hasOwnProperty('folderUri');
+}
+
+export function isWorkspaceBackupInfo(curr: IWorkspaceBackupInfo | IFolderBackupInfo): curr is IWorkspaceBackupInfo {
+	return curr && curr.hasOwnProperty('workspace');
+}
+
 
 //#endregion
 

--- a/src/vs/platform/workspaces/electron-main/workspacesHistoryMainService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesHistoryMainService.ts
@@ -80,7 +80,7 @@ export class WorkspacesHistoryMainService extends Disposable implements IWorkspa
 		this.lifecycleMainService.when(LifecycleMainPhase.AfterWindowOpen).then(() => this.handleWindowsJumpList());
 
 		// Add to history when entering workspace
-		this._register(this.workspacesManagementMainService.onDidEnterWorkspace(event => this.addRecentlyOpened([{ workspace: event.workspace }])));
+		this._register(this.workspacesManagementMainService.onDidEnterWorkspace(event => this.addRecentlyOpened([{ workspace: event.workspace, remoteAuthority: event.window.remoteAuthority }])));
 	}
 
 	private handleWindowsJumpList(): void {
@@ -246,11 +246,13 @@ export class WorkspacesHistoryMainService extends Disposable implements IWorkspa
 		const files: IRecentFile[] = [];
 
 		// Add current workspace to beginning if set
-		const currentWorkspace = include?.config?.workspace;
-		if (isWorkspaceIdentifier(currentWorkspace) && !this.workspacesManagementMainService.isUntitledWorkspace(currentWorkspace)) {
-			workspaces.push({ workspace: currentWorkspace });
-		} else if (isSingleFolderWorkspaceIdentifier(currentWorkspace)) {
-			workspaces.push({ folderUri: currentWorkspace.uri });
+		if (include) {
+			const currentWorkspace = include.config?.workspace;
+			if (isWorkspaceIdentifier(currentWorkspace) && !this.workspacesManagementMainService.isUntitledWorkspace(currentWorkspace)) {
+				workspaces.push({ workspace: currentWorkspace, remoteAuthority: include.remoteAuthority });
+			} else if (isSingleFolderWorkspaceIdentifier(currentWorkspace)) {
+				workspaces.push({ folderUri: currentWorkspace.uri, remoteAuthority: include.remoteAuthority });
+			}
 		}
 
 		// Add currently files to open to the beginning if any

--- a/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
@@ -7,7 +7,7 @@ import { AddFirstParameterToFunctions } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { IBackupMainService } from 'vs/platform/backup/electron-main/backup';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
-import { IEnterWorkspaceResult, IRecent, IRecentlyOpened, IWorkspaceFolderCreationData, IWorkspaceIdentifier, IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
+import { IEnterWorkspaceResult, IRecent, IRecentlyOpened, IWorkspaceBackupInfo, IFolderBackupInfo, IWorkspaceFolderCreationData, IWorkspaceIdentifier, IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 import { IWorkspacesHistoryMainService } from 'vs/platform/workspaces/electron-main/workspacesHistoryMainService';
 import { IWorkspacesManagementMainService } from 'vs/platform/workspaces/electron-main/workspacesManagementMainService';
 
@@ -73,7 +73,7 @@ export class WorkspacesMainService implements AddFirstParameterToFunctions<IWork
 
 	//#region Dirty Workspaces
 
-	async getDirtyWorkspaces(): Promise<Array<IWorkspaceIdentifier | URI>> {
+	async getDirtyWorkspaces(): Promise<Array<IWorkspaceBackupInfo | IFolderBackupInfo>> {
 		return this.backupMainService.getDirtyWorkspaces();
 	}
 

--- a/src/vs/platform/workspaces/test/electron-main/workspacesManagementMainService.test.ts
+++ b/src/vs/platform/workspaces/test/electron-main/workspacesManagementMainService.test.ts
@@ -13,7 +13,7 @@ import { extUriBiasedIgnorePathCase } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import * as pfs from 'vs/base/node/pfs';
 import { flakySuite, getRandomTestPath } from 'vs/base/test/node/testUtils';
-import { IBackupMainService, IWorkspaceBackupInfo } from 'vs/platform/backup/electron-main/backup';
+import { IBackupMainService } from 'vs/platform/backup/electron-main/backup';
 import { IEmptyWindowBackupInfo } from 'vs/platform/backup/node/backup';
 import { INativeOpenDialogOptions } from 'vs/platform/dialogs/common/dialogs';
 import { IDialogMainService } from 'vs/platform/dialogs/electron-main/dialogMainService';
@@ -22,7 +22,7 @@ import { OPTIONS, parseArgs } from 'vs/platform/environment/node/argv';
 import { NullLogService } from 'vs/platform/log/common/log';
 import product from 'vs/platform/product/common/product';
 import { IProductService } from 'vs/platform/product/common/productService';
-import { IRawFileWorkspaceFolder, IRawUriWorkspaceFolder, IStoredWorkspace, IStoredWorkspaceFolder, IWorkspaceFolderCreationData, IWorkspaceIdentifier, rewriteWorkspaceFileForNewLocation, WORKSPACE_EXTENSION } from 'vs/platform/workspaces/common/workspaces';
+import { IFolderBackupInfo, IRawFileWorkspaceFolder, IRawUriWorkspaceFolder, IStoredWorkspace, IStoredWorkspaceFolder, IWorkspaceBackupInfo, IWorkspaceFolderCreationData, IWorkspaceIdentifier, rewriteWorkspaceFileForNewLocation, WORKSPACE_EXTENSION } from 'vs/platform/workspaces/common/workspaces';
 import { WorkspacesManagementMainService } from 'vs/platform/workspaces/electron-main/workspacesManagementMainService';
 
 flakySuite('WorkspacesManagementMainService', () => {
@@ -46,15 +46,15 @@ flakySuite('WorkspacesManagementMainService', () => {
 
 		isHotExitEnabled(): boolean { throw new Error('Method not implemented.'); }
 		getWorkspaceBackups(): IWorkspaceBackupInfo[] { throw new Error('Method not implemented.'); }
-		getFolderBackupPaths(): URI[] { throw new Error('Method not implemented.'); }
+		getFolderBackupPaths(): IFolderBackupInfo[] { throw new Error('Method not implemented.'); }
 		getEmptyWindowBackupPaths(): IEmptyWindowBackupInfo[] { throw new Error('Method not implemented.'); }
 		registerWorkspaceBackupSync(workspace: IWorkspaceBackupInfo, migrateFrom?: string | undefined): string { throw new Error('Method not implemented.'); }
-		registerFolderBackupSync(folderUri: URI): string { throw new Error('Method not implemented.'); }
+		registerFolderBackupSync(folder: IFolderBackupInfo): string { throw new Error('Method not implemented.'); }
 		registerEmptyWindowBackupSync(backupFolder?: string | undefined, remoteAuthority?: string | undefined): string { throw new Error('Method not implemented.'); }
 		unregisterWorkspaceBackupSync(workspace: IWorkspaceIdentifier): void { throw new Error('Method not implemented.'); }
 		unregisterFolderBackupSync(folderUri: URI): void { throw new Error('Method not implemented.'); }
 		unregisterEmptyWindowBackupSync(backupFolder: string): void { throw new Error('Method not implemented.'); }
-		async getDirtyWorkspaces(): Promise<(IWorkspaceIdentifier | URI)[]> { return []; }
+		async getDirtyWorkspaces(): Promise<(IWorkspaceBackupInfo | IFolderBackupInfo)[]> { return []; }
 	}
 
 	function createUntitledWorkspace(folders: string[], names?: string[]) {

--- a/src/vs/workbench/browser/actions/windowActions.ts
+++ b/src/vs/workbench/browser/actions/windowActions.ts
@@ -39,6 +39,7 @@ export const inRecentFilesPickerContextKey = 'inRecentFilesPicker';
 interface IRecentlyOpenedPick extends IQuickPickItem {
 	resource: URI,
 	openable: IWindowOpenable;
+	remoteAuthority: string | undefined;
 }
 
 const fileCategory = { value: localize('file', "File"), original: 'File' };
@@ -162,7 +163,10 @@ abstract class BaseOpenRecentAction extends Action2 {
 					});
 
 					if (result.confirmed) {
-						hostService.openWindow([context.item.openable]);
+						hostService.openWindow(
+							[context.item.openable], {
+							remoteAuthority: context.item.remoteAuthority || null // local window if remoteAuthority is not set or can not be deducted from the openable
+						});
 						quickInputService.cancel();
 					}
 				}
@@ -170,7 +174,11 @@ abstract class BaseOpenRecentAction extends Action2 {
 		});
 
 		if (pick) {
-			return hostService.openWindow([pick.openable], { forceNewWindow: keyMods?.ctrlCmd, forceReuseWindow: keyMods?.alt });
+			return hostService.openWindow([pick.openable], {
+				forceNewWindow: keyMods?.ctrlCmd,
+				forceReuseWindow: keyMods?.alt,
+				remoteAuthority: pick.remoteAuthority || null // local window if remoteAuthority is not set or can not be deducted from the openable
+			});
 		}
 	}
 
@@ -215,7 +223,8 @@ abstract class BaseOpenRecentAction extends Action2 {
 			description: parentPath,
 			buttons: isDirty ? [isWorkspace ? this.dirtyRecentlyOpenedWorkspace : this.dirtyRecentlyOpenedFolder] : [this.removeFromRecentlyOpened],
 			openable,
-			resource
+			resource,
+			remoteAuthority: recent.remoteAuthority
 		};
 	}
 }

--- a/src/vs/workbench/browser/actions/windowActions.ts
+++ b/src/vs/workbench/browser/actions/windowActions.ts
@@ -18,7 +18,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { IModeService } from 'vs/editor/common/services/modeService';
-import { IRecent, isRecentFolder, isRecentWorkspace, IWorkspacesService, IWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IRecent, isRecentFolder, isRecentWorkspace, IWorkspacesService, IWorkspaceIdentifier, isFolderBackupInfo, isWorkspaceBackupInfo } from 'vs/platform/workspaces/common/workspaces';
 import { URI } from 'vs/base/common/uri';
 import { getIconClasses } from 'vs/editor/common/services/getIconClasses';
 import { FileKind } from 'vs/platform/files/common/files';
@@ -87,10 +87,10 @@ abstract class BaseOpenRecentAction extends Action2 {
 		const dirtyFolders = new ResourceMap<boolean>();
 		const dirtyWorkspaces = new ResourceMap<IWorkspaceIdentifier>();
 		for (const dirtyWorkspace of dirtyWorkspacesAndFolders) {
-			if (URI.isUri(dirtyWorkspace)) {
-				dirtyFolders.set(dirtyWorkspace, true);
+			if (isFolderBackupInfo(dirtyWorkspace)) {
+				dirtyFolders.set(dirtyWorkspace.folderUri, true);
 			} else {
-				dirtyWorkspaces.set(dirtyWorkspace.configPath, dirtyWorkspace);
+				dirtyWorkspaces.set(dirtyWorkspace.workspace.configPath, dirtyWorkspace.workspace);
 				hasWorkspaces = true;
 			}
 		}
@@ -117,10 +117,10 @@ abstract class BaseOpenRecentAction extends Action2 {
 
 		// Fill any backup workspace that is not yet shown at the end
 		for (const dirtyWorkspaceOrFolder of dirtyWorkspacesAndFolders) {
-			if (URI.isUri(dirtyWorkspaceOrFolder) && !recentFolders.has(dirtyWorkspaceOrFolder)) {
-				workspacePicks.push(this.toQuickPick(modelService, modeService, labelService, { folderUri: dirtyWorkspaceOrFolder }, true));
-			} else if (isWorkspaceIdentifier(dirtyWorkspaceOrFolder) && !recentWorkspaces.has(dirtyWorkspaceOrFolder.configPath)) {
-				workspacePicks.push(this.toQuickPick(modelService, modeService, labelService, { workspace: dirtyWorkspaceOrFolder }, true));
+			if (isFolderBackupInfo(dirtyWorkspaceOrFolder) && !recentFolders.has(dirtyWorkspaceOrFolder.folderUri)) {
+				workspacePicks.push(this.toQuickPick(modelService, modeService, labelService, dirtyWorkspaceOrFolder, true));
+			} else if (isWorkspaceBackupInfo(dirtyWorkspaceOrFolder) && !recentWorkspaces.has(dirtyWorkspaceOrFolder.workspace.configPath)) {
+				workspacePicks.push(this.toQuickPick(modelService, modeService, labelService, dirtyWorkspaceOrFolder, true));
 			}
 		}
 

--- a/src/vs/workbench/browser/actions/workspaceActions.ts
+++ b/src/vs/workbench/browser/actions/workspaceActions.ts
@@ -284,7 +284,7 @@ class DuplicateWorkspaceInNewWindowAction extends Action2 {
 		const newWorkspace = await workspacesService.createUntitledWorkspace(folders, remoteAuthority);
 		await workspaceEditingService.copyWorkspaceSettings(newWorkspace);
 
-		return hostService.openWindow([{ workspaceUri: newWorkspace.configPath }], { forceNewWindow: true });
+		return hostService.openWindow([{ workspaceUri: newWorkspace.configPath }], { forceNewWindow: true, remoteAuthority });
 	}
 }
 

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -336,7 +336,7 @@ export abstract class MenubarControl extends Disposable {
 
 			return this.hostService.openWindow([openable], {
 				forceNewWindow: !!openInNewWindow,
-				remoteAuthority
+				remoteAuthority: remoteAuthority || null // local window if remoteAuthority is not set or can not be deducted from the openable
 			});
 		});
 

--- a/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.ts
@@ -1050,7 +1050,10 @@ export class GettingStartedPage extends EditorPane {
 			link.setAttribute('aria-label', localize('welcomePage.openFolderWithPath', "Open folder {0} with path {1}", name, parentPath));
 			link.addEventListener('click', e => {
 				this.telemetryService.publicLog2<GettingStartedActionEvent, GettingStartedActionClassification>('gettingStarted.ActionExecuted', { command: 'openRecent', argument: undefined });
-				this.hostService.openWindow([windowOpenable], { forceNewWindow: e.ctrlKey || e.metaKey, remoteAuthority: recent.remoteAuthority });
+				this.hostService.openWindow([windowOpenable], {
+					forceNewWindow: e.ctrlKey || e.metaKey,
+					remoteAuthority: recent.remoteAuthority || null // local window if remoteAuthority is not set or can not be deducted from the openable
+				});
 				e.preventDefault();
 				e.stopPropagation();
 			});

--- a/src/vs/workbench/services/workspaces/browser/workspacesService.ts
+++ b/src/vs/workbench/services/workspaces/browser/workspacesService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { IWorkspacesService, IWorkspaceFolderCreationData, IWorkspaceIdentifier, IEnterWorkspaceResult, IRecentlyOpened, restoreRecentlyOpened, IRecent, isRecentFile, isRecentFolder, toStoreData, IStoredWorkspaceFolder, getStoredWorkspaceFolder, WORKSPACE_EXTENSION, IStoredWorkspace } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspacesService, IWorkspaceFolderCreationData, IWorkspaceIdentifier, IEnterWorkspaceResult, IRecentlyOpened, restoreRecentlyOpened, IRecent, isRecentFile, isRecentFolder, toStoreData, IStoredWorkspaceFolder, getStoredWorkspaceFolder, WORKSPACE_EXTENSION, IStoredWorkspace, IFolderBackupInfo, IWorkspaceBackupInfo } from 'vs/platform/workspaces/common/workspaces';
 import { URI } from 'vs/base/common/uri';
 import { Emitter } from 'vs/base/common/event';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
@@ -167,7 +167,7 @@ export class BrowserWorkspacesService extends Disposable implements IWorkspacesS
 
 	//#region Dirty Workspaces
 
-	async getDirtyWorkspaces(): Promise<Array<IWorkspaceIdentifier | URI>> {
+	async getDirtyWorkspaces(): Promise<Array<IWorkspaceBackupInfo | IFolderBackupInfo>> {
 		return []; // Currently not supported in web
 	}
 

--- a/src/vs/workbench/services/workspaces/browser/workspacesService.ts
+++ b/src/vs/workbench/services/workspaces/browser/workspacesService.ts
@@ -55,12 +55,13 @@ export class BrowserWorkspacesService extends Disposable implements IWorkspacesS
 
 	private addWorkspaceToRecentlyOpened(): void {
 		const workspace = this.workspaceService.getWorkspace();
+		const remoteAuthority = this.environmentService.remoteAuthority;
 		switch (this.workspaceService.getWorkbenchState()) {
 			case WorkbenchState.FOLDER:
-				this.addRecentlyOpened([{ folderUri: workspace.folders[0].uri }]);
+				this.addRecentlyOpened([{ folderUri: workspace.folders[0].uri, remoteAuthority }]);
 				break;
 			case WorkbenchState.WORKSPACE:
-				this.addRecentlyOpened([{ workspace: { id: workspace.id, configPath: workspace.configuration! } }]);
+				this.addRecentlyOpened([{ workspace: { id: workspace.id, configPath: workspace.configuration! }, remoteAuthority }]);
 				break;
 		}
 	}

--- a/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
@@ -125,7 +125,7 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 					await this.workspacesService.addRecentlyOpened([{
 						label: this.labelService.getWorkspaceLabel(newWorkspaceIdentifier, { verbose: true }),
 						workspace: newWorkspaceIdentifier,
-						remoteAuthority: this.environmentService.remoteAuthority
+						remoteAuthority: this.environmentService.remoteAuthority // remember whether this was a remote window
 					}]);
 
 					// Delete the untitled one

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -119,7 +119,7 @@ import { TextFileEditor } from 'vs/workbench/contrib/files/browser/editors/textF
 import { TextResourceEditorInput } from 'vs/workbench/common/editor/textResourceEditorInput';
 import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/untitledTextEditorInput';
 import { SideBySideEditor } from 'vs/workbench/browser/parts/editor/sideBySideEditor';
-import { IEnterWorkspaceResult, IRecent, IRecentlyOpened, IWorkspaceFolderCreationData, IWorkspaceIdentifier, IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
+import { IEnterWorkspaceResult, IFolderBackupInfo, IRecent, IRecentlyOpened, IWorkspaceBackupInfo, IWorkspaceFolderCreationData, IWorkspaceIdentifier, IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from 'vs/platform/workspace/common/workspaceTrust';
 import { TestWorkspaceTrustManagementService, TestWorkspaceTrustRequestService } from 'vs/workbench/services/workspaces/test/common/testWorkspaceTrustService';
 import { IExtensionTerminalProfile, IShellLaunchConfig, ITerminalProfile, TerminalLocation, TerminalShellType } from 'vs/platform/terminal/common/terminal';
@@ -1718,7 +1718,7 @@ export class TestWorkspacesService implements IWorkspacesService {
 	async removeRecentlyOpened(workspaces: URI[]): Promise<void> { }
 	async clearRecentlyOpened(): Promise<void> { }
 	async getRecentlyOpened(): Promise<IRecentlyOpened> { return { files: [], workspaces: [] }; }
-	async getDirtyWorkspaces(): Promise<(URI | IWorkspaceIdentifier)[]> { return []; }
+	async getDirtyWorkspaces(): Promise<(IFolderBackupInfo | IWorkspaceBackupInfo)[]> { return []; }
 	async enterWorkspace(path: URI): Promise<IEnterWorkspaceResult | undefined> { throw new Error('Method not implemented.'); }
 	async getWorkspaceIdentifier(workspacePath: URI): Promise<IWorkspaceIdentifier> { throw new Error('Method not implemented.'); }
 }


### PR DESCRIPTION
With virtual workspaces (e.g. remote repositories) we can't tell from the workspace URI if the workspace is opened in a local or a remote window. Although we prefer that virtual workspaces are always opened in local windows, we need to make sure to pass along the 'remoteAuthority' when persisting or opening workspaces e.g. from backup or history

The PR fixes some gaps found
- store remoteAuthority with backup also for folders (it was already the case for workspaces and empty windows)
- always pass the remote authority to addRecentlyOpened
- when opening a window from the history, use the remoteAuthority  to decide whether a remote or local window is to be opened
 
