### PR TITLE
refactor `CredentialsMainService` and ensure the right one is used

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -31,13 +31,15 @@ import { localize } from 'vs/nls';
 import { IBackupMainService } from 'vs/platform/backup/electron-main/backup';
 import { BackupMainService } from 'vs/platform/backup/electron-main/backupMainService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { CredentialsMainService, ICredentialsMainService } from 'vs/platform/credentials/node/credentialsMainService';
+import { ICredentialsMainService } from 'vs/platform/credentials/common/credentials';
+import { CredentialsMainService } from 'vs/platform/credentials/node/credentialsMainService';
 import { ElectronExtensionHostDebugBroadcastChannel } from 'vs/platform/debug/electron-main/extensionHostDebugIpc';
 import { IDiagnosticsService } from 'vs/platform/diagnostics/common/diagnostics';
 import { DiagnosticsMainService, IDiagnosticsMainService } from 'vs/platform/diagnostics/electron-main/diagnosticsMainService';
 import { DialogMainService, IDialogMainService } from 'vs/platform/dialogs/electron-main/dialogMainService';
 import { serve as serveDriver } from 'vs/platform/driver/electron-main/driver';
-import { EncryptionMainService, IEncryptionMainService } from 'vs/platform/encryption/node/encryptionMainService';
+import { IEncryptionMainService } from 'vs/platform/encryption/common/encryptionService';
+import { EncryptionMainService } from 'vs/platform/encryption/node/encryptionMainService';
 import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
 import { IEnvironmentMainService } from 'vs/platform/environment/electron-main/environmentMainService';
 import { isLaunchedFromCli } from 'vs/platform/environment/node/argvHelper';
