### PR TITLE
Create the named pipe server on the extension host

### DIFF
--- a/src/vs/platform/extensions/common/extensionHostProtocol.ts
+++ b/src/vs/platform/extensions/common/extensionHostProtocol.ts
@@ -74,6 +74,11 @@ export interface IExtHostReadyMessage {
 	type: 'VSCODE_EXTHOST_IPC_READY';
 }
 
+export interface IExtHostNamedPipeReadyMessage {
+	type: 'VSCODE_EXTHOST_NAMED_PIPE_READY';
+	pipeName: string;
+}
+
 export interface IExtHostSocketMessage {
 	type: 'VSCODE_EXTHOST_IPC_SOCKET';
 	initialDataChunk: string;

--- a/src/vs/platform/extensions/common/extensionHostStarter.ts
+++ b/src/vs/platform/extensions/common/extensionHostStarter.ts
@@ -28,7 +28,7 @@ export interface IExtensionHostStarter {
 	onDynamicExit(id: string): Event<{ code: number; signal: string }>;
 
 	createExtensionHost(): Promise<{ id: string }>;
-	start(id: string, opts: IExtensionHostProcessOptions): Promise<{ pid: number }>;
+	start(id: string, opts: IExtensionHostProcessOptions): Promise<{ pid: number; pipeName: string }>;
 	enableInspectPort(id: string): Promise<boolean>;
 	kill(id: string): Promise<void>;
 

--- a/src/vs/platform/extensions/electron-main/workerMainProcessExtensionHostStarter.ts
+++ b/src/vs/platform/extensions/electron-main/workerMainProcessExtensionHostStarter.ts
@@ -139,7 +139,7 @@ export class WorkerMainProcessExtensionHostStarter implements IDisposable, IExte
 		return proxy.createExtensionHost();
 	}
 
-	async start(id: string, opts: IExtensionHostProcessOptions): Promise<{ pid: number }> {
+	async start(id: string, opts: IExtensionHostProcessOptions): Promise<{ pid: number; pipeName: string }> {
 		const sw = StopWatch.create(false);
 		const proxy = await this._worker.getProxyObject();
 		if (this._shutdown) {

--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -15,7 +15,7 @@ import { NodeSocket, WebSocketNodeSocket } from 'vs/base/parts/ipc/node/ipc.net'
 import { getResolvedShellEnv } from 'vs/platform/terminal/node/shellEnv';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IRemoteExtensionHostStartParams } from 'vs/platform/remote/common/remoteAgentConnection';
-import { IExtHostReadyMessage, IExtHostSocketMessage, IExtHostReduceGraceTimeMessage } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { IExtHostReadyMessage, IExtHostSocketMessage, IExtHostReduceGraceTimeMessage } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { IServerEnvironmentService } from 'vs/server/node/serverEnvironmentService';
 import { IProcessEnvironment, isWindows } from 'vs/base/common/platform';
 import { logRemoteEntry } from 'vs/workbench/services/extensions/common/remoteConsoleUtil';

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -14,7 +14,7 @@ import * as languageConfiguration from 'vs/editor/common/languages/languageConfi
 import { score } from 'vs/editor/common/languageSelector';
 import * as files from 'vs/platform/files/common/files';
 import { ExtHostContext, MainContext, CandidatePortSource, ExtHostLogLevelServiceShape, TabKind } from 'vs/workbench/api/common/extHost.protocol';
-import { UIKind } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { UIKind } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { ExtHostApiCommands } from 'vs/workbench/api/common/extHostApiCommands';
 import { ExtHostClipboard } from 'vs/workbench/api/common/extHostClipboard';
 import { IExtHostCommands } from 'vs/workbench/api/common/extHostCommands';

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -62,7 +62,7 @@ import { InternalTimelineOptions, Timeline, TimelineChangeEvent, TimelineOptions
 import { TypeHierarchyItem } from 'vs/workbench/contrib/typeHierarchy/common/typeHierarchy';
 import { AuthenticationProviderInformation, AuthenticationSession, AuthenticationSessionsChangeEvent } from 'vs/workbench/services/authentication/common/authentication';
 import { EditorGroupColumn } from 'vs/workbench/services/editor/common/editorGroupColumn';
-import { IStaticWorkspaceData } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { IStaticWorkspaceData } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { IResolveAuthorityResult } from 'vs/workbench/services/extensions/common/extensionHostProxy';
 import { ActivationKind, ExtensionActivationReason, MissingExtensionDependency } from 'vs/workbench/services/extensions/common/extensions';
 import { createProxyIdentifier, Dto, IRPCProtocol, SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';

--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -13,7 +13,7 @@ import { TernarySearchTree } from 'vs/base/common/map';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ExtHostExtensionServiceShape, MainContext, MainThreadExtensionServiceShape, MainThreadTelemetryShape, MainThreadWorkspaceShape } from 'vs/workbench/api/common/extHost.protocol';
-import { IExtensionHostInitData } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { IExtensionHostInitData } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { ExtHostConfiguration, IExtHostConfiguration } from 'vs/workbench/api/common/extHostConfiguration';
 import { ActivatedExtension, EmptyExtension, ExtensionActivationTimes, ExtensionActivationTimesBuilder, ExtensionsActivator, IExtensionAPI, IExtensionModule, HostExtension, ExtensionActivationTimesFragment } from 'vs/workbench/api/common/extHostExtensionActivator';
 import { ExtHostStorage, IExtHostStorage } from 'vs/workbench/api/common/extHostStorage';

--- a/src/vs/workbench/api/common/extHostInitDataService.ts
+++ b/src/vs/workbench/api/common/extHostInitDataService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IExtensionHostInitData } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { IExtensionHostInitData } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
 export const IExtHostInitDataService = createDecorator<IExtHostInitDataService>('IExtHostInitDataService');

--- a/src/vs/workbench/api/common/extHostStoragePaths.ts
+++ b/src/vs/workbench/api/common/extHostStoragePaths.ts
@@ -7,7 +7,7 @@ import { IExtensionDescription } from 'vs/platform/extensions/common/extensions'
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IExtHostInitDataService } from 'vs/workbench/api/common/extHostInitDataService';
 import { ILogService } from 'vs/platform/log/common/log';
-import { IEnvironment, IStaticWorkspaceData } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { IEnvironment, IStaticWorkspaceData } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { IExtHostConsumerFileSystem } from 'vs/workbench/api/common/extHostFileSystemConsumer';
 import { URI } from 'vs/base/common/uri';
 

--- a/src/vs/workbench/api/common/extensionHostMain.ts
+++ b/src/vs/workbench/api/common/extensionHostMain.ts
@@ -11,7 +11,7 @@ import { URI } from 'vs/base/common/uri';
 import { IURITransformer } from 'vs/base/common/uriIpc';
 import { IMessagePassingProtocol } from 'vs/base/parts/ipc/common/ipc';
 import { MainContext, MainThreadConsoleShape } from 'vs/workbench/api/common/extHost.protocol';
-import { IExtensionHostInitData } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { IExtensionHostInitData } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { RPCProtocol } from 'vs/workbench/services/extensions/common/rpcProtocol';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { ILogService } from 'vs/platform/log/common/log';

--- a/src/vs/workbench/api/node/proxyResolver.ts
+++ b/src/vs/workbench/api/node/proxyResolver.ts
@@ -10,7 +10,7 @@ import * as tls from 'tls';
 import { IExtHostWorkspaceProvider } from 'vs/workbench/api/common/extHostWorkspace';
 import { ExtHostConfigProvider } from 'vs/workbench/api/common/extHostConfiguration';
 import { MainThreadTelemetryShape } from 'vs/workbench/api/common/extHost.protocol';
-import { IExtensionHostInitData } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { IExtensionHostInitData } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { ExtHostExtensionService } from 'vs/workbench/api/node/extHostExtensionService';
 import { URI } from 'vs/base/common/uri';
 import { ILogService } from 'vs/platform/log/common/log';

--- a/src/vs/workbench/api/worker/extensionHostWorker.ts
+++ b/src/vs/workbench/api/worker/extensionHostWorker.ts
@@ -6,7 +6,7 @@
 import { IMessagePassingProtocol } from 'vs/base/parts/ipc/common/ipc';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { Emitter } from 'vs/base/common/event';
-import { isMessageOfType, MessageType, createMessageOfType, IExtensionHostInitData } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { isMessageOfType, MessageType, createMessageOfType, IExtensionHostInitData } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { ExtensionHostMain } from 'vs/workbench/api/common/extensionHostMain';
 import { IHostUtils } from 'vs/workbench/api/common/extHostExtensionService';
 import { NestedWorker } from 'vs/workbench/services/extensions/worker/polyfillNestedWorker';

--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -7,7 +7,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { toDisposable, Disposable } from 'vs/base/common/lifecycle';
 import { IMessagePassingProtocol } from 'vs/base/parts/ipc/common/ipc';
 import { VSBuffer } from 'vs/base/common/buffer';
-import { createMessageOfType, MessageType, isMessageOfType, ExtensionHostExitCode, IExtensionHostInitData, UIKind } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { createMessageOfType, MessageType, isMessageOfType, ExtensionHostExitCode, IExtensionHostInitData, UIKind } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { ILabelService } from 'vs/platform/label/common/label';

--- a/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
@@ -26,7 +26,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { parseExtensionDevOptions } from 'vs/workbench/services/extensions/common/extensionDevOptions';
-import { createMessageOfType, isMessageOfType, MessageType, IExtensionHostInitData, UIKind } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { createMessageOfType, isMessageOfType, MessageType, IExtensionHostInitData, UIKind } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { ExtensionHostKind, ExtensionHostLogFileName, IExtensionHost } from 'vs/workbench/services/extensions/common/extensions';
 import { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { Extensions, IOutputChannelRegistry } from 'vs/workbench/services/output/common/output';

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -40,7 +40,7 @@ import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace
 import { ILogService } from 'vs/platform/log/common/log';
 import { CATEGORIES } from 'vs/workbench/common/actions';
 import { Schemas } from 'vs/base/common/network';
-import { ExtensionHostExitCode } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
+import { ExtensionHostExitCode } from 'vs/platform/extensions/common/extensionHostProtocol';
 import { updateProxyConfigurationsScope } from 'vs/platform/request/common/request';
 import { ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
 import { IExtensionManifestPropertiesService } from 'vs/workbench/services/extensions/common/extensionManifestPropertiesService';


### PR DESCRIPTION
This PR tries to work around a problem found in #142786 by creating the named pipe server on the extension host process and connecting to it from the renderer process.

This always fails to launch for me on a slow Windows VM. But after applying the following change things appear to work 🤯 :
```diff
diff --git a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
index 465993a2740..3ec9e5a9b8b 100644
--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -394,12 +394,11 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 		return new Promise((resolve, reject) => {
 			const socket = createConnection(pipeName, () => {
 				socket.off('error', reject);
-
-				// !!! We need to add a 'data' listener immediately to the
-				// socket to avoid missing any events.
-				resolve(new PersistentProtocol(new NodeSocket(socket, 'renderer-exthost')));
 			});
 			socket.on('error', reject);
+			// !!! We need to add a 'data' listener immediately to the
+			// socket to avoid missing any events.
+			resolve(new PersistentProtocol(new NodeSocket(socket, 'renderer-exthost')));
 		});
 	}
 

```