### PR TITLE
when view visibility changes, don't assume the panel should be focused 

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -145,11 +145,6 @@ export class TerminalViewPane extends ViewPane {
 				} else {
 					this._onDidChangeViewWelcomeState.fire();
 				}
-				if (!this._terminalService.activeInstance?.shellLaunchConfig.extHostTerminalId) {
-					// showPanel is already called with !preserveFocus
-					// when extension host terminals are created
-					this._terminalGroupService.showPanel(true);
-				}
 
 				if (hadTerminals) {
 					this._terminalGroupService.activeGroup?.setVisible(visible);
@@ -257,6 +252,7 @@ export class TerminalViewPane extends ViewPane {
 	}
 
 	private _focus() {
+		this._terminalGroupService.showPanel(true);
 		this._terminalService.activeInstance?.focusWhenReady();
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -145,7 +145,10 @@ export class TerminalViewPane extends ViewPane {
 				} else {
 					this._onDidChangeViewWelcomeState.fire();
 				}
-
+				// we don't know here whether or not it should be focused, so
+				// defer focusing the panel to the focus() call
+				// to prevent overriding preserveFocus for extensions
+				this._terminalGroupService.showPanel(false);
 				if (hadTerminals) {
 					this._terminalGroupService.activeGroup?.setVisible(visible);
 				}

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -245,18 +245,13 @@ export class TerminalViewPane extends ViewPane {
 				// Only focus the terminal if the activeElement has not changed since focus() was called
 				// TODO hack
 				if (document.activeElement === activeElement) {
-					this._focus();
+					this._terminalGroupService.showPanel(true);
 				}
 			}));
 
 			return;
 		}
-		this._focus();
-	}
-
-	private _focus() {
 		this._terminalGroupService.showPanel(true);
-		this._terminalService.activeInstance?.focusWhenReady();
 	}
 
 	override shouldShowWelcome(): boolean {


### PR DESCRIPTION
This PR fixes #128289
