### PR TITLE
Disable TypeScript/JavaScript hover provider when validate.enable is set to false

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/hover.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/hover.ts
@@ -31,6 +31,10 @@ class TypeScriptHoverProvider implements vscode.HoverProvider {
 			return undefined;
 		}
 
+		if (!vscode.workspace.getConfiguration(document.languageId, document).get('validate.enable', true)) {
+			return undefined;
+		}
+
 		const response = await this.client.interruptGetErr(async () => {
 			await this.fileConfigurationManager.ensureConfigurationForDocument(document, token);
 


### PR DESCRIPTION
This PR fixes #143842

### Validation steps

1. Set `javascript.validate.enable` to `false` and `typescript.validate.enable` to `false`
2. Create a file with a `.ts` or `.js` extension
3. Save the file with the following contents:

    ```ts
    const foo: string = 'bar';
    ```
4. Hover over `foo`

### Expected outcome

No hover gets shown