### PR TITLE
Correctly tell zsh/bash the length of prompt by ignoring shell integration sequences

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -59,8 +59,8 @@ command_complete() {
 update_prompt() {
 	PRIOR_PROMPT="$PS1"
 	IN_COMMAND_EXECUTION=""
-	PS1="$(prompt_start)$PREFIX$PS1$(prompt_end)"
-	PS2="$(continuation_start)$PS2$(continuation_end)"
+	PS1="\[$(prompt_start)\]$PREFIX$PS1\[$(prompt_end)\]"
+	PS2="\[$(continuation_start)\]$PS2\[$(continuation_end)\]"
 }
 
 precmd() {

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.zsh
@@ -56,8 +56,8 @@ command_complete() {
 update_prompt() {
 	PRIOR_PROMPT="$PS1"
 	IN_COMMAND_EXECUTION=""
-	PS1="$(prompt_start)$PREFIX$PS1$(prompt_end)"
-	PS2="$(continuation_start)$PS2$(continuation_end)"
+	PS1="%{$(prompt_start)%}$PREFIX$PS1%{$(prompt_end)%}"
+	PS2="%{$(continuation_start)%}$PS2%{$(continuation_end)%}"
 }
 
 precmd() {


### PR DESCRIPTION
Fixes #145163