### PR TITLE
rename mode => language in many places

### DIFF
--- a/src/vs/editor/common/services/getIconClasses.ts
+++ b/src/vs/editor/common/services/getIconClasses.ts
@@ -89,7 +89,7 @@ function detectLanguageId(modelService: IModelService, languageService: ILanguag
 		}
 	}
 
-	// only take if the mode is specific (aka no just plain text)
+	// only take if the language id is specific (aka no just plain text)
 	if (languageId && languageId !== PLAINTEXT_LANGUAGE_ID) {
 		return languageId;
 	}

--- a/src/vs/editor/common/services/resolverService.ts
+++ b/src/vs/editor/common/services/resolverService.ts
@@ -58,9 +58,9 @@ export interface ITextEditorModel extends IEditorModel {
 	isReadonly(): boolean;
 
 	/**
-	 * The mode id of the text model if known.
+	 * The language id of the text model if known.
 	 */
-	getMode(): string | undefined;
+	getLanguageId(): string | undefined;
 }
 
 export interface IResolvedTextEditorModel extends ITextEditorModel {

--- a/src/vs/editor/contrib/links/links.ts
+++ b/src/vs/editor/contrib/links/links.ts
@@ -174,8 +174,8 @@ export class LinkDetector implements IEditorContribution {
 		}));
 		this.listenersToRemove.add(editor.onDidChangeModelContent((e) => this.onChange()));
 		this.listenersToRemove.add(editor.onDidChangeModel((e) => this.onModelChanged()));
-		this.listenersToRemove.add(editor.onDidChangeModelLanguage((e) => this.onModelModeChanged()));
-		this.listenersToRemove.add(LinkProviderRegistry.onDidChange((e) => this.onModelModeChanged()));
+		this.listenersToRemove.add(editor.onDidChangeModelLanguage((e) => this.onModelLanguageChanged()));
+		this.listenersToRemove.add(LinkProviderRegistry.onDidChange((e) => this.onModelLanguageChanged()));
 
 		this.timeout = new async.TimeoutTimer();
 		this.computePromise = null;
@@ -192,7 +192,7 @@ export class LinkDetector implements IEditorContribution {
 		this.beginCompute();
 	}
 
-	private onModelModeChanged(): void {
+	private onModelLanguageChanged(): void {
 		this.stop();
 		this.beginCompute();
 	}

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -131,7 +131,7 @@ class SimpleModel implements IResolvedTextEditorModel {
 		return true;
 	}
 
-	public getMode(): string | undefined {
+	public getLanguageId(): string | undefined {
 		return this.model.getLanguageId();
 	}
 }

--- a/src/vs/platform/editor/common/editor.ts
+++ b/src/vs/platform/editor/common/editor.ts
@@ -88,10 +88,10 @@ export interface IBaseTextResourceEditorInput extends IBaseResourceEditorInput {
 	encoding?: string;
 
 	/**
-	 * The identifier of the language mode of the text input
+	 * The identifier of the language id of the text input
 	 * if known to use when displaying the contents.
 	 */
-	mode?: string;
+	languageId?: string;
 }
 
 export interface IResourceEditorInput extends IBaseResourceEditorInput {
@@ -289,7 +289,7 @@ export interface IEditorOptions {
 
 	/**
 	 * An optional property to signal that certain view state should be
-	 * applied when opening the editor. 
+	 * applied when opening the editor.
 	 */
 	viewState?: object;
 }

--- a/src/vs/workbench/api/browser/mainThreadDocuments.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocuments.ts
@@ -271,10 +271,10 @@ export class MainThreadDocuments extends Disposable implements MainThreadDocumen
 		});
 	}
 