@@ -589,7 +591,7 @@ export class CodeApplication extends Disposable {
 		services.set(INativeHostMainService, new SyncDescriptor(NativeHostMainService, [sharedProcess]));
 
 		// Credentials
-		services.set(ICredentialsMainService, new SyncDescriptor(CredentialsMainService));
+		services.set(ICredentialsMainService, new SyncDescriptor(CredentialsMainService, [false]));
 
 		// Webview Manager
 		services.set(IWebviewManagerService, new SyncDescriptor(WebviewMainService));

--- a/src/vs/code/electron-main/auth.ts
+++ b/src/vs/code/electron-main/auth.ts
@@ -9,11 +9,11 @@ import { Event } from 'vs/base/common/event';
 import { hash } from 'vs/base/common/hash';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { generateUuid } from 'vs/base/common/uuid';
-import { IEncryptionMainService } from 'vs/platform/encryption/node/encryptionMainService';
+import { ICredentialsMainService } from 'vs/platform/credentials/common/credentials';
+import { IEncryptionMainService } from 'vs/platform/encryption/common/encryptionService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
-import { ICredentialsMainService } from 'vs/platform/credentials/node/credentialsMainService';
 
 interface ElectronAuthenticationResponseDetails extends AuthenticationResponseDetails {
 	firstAuthAttempt?: boolean; // https://github.com/electron/electron/blob/84a42a050e7d45225e69df5bd2d2bf9f1037ea41/shell/browser/login_handler.cc#L70

--- a/src/vs/platform/credentials/common/credentials.ts
+++ b/src/vs/platform/credentials/common/credentials.ts
@@ -25,4 +25,16 @@ export interface ICredentialsChangeEvent {
 export interface ICredentialsService extends ICredentialsProvider {
 	readonly _serviceBrand: undefined;
 	readonly onDidChangePassword: Event<ICredentialsChangeEvent>;
+
+	/*
+	 * Each CredentialsService must provide a prefix that will be used
+	 * by the SecretStorage API when storing secrets.
+	 * This is a method that returns a Promise so that it can be defined in
+	 * the main process and proxied on the renderer side.
+	 */
+	getSecretStoragePrefix(): Promise<string>;
 }
+
+export const ICredentialsMainService = createDecorator<ICredentialsMainService>('credentialsMainService');
+
+export interface ICredentialsMainService extends ICredentialsService { }

--- a/src/vs/platform/encryption/common/encryptionService.ts
+++ b/src/vs/platform/encryption/common/encryptionService.ts
@@ -3,6 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+
+export const IEncryptionMainService = createDecorator<IEncryptionMainService>('encryptionMainService');
+
+export interface IEncryptionMainService extends ICommonEncryptionService { }
+
 export interface ICommonEncryptionService {
 
 	readonly _serviceBrand: undefined;

--- a/src/vs/platform/encryption/node/encryptionMainService.ts
+++ b/src/vs/platform/encryption/node/encryptionMainService.ts
@@ -4,11 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ICommonEncryptionService } from 'vs/platform/encryption/common/encryptionService';
-import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-
-export const IEncryptionMainService = createDecorator<IEncryptionMainService>('encryptionMainService');
-
-export interface IEncryptionMainService extends ICommonEncryptionService { }
 
 export interface Encryption {
 	encrypt(salt: string, value: string): Promise<string>;

--- a/src/vs/workbench/api/browser/mainThreadSecretState.ts
+++ b/src/vs/workbench/api/browser/mainThreadSecretState.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from 'vs/base/common/lifecycle';
-import { IProductService } from 'vs/platform/product/common/productService';
 import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { ICredentialsService } from 'vs/platform/credentials/common/credentials';
 import { IEncryptionService } from 'vs/workbench/services/encryption/common/encryptionService';
@@ -14,27 +13,28 @@ import { ExtHostContext, ExtHostSecretStateShape, IExtHostContext, MainContext, 
 export class MainThreadSecretState extends Disposable implements MainThreadSecretStateShape {
 	private readonly _proxy: ExtHostSecretStateShape;
 
+	private secretStoragePrefix = this.credentialsService.getSecretStoragePrefix();
+
 	constructor(
 		extHostContext: IExtHostContext,
 		@ICredentialsService private readonly credentialsService: ICredentialsService,
 		@IEncryptionService private readonly encryptionService: IEncryptionService,
-		@IProductService private readonly productService: IProductService
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostSecretState);
 
-		this._register(this.credentialsService.onDidChangePassword(e => {
-			const extensionId = e.service.substring(this.productService.urlProtocol.length);
+		this._register(this.credentialsService.onDidChangePassword(async e => {
+			const extensionId = e.service.substring((await this.secretStoragePrefix).length);
 			this._proxy.$onDidChangePassword({ extensionId, key: e.account });
 		}));
 	}
 
-	private getFullKey(extensionId: string): string {
-		return `${this.productService.urlProtocol}${extensionId}`;
+	private async getFullKey(extensionId: string): Promise<string> {
+		return `${await this.secretStoragePrefix}${extensionId}`;
 	}
 
 	async $getPassword(extensionId: string, key: string): Promise<string | undefined> {
-		const fullKey = this.getFullKey(extensionId);
+		const fullKey = await this.getFullKey(extensionId);
 		const password = await this.credentialsService.getPassword(fullKey, key);
 		const decrypted = password && await this.encryptionService.decrypt(password);
 
@@ -53,7 +53,7 @@ export class MainThreadSecretState extends Disposable implements MainThreadSecre
 	}
 
 	async $setPassword(extensionId: string, key: string, value: string): Promise<void> {
-		const fullKey = this.getFullKey(extensionId);
+		const fullKey = await this.getFullKey(extensionId);
 		const toEncrypt = JSON.stringify({
 			extensionId,
 			content: value
@@ -64,7 +64,7 @@ export class MainThreadSecretState extends Disposable implements MainThreadSecre
 
 	async $deletePassword(extensionId: string, key: string): Promise<void> {
 		try {
-			const fullKey = this.getFullKey(extensionId);
+			const fullKey = await this.getFullKey(extensionId);
 			await this.credentialsService.deletePassword(fullKey, key);
 		} catch (_) {
 			throw new Error('Cannot delete password');

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -68,7 +68,6 @@ import { mixin, safeStringify } from 'vs/base/common/objects';
 import { ICredentialsService } from 'vs/platform/credentials/common/credentials';
 import { IndexedDB } from 'vs/base/browser/indexedDB';
 import { BrowserCredentialsService } from 'vs/workbench/services/credentials/browser/credentialsService';
-import { ProxyChannel } from 'vs/base/parts/ipc/common/ipc';
 
 class BrowserMain extends Disposable {
 
@@ -269,10 +268,7 @@ class BrowserMain extends Disposable {
 		// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 		// Credentials Service
-		const credentialsService = environmentService.remoteAuthority
-			// If we have a remote authority, we can use the CredentialsService on the remote side
-			? ProxyChannel.toService<ICredentialsService>(remoteAgentService.getConnection()!.getChannel('credentials'))
-			: new BrowserCredentialsService(environmentService);
+		const credentialsService = new BrowserCredentialsService(environmentService, remoteAgentService, productService);
 		serviceCollection.set(ICredentialsService, credentialsService);
 
 		// Userdata Initialize Service

--- a/src/vs/workbench/services/credentials/test/browser/credentialsService.test.ts
+++ b/src/vs/workbench/services/credentials/test/browser/credentialsService.test.ts
@@ -6,7 +6,9 @@
 import * as assert from 'assert';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { BrowserCredentialsService } from 'vs/workbench/services/credentials/browser/credentialsService';
+import { TestRemoteAgentService } from 'vs/workbench/services/remote/test/common/testServices';
 import { TestEnvironmentService } from 'vs/workbench/test/browser/workbenchTestServices';
+import { TestProductService } from 'vs/workbench/test/common/workbenchTestServices';
 
 suite('CredentialsService - web', () => {
 	const serviceId1 = 'test.credentialsService1';
@@ -14,7 +16,7 @@ suite('CredentialsService - web', () => {
 	const disposables = new DisposableStore();
 	let credentialsService: BrowserCredentialsService;
 	setup(async () => {
-		credentialsService = disposables.add(new BrowserCredentialsService(TestEnvironmentService));
+		credentialsService = disposables.add(new BrowserCredentialsService(TestEnvironmentService, new TestRemoteAgentService(), TestProductService));
 		await credentialsService.setPassword(serviceId1, 'me1', '1');
 		await credentialsService.setPassword(serviceId1, 'me2', '2');
 		await credentialsService.setPassword(serviceId2, 'me3', '3');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixing some misc bugs to ensure:
* if no credentialsprovider is provided but we have a remote, use the remote side for secrets (and use keytar)
* don't have server and desktop use the same keychain location

fixes #140961
fixes https://github.com/microsoft/vscode-internalbacklog/issues/2576
fixes https://github.com/github/codespaces/issues/5933
