### PR TITLE
Task terminals with a failed `process` task aren't always reused properly

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -841,7 +841,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			});
 			promise = new Promise<ITaskSummary>((resolve, reject) => {
 				const onExit = terminal!.onExit((terminalLaunchResult) => {
-					const exitCode = terminalLaunchResult?.code;
+					const exitCode = typeof terminalLaunchResult === 'number' ? terminalLaunchResult : terminalLaunchResult?.code;
 					onData.dispose();
 					onExit.dispose();
 					let key = task.getMapKey();
@@ -850,7 +850,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 					}
 					this.removeFromActiveTasks(task);
 					this.fireTaskEvent(TaskEvent.create(TaskEventKind.Changed));
-					if (exitCode !== undefined) {
+					if (terminalLaunchResult !== undefined) {
 						// Only keep a reference to the terminal if it is not being disposed.
 						switch (task.command.presentation!.panel) {
 							case PanelKind.Dedicated:
@@ -921,12 +921,12 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			});
 			promise = new Promise<ITaskSummary>((resolve, reject) => {
 				const onExit = terminal!.onExit((terminalLaunchResult) => {
-					const exitCode = terminalLaunchResult?.code;
+					const exitCode = typeof terminalLaunchResult === 'number' ? terminalLaunchResult : terminalLaunchResult?.code;
 					onExit.dispose();
 					let key = task.getMapKey();
 					this.removeFromActiveTasks(task);
 					this.fireTaskEvent(TaskEvent.create(TaskEventKind.Changed));
-					if (exitCode !== undefined) {
+					if (terminalLaunchResult !== undefined) {
 						// Only keep a reference to the terminal if it is not being disposed.
 						switch (task.command.presentation!.panel) {
 							case PanelKind.Dedicated:

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -840,7 +840,8 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 				});
 			});
 			promise = new Promise<ITaskSummary>((resolve, reject) => {
-				const onExit = terminal!.onExit((exitCode) => {
+				const onExit = terminal!.onExit((terminalLaunchResult) => {
+					const exitCode = terminalLaunchResult?.code;
 					onData.dispose();
 					onExit.dispose();
 					let key = task.getMapKey();
@@ -878,7 +879,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 						processStartedSignaled = true;
 					}
 
-					this.fireTaskEvent(TaskEvent.create(TaskEventKind.ProcessEnded, task, exitCode));
+					this.fireTaskEvent(TaskEvent.create(TaskEventKind.ProcessEnded, task, exitCode ?? undefined));
 
 					for (let i = 0; i < eventCounter; i++) {
 						this.fireTaskEvent(TaskEvent.create(TaskEventKind.Inactive, task));
@@ -886,7 +887,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 					eventCounter = 0;
 					this.fireTaskEvent(TaskEvent.create(TaskEventKind.End, task));
 					toDispose.dispose();
-					resolve({ exitCode });
+					resolve({ exitCode: exitCode ?? undefined });
 				});
 			});
 		} else {
@@ -919,7 +920,8 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 				startStopProblemMatcher.processLine(line);
 			});
 			promise = new Promise<ITaskSummary>((resolve, reject) => {
-				const onExit = terminal!.onExit((exitCode) => {
+				const onExit = terminal!.onExit((terminalLaunchResult) => {
+					const exitCode = terminalLaunchResult?.code;
 					onExit.dispose();
 					let key = task.getMapKey();
 					this.removeFromActiveTasks(task);
@@ -961,13 +963,13 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 						processStartedSignaled = true;
 					}
 
-					this.fireTaskEvent(TaskEvent.create(TaskEventKind.ProcessEnded, task, exitCode));
+					this.fireTaskEvent(TaskEvent.create(TaskEventKind.ProcessEnded, task, exitCode ?? undefined));
 					if (this.busyTasks[mapKey]) {
 						delete this.busyTasks[mapKey];
 					}
 					this.fireTaskEvent(TaskEvent.create(TaskEventKind.Inactive, task));
 					this.fireTaskEvent(TaskEvent.create(TaskEventKind.End, task));
-					resolve({ exitCode });
+					resolve({ exitCode: exitCode ?? undefined });
 				});
 			});
 		}

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -523,10 +523,9 @@ export interface ITerminalInstance {
 	/**
 	 * Attach a listener that fires when the terminal's pty process exits. The number in the event
 	 * is the processes' exit code, an exit code of undefined means the process was killed as a result of
-	 * the ITerminalInstance being disposed. An exit code of null indicates that the process associated with
-	 * the terminal never started.
+	 * the ITerminalInstance being disposed.
 	 */
-	onExit: Event<{ code: number | undefined | null, message: string | undefined } | undefined>;
+	onExit: Event<number | ITerminalLaunchError | undefined>;
 
 	readonly exitCode: number | undefined;
 

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -522,10 +522,11 @@ export interface ITerminalInstance {
 
 	/**
 	 * Attach a listener that fires when the terminal's pty process exits. The number in the event
-	 * is the processes' exit code, an exit code of null means the process was killed as a result of
-	 * the ITerminalInstance being disposed.
+	 * is the processes' exit code, an exit code of undefined means the process was killed as a result of
+	 * the ITerminalInstance being disposed. An exit code of null indicates that the process associated with
+	 * the terminal never started.
 	 */
-	onExit: Event<number | undefined>;
+	onExit: Event<{ code: number | undefined | null, message: string | undefined } | undefined>;
 
 	readonly exitCode: number | undefined;
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -287,7 +287,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 	// The onExit event is special in that it fires and is disposed after the terminal instance
 	// itself is disposed
-	private readonly _onExit = new Emitter<number | undefined>();
+	private readonly _onExit = new Emitter<{ code: number | undefined | null, message: string | undefined } | undefined>();
 	readonly onExit = this._onExit.event;
 	private readonly _onDisposed = this._register(new Emitter<ITerminalInstance>());
 	readonly onDisposed = this._onDisposed.event;
@@ -1371,7 +1371,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		this._logService.debug(`Terminal process exit (instanceId: ${this.instanceId}) with code ${this._exitCode}`);
 
 		const parsedExitResult = parseExitResult(exitCodeOrError, this.shellLaunchConfig, this._processManager.processState, this._initialCwd, shellIntegrationAttempted);
-		this._exitCode = parsedExitResult?.code;
+		this._exitCode = parsedExitResult?.code ?? undefined;
 		const exitMessage = parsedExitResult?.message;
 
 		this._logService.debug(`Terminal process exit (instanceId: ${this.instanceId}) state ${this._processManager.processState}`);
@@ -1412,7 +1412,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}
 
 		// First onExit to consumers, this can happen after the terminal has already been disposed.
-		this._onExit.fire(this._exitCode);
+		this._onExit.fire(parsedExitResult);
 
 		// Dispose of the onExit event if the terminal will not be reused again
 		if (this._isDisposed) {
@@ -2333,13 +2333,13 @@ export function parseExitResult(
 	processState: ProcessState,
 	initialCwd: string | undefined,
 	shellIntegrationAttempted?: boolean
-): { code: number | undefined, message: string | undefined } | undefined {
+): { code: number | undefined | null, message: string | undefined } | undefined {
 	// Only return a message if the exit code is non-zero
 	if (exitCodeOrError === undefined || exitCodeOrError === 0) {
 		return { code: exitCodeOrError, message: undefined };
 	}
 
-	const code = typeof exitCodeOrError === 'number' ? exitCodeOrError : exitCodeOrError.code;
+	let code: number | undefined | null = typeof exitCodeOrError === 'number' ? exitCodeOrError : exitCodeOrError.code;
 
 	// Create exit code message
 	let message: string | undefined = undefined;
@@ -2398,6 +2398,7 @@ export function parseExitResult(
 				}
 			}
 			message = nls.localize('launchFailed.errorMessage', "The terminal process failed to launch: {0}.", innerMessage);
+			code = null;
 			break;
 		}
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -2398,7 +2398,7 @@ export function parseExitResult(
 				}
 			}
 			message = nls.localize('launchFailed.errorMessage', "The terminal process failed to launch: {0}.", innerMessage);
-			code = null;
+			code = code ?? null;
 			break;
 		}
 	}


### PR DESCRIPTION
Fixes #141728
