### PR TITLE
Finetune theme detection

### DIFF
--- a/src/vs/code/electron-browser/workbench/workbench.js
+++ b/src/vs/code/electron-browser/workbench/workbench.js
@@ -71,7 +71,7 @@
 	//#region Helpers
 
 	/**
-	 * @typedef {import('../../../platform/windows/common/windows').INativeWindowConfiguration} INativeWindowConfiguration
+	 * @typedef {import('../../../platform/window/common/window').INativeWindowConfiguration} INativeWindowConfiguration
 	 * @typedef {import('../../../platform/environment/common/argv').NativeParsedArgs} NativeParsedArgs
 	 *
 	 * @returns {{
@@ -105,10 +105,18 @@
 
 		let data = configuration.partsSplash;
 
-		// high contrast mode has been turned on from the outside, e.g. OS -> ignore stored colors and layouts
-		const isHighContrast = configuration.colorScheme.highContrast && configuration.autoDetectHighContrast;
-		if (data && isHighContrast && data.baseTheme !== 'hc-black' && data.baseTheme !== 'hc-light') {
-			data = undefined;
+		if (data) {
+			// high contrast mode has been turned by the OS -> ignore stored colors and layouts
+			if (configuration.autoDetectHighContrast && configuration.colorScheme.highContrast) {
+				if ((configuration.colorScheme.dark && data.baseTheme !== 'hc-black') || (!configuration.colorScheme.dark && data.baseTheme !== 'hc-light')) {
+					data = undefined;
+				}
+			} else if (configuration.autoDetectColorScheme) {
+				// OS color scheme is tracked and has changed
+				if ((configuration.colorScheme.dark && data.baseTheme !== 'vs-dark') || (!configuration.colorScheme.dark && data.baseTheme !== 'vs')) {
+					data = undefined;
+				}
+			}
 		}
 
 		// developing an extension -> ignore stored layouts
@@ -122,14 +130,26 @@
 			baseTheme = data.baseTheme;
 			shellBackground = data.colorInfo.editorBackground;
 			shellForeground = data.colorInfo.foreground;
-		} else if (isHighContrast) {
-			baseTheme = 'hc-black';
-			shellBackground = '#000000';
-			shellForeground = '#FFFFFF';
-		} else {
-			baseTheme = 'vs-dark';
-			shellBackground = '#1E1E1E';
-			shellForeground = '#CCCCCC';
+		} else if (configuration.autoDetectHighContrast && configuration.colorScheme.highContrast) {
+			if (configuration.colorScheme.dark) {
+				baseTheme = 'hc-black';
+				shellBackground = '#000000';
+				shellForeground = '#FFFFFF';
+			} else {
+				baseTheme = 'hc-light';
+				shellBackground = '#FFFFFF';
+				shellForeground = '#000000';
+			}
+		} else if (configuration.autoDetectColorScheme) {
+			if (configuration.colorScheme.dark) {
+				baseTheme = 'vs-dark';
+				shellBackground = '#1E1E1E';
+				shellForeground = '#CCCCCC';
+			} else {
+				baseTheme = 'vs';
+				shellBackground = '#FFFFFF';
+				shellForeground = '#000000';
+			}
 		}
 
 		const style = document.createElement('style');

--- a/src/vs/code/electron-sandbox/workbench/workbench.js
+++ b/src/vs/code/electron-sandbox/workbench/workbench.js
@@ -71,7 +71,7 @@
 	//#region Helpers
 
 	/**
-	 * @typedef {import('../../../platform/windows/common/windows').INativeWindowConfiguration} INativeWindowConfiguration
+	 * @typedef {import('../../../platform/window/common/window').INativeWindowConfiguration} INativeWindowConfiguration
 	 * @typedef {import('../../../platform/environment/common/argv').NativeParsedArgs} NativeParsedArgs
 	 *
 	 * @returns {{
@@ -105,10 +105,18 @@
 
 		let data = configuration.partsSplash;
 
-		// high contrast mode has been turned on from the outside, e.g. OS -> ignore stored colors and layouts
-		const isHighContrast = configuration.colorScheme.highContrast && configuration.autoDetectHighContrast;
-		if (data && isHighContrast && data.baseTheme !== 'hc-black' && data.baseTheme !== 'hc-light') {
-			data = undefined;
+		if (data) {
+			// high contrast mode has been turned by the OS -> ignore stored colors and layouts
+			if (configuration.autoDetectHighContrast && configuration.colorScheme.highContrast) {
+				if ((configuration.colorScheme.dark && data.baseTheme !== 'hc-black') || (!configuration.colorScheme.dark && data.baseTheme !== 'hc-light')) {
+					data = undefined;
+				}
+			} else if (configuration.autoDetectColorScheme) {
+				// OS color scheme is tracked and has changed
+				if ((configuration.colorScheme.dark && data.baseTheme !== 'vs-dark') || (!configuration.colorScheme.dark && data.baseTheme !== 'vs')) {
+					data = undefined;
+				}
+			}
 		}
 
 		// developing an extension -> ignore stored layouts
@@ -122,14 +130,26 @@
 			baseTheme = data.baseTheme;
 			shellBackground = data.colorInfo.editorBackground;
 			shellForeground = data.colorInfo.foreground;
-		} else if (isHighContrast) {
-			baseTheme = 'hc-black';
-			shellBackground = '#000000';
-			shellForeground = '#FFFFFF';
-		} else {
-			baseTheme = 'vs-dark';
-			shellBackground = '#1E1E1E';
-			shellForeground = '#CCCCCC';
+		} else if (configuration.autoDetectHighContrast && configuration.colorScheme.highContrast) {
+			if (configuration.colorScheme.dark) {
+				baseTheme = 'hc-black';
+				shellBackground = '#000000';
+				shellForeground = '#FFFFFF';
+			} else {
+				baseTheme = 'hc-light';
+				shellBackground = '#FFFFFF';
+				shellForeground = '#000000';
+			}
+		} else if (configuration.autoDetectColorScheme) {
+			if (configuration.colorScheme.dark) {
+				baseTheme = 'vs-dark';
+				shellBackground = '#1E1E1E';
+				shellForeground = '#CCCCCC';
+			} else {
+				baseTheme = 'vs';
+				shellBackground = '#FFFFFF';
+				shellForeground = '#000000';
+			}
 		}
 
 		const style = document.createElement('style');

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { exec } from 'child_process';
-import { app, BrowserWindow, clipboard, Display, Menu, MessageBoxOptions, MessageBoxReturnValue, nativeTheme, OpenDevToolsOptions, OpenDialogOptions, OpenDialogReturnValue, powerMonitor, SaveDialogOptions, SaveDialogReturnValue, screen, shell } from 'electron';
+import { app, BrowserWindow, clipboard, Display, Menu, MessageBoxOptions, MessageBoxReturnValue, OpenDevToolsOptions, OpenDialogOptions, OpenDialogReturnValue, powerMonitor, SaveDialogOptions, SaveDialogReturnValue, screen, shell } from 'electron';
 import { arch, cpus, freemem, loadavg, platform, release, totalmem, type } from 'os';
 import { promisify } from 'util';
 import { memoize } from 'vs/base/common/decorators';
@@ -59,16 +59,6 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		@IWorkspacesManagementMainService private readonly workspacesManagementMainService: IWorkspacesManagementMainService
 	) {
 		super();
-
-		this.registerListeners();
-	}
-
-	private registerListeners(): void {
-
-		// Color Scheme changes
-		nativeTheme.on('updated', () => {
-			this._onDidChangeColorScheme.fire(this.osColorScheme);
-		});
 	}
 
 
@@ -94,8 +84,7 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 
 	readonly onDidResumeOS = Event.fromNodeEventEmitter(powerMonitor, 'resume');
 
-	private readonly _onDidChangeColorScheme = this._register(new Emitter<IColorScheme>());
-	readonly onDidChangeColorScheme = this._onDidChangeColorScheme.event;
+	readonly onDidChangeColorScheme = this.themeMainService.onDidChangeColorScheme;
 
 	private readonly _onDidChangePassword = this._register(new Emitter<{ account: string; service: string }>());
 	readonly onDidChangePassword = this._onDidChangePassword.event;
@@ -573,15 +562,8 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		return virtualMachineHint.value();
 	}
 
-	private get osColorScheme(): IColorScheme {
-		return {
-			highContrast: nativeTheme.shouldUseInvertedColorScheme || nativeTheme.shouldUseHighContrastColors,
-			dark: nativeTheme.shouldUseDarkColors
-		};
-	}
-
 	public async getOSColorScheme(): Promise<IColorScheme> {
-		return this.osColorScheme;
+		return this.themeMainService.getColorScheme();
 	}
 
 

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -121,6 +121,7 @@ export interface IWindowSettings {
 	readonly zoomLevel: number;
 	readonly titleBarStyle: 'native' | 'custom';
 	readonly autoDetectHighContrast: boolean;
+	readonly autoDetectColorScheme: boolean;
 	readonly menuBarVisibility: MenuBarVisibility;
 	readonly newWindowDimensions: 'default' | 'inherit' | 'offset' | 'maximized' | 'fullscreen';
 	readonly nativeTabs: boolean;
@@ -279,6 +280,7 @@ export interface INativeWindowConfiguration extends IWindowConfiguration, Native
 	accessibilitySupport?: boolean;
 	colorScheme: IColorScheme;
 	autoDetectHighContrast?: boolean;
+	autoDetectColorScheme?: boolean;
 
 	perfMarks: PerformanceMark[];
 

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { app, BrowserWindow, MessageBoxOptions, nativeTheme, WebContents } from 'electron';
+import { app, BrowserWindow, MessageBoxOptions, WebContents } from 'electron';
 import { statSync } from 'fs';
 import { hostname, release } from 'os';
 import { coalesce, distinct, firstOrDefault } from 'vs/base/common/arrays';
@@ -49,6 +49,7 @@ import { getSingleFolderWorkspaceIdentifier, getWorkspaceIdentifier } from 'vs/p
 import { IWorkspacesHistoryMainService } from 'vs/platform/workspaces/electron-main/workspacesHistoryMainService';
 import { IWorkspacesManagementMainService } from 'vs/platform/workspaces/electron-main/workspacesManagementMainService';
 import { ICodeWindow, UnloadReason } from 'vs/platform/window/electron-main/window';
+import { IThemeMainService } from 'vs/platform/theme/electron-main/themeMainService';
 
 //#region Helper Interfaces
 
@@ -190,7 +191,8 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		@IDialogMainService private readonly dialogMainService: IDialogMainService,
 		@IFileService private readonly fileService: IFileService,
 		@IProductService private readonly productService: IProductService,
-		@IProtocolMainService private readonly protocolMainService: IProtocolMainService
+		@IProtocolMainService private readonly protocolMainService: IProtocolMainService,
+		@IThemeMainService private readonly themeMainService: IThemeMainService
 	) {
 		super();
 
@@ -1297,11 +1299,9 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			zoomLevel: typeof windowConfig?.zoomLevel === 'number' ? windowConfig.zoomLevel : undefined,
 
 			autoDetectHighContrast: windowConfig?.autoDetectHighContrast ?? true,
+			autoDetectColorScheme: windowConfig?.autoDetectColorScheme ?? false,
 			accessibilitySupport: app.accessibilitySupportEnabled,
-			colorScheme: {
-				dark: nativeTheme.shouldUseDarkColors,
-				highContrast: nativeTheme.shouldUseInvertedColorScheme || nativeTheme.shouldUseHighContrastColors
-			}
+			colorScheme: this.themeMainService.getColorScheme()
 		};
 
 		let window: ICodeWindow | undefined;

--- a/src/vs/workbench/services/themes/common/themeConfiguration.ts
+++ b/src/vs/workbench/services/themes/common/themeConfiguration.ts
@@ -14,7 +14,7 @@ import { workbenchColorsSchemaId } from 'vs/platform/theme/common/colorRegistry'
 import { tokenStylingSchemaId } from 'vs/platform/theme/common/tokenClassificationRegistry';
 import { ThemeSettings, IWorkbenchColorTheme, IWorkbenchFileIconTheme, IColorCustomizations, ITokenColorCustomizations, IWorkbenchProductIconTheme, ISemanticTokenColorCustomizations, ThemeSettingTarget } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IConfigurationService, ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
-import { isMacintosh, isWeb, isWindows } from 'vs/base/common/platform';
+import { isWeb } from 'vs/base/common/platform';
 
 const DEFAULT_THEME_DARK_SETTING_VALUE = 'Default Dark+';
 const DEFAULT_THEME_LIGHT_SETTING_VALUE = 'Default Light+';
@@ -66,7 +66,6 @@ const preferredHCDarkThemeSettingSchema: IConfigurationPropertySchema = {
 	enum: colorThemeSettingEnum,
 	enumDescriptions: colorThemeSettingEnumDescriptions,
 	enumItemLabels: colorThemeSettingEnumItemLabels,
-	included: isWindows || isMacintosh,
 	errorMessage: nls.localize('colorThemeError', "Theme is unknown or not installed."),
 };
 const preferredHCLightThemeSettingSchema: IConfigurationPropertySchema = {
@@ -76,7 +75,6 @@ const preferredHCLightThemeSettingSchema: IConfigurationPropertySchema = {
 	enum: colorThemeSettingEnum,
 	enumDescriptions: colorThemeSettingEnumDescriptions,
 	enumItemLabels: colorThemeSettingEnumItemLabels,
-	included: isWindows || isMacintosh,
 	errorMessage: nls.localize('colorThemeError', "Theme is unknown or not installed."),
 };
 const detectColorSchemeSettingSchema: IConfigurationPropertySchema = {


### PR DESCRIPTION
The OS color scheme is used when `window.autoDetectColorScheme` and `window.autoDetectHighContrast` are enabled.

The OS scheme is determined on Electrons `nativeTheme` which has properties `shouldUseHighContrastColors`, `shouldUseInvertedColorScheme` and `shouldUseDarkColors`.

Turns out every OS is setting these slightly different so the OS Scheme object has to be computed differently.

Windows:
- high contrast is enabled when `shouldUseHighContrastColors` is set
- for high contrast light `shouldUseInvertedColorScheme` is false, for high contrast dark it is true (`shouldUseDarkColors` is always false)

MacOS
- high contrast is enabled when `shouldUseInvertedColorScheme` is set
- for high contrast light `shouldUseDarkColors` is true, for high contrast dark it is false *as the theme colors are inverted) 

Linux (Tested on Ubuntu GNOME)
- high contrast is enabled when `shouldUseHighContrastColors` is set
- there's no high contrast light or dark mode. we use dark for backward compatibility (could be changed once our hc light theme is established)


Th PR moves that logic at a single place (themeMainService)
It also polishes some issues around the initial background color.