### PR TITLE
Use prefix to avoid clashes with shell functions

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -21,31 +21,31 @@ fi
 IN_COMMAND_EXECUTION="1"
 LAST_HISTORY_ID=$(history 1 | awk '{print $1;}')
 
-prompt_start() {
+__vsc_prompt_start() {
 	printf "\033]633;A\007"
 }
 
-prompt_end() {
+__vsc_prompt_end() {
 	printf "\033]633;B\007"
 }
 
-update_cwd() {
+__vsc_update_cwd() {
 	printf "\033]633;P;Cwd=%s\007" "$PWD"
 }
 
-command_output_start() {
+__vsc_command_output_start() {
 	printf "\033]633;C\007"
 }
 
-continuation_start() {
+__vsc_continuation_start() {
 	printf "\033]633;F\007"
 }
 
-continuation_end() {
+__vsc_continuation_end() {
 	printf "\033]633;G\007"
 }
 
-command_complete() {
+__vsc_command_complete() {
 	local HISTORY_ID=$(history 1 | awk '{print $1;}')
 	if [[ "$HISTORY_ID" == "$LAST_HISTORY_ID" ]]; then
 		printf "\033]633;D\007"
@@ -53,34 +53,35 @@ command_complete() {
 		printf "\033]633;D;%s\007" "$STATUS"
 		LAST_HISTORY_ID=$HISTORY_ID
 	fi
-	update_cwd
+	__vsc_update_cwd
 }
 
-update_prompt() {
+__vsc_update_prompt() {
 	PRIOR_PROMPT="$PS1"
 	IN_COMMAND_EXECUTION=""
-	PS1="\[$(prompt_start)\]$PREFIX$PS1\[$(prompt_end)\]"
-	PS2="\[$(continuation_start)\]$PS2\[$(continuation_end)\]"
+	PS1="\[$(__vsc_prompt_start)\]$PREFIX$PS1\[$(__vsc_prompt_end)\]"
+	PS2="\[$(__vsc_continuation_start)\]$PS2\[$(__vsc_continuation_end)\]"
 }
 
 precmd() {
-	command_complete "$STATUS"
+	__vsc_command_complete "$STATUS"
 
 	# in command execution
 	if [ -n "$IN_COMMAND_EXECUTION" ]; then
 		# non null
-		update_prompt
+		__vsc_update_prompt
 	fi
 }
 preexec() {
 	PS1="$PRIOR_PROMPT"
 	if [ -z "${IN_COMMAND_EXECUTION-}" ]; then
 		IN_COMMAND_EXECUTION="1"
-		command_output_start
+		__vsc_command_output_start
 	fi
 }
 
-update_prompt
+__vsc_update_prompt
+
 prompt_cmd_original() {
 	STATUS="$?"
 	if [[ "$ORIGINAL_PROMPT_COMMAND" =~ .+\;.+ ]]; then

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.zsh
@@ -18,39 +18,39 @@ unset ZDOTDIR # ensure ~/.zlogout runs as expected
 IN_COMMAND_EXECUTION="1"
 LAST_HISTORY_ID=0
 
-prompt_start() {
+__vsc_prompt_start() {
 	printf "\033]633;A\007"
 }
 
-prompt_end() {
+__vsc_prompt_end() {
 	printf "\033]633;B\007"
 }
 
-update_cwd() {
+__vsc_update_cwd() {
 	printf "\033]633;P;Cwd=%s\007" "$PWD"
 }
 
-command_output_start() {
+__vsc_command_output_start() {
 	printf "\033]633;C\007"
 }
 
-continuation_start() {
+__vsc_continuation_start() {
 	printf "\033]633;F\007"
 }
 
-continuation_end() {
+__vsc_continuation_end() {
 	printf "\033]633;G\007"
 }
 
-right_prompt_start() {
+__vsc_right_prompt_start() {
 	printf "\033]633;H\007"
 }
 
-right_prompt_end() {
+__vsc_right_prompt_end() {
 	printf "\033]633;I\007"
 }
 
-command_complete() {
+__vsc_command_complete() {
 	local HISTORY_ID=$(history | tail -n1 | awk '{print $1;}')
 	if [[ "$HISTORY_ID" == "$LAST_HISTORY_ID" ]]; then
 		printf "\033]633;D\007"
@@ -58,17 +58,17 @@ command_complete() {
 		printf "\033]633;D;%s\007" "$STATUS"
 		LAST_HISTORY_ID=$HISTORY_ID
 	fi
-	update_cwd
+	__vsc_update_cwd
 }
 
-update_prompt() {
+__vsc_update_prompt() {
 	PRIOR_PROMPT="$PS1"
 	IN_COMMAND_EXECUTION=""
-	PS1="%{$(prompt_start)%}$PREFIX$PS1%{$(prompt_end)%}"
-	PS2="%{$(continuation_start)%}$PS2%{$(continuation_end)%}"
+	PS1="%{$(__vsc_prompt_start)%}$PREFIX$PS1%{$(__vsc_prompt_end)%}"
+	PS2="%{$(__vsc_continuation_start)%}$PS2%{$(__vsc_continuation_end)%}"
 	if [ -n "$RPROMPT" ]; then
 		PRIOR_RPROMPT="$RPROMPT"
-		RPROMPT="%{$(right_prompt_start)%}$RPROMPT%{$(right_prompt_end)%}"
+		RPROMPT="%{$(__vsc_right_prompt_start)%}$RPROMPT%{$(__vsc_right_prompt_end)%}"
 	fi
 }
 
@@ -76,15 +76,15 @@ precmd() {
 	local STATUS="$?"
 	if [ -z "${IN_COMMAND_EXECUTION-}" ]; then
 		# not in command execution
-		command_output_start
+		__vsc_command_output_start
 	fi
 
-	command_complete "$STATUS"
+	__vsc_command_complete "$STATUS"
 
 	# in command execution
 	if [ -n "$IN_COMMAND_EXECUTION" ]; then
 		# non null
-		update_prompt
+		__vsc_update_prompt
 	fi
 }
 
@@ -94,7 +94,7 @@ preexec() {
 		RPROMPT="$PRIOR_RPROMPT"
 	fi
 	IN_COMMAND_EXECUTION="1"
-	command_output_start
+	__vsc_command_output_start
 }
 add-zsh-hook precmd precmd
 add-zsh-hook preexec preexec


### PR DESCRIPTION
Fixes #145584
