### PR TITLE
Button - convert text nodes to span when buttons supports icons

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1842,7 +1842,7 @@ export class Repository {
 				c({ status: parser.status, didHitLimit: false });
 			};
 
-			const limit = opts?.limit ?? 5000;
+			const limit = opts?.limit ?? 10000;
 			const onStdoutData = (raw: string) => {
 				parser.update(raw);
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1800,7 +1800,7 @@ export class Repository implements Disposable {
 		const scopedConfig = workspace.getConfiguration('git', Uri.file(this.repository.root));
 		const ignoreSubmodules = scopedConfig.get<boolean>('ignoreSubmodules');
 
-		const limit = scopedConfig.get<number>('statusLimit', 5000);
+		const limit = scopedConfig.get<number>('statusLimit', 10000);
 
 		const { status, didHitLimit } = await this.repository.getStatus({ limit, ignoreSubmodules });
 

--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -195,7 +195,21 @@ export class Button extends Disposable implements IButton {
 	set label(value: string) {
 		this._element.classList.add('monaco-text-button');
 		if (this.options.supportIcons) {
-			reset(this._element, ...renderLabelWithIcons(value));
+			// In order to be able to apply CSS styles we
+			// convert the text nodes into <span> elements.
+			const nodes = renderLabelWithIcons(value)
+				.map(value => {
+					if (typeof (value) === 'string') {
+						const node = document.createElement('span');
+						node.textContent = value.trim();
+
+						return node;
+					}
+
+					return value;
+				});
+
+			reset(this._element, ...nodes);
 		} else {
 			this._element.textContent = value;
 		}


### PR DESCRIPTION
As of right now, when a button supports icons, the icons are represented by `<span>` elements while the text is a plain text node. Since CSS styles cannot be applied to text nodes we do not have control over the overflow behaviour of the label in case we want to use ellipsis. This PR converts the text nodes into `<span>` elements. This change only impacts buttons that support icons.