### PR TITLE
Fix wrong relative line numbering (#138787)

### DIFF
--- a/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
+++ b/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
@@ -113,7 +113,8 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 		}
 
 		if (this._renderLineNumbers === RenderLineNumbersType.Relative) {
-			const diff = Math.abs(this._lastCursorModelPosition.lineNumber - modelLineNumber);
+			const lastCursorViewPosition = this._context.model.coordinatesConverter.convertModelPositionToViewPosition(this._lastCursorModelPosition);
+			const diff = Math.abs(lastCursorViewPosition.lineNumber - viewLineNumber);
 			if (diff === 0) {
 				return '<span class="relative-current-line-number">' + modelLineNumber + '</span>';
 			}


### PR DESCRIPTION
Calculate the relative line difference using view positions instead of model positions to prevent the inclusion of folded lines.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## Before
![example](https://user-images.githubusercontent.com/44070188/145656481-9cf93617-40d4-4680-befe-fd20d60c8604.png)
## After
![example3](https://user-images.githubusercontent.com/44070188/145656951-88ef8152-8e9e-458c-8451-46e262ba1943.png)

