### PR TITLE
Add WebFont feature

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,4 +1,4 @@
 disturl "https://electronjs.org/headers"
-target "13.5.2"
+target "14.2.5"
 runtime "electron"
 build_from_source "true"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "cssnano": "^4.1.11",
     "debounce": "^1.0.0",
     "deemon": "^1.4.0",
-    "electron": "13.5.1",
+    "electron": "14.2.5",
     "eslint": "8.7.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-jsdoc": "^19.1.0",

--- a/src/vs/code/electron-browser/workbench/workbench.html
+++ b/src/vs/code/electron-browser/workbench/workbench.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self' https: data: blob: vscode-remote-resource:; media-src 'self'; frame-src 'self' vscode-webview:; object-src 'self'; script-src 'self' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https: ws:; font-src 'self' https: vscode-remote-resource:;">
-		<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types amdLoader cellRendererEditorText defaultWorkerFactory diffEditorWidget editorGhostText domLineBreaksComputer editorViewLayer diffReview dompurify notebookRenderer safeInnerHtml standaloneColorizer tokenizeToString;">
+		<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types amdLoader cellRendererEditorText defaultWorkerFactory diffEditorWidget editorGhostText domLineBreaksComputer editorViewLayer diffReview dompurify notebookRenderer safeInnerHtml standaloneColorizer tokenizeToString webFontService;">
 	</head>
 	<body aria-label="">
 	</body>

--- a/src/vs/code/electron-sandbox/workbench/workbench.html
+++ b/src/vs/code/electron-sandbox/workbench/workbench.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self' https: data: blob: vscode-remote-resource:; media-src 'self'; frame-src 'self' vscode-webview:; object-src 'self'; script-src 'self' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https: ws:; font-src 'self' https: vscode-remote-resource:;">
-		<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types amdLoader cellRendererEditorText defaultWorkerFactory diffEditorWidget editorGhostText domLineBreaksComputer editorViewLayer diffReview dompurify notebookRenderer safeInnerHtml standaloneColorizer tokenizeToString;">
+		<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types amdLoader cellRendererEditorText defaultWorkerFactory diffEditorWidget editorGhostText domLineBreaksComputer editorViewLayer diffReview dompurify notebookRenderer safeInnerHtml standaloneColorizer tokenizeToString webFontService;">
 	</head>
 	<body aria-label="">
 	</body>

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -43,6 +43,11 @@ export const tocData: ITOCEntry<string> = {
 					settings: ['editor.font*']
 				},
 				{
+					id: 'editor/webFont',
+					label: localize('webFont', "Web Font"),
+					settings: ['editor.webFont.*']
+				},
+				{
 					id: 'editor/format',
 					label: localize('formatting', "Formatting"),
 					settings: ['editor.format*']

--- a/src/vs/workbench/contrib/webFont/browser/webFont.contribution.ts
+++ b/src/vs/workbench/contrib/webFont/browser/webFont.contribution.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from 'vs/nls';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
+import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
+import { WebFontService } from 'vs/workbench/contrib/webFont/browser/webFontService';
+import { IWebFontService } from 'vs/workbench/contrib/webFont/common/webFontService';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+
+registerSingleton(IWebFontService, WebFontService);
+
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(WebFontService, LifecyclePhase.Starting);
+
+configurationRegistry.registerConfiguration({
+	'id': 'webFont',
+	'order': 20,
+	'title': nls.localize('wenFontConfigurationTitle', "Web Font"),
+	'type': 'object',
+	'properties': {
+		'editor.webFont.fontFaceList': {
+			'type': 'array',
+			'description': nls.localize('webFontTest', "Font information that will be inserted in the CSS's font-face grammar."),
+			'default': [],
+			'items': {
+				'type': 'object',
+				properties: {
+					'ascent-override': {
+						'type': 'string'
+					},
+					'descent-override': {
+						'type': 'string'
+					},
+					'font-display': {
+						'type': 'string'
+					},
+					'font-family': {
+						'type': 'string'
+					},
+					'font-stretch': {
+						'type': 'string'
+					},
+					'font-style': {
+						'type': 'string'
+					},
+					'font-weight': {
+						'type': 'string'
+					},
+					'font-variant': {
+						'type': 'string'
+					},
+					'font-feature-settings': {
+						'type': 'string'
+					},
+					'font-variation-settings': {
+						'type': 'string'
+					},
+					'line-gap-override': {
+						'type': 'string'
+					},
+					'size-adjust': {
+						'type': 'string'
+					},
+					'src': {
+						'type': 'string'
+					},
+					'unicode-range': {
+						'type': 'string'
+					}
+				}
+
+			}
+		}
+	}
+});

--- a/src/vs/workbench/contrib/webFont/browser/webFontService.ts
+++ b/src/vs/workbench/contrib/webFont/browser/webFontService.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { fontFaceProperties, IFontFaceData, IWebFontService, WebFontSettings, } from 'vs/workbench/contrib/webFont/common/webFontService';
+import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+
+const ttPolicy = window.trustedTypes?.createPolicy('webFontService', {
+	createHTML: string => string
+});
+
+export class WebFontService implements IWebFontService {
+	declare readonly _serviceBrand: undefined;
+
+	private styleElement: HTMLStyleElement = document.createElement('style');
+
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService
+	) {
+		console.log('web font service instance');
+
+		this.createStyleElement();
+
+		this.loadWebFont();
+
+		this.installConfigurationListener();
+	}
+
+	private installConfigurationListener(): void {
+		this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(WebFontSettings.FONT_FACE_LIST)) {
+				this.loadWebFont();
+			}
+		});
+	}
+
+	private createStyleElement(): void {
+		this.styleElement = document.createElement('style');
+		this.styleElement.setAttribute('type', 'text/css');
+		this.styleElement.setAttribute('class', 'web-font-service-style');
+		document.head.appendChild(this.styleElement);
+	}
+
+	private loadWebFont(): void {
+
+
+		const fontFaceList = this.configurationService.getValue<IFontFaceData[]>(WebFontSettings.FONT_FACE_LIST);
+
+		let content = '';
+		fontFaceList.forEach(item => {
+			content +=
+				'@font-face {\n' +
+				fontFaceProperties.filter(property => item[property]).map(property => `    ${property}: ${item[property]};`).join('\n') + '\n' +
+				'}\n\n';
+		});
+
+		let html = ttPolicy?.createHTML(content) ?? content;
+		this.styleElement.innerHTML = html as string;
+
+
+	}
+}
+
+registerSingleton(IWebFontService, WebFontService);

