### PR TITLE
Fix link hover lifecycle problems

### DIFF
--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -417,7 +417,8 @@ export class ActivityActionViewItem extends BaseActionViewItem {
 			content: this.computeTitle(),
 			showPointer: true,
 			compact: true,
-			skipFadeInAnimation
+			hideOnKeyDown: true,
+			skipFadeInAnimation,
 		});
 	}
 

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -88,7 +88,10 @@ export class StatusbarPart extends Part implements IStatusbarService {
 		) { }
 
 		showHover(options: IHoverDelegateOptions, focus?: boolean): IHoverWidget | undefined {
-			return this.hoverService.showHover(options, focus);
+			return this.hoverService.showHover({
+				...options,
+				hideOnKeyDown: true
+			}, focus);
 		}
 
 		onDidHideHover(): void {

--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -109,10 +109,6 @@
 	position: relative;
 }
 
-.monaco-workbench .xterm .hoverHighlight {
-	pointer-events: none;
-}
-
 .monaco-workbench .editor-instance .terminal-wrapper > div,
 .monaco-workbench .pane-body.integrated-terminal .terminal-wrapper > div {
 	height: 100%;

--- a/src/vs/workbench/contrib/terminal/browser/media/widgets.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/widgets.css
@@ -5,20 +5,11 @@
 
 .monaco-workbench .terminal-widget-container {
 	position: absolute;
-	left: 10px;
-	bottom: 2px;
-	right: 10px;
+	left: 0;
+	bottom: 0;
+	right: 0;
 	top: 0;
 	overflow: visible;
-}
-
-.monaco-workbench .editor-instance .terminal-group .monaco-split-view2.horizontal .split-view-view:first-child .terminal-widget-container,
-.monaco-workbench .pane-body.integrated-terminal .terminal-group .monaco-split-view2.horizontal .split-view-view:first-child .terminal-widget-container {
-	left: 20px;
-}
-.monaco-workbench .editor-instance .terminal-group .monaco-split-view2.horizontal .split-view-view:last-child .terminal-widget-container,
-.monaco-workbench .pane-body.integrated-terminal .terminal-group .monaco-split-view2.horizontal .split-view-view:last-child .terminal-widget-container {
-	right: 20px;
 }
 
 .monaco-workbench .terminal-overlay-widget {

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -963,7 +963,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		// Attach the xterm object to the DOM, exposing it to the smoke tests
 		this._wrapperElement.xterm = xterm.raw;
 
-		xterm.attachToElement(xtermElement);
+		const screenElement = xterm.attachToElement(xtermElement);
 
 		if (!xterm.raw.element || !xterm.raw.textarea) {
 			throw new Error('xterm elements not set after open');
@@ -1089,7 +1089,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 		this._initDragAndDrop(container);
 
-		this._widgetManager.attachToElement(xterm.raw.element);
+		this._widgetManager.attachToElement(screenElement);
 		this._processManager.onProcessReady((e) => {
 			this._linkManager?.setWidgetManager(this._widgetManager);
 		});

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -167,7 +167,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 		this.raw.loadAddon(this._decorationAddon);
 	}
 
-	attachToElement(container: HTMLElement) {
+	attachToElement(container: HTMLElement): HTMLElement {
 		// Update the theme when attaching as the terminal location could have changed
 		this._updateTheme();
 		if (!this._container) {
@@ -177,6 +177,8 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 		if (this._shouldLoadWebgl()) {
 			this._enableWebglRenderer();
 		}
+		// Screen must be created at this point as xterm.open is called
+		return this._container.querySelector('.xterm-screen')!;
 	}
 
 	updateConfig(): void {

--- a/src/vs/workbench/services/hover/browser/hover.ts
+++ b/src/vs/workbench/services/hover/browser/hover.ts
@@ -68,7 +68,7 @@ export interface IHoverOptions {
 	additionalClasses?: string[];
 
 	/**
-	 * An optional  link handler for markdown links, if this is not provided the IOpenerService will
+	 * An optional link handler for markdown links, if this is not provided the IOpenerService will
 	 * be used to open the links using its default options.
 	 */
 	linkHandler?(url: string): void;
@@ -84,6 +84,11 @@ export interface IHoverOptions {
 	 * - Markdown that contains no links where selection is not important
 	 */
 	hideOnHover?: boolean;
+
+	/**
+	 * Whether to hide the hover when a key is pressed.
+	 */
+	hideOnKeyDown?: boolean;
 
 	/**
 	 * Position of the hover. The default is to show above the target. This option will be ignored

--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -50,9 +50,11 @@ export class HoverService implements IHoverService {
 		} else {
 			hoverDisposables.add(addDisposableListener(options.target, EventType.CLICK, () => this.hideHover()));
 		}
-		const focusedElement = <HTMLElement | null>document.activeElement;
-		if (focusedElement) {
-			hoverDisposables.add(addDisposableListener(focusedElement, EventType.KEY_DOWN, () => this.hideHover()));
+		if (options.hideOnKeyDown) {
+			const focusedElement = document.activeElement;
+			if (focusedElement) {
+				hoverDisposables.add(addDisposableListener(focusedElement, EventType.KEY_DOWN, () => this.hideHover()));
+			}
 		}
 
 		if ('IntersectionObserver' in window) {


### PR DESCRIPTION
- The mouse no longer needs to hover the tooltip to hide the link hover/target, this
  was fixed by having the widget container live under xterm.js' screen element instead
  of element. This ensures the events bubble in the right order and have the link get
  hidden by xterm.js (vscode link widget -> xterm.js link [listening to screen]).
- Don't hide the hover when a modifier was pressed. This regressed in #128362 because
  the behavior is desirable in the activity bar/status bar.

There is still a remaining issue where hovering a link, mousing over the
tooltip and then back to the link will not allow link activation. This
is hard to reproduce and I believe it's a bug in xterm.js somewhere.

Fixes #143982
Fixes #144583
