### PR TITLE
double encode state query parameter

### DIFF
--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -475,7 +475,10 @@ export class AzureActiveDirectoryService {
 		const nonce = randomBytes(16).toString('base64');
 		const port = (callbackUri.authority.match(/:([0-9]*)$/) || [])[1] || (callbackUri.scheme === 'https' ? 443 : 80);
 		const callbackEnvironment = this.getCallbackEnvironment(callbackUri);
-		const state = `${callbackEnvironment},${port},${encodeURIComponent(nonce)},${encodeURIComponent(callbackUri.query)}`;
+		// NOTE: We encode that second time to work around the fact that the Microsoft OAuth API decodes our state parameter before
+		// sending it back to us. This use to "just work" because vscode.env.openExternal used to encode before opening it but that has
+		// changed as of https://github.com/microsoft/vscode/commit/a81c3b045dde741a05c8f8365c47d4207a5fc1a6
+		const state = encodeURIComponent(`${callbackEnvironment},${port},${encodeURIComponent(nonce)},${encodeURIComponent(callbackUri.query)}`);
 		const signInUrl = `${loginEndpointUrl}${scopeData.tenant}/oauth2/v2.0/authorize`;
 		let uri = vscode.Uri.parse(signInUrl);
 		const codeVerifier = toBase64UrlEncoding(randomBytes(32).toString('base64'));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref https://github.com/microsoft/vscode-dev/issues/504

This double encodes the state query parameter because we use to do this automatically and because the Microsoft Auth endpoint decodes the query parameter once.
