### PR TITLE
Add "index" file first explorer sorting option

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -389,7 +389,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.sortOrder': {
 			'type': 'string',
-			'enum': [SortOrder.Default, SortOrder.Mixed, SortOrder.FilesFirst, SortOrder.Type, SortOrder.Modified, SortOrder.FoldersNestsFiles],
+			'enum': [SortOrder.Default, SortOrder.Mixed, SortOrder.FilesFirst, SortOrder.Type, SortOrder.Modified, SortOrder.FoldersNestsFiles, SortOrder.IndexFirst],
 			'default': SortOrder.Default,
 			'enumDescriptions': [
 				nls.localize('sortOrder.default', 'Files and folders are sorted by their names. Folders are displayed before files.'),
@@ -397,7 +397,8 @@ configurationRegistry.registerConfiguration({
 				nls.localize('sortOrder.filesFirst', 'Files and folders are sorted by their names. Files are displayed before folders.'),
 				nls.localize('sortOrder.type', 'Files and folders are grouped by extension type then sorted by their names. Folders are displayed before files.'),
 				nls.localize('sortOrder.modified', 'Files and folders are sorted by last modified date in descending order. Folders are displayed before files.'),
-				nls.localize('sortOrder.foldersNestsFiles', 'Files and folders are sorted by their names. Folders are displayed before files. Files with nested children are displayed before other files.')
+				nls.localize('sortOrder.foldersNestsFiles', 'Files and folders are sorted by their names. Folders are displayed before files. Files with nested children are displayed before other files.'),
+				nls.localize('sortOrder.indexFirst', 'Like default sorting, but files beginning in "index" are shown before other files.')
 			],
 			'description': nls.localize('sortOrder', "Controls the property-based sorting of files and folders in the explorer.")
 		},

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -750,7 +750,7 @@ export class FileSorter implements ITreeSorter<ExplorerItem> {
 			case 'mixed':
 				break; // not sorting when "mixed" is on
 
-			default: /* 'default', 'modified' */
+			default: /* 'default', 'modified', 'indexFirst' */
 				if (statA.isDirectory && !statB.isDirectory) {
 					return -1;
 				}
@@ -770,6 +770,20 @@ export class FileSorter implements ITreeSorter<ExplorerItem> {
 			case 'modified':
 				if (statA.mtime !== statB.mtime) {
 					return (statA.mtime && statB.mtime && statA.mtime < statB.mtime) ? 1 : -1;
+				}
+
+				return compareFileNames(statA.name, statB.name);
+
+			case 'indexFirst':
+				const isIndexFile = /(^|\/|\\)index\.[^\/\\]+$/
+				const statAIsIndex = isIndexFile.test(statA.name);
+				const statBIsIndex = isIndexFile.test(statB.name);
+				if (statAIsIndex && !statBIsIndex) {
+					return -1;
+				}
+
+				if (statBIsIndex && !statAIsIndex) {
+					return 1;
 				}
 
 				return compareFileNames(statA.name, statB.name);

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -120,6 +120,7 @@ export const enum SortOrder {
 	Type = 'type',
 	Modified = 'modified',
 	FoldersNestsFiles = 'foldersNestsFiles',
+	IndexFirst = 'indexFirst',
 }
 
 export const enum UndoEnablement {


### PR DESCRIPTION
This PR addresses one of the issues from https://github.com/microsoft/vscode/issues/27286 and fixes https://github.com/microsoft/vscode/issues/128834

This PR adds an `explorer.sortOrder` option `indexFirst` (default file sorting, but sorts files matching `**/index.*` first.)

