### PR TITLE
WIP: fix: editor mouseout will hide hover widget

### DIFF
--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -87,7 +87,14 @@ export class ModesHoverController implements IEditorContribution {
 			this._toUnhook.add(this._editor.onKeyDown((e: IKeyboardEvent) => this._onKeyDown(e)));
 		}
 
-		this._toUnhook.add(this._editor.onMouseLeave(hideWidgetsEventHandler));
+		this._toUnhook.add(this._editor.onMouseLeave((e) => {
+			const targetEm = (e.event.browserEvent.relatedTarget) as HTMLElement;
+			if (this._contentWidget?.getDomNode()?.contains(targetEm)) {
+				// when the mouse is inside hoverWidget
+				return;
+			}
+			hideWidgetsEventHandler();
+		}));
 		this._toUnhook.add(this._editor.onDidChangeModel(hideWidgetsEventHandler));
 		this._toUnhook.add(this._editor.onDidScrollChange((e: IScrollEvent) => this._onEditorScrollChanged(e)));
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
- https://github.com/microsoft/monaco-editor/issues/2156

The hover listens to mouse events from the editor
and since it is now rooted via overflowWidgetsDomNode outside the editor
it does not receive the editor mouse events anymore.
