### PR TITLE
Surface executing command in Terminal: Run Recent Command

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -85,6 +85,10 @@ export interface ICwdDetectionCapability {
 export interface ICommandDetectionCapability {
 	readonly type: TerminalCapability.CommandDetection;
 	readonly commands: readonly ITerminalCommand[];
+	/** The command currently being executed, otherwise undefined. */
+	readonly executingCommand: string | undefined;
+	/** The current cwd at the cursor's position. */
+	readonly cwd: string | undefined;
 	readonly onCommandStarted: Event<ITerminalCommand>;
 	readonly onCommandFinished: Event<ITerminalCommand>;
 	setCwd(value: string): void;

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -287,7 +287,7 @@ export class CommandDetectionCapability implements ICommandDetectionCapability {
 		// executed markers
 		this._onCursorMoveListener?.dispose();
 		this._onCursorMoveListener = undefined;
-		this._currentCommand.commandExecutedMarker = this._terminal.registerMarker(0);
+		this._evaluateCommandMarkersWindows();
 		this._currentCommand.commandExecutedX = this._terminal.buffer.active.cursorX;
 		this._logService.debug('CommandDetectionCapability#handleCommandExecuted', this._currentCommand.commandExecutedX, this._currentCommand.commandExecutedMarker?.line);
 	}
@@ -344,9 +344,11 @@ export class CommandDetectionCapability implements ICommandDetectionCapability {
 	}
 
 	private _preHandleCommandFinishedWindows(): void {
-		// On Windows, use the gathered cursor move markers to correct the command start and
-		// executed markers. This is done on command finished just in case command executed never
-		// happens (for example PSReadLine tab completion)
+		if (this._currentCommand.commandExecutedMarker) {
+			return;
+		}
+		// This is done on command finished just in case command executed never happens (for example
+		// PSReadLine tab completion)
 		if (this._commandMarkers.length === 0) {
 			// If the command start timeout doesn't happen before command finished, just use the
 			// current marker.
@@ -356,9 +358,17 @@ export class CommandDetectionCapability implements ICommandDetectionCapability {
 			if (this._currentCommand.commandStartMarker) {
 				this._commandMarkers.push(this._currentCommand.commandStartMarker);
 			}
-		} else {
-			this._commandMarkers = this._commandMarkers.sort((a, b) => a.line - b.line);
 		}
+		this._evaluateCommandMarkersWindows();
+	}
+
+	private _evaluateCommandMarkersWindows(): void {
+		// On Windows, use the gathered cursor move markers to correct the command start and
+		// executed markers.
+		if (this._commandMarkers.length === 0) {
+			return;
+		}
+		this._commandMarkers = this._commandMarkers.sort((a, b) => a.line - b.line);
 		this._currentCommand.commandStartMarker = this._commandMarkers[0];
 		if (this._currentCommand.commandStartMarker) {
 			const line = this._terminal.buffer.active.getLine(this._currentCommand.commandStartMarker.line);

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -54,7 +54,13 @@ export class CommandDetectionCapability implements ICommandDetectionCapability {
 	private _commandMarkers: IMarker[] = [];
 	private _dimensions: ITerminalDimensions;
 
-	get commands(): readonly ITerminalCommand[] { return this._commands; }
+	get commands(): readonly ITerminalCommand[] {
+		if (this._currentCommand.command) {
+			// TODO: as ITerminalCommand is unsafe
+			return [...this.commands, this._currentCommand as ITerminalCommand];
+		}
+		return this._commands;
+	}
 
 	private readonly _onCommandStarted = new Emitter<ITerminalCommand>();
 	readonly onCommandStarted = this._onCommandStarted.event;

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -54,13 +54,9 @@ export class CommandDetectionCapability implements ICommandDetectionCapability {
 	private _commandMarkers: IMarker[] = [];
 	private _dimensions: ITerminalDimensions;
 
-	get commands(): readonly ITerminalCommand[] {
-		if (this._currentCommand.command) {
-			// TODO: as ITerminalCommand is unsafe
-			return [...this.commands, this._currentCommand as ITerminalCommand];
-		}
-		return this._commands;
-	}
+	get commands(): readonly ITerminalCommand[] { return this._commands; }
+	get executingCommand(): string | undefined { return this._currentCommand.command; }
+	get cwd(): string | undefined { return this._cwd; }
 
 	private readonly _onCommandStarted = new Emitter<ITerminalCommand>();
 	readonly onCommandStarted = this._onCommandStarted.event;

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -784,8 +784,13 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		};
 
 		if (type === 'command') {
-			const commands = this.capabilities.get(TerminalCapability.CommandDetection)?.commands;
+			const cmdDetection = this.capabilities.get(TerminalCapability.CommandDetection);
+			const commands = cmdDetection?.commands;
 			// Current session history
+			const executingCommand = cmdDetection?.executingCommand;
+			if (executingCommand) {
+				commandMap.add(executingCommand);
+			}
 			if (commands && commands.length > 0) {
 				for (const entry of commands) {
 					// trim off any whitespace and/or line endings
@@ -827,6 +832,14 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 					commandMap.add(label);
 				}
 				items = items.reverse();
+			}
+			if (executingCommand) {
+				items.unshift({
+					label: executingCommand,
+					description: cmdDetection.cwd
+				});
+			}
+			if (items.length > 0) {
 				items.unshift({ type: 'separator', label: terminalStrings.currentSessionCategory });
 			}
 


### PR DESCRIPTION
Fixes #143704

Changes:

- Expose executingCommand/cwd on command detection capability and use in `runRecent`
- Windows executed command marker is evaluated earlier.
- Note that despite the above item, this does not work on Windows currently because we cannot reliably get the command line until it is finished.