### PR TITLE
remove specific TS version for RichNav task

### DIFF
--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -36,6 +36,5 @@ jobs:
         with:
           languages: typescript
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          typescriptVersion: 0.6.0-next.21
           configFiles: .lsifrc.json
         continue-on-error: true


### PR DESCRIPTION
Use the default version specified by the RichCodeNavIndexer task

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

@dbaeumer -- we set the default version in our RichNavIndexer task (latest update now points to 0.6.0-next.22), so no need to set it here.
