### PR TITLE
Fix a typo in the `.devcontainer` README

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -63,7 +63,7 @@ You may see improved VNC responsiveness when accessing a codespace from VS Code 
 
 4. After you have connected to the codespace, you can use a [VNC Viewer](https://www.realvnc.com/en/connect/download/viewer/) to connect to `localhost:5901` and enter `vscode` as the password.
 
-    > **Tip:** You may also need change your VNC client's **Picture Quaility** setting to **High** to get a full color desktop.
+    > **Tip:** You may also need change your VNC client's **Picture Quality** setting to **High** to get a full color desktop.
 
 5. Anything you start in VS Code, or the integrated terminal, will appear here.
 


### PR DESCRIPTION
This PR simply corrects a typo, nothing much 🙂 
