### PR TITLE
Give git process clues in SCM input placeholder

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2179,7 +2179,13 @@ export class Repository implements Disposable {
 	private updateInputBoxPlaceholder(): void {
 		const branchName = this.headShortName;
 
-		if (branchName) {
+		if (this._indexGroup?.resourceStates.length === 0) {
+			if (this._workingTreeGroup?.resourceStates.length + this._untrackedGroup?.resourceStates.length > 0) {
+				this._sourceControl.inputBox.placeholder = localize('commitMessageNothingStaged', "(no changes staged yet)");
+			} else {
+				this._sourceControl.inputBox.placeholder = localize('commitMessageNothingChanged', "(nothing changed yet)");
+			}
+		} else if (branchName) {
 			// '{0}' will be replaced by the corresponding key-command later in the process, which is why it needs to stay.
 			this._sourceControl.inputBox.placeholder = localize('commitMessageWithHeadLabel', "Message ({0} to commit on '{1}')", '{0}', branchName);
 		} else {


### PR DESCRIPTION
This PR uses the SCM input placeholder to help a git novice know what to do.

When no changes exist:

![image](https://user-images.githubusercontent.com/6726799/156368576-0cb6472e-90aa-4735-b858-ea639b2a331d.png)

When changes or untracked files exist but nothing has been staged yet:

![image](https://user-images.githubusercontent.com/6726799/156368793-791b65fa-4629-4a30-97da-c4739f86f6f3.png)

After staging something the usual placeholder appears:

![image](https://user-images.githubusercontent.com/6726799/156369048-4f2c0e28-07c6-4c5a-a00b-13c85b75ecb8.png)

