### PR TITLE
Improve command navigation behavior

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/commandTrackerAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/commandTrackerAddon.ts
@@ -78,7 +78,7 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 			? this._getTargetScrollLine(this._terminal, this._currentMarker, scrollPosition)
 			: Math.min(this._getLine(this._terminal, this._currentMarker), this._terminal.buffer.active.baseY);
 		const viewportY = this._terminal.buffer.active.viewportY;
-		if (!retainSelection && currentLineY !== viewportY) {
+		if (typeof this._currentMarker === 'object' ? !this._isMarkerInViewport(this._terminal, this._currentMarker) : currentLineY !== viewportY) {
 			// The user has scrolled, find the line based on the current scroll position. This only
 			// works when not retaining selection
 			const markersBelowViewport = this._getCommandMarkers().filter(e => e.line >= viewportY).length;
@@ -119,7 +119,7 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 			? this._getTargetScrollLine(this._terminal, this._currentMarker, scrollPosition)
 			: Math.min(this._getLine(this._terminal, this._currentMarker), this._terminal.buffer.active.baseY);
 		const viewportY = this._terminal.buffer.active.viewportY;
-		if (!retainSelection && currentLineY !== viewportY) {
+		if (typeof this._currentMarker === 'object' ? !this._isMarkerInViewport(this._terminal, this._currentMarker) : currentLineY !== viewportY) {
 			// The user has scrolled, find the line based on the current scroll position. This only
 			// works when not retaining selection
 			const markersAboveViewport = this._getCommandMarkers().filter(e => e.line <= viewportY).length;
@@ -151,8 +151,10 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 		if (!this._terminal) {
 			return;
 		}
-		const line = this._getTargetScrollLine(this._terminal, marker, position);
-		this._terminal.scrollToLine(line);
+		if (!this._isMarkerInViewport(this._terminal, marker)) {
+			const line = this._getTargetScrollLine(this._terminal, marker, position);
+			this._terminal.scrollToLine(line);
+		}
 	}
 
 	private _getTargetScrollLine(terminal: Terminal, marker: IMarker, position: ScrollPosition) {
@@ -162,6 +164,11 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 			return Math.max(marker.line - Math.floor(terminal.rows / 4), 0);
 		}
 		return marker.line;
+	}
+
+	private _isMarkerInViewport(terminal: Terminal, marker: IMarker) {
+		const viewportY = terminal.buffer.active.viewportY;
+		return marker.line >= viewportY && marker.line < viewportY + terminal.rows;
 	}
 
 	selectToPreviousCommand(): void {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/commandTrackerAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/commandTrackerAddon.ts
@@ -65,7 +65,7 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 		this._selectionStart = null;
 	}
 
-	scrollToPreviousCommand(scrollPosition: ScrollPosition = ScrollPosition.Top, retainSelection: boolean = false): void {
+	scrollToPreviousCommand(scrollPosition: ScrollPosition = ScrollPosition.Middle, retainSelection: boolean = false): void {
 		if (!this._terminal) {
 			return;
 		}
@@ -74,7 +74,9 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 		}
 
 		let markerIndex;
-		const currentLineY = Math.min(this._getLine(this._terminal, this._currentMarker), this._terminal.buffer.active.baseY);
+		const currentLineY = typeof this._currentMarker === 'object'
+			? this._getTargetScrollLine(this._terminal, this._currentMarker, scrollPosition)
+			: Math.min(this._getLine(this._terminal, this._currentMarker), this._terminal.buffer.active.baseY);
 		const viewportY = this._terminal.buffer.active.viewportY;
 		if (!retainSelection && currentLineY !== viewportY) {
 			// The user has scrolled, find the line based on the current scroll position. This only
@@ -104,7 +106,7 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 		this._scrollToMarker(this._currentMarker, scrollPosition);
 	}
 
-	scrollToNextCommand(scrollPosition: ScrollPosition = ScrollPosition.Top, retainSelection: boolean = false): void {
+	scrollToNextCommand(scrollPosition: ScrollPosition = ScrollPosition.Middle, retainSelection: boolean = false): void {
 		if (!this._terminal) {
 			return;
 		}
@@ -113,7 +115,9 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 		}
 
 		let markerIndex;
-		const currentLineY = Math.min(this._getLine(this._terminal, this._currentMarker), this._terminal.buffer.active.baseY);
+		const currentLineY = typeof this._currentMarker === 'object'
+			? this._getTargetScrollLine(this._terminal, this._currentMarker, scrollPosition)
+			: Math.min(this._getLine(this._terminal, this._currentMarker), this._terminal.buffer.active.baseY);
 		const viewportY = this._terminal.buffer.active.viewportY;
 		if (!retainSelection && currentLineY !== viewportY) {
 			// The user has scrolled, find the line based on the current scroll position. This only
@@ -147,11 +151,17 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 		if (!this._terminal) {
 			return;
 		}
-		let line = marker.line;
-		if (position === ScrollPosition.Middle) {
-			line = Math.max(line - Math.floor(this._terminal.rows / 2), 0);
-		}
+		const line = this._getTargetScrollLine(this._terminal, marker, position);
 		this._terminal.scrollToLine(line);
+	}
+
+	private _getTargetScrollLine(terminal: Terminal, marker: IMarker, position: ScrollPosition) {
+		// Middle is treated at 1/4 of the viewport's size because context below is almost always
+		// more important than context above in the terminal.
+		if (position === ScrollPosition.Middle) {
+			return Math.max(marker.line - Math.floor(terminal.rows / 4), 0);
+		}
+		return marker.line;
 	}
 
 	selectToPreviousCommand(): void {
@@ -232,7 +242,7 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 		return marker.line;
 	}
 
-	scrollToPreviousLine(xterm: Terminal, scrollPosition: ScrollPosition = ScrollPosition.Top, retainSelection: boolean = false): void {
+	scrollToPreviousLine(xterm: Terminal, scrollPosition: ScrollPosition = ScrollPosition.Middle, retainSelection: boolean = false): void {
 		if (!retainSelection) {
 			this._selectionStart = null;
 		}
@@ -255,7 +265,7 @@ export class CommandTrackerAddon extends Disposable implements ICommandTracker, 
 		this._scrollToMarker(this._currentMarker, scrollPosition);
 	}
 
-	scrollToNextLine(xterm: Terminal, scrollPosition: ScrollPosition = ScrollPosition.Top, retainSelection: boolean = false): void {
+	scrollToNextLine(xterm: Terminal, scrollPosition: ScrollPosition = ScrollPosition.Middle, retainSelection: boolean = false): void {
 		if (!retainSelection) {
 			this._selectionStart = null;
 		}


### PR DESCRIPTION
Fixes #145241

Summary:

- All scroll/select now use 1/4 down the viewport instead of some top some middle
- Scrolling no longer happens if the target line is within the viewport

Combined with https://github.com/microsoft/vscode/pull/145245, looks like:

![Recording 2022-03-16 at 11 27 56](https://user-images.githubusercontent.com/2193314/158662091-4ddccd62-4507-4a1f-91c0-59d26250e0af.gif)

