### PR TITLE
Fix array widget width and split view height

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -285,7 +285,7 @@
 }
 
 .settings-editor > .settings-body .settings-tree-container .monaco-list-row .monaco-tl-contents {
-	max-width: 1200px;
+	max-width: min(100%, 1200px); /* We don't want the widgets to be too long */
 	margin: auto;
 	box-sizing: border-box;
 	padding-left: 24px;

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -42,14 +42,17 @@
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-key {
 	margin-left: 0;
 }
+
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-value,
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value {
 	width: 100%;
 }
-.settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row:hover .setting-list-object-value,
-.settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row:focus .setting-list-object-value,
-.settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row.selected .setting-list-object-value {
-	margin-right: 44px;
+
+.settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-row .setting-list-object-value,
+.settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-value {
+	/* In case the text is too long, we don't want to block the pencil icon. */
+	box-sizing: border-box;
+	padding-right: 40px;
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-value,
@@ -153,6 +156,7 @@
 	margin-right: 4px;
 }
 
+.settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-row,
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-edit-row {
 	display: flex
 }

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1516,7 +1516,7 @@ export class SettingsEditor2 extends EditorPane {
 	}
 
 	private layoutTrees(dimension: DOM.Dimension): void {
-		const listHeight = dimension.height - (72 + 11 /* header height + editor padding */);
+		const listHeight = dimension.height - (72 + 11 + 14 /* header height + editor padding */);
 		const settingsTreeHeight = listHeight;
 		this.settingsTreeContainer.style.height = `${settingsTreeHeight}px`;
 		this.settingsTree.layout(settingsTreeHeight, dimension.width);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/144783

This PR does two things:
1. It makes sure that the list widget text in read mode can't get super long and stretch out the list widget horizontally.
2. It reduces the height of the splitview, which fixes some layout glitches during tab navigation or when trying to see the bottommost extension in the ToC.