### PR TITLE
fix markdownDescription for javascript.suggest.jsdoc.generateReturns

### DIFF
--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -77,7 +77,7 @@
 	"configuration.javascript.checkJs.experimentalDecorators.deprecation": "This setting has been deprecated in favor of `js/ts.implicitProjectConfig.experimentalDecorators`.",
 	"configuration.implicitProjectConfig.strictNullChecks": "Enable/disable [strict null checks](https://www.typescriptlang.org/tsconfig#strictNullChecks) in JavaScript and TypeScript files that are not part of a project. Existing `jsconfig.json` or `tsconfig.json` files override this setting.",
 	"configuration.implicitProjectConfig.strictFunctionTypes": "Enable/disable [strict function types](https://www.typescriptlang.org/tsconfig#strictFunctionTypes) in JavaScript and TypeScript files that are not part of a project. Existing `jsconfig.json` or `tsconfig.json` files override this setting.",
-	"configuration.suggest.jsdoc.generateReturns": "Enable/disable generating `@return` annotations for JSDoc templates. Requires using TypeScript 4.2+ in the workspace.",
+	"configuration.suggest.jsdoc.generateReturns": "Enable/disable generating `@returns` annotations for JSDoc templates. Requires using TypeScript 4.2+ in the workspace.",
 	"configuration.suggest.autoImports": "Enable/disable auto import suggestions.",
 	"inlayHints.parameterNames.none": "Disable parameter name hints.",
 	"inlayHints.parameterNames.literals": "Enable parameter name hints only for literal arguments.",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #

Fix description of `javascript.suggest.jsdoc.generateReturns` because it generates `@returns` not `@return`.