### PR TITLE
Add gap above Settings editor split view

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -137,6 +137,10 @@
 	box-sizing: border-box;
 }
 
+.settings-editor > .settings-body > .monaco-split-view2 {
+	margin-top: 14px;
+}
+
 .settings-editor.no-results > .settings-body .settings-toc-container,
 .settings-editor.no-results > .settings-body .settings-tree-container {
 	display: none;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/143771

This PR adds a gap above the Settings editor split view.
Note that the shadows now occur at a different height than the settings scope widget underline.

![Screencap showing the fix](https://user-images.githubusercontent.com/7199958/158412712-bd0cc5dc-19b4-4a76-8c10-faf923882c8e.gif)

