### PR TITLE
Fix some Solarized colors

### DIFF
--- a/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
+++ b/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
@@ -3,13 +3,13 @@
 	"tokenColors": [
 		{
 			"settings": {
-				"foreground": "#93A1A1"
+				"foreground": "#839496"
 			}
 		},
 		{
 			"scope": ["meta.embedded", "source.groovy.embedded"],
 			"settings": {
-				"foreground": "#93A1A1"
+				"foreground": "#839496"
 			}
 		},
 		{
@@ -17,7 +17,7 @@
 			"scope": "comment",
 			"settings": {
 				"fontStyle": "italic",
-				"foreground": "#657B83"
+				"foreground": "#586E75"
 			}
 		},
 		{
@@ -156,7 +156,7 @@
 			"name": "Tag start/end",
 			"scope": "punctuation.definition.tag",
 			"settings": {
-				"foreground": "#657B83"
+				"foreground": "#586E75"
 			}
 		},
 		{
@@ -369,7 +369,7 @@
 
 		// Editor
 		"editor.background": "#002B36",
-		// "editor.foreground": "#6688cc",
+		"editor.foreground": "#839496",
 		"editorWidget.background": "#00212B",
 		"editorCursor.foreground": "#D30102",
 		"editorWhitespace.foreground": "#93A1A180",
@@ -498,7 +498,7 @@
 		"terminal.ansiMagenta": "#d33682",
 		"terminal.ansiCyan": "#2aa198",
 		"terminal.ansiWhite": "#eee8d5",
-		"terminal.ansiBrightBlack": "#586e75",
+		"terminal.ansiBrightBlack": "#002b36",
 		"terminal.ansiBrightRed": "#cb4b16",
 		"terminal.ansiBrightGreen": "#586e75",
 		"terminal.ansiBrightYellow": "#657b83",

--- a/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
+++ b/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
@@ -66,7 +66,7 @@
 			"scope": "storage",
 			"settings": {
 				"fontStyle": "bold",
-				"foreground": "#073642"
+				"foreground": "#586E75"
 			}
 		},
 		{
@@ -361,8 +361,8 @@
 		// "scrollbarSlider.hoverBackground": "",
 		// Editor
 		"editor.background": "#FDF6E3",
+		"editor.foreground": "#657B83",
 		"notebook.cellEditorBackground": "#F7F0E0",
-		// "editor.foreground": "#6688cc",
 		"editorWidget.background": "#EEE8D5",
 		"editorCursor.foreground": "#657B83",
 		"editorWhitespace.foreground": "#586E7580",
@@ -480,14 +480,14 @@
 		"terminal.ansiMagenta": "#d33682",
 		"terminal.ansiCyan": "#2aa198",
 		"terminal.ansiWhite": "#eee8d5",
-		"terminal.ansiBrightBlack": "#586e75",
+		"terminal.ansiBrightBlack": "#002b36",
 		"terminal.ansiBrightRed": "#cb4b16",
 		"terminal.ansiBrightGreen": "#586e75",
 		"terminal.ansiBrightYellow": "#657b83",
 		"terminal.ansiBrightBlue": "#839496",
 		"terminal.ansiBrightMagenta": "#6c71c4",
 		"terminal.ansiBrightCyan": "#93a1a1",
-		"terminal.ansiBrightWhite": "#eee8d5",
+		"terminal.ansiBrightWhite": "#fdf6e3",
 		// Interactive Playground
 		"walkThrough.embeddedEditorBackground": "#00000014"
 	},


### PR DESCRIPTION
VS Code's bundled Solarized themes currently look quite different than all other Solarized themes out there (mainly due to 1., 3., 4. and 5. below, which cause a higher contrast than usual).

This PR contains a few fixes for both Solarized themes:
1. According to #105418, the empty scope's foreground color is supposed to be used for normal text. For some reason, this does not seem to work, therefore set `editor.foreground` explicitly.
2. Some of the ANSI colors have been set to values differing from the official theme at https://ethanschoonover.com/solarized/ due to contrast issues. Nowadays, this can instead be fixed with `terminal.integrated.minimumContrastRatio` (see #121107).
3. Solarized Dark uses `#93A1A1` for normal text in a few places where `#839496` should be used instead.
4. Solarized Dark uses `#657B83` in a few places, which is not part of the official theme, use the correct `#586E75` instead.
5. Solarized Light uses `#073642` in one place, which is not part of the official theme, use the correct `#586E75` instead.

Dark before:
![dark-before](https://user-images.githubusercontent.com/4062614/153286894-d238ce4f-0f2a-4b1e-b477-cf34752104d4.png)
Dark after:
![dark-after](https://user-images.githubusercontent.com/4062614/153286892-c6a7019a-c5ba-45e6-848c-c3e1c050f1a8.png)
Light before:
![light-before](https://user-images.githubusercontent.com/4062614/153286899-dc34ff7b-4a77-4ecd-bed5-12842d3b4633.png)
Light after:
![light-after](https://user-images.githubusercontent.com/4062614/153286897-8d30e5d1-4df6-44db-8fd0-43042bb0bb73.png)