### PR TITLE
Add `tarballProxyEndpoints` workbench option

### DIFF
--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -18,16 +18,13 @@ import { parseLineAndColumnAware } from 'vs/base/common/extpath';
 import { LogLevelToString } from 'vs/platform/log/common/log';
 import { ExtensionKind } from 'vs/platform/extensions/common/extensions';
 import { isUndefined } from 'vs/base/common/types';
-import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 
 class BrowserWorkbenchConfiguration implements IWindowConfiguration {
 
 	constructor(
 		private readonly options: IBrowserWorkbenchOptions,
 		private readonly payload: Map<string, string> | undefined
-	) {
-		CommandsRegistry.registerCommand('workbench.getTarballProxyEndpoints', () => (this.options.tarballProxyEndpoints ?? {}));
-	}
+	) { }
 
 	@memoize
 	get sessionId(): string { return generateUuid(); }

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -18,13 +18,16 @@ import { parseLineAndColumnAware } from 'vs/base/common/extpath';
 import { LogLevelToString } from 'vs/platform/log/common/log';
 import { ExtensionKind } from 'vs/platform/extensions/common/extensions';
 import { isUndefined } from 'vs/base/common/types';
+import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 
 class BrowserWorkbenchConfiguration implements IWindowConfiguration {
 
 	constructor(
 		private readonly options: IBrowserWorkbenchOptions,
 		private readonly payload: Map<string, string> | undefined
-	) { }
+	) {
+		CommandsRegistry.registerCommand('workbench.getTarballProxyEndpoints', () => (this.options.tarballProxyEndpoints ?? {}));
+	}
 
 	@memoize
 	get sessionId(): string { return generateUuid(); }

--- a/src/vs/workbench/workbench.web.api.ts
+++ b/src/vs/workbench/workbench.web.api.ts
@@ -680,6 +680,8 @@ function create(domElement: HTMLElement, options: IWorkbenchConstructionOptions)
 		}
 	}
 
+	CommandsRegistry.registerCommand('_workbench.getTarballProxyEndpoints', () => (options.tarballProxyEndpoints ?? {}));
+
 	// Startup workbench and resolve waiters
 	let instantiatedWorkbench: IWorkbench | undefined = undefined;
 	main(domElement, options).then(workbench => {

--- a/src/vs/workbench/workbench.web.api.ts
+++ b/src/vs/workbench/workbench.web.api.ts
@@ -416,7 +416,7 @@ interface IWorkbenchConstructionOptions {
 	 * [TEMPORARY]: This will be removed soon.
 	 * Endpoints to be used for proxying repository tarball download calls in the browser.
 	 */
-	readonly tarballProxyEndpoints?: { [providerId: string]: string }
+	readonly _tarballProxyEndpoints?: { [providerId: string]: string }
 
 	//#endregion
 
@@ -680,7 +680,7 @@ function create(domElement: HTMLElement, options: IWorkbenchConstructionOptions)
 		}
 	}
 
-	CommandsRegistry.registerCommand('_workbench.getTarballProxyEndpoints', () => (options.tarballProxyEndpoints ?? {}));
+	CommandsRegistry.registerCommand('_workbench.getTarballProxyEndpoints', () => (options._tarballProxyEndpoints ?? {}));
 
 	// Startup workbench and resolve waiters
 	let instantiatedWorkbench: IWorkbench | undefined = undefined;

--- a/src/vs/workbench/workbench.web.api.ts
+++ b/src/vs/workbench/workbench.web.api.ts
@@ -412,6 +412,12 @@ interface IWorkbenchConstructionOptions {
 	 */
 	readonly codeExchangeProxyEndpoints?: { [providerId: string]: string }
 
+	/**
+	 * [TEMPORARY]: This will be removed soon.
+	 * Endpoints to be used for proxying repository tarball download calls in the browser.
+	 */
+	readonly tarballProxyEndpoints?: { [providerId: string]: string }
+
 	//#endregion
 
 


### PR DESCRIPTION
As discussed @bpasero and @JacksonKearl --embedders can set `tarballProxyEndpoints` in options, and extensions can read this value using `workbench.getTarballProxyEndpoints`.

Please let me know if there is a better place to register the `workbench.getTarballProxyEndpoints` command.