### PR TITLE
Adds a way for web projects which have defined their TS version to get a full tsserver

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -231,7 +231,8 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 				ClientCapability.EnhancedSyntax);
 		}
 
-		if (isWeb()) {
+		const hasNotSpecifiedATypeScriptVersion = !(this._configuration.globalTsdk || this._configuration.localTsdk);
+		if (isWeb() && hasNotSpecifiedATypeScriptVersion) {
 			return new ClientCapabilities(
 				ClientCapability.Syntax,
 				ClientCapability.EnhancedSyntax);


### PR DESCRIPTION
This PR relies on #138211 - the central idea is that if you have set a ts sdk locally in your web project (instead of the default build) then you know what you're doing enough to get the full-fat TSServer implementation.