### PR TITLE
Spawn EH process with --expose-gc when in extension tests.

### DIFF
--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -255,6 +255,10 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 					opts.execArgv = ['--inspect-port=0'];
 				}
 
+				if (this._environmentService.extensionTestsLocationURI) {
+					opts.execArgv.unshift('--expose-gc');
+				}
+
 				if (this._environmentService.args['prof-v8-extensions']) {
 					opts.execArgv.unshift('--prof');
 				}


### PR DESCRIPTION
Fix #139139 - the Jupyter extension will use this in perf testing

It doesn't seem like there are any bad side effects to this besides it enabling the gc API. 

cc @deepak1556 in case you know of a reason why we shouldn't do this.

cc @jrieken in case this is relevant to your interests
