### PR TITLE
fix(suggest): only show readmore icon in focused label

### DIFF
--- a/src/vs/editor/contrib/suggest/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/media/suggest.css
@@ -229,7 +229,7 @@
 
 /** Ellipsis on hover **/
 
-.monaco-editor .suggest-widget:not(.docs-side) .monaco-list .monaco-list-row:hover>.contents>.main>.right.can-expand-details>.details-label {
+.monaco-editor .suggest-widget:not(.docs-side) .monaco-list .monaco-list-row.focused:hover>.contents>.main>.right.can-expand-details>.details-label {
 	width: calc(100% - 26px);
 }
 
@@ -284,7 +284,7 @@
 	display: inline-block;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row:hover>.contents>.main>.right>.readMore {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused:hover>.contents>.main>.right>.readMore {
 	visibility: visible;
 }
 


### PR DESCRIPTION
This PR fixes #139790

because of this https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/suggest/suggestWidget.ts#L665,
the suggest details only show content related to focused label.
this PR hidden readmore icon in unfocused labels.

thanks