### PR TITLE
Removes unused field ComputedEditorOption.deps

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -843,14 +843,12 @@ abstract class ComputedEditorOption<K1 extends EditorOption, V> implements IEdit
 	public readonly id: K1;
 	public readonly name: '_never_';
 	public readonly defaultValue: V;
-	public readonly deps: EditorOption[] | null;
 	public readonly schema: IConfigurationPropertySchema | undefined = undefined;
 
-	constructor(id: K1, deps: EditorOption[] | null = null) {
+	constructor(id: K1) {
 		this.id = id;
 		this.name = '_never_';
 		this.defaultValue = <any>undefined;
-		this.deps = deps;
 	}
 
 	public validate(input: any): V {
@@ -1303,7 +1301,7 @@ function _cursorStyleFromString(cursorStyle: 'line' | 'block' | 'underline' | 'l
 class EditorClassName extends ComputedEditorOption<EditorOption.editorClassName, string> {
 
 	constructor() {
-		super(EditorOption.editorClassName, [EditorOption.mouseStyle, EditorOption.extraEditorClassName]);
+		super(EditorOption.editorClassName);
 	}
 
 	public compute(env: IEnvironmentalOptions, options: IComputedEditorOptions, _: string): string {
@@ -2031,16 +2029,7 @@ export interface IMinimapLayoutInput {
 export class EditorLayoutInfoComputer extends ComputedEditorOption<EditorOption.layoutInfo, EditorLayoutInfo> {
 
 	constructor() {
-		super(
-			EditorOption.layoutInfo,
-			[
-				EditorOption.glyphMargin, EditorOption.lineDecorationsWidth, EditorOption.folding,
-				EditorOption.minimap, EditorOption.scrollbar, EditorOption.lineNumbers,
-				EditorOption.lineNumbersMinChars, EditorOption.scrollBeyondLastLine,
-				EditorOption.wordWrap, EditorOption.wordWrapColumn, EditorOption.wordWrapOverride1, EditorOption.wordWrapOverride2,
-				EditorOption.accessibilitySupport
-			]
-		);
+		super(EditorOption.layoutInfo);
 	}
 
 	public compute(env: IEnvironmentalOptions, options: IComputedEditorOptions, _: EditorLayoutInfo): EditorLayoutInfo {
@@ -4103,7 +4092,7 @@ class SmartSelect extends BaseEditorOption<EditorOption.smartSelect, SmartSelect
 class EditorTabFocusMode extends ComputedEditorOption<EditorOption.tabFocusMode, boolean> {
 
 	constructor() {
-		super(EditorOption.tabFocusMode, [EditorOption.readOnly]);
+		super(EditorOption.tabFocusMode);
 	}
 
 	public compute(env: IEnvironmentalOptions, options: IComputedEditorOptions, _: boolean): boolean {
@@ -4161,7 +4150,7 @@ export interface EditorWrappingInfo {
 class EditorWrappingInfoComputer extends ComputedEditorOption<EditorOption.wrappingInfo, EditorWrappingInfo> {
 
 	constructor() {
-		super(EditorOption.wrappingInfo, [EditorOption.layoutInfo]);
+		super(EditorOption.wrappingInfo);
 	}
 
 	public compute(env: IEnvironmentalOptions, options: IComputedEditorOptions, _: EditorWrappingInfo): EditorWrappingInfo {


### PR DESCRIPTION
I guess this field had some purpose (probably to precisely recompute what needs to be recomputed).
But since it is not used apparently, I suggest to remove it.