### PR TITLE
Make more settings renderable

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -170,6 +170,9 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			},
 			'extensions.confirmedUriHandlerExtensionIds': {
 				type: 'array',
+				items: {
+					type: 'string'
+				},
 				description: localize('handleUriConfirmedExtensions', "When an extension is listed here, a confirmation prompt will not be shown when that extension handles a URI."),
 				default: [],
 				scope: ConfigurationScope.APPLICATION
@@ -194,6 +197,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 						default: false
 					}
 				},
+				additionalProperties: false,
 				default: {
 					'pub.name': false
 				}

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -706,7 +706,7 @@ configurationRegistry.registerConfiguration({
 	properties: {
 		[NotebookSetting.displayOrder]: {
 			description: nls.localize('notebook.displayOrder.description', "Priority list for output mime types"),
-			type: ['array'],
+			type: 'array',
 			items: {
 				type: 'string'
 			},


### PR DESCRIPTION
This PR changes the schemas of the `extensions.confirmedUriHandlerExtensionIds` and `notebook.displayOrder` settings so that they both become string array settings that can be rendered in the Settings editor.

It also adds `additionalProperties: false` to the `extensions.supportVirtualWorkspaces` setting. In this case, only keys that match the given pattern property would be allowed, and other keys would be rejected. The setting then becomes renderable and shows up as a table widget in the Settings editor.

![Demo of the extensions.supportVirtualWorkspaces setting](https://user-images.githubusercontent.com/7199958/158445204-9ead27f7-ab12-4db3-913f-5b284ba75799.PNG)

Some questions to confirm or answer before merging:
1. Is `extensions.confirmedUriHandlerExtensionIds` a string array setting? It was previously just an array setting.
2. Should `extensions.supportVirtualWorkspaces` actually support keys outside of `patternProperties`? If yes, then we don't want the additional `additionalProperties` line.
