### PR TITLE
Add VS 2022 to supported versions

### DIFF
--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -45,7 +45,7 @@ function hasSupportedVisualStudioVersion() {
 	const path = require('path');
 	// Translated over from
 	// https://source.chromium.org/chromium/chromium/src/+/master:build/vs_toolchain.py;l=140-175
-	const supportedVersions = ['2019', '2017'];
+	const supportedVersions = ['2022', '2019', '2017'];
 
 	const availableVersions = [];
 	for (const version of supportedVersions) {


### PR DESCRIPTION
Adds '2022' to the list of supported Visual Studio versions for building.

I have tested this with VS 2022 installed and VS 2019 explicitly not installed anywhere, and it compiles just fine.

This PR fixes #138572
