### PR TITLE
Use `style="unicode-bidi:isolate"` instead of `dir="auto"` for parts containing RTL

### DIFF
--- a/src/vs/editor/common/viewLayout/viewLineRenderer.ts
+++ b/src/vs/editor/common/viewLayout/viewLineRenderer.ts
@@ -959,7 +959,7 @@ function _renderLine(input: ResolvedRenderLineInput, sb: IStringBuilder): Render
 
 		sb.appendASCIIString('<span ');
 		if (partContainsRTL) {
-			sb.appendASCIIString('dir="auto" ');
+			sb.appendASCIIString('style="unicode-bidi:isolate" ');
 		}
 		sb.appendASCIIString('class="');
 		sb.appendASCIIString(partRendersWhitespaceWithWidth ? 'mtkz' : partType);

--- a/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
+++ b/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
@@ -465,8 +465,8 @@ suite('viewLineRenderer.renderLine', () => {
 
 		const expectedOutput = [
 			'<span class="mtk6">var</span>',
-			'<span dir="auto" class="mtk1">\u00a0קודמות\u00a0=\u00a0</span>',
-			'<span dir="auto" class="mtk20">"מיותר\u00a0קודמות\u00a0צ\'ט\u00a0של,\u00a0אם\u00a0לשון\u00a0העברית\u00a0שינויים\u00a0ויש,\u00a0אם"</span>',
+			'<span style="unicode-bidi:isolate" class="mtk1">\u00a0קודמות\u00a0=\u00a0</span>',
+			'<span style="unicode-bidi:isolate" class="mtk20">"מיותר\u00a0קודמות\u00a0צ\'ט\u00a0של,\u00a0אם\u00a0לשון\u00a0העברית\u00a0שינויים\u00a0ויש,\u00a0אם"</span>',
 			'<span class="mtk1">;</span>'
 		].join('');
 
@@ -519,9 +519,9 @@ suite('viewLineRenderer.renderLine', () => {
 			'<span class="mtk4">\u00a0</span>',
 			'<span class="mtk5">value</span>',
 			'<span class="mtk4">=</span>',
-			'<span dir="auto" class="mtk6">"العربية"</span>',
+			'<span style="unicode-bidi:isolate" class="mtk6">"العربية"</span>',
 			'<span class="mtk2">&gt;</span>',
-			'<span dir="auto" class="mtk4">العربية</span>',
+			'<span style="unicode-bidi:isolate" class="mtk4">العربية</span>',
 			'<span class="mtk2">&lt;/</span>',
 			'<span class="mtk3">option</span>',
 			'<span class="mtk2">&gt;</span>',
@@ -738,7 +738,7 @@ suite('viewLineRenderer.renderLine', () => {
 		const lineText = 'את גרמנית בהתייחסות שמו, שנתי המשפט אל חפש, אם כתב אחרים ולחבר. של התוכן אודות בויקיפדיה כלל, של עזרה כימיה היא. על עמוד יוצרים מיתולוגיה סדר, אם שכל שתפו לעברית שינויים, אם שאלות אנגלית עזה. שמות בקלות מה סדר.';
 		const lineParts = createViewLineTokens([createPart(lineText.length, 1)]);
 		const expectedOutput = [
-			'<span dir="auto" class="mtk1">את\u00a0גרמנית\u00a0בהתייחסות\u00a0שמו,\u00a0שנתי\u00a0המשפט\u00a0אל\u00a0חפש,\u00a0אם\u00a0כתב\u00a0אחרים\u00a0ולחבר.\u00a0של\u00a0התוכן\u00a0אודות\u00a0בויקיפדיה\u00a0כלל,\u00a0של\u00a0עזרה\u00a0כימיה\u00a0היא.\u00a0על\u00a0עמוד\u00a0יוצרים\u00a0מיתולוגיה\u00a0סדר,\u00a0אם\u00a0שכל\u00a0שתפו\u00a0לעברית\u00a0שינויים,\u00a0אם\u00a0שאלות\u00a0אנגלית\u00a0עזה.\u00a0שמות\u00a0בקלות\u00a0מה\u00a0סדר.</span>'
+			'<span style="unicode-bidi:isolate" class="mtk1">את\u00a0גרמנית\u00a0בהתייחסות\u00a0שמו,\u00a0שנתי\u00a0המשפט\u00a0אל\u00a0חפש,\u00a0אם\u00a0כתב\u00a0אחרים\u00a0ולחבר.\u00a0של\u00a0התוכן\u00a0אודות\u00a0בויקיפדיה\u00a0כלל,\u00a0של\u00a0עזרה\u00a0כימיה\u00a0היא.\u00a0על\u00a0עמוד\u00a0יוצרים\u00a0מיתולוגיה\u00a0סדר,\u00a0אם\u00a0שכל\u00a0שתפו\u00a0לעברית\u00a0שינויים,\u00a0אם\u00a0שאלות\u00a0אנגלית\u00a0עזה.\u00a0שמות\u00a0בקלות\u00a0מה\u00a0סדר.</span>'
 		];
 		const actual = renderViewLine(new RenderLineInput(
 			false,


### PR DESCRIPTION
Fixes #146354 for stable while still having correct rendering for #97971, #99589, #100112, #126593 and #137036 (with render whitespace off). The fix is to use the [`unicode-bidi` CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-bidi) to avoid that a token (part) containing RTL influences siblings.


The test cases:

<table>
<tr><th>Issue</th><th>Code / 1.66.0 Light+ / Proposed Dark+</th><th>Outcome</th></tr>

<tr><td>#146354</td><td>

```html
<b>
	9- هزینه کاهش ارزش دریافتنی‌ها
</b>
```

<img width="259" alt="image" src="https://user-images.githubusercontent.com/5047891/161772367-185f7ce4-be67-4bfc-ac1f-bd9b02e8b6dc.png"><br/>


<img width="264" alt="image" src="https://user-images.githubusercontent.com/5047891/161772165-52d615c7-3da1-4c6c-b140-67bdf5f780f3.png">
</td><td>Fixes issue</td></tr>




<tr><td>#97971</td><td>

```js
var list = [['0101', 'عید نوروز'], ['0102', 'عید نوروز']];
```

<img width="441" alt="image" src="https://user-images.githubusercontent.com/5047891/161772526-016bb755-67fe-41ce-8f4b-1897406e0338.png">


<img width="446" alt="image" src="https://user-images.githubusercontent.com/5047891/161758994-d389a669-63e4-456e-b48f-fe6f9b6514db.png"></td><td>identical</td></tr>



<tr><td>#99589</td><td>

```json
{
  "invoice_vip":[
    ["🖨️ چاپ فاکتور","🎨 تنظیمات"]
  ]
}
```

<img width="254" alt="image" src="https://user-images.githubusercontent.com/5047891/161772601-ec90e8b6-c489-4ac9-a7fa-0a57cd4671b7.png">


<img width="262" alt="image" src="https://user-images.githubusercontent.com/5047891/161759628-5f18cd13-1e45-4276-be6b-98693ba970dc.png"></td><td>different, but reasonable</td></tr>


<tr><td>#100112</td><td>

```lua
what = (["على"] . ("محموله"))
```

<img width="224" alt="image" src="https://user-images.githubusercontent.com/5047891/161772660-b872bba0-72f2-4519-a4d5-507acee2e15c.png">


<img width="228" alt="image" src="https://user-images.githubusercontent.com/5047891/161771612-37819c5b-5507-4c71-a1ea-acd4d03db381.png"></td><td>identical</td></tr>


<tr><td>#126593</td><td>

```js
console.log(true ? "درست" : "غلط");
```

<img width="268" alt="image" src="https://user-images.githubusercontent.com/5047891/161772714-819c7638-b7b6-497d-9426-596cc0847b94.png"><br/>


<img width="271" alt="image" src="https://user-images.githubusercontent.com/5047891/161771771-84e7b2ee-5192-4914-9243-d4c7d1f9d6d7.png">
</td><td>identical</td></tr>


<tr><td>#137036</td><td>

```html
<option value="العربية">العربية</option>
```

<img width="316" alt="image" src="https://user-images.githubusercontent.com/5047891/161772752-d1e2615a-b3ef-428a-82fe-00288caab4f7.png"><br/>


<img width="307" alt="image" src="https://user-images.githubusercontent.com/5047891/161771954-0b76578e-7277-48f3-a29d-06d177c9f88e.png">
</td><td>identical</td></tr>



</table>