### PR TITLE
Avoid converting pre-encoded values in terminal URL links

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkOpeners.ts
@@ -209,7 +209,9 @@ export class TerminalUrlLinkOpener implements ITerminalLinkOpener {
 		if (!link.uri) {
 			throw new Error('Tried to open a url without a resolved URI');
 		}
-		this._openerService.open(link.uri || URI.parse(link.text), {
+		// It's important to use the raw string value here to avoid converting pre-encoded values
+		// from the URL like `%2B` -> `+`.
+		this._openerService.open(link.text, {
 			allowTunneling: this._isRemote,
 			allowContributedOpeners: true,
 		});


### PR DESCRIPTION
Fixes #144898
