### PR TITLE
initial device code flow for non-supported urls

### DIFF
--- a/extensions/microsoft-authentication/src/utils.ts
+++ b/extensions/microsoft-authentication/src/utils.ts
@@ -2,7 +2,24 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { Uri } from 'vscode';
+
+const VALID_DESKTOP_CALLBACK_SCHEMES = [
+	'vscode',
+	'vscode-insiders',
+	'code-oss',
+	'vscode-wsl',
+	'vscode-exploration'
+];
 
 export function toBase64UrlEncoding(base64string: string) {
 	return base64string.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_'); // Need to use base64url encoding
+}
+
+// This comes from the GitHub Authentication server
+export function isSupportedEnvironment(url: Uri): boolean {
+	return VALID_DESKTOP_CALLBACK_SCHEMES.includes(url.scheme)
+		|| url.authority.endsWith('vscode.dev')
+		|| url.authority.endsWith('github.dev')
+		|| url.authority.startsWith('localhost:');
 }


### PR DESCRIPTION
Note: the localhost case is already covered by the OAuth flow so we don't need to worry about that.

This covers a situation where the server is running behind some proxy like: mycode.net or any url really...

In this case, we don't know how to redirect back properly so we use the device code flow instead. We already do something similar for GitHub.

This PR fixes https://github.com/microsoft/vscode-internalbacklog/issues/2542