### PR TITLE
Add SplitView to Settings editor

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -9,6 +9,8 @@
 
 .settings-editor {
 	overflow: hidden;
+	max-width: 1500px;
+	margin: auto;
 }
 
 .settings-editor:focus {
@@ -24,7 +26,7 @@
 	padding-top: 3px;
 	padding-left: 24px;
 	padding-right: 24px;
-	max-width: 1000px;
+	max-width: 1500px;
 }
 
 .settings-editor > .settings-header > .search-container {
@@ -128,7 +130,7 @@
 
 .settings-editor > .settings-body > .no-results-message {
 	display: none;
-	max-width: 1000px;
+	max-width: 1500px;
 	margin: auto;
 	margin-top: 20px;
 	padding-left: 24px;
@@ -255,7 +257,7 @@
 
 .settings-editor > .settings-body .settings-toc-wrapper {
 	height: 100%;
-	max-width: 1000px;
+	max-width: 1500px;
 	margin: auto;
 }
 
@@ -277,7 +279,7 @@
 }
 
 .settings-editor > .settings-body .settings-tree-container .monaco-list-row .monaco-tl-contents {
-	max-width: 1000px;
+	max-width: 1500px;
 	margin: auto;
 	box-sizing: border-box;
 	padding-left: 24px;
@@ -285,7 +287,7 @@
 	overflow: visible;
 }
 .settings-editor > .settings-body .settings-tree-container .monaco-list-row .monaco-tl-contents.group-title {
-	max-width: min(100%, 1000px); /* Cut off title if too long for window */
+	max-width: min(100%, 1500px); /* Cut off title if too long for window */
 }
 
 .settings-editor > .settings-body .settings-tree-container .settings-group-title-label,

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -8,7 +8,6 @@
 }
 
 .settings-editor {
-	padding: 11px 0px 0px;
 	overflow: hidden;
 }
 
@@ -21,6 +20,7 @@
 	box-sizing: border-box;
 	margin: auto;
 	overflow: hidden;
+	margin-top: 11px;
 	padding-top: 3px;
 	padding-left: 24px;
 	padding-right: 24px;
@@ -205,7 +205,6 @@
 }
 
 .settings-editor > .settings-body .settings-toc-container .monaco-list {
-	width: 160px;
 	pointer-events: initial;
 }
 
@@ -281,7 +280,7 @@
 	max-width: 1000px;
 	margin: auto;
 	box-sizing: border-box;
-	padding-left: 221px;
+	padding-left: 24px;
 	padding-right: 24px;
 	overflow: visible;
 }

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -215,10 +215,6 @@
 	display: none;
 }
 
-.settings-editor > .settings-body .settings-toc-container .monaco-scrollable-element > .shadow {
-	display: none;
-}
-
 .settings-editor > .settings-body .settings-toc-container .monaco-list-row .monaco-tl-contents {
 	display: flex;
 }
