### PR TITLE
Jackson/lang-detect-min-text

### DIFF
--- a/src/vs/workbench/services/languageDetection/browser/languageDetectionSimpleWorker.ts
+++ b/src/vs/workbench/services/languageDetection/browser/languageDetectionSimpleWorker.ts
@@ -56,10 +56,13 @@ export class LanguageDetectionSimpleWorker extends EditorSimpleWorker {
 		};
 
 		const historicalResolver = async () => {
-			if (langBiases) {
-				const regexpDetection = await this.runRegexpModel(documentTextSample, langBiases);
-				if (regexpDetection) {
-					return regexpDetection;
+			// only detect when we have at least a line of data
+			if (documentTextSample.length > 20 || documentTextSample.includes('\n')) {
+				if (langBiases) {
+					const regexpDetection = await this.runRegexpModel(documentTextSample, langBiases);
+					if (regexpDetection) {
+						return regexpDetection;
+					}
 				}
 			}
 			return undefined;

--- a/src/vs/workbench/services/languageDetection/browser/languageDetectionSimpleWorker.ts
+++ b/src/vs/workbench/services/languageDetection/browser/languageDetectionSimpleWorker.ts
@@ -57,8 +57,8 @@ export class LanguageDetectionSimpleWorker extends EditorSimpleWorker {
 
 		const historicalResolver = async () => {
 			// only detect when we have at least a line of data
-			if (documentTextSample.length > 20 || documentTextSample.includes('\n')) {
-				if (langBiases) {
+			if (langBiases) {
+				if (documentTextSample.length > 20 || documentTextSample.includes('\n')) {
 					const regexpDetection = await this.runRegexpModel(documentTextSample, langBiases);
 					if (regexpDetection) {
 						return regexpDetection;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/143930. Basically just don't start guessing until we have a line or at least 20 chars.

Ideal solution would be for the model to better report confidence but for the candidate this is sufficient IMO.