### PR TITLE
Bump @vscode/windows-registry to 1.0.5 in remote

### DIFF
--- a/remote/package.json
+++ b/remote/package.json
@@ -14,8 +14,8 @@
     "https-proxy-agent": "^2.2.3",
     "iconv-lite-umd": "0.6.10",
     "jschardet": "3.0.0",
-    "keytar": "7.2.0",
     "minimist": "^1.2.5",
+    "keytar": "7.2.0",
     "native-watchdog": "1.3.0",
     "node-pty": "0.11.0-beta11",
     "spdlog": "^0.13.0",
@@ -34,7 +34,7 @@
     "yazl": "^2.4.3"
   },
   "optionalDependencies": {
-    "@vscode/windows-registry": "^1.0.5",
+    "@vscode/windows-registry": "1.0.5",
     "windows-process-tree": "^0.3.2"
   }
 }

--- a/remote/package.json
+++ b/remote/package.json
@@ -14,8 +14,8 @@
     "https-proxy-agent": "^2.2.3",
     "iconv-lite-umd": "0.6.10",
     "jschardet": "3.0.0",
-    "minimist": "^1.2.5",
     "keytar": "7.2.0",
+    "minimist": "^1.2.5",
     "native-watchdog": "1.3.0",
     "node-pty": "0.11.0-beta11",
     "spdlog": "^0.13.0",
@@ -34,7 +34,7 @@
     "yazl": "^2.4.3"
   },
   "optionalDependencies": {
-    "vscode-windows-registry": "1.0.4",
+    "@vscode/windows-registry": "^1.0.5",
     "windows-process-tree": "^0.3.2"
   }
 }

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -109,7 +109,7 @@
   resolved "https://registry.yarnpkg.com/@vscode/vscode-languagedetection/-/vscode-languagedetection-1.0.21.tgz#89b48f293f6aa3341bb888c1118d16ff13b032d3"
   integrity sha512-zSUH9HYCw5qsCtd7b31yqkpaCU6jhtkKLkvOOA8yTrIRfBSOFb8PPhgmMicD7B/m+t4PwOJXzU1XDtrM9Fd3/g==
 
-"@vscode/windows-registry@^1.0.5":
+"@vscode/windows-registry@1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.0.5.tgz#a6c463ac123ee7b23f9b90935aea086a97a778dc"
   integrity sha512-xEA/L3ki8qMSer3hwdm590G43YCjpMb7evqS5aSPFFAhAYepvVr12/szKFgx1v1aQHOcR2riWg5YqBLajOZoaw==

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -109,6 +109,11 @@
   resolved "https://registry.yarnpkg.com/@vscode/vscode-languagedetection/-/vscode-languagedetection-1.0.21.tgz#89b48f293f6aa3341bb888c1118d16ff13b032d3"
   integrity sha512-zSUH9HYCw5qsCtd7b31yqkpaCU6jhtkKLkvOOA8yTrIRfBSOFb8PPhgmMicD7B/m+t4PwOJXzU1XDtrM9Fd3/g==
 
+"@vscode/windows-registry@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.0.5.tgz#a6c463ac123ee7b23f9b90935aea086a97a778dc"
+  integrity sha512-xEA/L3ki8qMSer3hwdm590G43YCjpMb7evqS5aSPFFAhAYepvVr12/szKFgx1v1aQHOcR2riWg5YqBLajOZoaw==
+
 agent-base@4:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
@@ -960,11 +965,6 @@ vscode-windows-ca-certs@^0.3.0:
   integrity sha512-CYrpCEKmAFQJoZNReOrelNL+VKyebOVRCqL9evrBlVcpWQDliliJgU5RggGS8FPGtQ3jAKLQt9frF0qlxYYPKA==
   dependencies:
     node-addon-api "^3.0.2"
-
-vscode-windows-registry@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/vscode-windows-registry/-/vscode-windows-registry-1.0.4.tgz#9e565a497c84b6b82d200f88930baeff12912079"
-  integrity sha512-vjYaMzEygZrb8bN6I33XTajpF/gtDOk5CtQPPSaxanXg2kkrerEM9qovY6t6FtBGl3oLq6YHytYdYw4IpXgJdA==
 
 wide-align@^1.1.0:
   version "1.1.5"

--- a/src/vs/platform/environment/test/node/nativeModules.test.ts
+++ b/src/vs/platform/environment/test/node/nativeModules.test.ts
@@ -89,9 +89,9 @@ flakySuite('Native Modules (all platforms)', () => {
 		assert.ok(typeof processTree.getProcessTree === 'function', testErrorMessage('windows-process-tree'));
 	});
 
-	test('vscode-windows-registry', async () => {
+	test('@vscode/windows-registry', async () => {
 		const windowsRegistry = await import('@vscode/windows-registry');
-		assert.ok(typeof windowsRegistry.GetStringRegKey === 'function', testErrorMessage('vscode-windows-registry'));
+		assert.ok(typeof windowsRegistry.GetStringRegKey === 'function', testErrorMessage('@vscode/windows-registry'));
 	});
 
 	test('vscode-windows-ca-certs', async () => {

--- a/src/vs/workbench/api/common/extHostRequireInterceptor.ts
+++ b/src/vs/workbench/api/common/extHostRequireInterceptor.ts
@@ -100,6 +100,7 @@ class NodeModuleAliasingModuleFactory implements IAlternativeModuleProvider {
 	 */
 	private static readonly aliased: ReadonlyMap<string, string> = new Map([
 		['vscode-ripgrep', '@vscode/ripgrep'],
+		['vscode-windows-registry', '@vscode/windows-registry'],
 	]);
 
 	private readonly re?: RegExp;


### PR DESCRIPTION
Removed old references to vscode-windows-registry.

This PR fixes #140564