### PR TITLE
don't attempt to update a document that doesn't exist yet

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -386,7 +386,7 @@ registerAction2(class extends Action2 {
 			const allKernels = kernelService.getMatchingKernel({ uri: notebookUri, viewType: 'interactive' }).all;
 			const preferredKernel = allKernels.find(kernel => kernel.id === id);
 			if (preferredKernel) {
-				kernelService.selectKernelForNotebook(preferredKernel, { uri: notebookUri, viewType: 'interactive' });
+				kernelService.preselectKernelForNotebook(preferredKernel, { uri: notebookUri, viewType: 'interactive' });
 			}
 		}
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookKernelServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookKernelServiceImpl.ts
@@ -225,6 +225,15 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 		}
 	}
 
+	preselectKernelForNotebook(kernel: INotebookKernel, notebook: INotebookTextModelLike): void {
+		const key = NotebookTextModelLikeId.str(notebook);
+		const oldKernel = this._notebookBindings.get(key);
+		if (oldKernel !== kernel?.id) {
+			this._notebookBindings.set(key, kernel.id);
+			this._persistMementos();
+		}
+	}
+
 	updateKernelNotebookAffinity(kernel: INotebookKernel, notebook: URI, preference: number | undefined): void {
 		const info = this._kernels.get(kernel.id);
 		if (!info) {

--- a/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
@@ -82,6 +82,11 @@ export interface INotebookKernelService {
 	selectKernelForNotebook(kernel: INotebookKernel, notebook: INotebookTextModelLike): void;
 
 	/**
+	 * Set the kernel that a notebook should use when it starts up
+	 */
+	preselectKernelForNotebook(kernel: INotebookKernel, notebook: INotebookTextModelLike): void;
+
+	/**
 	 * Bind a notebook type to a kernel.
 	 * @param viewType
 	 * @param kernel


### PR DESCRIPTION
We need to set the pre-select the kernel for an interactive window so that it doesn't attempt to connect to the wrong one, but we don't have a Document object for the notebook at that point, so we shouldn't be trying to update it.
Creating the Document will automatically associate the kernel.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #140947
