### PR TITLE
JSDoc syntax highlighting in script (fix #135417)

### DIFF
--- a/extensions/html/syntaxes/html.tmLanguage.json
+++ b/extensions/html/syntaxes/html.tmLanguage.json
@@ -1923,16 +1923,6 @@
 															]
 														},
 														{
-															"begin": "/\\*",
-															"captures": {
-																"0": {
-																	"name": "punctuation.definition.comment.js"
-																}
-															},
-															"end": "\\*/|(?=</script)",
-															"name": "comment.block.js"
-														},
-														{
 															"include": "source.js"
 														}
 													]


### PR DESCRIPTION
this pattern can not handle all js comment highlighting, and the next part "include": "source.js" can be good to deal with this situation

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #135417