--- a/src/vs/workbench/contrib/webFont/browser/webFontService.ts
+++ b/src/vs/workbench/contrib/webFont/browser/webFontService.ts
@@ -19,8 +19,6 @@ export class WebFontService implements IWebFontService {
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
-		console.log('web font service instance');
-
 		this.createStyleElement();
 
 		this.loadWebFont();

--- a/src/vs/workbench/contrib/webFont/common/webFontService.ts
+++ b/src/vs/workbench/contrib/webFont/common/webFontService.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+
+export const IWebFontService = createDecorator<IWebFontService>('webFontService');
+
+export enum WebFontSettings {
+	FONT_FACE_LIST = 'editor.webFont.fontFaceList'
+}
+
+export interface IFontFaceData {
+	'font-family': string;
+	'src': string;
+	'ascent-override': string;
+	'descent-override': string;
+	'font-display': string;
+	'font-stretch': string;
+	'font-style': string;
+	'font-weight': string;
+	'font-variant': string;
+	'font-feature-settings': string;
+	'font-variation-settings': string;
+	'line-gap-override': string;
+	'unicode-range': string;
+	'size-adjust': string;
+}
+
+export const fontFaceProperties: Array<keyof IFontFaceData> = [
+	'font-family',
+	'src',
+	'ascent-override',
+	'descent-override',
+	'font-display',
+	'font-stretch',
+	'font-style',
+	'font-weight',
+	'font-variant',
+	'font-feature-settings',
+	'font-variation-settings',
+	'line-gap-override',
+	'unicode-range',
+	'size-adjust'
+];
+
+
+export interface IWebFontService {
+	readonly _serviceBrand: undefined;
+}

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -329,4 +329,7 @@ import 'vs/workbench/contrib/list/browser/list.contribution';
 // Audio Cues
 import 'vs/workbench/contrib/audioCues/browser/audioCues.contribution';
 
+// Web Font
+import 'vs/workbench/contrib/webFont/browser/webFont.contribution';
+
 //#endregion

--- a/yarn.lock
+++ b/yarn.lock
@@ -4303,10 +4303,10 @@ electron-to-chromium@^1.4.17:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.45.tgz#cf1144091d6683cbd45a231954a745f02fb24598"
   integrity sha512-czF9eYVuOmlY/vxyMQz2rGlNSjZpxNQYBe1gmQv7al171qOIhgyO9k7D5AKlgeTCSPKk+LHhj5ZyIdmEub9oNg==
 
-electron@13.5.1:
-  version "13.5.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.5.1.tgz#76c02c39be228532f886a170b472cbd3d93f0d0f"
-  integrity sha512-ZyxhIhmdaeE3xiIGObf0zqEyCyuIDqZQBv9NKX8w5FNzGm87j4qR0H1+GQg6vz+cA1Nnv1x175Zvimzc0/UwEQ==
+electron@14.2.5:
+  version "14.2.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-14.2.5.tgz#3303283f582535a09f079bbeb25fc7ce127cccbd"
+  integrity sha512-L5Y0s3LOAKtHYFQanxULZxfZzxkldNvCyfsFiiNwo7rMi1M+THKfSHCgDarHluSIGc4NvOEomV7P1RL97qpr6A==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
This PR added a function to automatically download font in vcode. The font is available even in an environment where the font of the fontFamily is not downloaded.

![pic01](https://user-images.githubusercontent.com/47781302/152552165-56491f00-7169-4bff-90ac-1768e1564e03.png)
![pic02](https://user-images.githubusercontent.com/47781302/152552194-d4682ebc-4a5d-4bd4-b0e8-bde05ca304ea.png)

And to use the size-adjust of the font-face, we updated it to electron@14.2.5 that uses more than 92 versions of chrome. The reason for using size-addjust was to size other ASCII code characters and UNICODE characters.

For example, if you write it as follows, you can match the size of all UNICODE with English characters.

![pic03](https://user-images.githubusercontent.com/47781302/152552883-ef4d0e93-3f7f-4496-a8e5-276813d47533.png)

