### PR TITLE
Using Python 3 for `code` bash script

### DIFF
--- a/resources/darwin/bin/code.sh
+++ b/resources/darwin/bin/code.sh
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
-function realpath() { python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
+function realpath() { python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
 CONTENTS="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")")"
 ELECTRON="$CONTENTS/MacOS/Electron"
 CLI="$CONTENTS/Resources/app/out/cli.js"


### PR DESCRIPTION
## General

This PR changes the `code` bash script to use `python3` instead of `python`.

Few questions that I don't know the answers to:

- How will this impact existing users? Will they need to rerun the install bash script? Should this be a process that happens automatically on app launch or something?
- Python 3 no longer comes bundled with macOS 12.3, instead it's bundled with the Xcode Developer Tools. Apple recommends bundling Python 3 directly within your application if it is required. Is this something we should consider? Or is it a safe assumption that all VS Code users will have Xcode Developer Tools installed?

This PR fixes #141738
