### PR TITLE
make `Proxied`-type also massage arguments into dto-shape

### DIFF
--- a/src/vs/workbench/services/extensions/common/proxyIdentifier.ts
+++ b/src/vs/workbench/services/extensions/common/proxyIdentifier.ts
@@ -65,7 +65,7 @@ export type Dto<T> = T extends { toJSON(): infer U }
 	: T;
 
 export type Proxied<T> = { [K in keyof T]: T[K] extends (...args: infer A) => infer R
-	? (...args: A) => Promise<Dto<Awaited<R>>>
+	? (...args: { [K in keyof A]: Dto<A[K]> }) => Promise<Dto<Awaited<R>>>
 	: never
 };
 


### PR DESCRIPTION
This PR continues https://github.com/microsoft/vscode/pull/140927 and ensures that arguments of proxied functions receive `Dto<T>`-types, e.g no functions and toJSON-results, iff any, just data-objects. 

In a first step I have adjusted return-types, e.g no `$doSomething()`-function can return `URI` (it is `UriComponents`) nor a function at any level. This is PR is about doing the same with arguments, e.g make sure receivers are aware of arguments having been JSON-serialised. 

This PR yields a few compile error which I have trouble fixing.  @connor4312 and @TylerLeonhardt I need you help to fix/understand these violations.

* @connor4312  `$publishTestResults` depends (via a very long chain) on `IRichLocation` which is `URI` and `Range` (should be UriComponents and IRange on the wire)
* @TylerLeonhardt `TransferQuickPickItem`  is a problem because it ends up brings in `ResolvedKeybinding` which has functions (impossible)

---

Note that the handy `Dto`-type can be used to fix most of the issues, e.g in extHost.protocol define `Dto<YourDomainModelObject>` and should solve most issues
