### PR TITLE
make sure theme is loaded when restoring it

### DIFF
--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -481,6 +481,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 				if (settingId !== this.currentColorTheme.settingsId) {
 					await this.internalSetColorTheme(theme.id, undefined);
 				} else if (theme !== this.currentColorTheme) {
+					await theme.ensureLoaded(this.extensionResourceLoaderService);
 					theme.setCustomizations(this.settings);
 					await this.applyTheme(theme, undefined, true);
 				}
@@ -656,6 +657,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 				if (settingId !== this.currentFileIconTheme.settingsId) {
 					await this.internalSetFileIconTheme(theme.id, undefined);
 				} else if (theme !== this.currentFileIconTheme) {
+					await theme.ensureLoaded(this.extensionResourceLoaderService);
 					this.applyAndSetFileIconTheme(theme, true);
 				}
 				return true;
@@ -761,6 +763,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 				if (settingId !== this.currentProductIconTheme.settingsId) {
 					await this.internalSetProductIconTheme(theme.id, undefined);
 				} else if (theme !== this.currentProductIconTheme) {
+					await theme.ensureLoaded(this.extensionResourceLoaderService, this.logService);
 					this.applyAndSetProductIconTheme(theme, true);
 				}
 				return true;


### PR DESCRIPTION
Fixes #138422

The code to restore a theme was updated last milestone to make sure we always use the themes from the registry.

What was missing is the code to ensure the theme from the registry is loaded.
