### PR TITLE
Fixes glob patterns `**/p*` incorrectly match on `/foo/ap`

### DIFF
--- a/src/vs/base/common/glob.ts
+++ b/src/vs/base/common/glob.ts
@@ -47,17 +47,18 @@ const PATH_REGEX = '[/\\\\]';		// any slash or backslash
 const NO_PATH_REGEX = '[^/\\\\]';	// any non-slash and non-backslash
 const ALL_FORWARD_SLASHES = /\//g;
 
-function starsToRegExp(starCount: number): string {
+function starsToRegExp(starCount: number, isLastPattern?: boolean): string {
 	switch (starCount) {
 		case 0:
 			return '';
 		case 1:
 			return `${NO_PATH_REGEX}*?`; // 1 star matches any number of characters except path separator (/ and \) - non greedy (?)
 		default:
-			// Matches:  (Path Sep OR Path Val followed by Path Sep OR Path Sep followed by Path Val) 0-many times
+			// Matches:  (Path Sep OR Path Val followed by Path Sep) 0-many times except when it's the last pattern
+			//           in which case also matches (Path Sep followed by Path Val)
 			// Group is non capturing because we don't need to capture at all (?:...)
 			// Overall we use non-greedy matching because it could be that we match too much
-			return `(?:${PATH_REGEX}|${NO_PATH_REGEX}+${PATH_REGEX}|${PATH_REGEX}${NO_PATH_REGEX}+)*?`;
+			return `(?:${PATH_REGEX}|${NO_PATH_REGEX}+${PATH_REGEX}${isLastPattern ? `|${PATH_REGEX}${NO_PATH_REGEX}+` : ''})*?`;
 	}
 }
 
@@ -135,7 +136,7 @@ function parseRegExp(pattern: string): string {
 					return;
 				}
 
-				regEx += starsToRegExp(2);
+				regEx += starsToRegExp(2, index === segments.length - 1);
 			}
 
 			// Anything else, not globstar

--- a/src/vs/base/test/common/glob.test.ts
+++ b/src/vs/base/test/common/glob.test.ts
@@ -725,7 +725,7 @@ suite('Glob', () => {
 		assert.strictEqual(glob.match(expr, 'foo.as'), null);
 	});
 
-	test.skip('expression with non-trivia glob (issue 144458)', function () {
+	test('expression with non-trivia glob (issue 144458)', function () {
 		let pattern = '**/p*';
 
 		assert.strictEqual(glob.match(pattern, 'foo/barp'), false);

--- a/src/vs/workbench/services/search/test/common/ignoreFile.test.ts
+++ b/src/vs/workbench/services/search/test/common/ignoreFile.test.ts
@@ -477,7 +477,7 @@ suite('Parsing .gitignore files', () => {
 		});
 
 		runTest({
-			pattern: `[._]*.s[a-w][a-z]
+			pattern: `[._]*s[a-w][a-z]
 			[._]s[a-w][a-z]
 			*.un~
 			*~`,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #144458
