### PR TITLE
Add option to hide title bar when not showing menu bar

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -16,7 +16,7 @@ import { PanelPart } from 'vs/workbench/browser/parts/panel/panelPart';
 import { Position, Parts, PanelOpensMaximizedOptions, IWorkbenchLayoutService, positionToString, panelOpensMaximizedFromString, PanelAlignment } from 'vs/workbench/services/layout/browser/layoutService';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { IStorageService, StorageScope, WillSaveStateReason } from 'vs/platform/storage/common/storage';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
 import { ITitleService } from 'vs/workbench/services/title/common/titleService';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { StartupKind, ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
@@ -260,6 +260,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		// Menubar visibility changes
 		if ((isWindows || isLinux || isWeb) && getTitleBarStyle(this.configurationService) === 'custom') {
 			this._register(this.titleService.onMenubarVisibilityChange(visible => this.onMenubarToggled(visible)));
+			this._register(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationChanged(e)));
 		}
 
 		// Theme changes
@@ -267,6 +268,13 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 		// Window focus changes
 		this._register(this.hostService.onDidChangeFocus(e => this.onWindowFocusChanged(e)));
+	}
+
+	private onConfigurationChanged(event: IConfigurationChangeEvent): void {
+		if (event.affectsConfiguration('window.menuBarVisibility') && this.configurationService.getValue('window.hideTitleBarWithoutMenuBar') || event.affectsConfiguration('window.hideTitleBarWithoutMenuBar')) {
+			this.workbenchGrid.setViewVisible(this.titleBarPartView, this.shouldShowTitleBar());
+			this._onDidLayout.fire(this._dimension);
+		}
 	}
 
 	private onMenubarToggled(visible: boolean) {
@@ -281,6 +289,10 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			}
 			// The menu bar toggles the title bar in full screen for toggle and classic settings
 			else if (this.windowState.runtime.fullscreen && (menuBarVisibility === 'toggle' || menuBarVisibility === 'classic')) {
+				this.workbenchGrid.setViewVisible(this.titleBarPartView, this.shouldShowTitleBar());
+			}
+			// The menu bar toggles the title bar with the hideTitleBarWithoutMenuBar setting enabled
+			else if ((menuBarVisibility === 'toggle' || menuBarVisibility === 'classic') && this.configurationService.getValue('window.hideTitleBarWithoutMenuBar')) {
 				this.workbenchGrid.setViewVisible(this.titleBarPartView, this.shouldShowTitleBar());
 			}
 
@@ -958,7 +970,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 
 		// non-fullscreen native must show the title bar
-		if (isNative && !this.windowState.runtime.fullscreen) {
+		if (isNative && !this.windowState.runtime.fullscreen && !this.configurationService.getValue('window.hideTitleBarWithoutMenuBar')) {
 			return true;
 		}
 

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -189,6 +189,12 @@ import { TELEMETRY_SETTING_ID } from 'vs/platform/telemetry/common/telemetry';
 				'scope': ConfigurationScope.APPLICATION,
 				'description': localize('titleBarStyle', "Adjust the appearance of the window title bar. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.")
 			},
+			'window.hideTitleBarWithoutMenuBar': {
+				'type': 'boolean',
+				'default': false,
+				'scope': ConfigurationScope.APPLICATION,
+				'description': localize('hideTitleBarWithoutMenuBar', "Controls whether to hide the custom title bar when it is not needed to display the menu bar."),
+			},
 			'window.dialogStyle': {
 				'type': 'string',
 				'enum': ['native', 'custom'],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #43154 by adding an option to hide the custom title bar when it is not needed to display the menu bar (i.e., for "toggle" and "compact" visibility settings).

The use case is Linux with tiling window manager (sway for me). Sway and other tiling window managers can draw their own title bars as seen below.

![VSCode without title bar](https://user-images.githubusercontent.com/10325838/151718236-1e3dc6ab-f8fb-4be5-95a7-cde5c9ab647d.png)

The functionality of this PR is similar to https://github.com/microsoft/vscode/pull/117149, though it is not concerned with zen mode.
