### PR TITLE
clear search decorations for all terminals in the visible group when find widget is hidden

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalFindWidget.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalFindWidget.ts
@@ -7,8 +7,9 @@ import { SimpleFindWidget } from 'vs/workbench/contrib/codeEditor/browser/find/s
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { FindReplaceState } from 'vs/editor/contrib/find/browser/findState';
-import { ITerminalService } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { ITerminalGroupService, ITerminalService } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
+import { TerminalLocation } from 'vs/platform/terminal/common/terminal';
 
 export class TerminalFindWidget extends SimpleFindWidget {
 	protected _findInputFocused: IContextKey<boolean>;
@@ -19,7 +20,8 @@ export class TerminalFindWidget extends SimpleFindWidget {
 		findState: FindReplaceState,
 		@IContextViewService _contextViewService: IContextViewService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
-		@ITerminalService private readonly _terminalService: ITerminalService
+		@ITerminalService private readonly _terminalService: ITerminalService,
+		@ITerminalGroupService private readonly _terminalGroupService: ITerminalGroupService
 	) {
 		super(_contextViewService, _contextKeyService, findState, true);
 		this._register(findState.onFindReplaceStateChange(() => {
@@ -68,7 +70,13 @@ export class TerminalFindWidget extends SimpleFindWidget {
 		if (instance) {
 			instance.focus();
 		}
-		instance?.xterm?.clearSearchDecorations();
+		if (this._terminalService.activeInstance?.target !== TerminalLocation.Editor && this._terminalGroupService.activeGroup) {
+			for (const terminal of this._terminalGroupService.activeGroup?.terminalInstances) {
+				terminal.xterm?.clearSearchDecorations();
+			}
+		} else {
+			instance?.xterm?.clearSearchDecorations();
+		}
 	}
 
 	protected _onInputChanged() {

--- a/src/vs/workbench/contrib/terminal/browser/terminalFindWidget.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalFindWidget.ts
@@ -70,8 +70,11 @@ export class TerminalFindWidget extends SimpleFindWidget {
 		if (instance) {
 			instance.focus();
 		}
-		if (this._terminalService.activeInstance?.target !== TerminalLocation.Editor && this._terminalGroupService.activeGroup) {
-			for (const terminal of this._terminalGroupService.activeGroup?.terminalInstances) {
+		// Terminals in a group currently share a find widget, so hide
+		// all decorations for terminals in this group
+		const activeGroup = this._terminalGroupService.activeGroup;
+		if (instance?.target !== TerminalLocation.Editor && activeGroup) {
+			for (const terminal of activeGroup.terminalInstances) {
 				terminal.xterm?.clearSearchDecorations();
 			}
 		} else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #145866
