### PR TITLE
Trim characters off match instead to get key, fixes #141614

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -2130,7 +2130,8 @@ function cleanRenderedMarkdown(element: Node): void {
 }
 
 function fixSettingLinks(text: string, linkify = true): string {
-	return text.replace(/`#([^#]*)#`|'#([^#]*)#'/g, (match, settingKey) => {
+	return text.replace(/`#([^#]*)#`|'#([^#]*)#'/g, (match) => {
+		const settingKey = match.substring(2, match.length - 2);
 		const targetDisplayFormat = settingKeyToDisplayFormat(settingKey);
 		const targetName = `${targetDisplayFormat.category}: ${targetDisplayFormat.label}`;
 		return linkify ?


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/141614.

The problem was that I changed a regex a while back to fix https://github.com/microsoft/vscode/issues/135677. The point is that we wanted to match `'#setting-name#'` as well as `<backtick>#setting-name<backtick>`, because some localized strings, such as ones in the French language pack, didn't use backticks for setting links. 

But, the capturing group behaviour changed afterwards, making it so that when the match was from the second group instead of the first group, `settingKey` was `undefined`. It also did not help that the type of that parameter was `any`, because it meant we were passing `undefined` to a function that took in a `string` parameter, which broke the Settings editor rendering.

It is safer in this case to just trim the excess characters off the match to get the settings key.
