### PR TITLE
Add a manual reset flag for settings update event

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -656,6 +656,7 @@ export interface ISettingChangeEvent {
 	key: string;
 	value: any; // undefined => reset/unconfigure
 	type: SettingValueType | SettingValueType[];
+	manualReset: boolean;
 }
 
 export interface ISettingLinkClickEvent {
@@ -781,7 +782,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 
 		const descriptionElement = DOM.append(container, $('.setting-item-description'));
 		const modifiedIndicatorElement = DOM.append(container, $('.setting-item-modified-indicator'));
-		modifiedIndicatorElement.title = localize('modified', "Modified");
+		modifiedIndicatorElement.title = localize('modified', "The setting has been configured in the current scope.");
 
 		const valueElement = DOM.append(container, $('.setting-item-value'));
 		const controlElement = DOM.append(valueElement, $('div.setting-item-control'));
@@ -882,7 +883,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 
 		template.miscLabel.updateOtherOverrides(element, template.elementDisposables, this._onDidClickOverrideElement);
 
-		const onChange = (value: any) => this._onDidChangeSetting.fire({ key: element.setting.key, value, type: template.context!.valueType });
+		const onChange = (value: any) => this._onDidChangeSetting.fire({ key: element.setting.key, value, type: template.context!.valueType, manualReset: false });
 		const deprecationText = element.setting.deprecationMessage || '';
 		if (deprecationText && element.setting.deprecationMessageIsMarkdown) {
 			const disposables = new DisposableStore();
@@ -1448,7 +1449,8 @@ export class SettingExcludeRenderer extends AbstractSettingRenderer implements I
 			this._onDidChangeSetting.fire({
 				key: template.context.setting.key,
 				value: Object.keys(newValue).length === 0 ? undefined : sortKeys(newValue),
-				type: template.context.valueType
+				type: template.context.valueType,
+				manualReset: false
 			});
 		}
 	}
@@ -1763,7 +1765,7 @@ export class SettingBoolRenderer extends AbstractSettingRenderer implements ITre
 		const controlElement = DOM.append(descriptionAndValueElement, $('.setting-item-bool-control'));
 		const descriptionElement = DOM.append(descriptionAndValueElement, $('.setting-item-description'));
 		const modifiedIndicatorElement = DOM.append(container, $('.setting-item-modified-indicator'));
-		modifiedIndicatorElement.title = localize('modified', "Modified");
+		modifiedIndicatorElement.title = localize('modified', "The setting has been configured in the current scope.");
 
 
 		const deprecationWarningElement = DOM.append(container, $('.setting-item-deprecation-message'));
@@ -1902,7 +1904,7 @@ export class SettingTreeRenderers {
 			new Action('settings.resetSetting', localize('resetSettingLabel', "Reset Setting"), undefined, undefined, async context => {
 				if (context instanceof SettingsTreeSettingElement) {
 					if (!context.isUntrusted) {
-						this._onDidChangeSetting.fire({ key: context.setting.key, value: undefined, type: context.setting.type as SettingValueType });
+						this._onDidChangeSetting.fire({ key: context.setting.key, value: undefined, type: context.setting.type as SettingValueType, manualReset: true });
 					}
 				}
 			}),


### PR DESCRIPTION
Add manual reset flag for settings update event

Ref https://github.com/microsoft/vscode/issues/58038

In particular, see https://github.com/microsoft/vscode/issues/58038#issue-357509406 and point 1 of https://github.com/microsoft/vscode/issues/58038#issuecomment-448219574.

Instead of thinking of settings as modified, I currently see them in terms of whether or not they've been configured, and what override order they come in.

Therefore, I think that because a workspace or folder config is meant to override user settings no matter who I give the workspace to, that those settings should remain configured unless the user specifically requests to reset the setting.

This flag could also come in useful for language overrides. For instance, while debugging a language filter implementation, I toggled a setting on and off, and caused it to reset when I didn't want it to.