### PR TITLE
Update SCM colors to increase contrast

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -20,8 +20,7 @@ import { URI } from 'vs/base/common/uri';
 import { ISCMService, ISCMRepository, ISCMProvider } from 'vs/workbench/contrib/scm/common/scm';
 import { ModelDecorationOptions } from 'vs/editor/common/model/textModel';
 import { registerThemingParticipant, IColorTheme, ICssStyleCollector, themeColorFromId, IThemeService, ThemeIcon } from 'vs/platform/theme/common/themeService';
-import { registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
-import { Color, RGBA } from 'vs/base/common/color';
+import { editorErrorForeground, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
 import { ICodeEditor, IEditorMouseEvent, MouseTargetType } from 'vs/editor/browser/editorBrowser';
 import { registerEditorAction, registerEditorContribution, ServicesAccessor, EditorAction } from 'vs/editor/browser/editorExtensions';
 import { PeekViewWidget, getOuterEditor, peekViewBorder, peekViewTitleBackground, peekViewTitleForeground, peekViewTitleInfoForeground } from 'vs/editor/contrib/peekView/browser/peekView';
@@ -52,6 +51,7 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 import { TextCompareEditorActiveContext } from 'vs/workbench/common/contextkeys';
 import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
 import { IChange } from 'vs/editor/common/diff/diffComputer';
+import { Color } from 'vs/base/common/color';
 
 class DiffActionRunner extends ActionRunner {
 
@@ -849,39 +849,39 @@ export class DirtyDiffController extends Disposable implements IEditorContributi
 }
 
 export const editorGutterModifiedBackground = registerColor('editorGutter.modifiedBackground', {
-	dark: new Color(new RGBA(12, 125, 157)),
-	light: new Color(new RGBA(102, 175, 224)),
-	hc: new Color(new RGBA(0, 155, 249))
+	dark: '#1B81A8',
+	light: '#2090D3',
+	hc: '#1B81A8'
 }, nls.localize('editorGutterModifiedBackground', "Editor gutter background color for lines that are modified."));
 
 export const editorGutterAddedBackground = registerColor('editorGutter.addedBackground', {
-	dark: new Color(new RGBA(88, 124, 12)),
-	light: new Color(new RGBA(129, 184, 139)),
-	hc: new Color(new RGBA(51, 171, 78))
+	dark: '#487E02',
+	light: '#48985D',
+	hc: '#487E02'
 }, nls.localize('editorGutterAddedBackground', "Editor gutter background color for lines that are added."));
 
 export const editorGutterDeletedBackground = registerColor('editorGutter.deletedBackground', {
-	dark: new Color(new RGBA(148, 21, 27)),
-	light: new Color(new RGBA(202, 75, 81)),
-	hc: new Color(new RGBA(252, 93, 109))
+	dark: editorErrorForeground,
+	light: editorErrorForeground,
+	hc: editorErrorForeground
 }, nls.localize('editorGutterDeletedBackground', "Editor gutter background color for lines that are deleted."));
 
 export const minimapGutterModifiedBackground = registerColor('minimapGutter.modifiedBackground', {
-	dark: new Color(new RGBA(12, 125, 157)),
-	light: new Color(new RGBA(102, 175, 224)),
-	hc: new Color(new RGBA(0, 155, 249))
+	dark: editorGutterModifiedBackground,
+	light: editorGutterModifiedBackground,
+	hc: editorGutterModifiedBackground
 }, nls.localize('minimapGutterModifiedBackground', "Minimap gutter background color for lines that are modified."));
 
 export const minimapGutterAddedBackground = registerColor('minimapGutter.addedBackground', {
-	dark: new Color(new RGBA(88, 124, 12)),
-	light: new Color(new RGBA(129, 184, 139)),
-	hc: new Color(new RGBA(51, 171, 78))
+	dark: editorGutterAddedBackground,
+	light: editorGutterAddedBackground,
+	hc: editorGutterAddedBackground
 }, nls.localize('minimapGutterAddedBackground', "Minimap gutter background color for lines that are added."));
 
 export const minimapGutterDeletedBackground = registerColor('minimapGutter.deletedBackground', {
-	dark: new Color(new RGBA(148, 21, 27)),
-	light: new Color(new RGBA(202, 75, 81)),
-	hc: new Color(new RGBA(252, 93, 109))
+	dark: editorGutterDeletedBackground,
+	light: editorGutterDeletedBackground,
+	hc: editorGutterDeletedBackground
 }, nls.localize('minimapGutterDeletedBackground', "Minimap gutter background color for lines that are deleted."));
 
 export const overviewRulerModifiedForeground = registerColor('editorOverviewRuler.modifiedForeground', { dark: transparent(editorGutterModifiedBackground, 0.6), light: transparent(editorGutterModifiedBackground, 0.6), hc: transparent(editorGutterModifiedBackground, 0.6) }, nls.localize('overviewRulerModifiedForeground', 'Overview ruler marker color for modified content.'));


### PR DESCRIPTION
Refs #142809

This updates the default SCM colors to pass the 3:1 color contrast ratio for non-text

## Dark
<img width="634" alt="CleanShot 2022-03-01 at 09 49 07@2x" src="https://user-images.githubusercontent.com/35271042/156221583-6c05d20b-b0de-4625-8485-50b629e377e2.png">


## Light
<img width="634" alt="CleanShot 2022-03-01 at 09 49 13@2x" src="https://user-images.githubusercontent.com/35271042/156221600-ccb1f293-332f-48a0-8365-191ae03ddc45.png">


|Dark|Light|
|---|---|
|<img width="480" src="https://user-images.githubusercontent.com/35271042/156220227-b21a0c54-524d-42be-a313-6ef7f27fd1bc.png">|<img width="480" alt="CleanShot 2022-03-01 at 09 42 35@2x" src="https://user-images.githubusercontent.com/35271042/156220623-f597eec8-19af-4804-821c-8635360017ef.png">|
|<img width="480" alt="CleanShot 2022-03-01 at 09 39 52@2x" src="https://user-images.githubusercontent.com/35271042/156220210-8dbef46e-bd92-430c-a008-861c0de51f4f.png">|<img width="480" alt="CleanShot 2022-03-01 at 09 40 50@2x" src="https://user-images.githubusercontent.com/35271042/156220421-b10a3cda-a556-4b38-9948-1c4b85f74a18.png">|
|<img width="480" alt="CleanShot 2022-03-01 at 09 30 53@2x" src="https://user-images.githubusercontent.com/35271042/156218841-06289f63-5b32-4ef9-a6f9-50b7df563304.png">|<img width="480" alt="CleanShot 2022-03-01 at 09 43 21@2x" src="https://user-images.githubusercontent.com/35271042/156220724-4ab7c8c4-e2b6-4ba1-8473-107640aac8af.png">|