### PR TITLE
Add a `.code` property to undo redo elements (that is not localized)

### DIFF
--- a/src/vs/editor/browser/services/bulkEditService.ts
+++ b/src/vs/editor/browser/services/bulkEditService.ts
@@ -70,6 +70,7 @@ export interface IBulkEditOptions {
 	token?: CancellationToken;
 	showPreview?: boolean;
 	label?: string;
+	code?: string;
 	quotableLabel?: string;
 	undoRedoSource?: UndoRedoSource;
 	undoRedoGroupId?: number;

--- a/src/vs/editor/common/model/editStack.ts
+++ b/src/vs/editor/common/model/editStack.ts
@@ -163,6 +163,7 @@ export class SingleModelEditStackElement implements IResourceUndoRedoElement {
 
 	constructor(
 		public readonly label: string,
+		public readonly code: string,
 		model: ITextModel,
 		beforeCursorState: Selection[] | null
 	) {
@@ -241,7 +242,6 @@ export class SingleModelEditStackElement implements IResourceUndoRedoElement {
 export class MultiModelEditStackElement implements IWorkspaceUndoRedoElement {
 
 	public readonly type = UndoRedoElementType.Workspace;
-	public readonly label: string;
 	private _isOpen: boolean;
 
 	private readonly _editStackElementsArr: SingleModelEditStackElement[];
@@ -254,10 +254,10 @@ export class MultiModelEditStackElement implements IWorkspaceUndoRedoElement {
 	}
 
 	constructor(
-		label: string,
+		public readonly label: string,
+		public readonly code: string,
 		editStackElements: SingleModelEditStackElement[]
 	) {
-		this.label = label;
 		this._isOpen = true;
 		this._editStackElementsArr = editStackElements.slice(0);
 		this._editStackElementsMap = new Map<string, SingleModelEditStackElement>();
@@ -413,7 +413,7 @@ export class EditStack {
 		if (isEditStackElement(lastElement) && lastElement.canAppend(this._model)) {
 			return lastElement;
 		}
-		const newElement = new SingleModelEditStackElement(nls.localize('edit', "Typing"), this._model, beforeCursorState);
+		const newElement = new SingleModelEditStackElement(nls.localize('edit', "Typing"), 'undoredo.textBufferEdit', this._model, beforeCursorState);
 		this._undoRedoService.pushElement(newElement);
 		return newElement;
 	}

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -168,7 +168,7 @@ export async function applyCodeAction(
 	await item.resolve(CancellationToken.None);
 
 	if (item.action.edit) {
-		await bulkEditService.apply(ResourceEdit.convert(item.action.edit), { editor, label: item.action.title });
+		await bulkEditService.apply(ResourceEdit.convert(item.action.edit), { editor, label: item.action.title, code: 'undoredo.codeAction' });
 	}
 
 	if (item.action.command) {

--- a/src/vs/editor/contrib/rename/browser/rename.ts
+++ b/src/vs/editor/contrib/rename/browser/rename.ts
@@ -237,6 +237,7 @@ class RenameController implements IEditorContribution {
 				editor: this.editor,
 				showPreview: inputFieldResult.wantsPreview,
 				label: nls.localize('label', "Renaming '{0}'", loc?.text),
+				code: 'undoredo.rename',
 				quotableLabel: nls.localize('quotableLabel', "Renaming {0}", loc?.text),
 			}).then(result => {
 				if (result.ariaSummary) {

--- a/src/vs/platform/undoRedo/common/undoRedo.ts
+++ b/src/vs/platform/undoRedo/common/undoRedo.ts
@@ -16,8 +16,18 @@ export const enum UndoRedoElementType {
 
 export interface IResourceUndoRedoElement {
 	readonly type: UndoRedoElementType.Resource;
+	/**
+	 * The resource impacted by this element.
+	 */
 	readonly resource: URI;
+	/**
+	 * A user presentable label. May be localized.
+	 */
 	readonly label: string;
+	/**
+	 * A code describing the operation. Will not be localized.
+	 */
+	readonly code: string;
 	/**
 	 * Show a message to the user confirming when trying to undo this element
 	 */
@@ -28,8 +38,18 @@ export interface IResourceUndoRedoElement {
 
 export interface IWorkspaceUndoRedoElement {
 	readonly type: UndoRedoElementType.Workspace;
+	/**
+	 * The resources impacted by this element.
+	 */
 	readonly resources: readonly URI[];
+	/**
+	 * A user presentable label. May be localized.
+	 */
 	readonly label: string;
+	/**
+	 * A code describing the operation. Will not be localized.
+	 */
+	readonly code: string;
 	/**
 	 * Show a message to the user confirming when trying to undo this element
 	 */

--- a/src/vs/platform/undoRedo/test/common/undoRedoService.test.ts
+++ b/src/vs/platform/undoRedo/test/common/undoRedoService.test.ts
@@ -34,6 +34,7 @@ suite('UndoRedoService', () => {
 			type: UndoRedoElementType.Resource,
 			resource: resource,
 			label: 'typing 1',
+			code: 'typing',
 			undo: () => { undoCall1++; },
 			redo: () => { redoCall1++; }
 		};
@@ -68,6 +69,7 @@ suite('UndoRedoService', () => {
 			type: UndoRedoElementType.Resource,
 			resource: resource,
 			label: 'typing 2',
+			code: 'typing',
 			undo: () => { undoCall2++; },
 			redo: () => { redoCall2++; }
 		};
@@ -99,6 +101,7 @@ suite('UndoRedoService', () => {
 			type: UndoRedoElementType.Resource,
 			resource: resource,
 			label: 'typing 2',
+			code: 'typing',
 			undo: () => { undoCall3++; },
 			redo: () => { redoCall3++; }
 		};
@@ -146,6 +149,7 @@ suite('UndoRedoService', () => {
 			type: UndoRedoElementType.Workspace,
 			resources: [resource1, resource2],
 			label: 'typing 1',
+			code: 'typing',
 			undo: () => { undoCall1++; },
 			redo: () => { redoCall1++; },
 			split: () => {
@@ -154,6 +158,7 @@ suite('UndoRedoService', () => {
 						type: UndoRedoElementType.Resource,
 						resource: resource1,
 						label: 'typing 1.1',
+						code: 'typing',
 						undo: () => { undoCall11++; },
 						redo: () => { redoCall11++; }
 					},
@@ -161,6 +166,7 @@ suite('UndoRedoService', () => {
 						type: UndoRedoElementType.Resource,
 						resource: resource2,
 						label: 'typing 1.2',
+						code: 'typing',
 						undo: () => { undoCall12++; },
 						redo: () => { redoCall12++; }
 					}

--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -480,6 +480,7 @@ class MainThreadCustomEditorModel extends ResourceWorkingCopy implements ICustom
 			type: UndoRedoElementType.Resource,
 			resource: this._editorResource,
 			label: label ?? localize('defaultEditLabel', "Edit"),
+			code: 'undoredo.customEditorEdit',
 			undo: () => this.undo(),
 			redo: () => this.redo(),
 		});

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
@@ -27,6 +27,7 @@ class BulkEdit {
 
 	constructor(
 		private readonly _label: string | undefined,
+		private readonly _code: string | undefined,
 		private readonly _editor: ICodeEditor | undefined,
 		private readonly _progress: IProgress<IProgressStep>,
 		private readonly _token: CancellationToken,
@@ -108,13 +109,13 @@ class BulkEdit {
 
 	private async _performFileEdits(edits: ResourceFileEdit[], undoRedoGroup: UndoRedoGroup, undoRedoSource: UndoRedoSource | undefined, confirmBeforeUndo: boolean, progress: IProgress<void>) {
 		this._logService.debug('_performFileEdits', JSON.stringify(edits));
-		const model = this._instaService.createInstance(BulkFileEdits, this._label || localize('workspaceEdit', "Workspace Edit"), undoRedoGroup, undoRedoSource, confirmBeforeUndo, progress, this._token, edits);
+		const model = this._instaService.createInstance(BulkFileEdits, this._label || localize('workspaceEdit', "Workspace Edit"), this._code || 'undoredo.workspaceEdit', undoRedoGroup, undoRedoSource, confirmBeforeUndo, progress, this._token, edits);
 		await model.apply();
 	}
 
 	private async _performTextEdits(edits: ResourceTextEdit[], undoRedoGroup: UndoRedoGroup, undoRedoSource: UndoRedoSource | undefined, progress: IProgress<void>): Promise<void> {
 		this._logService.debug('_performTextEdits', JSON.stringify(edits));
-		const model = this._instaService.createInstance(BulkTextEdits, this._label || localize('workspaceEdit', "Workspace Edit"), this._editor, undoRedoGroup, undoRedoSource, progress, this._token, edits);
+		const model = this._instaService.createInstance(BulkTextEdits, this._label || localize('workspaceEdit', "Workspace Edit"), this._code || 'undoredo.workspaceEdit', this._editor, undoRedoGroup, undoRedoSource, progress, this._token, edits);
 		await model.apply();
 	}
 
@@ -199,6 +200,7 @@ export class BulkEditService implements IBulkEditService {
 		const bulkEdit = this._instaService.createInstance(
 			BulkEdit,
 			label,
+			options?.code,
 			codeEditor,
 			options?.progress ?? Progress.None,
 			options?.token ?? CancellationToken.None,

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
@@ -289,6 +289,7 @@ class FileUndoRedoElement implements IWorkspaceUndoRedoElement {
 
 	constructor(
 		readonly label: string,
+		readonly code: string,
 		readonly operations: IFileOperation[],
 		readonly confirmBeforeUndo: boolean
 	) {
@@ -320,6 +321,7 @@ export class BulkFileEdits {
 
 	constructor(
 		private readonly _label: string,
+		private readonly _code: string,
 		private readonly _undoRedoGroup: UndoRedoGroup,
 		private readonly _undoRedoSource: UndoRedoSource | undefined,
 		private readonly _confirmBeforeUndo: boolean,
@@ -393,6 +395,6 @@ export class BulkFileEdits {
 			this._progress.report(undefined);
 		}
 
-		this._undoRedoService.pushElement(new FileUndoRedoElement(this._label, undoOperations, this._confirmBeforeUndo), this._undoRedoGroup, this._undoRedoSource);
+		this._undoRedoService.pushElement(new FileUndoRedoElement(this._label, this._code, undoOperations, this._confirmBeforeUndo), this._undoRedoGroup, this._undoRedoSource);
 	}
 }

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
@@ -144,6 +144,7 @@ export class BulkTextEdits {
 
 	constructor(
 		private readonly _label: string,
+		private readonly _code: string,
 		private readonly _editor: ICodeEditor | undefined,
 		private readonly _undoRedoGroup: UndoRedoGroup,
 		private readonly _undoRedoSource: UndoRedoSource | undefined,
@@ -249,7 +250,7 @@ export class BulkTextEdits {
 				// This edit touches a single model => keep things simple
 				const task = tasks[0];
 				if (!task.isNoOp()) {
-					const singleModelEditStackElement = new SingleModelEditStackElement(this._label, task.model, task.getBeforeCursorState());
+					const singleModelEditStackElement = new SingleModelEditStackElement(this._label, this._code, task.model, task.getBeforeCursorState());
 					this._undoRedoService.pushElement(singleModelEditStackElement, this._undoRedoGroup, this._undoRedoSource);
 					task.apply();
 					singleModelEditStackElement.close();
@@ -259,7 +260,8 @@ export class BulkTextEdits {
 				// prepare multi model undo element
 				const multiModelEditStackElement = new MultiModelEditStackElement(
 					this._label,
-					tasks.map(t => new SingleModelEditStackElement(this._label, t.model, t.getBeforeCursorState()))
+					this._code,
+					tasks.map(t => new SingleModelEditStackElement(this._label, this._code, t.model, t.getBeforeCursorState()))
 				);
 				this._undoRedoService.pushElement(multiModelEditStackElement, this._undoRedoGroup, this._undoRedoSource);
 				for (const task of tasks) {

--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -169,6 +169,7 @@ export class ExplorerService implements IExplorerService {
 			await this.bulkEditService.apply(edit, {
 				undoRedoSource: UNDO_REDO_SOURCE,
 				label: options.undoLabel,
+				code: 'undoredo.explorerOperation',
 				progress,
 				token: cancellationTokenSource.token,
 				confirmBeforeUndo: options.confirmBeforeUndo

--- a/src/vs/workbench/contrib/notebook/browser/contrib/format/formatting.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/format/formatting.ts
@@ -91,7 +91,7 @@ registerAction2(class extends Action2 {
 				return [];
 			}));
 
-			await bulkEditService.apply(/* edit */flatten(allCellEdits), { label: localize('label', "Format Notebook") });
+			await bulkEditService.apply(/* edit */flatten(allCellEdits), { label: localize('label', "Format Notebook"), code: 'undoredo.formatNotebook', });
 
 		} finally {
 			disposable.dispose();

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/cellEdit.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/cellEdit.ts
@@ -22,6 +22,7 @@ export interface IViewCellEditingDelegate extends ITextCellEditingDelegate {
 export class JoinCellEdit implements IResourceUndoRedoElement {
 	type: UndoRedoElementType.Resource = UndoRedoElementType.Resource;
 	label: string = 'Join Cell';
+	code: string = 'undoredo.notebooks.joinCell';
 	private _deletedRawCell: NotebookCellTextModel;
 	constructor(
 		public resource: URI,

--- a/src/vs/workbench/contrib/notebook/common/model/cellEdit.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/cellEdit.ts
@@ -22,6 +22,7 @@ export interface ITextCellEditingDelegate {
 export class MoveCellEdit implements IResourceUndoRedoElement {
 	type: UndoRedoElementType.Resource = UndoRedoElementType.Resource;
 	label: string = 'Move Cell';
+	code: string = 'undoredo.notebooks.moveCell';
 
 	constructor(
 		public resource: URI,
@@ -54,6 +55,7 @@ export class MoveCellEdit implements IResourceUndoRedoElement {
 export class SpliceCellsEdit implements IResourceUndoRedoElement {
 	type: UndoRedoElementType.Resource = UndoRedoElementType.Resource;
 	label: string = 'Insert Cell';
+	code: string = 'undoredo.notebooks.insertCell';
 	constructor(
 		public resource: URI,
 		private diffs: [number, NotebookCellTextModel[], NotebookCellTextModel[]][],
@@ -87,6 +89,7 @@ export class SpliceCellsEdit implements IResourceUndoRedoElement {
 export class CellMetadataEdit implements IResourceUndoRedoElement {
 	type: UndoRedoElementType.Resource = UndoRedoElementType.Resource;
 	label: string = 'Update Cell Metadata';
+	code: string = 'undoredo.notebooks.updateCellMetadata';
 	constructor(
 		public resource: URI,
 		readonly index: number,

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -26,6 +26,8 @@ import { isDefined } from 'vs/base/common/types';
 class StackOperation implements IWorkspaceUndoRedoElement {
 	type: UndoRedoElementType.Workspace;
 
+	readonly code = 'undoredo.notebooks.stackOperation';
+
 	private _operations: IUndoRedoElement[] = [];
 	private _beginSelectionState: ISelectionState | undefined = undefined;
 	private _resultSelectionState: ISelectionState | undefined = undefined;
@@ -699,6 +701,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 						return that.uri;
 					}
 					readonly label = 'Update Notebook Metadata';
+					readonly code = 'undoredo.notebooks.updateCellMetadata';
 					undo() {
 						that._updateNotebookMetadata(oldMetadata, false);
 					}
@@ -923,6 +926,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 					return that.uri;
 				}
 				readonly label = 'Update Cell Language';
+				readonly code = 'undoredo.notebooks.updateCellLanguage';
 				undo() {
 					that._changeCellLanguage(cell, oldLanguage, false);
 				}


### PR DESCRIPTION
This would allow users of `IUndoRedoService`, like the local history feature, to work with undo redo elements and filter out certain generic labels, like "Typing", which are now localized.

cc @bpasero