### PR TITLE
Fix and improve IW input placeholder text

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -56,6 +56,7 @@ import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
 import { ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
+import { NOTEBOOK_KERNEL } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 
 const DECORATION_KEY = 'interactiveInputDecoration';
 const INTERACTIVE_EDITOR_VIEW_STATE_PREFERENCE_KEY = 'InteractiveEditorViewState';
@@ -435,8 +436,8 @@ export class InteractiveEditor extends EditorPane {
 			}
 		}));
 
-		this.#widgetDisposableStore.add(this.#notebookKernelService.onDidChangeNotebookAffinity(this.#updateInputEditorLanguage, this));
-		this.#widgetDisposableStore.add(this.#notebookKernelService.onDidChangeSelectedNotebooks(this.#updateInputEditorLanguage, this));
+		this.#widgetDisposableStore.add(this.#notebookKernelService.onDidChangeNotebookAffinity(this.#syncWithKernel, this));
+		this.#widgetDisposableStore.add(this.#notebookKernelService.onDidChangeSelectedNotebooks(this.#syncWithKernel, this));
 
 		this.#widgetDisposableStore.add(this.themeService.onDidColorThemeChange(() => {
 			if (this.isVisible()) {
@@ -491,8 +492,7 @@ export class InteractiveEditor extends EditorPane {
 			}
 		}));
 
-		this.#updateInputDecoration();
-		this.#updateInputEditorLanguage();
+		this.#syncWithKernel();
 	}
 
 	#lastCell: ICellViewModel | undefined = undefined;
@@ -592,22 +592,24 @@ export class InteractiveEditor extends EditorPane {
 		}));
 	}
 
-	#updateInputEditorLanguage() {
+	#syncWithKernel() {
 		const notebook = this.#notebookWidget.value?.textModel;
 		const textModel = this.#codeEditorWidget.getModel();
 
-		if (!notebook || !textModel) {
-			return;
+		if (notebook && textModel) {
+			const info = this.#notebookKernelService.getMatchingKernel(notebook);
+			const selectedOrSuggested = info.selected ?? info.suggestions[0];
+
+			if (selectedOrSuggested) {
+				const language = selectedOrSuggested.supportedLanguages[0];
+				const newMode = language ? this.#languageService.createById(language).languageId : PLAINTEXT_LANGUAGE_ID;
+				textModel.setMode(newMode);
+
+				NOTEBOOK_KERNEL.bindTo(this.#contextKeyService).set(selectedOrSuggested.id);
+			}
 		}
 
-		const info = this.#notebookKernelService.getMatchingKernel(notebook);
-		const selectedOrSuggested = info.selected ?? info.suggestions[0];
-
-		if (selectedOrSuggested) {
-			const language = selectedOrSuggested.supportedLanguages[0];
-			const newMode = language ? this.#languageService.createById(language).languageId : PLAINTEXT_LANGUAGE_ID;
-			textModel.setMode(newMode);
-		}
+		this.#updateInputDecoration();
 	}
 
 	layout(dimension: DOM.Dimension): void {
@@ -661,8 +663,9 @@ export class InteractiveEditor extends EditorPane {
 
 		if (model?.getValueLength() === 0) {
 			const transparentForeground = resolveColorValue(editorForeground, this.themeService.getColorTheme())?.transparent(0.4);
-			const keybinding = this.#keybindingService.lookupKeybinding('interactive.execute')?.getLabel();
-			const text = nls.localize('interactiveInputPlaceHolder', "Type code here and press {0} to run", keybinding ?? 'ctrl+enter');
+			const languageId = model.getLanguageId();
+			const keybinding = this.#keybindingService.lookupKeybinding('interactive.execute', this.#contextKeyService)?.getLabel();
+			const text = nls.localize('interactiveInputPlaceHolder', "Type '{0}' code here and press {1} to run", languageId, keybinding ?? 'ctrl+enter');
 			decorations.push({
 				range: {
 					startLineNumber: 0,


### PR DESCRIPTION
This PR allows https://github.com/microsoft/vscode-jupyter/issues/9038 to be fixed.

Currently Jupyter extension's contributed keybinding (Shift+Enter) for the `interactive.execute` command always wins over the default keybinding (Ctrl+Enter), even if the Jupyter extension uses the new `notebookKernel` contextkey added in #143163 so the binding only applies when one of its kernels is being used.

This PR corrects this, and also adds the languageId to the placeholder.

Before, with a Jupyter kernel (Python):

![image](https://user-images.githubusercontent.com/6726799/154305448-8d1e2e81-f8de-4ca0-9290-368f9be0aed9.png)

Before, with a kernel contributed by another extension and Jupyter extension also enabled:

![image](https://user-images.githubusercontent.com/6726799/154305615-3544fa8c-dd99-4205-b9c2-5e6b23ab32a4.png)

Jupyter keybinding is displayed.

Before, with a kernel contributed by another extension and Jupyter extension disabled:

![image](https://user-images.githubusercontent.com/6726799/154305912-179837fd-1afa-4d6a-8d4c-22e7a34d2e07.png)

Default keybinding is displayed.

After, Jupyter:

![image](https://user-images.githubusercontent.com/6726799/154303640-c946b80e-ab5b-46ab-88b1-959b6689567c.png)

After, other extension, Jupyter enabled:

![image](https://user-images.githubusercontent.com/6726799/154304228-1db89464-41ed-4e4e-a0db-bc98bc731c71.png)

pinging @rchiodo and @rebornix 



