### PR TITLE
Correct description of bracket guide setting

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3672,7 +3672,7 @@ class GuideOptions extends BaseEditorOption<EditorOption.guides, IGuidesOptions,
 				'editor.guides.highlightActiveBracketPair': {
 					type: 'boolean',
 					default: defaults.highlightActiveBracketPair,
-					description: nls.localize('editor.guides.highlightActiveBracketPair', "Controls whether bracket pair guides are enabled or not.")
+					description: nls.localize('editor.guides.highlightActiveBracketPair', "Controls whether the editor should highlight the active bracket pair.")
 				},
 				'editor.guides.indentation': {
 					type: 'boolean',


### PR DESCRIPTION
The previous description for editor.guides.highlightActiveBracketPair was copied from editor.guides.bracketPairs

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #143724
