### PR TITLE
Fixes wrong extension running location shown in running extension editor

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
@@ -370,15 +370,15 @@ export abstract class AbstractRuntimeExtensionsEditor extends EditorPane {
 				}
 
 				let extraLabel: string | null = null;
-				if (element.description.extensionLocation.scheme === Schemas.vscodeRemote) {
+				if (element.status.runningLocation === ExtensionRunningLocation.LocalWebWorker) {
+					extraLabel = `$(globe) web worker`;
+				} else if (element.description.extensionLocation.scheme === Schemas.vscodeRemote) {
 					const hostLabel = this._labelService.getHostLabel(Schemas.vscodeRemote, this._environmentService.remoteAuthority);
 					if (hostLabel) {
 						extraLabel = `$(remote) ${hostLabel}`;
 					} else {
 						extraLabel = `$(remote) ${element.description.extensionLocation.authority}`;
 					}
-				} else if (element.status.runningLocation === ExtensionRunningLocation.LocalWebWorker) {
-					extraLabel = `$(globe) web worker`;
 				}
 
 				if (extraLabel) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #144527
