### PR TITLE
Remove unused terminal css rules

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -162,15 +162,6 @@
 	border-top-style: solid;
 }
 
-.monaco-workbench .pane-body.integrated-terminal.enable-ligatures {
-	font-variant-ligatures: normal;
-}
-
-
-.monaco-workbench .pane-body.integrated-terminal.disable-bold .xterm-bold {
-	font-weight: normal !important;
-}
-
 /* Use the default cursor when alt is active to help with clicking to move cursor */
 .monaco-workbench .pane-body.integrated-terminal .terminal-groups-container.alt-active .xterm {
 	cursor: default;


### PR DESCRIPTION
Part of #144259

Ligatures never made it in and bold is now handles by xterm where you can configure both bold and normal text weight.