### PR TITLE
fix 146174

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
@@ -253,6 +253,7 @@ export class InlineCompletionsSession extends BaseGhostTextWidgetModel {
 
 		this._register(this.editor.onDidChangeCursorPosition((e) => {
 			// Ghost text depends on the cursor position
+			this.cache.value?.updateRanges();
 			if (this.cache.value) {
 				this.updateFilteredInlineCompletions();
 				this.onDidChangeEmitter.fire();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #146174 for the release branch


The issue was that `onDidChangeCursorPosition` is now being called before `onDidChangeModelContent`.
However, the decorations were only updated in `onDidChangeModelContent`, thus the code executed on `onDidChangeCursorPosition` used stale ranges.

This commit fixes that by also updating the ranges in `onDidChangeCursorPosition`.