### PR TITLE
Update ripgrep binaries to include ppc64le and s390x

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "vscode-oniguruma": "1.6.1",
     "vscode-proxy-agent": "^0.11.0",
     "vscode-regexpp": "^3.1.0",
-    "vscode-ripgrep": "^1.12.1",
+    "vscode-ripgrep": "^1.13.2",
     "vscode-textmate": "6.0.0",
     "xterm": "4.16.0",
     "xterm-addon-search": "0.9.0-beta.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10426,10 +10426,10 @@ vscode-regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/vscode-regexpp/-/vscode-regexpp-3.1.0.tgz#42d059b6fffe99bd42939c0d013f632f0cad823f"
   integrity sha512-pqtN65VC1jRLawfluX4Y80MMG0DHJydWhe5ZwMHewZD6sys4LbU6lHwFAHxeuaVE6Y6+xZOtAw+9hvq7/0ejkg==
 
-vscode-ripgrep@^1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.12.1.tgz#4a319809d4010ea230659ce605fddacd1e36a589"
-  integrity sha512-4edKlcXNSKdC9mIQmQ9Wl25v0SF5DOK31JlvKHKHYV4co0V2MjI9pbDPdmogwbtiykz+kFV/cKnZH2TgssEasQ==
+vscode-ripgrep@^1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.13.2.tgz#8ccebc33f14d54442c4b11962aead163c55b506e"
+  integrity sha512-RlK9U87EokgHfiOjDQ38ipQQX936gWOcWPQaJpYf+kAkz1PQ1pK2n7nhiscdOmLu6XGjTs7pWFJ/ckonpN7twQ==
   dependencies:
     https-proxy-agent "^4.0.0"
     proxy-from-env "^1.1.0"


### PR DESCRIPTION
ripgrep is a binary dependency, which gets pulled in through
vscode-ripgrep, which itself downloads binaries from
https://github.com/microsoft/ripgrep-prebuilt. The v13.0.0-2
of ripgrep-prebuilt (and only this version) didn't include
binaries for s390x and ppc due to a change in CI
infrastructure. The newer version v13.0.0-4 includes those binaries
again (and has no other user-visible changes, see
https://github.com/microsoft/ripgrep-prebuilt/releases).

The previously used version of vscode-ripgrep pulled in
v13.0.0-2 of the prebuilt binaries. The newer version 1.13.2
pulls in v13.0.0-4 of the binaries. Again, this version bump
only includes the changes to the binaries and nothing else
(see also
https://github.com/microsoft/vscode-ripgrep/compare/v1.12.1...v1.13.2
The version numbers are slightly misleading here.)
