### PR TITLE
Update to vscode-latex-basics 1.3.0

### DIFF
--- a/extensions/latex/cgmanifest.json
+++ b/extensions/latex/cgmanifest.json
@@ -6,7 +6,7 @@
 				"git": {
 					"name": "jlelong/vscode-latex-basics",
 					"repositoryUrl": "https://github.com/jlelong/vscode-latex-basics",
-					"commitHash": "4f330febaf180ed7faf3aa228d38611d8b5adbf5"
+					"commitHash": "4ef954d31faccf96545d736a5ccc0e09d8109f12"
 				}
 			},
 			"license": "MIT",

--- a/extensions/latex/latex-language-configuration.json
+++ b/extensions/latex/latex-language-configuration.json
@@ -106,6 +106,15 @@
 		"increaseIndentPattern": "\\\\begin{(?!document)([^}]*)}(?!.*\\\\end{\\1})",
 		"decreaseIndentPattern": "^\\s*\\\\end{(?!document)"
 	},
-	"autoCloseBefore": ";:.,=}])>\\` \n\t$",
-	"wordPattern": "([^\\s`'\"~_!?|$#@%^&*\\-=+;:,.<>(){}[\\]\\/]+)"
+	"folding": {
+		"markers": {
+			"start": "^\\s*%?\\s*(region|\\\\begingroup)\\b",
+			"end": "^\\s*%?\\s*(endregion|\\\\endgroup)\\b"
+		}
+	},
+	"autoCloseBefore": ";:.,={}])>\\` \n\t$",
+	"wordPattern": {
+		"pattern": "(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark}){2,}",
+		"flags": "u"
+	}
 }

--- a/extensions/latex/markdown-latex-combined-language-configuration.json
+++ b/extensions/latex/markdown-latex-combined-language-configuration.json
@@ -111,13 +111,16 @@
 		"increaseIndentPattern": "\\\\begin{(?!document)([^}]*)}(?!.*\\\\end{\\1})",
 		"decreaseIndentPattern": "^\\s*\\\\end{(?!document)"
 	},
-	"autoCloseBefore": ";:.,=}])>\\` \n\t$",
-	"wordPattern": "([^\\s`'\"~_!?|$#@%^&*\\-=+;:,.<>(){}[\\]\\/]+)",
 	"folding": {
 		"offSide": true,
 		"markers": {
 			"start": "^\\s*<!--\\s*#?region\\b.*-->",
 			"end": "^\\s*<!--\\s*#?endregion\\b.*-->"
 		}
+	},
+	"autoCloseBefore": ";:.,={}])>\\` \n\t$",
+	"wordPattern": {
+		"pattern": "([*_]{1,2})?(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})(((\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})|[_])?(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark}))*\\1",
+		"flags": "u"
 	}
 }

--- a/extensions/latex/syntaxes/markdown-latex-combined.tmLanguage.json
+++ b/extensions/latex/syntaxes/markdown-latex-combined.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/jlelong/vscode-latex-basics/commit/5f26a6daf70352a6f3f40b3b4437a605f5d954ee",
+	"version": "https://github.com/jlelong/vscode-latex-basics/commit/4ef954d31faccf96545d736a5ccc0e09d8109f12",
 	"name": "Markdown",
 	"scopeName": "text.tex.markdown_latex_combined",
 	"patterns": [
@@ -2443,6 +2443,9 @@
 					"include": "#raw"
 				},
 				{
+					"include": "#strikethrough"
+				},
+				{
 					"include": "#escape"
 				},
 				{
@@ -2537,6 +2540,9 @@
 				},
 				{
 					"include": "#link-ref-shortcut"
+				},
+				{
+					"include": "#strikethrough"
 				}
 			]
 		},
@@ -2688,6 +2694,9 @@
 				},
 				{
 					"include": "#link-ref-shortcut"
+				},
+				{
+					"include": "#strikethrough"
 				}
 			]
 		},
@@ -2847,8 +2856,76 @@
 					"name": "punctuation.definition.raw.markdown"
 				}
 			},
-			"match": "(`+)([^`]|(?!(?<!`)\\1(?!`))`)*+(\\1)",
+			"match": "(`+)((?:[^`]|(?!(?<!`)\\1(?!`))`)*+)(\\1)",
 			"name": "markup.inline.raw.string.markdown"
+		},
+		"strikethrough": {
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.strikethrough.markdown"
+				},
+				"2": {
+					"patterns": [
+						{
+							"applyEndPatternLast": 1,
+							"begin": "(?=<[^>]*?>)",
+							"end": "(?<=>)",
+							"patterns": [
+								{
+									"include": "text.html.derivative"
+								}
+							]
+						},
+						{
+							"include": "#escape"
+						},
+						{
+							"include": "#ampersand"
+						},
+						{
+							"include": "#bracket"
+						},
+						{
+							"include": "#raw"
+						},
+						{
+							"include": "#bold"
+						},
+						{
+							"include": "#italic"
+						},
+						{
+							"include": "#image-inline"
+						},
+						{
+							"include": "#link-inline"
+						},
+						{
+							"include": "#link-inet"
+						},
+						{
+							"include": "#link-email"
+						},
+						{
+							"include": "#image-ref"
+						},
+						{
+							"include": "#link-ref-literal"
+						},
+						{
+							"include": "#link-ref"
+						},
+						{
+							"include": "#link-ref-shortcut"
+						}
+					]
+				},
+				"3": {
+					"name": "punctuation.definition.strikethrough.markdown"
+				}
+			},
+			"match": "(~+)((?:[^~]|(?!(?<!~)\\1(?!~))~)*+)(\\1)",
+			"name": "markup.strikethrough.markdown"
 		}
 	}
 }


### PR DESCRIPTION
- Use unicode character classes to define `wordPattern` 
  - microsoft/vscode#144913
  - jlelong/vscode-latex-basics#17
- Add `{` to `autoCloseBefore`: jlelong/vscode-latex-basics#16
- Add region folding TeX files: jlelong/vscode-latex-basics#21

@alexr00 I saw that you have already updated the grammar files for the new release of VS Code. Some of the above fixes require updates of the language configuration files too. Of course, it can wait for the April 2022 release.