### PR TITLE
Fix uncaught exception when searching for invalid regex

### DIFF
--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -1058,7 +1058,14 @@ export class SearchModel extends Disposable {
 		this._searchResult.query = this._searchQuery;
 
 		const progressEmitter = new Emitter<void>();
-		this._replacePattern = new ReplacePattern(this.replaceString, this._searchQuery.contentPattern);
+		try {
+			this._replacePattern = new ReplacePattern(this.replaceString, this._searchQuery.contentPattern);
+		} catch (e) {
+			if (e instanceof SyntaxError) {
+				return Promise.reject(e.message);
+			}
+			throw e;
+		}
 
 		// In search on type case, delay the streaming of results just a bit, so that we don't flash the only "local results" fast path
 		this._startStreamDelay = new Promise(resolve => setTimeout(resolve, this.searchConfig.searchOnType ? 150 : 0));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #138331

Prior to this fix, the exception was uncaught and would result in the progress bar continuing until the window is reloaded.  To test, you can do a project-wide regex search for `*`.
