### PR TITLE
Move strip comments into own module and write tests

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -60,6 +60,7 @@ const vscodeResources = [
 	'!out-build/vs/code/browser/**/*.html',
 	'!out-build/vs/editor/standalone/**/*.svg',
 	'out-build/vs/base/common/performance.js',
+	'out-build/vs/base/common/stripComments.js',
 	'out-build/vs/base/node/languagePacks.js',
 	'out-build/vs/base/node/{stdForkStart.js,terminateProcess.sh,cpuUsage.sh,ps.sh}',
 	'out-build/vs/base/browser/ui/codicons/codicon/**',

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ const os = require('os');
 const bootstrap = require('./bootstrap');
 const bootstrapNode = require('./bootstrap-node');
 const { getUserDataPath } = require('./vs/platform/environment/node/userDataPath');
+const { stripComments } = require('./vs/base/common/stripComments');
 /** @type {Partial<IProductConfiguration>} */
 const product = require('../product.json');
 const { app, protocol, crashReporter } = require('electron');
@@ -581,34 +582,6 @@ async function resolveNlsConfiguration() {
 	}
 
 	return nlsConfiguration;
-}
-
-/**
- * @param {string} content
- * @returns {string}
- */
-function stripComments(content) {
-	const regexp = /("(?:[^\\"]*(?:\\.)?)*")|('(?:[^\\']*(?:\\.)?)*')|(\/\*(?:\r?\n|.)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))/g;
-
-	return content.replace(regexp, function (match, m1, m2, m3, m4) {
-		// Only one of m1, m2, m3, m4 matches
-		if (m3) {
-			// A block comment. Replace with nothing
-			return '';
-		} else if (m4) {
-			// A line comment. If it ends in \r?\n then keep it.
-			const length_1 = m4.length;
-			if (length_1 > 2 && m4[length_1 - 1] === '\n') {
-				return m4[length_1 - 2] === '\r' ? '\r\n' : '\n';
-			}
-			else {
-				return '';
-			}
-		} else {
-			// We match a string
-			return match;
-		}
-	});
 }
 
 /**

--- a/src/vs/base/common/stripComments.d.ts
+++ b/src/vs/base/common/stripComments.d.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Strips single and multiline comments JavaScript comments from JSON
+ * content. Ignores characters in strings BUT doesn't support
+ * string continuation across multiple lines since it is not supported
+ * in JSON.
+ * @param content the content to strip comments from
+ * @returns the content without comments
+ */
+export function stripComments(content: string): string;

--- a/src/vs/base/common/stripComments.d.ts
+++ b/src/vs/base/common/stripComments.d.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Strips single and multiline comments JavaScript comments from JSON
+ * Strips single and multi line JavaScript comments from JSON
  * content. Ignores characters in strings BUT doesn't support
- * string continuation across multiple lines since it is not supported
- * in JSON.
+ * string continuation across multiple lines since it is not
+ * supported in JSON.
  * @param content the content to strip comments from
  * @returns the content without comments
  */

