### PR TITLE
explorer - add "Open Recent" to web serverless empty explorer

### DIFF
--- a/src/vs/workbench/browser/actions/windowActions.ts
+++ b/src/vs/workbench/browser/actions/windowActions.ts
@@ -232,9 +232,11 @@ abstract class BaseOpenRecentAction extends Action2 {
 
 export class OpenRecentAction extends BaseOpenRecentAction {
 
+	static ID = 'workbench.action.openRecent';
+
 	constructor() {
 		super({
-			id: 'workbench.action.openRecent',
+			id: OpenRecentAction.ID,
 			title: {
 				value: localize('openRecent', "Open Recent..."),
 				mnemonicTitle: localize({ key: 'miMore', comment: ['&& denotes a mnemonic'] }, "&&More..."),

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -39,6 +39,7 @@ import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegis
 import { IsMacNativeContext, IsWebContext } from 'vs/platform/contextkey/common/contextkeys';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { OpenRecentAction } from 'vs/workbench/browser/actions/windowActions';
 
 export type IOpenRecentAction = IAction & { uri: URI; remoteAuthority?: string };
 
@@ -592,7 +593,7 @@ export class CustomMenubarControl extends MenubarControl {
 
 	private insertActionsBefore(nextAction: IAction, target: IAction[]): void {
 		switch (nextAction.id) {
-			case 'workbench.action.openRecent':
+			case OpenRecentAction.ID:
 				target.push(...this.getOpenRecentActions());
 				break;
 

--- a/src/vs/workbench/contrib/watermark/browser/watermark.ts
+++ b/src/vs/workbench/contrib/watermark/browser/watermark.ts
@@ -16,6 +16,7 @@ import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions as 
 import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { OpenFolderAction, OpenFileFolderAction, OpenFileAction } from 'vs/workbench/browser/actions/workspaceActions';
+import { OpenRecentAction } from 'vs/workbench/browser/actions/windowActions';
 import { ShowAllCommandsAction } from 'vs/workbench/contrib/quickaccess/browser/commandsQuickAccess';
 import { Parts, IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { FindInFilesActionId } from 'vs/workbench/contrib/search/common/constants';
@@ -47,7 +48,7 @@ const quickAccess: WatermarkEntry = { text: nls.localize('watermark.quickAccess'
 const openFileNonMacOnly: WatermarkEntry = { text: nls.localize('watermark.openFile', "Open File"), id: OpenFileAction.ID, mac: false };
 const openFolderNonMacOnly: WatermarkEntry = { text: nls.localize('watermark.openFolder', "Open Folder"), id: OpenFolderAction.ID, mac: false };
 const openFileOrFolderMacOnly: WatermarkEntry = { text: nls.localize('watermark.openFileFolder', "Open File or Folder"), id: OpenFileFolderAction.ID, mac: true };
-const openRecent: WatermarkEntry = { text: nls.localize('watermark.openRecent', "Open Recent"), id: 'workbench.action.openRecent' };
+const openRecent: WatermarkEntry = { text: nls.localize('watermark.openRecent', "Open Recent"), id: OpenRecentAction.ID };
 const newUntitledFile: WatermarkEntry = { text: nls.localize('watermark.newUntitledFile', "New Untitled File"), id: NEW_UNTITLED_FILE_COMMAND_ID };
 const newUntitledFileMacOnly: WatermarkEntry = Object.assign({ mac: true }, newUntitledFile);
 const findInFiles: WatermarkEntry = { text: nls.localize('watermark.findInFiles', "Find in Files"), id: FindInFilesActionId };

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -71,6 +71,7 @@ import { getTelemetryLevel } from 'vs/platform/telemetry/common/telemetryUtils';
 import { WorkbenchStateContext } from 'vs/workbench/common/contextkeys';
 import { IsIOSContext } from 'vs/platform/contextkey/common/contextkeys';
 import { AddRootFolderAction } from 'vs/workbench/browser/actions/workspaceActions';
+import { OpenRecentAction } from 'vs/workbench/browser/actions/windowActions';
 import { Checkbox } from 'vs/base/browser/ui/checkbox/checkbox';
 import { Codicon } from 'vs/base/common/codicons';
 import { restoreWalkthroughsConfigurationKey, RestoreWalkthroughsConfigurationValue } from 'vs/workbench/contrib/welcomePage/browser/welcomePage';
@@ -347,7 +348,7 @@ export class GettingStartedPage extends EditorPane {
 				break;
 			}
 			case 'showMoreRecents': {
-				this.commandService.executeCommand('workbench.action.openRecent');
+				this.commandService.executeCommand(OpenRecentAction.ID);
 				break;
 			}
 			case 'seeAllWalkthroughs': {
@@ -1100,7 +1101,7 @@ export class GettingStartedPage extends EditorPane {
 					$('button.button-link',
 						{
 							'x-dispatch': 'showMoreRecents',
-							title: localize('show more recents', "Show All Recent Folders {0}", this.getKeybindingLabel('workbench.action.openRecent'))
+							title: localize('show more recents', "Show All Recent Folders {0}", this.getKeybindingLabel(OpenRecentAction.ID))
 						}, 'More...')),
 				renderElement: renderRecent,
 				contextService: this.contextService

--- a/src/vs/workbench/electron-sandbox/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/electron-sandbox/parts/titlebar/menubarControl.ts
@@ -24,6 +24,7 @@ import { INativeHostService } from 'vs/platform/native/electron-sandbox/native';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { OpenRecentAction } from 'vs/workbench/browser/actions/windowActions';
 
 export class NativeMenubarControl extends MenubarControl {
 
@@ -138,7 +139,7 @@ export class NativeMenubarControl extends MenubarControl {
 
 					menuToDispose.dispose();
 				} else {
-					if (menuItem.id === 'workbench.action.openRecent') {
+					if (menuItem.id === OpenRecentAction.ID) {
 						const actions = this.getOpenRecentActions().map(this.transformOpenRecentAction);
 						menuToPopulate.items.push(...actions);
 					}


### PR DESCRIPTION
This makes:
- the existing "Empty Explorer" welcome contributions easier to read by documenting the context keys and rules better [1]
- add a "Open Recent" for vscode.dev [2]

**[1]** maybe this is a chance to review some of the rules and see if they still apply. The reasoning behind some is really not entirely clear to me.

**[2]** the condition used here is `WorkbenchStateContext.isEqualTo('workspace')` and `OpenFolderWorkspaceSupportContext.toNegated()` which is used in other places to identify vscode.dev (we automatically put the user into an empty workspace with `tmp` scheme to enable opening local folders without window reload, but we never support opening folders or workspaces otherwise). Compare with a similar commit I pushed to have "Open Folder" map to "Add Folder to Workspace": https://github.com/microsoft/vscode/commit/12f9c5fc6d5329bfb0c4402b9fbc6013ed9be0da

I felt that showing "Open Recent" for every explorer might be a bit too much because the button is quite heavy when you stack 2 of them:

![image](https://user-images.githubusercontent.com/900690/154814046-a7762b60-80e2-472c-a3e5-e3e3da1c9e24.png)

Compared to the current welcome screen (which btw wrongly talks about "Adding Folder" to the workspace):

![image](https://user-images.githubusercontent.com/900690/154814091-86372e63-65d7-43fe-832a-f425631fa762.png)



//cc @isidorn 