### PR TITLE
Rename user facing instances of SCM to Source Control

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -145,7 +145,7 @@ export const tocData: ITOCEntry<string> = {
 				},
 				{
 					id: 'features/scm',
-					label: localize('scm', "SCM"),
+					label: localize('scm', "Source Control"),
 					settings: ['scm.*']
 				},
 				{

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -83,7 +83,7 @@ viewsRegistry.registerViews([{
 	containerIcon: sourceControlViewIcon,
 	openCommandActionDescriptor: {
 		id: viewContainer.id,
-		mnemonicTitle: localize({ key: 'miViewSCM', comment: ['&& denotes a mnemonic'] }, "S&&CM"),
+		mnemonicTitle: localize({ key: 'miViewSCM', comment: ['&& denotes a mnemonic'] }, "Source &&Control"),
 		keybindings: {
 			primary: 0,
 			win: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyG },
@@ -118,7 +118,7 @@ Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	id: 'scm',
 	order: 5,
-	title: localize('scmConfigurationTitle', "SCM"),
+	title: localize('scmConfigurationTitle', "Source Control"),
 	type: 'object',
 	scope: ConfigurationScope.RESOURCE,
 	properties: {
@@ -215,14 +215,14 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			enumDescriptions: [
 				localize('scm.defaultViewSortKey.name', "Sort the repository changes by file name."),
 				localize('scm.defaultViewSortKey.path', "Sort the repository changes by path."),
-				localize('scm.defaultViewSortKey.status', "Sort the repository changes by SCM status.")
+				localize('scm.defaultViewSortKey.status', "Sort the repository changes by Source Control status.")
 			],
 			description: localize('scm.defaultViewSortKey', "Controls the default Source Control repository sort mode."),
 			default: 'path'
 		},
 		'scm.autoReveal': {
 			type: 'boolean',
-			description: localize('autoReveal', "Controls whether the SCM view should automatically reveal and select files when opening them."),
+			description: localize('autoReveal', "Controls whether the Source Control view should automatically reveal and select files when opening them."),
 			default: true
 		},
 		'scm.inputFontFamily': {
@@ -237,7 +237,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		},
 		'scm.alwaysShowRepositories': {
 			type: 'boolean',
-			markdownDescription: localize('alwaysShowRepository', "Controls whether repositories should always be visible in the SCM view."),
+			markdownDescription: localize('alwaysShowRepository', "Controls whether repositories should always be visible in the Source Control view."),
 			default: false
 		},
 		'scm.repositories.visible': {
@@ -247,7 +247,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		},
 		'scm.showActionButton': {
 			type: 'boolean',
-			markdownDescription: localize('showActionButton', "Controls whether an action button can be shown in the SCM view."),
+			markdownDescription: localize('showActionButton', "Controls whether an action button can be shown in the Source Control view."),
 			default: true
 		}
 	}
@@ -255,7 +255,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'scm.acceptInput',
-	description: { description: localize('scm accept', "SCM: Accept Input"), args: [] },
+	description: { description: localize('scm accept', "Source Control: Accept Input"), args: [] },
 	weight: KeybindingWeight.WorkbenchContrib,
 	when: ContextKeyExpr.has('scmRepository'),
 	primary: KeyMod.CtrlCmd | KeyCode.Enter,
@@ -276,7 +276,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 });
 
 const viewNextCommitCommand = {
-	description: { description: localize('scm view next commit', "SCM: View Next Commit"), args: [] },
+	description: { description: localize('scm view next commit', "Source Control: View Next Commit"), args: [] },
 	weight: KeybindingWeight.WorkbenchContrib,
 	handler: (accessor: ServicesAccessor) => {
 		const contextKeyService = accessor.get(IContextKeyService);
@@ -287,7 +287,7 @@ const viewNextCommitCommand = {
 };
 
 const viewPreviousCommitCommand = {
-	description: { description: localize('scm view previous commit', "SCM: View Previous Commit"), args: [] },
+	description: { description: localize('scm view previous commit', "Source Control: View Previous Commit"), args: [] },
 	weight: KeybindingWeight.WorkbenchContrib,
 	handler: (accessor: ServicesAccessor) => {
 		const contextKeyService = accessor.get(IContextKeyService);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #146723

This PR fixes all the public facing (not including error messages) instances of SCM (searching for `\bS(&&)?C(&&)?M\b`) that I could find.

This should replace the menu item in the view menu, descriptive terms for keybindings, the configurations group as well as descriptions for a few configs.
