### PR TITLE
Language filter initial draft

### DIFF
--- a/src/vs/platform/configuration/common/configuration.ts
+++ b/src/vs/platform/configuration/common/configuration.ts
@@ -290,3 +290,7 @@ export function getMigratedSettingValue<T>(configurationService: IConfigurationS
 		return setting.defaultValue!;
 	}
 }
+
+export function getLanguageTagSettingPlainKey(settingKey: string) {
+	return settingKey.replace(/[\[\]]/g, '');
+}

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -9,6 +9,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as types from 'vs/base/common/types';
 import * as nls from 'vs/nls';
+import { getLanguageTagSettingPlainKey } from 'vs/platform/configuration/common/configuration';
 import { Extensions as JSONExtensions, IJSONContributionRegistry } from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
 
@@ -292,7 +293,7 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 				if (OVERRIDE_PROPERTY_REGEX.test(key)) {
 					const defaultValue = { ...(this.configurationDefaultsOverrides.get(key)?.value || {}), ...overrides[key] };
 					this.configurationDefaultsOverrides.set(key, { source, value: defaultValue });
-					const plainKey = key.replace(/[\[\]]/g, '');
+					const plainKey = getLanguageTagSettingPlainKey(key);
 					const property: IRegisteredConfigurationPropertySchema = {
 						type: 'object',
 						default: defaultValue,

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -43,7 +43,7 @@ import { commonlyUsedData, tocData } from 'vs/workbench/contrib/preferences/brow
 import { AbstractSettingRenderer, HeightChangeParams, ISettingLinkClickEvent, ISettingOverrideClickEvent, resolveConfiguredUntrustedSettings, createTocTreeForExtensionSettings, resolveSettingsTree, SettingsTree, SettingTreeRenderers } from 'vs/workbench/contrib/preferences/browser/settingsTree';
 import { ISettingsEditorViewState, parseQuery, SearchResultIdx, SearchResultModel, SettingsTreeElement, SettingsTreeGroupChild, SettingsTreeGroupElement, SettingsTreeModel, SettingsTreeSettingElement } from 'vs/workbench/contrib/preferences/browser/settingsTreeModels';
 import { createTOCIterator, TOCTree, TOCTreeModel } from 'vs/workbench/contrib/preferences/browser/tocTree';
-import { CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_ROW_FOCUS, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, EXTENSION_SETTING_TAG, FEATURE_SETTING_TAG, ID_SETTING_TAG, IPreferencesSearchService, ISearchProvider, LANGUAGE_SETTING_TAG, MODIFIED_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, WORKSPACE_TRUST_SETTING_TAG } from 'vs/workbench/contrib/preferences/common/preferences';
+import { CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_ROW_FOCUS, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, ENABLE_LANGUAGE_FILTER, EXTENSION_SETTING_TAG, FEATURE_SETTING_TAG, ID_SETTING_TAG, IPreferencesSearchService, ISearchProvider, LANGUAGE_SETTING_TAG, MODIFIED_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, WORKSPACE_TRUST_SETTING_TAG } from 'vs/workbench/contrib/preferences/common/preferences';
 import { settingsHeaderBorder, settingsSashBorder, settingsTextInputBorder } from 'vs/workbench/contrib/preferences/common/settingsEditorColorRegistry';
 import { IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IOpenSettingsOptions, IPreferencesService, ISearchResult, ISettingsEditorModel, ISettingsEditorOptions, SettingMatchType, SettingValueType, validateSettingsEditorOptions } from 'vs/workbench/services/preferences/common/preferences';
@@ -99,7 +99,7 @@ export class SettingsEditor2 extends EditorPane {
 	private static NARROW_TOTAL_WIDTH: number = SettingsEditor2.TOC_MIN_WIDTH + SettingsEditor2.EDITOR_MIN_WIDTH;
 	private static MEDIUM_TOTAL_WIDTH: number = 1000;
 
-	private static readonly SUGGESTIONS: string[] = [
+	private static SUGGESTIONS: string[] = [
 		`@${MODIFIED_SETTING_TAG}`,
 		'@tag:notebookLayout',
 		`@tag:${REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG}`,
@@ -109,7 +109,6 @@ export class SettingsEditor2 extends EditorPane {
 		'@tag:telemetry',
 		`@${ID_SETTING_TAG}`,
 		`@${EXTENSION_SETTING_TAG}`,
-		`@${LANGUAGE_SETTING_TAG}`,
 		`@${FEATURE_SETTING_TAG}scm`,
 		`@${FEATURE_SETTING_TAG}explorer`,
 		`@${FEATURE_SETTING_TAG}search`,
@@ -262,6 +261,10 @@ export class SettingsEditor2 extends EditorPane {
 		}));
 
 		this.modelDisposables = this._register(new DisposableStore());
+
+		if (ENABLE_LANGUAGE_FILTER && !SettingsEditor2.SUGGESTIONS.includes(`@${LANGUAGE_SETTING_TAG}`)) {
+			SettingsEditor2.SUGGESTIONS.push(`@${LANGUAGE_SETTING_TAG}`);
+		}
 	}
 
 	override get minimumWidth(): number { return SettingsEditor2.EDITOR_MIN_WIDTH; }

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -30,7 +30,7 @@ import { isArray, isDefined, isUndefinedOrNull } from 'vs/base/common/types';
 import { localize } from 'vs/nls';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { ConfigurationTarget, getLanguageTagSettingPlainKey, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
@@ -391,9 +391,9 @@ export function resolveSettingsTree(tocData: ITOCEntry<string>, coreSettingsGrou
 	};
 }
 
-export function resolveConfiguredUntrustedSettings(groups: ISettingsGroup[], target: SettingsTarget, configurationService: IWorkbenchConfigurationService): ISetting[] {
+export function resolveConfiguredUntrustedSettings(groups: ISettingsGroup[], target: SettingsTarget, languageFilters: Set<string> | undefined, configurationService: IWorkbenchConfigurationService): ISetting[] {
 	const allSettings = getFlatSettings(groups);
-	return [...allSettings].filter(setting => setting.restricted && inspectSetting(setting.key, target, configurationService).isConfigured);
+	return [...allSettings].filter(setting => setting.restricted && inspectSetting(setting.key, target, languageFilters, configurationService).isConfigured);
 }
 
 function compareNullableIntegers(a?: number, b?: number) {
@@ -738,6 +738,9 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 	protected readonly _onDidChangeSettingHeight = this._register(new Emitter<HeightChangeParams>());
 	readonly onDidChangeSettingHeight: Event<HeightChangeParams> = this._onDidChangeSettingHeight.event;
 
+	protected readonly _onApplyLanguageFilter = this._register(new Emitter<string>());
+	readonly onApplyLanguageFilter: Event<string> = this._onApplyLanguageFilter.event;
+
 	private readonly markdownRenderer: MarkdownRenderer;
 
 	constructor(
@@ -846,7 +849,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		const toolbar = new ToolBar(container, this._contextMenuService, {
 			toggleMenuTitle,
 			renderDropdownAsChildElement: !isIOS,
-			moreIcon: settingsMoreActionIcon // change icon from ellipsis to gear
+			moreIcon: settingsMoreActionIcon
 		});
 		return toolbar;
 	}
@@ -1046,8 +1049,7 @@ export class SettingComplexRenderer extends AbstractSettingRenderer implements I
 
 		const openSettingsButton = new Button(common.controlElement, { title: true, buttonBackground: undefined, buttonHoverBackground: undefined });
 		common.toDispose.add(openSettingsButton);
-		common.toDispose.add(openSettingsButton.onDidClick(() => template.onChange!()));
-		openSettingsButton.label = SettingComplexRenderer.EDIT_IN_JSON_LABEL;
+
 		openSettingsButton.element.classList.add('edit-in-settings-button');
 		openSettingsButton.element.classList.add(AbstractSettingRenderer.CONTROL_CLASS);
 
@@ -1076,10 +1078,28 @@ export class SettingComplexRenderer extends AbstractSettingRenderer implements I
 	}
 
 	protected renderValue(dataElement: SettingsTreeSettingElement, template: ISettingComplexItemTemplate, onChange: (value: string) => void): void {
-		template.onChange = () => this._onDidOpenSettings.fire(dataElement.setting.key);
+		const plainKey = getLanguageTagSettingPlainKey(dataElement.setting.key);
+		const editLanguageSettingLabel = localize('editLanguageSettingLabel', "Edit settings for {0}", plainKey);
+		const isLanguageTagSetting = dataElement.setting.isLanguageTagSetting;
+		template.button.label = isLanguageTagSetting
+			? editLanguageSettingLabel
+			: SettingComplexRenderer.EDIT_IN_JSON_LABEL;
+
+		template.elementDisposables.add(template.button.onDidClick(() => {
+			if (isLanguageTagSetting) {
+				this._onApplyLanguageFilter.fire(plainKey);
+			} else {
+				this._onDidOpenSettings.fire(dataElement.setting.key);
+			}
+		}));
+
 		this.renderValidations(dataElement, template);
 
-		template.button.element.setAttribute('aria-label', `${SettingComplexRenderer.EDIT_IN_JSON_LABEL}: ${dataElement.setting.key}`);
+		if (isLanguageTagSetting) {
+			template.button.element.setAttribute('aria-label', editLanguageSettingLabel);
+		} else {
+			template.button.element.setAttribute('aria-label', `${SettingComplexRenderer.EDIT_IN_JSON_LABEL}: ${dataElement.setting.key}`);
+		}
 	}
 
 	private renderValidations(dataElement: SettingsTreeSettingElement, template: ISettingComplexItemTemplate) {
@@ -1892,6 +1912,8 @@ export class SettingTreeRenderers {
 
 	readonly onDidChangeSettingHeight: Event<HeightChangeParams>;
 
+	readonly onApplyLanguageFilter: Event<string>;
+
 	readonly allRenderers: ITreeRenderer<SettingsTreeElement, never, any>[];
 
 	private readonly settingActions: IAction[];
@@ -1939,6 +1961,7 @@ export class SettingTreeRenderers {
 		this.onDidClickSettingLink = Event.any(...settingRenderers.map(r => r.onDidClickSettingLink));
 		this.onDidFocusSetting = Event.any(...settingRenderers.map(r => r.onDidFocusSetting));
 		this.onDidChangeSettingHeight = Event.any(...settingRenderers.map(r => r.onDidChangeSettingHeight));
+		this.onApplyLanguageFilter = Event.any(...settingRenderers.map(r => r.onApplyLanguageFilter));
 
 		this.allRenderers = [
 			...settingRenderers,

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -391,9 +391,9 @@ export function resolveSettingsTree(tocData: ITOCEntry<string>, coreSettingsGrou
 	};
 }
 
-export function resolveConfiguredUntrustedSettings(groups: ISettingsGroup[], target: SettingsTarget, languageFilters: Set<string> | undefined, configurationService: IWorkbenchConfigurationService): ISetting[] {
+export function resolveConfiguredUntrustedSettings(groups: ISettingsGroup[], target: SettingsTarget, languageFilter: string | undefined, configurationService: IWorkbenchConfigurationService): ISetting[] {
 	const allSettings = getFlatSettings(groups);
-	return [...allSettings].filter(setting => setting.restricted && inspectSetting(setting.key, target, languageFilters, configurationService).isConfigured);
+	return [...allSettings].filter(setting => setting.restricted && inspectSetting(setting.key, target, languageFilter, configurationService).isConfigured);
 }
 
 function compareNullableIntegers(a?: number, b?: number) {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -549,17 +549,20 @@ export function inspectSetting(key: string, target: SettingsTarget, languageFilt
 
 	const overrideIdentifiers = inspected.overrideIdentifiers;
 	const inspectedLanguageOverrides = new Map<string, IConfigurationValue<unknown>>();
+
+	// We must reset isConfigured to be false if languageFilter is set, and manually
+	// determine whether it can be set to true later.
+	if (languageFilter) {
+		isConfigured = false;
+	}
 	if (overrideIdentifiers) {
 		// The setting we're looking at has language overrides.
 		for (const overrideIdentifier of overrideIdentifiers) {
 			inspectedLanguageOverrides.set(overrideIdentifier, configurationService.inspect(key, { overrideIdentifier }));
 		}
 
-		// If we're viewing a setting under a language filter, pretend it's
-		// not configured again.
 		// For all language filters, see if there's an override for that filter.
 		if (languageFilter) {
-			isConfigured = false;
 			if (inspectedLanguageOverrides.has(languageFilter)) {
 				const overrideValue = inspectedLanguageOverrides.get(languageFilter)![targetOverrideSelector]?.override;
 				if (typeof overrideValue !== 'undefined') {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -211,17 +211,14 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 			}
 		}
 
-		if (languageSelector) {
-			// We have a language filter in this case.
-			if (this.languageOverrideValues.has(languageSelector)) {
-				const overrideValues = this.languageOverrideValues.get(languageSelector)!;
-				// In the worst case, go back to using the previous display value.
-				// Also, sometimes the override is in the form of a default value override, so consider that second.
-				displayValue = overrideValues[targetSelector] ?? overrideValues.defaultValue ?? displayValue;
-				this.value = displayValue;
-				this.scopeValue = isConfigured && overrideValues[targetSelector];
-				this.defaultValue = overrideValues.defaultValue ?? inspected.defaultValue;
-			}
+		if (languageSelector && this.languageOverrideValues.has(languageSelector)) {
+			const overrideValues = this.languageOverrideValues.get(languageSelector)!;
+			// In the worst case, go back to using the previous display value.
+			// Also, sometimes the override is in the form of a default value override, so consider that second.
+			displayValue = (isConfigured ? overrideValues[targetSelector] : overrideValues.defaultValue) ?? displayValue;
+			this.value = displayValue;
+			this.scopeValue = isConfigured && overrideValues[targetSelector];
+			this.defaultValue = overrideValues.defaultValue ?? inspected.defaultValue;
 		} else {
 			this.value = displayValue;
 			this.scopeValue = isConfigured && inspected[targetSelector];

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -11,7 +11,7 @@ import { localize } from 'vs/nls';
 import { ConfigurationTarget, IConfigurationValue } from 'vs/platform/configuration/common/configuration';
 import { SettingsTarget } from 'vs/workbench/contrib/preferences/browser/preferencesWidgets';
 import { ITOCEntry, knownAcronyms, knownTermMappings, tocData } from 'vs/workbench/contrib/preferences/browser/settingsLayout';
-import { MODIFIED_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG } from 'vs/workbench/contrib/preferences/common/preferences';
+import { ENABLE_LANGUAGE_FILTER, MODIFIED_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG } from 'vs/workbench/contrib/preferences/common/preferences';
 import { IExtensionSetting, ISearchResult, ISetting, SettingValueType } from 'vs/workbench/services/preferences/common/preferences';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { FOLDER_SCOPES, WORKSPACE_SCOPES, REMOTE_MACHINE_SCOPES, LOCAL_MACHINE_SCOPES, IWorkbenchConfigurationService } from 'vs/workbench/services/configuration/common/configuration';
@@ -892,7 +892,11 @@ export function parseQuery(query: string): IParsedQuery {
 	query = getTagsForType(query, extensionRegex, extensions);
 	query = getTagsForType(query, featureRegex, features);
 	query = getTagsForType(query, idRegex, ids);
-	query = getTagsForType(query, languageRegex, langs);
+
+	if (ENABLE_LANGUAGE_FILTER) {
+		query = getTagsForType(query, languageRegex, langs);
+	}
+
 	query = query.trim();
 
 	// For now, only return the first found language filter

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -147,14 +147,13 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 		setting: ISetting,
 		parent: SettingsTreeGroupElement,
 		inspectResult: IInspectResult,
-		isWorkspaceTrusted: boolean,
-		configurationService: IWorkbenchConfigurationService
+		isWorkspaceTrusted: boolean
 	) {
 		super(sanitizeId(parent.id + '_' + setting.key));
 		this.setting = setting;
 		this.parent = parent;
 
-		this.update(inspectResult, isWorkspaceTrusted, configurationService);
+		this.update(inspectResult, isWorkspaceTrusted);
 	}
 
 	get displayCategory(): string {
@@ -179,7 +178,7 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 		this._displayCategory = displayKeyFormat.category;
 	}
 
-	update(inspectResult: IInspectResult, isWorkspaceTrusted: boolean, configurationService: IWorkbenchConfigurationService): void {
+	update(inspectResult: IInspectResult, isWorkspaceTrusted: boolean): void {
 		const { isConfigured, inspected, targetSelector, inspectedLanguageOverrides, languageSelectors } = inspectResult;
 
 		switch (targetSelector) {
@@ -462,7 +461,7 @@ export class SettingsTreeModel {
 	private updateSettings(settings: SettingsTreeSettingElement[]): void {
 		settings.forEach(element => {
 			const inspectResult = inspectSetting(element.setting.key, this._viewState.settingsTarget, this._viewState.languageFilters, this._configurationService);
-			element.update(inspectResult, this._isWorkspaceTrusted, this._configurationService);
+			element.update(inspectResult, this._isWorkspaceTrusted);
 		});
 	}
 
@@ -498,7 +497,7 @@ export class SettingsTreeModel {
 
 	private createSettingsTreeSettingElement(setting: ISetting, parent: SettingsTreeGroupElement): SettingsTreeSettingElement {
 		const inspectResult = inspectSetting(setting.key, this._viewState.settingsTarget, this._viewState.languageFilters, this._configurationService);
-		const element = new SettingsTreeSettingElement(setting, parent, inspectResult, this._isWorkspaceTrusted, this._configurationService);
+		const element = new SettingsTreeSettingElement(setting, parent, inspectResult, this._isWorkspaceTrusted);
 
 		const nameElements = this._treeElementsBySettingName.get(setting.key) || [];
 		nameElements.push(element);

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -75,6 +75,7 @@ export const MODIFIED_SETTING_TAG = 'modified';
 export const EXTENSION_SETTING_TAG = 'ext:';
 export const FEATURE_SETTING_TAG = 'feature:';
 export const ID_SETTING_TAG = 'id:';
+export const LANGUAGE_SETTING_TAG = 'lang:';
 export const WORKSPACE_TRUST_SETTING_TAG = 'workspaceTrust';
 export const REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG = 'requireTrustedWorkspace';
 export const KEYBOARD_LAYOUT_OPEN_PICKER = 'workbench.action.openKeyboardLayoutPicker';

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -79,3 +79,5 @@ export const LANGUAGE_SETTING_TAG = 'lang:';
 export const WORKSPACE_TRUST_SETTING_TAG = 'workspaceTrust';
 export const REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG = 'requireTrustedWorkspace';
 export const KEYBOARD_LAYOUT_OPEN_PICKER = 'workbench.action.openKeyboardLayoutPicker';
+
+export const ENABLE_LANGUAGE_FILTER = true;

--- a/src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts
@@ -324,7 +324,7 @@ suite('SettingsTree', () => {
 				featureFilters: [],
 				query: '',
 				idFilters: [],
-				languageFilters: ['cpp', 'python']
+				languageFilters: ['cpp']
 			});
 	});
 });

--- a/src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts
@@ -150,7 +150,7 @@ suite('SettingsTree', () => {
 				query: '',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -161,7 +161,7 @@ suite('SettingsTree', () => {
 				query: '',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -172,7 +172,7 @@ suite('SettingsTree', () => {
 				query: '',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -183,7 +183,7 @@ suite('SettingsTree', () => {
 				query: 'foo',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -194,7 +194,7 @@ suite('SettingsTree', () => {
 				query: '',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -205,7 +205,7 @@ suite('SettingsTree', () => {
 				query: 'my query',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -216,7 +216,7 @@ suite('SettingsTree', () => {
 				query: 'test  query',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -227,7 +227,7 @@ suite('SettingsTree', () => {
 				query: 'test',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -238,7 +238,7 @@ suite('SettingsTree', () => {
 				query: 'query has @ for some reason',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -249,7 +249,7 @@ suite('SettingsTree', () => {
 				query: '',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -260,7 +260,7 @@ suite('SettingsTree', () => {
 				query: '',
 				featureFilters: [],
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 		testParseQuery(
 			'@feature:scm',
@@ -270,7 +270,7 @@ suite('SettingsTree', () => {
 				featureFilters: ['scm'],
 				query: '',
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -281,7 +281,7 @@ suite('SettingsTree', () => {
 				featureFilters: ['scm', 'terminal'],
 				query: '',
 				idFilters: [],
-				languageFilters: []
+				languageFilter: undefined
 			});
 		testParseQuery(
 			'@id:files.autoSave',
@@ -291,7 +291,7 @@ suite('SettingsTree', () => {
 				featureFilters: [],
 				query: '',
 				idFilters: ['files.autoSave'],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -302,7 +302,7 @@ suite('SettingsTree', () => {
 				featureFilters: [],
 				query: '',
 				idFilters: ['files.autoSave', 'terminal.integrated.commandsToSkipShell'],
-				languageFilters: []
+				languageFilter: undefined
 			});
 
 		testParseQuery(
@@ -313,7 +313,7 @@ suite('SettingsTree', () => {
 				featureFilters: [],
 				query: '',
 				idFilters: [],
-				languageFilters: ['cpp']
+				languageFilter: 'cpp'
 			});
 
 		testParseQuery(
@@ -324,7 +324,7 @@ suite('SettingsTree', () => {
 				featureFilters: [],
 				query: '',
 				idFilters: [],
-				languageFilters: ['cpp']
+				languageFilter: 'cpp'
 			});
 	});
 });

--- a/src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts
@@ -149,7 +149,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				query: '',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -159,7 +160,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				query: '',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -169,7 +171,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				query: '',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -179,7 +182,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				query: 'foo',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -189,7 +193,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				query: '',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -199,7 +204,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				query: 'my query',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -209,7 +215,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				query: 'test  query',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -219,7 +226,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				query: 'test',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -229,7 +237,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				query: 'query has @ for some reason',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -239,7 +248,8 @@ suite('SettingsTree', () => {
 				extensionFilters: ['github.vscode-pull-request-github'],
 				query: '',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -249,7 +259,8 @@ suite('SettingsTree', () => {
 				extensionFilters: ['github.vscode-pull-request-github', 'vscode.git'],
 				query: '',
 				featureFilters: [],
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 		testParseQuery(
 			'@feature:scm',
@@ -258,7 +269,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				featureFilters: ['scm'],
 				query: '',
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -268,7 +280,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				featureFilters: ['scm', 'terminal'],
 				query: '',
-				idFilters: []
+				idFilters: [],
+				languageFilters: []
 			});
 		testParseQuery(
 			'@id:files.autoSave',
@@ -277,7 +290,8 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				featureFilters: [],
 				query: '',
-				idFilters: ['files.autoSave']
+				idFilters: ['files.autoSave'],
+				languageFilters: []
 			});
 
 		testParseQuery(
@@ -287,7 +301,30 @@ suite('SettingsTree', () => {
 				extensionFilters: [],
 				featureFilters: [],
 				query: '',
-				idFilters: ['files.autoSave', 'terminal.integrated.commandsToSkipShell']
+				idFilters: ['files.autoSave', 'terminal.integrated.commandsToSkipShell'],
+				languageFilters: []
+			});
+
+		testParseQuery(
+			'@lang:cpp',
+			<IParsedQuery>{
+				tags: [],
+				extensionFilters: [],
+				featureFilters: [],
+				query: '',
+				idFilters: [],
+				languageFilters: ['cpp']
+			});
+
+		testParseQuery(
+			'@lang:cpp,python',
+			<IParsedQuery>{
+				tags: [],
+				extensionFilters: [],
+				featureFilters: [],
+				query: '',
+				idFilters: [],
+				languageFilters: ['cpp', 'python']
 			});
 	});
 });


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/issues/131707

## Summary

This PR adds an initial draft of the language filter:
- `@lang:` is suggested in the search widget
- `@lang:langId` shows all language-overridable settings, but the values shown correspond to either the default setting value, or the language-specific setting value. TODO: determine whether we are showing/can show the language-specific overridden default value whenever it shows up.
- When a language filter has multiple languages set, we only read the first one for now to determine which language to filter by
- When a setting is modified while a language filter is set, the setting is modified as a language-specific setting value for the given language
- When a setting is modified while a language filter is set (even when outside of the workspace scope), the setting remains in the Settings editor JSON file until the user explicitly resets it. This change makes it easier to debug the feature, but I'm not sure how necessary it is.

## Demo

![Language filter demo screencap](https://user-images.githubusercontent.com/7199958/158274636-486840c7-b11f-42ae-8fc3-84f792b08a62.gif)

