### PR TITLE
Restrict additionalProperties of typescript.tsserver.watchOptions setting

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -1151,7 +1151,8 @@
               "type": "boolean",
               "description": "%configuration.tsserver.watchOptions.synchronousWatchDirectory%"
             }
-          }
+          },
+          "additionalProperties": false
         },
         "typescript.workspaceSymbols.scope": {
           "type": "string",


### PR DESCRIPTION
By restricting the `additionalProperties` field of the `typescript.tsserver.watchOptions` setting, we can get the setting to show up in the Settings editor.

The main question is: should the setting actually allow additional properties apart from what was given? If yes, then this PR might be invalid.

![A screenshot that shows the setting rendering as a table in the Settings editor, rather than directing the user to edit the settings.json file](https://user-images.githubusercontent.com/7199958/158444088-dab5ccef-24c9-4ef0-b0bf-e77933d9f6dc.PNG)
