### PR TITLE
Pass renderer locale to exthost, fixes #85675

### DIFF
--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -219,7 +219,8 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 					VSCODE_LOG_NATIVE: this._isExtensionDevHost,
 					VSCODE_IPC_HOOK_EXTHOST: pipeName,
 					VSCODE_HANDLES_UNCAUGHT_ERRORS: true,
-					VSCODE_LOG_STACK: !this._isExtensionDevTestFromCli && (this._isExtensionDevHost || !this._environmentService.isBuilt || this._productService.quality !== 'stable' || this._environmentService.verbose)
+					VSCODE_LOG_STACK: !this._isExtensionDevTestFromCli && (this._isExtensionDevHost || !this._environmentService.isBuilt || this._productService.quality !== 'stable' || this._environmentService.verbose),
+					'LANG': processEnv['LANG'] ?? Intl.DateTimeFormat().resolvedOptions().locale
 				});
 
 				if (this._environmentService.debugExtensionHost.env) {

--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -212,6 +212,11 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 
 				this._extensionHostProcess = new ExtensionHostProcess(extensionHostCreationResult.id, this._extensionHostStarter);
 
+				let lang = processEnv['LANG'];
+				if (platform.isMacintosh && lang === undefined) {
+					lang = Intl.DateTimeFormat().resolvedOptions().locale;
+				}
+
 				const env = objects.mixin(processEnv, {
 					VSCODE_AMD_ENTRYPOINT: 'vs/workbench/api/node/extensionHostProcess',
 					VSCODE_PIPE_LOGGING: 'true',
@@ -220,7 +225,7 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 					VSCODE_IPC_HOOK_EXTHOST: pipeName,
 					VSCODE_HANDLES_UNCAUGHT_ERRORS: true,
 					VSCODE_LOG_STACK: !this._isExtensionDevTestFromCli && (this._isExtensionDevHost || !this._environmentService.isBuilt || this._productService.quality !== 'stable' || this._environmentService.verbose),
-					'LANG': processEnv['LANG'] ?? Intl.DateTimeFormat().resolvedOptions().locale
+					'LANG': lang
 				});
 
 				if (this._environmentService.debugExtensionHost.env) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #85675.

The PR passes in the main process' locale as a `LANG` environment variable to the extension host so that extensions use the same locale as the renderer. 

Some notes:
- Any processes that an extension spawns will also use that same locale, unless the user specifies a different locale in the spawn options.
- The PR should be merged in February so give more time for testing on Insiders.
