### PR TITLE
Add `hwb` color function to CSS syntax

### DIFF
--- a/extensions/css/syntaxes/css.tmLanguage.json
+++ b/extensions/css/syntaxes/css.tmLanguage.json
@@ -850,7 +850,7 @@
 					]
 				},
 				{
-					"begin": "(?i)(?<![\\w-])(rgba?|hsla?)(\\()",
+					"begin": "(?i)(?<![\\w-])(rgba?|hsla?|hwb)(\\()",
 					"beginCaptures": {
 						"1": {
 							"name": "support.function.misc.css"


### PR DESCRIPTION
see : https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hwb()

This PR adds `hwb` in the same style as `rgb`/`rgba`/`hsl`/`hsla`.

Current behaviour :

<img width="127" alt="Screenshot 2022-02-08 at 18 43 55" src="https://user-images.githubusercontent.com/11521496/153045073-e3245d23-4da2-4161-98a2-81e26a5a9dca.png">

Intended to make `hwb` appear the same as `hsl` in this example :

<img width="127" alt="Screenshot 2022-02-08 at 18 44 32" src="https://user-images.githubusercontent.com/11521496/153045188-a9bc5f1f-1e1a-4452-8054-b9b284c2ed62.png">

If that is not the way to do this, please let me know :)
Happy to make more changes.