### PR TITLE
Alter overflow guard width to avoid text spilling

### DIFF
--- a/src/vs/editor/browser/view/view.ts
+++ b/src/vs/editor/browser/view/view.ts
@@ -288,7 +288,7 @@ export class View extends ViewEventHandler {
 		this.domNode.setWidth(layoutInfo.width);
 		this.domNode.setHeight(layoutInfo.height);
 
-		this._overflowGuardContainer.setWidth(layoutInfo.width);
+		this._overflowGuardContainer.setWidth(layoutInfo.width - 8);
 		this._overflowGuardContainer.setHeight(layoutInfo.height);
 
 		this._linesContent.setWidth(1000000);


### PR DESCRIPTION
I've altered the code so that the width of the overflow guard is a few pixels smaller, preventing the text from spilling over the edge of the search box. The Extensions search box is the only place this particular CSS class is used, so this fix won't affect style elsewhere.

This PR fixes #140367 
