### PR TITLE
Improve UX for markdown snippets

### DIFF
--- a/extensions/markdown-basics/snippets/markdown.code-snippets
+++ b/extensions/markdown-basics/snippets/markdown.code-snippets
@@ -71,12 +71,12 @@
 	},
 	"Insert link": {
 		"prefix": "link",
-		"body": "[${TM_SELECTED_TEXT:${1:text}}](https://${2:link})$0",
+		"body": "[${TM_SELECTED_TEXT:${1:text}}](${2:https://})$0",
 		"description": "Insert link"
 	},
 	"Insert image": {
 		"prefix": "image",
-		"body": "![${TM_SELECTED_TEXT:${1:alt}}](https://${2:link})$0",
+		"body": "![${TM_SELECTED_TEXT:${1:alt}}](${2:https://})$0",
 		"description": "Insert image"
 	},
 	"Insert strikethrough": {


### PR DESCRIPTION
This small change allows to directly paste a link into markdown when using the `link` and `image` snippets.

Before, when inserting a `link` snippet, you had the following result:

<img width="175" alt="image" src="https://user-images.githubusercontent.com/817508/161068956-705a668a-d93f-4bf6-b486-711c3b542939.png">

The issue I see here is, if you already have a link in your clipboard like `https://example.com`, you can't paste it immediately otherwise you will get the following content:

<img width="285" alt="image" src="https://user-images.githubusercontent.com/817508/161070213-6641a9ff-2f06-4aad-aa1f-a0b244f9372c.png">

With my commit, by inserting the snippet you will get:

<img width="154" alt="image" src="https://user-images.githubusercontent.com/817508/161070747-ddc15720-c016-49db-acf3-de3e29a6292c.png">

Allowing you to paste from your clipboard and get the following result:

<img width="225" alt="image" src="https://user-images.githubusercontent.com/817508/161071063-9e40a477-4da7-45fa-99fe-55d676acfb8e.png">

I also removed the `link` placeholder, which allows you to simply press the right key and tap a domain just after the `https://` part.