### PR TITLE
Allow prominent StatusBarItem background in extensions

### DIFF
--- a/src/vs/workbench/api/common/extHostStatusBar.ts
+++ b/src/vs/workbench/api/common/extHostStatusBar.ts
@@ -20,7 +20,8 @@ export class ExtHostStatusBarEntry implements vscode.StatusBarItem {
 	private static ALLOWED_BACKGROUND_COLORS = new Map<string, ThemeColor>(
 		[
 			['statusBarItem.errorBackground', new ThemeColor('statusBarItem.errorForeground')],
-			['statusBarItem.warningBackground', new ThemeColor('statusBarItem.warningForeground')]
+			['statusBarItem.warningBackground', new ThemeColor('statusBarItem.warningForeground')],
+			['statusBarItem.prominentBackground', new ThemeColor('statusBarItem.prominentForeground')]
 		]
 	);
 


### PR DESCRIPTION
Allow using `statusBarItem.prominentBackground` in extension-provided StatusBarItems.
This PR fixes #140437
