### PR TITLE
Always use a unique authority for desktop webviews too

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -95,7 +95,7 @@ namespace WebviewState {
 export class WebviewElement extends Disposable implements IWebview, WebviewFindDelegate {
 
 	public readonly id: string;
-	private readonly iframeId: string;
+	protected readonly iframeId: string;
 
 	protected get platform(): string { return 'browser'; }
 

--- a/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
@@ -91,7 +91,7 @@ export class ElectronWebviewElement extends WebviewElement {
 	}
 
 	protected override get webviewContentEndpoint(): string {
-		return `${Schemas.vscodeWebview}://${this.id}`;
+		return `${Schemas.vscodeWebview}://${this.iframeId}`;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #138409

This fix changes webviews on desktop to always use a unique authority instead of reusing the id passed in. In practice, this change should only effect internal webviews, such as those on extension pages or in getting started, since those were the only webviews that were using a hardcoded id

This aligns webviews on desktop with web.
