### PR TITLE
Add an eager `pointerup` listener which shouldn't miss any events

### DIFF
--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -115,6 +115,14 @@ export class MouseHandler extends ViewEventHandler {
 				mousePointerId = pointerId;
 			}
 		}));
+		// The `pointerup` listener registered by `GlobalEditorPointerMoveMonitor` does not get invoked 100% of the times.
+		// I speculate that this is because the `pointerup` listener is only registered during the `mousedown` event, and perhaps
+		// the `pointerup` event is already queued for dispatching, which makes it that the new listener doesn't get fired.
+		// See https://github.com/microsoft/vscode/issues/146486 for repro steps.
+		// To compensate for that, we simply register here a `pointerup` listener and just communicate it.
+		this._register(dom.addDisposableListener(this.viewHelper.viewDomNode, dom.EventType.POINTER_UP, (e: PointerEvent) => {
+			this._mouseDownOperation.onPointerUp();
+		}));
 		this._register(mouseEvents.onMouseDown(this.viewHelper.viewDomNode, (e) => this._onMouseDown(e, mousePointerId)));
 
 		const onMouseWheel = (browserEvent: IMouseWheelEvent) => {
@@ -440,6 +448,10 @@ class MouseDownOperation extends Disposable {
 	}
 
 	public onHeightChanged(): void {
+		this._mouseMoveMonitor.stopMonitoring();
+	}
+
+	public onPointerUp(): void {
 		this._mouseMoveMonitor.stopMonitoring();
 	}
 


### PR DESCRIPTION
Fixes #146486

Following the steps in #146486, I could reproduce from source. By adding logging, I could see that the `pointerup` listener added [here](https://github.com/microsoft/vscode/blob/e12596ec377552e522e932c12d3581f9f4096795/src/vs/base/browser/globalPointerMoveMonitor.ts#L112-L116) does not fire and that is why the editor gets "stuck" in selection mode. I speculate that the listener does not fire because it is added only during the `mousedown` event handler and perhaps the `pointerup` has already occurred and has already started being dispatched before the listener has a chance to register. 