### PR TITLE
support dnd for markers and matches

### DIFF
--- a/src/vs/platform/opener/common/opener.ts
+++ b/src/vs/platform/opener/common/opener.ts
@@ -137,16 +137,28 @@ export function matchesSomeScheme(target: URI | string, ...schemes: string[]): b
 	return schemes.some(scheme => matchesScheme(target, scheme));
 }
 
-export function selectionFragment(target: URI): { startLineNumber: number; startColumn: number } | undefined {
-	let selection: { startLineNumber: number; startColumn: number } | undefined = undefined;
-	const match = /^L?(\d+)(?:,(\d+))?/.exec(target.fragment);
+/**
+ * file:///some/file.js#73
+ * file:///some/file.js#L73
+ * file:///some/file.js#73,84
+ * file:///some/file.js#L73,84
+ * file:///some/file.js#73-83
+ * file:///some/file.js#L73-L83
+ * file:///some/file.js#73,84-83,52
+ * file:///some/file.js#L73,84-L83,52
+ */
+export function selectionFragment(target: URI): { startLineNumber: number; startColumn: number; endLineNumber?: number; endColumn?: number } | undefined {
+	let selection: { startLineNumber: number; startColumn: number; endLineNumber?: number; endColumn?: number } | undefined = undefined;
+	const match = /^L?(\d+)(?:,(\d+))?(-L?(\d+)(?:,(\d+))?)?/.exec(target.fragment);
 	if (match) {
-		// support file:///some/file.js#73,84
-		// support file:///some/file.js#L73
 		selection = {
 			startLineNumber: parseInt(match[1]),
-			startColumn: match[2] ? parseInt(match[2]) : 1
+			startColumn: match[2] ? parseInt(match[2]) : 1,
 		};
+		if (match[4]) {
+			selection.endLineNumber = parseInt(match[4]);
+			selection.endColumn = match[5] ? parseInt(match[5]) : 1;
+		}
 	}
 	return selection;
 }

--- a/src/vs/platform/opener/test/common/opener.test.ts
+++ b/src/vs/platform/opener/test/common/opener.test.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { URI } from 'vs/base/common/uri';
+import { selectionFragment } from 'vs/platform/opener/common/opener';
+
+suite('selectionFragment', () => {
+
+	test('get selectionFragment with only startLineNumber', async () => {
+		const uri = URI.parse('file:///some/file.js#73');
+		assert.deepStrictEqual(selectionFragment(uri), { startLineNumber: 73, startColumn: 1 });
+	});
+
+	test('get selectionFragment with only startLineNumber in L format', async () => {
+		const uri = URI.parse('file:///some/file.js#L73');
+		assert.deepStrictEqual(selectionFragment(uri), { startLineNumber: 73, startColumn: 1 });
+	});
+
+	test('get selectionFragment with startLineNumber and startColumn', async () => {
+		const uri = URI.parse('file:///some/file.js#73,84');
+		assert.deepStrictEqual(selectionFragment(uri), { startLineNumber: 73, startColumn: 84 });
+	});
+
+	test('get selectionFragment with startLineNumber and startColumn in L format', async () => {
+		const uri = URI.parse('file:///some/file.js#L73,84');
+		assert.deepStrictEqual(selectionFragment(uri), { startLineNumber: 73, startColumn: 84 });
+	});
+
+	test('get selectionFragment with range and no column number', async () => {
+		const uri = URI.parse('file:///some/file.js#73-83');
+		assert.deepStrictEqual(selectionFragment(uri), { startLineNumber: 73, startColumn: 1, endLineNumber: 83, endColumn: 1 });
+	});
+
+	test('get selectionFragment with range and no column number in L format', async () => {
+		const uri = URI.parse('file:///some/file.js#L73-L83');
+		assert.deepStrictEqual(selectionFragment(uri), { startLineNumber: 73, startColumn: 1, endLineNumber: 83, endColumn: 1 });
+	});
+
+	test('get selectionFragment with range and no column number in L format only for start', async () => {
+		const uri = URI.parse('file:///some/file.js#L73-83');
+		assert.deepStrictEqual(selectionFragment(uri), { startLineNumber: 73, startColumn: 1, endLineNumber: 83, endColumn: 1 });
+	});
+
+	test('get selectionFragment with range and no column number in L format only for end', async () => {
+		const uri = URI.parse('file:///some/file.js#73-L83');
+		assert.deepStrictEqual(selectionFragment(uri), { startLineNumber: 73, startColumn: 1, endLineNumber: 83, endColumn: 1 });
+	});
+
+	test('get selectionFragment with complete range', async () => {
+		const uri = URI.parse('file:///some/file.js#73,84-83,52');
+		assert.deepStrictEqual(selectionFragment(uri), { startLineNumber: 73, startColumn: 84, endLineNumber: 83, endColumn: 52 });
+	});
+
+	test('get selectionFragment with complete range in L format', async () => {
+		const uri = URI.parse('file:///some/file.js#L73,84-L83,52');
+		assert.deepStrictEqual(selectionFragment(uri), { startLineNumber: 73, startColumn: 84, endLineNumber: 83, endColumn: 52 });
+	});
+
+});

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -21,7 +21,7 @@ import { QuickFixAction, QuickFixActionViewItem } from 'vs/workbench/contrib/mar
 import { ILabelService } from 'vs/platform/label/common/label';
 import { dirname, basename, isEqual } from 'vs/base/common/resources';
 import { IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
-import { ITreeFilter, TreeVisibility, TreeFilterResult, ITreeRenderer, ITreeNode, ITreeDragAndDrop, ITreeDragOverReaction } from 'vs/base/browser/ui/tree/tree';
+import { ITreeFilter, TreeVisibility, TreeFilterResult, ITreeRenderer, ITreeNode } from 'vs/base/browser/ui/tree/tree';
 import { FilterOptions } from 'vs/workbench/contrib/markers/browser/markersFilterOptions';
 import { IMatch } from 'vs/base/common/filters';
 import { Event, Emitter } from 'vs/base/common/event';
@@ -30,9 +30,6 @@ import { isUndefinedOrNull } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { Action, IAction } from 'vs/base/common/actions';
 import { localize } from 'vs/nls';
-import { IDragAndDropData } from 'vs/base/browser/dnd';
-import { ElementsDragAndDropData } from 'vs/base/browser/ui/list/listView';
-import { fillEditorsDragData } from 'vs/workbench/browser/dnd';
 import { CancelablePromise, createCancelablePromise, Delayer } from 'vs/base/common/async';
 import { IModelService } from 'vs/editor/common/services/model';
 import { Range } from 'vs/editor/common/core/range';
@@ -798,44 +795,4 @@ export class MarkersViewModel extends Disposable {
 		super.dispose();
 	}
 
-}
-
-export class ResourceDragAndDrop implements ITreeDragAndDrop<MarkerElement> {
-	constructor(
-		private instantiationService: IInstantiationService
-	) { }
-
-	onDragOver(data: IDragAndDropData, targetElement: MarkerElement, targetIndex: number, originalEvent: DragEvent): boolean | ITreeDragOverReaction {
-		return false;
-	}
-
-	getDragURI(element: MarkerElement): string | null {
-		if (element instanceof ResourceMarkers) {
-			return element.resource.toString();
-		}
-		return null;
-	}
-
-	getDragLabel?(elements: MarkerElement[]): string | undefined {
-		if (elements.length > 1) {
-			return String(elements.length);
-		}
-		const element = elements[0];
-		return element instanceof ResourceMarkers ? basename(element.resource) : undefined;
-	}
-
-	onDragStart(data: IDragAndDropData, originalEvent: DragEvent): void {
-		const elements = (data as ElementsDragAndDropData<MarkerElement>).elements;
-		const resources = elements
-			.filter(e => e instanceof ResourceMarkers)
-			.map(resourceMarker => (resourceMarker as ResourceMarkers).resource);
-
-		if (resources.length) {
-			// Apply some datatransfer types to allow for dragging the element outside of the application
-			this.instantiationService.invokeFunction(accessor => fillEditorsDragData(accessor, resources, originalEvent));
-		}
-	}
-
-	drop(data: IDragAndDropData, targetElement: MarkerElement, targetIndex: number, originalEvent: DragEvent): void {
-	}
 }

--- a/src/vs/workbench/contrib/markers/browser/markersView.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersView.ts
@@ -30,7 +30,7 @@ import { FilterOptions } from 'vs/workbench/contrib/markers/browser/markersFilte
 import { IExpression } from 'vs/base/common/glob';
 import { deepClone } from 'vs/base/common/objects';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
-import { FilterData, Filter, VirtualDelegate, ResourceMarkersRenderer, MarkerRenderer, RelatedInformationRenderer, MarkersTreeAccessibilityProvider, MarkersViewModel, ResourceDragAndDrop } from 'vs/workbench/contrib/markers/browser/markersTreeViewer';
+import { FilterData, Filter, VirtualDelegate, ResourceMarkersRenderer, MarkerRenderer, RelatedInformationRenderer, MarkersTreeAccessibilityProvider, MarkersViewModel } from 'vs/workbench/contrib/markers/browser/markersTreeViewer';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { ActionBar, IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IMenuService, MenuId } from 'vs/platform/actions/common/actions';
@@ -56,6 +56,7 @@ import { ResourceMap } from 'vs/base/common/map';
 import { EditorResourceAccessor, SideBySideEditor } from 'vs/workbench/common/editor';
 import { IMarkersView } from 'vs/workbench/contrib/markers/browser/markers';
 import { createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { ResourceListDnDHandler } from 'vs/workbench/browser/dnd';
 
 function createResourceMarkersIterator(resourceMarkers: ResourceMarkers): Iterable<ITreeElement<MarkerElement>> {
 	return Iterable.map(resourceMarkers.markers, m => {
@@ -391,7 +392,15 @@ export class MarkersView extends ViewPane implements IMarkersView {
 				filter: this.filter,
 				accessibilityProvider,
 				identityProvider,
-				dnd: new ResourceDragAndDrop(this.instantiationService),
+				dnd: this.instantiationService.createInstance(ResourceListDnDHandler, (element) => {
+					if (element instanceof ResourceMarkers) {
+						return element.resource;
+					}
+					if (element instanceof Marker) {
+						return element.resource.with({ fragment: `${element.range.startLineNumber},${element.range.startColumn}-${element.range.endLineNumber},${element.range.endColumn}` });
+					}
+					return null;
+				}),
 				expandOnlyOnTwistieClick: (e: MarkerElement) => e instanceof Marker && e.relatedInformation.length > 0,
 				overrideStyles: {
 					listBackground: this.getBackgroundColor()

--- a/src/vs/workbench/contrib/markers/browser/markersView.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersView.ts
@@ -399,6 +399,9 @@ export class MarkersView extends ViewPane implements IMarkersView {
 					if (element instanceof Marker) {
 						return element.resource.with({ fragment: `${element.range.startLineNumber},${element.range.startColumn}-${element.range.endLineNumber},${element.range.endColumn}` });
 					}
+					if (element instanceof RelatedInformation) {
+						return element.raw.resource.with({ fragment: `${element.raw.startLineNumber},${element.raw.startColumn}-${element.raw.endLineNumber},${element.raw.endColumn}` });
+					}
 					return null;
 				}),
 				expandOnlyOnTwistieClick: (e: MarkerElement) => e instanceof Marker && e.relatedInformation.length > 0,


### PR DESCRIPTION
This PR fixes #142508 

- Support DnD for maker entries in problems view and matches in search view
- Added range selection support in URI fragments

Syntax for range fragment - Extended current position format to support range as follows:

`file:///some/file.js#73,84-83,52`
`file:///some/file.js#L73,84-L83,52`

- Search and Problems view re-use common `ResourceDnDHandler`
