### PR TITLE
Transfer webview resource buffers

### DIFF
--- a/src/vs/base/common/stream.ts
+++ b/src/vs/base/common/stream.ts
@@ -159,8 +159,8 @@ export function isReadableBufferedStream<T>(obj: unknown): obj is ReadableBuffer
 	return isReadableStream(candidate.stream) && Array.isArray(candidate.buffer) && typeof candidate.ended === 'boolean';
 }
 
-export interface IReducer<T> {
-	(data: T[]): T;
+export interface IReducer<T, R = T> {
+	(data: T[]): R;
 }
 
 export interface IDataTransformer<Original, Transformed> {
@@ -504,9 +504,9 @@ export function peekReadable<T>(readable: Readable<T>, reducer: IReducer<T>, max
  * a stream fully, awaiting all the events without caring
  * about the data.
  */
-export function consumeStream<T>(stream: ReadableStreamEvents<T>, reducer: IReducer<T>): Promise<T>;
+export function consumeStream<T, R = T>(stream: ReadableStreamEvents<T>, reducer: IReducer<T, R>): Promise<R>;
 export function consumeStream(stream: ReadableStreamEvents<unknown>): Promise<undefined>;
-export function consumeStream<T>(stream: ReadableStreamEvents<T>, reducer?: IReducer<T>): Promise<T | undefined> {
+export function consumeStream<T, R = T>(stream: ReadableStreamEvents<T>, reducer?: IReducer<T, R>): Promise<R | undefined> {
 	return new Promise((resolve, reject) => {
 		const chunks: T[] = [];
 

--- a/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Delayer } from 'vs/base/common/async';
+import { VSBuffer, VSBufferReadableStream } from 'vs/base/common/buffer';
 import { Schemas } from 'vs/base/common/network';
+import { consumeStream } from 'vs/base/common/stream';
 import { ProxyChannel } from 'vs/base/parts/ipc/common/ipc';
 import { IMenuService } from 'vs/platform/actions/common/actions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -16,8 +18,8 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { INativeHostService } from 'vs/platform/native/electron-sandbox/native';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
-import { ITunnelService } from 'vs/platform/tunnel/common/tunnel';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { ITunnelService } from 'vs/platform/tunnel/common/tunnel';
 import { FindInFrameOptions, IWebviewManagerService } from 'vs/platform/webview/common/webviewManagerService';
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
 import { WebviewContentOptions, WebviewExtensionDescription, WebviewOptions } from 'vs/workbench/contrib/webview/browser/webview';
@@ -92,6 +94,22 @@ export class ElectronWebviewElement extends WebviewElement {
 
 	protected override get webviewContentEndpoint(): string {
 		return `${Schemas.vscodeWebview}://${this.iframeId}`;
+	}
+
+	protected override streamToBuffer(stream: VSBufferReadableStream): Promise<ArrayBufferLike> {
+		// Join buffers from stream without using the Node.js backing pool.
+		// This lets us transfer the buffer to the webview.
+		return consumeStream<VSBuffer, ArrayBufferLike>(stream, (buffers: readonly VSBuffer[]) => {
+			const totalLength = buffers.reduce((prev, curr) => prev + curr.byteLength, 0);
+			const ret = Buffer.alloc(totalLength);
+			let offset = 0;
+			for (let i = 0, len = buffers.length; i < len; i++) {
+				const element = buffers[i];
+				ret.set(element.buffer, offset);
+				offset += element.byteLength;
+			}
+			return ret.buffer;
+		});
 	}
 
 	/**

--- a/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
@@ -98,17 +98,17 @@ export class ElectronWebviewElement extends WebviewElement {
 
 	protected override streamToBuffer(stream: VSBufferReadableStream): Promise<ArrayBufferLike> {
 		// Join buffers from stream without using the Node.js backing pool.
-		// This lets us transfer the buffer to the webview.
+		// This lets us transfer the resulting buffer to the webview.
 		return consumeStream<VSBuffer, ArrayBufferLike>(stream, (buffers: readonly VSBuffer[]) => {
 			const totalLength = buffers.reduce((prev, curr) => prev + curr.byteLength, 0);
-			const ret = Buffer.alloc(totalLength);
+			const ret = new ArrayBuffer(totalLength);
+			const view = new Uint8Array(ret);
 			let offset = 0;
-			for (let i = 0, len = buffers.length; i < len; i++) {
-				const element = buffers[i];
-				ret.set(element.buffer, offset);
+			for (const element of buffers) {
+				view.set(element.buffer, offset);
 				offset += element.byteLength;
 			}
-			return ret.buffer;
+			return ret;
 		});
 	}
 


### PR DESCRIPTION
Transfer the underlying buffer of a webview resource load to avoid an extra data copy. This improves performance. The perf improvement is small for normal requests, but becomes more signficant the larger the resource becomes

To support this, I needed to expose a new option that forces VSBuffer to use `UInt8Array` instead of a Node buffer. In my testing, trying to transfer a node Buffer ends up breaking our general ipc buffers and breaks the entire app. Not sure if there's a better way to do this

