### PR TITLE
fix: view zone position in diffEditor with hidden area

### DIFF
--- a/src/vs/editor/common/viewModel/viewModel.ts
+++ b/src/vs/editor/common/viewModel/viewModel.ts
@@ -30,6 +30,8 @@ export interface IViewModel extends ICursorSimpleModel {
 
 	readonly cursorConfig: CursorConfiguration;
 
+	readonly hiddenAreas: IRange[];
+
 	addViewEventHandler(eventHandler: ViewEventHandler): void;
 	removeViewEventHandler(eventHandler: ViewEventHandler): void;
 

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -453,6 +453,10 @@ export class ViewModel extends Disposable implements IViewModel {
 		}));
 	}
 
+	public get hiddenAreas() {
+		return this._lines.getHiddenAreas();
+	}
+
 	public setHiddenAreas(ranges: Range[]): void {
 		let lineMappingChanged = false;
 		try {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR helps with #3562, fixing the problem of view zone position calculation in diff editor with hidden areas on both sides.

---

To achieve the goal of collapsing unchanged areas in diff editor, a possible solution is hiding the same lines' area by using `setHiddenAreas` api in diff editor and then using view zone widget to control the uncollapse behavior:

![image](https://user-images.githubusercontent.com/13199771/147443568-88602f42-17b5-404b-8cc9-e45cf6c810b2.png)

![image](https://user-images.githubusercontent.com/13199771/147444006-a206bdee-62ef-4f64-9f7f-2d28936543af.png)

VS Code (monaco) produces view zones on the other side by using the relative line-number of original/modified editor view zones. When we call `setHiddenAreas` on the editors, the line-number used to place the generated view zones would be inaccurate, which will cause mismatch of whitespaces and view zones:

![image](https://user-images.githubusercontent.com/13199771/147445050-666a2e9e-caa4-43fd-8ed9-4c52a0a65309.png)

This PR calculates the actual line number from the relative line-number and hidden area info, fixing the mismatch problem.

