### PR TITLE
Prevent link highlight in markdown code blocks and spans

### DIFF
--- a/extensions/markdown-language-features/src/extension.ts
+++ b/extensions/markdown-language-features/src/extension.ts
@@ -55,7 +55,7 @@ function registerMarkdownLanguageFeatures(
 
 	return vscode.Disposable.from(
 		vscode.languages.registerDocumentSymbolProvider(selector, symbolProvider),
-		vscode.languages.registerDocumentLinkProvider(selector, new LinkProvider()),
+		vscode.languages.registerDocumentLinkProvider(selector, new LinkProvider(engine)),
 		vscode.languages.registerFoldingRangeProvider(selector, new MarkdownFoldingProvider(engine)),
 		vscode.languages.registerSelectionRangeProvider(selector, new MarkdownSmartSelect(engine)),
 		vscode.languages.registerWorkspaceSymbolProvider(new MarkdownWorkspaceSymbolProvider(symbolProvider)),

--- a/extensions/markdown-language-features/src/features/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/features/documentLinkProvider.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import Token = require('markdown-it/lib/token');
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { OpenDocumentLinkCommand } from '../commands/openDocumentLink';
@@ -104,78 +103,69 @@ export function stripAngleBrackets(link: string) {
 	return link.replace(angleBracketLinkRe, '$1');
 }
 
-const codeSpanAndLinkPattern = /(?:(?<!`)(`+)(?!`)(?:.+?|.*?(?:(?:\r?\n).+?)*?)(?:\r?\n)?(?<!`)\1(?!`))|(?:(\[((!\[[^\]]*?\]\(\s*)([^\s\(\)]+?)\s*\)\]|(?:\\\]|[^\]])*\])\(\s*)(([^\s\(\)]|\([^\s\(\)]*?\))+)\s*(".*?")?\))/g;
+const linkPattern = /(\[((!\[[^\]]*?\]\(\s*)([^\s\(\)]+?)\s*\)\]|(?:\\\]|[^\]])*\])\(\s*)(([^\s\(\)]|\([^\s\(\)]*?\))+)\s*(".*?")?\)/g;
 const referenceLinkPattern = /(\[((?:\\\]|[^\]])+)\]\[\s*?)([^\s\]]*?)\]/g;
 const definitionPattern = /^([\t ]*\[(?!\^)((?:\\\]|[^\]])+)\]:\s*)([^<]\S*|<[^>]+>)/gm;
+const inlineCodePattern = /(?:(?<!`)(`+)(?!`)(?:.+?|.*?(?:(?:\r?\n).+?)*?)(?:\r?\n)?(?<!`)\1(?!`))/g;
 
-/**
- * Asserts if number is inside at least one interval in the array of intervals.
- *
- * @param intervals An array of [a,b) sorted by `a` in ascending order.
- */
-const isNumberInIntervals = (intervals: [number, number][], start: number, end: number, target: number): Boolean => {
-	if (start > end) {
-		return false;
-	}
-	const mid = start + Math.floor((end - start) / 2);
-	const pair = intervals[mid];
-	if (target >= pair[0] && target < pair[1]) {
-		return true;
-	}
-	if (target >= pair[1]) {
-		return isNumberInIntervals(intervals, mid + 1, end, target);
-	}
-	return isNumberInIntervals(intervals, start, mid - 1, target);
+type CodeInDocument = {
+	/**
+	 * code blocks and fences each represented by [line_start,line_end).
+	 */
+	multiline: [number, number][];
+	/**
+	 * inline code spans each represented by {@link vscode.Range}.
+	 */
+	inline: vscode.Range[];
 };
 
-const extractLineIntervalsOfCodeblocksAndFences = (tokens: Token[]): [number, number][] =>
-	tokens.reduce<[number, number][]>((acc, t) => {
-		if ((t.type === 'code_block' || t.type === 'fence') && t.map) {
-			return [...acc, t.map];
-		}
-		return acc;
-	}, []);
+async function findCode(document: vscode.TextDocument, engine: MarkdownEngine): Promise<CodeInDocument> {
+	const tokens = await engine.parse(document);
+	const multiline = tokens.filter(t => (t.type === 'code_block' || t.type === 'fence') && !!t.map).map(t => t.map) as [number, number][];
+
+	const text = document.getText();
+	const inline = [...text.matchAll(inlineCodePattern)].map(match => {
+		const start = match.index || 0;
+		return new vscode.Range(document.positionAt(start), document.positionAt(start + match[0].length));
+	});
+
+	return { multiline, inline };
+}
+
+function isLinkInsideCode(code: CodeInDocument, link: vscode.DocumentLink) {
+	return code.multiline.some(interval => link.range.start.line >= interval[0] && link.range.start.line < interval[1]) ||
+		code.inline.some(position => position.intersection(link.range));
+}
 
 export default class LinkProvider implements vscode.DocumentLinkProvider {
-
-	private _codeLineIntervals: [number, number][] = [];
-
 	constructor(
 		private readonly engine: MarkdownEngine
 	) { }
-
-	private isLineInsideIndentedOrFencedCode(line: number): Boolean {
-		return isNumberInIntervals(this._codeLineIntervals, 0, this._codeLineIntervals.length - 1, line);
-	}
 
 	public async provideDocumentLinks(
 		document: vscode.TextDocument,
 		_token: vscode.CancellationToken
 	): Promise<vscode.DocumentLink[]> {
 		const text = document.getText();
-		const tokens = await this.engine.parse(document);
-		this._codeLineIntervals = extractLineIntervalsOfCodeblocksAndFences(tokens);
 		return [
-			...this.providerInlineLinks(text, document),
+			...(await this.providerInlineLinks(text, document)),
 			...this.provideReferenceLinks(text, document)
 		];
 	}
 
-	private providerInlineLinks(
+	private async providerInlineLinks(
 		text: string,
 		document: vscode.TextDocument,
-	): vscode.DocumentLink[] {
+	): Promise<vscode.DocumentLink[]> {
 		const results: vscode.DocumentLink[] = [];
-		for (const match of text.matchAll(codeSpanAndLinkPattern)) {
-			if (match[1]) {
-				continue;
-			}
-			const matchImage = match[5] && extractDocumentLink(document, match[4].length + 1, match[5], match.index);
-			if (matchImage && !this.isLineInsideIndentedOrFencedCode(matchImage.range.start.line)) {
+		const codeInDocument = await findCode(document, this.engine);
+		for (const match of text.matchAll(linkPattern)) {
+			const matchImage = match[4] && extractDocumentLink(document, match[3].length + 1, match[4], match.index);
+			if (matchImage && !isLinkInsideCode(codeInDocument, matchImage)) {
 				results.push(matchImage);
 			}
-			const matchLink = extractDocumentLink(document, match[2].length, match[6], match.index);
-			if (matchLink && !this.isLineInsideIndentedOrFencedCode(matchLink.range.start.line)) {
+			const matchLink = extractDocumentLink(document, match[1].length, match[5], match.index);
+			if (matchLink && !isLinkInsideCode(codeInDocument, matchLink)) {
 				results.push(matchLink);
 			}
 		}

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
 import LinkProvider from '../features/documentLinkProvider';
+import { createNewMarkdownEngine } from './engine';
 import { InMemoryDocument } from './inMemoryDocument';
 import { noopToken } from './util';
 
@@ -15,7 +16,7 @@ const testFile = vscode.Uri.joinPath(vscode.workspace.workspaceFolders![0].uri, 
 
 function getLinksForFile(fileContents: string) {
 	const doc = new InMemoryDocument(testFile, fileContents);
-	const provider = new LinkProvider();
+	const provider = new LinkProvider(createNewMarkdownEngine());
 	return provider.provideDocumentLinks(doc, noopToken);
 }
 
@@ -27,63 +28,63 @@ function assertRangeEqual(expected: vscode.Range, actual: vscode.Range) {
 }
 
 suite('markdown.DocumentLinkProvider', () => {
-	test('Should not return anything for empty document', () => {
-		const links = getLinksForFile('');
+	test('Should not return anything for empty document', async () => {
+		const links = await getLinksForFile('');
 		assert.strictEqual(links.length, 0);
 	});
 
-	test('Should not return anything for simple document without links', () => {
-		const links = getLinksForFile('# a\nfdasfdfsafsa');
+	test('Should not return anything for simple document without links', async () => {
+		const links = await getLinksForFile('# a\nfdasfdfsafsa');
 		assert.strictEqual(links.length, 0);
 	});
 
-	test('Should detect basic http links', () => {
-		const links = getLinksForFile('a [b](https://example.com) c');
+	test('Should detect basic http links', async () => {
+		const links = await getLinksForFile('a [b](https://example.com) c');
 		assert.strictEqual(links.length, 1);
 		const [link] = links;
 		assertRangeEqual(link.range, new vscode.Range(0, 6, 0, 25));
 	});
 
-	test('Should detect basic workspace links', () => {
+	test('Should detect basic workspace links', async () => {
 		{
-			const links = getLinksForFile('a [b](./file) c');
+			const links = await getLinksForFile('a [b](./file) c');
 			assert.strictEqual(links.length, 1);
 			const [link] = links;
 			assertRangeEqual(link.range, new vscode.Range(0, 6, 0, 12));
 		}
 		{
-			const links = getLinksForFile('a [b](file.png) c');
+			const links = await getLinksForFile('a [b](file.png) c');
 			assert.strictEqual(links.length, 1);
 			const [link] = links;
 			assertRangeEqual(link.range, new vscode.Range(0, 6, 0, 14));
 		}
 	});
 
-	test('Should detect links with title', () => {
-		const links = getLinksForFile('a [b](https://example.com "abc") c');
+	test('Should detect links with title', async () => {
+		const links = await getLinksForFile('a [b](https://example.com "abc") c');
 		assert.strictEqual(links.length, 1);
 		const [link] = links;
 		assertRangeEqual(link.range, new vscode.Range(0, 6, 0, 25));
 	});
 
 	// #35245
-	test('Should handle links with escaped characters in name', () => {
-		const links = getLinksForFile('a [b\\]](./file)');
+	test('Should handle links with escaped characters in name', async () => {
+		const links = await getLinksForFile('a [b\\]](./file)');
 		assert.strictEqual(links.length, 1);
 		const [link] = links;
 		assertRangeEqual(link.range, new vscode.Range(0, 8, 0, 14));
 	});
 
 
-	test('Should handle links with balanced parens', () => {
+	test('Should handle links with balanced parens', async () => {
 		{
-			const links = getLinksForFile('a [b](https://example.com/a()c) c');
+			const links = await getLinksForFile('a [b](https://example.com/a()c) c');
 			assert.strictEqual(links.length, 1);
 			const [link] = links;
 			assertRangeEqual(link.range, new vscode.Range(0, 6, 0, 30));
 		}
 		{
-			const links = getLinksForFile('a [b](https://example.com/a(b)c) c');
+			const links = await getLinksForFile('a [b](https://example.com/a(b)c) c');
 			assert.strictEqual(links.length, 1);
 			const [link] = links;
 			assertRangeEqual(link.range, new vscode.Range(0, 6, 0, 31));
@@ -91,15 +92,15 @@ suite('markdown.DocumentLinkProvider', () => {
 		}
 		{
 			// #49011
-			const links = getLinksForFile('[A link](http://ThisUrlhasParens/A_link(in_parens))');
+			const links = await getLinksForFile('[A link](http://ThisUrlhasParens/A_link(in_parens))');
 			assert.strictEqual(links.length, 1);
 			const [link] = links;
 			assertRangeEqual(link.range, new vscode.Range(0, 9, 0, 50));
 		}
 	});
 
-	test('Should handle two links without space', () => {
-		const links = getLinksForFile('a ([test](test)[test2](test2)) c');
+	test('Should handle two links without space', async () => {
+		const links = await getLinksForFile('a ([test](test)[test2](test2)) c');
 		assert.strictEqual(links.length, 2);
 		const [link1, link2] = links;
 		assertRangeEqual(link1.range, new vscode.Range(0, 10, 0, 14));
@@ -107,23 +108,23 @@ suite('markdown.DocumentLinkProvider', () => {
 	});
 
 	// #49238
-	test('should handle hyperlinked images', () => {
+	test('should handle hyperlinked images', async () => {
 		{
-			const links = getLinksForFile('[![alt text](image.jpg)](https://example.com)');
+			const links = await getLinksForFile('[![alt text](image.jpg)](https://example.com)');
 			assert.strictEqual(links.length, 2);
 			const [link1, link2] = links;
 			assertRangeEqual(link1.range, new vscode.Range(0, 13, 0, 22));
 			assertRangeEqual(link2.range, new vscode.Range(0, 25, 0, 44));
 		}
 		{
-			const links = getLinksForFile('[![a]( whitespace.jpg )]( https://whitespace.com )');
+			const links = await getLinksForFile('[![a]( whitespace.jpg )]( https://whitespace.com )');
 			assert.strictEqual(links.length, 2);
 			const [link1, link2] = links;
 			assertRangeEqual(link1.range, new vscode.Range(0, 7, 0, 21));
 			assertRangeEqual(link2.range, new vscode.Range(0, 26, 0, 48));
 		}
 		{
-			const links = getLinksForFile('[![a](img1.jpg)](file1.txt) text [![a](img2.jpg)](file2.txt)');
+			const links = await getLinksForFile('[![a](img1.jpg)](file1.txt) text [![a](img2.jpg)](file2.txt)');
 			assert.strictEqual(links.length, 4);
 			const [link1, link2, link3, link4] = links;
 			assertRangeEqual(link1.range, new vscode.Range(0, 6, 0, 14));
@@ -133,13 +134,13 @@ suite('markdown.DocumentLinkProvider', () => {
 		}
 	});
 
-	test('Should not consider link references starting with ^ character valid (#107471)', () => {
-		const links = getLinksForFile('[^reference]: https://example.com');
+	test('Should not consider link references starting with ^ character valid (#107471)', async () => {
+		const links = await getLinksForFile('[^reference]: https://example.com');
 		assert.strictEqual(links.length, 0);
 	});
 
-	test('Should find definitions links with spaces in angle brackets (#136073)', () => {
-		const links = getLinksForFile([
+	test('Should find definitions links with spaces in angle brackets (#136073)', async () => {
+		const links = await getLinksForFile([
 			'[a]: <b c>',
 			'[b]: <cd>',
 		].join('\n'));
@@ -148,6 +149,27 @@ suite('markdown.DocumentLinkProvider', () => {
 		const [link1, link2] = links;
 		assertRangeEqual(link1.range, new vscode.Range(0, 6, 0, 9));
 		assertRangeEqual(link2.range, new vscode.Range(1, 6, 1, 8));
+	});
+
+	test('Should not consider links in fenced, indented and inline code', async () => {
+		const links = await getLinksForFile(['```',
+			'[b](https://example.com)',
+			'```',
+			'~~~',
+			'[b](https://example.com)',
+			'~~~',
+			'    [b](https://example.com)',
+			'``',
+			'[b](https://example.com)',
+			'``',
+			'`` ',
+			'',
+			'[b](https://example.com)',
+			'',
+			'``',
+			'`[b](https://example.com)`',
+			'[b](https://example.com)'].join('\n'));
+		assert.strictEqual(links.length, 2);
 	});
 });
 

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -153,23 +153,26 @@ suite('markdown.DocumentLinkProvider', () => {
 
 	test('Should not consider links in fenced, indented and inline code', async () => {
 		const links = await getLinksForFile(['```',
-			'[b](https://example.com)',
+			'[ignore](https://1.com)',
 			'```',
 			'~~~',
-			'[b](https://example.com)',
+			'[ignore](https://2.com)',
 			'~~~',
-			'    [b](https://example.com)',
-			'``',
-			'[b](https://example.com)',
+			'    [ignore](https://3.com)',
+			'`` ',
+			'[ignore](https://4.com) ',
 			'``',
 			'`` ',
 			'',
-			'[b](https://example.com)',
+			'[link](https://5.com)',
 			'',
 			'``',
-			'`[b](https://example.com)`',
-			'[b](https://example.com)'].join('\n'));
-		assert.strictEqual(links.length, 2);
+			'`[ignore](https://6.com)`',
+			'[link](https://7.com) `[b](https://8.com)',
+			'` [link](https://9.com)',
+			'`',
+			'[ignore](https://10.com)`'].join('\n'));
+		assert.deepStrictEqual(links.map(l => l.target?.authority), ['5.com', '7.com', '9.com']);
 	});
 });
 

--- a/extensions/markdown-language-features/test-workspace/a.md
+++ b/extensions/markdown-language-features/test-workspace/a.md
@@ -4,7 +4,22 @@
 
 [./b.md](./b.md)
 
-[/b.md](/b.md)
+[/b.md](/b.md) `[/b.md](/b.md)`
 
 [b#header1](b#header1)
 
+```
+[b](b)
+```
+
+~~~
+[b](b)
+~~~
+
+    // Indented code
+    [b](b)
+
+``
+a
+asdf
+``

--- a/extensions/markdown-language-features/test-workspace/a.md
+++ b/extensions/markdown-language-features/test-workspace/a.md
@@ -18,8 +18,3 @@
 
     // Indented code
     [b](b)
-
-``
-a
-asdf
-``


### PR DESCRIPTION
This PR fixes #139770. There were four cases to look out for:
1. Indented code blocks
2. Fenced code blocks (surrounded ` ``` ` or `~~~` ) 
3. Inline code spans
   1. With backticks inside
   2. With newlines inside
   3. More than one backtick at beginning/end
   4. Cannot be preceded/followed with backticks

1 and 2 were solved by getting line numbers from https://github.com/microsoft/vscode/blob/2a0d371ca3a7c216185eb8f4bc3831420b3c9d1c/extensions/markdown-language-features/src/markdownEngine.ts#L94

For 3, the markdown engine doesn't provide character positions for inline elements. Hence I expanded the regex to capture inline code spans as well. A capture of inline code span takes precedence over link. If an inline code span is matched, we simply ignore it. Inline code span regex can be tested [here](https://regexr.com/6dd2h) with examples from [CommonMark Spec](https://spec.commonmark.org/0.30/#code-spans).

## Issues

1. ``[not a `link](/foo`)`` is still detected as a valid link because the entire line match takes precedence over codespan match.
2. Multiline Inline code span still shows up underlined in editor but for different reasons. (DocumentLinkProvider doesn't return it as link and we don't see Follow Link on hovering)
![image](https://user-images.githubusercontent.com/12442986/149667764-ce7b9883-7ce3-4cae-bf47-bd3c799f5417.png)