### PR TITLE
Fix Page Up/Down in notebook editor cells

### DIFF
--- a/src/vs/editor/browser/controller/coreCommands.ts
+++ b/src/vs/editor/browser/controller/coreCommands.ts
@@ -598,7 +598,7 @@ export namespace CoreNavigationCommands {
 					direction: this._staticArgs.direction,
 					unit: this._staticArgs.unit,
 					select: this._staticArgs.select,
-					value: viewModel.cursorConfig.pageSize
+					value: dynamicArgs.pageSize || viewModel.cursorConfig.pageSize
 				};
 			}
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
@@ -16,6 +16,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { INotebookActionContext, INotebookCellActionContext, NotebookAction, NotebookCellAction, NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT } from 'vs/workbench/contrib/notebook/browser/controller/coreActions';
 import { CellEditState, NOTEBOOK_CELL_HAS_OUTPUTS, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_OUTPUT_FOCUSED } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { CellKind, NOTEBOOK_EDITOR_CURSOR_BOUNDARY } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
 
 const NOTEBOOK_FOCUS_TOP = 'notebook.focusTop';
 const NOTEBOOK_FOCUS_BOTTOM = 'notebook.focusBottom';
@@ -24,6 +25,10 @@ const NOTEBOOK_FOCUS_NEXT_EDITOR = 'notebook.focusNextEditor';
 const FOCUS_IN_OUTPUT_COMMAND_ID = 'notebook.cell.focusInOutput';
 const FOCUS_OUT_OUTPUT_COMMAND_ID = 'notebook.cell.focusOutOutput';
 export const CENTER_ACTIVE_CELL = 'notebook.centerActiveCell';
+const NOTEBOOK_CURSOR_PAGEUP_COMMAND_ID = 'notebook.cell.cursorPageUp';
+const NOTEBOOK_CURSOR_PAGEUP_SELECT_COMMAND_ID = 'notebook.cell.cursorPageUpSelect';
+const NOTEBOOK_CURSOR_PAGEDOWN_COMMAND_ID = 'notebook.cell.cursorPageDown';
+const NOTEBOOK_CURSOR_PAGEDOWN_SELECT_COMMAND_ID = 'notebook.cell.cursorPageDownSelect';
 
 
 registerAction2(class extends NotebookCellAction {
@@ -233,6 +238,110 @@ registerAction2(class CenterActiveCellAction extends NotebookCellAction {
 		return context.notebookEditor.revealInCenter(context.cell);
 	}
 });
+
+registerAction2(class extends NotebookCellAction {
+	constructor() {
+		super({
+			id: NOTEBOOK_CURSOR_PAGEUP_COMMAND_ID,
+			title: localize('cursorPageUp', "Cell Cursor Page Up"),
+			keybinding: [
+				{
+					when: ContextKeyExpr.and(
+						NOTEBOOK_EDITOR_FOCUSED,
+						ContextKeyExpr.has(InputFocusedContextKey),
+						EditorContextKeys.editorTextFocus,
+					),
+					primary: KeyCode.PageUp,
+					weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+				}
+			]
+		});
+	}
+
+	async runWithContext(accessor: ServicesAccessor, context: INotebookCellActionContext): Promise<void> {
+		EditorExtensionsRegistry.getEditorCommand('cursorPageUp').runCommand(accessor, { pageSize: getPageSize(context) });
+	}
+});
+
+registerAction2(class extends NotebookCellAction {
+	constructor() {
+		super({
+			id: NOTEBOOK_CURSOR_PAGEUP_SELECT_COMMAND_ID,
+			title: localize('cursorPageUpSelect', "Cell Cursor Page Up Select"),
+			keybinding: [
+				{
+					when: ContextKeyExpr.and(
+						NOTEBOOK_EDITOR_FOCUSED,
+						ContextKeyExpr.has(InputFocusedContextKey),
+						EditorContextKeys.editorTextFocus,
+					),
+					primary: KeyMod.Shift | KeyCode.PageUp,
+					weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+				}
+			]
+		});
+	}
+
+	async runWithContext(accessor: ServicesAccessor, context: INotebookCellActionContext): Promise<void> {
+		EditorExtensionsRegistry.getEditorCommand('cursorPageUpSelect').runCommand(accessor, { pageSize: getPageSize(context) });
+	}
+});
+
+registerAction2(class extends NotebookCellAction {
+	constructor() {
+		super({
+			id: NOTEBOOK_CURSOR_PAGEDOWN_COMMAND_ID,
+			title: localize('cursorPageDown', "Cell Cursor Page Down"),
+			keybinding: [
+				{
+					when: ContextKeyExpr.and(
+						NOTEBOOK_EDITOR_FOCUSED,
+						ContextKeyExpr.has(InputFocusedContextKey),
+						EditorContextKeys.editorTextFocus,
+					),
+					primary: KeyCode.PageDown,
+					weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+				}
+			]
+		});
+	}
+
+	async runWithContext(accessor: ServicesAccessor, context: INotebookCellActionContext): Promise<void> {
+		EditorExtensionsRegistry.getEditorCommand('cursorPageDown').runCommand(accessor, { pageSize: getPageSize(context) });
+	}
+});
+
+registerAction2(class extends NotebookCellAction {
+	constructor() {
+		super({
+			id: NOTEBOOK_CURSOR_PAGEDOWN_SELECT_COMMAND_ID,
+			title: localize('cursorPageDownSelect', "Cell Cursor Page Down Select"),
+			keybinding: [
+				{
+					when: ContextKeyExpr.and(
+						NOTEBOOK_EDITOR_FOCUSED,
+						ContextKeyExpr.has(InputFocusedContextKey),
+						EditorContextKeys.editorTextFocus,
+					),
+					primary: KeyMod.Shift | KeyCode.PageDown,
+					weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+				}
+			]
+		});
+	}
+
+	async runWithContext(accessor: ServicesAccessor, context: INotebookCellActionContext): Promise<void> {
+		EditorExtensionsRegistry.getEditorCommand('cursorPageDownSelect').runCommand(accessor, { pageSize: getPageSize(context) });
+	}
+});
+
+
+function getPageSize(context: INotebookCellActionContext) {
+	const editor = context.notebookEditor;
+	const layoutInfo = editor._getViewModel().layoutInfo;
+	const lineHeight = layoutInfo?.fontInfo.lineHeight || 17;
+	return Math.max(1, Math.floor((layoutInfo?.height || 0) / lineHeight) - 2);
+}
 
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #139979

pageSize is being calculated incorrectly in [cursorCommon.ts#L125](https://github.com/microsoft/vscode/blob/main/src/vs/editor/common/controller/cursorCommon.ts#L125) as `layoutinfo.height` corresponds to cell height (instead of window height) in case of notebook editor cells. 

To fix this, new actions corresponding to <kbd>PgUp</kbd> and <kbd>PgDown</kbd> have been added.


<h2>Before:</h2>

![before](https://user-images.githubusercontent.com/26321479/147846572-ac97b2e0-fd34-41ed-aa31-f444710d65a7.gif)

<h2>After:</h2>

![after](https://user-images.githubusercontent.com/26321479/147846578-c7b71b7d-e61e-4488-a54e-2e2f9e24539c.gif)

