### PR TITLE
Add option to not pass --no-ignore-parent to rg

### DIFF
--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -480,6 +480,7 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 			ignoreSymlinks: typeof options.followSymlinks === 'boolean' ? !options.followSymlinks : undefined,
 			disregardIgnoreFiles: typeof options.useIgnoreFiles === 'boolean' ? !options.useIgnoreFiles : undefined,
 			disregardGlobalIgnoreFiles: typeof options.useGlobalIgnoreFiles === 'boolean' ? !options.useGlobalIgnoreFiles : undefined,
+			disregardParentIgnoreFiles: typeof options.useParentIgnoreFiles === 'boolean' ? !options.useParentIgnoreFiles : undefined,
 			disregardExcludeSettings: typeof options.useDefaultExcludes === 'boolean' ? !options.useDefaultExcludes : true,
 			fileEncoding: options.encoding,
 			maxResults: options.maxResults,

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -882,6 +882,12 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			scope: ConfigurationScope.RESOURCE
 		},
+		'search.useParentIgnoreFiles': {
+			type: 'boolean',
+			markdownDescription: nls.localize('useParentIgnoreFiles', "Controls whether to use `.gitignore` and `.ignore` files in parent directories when searching for files. Requires `#search.useIgnoreFiles#` to be enabled."),
+			default: false,
+			scope: ConfigurationScope.RESOURCE
+		},
 		'search.quickOpen.includeSymbols': {
 			type: 'boolean',
 			description: nls.localize('search.quickOpen.includeSymbols', "Whether to include results from a global symbol search in the file results for Quick Open."),

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1574,7 +1574,7 @@ export class SearchView extends ViewPane {
 
 	private onOpenSettings(e: dom.EventLike): void {
 		dom.EventHelper.stop(e, false);
-		this.openSettings('@id:files.exclude,search.exclude,search.useGlobalIgnoreFiles,search.useIgnoreFiles');
+		this.openSettings('@id:files.exclude,search.exclude,search.useParentIgnoreFiles,search.useGlobalIgnoreFiles,search.useIgnoreFiles');
 	}
 
 	private openSettings(query: string): Promise<IEditorPane | undefined> {

--- a/src/vs/workbench/contrib/search/common/queryBuilder.ts
+++ b/src/vs/workbench/contrib/search/common/queryBuilder.ts
@@ -59,6 +59,7 @@ export interface ICommonQueryBuilderOptions {
 	maxFileSize?: number;
 	disregardIgnoreFiles?: boolean;
 	disregardGlobalIgnoreFiles?: boolean;
+	disregardParentIgnoreFiles?: boolean;
 	disregardExcludeSettings?: boolean;
 	disregardSearchExcludeSettings?: boolean;
 	ignoreSymlinks?: boolean;
@@ -507,6 +508,7 @@ export class QueryBuilder {
 			fileEncoding: folderConfig.files && folderConfig.files.encoding,
 			disregardIgnoreFiles: typeof options.disregardIgnoreFiles === 'boolean' ? options.disregardIgnoreFiles : !folderConfig.search.useIgnoreFiles,
 			disregardGlobalIgnoreFiles: typeof options.disregardGlobalIgnoreFiles === 'boolean' ? options.disregardGlobalIgnoreFiles : !folderConfig.search.useGlobalIgnoreFiles,
+			disregardParentIgnoreFiles: typeof options.disregardParentIgnoreFiles === 'boolean' ? options.disregardParentIgnoreFiles : !folderConfig.search.useParentIgnoreFiles,
 			ignoreSymlinks: typeof options.ignoreSymlinks === 'boolean' ? options.ignoreSymlinks : !folderConfig.search.followSymlinks,
 		};
 	}

--- a/src/vs/workbench/contrib/search/test/browser/queryBuilder.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/queryBuilder.test.ts
@@ -22,7 +22,7 @@ import { Workspace } from 'vs/platform/workspace/test/common/testWorkspace';
 import { extUriBiasedIgnorePathCase } from 'vs/base/common/resources';
 
 const DEFAULT_EDITOR_CONFIG = {};
-const DEFAULT_USER_CONFIG = { useRipgrep: true, useIgnoreFiles: true, useGlobalIgnoreFiles: true };
+const DEFAULT_USER_CONFIG = { useRipgrep: true, useIgnoreFiles: true, useGlobalIgnoreFiles: true, useParentIgnoreFiles: true };
 const DEFAULT_QUERY_PROPS = {};
 const DEFAULT_TEXT_QUERY_PROPS = { usePCRE2: false };
 

--- a/src/vs/workbench/contrib/search/test/electron-browser/queryBuilder.test.ts
+++ b/src/vs/workbench/contrib/search/test/electron-browser/queryBuilder.test.ts
@@ -15,7 +15,7 @@ import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { Workspace } from 'vs/platform/workspace/test/common/testWorkspace';
 
 const DEFAULT_EDITOR_CONFIG = {};
-const DEFAULT_USER_CONFIG = { useRipgrep: true, useIgnoreFiles: true, useGlobalIgnoreFiles: true };
+const DEFAULT_USER_CONFIG = { useRipgrep: true, useIgnoreFiles: true, useGlobalIgnoreFiles: true, useParentIgnoreFiles: true };
 
 suite('QueryBuilder', () => {
 	const ROOT_1 = fixPath('/foo/root1');

--- a/src/vs/workbench/services/search/common/fileSearchManager.ts
+++ b/src/vs/workbench/services/search/common/fileSearchManager.ts
@@ -172,6 +172,7 @@ class FileSearchEngine {
 			includes,
 			useIgnoreFiles: !fq.disregardIgnoreFiles,
 			useGlobalIgnoreFiles: !fq.disregardGlobalIgnoreFiles,
+			useParentIgnoreFiles: !fq.disregardParentIgnoreFiles,
 			followSymlinks: !fq.ignoreSymlinks,
 			maxResults: this.config.maxResults,
 			session: this.sessionToken

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -69,6 +69,7 @@ export interface IFolderQuery<U extends UriComponents = URI> {
 	fileEncoding?: string;
 	disregardIgnoreFiles?: boolean;
 	disregardGlobalIgnoreFiles?: boolean;
+	disregardParentIgnoreFiles?: boolean;
 	ignoreSymlinks?: boolean;
 }
 
@@ -364,6 +365,7 @@ export interface ISearchConfigurationProperties {
 	 */
 	useIgnoreFiles: boolean;
 	useGlobalIgnoreFiles: boolean;
+	useParentIgnoreFiles: boolean;
 	followSymlinks: boolean;
 	smartCase: boolean;
 	globalFindClipboard: boolean;

--- a/src/vs/workbench/services/search/common/searchExtTypes.ts
+++ b/src/vs/workbench/services/search/common/searchExtTypes.ts
@@ -161,6 +161,12 @@ export interface SearchOptions {
 	 * See the vscode setting `"search.useGlobalIgnoreFiles"`.
 	 */
 	useGlobalIgnoreFiles: boolean;
+
+	/**
+	 * Whether files in parent directories that exclude files, like .gitignore, should be respected.
+	 * See the vscode setting `"search.useParentIgnoreFiles"`.
+	 */
+	useParentIgnoreFiles: boolean;
 }
 
 /**
@@ -418,6 +424,12 @@ export interface FindTextInFilesOptions {
 	 * See the vscode setting `"search.useGlobalIgnoreFiles"`.
 	 */
 	useGlobalIgnoreFiles?: boolean;
+
+	/**
+	 * Whether files in parent directories that exclude files, like .gitignore, should be respected.
+	 * See the vscode setting `"search.useParentIgnoreFiles"`.
+	 */
+	useParentIgnoreFiles: boolean;
 
 	/**
 	 * Whether symlinks should be followed while searching.

--- a/src/vs/workbench/services/search/common/textSearchManager.ts
+++ b/src/vs/workbench/services/search/common/textSearchManager.ts
@@ -189,6 +189,7 @@ export class TextSearchManager {
 			includes,
 			useIgnoreFiles: !fq.disregardIgnoreFiles,
 			useGlobalIgnoreFiles: !fq.disregardGlobalIgnoreFiles,
+			useParentIgnoreFiles: !fq.disregardParentIgnoreFiles,
 			followSymlinks: !fq.ignoreSymlinks,
 			encoding: fq.fileEncoding && this.fileUtils.toCanonicalName(fq.fileEncoding),
 			maxFileSize: this.query.maxFileSize,

--- a/src/vs/workbench/services/search/node/ripgrepFileSearch.ts
+++ b/src/vs/workbench/services/search/node/ripgrepFileSearch.ts
@@ -58,7 +58,7 @@ function getRgArgs(config: IFileQuery, folderQuery: IFolderQuery, includePattern
 	if (folderQuery.disregardIgnoreFiles !== false) {
 		// Don't use .gitignore or .ignore
 		args.push('--no-ignore');
-	} else {
+	} else if (folderQuery.disregardParentIgnoreFiles !== false) {
 		args.push('--no-ignore-parent');
 	}
 

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -403,7 +403,9 @@ function getRgArgs(query: TextSearchQuery, options: TextSearchOptions): string[]
 	}
 
 	if (options.useIgnoreFiles) {
-		args.push('--no-ignore-parent');
+		if (!options.useParentIgnoreFiles) {
+			args.push('--no-ignore-parent');
+		}
 	} else {
 		// Don't use .gitignore or .ignore
 		args.push('--no-ignore');

--- a/src/vscode-dts/vscode.proposed.findTextInFiles.d.ts
+++ b/src/vscode-dts/vscode.proposed.findTextInFiles.d.ts
@@ -48,6 +48,12 @@ declare module 'vscode' {
 		useGlobalIgnoreFiles?: boolean;
 
 		/**
+		 * Whether files in parent directories that exclude files, like .gitignore, should be respected.
+		 * See the vscode setting `"search.useParentIgnoreFiles"`.
+		 */
+		useParentIgnoreFiles?: boolean;
+
+		/**
 		 * Whether symlinks should be followed while searching.
 		 * See the vscode setting `"search.followSymlinks"`.
 		 */

--- a/src/vscode-dts/vscode.proposed.textSearchProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.textSearchProvider.d.ts
@@ -80,6 +80,12 @@ declare module 'vscode' {
 		 * See the vscode setting `"search.useGlobalIgnoreFiles"`.
 		 */
 		useGlobalIgnoreFiles: boolean;
+
+		/**
+		 * Whether files in parent directories that exclude files, like .gitignore, should be respected.
+		 * See the vscode setting `"search.useParentIgnoreFiles"`.
+		 */
+		useParentIgnoreFiles: boolean;
 	}
 
 	/**


### PR DESCRIPTION
@roblourens This PR fixes #118229. You can test it using these steps:

1. Create the following directory structure:
   ```
   foo
   ├── bar
   │   └── baz.txt
   └── .gitignore
   ```
2. In `foo/`, run the following command:
   ```sh
   git init
   ```
3. Put the following contents in `foo/.gitignore`:
   ```gitignore
   baz.txt
   ```
4. Put the following contents in `foo/bar/baz.txt`:
   ```
   qux
   ```
5. [Build and run this PR.](https://github.com/microsoft/vscode/wiki/How-to-Contribute)
6. Open the folder `foo/bar/`.
7. Run the command **Go to File...** (<kbd>Ctrl</kbd>+<kbd>P</kbd> on Linux). Type in `baz`: the file `baz.txt` should appear.
8. In the **Search** sidebar (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> on Linux), type in `qux`: its appearance in `baz.txt` should appear.
9. If you opened `baz.txt` in VS Code in step 7 or 8, run **Go to File...** again and click the "X" next to `baz.txt` (it would say "recently opened" in that case).
10. Run the command **Preferences: Open Settings (UI)** (<kbd>Ctrl</kbd>+<kbd>,</kbd> on Linux). Type "ignore" in the search bar, then enable the setting **Search: Use Parent Ignore Files**.
11. Repeat steps 7 and 8: nothing should appear.

I wrote this by piggybacking off of #59717: I searched for the string `GlobalIgnoreFiles` in the codebase and added similar code for `ParentIgnoreFiles` alongside each occurrence I found. Please let me know if I missed anything, or if I should add any automated tests to accompany the code changes.