### PR TITLE
Fix infinite recursion in `getDirectoryHandle`

### DIFF
--- a/src/vs/platform/files/browser/htmlFileSystemProvider.ts
+++ b/src/vs/platform/files/browser/htmlFileSystemProvider.ts
@@ -382,6 +382,11 @@ export class HTMLFileSystemProvider implements IFileSystemProviderWithFileReadWr
 			return handle;
 		}
 
+		const parentUri = this.extUri.dirname(resource);
+		// Root directory's parent is itself
+		if (this.extUri.isEqual(parentUri, resource)) {
+			return undefined;
+		}
 		const parent = await this.getDirectoryHandle(this.extUri.dirname(resource));
 
 		try {

--- a/src/vs/platform/files/browser/htmlFileSystemProvider.ts
+++ b/src/vs/platform/files/browser/htmlFileSystemProvider.ts
@@ -383,11 +383,11 @@ export class HTMLFileSystemProvider implements IFileSystemProviderWithFileReadWr
 		}
 
 		const parentUri = this.extUri.dirname(resource);
-		// Root directory's parent is itself
 		if (this.extUri.isEqual(parentUri, resource)) {
-			return undefined;
+			return undefined; // return when root is reached to prevent infinite recursion
 		}
-		const parent = await this.getDirectoryHandle(this.extUri.dirname(resource));
+
+		const parent = await this.getDirectoryHandle(parentUri);
 
 		try {
 			return await parent?.getDirectoryHandle(extUri.basename(resource));


### PR DESCRIPTION
While opening the root dir (or disk root on windows), launch debug, `getDirectoryHandle` will try to find its parent dir. However `dirname(root)` returns root itself. This caused UI freezed on web target.

Add equal detection to fix this bug.