### PR TITLE
hasCustomMarkdownPreview disables markdown preview buttons in context menus

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -126,14 +126,14 @@
       "explorer/context": [
         {
           "command": "markdown.showPreview",
-          "when": "resourceLangId == markdown",
+          "when": "resourceLangId == markdown && !hasCustomMarkdownPreview",
           "group": "navigation"
         }
       ],
       "editor/title/context": [
         {
           "command": "markdown.showPreview",
-          "when": "resourceLangId == markdown",
+          "when": "resourceLangId == markdown && !hasCustomMarkdownPreview",
           "group": "1_open"
         }
       ],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #139240.
