### PR TITLE
Fix bare math blocks with nested begin/end

### DIFF
--- a/extensions/markdown-math/yarn.lock
+++ b/extensions/markdown-math/yarn.lock
@@ -4,7 +4,7 @@
 
 "@iktakahiro/markdown-it-katex@https://github.com/mjbvz/markdown-it-katex.git":
   version "4.0.1"
-  resolved "https://github.com/mjbvz/markdown-it-katex.git#820d9025ad84937eb3f9f7efbc1be7595e20b19f"
+  resolved "https://github.com/mjbvz/markdown-it-katex.git#b1ed14de467031f5d4f9c1588dd1868cab0b8744"
   dependencies:
     katex "^0.13.0"
 


### PR DESCRIPTION
Fixes #141905

This picks up https://github.com/mjbvz/markdown-it-katex/commit/b1ed14de467031f5d4f9c1588dd1868cab0b8744

