### PR TITLE
Emmet reduce JSX array noise

### DIFF
--- a/extensions/emmet/src/defaultCompletionProvider.ts
+++ b/extensions/emmet/src/defaultCompletionProvider.ts
@@ -174,7 +174,7 @@ export class DefaultCompletionItemProvider implements vscode.CompletionItemProvi
 				isNoisePromise = Promise.resolve(true);
 			} else {
 				isNoisePromise = vscode.commands.executeCommand<vscode.SymbolInformation[] | undefined>('vscode.executeDocumentSymbolProvider', document.uri).then(symbols => {
-					return !!symbols && symbols?.some(x => abbreviation === x.name || (abbreviation.startsWith(x.name + '.') && !/>|\*|\+/.test(abbreviation)));
+					return !!symbols && symbols.some(x => abbreviation === x.name || (abbreviation.startsWith(x.name + '.') && !/>|\*|\+/.test(abbreviation)));
 				});
 			}
 		}

--- a/extensions/emmet/src/defaultCompletionProvider.ts
+++ b/extensions/emmet/src/defaultCompletionProvider.ts
@@ -161,25 +161,27 @@ export class DefaultCompletionItemProvider implements vscode.CompletionItemProvi
 			return;
 		}
 
-		let noiseCheckPromise: Thenable<any> = Promise.resolve();
+		let isNoisePromise: Thenable<boolean> = Promise.resolve(false);
 
 		// Fix for https://github.com/microsoft/vscode/issues/32647
 		// Check for document symbols in js/ts/jsx/tsx and avoid triggering emmet for abbreviations of the form symbolName.sometext
 		// Presence of > or * or + in the abbreviation denotes valid abbreviation that should trigger emmet
 		if (!isStyleSheet(syntax) && (document.languageId === 'javascript' || document.languageId === 'javascriptreact' || document.languageId === 'typescript' || document.languageId === 'typescriptreact')) {
 			let abbreviation: string = extractAbbreviationResults.abbreviation;
-			if (abbreviation.startsWith('this.')) {
-				noiseCheckPromise = Promise.resolve(true);
+			// For the second condition, we don't want abbreviations that have [] characters but not ='s in them to expand
+			// In turn, users must explicitly expand abbreviations of the form Component[attr1 attr2], but it means we don't try to expand a[i].
+			if (abbreviation.startsWith('this.') || /\[[^\]=]*\]/.test(abbreviation)) {
+				isNoisePromise = Promise.resolve(true);
 			} else {
-				noiseCheckPromise = vscode.commands.executeCommand<vscode.SymbolInformation[]>('vscode.executeDocumentSymbolProvider', document.uri).then((symbols: vscode.SymbolInformation[] | undefined) => {
-					return symbols && symbols.find(x => abbreviation === x.name || (abbreviation.startsWith(x.name + '.') && !/>|\*|\+/.test(abbreviation)));
+				isNoisePromise = vscode.commands.executeCommand<vscode.SymbolInformation[] | undefined>('vscode.executeDocumentSymbolProvider', document.uri).then(symbols => {
+					return !!symbols && symbols?.some(x => abbreviation === x.name || (abbreviation.startsWith(x.name + '.') && !/>|\*|\+/.test(abbreviation)));
 				});
 			}
 		}
 
-		return noiseCheckPromise.then((noise): vscode.CompletionList | undefined => {
-			if (noise) {
-				return;
+		return isNoisePromise.then((isNoise): vscode.CompletionList | undefined => {
+			if (isNoise) {
+				return undefined;
 			}
 
 			const config = getEmmetConfiguration(syntax!);

--- a/extensions/emmet/src/test/completion.test.ts
+++ b/extensions/emmet/src/test/completion.test.ts
@@ -15,30 +15,38 @@ suite('Tests for completion in CSS embedded in HTML', () => {
 	teardown(closeAllEditors);
 
 	test('style attribute & attribute value in html', async () => {
-		await testHtmlCompletionProvider('<div style="|"', [{ label: 'padding: ;' }]);
-		await testHtmlCompletionProvider(`<div style='|'`, [{ label: 'padding: ;' }]);
-		await testHtmlCompletionProvider(`<div style='p|'`, [{ label: 'padding: ;' }]);
-		await testHtmlCompletionProvider(`<div style='color: #0|'`, [{ label: '#000000' }]);
+		await testCompletionProvider('html', '<div style="|"', [{ label: 'padding: ;' }]);
+		await testCompletionProvider('html', `<div style='|'`, [{ label: 'padding: ;' }]);
+		await testCompletionProvider('html', `<div style='p|'`, [{ label: 'padding: ;' }]);
+		await testCompletionProvider('html', `<div style='color: #0|'`, [{ label: '#000000' }]);
 	});
 
 	// https://github.com/microsoft/vscode/issues/79766
 	test('#79766, correct region determination', async () => {
-		await testHtmlCompletionProvider(`<div style="color: #000">di|</div>`, [
+		await testCompletionProvider('html', `<div style="color: #000">di|</div>`, [
 			{ label: 'div', documentation: `<div>|</div>` }
 		]);
 	});
 
 	// https://github.com/microsoft/vscode/issues/86941
 	test('#86941, widows should not be completed', async () => {
-		await testCssCompletionProvider(`.foo { wi| }`, [
-			{ label: 'widows: ;', documentation: `widows: ;` }
-		]);
+		await testCompletionProvider('css', `.foo { wi| }`, undefined);
 	});
 
 	// https://github.com/microsoft/vscode/issues/117020
 	test('#117020, ! at end of abbreviation should have completion', async () => {
-		await testCssCompletionProvider(`.foo { bdbn!| }`, [
+		await testCompletionProvider('css', `.foo { bdbn!| }`, [
 			{ label: 'border-bottom: none !important;', documentation: `border-bottom: none !important;` }
+		]);
+	});
+
+	// https://github.com/microsoft/vscode/issues/138461
+	test('#138461, JSX array noise', async () => {
+		await testCompletionProvider('jsx', 'a[i]', undefined);
+		await testCompletionProvider('jsx', 'Component[a b]', undefined);
+		await testCompletionProvider('jsx', '[a, b]', undefined);
+		await testCompletionProvider('jsx', '[a=b]', [
+			{ label: '<div a="b"></div>', documentation: '<div a="b">|</div>' }
 		]);
 	});
 });
@@ -49,11 +57,11 @@ interface TestCompletionItem {
 	documentation?: string;
 }
 
-function testHtmlCompletionProvider(contents: string, expectedItems: TestCompletionItem[]): Thenable<any> {
+function testCompletionProvider(fileExtension: string, contents: string, expectedItems: TestCompletionItem[] | undefined): Thenable<boolean> {
 	const cursorPos = contents.indexOf('|');
-	const htmlContents = contents.slice(0, cursorPos) + contents.slice(cursorPos + 1);
+	const slicedContents = contents.slice(0, cursorPos) + contents.slice(cursorPos + 1);
 
-	return withRandomFileEditor(htmlContents, 'html', async (editor, _doc) => {
+	return withRandomFileEditor(slicedContents, fileExtension, async (editor, _doc) => {
 		const selection = new Selection(editor.document.positionAt(cursorPos), editor.document.positionAt(cursorPos));
 		editor.selection = selection;
 		const cancelSrc = new CancellationTokenSource();
@@ -69,51 +77,14 @@ function testHtmlCompletionProvider(contents: string, expectedItems: TestComplet
 
 		const completionList = await completionPromise;
 		if (!completionList || !completionList.items || !completionList.items.length) {
-			return Promise.resolve();
-		}
-
-		expectedItems.forEach(eItem => {
-			const matches = completionList.items.filter(i => i.label === eItem.label);
-			const match = matches && matches.length > 0 ? matches[0] : undefined;
-			assert.ok(match, `Didn't find completion item with label ${eItem.label}`);
-
-			if (match) {
-				assert.strictEqual(match.detail, 'Emmet Abbreviation', `Match needs to come from Emmet`);
-
-				if (eItem.documentation) {
-					assert.strictEqual(match.documentation, eItem.documentation, `Emmet completion Documentation doesn't match`);
-				}
+			if (completionList === undefined) {
+				assert.strictEqual(expectedItems, completionList);
 			}
-		});
-
-		return Promise.resolve();
-	});
-}
-
-function testCssCompletionProvider(contents: string, expectedItems: TestCompletionItem[]): Thenable<any> {
-	const cursorPos = contents.indexOf('|');
-	const cssContents = contents.slice(0, cursorPos) + contents.slice(cursorPos + 1);
-
-	return withRandomFileEditor(cssContents, 'css', async (editor, _doc) => {
-		const selection = new Selection(editor.document.positionAt(cursorPos), editor.document.positionAt(cursorPos));
-		editor.selection = selection;
-		const cancelSrc = new CancellationTokenSource();
-		const completionPromise = completionProvider.provideCompletionItems(
-			editor.document,
-			editor.selection.active,
-			cancelSrc.token,
-			{ triggerKind: CompletionTriggerKind.Invoke, triggerCharacter: undefined }
-		);
-		if (!completionPromise) {
 			return Promise.resolve();
 		}
 
-		const completionList = await completionPromise;
-		if (!completionList || !completionList.items || !completionList.items.length) {
-			return Promise.resolve();
-		}
-
-		expectedItems.forEach(eItem => {
+		assert.strictEqual(expectedItems === undefined, false);
+		expectedItems!.forEach(eItem => {
 			const matches = completionList.items.filter(i => i.label === eItem.label);
 			const match = matches && matches.length > 0 ? matches[0] : undefined;
 			assert.ok(match, `Didn't find completion item with label ${eItem.label}`);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/138461

I thought that we'd have to do a large refactor first, but I realized there's a much simpler mitigation that I can push in instead.

The mitigation disallows completions to show up in JS and JSX files for cases where the abbreviation contains `[]` characters without a `=` inside. The advantage in this case is we don't try to expand array indexes like `arr[i]`, or left-side array de-structuring cases like `const [a, b]`. 

The disadvantage is that we now don't show suggestions for abbreviations like `div[a b]`. Either the user must type an abbreviation of the form `div[a=someValue b=someOtherValue]`, turn on `emmet.triggerExpansionOnTab`, or run the expand command. But, considering how often one means to type an array index or a left-side de-structuring, and how there already are workarounds, I think it is worth pushing in this mitigation to improve the QoL for JSX users.

I also improved some typing information so we use fewer `any`s.
