### PR TITLE
Tweak URI search tree iterator to support folder-level query parameters

### DIFF
--- a/src/vs/base/common/map.ts
+++ b/src/vs/base/common/map.ts
@@ -199,7 +199,9 @@ export class UriIterator implements IKeyIterator<URI> {
 	private _states: UriIteratorState[] = [];
 	private _stateIdx: number = 0;
 
-	constructor(private readonly _ignorePathCasing: (uri: URI) => boolean) { }
+	constructor(
+		private readonly _ignorePathCasing: (uri: URI) => boolean,
+		private readonly _ignoreQueryAndFragment: (uri: URI) => boolean) { }
 
 	reset(key: URI): this {
 		this._value = key;
@@ -210,17 +212,19 @@ export class UriIterator implements IKeyIterator<URI> {
 		if (this._value.authority) {
 			this._states.push(UriIteratorState.Authority);
 		}
-		if (this._value.query) {
-			this._states.push(UriIteratorState.Query);
-		}
-		if (this._value.fragment) {
-			this._states.push(UriIteratorState.Fragment);
-		}
 		if (this._value.path) {
 			this._pathIterator = new PathIterator(false, !this._ignorePathCasing(key));
 			this._pathIterator.reset(key.path);
 			if (this._pathIterator.value()) {
 				this._states.push(UriIteratorState.Path);
+			}
+		}
+		if (!this._ignoreQueryAndFragment(key)) {
+			if (this._value.query) {
+				this._states.push(UriIteratorState.Query);
+			}
+			if (this._value.fragment) {
+				this._states.push(UriIteratorState.Fragment);
 			}
 		}
 		this._stateIdx = 0;
@@ -328,8 +332,8 @@ const enum Dir {
 
 export class TernarySearchTree<K, V> {
 
-	static forUris<E>(ignorePathCasing: (key: URI) => boolean = () => false): TernarySearchTree<URI, E> {
-		return new TernarySearchTree<URI, E>(new UriIterator(ignorePathCasing));
+	static forUris<E>(ignorePathCasing: (key: URI) => boolean = () => false, ignoreQueryAndFragment: (key: URI) => boolean = () => false): TernarySearchTree<URI, E> {
+		return new TernarySearchTree<URI, E>(new UriIterator(ignorePathCasing, ignoreQueryAndFragment));
 	}
 
 	static forPaths<E>(ignorePathCasing = false): TernarySearchTree<string, E> {

--- a/src/vs/base/common/map.ts
+++ b/src/vs/base/common/map.ts
@@ -210,18 +210,18 @@ export class UriIterator implements IKeyIterator<URI> {
 		if (this._value.authority) {
 			this._states.push(UriIteratorState.Authority);
 		}
+		if (this._value.query) {
+			this._states.push(UriIteratorState.Query);
+		}
+		if (this._value.fragment) {
+			this._states.push(UriIteratorState.Fragment);
+		}
 		if (this._value.path) {
 			this._pathIterator = new PathIterator(false, !this._ignorePathCasing(key));
 			this._pathIterator.reset(key.path);
 			if (this._pathIterator.value()) {
 				this._states.push(UriIteratorState.Path);
 			}
-		}
-		if (this._value.query) {
-			this._states.push(UriIteratorState.Query);
-		}
-		if (this._value.fragment) {
-			this._states.push(UriIteratorState.Fragment);
 		}
 		this._stateIdx = 0;
 		return this;

--- a/src/vs/base/test/common/map.test.ts
+++ b/src/vs/base/test/common/map.test.ts
@@ -407,6 +407,13 @@ suite('Map', () => {
 		assert.strictEqual(iter.hasNext(), true);
 		iter.next();
 
+		// query
+		assert.strictEqual(iter.value(), 'foo');
+		assert.strictEqual(iter.cmp('z') > 0, true);
+		assert.strictEqual(iter.cmp('a') < 0, true);
+		assert.strictEqual(iter.hasNext(), true);
+		iter.next();
+
 		// path
 		assert.strictEqual(iter.value(), 'usr');
 		assert.strictEqual(iter.hasNext(), true);
@@ -419,13 +426,6 @@ suite('Map', () => {
 
 		// path
 		assert.strictEqual(iter.value(), 'file.txt');
-		assert.strictEqual(iter.hasNext(), true);
-		iter.next();
-
-		// query
-		assert.strictEqual(iter.value(), 'foo');
-		assert.strictEqual(iter.cmp('z') > 0, true);
-		assert.strictEqual(iter.cmp('a') < 0, true);
 		assert.strictEqual(iter.hasNext(), false);
 	});
 
@@ -917,6 +917,17 @@ suite('Map', () => {
 		assert.strictEqual(trie.findSubstr(URI.file('/user/foo/far/boo')), 2);
 		assert.strictEqual(trie.findSubstr(URI.file('/user/foo/bar')), 1);
 		assert.strictEqual(trie.findSubstr(URI.file('/user/foo/bar/far/boo')), 1);
+	});
+
+	test('TernarySearchTree (URI) - query parameters', function () {
+		let trie = new TernarySearchTree<URI, number>(new UriIterator(() => false));
+		const root = URI.parse('memfs:/?param=1');
+		trie.set(root, 1);
+
+		assert.strictEqual(trie.get(URI.parse('memfs:/?param=1')), 1);
+
+		assert.strictEqual(trie.findSubstr(URI.parse('memfs:/?param=1')), 1);
+		assert.strictEqual(trie.findSubstr(URI.parse('memfs:/aaa?param=1')), 1);
 	});
 
 	test('TernarySearchTree (URI) - lookup', function () {

--- a/src/vs/platform/workspace/common/workspace.ts
+++ b/src/vs/platform/workspace/common/workspace.ts
@@ -295,7 +295,7 @@ export function isWorkspaceFolder(thing: unknown): thing is IWorkspaceFolder {
 
 export class Workspace implements IWorkspace {
 
-	private _foldersMap: TernarySearchTree<URI, WorkspaceFolder> = TernarySearchTree.forUris<WorkspaceFolder>(this._ignorePathCasing);
+	private _foldersMap: TernarySearchTree<URI, WorkspaceFolder> = TernarySearchTree.forUris<WorkspaceFolder>(this._ignorePathCasing, () => true);
 	private _folders!: WorkspaceFolder[];
 
 	constructor(
@@ -354,7 +354,7 @@ export class Workspace implements IWorkspace {
 	}
 
 	private updateFoldersMap(): void {
-		this._foldersMap = TernarySearchTree.forUris<WorkspaceFolder>(this._ignorePathCasing);
+		this._foldersMap = TernarySearchTree.forUris<WorkspaceFolder>(this._ignorePathCasing, () => true);
 		for (const folder of this.folders) {
 			this._foldersMap.set(folder.uri, folder);
 		}

--- a/src/vs/workbench/contrib/files/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/files/common/explorerModel.ts
@@ -67,6 +67,11 @@ export class ExplorerModel implements IDisposable {
 	 */
 	findClosest(resource: URI): ExplorerItem | null {
 		const folder = this.contextService.getWorkspaceFolder(resource);
+		const workspace = this.contextService.getWorkspace();
+		if (!folder) {
+			const folder2 = this.contextService.getWorkspaceFolder(resource);
+			console.log(folder, workspace, resource);
+		}
 		if (folder) {
 			const root = this.roots.find(r => this.uriIdentityService.extUri.isEqual(r.resource, folder.uri));
 			if (root) {

--- a/src/vs/workbench/contrib/files/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/files/common/explorerModel.ts
@@ -67,11 +67,6 @@ export class ExplorerModel implements IDisposable {
 	 */
 	findClosest(resource: URI): ExplorerItem | null {
 		const folder = this.contextService.getWorkspaceFolder(resource);
-		const workspace = this.contextService.getWorkspace();
-		if (!folder) {
-			const folder2 = this.contextService.getWorkspaceFolder(resource);
-			console.log(folder, workspace, resource);
-		}
 		if (folder) {
 			const root = this.roots.find(r => this.uriIdentityService.extUri.isEqual(r.resource, folder.uri));
 			if (root) {

--- a/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
@@ -105,6 +105,27 @@ suite('WorkspaceContextService - Folder', () => {
 		assert.strictEqual(actual, testObject.getWorkspace().folders[0]);
 	});
 
+	test('getWorkspaceFolder() - queries', async () => {
+
+		const logService = new NullLogService();
+		const fileService = disposables.add(new FileService(logService));
+		const fileSystemProvider = disposables.add(new InMemoryFileSystemProvider());
+		fileService.registerProvider(ROOT.scheme, fileSystemProvider);
+
+		const folder = joinPath(ROOT, folderName).with({ query: 'myquery=1' });
+		await fileService.createFolder(folder);
+
+		const environmentService = TestEnvironmentService;
+		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
+		const testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, fileService, new RemoteAgentService(null, environmentService, TestProductService, new RemoteAuthorityResolverService(undefined, undefined), new SignService(undefined), new NullLogService()), new UriIdentityService(fileService), new NullLogService()));
+		await (<WorkspaceService>testObject).initialize(convertToWorkspacePayload(folder));
+
+
+		const actual = testObject.getWorkspaceFolder(joinPath(folder, 'a'));
+
+		assert.strictEqual(actual, testObject.getWorkspace().folders[0]);
+	});
+
 	test('isCurrentWorkspace() => true', () => {
 		assert.ok(testObject.isCurrentWorkspace(folder));
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/139383

@jrieken not sure about this one. On one hand I'd expect `getWorkspaceFolder(URI.parse("memfs:/aaa?query=1")` with a workspace folder `"memfs:/?query=1"` to return that folder, on the other hand this is a pretty core routine and the change could have some unintended side effects. (for instance, should `getWorkspaceFolder(URI.parse("memfs:/aaa?query=1")` return `"memfs:/"` if that's the only folder available?)