### PR TITLE
Tweak object widget widths

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -22,11 +22,6 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
-.settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key,
-.settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-key {
-	margin-left: 4px;
-	min-width: 40%;
-}
 
 .settings-editor > .settings-body .settings-tree-container .setting-item-bool .setting-list-object-input-key-checkbox {
 	margin-left: 4px;
@@ -39,8 +34,13 @@
 	cursor: pointer;
 }
 
+.settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-key {
+	margin-left: 4px;
+	width: 40%;
+}
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-key {
 	margin-left: 0;
+	min-width: 40%;
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-input-value,
@@ -53,6 +53,10 @@
 	/* In case the text is too long, we don't want to block the pencil icon. */
 	box-sizing: border-box;
 	padding-right: 40px;
+}
+
+.settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-object-widget .setting-list-object-value {
+	width: 60%;
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item.setting-item-list .setting-list-value,


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/issues/144783

This PR aligns elements of the object widget in the Settings editor better, especially in read mode.

![Demo](https://user-images.githubusercontent.com/7199958/159087193-854a2fb6-f113-4b4d-aef3-3984f233e6fe.PNG)
