### PR TITLE
Replace the isStandalone const with a method of the same name

### DIFF
--- a/src/vs/base/browser/browser.ts
+++ b/src/vs/base/browser/browser.ts
@@ -186,4 +186,15 @@ export const isSafari = (!isChrome && (userAgent.indexOf('Safari') >= 0));
 export const isWebkitWebView = (!isChrome && !isSafari && isWebKit);
 export const isElectron = (userAgent.indexOf('Electron/') >= 0);
 export const isAndroid = (userAgent.indexOf('Android') >= 0);
-export const isStandalone = (window.matchMedia && window.matchMedia('(display-mode: standalone)').matches);
+
+let standalone = false;
+if (window.matchMedia) {
+	const matchMedia = window.matchMedia('(display-mode: standalone)');
+	standalone = matchMedia.matches;
+	matchMedia.addEventListener('change', ({ matches }) => {
+		standalone = matches;
+	});
+}
+export function isStandalone(): boolean {
+	return standalone;
+}

--- a/src/vs/base/browser/canIUse.ts
+++ b/src/vs/base/browser/canIUse.ts
@@ -28,7 +28,7 @@ export const BrowserFeatures = {
 		)
 	},
 	keyboard: (() => {
-		if (platform.isNative || browser.isStandalone) {
+		if (platform.isNative || browser.isStandalone()) {
 			return KeyboardSupport.Always;
 		}
 

--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -375,7 +375,7 @@ class WorkspaceProvider implements IWorkspaceProvider {
 				return true;
 			} else {
 				let result;
-				if (isStandalone) {
+				if (isStandalone()) {
 					result = window.open(targetHref, '_blank', 'toolbar=no'); // ensures to open another 'standalone' window!
 				} else {
 					result = window.open(targetHref);

--- a/src/vs/editor/contrib/gotoSymbol/browser/goToCommands.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/goToCommands.ts
@@ -257,7 +257,7 @@ export class DefinitionAction extends SymbolNavigationAction {
 	}
 }
 
-const goToDefinitionKb = isWeb && !isStandalone
+const goToDefinitionKb = isWeb && !isStandalone()
 	? KeyMod.CtrlCmd | KeyCode.F12
 	: KeyCode.F12;
 

--- a/src/vs/workbench/browser/style.ts
+++ b/src/vs/workbench/browser/style.ts
@@ -144,7 +144,7 @@ registerThemingParticipant((theme, collector) => {
 	}
 
 	// Update body background color to ensure the home indicator area looks similar to the workbench
-	if (isIOS && isStandalone) {
+	if (isIOS && isStandalone()) {
 		collector.addRule(`body { background-color: ${workbenchBackground}; }`);
 	}
 

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -492,7 +492,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('window.confirmBeforeClose.keyboardOnly', "Only ask for confirmation if a keybinding was detected. Note that detection may not be possible in some cases."),
 					localize('window.confirmBeforeClose.never', "Never explicitly ask for confirmation unless data loss is imminent.")
 				],
-				'default': isWeb && !isStandalone ? 'keyboardOnly' : 'never', // on by default in web, unless PWA
+				'default': isWeb && !isStandalone() ? 'keyboardOnly' : 'never', // on by default in web, unless PWA
 				'description': localize('confirmBeforeCloseWeb', "Controls whether to show a confirmation dialog before closing the browser tab or window. Note that even if enabled, browsers may still decide to close a tab or window without confirmation and that this setting is only a hint that may not work in all cases."),
 				'scope': ConfigurationScope.APPLICATION,
 				'included': isWeb


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #143197

Logic based on if the window is standalone should be based on if it is currently standalone, rather than if it was standalone when VS Code was started.
