### PR TITLE
Fix regular expression for auto indent

### DIFF
--- a/extensions/javascript/tags-language-configuration.json
+++ b/extensions/javascript/tags-language-configuration.json
@@ -133,7 +133,7 @@
 				"pattern": "^>$"
 			},
 			"afterText": {
-				"pattern": "/^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>$",
+				"pattern": "^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>$",
 				"flags": "i"
 			},
 			"action": {


### PR DESCRIPTION
Fixes #144505

Removes a `/` that was mistakenly copied over when moving these rules to json
