### PR TITLE
fix generates different html content for the same markdown when get the cached token

### DIFF
--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -164,6 +164,7 @@ export class MarkdownEngine {
 	): Token[] {
 		const cached = this._tokenCache.tryGetCached(document, config);
 		if (cached) {
+			this.resetSlugCount();
 			return cached;
 		}
 
@@ -173,9 +174,13 @@ export class MarkdownEngine {
 	}
 
 	private tokenizeString(text: string, engine: MarkdownIt) {
-		this._slugCount = new Map<string, number>();
+		this.resetSlugCount();
 
 		return engine.parse(text.replace(UNICODE_NEWLINE_REGEX, ''), {});
+	}
+	
+	public resetSlugCount(): void {
+		this._slugCount = new Map<string, number>();
 	}
 
 	public async render(input: SkinnyTextDocument | string, resourceProvider?: WebviewResourceProvider): Promise<RenderOutput> {


### PR DESCRIPTION
fix generates different html content for the same markdown when get the cached token

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #

Hi,I found start from the second time calling render, the id for the Introduction will appended by a number:

Markdown:
```
[abc](#abc)
# abc
```

first calling after is correct:

```
<h1 data-line="4" class="code-line" id="abc">abc</h1>
```

but second calling after, an error is beginning to occur:

```
<h1 data-line="4" class="code-line" id="abc-1">abc</h1>
```

Steps to Reproduce:
1. Click the "Open preview to the side" button
2. Switch back to md
3. Click the "Open preview to the side" button again, and Click on the link titled "abc". The expected behavior is for the preview window to scroll down to the header titled "abc". It does not.

i fond this pr :microsoft#47537 so the number is to resolve differentiate same header, but In the case of a hit cache, it's wrong

i find other pr:https://github.com/microsoft/vscode/commit/f732547a3d548a640e5120eca4bfb59cbedc3c48#diff-0cd672777508d358387063c50187200e7192fdd34946ae7c5a02b5430935d253
look like the same thing
