### PR TITLE
Decode header suggestions in Markdown path IntelliSense

### DIFF
--- a/extensions/markdown-language-features/src/features/pathCompletions.ts
+++ b/extensions/markdown-language-features/src/features/pathCompletions.ts
@@ -237,7 +237,7 @@ export class PathCompletionProvider implements vscode.CompletionItemProvider {
 			const replacementRange = new vscode.Range(insertionRange.start, position.translate({ characterDelta: context.linkSuffix.length }));
 			yield {
 				kind: vscode.CompletionItemKind.Reference,
-				label: '#' + entry.slug.value,
+				label: '#' + decodeURI(entry.slug.value),
 				range: {
 					inserting: insertionRange,
 					replacing: replacementRange,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #142330

Markdown path IntelliSense header link will suggest an encoded string.
It's fix to decode this and display the displayable character string.

The inserted decoded header works properly as an anchor.

<img width="639" alt="スクリーンショット 2022-02-07 21 51 03" src="https://user-images.githubusercontent.com/13635244/152793890-88cbe4e4-0250-4e5e-b596-761975e00ca2.png">

