### PR TITLE
Restrict vscode-file requests to main window

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -178,7 +178,7 @@ export class CodeApplication extends Disposable {
 			}
 
 			for (const window of this.windowsMainService.getWindows()) {
-				if (window.win && details.frame.routingId === window.win.webContents.mainFrame.routingId) {
+				if (window.win && details.frame.processId === window.win.webContents.mainFrame.processId) {
 					return true;
 				}
 			}

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -173,12 +173,15 @@ export class CodeApplication extends Disposable {
 		};
 
 		const isAllowedVsCodeFileRequest = (details: Electron.OnBeforeRequestListenerDetails) => {
-			if (!details.frame || !this.windowsMainService) {
+			const frame = details.frame;
+			if (!frame || !this.windowsMainService) {
 				return false;
 			}
 
-			for (const window of this.windowsMainService.getWindows()) {
-				if (window.win && details.frame.processId === window.win.webContents.mainFrame.processId) {
+			// Check to see if the request comes from one of the main windows (or shared process) and not from embedded content
+			const windows = BrowserWindow.getAllWindows();
+			for (const window of windows) {
+				if (frame.processId === window.webContents.mainFrame.processId) {
 					return true;
 				}
 			}

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -153,6 +153,87 @@ export class CodeApplication extends Disposable {
 
 		//#endregion
 
+		//#region Request filtering
+
+		// Block all SVG requests from unsupported origins
+		const supportedSvgSchemes = new Set([Schemas.file, Schemas.vscodeFileResource, Schemas.vscodeRemoteResource, 'devtools']);
+
+		// But allow them if the are made from inside an webview
+		const isSafeFrame = (requestFrame: WebFrameMain | undefined): boolean => {
+			for (let frame: WebFrameMain | null | undefined = requestFrame; frame; frame = frame.parent) {
+				if (frame.url.startsWith(`${Schemas.vscodeWebview}://`)) {
+					return true;
+				}
+			}
+			return false;
+		};
+
+		const isSvgRequestFromSafeContext = (details: Electron.OnBeforeRequestListenerDetails | Electron.OnHeadersReceivedListenerDetails): boolean => {
+			return details.resourceType === 'xhr' || isSafeFrame(details.frame);
+		};
+
+		const isAllowedVsCodeFileRequest = (details: Electron.OnBeforeRequestListenerDetails) => {
+			if (!details.frame || !this.windowsMainService) {
+				return false;
+			}
+
+			for (const window of this.windowsMainService.getWindows()) {
+				if (window.win && details.frame.routingId === window.win.webContents.mainFrame.routingId) {
+					return true;
+				}
+			}
+
+			return false;
+		};
+
+		session.defaultSession.webRequest.onBeforeRequest((details, callback) => {
+			const uri = URI.parse(details.url);
+
+			if (uri.scheme === Schemas.vscodeFileResource) {
+				if (!isAllowedVsCodeFileRequest(details)) {
+					this.logService.error('Blocked vscode-file request', details.url);
+					return callback({ cancel: true });
+				}
+			}
+
+			// Block most svgs
+			if (uri.path.endsWith('.svg')) {
+				const isSafeResourceUrl = supportedSvgSchemes.has(uri.scheme);
+				if (!isSafeResourceUrl) {
+					return callback({ cancel: !isSvgRequestFromSafeContext(details) });
+				}
+			}
+
+			return callback({ cancel: false });
+		});
+
+		// Configure SVG header content type properly
+		// https://github.com/microsoft/vscode/issues/97564
+		session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+			const responseHeaders = details.responseHeaders as Record<string, (string) | (string[])>;
+			const contentTypes = (responseHeaders['content-type'] || responseHeaders['Content-Type']);
+
+			if (contentTypes && Array.isArray(contentTypes)) {
+				const uri = URI.parse(details.url);
+				if (uri.path.endsWith('.svg')) {
+					if (supportedSvgSchemes.has(uri.scheme)) {
+						responseHeaders['Content-Type'] = ['image/svg+xml'];
+
+						return callback({ cancel: false, responseHeaders });
+					}
+				}
+
+				// remote extension schemes have the following format
+				// http://127.0.0.1:<port>/vscode-remote-resource?path=
+				if (!uri.path.includes(Schemas.vscodeRemoteResource) && contentTypes.some(contentType => contentType.toLowerCase().includes('image/svg'))) {
+					return callback({ cancel: !isSvgRequestFromSafeContext(details) });
+				}
+			}
+
+			return callback({ cancel: false });
+		});
+
+		//#endregion
 
 		//#region Code Cache
 
@@ -404,8 +485,6 @@ export class CodeApplication extends Disposable {
 		// Setup Auth Handler
 		this._register(appInstantiationService.createInstance(ProxyAuthHandler));
 
-		this.registerWebRequestFilter();
-
 		// Init Channels
 		appInstantiationService.invokeFunction(accessor => this.initChannels(accessor, mainProcessElectronServer, sharedProcessClient));
 
@@ -419,91 +498,6 @@ export class CodeApplication extends Disposable {
 		if (this.environmentMainService.args.trace) {
 			appInstantiationService.invokeFunction(accessor => this.stopTracingEventually(accessor, windows));
 		}
-	}
-
-	/**
-	 * Add filtering of web requests.
-	 */
-	private registerWebRequestFilter() {
-		const { defaultSession } = session;
-
-		// Block all SVG requests from unsupported origins
-		const supportedSvgSchemes = new Set([Schemas.file, Schemas.vscodeFileResource, Schemas.vscodeRemoteResource, 'devtools']);
-
-		// But allow them if the are made from inside an webview
-		const isSafeFrame = (requestFrame: WebFrameMain | undefined): boolean => {
-			for (let frame: WebFrameMain | null | undefined = requestFrame; frame; frame = frame.parent) {
-				if (frame.url.startsWith(`${Schemas.vscodeWebview}://`)) {
-					return true;
-				}
-			}
-			return false;
-		};
-
-		const isSvgRequestFromSafeContext = (details: Electron.OnBeforeRequestListenerDetails | Electron.OnHeadersReceivedListenerDetails): boolean => {
-			return details.resourceType === 'xhr' || isSafeFrame(details.frame);
-		};
-
-		const isAllowedVsCodeFileRequest = (details: Electron.OnBeforeRequestListenerDetails) => {
-			if (!details.frame || !this.windowsMainService) {
-				return false;
-			}
-
-			for (const window of this.windowsMainService.getWindows()) {
-				if (window.win && details.frame.routingId === window.win.webContents.mainFrame.routingId) {
-					return true;
-				}
-			}
-
-			return false;
-		};
-
-		defaultSession.webRequest.onBeforeRequest((details, callback) => {
-			const uri = URI.parse(details.url);
-
-			if (uri.scheme === Schemas.vscodeFileResource) {
-				if (!isAllowedVsCodeFileRequest(details)) {
-					this.logService.error('Blocked vscode-file request', details.url);
-					return callback({ cancel: true });
-				}
-			}
-
-			// Block most svgs
-			if (uri.path.endsWith('.svg')) {
-				const isSafeResourceUrl = supportedSvgSchemes.has(uri.scheme);
-				if (!isSafeResourceUrl) {
-					return callback({ cancel: !isSvgRequestFromSafeContext(details) });
-				}
-			}
-
-			return callback({ cancel: false });
-		});
-
-		// Configure SVG header content type properly
-		// https://github.com/microsoft/vscode/issues/97564
-		defaultSession.webRequest.onHeadersReceived((details, callback) => {
-			const responseHeaders = details.responseHeaders as Record<string, (string) | (string[])>;
-			const contentTypes = (responseHeaders['content-type'] || responseHeaders['Content-Type']);
-
-			if (contentTypes && Array.isArray(contentTypes)) {
-				const uri = URI.parse(details.url);
-				if (uri.path.endsWith('.svg')) {
-					if (supportedSvgSchemes.has(uri.scheme)) {
-						responseHeaders['Content-Type'] = ['image/svg+xml'];
-
-						return callback({ cancel: false, responseHeaders });
-					}
-				}
-
-				// remote extension schemes have the following format
-				// http://127.0.0.1:<port>/vscode-remote-resource?path=
-				if (!uri.path.includes(Schemas.vscodeRemoteResource) && contentTypes.some(contentType => contentType.toLowerCase().includes('image/svg'))) {
-					return callback({ cancel: !isSvgRequestFromSafeContext(details) });
-				}
-			}
-
-			return callback({ cancel: false });
-		});
 	}
 
 	private async resolveMachineId(): Promise<string> {

--- a/src/vs/platform/windows/electron-main/window.ts
+++ b/src/vs/platform/windows/electron-main/window.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { app, BrowserWindow, BrowserWindowConstructorOptions, Display, Event, nativeImage, NativeImage, Rectangle, screen, SegmentedControlSegment, systemPreferences, TouchBar, TouchBarSegmentedControl, WebFrameMain } from 'electron';
+import { app, BrowserWindow, BrowserWindowConstructorOptions, Display, Event, nativeImage, NativeImage, Rectangle, screen, SegmentedControlSegment, systemPreferences, TouchBar, TouchBarSegmentedControl } from 'electron';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
@@ -426,61 +426,6 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 			this._onDidClose.fire();
 
 			this.dispose();
-		});
-
-		// Block all SVG requests from unsupported origins
-		const supportedSvgSchemes = new Set([Schemas.file, Schemas.vscodeFileResource, Schemas.vscodeRemoteResource, 'devtools']);
-
-		// But allow them if the are made from inside an webview
-		const isSafeFrame = (requestFrame: WebFrameMain | undefined): boolean => {
-			for (let frame: WebFrameMain | null | undefined = requestFrame; frame; frame = frame.parent) {
-				if (frame.url.startsWith(`${Schemas.vscodeWebview}://`)) {
-					return true;
-				}
-			}
-			return false;
-		};
-
-		const isRequestFromSafeContext = (details: Electron.OnBeforeRequestListenerDetails | Electron.OnHeadersReceivedListenerDetails): boolean => {
-			return details.resourceType === 'xhr' || isSafeFrame(details.frame);
-		};
-
-		this._win.webContents.session.webRequest.onBeforeRequest((details, callback) => {
-			const uri = URI.parse(details.url);
-			if (uri.path.endsWith('.svg')) {
-				const isSafeResourceUrl = supportedSvgSchemes.has(uri.scheme);
-				if (!isSafeResourceUrl) {
-					return callback({ cancel: !isRequestFromSafeContext(details) });
-				}
-			}
-
-			return callback({ cancel: false });
-		});
-
-		// Configure SVG header content type properly
-		// https://github.com/microsoft/vscode/issues/97564
-		this._win.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-			const responseHeaders = details.responseHeaders as Record<string, (string) | (string[])>;
-			const contentTypes = (responseHeaders['content-type'] || responseHeaders['Content-Type']);
-
-			if (contentTypes && Array.isArray(contentTypes)) {
-				const uri = URI.parse(details.url);
-				if (uri.path.endsWith('.svg')) {
-					if (supportedSvgSchemes.has(uri.scheme)) {
-						responseHeaders['Content-Type'] = ['image/svg+xml'];
-
-						return callback({ cancel: false, responseHeaders });
-					}
-				}
-
-				// remote extension schemes have the following format
-				// http://127.0.0.1:<port>/vscode-remote-resource?path=
-				if (!uri.path.includes(Schemas.vscodeRemoteResource) && contentTypes.some(contentType => contentType.toLowerCase().includes('image/svg'))) {
-					return callback({ cancel: !isRequestFromSafeContext(details) });
-				}
-			}
-
-			return callback({ cancel: false });
 		});
 
 		// Remember that we loaded


### PR DESCRIPTION
This change tries to limit use of the `vscode-file` protocol to the main window.

