### PR TITLE
Consider order fields when doing searches in the Settings editor

### DIFF
--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -89,6 +89,8 @@ export interface ISetting {
 	editPresentation?: EditPresentationTypes;
 	defaultValueSource?: string | IExtensionInfo;
 	isLanguageTagSetting?: boolean;
+	categoryOrder?: number;
+	categoryLabel?: string;
 }
 
 export interface IExtensionSetting extends ISetting {

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -16,7 +16,7 @@ import { ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 import { ITextEditorModel } from 'vs/editor/common/services/resolverService';
 import * as nls from 'vs/nls';
 import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ConfigurationScope, Extensions, IConfigurationNode, IConfigurationPropertySchema, IConfigurationRegistry, IExtensionInfo, IRegisteredConfigurationPropertySchema, OVERRIDE_PROPERTY_REGEX } from 'vs/platform/configuration/common/configurationRegistry';
+import { ConfigurationScope, Extensions, IConfigurationNode, IConfigurationRegistry, IExtensionInfo, IRegisteredConfigurationPropertySchema, OVERRIDE_PROPERTY_REGEX } from 'vs/platform/configuration/common/configurationRegistry';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { EditorModel } from 'vs/workbench/common/editor/editorModel';
@@ -57,6 +57,18 @@ export abstract class AbstractSettingsModel extends EditorModel {
 			});
 	}
 
+	private compareTwoNullableNumbers(a: number | undefined, b: number | undefined): number {
+		const aOrMax = a ?? Number.MAX_SAFE_INTEGER;
+		const bOrMax = b ?? Number.MAX_SAFE_INTEGER;
+		if (aOrMax < bOrMax) {
+			return -1;
+		} else if (aOrMax > bOrMax) {
+			return 1;
+		} else {
+			return 0;
+		}
+	}
+
 	filterSettings(filter: string, groupFilter: IGroupFilter, settingMatcher: ISettingMatcher): ISettingMatch[] {
 		const allGroups = this.filterGroups;
 
@@ -86,15 +98,22 @@ export abstract class AbstractSettingsModel extends EditorModel {
 				return b.matchType - a.matchType;
 			} else {
 				// The match types are the same.
-				// See if the settings belong to the same extension and have an order.
-				// If yes, use that order (ascending). Otherwise, fall back.
 				if (a.setting.extensionInfo && b.setting.extensionInfo
-					&& a.setting.extensionInfo.id === b.setting.extensionInfo.id
-					&& (a.setting.order !== undefined || b.setting.order !== undefined)) {
-					const aOrder = a.setting.order ?? Number.MAX_SAFE_INTEGER;
-					const bOrder = b.setting.order ?? Number.MAX_SAFE_INTEGER;
-					return aOrder - bOrder;
+					&& a.setting.extensionInfo.id === b.setting.extensionInfo.id) {
+					// These settings belong to the same extension.
+					if (a.setting.categoryLabel !== b.setting.categoryLabel
+						&& (a.setting.categoryOrder !== undefined || b.setting.categoryOrder !== undefined)
+						&& a.setting.categoryOrder !== b.setting.categoryOrder) {
+						// These two settings don't belong to the same category and have different category orders.
+						return this.compareTwoNullableNumbers(a.setting.categoryOrder, b.setting.categoryOrder);
+					} else if (a.setting.categoryLabel === b.setting.categoryLabel
+						&& (a.setting.order !== undefined || b.setting.order !== undefined)
+						&& a.setting.order !== b.setting.order) {
+						// These two settings belong to the same category, but have different orders.
+						return this.compareTwoNullableNumbers(a.setting.order, b.setting.order);
+					}
 				}
+				// In the worst case, go back to lexicographical order.
 				return b.score - a.score;
 			}
 		});
@@ -611,7 +630,7 @@ export class DefaultSettings extends Disposable {
 				result.push(settingsGroup);
 			}
 			const configurationSettings: ISetting[] = [];
