### PR TITLE
Created a new command workbench.action.selectThemeByName that can be …

### DIFF
--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -382,6 +382,35 @@ registerAction2(class extends Action2 {
 	}
 });
 
+const SelectColorThemeByNameCommandId = 'workbench.action.selectThemeByName';
+
+registerAction2(class extends Action2 {
+
+	constructor() {
+		super({
+			id: SelectColorThemeByNameCommandId,
+			title: localize('selectThemeByName.label', "Color Theme By Name"),
+			category: CATEGORIES.Preferences
+		});
+	}
+
+	override async run(accessor: ServicesAccessor, newTheme: any) {
+		const themeService = accessor.get(IWorkbenchThemeService);
+		themeService.getColorThemes().then(results => {
+			const filteredTheme: IWorkbenchColorTheme | undefined = results.find(
+				function (results) {
+					return results.settingsId === `${newTheme}`;
+				}
+			);
+			if (filteredTheme === undefined) {
+				console.log(localize('selectThemeByName.errorLog', "No theme found that matches ") + `\"${newTheme}\"`);
+			} else {
+				themeService.setColorTheme(filteredTheme, 'auto').then();
+			}
+		});
+	}
+});
+
 const SelectFileIconThemeCommandId = 'workbench.action.selectIconTheme';
 
 registerAction2(class extends Action2 {


### PR DESCRIPTION
…used to key bind a specific theme ID argument with a key set.

This PR fixes #100460 (https://github.com/microsoft/vscode/issues/100460)

This is my first time contributing to a large project like this so it might/probably needs some edits which I will gladly do if needed.

This pull request creates a new command that can be used with a keybinding to select a specific Theme
![Theme Keybinding Example](https://user-images.githubusercontent.com/44900498/152861700-19e9fcb9-7c90-4f11-9269-a425c8e16a97.PNG)
![CommandSnap](https://user-images.githubusercontent.com/44900498/152861708-f0a0852c-88a7-44b8-9c61-0bda74f97a89.PNG)
 
 I noticed the misplaced then() at the end of the code a little to late. I'll remove it, and push up that fix after it is approved that there are no other mistakes.