### PR TITLE
Show terminal overview ruler above scroll bar

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -70,6 +70,12 @@
 	z-index: 30;
 }
 
+.monaco-workbench .editor-instance .xterm-decoration-overview-ruler,
+.monaco-workbench .pane-body.integrated-terminal .xterm-decoration-overview-ruler {
+	z-index: 31; /* Must be higher than .xterm-viewport */
+	pointer-events: none;
+}
+
 .monaco-workbench .editor-instance .xterm-screen,
 .monaco-workbench .pane-body.integrated-terminal .xterm-screen {
 	z-index: 31;


### PR DESCRIPTION
Styling the native scroll bar is hard, looks like it's not possible to
get the ideal behavior.

Fixes #145213
