### PR TITLE
Open settings UI editor while configuring language specific settings

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
@@ -23,7 +23,7 @@ export class ConfigureLanguageBasedSettingsAction extends Action {
 		@IModelService private readonly modelService: IModelService,
 		@ILanguageService private readonly languageService: ILanguageService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
-		@IPreferencesService private readonly preferencesService: IPreferencesService,
+		@IPreferencesService private readonly preferencesService: IPreferencesService
 	) {
 		super(id, label);
 	}

--- a/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
@@ -11,7 +11,6 @@ import { ILanguageService } from 'vs/editor/common/languages/language';
 import * as nls from 'vs/nls';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export class ConfigureLanguageBasedSettingsAction extends Action {
 
@@ -25,7 +24,6 @@ export class ConfigureLanguageBasedSettingsAction extends Action {
 		@ILanguageService private readonly languageService: ILanguageService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@IPreferencesService private readonly preferencesService: IPreferencesService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super(id, label);
 	}
@@ -57,11 +55,7 @@ export class ConfigureLanguageBasedSettingsAction extends Action {
 				if (pick) {
 					const languageId = this.languageService.getLanguageIdByLanguageName(pick.label);
 					if (typeof languageId === 'string') {
-						if (this.configurationService.getValue('workbench.settings.editor') === 'json') {
-							return this.preferencesService.openUserSettings({ jsonEditor: true, revealSetting: { key: `[${languageId}]`, edit: true } });
-						} else {
-							return this.preferencesService.openUserSettings({ query: `@lang:${languageId}` });
-						}
+						return this.preferencesService.openLanguageSpecificSettings(languageId);
 					}
 				}
 				return undefined;

--- a/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
@@ -55,7 +55,7 @@ export class ConfigureLanguageBasedSettingsAction extends Action {
 				if (pick) {
 					const languageId = this.languageService.getLanguageIdByLanguageName(pick.label);
 					if (typeof languageId === 'string') {
-						return this.preferencesService.openUserSettings({ jsonEditor: true, revealSetting: { key: `[${languageId}]`, edit: true } });
+						return this.preferencesService.openUserSettings({ query: `@lang:${languageId}` });
 					}
 				}
 				return undefined;

--- a/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
@@ -11,6 +11,7 @@ import { ILanguageService } from 'vs/editor/common/languages/language';
 import * as nls from 'vs/nls';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export class ConfigureLanguageBasedSettingsAction extends Action {
 
@@ -23,7 +24,8 @@ export class ConfigureLanguageBasedSettingsAction extends Action {
 		@IModelService private readonly modelService: IModelService,
 		@ILanguageService private readonly languageService: ILanguageService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
-		@IPreferencesService private readonly preferencesService: IPreferencesService
+		@IPreferencesService private readonly preferencesService: IPreferencesService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super(id, label);
 	}
@@ -55,7 +57,11 @@ export class ConfigureLanguageBasedSettingsAction extends Action {
 				if (pick) {
 					const languageId = this.languageService.getLanguageIdByLanguageName(pick.label);
 					if (typeof languageId === 'string') {
-						return this.preferencesService.openUserSettings({ query: `@lang:${languageId}` });
+						if (this.configurationService.getValue('workbench.settings.editor') === 'json') {
+							return this.preferencesService.openUserSettings({ jsonEditor: true, revealSetting: { key: `[${languageId}]`, edit: true } });
+						} else {
+							return this.preferencesService.openUserSettings({ query: `@lang:${languageId}` });
+						}
 					}
 				}
 				return undefined;

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -218,6 +218,18 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return this.open(this.userSettingsResource, options);
 	}
 
+	openLanguageSpecificSettings(languageId: string, options: IOpenSettingsOptions = {}): Promise<IEditorPane | undefined> {
+		if (this.shouldOpenJsonByDefault()) {
+			options.query = undefined;
+			options.revealSetting = { key: `[${languageId}]`, edit: true };
+		} else {
+			options.query = `@lang:${languageId}${options.query ? ` ${options.query}` : ''}`;
+		}
+		options.target = options.target ?? ConfigurationTarget.USER_LOCAL;
+
+		return this.open(this.userSettingsResource, options);
+	}
+
 	private open(settingsResource: URI, options: IOpenSettingsOptions): Promise<IEditorPane | undefined> {
 		options = {
 			...options,

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -239,6 +239,7 @@ export interface IPreferencesService {
 	openFolderSettings(options: IOpenSettingsOptions & { folderUri: IOpenSettingsOptions['folderUri'] }): Promise<IEditorPane | undefined>;
 	openGlobalKeybindingSettings(textual: boolean, options?: IKeybindingsEditorOptions): Promise<void>;
 	openDefaultKeybindingsFile(): Promise<IEditorPane | undefined>;
+	openLanguageSpecificSettings(language: string, options?: IOpenSettingsOptions): Promise<IEditorPane | undefined>;
 	getEditableSettingsURI(configurationTarget: ConfigurationTarget, resource?: URI): Promise<URI | null>;
 
 	createSplitJsonEditorInput(configurationTarget: ConfigurationTarget, resource: URI): EditorInput;


### PR DESCRIPTION
This PR fixes #146161

Open settings UI editor while configuring language specific settings
