### PR TITLE
Don't do a word selection when double clicking on injected text.

### DIFF
--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -559,6 +559,8 @@ class MouseDownOperation extends Disposable {
 
 			leftButton: this._mouseState.leftButton,
 			middleButton: this._mouseState.middleButton,
+
+			onInjectedText: position.type === MouseTargetType.CONTENT_TEXT && position.detail.injectedText !== null
 		});
 	}
 }

--- a/src/vs/editor/browser/controller/pointerHandler.ts
+++ b/src/vs/editor/browser/controller/pointerHandler.ts
@@ -8,7 +8,7 @@ import * as platform from 'vs/base/common/platform';
 import { EventType, Gesture, GestureEvent } from 'vs/base/browser/touch';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IPointerHandlerHelper, MouseHandler, createMouseMoveEventMerger } from 'vs/editor/browser/controller/mouseHandler';
-import { IMouseTarget } from 'vs/editor/browser/editorBrowser';
+import { IMouseTarget, MouseTargetType } from 'vs/editor/browser/editorBrowser';
 import { EditorMouseEvent, EditorPointerEventFactory } from 'vs/editor/browser/editorDom';
 import { ViewController } from 'vs/editor/browser/view/viewController';
 import { ViewContext } from 'vs/editor/common/viewModel/viewContext';
@@ -77,6 +77,7 @@ export class PointerEventHandler extends MouseHandler {
 
 				leftButton: false,
 				middleButton: false,
+				onInjectedText: target.type === MouseTargetType.CONTENT_TEXT && target.detail.injectedText !== null
 			});
 		}
 	}

--- a/src/vs/editor/browser/view/viewController.ts
+++ b/src/vs/editor/browser/view/viewController.ts
@@ -32,6 +32,7 @@ export interface IMouseDispatchData {
 
 	leftButton: boolean;
 	middleButton: boolean;
+	onInjectedText: boolean;
 }
 
 export interface ICommandDelegate {
@@ -165,13 +166,15 @@ export class ViewController {
 				}
 			}
 		} else if (data.mouseDownCount === 2) {
-			if (this._hasMulticursorModifier(data)) {
-				this._lastCursorWordSelect(data.position);
-			} else {
-				if (data.inSelectionMode) {
-					this._wordSelectDrag(data.position);
+			if (!data.onInjectedText) {
+				if (this._hasMulticursorModifier(data)) {
+					this._lastCursorWordSelect(data.position);
 				} else {
-					this._wordSelect(data.position);
+					if (data.inSelectionMode) {
+						this._wordSelectDrag(data.position);
+					} else {
+						this._wordSelect(data.position);
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION

This PR fixes https://github.com/microsoft/vscode/issues/143555
FYI @jrieken

This affects all injected text, not just inlay hints.
I think it does not make much sense to do word selection when double clicking on inlay hints, so I think this is fine.