-			for (const setting of [...settingsGroup.sections[settingsGroup.sections.length - 1].settings, ...this.parseSettings(config.properties, config.extensionInfo)]) {
+			for (const setting of [...settingsGroup.sections[settingsGroup.sections.length - 1].settings, ...this.parseSettings(config)]) {
 				if (!seenSettings[setting.key]) {
 					configurationSettings.push(setting);
 					seenSettings[setting.key] = true;
@@ -638,8 +657,12 @@ export class DefaultSettings extends Disposable {
 		return result;
 	}
 
-	private parseSettings(settingsObject: { [path: string]: IConfigurationPropertySchema }, extensionInfo?: IExtensionInfo): ISetting[] {
+	private parseSettings(config: IConfigurationNode): ISetting[] {
 		const result: ISetting[] = [];
+		const settingsObject = config.properties;
+		const extensionInfo = config.extensionInfo;
+		const categoryLabel = config.id ?? config.title;
+		const categoryOrder = config.order;
 		for (const key in settingsObject) {
 			const prop = settingsObject[key];
 			if (this.matchesScope(prop)) {
@@ -722,7 +745,9 @@ export class DefaultSettings extends Disposable {
 					editPresentation: prop.editPresentation,
 					order: prop.order,
 					defaultValueSource,
-					isLanguageTagSetting
+					isLanguageTagSetting,
+					categoryLabel,
+					categoryOrder
 				});
 			}
 		}

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -659,10 +659,15 @@ export class DefaultSettings extends Disposable {
 
 	private parseSettings(config: IConfigurationNode): ISetting[] {
 		const result: ISetting[] = [];
+
 		const settingsObject = config.properties;
 		const extensionInfo = config.extensionInfo;
-		const categoryLabel = config.id ?? config.title;
+
+		// Try using the title if the category id wasn't given
+		// (in which case the category id is the same as the extension id)
+		const categoryLabel = config.extensionInfo?.id === config.id ? config.title : config.id;
 		const categoryOrder = config.order;
+
 		for (const key in settingsObject) {
 			const prop = settingsObject[key];
 			if (this.matchesScope(prop)) {

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -80,12 +80,21 @@ export abstract class AbstractSettingsModel extends EditorModel {
 		}
 
 		filterMatches.sort((a, b) => {
-			// Sort by match type if the match types are not equal.
-			// The priority of the match type is given by the SettingMatchType enum.
-			// If they're equal, fall back to the "stable sort" counter score.
 			if (a.matchType !== b.matchType) {
+				// Sort by match type if the match types are not the same.
+				// The priority of the match type is given by the SettingMatchType enum.
 				return b.matchType - a.matchType;
 			} else {
+				// The match types are the same.
+				// See if the settings belong to the same extension and have an order.
+				// If yes, use that order (ascending). Otherwise, fall back.
+				if (a.setting.extensionInfo && b.setting.extensionInfo
+					&& a.setting.extensionInfo.id === b.setting.extensionInfo.id
+					&& (a.setting.order !== undefined || b.setting.order !== undefined)) {
+					const aOrder = a.setting.order ?? Number.MAX_SAFE_INTEGER;
+					const bOrder = b.setting.order ?? Number.MAX_SAFE_INTEGER;
+					return aOrder - bOrder;
+				}
 				return b.score - a.score;
 			}
 		});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/143513

This PR allows for the `order` fields of settings and categories to be preserved when users do a search, unless the matches have different match types, such as if one of the matches is a whole word match and the other one isn't.
Previously, the `order` fields would only be considered when the user was not doing a search.

For example, for the screencap below, the settings are in the order C A B (from the B configuration), then D E F (from the A configuration). Even after searching for "Setting", that order is still preserved, which is what we want.

![Demo](https://user-images.githubusercontent.com/7199958/156257525-0ef255a0-d359-43cd-9a60-e717b9f31701.gif)
