### PR TITLE
Prevent the image preview transparency background from being affected by scaling

### DIFF
--- a/extensions/image-preview/media/main.js
+++ b/extensions/image-preview/media/main.js
@@ -86,8 +86,8 @@
 			scale = 'fit';
 			image.classList.add('scale-to-fit');
 			image.classList.remove('pixelated');
-			image.style.minWidth = 'auto';
-			image.style.width = 'auto';
+			// @ts-ignore Non-standard CSS property
+			image.style.zoom = 'normal';
 			vscode.setState(undefined);
 		} else {
 			scale = clamp(newScale, MIN_SCALE, MAX_SCALE);
@@ -101,8 +101,8 @@
 			const dy = (window.scrollY + container.clientHeight / 2) / container.scrollHeight;
 
 			image.classList.remove('scale-to-fit');
-			image.style.minWidth = `${(image.naturalWidth * scale)}px`;
-			image.style.width = `${(image.naturalWidth * scale)}px`;
+			// @ts-ignore Non-standard CSS property
+			image.style.zoom = scale;
 
 			const newScrollX = container.scrollWidth * dx - container.clientWidth / 2;
 			const newScrollY = container.scrollHeight * dy - container.clientHeight / 2;


### PR DESCRIPTION
Fixes #141292 

![](https://user-images.githubusercontent.com/24855774/151431780-be76c07c-d341-4b0e-8fc3-3dc4aa54e5ff.png)
![](https://user-images.githubusercontent.com/24855774/151431811-79fd8603-cf6a-4e0a-9b15-f3bfa591a5f9.png)