### PR TITLE
Add language-specific scope widget indicators

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1304,6 +1304,8 @@ export class SettingsEditor2 extends EditorPane {
 			this.viewState.languageFilter = parsedQuery.languageFilter;
 		}
 
+		this.settingsTargetsWidget.updateLanguageFilterIndicators(this.viewState.languageFilter);
+
 		if (query && query !== '@') {
 			query = this.parseSettingFromJSON(query) || query;
 			return this.triggerFilterPreferences(query);


### PR DESCRIPTION
Fixes #145716

This PR adds scope widget indicators in the form of [languageId] at the end of tab labels whenever there is a language filter in place. If the language filter isn't a valid language, the indicator is not shown.

![Screencap demo on the OSS build](https://user-images.githubusercontent.com/7199958/160910017-ecd3e897-db1d-499c-9f1d-ee4d843924d7.gif)

