### PR TITLE
Fix Socks5 Proxy Regex Checking Warning

### DIFF
--- a/src/vs/platform/request/common/request.ts
+++ b/src/vs/platform/request/common/request.ts
@@ -87,7 +87,7 @@ function registerProxyConfigurations(scope: ConfigurationScope): void {
 		properties: {
 			'http.proxy': {
 				type: 'string',
-				pattern: '^https?://([^:]*(:[^@]*)?@)?([^:]+|\\[[:0-9a-fA-F]+\\])(:\\d+)?/?$|^$',
+				pattern: '^(https?|socks5?)://([^:]*(:[^@]*)?@)?([^:]+|\\[[:0-9a-fA-F]+\\])(:\\d+)?/?$|^$',
 				markdownDescription: localize('proxy', "The proxy setting to use. If not set, will be inherited from the `http_proxy` and `https_proxy` environment variables."),
 				restricted: true
 			},


### PR DESCRIPTION
## Socks5 proxy was supported in #9971 and  #27838
## but the settings warning wasn't updated.

### Before the PR
<img width="443" alt="Jietu20220312-201129" src="https://user-images.githubusercontent.com/7548568/158020362-2362f323-b785-4ba8-b1c6-c7c11d9edb14.png">

### After the PR
<img width="470" alt="Jietu20220312-213641" src="https://user-images.githubusercontent.com/7548568/158020379-05450e3c-fcac-4177-8aa8-2e7ee25a3b15.png">
<img width="464" alt="Jietu20220312-213717" src="https://user-images.githubusercontent.com/7548568/158020400-48a76900-24ff-4cbb-88b5-1d2cc5b11aa4.png">

