### PR TITLE
scale instead of zoom

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-workbench .part.titlebar {
+.monaco-workbench .part.titlebar > .titlebar-container {
 	box-sizing: border-box;
 	width: 100%;
 	padding: 0 70px;
@@ -19,7 +19,11 @@
 	display: flex;
 }
 
-.monaco-workbench .part.titlebar > .titlebar-drag-region {
+.monaco-workbench .part.titlebar > .titlebar-container {
+	transform-origin: 0 0;
+}
+
+.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-drag-region {
 	top: 0;
 	left: 0;
 	display: block;
@@ -29,7 +33,7 @@
 	-webkit-app-region: drag;
 }
 
-.monaco-workbench .part.titlebar > .window-title {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-title {
 	flex: 0 1 auto;
 	font-size: 12px;
 	overflow: hidden;
@@ -41,9 +45,9 @@
 }
 
 /* Windows/Linux: Rules for custom title (icon, window controls)  */
-.monaco-workbench.web .part.titlebar,
-.monaco-workbench.windows .part.titlebar,
-.monaco-workbench.linux .part.titlebar {
+.monaco-workbench.web .part.titlebar > .titlebar-container,
+.monaco-workbench.windows .part.titlebar > .titlebar-container,
+.monaco-workbench.linux .part.titlebar > .titlebar-container {
 	padding: 0;
 	height: 30px;
 	line-height: 30px;
@@ -51,23 +55,23 @@
 	overflow: visible;
 }
 
-.monaco-workbench.web .part.titlebar > .window-title,
-.monaco-workbench.windows .part.titlebar > .window-title,
-.monaco-workbench.linux .part.titlebar > .window-title {
+.monaco-workbench.web .part.titlebar > .titlebar-container > .window-title,
+.monaco-workbench.windows .part.titlebar > .titlebar-container > .window-title,
+.monaco-workbench.linux .part.titlebar > .titlebar-container > .window-title {
 	cursor: default;
 }
 
-.monaco-workbench .part.titlebar > .menubar {
+.monaco-workbench .part.titlebar > .titlebar-container > .menubar {
 	/* move menubar above drag region as negative z-index on drag region cause greyscale AA */
 	z-index: 2500;
 }
 
-.monaco-workbench.linux .part.titlebar > .window-title {
+.monaco-workbench.linux .part.titlebar > .titlebar-container > .window-title {
 	font-size: inherit;
 }
 
-.monaco-workbench.windows .part.titlebar > .resizer,
-.monaco-workbench.linux .part.titlebar > .resizer {
+.monaco-workbench.windows .part.titlebar > .titlebar-container > .resizer,
+.monaco-workbench.linux .part.titlebar > .titlebar-container > .resizer {
 	-webkit-app-region: no-drag;
 	position: absolute;
 	top: 0;
@@ -75,12 +79,12 @@
 	height: 4px;
 }
 
-.monaco-workbench.windows.fullscreen .part.titlebar > .resizer,
-.monaco-workbench.linux.fullscreen .part.titlebar > .resizer {
+.monaco-workbench.windows.fullscreen .part.titlebar > .titlebar-container > .resizer,
+.monaco-workbench.linux.fullscreen .part.titlebar > .titlebar-container > .resizer {
 	display: none;
 }
 
-.monaco-workbench .part.titlebar > .window-appicon {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-appicon {
 	width: 35px;
 	height: 100%;
 	position: relative;
@@ -88,14 +92,14 @@
 	flex-shrink: 0;
 }
 
-.monaco-workbench .part.titlebar > .window-appicon:not(.codicon) {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-appicon:not(.codicon) {
 	background-image: url('../../../media/code-icon.svg');
 	background-repeat: no-repeat;
 	background-position: center center;
 	background-size: 16px;
 }
 
-.monaco-workbench .part.titlebar .window-appicon > .home-bar-icon-badge {
+.monaco-workbench .part.titlebar > .titlebar-container .window-appicon > .home-bar-icon-badge {
 	position: absolute;
 	right: 9px;
 	bottom: 6px;
@@ -111,15 +115,15 @@
 	border-left: 1px solid transparent;
 }
 
-.monaco-workbench .part.titlebar > .window-appicon.codicon {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-appicon.codicon {
 	line-height: 30px;
 }
 
-.monaco-workbench.fullscreen .part.titlebar > .window-appicon {
+.monaco-workbench.fullscreen .part.titlebar > .titlebar-container > .window-appicon {
 	display: none;
 }
 
-.monaco-workbench .part.titlebar > .window-controls-container {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-controls-container {
 	display: flex;
 	flex-grow: 0;
 	flex-shrink: 0;
@@ -132,50 +136,50 @@
 	margin-left: auto;
 }
 
-.monaco-workbench .part.titlebar > .window-controls-container.show-layout-control {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-controls-container.show-layout-control {
 	min-width: 160px;
 }
 
-.monaco-workbench.web .part.titlebar > .window-controls-container.show-layout-control {
+.monaco-workbench.web .part.titlebar > .titlebar-container > .window-controls-container.show-layout-control {
 	min-width: 28px;
 	padding-right: 8px;
 }
 
-.monaco-workbench.mac:not(.web) .part.titlebar > .window-controls-container {
+.monaco-workbench.mac:not(.web) .part.titlebar > .titlebar-container > .window-controls-container {
 	position: absolute;
 	right: 8px;
 	min-width: 28px;
 	display: none;
 }
 
-.monaco-workbench.mac:not(.web) .part.titlebar > .window-controls-container.show-layout-control {
+.monaco-workbench.mac:not(.web) .part.titlebar > .titlebar-container > .window-controls-container.show-layout-control {
 	display: flex;
 }
 
-.monaco-workbench.fullscreen .part.titlebar > .window-controls-container {
+.monaco-workbench.fullscreen .part.titlebar > .titlebar-container > .window-controls-container {
 	display: none;
 	background-color: transparent;
 }
 
-.monaco-workbench .part.titlebar > .window-controls-container > .layout-dropdown-container {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-controls-container > .layout-dropdown-container {
 	padding-right: 2px;
 	display: none;
 }
 
-.monaco-workbench .part.titlebar > .window-controls-container.show-layout-control > .layout-dropdown-container {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-controls-container.show-layout-control > .layout-dropdown-container {
 	display: flex;
 	justify-content: center;
 }
 
-.monaco-workbench:not(.mac):not(.web) .part.titlebar > .window-controls-container.show-layout-control > .layout-dropdown-container {
+.monaco-workbench:not(.mac):not(.web) .part.titlebar > .titlebar-container > .window-controls-container.show-layout-control > .layout-dropdown-container {
 	min-width: 46px;
 }
 
-.monaco-workbench .part.titlebar > .window-controls-container.show-layout-control > .layout-dropdown-container .codicon {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-controls-container.show-layout-control > .layout-dropdown-container .codicon {
 	color: inherit;
 }
 
-.monaco-workbench .part.titlebar > .window-controls-container > .window-icon {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-controls-container > .window-icon {
 	display: inline-block;
 	line-height: 30px;
 	height: 100%;
@@ -183,18 +187,18 @@
 	font-size: 16px;
 }
 
-.monaco-workbench .part.titlebar > .window-controls-container > .window-icon:hover {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-controls-container > .window-icon:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }
 
-.monaco-workbench .part.titlebar.light > .window-controls-container > .window-icon:hover {
+.monaco-workbench .part.titlebar > .titlebar-container.light > .window-controls-container > .window-icon:hover {
 	background-color: rgba(0, 0, 0, 0.1);
 }
 
-.monaco-workbench .part.titlebar > .window-controls-container > .window-icon.window-close:hover {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-controls-container > .window-icon.window-close:hover {
 	background-color: rgba(232, 17, 35, 0.9);
 }
 
-.monaco-workbench .part.titlebar > .window-controls-container .window-icon.window-close:hover {
+.monaco-workbench .part.titlebar > .titlebar-container > .window-controls-container .window-icon.window-close:hover {
 	color: white;
 }

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -67,6 +67,7 @@ export class TitlebarPart extends Part implements ITitleService {
 
 	declare readonly _serviceBrand: undefined;
 
+	protected rootContainer!: HTMLElement;
 	protected title!: HTMLElement;
 
 	protected customMenubar: CustomMenubarControl | undefined;
@@ -355,7 +356,7 @@ export class TitlebarPart extends Part implements ITitleService {
 
 		this.customMenubar = this._register(this.instantiationService.createInstance(CustomMenubarControl));
 
-		this.menubar = this.element.insertBefore($('div.menubar'), this.title);
+		this.menubar = this.rootContainer.insertBefore($('div.menubar'), this.title);
 		this.menubar.setAttribute('role', 'menubar');
 
 		this.customMenubar.create(this.menubar);
@@ -365,10 +366,11 @@ export class TitlebarPart extends Part implements ITitleService {
 
 	override createContentArea(parent: HTMLElement): HTMLElement {
 		this.element = parent;
+		this.rootContainer = append(parent, $('.titlebar-container'));
 
 		// App Icon (Native Windows/Linux and Web)
 		if (!isMacintosh || isWeb) {
-			this.appIcon = prepend(this.element, $('a.window-appicon'));
+			this.appIcon = prepend(this.rootContainer, $('a.window-appicon'));
 
 			// Web-only home indicator and menu
 			if (isWeb) {
@@ -394,7 +396,7 @@ export class TitlebarPart extends Part implements ITitleService {
 		}
 
 		// Title
-		this.title = append(this.element, $('div.window-title'));
+		this.title = append(this.rootContainer, $('div.window-title'));
 		if (this.pendingTitle) {
 			this.title.innerText = this.pendingTitle;
 		} else {
@@ -402,7 +404,7 @@ export class TitlebarPart extends Part implements ITitleService {
 		}
 
 		if (this.titleBarStyle !== 'native') {
-			this.windowControls = append(this.element, $('div.window-controls-container'));
+			this.windowControls = append(this.rootContainer, $('div.window-controls-container'));
 			this.windowControls.classList.toggle('show-layout-control', this.layoutControlEnabled);
 
 			const layoutDropdownContainer = append(this.windowControls, $('div.layout-dropdown-container'));
@@ -557,15 +559,13 @@ export class TitlebarPart extends Part implements ITitleService {
 		if (getTitleBarStyle(this.configurationService) === 'custom') {
 			// Only prevent zooming behavior on macOS or when the menubar is not visible
 			if ((!isWeb && isMacintosh) || this.currentMenubarVisibility === 'hidden') {
-				(this.title.style as any).zoom = `${1 / getZoomFactor()}`;
-				if (this.windowControls) {
-					(this.windowControls.style as any).zoom = `${1 / getZoomFactor()}`;
-				}
+				(this.rootContainer.style as any).height = `${100.0 * getZoomFactor()}%`;
+				(this.rootContainer.style as any).width = `${100.0 * getZoomFactor()}%`;
+				(this.rootContainer.style as any).transform = `scale(${1 / getZoomFactor()})`;
 			} else {
-				(this.title.style as any).zoom = '';
-				if (this.windowControls) {
-					(this.windowControls.style as any).zoom = '';
-				}
+				(this.rootContainer.style as any).height = '100%';
+				(this.rootContainer.style as any).width = '100%';
+				(this.rootContainer.style as any).transform = '';
 			}
 
 			runAtThisOrScheduleAtNextAnimationFrame(() => this.adjustTitleMarginToCenter());

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -559,13 +559,13 @@ export class TitlebarPart extends Part implements ITitleService {
 		if (getTitleBarStyle(this.configurationService) === 'custom') {
 			// Only prevent zooming behavior on macOS or when the menubar is not visible
 			if ((!isWeb && isMacintosh) || this.currentMenubarVisibility === 'hidden') {
-				(this.rootContainer.style as any).height = `${100.0 * getZoomFactor()}%`;
-				(this.rootContainer.style as any).width = `${100.0 * getZoomFactor()}%`;
-				(this.rootContainer.style as any).transform = `scale(${1 / getZoomFactor()})`;
+				this.rootContainer.style.height = `${100.0 * getZoomFactor()}%`;
+				this.rootContainer.style.width = `${100.0 * getZoomFactor()}%`;
+				this.rootContainer.style.transform = `scale(${1 / getZoomFactor()})`;
 			} else {
-				(this.rootContainer.style as any).height = '100%';
-				(this.rootContainer.style as any).width = '100%';
-				(this.rootContainer.style as any).transform = '';
+				this.rootContainer.style.height = '100%';
+				this.rootContainer.style.width = '100%';
+				this.rootContainer.style.transform = '';
 			}
 
 			runAtThisOrScheduleAtNextAnimationFrame(() => this.adjustTitleMarginToCenter());

--- a/src/vs/workbench/electron-sandbox/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/electron-sandbox/parts/titlebar/titlebarPart.ts
@@ -183,7 +183,7 @@ export class TitlebarPart extends BrowserTitleBarPart {
 		}
 
 		// Draggable region that we can manipulate for #52522
-		this.dragRegion = prepend(this.element, $('div.titlebar-drag-region'));
+		this.dragRegion = prepend(this.rootContainer, $('div.titlebar-drag-region'));
 
 		// Window Controls (Native Windows/Linux)
 		if (!isMacintosh && this.windowControls) {
@@ -211,7 +211,7 @@ export class TitlebarPart extends BrowserTitleBarPart {
 			}));
 
 			// Resizer
-			this.resizer = append(this.element, $('div.resizer'));
+			this.resizer = append(this.rootContainer, $('div.resizer'));
 
 			this._register(this.layoutService.onDidChangeWindowMaximized(maximized => this.onDidChangeWindowMaximized(maximized)));
 			this.onDidChangeWindowMaximized(this.layoutService.isWindowMaximized());
@@ -224,29 +224,14 @@ export class TitlebarPart extends BrowserTitleBarPart {
 		this.lastLayoutDimensions = dimension;
 
 		if (getTitleBarStyle(this.configurationService) === 'custom') {
-			// Only prevent zooming behavior on macOS or when the menubar is not visible
 			if (isMacintosh || this.currentMenubarVisibility === 'hidden') {
-				(this.title.style as any).zoom = `${1 / getZoomFactor()}`;
-				if (isWindows || isLinux) {
-					if (this.appIcon) {
-						(this.appIcon.style as any).zoom = `${1 / getZoomFactor()}`;
-					}
-				}
-
-				if (this.windowControls) {
-					(this.windowControls.style as any).zoom = `${1 / getZoomFactor()}`;
-				}
+				(this.rootContainer.style as any).height = `${100.0 * getZoomFactor()}%`;
+				(this.rootContainer.style as any).width = `${100.0 * getZoomFactor()}%`;
+				(this.rootContainer.style as any).transform = `scale(${1 / getZoomFactor()})`;
 			} else {
-				(this.title.style as any).zoom = '';
-				if (isWindows || isLinux) {
-					if (this.appIcon) {
-						(this.appIcon.style as any).zoom = '';
-					}
-				}
-
-				if (this.windowControls) {
-					(this.windowControls.style as any).zoom = '';
-				}
+				(this.rootContainer.style as any).height = `100%`;
+				(this.rootContainer.style as any).width = `100%`;
+				(this.rootContainer.style as any).transform = '';
 			}
 
 			runAtThisOrScheduleAtNextAnimationFrame(() => this.adjustTitleMarginToCenter());

--- a/src/vs/workbench/electron-sandbox/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/electron-sandbox/parts/titlebar/titlebarPart.ts
@@ -225,13 +225,13 @@ export class TitlebarPart extends BrowserTitleBarPart {
 
 		if (getTitleBarStyle(this.configurationService) === 'custom') {
 			if (isMacintosh || this.currentMenubarVisibility === 'hidden') {
-				(this.rootContainer.style as any).height = `${100.0 * getZoomFactor()}%`;
-				(this.rootContainer.style as any).width = `${100.0 * getZoomFactor()}%`;
-				(this.rootContainer.style as any).transform = `scale(${1 / getZoomFactor()})`;
+				this.rootContainer.style.height = `${100.0 * getZoomFactor()}%`;
+				this.rootContainer.style.width = `${100.0 * getZoomFactor()}%`;
+				this.rootContainer.style.transform = `scale(${1 / getZoomFactor()})`;
 			} else {
-				(this.rootContainer.style as any).height = `100%`;
-				(this.rootContainer.style as any).width = `100%`;
-				(this.rootContainer.style as any).transform = '';
+				this.rootContainer.style.height = `100%`;
+				this.rootContainer.style.width = `100%`;
+				this.rootContainer.style.transform = '';
 			}
 
 			runAtThisOrScheduleAtNextAnimationFrame(() => this.adjustTitleMarginToCenter());


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #141388

I tested this on Windows with menubar hidden and macOS with the custom titlebar. The change is to counteract the zooming of the window with scaling instead of the zoom property. This is helpful because we can avoid the "accidental" translation of the coordinates in the titlebar.