@@ -415,7 +411,7 @@
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-text .setting-item-validation-message {
-	width: 500px;
+	width: 420px;
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-number .setting-item-validation-message {
@@ -497,7 +493,7 @@
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-text .setting-item-control {
-	width: 500px;
+	width: 420px;
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-enum .setting-item-value > .setting-item-control,

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -125,7 +125,6 @@
 
 .settings-editor > .settings-body {
 	position: relative;
-	margin-top: 14px;
 }
 
 .settings-editor > .settings-body > .no-results-message {
@@ -245,6 +244,14 @@
 	border-spacing: 0;
 	border-collapse: separate;
 	position: relative;
+}
+
+.settings-editor > .settings-body .settings-tree-container .monaco-scrollable-element {
+	padding-top: 14px;
+}
+
+.settings-editor > .settings-body .settings-toc-container .monaco-scrollable-element {
+	padding-top: 14px;
 }
 
 .settings-editor > .settings-body .settings-toc-wrapper {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1511,7 +1511,7 @@ export class SettingsEditor2 extends EditorPane {
 
 	private layoutTrees(dimension: DOM.Dimension): void {
 		const listHeight = dimension.height - (72 + 11 /* header height + editor padding */);
-		const settingsTreeHeight = listHeight - 14;
+		const settingsTreeHeight = listHeight;
 		this.settingsTreeContainer.style.height = `${settingsTreeHeight}px`;
 		this.settingsTree.layout(settingsTreeHeight, dimension.width);
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -700,7 +700,7 @@ export class SettingsEditor2 extends EditorPane {
 			layout: (width) => {
 				this.tocTreeContainer.style.width = `${width}px`;
 			}
-		}, startingWidth);
+		}, startingWidth, undefined, true);
 		this.splitView.addView({
 			onDidChange: Event.None,
 			element: this.settingsTreeContainer,
@@ -709,7 +709,7 @@ export class SettingsEditor2 extends EditorPane {
 			layout: (width) => {
 				this.settingsTreeContainer.style.width = `${width}px`;
 			}
-		}, Sizing.Distribute);
+		}, Sizing.Distribute, undefined, true);
 		this._register(this.splitView.onDidSashReset(() => {
 			const totalSize = this.splitView.getViewSize(0) + this.splitView.getViewSize(1);
 			this.splitView.resizeView(0, SettingsEditor2.TOC_RESET_WIDTH);
@@ -1521,11 +1521,16 @@ export class SettingsEditor2 extends EditorPane {
 
 		this.splitView.el.style.height = `${settingsTreeHeight}px`;
 		const firstViewVisible = dimension.width >= SettingsEditor2.NARROW_TOTAL_WIDTH;
+
+		// We call layout first so the splitView has an idea of how much
+		// space it has, otherwise setViewVisible results in the first panel
+		// showing up at the minimum size whenever the Settings editor
+		// opens for the first time.
+		this.splitView.layout(this.bodyContainer.clientWidth);
 		this.splitView.setViewVisible(0, firstViewVisible);
 		this.splitView.style({
 			separatorBorder: firstViewVisible ? this.theme.getColor(settingsSashBorder)! : Color.transparent
 		});
-		this.splitView.layout(this.bodyContainer.clientWidth);
 	}
 
 	protected override saveState(): void {

--- a/src/vs/workbench/contrib/preferences/common/settingsEditorColorRegistry.ts
+++ b/src/vs/workbench/contrib/preferences/common/settingsEditorColorRegistry.ts
@@ -16,6 +16,7 @@ export const modifiedItemIndicator = registerColor('settings.modifiedItemIndicat
 	hc: new Color(new RGBA(0, 73, 122))
 }, localize('modifiedItemForeground', "The color of the modified setting indicator."));
 export const settingsHeaderBorder = registerColor('settings.headerBorder', { dark: PANEL_BORDER, light: PANEL_BORDER, hc: PANEL_BORDER }, localize('settingsHeaderBorder', "The color of the header container border."));
+export const settingsSashBorder = registerColor('settings.sashBorder', { dark: PANEL_BORDER, light: PANEL_BORDER, hc: PANEL_BORDER }, localize('settingsSashBorder', "The color of the Settings editor splitview sash border."));
 
 // Enum control colors
 export const settingsSelectBackground = registerColor(`settings.dropdownBackground`, { dark: selectBackground, light: selectBackground, hc: selectBackground }, localize('settingsDropdownBackground', "Settings editor dropdown background."));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/79581
Fixes https://github.com/microsoft/vscode/issues/92935

This PR adds a splitview to the Settings editor so that one can widen the table of contents, along with the ability to customize the border colours used within the Settings editor (settingsHeaderBorder and settingsSashBorder).
It also refactors the code so that the colours are in their own registry (like how the terminal does it), and groups some more constants at the top of the `SettingsEditor2.ts` file.
Additionally, because we're using a splitview, users can now easily tab back from the editor to the table of contents.

Note that a lot of the CSS changes are just to apply the CSS rules to the Settings editor renderers properly, because there are now extra DOM elements between the Settings editor container and the renderer containers due to the splitview.
Also, I did not add snapping to the left side, because even though one would be able to hide the table of contents, it would cause the sash to be very close to the sidebar sash, making it harder for the user to re-show the table of contents.

Another note is that when the overall Settings editor width is too small (i.e. below 600px), the table of contents still automatically hides.

![Screencap of splitview feature](https://user-images.githubusercontent.com/7199958/150616142-3eaf5ba7-8df8-48cb-a3cf-4e27ae1938d7.gif)

