### PR TITLE
Always fire onDidChangeState when focusMode is set

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
@@ -104,10 +104,8 @@ export abstract class BaseCellViewModel extends Disposable {
 		return this._focusMode;
 	}
 	set focusMode(newMode: CellFocusMode) {
-		if (this._focusMode !== newMode) {
-			this._focusMode = newMode;
-			this._onDidChangeState.fire({ focusModeChanged: true });
-		}
+		this._focusMode = newMode;
+		this._onDidChangeState.fire({ focusModeChanged: true });
 	}
 
 	protected _textEditor?: ICodeEditor;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This puts focusMode back the way it was before. That check should be ok, but we use focusMode to show whether the editor _should_ be focused and also whether it _is_ focused.

This PR fixes #138427
