### PR TITLE
Fix smart select when no extension provider is registered

### DIFF
--- a/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
+++ b/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
@@ -79,9 +79,6 @@ class SmartSelectController implements IEditorContribution {
 
 		const selections = this._editor.getSelections();
 		const model = this._editor.getModel();
-		if (!this._languageFeaturesService.selectionRangeProvider.has(model)) {
-			return;
-		}
 
 		if (!this._state) {
 


### PR DESCRIPTION
With https://github.com/microsoft/vscode/commit/05a6debf1838c3b54ac36570392d0e8ac0fa739b no more static registration of smart selector providers is happening. This affected the word-based default provider which is now added [after querying the registry](https://github.com/microsoft/vscode/blob/2fd67d3f5288e0e143d849825082fec6afd1c726/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts#L216). However, that means we cannot return early when no provider is registered anymore.  