### PR TITLE
a quick implementation, adding "Open with Code" option to Windows 11 explorer's context menu

### DIFF
--- a/build/win32/shell-extension-win11/build.cmd
+++ b/build/win32/shell-extension-win11/build.cmd
@@ -1,0 +1,44 @@
+@echo off
+:: build the handler dll and sparse package needed for context menu extension
+
+:: Visual Studio 2019 Windows Desktop Development tools are required
+
+set ARCH=X64
+:: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+
+:: set ARCH=X86
+:: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars32.bat"
+
+mkdir Release
+mkdir Release\sparse-pkg
+
+:: replace placeholders with real values
+
+powershell -Command "(gc handler\menuhandler.cpp) -replace '@@ROOT_KEY@@', '*\\shell\\VSCode' | Out-File -encoding ASCII Release\menuhandler.cpp"
+
+powershell -Command "(gc sparse-pkg\AppxManifest.xml) -replace '@@NAME@@', 'code-oss' -replace '@@APPNAME@@', 'Code - OSS' | Out-File -encoding ASCII Release\sparse-pkg\AppxManifest.xml"
+
+:: dependency preparation
+
+powershell -Command "iwr https://www.nuget.org/api/v2/package/Microsoft.Windows.ImplementationLibrary/1.0.201120.3 -OutFile Release\wil.zip; Expand-Archive -Force -LiteralPath Release\wil.zip Release\WilUnzipped; cp -Force -r Release\WilUnzipped\include\wil Release"
+
+copy ..\..\..\resources\win32\code_150x150.png Release\sparse-pkg\code.png
+
+:: Command lines as called by msbuild.exe in building the SparsePackages/PhotoStoreContextMenu demo
+
+cl.exe /c /Zi /nologo /W3 /WX- /diagnostics:column /sdl /Oi /GL /O2 /Oy- /D WIN32 /D NDEBUG /D _WINDOWS /D _USRDLL /D _WINDLL /D _UNICODE /D UNICODE /Gm- /EHsc /MD /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /permissive- /Fp"Release\menuhandler.pch" /Fo"Release\\" /Fd"Release\vc142.pdb" /external:W3 /Gd /TP /analyze- /FC /errorReport:queue "Release\menuhandler.cpp"
+
+link.exe /ERRORREPORT:QUEUE /OUT:"Release\menuhandler.dll" /INCREMENTAL:NO /NOLOGO runtimeobject.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib shlwapi.lib /DEF:"handler\Source.def" /MANIFEST /MANIFESTUAC:NO /manifest:embed /PDB:"Release\menuhandler.pdb" /SUBSYSTEM:WINDOWS /OPT:REF /OPT:ICF /LTCG:incremental /LTCGOUT:"Release\menuhandler.iobj" /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"Release\menuhandler.lib" /MACHINE:%ARCH% /DLL "Release\menuhandler.obj"
+
+MakeAppx.exe pack /d "Release\\sparse-pkg\\" /p "Release\code-sparse.appx" /nv
+
+:: Sign the sparse package
+
+MakeCert.exe /n "CN=localhost" /r /h 0 /eku "1.3.6.1.5.5.7.3.3,1.3.6.1.4.1.311.10.3.13" /e "12/31/2099" /sv "Release\Key.pvk" "Release\Key.cer"
+
+Pvk2Pfx.exe /pvk "Release\Key.pvk" /spc "Release\Key.cer" /pfx "Release\Key.pfx"
+
+SignTool.exe sign /fd SHA256 /a /f "Release\Key.pfx" "Release\code-sparse.appx"
+
+:: These built files need to be copied to the installation package for setup.ps1 to use:
+:: Release\menuhandler.dll, Release\Key.cer, Release\code-sparse.appx

--- a/build/win32/shell-extension-win11/handler/Source.def
+++ b/build/win32/shell-extension-win11/handler/Source.def
@@ -1,0 +1,5 @@
+LIBRARY
+EXPORTS             
+DllCanUnloadNow           PRIVATE
+DllGetClassObject         PRIVATE
+DllGetActivationFactory   PRIVATE

