### PR TITLE
improve wording, polish of terminal link commands

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -1896,22 +1896,8 @@ export function registerTerminalActions() {
 	registerAction2(class extends Action2 {
 		constructor() {
 			super({
-				id: TerminalCommandId.ShowWordLinkQuickpick,
-				title: { value: localize('workbench.action.terminal.showWordLinkQuickpick', "Show Word Link Quick Pick"), original: 'Show Word Link Quickpick' },
-				f1: true,
-				category,
-				precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
-			});
-		}
-		run(accessor: ServicesAccessor) {
-			accessor.get(ITerminalService).doWithActiveInstance(t => t.showLinkQuickpick(TerminalLinkProviderType.Word));
-		}
-	});
-	registerAction2(class extends Action2 {
-		constructor() {
-			super({
 				id: TerminalCommandId.ShowProtocolLinkQuickpick,
-				title: { value: localize('workbench.action.terminal.showProtocolLinkQuickpick', "Show Protocol Link Quick Pick"), original: 'Show Protocol Link Quickpick' },
+				title: { value: localize('workbench.action.terminal.showProtocolLinkQuickpick', "Show Web Links"), original: 'Show Web Links' },
 				f1: true,
 				category,
 				precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
@@ -1925,7 +1911,7 @@ export function registerTerminalActions() {
 		constructor() {
 			super({
 				id: TerminalCommandId.ShowValidatedLinkQuickpick,
-				title: { value: localize('workbench.action.terminal.showValidatedLinkQuickpick', "Show Validated Link Quick Pick"), original: 'Show Validated Link Quickpick' },
+				title: { value: localize('workbench.action.terminal.showValidatedLinkQuickpick', "Show File Links"), original: 'Show File Links' },
 				f1: true,
 				category,
 				precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),

--- a/src/vs/workbench/contrib/terminal/browser/terminalLinkQuickpick.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalLinkQuickpick.ts
@@ -7,7 +7,7 @@ import { EventType } from 'vs/base/browser/dom';
 import { localize } from 'vs/nls';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IPickOptions, IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
-import { TerminalLinkProviderType } from 'vs/workbench/contrib/terminal/browser/links/terminalLinkManager';
+import { ITerminalLinkItem, TerminalLinkProviderType } from 'vs/workbench/contrib/terminal/browser/links/terminalLinkManager';
 import { TerminalLinkQuickpickEvent } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { ILink } from 'xterm';
 
@@ -17,7 +17,7 @@ export class TerminalLinkQuickpick {
 		@IClipboardService private readonly _clipboardService: IClipboardService
 	) { }
 
-	async show(type: TerminalLinkProviderType, links: ILink[]): Promise<void> {
+	async show(type: TerminalLinkProviderType, links: ITerminalLinkItem[]): Promise<void> {
 		const picks = await this._generatePicks(links);
 		const options: IPickOptions<ITerminalLinkQuickPickItem> = {
 			placeHolder: type === TerminalLinkProviderType.Validated ? localize('terminal.integrated.openValidatedOrProtocolLink', "Select the link to open") : localize('terminal.integrated.copyWordLink', "Select the link to copy"),
@@ -29,7 +29,7 @@ export class TerminalLinkQuickpick {
 		if (!pick) {
 			return;
 		}
-		if (type === TerminalLinkProviderType.Word) {
+		if (pick.link.isWord) {
 			this._clipboardService.writeText(pick.label);
 		} else {
 			const event = new TerminalLinkQuickpickEvent(EventType.CLICK);
@@ -56,7 +56,7 @@ export class TerminalLinkQuickpick {
 }
 
 export interface ITerminalLinkQuickPickItem extends IQuickPickItem {
-	link: ILink
+	link: ITerminalLinkItem
 }
 
 

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -453,7 +453,6 @@ export const enum TerminalCommandId {
 	KillAll = 'workbench.action.terminal.killAll',
 	QuickKill = 'workbench.action.terminal.quickKill',
 	ConfigureTerminalSettings = 'workbench.action.terminal.openSettings',
-	ShowWordLinkQuickpick = 'workbench.action.terminal.showWordLinkQuickpick',
 	ShowValidatedLinkQuickpick = 'workbench.action.terminal.showValidatedLinkQuickpick',
 	ShowProtocolLinkQuickpick = 'workbench.action.terminal.showProtocolLinkQuickpick',
 	CopySelection = 'workbench.action.terminal.copySelection',


### PR DESCRIPTION
This PR fixes #95570

The commands are now:
`Terminal: show web links`
`Terminal: show file links (displays files at the top then words below)`

selecting the file or web link should open it.

selecting a word link should copy it.

not sure if it's confusing to combine the word/file links into one action for that reason?