### PR TITLE
only exit zen mode by workbench.action.exitZenMode if its already in zen mode

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -540,7 +540,10 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	weight: KeybindingWeight.EditorContrib - 1000,
 	handler(accessor: ServicesAccessor) {
 		const layoutService = accessor.get(IWorkbenchLayoutService);
-		layoutService.toggleZenMode();
+		const contextKeyService = accessor.get(IContextKeyService);
+		if (InEditorZenModeContext.getValue(contextKeyService)) {
+			layoutService.toggleZenMode();
+		}
 	},
 	when: InEditorZenModeContext,
 	primary: KeyChord(KeyCode.Escape, KeyCode.Escape)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #140392
## Issue 
`workbench.action.exitZenMode` is toggling Zen mode.

##  Fix
For `workbench.action.exitZenMode` added a check to ensure Zen Mode is only toggled when it's actually in Zen Mode.

## Test
- Associate a shortcut to `workbench.action.exitZenMode`.
- The shortcut only exits Zen Mode and doesn't toggle it anymore.
