### PR TITLE
Codicon registry cleanup

### DIFF
--- a/src/vs/base/browser/ui/codicons/codicon/codicon.css
+++ b/src/vs/base/browser/ui/codicons/codicon/codicon.css
@@ -22,4 +22,4 @@
 	-ms-user-select: none;
 }
 
-/* icon rules are dynamically created in codiconStyles */
+/* icon rules are dynamically created by the platform theme service (see iconsStyleSheet.ts) */

--- a/src/vs/base/common/codicons.ts
+++ b/src/vs/base/common/codicons.ts
@@ -402,6 +402,7 @@ export class Codicon implements CSSIcon {
 	public static readonly starHalf = new Codicon('star-half', { fontCharacter: '\\eb5a' });
 	public static readonly symbolClass = new Codicon('symbol-class', { fontCharacter: '\\eb5b' });
 	public static readonly symbolColor = new Codicon('symbol-color', { fontCharacter: '\\eb5c' });
+	public static readonly symbolCustomColor = new Codicon('symbol-customcolor', { fontCharacter: '\\eb5c' });
 	public static readonly symbolConstant = new Codicon('symbol-constant', { fontCharacter: '\\eb5d' });
 	public static readonly symbolEnumMember = new Codicon('symbol-enum-member', { fontCharacter: '\\eb5e' });
 	public static readonly symbolField = new Codicon('symbol-field', { fontCharacter: '\\eb5f' });

--- a/src/vs/base/common/codicons.ts
+++ b/src/vs/base/common/codicons.ts
@@ -25,8 +25,8 @@ export function getCodiconAriaLabel(text: string | undefined) {
  * The Codicon library is a set of default icons that are built-in in VS Code.
  *
  * In the product (outside of base) Codicons should only be used as defaults. In order to have all icons in VS Code
- * themeable, component should ise define new, component specific icons using `iconRegistry.registerIcon`.
- * In that call a Codicon can be names as default.
+ * themeable, component should define new, UI component specific icons using `iconRegistry.registerIcon`.
+ * In that call a Codicon can be named as default.
  */
 export class Codicon implements CSSIcon {
 
@@ -42,7 +42,7 @@ export class Codicon implements CSSIcon {
 	private static _allCodicons : Codicon[] = [];
 
 	/**
-	 * @returns Returns all Codicons. Only to be used by the icon registry in platform.
+	 * @returns Returns all default icons covered by the codicon font. Only to be used by the icon registry in platform.
 	 */
 	public static getAll() : readonly Codicon[] {
 		return Codicon._allCodicons;

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -18,7 +18,7 @@ import { LanguageFeatureRegistry } from 'vs/editor/common/modes/languageFeatureR
 import { TokenizationRegistryImpl } from 'vs/editor/common/modes/tokenizationRegistry';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IMarkerData } from 'vs/platform/markers/common/markers';
-import { iconRegistry, Codicon, CSSIcon } from 'vs/base/common/codicons';
+import { Codicon, CSSIcon } from 'vs/base/common/codicons';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 /**
  * Open ended enum at runtime
@@ -371,94 +371,102 @@ export const enum CompletionItemKind {
 /**
  * @internal
  */
-export const completionKindToCssClass = (function () {
-	let data = Object.create(null);
-	data[CompletionItemKind.Method] = 'symbol-method';
-	data[CompletionItemKind.Function] = 'symbol-function';
-	data[CompletionItemKind.Constructor] = 'symbol-constructor';
-	data[CompletionItemKind.Field] = 'symbol-field';
-	data[CompletionItemKind.Variable] = 'symbol-variable';
-	data[CompletionItemKind.Class] = 'symbol-class';
-	data[CompletionItemKind.Struct] = 'symbol-struct';
-	data[CompletionItemKind.Interface] = 'symbol-interface';
-	data[CompletionItemKind.Module] = 'symbol-module';
-	data[CompletionItemKind.Property] = 'symbol-property';
-	data[CompletionItemKind.Event] = 'symbol-event';
-	data[CompletionItemKind.Operator] = 'symbol-operator';
-	data[CompletionItemKind.Unit] = 'symbol-unit';
-	data[CompletionItemKind.Value] = 'symbol-value';
-	data[CompletionItemKind.Constant] = 'symbol-constant';
-	data[CompletionItemKind.Enum] = 'symbol-enum';
-	data[CompletionItemKind.EnumMember] = 'symbol-enum-member';
-	data[CompletionItemKind.Keyword] = 'symbol-keyword';
-	data[CompletionItemKind.Snippet] = 'symbol-snippet';
-	data[CompletionItemKind.Text] = 'symbol-text';
-	data[CompletionItemKind.Color] = 'symbol-color';
-	data[CompletionItemKind.File] = 'symbol-file';
-	data[CompletionItemKind.Reference] = 'symbol-reference';
-	data[CompletionItemKind.Customcolor] = 'symbol-customcolor';
-	data[CompletionItemKind.Folder] = 'symbol-folder';
-	data[CompletionItemKind.TypeParameter] = 'symbol-type-parameter';
-	data[CompletionItemKind.User] = 'account';
-	data[CompletionItemKind.Issue] = 'issues';
+export namespace CompletionItemKinds {
 
-	return function (kind: CompletionItemKind): string {
-		const name = data[kind];
-		let codicon = name && iconRegistry.get(name);
+	const byKind = new Map<CompletionItemKind, CSSIcon>();
+	byKind.set(CompletionItemKind.Method, Codicon.symbolMethod);
+	byKind.set(CompletionItemKind.Function, Codicon.symbolFunction);
+	byKind.set(CompletionItemKind.Constructor, Codicon.symbolConstructor);
+	byKind.set(CompletionItemKind.Field, Codicon.symbolField);
+	byKind.set(CompletionItemKind.Variable, Codicon.symbolVariable);
+	byKind.set(CompletionItemKind.Class, Codicon.symbolClass);
+	byKind.set(CompletionItemKind.Struct, Codicon.symbolStruct);
+	byKind.set(CompletionItemKind.Interface, Codicon.symbolInterface);
+	byKind.set(CompletionItemKind.Module, Codicon.symbolModule);
+	byKind.set(CompletionItemKind.Property, Codicon.symbolProperty);
+	byKind.set(CompletionItemKind.Event, Codicon.symbolEvent);
+	byKind.set(CompletionItemKind.Operator, Codicon.symbolOperator);
+	byKind.set(CompletionItemKind.Unit, Codicon.symbolUnit);
+	byKind.set(CompletionItemKind.Value, Codicon.symbolValue);
+	byKind.set(CompletionItemKind.Enum, Codicon.symbolEnum);
+	byKind.set(CompletionItemKind.Constant, Codicon.symbolConstant);
+	byKind.set(CompletionItemKind.Enum, Codicon.symbolEnum);
+	byKind.set(CompletionItemKind.EnumMember, Codicon.symbolEnumMember);
+	byKind.set(CompletionItemKind.Keyword, Codicon.symbolKeyword);
+	byKind.set(CompletionItemKind.Snippet, Codicon.symbolSnippet);
+	byKind.set(CompletionItemKind.Text, Codicon.symbolText);
+	byKind.set(CompletionItemKind.Color, Codicon.symbolColor);
+	byKind.set(CompletionItemKind.File, Codicon.symbolFile);
+	byKind.set(CompletionItemKind.Reference, Codicon.symbolReference);
+	byKind.set(CompletionItemKind.Customcolor, Codicon.symbolCustomColor);
+	byKind.set(CompletionItemKind.Folder, Codicon.symbolFolder);
+	byKind.set(CompletionItemKind.TypeParameter, Codicon.symbolTypeParameter);
+	byKind.set(CompletionItemKind.User, Codicon.account);
+	byKind.set(CompletionItemKind.Issue, Codicon.issues);
+
+	/**
+	 * @internal
+	 */
+	export function toIcon(kind: CompletionItemKind): CSSIcon {
+		let codicon = byKind.get(kind);
 		if (!codicon) {
 			console.info('No codicon found for CompletionItemKind ' + kind);
 			codicon = Codicon.symbolProperty;
 		}
-		return codicon.classNames;
-	};
-})();
+		return codicon;
+	}
 
-/**
- * @internal
- */
-export let completionKindFromString: {
-	(value: string): CompletionItemKind;
-	(value: string, strict: true): CompletionItemKind | undefined;
-} = (function () {
-	let data: Record<string, CompletionItemKind> = Object.create(null);
-	data['method'] = CompletionItemKind.Method;
-	data['function'] = CompletionItemKind.Function;
-	data['constructor'] = <any>CompletionItemKind.Constructor;
-	data['field'] = CompletionItemKind.Field;
-	data['variable'] = CompletionItemKind.Variable;
-	data['class'] = CompletionItemKind.Class;
-	data['struct'] = CompletionItemKind.Struct;
-	data['interface'] = CompletionItemKind.Interface;
-	data['module'] = CompletionItemKind.Module;
-	data['property'] = CompletionItemKind.Property;
-	data['event'] = CompletionItemKind.Event;
-	data['operator'] = CompletionItemKind.Operator;
-	data['unit'] = CompletionItemKind.Unit;
-	data['value'] = CompletionItemKind.Value;
-	data['constant'] = CompletionItemKind.Constant;
-	data['enum'] = CompletionItemKind.Enum;
-	data['enum-member'] = CompletionItemKind.EnumMember;
-	data['enumMember'] = CompletionItemKind.EnumMember;
-	data['keyword'] = CompletionItemKind.Keyword;
-	data['snippet'] = CompletionItemKind.Snippet;
-	data['text'] = CompletionItemKind.Text;
-	data['color'] = CompletionItemKind.Color;
-	data['file'] = CompletionItemKind.File;
-	data['reference'] = CompletionItemKind.Reference;
-	data['customcolor'] = CompletionItemKind.Customcolor;
-	data['folder'] = CompletionItemKind.Folder;
-	data['type-parameter'] = CompletionItemKind.TypeParameter;
-	data['typeParameter'] = CompletionItemKind.TypeParameter;
-	data['account'] = CompletionItemKind.User;
-	data['issue'] = CompletionItemKind.Issue;
-	return function (value: string, strict?: true) {
-		let res = data[value];
+	const data = new Map<string, CompletionItemKind>();
+	data.set('method', CompletionItemKind.Method);
+	data.set('function', CompletionItemKind.Function);
+	data.set('constructor', <any>CompletionItemKind.Constructor);
+	data.set('field', CompletionItemKind.Field);
+	data.set('variable', CompletionItemKind.Variable);
+	data.set('class', CompletionItemKind.Class);
+	data.set('struct', CompletionItemKind.Struct);
+	data.set('interface', CompletionItemKind.Interface);
+	data.set('module', CompletionItemKind.Module);
+	data.set('property', CompletionItemKind.Property);
+	data.set('event', CompletionItemKind.Event);
+	data.set('operator', CompletionItemKind.Operator);
+	data.set('unit', CompletionItemKind.Unit);
+	data.set('value', CompletionItemKind.Value);
+	data.set('constant', CompletionItemKind.Constant);
+	data.set('enum', CompletionItemKind.Enum);
+	data.set('enum-member', CompletionItemKind.EnumMember);
+	data.set('enumMember', CompletionItemKind.EnumMember);
+	data.set('keyword', CompletionItemKind.Keyword);
+	data.set('snippet', CompletionItemKind.Snippet);
+	data.set('text', CompletionItemKind.Text);
+	data.set('color', CompletionItemKind.Color);
+	data.set('file', CompletionItemKind.File);
+	data.set('reference', CompletionItemKind.Reference);
+	data.set('customcolor', CompletionItemKind.Customcolor);
+	data.set('folder', CompletionItemKind.Folder);
+	data.set('type-parameter', CompletionItemKind.TypeParameter);
+	data.set('typeParameter', CompletionItemKind.TypeParameter);
+	data.set('account', CompletionItemKind.User);
+	data.set('issue', CompletionItemKind.Issue);
+
+	/**
+	 * @internal
+	 */
+	export function fromString(value: string): CompletionItemKind;
+	/**
+	 * @internal
+	 */
+	export function fromString(value: string, strict: true): CompletionItemKind | undefined;
+	/**
+	 * @internal
+	 */
+	export function fromString(value: string, strict?: boolean): CompletionItemKind | undefined {
+		let res = data.get(value);
 		if (typeof res === 'undefined' && !strict) {
 			res = CompletionItemKind.Property;
 		}
 		return res;
-	};
-})();
+	}
+}
 
 export interface CompletionItemLabel {
 	label: string;

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -18,7 +18,7 @@ import { LanguageFeatureRegistry } from 'vs/editor/common/modes/languageFeatureR
 import { TokenizationRegistryImpl } from 'vs/editor/common/modes/tokenizationRegistry';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IMarkerData } from 'vs/platform/markers/common/markers';
-import { iconRegistry, Codicon } from 'vs/base/common/codicons';
+import { iconRegistry, Codicon, CSSIcon } from 'vs/base/common/codicons';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 /**
  * Open ended enum at runtime
@@ -1103,84 +1103,43 @@ export const enum SymbolTag {
  */
 export namespace SymbolKinds {
 
-	const byName = new Map<string, SymbolKind>();
-	byName.set('file', SymbolKind.File);
-	byName.set('module', SymbolKind.Module);
-	byName.set('namespace', SymbolKind.Namespace);
-	byName.set('package', SymbolKind.Package);
-	byName.set('class', SymbolKind.Class);
-	byName.set('method', SymbolKind.Method);
-	byName.set('property', SymbolKind.Property);
-	byName.set('field', SymbolKind.Field);
-	byName.set('constructor', SymbolKind.Constructor);
-	byName.set('enum', SymbolKind.Enum);
-	byName.set('interface', SymbolKind.Interface);
-	byName.set('function', SymbolKind.Function);
-	byName.set('variable', SymbolKind.Variable);
-	byName.set('constant', SymbolKind.Constant);
-	byName.set('string', SymbolKind.String);
-	byName.set('number', SymbolKind.Number);
-	byName.set('boolean', SymbolKind.Boolean);
-	byName.set('array', SymbolKind.Array);
-	byName.set('object', SymbolKind.Object);
-	byName.set('key', SymbolKind.Key);
-	byName.set('null', SymbolKind.Null);
-	byName.set('enum-member', SymbolKind.EnumMember);
-	byName.set('struct', SymbolKind.Struct);
-	byName.set('event', SymbolKind.Event);
-	byName.set('operator', SymbolKind.Operator);
-	byName.set('type-parameter', SymbolKind.TypeParameter);
-
-	const byKind = new Map<SymbolKind, string>();
-	byKind.set(SymbolKind.File, 'file');
-	byKind.set(SymbolKind.Module, 'module');
-	byKind.set(SymbolKind.Namespace, 'namespace');
-	byKind.set(SymbolKind.Package, 'package');
-	byKind.set(SymbolKind.Class, 'class');
-	byKind.set(SymbolKind.Method, 'method');
-	byKind.set(SymbolKind.Property, 'property');
-	byKind.set(SymbolKind.Field, 'field');
-	byKind.set(SymbolKind.Constructor, 'constructor');
-	byKind.set(SymbolKind.Enum, 'enum');
-	byKind.set(SymbolKind.Interface, 'interface');
-	byKind.set(SymbolKind.Function, 'function');
-	byKind.set(SymbolKind.Variable, 'variable');
-	byKind.set(SymbolKind.Constant, 'constant');
-	byKind.set(SymbolKind.String, 'string');
-	byKind.set(SymbolKind.Number, 'number');
-	byKind.set(SymbolKind.Boolean, 'boolean');
-	byKind.set(SymbolKind.Array, 'array');
-	byKind.set(SymbolKind.Object, 'object');
-	byKind.set(SymbolKind.Key, 'key');
-	byKind.set(SymbolKind.Null, 'null');
-	byKind.set(SymbolKind.EnumMember, 'enum-member');
-	byKind.set(SymbolKind.Struct, 'struct');
-	byKind.set(SymbolKind.Event, 'event');
-	byKind.set(SymbolKind.Operator, 'operator');
-	byKind.set(SymbolKind.TypeParameter, 'type-parameter');
+	const byKind = new Map<SymbolKind, CSSIcon>();
+	byKind.set(SymbolKind.File, Codicon.symbolFile);
+	byKind.set(SymbolKind.Module, Codicon.symbolModule);
+	byKind.set(SymbolKind.Namespace, Codicon.symbolNamespace);
+	byKind.set(SymbolKind.Package, Codicon.symbolPackage);
+	byKind.set(SymbolKind.Class, Codicon.symbolClass);
+	byKind.set(SymbolKind.Method, Codicon.symbolMethod);
+	byKind.set(SymbolKind.Property, Codicon.symbolProperty);
+	byKind.set(SymbolKind.Field, Codicon.symbolField);
+	byKind.set(SymbolKind.Constructor, Codicon.symbolConstructor);
+	byKind.set(SymbolKind.Enum, Codicon.symbolEnum);
+	byKind.set(SymbolKind.Interface, Codicon.symbolInterface);
+	byKind.set(SymbolKind.Function, Codicon.symbolFunction);
+	byKind.set(SymbolKind.Variable, Codicon.symbolVariable);
+	byKind.set(SymbolKind.Constant, Codicon.symbolConstant);
+	byKind.set(SymbolKind.String, Codicon.symbolString);
+	byKind.set(SymbolKind.Number, Codicon.symbolNumber);
+	byKind.set(SymbolKind.Boolean, Codicon.symbolBoolean);
+	byKind.set(SymbolKind.Array, Codicon.symbolArray);
+	byKind.set(SymbolKind.Object, Codicon.symbolObject);
+	byKind.set(SymbolKind.Key, Codicon.symbolKey);
+	byKind.set(SymbolKind.Null, Codicon.symbolNull);
+	byKind.set(SymbolKind.EnumMember, Codicon.symbolEnumMember);
+	byKind.set(SymbolKind.Struct, Codicon.symbolStruct);
+	byKind.set(SymbolKind.Event, Codicon.symbolEvent);
+	byKind.set(SymbolKind.Operator, Codicon.symbolOperator);
+	byKind.set(SymbolKind.TypeParameter, Codicon.symbolTypeParameter);
 	/**
 	 * @internal
 	 */
-	export function fromString(value: string): SymbolKind | undefined {
-		return byName.get(value);
-	}
-	/**
-	 * @internal
-	 */
-	export function toString(kind: SymbolKind): string | undefined {
-		return byKind.get(kind);
-	}
-	/**
-	 * @internal
-	 */
-	export function toCssClassName(kind: SymbolKind, inline?: boolean): string {
-		const symbolName = byKind.get(kind);
-		let codicon = symbolName && iconRegistry.get('symbol-' + symbolName);
-		if (!codicon) {
+	export function toIcon(kind: SymbolKind): CSSIcon {
+		let icon = byKind.get(kind);
+		if (!icon) {
 			console.info('No codicon found for SymbolKind ' + kind);
-			codicon = Codicon.symbolProperty;
+			icon = Codicon.symbolProperty;
 		}
-		return `${inline ? 'inline' : 'block'} ${codicon.classNames}`;
+		return icon;
 	}
 }
 

--- a/src/vs/editor/contrib/quickAccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/gotoSymbolQuickAccess.ts
@@ -235,7 +235,7 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 			const symbol = symbols[index];
 
 			const symbolLabel = trim(symbol.name);
-			const symbolLabelWithIcon = `$(symbol-${SymbolKinds.toString(symbol.kind) || 'property'}) ${symbolLabel}`;
+			const symbolLabelWithIcon = `$(${SymbolKinds.toIcon(symbol.kind).id}) ${symbolLabel}`;
 			const symbolLabelIconOffset = symbolLabelWithIcon.length - symbolLabel.length;
 
 			let containerLabel = symbol.containerName;

--- a/src/vs/editor/contrib/suggest/suggestMemory.ts
+++ b/src/vs/editor/contrib/suggest/suggestMemory.ts
@@ -9,7 +9,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { LRUCache, TernarySearchTree } from 'vs/base/common/map';
 import { IPosition } from 'vs/editor/common/core/position';
 import { ITextModel } from 'vs/editor/common/model';
-import { CompletionItemKind, completionKindFromString } from 'vs/editor/common/modes';
+import { CompletionItemKind, CompletionItemKinds } from 'vs/editor/common/modes';
 import { CompletionItem } from 'vs/editor/contrib/suggest/suggest';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
@@ -138,7 +138,7 @@ export class LRUMemory extends Memory {
 		let seq = 0;
 		for (const [key, value] of data) {
 			value.touch = seq;
-			value.type = typeof value.type === 'number' ? value.type : completionKindFromString(value.type);
+			value.type = typeof value.type === 'number' ? value.type : CompletionItemKinds.fromString(value.type);
 			this._cache.set(key, value);
 		}
 		this._seq = this._cache.size;
@@ -206,7 +206,7 @@ export class PrefixMemory extends Memory {
 		if (data.length > 0) {
 			this._seq = data[0][1].touch + 1;
 			for (const [key, value] of data) {
-				value.type = typeof value.type === 'number' ? value.type : completionKindFromString(value.type);
+				value.type = typeof value.type === 'number' ? value.type : CompletionItemKinds.fromString(value.type);
 				this._trie.set(key, value);
 			}
 		}

--- a/src/vs/editor/contrib/suggest/suggestWidgetRenderer.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidgetRenderer.ts
@@ -8,14 +8,14 @@ import { $, append, hide, show } from 'vs/base/browser/dom';
 import { IconLabel, IIconLabelValueOptions } from 'vs/base/browser/ui/iconLabel/iconLabel';
 import { IListRenderer } from 'vs/base/browser/ui/list/list';
 import { flatten } from 'vs/base/common/arrays';
-import { Codicon } from 'vs/base/common/codicons';
+import { Codicon, CSSIcon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
 import { createMatches } from 'vs/base/common/filters';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorOption, EDITOR_FONT_DEFAULTS } from 'vs/editor/common/config/editorOptions';
-import { CompletionItemKind, CompletionItemTag, completionKindToCssClass } from 'vs/editor/common/modes';
+import { CompletionItemKind, CompletionItemKinds, CompletionItemTag } from 'vs/editor/common/modes';
 import { getIconClasses } from 'vs/editor/common/services/getIconClasses';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { ILanguageService } from 'vs/editor/common/services/languageService';
@@ -198,7 +198,7 @@ export class ItemRenderer implements IListRenderer<CompletionItem, ISuggestionTe
 			// normal icon
 			data.icon.className = 'icon hide';
 			data.iconContainer.className = '';
-			data.iconContainer.classList.add('suggest-icon', ...completionKindToCssClass(completion.kind).split(' '));
+			data.iconContainer.classList.add('suggest-icon', ...CSSIcon.asClassNameArray(CompletionItemKinds.toIcon(completion.kind)));
 		}
 
 		if (completion.tags && completion.tags.indexOf(CompletionItemTag.Deprecated) >= 0) {

--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { iconRegistry } from 'vs/base/common/codicons';
+import { Codicon } from 'vs/base/common/codicons';
 import { IJSONSchema, IJSONSchemaMap } from 'vs/base/common/jsonSchema';
 import { OperatingSystem } from 'vs/base/common/platform';
 import { localize } from 'vs/nls';
@@ -27,8 +27,8 @@ const terminalProfileBaseProperties: IJSONSchemaMap = {
 	icon: {
 		description: localize('terminalProfile.icon', 'A codicon ID to associate with this terminal.'),
 		type: 'string',
-		enum: Array.from(iconRegistry.all, icon => icon.id),
-		markdownEnumDescriptions: Array.from(iconRegistry.all, icon => `$(${icon.id})`),
+		enum: Array.from(Codicon.getAll(), icon => icon.id),
+		markdownEnumDescriptions: Array.from(Codicon.getAll(), icon => `$(${icon.id})`),
 	},
 	color: {
 		description: localize('terminalProfile.color', 'A theme color ID to associate with this terminal.'),

--- a/src/vs/platform/theme/browser/iconsStyleSheet.ts
+++ b/src/vs/platform/theme/browser/iconsStyleSheet.ts
@@ -6,7 +6,6 @@
 import { asCSSPropertyValue, asCSSUrl } from 'vs/base/browser/dom';
 import { Emitter, Event } from 'vs/base/common/event';
 import { getIconRegistry, IconContribution, IconFontContribution } from 'vs/platform/theme/common/iconRegistry';
-import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 
 
 export interface IIconsStyleSheet {
@@ -24,13 +23,9 @@ export function getIconsStyleSheet(): IIconsStyleSheet {
 		getCSS() {
 			const usedFontIds: { [id: string]: IconFontContribution } = {};
 			const formatIconRule = (contribution: IconContribution): string | undefined => {
-				let definition = contribution.defaults;
-				while (ThemeIcon.isThemeIcon(definition)) {
-					const c = iconRegistry.getIcon(definition.id);
-					if (!c) {
-						return undefined;
-					}
-					definition = c.defaults;
+				const definition = IconContribution.getDefinition(contribution, iconRegistry);
+				if (!definition) {
+					return undefined;
 				}
 				const fontId = definition.fontId;
 				if (fontId) {

--- a/src/vs/platform/theme/common/iconRegistry.ts
+++ b/src/vs/platform/theme/common/iconRegistry.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RunOnceScheduler } from 'vs/base/common/async';
-import * as Codicons from 'vs/base/common/codicons';
+import { Codicon, CSSIcon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
 import { IJSONSchema, IJSONSchemaMap } from 'vs/base/common/jsonSchema';
 import { URI } from 'vs/base/common/uri';
@@ -138,7 +138,7 @@ class IconRegistry implements IIconRegistry {
 		type: 'object',
 		properties: {}
 	};
-	private iconReferenceSchema: IJSONSchema & { enum: string[], enumDescriptions: string[] } = { type: 'string', pattern: `^${Codicons.CSSIcon.iconNameExpression}$`, enum: [], enumDescriptions: [] };
+	private iconReferenceSchema: IJSONSchema & { enum: string[], enumDescriptions: string[] } = { type: 'string', pattern: `^${CSSIcon.iconNameExpression}$`, enum: [], enumDescriptions: [] };
 
 	private iconFontsById: { [key: string]: IconFontContribution };
 
@@ -275,10 +275,9 @@ export function getIconRegistry(): IIconRegistry {
 }
 
 function initialize() {
-	for (const icon of Codicons.iconRegistry.all) {
+	for (const icon of Codicon.getAll()) {
 		iconRegistry.registerIcon(icon.id, icon.definition, icon.description);
 	}
-	Codicons.iconRegistry.onDidRegister(icon => iconRegistry.registerIcon(icon.id, icon.definition, icon.description));
 }
 initialize();
 
@@ -300,10 +299,10 @@ iconRegistry.onDidChange(() => {
 
 // common icons
 
-export const widgetClose = registerIcon('widget-close', Codicons.Codicon.close, localize('widgetClose', 'Icon for the close action in widgets.'));
+export const widgetClose = registerIcon('widget-close', Codicon.close, localize('widgetClose', 'Icon for the close action in widgets.'));
 
-export const gotoPreviousLocation = registerIcon('goto-previous-location', Codicons.Codicon.arrowUp, localize('previousChangeIcon', 'Icon for goto previous editor location.'));
-export const gotoNextLocation = registerIcon('goto-next-location', Codicons.Codicon.arrowDown, localize('nextChangeIcon', 'Icon for goto next editor location.'));
+export const gotoPreviousLocation = registerIcon('goto-previous-location', Codicon.arrowUp, localize('previousChangeIcon', 'Icon for goto previous editor location.'));
+export const gotoNextLocation = registerIcon('goto-next-location', Codicon.arrowDown, localize('nextChangeIcon', 'Icon for goto next editor location.'));
 
-export const syncing = ThemeIcon.modify(Codicons.Codicon.sync, 'spin');
-export const spinningLoading = ThemeIcon.modify(Codicons.Codicon.loading, 'spin');
+export const syncing = ThemeIcon.modify(Codicon.sync, 'spin');
+export const spinningLoading = ThemeIcon.modify(Codicon.loading, 'spin');

--- a/src/vs/platform/theme/common/iconRegistry.ts
+++ b/src/vs/platform/theme/common/iconRegistry.ts
@@ -27,6 +27,20 @@ export interface IconDefinition {
 	fontCharacter: string;
 }
 
+export namespace IconContribution {
+	export function getDefinition(contribution: IconContribution, registry: IIconRegistry): IconDefinition | undefined {
+		let definition = contribution.defaults;
+		while (ThemeIcon.isThemeIcon(definition)) {
+			const c = iconRegistry.getIcon(definition.id);
+			if (!c) {
+				return undefined;
+			}
+			definition = c.defaults;
+		}
+		return definition;
+	}
+}
+
 export interface IconContribution {
 	id: string;
 	description: string | undefined;

--- a/src/vs/platform/theme/common/themeService.ts
+++ b/src/vs/platform/theme/common/themeService.ts
@@ -51,6 +51,10 @@ export namespace ThemeIcon {
 		return { id: name };
 	}
 
+	export function fromId(id: string) : ThemeIcon {
+		return { id };
+	}
+
 	export function modify(icon: ThemeIcon, modifier: 'disabled' | 'spin' | undefined): ThemeIcon {
 		let id = icon.id;
 		const tildeIndex = id.lastIndexOf('~');

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -41,13 +41,13 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { Schemas } from 'vs/base/common/network';
 import { withNullAsUndefined } from 'vs/base/common/types';
-import { Codicon, iconRegistry } from 'vs/base/common/codicons';
+import { Codicon } from 'vs/base/common/codicons';
 import { getVirtualWorkspaceLocation } from 'vs/platform/remote/common/remoteHosts';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { DropdownMenuActionViewItem } from 'vs/base/browser/ui/dropdown/dropdownActionViewItem';
 import { AnchorAlignment } from 'vs/base/browser/ui/contextview/contextview';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
+import { getIconRegistry, registerIcon } from 'vs/platform/theme/common/iconRegistry';
 
 const layoutControlIcon = registerIcon('layout-control', Codicon.layout, localize('layoutControlIcon', "Icon for the layout control menu found in the title bar."));
 
@@ -380,13 +380,10 @@ export class TitlebarPart extends Part implements ITitleService {
 			if (isWeb) {
 				const homeIndicator = this.environmentService.options?.homeIndicator;
 				if (homeIndicator) {
-					let codicon = iconRegistry.get(homeIndicator.icon);
-					if (!codicon) {
-						codicon = Codicon.code;
-					}
+					const icon: ThemeIcon = getIconRegistry().getIcon(homeIndicator.icon) ? { id: homeIndicator.icon } : Codicon.code;
 
 					this.appIcon.setAttribute('href', homeIndicator.href);
-					this.appIcon.classList.add(...codicon.classNamesArray);
+					this.appIcon.classList.add(...ThemeIcon.asClassNameArray(icon));
 					this.appIconBadge = document.createElement('div');
 					this.appIconBadge.classList.add('home-bar-icon-badge');
 					this.appIcon.appendChild(this.appIconBadge);

--- a/src/vs/workbench/contrib/callHierarchy/browser/callHierarchyTree.ts
+++ b/src/vs/workbench/contrib/callHierarchy/browser/callHierarchyTree.ts
@@ -14,6 +14,7 @@ import { compare } from 'vs/base/common/strings';
 import { Range } from 'vs/editor/common/core/range';
 import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
 import { localize } from 'vs/nls';
+import { CSSIcon } from 'vs/base/common/codicons';
 
 export class Call {
 	constructor(
@@ -118,7 +119,7 @@ export class CallRenderer implements ITreeRenderer<Call, FuzzyScore, CallRenderi
 	renderElement(node: ITreeNode<Call, FuzzyScore>, _index: number, template: CallRenderingTemplate): void {
 		const { element, filterData } = node;
 		const deprecated = element.item.tags?.includes(SymbolTag.Deprecated);
-		template.icon.className = SymbolKinds.toCssClassName(element.item.kind, true);
+		template.icon.classList.add('inline', ...CSSIcon.asClassNameArray(SymbolKinds.toIcon(element.item.kind)));
 		template.label.setLabel(
 			element.item.name,
 			element.item.detail,

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
@@ -23,6 +23,7 @@ import { IdleValue } from 'vs/base/common/async';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfigurationService';
 import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
 import { IOutlineComparator, OutlineConfigKeys } from 'vs/workbench/services/outline/browser/outline';
+import { CSSIcon } from 'vs/base/common/codicons';
 
 export type DocumentSymbolItem = OutlineGroup | OutlineElement;
 
@@ -141,7 +142,7 @@ export class DocumentSymbolRenderer implements ITreeRenderer<OutlineElement, Fuz
 		if (this._configurationService.getValue(OutlineConfigKeys.icons)) {
 			// add styles for the icons
 			template.iconClass.className = '';
-			template.iconClass.classList.add(`outline-element-icon`, ...SymbolKinds.toCssClassName(element.symbol.kind, true).split(' '));
+			template.iconClass.classList.add('outline-element-icon', 'inline', ...CSSIcon.asClassNameArray(SymbolKinds.toIcon(element.symbol.kind)));
 		}
 		if (element.symbol.tags.indexOf(SymbolTag.Deprecated) >= 0) {
 			options.extraClasses!.push(`deprecated`);

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -30,7 +30,7 @@ import { Range } from 'vs/editor/common/core/range';
 import { IDecorationOptions } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { ITextModel } from 'vs/editor/common/model';
-import { CompletionContext, CompletionItem, CompletionItemInsertTextRule, CompletionItemKind, completionKindFromString, CompletionList, CompletionProviderRegistry } from 'vs/editor/common/modes';
+import { CompletionContext, CompletionItem, CompletionItemInsertTextRule, CompletionItemKind, CompletionItemKinds, CompletionList, CompletionProviderRegistry } from 'vs/editor/common/modes';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
 import { SuggestController } from 'vs/editor/contrib/suggest/suggestController';
@@ -252,7 +252,7 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 										suggestions.push({
 											label: item.label,
 											insertText,
-											kind: completionKindFromString(item.type || 'property'),
+											kind: CompletionItemKinds.fromString(item.type || 'property'),
 											filterText: (item.start && item.length) ? text.substr(item.start, item.length).concat(item.label) : undefined,
 											range: computeRange(item.length || overwriteBefore),
 											sortText: item.sortText,

--- a/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
@@ -129,7 +129,7 @@ export class SymbolsQuickAccessProvider extends PickerQuickAccessProvider<ISymbo
 			}
 
 			const symbolLabel = symbol.name;
-			const symbolLabelWithIcon = `$(symbol-${SymbolKinds.toString(symbol.kind) || 'property'}) ${symbolLabel}`;
+			const symbolLabelWithIcon = `$(${SymbolKinds.toIcon(symbol.kind).id}) ${symbolLabel}`;
 			const symbolLabelIconOffset = symbolLabelWithIcon.length - symbolLabel.length;
 
 			// Score by symbol label if searching
@@ -279,8 +279,8 @@ export class SymbolsQuickAccessProvider extends PickerQuickAccessProvider<ISymbo
 
 		// By kind
 		if (symbolA.symbol && symbolB.symbol) {
-			const symbolAKind = SymbolKinds.toCssClassName(symbolA.symbol.kind);
-			const symbolBKind = SymbolKinds.toCssClassName(symbolB.symbol.kind);
+			const symbolAKind = SymbolKinds.toIcon(symbolA.symbol.kind).id;
+			const symbolBKind = SymbolKinds.toIcon(symbolB.symbol.kind).id;
 			return symbolAKind.localeCompare(symbolBKind);
 		}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalIcon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalIcon.ts
@@ -3,10 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Codicon, iconRegistry } from 'vs/base/common/codicons';
+import { Codicon } from 'vs/base/common/codicons';
 import { hash } from 'vs/base/common/hash';
 import { URI } from 'vs/base/common/uri';
 import { IExtensionTerminalProfile, ITerminalProfile } from 'vs/platform/terminal/common/terminal';
+import { getIconRegistry } from 'vs/platform/theme/common/iconRegistry';
 import { ColorScheme } from 'vs/platform/theme/common/theme';
 import { IColorTheme, ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { ITerminalInstance } from 'vs/workbench/contrib/terminal/browser/terminal';
@@ -94,7 +95,7 @@ export function getUriClasses(terminal: ITerminalInstance | IExtensionTerminalPr
 	let uri = undefined;
 
 	if (extensionContributed) {
-		if (typeof icon === 'string' && (icon.startsWith('$(') || iconRegistry.get(icon))) {
+		if (typeof icon === 'string' && (icon.startsWith('$(') || getIconRegistry().getIcon(icon))) {
 			return iconClasses;
 		} else if (typeof icon === 'string') {
 			uri = URI.parse(icon);

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1798,15 +1798,16 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	}
 
 	async changeIcon() {
-		const items: IQuickPickItem[] = [];
+		type Item = IQuickPickItem & { icon: TerminalIcon };
+		const items: Item[] = [];
 		for (const icon of iconRegistry.all) {
-			items.push({ label: `$(${icon.id})`, description: `${icon.id}` });
+			items.push({ label: `$(${icon.id})`, description: `${icon.id}`, icon });
 		}
 		const result = await this._quickInputService.pick(items, {
 			matchOnDescription: true
 		});
-		if (result && result.description) {
-			this._icon = iconRegistry.get(result.description);
+		if (result) {
+			this._icon = result.icon;
 			this._onIconChanged.fire(this);
 		}
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -42,7 +42,7 @@ import { IProcessDataEvent, IShellLaunchConfig, ITerminalDimensionsOverride, ITe
 import { IProductService } from 'vs/platform/product/common/productService';
 import { formatMessageForTerminal } from 'vs/workbench/contrib/terminal/common/terminalStrings';
 import { AutoOpenBarrier, Promises } from 'vs/base/common/async';
-import { Codicon, iconRegistry } from 'vs/base/common/codicons';
+import { Codicon } from 'vs/base/common/codicons';
 import { ITerminalStatusList, TerminalStatus, TerminalStatusList } from 'vs/workbench/contrib/terminal/browser/terminalStatusList';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
@@ -1800,7 +1800,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	async changeIcon() {
 		type Item = IQuickPickItem & { icon: TerminalIcon };
 		const items: Item[] = [];
-		for (const icon of iconRegistry.all) {
+		for (const icon of Codicon.getAll()) {
 			items.push({ label: `$(${icon.id})`, description: `${icon.id}`, icon });
 		}
 		const result = await this._quickInputService.pick(items, {

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { iconRegistry, Codicon } from 'vs/base/common/codicons';
+import { Codicon } from 'vs/base/common/codicons';
 import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IQuickInputService, IKeyMods, IPickOptions, IQuickPickSeparator, IQuickInputButton, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { IExtensionTerminalProfile, ITerminalProfile, ITerminalProfileObject, TerminalSettingPrefix } from 'vs/platform/terminal/common/terminal';
@@ -14,6 +14,7 @@ import { IThemeService, ThemeIcon } from 'vs/platform/theme/common/themeService'
 import { ITerminalProfileService } from 'vs/workbench/contrib/terminal/common/terminal';
 import { IQuickPickTerminalObject, ITerminalInstance } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
+import { getIconRegistry } from 'vs/platform/theme/common/iconRegistry';
 
 
 type DefaultProfileName = string;
@@ -144,10 +145,17 @@ export class TerminalProfileQuickpick {
 		quickPickItems.push({ type: 'separator', label: nls.localize('ICreateContributedTerminalProfileOptions', "contributed") });
 		const contributedProfiles: IProfileQuickPickItem[] = [];
 		for (const contributed of this._terminalProfileService.contributedProfiles) {
-			if (typeof contributed.icon === 'string' && contributed.icon.startsWith('$(')) {
-				contributed.icon = contributed.icon.substring(2, contributed.icon.length - 1);
+			let icon: ThemeIcon | undefined;
+			if (typeof contributed.icon === 'string') {
+				if (contributed.icon.startsWith('$(')) {
+					icon = ThemeIcon.fromString(contributed.icon);
+				} else {
+					icon = ThemeIcon.fromId(contributed.icon);
+				}
 			}
-			const icon = contributed.icon && typeof contributed.icon === 'string' ? (iconRegistry.get(contributed.icon) || Codicon.terminal) : Codicon.terminal;
+			if (!icon || !getIconRegistry().getIcon(icon.id)) {
+				icon = Codicon.terminal;
+			}
 			const uriClasses = getUriClasses(contributed, this._themeService.getColorTheme().type, true);
 			const colorClass = getColorClass(contributed);
 			const iconClasses = [];

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -15,7 +15,7 @@ import { IProcessEnvironment, OperatingSystem, OS } from 'vs/base/common/platfor
 import { IShellLaunchConfig, ITerminalProfile, ITerminalProfileObject, TerminalIcon, TerminalSettingId, TerminalSettingPrefix } from 'vs/platform/terminal/common/terminal';
 import { IShellLaunchConfigResolveOptions, ITerminalProfileResolverService, ITerminalProfileService } from 'vs/workbench/contrib/terminal/common/terminal';
 import * as path from 'vs/base/common/path';
-import { Codicon, iconRegistry } from 'vs/base/common/codicons';
+import { Codicon } from 'vs/base/common/codicons';
 import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService';
 import { debounce } from 'vs/base/common/decorators';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
@@ -172,7 +172,7 @@ export abstract class BaseTerminalProfileResolverService implements ITerminalPro
 			return undefined;
 		}
 		if (typeof icon === 'string') {
-			return iconRegistry.get(icon);
+			return ThemeIcon.fromId(icon);
 		}
 		if (ThemeIcon.isThemeIcon(icon)) {
 			return icon;

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -5,7 +5,6 @@
 
 import * as dom from 'vs/base/browser/dom';
 import { timeout } from 'vs/base/common/async';
-import { Codicon, iconRegistry } from 'vs/base/common/codicons';
 import { debounce } from 'vs/base/common/decorators';
 import { Emitter, Event } from 'vs/base/common/event';
 import { dispose, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
@@ -20,7 +19,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ICreateContributedTerminalProfileOptions, IShellLaunchConfig, ITerminalLaunchError, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, TerminalLocation, TerminalLocationString } from 'vs/platform/terminal/common/terminal';
 import { iconForeground } from 'vs/platform/theme/common/colorRegistry';
-import { IconDefinition } from 'vs/platform/theme/common/iconRegistry';
+import { getIconRegistry, IconContribution } from 'vs/platform/theme/common/iconRegistry';
 import { ColorScheme } from 'vs/platform/theme/common/theme';
 import { IThemeService, Themable, ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { VirtualWorkspaceContext } from 'vs/workbench/browser/contextkeys';
@@ -1126,16 +1125,16 @@ class TerminalEditorStyle extends Themable {
 				);
 			}
 			if (ThemeIcon.isThemeIcon(icon)) {
-				const codicon = iconRegistry.get(icon.id);
-				if (codicon) {
-					let def: Codicon | IconDefinition = codicon;
-					while ('definition' in def) {
-						def = def.definition;
+				const iconRegistry = getIconRegistry();
+				const iconContribution = iconRegistry.getIcon(icon.id);
+				if (iconContribution) {
+					const def = IconContribution.getDefinition(iconContribution, iconRegistry);
+					if (def) {
+						css += (
+							`.monaco-workbench .terminal-tab.codicon-${icon.id}::before` +
+							`{content: '${def.fontCharacter}' !important; font-family: ${dom.asCSSPropertyValue(def.fontId ?? 'codicon')} !important;}`
+						);
 					}
-					css += (
-						`.monaco-workbench .terminal-tab.codicon-${icon.id}::before` +
-						`{content: '${def.fontCharacter}' !important;}`
-					);
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/typeHierarchy/browser/typeHierarchyTree.ts
+++ b/src/vs/workbench/contrib/typeHierarchy/browser/typeHierarchyTree.ts
@@ -14,6 +14,7 @@ import { compare } from 'vs/base/common/strings';
 import { Range } from 'vs/editor/common/core/range';
 import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
 import { localize } from 'vs/nls';
+import { CSSIcon } from 'vs/base/common/codicons';
 
 export class Type {
 	constructor(
@@ -114,7 +115,7 @@ export class TypeRenderer implements ITreeRenderer<Type, FuzzyScore, TypeRenderi
 	renderElement(node: ITreeNode<Type, FuzzyScore>, _index: number, template: TypeRenderingTemplate): void {
 		const { element, filterData } = node;
 		const deprecated = element.item.tags?.includes(SymbolTag.Deprecated);
-		template.icon.className = SymbolKinds.toCssClassName(element.item.kind, true);
+		template.icon.classList.add('inline', ...CSSIcon.asClassNameArray(SymbolKinds.toIcon(element.item.kind)));
 		template.label.setLabel(
 			element.item.name,
 			element.item.detail,

--- a/src/vs/workbench/contrib/welcome/banner/browser/welcomeBanner.contribution.ts
+++ b/src/vs/workbench/contrib/welcome/banner/browser/welcomeBanner.contribution.ts
@@ -7,10 +7,10 @@ import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
 import { IBannerService } from 'vs/workbench/services/banner/browser/bannerService';
-import { Codicon, iconRegistry } from 'vs/base/common/codicons';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { URI } from 'vs/base/common/uri';
+import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 
 class WelcomeBannerContribution {
 
@@ -30,9 +30,9 @@ class WelcomeBannerContribution {
 			return; // welcome banner dismissed
 		}
 
-		let icon: Codicon | URI | undefined = undefined;
+		let icon: ThemeIcon | URI | undefined = undefined;
 		if (typeof welcomeBanner.icon === 'string') {
-			icon = iconRegistry.get(welcomeBanner.icon);
+			icon = ThemeIcon.fromId(welcomeBanner.icon);
 		} else if (welcomeBanner.icon) {
 			icon = URI.revive(welcomeBanner.icon);
 		}


### PR DESCRIPTION
The codicon registry is only to be used by the platfoms icon registry.

UI component must only use the platfoms icon registry. The platfoms icon registry allows all icons (including the ones from the codicon font) to be themes by product icon themes.

