### PR TITLE
Revert "remote-cli not being added to PATH with `"terminal.integrated.inheritEnv": false`"

### DIFF
--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -21,19 +21,26 @@ import { IProcessEnvironment, isWindows } from 'vs/base/common/platform';
 import { logRemoteEntry } from 'vs/workbench/services/extensions/common/remoteConsoleUtil';
 import { removeDangerousEnvVariables } from 'vs/base/node/processes';
 
-export async function buildUserEnvironment(startParamsEnv: { [key: string]: string | null } = {}, withUserShellEnvironment: boolean, language: string, isDebug: boolean, environmentService: IServerEnvironmentService, logService: ILogService): Promise<IProcessEnvironment> {
+export async function buildUserEnvironment(startParamsEnv: { [key: string]: string | null } = {}, language: string, isDebug: boolean, environmentService: IServerEnvironmentService, logService: ILogService): Promise<IProcessEnvironment> {
 	const nlsConfig = await getNLSConfiguration(language, environmentService.userDataPath);
 
-	let userShellEnv: typeof process.env = {};
-	if (withUserShellEnvironment) {
-		try {
-			userShellEnv = await getResolvedShellEnv(logService, environmentService.args, process.env);
-		} catch (error) {
-			logService.error('ExtensionHostConnection#buildUserEnvironment resolving shell environment failed', error);
-		}
+	let userShellEnv: typeof process.env | undefined = undefined;
+	try {
+		userShellEnv = await getResolvedShellEnv(logService, environmentService.args, process.env);
+	} catch (error) {
+		logService.error('ExtensionHostConnection#buildUserEnvironment resolving shell environment failed', error);
+		userShellEnv = {};
 	}
 
+	const binFolder = environmentService.isBuilt ? join(environmentService.appRoot, 'bin') : join(environmentService.appRoot, 'resources', 'server', 'bin-dev');
+	const remoteCliBinFolder = join(binFolder, 'remote-cli'); // contains the `code` command that can talk to the remote server
 	const processEnv = process.env;
+	let PATH = startParamsEnv['PATH'] || (userShellEnv ? userShellEnv['PATH'] : undefined) || processEnv['PATH'];
+	if (PATH) {
+		PATH = remoteCliBinFolder + delimiter + PATH;
+	} else {
+		PATH = remoteCliBinFolder;
+	}
 
 	const env: IProcessEnvironment = {
 		...processEnv,
@@ -50,23 +57,13 @@ export async function buildUserEnvironment(startParamsEnv: { [key: string]: stri
 		},
 		...startParamsEnv
 	};
-
-	const binFolder = environmentService.isBuilt ? join(environmentService.appRoot, 'bin') : join(environmentService.appRoot, 'resources', 'server', 'bin-dev');
-	const remoteCliBinFolder = join(binFolder, 'remote-cli'); // contains the `code` command that can talk to the remote server
-
-	let PATH = env.PATH;
-	if (PATH) {
-		PATH = remoteCliBinFolder + delimiter + PATH;
-	} else {
-		PATH = remoteCliBinFolder;
-	}
-	setCaseInsensitive(env, 'PATH', PATH);
-
 	if (!environmentService.args['without-browser-env-var']) {
 		env.BROWSER = join(binFolder, 'helpers', isWindows ? 'browser.cmd' : 'browser.sh'); // a command that opens a browser on the local machine
 	}
 
+	setCaseInsensitive(env, 'PATH', PATH);
 	removeNulls(env);
+
 	return env;
 }
 
@@ -192,7 +189,7 @@ export class ExtensionHostConnection {
 				execArgv = [`--inspect${startParams.break ? '-brk' : ''}=${startParams.port}`];
 			}
 
-			const env = await buildUserEnvironment(startParams.env, true, startParams.language, !!startParams.debugId, this._environmentService, this._logService);
+			const env = await buildUserEnvironment(startParams.env, startParams.language, !!startParams.debugId, this._environmentService, this._logService);
 			removeDangerousEnvVariables(env);
 
 			const opts = {

--- a/src/vs/server/node/remoteTerminalChannel.ts
+++ b/src/vs/server/node/remoteTerminalChannel.ts
@@ -180,7 +180,13 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 		};
 
 
-		const baseEnv = await buildUserEnvironment(args.resolverEnv, !!args.shellLaunchConfig.useShellEnvironment, platform.language, false, this._environmentService, this._logService);
+		let baseEnv: platform.IProcessEnvironment;
+		if (args.shellLaunchConfig.useShellEnvironment) {
+			this._logService.trace('*');
+			baseEnv = await buildUserEnvironment(args.resolverEnv, platform.language, false, this._environmentService, this._logService);
+		} else {
+			baseEnv = this._getEnvironment();
+		}
 		this._logService.trace('baseEnv', baseEnv);
 
 		const reviveWorkspaceFolder = (workspaceData: IWorkspaceFolderData): IWorkspaceFolder => {


### PR DESCRIPTION
Reverts microsoft/vscode#142740 because it breaks windows browser remote integration tests