### PR TITLE
Fix decorations and mouse hit-testing when editor is scaled via transform

### DIFF
--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -10,7 +10,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import * as platform from 'vs/base/common/platform';
 import { HitTestContext, IViewZoneData, MouseTarget, MouseTargetFactory, PointerHandlerLastRenderData } from 'vs/editor/browser/controller/mouseTarget';
 import { IMouseTarget, MouseTargetType } from 'vs/editor/browser/editorBrowser';
-import { ClientCoordinates, EditorMouseEvent, EditorMouseEventFactory, GlobalEditorMouseMoveMonitor, createEditorPagePosition } from 'vs/editor/browser/editorDom';
+import { ClientCoordinates, EditorMouseEvent, EditorMouseEventFactory, GlobalEditorMouseMoveMonitor, createEditorPagePosition, createCoordinatesRelativeToEditor } from 'vs/editor/browser/editorDom';
 import { ViewController } from 'vs/editor/browser/view/viewController';
 import { EditorZoom } from 'vs/editor/common/config/editorZoom';
 import { Position } from 'vs/editor/common/core/position';
@@ -172,7 +172,8 @@ export class MouseHandler extends ViewEventHandler {
 			return null;
 		}
 
-		return this.mouseTargetFactory.createMouseTarget(this.viewHelper.getLastRenderData(), editorPos, pos, null);
+		const relativePos = createCoordinatesRelativeToEditor(this.viewHelper.viewDomNode, editorPos, pos);
+		return this.mouseTargetFactory.createMouseTarget(this.viewHelper.getLastRenderData(), editorPos, pos, relativePos, null);
 	}
 
 	protected _createMouseTarget(e: EditorMouseEvent, testEventTarget: boolean): IMouseTarget {
@@ -185,11 +186,11 @@ export class MouseHandler extends ViewEventHandler {
 				);
 			}
 		}
