### PR TITLE
Consider outdated targetplatform while loading extensions

### DIFF
--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -171,7 +171,8 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	services.set(ICredentialsMainService, new SyncDescriptor(CredentialsMainService, [true]));
 
 	instantiationService.invokeFunction(accessor => {
-		const remoteExtensionEnvironmentChannel = new RemoteAgentEnvironmentChannel(connectionToken, environmentService, extensionManagementCLIService, logService, productService);
+		const extensionManagementService = accessor.get(IExtensionManagementService);
+		const remoteExtensionEnvironmentChannel = new RemoteAgentEnvironmentChannel(connectionToken, environmentService, extensionManagementCLIService, extensionManagementService, logService, productService);
 		socketServer.registerChannel('remoteextensionsenvironment', remoteExtensionEnvironmentChannel);
 
 		const telemetryChannel = new ServerTelemetryChannel(accessor.get(IServerTelemetryService), appInsightsAppender);
@@ -184,7 +185,6 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 
 		socketServer.registerChannel('request', new RequestChannel(accessor.get(IRequestService)));
 
-		const extensionManagementService = accessor.get(IExtensionManagementService);
 		const channel = new ExtensionManagementChannel(extensionManagementService, (ctx: RemoteAgentConnectionContext) => getUriTransformer(ctx.remoteAuthority));
 		socketServer.registerChannel('extensions', channel);
 

--- a/src/vs/workbench/services/extensions/common/extensionPoints.ts
+++ b/src/vs/workbench/services/extensions/common/extensionPoints.ts
@@ -12,7 +12,7 @@ import * as arrays from 'vs/base/common/arrays';
 import { getParseErrorMessage } from 'vs/base/common/jsonErrorMessages';
 import * as types from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
-import { getGalleryExtensionId, groupByExtension, getExtensionId, ExtensionKey } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
+import { getGalleryExtensionId, getExtensionId, ExtensionKey } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { isValidExtensionVersion } from 'vs/platform/extensions/common/extensionValidator';
 import { ExtensionIdentifier, IExtensionDescription, IRelaxedExtensionDescription, TargetPlatform, UNDEFINED_PUBLISHER } from 'vs/platform/extensions/common/extensions';
 import { Metadata } from 'vs/platform/extensionManagement/common/extensionManagement';
@@ -517,6 +517,7 @@ export class ExtensionScannerInput {
 		public readonly absoluteFolderPath: string,
 		public readonly isBuiltin: boolean,
 		public readonly isUnderDevelopment: boolean,
+		public readonly targetPlatform: TargetPlatform,
 		public readonly translations: Translations
 	) {
 		// Keep empty!! (JSON.parse)
@@ -643,9 +644,7 @@ export class ExtensionScanner {
 			extensionDescriptions = extensionDescriptions.filter(item => item !== null && !obsolete[new ExtensionKey({ id: getGalleryExtensionId(item.publisher, item.name) }, item.version, item.targetPlatform).toString()]);
 
 			if (!isBuiltin) {
-				// Filter out outdated extensions
-				const byExtension: IExtensionDescription[][] = groupByExtension(extensionDescriptions, e => ({ id: e.identifier.value, uuid: e.uuid }));
-				extensionDescriptions = byExtension.map(p => p.sort((a, b) => semver.rcompare(a.version, b.version))[0]);
+				extensionDescriptions = this.filterOutdatedExtensions(extensionDescriptions, input.targetPlatform);
 			}
 
 			extensionDescriptions.sort((a, b) => {
@@ -720,5 +719,23 @@ export class ExtensionScanner {
 			});
 			return resultArr;
 		});
+	}
+
+	private static filterOutdatedExtensions(extensions: IExtensionDescription[], targetPlatform: TargetPlatform): IExtensionDescription[] {
+		const result = new Map<string, IExtensionDescription>();
+		for (const extension of extensions) {
+			const extensionKey = extension.identifier.value;
+			const existing = result.get(extensionKey);
+			if (existing) {
+				if (semver.gt(existing.version, extension.version)) {
+					continue;
+				}
+				if (semver.eq(existing.version, extension.version) && existing.targetPlatform === targetPlatform) {
+					continue;
+				}
+			}
+			result.set(extensionKey, extension);
+		}
+		return [...result.values()];
 	}
 }


### PR DESCRIPTION
This PR takes current target platform into consideration while filtering outdated extensions. For eg., On `win32-x64` platform, if there are two instances of same extension with same version but with different compatible target platforms (say `win32-ia32` and `win32-x64`) then instance with `win32-x64` target platform shall be picked.

Related issue - https://github.com/microsoft/vscode/issues/141696
