### PR TITLE
Fixes Ctrl + Shift + {Left, Right, Home, End} is broken after a terminal is opened & closed on Firefox

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -917,9 +917,9 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}
 		this.xterm?.dispose();
 
-		// Workaround until https://bugzilla.mozilla.org/show_bug.cgi?id=559561 is fixed
+		// HACK: Workaround for Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=559561,
 		// as 'blur' event in xterm.raw.textarea is not triggered on xterm.dispose()
-		// Fixes #138358
+		// See https://github.com/microsoft/vscode/issues/138358
 		if (isFirefox) {
 			this._terminalFocusContextKey.reset();
 			this._terminalHasTextContextKey.reset();

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -66,6 +66,7 @@ import { LineDataEventAddon } from 'vs/workbench/contrib/terminal/browser/xterm/
 import { XtermTerminal } from 'vs/workbench/contrib/terminal/browser/xterm/xtermTerminal';
 import { escapeNonWindowsPath } from 'vs/platform/terminal/common/terminalEnvironment';
 import { IWorkspaceTrustRequestService } from 'vs/platform/workspace/common/workspaceTrust';
+import { isFirefox } from 'vs/base/browser/browser';
 
 const enum Constants {
 	/**
@@ -915,6 +916,15 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			}
 		}
 		this.xterm?.dispose();
+
+		// Workaround until https://bugzilla.mozilla.org/show_bug.cgi?id=559561 is fixed
+		// as 'blur' event in xterm.raw.textarea is not triggered on xterm.dispose()
+		// Fixes #138358
+		if (isFirefox) {
+			this._terminalFocusContextKey.reset();
+			this._terminalHasTextContextKey.reset();
+			this._onDidBlur.fire(this);
+		}
 
 		if (this._pressAnyKeyToCloseListener) {
 			this._pressAnyKeyToCloseListener.dispose();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #138358

Added a workaround as this is a 12 year old firefox issue :disappointed: 
https://bugzilla.mozilla.org/show_bug.cgi?id=559561
