### PR TITLE
feat: gitExtension API also expose repository.revert()

### DIFF
--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -108,6 +108,10 @@ export class ApiRepository implements Repository {
 		return this._repository.add(paths.map(p => Uri.file(p)));
 	}
 
+	revert(paths: string[]) {
+		return this._repository.revert(paths.map(p => Uri.file(p)));
+	}
+
 	clean(paths: string[]) {
 		return this._repository.clean(paths.map(p => Uri.file(p)));
 	}

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -173,6 +173,7 @@ export interface Repository {
 	getCommit(ref: string): Promise<Commit>;
 
 	add(paths: string[]): Promise<void>;
+	revert(paths: string[]): Promise<void>;
 	clean(paths: string[]): Promise<void>;
 
 	apply(patch: string, reverse?: boolean): Promise<void>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #145028 

idk if there is any argument for not exposing it. i just stumbled upon this, while building an extension, that uses this API.