### PR TITLE
Fix connection token parsing

### DIFF
--- a/src/vs/server/main.js
+++ b/src/vs/server/main.js
@@ -181,7 +181,7 @@ async function parsePort(host, strPort, strPickPort) {
 			process.exit(1);
 
 		} else {
-			console.warn('--port "${strPort}" is not a valid number or range.');
+			console.warn(`--port "${strPort}" is not a valid number or range.`);
 			process.exit(1);
 		}
 	}

--- a/src/vs/server/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/remoteExtensionHostAgentServer.ts
@@ -957,7 +957,7 @@ function parseConnectionToken(args: ServerParsedArgs): { connectionToken: string
 		if (connectionToken !== undefined && !connectionTokenRegex.test(connectionToken)) {
 			console.warn(`The connection token '${connectionToken}' does not adhere to the characters 0-9, a-z, A-Z or -.`);
 			process.exit(1);
-		} else {
+		} else if (connectionToken === undefined) {
 			connectionToken = generateUuid();
 			console.log(`Connection token: ${connectionToken}`);
 			if (compatibility) {


### PR DESCRIPTION
Minor fix for the server connection token, `connectionToken = generateUuid();` was being executed even if `--connection-token` was provided

cc @aeschli 