### PR TITLE
Fix parseAddress regex

### DIFF
--- a/src/vs/workbench/services/remote/common/remoteExplorerService.ts
+++ b/src/vs/workbench/services/remote/common/remoteExplorerService.ts
@@ -120,7 +120,7 @@ export function makeAddress(host: string, port: number): string {
 }
 
 export function parseAddress(address: string): { host: string, port: number } | undefined {
-	const matches = address.match(/^([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\:|localhost:|[a-zA-Z\-]+:)?([0-9]+)$/);
+	const matches = address.match(/^([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*:)?([0-9]+)$/);
 	if (!matches) {
 		return undefined;
 	}


### PR DESCRIPTION
The previous regex was not very good and meant that hostnames containing digits and full stops were not accepted. This one should be more accurate. You can test it [here](https://regex101.com/r/ZVItcq/1).

Because regex's are completely unreadable here's how it breaks down:

```
^    - Start
(     - Hostname group
  [a-zA-Z0-9-]+    - First domain component
  (?:                         - Optional subsequent components
     \.[a-zA-Z0-9-]+     - Each subsequent component is a . followed by the component
  )*                      - Any number of subsequent components
:     - Port separator
)?   - Hostname group is optional
([0-9]+)    - Port, which is mandator
$   - End
```

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
