### PR TITLE
Fix `undefined`s in text search results

### DIFF
--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorSerialization.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorSerialization.ts
@@ -39,7 +39,7 @@ const matchToSearchResultFormat = (match: Match, longestLineNumber: number): { l
 			const prefixOffset = prefix.length;
 
 			// split instead of replace to avoid creating a new string object
-			const line = prefix + sourceLine.split(/\r?\n?$/, 1)[0];
+			const line = prefix + (sourceLine.split(/\r?\n?$/, 1)[0] || '');
 
 			const rangeOnThisLine = ({ start, end }: { start?: number; end?: number; }) => new Range(1, (start ?? 1) + prefixOffset, 1, (end ?? sourceLine.length + 1) + prefixOffset);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #141519

When `sourceLine` is the empty string, `.split()` returns an empty array so `.split()[0]` is `undefined`. I tested this change manually using the example in the issue, but please let me know if there's a test suite I should be adding this to. Thanks!