### PR TITLE
Fix #142028

### DIFF
--- a/src/vs/workbench/contrib/testing/common/testingStates.ts
+++ b/src/vs/workbench/contrib/testing/common/testingStates.ts
@@ -59,3 +59,15 @@ export const maxPriority = (...states: TestResultState[]) => {
 export const statesInOrder = Object.keys(statePriority).map(s => Number(s) as TestResultState).sort(cmpPriority);
 
 export const isRunningState = (s: TestResultState) => s === TestResultState.Queued || s === TestResultState.Running;
+
+/**
+ * Some states are considered terminal; once these are set for a given test run, they
+ * are not reset back to a non-terminal state, or to a terminal state with lower
+ * priority.
+ */
+export const terminalStatePriorities: { [key in TestResultState]?: number } = {
+	[TestResultState.Passed]: 0,
+	[TestResultState.Skipped]: 1,
+	[TestResultState.Failed]: 2,
+	[TestResultState.Errored]: 3,
+};

--- a/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
@@ -144,14 +144,15 @@ suite('Workbench - Test Results Service', () => {
 
 		test('updateState', () => {
 			changed.clear();
-			r.updateState(new TestId(['ctrlId', 'id-a', 'id-aa']).toString(), 't', TestResultState.Running);
+			const testId = new TestId(['ctrlId', 'id-a', 'id-aa']).toString();
+			r.updateState(testId, 't', TestResultState.Running);
 			assert.deepStrictEqual(r.counts, {
 				...makeEmptyCounts(),
 				[TestResultState.Unset]: 2,
 				[TestResultState.Running]: 1,
 				[TestResultState.Queued]: 1,
 			});
-			assert.deepStrictEqual(r.getStateById(new TestId(['ctrlId', 'id-a', 'id-aa']).toString())?.ownComputedState, TestResultState.Running);
+			assert.deepStrictEqual(r.getStateById(testId)?.ownComputedState, TestResultState.Running);
 			// update computed state:
 			assert.deepStrictEqual(r.getStateById(tests.root.id)?.computedState, TestResultState.Running);
 			assert.deepStrictEqual(getChangeSummary(), [
@@ -159,6 +160,15 @@ suite('Workbench - Test Results Service', () => {
 				{ label: 'aa', reason: TestResultItemChangeReason.OwnStateChange },
 				{ label: 'root', reason: TestResultItemChangeReason.ComputedStateChange },
 			]);
+
+			r.updateState(testId, 't', TestResultState.Passed);
+			assert.deepStrictEqual(r.getStateById(testId)?.ownComputedState, TestResultState.Passed);
+
+			r.updateState(testId, 't', TestResultState.Errored);
+			assert.deepStrictEqual(r.getStateById(testId)?.ownComputedState, TestResultState.Errored);
+
+			r.updateState(testId, 't', TestResultState.Passed);
+			assert.deepStrictEqual(r.getStateById(testId)?.ownComputedState, TestResultState.Errored);
 		});
 
 		test('retire', () => {


### PR DESCRIPTION
If a test is run multiple times during a single test run, don't allow to set
the state back to a lower one, e.g. if the first test run failed but the second
passed. See #142028 for a reproduction recipe.

Fixes #142028