### PR TITLE
Add "pnpm-lock.yaml" to default file nesting patterns

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -485,7 +485,7 @@ configurationRegistry.registerConfiguration({
 				'*.jsx': '$(capture).js',
 				'*.tsx': '$(capture).ts',
 				'tsconfig.json': 'tsconfig.*.json',
-				'package.json': 'package-lock.json, .npmrc, yarn.lock, .yarnrc',
+				'package.json': 'package-lock.json, .npmrc, yarn.lock, .yarnrc, pnpm-lock.yaml',
 			}
 		}
 	}


### PR DESCRIPTION
"pnpm-lock.yaml" is lock file of pnpm, so it can be collapsed with "package.json".