### PR TITLE
Use Separate Options Configuration for Find (CMD+F, CTRL+F) and Selection Match (CMD+D, CTRL+D)

### DIFF
--- a/src/vs/editor/contrib/find/findOptionsWidget.ts
+++ b/src/vs/editor/contrib/find/findOptionsWidget.ts
@@ -52,7 +52,7 @@ export class FindOptionsWidget extends Widget implements IOverlayWidget {
 
 		this.caseSensitive = this._register(new CaseSensitiveCheckbox({
 			appendTitle: this._keybindingLabelFor(FIND_IDS.ToggleCaseSensitiveCommand),
-			isChecked: this._state.matchCase,
+			isChecked: this._state.matchCaseSelectionMatch,
 			inputActiveOptionBorder: inputActiveOptionBorderColor,
 			inputActiveOptionForeground: inputActiveOptionForegroundColor,
 			inputActiveOptionBackground: inputActiveOptionBackgroundColor
@@ -60,13 +60,13 @@ export class FindOptionsWidget extends Widget implements IOverlayWidget {
 		this._domNode.appendChild(this.caseSensitive.domNode);
 		this._register(this.caseSensitive.onChange(() => {
 			this._state.change({
-				matchCase: this.caseSensitive.checked
+				matchCaseSelectionMatch: this.caseSensitive.checked
 			}, false);
 		}));
 
 		this.wholeWords = this._register(new WholeWordsCheckbox({
 			appendTitle: this._keybindingLabelFor(FIND_IDS.ToggleWholeWordCommand),
-			isChecked: this._state.wholeWord,
+			isChecked: this._state.wholeWordSelectionMatch,
 			inputActiveOptionBorder: inputActiveOptionBorderColor,
 			inputActiveOptionForeground: inputActiveOptionForegroundColor,
 			inputActiveOptionBackground: inputActiveOptionBackgroundColor
@@ -74,13 +74,13 @@ export class FindOptionsWidget extends Widget implements IOverlayWidget {
 		this._domNode.appendChild(this.wholeWords.domNode);
 		this._register(this.wholeWords.onChange(() => {
 			this._state.change({
-				wholeWord: this.wholeWords.checked
+				wholeWordSelectionMatch: this.wholeWords.checked
 			}, false);
 		}));
 
 		this.regex = this._register(new RegexCheckbox({
 			appendTitle: this._keybindingLabelFor(FIND_IDS.ToggleRegexCommand),
-			isChecked: this._state.isRegex,
+			isChecked: this._state.isRegexSelectionMatch,
 			inputActiveOptionBorder: inputActiveOptionBorderColor,
 			inputActiveOptionForeground: inputActiveOptionForegroundColor,
 			inputActiveOptionBackground: inputActiveOptionBackgroundColor
@@ -88,7 +88,7 @@ export class FindOptionsWidget extends Widget implements IOverlayWidget {
 		this._domNode.appendChild(this.regex.domNode);
 		this._register(this.regex.onChange(() => {
 			this._state.change({
-				isRegex: this.regex.checked
+				isRegexSelectionMatch: this.regex.checked
 			}, false);
 		}));
 
@@ -96,16 +96,16 @@ export class FindOptionsWidget extends Widget implements IOverlayWidget {
 
 		this._register(this._state.onFindReplaceStateChange((e) => {
 			let somethingChanged = false;
-			if (e.isRegex) {
-				this.regex.checked = this._state.isRegex;
+			if (e.isRegexSelectionMatch) {
+				this.regex.checked = this._state.isRegexSelectionMatch;
 				somethingChanged = true;
 			}
-			if (e.wholeWord) {
-				this.wholeWords.checked = this._state.wholeWord;
+			if (e.wholeWordSelectionMatch) {
+				this.wholeWords.checked = this._state.wholeWordSelectionMatch;
 				somethingChanged = true;
 			}
-			if (e.matchCase) {
-				this.caseSensitive.checked = this._state.matchCase;
+			if (e.matchCaseSelectionMatch) {
+				this.caseSensitive.checked = this._state.matchCaseSelectionMatch;
 				somethingChanged = true;
 			}
 			if (!this._state.isRevealed && somethingChanged) {

--- a/src/vs/editor/contrib/find/findState.ts
+++ b/src/vs/editor/contrib/find/findState.ts
@@ -17,8 +17,11 @@ export interface FindReplaceStateChangedEvent {
 	isRevealed: boolean;
 	isReplaceRevealed: boolean;
 	isRegex: boolean;
+	isRegexSelectionMatch: boolean;
 	wholeWord: boolean;
+	wholeWordSelectionMatch: boolean;
 	matchCase: boolean;
+	matchCaseSelectionMatch: boolean;
 	preserveCase: boolean;
 	searchScope: boolean;
 	matchesPosition: boolean;
@@ -41,10 +44,13 @@ export interface INewFindReplaceState<T extends { update: (value: T) => void; } 
 	isRevealed?: boolean;
 	isReplaceRevealed?: boolean;
 	isRegex?: boolean;
+	isRegexSelectionMatch?: boolean;
 	isRegexOverride?: FindOptionOverride;
 	wholeWord?: boolean;
+	wholeWordSelectionMatch?: boolean;
 	wholeWordOverride?: FindOptionOverride;
 	matchCase?: boolean;
+	matchCaseSelectionMatch?: boolean;
 	matchCaseOverride?: FindOptionOverride;
 	preserveCase?: boolean;
 	preserveCaseOverride?: FindOptionOverride;
@@ -70,10 +76,13 @@ export class FindReplaceState<T extends { update: (value: T) => void; } = { upda
 	private _isRevealed: boolean;
 	private _isReplaceRevealed: boolean;
 	private _isRegex: boolean;
+	private _isRegexSelectionMatch: boolean;
 	private _isRegexOverride: FindOptionOverride;
 	private _wholeWord: boolean;
+	private _wholeWordSelectionMatch: boolean;
 	private _wholeWordOverride: FindOptionOverride;
 	private _matchCase: boolean;
+	private _matchCaseSelectionMatch: boolean;
 	private _matchCaseOverride: FindOptionOverride;
 	private _preserveCase: boolean;
 	private _preserveCaseOverride: FindOptionOverride;
@@ -91,8 +100,11 @@ export class FindReplaceState<T extends { update: (value: T) => void; } = { upda
 	public get isRevealed(): boolean { return this._isRevealed; }
 	public get isReplaceRevealed(): boolean { return this._isReplaceRevealed; }
 	public get isRegex(): boolean { return effectiveOptionValue(this._isRegexOverride, this._isRegex); }
+	public get isRegexSelectionMatch(): boolean { return effectiveOptionValue(this._isRegexOverride, this._isRegexSelectionMatch); }
 	public get wholeWord(): boolean { return effectiveOptionValue(this._wholeWordOverride, this._wholeWord); }
+	public get wholeWordSelectionMatch(): boolean { return effectiveOptionValue(this._wholeWordOverride, this._wholeWordSelectionMatch); }
 	public get matchCase(): boolean { return effectiveOptionValue(this._matchCaseOverride, this._matchCase); }
+	public get matchCaseSelectionMatch(): boolean { return effectiveOptionValue(this._matchCaseOverride, this._matchCaseSelectionMatch); }
 	public get preserveCase(): boolean { return effectiveOptionValue(this._preserveCaseOverride, this._preserveCase); }
 
 	public get actualIsRegex(): boolean { return this._isRegex; }
@@ -115,10 +127,13 @@ export class FindReplaceState<T extends { update: (value: T) => void; } = { upda
 		this._isRevealed = false;
 		this._isReplaceRevealed = false;
 		this._isRegex = false;
+		this._isRegexSelectionMatch = false;
 		this._isRegexOverride = FindOptionOverride.NotSet;
 		this._wholeWord = false;
+		this._wholeWordSelectionMatch = false;
 		this._wholeWordOverride = FindOptionOverride.NotSet;
 		this._matchCase = false;
+		this._matchCaseSelectionMatch = false;
 		this._matchCaseOverride = FindOptionOverride.NotSet;
 		this._preserveCase = false;
 		this._preserveCaseOverride = FindOptionOverride.NotSet;
@@ -140,8 +155,11 @@ export class FindReplaceState<T extends { update: (value: T) => void; } = { upda
 			isRevealed: false,
 			isReplaceRevealed: false,
 			isRegex: false,
+			isRegexSelectionMatch: false,
 			wholeWord: false,
+			wholeWordSelectionMatch: false,
 			matchCase: false,
+			matchCaseSelectionMatch: false,
 			preserveCase: false,
 			searchScope: false,
 			matchesPosition: false,
@@ -193,8 +211,11 @@ export class FindReplaceState<T extends { update: (value: T) => void; } = { upda
 			isRevealed: false,
 			isReplaceRevealed: false,
 			isRegex: false,
+			isRegexSelectionMatch: false,
 			wholeWord: false,
+			wholeWordSelectionMatch: false,
 			matchCase: false,
+			matchCaseSelectionMatch: false,
 			preserveCase: false,
 			searchScope: false,
 			matchesPosition: false,
@@ -242,11 +263,20 @@ export class FindReplaceState<T extends { update: (value: T) => void; } = { upda
 		if (typeof newState.isRegex !== 'undefined') {
 			this._isRegex = newState.isRegex;
 		}
+		if (typeof newState.isRegexSelectionMatch !== 'undefined') {
+			this._isRegexSelectionMatch = newState.isRegexSelectionMatch;
+		}
 		if (typeof newState.wholeWord !== 'undefined') {
 			this._wholeWord = newState.wholeWord;
 		}
+		if (typeof newState.wholeWordSelectionMatch !== 'undefined') {
+			this._wholeWordSelectionMatch = newState.wholeWordSelectionMatch;
+		}
 		if (typeof newState.matchCase !== 'undefined') {
 			this._matchCase = newState.matchCase;
+		}
+		if (typeof newState.matchCaseSelectionMatch !== 'undefined') {
+			this._matchCaseSelectionMatch = newState.matchCaseSelectionMatch;
 		}
 		if (typeof newState.preserveCase !== 'undefined') {
 			this._preserveCase = newState.preserveCase;


### PR DESCRIPTION
## Issue
- Currently both Find (CMD+F, CTRL+F) and Selection Match (CMD+D, CTRL+D) share the same options (`matchCase`, `wholeWord`, etc)
- Often times as a VSCode user I use Find without any options by default, but I use Selection Match with `matchCase` on by default
- A mouse click is required to toggle the `matchCase` every time Find and Selection Match is used sequentially (which happens often) and makes the coding experience impractical
- Resolves #8869
- Similar existing advocacy:
  - https://github.com/microsoft/vscode/issues/8869#issuecomment-231480135
  - https://github.com/microsoft/vscode/issues/8869#issuecomment-255771213
  - https://github.com/microsoft/vscode/issues/8869#issuecomment-267373751

https://user-images.githubusercontent.com/8948878/149634499-94e605be-32c6-4a4c-9552-a170d3d2e035.mov


## Desired Behaviour
- Allow the user to configure Find and Selection Match options independently

## Changelog
- Made Selection Match (CMD+D, CTRL+D) use different options configuration than Find (CMD+F, CTRL+F)

https://user-images.githubusercontent.com/8948878/149634509-6026de35-4f7b-4916-90f5-47d95b6b403a.mov