-		return this.mouseTargetFactory.createMouseTarget(this.viewHelper.getLastRenderData(), e.editorPos, e.pos, testEventTarget ? target : null);
+		return this.mouseTargetFactory.createMouseTarget(this.viewHelper.getLastRenderData(), e.editorPos, e.pos, e.relativePos, testEventTarget ? target : null);
 	}
 
 	private _getMouseColumn(e: EditorMouseEvent): number {
-		return this.mouseTargetFactory.getMouseColumn(e.editorPos, e.pos);
+		return this.mouseTargetFactory.getMouseColumn(e.relativePos);
 	}
 
 	protected _onContextMenu(e: EditorMouseEvent, testEventTarget: boolean): void {
@@ -476,7 +477,7 @@ class MouseDownOperation extends Disposable {
 		}
 
 		if (e.posy > editorContent.y + editorContent.height) {
-			const verticalOffset = viewLayout.getCurrentScrollTop() + (e.posy - editorContent.y);
+			const verticalOffset = viewLayout.getCurrentScrollTop() + e.relativePos.y;
 			const viewZoneData = HitTestContext.getZoneAtCoord(this._context, verticalOffset);
 			if (viewZoneData) {
 				const newPosition = this._helpPositionJumpOverViewZone(viewZoneData);
@@ -489,7 +490,7 @@ class MouseDownOperation extends Disposable {
 			return new MouseTarget(null, MouseTargetType.OUTSIDE_EDITOR, mouseColumn, new Position(belowLineNumber, model.getLineMaxColumn(belowLineNumber)));
 		}
 
-		const possibleLineNumber = viewLayout.getLineNumberAtVerticalOffset(viewLayout.getCurrentScrollTop() + (e.posy - editorContent.y));
+		const possibleLineNumber = viewLayout.getLineNumberAtVerticalOffset(viewLayout.getCurrentScrollTop() + e.relativePos.y);
 
 		if (e.posx < editorContent.x) {
 			return new MouseTarget(null, MouseTargetType.OUTSIDE_EDITOR, mouseColumn, new Position(possibleLineNumber, 1));

--- a/src/vs/editor/browser/controller/mouseTarget.ts
+++ b/src/vs/editor/browser/controller/mouseTarget.ts
@@ -385,9 +385,18 @@ abstract class BareHitTestRequest {
 		this.editorPos = editorPos;
 		this.pos = pos;
 
-		this.mouseVerticalOffset = Math.max(0, ctx.getCurrentScrollTop() + pos.y - editorPos.y);
-		this.mouseContentHorizontalOffset = ctx.getCurrentScrollLeft() + pos.x - editorPos.x - ctx.layoutInfo.contentLeft;
-		this.isInMarginArea = (pos.x - editorPos.x < ctx.layoutInfo.contentLeft && pos.x - editorPos.x >= ctx.layoutInfo.glyphMarginLeft);
+		let { x, y } = pos;
+
+		const scaleX = editorPos.width / ctx.layoutInfo.width;
+		const scaleY = editorPos.height / ctx.layoutInfo.height;
+
+		// Adjust mouse offsets if editor appears to be scaled via transforms
+		if (scaleX != 1) { x = editorPos.x + (x - editorPos.x) / scaleX; }
+		if (scaleY != 1) { y = editorPos.y + (y - editorPos.y) / scaleY; }
+
+		this.mouseVerticalOffset = Math.max(0, ctx.getCurrentScrollTop() + y - editorPos.y);
+		this.mouseContentHorizontalOffset = ctx.getCurrentScrollLeft() + x - editorPos.x - ctx.layoutInfo.contentLeft;
+		this.isInMarginArea = (x - editorPos.x < ctx.layoutInfo.contentLeft && x - editorPos.x >= ctx.layoutInfo.glyphMarginLeft);
 		this.isInContentArea = !this.isInMarginArea;
 		this.mouseColumn = Math.max(0, MouseTargetFactory._getMouseColumn(this.mouseContentHorizontalOffset, ctx.typicalHalfwidthCharacterWidth));
 	}

--- a/src/vs/editor/browser/controller/mouseTarget.ts
+++ b/src/vs/editor/browser/controller/mouseTarget.ts
@@ -391,8 +391,8 @@ abstract class BareHitTestRequest {
 		const scaleY = editorPos.height / ctx.layoutInfo.height;
 
 		// Adjust mouse offsets if editor appears to be scaled via transforms
-		if (scaleX != 1) { x = editorPos.x + (x - editorPos.x) / scaleX; }
-		if (scaleY != 1) { y = editorPos.y + (y - editorPos.y) / scaleY; }
+		if (scaleX !== 1) { x = editorPos.x + (x - editorPos.x) / scaleX; }
+		if (scaleY !== 1) { y = editorPos.y + (y - editorPos.y) / scaleY; }
 
 		this.mouseVerticalOffset = Math.max(0, ctx.getCurrentScrollTop() + y - editorPos.y);
 		this.mouseContentHorizontalOffset = ctx.getCurrentScrollLeft() + x - editorPos.x - ctx.layoutInfo.contentLeft;

--- a/src/vs/editor/browser/controller/mouseTarget.ts
+++ b/src/vs/editor/browser/controller/mouseTarget.ts
@@ -5,7 +5,7 @@
 
 import { IPointerHandlerHelper } from 'vs/editor/browser/controller/mouseHandler';
 import { IMouseTarget, MouseTargetType } from 'vs/editor/browser/editorBrowser';
-import { ClientCoordinates, EditorMouseEvent, EditorPagePosition, PageCoordinates } from 'vs/editor/browser/editorDom';
+import { ClientCoordinates, EditorMouseEvent, EditorPagePosition, PageCoordinates, CoordinatesRelativeToEditor } from 'vs/editor/browser/editorDom';
 import { PartFingerprint, PartFingerprints } from 'vs/editor/browser/view/viewPart';
 import { ViewLine } from 'vs/editor/browser/viewParts/lines/viewLine';
 import { IViewCursorRenderData } from 'vs/editor/browser/viewParts/viewCursors/viewCursor';
@@ -374,6 +374,7 @@ abstract class BareHitTestRequest {
 
 	public readonly editorPos: EditorPagePosition;
 	public readonly pos: PageCoordinates;
+	public readonly relativePos: CoordinatesRelativeToEditor;
 	public readonly mouseVerticalOffset: number;
 	public readonly isInMarginArea: boolean;
 	public readonly isInContentArea: boolean;
@@ -381,22 +382,14 @@ abstract class BareHitTestRequest {
 
 	protected readonly mouseColumn: number;
 
-	constructor(ctx: HitTestContext, editorPos: EditorPagePosition, pos: PageCoordinates) {
+	constructor(ctx: HitTestContext, editorPos: EditorPagePosition, pos: PageCoordinates, relativePos: CoordinatesRelativeToEditor) {
 		this.editorPos = editorPos;
 		this.pos = pos;
+		this.relativePos = relativePos;
 
-		let { x, y } = pos;
-
-		const scaleX = editorPos.width / ctx.layoutInfo.width;
-		const scaleY = editorPos.height / ctx.layoutInfo.height;
-
-		// Adjust mouse offsets if editor appears to be scaled via transforms
-		if (scaleX !== 1) { x = editorPos.x + (x - editorPos.x) / scaleX; }
-		if (scaleY !== 1) { y = editorPos.y + (y - editorPos.y) / scaleY; }
-
-		this.mouseVerticalOffset = Math.max(0, ctx.getCurrentScrollTop() + y - editorPos.y);
-		this.mouseContentHorizontalOffset = ctx.getCurrentScrollLeft() + x - editorPos.x - ctx.layoutInfo.contentLeft;
-		this.isInMarginArea = (x - editorPos.x < ctx.layoutInfo.contentLeft && x - editorPos.x >= ctx.layoutInfo.glyphMarginLeft);
+		this.mouseVerticalOffset = Math.max(0, ctx.getCurrentScrollTop() + this.relativePos.y);
+		this.mouseContentHorizontalOffset = ctx.getCurrentScrollLeft() + this.relativePos.x - ctx.layoutInfo.contentLeft;
+		this.isInMarginArea = (this.relativePos.x < ctx.layoutInfo.contentLeft && this.relativePos.x >= ctx.layoutInfo.glyphMarginLeft);
 		this.isInContentArea = !this.isInMarginArea;
 		this.mouseColumn = Math.max(0, MouseTargetFactory._getMouseColumn(this.mouseContentHorizontalOffset, ctx.typicalHalfwidthCharacterWidth));
 	}
@@ -407,8 +400,8 @@ class HitTestRequest extends BareHitTestRequest {
 	public readonly target: Element | null;
 	public readonly targetPath: Uint8Array;
 
-	constructor(ctx: HitTestContext, editorPos: EditorPagePosition, pos: PageCoordinates, target: Element | null) {
-		super(ctx, editorPos, pos);
+	constructor(ctx: HitTestContext, editorPos: EditorPagePosition, pos: PageCoordinates, relativePos: CoordinatesRelativeToEditor, target: Element | null) {
+		super(ctx, editorPos, pos, relativePos);
 		this._ctx = ctx;
 
 		if (target) {
@@ -421,7 +414,7 @@ class HitTestRequest extends BareHitTestRequest {
 	}
 
 	public override toString(): string {
-		return `pos(${this.pos.x},${this.pos.y}), editorPos(${this.editorPos.x},${this.editorPos.y}), mouseVerticalOffset: ${this.mouseVerticalOffset}, mouseContentHorizontalOffset: ${this.mouseContentHorizontalOffset}\n\ttarget: ${this.target ? (<HTMLElement>this.target).outerHTML : null}`;
+		return `pos(${this.pos.x},${this.pos.y}), editorPos(${this.editorPos.x},${this.editorPos.y}), relativePos(${this.relativePos.x},${this.relativePos.y}), mouseVerticalOffset: ${this.mouseVerticalOffset}, mouseContentHorizontalOffset: ${this.mouseContentHorizontalOffset}\n\ttarget: ${this.target ? (<HTMLElement>this.target).outerHTML : null}`;
 	}
 
 	public fulfill(type: MouseTargetType.UNKNOWN, position?: Position | null, range?: EditorRange | null): MouseTarget;
@@ -445,7 +438,7 @@ class HitTestRequest extends BareHitTestRequest {
 	}
 
 	public withTarget(target: Element | null): HitTestRequest {
-		return new HitTestRequest(this._ctx, this.editorPos, this.pos, target);
+		return new HitTestRequest(this._ctx, this.editorPos, this.pos, this.relativePos, target);
 	}
 }
 
@@ -489,9 +482,9 @@ export class MouseTargetFactory {
 		return false;
 	}
 
-	public createMouseTarget(lastRenderData: PointerHandlerLastRenderData, editorPos: EditorPagePosition, pos: PageCoordinates, target: HTMLElement | null): IMouseTarget {
+	public createMouseTarget(lastRenderData: PointerHandlerLastRenderData, editorPos: EditorPagePosition, pos: PageCoordinates, relativePos: CoordinatesRelativeToEditor, target: HTMLElement | null): IMouseTarget {
 		const ctx = new HitTestContext(this._context, this._viewHelper, lastRenderData);
-		const request = new HitTestRequest(ctx, editorPos, pos, target);
+		const request = new HitTestRequest(ctx, editorPos, pos, relativePos, target);
 		try {
 			const r = MouseTargetFactory._createMouseTarget(ctx, request, false);
 			// console.log(r.toString());
@@ -641,7 +634,7 @@ export class MouseTargetFactory {
 		if (request.isInMarginArea) {
 			const res = ctx.getFullLineRangeAtCoord(request.mouseVerticalOffset);
 			const pos = res.range.getStartPosition();
-			let offset = Math.abs(request.pos.x - request.editorPos.x);
+			let offset = Math.abs(request.relativePos.x);
 			const detail: IMarginData = {
 				isAfterLines: res.isAfterLines,
 				glyphMarginLeft: ctx.layoutInfo.glyphMarginLeft,
@@ -754,10 +747,10 @@ export class MouseTargetFactory {
 		return null;
 	}
 
-	public getMouseColumn(editorPos: EditorPagePosition, pos: PageCoordinates): number {
+	public getMouseColumn(relativePos: CoordinatesRelativeToEditor): number {
 		const options = this._context.configuration.options;
 		const layoutInfo = options.get(EditorOption.layoutInfo);
-		const mouseContentHorizontalOffset = this._context.viewLayout.getCurrentScrollLeft() + pos.x - editorPos.x - layoutInfo.contentLeft;
+		const mouseContentHorizontalOffset = this._context.viewLayout.getCurrentScrollLeft() + relativePos.x - layoutInfo.contentLeft;
 		return MouseTargetFactory._getMouseColumn(mouseContentHorizontalOffset, options.get(EditorOption.fontInfo).typicalHalfwidthCharacterWidth);
 	}
 
@@ -843,8 +836,8 @@ export class MouseTargetFactory {
 		if (adjustedPageY <= request.editorPos.y) {
 			adjustedPageY = request.editorPos.y + 1;
 		}
-		if (adjustedPageY >= request.editorPos.y + ctx.layoutInfo.height) {
-			adjustedPageY = request.editorPos.y + ctx.layoutInfo.height - 1;
+		if (adjustedPageY >= request.editorPos.y + request.editorPos.height) {
+			adjustedPageY = request.editorPos.y + request.editorPos.height - 1;
 		}
 
 		const adjustedPage = new PageCoordinates(request.pos.x, adjustedPageY);

--- a/src/vs/editor/browser/editorDom.ts
+++ b/src/vs/editor/browser/editorDom.ts
@@ -62,9 +62,43 @@ export class EditorPagePosition {
 	) { }
 }
 
+/**
+ * Coordinates relative to the the (top;left) of the editor that can be used safely with other internal editor metrics.
+ * **NOTE**: This position is obtained by taking page coordinates and transforming them relative to the
+ * editor's (top;left) position in a way in which scale transformations are taken into account.
+ * **NOTE**: These coordinates could be negative if the mouse position is outside the editor.
+ */
+export class CoordinatesRelativeToEditor {
+	_positionRelativeToEditorBrand: void = undefined;
+
+	constructor(
+		public readonly x: number,
+		public readonly y: number
+	) { }
+}
+
 export function createEditorPagePosition(editorViewDomNode: HTMLElement): EditorPagePosition {
 	const editorPos = dom.getDomNodePagePosition(editorViewDomNode);
 	return new EditorPagePosition(editorPos.left, editorPos.top, editorPos.width, editorPos.height);
+}
+
+export function createCoordinatesRelativeToEditor(editorViewDomNode: HTMLElement, editorPagePosition: EditorPagePosition, pos: PageCoordinates) {
+	// The editor's page position is read from the DOM using getBoundingClientRect().
+	//
+	// getBoundingClientRect() returns the actual dimensions, while offsetWidth and offsetHeight
+	// reflect the unscaled size. We can use this difference to detect a transform:scale()
+	// and we will apply the transformation in inverse to get mouse coordinates that make sense inside the editor.
+	//
+	// This could be expanded to cover rotation as well maybe by walking the DOM up from `editorViewDomNode`
+	// and computing the effective transformation matrix using getComputedStyle(element).transform.
+	//
+	const scaleX = editorPagePosition.width / editorViewDomNode.offsetWidth;
+	const scaleY = editorPagePosition.height / editorViewDomNode.offsetHeight;
+
+	// Adjust mouse offsets if editor appears to be scaled via transforms
+	const relativeX = (pos.x - editorPagePosition.x) / scaleX;
+	const relativeY = (pos.y - editorPagePosition.y) / scaleY;
+	return new CoordinatesRelativeToEditor(relativeX, relativeY);
 }
 
 export class EditorMouseEvent extends StandardMouseEvent {
@@ -80,10 +114,18 @@ export class EditorMouseEvent extends StandardMouseEvent {
 	 */
 	public readonly editorPos: EditorPagePosition;
 
+	/**
+	 * Coordinates relative to the (top;left) of the editor.
+	 * *NOTE*: These coordinates are preferred because they take into account transformations applied to the editor.
+	 * *NOTE*: These coordinates could be negative if the mouse position is outside the editor.
+	 */
+	public readonly relativePos: CoordinatesRelativeToEditor;
+
 	constructor(e: MouseEvent, editorViewDomNode: HTMLElement) {
 		super(e);
 		this.pos = new PageCoordinates(this.posx, this.posy);
 		this.editorPos = createEditorPagePosition(editorViewDomNode);
+		this.relativePos = createCoordinatesRelativeToEditor(editorViewDomNode, this.editorPos, this.pos);
 	}
 }
 

--- a/src/vs/editor/browser/viewParts/lines/rangeUtil.ts
+++ b/src/vs/editor/browser/viewParts/lines/rangeUtil.ts
@@ -69,7 +69,7 @@ export class RangeUtil {
 		return result;
 	}
 
-	private static _createHorizontalRangesFromClientRects(clientRects: DOMRectList | null, clientRectDeltaLeft: number): FloatHorizontalRange[] | null {
+	private static _createHorizontalRangesFromClientRects(clientRects: DOMRectList | null, clientRectDeltaLeft: number, clientRectScale: number): FloatHorizontalRange[] | null {
 		if (!clientRects || clientRects.length === 0) {
 			return null;
 		}
@@ -80,13 +80,13 @@ export class RangeUtil {
 		const result: FloatHorizontalRange[] = [];
 		for (let i = 0, len = clientRects.length; i < len; i++) {
 			const clientRect = clientRects[i];
-			result[i] = new FloatHorizontalRange(Math.max(0, clientRect.left - clientRectDeltaLeft), clientRect.width);
+			result[i] = new FloatHorizontalRange(Math.max(0, (clientRect.left - clientRectDeltaLeft) / clientRectScale), clientRect.width / clientRectScale);
 		}
 
 		return this._mergeAdjacentRanges(result);
 	}
 
-	public static readHorizontalRanges(domNode: HTMLElement, startChildIndex: number, startOffset: number, endChildIndex: number, endOffset: number, clientRectDeltaLeft: number, endNode: HTMLElement): FloatHorizontalRange[] | null {
+	public static readHorizontalRanges(domNode: HTMLElement, startChildIndex: number, startOffset: number, endChildIndex: number, endOffset: number, clientRectDeltaLeft: number, clientRectScale: number, endNode: HTMLElement): FloatHorizontalRange[] | null {
 		// Panic check
 		const min = 0;
 		const max = domNode.children.length - 1;
@@ -100,7 +100,7 @@ export class RangeUtil {
 			// We must find the position at the beginning of a <span>
 			// To cover cases of empty <span>s, avoid using a range and use the <span>'s bounding box
 			const clientRects = domNode.children[startChildIndex].getClientRects();
-			return this._createHorizontalRangesFromClientRects(clientRects, clientRectDeltaLeft);
+			return this._createHorizontalRangesFromClientRects(clientRects, clientRectDeltaLeft, clientRectScale);
 		}
 
 		// If crossing over to a span only to select offset 0, then use the previous span's maximum offset
@@ -135,6 +135,6 @@ export class RangeUtil {
 		endOffset = Math.min(endElement.textContent!.length, Math.max(0, endOffset));
 
 		const clientRects = this._readClientRects(startElement, startOffset, endElement, endOffset, endNode);
-		return this._createHorizontalRangesFromClientRects(clientRects, clientRectDeltaLeft);
+		return this._createHorizontalRangesFromClientRects(clientRects, clientRectDeltaLeft, clientRectScale);
 	}
 }

--- a/src/vs/editor/browser/viewParts/lines/viewLine.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLine.ts
@@ -61,12 +61,16 @@ export class DomReadingContext {
 	}
 
 	public get clientRectDeltaLeft(): number {
-		if (!this._clientRectRead) this.readClientRect();
+		if (!this._clientRectRead) {
+			this.readClientRect();
+		}
 		return this._clientRectDeltaLeft;
 	}
 
 	public get clientRectScale(): number {
-		if (!this._clientRectRead) this.readClientRect();
+		if (!this._clientRectRead) {
+			this.readClientRect();
+		}
 		return this._clientRectScale;
 	}
 

--- a/src/vs/editor/browser/viewParts/lines/viewLine.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLine.ts
@@ -48,13 +48,26 @@ export class DomReadingContext {
 
 	private readonly _domNode: HTMLElement;
 	private _clientRectDeltaLeft: number;
-	private _clientRectDeltaLeftRead: boolean;
-	public get clientRectDeltaLeft(): number {
-		if (!this._clientRectDeltaLeftRead) {
-			this._clientRectDeltaLeftRead = true;
-			this._clientRectDeltaLeft = this._domNode.getBoundingClientRect().left;
+	private _clientRectScale: number;
+	private _clientRectRead: boolean;
+
+	private readClientRect(): void {
+		if (!this._clientRectRead) {
+			this._clientRectRead = true;
+			const rect = this._domNode.getBoundingClientRect();
+			this._clientRectDeltaLeft = rect.left;
+			this._clientRectScale = rect.width / this._domNode.offsetWidth;
 		}
+	}
+
+	public get clientRectDeltaLeft(): number {
+		if (!this._clientRectRead) this.readClientRect();
 		return this._clientRectDeltaLeft;
+	}
+
+	public get clientRectScale(): number {
+		if (!this._clientRectRead) this.readClientRect();
+		return this._clientRectScale;
 	}
 
 	public readonly endNode: HTMLElement;
@@ -62,7 +75,8 @@ export class DomReadingContext {
 	constructor(domNode: HTMLElement, endNode: HTMLElement) {
 		this._domNode = domNode;
 		this._clientRectDeltaLeft = 0;
-		this._clientRectDeltaLeftRead = false;
+		this._clientRectScale = 1;
+		this._clientRectRead = false;
 		this.endNode = endNode;
 	}
 
@@ -587,7 +601,7 @@ class RenderedViewLine implements IRenderedViewLine {
 	private _actualReadPixelOffset(domNode: FastDomNode<HTMLElement>, lineNumber: number, column: number, context: DomReadingContext): number {
 		if (this._characterMapping.length === 0) {
 			// This line has no content
-			const r = RangeUtil.readHorizontalRanges(this._getReadingTarget(domNode), 0, 0, 0, 0, context.clientRectDeltaLeft, context.endNode);
+			const r = RangeUtil.readHorizontalRanges(this._getReadingTarget(domNode), 0, 0, 0, 0, context.clientRectDeltaLeft, context.clientRectScale, context.endNode);
 			if (!r || r.length === 0) {
 				return -1;
 			}
@@ -601,7 +615,7 @@ class RenderedViewLine implements IRenderedViewLine {
 
 		const domPosition = this._characterMapping.getDomPosition(column);
 
-		const r = RangeUtil.readHorizontalRanges(this._getReadingTarget(domNode), domPosition.partIndex, domPosition.charIndex, domPosition.partIndex, domPosition.charIndex, context.clientRectDeltaLeft, context.endNode);
+		const r = RangeUtil.readHorizontalRanges(this._getReadingTarget(domNode), domPosition.partIndex, domPosition.charIndex, domPosition.partIndex, domPosition.charIndex, context.clientRectDeltaLeft, context.clientRectScale, context.endNode);
 		if (!r || r.length === 0) {
 			return -1;
 		}
@@ -627,7 +641,7 @@ class RenderedViewLine implements IRenderedViewLine {
 		const startDomPosition = this._characterMapping.getDomPosition(startColumn);
 		const endDomPosition = this._characterMapping.getDomPosition(endColumn);
 
-		return RangeUtil.readHorizontalRanges(this._getReadingTarget(domNode), startDomPosition.partIndex, startDomPosition.charIndex, endDomPosition.partIndex, endDomPosition.charIndex, context.clientRectDeltaLeft, context.endNode);
+		return RangeUtil.readHorizontalRanges(this._getReadingTarget(domNode), startDomPosition.partIndex, startDomPosition.charIndex, endDomPosition.partIndex, endDomPosition.charIndex, context.clientRectDeltaLeft, context.clientRectScale, context.endNode);
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #139281

This PR also fixes  microsoft/monaco-editor#2347 and microsoft/monaco-editor#531

When a rendered ViewLine contains foreign elements or is uses a non-monospaced font, VSCode uses a helper (RangeUtil.readHorizontalRanges) to calculate the pixel widths and offsets. This in turn uses `Element#getClientRects` and `Range#getClientRects` to retrieve the raw sizes as reported by the browser. If the editor element, or any of its parents are scaled using css transforms, the calculated sizes are incorrect.

This tiny patch calculates the scale of the view-lines in the `DomReadingContext`, and adjusts the resulting ranges in `_createHorizontalRangesFromClientRects`. It is only checking the offsetWidth of the viewLines element once, in the same step that it previously called `getBoundingClientRect()` on this element. It will not result in any additional layouts or reflows.

We ran into this issue at Scrimba.com (using monaco) when trying to animate the size of the editor when it transitions in. Decorations and selections have incorrect sizes and positions. This is also easy to test on the monaco playgrounds by simply scaling the whole document body `document.body.style.transform = 'scale(0.75)'` and then selecting code in any of the examples (only lines with variable length text or foreign elements).

Steps to Reproduce / test:

1. Go to vscode.dev
2. Create a simple css file with the content body { color: red; }
3. Scale the document document.body.style.transform = "scale(0.75)"
4. Select the code and/or move caret around to see wrong positions and sizes

Do the same in locally built vscode.dev to see that things are now rendered correctly.


