### PR TITLE
Scroll to top button not getting themed

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -824,7 +824,7 @@ export class ExtensionEditor extends EditorPane {
 						height: 40px;
 						right: 25px;
 						bottom: 25px;
-						background-color:#444444;
+						background-color:var(--vscode-textLink-foreground);
 						border-radius: 50%;
 						cursor: pointer;
 						box-shadow: 1px 1px 1px rgba(0,0,0,.25);
@@ -835,7 +835,7 @@ export class ExtensionEditor extends EditorPane {
 					}
 
 					#scroll-to-top:hover {
-						background-color:#007acc;
+						background-color:var(--vscode-textLink-activeForeground);
 						box-shadow: 2px 2px 2px rgba(0,0,0,.25);
 					}
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -824,7 +824,7 @@ export class ExtensionEditor extends EditorPane {
 						height: 40px;
 						right: 25px;
 						bottom: 25px;
-						background-color:var(--vscode-textLink-foreground);
+						background-color:var(--vscode-button-background);
 						border-radius: 50%;
 						cursor: pointer;
 						box-shadow: 1px 1px 1px rgba(0,0,0,.25);
@@ -835,7 +835,7 @@ export class ExtensionEditor extends EditorPane {
 					}
 
 					#scroll-to-top:hover {
-						background-color:var(--vscode-textLink-activeForeground);
+						background-color:var(--vscode-button-hoverBackground);
 						box-shadow: 2px 2px 2px rgba(0,0,0,.25);
 					}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #142916

## Issue
Scroll to top button was not getting themed

## Fix
Updated scroll to top button color to `--vscode-button-background` and hover color to `--vscode-button-hoverBackground`.

## Test
- Install a color theme from VSIX.
- Go to the extension page to check if scroll to top button is displayed as per current theme.

