### PR TITLE
Avoid NPE

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -482,6 +482,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		for (let i = removeRange.end - 1; i >= removeRange.start; i--) {
 			const item = this.items[i];
 			item.dragStartDisposable.dispose();
+			item.checkedDisposable.dispose();
 
 			if (item.row) {
 				let rows = rowsToDispose.get(item.templateId);


### PR DESCRIPTION
Closes: #145495

Inside `_splice`, `item.row` can be set to `null`. In that case, we must make sure to also dispose our `item.checkedDisposable`. The disposal of `item.dragStartDisposable` right above hints at this.