### PR TITLE
Autocomplete activation event onWebviewPanel

### DIFF
--- a/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
@@ -246,6 +246,11 @@ export const schema: IJSONSchema = {
 				type: 'string',
 				defaultSnippets: [
 					{
+						label: 'onWebviewPanel',
+						description: nls.localize('vscode.extension.activationEvents.onWebviewPanel', 'An activation event emmited when a webview is loaded of a certain viewType'),
+						body: 'onWebviewPanel:viewType'
+					},
+					{
 						label: 'onLanguage',
 						description: nls.localize('vscode.extension.activationEvents.onLanguage', 'An activation event emitted whenever a file that resolves to the specified language gets opened.'),
 						body: 'onLanguage:${1:languageId}'


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #139564

## How to Test
1. Open a VSCode extension project
2. In the package.json file, under "activationEvents", start typing onWebviewPanel.
3. Hit Ctrl+Space for IntelliSense to show recommendations

You should see the onWebviewPanel in the recommendations as well as a description.