### PR TITLE
Perf: Update editor configuration only after extensions are registered

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
+++ b/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
@@ -11,6 +11,7 @@ import { IConfigurationRegistry, Extensions as ConfigurationExtensions, IConfigu
 import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuration';
 import { IEditorResolverService, RegisteredEditorInfo, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 import { IJSONSchemaMap } from 'vs/base/common/jsonSchema';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 
 export class DynamicEditorGroupAutoLockConfiguration extends Disposable implements IWorkbenchContribution {
 
@@ -32,12 +33,15 @@ export class DynamicEditorGroupAutoLockConfiguration extends Disposable implemen
 	private configurationNode: IConfigurationNode | undefined;
 
 	constructor(
-		@IEditorResolverService private readonly editorResolverService: IEditorResolverService
+		@IEditorResolverService private readonly editorResolverService: IEditorResolverService,
+		@IExtensionService extensionService: IExtensionService,
 	) {
 		super();
 
-		this.updateConfiguration();
-		this.registerListeners();
+		extensionService.whenInstalledExtensionsRegistered().then(() => {
+			this.updateConfiguration();
+			this.registerListeners();
+		});
 	}
 
 	private registerListeners(): void {

--- a/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
+++ b/src/vs/workbench/browser/parts/editor/editorConfiguration.ts
@@ -38,10 +38,16 @@ export class DynamicEditorGroupAutoLockConfiguration extends Disposable implemen
 	) {
 		super();
 
-		extensionService.whenInstalledExtensionsRegistered().then(() => {
+		// Editor configurations are getting updated very aggressively
+		// (atleast 20 times) while the extensions are getting registered.
+		// As such push out the dynamic editor auto lock configuration
+		// until after extensions registered.
+		(async ()=> {
+			await extensionService.whenInstalledExtensionsRegistered();
+
 			this.updateConfiguration();
 			this.registerListeners();
-		});
+		})();
 	}
 
 	private registerListeners(): void {


### PR DESCRIPTION
Editor configurations are getting updated very aggressively (atleast 20 times) while the extensions are getting registered. This is consuming atleast 200ms. 

|          | Insiders (`0cc0904c56`)     | joh/pausedEvents [`7907361`](https://az764295.vo.msecnd.net/insider/790736142c236ffc44a65d2e0f0bad5a55aaa085/VSCode-darwin.zip)|  PR [`c4bd3f8`](https://az764295.vo.msecnd.net/insider/c4bd3f869de30a6ebb97bcc215f652ffe66a236e/VSCode-darwin.zip)|
|--------------|-----------|------------|---|
| builtin extensions | 185.6      | 71         (**-114.6ms**) | 94.5 (**-90.2ms**)|
| builtin extensions and 30 more   | 448.8 | 148.2  (**-300.6ms**) | 163.8 (**-285ms**) |

Thanks to @jrieken for comparing this change with the current insiders and also with his generic solution.

Please see https://github.com/microsoft/vscode/pull/138259 for more information and perf numbers.

This changes editor configuration to update only after extensions are registered, therefore configuration is being updated only once by this.