### PR TITLE
Respect selection column for multi-line selection in find widget

### DIFF
--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
@@ -691,7 +691,7 @@ export class PieceTreeBase {
 			m = searcher.next(searchText);
 
 			if (m) {
-				if (offsetInBuffer(m.index) >= end) {
+				if (offsetInBuffer(m.index) >= end || offsetInBuffer(m.index) + m[0].length > end) {
 					return resultLen;
 				}
 				this.positionInBuffer(node, offsetInBuffer(m.index) - startOffsetInBuffer, ret);

--- a/src/vs/editor/contrib/find/browser/findModel.ts
+++ b/src/vs/editor/contrib/find/browser/findModel.ts
@@ -187,20 +187,6 @@ export class FindModelBoundToEditorModel {
 		} else {
 			findScopes = this._decorations.getFindScopes();
 		}
-		if (findScopes !== null) {
-			findScopes = findScopes.map(findScope => {
-				if (findScope.startLineNumber !== findScope.endLineNumber) {
-					let endLineNumber = findScope.endLineNumber;
-
-					if (findScope.endColumn === 1) {
-						endLineNumber = endLineNumber - 1;
-					}
-
-					return new Range(findScope.startLineNumber, 1, endLineNumber, this._editor.getModel().getLineMaxColumn(endLineNumber));
-				}
-				return findScope;
-			});
-		}
 
 		let findMatches = this._findMatches(findScopes, false, MATCHES_LIMIT);
 		this._decorations.set(findMatches, findScopes);


### PR DESCRIPTION
- findModel.research uses findScopes unmodified
- pieceTreeBase.findMatchesInNode doesn't consider match which ends after findScope

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #144184
