### PR TITLE
Fixes keyboard shortcut for `workbench.action.terminal.copySelection` conflicts with `workbench.action.terminal.new` in web

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.web.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.web.contribution.ts
@@ -8,6 +8,7 @@ import { KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/co
 import { ITerminalProfileResolverService, TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { BrowserTerminalProfileResolverService } from 'vs/workbench/contrib/terminal/browser/terminalProfileResolverService';
+import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
 
 registerSingleton(ITerminalProfileResolverService, BrowserTerminalProfileResolverService, true);
 
@@ -16,6 +17,6 @@ registerSingleton(ITerminalProfileResolverService, BrowserTerminalProfileResolve
 KeybindingsRegistry.registerKeybindingRule({
 	id: TerminalCommandId.New,
 	weight: KeybindingWeight.WorkbenchContrib,
-	when: undefined,
+	when: TerminalContextKeys.notFocus,
 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyC
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #139939
