### PR TITLE
adjust command decoration font size and margins based on terminal font size

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -102,16 +102,6 @@
 	padding-right: 20px;
 }
 
-.monaco-workbench .pane-body.integrated-terminal .terminal-group .monaco-split-view2.horizontal .split-view-view:first-child .xterm .terminal-command-decoration {
-	margin-left: -17px;
-}
-
-.monaco-workbench .editor-instance .xterm .terminal-command-decoration,
-.monaco-split-view2.vertical .split-view-view .xterm .terminal-command-decoration,
-.monaco-workbench .pane-body.integrated-terminal .terminal-group .monaco-split-view2.horizontal .split-view-view .xterm .terminal-command-decoration {
-	margin-left: -12px;
-}
-
 .monaco-workbench .editor-instance .xterm a:not(.xterm-invalid-link),
 .monaco-workbench .pane-body.integrated-terminal .xterm a:not(.xterm-invalid-link) {
 	/* To support message box sizing */

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -70,7 +70,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 				e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationIconSuccess) ||
 				e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationIconError)) {
 				this._refreshClasses();
-			} else if (e.affectsConfiguration(TerminalSettingId.FontSize)) {
+			} else if (e.affectsConfiguration(TerminalSettingId.FontSize) || e.affectsConfiguration(TerminalSettingId.LineHeight)) {
 				this.refreshLayouts();
 			} else if (e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationsEnabled) && !this._configurationService.getValue(TerminalSettingId.ShellIntegrationDecorationsEnabled)) {
 				this._commandStartedListener?.dispose();

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -89,8 +89,8 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 
 	private _refreshClasses(): void {
 		this._updateClasses(this._placeholderDecoration?.element);
-		for (const decoration of this._decorations) {
-			this._updateClasses(decoration[1].decoration.element, decoration[1].exitCode);
+		for (const decoration of this._decorations.values()) {
+			this._updateClasses(decoration.decoration.element, decoration.exitCode);
 		}
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -29,7 +29,7 @@ const enum DecorationSelector {
 	DefaultColor = 'default',
 	Codicon = 'codicon',
 	XtermDecoration = 'xterm-decoration',
-	FirstSplitContainer = '.monaco-split-view2.horizontal .split-view-view:first-child .xterm .xterm-decoration-container'
+	FirstSplitContainer = '.pane-body.integrated-terminal .terminal-group .monaco-split-view2.horizontal .split-view-view:first-child .xterm'
 }
 
 const enum DecorationStyles {
@@ -64,6 +64,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 		this._register(this._contextMenuService.onDidShowContextMenu(() => this._contextMenuVisible = true));
 		this._register(this._contextMenuService.onDidHideContextMenu(() => this._contextMenuVisible = false));
 		this._hoverDelayer = this._register(new Delayer(this._configurationService.getValue('workbench.hover.delay')));
+
 		this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationIcon) ||
 				e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationIconSuccess) ||
@@ -93,6 +94,15 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 				}
 			}
 		});
+	}
+
+	public refresh(): void {
+		for (const decoration of this._decorations) {
+			if (decoration[1].decoration?.element) {
+				decoration[1].decoration.element.classList.remove(DecorationSelector.Codicon);
+				this._applyStyles(decoration[1].decoration.element, decoration[1].exitCode);
+			}
+		}
 	}
 
 	private _clearDecorations(): void {
@@ -188,7 +198,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 					target.style.fontSize = `${scalar * DecorationStyles.DefaultDimension}px`;
 
 					// the first split terminal in the panel has more room
-					if (document.querySelectorAll(DecorationSelector.FirstSplitContainer)[0] === target.parentElement) {
+					if (target.closest(DecorationSelector.FirstSplitContainer)) {
 						target.style.marginLeft = `${scalar * DecorationStyles.MarginLeftFirstSplit}px`;
 					} else {
 						target.style.marginLeft = `${scalar * DecorationStyles.MarginLeft}px`;

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -147,7 +147,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 		this.add(this._viewDescriptorService.onDidChangeLocation(({ views }) => {
 			if (views.some(v => v.id === TERMINAL_VIEW_ID)) {
 				this._updateTheme();
-				this._decorationAddon?.refresh();
+				this._decorationAddon?.refreshLayouts();
 			}
 		}));
 

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -58,6 +58,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 	// Always on addons
 	private _commandTrackerAddon: CommandTrackerAddon;
 	private _shellIntegrationAddon: ShellIntegrationAddon;
+	private _decorationAddon: DecorationAddon | undefined;
 
 	// Optional addons
 	private _searchAddon?: SearchAddonType;
@@ -146,6 +147,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 		this.add(this._viewDescriptorService.onDidChangeLocation(({ views }) => {
 			if (views.some(v => v.id === TERMINAL_VIEW_ID)) {
 				this._updateTheme();
+				this._decorationAddon?.refresh();
 			}
 		}));
 
@@ -160,9 +162,9 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 		}
 	}
 	private _createDecorationAddon(capabilities: ITerminalCapabilityStore): void {
-		const decorationAddon = this._instantiationService.createInstance(DecorationAddon, capabilities);
-		decorationAddon.onDidRequestRunCommand(command => this._onDidRequestRunCommand.fire(command));
-		this.raw.loadAddon(decorationAddon);
+		this._decorationAddon = this._instantiationService.createInstance(DecorationAddon, capabilities);
+		this._decorationAddon.onDidRequestRunCommand(command => this._onDidRequestRunCommand.fire(command));
+		this.raw.loadAddon(this._decorationAddon);
 	}
 
 	attachToElement(container: HTMLElement) {


### PR DESCRIPTION
This PR fixes #143932

See https://github.com/microsoft/vscode/issues/143932#issuecomment-1050463278 which explains the decision to cap the decoration size