### PR TITLE
ci: fix build with latest node-gyp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   windows:
     name: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     timeout-minutes: 60
     env:
       CHILD_CONCURRENCY: "1"

--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   richnav:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
 

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -79,6 +79,10 @@ steps:
       set -e
       export npm_config_arch=$(VSCODE_ARCH)
       export npm_config_node_gyp=$(which node-gyp)
+      # Electron <= 13 does not ship with correct config.gypi headers,
+      # remove this once we update to newer versions.
+      # Refs https://github.com/nodejs/node-gyp/pull/2497
+      export npm_config_force_process_config=true
 
       for i in {1..3}; do # try 3 times, for Terrapin
         yarn --frozen-lockfile && break


### PR DESCRIPTION
This also fixes the build issue with the github agent by switching to use `windows-2019` explicitly since the latest has been switched to `windows-2022` and it will require additional changes from which I am not backporting to the release branch.

https://github.com/microsoft/vscode/commit/d35ee52e1d8e37360f57c3e10fabd6f404f0ea6b
https://github.com/microsoft/vscode/commit/5783ee998dd098f03e4380b6549d41eb6f80ee37
