### PR TITLE
menus: fix performance issues scrolling with lots of submenus

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -802,8 +802,10 @@ class SubmenuMenuActionViewItem extends BaseMenuActionViewItem {
 		}));
 
 		this._register(this.parentData.parent.onScroll(() => {
-			this.parentData.parent.focus(false);
-			this.cleanupExistingSubmenu(false);
+			if (this.parentData.submenu === this.mysubmenu) {
+				this.parentData.parent.focus(false);
+				this.cleanupExistingSubmenu(true);
+			}
 		}));
 	}
 


### PR DESCRIPTION
@sbatten this seems to be the cause of https://github.com/microsoft/vscode/issues/139952. In that case, there are a few hundred submenus. Whenever the parent menu scrolls, _every_ menu tries to have it cleanup other submenus and (more importantly) re-focus the active element.

I think the intention here is for the submenu to clean _its own_ menu, if it's open, and then fix the focus back to the parent if so. This is original code from https://github.com/microsoft/vscode/pull/62819

Fixes #139952