-	private _doCreateUntitled(associatedResource?: URI, mode?: string, initialValue?: string): Promise<URI> {
+	private _doCreateUntitled(associatedResource?: URI, languageId?: string, initialValue?: string): Promise<URI> {
 		return this._textFileService.untitled.resolve({
 			associatedResource,
-			mode,
+			languageId,
 			initialValue
 		}).then(model => {
 			const resource = model.resource;

--- a/src/vs/workbench/api/common/extHostDocuments.ts
+++ b/src/vs/workbench/api/common/extHostDocuments.ts
@@ -109,7 +109,7 @@ export class ExtHostDocuments implements ExtHostDocumentsShape {
 		if (!data) {
 			throw new Error('unknown document');
 		}
-		// Treat a mode change as a remove + add
+		// Treat a language change as a remove + add
 
 		this._onDidRemoveDocument.fire(data.document);
 		data._acceptLanguageId(newLanguageId);

--- a/src/vs/workbench/browser/dnd.ts
+++ b/src/vs/workbench/browser/dnd.ts
@@ -383,9 +383,9 @@ export function fillEditorsDragData(accessor: ServicesAccessor, resourcesOrEdito
 				const textFileModel = textFileService.files.get(resource);
 				if (textFileModel) {
 
-					// mode
-					if (typeof editor.mode !== 'string') {
-						editor.mode = textFileModel.getMode();
+					// language
+					if (typeof editor.languageId !== 'string') {
+						editor.languageId = textFileModel.getLanguageId();
 					}
 
 					// encoding

--- a/src/vs/workbench/browser/labels.ts
+++ b/src/vs/workbench/browser/labels.ts
@@ -135,13 +135,13 @@ export class ResourceLabels extends Disposable {
 		// notify when extensions are registered with potentially new languages
 		this._register(this.languageService.onDidChange(() => this.widgets.forEach(widget => widget.notifyExtensionsRegistered())));
 
-		// notify when model mode changes
+		// notify when model language changes
 		this._register(this.modelService.onModelLanguageChanged(e => {
 			if (!e.model.uri) {
 				return; // we need the resource to compare
 			}
 
-			this.widgets.forEach(widget => widget.notifyModelModeChanged(e.model));
+			this.widgets.forEach(widget => widget.notifyModelLanguageChanged(e.model));
 		}));
 
 		// notify when model is added
@@ -310,7 +310,7 @@ class ResourceLabelWidget extends IconLabel {
 		}
 	}
 
-	notifyModelModeChanged(model: ITextModel): void {
+	notifyModelLanguageChanged(model: ITextModel): void {
 		this.handleModelEvent(model);
 	}
 

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -19,7 +19,7 @@ import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/u
 import { TextResourceEditorInput } from 'vs/workbench/common/editor/textResourceEditorInput';
 import { TextDiffEditor } from 'vs/workbench/browser/parts/editor/textDiffEditor';
 import { BinaryResourceDiffEditor } from 'vs/workbench/browser/parts/editor/binaryDiffEditor';
-import { ChangeEncodingAction, ChangeEOLAction, ChangeModeAction, EditorStatus } from 'vs/workbench/browser/parts/editor/editorStatus';
+import { ChangeEncodingAction, ChangeEOLAction, ChangeLanguageAction, EditorStatus } from 'vs/workbench/browser/parts/editor/editorStatus';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions, CATEGORIES } from 'vs/workbench/common/actions';
 import { SyncActionDescriptor, MenuRegistry, MenuId, IMenuItem } from 'vs/platform/actions/common/actions';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
@@ -162,7 +162,7 @@ quickAccessRegistry.registerQuickAccessProvider({
 
 // Editor Status
 const registry = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions);
-registry.registerWorkbenchAction(SyncActionDescriptor.from(ChangeModeAction, { primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyM) }), 'Change Language Mode', undefined, ContextKeyExpr.not('notebookEditorFocused'));
+registry.registerWorkbenchAction(SyncActionDescriptor.from(ChangeLanguageAction, { primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyM) }), 'Change Language Mode', undefined, ContextKeyExpr.not('notebookEditorFocused'));
 registry.registerWorkbenchAction(SyncActionDescriptor.from(ChangeEOLAction), 'Change End of Line Sequence');
 registry.registerWorkbenchAction(SyncActionDescriptor.from(ChangeEncodingAction), 'Change File Encoding');
 

--- a/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
@@ -154,7 +154,7 @@ export class TextResourceEditor extends AbstractTextResourceEditor {
 		const control = super.createEditorControl(parent, configuration);
 
 		// Install a listener for paste to update this editors
-		// language mode if the paste includes a specific mode
+		// language if the paste includes a specific language
 		const codeEditor = getCodeEditor(control);
 		if (codeEditor) {
 			this._register(codeEditor.onDidPaste(e => this.onDidEditorPaste(e, codeEditor)));
@@ -164,8 +164,8 @@ export class TextResourceEditor extends AbstractTextResourceEditor {
 	}
 
 	private onDidEditorPaste(e: IPasteEvent, codeEditor: ICodeEditor): void {
-		if (this.input instanceof UntitledTextEditorInput && this.input.model.hasModeSetExplicitly) {
-			return; // do not override mode if it was set explicitly
+		if (this.input instanceof UntitledTextEditorInput && this.input.model.hasLanguageSetExplicitly) {
+			return; // do not override language if it was set explicitly
 		}
 
 		if (e.range.startLineNumber !== 1 || e.range.startColumn !== 1) {

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -14,7 +14,7 @@ import type { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { IInstantiationService, IConstructorSignature0, ServicesAccessor, BrandedService } from 'vs/platform/instantiation/common/instantiation';
 import { IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { Registry } from 'vs/platform/registry/common/platform';
-import { IEncodingSupport, IModeSupport } from 'vs/workbench/services/textfile/common/textfiles';
+import { IEncodingSupport, ILanguageSupport } from 'vs/workbench/services/textfile/common/textfiles';
 import { IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { ICompositeControl, IComposite } from 'vs/workbench/common/composite';
 import { FileType, IFileService } from 'vs/platform/files/common/files';
@@ -247,7 +247,7 @@ export interface IFileEditorFactory {
 	/**
 	 * Creates new new editor capable of showing files.
 	 */
-	createFileEditor(resource: URI, preferredResource: URI | undefined, preferredName: string | undefined, preferredDescription: string | undefined, preferredEncoding: string | undefined, preferredMode: string | undefined, preferredContents: string | undefined, instantiationService: IInstantiationService): IFileEditorInput;
+	createFileEditor(resource: URI, preferredResource: URI | undefined, preferredName: string | undefined, preferredDescription: string | undefined, preferredEncoding: string | undefined, preferredLanguageId: string | undefined, preferredContents: string | undefined, instantiationService: IInstantiationService): IFileEditorInput;
 
 	/**
 	 * Check if the provided object is a file editor.
@@ -621,7 +621,7 @@ export interface IUntypedFileEditorInput extends ITextResourceEditorInput {
  * This is a tagging interface to declare an editor input being capable of dealing with files. It is only used in the editor registry
  * to register this kind of input to the platform.
  */
-export interface IFileEditorInput extends EditorInput, IEncodingSupport, IModeSupport, EditorInputWithPreferredResource {
+export interface IFileEditorInput extends EditorInput, IEncodingSupport, ILanguageSupport, EditorInputWithPreferredResource {
 
 	/**
 	 * Gets the resource this file input is about. This will always be the
@@ -660,9 +660,9 @@ export interface IFileEditorInput extends EditorInput, IEncodingSupport, IModeSu
 	setPreferredEncoding(encoding: string): void;
 
 	/**
-	 * Sets the preferred language mode to use for this file input.
+	 * Sets the preferred language id to use for this file input.
 	 */
-	setPreferredMode(mode: string): void;
+	setPreferredLanguageId(languageId: string): void;
 
 	/**
 	 * Sets the preferred contents to use for this file input.

--- a/src/vs/workbench/common/editor/textEditorModel.ts
+++ b/src/vs/workbench/common/editor/textEditorModel.ts
@@ -5,7 +5,7 @@
 
 import { ITextModel, ITextBufferFactory, ITextSnapshot, ModelConstants } from 'vs/editor/common/model';
 import { EditorModel } from 'vs/workbench/common/editor/editorModel';
-import { IModeSupport } from 'vs/workbench/services/textfile/common/textfiles';
+import { ILanguageSupport } from 'vs/workbench/services/textfile/common/textfiles';
 import { URI } from 'vs/base/common/uri';
 import { ITextEditorModel, IResolvedTextEditorModel } from 'vs/editor/common/services/resolverService';
 import { ILanguageService, ILanguageSelection } from 'vs/editor/common/services/language';
@@ -21,7 +21,7 @@ import { localize } from 'vs/nls';
 /**
  * The base text editor model leverages the code editor model. This class is only intended to be subclassed and not instantiated.
  */
-export class BaseTextEditorModel extends EditorModel implements ITextEditorModel, IModeSupport {
+export class BaseTextEditorModel extends EditorModel implements ITextEditorModel, ILanguageSupport {
 
 	private static readonly AUTO_DETECT_LANGUAGE_THROTTLE_DELAY = 600;
 
@@ -75,30 +75,30 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 		return true;
 	}
 
-	private _hasModeSetExplicitly: boolean = false;
-	get hasModeSetExplicitly(): boolean { return this._hasModeSetExplicitly; }
+	private _hasLanguageSetExplicitly: boolean = false;
+	get hasLanguageSetExplicitly(): boolean { return this._hasLanguageSetExplicitly; }
 
-	setMode(mode: string): void {
+	setLanguageId(languageId: string): void {
 
-		// Remember that an explicit mode was set
-		this._hasModeSetExplicitly = true;
+		// Remember that an explicit language was set
+		this._hasLanguageSetExplicitly = true;
 
-		this.setModeInternal(mode);
+		this.setLanguageIdInternal(languageId);
 	}
 
-	private setModeInternal(mode: string): void {
+	private setLanguageIdInternal(languageId: string): void {
 		if (!this.isResolved()) {
 			return;
 		}
 
-		if (!mode || mode === this.textEditorModel.getLanguageId()) {
+		if (!languageId || languageId === this.textEditorModel.getLanguageId()) {
 			return;
 		}
 
-		this.modelService.setMode(this.textEditorModel, this.languageService.createById(mode));
+		this.modelService.setMode(this.textEditorModel, this.languageService.createById(languageId));
 	}
 
-	getMode(): string | undefined {
+	getLanguageId(): string | undefined {
 		return this.textEditorModel?.getLanguageId();
 	}
 
@@ -108,16 +108,16 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 
 	private async doAutoDetectLanguage(): Promise<void> {
 		if (
-			this.hasModeSetExplicitly || 															// skip detection when the user has made an explicit choice on the mode
-			!this.textEditorModelHandle ||															// require a URI to run the detection for
-			!this.languageDetectionService.isEnabledForMode(this.getMode() ?? PLAINTEXT_LANGUAGE_ID)	// require a valid mode that is enlisted for detection
+			this.hasLanguageSetExplicitly || 																	// skip detection when the user has made an explicit choice on the language
+			!this.textEditorModelHandle ||																		// require a URI to run the detection for
+			!this.languageDetectionService.isEnabledForLanguage(this.getLanguageId() ?? PLAINTEXT_LANGUAGE_ID)	// require a valid language that is enlisted for detection
 		) {
 			return;
 		}
 
 		const lang = await this.languageDetectionService.detectLanguage(this.textEditorModelHandle);
 		if (lang && !this.isDisposed()) {
-			this.setModeInternal(lang);
+			this.setLanguageIdInternal(lang);
 			const languageName = this.languageService.getLanguageName(lang);
 			if (languageName) {
 				this.accessibilityService.alert(localize('languageAutoDetected', "Language {0} was automatically detected and set as the language mode.", languageName));
@@ -126,12 +126,12 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 	}
 
 	/**
-	 * Creates the text editor model with the provided value, optional preferred mode
+	 * Creates the text editor model with the provided value, optional preferred language
 	 * (can be comma separated for multiple values) and optional resource URL.
 	 */
-	protected createTextEditorModel(value: ITextBufferFactory, resource: URI | undefined, preferredMode?: string): ITextModel {
+	protected createTextEditorModel(value: ITextBufferFactory, resource: URI | undefined, preferredLanguageId?: string): ITextModel {
 		const firstLineText = this.getFirstLineText(value);
-		const languageSelection = this.getOrCreateMode(resource, this.languageService, preferredMode, firstLineText);
+		const languageSelection = this.getOrCreateLanguage(resource, this.languageService, preferredLanguageId, firstLineText);
 
 		return this.doCreateTextEditorModel(value, languageSelection, resource);
 	}
@@ -167,25 +167,25 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 	}
 
 	/**
-	 * Gets the mode for the given identifier. Subclasses can override to provide their own implementation of this lookup.
+	 * Gets the language for the given identifier. Subclasses can override to provide their own implementation of this lookup.
 	 *
-	 * @param firstLineText optional first line of the text buffer to set the mode on. This can be used to guess a mode from content.
+	 * @param firstLineText optional first line of the text buffer to set the language on. This can be used to guess a language from content.
 	 */
-	protected getOrCreateMode(resource: URI | undefined, languageService: ILanguageService, preferredMode: string | undefined, firstLineText?: string): ILanguageSelection {
+	protected getOrCreateLanguage(resource: URI | undefined, languageService: ILanguageService, preferredLanguage: string | undefined, firstLineText?: string): ILanguageSelection {
 
-		// lookup mode via resource path if the provided mode is unspecific
-		if (!preferredMode || preferredMode === PLAINTEXT_LANGUAGE_ID) {
+		// lookup language via resource path if the provided language is unspecific
+		if (!preferredLanguage || preferredLanguage === PLAINTEXT_LANGUAGE_ID) {
 			return languageService.createByFilepathOrFirstLine(withUndefinedAsNull(resource), firstLineText);
 		}
 
-		// otherwise take the preferred mode for granted
-		return languageService.createById(preferredMode);
+		// otherwise take the preferred language for granted
+		return languageService.createById(preferredLanguage);
 	}
 
 	/**
 	 * Updates the text editor model with the provided value. If the value is the same as the model has, this is a no-op.
 	 */
-	updateTextEditorModel(newValue?: ITextBufferFactory, preferredMode?: string): void {
+	updateTextEditorModel(newValue?: ITextBufferFactory, preferredLanguageId?: string): void {
 		if (!this.isResolved()) {
 			return;
 		}
@@ -195,9 +195,9 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 			this.modelService.updateModel(this.textEditorModel, newValue);
 		}
 
-		// mode (only if specific and changed)
-		if (preferredMode && preferredMode !== PLAINTEXT_LANGUAGE_ID && this.textEditorModel.getLanguageId() !== preferredMode) {
-			this.modelService.setMode(this.textEditorModel, this.languageService.createById(preferredMode));
+		// language (only if specific and changed)
+		if (preferredLanguageId && preferredLanguageId !== PLAINTEXT_LANGUAGE_ID && this.textEditorModel.getLanguageId() !== preferredLanguageId) {
+			this.modelService.setMode(this.textEditorModel, this.languageService.createById(preferredLanguageId));
 		}
 	}
 

--- a/src/vs/workbench/common/editor/textResourceEditorInput.ts
+++ b/src/vs/workbench/common/editor/textResourceEditorInput.ts
@@ -7,7 +7,7 @@ import { DEFAULT_EDITOR_ASSOCIATION, GroupIdentifier, IRevertOptions, isEditorIn
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { AbstractResourceEditorInput } from 'vs/workbench/common/editor/resourceEditorInput';
 import { URI } from 'vs/base/common/uri';
-import { ITextFileService, ITextFileSaveOptions, IModeSupport } from 'vs/workbench/services/textfile/common/textfiles';
+import { ITextFileService, ITextFileSaveOptions, ILanguageSupport } from 'vs/workbench/services/textfile/common/textfiles';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ILabelService } from 'vs/platform/label/common/label';
@@ -91,7 +91,7 @@ export abstract class AbstractTextResourceEditorInput extends AbstractResourceEd
  * A read-only text editor input whos contents are made of the provided resource that points to an existing
  * code editor model.
  */
-export class TextResourceEditorInput extends AbstractTextResourceEditorInput implements IModeSupport {
+export class TextResourceEditorInput extends AbstractTextResourceEditorInput implements ILanguageSupport {
 
 	static readonly ID: string = 'workbench.editors.resourceEditorInput';
 
@@ -110,7 +110,7 @@ export class TextResourceEditorInput extends AbstractTextResourceEditorInput imp
 		resource: URI,
 		private name: string | undefined,
 		private description: string | undefined,
-		private preferredMode: string | undefined,
+		private preferredLanguageId: string | undefined,
 		private preferredContents: string | undefined,
 		@ITextModelService private readonly textModelResolverService: ITextModelService,
 		@ITextFileService textFileService: ITextFileService,
@@ -146,16 +146,16 @@ export class TextResourceEditorInput extends AbstractTextResourceEditorInput imp
 		}
 	}
 
-	setMode(mode: string): void {
-		this.setPreferredMode(mode);
+	setLanguageId(languageId: string): void {
+		this.setPreferredLanguageId(languageId);
 
 		if (this.cachedModel) {
-			this.cachedModel.setMode(mode);
+			this.cachedModel.setLanguageId(languageId);
 		}
 	}
 
-	setPreferredMode(mode: string): void {
-		this.preferredMode = mode;
+	setPreferredLanguageId(languageId: string): void {
+		this.preferredLanguageId = languageId;
 	}
 
 	setPreferredContents(contents: string): void {
@@ -164,15 +164,15 @@ export class TextResourceEditorInput extends AbstractTextResourceEditorInput imp
 
 	override async resolve(): Promise<ITextEditorModel> {
 
-		// Unset preferred contents and mode after resolving
+		// Unset preferred contents and language after resolving
 		// once to prevent these properties to stick. We still
-		// want the user to change the language mode in the editor
+		// want the user to change the language in the editor
 		// and want to show updated contents (if any) in future
 		// `resolve` calls.
 		const preferredContents = this.preferredContents;
-		const preferredMode = this.preferredMode;
+		const preferredLanguageId = this.preferredLanguageId;
 		this.preferredContents = undefined;
-		this.preferredMode = undefined;
+		this.preferredLanguageId = undefined;
 
 		if (!this.modelReference) {
 			this.modelReference = this.textModelResolverService.createModelReference(this.resource);
@@ -191,9 +191,9 @@ export class TextResourceEditorInput extends AbstractTextResourceEditorInput imp
 
 		this.cachedModel = model;
 
-		// Set contents and mode if preferred
-		if (typeof preferredContents === 'string' || typeof preferredMode === 'string') {
-			model.updateTextEditorModel(typeof preferredContents === 'string' ? createTextBufferFactory(preferredContents) : undefined, preferredMode);
+		// Set contents and language if preferred
+		if (typeof preferredContents === 'string' || typeof preferredLanguageId === 'string') {
+			model.updateTextEditorModel(typeof preferredContents === 'string' ? createTextBufferFactory(preferredContents) : undefined, preferredLanguageId);
 		}
 
 		return model;

--- a/src/vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint.ts
@@ -9,7 +9,7 @@ import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentW
 import { localize } from 'vs/nls';
 import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { inputPlaceholderForeground, textLinkForeground } from 'vs/platform/theme/common/colorRegistry';
-import { ChangeModeAction } from 'vs/workbench/browser/parts/editor/editorStatus';
+import { ChangeLanguageAction } from 'vs/workbench/browser/parts/editor/editorStatus';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { PLAINTEXT_LANGUAGE_ID } from 'vs/editor/common/modes/modesRegistry';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
@@ -106,7 +106,7 @@ class UntitledTextEditorHintContentWidget implements IContentWidget {
 			const language = $('a.language-mode');
 			language.style.cursor = 'pointer';
 			language.innerText = localize('selectAlanguage2', "Select a language");
-			const languageKeyBinding = this.keybindingService.lookupKeybinding(ChangeModeAction.ID);
+			const languageKeyBinding = this.keybindingService.lookupKeybinding(ChangeLanguageAction.ID);
 			const languageKeybindingLabel = languageKeyBinding?.getLabel();
 			if (languageKeybindingLabel) {
 				language.title = localize('keyboardBindingTooltip', "{0}", languageKeybindingLabel);
@@ -129,7 +129,7 @@ class UntitledTextEditorHintContentWidget implements IContentWidget {
 				e.stopPropagation();
 				// Need to focus editor before so current editor becomes active and the command is properly executed
 				this.editor.focus();
-				await this.commandService.executeCommand(ChangeModeAction.ID, { from: 'hint' });
+				await this.commandService.executeCommand(ChangeLanguageAction.ID, { from: 'hint' });
 				this.editor.focus();
 			};
 			this.toDispose.push(dom.addDisposableListener(language, 'click', languageOnClickOrTap));

--- a/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
@@ -169,7 +169,7 @@ export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWi
 
 	private setInputMode(): void {
 		if (this.editor.hasModel()) {
-			// Use plaintext language mode for log messages, otherwise respect underlying editor mode #125619
+			// Use plaintext language for log messages, otherwise respect underlying editor language #125619
 			const languageId = this.context === Context.LOG_MESSAGE ? PLAINTEXT_LANGUAGE_ID : this.editor.getModel().getLanguageId();
 			this.input.getModel().setMode(languageId);
 		}

--- a/src/vs/workbench/contrib/debug/common/debugUtils.ts
+++ b/src/vs/workbench/contrib/debug/common/debugUtils.ts
@@ -310,7 +310,7 @@ function compareOrders(first: number | undefined, second: number | undefined): n
 }
 
 export async function saveAllBeforeDebugStart(configurationService: IConfigurationService, editorService: IEditorService): Promise<void> {
-	const saveBeforeStartConfig: string = configurationService.getValue('debug.saveBeforeStart', { overrideIdentifier: editorService.activeTextEditorMode });
+	const saveBeforeStartConfig: string = configurationService.getValue('debug.saveBeforeStart', { overrideIdentifier: editorService.activeTextEditorLanguageId });
 	if (saveBeforeStartConfig !== 'none') {
 		await editorService.saveAll();
 		if (saveBeforeStartConfig === 'allEditorsInActiveGroup') {

--- a/src/vs/workbench/contrib/files/browser/editors/binaryFileEditor.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/binaryFileEditor.ts
@@ -81,7 +81,7 @@ export class BinaryFileEditor extends BaseBinaryResourceEditor {
 				for (const editor of resolvedEditor.editor instanceof DiffEditorInput ? [resolvedEditor.editor.original, resolvedEditor.editor.modified] : [resolvedEditor.editor]) {
 					if (editor instanceof FileEditorInput) {
 						editor.setForceOpenAsText();
-						editor.setPreferredMode(BINARY_TEXT_FILE_MODE); // https://github.com/microsoft/vscode/issues/131076
+						editor.setPreferredLanguageId(BINARY_TEXT_FILE_MODE); // https://github.com/microsoft/vscode/issues/131076
 					}
 				}
 			}

--- a/src/vs/workbench/contrib/files/browser/editors/fileEditorHandler.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/fileEditorHandler.ts
@@ -22,7 +22,7 @@ interface ISerializedFileEditorInput {
 	name?: string;
 	description?: string;
 	encoding?: string;
-	modeId?: string;
+	modeId?: string; // should be `languageId` but is kept for backwards compatibility
 }
 
 export class FileEditorInputSerializer implements IEditorSerializer {
@@ -41,7 +41,7 @@ export class FileEditorInputSerializer implements IEditorSerializer {
 			name: fileEditorInput.getPreferredName(),
 			description: fileEditorInput.getPreferredDescription(),
 			encoding: fileEditorInput.getEncoding(),
-			modeId: fileEditorInput.getPreferredMode() // only using the preferred user associated mode here if available to not store redundant data
+			modeId: fileEditorInput.getPreferredLanguageId() // only using the preferred user associated language here if available to not store redundant data
 		};
 
 		return JSON.stringify(serializedFileEditorInput);
@@ -55,9 +55,9 @@ export class FileEditorInputSerializer implements IEditorSerializer {
 			const name = serializedFileEditorInput.name;
 			const description = serializedFileEditorInput.description;
 			const encoding = serializedFileEditorInput.encoding;
-			const mode = serializedFileEditorInput.modeId;
+			const languageId = serializedFileEditorInput.modeId;
 
-			const fileEditorInput = accessor.get(ITextEditorService).createTextEditor({ resource, label: name, description, encoding, mode, forceFile: true }) as FileEditorInput;
+			const fileEditorInput = accessor.get(ITextEditorService).createTextEditor({ resource, label: name, description, encoding, languageId, forceFile: true }) as FileEditorInput;
 			if (preferredResource) {
 				fileEditorInput.setPreferredResource(preferredResource);
 			}

--- a/src/vs/workbench/contrib/files/browser/editors/fileEditorInput.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/fileEditorInput.ts
@@ -67,7 +67,7 @@ export class FileEditorInput extends AbstractTextResourceEditorInput implements 
 	private preferredName: string | undefined;
 	private preferredDescription: string | undefined;
 	private preferredEncoding: string | undefined;
-	private preferredMode: string | undefined;
+	private preferredLanguageId: string | undefined;
 	private preferredContents: string | undefined;
 
 	private forceOpenAs: ForceOpenAs = ForceOpenAs.None;
@@ -83,7 +83,7 @@ export class FileEditorInput extends AbstractTextResourceEditorInput implements 
 		preferredName: string | undefined,
 		preferredDescription: string | undefined,
 		preferredEncoding: string | undefined,
-		preferredMode: string | undefined,
+		preferredLanguageId: string | undefined,
 		preferredContents: string | undefined,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ITextFileService textFileService: ITextFileService,
@@ -111,8 +111,8 @@ export class FileEditorInput extends AbstractTextResourceEditorInput implements 
 			this.setPreferredEncoding(preferredEncoding);
 		}
 
-		if (preferredMode) {
-			this.setPreferredMode(preferredMode);
+		if (preferredLanguageId) {
+			this.setPreferredLanguageId(preferredLanguageId);
 		}
 
 		if (typeof preferredContents === 'string') {
@@ -232,28 +232,28 @@ export class FileEditorInput extends AbstractTextResourceEditorInput implements 
 		this.setForceOpenAsText();
 	}
 
-	getMode(): string | undefined {
+	getLanguageId(): string | undefined {
 		if (this.model) {
-			return this.model.getMode();
+			return this.model.getLanguageId();
 		}
 
-		return this.preferredMode;
+		return this.preferredLanguageId;
 	}
 
-	getPreferredMode(): string | undefined {
-		return this.preferredMode;
+	getPreferredLanguageId(): string | undefined {
+		return this.preferredLanguageId;
 	}
 
-	setMode(mode: string): void {
-		this.setPreferredMode(mode);
+	setLanguageId(languageId: string): void {
+		this.setPreferredLanguageId(languageId);
 
-		this.model?.setMode(mode);
+		this.model?.setLanguageId(languageId);
 	}
 
-	setPreferredMode(mode: string): void {
-		this.preferredMode = mode;
+	setPreferredLanguageId(languageId: string): void {
+		this.preferredLanguageId = languageId;
 
-		// mode is a good hint to open the file as text
+		// languages are a good hint to open the file as text
 		this.setForceOpenAsText();
 	}
 
@@ -324,7 +324,7 @@ export class FileEditorInput extends AbstractTextResourceEditorInput implements 
 			// Resolve resource via text file service and only allow
 			// to open binary files if we are instructed so
 			await this.textFileService.files.resolve(this.resource, {
-				mode: this.preferredMode,
+				languageId: this.preferredLanguageId,
 				encoding: this.preferredEncoding,
 				contents: typeof preferredContents === 'string' ? createTextBufferFactory(preferredContents) : undefined,
 				reload: { async: true }, // trigger a reload of the model if it exists already but do not wait to show the model
@@ -399,7 +399,7 @@ export class FileEditorInput extends AbstractTextResourceEditorInput implements 
 
 		if (typeof options?.preserveViewState === 'number') {
 			untypedInput.encoding = this.getEncoding();
-			untypedInput.mode = this.getMode();
+			untypedInput.languageId = this.getLanguageId();
 			untypedInput.contents = (() => {
 				const model = this.textFileService.files.get(this.resource);
 				if (model && model.isDirty()) {

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -71,8 +71,8 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerFile
 
 	typeId: FILE_EDITOR_INPUT_ID,
 
-	createFileEditor: (resource, preferredResource, preferredName, preferredDescription, preferredEncoding, preferredMode, preferredContents, instantiationService): IFileEditorInput => {
-		return instantiationService.createInstance(FileEditorInput, resource, preferredResource, preferredName, preferredDescription, preferredEncoding, preferredMode, preferredContents);
+	createFileEditor: (resource, preferredResource, preferredName, preferredDescription, preferredEncoding, preferredLanguageId, preferredContents, instantiationService): IFileEditorInput => {
+		return instantiationService.createInstance(FileEditorInput, resource, preferredResource, preferredName, preferredDescription, preferredEncoding, preferredLanguageId, preferredContents);
 	},
 
 	isFileEditor: (obj): obj is IFileEditorInput => {
@@ -260,7 +260,7 @@ configurationRegistry.registerConfiguration({
 		'files.hotExit': hotExitConfiguration,
 		'files.defaultLanguage': {
 			'type': 'string',
-			'markdownDescription': nls.localize('defaultLanguage', "The default language mode that is assigned to new files. If configured to `${activeEditorLanguage}`, will use the language mode of the currently active text editor if any.")
+			'markdownDescription': nls.localize('defaultLanguage', "The default language identifier that is assigned to new files. If configured to `${activeEditorLanguage}`, will use the language identifier of the currently active text editor if any.")
 		},
 		'files.maxMemoryForLargeFilesMB': {
 			'type': 'number',

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -75,7 +75,7 @@ export const FILE_EDITOR_INPUT_ID = 'workbench.editors.files.fileEditorInput';
 export const BINARY_FILE_EDITOR_ID = 'workbench.editors.files.binaryFileEditor';
 
 /**
- * Language mode for binary files opened as text.
+ * Language identifier for binary files opened as text.
  */
 export const BINARY_TEXT_FILE_MODE = 'code-text-binary';
 

--- a/src/vs/workbench/contrib/files/test/browser/fileEditorInput.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/fileEditorInput.test.ts
@@ -29,8 +29,8 @@ suite('Files - FileEditorInput', () => {
 	let instantiationService: IInstantiationService;
 	let accessor: TestServiceAccessor;
 
-	function createFileInput(resource: URI, preferredResource?: URI, preferredMode?: string, preferredName?: string, preferredDescription?: string, preferredContents?: string): FileEditorInput {
-		return instantiationService.createInstance(FileEditorInput, resource, preferredResource, preferredName, preferredDescription, undefined, preferredMode, preferredContents);
+	function createFileInput(resource: URI, preferredResource?: URI, preferredLanguageId?: string, preferredName?: string, preferredDescription?: string, preferredContents?: string): FileEditorInput {
+		return instantiationService.createInstance(FileEditorInput, resource, preferredResource, preferredName, preferredDescription, undefined, preferredLanguageId, preferredContents);
 	}
 
 	class TestTextEditorService extends TextEditorService {
@@ -169,27 +169,27 @@ suite('Files - FileEditorInput', () => {
 		listener.dispose();
 	});
 
-	test('preferred mode', async function () {
-		const mode = 'file-input-test';
+	test('preferred language', async function () {
+		const languageId = 'file-input-test';
 		ModesRegistry.registerLanguage({
-			id: mode,
+			id: languageId,
 		});
 
-		const input = createFileInput(toResource.call(this, '/foo/bar/file.js'), undefined, mode);
-		assert.strictEqual(input.getPreferredMode(), mode);
+		const input = createFileInput(toResource.call(this, '/foo/bar/file.js'), undefined, languageId);
+		assert.strictEqual(input.getPreferredLanguageId(), languageId);
 
 		const model = await input.resolve() as TextFileEditorModel;
-		assert.strictEqual(model.textEditorModel!.getLanguageId(), mode);
+		assert.strictEqual(model.textEditorModel!.getLanguageId(), languageId);
 
-		input.setMode('text');
-		assert.strictEqual(input.getPreferredMode(), 'text');
+		input.setLanguageId('text');
+		assert.strictEqual(input.getPreferredLanguageId(), 'text');
 		assert.strictEqual(model.textEditorModel!.getLanguageId(), PLAINTEXT_LANGUAGE_ID);
 
 		const input2 = createFileInput(toResource.call(this, '/foo/bar/file.js'));
-		input2.setPreferredMode(mode);
+		input2.setPreferredLanguageId(languageId);
 
 		const model2 = await input2.resolve() as TextFileEditorModel;
-		assert.strictEqual(model2.textEditorModel!.getLanguageId(), mode);
+		assert.strictEqual(model2.textEditorModel!.getLanguageId(), languageId);
 	});
 
 	test('preferred contents', async function () {

--- a/src/vs/workbench/contrib/preferences/browser/keyboardLayoutPicker.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keyboardLayoutPicker.ts
@@ -178,7 +178,7 @@ export class KeyboardLayoutPickerAction extends Action {
 				}
 				return this.editorService.openEditor({
 					resource: stat.resource,
-					mode: 'jsonc',
+					languageId: 'jsonc',
 					options: { pinned: true }
 				});
 			}, (error) => {

--- a/src/vs/workbench/contrib/surveys/browser/languageSurveys.contribution.ts
+++ b/src/vs/workbench/contrib/surveys/browser/languageSurveys.contribution.ts
@@ -55,7 +55,7 @@ class LanguageSurvey extends Disposable {
 			// Process model-save event every 250ms to reduce load
 			const onModelsSavedWorker = this._register(new RunOnceWorker<ITextFileEditorModel>(models => {
 				models.forEach(m => {
-					if (m.getMode() === data.languageId && date !== storageService.get(EDITED_LANGUAGE_DATE_KEY, StorageScope.GLOBAL)) {
+					if (m.getLanguageId() === data.languageId && date !== storageService.get(EDITED_LANGUAGE_DATE_KEY, StorageScope.GLOBAL)) {
 						const editedCount = storageService.getNumber(EDITED_LANGUAGE_COUNT_KEY, StorageScope.GLOBAL, 0) + 1;
 						storageService.store(EDITED_LANGUAGE_COUNT_KEY, editedCount, StorageScope.GLOBAL, StorageTarget.USER);
 						storageService.store(EDITED_LANGUAGE_DATE_KEY, date, StorageScope.GLOBAL, StorageTarget.USER);

--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -571,7 +571,7 @@ registerAction2(class extends Action2 {
 		contents = contents.replace(/\"__/g, '//"');
 
 		const editorService = accessor.get(IEditorService);
-		return editorService.openEditor({ resource: undefined, contents, mode: 'jsonc', options: { pinned: true } });
+		return editorService.openEditor({ resource: undefined, contents, languageId: 'jsonc', options: { pinned: true } });
 	}
 });
 

--- a/src/vs/workbench/contrib/url/browser/trustedDomains.ts
+++ b/src/vs/workbench/contrib/url/browser/trustedDomains.ts
@@ -30,7 +30,7 @@ export const manageTrustedDomainSettingsCommand = {
 	},
 	handler: async (accessor: ServicesAccessor) => {
 		const editorService = accessor.get(IEditorService);
-		editorService.openEditor({ resource: TRUSTED_DOMAINS_URI, mode: 'jsonc', options: { pinned: true } });
+		editorService.openEditor({ resource: TRUSTED_DOMAINS_URI, languageId: 'jsonc', options: { pinned: true } });
 		return;
 	}
 };
@@ -114,7 +114,7 @@ export async function configureOpenerTrustedDomainsHandler(
 			case 'manage':
 				await editorService.openEditor({
 					resource: TRUSTED_DOMAINS_URI.with({ fragment: resource.toString() }),
-					mode: 'jsonc',
+					languageId: 'jsonc',
 					options: { pinned: true }
 				});
 				return trustedDomains;

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -410,7 +410,7 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		return undefined;
 	}
 
-	get activeTextEditorMode(): string | undefined {
+	get activeTextEditorLanguageId(): string | undefined {
 		let activeCodeEditor: ICodeEditor | undefined = undefined;
 
 		const activeTextEditorControl = this.activeTextEditorControl;

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -145,11 +145,11 @@ export interface IEditorService {
 	readonly activeTextEditorControl: IEditor | IDiffEditor | undefined;
 
 	/**
-	 * The currently active text editor mode or `undefined` if there is currently no active
+	 * The currently active text editor language id or `undefined` if there is currently no active
 	 * editor or the active editor control is neither a text nor a diff editor. If the active
-	 * editor is a diff editor, the modified side's mode will be taken.
+	 * editor is a diff editor, the modified side's language id will be taken.
 	 */
-	readonly activeTextEditorMode: string | undefined;
+	readonly activeTextEditorLanguageId: string | undefined;
 
 	/**
 	 * All editor panes that are currently visible across all editor groups.

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -91,7 +91,7 @@ suite('EditorService', () => {
 		assert.strictEqual(service.visibleEditorPanes.length, 1);
 		assert.strictEqual(service.visibleEditorPanes[0], editor);
 		assert.ok(!service.activeTextEditorControl);
-		assert.ok(!service.activeTextEditorMode);
+		assert.ok(!service.activeTextEditorLanguageId);
 		assert.strictEqual(service.visibleTextEditorControls.length, 0);
 		assert.strictEqual(service.isOpened(input), true);
 		assert.strictEqual(service.isOpened({ resource: input.resource, typeId: input.typeId, editorId: input.editorId }), true);
@@ -2013,7 +2013,7 @@ suite('EditorService', () => {
 
 		assert.strictEqual(service.activeEditorPane, editor);
 		assert.strictEqual(service.activeTextEditorControl, editor?.getControl());
-		assert.strictEqual(service.activeTextEditorMode, PLAINTEXT_LANGUAGE_ID);
+		assert.strictEqual(service.activeTextEditorLanguageId, PLAINTEXT_LANGUAGE_ID);
 	});
 
 	test('openEditor returns NULL when opening fails or is inactive', async function () {

--- a/src/vs/workbench/services/languageDetection/browser/languageDetectionWorkerServiceImpl.ts
+++ b/src/vs/workbench/services/languageDetection/browser/languageDetectionWorkerServiceImpl.ts
@@ -55,7 +55,7 @@ export class LanguageDetectionService extends Disposable implements ILanguageDet
 		);
 	}
 
-	public isEnabledForMode(languageId: string): boolean {
+	public isEnabledForLanguage(languageId: string): boolean {
 		return !!languageId && this._configurationService.getValue<boolean>(LanguageDetectionService.enablementSettingKey, { overrideIdentifier: languageId });
 	}
 

--- a/src/vs/workbench/services/languageDetection/common/languageDetectionWorkerService.ts
+++ b/src/vs/workbench/services/languageDetection/common/languageDetectionWorkerService.ts
@@ -13,13 +13,13 @@ export interface ILanguageDetectionService {
 
 	/**
 	 * @param languageId The languageId to check if language detection is currently enabled.
-	 * @returns whether or not language detection is on for this language mode.
+	 * @returns whether or not language detection is on for this language.
 	 */
-	isEnabledForMode(languageId: string): boolean;
+	isEnabledForLanguage(languageId: string): boolean;
 
 	/**
 	 * @param resource The resource to detect the language for.
-	 * @returns the language mode for the given resource or undefined if the model is not confident enough.
+	 * @returns the language id for the given resource or undefined if the model is not confident enough.
 	 */
 	detectLanguage(resource: URI): Promise<string | undefined>;
 }

--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -512,7 +512,7 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 			targetTextModel = targetModel.textEditorModel;
 		}
 
-		// take over model value, encoding and mode (only if more specific) from source model
+		// take over model value, encoding and language (only if more specific) from source model
 		if (sourceTextModel && targetTextModel) {
 
 			// encoding
@@ -521,11 +521,11 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 			// content
 			this.modelService.updateModel(targetTextModel, createTextBufferFactoryFromSnapshot(sourceTextModel.createSnapshot()));
 
-			// mode
-			const sourceMode = sourceTextModel.getLanguageId();
-			const targetMode = targetTextModel.getLanguageId();
-			if (sourceMode !== PLAINTEXT_LANGUAGE_ID && targetMode === PLAINTEXT_LANGUAGE_ID) {
-				targetTextModel.setMode(sourceMode); // only use if more specific than plain/text
+			// language
+			const sourceLanguageId = sourceTextModel.getLanguageId();
+			const targetLanguageId = targetTextModel.getLanguageId();
+			if (sourceLanguageId !== PLAINTEXT_LANGUAGE_ID && targetLanguageId === PLAINTEXT_LANGUAGE_ID) {
+				targetTextModel.setMode(sourceLanguageId); // only use if more specific than plain/text
 			}
 
 			// transient properties
@@ -581,10 +581,10 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 					untitledName = basename(resource);
 				}
 
-				// Add mode file extension if specified
-				const mode = model.getMode();
-				if (mode && mode !== PLAINTEXT_LANGUAGE_ID) {
-					suggestedFilename = this.suggestFilename(mode, untitledName);
+				// Add language file extension if specified
+				const languageId = model.getLanguageId();
+				if (languageId && languageId !== PLAINTEXT_LANGUAGE_ID) {
+					suggestedFilename = this.suggestFilename(languageId, untitledName);
 				} else {
 					suggestedFilename = untitledName;
 				}
@@ -601,20 +601,20 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 		return joinPath(defaultFilePath, suggestedFilename);
 	}
 
-	suggestFilename(mode: string, untitledName: string) {
-		const languageName = this.languageService.getLanguageName(mode);
+	suggestFilename(languageId: string, untitledName: string) {
+		const languageName = this.languageService.getLanguageName(languageId);
 		if (!languageName) {
 			return untitledName;
 		}
 
-		const extension = this.languageService.getExtensions(mode)[0];
+		const extension = this.languageService.getExtensions(languageId)[0];
 		if (extension) {
 			if (!untitledName.endsWith(extension)) {
 				return untitledName + extension;
 			}
 		}
 
-		const filename = this.languageService.getFilenames(mode)[0];
+		const filename = this.languageService.getFilenames(languageId)[0];
 		return filename || untitledName;
 	}
 

--- a/src/vs/workbench/services/textfile/common/textEditorService.ts
+++ b/src/vs/workbench/services/textfile/common/textEditorService.ts
@@ -9,7 +9,7 @@ import { ResourceMap } from 'vs/base/common/map';
 import { createDecorator, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorFactoryRegistry, IFileEditorInput, IUntypedEditorInput, IUntypedFileEditorInput, EditorExtensions, isResourceDiffEditorInput, isResourceSideBySideEditorInput, IUntitledTextResourceEditorInput, DEFAULT_EDITOR_ASSOCIATION } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
-import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
+import { INewUntitledTextEditorOptions, IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
 import { Schemas } from 'vs/base/common/network';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { SideBySideEditorInput } from 'vs/workbench/common/editor/sideBySideEditorInput';
@@ -104,8 +104,8 @@ export class TextEditorService extends Disposable implements ITextEditorService 
 		// Untitled text file support
 		const untitledInput = input as IUntitledTextResourceEditorInput;
 		if (untitledInput.forceUntitled || !untitledInput.resource || (untitledInput.resource.scheme === Schemas.untitled)) {
-			const untitledOptions = {
-				mode: untitledInput.mode,
+			const untitledOptions: Partial<INewUntitledTextEditorOptions> = {
+				languageId: untitledInput.languageId,
 				initialValue: untitledInput.contents,
 				encoding: untitledInput.encoding
 			};
@@ -157,11 +157,11 @@ export class TextEditorService extends Disposable implements ITextEditorService 
 
 				// File
 				if (textResourceEditorInput.forceFile || this.fileService.hasProvider(canonicalResource)) {
-					return this.fileEditorFactory.createFileEditor(canonicalResource, preferredResource, textResourceEditorInput.label, textResourceEditorInput.description, textResourceEditorInput.encoding, textResourceEditorInput.mode, textResourceEditorInput.contents, this.instantiationService);
+					return this.fileEditorFactory.createFileEditor(canonicalResource, preferredResource, textResourceEditorInput.label, textResourceEditorInput.description, textResourceEditorInput.encoding, textResourceEditorInput.languageId, textResourceEditorInput.contents, this.instantiationService);
 				}
 
 				// Resource
-				return this.instantiationService.createInstance(TextResourceEditorInput, canonicalResource, textResourceEditorInput.label, textResourceEditorInput.description, textResourceEditorInput.mode, textResourceEditorInput.contents);
+				return this.instantiationService.createInstance(TextResourceEditorInput, canonicalResource, textResourceEditorInput.label, textResourceEditorInput.description, textResourceEditorInput.languageId, textResourceEditorInput.contents);
 			}, cachedInput => {
 
 				// Untitled
@@ -185,8 +185,8 @@ export class TextEditorService extends Disposable implements ITextEditorService 
 						cachedInput.setPreferredEncoding(textResourceEditorInput.encoding);
 					}
 
-					if (textResourceEditorInput.mode) {
-						cachedInput.setPreferredMode(textResourceEditorInput.mode);
+					if (textResourceEditorInput.languageId) {
+						cachedInput.setPreferredLanguageId(textResourceEditorInput.languageId);
 					}
 
 					if (typeof textResourceEditorInput.contents === 'string') {
@@ -204,8 +204,8 @@ export class TextEditorService extends Disposable implements ITextEditorService 
 						cachedInput.setDescription(textResourceEditorInput.description);
 					}
 
-					if (textResourceEditorInput.mode) {
-						cachedInput.setPreferredMode(textResourceEditorInput.mode);
+					if (textResourceEditorInput.languageId) {
+						cachedInput.setPreferredLanguageId(textResourceEditorInput.languageId);
 					}
 
 					if (typeof textResourceEditorInput.contents === 'string') {

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -102,8 +102,8 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 
 	constructor(
 		readonly resource: URI,
-		private preferredEncoding: string | undefined,	// encoding as chosen by the user
-		private preferredMode: string | undefined,		// mode as chosen by the user
+		private preferredEncoding: string | undefined,		// encoding as chosen by the user
+		private preferredLanguageId: string | undefined,	// language id as chosen by the user
 		@ILanguageService languageService: ILanguageService,
 		@IModelService modelService: IModelService,
 		@IFileService private readonly fileService: IFileService,
@@ -189,15 +189,15 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		}
 
 		const firstLineText = this.getFirstLineText(this.textEditorModel);
-		const languageSelection = this.getOrCreateMode(this.resource, this.languageService, this.preferredMode, firstLineText);
+		const languageSelection = this.getOrCreateLanguage(this.resource, this.languageService, this.preferredLanguageId, firstLineText);
 
 		this.modelService.setMode(this.textEditorModel, languageSelection);
 	}
 
-	override setMode(mode: string): void {
-		super.setMode(mode);
+	override setLanguageId(languageId: string): void {
+		super.setLanguageId(languageId);
 
-		this.preferredMode = mode;
+		this.preferredLanguageId = languageId;
 	}
 
 	//#region Backup
@@ -531,7 +531,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		this.logService.trace('[text file model] doCreateTextModel()', this.resource.toString(true));
 
 		// Create model
-		const textModel = this.createTextEditorModel(value, resource, this.preferredMode);
+		const textModel = this.createTextEditorModel(value, resource, this.preferredLanguageId);
 
 		// Model Listeners
 		this.installModelListeners(textModel);
@@ -546,7 +546,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		// Update model value in a block that ignores content change events for dirty tracking
 		this.ignoreDirtyOnModelContentChange = true;
 		try {
-			this.updateTextEditorModel(value, this.preferredMode);
+			this.updateTextEditorModel(value, this.preferredLanguageId);
 		} finally {
 			this.ignoreDirtyOnModelContentChange = false;
 		}
@@ -616,8 +616,8 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 	private whenReadyToDetectLanguage(): Promise<boolean> {
 		if (TextFileEditorModel._whenReadyToDetectLanguage === undefined) {
 			// We need to wait until installed extensions are registered because if the editor is created before that (like when restoring an editor)
-			// it could be created with a mode of plaintext. This would trigger language detection even though the real issue is that the
-			// language extensions are not yet loaded to provide the actual mode.
+			// it could be created with a language of plaintext. This would trigger language detection even though the real issue is that the
+			// language extensions are not yet loaded to provide the actual language.
 			TextFileEditorModel._whenReadyToDetectLanguage = this.extensionService.whenInstalledExtensionsRegistered();
 		}
 		return TextFileEditorModel._whenReadyToDetectLanguage;
@@ -625,10 +625,10 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 
 	protected override async autoDetectLanguage(): Promise<void> {
 		await this.whenReadyToDetectLanguage();
-		const mode = this.getMode();
+		const languageId = this.getLanguageId();
 		if (
 			this.resource.scheme === this.pathService.defaultUriScheme &&	// make sure to not detect language for non-user visible documents
-			(!mode || mode === PLAINTEXT_LANGUAGE_ID) &&						// only run on files with plaintext mode set or no mode set at all
+			(!languageId || languageId === PLAINTEXT_LANGUAGE_ID) &&		// only run on files with plaintext language set or no language set at all
 			!this.resourceHasExtension										// only run if this particular file doesn't have an extension
 		) {
 			return super.autoDetectLanguage();
@@ -855,7 +855,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 					const stat = await this.textFileService.write(lastResolvedFileStat.resource, resolvedTextFileEditorModel.createSnapshot(), {
 						mtime: lastResolvedFileStat.mtime,
 						encoding: this.getEncoding(),
-						etag: (options.ignoreModifiedSince || !this.filesConfigurationService.preventSaveConflicts(lastResolvedFileStat.resource, resolvedTextFileEditorModel.getMode())) ? ETAG_DISABLED : lastResolvedFileStat.etag,
+						etag: (options.ignoreModifiedSince || !this.filesConfigurationService.preventSaveConflicts(lastResolvedFileStat.resource, resolvedTextFileEditorModel.getLanguageId())) ? ETAG_DISABLED : lastResolvedFileStat.etag,
 						unlock: options.writeUnlock,
 						writeElevated: options.writeElevated
 					});
@@ -973,14 +973,14 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		return this.saveSequentializer.pending;
 	}
 
-	override getMode(this: IResolvedTextFileEditorModel): string;
-	override getMode(): string | undefined;
-	override getMode(): string | undefined {
+	override getLanguageId(this: IResolvedTextFileEditorModel): string;
+	override getLanguageId(): string | undefined;
+	override getLanguageId(): string | undefined {
 		if (this.textEditorModel) {
 			return this.textEditorModel.getLanguageId();
 		}
 
-		return this.preferredMode;
+		return this.preferredLanguageId;
 	}
 
 	//#region Encoding

--- a/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
@@ -171,13 +171,13 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 		}
 	}
 
-	private readonly mapCorrelationIdToModelsToRestore = new Map<number, { source: URI, target: URI, snapshot?: ITextSnapshot; mode?: string; encoding?: string; }[]>();
+	private readonly mapCorrelationIdToModelsToRestore = new Map<number, { source: URI, target: URI, snapshot?: ITextSnapshot; languageId?: string; encoding?: string; }[]>();
 
 	private onWillRunWorkingCopyFileOperation(e: WorkingCopyFileEvent): void {
 
 		// Move / Copy: remember models to restore after the operation
 		if (e.operation === FileOperation.MOVE || e.operation === FileOperation.COPY) {
-			const modelsToRestore: { source: URI, target: URI, snapshot?: ITextSnapshot; mode?: string; encoding?: string; }[] = [];
+			const modelsToRestore: { source: URI, target: URI, snapshot?: ITextSnapshot; languageId?: string; encoding?: string; }[] = [];
 
 			for (const { source, target } of e.files) {
 				if (source) {
@@ -213,7 +213,7 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 						modelsToRestore.push({
 							source: sourceModelResource,
 							target: targetModelResource,
-							mode: sourceModel.getMode(),
+							languageId: sourceModel.getLanguageId(),
 							encoding: sourceModel.getEncoding(),
 							snapshot: sourceModel.isDirty() ? sourceModel.createSnapshot() : undefined
 						});
@@ -281,16 +281,16 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 								encoding: modelToRestore.encoding
 							});
 
-							// restore previous mode only if the mode is now unspecified and it was specified
+							// restore previous language only if the language is now unspecified and it was specified
 							// but not when the file was explicitly stored with the plain text extension
 							// (https://github.com/microsoft/vscode/issues/125795)
 							if (
-								modelToRestore.mode &&
-								modelToRestore.mode !== PLAINTEXT_LANGUAGE_ID &&
-								restoredModel.getMode() === PLAINTEXT_LANGUAGE_ID &&
+								modelToRestore.languageId &&
+								modelToRestore.languageId !== PLAINTEXT_LANGUAGE_ID &&
+								restoredModel.getLanguageId() === PLAINTEXT_LANGUAGE_ID &&
 								extname(modelToRestore.target) !== PLAINTEXT_EXTENSION
 							) {
-								restoredModel.updateTextEditorModel(undefined, modelToRestore.mode);
+								restoredModel.updateTextEditorModel(undefined, modelToRestore.languageId);
 							}
 						}));
 					}
@@ -389,7 +389,7 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 		else {
 			didCreateModel = true;
 
-			const newModel = model = this.instantiationService.createInstance(TextFileEditorModel, resource, options ? options.encoding : undefined, options ? options.mode : undefined);
+			const newModel = model = this.instantiationService.createInstance(TextFileEditorModel, resource, options ? options.encoding : undefined, options ? options.languageId : undefined);
 			modelResolve = model.resolve(options);
 
 			this.registerModel(newModel);
@@ -430,9 +430,9 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 			this.mapResourceToPendingModelResolvers.delete(resource);
 		}
 
-		// Apply mode if provided
-		if (options?.mode) {
-			model.setMode(options.mode);
+		// Apply language if provided
+		if (options?.languageId) {
+			model.setLanguageId(options.languageId);
 		}
 
 		// Model can be dirty if a backup was restored, so we make sure to

--- a/src/vs/workbench/services/textfile/common/textfiles.ts
+++ b/src/vs/workbench/services/textfile/common/textfiles.ts
@@ -273,9 +273,9 @@ export interface ITextFileEditorModelResolveOrCreateOptions {
 	readonly reason?: TextFileResolveReason;
 
 	/**
-	 * The language mode to use for the model text content.
+	 * The language id to use for the model text content.
 	 */
-	readonly mode?: string;
+	readonly languageId?: string;
 
 	/**
 	 * The encoding to use when resolving the model text content.
@@ -468,15 +468,15 @@ export interface IEncodingSupport {
 	setEncoding(encoding: string, mode: EncodingMode): Promise<void>;
 }
 
-export interface IModeSupport {
+export interface ILanguageSupport {
 
 	/**
-	 * Sets the language mode of the object.
+	 * Sets the language id of the object.
 	 */
-	setMode(mode: string, setExplicitly?: boolean): void;
+	setLanguageId(languageId: string, setExplicitly?: boolean): void;
 }
 
-export interface ITextFileEditorModel extends ITextEditorModel, IEncodingSupport, IModeSupport, IWorkingCopy {
+export interface ITextFileEditorModel extends ITextEditorModel, IEncodingSupport, ILanguageSupport, IWorkingCopy {
 
 	readonly onDidChangeContent: Event<void>;
 	readonly onDidSaveError: Event<void>;
@@ -496,7 +496,7 @@ export interface ITextFileEditorModel extends ITextEditorModel, IEncodingSupport
 
 	isDirty(): this is IResolvedTextFileEditorModel;
 
-	getMode(): string | undefined;
+	getLanguageId(): string | undefined;
 
 	isResolved(): this is IResolvedTextFileEditorModel;
 }
@@ -504,7 +504,7 @@ export interface ITextFileEditorModel extends ITextEditorModel, IEncodingSupport
 export function isTextFileEditorModel(model: ITextEditorModel): model is ITextFileEditorModel {
 	const candidate = model as ITextFileEditorModel;
 
-	return areFunctions(candidate.setEncoding, candidate.getEncoding, candidate.save, candidate.revert, candidate.isDirty, candidate.getMode);
+	return areFunctions(candidate.setEncoding, candidate.getEncoding, candidate.save, candidate.revert, candidate.isDirty, candidate.getLanguageId);
 }
 
 export interface IResolvedTextFileEditorModel extends ITextFileEditorModel {

--- a/src/vs/workbench/services/textfile/test/browser/textEditorService.test.ts
+++ b/src/vs/workbench/services/textfile/test/browser/textEditorService.test.ts
@@ -52,9 +52,9 @@ suite('TextEditorService', () => {
 		const instantiationService = workbenchInstantiationService(undefined, disposables);
 		const service = instantiationService.createInstance(TextEditorService);
 
-		const mode = 'create-input-test';
+		const languageId = 'create-input-test';
 		ModesRegistry.registerLanguage({
-			id: mode,
+			id: languageId,
 		});
 
 		// Untyped Input (file)
@@ -84,13 +84,13 @@ suite('TextEditorService', () => {
 		contentInput = <FileEditorInput>input;
 		assert.strictEqual(contentInput.getPreferredEncoding(), 'utf16le');
 
-		// Untyped Input (file, mode)
-		input = service.createTextEditor({ resource: toResource.call(this, '/index.html'), mode });
+		// Untyped Input (file, language)
+		input = service.createTextEditor({ resource: toResource.call(this, '/index.html'), languageId: languageId });
 		assert(input instanceof FileEditorInput);
 		contentInput = <FileEditorInput>input;
-		assert.strictEqual(contentInput.getPreferredMode(), mode);
+		assert.strictEqual(contentInput.getPreferredLanguageId(), languageId);
 		let fileModel = (await contentInput.resolve() as ITextFileEditorModel);
-		assert.strictEqual(fileModel.textEditorModel?.getLanguageId(), mode);
+		assert.strictEqual(fileModel.textEditorModel?.getLanguageId(), languageId);
 
 		// Untyped Input (file, contents)
 		input = service.createTextEditor({ resource: toResource.call(this, '/index.html'), contents: 'My contents' });
@@ -100,11 +100,11 @@ suite('TextEditorService', () => {
 		assert.strictEqual(fileModel.textEditorModel?.getValue(), 'My contents');
 		assert.strictEqual(fileModel.isDirty(), true);
 
-		// Untyped Input (file, different mode)
-		input = service.createTextEditor({ resource: toResource.call(this, '/index.html'), mode: 'text' });
+		// Untyped Input (file, different language)
+		input = service.createTextEditor({ resource: toResource.call(this, '/index.html'), languageId: 'text' });
 		assert(input instanceof FileEditorInput);
 		contentInput = <FileEditorInput>input;
-		assert.strictEqual(contentInput.getPreferredMode(), 'text');
+		assert.strictEqual(contentInput.getPreferredLanguageId(), 'text');
 
 		// Untyped Input (untitled)
 		input = service.createTextEditor({ resource: undefined, options: { selection: { startLineNumber: 1, startColumn: 1 } } });
@@ -119,10 +119,10 @@ suite('TextEditorService', () => {
 		assert.strictEqual(model.textEditorModel?.getValue(), 'Hello Untitled');
 
 		// Untyped Input (untitled withtoUntyped2
-		input = service.createTextEditor({ resource: undefined, mode, options: { selection: { startLineNumber: 1, startColumn: 1 } } });
+		input = service.createTextEditor({ resource: undefined, languageId: languageId, options: { selection: { startLineNumber: 1, startColumn: 1 } } });
 		assert(input instanceof UntitledTextEditorInput);
 		model = await input.resolve() as UntitledTextEditorModel;
-		assert.strictEqual(model.getMode(), mode);
+		assert.strictEqual(model.getLanguageId(), languageId);
 
 		// Untyped Input (untitled with file path)
 		input = service.createTextEditor({ resource: URI.file('/some/path.txt'), forceUntitled: true, options: { selection: { startLineNumber: 1, startColumn: 1 } } });

--- a/src/vs/workbench/services/textfile/test/browser/textFileEditorModel.test.ts
+++ b/src/vs/workbench/services/textfile/test/browser/textFileEditorModel.test.ts
@@ -296,17 +296,17 @@ suite('Files - TextFileEditorModel', () => {
 		model.dispose();
 	});
 
-	test('create with mode', async function () {
-		const mode = 'text-file-model-test';
+	test('create with language', async function () {
+		const languageId = 'text-file-model-test';
 		ModesRegistry.registerLanguage({
-			id: mode,
+			id: languageId,
 		});
 
-		const model: TextFileEditorModel = instantiationService.createInstance(TextFileEditorModel, toResource.call(this, '/path/index_async.txt'), 'utf8', mode);
+		const model: TextFileEditorModel = instantiationService.createInstance(TextFileEditorModel, toResource.call(this, '/path/index_async.txt'), 'utf8', languageId);
 
 		await model.resolve();
 
-		assert.strictEqual(model.textEditorModel!.getLanguageId(), mode);
+		assert.strictEqual(model.textEditorModel!.getLanguageId(), languageId);
 
 		model.dispose();
 		assert.ok(!accessor.modelService.getModel(model.resource));

--- a/src/vs/workbench/services/textfile/test/browser/textFileEditorModelManager.test.ts
+++ b/src/vs/workbench/services/textfile/test/browser/textFileEditorModelManager.test.ts
@@ -408,20 +408,20 @@ suite('Files - TextFileEditorModelManager', () => {
 		manager.dispose();
 	});
 
-	test('mode', async function () {
-		const mode = 'text-file-model-manager-test';
+	test('language', async function () {
+		const languageId = 'text-file-model-manager-test';
 		ModesRegistry.registerLanguage({
-			id: mode,
+			id: languageId,
 		});
 
 		const manager: TextFileEditorModelManager = instantiationService.createInstance(TextFileEditorModelManager);
 
 		const resource = toResource.call(this, '/path/index_something.txt');
 
-		let model = await manager.resolve(resource, { mode });
-		assert.strictEqual(model.textEditorModel!.getLanguageId(), mode);
+		let model = await manager.resolve(resource, { languageId: languageId });
+		assert.strictEqual(model.textEditorModel!.getLanguageId(), languageId);
 
-		model = await manager.resolve(resource, { mode: 'text' });
+		model = await manager.resolve(resource, { languageId: 'text' });
 		assert.strictEqual(model.textEditorModel!.getLanguageId(), PLAINTEXT_LANGUAGE_ID);
 
 		model.dispose();

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorHandler.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorHandler.ts
@@ -22,7 +22,7 @@ import { IWorkingCopyEditorService } from 'vs/workbench/services/workingCopy/com
 
 interface ISerializedUntitledTextEditorInput {
 	resourceJSON: UriComponents;
-	modeId: string | undefined;
+	modeId: string | undefined; // should be `languageId` but is kept for backwards compatibility
 	encoding: string | undefined;
 }
 
@@ -50,21 +50,21 @@ export class UntitledTextEditorInputSerializer implements IEditorSerializer {
 			resource = toLocalResource(resource, this.environmentService.remoteAuthority, this.pathService.defaultUriScheme); // untitled with associated file path use the local schema
 		}
 
-		// Mode: only remember mode if it is either specific (not text)
-		// or if the mode was explicitly set by the user. We want to preserve
-		// this information across restarts and not set the mode unless
+		// Language: only remember language if it is either specific (not text)
+		// or if the language was explicitly set by the user. We want to preserve
+		// this information across restarts and not set the language unless
 		// this is the case.
-		let modeId: string | undefined;
-		const modeIdCandidate = untitledTextEditorInput.getMode();
-		if (modeIdCandidate !== PLAINTEXT_LANGUAGE_ID) {
-			modeId = modeIdCandidate;
-		} else if (untitledTextEditorInput.model.hasModeSetExplicitly) {
-			modeId = modeIdCandidate;
+		let languageId: string | undefined;
+		const languageIdCandidate = untitledTextEditorInput.getLanguageId();
+		if (languageIdCandidate !== PLAINTEXT_LANGUAGE_ID) {
+			languageId = languageIdCandidate;
+		} else if (untitledTextEditorInput.model.hasLanguageSetExplicitly) {
+			languageId = languageIdCandidate;
 		}
 
 		const serialized: ISerializedUntitledTextEditorInput = {
 			resourceJSON: resource.toJSON(),
-			modeId,
+			modeId: languageId,
 			encoding: untitledTextEditorInput.getEncoding()
 		};
 
@@ -75,10 +75,10 @@ export class UntitledTextEditorInputSerializer implements IEditorSerializer {
 		return instantiationService.invokeFunction(accessor => {
 			const deserialized: ISerializedUntitledTextEditorInput = JSON.parse(serializedEditorInput);
 			const resource = URI.revive(deserialized.resourceJSON);
-			const mode = deserialized.modeId;
+			const languageId = deserialized.modeId;
 			const encoding = deserialized.encoding;
 
-			return accessor.get(ITextEditorService).createTextEditor({ resource, mode, encoding, forceUntitled: true }) as UntitledTextEditorInput;
+			return accessor.get(ITextEditorService).createTextEditor({ resource, languageId, encoding, forceUntitled: true }) as UntitledTextEditorInput;
 		});
 	}
 }

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorInput.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorInput.ts
@@ -7,7 +7,7 @@ import { DEFAULT_EDITOR_ASSOCIATION, findViewStateForEditor, GroupIdentifier, IU
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { AbstractTextResourceEditorInput } from 'vs/workbench/common/editor/textResourceEditorInput';
 import { IUntitledTextEditorModel } from 'vs/workbench/services/untitled/common/untitledTextEditorModel';
-import { EncodingMode, IEncodingSupport, IModeSupport, ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
+import { EncodingMode, IEncodingSupport, ILanguageSupport, ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IFileService } from 'vs/platform/files/common/files';
@@ -20,7 +20,7 @@ import { IEditorResolverService } from 'vs/workbench/services/editor/common/edit
 /**
  * An editor input to be used for untitled text buffers.
  */
-export class UntitledTextEditorInput extends AbstractTextResourceEditorInput implements IEncodingSupport, IModeSupport {
+export class UntitledTextEditorInput extends AbstractTextResourceEditorInput implements IEncodingSupport, ILanguageSupport {
 
 	static readonly ID: string = 'workbench.editors.untitledEditorInput';
 
@@ -109,12 +109,12 @@ export class UntitledTextEditorInput extends AbstractTextResourceEditorInput imp
 		return this.model.setEncoding(encoding);
 	}
 
-	setMode(mode: string): void {
-		this.model.setMode(mode);
+	setLanguageId(languageId: string): void {
+		this.model.setLanguageId(languageId);
 	}
 
-	getMode(): string | undefined {
-		return this.model.getMode();
+	getLanguageId(): string | undefined {
+		return this.model.getLanguageId();
 	}
 
 	override async resolve(): Promise<IUntitledTextEditorModel> {
@@ -138,7 +138,7 @@ export class UntitledTextEditorInput extends AbstractTextResourceEditorInput imp
 
 		if (typeof options?.preserveViewState === 'number') {
 			untypedInput.encoding = this.getEncoding();
-			untypedInput.mode = this.getMode();
+			untypedInput.languageId = this.getLanguageId();
 			untypedInput.contents = this.model.isDirty() ? this.model.textEditorModel?.getValue() : undefined;
 			untypedInput.options.viewState = findViewStateForEditor(this, options.preserveViewState, this.editorService);
 		}

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -16,7 +16,7 @@ import { createTextBufferFactoryFromStream } from 'vs/editor/common/model/textMo
 import { ITextEditorModel } from 'vs/editor/common/services/resolverService';
 import { IWorkingCopyService } from 'vs/workbench/services/workingCopy/common/workingCopyService';
 import { IWorkingCopy, WorkingCopyCapabilities, IWorkingCopyBackup, NO_TYPE_ID } from 'vs/workbench/services/workingCopy/common/workingCopy';
-import { IEncodingSupport, IModeSupport, ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
+import { IEncodingSupport, ILanguageSupport, ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IModelContentChangedEvent } from 'vs/editor/common/model/textModelEvents';
 import { withNullAsUndefined, assertIsDefined } from 'vs/base/common/types';
 import { ILabelService } from 'vs/platform/label/common/label';
@@ -29,7 +29,7 @@ import { bufferToStream, VSBuffer, VSBufferReadableStream } from 'vs/base/common
 import { ILanguageDetectionService } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
-export interface IUntitledTextEditorModel extends ITextEditorModel, IModeSupport, IEncodingSupport, IWorkingCopy {
+export interface IUntitledTextEditorModel extends ITextEditorModel, ILanguageSupport, IEncodingSupport, IWorkingCopy {
 
 	/**
 	 * Emits an event when the encoding of this untitled model changes.
@@ -52,9 +52,9 @@ export interface IUntitledTextEditorModel extends ITextEditorModel, IModeSupport
 	readonly hasAssociatedFilePath: boolean;
 
 	/**
-	 * Whether this model has an explicit language mode or not.
+	 * Whether this model has an explicit language or not.
 	 */
-	readonly hasModeSetExplicitly: boolean;
+	readonly hasLanguageSetExplicitly: boolean;
 
 	/**
 	 * Sets the encoding to use for this untitled model.
@@ -72,13 +72,12 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 	private static readonly FIRST_LINE_NAME_MAX_LENGTH = 40;
 	private static readonly FIRST_LINE_NAME_CANDIDATE_MAX_LENGTH = UntitledTextEditorModel.FIRST_LINE_NAME_MAX_LENGTH * 10;
 
-	// support the special '${activeEditorLanguage}' mode by
-	// looking up the language mode from the editor that is
-	// active before the untitled editor opens. This special
-	// mode is only used for the initial language mode and
-	// can be changed after the fact (either manually or through
-	// auto-detection).
-	private static readonly ACTIVE_EDITOR_LANGUAGE_MODE = '${activeEditorLanguage}';
+	// support the special '${activeEditorLanguage}' language by
+	// looking up the language id from the editor that is active
+	// before the untitled editor opens. This special id is only
+	// used for the initial language and can be changed after the
+	// fact (either manually or through auto-detection).
+	private static readonly ACTIVE_EDITOR_LANGUAGE_ID = '${activeEditorLanguage}';
 
 	//#region Events
 
@@ -127,7 +126,7 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 		readonly resource: URI,
 		readonly hasAssociatedFilePath: boolean,
 		private readonly initialValue: string | undefined,
-		private preferredMode: string | undefined,
+		private preferredLanguageId: string | undefined,
 		private preferredEncoding: string | undefined,
 		@ILanguageService languageService: ILanguageService,
 		@IModelService modelService: IModelService,
@@ -147,8 +146,8 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 
 		// This is typically controlled by the setting `files.defaultLanguage`.
 		// If that setting is set, we should not detect the language.
-		if (preferredMode) {
-			this.setMode(preferredMode);
+		if (preferredLanguageId) {
+			this.setLanguageId(preferredLanguageId);
 		}
 
 		// Fetch config
@@ -187,25 +186,25 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 	}
 
 
-	//#region Mode
+	//#region Language
 
-	override setMode(mode: string): void {
-		let actualMode: string | undefined = mode === UntitledTextEditorModel.ACTIVE_EDITOR_LANGUAGE_MODE
-			? this.editorService.activeTextEditorMode
-			: mode;
-		this.preferredMode = actualMode;
+	override setLanguageId(languageId: string): void {
+		let actualLanguage: string | undefined = languageId === UntitledTextEditorModel.ACTIVE_EDITOR_LANGUAGE_ID
+			? this.editorService.activeTextEditorLanguageId
+			: languageId;
+		this.preferredLanguageId = actualLanguage;
 
-		if (actualMode) {
-			super.setMode(actualMode);
+		if (actualLanguage) {
+			super.setLanguageId(actualLanguage);
 		}
 	}
 
-	override getMode(): string | undefined {
+	override getLanguageId(): string | undefined {
 		if (this.textEditorModel) {
 			return this.textEditorModel.getLanguageId();
 		}
 
-		return this.preferredMode;
+		return this.preferredLanguageId;
 	}
 
 	//#endregion
@@ -310,21 +309,21 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 			// accordingly.
 			const untitledContentsFactory = await createTextBufferFactoryFromStream(await this.textFileService.getDecodedStream(this.resource, untitledContents, { encoding: UTF8 }));
 
-			this.createTextEditorModel(untitledContentsFactory, this.resource, this.preferredMode);
+			this.createTextEditorModel(untitledContentsFactory, this.resource, this.preferredLanguageId);
 			createdUntitledModel = true;
 		}
 
 		// Otherwise: the untitled model already exists and we must assume
 		// that the value of the model was changed by the user. As such we
-		// do not update the contents, only the mode if configured.
+		// do not update the contents, only the language if configured.
 		else {
-			this.updateTextEditorModel(undefined, this.preferredMode);
+			this.updateTextEditorModel(undefined, this.preferredLanguageId);
 		}
 
 		// Listen to text model events
 		const textEditorModel = assertIsDefined(this.textEditorModel);
 		this._register(textEditorModel.onDidChangeContent(e => this.onModelContentChanged(textEditorModel, e)));
-		this._register(textEditorModel.onDidChangeLanguage(() => this.onConfigurationChange(true))); // mode change can have impact on config
+		this._register(textEditorModel.onDidChangeLanguage(() => this.onConfigurationChange(true))); // language change can have impact on config
 
 		// Only adjust name and dirty state etc. if we
 		// actually created the untitled model

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorService.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorService.ts
@@ -25,9 +25,9 @@ export interface INewUntitledTextEditorOptions {
 	initialValue?: string;
 
 	/**
-	 * Preferred language mode to use when saving the untitled editor.
+	 * Preferred language id to use when saving the untitled editor.
 	 */
-	mode?: string;
+	languageId?: string;
 
 	/**
 	 * Preferred encoding to use when saving the untitled editor.
@@ -194,13 +194,13 @@ export class UntitledTextEditorService extends Disposable implements IUntitledTe
 			}
 		}
 
-		// Language mode
-		if (options.mode) {
-			massagedOptions.mode = options.mode;
+		// Language id
+		if (options.languageId) {
+			massagedOptions.languageId = options.languageId;
 		} else if (!massagedOptions.associatedResource) {
 			const configuration = this.configurationService.getValue<IFilesConfiguration>();
 			if (configuration.files?.defaultLanguage) {
-				massagedOptions.mode = configuration.files.defaultLanguage;
+				massagedOptions.languageId = configuration.files.defaultLanguage;
 			}
 		}
 
@@ -224,7 +224,7 @@ export class UntitledTextEditorService extends Disposable implements IUntitledTe
 		}
 
 		// Create new model with provided options
-		const model = this._register(this.instantiationService.createInstance(UntitledTextEditorModel, untitledResource, !!options.associatedResource, options.initialValue, options.mode, options.encoding));
+		const model = this._register(this.instantiationService.createInstance(UntitledTextEditorModel, untitledResource, !!options.associatedResource, options.initialValue, options.languageId, options.encoding));
 
 		this.registerModel(model);
 

--- a/src/vs/workbench/services/untitled/test/browser/untitledTextEditor.test.ts
+++ b/src/vs/workbench/services/untitled/test/browser/untitledTextEditor.test.ts
@@ -233,7 +233,7 @@ suite('Untitled text editors', () => {
 		const service = accessor.untitledTextEditorService;
 		const input = service.create();
 
-		assert.strictEqual(input.getMode(), defaultLanguage);
+		assert.strictEqual(input.getLanguageId(), defaultLanguage);
 
 		config.setUserConfiguration('files', { 'defaultLanguage': undefined });
 
@@ -244,74 +244,74 @@ suite('Untitled text editors', () => {
 		const config = accessor.testConfigurationService;
 		config.setUserConfiguration('files', { 'defaultLanguage': '${activeEditorLanguage}' });
 
-		accessor.editorService.activeTextEditorMode = 'typescript';
+		accessor.editorService.activeTextEditorLanguageId = 'typescript';
 
 		const service = accessor.untitledTextEditorService;
 		const model = service.create();
 
-		assert.strictEqual(model.getMode(), 'typescript');
+		assert.strictEqual(model.getLanguageId(), 'typescript');
 
 		config.setUserConfiguration('files', { 'defaultLanguage': undefined });
-		accessor.editorService.activeTextEditorMode = undefined;
+		accessor.editorService.activeTextEditorLanguageId = undefined;
 
 		model.dispose();
 	});
 
-	test('created with mode overrides files.defaultLanguage setting', () => {
-		const mode = 'typescript';
+	test('created with language overrides files.defaultLanguage setting', () => {
+		const language = 'typescript';
 		const defaultLanguage = 'javascript';
 		const config = accessor.testConfigurationService;
 		config.setUserConfiguration('files', { 'defaultLanguage': defaultLanguage });
 
 		const service = accessor.untitledTextEditorService;
-		const input = service.create({ mode });
+		const input = service.create({ languageId: language });
 
-		assert.strictEqual(input.getMode(), mode);
+		assert.strictEqual(input.getLanguageId(), language);
 
 		config.setUserConfiguration('files', { 'defaultLanguage': undefined });
 
 		input.dispose();
 	});
 
-	test('can change mode afterwards', async () => {
-		const mode = 'untitled-input-test';
+	test('can change language afterwards', async () => {
+		const languageId = 'untitled-input-test';
 
 		ModesRegistry.registerLanguage({
-			id: mode,
+			id: languageId,
 		});
 
 		const service = accessor.untitledTextEditorService;
-		const input = instantiationService.createInstance(UntitledTextEditorInput, service.create({ mode }));
+		const input = instantiationService.createInstance(UntitledTextEditorInput, service.create({ languageId: languageId }));
 
-		assert.strictEqual(input.getMode(), mode);
+		assert.strictEqual(input.getLanguageId(), languageId);
 
 		const model = await input.resolve();
-		assert.strictEqual(model.getMode(), mode);
+		assert.strictEqual(model.getLanguageId(), languageId);
 
-		input.setMode(PLAINTEXT_LANGUAGE_ID);
+		input.setLanguageId(PLAINTEXT_LANGUAGE_ID);
 
-		assert.strictEqual(input.getMode(), PLAINTEXT_LANGUAGE_ID);
+		assert.strictEqual(input.getLanguageId(), PLAINTEXT_LANGUAGE_ID);
 
 		input.dispose();
 		model.dispose();
 	});
 
-	test('remembers that mode was set explicitly', async () => {
-		const mode = 'untitled-input-test';
+	test('remembers that language was set explicitly', async () => {
+		const language = 'untitled-input-test';
 
 		ModesRegistry.registerLanguage({
-			id: mode,
+			id: language,
 		});
 
 		const service = accessor.untitledTextEditorService;
 		const model = service.create();
 		const input = instantiationService.createInstance(UntitledTextEditorInput, model);
 
-		assert.ok(!input.model.hasModeSetExplicitly);
-		input.setMode(PLAINTEXT_LANGUAGE_ID);
-		assert.ok(input.model.hasModeSetExplicitly);
+		assert.ok(!input.model.hasLanguageSetExplicitly);
+		input.setLanguageId(PLAINTEXT_LANGUAGE_ID);
+		assert.ok(input.model.hasLanguageSetExplicitly);
 
-		assert.strictEqual(input.getMode(), PLAINTEXT_LANGUAGE_ID);
+		assert.strictEqual(input.getLanguageId(), PLAINTEXT_LANGUAGE_ID);
 
 		input.dispose();
 		model.dispose();

--- a/src/vs/workbench/test/browser/parts/editor/editorGroupModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editorGroupModel.test.ts
@@ -214,8 +214,8 @@ suite('EditorGroupModel', () => {
 		setPreferredEncoding(encoding: string) { }
 		setForceOpenAsBinary(): void { }
 		setPreferredContents(contents: string): void { }
-		setMode(mode: string) { }
-		setPreferredMode(mode: string) { }
+		setLanguageId(languageId: string) { }
+		setPreferredLanguageId(languageId: string) { }
 		isResolved(): boolean { return false; }
 
 		override matches(other: TestFileEditorInput): boolean {

--- a/src/vs/workbench/test/browser/parts/editor/editorModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editorModel.test.ts
@@ -38,8 +38,8 @@ suite('EditorModel', () => {
 
 	class MyEditorModel extends EditorModel { }
 	class MyTextEditorModel extends BaseTextEditorModel {
-		override createTextEditorModel(value: ITextBufferFactory, resource?: URI, preferredMode?: string) {
-			return super.createTextEditorModel(value, resource, preferredMode);
+		override createTextEditorModel(value: ITextBufferFactory, resource?: URI, preferredLanguageId?: string) {
+			return super.createTextEditorModel(value, resource, preferredLanguageId);
 		}
 
 		override isReadonly(): boolean {

--- a/src/vs/workbench/test/browser/parts/editor/textResourceEditorInput.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/textResourceEditorInput.test.ts
@@ -41,7 +41,7 @@ suite('TextResourceEditorInput', () => {
 		assert.strictEqual(snapshotToString(((model as TextResourceEditorModel).createSnapshot()!)), 'function test() {}');
 	});
 
-	test('preferred mode (via ctor)', async () => {
+	test('preferred language (via ctor)', async () => {
 		ModesRegistry.registerLanguage({
 			id: 'resource-input-test',
 		});
@@ -55,14 +55,14 @@ suite('TextResourceEditorInput', () => {
 		assert.ok(model);
 		assert.strictEqual(model.textEditorModel?.getLanguageId(), 'resource-input-test');
 
-		input.setMode('text');
+		input.setLanguageId('text');
 		assert.strictEqual(model.textEditorModel?.getLanguageId(), PLAINTEXT_LANGUAGE_ID);
 
 		await input.resolve();
 		assert.strictEqual(model.textEditorModel?.getLanguageId(), PLAINTEXT_LANGUAGE_ID);
 	});
 
-	test('preferred mode (via setPreferredMode)', async () => {
+	test('preferred language (via setPreferredLanguageId)', async () => {
 		ModesRegistry.registerLanguage({
 			id: 'resource-input-test',
 		});
@@ -71,7 +71,7 @@ suite('TextResourceEditorInput', () => {
 		accessor.modelService.createModel('function test() {}', accessor.languageService.createById(PLAINTEXT_LANGUAGE_ID), resource);
 
 		const input = instantiationService.createInstance(TextResourceEditorInput, resource, 'The Name', 'The Description', undefined, undefined);
-		input.setPreferredMode('resource-input-test');
+		input.setPreferredLanguageId('resource-input-test');
 
 		const model = await input.resolve();
 		assert.ok(model);

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -157,8 +157,8 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerFile
 
 	typeId: FILE_EDITOR_INPUT_ID,
 
-	createFileEditor: (resource, preferredResource, preferredName, preferredDescription, preferredEncoding, preferredMode, preferredContents, instantiationService): IFileEditorInput => {
-		return instantiationService.createInstance(FileEditorInput, resource, preferredResource, preferredName, preferredDescription, preferredEncoding, preferredMode, preferredContents);
+	createFileEditor: (resource, preferredResource, preferredName, preferredDescription, preferredEncoding, preferredLanguageId, preferredContents, instantiationService): IFileEditorInput => {
+		return instantiationService.createInstance(FileEditorInput, resource, preferredResource, preferredName, preferredDescription, preferredEncoding, preferredLanguageId, preferredContents);
 	},
 
 	isFileEditor: (obj): obj is IFileEditorInput => {
@@ -887,7 +887,7 @@ export class TestEditorService implements EditorServiceImpl {
 	public set activeTextEditorControl(value: ICodeEditor | IDiffEditor | undefined) { this._activeTextEditorControl = value; }
 
 	activeEditorPane: IVisibleEditorPane | undefined;
-	activeTextEditorMode: string | undefined;
+	activeTextEditorLanguageId: string | undefined;
 
 	private _activeEditor: EditorInput | undefined;
 	public get activeEditor(): EditorInput | undefined { return this._activeEditor; }
@@ -1590,8 +1590,8 @@ export class TestFileEditorInput extends EditorInput implements IFileEditorInput
 	setPreferredDescription(description: string): void { }
 	setPreferredEncoding(encoding: string) { }
 	setPreferredContents(contents: string): void { }
-	setMode(mode: string) { }
-	setPreferredMode(mode: string) { }
+	setLanguageId(languageId: string) { }
+	setPreferredLanguageId(languageId: string) { }
 	setForceOpenAsBinary(): void { }
 	setFailToOpen(): void {
 		this.fails = true;


### PR DESCRIPTION
@alexdima not really meant for a thorough review but just high level if that is the change you had in mind. Those places where `modeId` was part of UI state I left as is.

While doing this I noticed some pieces in editor land still talking about "mode"
* `IModelService.setMode`
* `ITextModel.setMode`
* `ModesRegistry`

We also seem to be using "Language Mode" in many user facing strings and I did not change that.