### PR TITLE
Surface the maximum and minimum values for `editor.hover.delay` (#140215)

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1845,6 +1845,8 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 				'editor.hover.delay': {
 					type: 'number',
 					default: defaults.delay,
+					minimum: 0,
+					maximum: 10000,
 					description: nls.localize('hover.delay', "Controls the delay in milliseconds after which the hover is shown.")
 				},
 				'editor.hover.sticky': {


### PR DESCRIPTION
This PR fixes #140215 

After the change:

![image](https://user-images.githubusercontent.com/6726799/148393359-3723edba-73bc-4b32-9e67-65cf31c47ba9.png)

![image](https://user-images.githubusercontent.com/6726799/148393440-721cecba-5a1c-484c-aaf4-540a8bfaf2b7.png)

