### PR TITLE
Do not render whitespace in tokens that contain RTL text

### DIFF
--- a/src/vs/editor/common/viewLayout/viewLineRenderer.ts
+++ b/src/vs/editor/common/viewLayout/viewLineRenderer.ts
@@ -773,6 +773,18 @@ function _applyRenderWhitespace(input: RenderLineInput, lineContent: string, len
 			isInWhitespace = lineIsEmptyOrWhitespace || charIndex > lastNonWhitespaceIndex;
 		}
 
+		if (isInWhitespace && tokenContainsRTL) {
+			// If the token contains RTL text, breaking it up into multiple line parts
+			// to render whitespace might affect the browser's bidi layout.
+			//
+			// We render whitespace in such tokens only if the whitespace
+			// is the leading or the trailing whitespace of the line,
+			// which doesn't affect the browser's bidi layout.
+			if (charIndex >= firstNonWhitespaceIndex && charIndex <= lastNonWhitespaceIndex) {
+				isInWhitespace = false;
+			}
+		}
+
 		if (wasInWhitespace) {
 			// was in whitespace token
 			if (!isInWhitespace || (!useMonospaceOptimizations && tmpIndent >= tabSize)) {

--- a/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
+++ b/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
@@ -553,6 +553,52 @@ suite('viewLineRenderer.renderLine', () => {
 		assert.strictEqual(_actual.containsRTL, true);
 	});
 
+	test('issue #99589: Rendering whitespace influences bidi layout', () => {
+		const lineText = '    [\"🖨️ چاپ فاکتور\",\"🎨 تنظیمات\"]';
+
+		const lineParts = createViewLineTokens([
+			createPart(5, 2),
+			createPart(21, 3),
+			createPart(22, 2),
+			createPart(34, 3),
+			createPart(35, 2),
+		]);
+
+		const expectedOutput = [
+			'<span class="mtkw">\u00b7\u00b7\u00b7\u00b7</span>',
+			'<span class="mtk2">[</span>',
+			'<span style="unicode-bidi:isolate" class="mtk3">"🖨️\u00a0چاپ\u00a0فاکتور"</span>',
+			'<span class="mtk2">,</span>',
+			'<span style="unicode-bidi:isolate" class="mtk3">"🎨\u00a0تنظیمات"</span>',
+			'<span class="mtk2">]</span>'
+		].join('');
+
+		const _actual = renderViewLine(new RenderLineInput(
+			true,
+			true,
+			lineText,
+			false,
+			false,
+			true,
+			0,
+			lineParts,
+			[],
+			4,
+			0,
+			10,
+			10,
+			10,
+			-1,
+			'all',
+			false,
+			false,
+			null
+		));
+
+		assert.strictEqual(_actual.html, '<span dir="ltr">' + expectedOutput + '</span>');
+		assert.strictEqual(_actual.containsRTL, true);
+	});
+
 	test('issue #6885: Splits large tokens', () => {
 		//                                                                                                                  1         1         1
 		//                        1         2         3         4         5         6         7         8         9         0         1         2


### PR DESCRIPTION
(except for line leading and trailing whitespace)

Fixes #99589

The newest behavior in #99589 is another regression caused by the new treatment we do for RTL tokens. We discovered this during issue verification, but I didn't think it was a big deal. However, we have received a lot of duplicates for it, so this PR addresses it in stable by skipping rendering whitespace in tokens that contain RTL. However, if a line begins with a token that contains RTL or ends in such a token, leading and trailing whitespace is rendered because, from observations, that doesn't seem to impact negatively the bidi layout done by browsers.

Example:
```js
const x = ["🖨️ چاپ فاکتور","🎨 تنظیمات"]
/*
   🎨 تنظیمات.   
*/
``` 

| Configuration | Before this change | After this change |
|---|---|---|
| whitespace off | <img width="294" alt="image" src="https://user-images.githubusercontent.com/5047891/161821172-b91ae3f4-72a5-44c0-9613-3e820cedbb69.png"> | <img width="308" alt="image" src="https://user-images.githubusercontent.com/5047891/161820715-6be56803-4212-4d5b-838e-595f9afa6cf6.png"> |
| whitespace on | <img width="298" alt="image" src="https://user-images.githubusercontent.com/5047891/161821105-b8b997f3-c54b-4b87-a710-2fb741edbd5f.png"> | <img width="302" alt="image" src="https://user-images.githubusercontent.com/5047891/161820972-19badfe3-9726-4ffd-857b-c0a310faa581.png"> |