### PR TITLE
Disable multiroot workspace support context key in desktop virtual filesystem

### DIFF
--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -155,10 +155,10 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		// is driven by the ability to resolve a workspace configuration file (*.code-workspace)
 		// with a built-in file system provider.
 		// This condition is met:
-		// - desktop: always
+		// - desktop: when not in a virtual workspace
 		// -     web: only when connected to a remote
 		this.enterMultiRootWorkspaceSupportContext = EnterMultiRootWorkspaceSupportContext.bindTo(this.contextKeyService);
-		this.enterMultiRootWorkspaceSupportContext.set(isNative || typeof this.environmentService.remoteAuthority === 'string');
+		this.enterMultiRootWorkspaceSupportContext.set(isNative && this.virtualWorkspaceContext.get() === '' || typeof this.environmentService.remoteAuthority === 'string');
 
 		// Editor Layout
 		this.splitEditorsVerticallyContext = SplitEditorsVertically.bindTo(this.contextKeyService);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/144702

This context key is already `false` in RemoteHub repos on web--it should also be `false` in RemoteHub repos on desktop. (In theory we could support Add Folder to Workspace from RemoteHub, but I think we may want more use cases before investing in this scenario.)

With this change in OSS + RemoteHub:
![image](https://user-images.githubusercontent.com/30305945/157697083-c59df611-2f47-4b9d-9143-0b3eeb09e4e1.png)

Without this change in OSS + RemoteHub:
![image](https://user-images.githubusercontent.com/30305945/157697138-e22a0940-632f-4c78-9aba-29d3fb0273e9.png)

