### PR TITLE
include 'create notebook' in the command pallette

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -31,7 +31,9 @@
 		"commands": [
 			{
 				"command": "ipynb.newUntitledIpynb",
-				"title": "Jupyter Notebook"
+        "title": "New Jupyter Notebook",
+				"shortTitle": "Jupyter Notebook",
+        "category": "Create"
 			},
 			{
 				"command": "ipynb.openIpynbInNotebookEditor",
@@ -53,15 +55,13 @@
 		"menus": {
 			"file/newFile": [
 				{
-					"command": "ipynb.newUntitledIpynb",
-					"when": "!jupyterEnabled"
+					"command": "ipynb.newUntitledIpynb"
 				}
 			],
 			"commandPalette": [
-				{
-					"command": "ipynb.newUntitledIpynb",
-					"when": "false"
-				},
+        {
+          "command": "ipynb.newUntitledIpynb"
+        },
 				{
 					"command": "ipynb.openIpynbInNotebookEditor",
 					"when": "false"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Part of https://github.com/microsoft/vscode-jupyter/issues/9250 and should be coordinated with the related PR in the Jupyter extension.

- The short title is used in the "new file..." menu, this is how the jupyter extension was adding the commands.
- I added the category "Create" to be consistent with `Create: New File...` so that it reads `Create: New Jupyter Notebook`
