### PR TITLE
Workaround Safari clipboard.writeText behavior

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -238,7 +238,7 @@ export class DynamicStandaloneServices extends Disposable {
 
 		ensure(IOpenerService, () => new OpenerService(codeEditorService, commandService));
 
-		ensure(IClipboardService, () => new BrowserClipboardService());
+		ensure(IClipboardService, () => new BrowserClipboardService(layoutService, logService));
 
 		ensure(IContextMenuService, () => {
 			const contextMenuService = new ContextMenuService(telemetryService, notificationService, contextViewService, keybindingService, themeService);

--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isSafari } from 'vs/base/browser/browser';
+import { isWebKit } from 'vs/base/browser/browser';
 import { $, addDisposableListener } from 'vs/base/browser/dom';
 import { DeferredPromise } from 'vs/base/common/async';
 import { Disposable } from 'vs/base/common/lifecycle';
@@ -22,7 +22,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 		@ILayoutService private readonly layoutService: ILayoutService,
 		@ILogService private readonly logService: ILogService) {
 		super();
-		if (isSafari) {
+		if (isWebKit) {
 			this.installSafariWriteTextWorkaround();
 		}
 	}

--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -52,8 +52,8 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 			this.safariPendingClipboardWritePromise = currentWritePromise;
 
 			// The ctor of ClipboardItem allows you to pass in a promise that will resolve to a string.
-			// This allows us to pass in a Promise that will either be resolved with undefined if it was 'cancelled'
-			// by another event or resolved with the contents of the first call to this.writeText.
+			// This allows us to pass in a Promise that will either be cancelled by another event or
+			// resolved with the contents of the first call to this.writeText.
 			// see https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem#parameters
 			navigator.clipboard.write([new ClipboardItem({
 				'text/plain': currentWritePromise.p,

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -54,6 +54,8 @@ import { ICellRange } from 'vs/workbench/contrib/notebook/common/notebookRange';
 import { TextModelResolverService } from 'vs/workbench/services/textmodelResolver/common/textModelResolverService';
 import { TestWorkspaceTrustRequestService } from 'vs/workbench/services/workspaces/test/common/testWorkspaceTrustService';
 import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
+import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
+import { TestLayoutService } from 'vs/workbench/test/browser/workbenchTestServices';
 
 export class TestCell extends NotebookCellTextModel {
 	constructor(
@@ -167,8 +169,9 @@ export function setupInstantiationService(disposables = new DisposableStore()) {
 	instantiationService.stub(ITextModelService, <ITextModelService>instantiationService.createInstance(TextModelResolverService));
 	instantiationService.stub(IContextKeyService, instantiationService.createInstance(ContextKeyService));
 	instantiationService.stub(IListService, instantiationService.createInstance(ListService));
-	instantiationService.stub(IClipboardService, new BrowserClipboardService());
+	instantiationService.stub(ILayoutService, new TestLayoutService());
 	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(IClipboardService, instantiationService.createInstance(BrowserClipboardService));
 	instantiationService.stub(IStorageService, new TestStorageService());
 	instantiationService.stub(IWorkspaceTrustRequestService, new TestWorkspaceTrustRequestService(true));
 

--- a/src/vs/workbench/services/clipboard/browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/browser/clipboardService.ts
@@ -12,8 +12,8 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { once } from 'vs/base/common/functional';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
-import { isSafari } from 'vs/base/browser/browser';
 import { ILogService } from 'vs/platform/log/common/log';
+import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 
 export class BrowserClipboardService extends BaseBrowserClipboardService {
 
@@ -21,9 +21,10 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 		@INotificationService private readonly notificationService: INotificationService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
-		@ILogService private readonly logService: ILogService
+		@ILogService logService: ILogService,
+		@ILayoutService layoutService: ILayoutService
 	) {
-		super();
+		super(layoutService, logService);
 	}
 
 	override async readText(type?: string): Promise<string> {
@@ -36,12 +37,6 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 		} catch (error) {
 			if (!!this.environmentService.extensionTestsLocationURI) {
 				return ''; // do not ask for input in tests (https://github.com/microsoft/vscode/issues/112264)
-			}
-
-			if (isSafari) {
-				this.logService.error(error);
-
-				return ''; // Safari does not seem to provide anyway to enable cipboard access (https://github.com/microsoft/vscode-internalbacklog/issues/2162#issuecomment-852042867)
 			}
 
 			return new Promise<string>(resolve => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In Safari, it has the following note:

"The request to write to the clipboard must be triggered during a user gesture. A call to clipboard.write or clipboard.writeText outside the scope of a user gesture(such as "click" or "touch" event handlers) will result in the immediate rejection of the promise returned by the API call."

From: https://webkit.org/blog/10855/async-clipboard-api/
	
Since extensions run in a web worker, and handle gestures in an asynchronous way, they are not classified by Safari as "in response to a user gesture" and will reject.

This function sets up some handlers to work around that behavior by leveraging the ClipboardItem API that takes in a Promise:
https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem#parameters

This PR fixes #106997
