### PR TITLE
ci: unify artifacts processing on darwin

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -315,7 +315,7 @@ steps:
 
   - publish: $(Agent.BuildDirectory)/vscode-server-darwin-$(VSCODE_ARCH)-web.zip
     artifact: vscode_web_darwin_$(VSCODE_ARCH)_archive-unsigned
-    displayName: Publish arm64 web server archive
+    displayName: Publish web server archive
     condition: and(succeeded(), ne(variables['VSCODE_PUBLISH'], 'false'), ne(variables['VSCODE_ARCH'], 'universal'))
 
   - task: AzureCLI@2

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -308,31 +308,15 @@ steps:
     displayName: Publish client archive
     condition: and(succeeded(), ne(variables['VSCODE_PUBLISH'], 'false'))
 
-  - script: |
-      mv $(agent.builddirectory)/vscode-server-darwin-x64.zip $(agent.builddirectory)/vscode-server-darwin.zip
-      mv $(agent.builddirectory)/vscode-server-darwin-x64-web.zip $(agent.builddirectory)/vscode-server-darwin-web.zip
-    displayName: Rename x64 server builds to their legacy names
-    condition: and(succeeded(), ne(variables['VSCODE_PUBLISH'], 'false'), eq(variables['VSCODE_ARCH'], 'x64'))
+  - publish: $(Agent.BuildDirectory)/vscode-server-darwin-$(VSCODE_ARCH).zip
+    artifact: vscode_server_darwin_$(VSCODE_ARCH)_archive-unsigned
+    displayName: Publish server archive
+    condition: and(succeeded(), ne(variables['VSCODE_PUBLISH'], 'false'), ne(variables['VSCODE_ARCH'], 'universal'))
 
-  - publish: $(Agent.BuildDirectory)/vscode-server-darwin-arm64.zip
-    artifact: vscode_server_darwin_arm64_archive-unsigned
-    displayName: Publish arm64 server archive
-    condition: and(succeeded(), ne(variables['VSCODE_PUBLISH'], 'false'), eq(variables['VSCODE_ARCH'], 'arm64'))
-
-  - publish: $(Agent.BuildDirectory)/vscode-server-darwin-arm64-web.zip
-    artifact: vscode_web_darwin_arm64_archive-unsigned
+  - publish: $(Agent.BuildDirectory)/vscode-server-darwin-$(VSCODE_ARCH)-web.zip
+    artifact: vscode_web_darwin_$(VSCODE_ARCH)_archive-unsigned
     displayName: Publish arm64 web server archive
-    condition: and(succeeded(), ne(variables['VSCODE_PUBLISH'], 'false'), eq(variables['VSCODE_ARCH'], 'arm64'))
-
-  - publish: $(Agent.BuildDirectory)/vscode-server-darwin.zip
-    artifact: vscode_server_darwin_x64_archive-unsigned
-    displayName: Publish x64 server archive
-    condition: and(succeeded(), ne(variables['VSCODE_PUBLISH'], 'false'), eq(variables['VSCODE_ARCH'], 'x64'))
-
-  - publish: $(Agent.BuildDirectory)/vscode-server-darwin-web.zip
-    artifact: vscode_web_darwin_x64_archive-unsigned
-    displayName: Publish x64 web server archive
-    condition: and(succeeded(), ne(variables['VSCODE_PUBLISH'], 'false'), eq(variables['VSCODE_ARCH'], 'x64'))
+    condition: and(succeeded(), ne(variables['VSCODE_PUBLISH'], 'false'), ne(variables['VSCODE_ARCH'], 'universal'))
 
   - task: AzureCLI@2
     inputs:


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode/pull/145053#discussion_r827955961

This renames our x64 server archives file name from `vscode-server-darwin.zip` to `vscode-server-darwin-x64.zip`. 

**Please note** this does not change the asset id related with this artifact and continues to remain `server-darwin`.

Downstream consumer, `remote-ssh` extension seems to rely on the asset id `https://update.code.visualstudio.com/commit:<sha>/server-darwin` rather than the file name, so this change should not break the extension. @roblourens @tanhakabir can you please confirm ?