### PR TITLE
Unset ZDOTDIR before standard scripts run and add VSCODE_SHELL_INTEGRATION

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -3,6 +3,8 @@
 #   Licensed under the MIT License. See License.txt in the project root for license information.
 # ---------------------------------------------------------------------------------------------
 
+VSCODE_SHELL_INTEGRATION=1
+
 if [ -z "$VSCODE_SHELL_LOGIN" ]; then
 	. ~/.bashrc
 else
@@ -16,6 +18,11 @@ else
 		. ~/.profile
 	fi
 	VSCODE_SHELL_LOGIN=""
+fi
+
+if [ -z "$VSCODE_SHELL_INTEGRATION" ]; then
+	echo -e "\033[1;32mShell integration was disabled by the shell\033[0m"
+	return
 fi
 
 IN_COMMAND_EXECUTION="1"

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.zsh
@@ -4,6 +4,10 @@
 # ---------------------------------------------------------------------------------------------
 autoload -Uz add-zsh-hook
 
+# Now that the init script is running, unset ZDOTDIR to ensure ~/.zlogout runs as expected as well
+# as prevent problems that may occur if the user's init scripts depend on ZDOTDIR not being set.
+unset ZDOTDIR
+
 if [ -f ~/.zshenv ]; then
 	. ~/.zshenv
 fi
@@ -13,7 +17,6 @@ fi
 if [ -f ~/.zshrc ]; then
 	. ~/.zshrc
 fi
-unset ZDOTDIR # ensure ~/.zlogout runs as expected
 
 IN_COMMAND_EXECUTION="1"
 LAST_HISTORY_ID=0

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.zsh
@@ -8,6 +8,10 @@ autoload -Uz add-zsh-hook
 # as prevent problems that may occur if the user's init scripts depend on ZDOTDIR not being set.
 unset ZDOTDIR
 
+# This variable allows the shell to both detect that VS Code's shell integration is enabled as well
+# as disable it by unsetting the variable.
+VSCODE_SHELL_INTEGRATION=1
+
 if [ -f ~/.zshenv ]; then
 	. ~/.zshenv
 fi
@@ -16,6 +20,11 @@ if [[ -o "login" &&  -f ~/.zprofile ]]; then
 fi
 if [ -f ~/.zshrc ]; then
 	. ~/.zshrc
+fi
+
+if [ -z "$VSCODE_SHELL_INTEGRATION" ]; then
+	echo -e "\033[1;32mShell integration was disabled by the shell\033[0m"
+	return
 fi
 
 IN_COMMAND_EXECUTION="1"


### PR DESCRIPTION
Fixes #145587
Fixes https://github.com/microsoft/vscode/issues/145583
Fixes https://github.com/microsoft/vscode/issues/145582