--- a/src/vs/base/common/stripComments.js
+++ b/src/vs/base/common/stripComments.js
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+//@ts-check
+
+(function () {
+	function factory(path, os, productName, cwd) {
+		// First group matches a double quoted string
+		// Second group matches a single quoted string
+		// Third group matches a multi line comment
+		// Forth group matches a single line comment
+		const regexp = /("[^"\\]*(?:\\.[^"\\]*)*")|('[^'\\]*(?:\\.[^'\\]*)*')|(\/\*[^\/\*]*(?:(?:\*|\/)[^\/\*]*)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))/g;
+
+		/**
+		 *
+		 * @param {string} content
+		 * @returns {string}
+		 */
+		function stripComments(content) {
+			console.log(`Stripping comments`);
+			return content.replace(regexp, function (match, _m1, _m2, m3, m4) {
+				// Only one of m1, m2, m3, m4 matches
+				if (m3) {
+					// A block comment. Replace with nothing
+					return '';
+				} else if (m4) {
+					// Since m4 is a single line comment is is at least of length 2 (e.g. //)
+					// If it ends in \r?\n then keep it.
+					const length = m4.length
+					if (m4[length - 1] === '\n') {
+						return m4[length - 2] === '\r' ? '\r\n' : '\n';
+					}
+					else {
+						return '';
+					}
+				} else {
+					// We match a string
+					return match;
+				}
+			});
+		}
+		return {
+			stripComments
+		};
+	}
+
+
+	if (typeof define === 'function') {
+		// amd
+		define([], function () { return factory(); });
+	} else if (typeof module === 'object' && typeof module.exports === 'object') {
+		// commonjs
+		module.exports = factory();
+	} else {
+		console.trace('strip comments defined in UNKNOWN context (neither requirejs or commonjs)');
+	}
+})();

--- a/src/vs/base/common/stripComments.js
+++ b/src/vs/base/common/stripComments.js
@@ -30,7 +30,7 @@
 				} else if (m4) {
 					// Since m4 is a single line comment is is at least of length 2 (e.g. //)
 					// If it ends in \r?\n then keep it.
-					const length = m4.length
+					const length = m4.length;
 					if (m4[length - 1] === '\n') {
 						return m4[length - 2] === '\r' ? '\r\n' : '\n';
 					}

--- a/src/vs/base/test/common/stripComments.test.ts
+++ b/src/vs/base/test/common/stripComments.test.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+
+import { stripComments } from 'vs/base/common/stripComments';
+
+// We use this regular expression quite often to strip comments in JSON files.
+
+suite('Strip Comments', () => {
+	test('Line comment', () => {
+		const content: string = [
+			"{",
+			"  \"prop\": 10 // a comment",
+			"}",
+		].join('\n');
+		const expected = [
+			"{",
+			"  \"prop\": 10 ",
+			"}",
+		].join('\n');
+		assert.strictEqual(stripComments(content), expected);
+	});
+	test('Line comment - EOF', () => {
+		const content: string = [
+			"{",
+			"}",
+			"// a comment"
+		].join('\n');
+		const expected = [
+			"{",
+			"}",
+			""
+		].join('\n');
+		assert.strictEqual(stripComments(content), expected);
+	});
+	test('Line comment - \\r\\n', () => {
+		const content: string = [
+			"{",
+			"  \"prop\": 10 // a comment",
+			"}",
+		].join('\r\n');
+		const expected = [
+			"{",
+			"  \"prop\": 10 ",
+			"}",
+		].join('\r\n');
+		assert.strictEqual(stripComments(content), expected);
+	});
+	test('Line comment - EOF - \\r\\n', () => {
+		const content: string = [
+			"{",
+			"}",
+			"// a comment"
+		].join('\r\n');
+		const expected = [
+			"{",
+			"}",
+			""
+		].join('\r\n');
+		assert.strictEqual(stripComments(content), expected);
+	});
+	test('Block comment - single line', () => {
+		const content: string = [
+			"{",
+			"  /* before */\"prop\": 10/* after */",
+			"}",
+		].join('\n');
+		const expected = [
+			"{",
+			"  \"prop\": 10",
+			"}",
+		].join('\n');
+		assert.strictEqual(stripComments(content), expected);
+	});
+	test('Block comment - multi line', () => {
+		const content: string = [
+			"{",
+			"  /**",
+			"   * Some comment",
+			"   */",
+			"  \"prop\": 10",
+			"}",
+		].join('\n');
+		const expected = [
+			"{",
+			"  ",
+			"  \"prop\": 10",
+			"}",
+		].join('\n');
+		assert.strictEqual(stripComments(content), expected);
+	});
+	test('Block comment - shortest match', () => {
+		const content = "/* abc */ */";
+		const expected = " */";
+		assert.strictEqual(stripComments(content), expected);
+	});
+	test('No strings - double quote', () => {
+		const content: string = [
+			"{",
+			"  \"/* */\": 10",
+			"}"
+		].join('\n');
+		const expected: string = [
+			"{",
+			"  \"/* */\": 10",
+			"}"
+		].join('\n');
+		assert.strictEqual(stripComments(content), expected);
+	});
+	test('No strings - single quote', () => {
+		const content: string = [
+			"{",
+			"  '/* */': 10",
+			"}"
+		].join('\n');
+		const expected: string = [
+			"{",
+			"  '/* */': 10",
+			"}"
+		].join('\n');
+		assert.strictEqual(stripComments(content), expected);
+	});
+});


### PR DESCRIPTION
Move the strip comments functionality into its own module and provides tests.

It also avoids catastrophic back trace behavior with the string matching (single and double quote) patterns by making the handling of the escape characters `\` and the capturing of the following characters more explicit. 

To test this you can do the following:

- open https://regex101.com/
- switch to JS mode
- use the old pattern `("(?:[^\\"]*(?:\\.)?)*")|('(?:[^\\']*(?:\\.)?)*')|(\/\*(?:\r?\n|.)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))` (the problematic part is actually `("(?:[^\\"]*(?:\\.)?)*")|('(?:[^\\']*(?:\\.)?)*')`)
- As a test string use `"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`
- This will result in a time out
- You can switch also to PCRE2 mode which will tell you about the backtracking  problem.

Use the new pattern `("[^"\\]*(?:\\.[^"\\]*)*")|('[^'\\]*(?:\\.[^'\\]*)*')|(\/\*[^\/\*]*(?:(?:\*|\/)[^\/\*]*)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))`

Everything should be fine. I also improved performance to find multi line comments using a similar technique as I used for the escape character `\` in strings.
