### PR TITLE
Use markdown renderer for text/latex

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -46,7 +46,8 @@
         "displayName": "Markdown it renderer",
         "entrypoint": "./notebook-out/index.js",
         "mimeTypes": [
-          "text/markdown"
+          "text/markdown",
+          "text/latex"
         ]
       }
     ],

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -600,7 +600,6 @@ const _mimeTypeInfo = new Map<string, MimeTypeInfo>([
 	['image/git', { alwaysSecure: true, supportedByCore: true }],
 	['image/svg+xml', { supportedByCore: true }],
 	['application/json', { alwaysSecure: true, supportedByCore: true }],
-	[Mimes.latex, { alwaysSecure: true, supportedByCore: true }],
 	[Mimes.text, { alwaysSecure: true, supportedByCore: true }],
 	['text/html', { supportedByCore: true }],
 	['text/x-javascript', { alwaysSecure: true, supportedByCore: true }], // secure because rendered as text, not executed


### PR DESCRIPTION
Fixes #123144

Uses the standard markdown renderer for `text/latex` outputs. This enables support for python outputs such as:

```python
%%latex
Given : $\pi = 3.14$ , $\alpha = \frac{3\pi}{4}\, rad$
```

Using the markdown renderer probably isn't strictly correct, but the latex output's syntax matches what we already support for MD (it's a little odd to me that it's not just a raw equation but I don't use latex in notebooks so  🤷 )