### PR TITLE
[server-cli] Fix empty ext management arguments

### DIFF
--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -57,10 +57,10 @@ export interface NativeParsedArgs {
 	'list-extensions'?: boolean;
 	'show-versions'?: boolean;
 	'category'?: string;
-	'install-extension'?: string[]; // undefined or array of 1 or more
+	'install-extension'?: string[] | ''; // undefined, array of 1 or more, or empty string if not provided
 	'pre-release'?: boolean;
 	'install-builtin-extension'?: string[]; // undefined or array of 1 or more
-	'uninstall-extension'?: string[]; // undefined or array of 1 or more
+	'uninstall-extension'?: string[] | ''; // undefined, array of 1 or more, or empty string if not provided
 	'locate-extension'?: string[]; // undefined or array of 1 or more
 	'enable-proposed-api'?: string[]; // undefined or array of 1 or more
 	'open-url'?: boolean;

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -201,8 +201,8 @@ export function main(desc: ProductDescription, args: string[]): void {
 	if (cliCommand) {
 		if (parsedArgs['install-extension'] !== undefined || parsedArgs['uninstall-extension'] !== undefined || parsedArgs['list-extensions']) {
 			const cmdLine: string[] = [];
-			parsedArgs['install-extension']?.forEach(id => cmdLine.push('--install-extension', id));
-			parsedArgs['uninstall-extension']?.forEach(id => cmdLine.push('--uninstall-extension', id));
+			if (parsedArgs['install-extension']) { parsedArgs['install-extension']?.forEach(id => cmdLine.push('--install-extension', id)); }
+			if (parsedArgs['uninstall-extension']) { parsedArgs['uninstall-extension']?.forEach(id => cmdLine.push('--uninstall-extension', id)); }
 			['list-extensions', 'force', 'show-versions', 'category'].forEach(opt => {
 				const value = parsedArgs[<keyof NativeParsedArgs>opt];
 				if (value !== undefined) {
@@ -268,6 +268,10 @@ export function main(desc: ProductDescription, args: string[]): void {
 		}
 
 		if (parsedArgs['install-extension'] !== undefined || parsedArgs['uninstall-extension'] !== undefined || parsedArgs['list-extensions']) {
+			if (parsedArgs['install-extension'] === '' || parsedArgs['uninstall-extension'] === '') {
+				console.error('Please provide 1 or more extension IDs');
+				return;
+			}
 			sendToPipe({
 				type: 'extensionManagement',
 				list: parsedArgs['list-extensions'] ? { showVersions: parsedArgs['show-versions'], category: parsedArgs['category'] } : undefined,

--- a/src/vs/server/node/serverEnvironmentService.ts
+++ b/src/vs/server/node/serverEnvironmentService.ts
@@ -169,9 +169,9 @@ export interface ServerParsedArgs {
 	'extensions-dir'?: string;
 	'extensions-download-dir'?: string;
 	'builtin-extensions-dir'?: string;
-	'install-extension'?: string[];
+	'install-extension'?: string[] | '';
 	'install-builtin-extension'?: string[];
-	'uninstall-extension'?: string[];
+	'uninstall-extension'?: string[] | '';
 	'list-extensions'?: boolean;
 	'locate-extension'?: string[];
 	'show-versions'?: boolean;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## Description

If the user used the remote CLI to do extension management (remove or install extensions - `--install-extension` & `--uninstall-extension`) and wouldn’t supply any paths / ids as inputs, the CLI would throw with a debatably messy output. I think the PR is best explained by the following:

This PR brings `code --install-extension` from this:

```bash
The factory method of "vs/server/node/server.cli" has thrown an exception
TypeError: H?.map is not a function
    at a (/ide/out/vs/server/node/server.cli.js:12:8197)
    at o (/ide/out/vs/server/node/server.cli.js:12:5894)
    at Object.<anonymous> (/ide/out/vs/server/node/server.cli.js:12:8811)
    at Function.i._safeInvokeFunction (/ide/out/vs/loader.js:5:1337)
    at Function.i._invokeFactory (/ide/out/vs/loader.js:5:1584)
    at i.complete (/ide/out/vs/loader.js:5:1821)
    at i._onModuleComplete (/ide/out/vs/loader.js:6:991)
    at i._onModuleComplete (/ide/out/vs/loader.js:6:1235)
    at i._onModuleComplete (/ide/out/vs/loader.js:6:1235)
    at i._onModuleComplete (/ide/out/vs/loader.js:6:1235)
    at i._resolve (/ide/out/vs/loader.js:6:510)
    at i.defineModule (/ide/out/vs/loader.js:5:6142)
    at o (/ide/out/vs/loader.js:5:10603)
    at Object._ (/ide/out/vs/loader.js:6:6868)
    at Function.i._safeInvokeFunction (/ide/out/vs/loader.js:5:1337)
    at Function.i._invokeFactory (/ide/out/vs/loader.js:5:1584)
    at i.complete (/ide/out/vs/loader.js:5:1821)
    at i._onModuleComplete (/ide/out/vs/loader.js:6:991)
    at i._onModuleComplete (/ide/out/vs/loader.js:6:1235)
    at i._resolve (/ide/out/vs/loader.js:6:510)
    at i.defineModule (/ide/out/vs/loader.js:5:6142)
    at v (/ide/out/vs/loader.js:6:1702)
    at g (/ide/out/vs/loader.js:4:2554)
    at Object.<anonymous> (/ide/out/vs/server/node/server.cli.nls.js:3:46)
    at e._createAndEvalScript (/ide/out/vs/loader.js:4:2598)
    at /ide/out/vs/loader.js:4:2237
    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3) {
  phase: 'factory',
  moduleId: 'vs/server/node/server.cli'
}
```

to this:

![image](https://user-images.githubusercontent.com/29888641/161155705-057e836a-7100-4d72-abb1-3bccb954e266.png)

## How to test

I've had some issues with debugging, so I ended up building the `reh-web` version for my platform, started the server and opened the result in my browser. In there I could then try the command `code-oss --install-extension` to verify my changes.

```bash
yarn gulp vscode-reh-web-darwin-arm64 # for me, on Apple Silicon
bin/code-oss --without-connection-token
```
