### PR TITLE
Adds token to make 403s less likely when downloading ripgrep.

### DIFF
--- a/build/azure-pipelines/linux/product-build-linux-server.yml
+++ b/build/azure-pipelines/linux/product-build-linux-server.yml
@@ -48,6 +48,8 @@ steps:
         echo "Yarn failed $i, trying again..."
       done
     displayName: Install dependencies
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
     condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'x64'))
 
   - script: |


### PR DESCRIPTION
See failed attempts:

![image](https://user-images.githubusercontent.com/2931520/157264466-6ddaa443-848b-4772-9c26-200aac98f6cb.png)

https://dev.azure.com/monacotools/Monaco/_build/results?buildId=159595&view=logs&j=b0db4dbe-6d94-53f6-4aec-46348eae3866&t=984fc7b9-39fa-521c-8d23-363772216f68&s=df3a2a6a-32d9-53da-5bbf-a4da720f0bc7


Deleting invalid download cache
Downloading ripgrep failed: Error: Request failed: 403
    at ClientRequest.<anonymous> (/__w/1/s/remote/node_modules/@vscode/ripgrep/lib/download.js:143:24)