### PR TITLE
Add back id param to webview service worker path

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -210,7 +210,7 @@ const workerReady = new Promise((resolve, reject) => {
 		return reject(new Error('Service Workers are not enabled. Webviews will not work. Try disabling private/incognito mode.'));
 	}
 
-	const swPath = `service-worker.js?v=${expectedWorkerVersion}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}`;
+	const swPath = `service-worker.js?v=${expectedWorkerVersion}&id=${ID}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}`;
 	navigator.serviceWorker.register(swPath)
 		.then(() => navigator.serviceWorker.ready)
 		.then(async registration => {


### PR DESCRIPTION
The `id` search param is used in `service-worker.js`, but seems forgot in [this commit](https://github.com/microsoft/vscode/commit/1d996470961dd59e5b69667022ef788fec9e7125). This cause webview load failed sometime on web target (run `yarn web`). 

Param used here:

https://github.com/microsoft/vscode/blob/4d5ca3a392f2f74d23a4bf2dc5476b1744f6de51/src/vs/workbench/contrib/webview/browser/pre/service-worker.js#L379-L386

https://github.com/microsoft/vscode/blob/4d5ca3a392f2f74d23a4bf2dc5476b1744f6de51/src/vs/workbench/contrib/webview/browser/pre/service-worker.js#L336
