### PR TITLE
Identify language tag settings

### DIFF
--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -292,10 +292,11 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 				if (OVERRIDE_PROPERTY_REGEX.test(key)) {
 					const defaultValue = { ...(this.configurationDefaultsOverrides.get(key)?.value || {}), ...overrides[key] };
 					this.configurationDefaultsOverrides.set(key, { source, value: defaultValue });
+					const plainKey = key.replace(/[\[\]]/g, '');
 					const property: IRegisteredConfigurationPropertySchema = {
 						type: 'object',
 						default: defaultValue,
-						description: nls.localize('defaultLanguageConfiguration.description', "Configure settings to be overridden for {0} language.", key),
+						description: nls.localize('defaultLanguageConfiguration.description', "Configure settings to be overridden for the {0} language.", plainKey),
 						$ref: resourceLanguageSettingsSchemaId,
 						defaultDefaultValue: defaultValue,
 						source: types.isString(source) ? undefined : source,

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -340,6 +340,10 @@
 	padding-left: 1px;
 }
 
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-label .codicon {
+	vertical-align: text-top;
+}
+
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-overrides a.modified-scope {
 	text-decoration: underline;
 	cursor: pointer;

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -583,7 +583,7 @@ interface ISettingItemTemplate<T = any> extends IDisposableTemplate {
 	context?: SettingsTreeSettingElement;
 	containerElement: HTMLElement;
 	categoryElement: HTMLElement;
-	labelElement: HTMLElement;
+	labelElement: SimpleIconLabel;
 	descriptionElement: HTMLElement;
 	controlElement: HTMLElement;
 	deprecationWarningElement: HTMLElement;
@@ -775,7 +775,8 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		const titleElement = DOM.append(container, $('.setting-item-title'));
 		const labelCategoryContainer = DOM.append(titleElement, $('.setting-item-cat-label-container'));
 		const categoryElement = DOM.append(labelCategoryContainer, $('span.setting-item-category'));
-		const labelElement = DOM.append(labelCategoryContainer, $('span.setting-item-label'));
+		const labelElementContainer = DOM.append(labelCategoryContainer, $('span.setting-item-label'));
+		const labelElement = new SimpleIconLabel(labelElementContainer);
 
 		const miscLabel = new SettingsTreeMiscLabel(titleElement);
 
@@ -867,7 +868,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		template.categoryElement.textContent = element.displayCategory && (element.displayCategory + ': ');
 		template.categoryElement.title = titleTooltip;
 
-		template.labelElement.textContent = element.displayLabel;
+		template.labelElement.text = element.displayLabel;
 		template.labelElement.title = titleTooltip;
 
 		template.descriptionElement.innerText = '';
@@ -1756,7 +1757,8 @@ export class SettingBoolRenderer extends AbstractSettingRenderer implements ITre
 
 		const titleElement = DOM.append(container, $('.setting-item-title'));
 		const categoryElement = DOM.append(titleElement, $('span.setting-item-category'));
-		const labelElement = DOM.append(titleElement, $('span.setting-item-label'));
+		const labelElementContainer = DOM.append(titleElement, $('span.setting-item-label'));
+		const labelElement = new SimpleIconLabel(labelElementContainer);
 		const miscLabel = new SettingsTreeMiscLabel(titleElement);
 
 		const descriptionAndValueElement = DOM.append(container, $('.setting-item-value-description'));
@@ -2301,6 +2303,10 @@ class SettingsTreeDelegate extends CachedListVirtualDelegate<SettingsTreeGroupCh
 
 			if (element.valueType === SettingValueType.BooleanObject) {
 				return SETTINGS_BOOL_OBJECT_TEMPLATE_ID;
+			}
+
+			if (element.valueType === SettingValueType.LanguageTag) {
+				return SETTINGS_COMPLEX_TEMPLATE_ID;
 			}
 
 			return SETTINGS_COMPLEX_TEMPLATE_ID;

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -166,7 +166,7 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 	}
 
 	private initLabels(): void {
-		const displayKeyFormat = settingKeyToDisplayFormat(this.setting.key, this.parent!.id);
+		const displayKeyFormat = settingKeyToDisplayFormat(this.setting.key, this.parent!.id, this.setting.isLanguageTagSetting);
 		this._displayLabel = displayKeyFormat.label;
 		this._displayCategory = displayKeyFormat.category;
 	}
@@ -258,6 +258,8 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 			} else {
 				this.valueType = SettingValueType.Object;
 			}
+		} else if (this.setting.isLanguageTagSetting) {
+			this.valueType = SettingValueType.LanguageTag;
 		} else {
 			this.valueType = SettingValueType.Complex;
 		}
@@ -503,7 +505,7 @@ function sanitizeId(id: string): string {
 	return id.replace(/[\.\/]/, '_');
 }
 
-export function settingKeyToDisplayFormat(key: string, groupId = ''): { category: string; label: string } {
+export function settingKeyToDisplayFormat(key: string, groupId: string = '', isLanguageTagSetting: boolean = false): { category: string; label: string } {
 	const lastDotIdx = key.lastIndexOf('.');
 	let category = '';
 	if (lastDotIdx >= 0) {
@@ -514,6 +516,11 @@ export function settingKeyToDisplayFormat(key: string, groupId = ''): { category
 	groupId = groupId.replace(/\//g, '.');
 	category = trimCategoryForGroup(category, groupId);
 	category = wordifyKey(category);
+
+	if (isLanguageTagSetting) {
+		key = key.replace(/[\[\]]/g, '');
+		key = '$(bracket) ' + key;
+	}
 
 	const label = wordifyKey(key);
 	return { category, label };

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -34,7 +34,8 @@ export enum SettingValueType {
 	NullableInteger = 'nullable-integer',
 	NullableNumber = 'nullable-number',
 	Object = 'object',
-	BooleanObject = 'boolean-object'
+	BooleanObject = 'boolean-object',
+	LanguageTag = 'language-tag'
 }
 
 export interface ISettingsGroup {
@@ -87,6 +88,7 @@ export interface ISetting {
 	allKeysAreBoolean?: boolean;
 	editPresentation?: EditPresentationTypes;
 	defaultValueSource?: string | IExtensionInfo;
+	isLanguageTagSetting?: boolean;
 }
 
 export interface IExtensionSetting extends ISetting {

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -676,6 +676,11 @@ export class DefaultSettings extends Disposable {
 					defaultValueSource = registeredConfigurationProp.defaultValueSource;
 				}
 
+				let isLanguageTagSetting = false;
+				if (OVERRIDE_PROPERTY_REGEX.test(key)) {
+					isLanguageTagSetting = true;
+				}
+
 				result.push({
 					key,
 					value,
@@ -707,7 +712,8 @@ export class DefaultSettings extends Disposable {
 					allKeysAreBoolean,
 					editPresentation: prop.editPresentation,
 					order: prop.order,
-					defaultValueSource
+					defaultValueSource,
+					isLanguageTagSetting
 				});
 			}
 		}


### PR DESCRIPTION
This PR helps with the language filter implementation in the Settings editor.

The PR changes the design of the display label, and adds some new metadata in the code to identify when a setting is a language tag setting. We still make those settings use the complex renderer, though.

Eventually, those settings should have links that allow language filters to be applied.

![Screenshot showing the new SCSS label, with a bracket codicon in front](https://user-images.githubusercontent.com/7199958/156847780-b111d805-8683-428f-8da8-8d2276aaadce.PNG)
