### PR TITLE
Allow stack frame without source as top stack frame when using disassembly view

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -475,7 +475,10 @@ export class Thread implements IThread {
 
 	getTopStackFrame(): IStackFrame | undefined {
 		const callStack = this.getCallStack();
-		const firstAvailableStackFrame = callStack.find(sf => !!(sf && sf.source && sf.source.available && sf.source.presentationHint !== 'deemphasize'));
+		// Allow stack frame without source and with instructionReferencePointer as top stack frame when using disassembly view.
+		const firstAvailableStackFrame = callStack.find(sf => !!(sf &&
+			((this.stoppedDetails?.reason === 'instruction breakpoint' || (this.stoppedDetails?.reason === 'step' && this.lastSteppingGranularity === 'instruction')) && sf.instructionPointerReference) ||
+			(sf.source && sf.source.available && sf.source.presentationHint !== 'deemphasize')));
 		return firstAvailableStackFrame || (callStack.length > 0 ? callStack[0] : undefined);
 	}
 


### PR DESCRIPTION
When there's a top stack frame that doesn't have source code but has instructionPointerReference, it was not considered as top stack frame regardless of the view. However, in this case, disassembly is available, and therefore causes confusion. In this PR, top frame finding logic is changed so when using disassembly view, stack frame without source and with instructionPointerReference is allowed to be top stack frame.