### PR TITLE
Update webviewElement.ts

### DIFF
--- a/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
@@ -93,7 +93,8 @@ export class ElectronWebviewElement extends WebviewElement {
 	}
 
 	protected override get webviewContentEndpoint(): string {
-		return `${Schemas.vscodeWebview}://${this.iframeId}`;
+		const origin = this.extension?.id.value ?? this.iframeId;
+		return `${Schemas.vscodeWebview}://${origin}`;
 	}
 
 	protected override streamToBuffer(stream: VSBufferReadableStream): Promise<ArrayBufferLike> {


### PR DESCRIPTION
Fix for extension webviews src urls to have the origin.

currently vscode has an id for making the webview element unique and they had an iframeId that was used for channel communication. It is using the iframeId as the origin of iframe url. Since the origin changes every time a WebView is created there's no way how to utilize things like http cache or IndexDB - they are always created empty again for every webview

The fix is to use the extensionId if available as the origin. IframeId is still used in the query parameter for cache busting and channel communication. Using the extensionId as the origin makes things like like http cache or IndexDB usable and enables caching/sharing data across multiple WebViews created by the same extension

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #132464
