### PR TITLE
Update coverage folder location

### DIFF
--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -31,7 +31,7 @@ Unit tests from layers `common` and `browser` are run inside `chromium`, `webkit
 
 ## Coverage
 
-The following command will create a `coverage` folder at the root of the workspace:
+The following command will create a `coverage` folder in the `.build` folder at the root of the workspace:
 
 **OS X and Linux**
 


### PR DESCRIPTION
The coverage folder isn't generated at the root of the workspace, it's put in the `.build` folder currently.

Fixes https://github.com/microsoft/vscode/issues/145607