### PR TITLE
Fix wrapping for truncated output

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/output/transforms/textHelper.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/output/transforms/textHelper.ts
@@ -90,15 +90,15 @@ export function truncatedArrayOfString(notebookUri: URI, cellViewModel: IGeneric
 
 	container.appendChild(generateViewMoreElement(notebookUri, cellViewModel, outputId, disposables, openerService));
 
-	const pre = DOM.$('pre');
-	container.appendChild(pre);
-	pre.appendChild(handleANSIOutput(buffer.getValueInRange(new Range(1, 1, linesLimit - 5, buffer.getLineLastNonWhitespaceColumn(linesLimit - 5)), EndOfLinePreference.TextDefined), linkDetector, themeService, undefined));
+	const div = DOM.$('div');
+	container.appendChild(div);
+	div.appendChild(handleANSIOutput(buffer.getValueInRange(new Range(1, 1, linesLimit - 5, buffer.getLineLastNonWhitespaceColumn(linesLimit - 5)), EndOfLinePreference.TextDefined), linkDetector, themeService, undefined));
 
 	// view more ...
 	DOM.append(container, DOM.$('span' + Codicon.toolBarMore.cssSelector));
 
 	const lineCount = buffer.getLineCount();
-	const pre2 = DOM.$('div');
-	container.appendChild(pre2);
-	pre2.appendChild(handleANSIOutput(buffer.getValueInRange(new Range(lineCount - 5, 1, lineCount, buffer.getLineLastNonWhitespaceColumn(lineCount)), EndOfLinePreference.TextDefined), linkDetector, themeService, undefined));
+	const div2 = DOM.$('div');
+	container.appendChild(div2);
+	div2.appendChild(handleANSIOutput(buffer.getValueInRange(new Range(lineCount - 5, 1, lineCount, buffer.getLineLastNonWhitespaceColumn(lineCount)), EndOfLinePreference.TextDefined), linkDetector, themeService, undefined));
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #136184

Root cause was the styles being applied for the ```<pre>``` node weren't consistent. The code was using divs for the post ```...``` so changing the whole thing to use divs fixed the wrapping problem.

Before change:

![image](https://user-images.githubusercontent.com/19672699/150039082-c03f09e8-10db-48d9-9ee5-29c33ddce018.png)

After change:

![image](https://user-images.githubusercontent.com/19672699/150039136-2f76decf-76f3-41fe-b997-6ff773a60fae.png)

