### PR TITLE
Add ability to set custom command aliases

### DIFF
--- a/src/vs/workbench/browser/quickaccess.ts
+++ b/src/vs/workbench/browser/quickaccess.ts
@@ -21,6 +21,7 @@ export interface IWorkbenchQuickAccessConfiguration {
 		commandPalette: {
 			history: number;
 			preserveInput: boolean;
+			commandAliases: Record<string, string>;
 		};
 		quickOpen: {
 			enableExperimentalNewVersion: boolean;

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -329,6 +329,14 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('preserveInput', "Controls whether the last typed input to the command palette should be restored when opening it the next time."),
 				'default': false
 			},
+			'workbench.commandPalette.commandAliases': {
+				'type': 'object',
+				'additionalProperties': {
+					'type': 'string'
+				},
+				'description': localize('workbench.commandPalette.commandAliases', "Controls custom aliases for commands. Key is the command ID and value is the custom user alias."),
+				'default': false
+			},
 			'workbench.quickOpen.closeOnFocusLost': {
 				'type': 'boolean',
 				'description': localize('closeOnFocusLost', "Controls whether Quick Open should close automatically once it loses focus."),

--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -66,6 +66,7 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
 		@IPreferencesService private readonly preferencesService: IPreferencesService,
+		@IQuickInputService private readonly quickInputService: IQuickInputService,
 	) {
 		super({
 			showAlias: !Language.isDefaultVariant(),
@@ -80,7 +81,8 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 		const commandPaletteConfig = this.configurationService.getValue<IWorkbenchQuickAccessConfiguration>().workbench.commandPalette;
 
 		return {
-			preserveInput: commandPaletteConfig.preserveInput
+			preserveInput: commandPaletteConfig.preserveInput,
+			commandAliases: commandPaletteConfig.commandAliases || {}
 		};
 	}
 
@@ -99,11 +101,28 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 		].map(c => ({
 			...c,
 			buttons: [{
+				iconClass: Codicon.edit.classNames,
+				tooltip: localize('add custom alias', "Add Custom Alias"),
+			}, {
 				iconClass: Codicon.gear.classNames,
 				tooltip: localize('configure keybinding', "Configure Keybinding"),
 			}],
-			trigger: (): TriggerAction => {
-				this.preferencesService.openGlobalKeybindingSettings(false, { query: `@command:${c.commandId}` });
+			trigger: (buttonIndex: number): TriggerAction => {
+				// New alias
+				if (buttonIndex === 0) {
+					this.quickInputService.input({ prompt: localize('newCommandAlias', "New alias for {0}", c.commandId), value: c.userCommandAlias ?? c.label }).then(input => {
+						let aliases = Object.assign({}, this.configurationService.getValue<IWorkbenchQuickAccessConfiguration>().workbench.commandPalette.commandAliases);
+						if (input) {
+							aliases[c.commandId] = input;
+						} else if (c.commandId in aliases) {
+							delete aliases[c.commandId];
+						}
+						this.configurationService.updateValue('workbench.commandPalette.commandAliases', aliases);
+					});
+					// Keyboard shortcut
+				} else if (buttonIndex === 1) {
+					this.preferencesService.openGlobalKeybindingSettings(false, { query: `@command:${c.commandId}` });
+				}
 				return TriggerAction.CLOSE_PICKER;
 			},
 		}));
@@ -134,10 +153,12 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 			const commandAlias = (aliasLabel && category) ?
 				aliasCategory ? `${aliasCategory}: ${aliasLabel}` : `${category}: ${aliasLabel}` :
 				aliasLabel;
+			const userCommandAlias = (this.configuration.commandAliases && (action.item.id in this.configuration.commandAliases)) ? this.configuration.commandAliases[action.item.id] : undefined;
 
 			globalCommandPicks.push({
 				commandId: action.item.id,
 				commandAlias,
+				userCommandAlias,
 				label: stripIcons(label)
 			});
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #50836

This allows you to set a custom alias for commands.  You can do this by updating the `workbench.commandPalette.commandAliases` setting manually or using the new pencil/edit icon in the quick access menu.
