### PR TITLE
Add extension information to snippet picker

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -164,14 +164,14 @@ class InsertSnippetAction extends EditorAction {
 					detail: snippet.description,
 					snippet
 				};
-				if (!prevSnippet || prevSnippet.snippetSource !== snippet.snippetSource) {
+				{
 					let label = '';
 					switch (snippet.snippetSource) {
 						case SnippetSource.User:
 							label = nls.localize('sep.userSnippet', "User Snippets");
 							break;
 						case SnippetSource.Extension:
-							label = nls.localize('sep.extSnippet', "Extension Snippets");
+							label = nls.localize('sep.extSnippet', "Extension Snippets (extension: {0})", snippet.source);
 							break;
 						case SnippetSource.Workspace:
 							label = nls.localize('sep.workspaceSnippet', "Workspace Snippets");

--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -171,7 +171,7 @@ class InsertSnippetAction extends EditorAction {
 							label = nls.localize('sep.userSnippet', "User Snippets");
 							break;
 						case SnippetSource.Extension:
-							label = nls.localize('sep.extSnippet', "Extension: {0}", snippet.source);
+							label = nls.localize('sep.extSnippet', "{0}", snippet.source);
 							break;
 						case SnippetSource.Workspace:
 							label = nls.localize('sep.workspaceSnippet', "Workspace Snippets");

--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -164,14 +164,14 @@ class InsertSnippetAction extends EditorAction {
 					detail: snippet.description,
 					snippet
 				};
-				{
+				if (!prevSnippet || prevSnippet.snippetSource !== snippet.snippetSource || prevSnippet.source !== snippet.source) {
 					let label = '';
 					switch (snippet.snippetSource) {
 						case SnippetSource.User:
 							label = nls.localize('sep.userSnippet', "User Snippets");
 							break;
 						case SnippetSource.Extension:
-							label = nls.localize('sep.extSnippet', "Extension Snippets (extension: {0})", snippet.source);
+							label = nls.localize('sep.extSnippet', "Extension: {0}", snippet.source);
 							break;
 						case SnippetSource.Workspace:
 							label = nls.localize('sep.workspaceSnippet', "Workspace Snippets");
@@ -179,6 +179,8 @@ class InsertSnippetAction extends EditorAction {
 					}
 					result.push({ type: 'separator', label });
 				}
+
+
 
 				if (snippet.snippetSource === SnippetSource.Extension) {
 					const isEnabled = snippetService.isEnabled(snippet);

--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -171,7 +171,7 @@ class InsertSnippetAction extends EditorAction {
 							label = nls.localize('sep.userSnippet', "User Snippets");
 							break;
 						case SnippetSource.Extension:
-							label = nls.localize('sep.extSnippet', "{0}", snippet.source);
+							label = snippet.source;
 							break;
 						case SnippetSource.Workspace:
 							label = nls.localize('sep.workspaceSnippet', "Workspace Snippets");
@@ -179,8 +179,6 @@ class InsertSnippetAction extends EditorAction {
 					}
 					result.push({ type: 'separator', label });
 				}
-
-
 
 				if (snippet.snippetSource === SnippetSource.Extension) {
 					const isEnabled = snippetService.isEnabled(snippet);

--- a/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
@@ -112,6 +112,10 @@ export class Snippet {
 			return -1;
 		} else if (a.snippetSource > b.snippetSource) {
 			return 1;
+		} else if (a.source < b.source) {
+			return -1;
+		} else if (a.source > b.source) {
+			return 1;
 		} else if (a.name > b.name) {
 			return 1;
 		} else if (a.name < b.name) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #138105.

To test this:
* Launch VSCode and open 'Insert Snippet' from the Command Palette
* Depending on installed extensions/language of the open file, you should see some snippets from installed extensions (example: 
<img width="604" alt="Screen Shot 2021-12-10 at 14 13 35" src="https://user-images.githubusercontent.com/12522122/145631118-55cff284-8241-4bc0-9c9c-aa8f33a4e72f.png">)
