### PR TITLE
Allow independent window zoom

### DIFF
--- a/src/vs/workbench/electron-sandbox/actions/windowActions.ts
+++ b/src/vs/workbench/electron-sandbox/actions/windowActions.ts
@@ -72,6 +72,7 @@ abstract class BaseZoomAction extends Action2 {
 
 	protected async setConfiguredZoomLevel(accessor: ServicesAccessor, level: number): Promise<void> {
 		const configurationService = accessor.get(IConfigurationService);
+		const independentZoom = configurationService.getValue('window.independentZoom');
 
 		level = Math.round(level); // when reaching smallest zoom, prevent fractional zoom levels
 
@@ -79,7 +80,9 @@ abstract class BaseZoomAction extends Action2 {
 			return; // https://github.com/microsoft/vscode/issues/48357
 		}
 
-		await configurationService.updateValue(BaseZoomAction.SETTING_KEY, level);
+		if (!independentZoom) {
+			await configurationService.updateValue(BaseZoomAction.SETTING_KEY, level);
+		}
 
 		applyZoom(level);
 	}

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -157,6 +157,12 @@ import { TELEMETRY_SETTING_ID } from 'vs/platform/telemetry/common/telemetry';
 				'description': localize('zoomLevel', "Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity."),
 				ignoreSync: true
 			},
+			'window.independentZoom': {
+				'type': 'boolean',
+				'default': false,
+				'description': localize('independentZoom', "Controls whether the zoom is applied across all vscode instances or individually to each one."),
+				ignoreSync: true
+			},
 			'window.newWindowDimensions': {
 				'type': 'string',
 				'enum': ['default', 'inherit', 'offset', 'maximized', 'fullscreen'],


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode/issues/143663
which is same as this: https://github.com/Microsoft/vscode/issues/72011

**Description**
This adds a new setting to allow users to control the zoom independently for each window. Enabling the `independentZoom` option allows you to control the zoom (default ctrl +/-) for the selected window, without modifying the others or saving the zoom to the config. It still allows a default value for zoom (eg: -1) which all widows will start with.

The only way to persist the zoom settings when this option is enabled is to directly modify the zoom value in the config.

**Use case**
When using multiple displays with multiple resolutions / ppi, I would like to be able to modify the zoom (scaling) of the vscode window and have it only persist on that instance. I might have two vscode windows opened and increasing the zoom on one windows _should_ not increase it across all instances.

I'd imagine this is just a starting point for more zoom/scaling configurations and perhaps there will be a way to save these settings in the future. 

I did not add tests to this but i'd be more than happy to spend some time writing them if someone could point me in the right direction where this kind of functionality could be tested. 

[Here's](https://www.loom.com/share/ff4c6b0d6853424e96b4f5c0db6185aa) a quick demo of the functionality.