### PR TITLE
feat: manage links in terminal

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -90,6 +90,8 @@ export const enum TerminalSettingId {
 	WindowsEnableConpty = 'terminal.integrated.windowsEnableConpty',
 	WordSeparators = 'terminal.integrated.wordSeparators',
 	EnableFileLinks = 'terminal.integrated.enableFileLinks',
+	EnableUriLinks = 'terminal.integrated.enableUriLinks',
+	EnableWordLinks = 'terminal.integrated.enableWordLinks',
 	UnicodeVersion = 'terminal.integrated.unicodeVersion',
 	LocalEchoLatencyThreshold = 'terminal.integrated.localEchoLatencyThreshold',
 	LocalEchoEnabled = 'terminal.integrated.localEchoEnabled',

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkManager.ts
@@ -71,12 +71,16 @@ export class TerminalLinkManager extends DisposableStore {
 		super();
 
 		// Setup link detectors in their order of priority
-		this._setupLinkDetector(TerminalUriLinkDetector.id, this._instantiationService.createInstance(TerminalUriLinkDetector, this._xterm, this._resolvePath.bind(this)));
+		if (this._configurationService.getValue<ITerminalConfiguration>(TERMINAL_CONFIG_SECTION).enableUriLinks) {
+			this._setupLinkDetector(TerminalUriLinkDetector.id, this._instantiationService.createInstance(TerminalUriLinkDetector, this._xterm, this._resolvePath.bind(this)));
+		}
 		if (this._configurationService.getValue<ITerminalConfiguration>(TERMINAL_CONFIG_SECTION).enableFileLinks) {
 			this._setupLinkDetector(TerminalLocalLinkDetector.id, this._instantiationService.createInstance(TerminalLocalLinkDetector, this._xterm, capabilities, this._processManager.os || OS, this._resolvePath.bind(this)));
 		}
 		this._setupLinkDetector(TerminalShellIntegrationLinkDetector.id, this._instantiationService.createInstance(TerminalShellIntegrationLinkDetector, this._xterm));
-		this._setupLinkDetector(TerminalWordLinkDetector.id, this._instantiationService.createInstance(TerminalWordLinkDetector, this._xterm));
+		if (this._configurationService.getValue<ITerminalConfiguration>(TERMINAL_CONFIG_SECTION).enableWordLinks) {
+			this._setupLinkDetector(TerminalWordLinkDetector.id, this._instantiationService.createInstance(TerminalWordLinkDetector, this._xterm));
+		}
 
 		capabilities.get(TerminalCapability.CwdDetection)?.onDidChangeCwd(cwd => {
 			this.processCwd = cwd;

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -268,6 +268,8 @@ export interface ITerminalConfiguration {
 	windowsEnableConpty: boolean;
 	wordSeparators: string;
 	enableFileLinks: boolean;
+	enableUriLinks: boolean;
+	enableWordLinks: boolean;
 	unicodeVersion: '6' | '11';
 	localEchoLatencyThreshold: number;
 	localEchoExcludePrograms: ReadonlyArray<string>;

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -447,6 +447,16 @@ const terminalConfiguration: IConfigurationNode = {
 			type: 'boolean',
 			default: true
 		},
+		[TerminalSettingId.EnableUriLinks]: {
+			description: localize('terminal.integrated.enableUriLinks', "Whether to enable uri links in the terminal."),
+			type: 'boolean',
+			default: true
+		},
+		[TerminalSettingId.EnableWordLinks]: {
+			description: localize('terminal.integrated.enableWordLinks', "Whether to enable word in the terminal to be searched in the workspace."),
+			type: 'boolean',
+			default: true
+		},
 		[TerminalSettingId.UnicodeVersion]: {
 			type: 'string',
 			enum: ['6', '11'],


### PR DESCRIPTION
This PR allows the user to selected which kind of link should be enabled or not.

When `"terminal.integrated.enableWordLinks": false`, it would fix the issue found in https://github.com/microsoft/vscode/issues/99924#issuecomment-648832402.

It wouldn't have been easy without the work done by @Tyriar in #141755. Thx