### PR TITLE
Updates code cli to remove python requirement.

### DIFF
--- a/resources/darwin/bin/code.sh
+++ b/resources/darwin/bin/code.sh
@@ -3,9 +3,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
-function realpath() { python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
-CONTENTS="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")")"
-ELECTRON="$CONTENTS/MacOS/Electron"
-CLI="$CONTENTS/Resources/app/out/cli.js"
-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" --ms-enable-electron-run-as-node "$@"
-exit $?
+CODE_PATH=$(readlink "${0}")
+APP_BUNDLE=${CODE_PATH%%${CODE_PATH#*.app}}
+ELECTRON="${APP_BUNDLE}/Contents/MacOS/Electron"
+CLI="${APP_BUNDLE}/Contents/Resources/app/out/cli.js"
+ELECTRON_RUN_AS_NODE=1 "${ELECTRON}" "${CLI}" --ms-enable-electron-run-as-node "${@}"
+exit ${?}


### PR DESCRIPTION
macOS 12.3 is dropping the system supplied version of python. Thus, /usr/bin/python will no longer be available. This PR replaces the use of /usr/bin/python for more bash-native options.

Fixes #141880