--- a/build/win32/shell-extension-win11/handler/menuhandler.cpp
+++ b/build/win32/shell-extension-win11/handler/menuhandler.cpp
@@ -1,0 +1,162 @@
+// menuhandler.cpp : Defines the entry point for the context menu DLL handler.
+
+// This code is aggressively copied from
+// https://github.com/microsoft/AppModelSamples/Samples/SparsePackages/PhotoStoreContextMenu/dllmain.cpp
+
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#include <windows.h>
+#include <shlwapi.h>
+#include <shobjidl_core.h>
+#include <wrl/client.h>
+#include <wrl/implements.h>
+#include <wrl/module.h>
+#include "wil\resource.h"
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace Microsoft::WRL;
+
+BOOL APIENTRY DllMain(HMODULE hModule,
+    DWORD ul_reason_for_call,
+    LPVOID lpReserved)
+{
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+class ExplorerCommandBase : public RuntimeClass<RuntimeClassFlags<ClassicCom>, IExplorerCommand, IObjectWithSite> {
+public:
+    virtual const wchar_t* Title() = 0;
+    virtual const EXPCMDFLAGS Flags() { return ECF_DEFAULT; }
+    virtual const EXPCMDSTATE State(_In_opt_ IShellItemArray* selection) { return ECS_ENABLED; }
+
+    // IExplorerCommand
+    IFACEMETHODIMP GetTitle(_In_opt_ IShellItemArray* items, _Outptr_result_nullonfailure_ PWSTR* name)
+    {
+        *name = nullptr;
+        auto title = wil::make_cotaskmem_string_nothrow(Title());
+        RETURN_IF_NULL_ALLOC(title);
+        *name = title.release();
+        return S_OK;
+    }
+    IFACEMETHODIMP GetIcon(_In_opt_ IShellItemArray*, _Outptr_result_nullonfailure_ PWSTR* icon)
+    {
+        wchar_t str_data[1028];
+        DWORD size = sizeof(str_data);
+        RETURN_IF_FAILED(RegGetValue(
+            HKEY_CLASSES_ROOT, L"@@ROOT_KEY@@", L"Icon",
+            RRF_RT_REG_EXPAND_SZ | RRF_NOEXPAND, NULL, str_data, &size
+		));
+        return SHStrDup(str_data, icon);
+    }
+    IFACEMETHODIMP GetToolTip(_In_opt_ IShellItemArray*, _Outptr_result_nullonfailure_ PWSTR* infoTip)
+    {
+        *infoTip = nullptr;
+        return E_NOTIMPL;
+    }
+    IFACEMETHODIMP GetCanonicalName(_Out_ GUID* guidCommandName)
+    {
+        *guidCommandName = GUID_NULL;
+        return S_OK;
+    }
+    IFACEMETHODIMP GetState(_In_opt_ IShellItemArray* selection, _In_ BOOL okToBeSlow, _Out_ EXPCMDSTATE* cmdState)
+    {
+        *cmdState = State(selection);
+        return S_OK;
+    }
+    IFACEMETHODIMP Invoke(_In_opt_ IShellItemArray* selection, _In_opt_ IBindCtx*) noexcept
+    try {
+        HWND parent = nullptr;
+        if (m_site) {
+            ComPtr<IOleWindow> oleWindow;
+            RETURN_IF_FAILED(m_site.As(&oleWindow));
+            RETURN_IF_FAILED(oleWindow->GetWindow(&parent));
+        }
+
+        if (selection) {
+            DWORD count;
+            RETURN_IF_FAILED(selection->GetCount(&count));
+
+            IShellItem* psi;
+            LPWSTR itemName;
+
+			wchar_t cmdline_buf[1028];
+			DWORD size = sizeof(cmdline_buf);
+			RETURN_IF_FAILED(RegGetValue(
+				HKEY_CLASSES_ROOT, L"@@ROOT_KEY@@\\command", L"",
+				RRF_RT_REG_EXPAND_SZ | RRF_NOEXPAND, NULL, cmdline_buf, &size
+			));
+			
+
+            for (DWORD i = 0; i < count; ++i) {
+                selection->GetItemAt(i, &psi);
+                RETURN_IF_FAILED(psi->GetDisplayName(SIGDN_FILESYSPATH, &itemName));
+
+				std::wstring cmdline{ cmdline_buf };
+				cmdline = cmdline.replace(cmdline.find(L"%1"), 2, itemName);
+
+                STARTUPINFO si = {};
+                PROCESS_INFORMATION pi = {};
+
+                CreateProcess(
+                    nullptr, (LPWSTR)cmdline.c_str(),
+                    nullptr, nullptr, false, 0, nullptr, nullptr, &si, &pi);
+            }
+        }
+
+        return S_OK;
+    }
+    CATCH_RETURN();
+
+    IFACEMETHODIMP GetFlags(_Out_ EXPCMDFLAGS* flags)
+    {
+        *flags = Flags();
+        return S_OK;
+    }
+    IFACEMETHODIMP EnumSubCommands(_COM_Outptr_ IEnumExplorerCommand** enumCommands)
+    {
+        *enumCommands = nullptr;
+        return E_NOTIMPL;
+    }
+
+    // IObjectWithSite
+    IFACEMETHODIMP SetSite(_In_ IUnknown* site) noexcept
+    {
+        m_site = site;
+        return S_OK;
+    }
+    IFACEMETHODIMP GetSite(_In_ REFIID riid, _COM_Outptr_ void** site) noexcept { return m_site.CopyTo(riid, site); }
+
+protected:
+    ComPtr<IUnknown> m_site;
+};
+
+class __declspec(uuid("BF6EE3D9-EC02-4489-AD75-ACDED99BAB44")) ExplorerCommandHandler final : public ExplorerCommandBase {
+public:
+    const wchar_t* Title() override { return L"Open with Code"; }
+};
+
+CoCreatableClass(ExplorerCommandHandler)
+CoCreatableClassWrlCreatorMapInclude(ExplorerCommandHandler)
+
+STDAPI DllGetActivationFactory(_In_ HSTRING activatableClassId, _COM_Outptr_ IActivationFactory** factory)
+{
+    return Module<ModuleType::InProc>::GetModule().GetActivationFactory(activatableClassId, factory);
+}
+
+STDAPI DllCanUnloadNow()
+{
+    return Module<InProc>::GetModule().GetObjectCount() == 0 ? S_OK : S_FALSE;
+}
+
+STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _COM_Outptr_ void** instance)
+{
+    return Module<InProc>::GetModule().GetClassObject(rclsid, riid, instance);
+}

