### PR TITLE
Event api proposal cleanup

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -10,7 +10,8 @@
 	},
 	"enabledApiProposals": [
 		"notebookEditor",
-		"notebookEditorEdit"
+		"notebookEditorEdit",
+		"notebookDocumentEvents"
 	],
 	"activationEvents": [
 		"*"
@@ -31,9 +32,9 @@
 		"commands": [
 			{
 				"command": "ipynb.newUntitledIpynb",
-        "title": "New Jupyter Notebook",
+				"title": "New Jupyter Notebook",
 				"shortTitle": "Jupyter Notebook",
-        "category": "Create"
+				"category": "Create"
 			},
 			{
 				"command": "ipynb.openIpynbInNotebookEditor",
@@ -60,9 +61,9 @@
 				}
 			],
 			"commandPalette": [
-        {
-          "command": "ipynb.newUntitledIpynb"
-        },
+				{
+					"command": "ipynb.newUntitledIpynb"
+				},
 				{
 					"command": "ipynb.openIpynbInNotebookEditor",
 					"when": "false"

--- a/extensions/ipynb/tsconfig.json
+++ b/extensions/ipynb/tsconfig.json
@@ -11,5 +11,6 @@
 		"../../src/vscode-dts/vscode.d.ts",
 		"../../src/vscode-dts/vscode.proposed.notebookEditor.d.ts",
 		"../../src/vscode-dts/vscode.proposed.notebookEditorEdit.d.ts",
+		"../../src/vscode-dts/vscode.proposed.notebookDocumentEvents.d.ts",
 	]
 }

--- a/extensions/vscode-api-tests/package.json
+++ b/extensions/vscode-api-tests/package.json
@@ -23,6 +23,7 @@
     "notebookControllerKind",
     "notebookDebugOptions",
     "notebookDeprecated",
+    "notebookDocumentEvents",
     "notebookEditor",
     "notebookEditorDecorationType",
     "notebookEditorEdit",

--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.document.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.document.test.ts
@@ -261,7 +261,7 @@ suite.skip('Notebook Document', function () {
 			value: 'new_code'
 		}]);
 
-		const event = utils.asPromise<vscode.NotebookCellsChangeEvent>(vscode.notebooks.onDidChangeNotebookCells);
+		const event = utils.asPromise<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument);
 
 		const success = await vscode.workspace.applyEdit(edit);
 		assert.strictEqual(success, true);
