### PR TITLE
WIP: Explore option for multiselect in QuickOpen picker

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1267,7 +1267,7 @@ export class QuickInputController extends Disposable {
 		}));
 
 		const customButtonContainer = dom.append(headerContainer, $('.quick-input-action'));
-		const customButton = new Button(customButtonContainer);
+		const customButton = new Button(customButtonContainer, { supportIcons: true });
 		customButton.label = localize('custom', "Custom");
 		this._register(customButton.onDidClick(e => {
 			this.onDidCustomEmitter.fire();

--- a/src/vs/platform/quickinput/browser/quickAccess.ts
+++ b/src/vs/platform/quickinput/browser/quickAccess.ts
@@ -11,6 +11,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { DefaultQuickAccessFilterValue, Extensions, IQuickAccessController, IQuickAccessOptions, IQuickAccessProvider, IQuickAccessProviderDescriptor, IQuickAccessRegistry } from 'vs/platform/quickinput/common/quickAccess';
 import { IQuickInputService, IQuickPick, IQuickPickItem, ItemActivation } from 'vs/platform/quickinput/common/quickInput';
 import { Registry } from 'vs/platform/registry/common/platform';
+import * as nls from 'vs/nls';
 
 export class QuickAccessController extends Disposable implements IQuickAccessController {
 
@@ -109,6 +110,21 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 		if (descriptor?.placeholder) {
 			picker.ariaLabel = descriptor?.placeholder;
 		}
+
+		// Add toggle for multiselect mode
+		picker.customButton = true;
+		picker.canSelectMany = false;
+		picker.customHover = nls.localize('quickAccessToggle', "Toggle Multi-Select Mode");
+		const setCustomLabel = () => {
+			//picker.customLabel = picker.canSelectMany ? '$(check)' : '$(check-all)';
+			picker.customLabel = picker.canSelectMany ? '$(file)' : '$(files)';
+		};
+		setCustomLabel();
+		picker.onDidCustom(() => {
+			picker.selectedItems = [];
+			picker.canSelectMany = !picker.canSelectMany;
+			setCustomLabel();
+		});
 
 		// Pick mode: setup a promise that can be resolved
 		// with the selected items and prevent execution

--- a/src/vs/platform/quickinput/browser/quickAccess.ts
+++ b/src/vs/platform/quickinput/browser/quickAccess.ts
@@ -111,20 +111,23 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 			picker.ariaLabel = descriptor?.placeholder;
 		}
 
-		// Add toggle for multiselect mode
-		picker.customButton = true;
-		picker.canSelectMany = false;
-		picker.customHover = nls.localize('quickAccessToggle', "Toggle Multi-Select Mode");
-		const setCustomLabel = () => {
-			//picker.customLabel = picker.canSelectMany ? '$(check)' : '$(check-all)';
-			picker.customLabel = picker.canSelectMany ? '$(file)' : '$(files)';
-		};
-		setCustomLabel();
-		picker.onDidCustom(() => {
-			picker.selectedItems = [];
-			picker.canSelectMany = !picker.canSelectMany;
+		// Add toggle for file picker multiselect mode
+		if (value === '') {
+			picker.customButton = true;
+			picker.canSelectMany = false;
+			picker.customHover = nls.localize('quickAccessToggle', "Toggle Multi-Select Mode");
+			const setCustomLabel = () => {
+				//picker.customLabel = picker.canSelectMany ? '$(check)' : '$(check-all)';
+				picker.customLabel = picker.canSelectMany ? '$(file)' : '$(files)';
+			};
 			setCustomLabel();
-		});
+			picker.onDidCustom(() => {
+				picker.selectedItems = [];
+				picker.canSelectMany = !picker.canSelectMany;
+				setCustomLabel();
+				picker.focusOnInput();
+			});
+		}
 
 		// Pick mode: setup a promise that can be resolved
 		// with the selected items and prevent execution


### PR DESCRIPTION
This PR was inspired by https://github.com/microsoft/vscode/issues/66971#issuecomment-1045993327

It is currently WIP. The UX is ready to see and try, but support for actually opening all items in the multiselect case is still a TODO.

Pinging @bpasero

![junk](https://user-images.githubusercontent.com/6726799/154810272-4912f085-1c5a-4af7-98e3-554aa1730f5a.gif)

@misolori I'm not sure if I'm following the correct convention for toggle buttons whose icon changes. Mine show the icon representing the state you get after you click it.

I also experimented with `check` and `check-all` but as it's a file picker I decided `file` and `files` made more sense.