--- a/build/win32/shell-extension-win11/setup.ps1
+++ b/build/win32/shell-extension-win11/setup.ps1
@@ -1,0 +1,7 @@
+# Setup the "Open with Code" Context Menu Item
+
+$releasePath = (resolve-path Release)
+
+Certutil.exe -user -addStore TrustedPeople ${releasePath}\Key.cer
+
+Add-AppxPackage ${releasePath}\code-sparse.appx -ExternalLocation ${releasePath}

--- a/build/win32/shell-extension-win11/sparse-pkg/AppxManifest.xml
+++ b/build/win32/shell-extension-win11/sparse-pkg/AppxManifest.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2"
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
+  xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
+  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+  xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+  IgnorableNamespaces="uap uap2 uap3 rescap desktop desktop4 desktop5 uap10 com">
+  <Identity Name="@@NAME@@" ProcessorArchitecture="neutral" Publisher="CN=localhost" Version="1.0.0.0" />
+  <Properties>
+    <DisplayName>@@APPNAME@@</DisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+    <Logo>code.png</Logo>
+    <uap10:AllowExternalContent>true</uap10:AllowExternalContent>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19000.0" MaxVersionTested="10.0.19000.0" />
+  </Dependencies>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+    <rescap:Capability Name="unvirtualizedResources"/>
+  </Capabilities>
+  <Applications>
+    <Application Id="Code" Executable="@@NAME@@.exe" uap10:TrustLevel="mediumIL" uap10:RuntimeBehavior="win32App">
+      <uap:VisualElements AppListEntry="none" DisplayName="@@APPNAME@@" Description="@@APPNAME@@" BackgroundColor="transparent" Square150x150Logo="code.png" Square44x44Logo="code.png">
+      </uap:VisualElements>
+      <Extensions>
+        <desktop4:Extension Category="windows.fileExplorerContextMenus">
+          <desktop4:FileExplorerContextMenus>
+            <desktop5:ItemType Type="Directory">
+              <desktop5:Verb Id="OpenWithCode" Clsid="BF6EE3D9-EC02-4489-AD75-ACDED99BAB44" />
+            </desktop5:ItemType>
+            <desktop5:ItemType Type="Directory\Background">
+              <desktop5:Verb Id="OpenWithCode" Clsid="BF6EE3D9-EC02-4489-AD75-ACDED99BAB44" />
+            </desktop5:ItemType>
+            <desktop5:ItemType Type="*">
+              <desktop5:Verb Id="OpenWithCode" Clsid="BF6EE3D9-EC02-4489-AD75-ACDED99BAB44" />
+            </desktop5:ItemType>
+          </desktop4:FileExplorerContextMenus>
+        </desktop4:Extension>
+        <com:Extension Category="windows.comServer">
+          <com:ComServer>
+            <com:SurrogateServer  DisplayName="Context menu verb handler">
+              <com:Class Id="BF6EE3D9-EC02-4489-AD75-ACDED99BAB44" Path="menuhandler.dll" ThreadingModel="STA"/>
+            </com:SurrogateServer>
+          </com:ComServer>
+        </com:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+</Package>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #127365

