### PR TITLE
Fix history to be saved in the input instead of the editor

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditorInput.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditorInput.ts
@@ -14,6 +14,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IUntypedEditorInput } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { IInteractiveDocumentService } from 'vs/workbench/contrib/interactive/browser/interactiveDocumentService';
+import { IInteractiveHistoryService } from 'vs/workbench/contrib/interactive/browser/interactiveHistoryService';
 import { IResolvedNotebookEditorModel } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { ICompositeNotebookEditorInput, NotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
 
@@ -62,6 +63,7 @@ export class InteractiveEditorInput extends EditorInput implements ICompositeNot
 	}
 	private _textModelService: ITextModelService;
 	private _interactiveDocumentService: IInteractiveDocumentService;
+	private _historyService: IInteractiveHistoryService;
 
 
 	constructor(
@@ -72,7 +74,8 @@ export class InteractiveEditorInput extends EditorInput implements ICompositeNot
 		@IModelService modelService: IModelService,
 		@ITextModelService textModelService: ITextModelService,
 
-		@IInteractiveDocumentService interactiveDocumentService: IInteractiveDocumentService
+		@IInteractiveDocumentService interactiveDocumentService: IInteractiveDocumentService,
+		@IInteractiveHistoryService historyService: IInteractiveHistoryService
 	) {
 		const input = NotebookEditorInput.create(instantiationService, resource, 'interactive', {});
 		super();
@@ -85,6 +88,7 @@ export class InteractiveEditorInput extends EditorInput implements ICompositeNot
 		this._inputModelRef = null;
 		this._textModelService = textModelService;
 		this._interactiveDocumentService = interactiveDocumentService;
+		this._historyService = historyService;
 
 		this._registerListeners();
 	}
@@ -173,5 +177,9 @@ export class InteractiveEditorInput extends EditorInput implements ICompositeNot
 		this._inputModelRef?.dispose();
 		this._inputModelRef = null;
 		super.dispose();
+	}
+
+	get historyService() {
+		return this._historyService;
 	}
 }

--- a/src/vs/workbench/contrib/interactive/browser/interactiveHistoryService.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveHistoryService.ts
@@ -19,6 +19,7 @@ export interface IInteractiveHistoryService {
 	getNextValue(uri: URI): string | null;
 	replaceLast(uri: URI, value: string): void;
 	clearHistory(uri: URI): void;
+	has(uri: URI): boolean;
 }
 
 export class InteractiveHistoryService extends Disposable implements IInteractiveHistoryService {
@@ -71,4 +72,9 @@ export class InteractiveHistoryService extends Disposable implements IInteractiv
 	clearHistory(uri: URI) {
 		this.#history.delete(uri);
 	}
+
+	has(uri: URI) {
+		return this.#history.has(uri) ? true : false;
+	}
+
 }


### PR DESCRIPTION
This PR fixes #138557

Input history was not being saved. It's a special case though. It should only exist between tab switches but not between VS code restarts.
