### PR TITLE
Fix `git` getBranch [v1.65.0]

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2010,10 +2010,10 @@ export class Repository {
 
 		let supportsAheadBehind = true;
 		if (this._git.compareGitVersionTo('1.9.0') === -1) {
-			args.push('--format=%(refname)%00%(upstream:short)%00%(objectname)');
+			args.push('--format=%(refname)%00%(upstream:remotename)%00%(upstream:remoteref)%00%(objectname)');
 			supportsAheadBehind = false;
 		} else {
-			args.push('--format=%(refname)%00%(upstream:short)%00%(objectname)%00%(upstream:track)');
+			args.push('--format=%(refname)%00%(upstream:remotename)%00%(upstream:remoteref)%00%(objectname)%00%(upstream:track)');
 		}
 
 		if (/^refs\/(head|remotes)\//i.test(name)) {
@@ -2024,11 +2024,10 @@ export class Repository {
 
 		const result = await this.exec(args);
 		const branches: Branch[] = result.stdout.trim().split('\n').map<Branch | undefined>(line => {
-			let [branchName, upstream, ref, status] = line.trim().split('\0');
+			let [branchName, remoteName, upstreamRef, ref, status] = line.trim().split('\0');
 
 			if (branchName.startsWith('refs/heads/')) {
 				branchName = branchName.substring(11);
-				const index = upstream.indexOf('/');
 
 				let ahead;
 				let behind;
@@ -2040,9 +2039,9 @@ export class Repository {
 				return {
 					type: RefType.Head,
 					name: branchName,
-					upstream: upstream ? {
-						name: upstream.substring(index + 1),
-						remote: upstream.substring(0, index)
+					upstream: remoteName && upstreamRef ? {
+						name: upstreamRef.substring(11),
+						remote: remoteName
 					} : undefined,
 					commit: ref || undefined,
 					ahead: Number(ahead) || 0,


### PR DESCRIPTION
Introduced with 6011bf7e7ad87a06908e9947fd5ccd948739f953 in v1.65.0

Git `getBranch` will return an invalid `upstreamRef` if the local branch name doesn't match the upstream one.

**Currently**
| Field |  |
| ----- | -------- |
| `refname` | refs/heads/`branch` |
| `upstream:short` | `remote-name`/`remote-branch-name` |
| `upstream.name` | `h-name` |
| `upstream.remote` | `remote-name/remote-bran` |

**New**
| Field | Example |
| ----- | -------- |
| `upstream:short` | `remote-name`/`remote-branch-name` |
| `upstream:remotename` | `remote-name` |
| `upstream:remoteref` | refs/heads/`remote-branch-name` |

https://git-scm.com/docs/git-for-each-ref#Documentation/git-for-each-ref.txt-upstream

/CC: @lszomoru