### PR TITLE
Save input box on a remote window has weird suggestion for file name when closing an untitled file

### DIFF
--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -576,7 +576,7 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 				// of untitled model if it is a valid path name,
 				// otherwise fallback to `basename`.
 				let untitledName = model.name;
-				if (!(await this.pathService.hasValidBasename(joinPath(defaultFilePath, untitledName)))) {
+				if (!(await this.pathService.hasValidBasename(joinPath(defaultFilePath, untitledName), untitledName))) {
 					untitledName = basename(resource);
 				}
 


### PR DESCRIPTION
Fixes #144822
