### PR TITLE
Git - remote incorrect if local/remote branch name does not match

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2028,6 +2028,7 @@ export class Repository {
 
 			if (branchName.startsWith('refs/heads/')) {
 				branchName = branchName.substring(11);
+				const index = upstream.indexOf('/');
 
 				let ahead;
 				let behind;
@@ -2040,8 +2041,8 @@ export class Repository {
 					type: RefType.Head,
 					name: branchName,
 					upstream: upstream ? {
-						name: upstream.substring(upstream.length - branchName.length),
-						remote: upstream.substring(0, upstream.length - branchName.length - 1)
+						name: upstream.substring(index + 1),
+						remote: upstream.substring(0, index)
 					} : undefined,
 					commit: ref || undefined,
 					ahead: Number(ahead) || 0,


### PR DESCRIPTION
This reverts commit 6011bf7e7ad87a06908e9947fd5ccd948739f953.