### PR TITLE
feat(jsonc): more interactive completion for "path" property

### DIFF
--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -290,7 +290,7 @@ jsonRegistry.registerSchema('vscode://schemas/workspaceConfig', {
 			description: nls.localize('workspaceConfig.folders.description', "List of folders to be loaded in the workspace."),
 			items: {
 				type: 'object',
-				default: { path: '' },
+				defaultSnippets: [{ body: { path: '$1' } }],
 				oneOf: [{
 					properties: {
 						path: {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes # none

When editing `<any>.code-workspace` file, the completion `{ "path": ""}` is kind of not so convenience.

_Before_

![before](https://user-images.githubusercontent.com/24731539/156094712-151ed476-a618-410e-bdb3-c63ef0b7a62b.gif)

The situation is eased using `defaultSnippets` which supports tabstops.

_After_

![after](https://user-images.githubusercontent.com/24731539/156094781-c1f7a15e-06ea-4661-b62e-cd24b460afe4.gif)
