### PR TITLE
Fix mouse selectbox scrollbar regression

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -777,8 +777,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		this._register(onSelectDropDownKeyDown.filter(e => (e.keyCode >= KeyCode.Digit0 && e.keyCode <= KeyCode.KeyZ) || (e.keyCode >= KeyCode.Semicolon && e.keyCode <= KeyCode.NumpadDivide)).on(this.onCharacter, this));
 
 		// SetUp list mouse controller - control navigation, disabled items, focus
-
-		this._register(dom.addDisposableListener(this.selectList.getHTMLElement(), dom.EventType.POINTER_DOWN, e => this.onPointerDown(e)));
+		this._register(dom.addDisposableListener(this.selectList.getHTMLElement(), dom.EventType.POINTER_UP, e => this.onPointerUp(e)));
 
 		this._register(this.selectList.onMouseOver(e => typeof e.index !== 'undefined' && this.selectList.setFocus([e.index])));
 		this._register(this.selectList.onDidChangeFocus(e => this.onListFocus(e)));
@@ -800,7 +799,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 
 	// List mouse controller - active exit, select option, fire onDidSelect if change, return focus to parent select
 	// Also takes in touchend events
-	private onPointerDown(e: PointerEvent): void {
+	private onPointerUp(e: PointerEvent): void {
 
 		if (!this.selectList.length) {
 			return;
@@ -814,7 +813,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		}
 
 		// Check our mouse event is on an option (not scrollbar)
-		if (!!target.classList.contains('slider')) {
+		if (target.classList.contains('slider')) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #142421

The commit that caused the regression, for reference: https://github.com/microsoft/vscode/commit/f4710a198fbc1b727a82f3ede4a718522182394c

I tested the change manually using the output tab selectbox, and the scrollbar has mouse support again. Touch support on the scrollbar never seemed to work, even with the breaking commit above, so there is no regression there. However, touch support to open the selectbox, scroll using finger drag, and select items still works, so it is better than what we had before.
