### PR TITLE
debug: bump js-debug

### DIFF
--- a/product.json
+++ b/product.json
@@ -67,7 +67,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.64.2",
+			"version": "1.64.3",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
This contains the following changes: https://github.com/microsoft/vscode-js-debug/compare/v1.64.2...v1.64.3

For: https://github.com/microsoft/vscode-js-debug/issues/1190. Initially it sounded like the Blazor team would be able to release an extension update to fix the issue, but that's not actually the case (it's part of .NET itself) so Blazor wasm debugging is broken on stable right now. This adds a patch to fix it.