The added code follows the `IExplorerCommand + app identity` method recommended by [Windows Blog](https://blogs.windows.com/windowsdeveloper/2021/07/19/extending-the-context-menu-and-share-dialog-in-windows-11/), which is the minimal code necessary to implement this feature, and has *not been integrated into the Inno Setup script*. I hope that these codes can be used as an inspiration, and the VS Code developers would find out a sensible way to achieve this feature.

![Screenshot 2021-12-22 230721](https://user-images.githubusercontent.com/26765742/147120434-0c54a018-ea84-471b-9498-cf904baa7117.png)

![Screenshot 2021-12-22 230859](https://user-images.githubusercontent.com/26765742/147120449-c6eeb092-9678-4ade-a317-9f18f267a94c.png)

The added codes are located at `/build/win32/shell-extension-win11`, including an action handler, a minimal sparse package manifest, build script and setup script.

Because these are not integrated into Inno Setup, a manual build process is needed:

Assume that VS2019 with desktop development workload is installed in the working environment. `build.cmd` can make the sparse package and `.dll` library file for handling menu actions, which are needed by Windows. It also self-issues a test certificate to sign the sparse package. (This maybe needs to be implemented in a more formal way.)

By executing `build.cmd` 3 files will be put in the `/build/...-win11/Release` directory, namely `menuhandler.dll`, `Key.cer` and `code-sparse.appx`. The certificate issuance and signature process will prompt to enter a password for 3 times, just enter the same password.

Copy these 3 files with `setup.ps1` to anywhere inside an VS Code installation, and execute `setup.ps1` with administrator privileges. After restarting explorer.exe, you can see the option of "Open by Code" in context menus of files and directories.

The menu action is handled by C++ code implementing the COM interface, while currently for older versions of Windows this is achieved by the installer to directly write into registry. So the COM implemention directly reads the keys from registry to present the icon and determine the executable file path, to keep it simple and stupid. Perhaps this approach needs further improvement.

Localization has not been implemented yet, but by reading the registry, it should be easy.