### PR TITLE
Fix overview ruler width

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -131,7 +131,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 			scrollSensitivity: config.mouseWheelScrollSensitivity,
 			rendererType: this._getBuiltInXtermRenderer(config.gpuAcceleration, XtermTerminal._suggestedRendererType),
 			wordSeparator: config.wordSeparators,
-			overviewRulerWidth: 15
+			overviewRulerWidth: 10
 		}));
 		this._core = (this.raw as any)._core as IXtermCore;
 


### PR DESCRIPTION
Fixes #145388

`overviewRulerWidth` should be measured in CSS pixels, xterm.js is in charge of converting those to actual pixels.