@@ -274,13 +274,13 @@ suite.skip('Notebook Document', function () {
 		assert.strictEqual(document.cellAt(1).document.getText(), 'new_code');
 
 		// check event data
-		assert.strictEqual(data.document === document, true);
-		assert.strictEqual(data.changes.length, 1);
-		assert.strictEqual(data.changes[0].deletedCount, 0);
-		assert.strictEqual(data.changes[0].deletedItems.length, 0);
-		assert.strictEqual(data.changes[0].items.length, 2);
-		assert.strictEqual(data.changes[0].items[0], document.cellAt(0));
-		assert.strictEqual(data.changes[0].items[1], document.cellAt(1));
+		assert.strictEqual(data.notebook === document, true);
+		assert.strictEqual(data.contentChanges.length, 1);
+		assert.strictEqual(data.contentChanges[0].range.isEmpty, true);
+		assert.strictEqual(data.contentChanges[0].removedCells.length, 0);
+		assert.strictEqual(data.contentChanges[0].addedCells.length, 2);
+		assert.strictEqual(data.contentChanges[0].addedCells[0], document.cellAt(0));
+		assert.strictEqual(data.contentChanges[0].addedCells[1], document.cellAt(1));
 	});
 
 	test('workspace edit API (replaceMetadata)', async function () {
@@ -299,7 +299,7 @@ suite.skip('Notebook Document', function () {
 		const document = await vscode.workspace.openNotebookDocument(uri);
 
 		const edit = new vscode.WorkspaceEdit();
-		const event = utils.asPromise<vscode.NotebookCellMetadataChangeEvent>(vscode.notebooks.onDidChangeCellMetadata);
+		const event = utils.asPromise<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument);
 
 		edit.replaceNotebookCellMetadata(document.uri, 0, { inputCollapsed: true });
 		const success = await vscode.workspace.applyEdit(edit);
@@ -310,8 +310,10 @@ suite.skip('Notebook Document', function () {
 		assert.strictEqual(document.cellAt(0).metadata.inputCollapsed, true);
 
 		// check event data
-		assert.strictEqual(data.document === document, true);
-		assert.strictEqual(data.cell.index, 0);
+		assert.strictEqual(data.notebook === document, true);
+		assert.strictEqual(data.contentChanges.length, 0);
+		assert.strictEqual(data.cellChanges.length, 1);
+		assert.strictEqual(data.cellChanges[0].cell.index, 0);
 	});
 
 	test('document save API', async function () {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.test.ts
@@ -194,41 +194,52 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const notebook = await openRandomNotebookDocument();
 		const editor = await vscode.window.showNotebookDocument(notebook);
 
-		const cellsChangeEvent = asPromise<vscode.NotebookCellsChangeEvent>(vscode.notebooks.onDidChangeNotebookCells);
+		const cellsChangeEvent = asPromise<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument);
 		await vscode.commands.executeCommand('notebook.cell.insertCodeCellBelow');
 		const cellChangeEventRet = await cellsChangeEvent;
-		assert.strictEqual(cellChangeEventRet.document, editor.document);
-		assert.strictEqual(cellChangeEventRet.changes.length, 1);
-		assert.deepStrictEqual(cellChangeEventRet.changes[0], {
-			start: 1,
-			deletedCount: 0,
-			deletedItems: [],
-			items: [
-				editor.document.cellAt(1)
-			]
+		assert.strictEqual(cellChangeEventRet.notebook, editor.document);
+		assert.strictEqual(cellChangeEventRet.contentChanges.length, 1);
+		assert.deepStrictEqual(cellChangeEventRet.contentChanges[0], <vscode.NotebookDocumentContentChange>{
+			range: new vscode.NotebookRange(1, 1),
+			removedCells: [],
+			addedCells: [editor.document.cellAt(1)]
 		});
 
-		const moveCellEvent = asPromise<vscode.NotebookCellsChangeEvent>(vscode.notebooks.onDidChangeNotebookCells);
+		const moveCellEvent = asPromise<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument);
 		await vscode.commands.executeCommand('notebook.cell.moveUp');
 		await moveCellEvent;
 
-		const cellOutputChange = asPromise<vscode.NotebookCellOutputsChangeEvent>(vscode.notebooks.onDidChangeCellOutputs);
+		const cellOutputChange = asPromise<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument);
 		await vscode.commands.executeCommand('notebook.cell.execute');
 		const cellOutputsAddedRet = await cellOutputChange;
-		assert.deepStrictEqual(cellOutputsAddedRet, {
-			document: editor.document,
-			cells: [editor.document.cellAt(0)]
-		});
-		assert.strictEqual(cellOutputsAddedRet.cells[0].outputs.length, 1);
 
-		const cellOutputClear = asPromise<vscode.NotebookCellOutputsChangeEvent>(vscode.notebooks.onDidChangeCellOutputs);
+		assert.strictEqual(cellOutputsAddedRet.notebook.uri.toString(), editor.document.uri.toString());
+		assert.strictEqual(cellOutputsAddedRet.metadata, undefined);
+		assert.strictEqual(cellOutputsAddedRet.contentChanges.length, 0);
+		assert.strictEqual(cellOutputsAddedRet.cellChanges.length, 1);
+		assert.deepStrictEqual(cellOutputsAddedRet.cellChanges[0].cell, editor.document.cellAt(0));
+		assert.deepStrictEqual(cellOutputsAddedRet.cellChanges[0].executionSummary, { executionOrder: undefined, success: undefined, timing: undefined }); // TODO@jrieken should this be undefined instead all empty?
+		assert.strictEqual(cellOutputsAddedRet.cellChanges[0].document, undefined);
+		assert.strictEqual(cellOutputsAddedRet.cellChanges[0].metadata, undefined);
+		assert.strictEqual(cellOutputsAddedRet.cellChanges[0].outputs, undefined);
+		assert.strictEqual(cellOutputsAddedRet.cellChanges[0].cell.outputs.length, 1);
+
+		const cellOutputClear = asPromise<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument);
 		await vscode.commands.executeCommand('notebook.cell.clearOutputs');
 		const cellOutputsCleardRet = await cellOutputClear;
-		assert.deepStrictEqual(cellOutputsCleardRet, {
-			document: editor.document,
-			cells: [editor.document.cellAt(0)]
+		assert.deepStrictEqual(cellOutputsCleardRet, <vscode.NotebookDocumentChangeEvent>{
+			notebook: editor.document,
+			metadata: undefined,
+			contentChanges: [],
+			cellChanges: [{
+				cell: editor.document.cellAt(0),
+				document: undefined,
+				executionSummary: undefined,
+				metadata: undefined,
+				outputs: editor.document.cellAt(0).outputs
+			}],
 		});
-		assert.strictEqual(cellOutputsAddedRet.cells[0].outputs.length, 0);
+		assert.strictEqual(cellOutputsCleardRet.cellChanges[0].cell.outputs.length, 0);
 
 		// const cellChangeLanguage = getEventOncePromise<vscode.NotebookCellLanguageChangeEvent>(vscode.notebooks.onDidChangeCellLanguage);
 		// await vscode.commands.executeCommand('notebook.cell.changeToMarkdown');
@@ -244,16 +255,14 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const notebook = await openRandomNotebookDocument();
 		const editor = await vscode.window.showNotebookDocument(notebook);
 
-		const cellsChangeEvent = asPromise<vscode.NotebookCellsChangeEvent>(vscode.notebooks.onDidChangeNotebookCells);
-		const cellMetadataChangeEvent = asPromise<vscode.NotebookCellMetadataChangeEvent>(vscode.notebooks.onDidChangeCellMetadata);
+		const notebookChangeEvent = asPromise<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument);
 		const version = editor.document.version;
 		await editor.edit(editBuilder => {
 			editBuilder.replaceCells(1, 0, [{ kind: vscode.NotebookCellKind.Code, languageId: 'javascript', value: 'test 2', outputs: [], metadata: undefined }]);
 			editBuilder.replaceCellMetadata(0, { inputCollapsed: false });
 		});
 
-		await cellsChangeEvent;
-		await cellMetadataChangeEvent;
+		await notebookChangeEvent;
 		assert.strictEqual(version + 1, editor.document.version);
 	});
 
@@ -261,16 +270,14 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const notebook = await openRandomNotebookDocument();
 		const editor = await vscode.window.showNotebookDocument(notebook);
 
-		const cellsChangeEvent = asPromise<vscode.NotebookCellsChangeEvent>(vscode.notebooks.onDidChangeNotebookCells);
-		const cellMetadataChangeEvent = asPromise<vscode.NotebookCellMetadataChangeEvent>(vscode.notebooks.onDidChangeCellMetadata);
+		const notebookChangeEvent = asPromise<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument);
 		const version = editor.document.version;
 		await editor.edit(editBuilder => {
 			editBuilder.replaceCells(1, 0, [{ kind: vscode.NotebookCellKind.Code, languageId: 'javascript', value: 'test 2', outputs: [], metadata: undefined }]);
 			editBuilder.replaceCellMetadata(0, { inputCollapsed: false });
 		});
 
-		await cellsChangeEvent;
-		await cellMetadataChangeEvent;
+		await notebookChangeEvent;
 		assert.strictEqual(editor.document.cellCount, 3);
 		assert.strictEqual(editor.document.cellAt(0)?.metadata.inputCollapsed, false);
 		assert.strictEqual(version + 1, editor.document.version);
@@ -285,7 +292,7 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 	test.skip('#98841, initialzation should not emit cell change events.', async function () {
 		let count = 0;
 
-		testDisposables.push(vscode.notebooks.onDidChangeNotebookCells(() => {
+		testDisposables.push(vscode.workspace.onDidChangeNotebookDocument(() => {
 			count++;
 		}));
 
@@ -387,9 +394,9 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 
 		const activeCell = getFocusedCell(editor);
 		assert.strictEqual(activeCell?.index, 0);
-		const moveChange = asPromise(vscode.notebooks.onDidChangeNotebookCells);
+		const notebookChangeEvent = asPromise(vscode.workspace.onDidChangeNotebookDocument);
 		await vscode.commands.executeCommand('notebook.cell.moveDown');
-		assert.ok(await moveChange);
+		assert.ok(await notebookChangeEvent);
 
 		const newActiveCell = getFocusedCell(editor);
 		assert.strictEqual(newActiveCell?.index, 1);
@@ -440,13 +447,13 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const editor = vscode.window.activeNotebookEditor!;
 		const cell = editor.document.cellAt(0);
 
-		await withEvent(vscode.notebooks.onDidChangeCellOutputs, async (event) => {
+		await withEvent(vscode.workspace.onDidChangeNotebookDocument, async (event) => {
 			await vscode.commands.executeCommand('notebook.execute');
 			await event;
 			assert.strictEqual(cell.outputs.length, 1, 'should execute'); // runnable, it worked
 		});
 
-		await withEvent(vscode.notebooks.onDidChangeCellOutputs, async event => {
+		await withEvent(vscode.workspace.onDidChangeNotebookDocument, async event => {
 			await vscode.commands.executeCommand('notebook.cell.clearOutputs');
 			await event;
 			assert.strictEqual(cell.outputs.length, 0, 'should clear');
@@ -455,7 +462,7 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const secondResource = await createRandomNotebookFile();
 		await vscode.commands.executeCommand('vscode.openWith', secondResource, 'notebookCoreTest');
 
-		await withEvent<vscode.NotebookCellOutputsChangeEvent>(vscode.notebooks.onDidChangeCellOutputs, async (event) => {
+		await withEvent<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument, async (event) => {
 			await vscode.commands.executeCommand('notebook.cell.execute', { start: 0, end: 1 }, resource);
 			await event;
 			assert.strictEqual(cell.outputs.length, 1, 'should execute'); // runnable, it worked
@@ -473,13 +480,13 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		let secondCellExecuted = false;
 		let resolve: () => void;
 		const p = new Promise<void>(r => resolve = r);
-		const listener = vscode.notebooks.onDidChangeCellOutputs(e => {
-			e.cells.forEach(cell => {
-				if (cell.index === 0) {
+		const listener = vscode.workspace.onDidChangeNotebookDocument(e => {
+			e.cellChanges.forEach(change => {
+				if (change.cell.index === 0) {
 					firstCellExecuted = true;
 				}
 
-				if (cell.index === 1) {
+				if (change.cell.index === 1) {
 					secondCellExecuted = true;
 				}
 			});
@@ -501,13 +508,13 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const editor = vscode.window.activeNotebookEditor!;
 		const cell = editor.document.cellAt(0);
 
-		await withEvent<vscode.NotebookCellOutputsChangeEvent>(vscode.notebooks.onDidChangeCellOutputs, async (event) => {
+		await withEvent<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument, async (event) => {
 			await vscode.commands.executeCommand('notebook.execute');
 			await event;
 			assert.strictEqual(cell.outputs.length, 1, 'should execute'); // runnable, it worked
 		});
 
-		const clearChangeEvent = asPromise<vscode.NotebookCellOutputsChangeEvent>(vscode.notebooks.onDidChangeCellOutputs);
+		const clearChangeEvent = asPromise<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument);
 		await vscode.commands.executeCommand('notebook.cell.clearOutputs');
 		await clearChangeEvent;
 		assert.strictEqual(cell.outputs.length, 0, 'should clear');
@@ -515,7 +522,7 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const secondResource = await createRandomNotebookFile();
 		await vscode.commands.executeCommand('vscode.openWith', secondResource, 'notebookCoreTest');
 
-		await withEvent<vscode.NotebookCellOutputsChangeEvent>(vscode.notebooks.onDidChangeCellOutputs, async (event) => {
+		await withEvent<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument, async (event) => {
 			await vscode.commands.executeCommand('notebook.execute', resource);
 			await event;
 			assert.strictEqual(cell.outputs.length, 1, 'should execute'); // runnable, it worked
@@ -547,7 +554,7 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		};
 		testDisposables.push(alternativeKernel.controller);
 
-		await withEvent<vscode.NotebookCellOutputsChangeEvent>(vscode.notebooks.onDidChangeCellOutputs, async (event) => {
+		await withEvent<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument, async (event) => {
 			await assertKernel(defaultKernel, notebook);
 			await vscode.commands.executeCommand('notebook.cell.execute');
 			await event;
@@ -557,7 +564,7 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 			assert.deepStrictEqual(new TextDecoder().decode(cell.outputs[0].items[0].data), cell.document.getText());
 		});
 
-		await withEvent<vscode.NotebookCellOutputsChangeEvent>(vscode.notebooks.onDidChangeCellOutputs, async (event) => {
+		await withEvent<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument, async (event) => {
 			await assertKernel(alternativeKernel, notebook);
 			await vscode.commands.executeCommand('notebook.cell.execute');
 			await event;
@@ -798,16 +805,16 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const notebook = await vscode.workspace.openNotebookDocument(resource);
 		const editor = await vscode.window.showNotebookDocument(notebook);
 
-		const cellsChangeEvent = asPromise<vscode.NotebookCellsChangeEvent>(vscode.notebooks.onDidChangeNotebookCells);
+		const cellsChangeEvent = asPromise<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument);
 		await editor.edit(editBuilder => {
 			editBuilder.replaceCells(1, 0, [{ kind: vscode.NotebookCellKind.Code, languageId: 'javascript', value: 'test 2', outputs: [], metadata: undefined }]);
 		});
 
 		const cellChangeEventRet = await cellsChangeEvent;
-		assert.strictEqual(cellChangeEventRet.document === notebook, true);
-		assert.strictEqual(cellChangeEventRet.document.isDirty, true);
+		assert.strictEqual(cellChangeEventRet.notebook === notebook, true);
+		assert.strictEqual(cellChangeEventRet.notebook.isDirty, true);
 
-		const saveEvent = asPromise(vscode.notebooks.onDidSaveNotebookDocument);
+		const saveEvent = asPromise(vscode.workspace.onDidSaveNotebookDocument);
 
 		await notebook.save();
 

--- a/src/vs/workbench/api/browser/mainThreadNotebookDocuments.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookDocuments.ts
@@ -109,10 +109,6 @@ export class MainThreadNotebookDocuments implements MainThreadNotebookDocumentsS
 					this._notebookEditorModelResolverService.isDirty(textModel.uri),
 					hasDocumentMetadataChangeEvent ? textModel.metadata : undefined
 				);
-
-				if (hasDocumentMetadataChangeEvent) {
-					this._proxy.$acceptDocumentPropertiesChanged(textModel.uri, { metadata: textModel.metadata });
-				}
 			}));
 
 			this._documentEventListenersMapping.set(textModel.uri, disposableStore);

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -153,7 +153,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostDocumentContentProviders = rpcProtocol.set(ExtHostContext.ExtHostDocumentContentProviders, new ExtHostDocumentContentProvider(rpcProtocol, extHostDocumentsAndEditors, extHostLogService));
 	const extHostDocumentSaveParticipant = rpcProtocol.set(ExtHostContext.ExtHostDocumentSaveParticipant, new ExtHostDocumentSaveParticipant(extHostLogService, extHostDocuments, rpcProtocol.getProxy(MainContext.MainThreadBulkEdits)));
 	const extHostNotebook = rpcProtocol.set(ExtHostContext.ExtHostNotebook, new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments, extensionStoragePaths));
-	const extHostNotebookDocuments = rpcProtocol.set(ExtHostContext.ExtHostNotebookDocuments, new ExtHostNotebookDocuments(extHostLogService, extHostNotebook));
+	const extHostNotebookDocuments = rpcProtocol.set(ExtHostContext.ExtHostNotebookDocuments, new ExtHostNotebookDocuments(extHostNotebook));
 	const extHostNotebookEditors = rpcProtocol.set(ExtHostContext.ExtHostNotebookEditors, new ExtHostNotebookEditors(extHostLogService, rpcProtocol, extHostNotebook));
 	const extHostNotebookKernels = rpcProtocol.set(ExtHostContext.ExtHostNotebookKernels, new ExtHostNotebookKernels(rpcProtocol, initData, extHostNotebook, extHostCommands, extHostLogService));
 	const extHostNotebookRenderers = rpcProtocol.set(ExtHostContext.ExtHostNotebookRenderers, new ExtHostNotebookRenderers(rpcProtocol, extHostNotebook));
@@ -1118,10 +1118,6 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			registerNotebookCellStatusBarItemProvider: (notebookType: string, provider: vscode.NotebookCellStatusBarItemProvider) => {
 				return extHostNotebook.registerNotebookCellStatusBarItemProvider(extension, notebookType, provider);
 			},
-			get onDidSaveNotebookDocument(): Event<vscode.NotebookDocument> {
-				checkProposedApiEnabled(extension, 'notebookEditor');
-				return extHostNotebookDocuments.onDidSaveNotebookDocument;
-			},
 			createNotebookEditorDecorationType(options: vscode.NotebookDecorationRenderOptions): vscode.NotebookEditorDecorationType {
 				checkProposedApiEnabled(extension, 'notebookEditorDecorationType');
 				return extHostNotebookEditors.createNotebookEditorDecorationType(options);
@@ -1129,29 +1125,13 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			createRendererMessaging(rendererId) {
 				return extHostNotebookRenderers.createRendererMessaging(extension, rendererId);
 			},
-			onDidChangeNotebookDocumentMetadata(listener, thisArgs?, disposables?) {
-				checkProposedApiEnabled(extension, 'notebookEditor');
-				return extHostNotebookDocuments.onDidChangeNotebookDocumentMetadata(listener, thisArgs, disposables);
-			},
-			onDidChangeNotebookCells(listener, thisArgs?, disposables?) {
-				checkProposedApiEnabled(extension, 'notebookEditor');
-				return extHostNotebook.onDidChangeNotebookCells(listener, thisArgs, disposables);
-			},
 			onDidChangeNotebookCellExecutionState(listener, thisArgs?, disposables?) {
 				checkProposedApiEnabled(extension, 'notebookCellExecutionState');
 				return extHostNotebookKernels.onDidChangeNotebookCellExecutionState(listener, thisArgs, disposables);
 			},
-			onDidChangeCellOutputs(listener, thisArgs?, disposables?) {
-				checkProposedApiEnabled(extension, 'notebookEditor');
-				return extHostNotebook.onDidChangeCellOutputs(listener, thisArgs, disposables);
-			},
-			onDidChangeCellMetadata(listener, thisArgs?, disposables?) {
-				checkProposedApiEnabled(extension, 'notebookEditor');
-				return extHostNotebook.onDidChangeCellMetadata(listener, thisArgs, disposables);
-			},
 			createConcatTextDocument(notebook, selector) {
 				checkProposedApiEnabled(extension, 'notebookConcatTextDocument');
-				return new ExtHostNotebookConcatDocument(extHostNotebook, extHostDocuments, notebook, selector);
+				return new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook, selector);
 			},
 		};
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2064,7 +2064,6 @@ export interface ExtHostNotebookDocumentsShape {
 	$acceptModelChanged(uriComponents: UriComponents, event: SerializableObjectWithBuffers<NotebookCellsChangedEventDto>, isDirty: boolean, newMetadata?: notebookCommon.NotebookDocumentMetadata): void;
 	$acceptDirtyStateChanged(uriComponents: UriComponents, isDirty: boolean): void;
 	$acceptModelSaved(uriComponents: UriComponents): void;
-	$acceptDocumentPropertiesChanged(uriComponents: UriComponents, data: INotebookDocumentPropertiesChangeData): void;
 }
 
 export type INotebookEditorViewColumnInfo = Record<string, number>;

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -48,12 +48,6 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 	private readonly _editors = new Map<string, ExtHostNotebookEditor>();
 	private readonly _commandsConverter: CommandsConverter;
 
-	private readonly _onDidChangeNotebookCells = new Emitter<vscode.NotebookCellsChangeEvent>();
-	readonly onDidChangeNotebookCells = this._onDidChangeNotebookCells.event;
-	private readonly _onDidChangeCellOutputs = new Emitter<vscode.NotebookCellOutputsChangeEvent>();
-	readonly onDidChangeCellOutputs = this._onDidChangeCellOutputs.event;
-	private readonly _onDidChangeCellMetadata = new Emitter<vscode.NotebookCellMetadataChangeEvent>();
-	readonly onDidChangeCellMetadata = this._onDidChangeCellMetadata.event;
 	private readonly _onDidChangeActiveNotebookEditor = new Emitter<vscode.NotebookEditor | undefined>();
 	readonly onDidChangeActiveNotebookEditor = this._onDidChangeActiveNotebookEditor.event;
 
@@ -442,23 +436,11 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 				if (this._documents.has(uri)) {
 					throw new Error(`adding EXISTING notebook ${uri} `);
 				}
-				const that = this;
 
 				const document = new ExtHostNotebookDocument(
 					this._notebookDocumentsProxy,
 					this._textDocumentsAndEditors,
 					this._textDocuments,
-					{
-						emitModelChange(event: vscode.NotebookCellsChangeEvent): void {
-							that._onDidChangeNotebookCells.fire(event);
-						},
-						emitCellOutputsChange(event: vscode.NotebookCellOutputsChangeEvent): void {
-							that._onDidChangeCellOutputs.fire(event);
-						},
-						emitCellMetadataChange(event: vscode.NotebookCellMetadataChangeEvent): void {
-							that._onDidChangeCellMetadata.fire(event);
-						}
-					},
 					uri,
 					modelData
 				);

--- a/src/vs/workbench/api/common/extHostNotebookConcatDocument.ts
+++ b/src/vs/workbench/api/common/extHostNotebookConcatDocument.ts
@@ -6,7 +6,6 @@
 import * as types from 'vs/workbench/api/common/extHostTypes';
 import * as vscode from 'vscode';
 import { Event, Emitter } from 'vs/base/common/event';
-import { ExtHostNotebookController } from 'vs/workbench/api/common/extHostNotebook';
 import { ExtHostDocuments } from 'vs/workbench/api/common/extHostDocuments';
 import { PrefixSumComputer } from 'vs/editor/common/model/prefixSumComputer';
 import { DisposableStore } from 'vs/base/common/lifecycle';
@@ -14,6 +13,7 @@ import { score } from 'vs/editor/common/languageSelector';
 import { ResourceMap } from 'vs/base/common/map';
 import { URI } from 'vs/base/common/uri';
 import { generateUuid } from 'vs/base/common/uuid';
+import { ExtHostNotebookDocuments } from 'vs/workbench/api/common/extHostNotebookDocuments';
 
 export class ExtHostNotebookConcatDocument implements vscode.NotebookConcatTextDocument {
 
@@ -32,7 +32,7 @@ export class ExtHostNotebookConcatDocument implements vscode.NotebookConcatTextD
 	readonly uri = URI.from({ scheme: 'vscode-concat-doc', path: generateUuid() });
 
 	constructor(
-		extHostNotebooks: ExtHostNotebookController,
+		extHostNotebooks: ExtHostNotebookDocuments,
 		extHostDocuments: ExtHostDocuments,
 		private readonly _notebook: vscode.NotebookDocument,
 		private readonly _selector: vscode.DocumentSelector | undefined,
@@ -56,7 +56,7 @@ export class ExtHostNotebookConcatDocument implements vscode.NotebookConcatTextD
 			}
 		};
 
-		this._disposables.add(extHostNotebooks.onDidChangeNotebookCells(e => documentChange(e.document)));
+		this._disposables.add(extHostNotebooks.onDidChangeNotebookDocument(e => documentChange(e.notebook)));
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/api/common/extHostNotebookDocument.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocument.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Schemas } from 'vs/base/common/network';
-import { deepFreeze, equals } from 'vs/base/common/objects';
 import { URI } from 'vs/base/common/uri';
 import * as extHostProtocol from 'vs/workbench/api/common/extHost.protocol';
 import { ExtHostDocuments } from 'vs/workbench/api/common/extHostDocuments';
@@ -16,10 +15,12 @@ import * as vscode from 'vscode';
 
 class RawContentChangeEvent {
 
-
-	constructor(readonly start: number, readonly deletedCount: number, readonly deletedItems: vscode.NotebookCell[], readonly items: ExtHostCell[]) {
-
-	}
+	constructor(
+		readonly start: number,
+		readonly deletedCount: number,
+		readonly deletedItems: vscode.NotebookCell[],
+		readonly items: ExtHostCell[]
+	) { }
 
 	asApiEvent(): vscode.NotebookDocumentContentChange {
 		return {
@@ -27,18 +28,6 @@ class RawContentChangeEvent {
 			addedCells: this.items.map(cell => cell.apiCell),
 			removedCells: this.deletedItems,
 		};
-	}
-
-
-	static asApiEvents(events: RawContentChangeEvent[]): readonly vscode.NotebookCellsChangeData[] {
-		return events.map(event => {
-			return {
-				start: event.start,
-				deletedCount: event.deletedCount,
-				deletedItems: event.deletedItems,
-				items: event.items.map(data => data.apiCell)
-			};
-		});
 	}
 }
 
@@ -138,12 +127,6 @@ export class ExtHostCell {
 	}
 }
 
-export interface INotebookEventEmitter {
-	emitModelChange(events: vscode.NotebookCellsChangeEvent): void;
-	emitCellOutputsChange(event: vscode.NotebookCellOutputsChangeEvent): void;
-	emitCellMetadataChange(event: vscode.NotebookCellMetadataChangeEvent): void;
-}
-
 
 export class ExtHostNotebookDocument {
 
@@ -165,7 +148,6 @@ export class ExtHostNotebookDocument {
 		private readonly _proxy: extHostProtocol.MainThreadNotebookDocumentsShape,
 		private readonly _textDocumentsAndEditors: ExtHostDocumentsAndEditors,
 		private readonly _textDocuments: ExtHostDocuments,
-		private readonly _emitter: INotebookEventEmitter,
 		readonly uri: URI,
 		data: extHostProtocol.INotebookModelAddedData
 	) {
@@ -388,13 +370,6 @@ export class ExtHostNotebookDocument {
 				bucket.push(changeEvent.asApiEvent());
 			}
 		}
-
-		if (!initialization) {
-			this._emitter.emitModelChange(deepFreeze({
-				document: this.apiNotebook,
-				changes: RawContentChangeEvent.asApiEvents(contentChangeEvents)
-			}));
-		}
 	}
 
 	private _moveCell(index: number, newIdx: number, bucket: vscode.NotebookDocumentContentChange[]): void {
@@ -407,22 +382,16 @@ export class ExtHostNotebookDocument {
 		for (const change of changes) {
 			bucket.push(change.asApiEvent());
 		}
-		this._emitter.emitModelChange(deepFreeze({
-			document: this.apiNotebook,
-			changes: RawContentChangeEvent.asApiEvents(changes)
-		}));
 	}
 
 	private _setCellOutputs(index: number, outputs: extHostProtocol.NotebookOutputDto[]): void {
 		const cell = this._cells[index];
 		cell.setOutputs(outputs);
-		this._emitter.emitCellOutputsChange(deepFreeze({ document: this.apiNotebook, cells: [cell.apiCell] }));
 	}
 
 	private _setCellOutputItems(index: number, outputId: string, append: boolean, outputItems: extHostProtocol.NotebookOutputItemDto[]): void {
 		const cell = this._cells[index];
 		cell.setOutputItems(outputId, append, outputItems);
-		this._emitter.emitCellOutputsChange(deepFreeze({ document: this.apiNotebook, cells: [cell.apiCell] }));
 	}
 
 	private _changeCellLanguage(index: number, newLanguageId: string): void {
@@ -439,14 +408,7 @@ export class ExtHostNotebookDocument {
 
 	private _changeCellMetadata(index: number, newMetadata: notebookCommon.NotebookCellMetadata): void {
 		const cell = this._cells[index];
-
-		const originalExtMetadata = cell.apiCell.metadata;
 		cell.setMetadata(newMetadata);
-		const newExtMetadata = cell.apiCell.metadata;
-
-		if (!equals(originalExtMetadata, newExtMetadata)) {
-			this._emitter.emitCellMetadataChange(deepFreeze({ document: this.apiNotebook, cell: cell.apiCell }));
-		}
 	}
 
 	private _changeCellInternalMetadata(index: number, newInternalMetadata: notebookCommon.NotebookCellInternalMetadata): void {

--- a/src/vs/workbench/api/common/extHostNotebookDocuments.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocuments.ts
@@ -5,7 +5,6 @@
 
 import { Emitter } from 'vs/base/common/event';
 import { URI, UriComponents } from 'vs/base/common/uri';
-import { ILogService } from 'vs/platform/log/common/log';
 import * as extHostProtocol from 'vs/workbench/api/common/extHost.protocol';
 import { ExtHostNotebookController } from 'vs/workbench/api/common/extHostNotebook';
 import { NotebookDocumentMetadata } from 'vs/workbench/contrib/notebook/common/notebookCommon';
@@ -14,9 +13,6 @@ import type * as vscode from 'vscode';
 
 export class ExtHostNotebookDocuments implements extHostProtocol.ExtHostNotebookDocumentsShape {
 
-	private readonly _onDidChangeNotebookDocumentMetadata = new Emitter<vscode.NotebookDocumentMetadataChangeEvent>();
-	readonly onDidChangeNotebookDocumentMetadata = this._onDidChangeNotebookDocumentMetadata.event;
-
 	private readonly _onDidSaveNotebookDocument = new Emitter<vscode.NotebookDocument>();
 	readonly onDidSaveNotebookDocument = this._onDidSaveNotebookDocument.event;
 
@@ -24,7 +20,6 @@ export class ExtHostNotebookDocuments implements extHostProtocol.ExtHostNotebook
 	readonly onDidChangeNotebookDocument = this._onDidChangeNotebookDocument.event;
 
 	constructor(
-		@ILogService private readonly _logService: ILogService,
 		private readonly _notebooksAndEditors: ExtHostNotebookController,
 	) { }
 
@@ -42,14 +37,5 @@ export class ExtHostNotebookDocuments implements extHostProtocol.ExtHostNotebook
 	$acceptModelSaved(uri: UriComponents): void {
 		const document = this._notebooksAndEditors.getNotebookDocument(URI.revive(uri));
 		this._onDidSaveNotebookDocument.fire(document.apiNotebook);
-	}
-
-	$acceptDocumentPropertiesChanged(uri: UriComponents, data: extHostProtocol.INotebookDocumentPropertiesChangeData): void {
-		this._logService.debug('ExtHostNotebook#$acceptDocumentPropertiesChanged', uri.path, data);
-		const document = this._notebooksAndEditors.getNotebookDocument(URI.revive(uri));
-		document.acceptDocumentPropertiesChanged(data);
-		if (data.metadata) {
-			this._onDidChangeNotebookDocumentMetadata.fire({ document: document.apiNotebook });
-		}
 	}
 }

--- a/src/vs/workbench/api/test/browser/extHostNotebook.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostNotebook.test.ts
@@ -60,7 +60,7 @@ suite('NotebookCell#Document', function () {
 			}
 		};
 		extHostNotebooks = new ExtHostNotebookController(rpcProtocol, new ExtHostCommands(rpcProtocol, new NullLogService()), extHostDocumentsAndEditors, extHostDocuments, extHostStoragePaths);
-		extHostNotebookDocuments = new ExtHostNotebookDocuments(new NullLogService(), extHostNotebooks);
+		extHostNotebookDocuments = new ExtHostNotebookDocuments(extHostNotebooks);
 
 		let reg = extHostNotebooks.registerNotebookContentProvider(nullExtensionDescription, 'test', new class extends mock<vscode.NotebookContentProvider>() {
 			// async openNotebook() { }
@@ -146,12 +146,13 @@ suite('NotebookCell#Document', function () {
 	test('cell document is vscode.TextDocument after changing it', async function () {
 
 		const p = new Promise<void>((resolve, reject) => {
-			extHostNotebooks.onDidChangeNotebookCells(e => {
-				try {
-					assert.strictEqual(e.changes.length, 1);
-					assert.strictEqual(e.changes[0].items.length, 2);
 
-					const [first, second] = e.changes[0].items;
+			extHostNotebookDocuments.onDidChangeNotebookDocument(e => {
+				try {
+					assert.strictEqual(e.contentChanges.length, 1);
+					assert.strictEqual(e.contentChanges[0].addedCells.length, 2);
+
+					const [first, second] = e.contentChanges[0].addedCells;
 
 					const doc1 = extHostDocuments.getAllDocumentData().find(data => isEqual(data.document.uri, first.document.uri));
 					assert.ok(doc1);
@@ -167,6 +168,7 @@ suite('NotebookCell#Document', function () {
 					reject(err);
 				}
 			});
+
 		});
 
 		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
@@ -317,7 +319,7 @@ suite('NotebookCell#Document', function () {
 
 	test('ERR MISSING extHostDocument for notebook cell: #116711', async function () {
 
-		const p = Event.toPromise(extHostNotebooks.onDidChangeNotebookCells);
+		const p = Event.toPromise(extHostNotebookDocuments.onDidChangeNotebookDocument);
 
 		// DON'T call this, make sure the cell-documents have not been created yet
 		// assert.strictEqual(notebook.notebookDocument.cellCount, 2);
@@ -350,14 +352,14 @@ suite('NotebookCell#Document', function () {
 
 		const event = await p;
 
-		assert.strictEqual(event.document === notebook.apiNotebook, true);
-		assert.strictEqual(event.changes.length, 1);
-		assert.strictEqual(event.changes[0].deletedCount, 2);
-		assert.strictEqual(event.changes[0].deletedItems[0].document.isClosed, true);
-		assert.strictEqual(event.changes[0].deletedItems[1].document.isClosed, true);
-		assert.strictEqual(event.changes[0].items.length, 2);
-		assert.strictEqual(event.changes[0].items[0].document.isClosed, false);
-		assert.strictEqual(event.changes[0].items[1].document.isClosed, false);
+		assert.strictEqual(event.notebook === notebook.apiNotebook, true);
+		assert.strictEqual(event.contentChanges.length, 1);
+		assert.strictEqual(event.contentChanges[0].range.end - event.contentChanges[0].range.start, 2);
+		assert.strictEqual(event.contentChanges[0].removedCells[0].document.isClosed, true);
+		assert.strictEqual(event.contentChanges[0].removedCells[1].document.isClosed, true);
+		assert.strictEqual(event.contentChanges[0].addedCells.length, 2);
+		assert.strictEqual(event.contentChanges[0].addedCells[0].document.isClosed, false);
+		assert.strictEqual(event.contentChanges[0].addedCells[1].document.isClosed, false);
 	});
 
 

--- a/src/vs/workbench/api/test/browser/extHostNotebookConcatDocument.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostNotebookConcatDocument.test.ts
@@ -56,7 +56,7 @@ suite('NotebookConcatDocument', function () {
 			}
 		};
 		extHostNotebooks = new ExtHostNotebookController(rpcProtocol, new ExtHostCommands(rpcProtocol, new NullLogService()), extHostDocumentsAndEditors, extHostDocuments, extHostStoragePaths);
-		extHostNotebookDocuments = new ExtHostNotebookDocuments(new NullLogService(), extHostNotebooks);
+		extHostNotebookDocuments = new ExtHostNotebookDocuments(extHostNotebooks);
 
 		let reg = extHostNotebooks.registerNotebookContentProvider(nullExtensionDescription, 'test', new class extends mock<vscode.NotebookContentProvider>() {
 			// async openNotebook() { }
@@ -93,7 +93,7 @@ suite('NotebookConcatDocument', function () {
 	});
 
 	test('empty', function () {
-		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
+		let doc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, undefined);
 		assert.strictEqual(doc.getText(), '');
 		assert.strictEqual(doc.version, 0);
 
@@ -156,7 +156,7 @@ suite('NotebookConcatDocument', function () {
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2); // markdown and code
 
-		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
+		let doc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, undefined);
 
 		assert.strictEqual(doc.contains(cellUri1), true);
 		assert.strictEqual(doc.contains(cellUri2), true);
@@ -194,7 +194,7 @@ suite('NotebookConcatDocument', function () {
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2); // markdown and code
 
-		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
+		let doc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, undefined);
 		assertLines(doc, 'Hello', 'World', 'Hello World!', 'Hallo', 'Welt', 'Hallo Welt!');
 
 		assertLocation(doc, new Position(0, 0), new Location(notebook.apiNotebook.cellAt(0).document.uri, new Position(0, 0)));
@@ -207,7 +207,7 @@ suite('NotebookConcatDocument', function () {
 
 	test('location, position mapping, cell changes', function () {
 
-		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
+		let doc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, undefined);
 
 		// UPDATE 1
 		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
@@ -284,7 +284,7 @@ suite('NotebookConcatDocument', function () {
 
 	test('location, position mapping, cell-document changes', function () {
 
-		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
+		let doc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, undefined);
 
 		// UPDATE 1
 		extHostNotebookDocuments.$acceptModelChanged(notebookUri, new SerializableObjectWithBuffers({
@@ -374,9 +374,9 @@ suite('NotebookConcatDocument', function () {
 			]
 		}), false);
 
-		const mixedDoc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
-		const fooLangDoc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, 'fooLang');
-		const barLangDoc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, 'barLang');
+		const mixedDoc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, undefined);
+		const fooLangDoc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, 'fooLang');
+		const barLangDoc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, 'barLang');
 
 		assertLines(mixedDoc, 'fooLang-document', 'barLang-document');
 		assertLines(fooLangDoc, 'fooLang-document');
@@ -448,7 +448,7 @@ suite('NotebookConcatDocument', function () {
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2); // markdown and code
 
-		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
+		let doc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, undefined);
 		assertLines(doc, 'Hello', 'World', 'Hello World!', 'Hallo', 'Welt', 'Hallo Welt!');
 
 		assertOffsetAtPosition(doc, 0, { line: 0, character: 0 });
@@ -505,7 +505,7 @@ suite('NotebookConcatDocument', function () {
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2); // markdown and code
 
-		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
+		let doc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, undefined);
 		assertLines(doc, 'Hello', 'World', 'Hello World!', 'Hallo', 'Welt', 'Hallo Welt!');
 
 		assertLocationAtPosition(doc, { line: 0, character: 0 }, { uri: notebook.apiNotebook.cellAt(0).document.uri, line: 0, character: 0 });
@@ -554,7 +554,7 @@ suite('NotebookConcatDocument', function () {
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 3); // markdown and code
 
-		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
+		let doc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, undefined);
 		assertLines(doc, 'Hello', 'World', 'Hello World!', 'Hallo', 'Welt', 'Hallo Welt!', 'Three', 'Drei', 'Drüü');
 
 		assert.strictEqual(doc.getText(new Range(0, 0, 0, 0)), '');
@@ -593,7 +593,7 @@ suite('NotebookConcatDocument', function () {
 
 		assert.strictEqual(notebook.apiNotebook.cellCount, 1 + 2); // markdown and code
 
-		let doc = new ExtHostNotebookConcatDocument(extHostNotebooks, extHostDocuments, notebook.apiNotebook, undefined);
+		let doc = new ExtHostNotebookConcatDocument(extHostNotebookDocuments, extHostDocuments, notebook.apiNotebook, undefined);
 		assertLines(doc, 'Hello', 'World', 'Hello World!', 'Hallo', 'Welt', 'Hallo Welt!');
 
 

--- a/src/vs/workbench/api/test/browser/extHostNotebookKernel.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostNotebookKernel.test.ts
@@ -98,7 +98,7 @@ suite('NotebookKernel', function () {
 		extHostCommands = new ExtHostCommands(rpcProtocol, new NullLogService());
 		extHostNotebooks = new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments, extHostStoragePaths);
 
-		extHostNotebookDocuments = new ExtHostNotebookDocuments(new NullLogService(), extHostNotebooks);
+		extHostNotebookDocuments = new ExtHostNotebookDocuments(extHostNotebooks);
 
 		extHostNotebooks.$acceptDocumentAndEditorsDelta(new SerializableObjectWithBuffers({
 			addedDocuments: [{

--- a/src/vscode-dts/vscode.proposed.notebookEditor.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookEditor.d.ts
@@ -69,58 +69,6 @@ declare module 'vscode' {
 		readonly viewColumn?: ViewColumn;
 	}
 
-	/** @deprecated */
-	export interface NotebookDocumentMetadataChangeEvent {
-		/**
-		 * The {@link NotebookDocument notebook document} for which the document metadata have changed.
-		 */
-		//todo@API rename to notebook?
-		readonly document: NotebookDocument;
-	}
-
-	/** @deprecated */
-	export interface NotebookCellsChangeData {
-		readonly start: number;
-		// todo@API end? Use NotebookCellRange instead?
-		readonly deletedCount: number;
-		// todo@API removedCells, deletedCells?
-		readonly deletedItems: NotebookCell[];
-		// todo@API addedCells, insertedCells, newCells?
-		readonly items: NotebookCell[];
-	}
-
-	/** @deprecated */
-	export interface NotebookCellsChangeEvent {
-		/**
-		 * The {@link NotebookDocument notebook document} for which the cells have changed.
-		 */
-		//todo@API rename to notebook?
-		readonly document: NotebookDocument;
-		readonly changes: ReadonlyArray<NotebookCellsChangeData>;
-	}
-
-	/** @deprecated */
-	export interface NotebookCellOutputsChangeEvent {
-		/**
-		 * The {@link NotebookDocument notebook document} for which the cell outputs have changed.
-		 */
-		//todo@API remove? use cell.notebook instead?
-		readonly document: NotebookDocument;
-		// NotebookCellOutputsChangeEvent.cells vs NotebookCellMetadataChangeEvent.cell
-		readonly cells: NotebookCell[];
-	}
-
-	/** @deprecated */
-	export interface NotebookCellMetadataChangeEvent {
-		/**
-		 * The {@link NotebookDocument notebook document} for which the cell metadata have changed.
-		 */
-		//todo@API remove? use cell.notebook instead?
-		readonly document: NotebookDocument;
-		// NotebookCellOutputsChangeEvent.cells vs NotebookCellMetadataChangeEvent.cell
-		readonly cell: NotebookCell;
-	}
-
 	export interface NotebookEditorSelectionChangeEvent {
 		/**
 		 * The {@link NotebookEditor notebook editor} for which the selections have changed.
@@ -137,27 +85,11 @@ declare module 'vscode' {
 		readonly visibleRanges: ReadonlyArray<NotebookRange>;
 	}
 
-
 	export interface NotebookDocumentShowOptions {
 		viewColumn?: ViewColumn;
 		preserveFocus?: boolean;
 		preview?: boolean;
 		selections?: NotebookRange[];
-	}
-
-	export namespace notebooks {
-		/** @deprecated */
-		export const onDidSaveNotebookDocument: Event<NotebookDocument>;
-		/** @deprecated */
-		export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
-		/** @deprecated */
-		export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
-		// todo@API add onDidChangeNotebookCellOutputs
-		/** @deprecated */
-		export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
-		// todo@API add onDidChangeNotebookCellMetadata
-		/** @deprecated */
-		export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
 	}
 
 	export namespace window {


### PR DESCRIPTION
Remove the old notebook document related events from the `notebook` namespace. The replacement is the, already existing [notebookDocumentEvents](https://github.com/microsoft/vscode/blob/9d2324412916035d7a955150ac1774d5b25e265a/src/vscode-dts/vscode.proposed.notebookDocumentEvents.d.ts)-proposal

Fixes https://github.com/microsoft/vscode/pull/146185