### PR TITLE
Match z-index on parameter hints to the hover

### DIFF
--- a/src/vs/editor/contrib/parameterHints/browser/parameterHints.css
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHints.css
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-editor .parameter-hints-widget {
-	z-index: 10;
+	/* Must be higher than sash's z-index and terminal canvases */
+	z-index: 40;
 	display: flex;
 	flex-direction: column;
 	line-height: 1.5em;


### PR DESCRIPTION
Fixes #140761

Matches:

https://github.com/microsoft/vscode/blob/36cff235c26581933b44bd1877f11e5c036632b3/src/vs/workbench/services/hover/browser/media/hover.css#L10-L11

The editor hover had an even higher z-index since vscode was open sourced:

https://github.com/microsoft/vscode/blob/c2b59954cb2b0b1d206070a1fdac8470cd1dc882/src/vs/base/browser/ui/hover/hover.css#L10