### PR TITLE
Adjust Settings editor narrow total width

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -96,7 +96,8 @@ export class SettingsEditor2 extends EditorPane {
 	private static TOC_MIN_WIDTH: number = 100;
 	private static TOC_RESET_WIDTH: number = 200;
 	private static EDITOR_MIN_WIDTH: number = 500;
-	private static NARROW_TOTAL_WIDTH: number = SettingsEditor2.TOC_MIN_WIDTH + SettingsEditor2.EDITOR_MIN_WIDTH;
+	// Below NARROW_TOTAL_WIDTH, we only render the editor rather than the ToC.
+	private static NARROW_TOTAL_WIDTH: number = SettingsEditor2.TOC_RESET_WIDTH + SettingsEditor2.EDITOR_MIN_WIDTH;
 	private static MEDIUM_TOTAL_WIDTH: number = 1000;
 
 	private static readonly SUGGESTIONS: string[] = [


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/145243
Fixes https://github.com/microsoft/vscode/issues/143690

We increase the Settings editor narrow total width. In turn, the ToC only shows up when the Settings editor is wide enough.

Pros:
- When the ToC shows up, it doesn't show up ridiculously narrow.
- When the ToC shows up, the sash already has 100px of wiggle room.

Cons:
- The splitview total width must be at least 700px wide for the ToC to even show up. This is calculated based on the ToC reset width, which is 200px, as well as the editor side min width, which is currently at 500px. The editor side min width is that wide because we currently don't have a horizontal scroll bar for the editor side in case of min overflow, and because string setting inputboxes are currently very long, in case they represent path settings. "Editor side" means the non-ToC portion of the Settings editor, in this case.

Considering how users who use VS Code with a narrower width might get annoyed at the ToC not showing up, a better solution is probably to figure out how to add a horizontal scrollbar to just the editor side in case it is too narrow.

Adding @misolori as a reviewer for thoughts on this issue.
Also CC @stevencl. 