### PR TITLE
Snippet instrumentation

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -674,9 +674,9 @@ export interface CompletionItem {
 	 */
 	command?: Command;
 	/**
-	 * Identifier for the extension that contributed this completion.
+	 * @internal
 	 */
-	extensionId?: string;
+	extensionId?: ExtensionIdentifier;
 
 	/**
 	 * @internal

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -673,6 +673,10 @@ export interface CompletionItem {
 	 * A command that should be run upon acceptance of this item.
 	 */
 	command?: Command;
+	/**
+	 * Identifier for the extension that contributed this completion.
+	 */
+	extensionId?: string;
 
 	/**
 	 * @internal

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -26,6 +26,7 @@ import { LanguageFeatureRegistry } from 'vs/editor/common/languageFeatureRegistr
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { historyNavigationVisible } from 'vs/platform/history/browser/contextScopedHistoryWidget';
 import { InternalQuickSuggestionsOptions, QuickSuggestionsValue } from 'vs/editor/common/config/editorOptions';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 
 export const Context = {
 	Visible: historyNavigationVisible,
@@ -67,7 +68,7 @@ export class CompletionItem {
 	word?: string;
 
 	// instrumentation
-	readonly extensionId?: string;
+	readonly extensionId?: ExtensionIdentifier;
 
 	// resolving
 	private _isResolved?: boolean;

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -66,6 +66,9 @@ export class CompletionItem {
 	idx?: number;
 	word?: string;
 
+	// instrumentation
+	readonly extensionId?: string;
+
 	// resolving
 	private _isResolved?: boolean;
 	private _resolveCache?: Promise<void>;
@@ -88,6 +91,8 @@ export class CompletionItem {
 
 		this.sortTextLow = completion.sortText && completion.sortText.toLowerCase();
 		this.filterTextLow = completion.filterText && completion.filterText.toLowerCase();
+
+		this.extensionId = completion.extensionId;
 
 		// normalize ranges
 		if (Range.isIRange(completion.range)) {

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -441,11 +441,11 @@ export class SuggestController implements IEditorContribution {
 		});
 	}
 
-	// private _telemetryGate: number = 0;
-	private _reportSuggestionAcceptedTelemetry(item: CompletionItem /*| SnippetCompletion */, model: ITextModel, acceptedSuggestion: ISelectedSuggestion) {
-		// if (this._telemetryGate++ % 100 !== 0) {
-		// 	return;
-		// }
+	private _telemetryGate: number = 0;
+	private _reportSuggestionAcceptedTelemetry(item: CompletionItem, model: ITextModel, acceptedSuggestion: ISelectedSuggestion) {
+		if (this._telemetryGate++ % 100 !== 0) {
+			return;
+		}
 
 		type AcceptedSuggestion = { providerId: string; fileExtension: string; languageId: string; basenameHash: string; kind: number };
 		type AcceptedSuggestionClassification = {

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -45,6 +45,9 @@ import { ISelectedSuggestion, SuggestWidget } from './suggestWidget';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { basename, extname } from 'vs/base/common/resources';
 import { hash } from 'vs/base/common/hash';
+// FIXME: Not what want! What is a better way to access snippets property?
+// eslint-disable-next-line code-import-patterns
+// import { SnippetCompletion } from 'vs/workbench/contrib/snippets/browser/snippetCompletionProvider';
 
 // sticky suggest widget which doesn't disappear on focus out and such
 let _sticky = false;
@@ -434,7 +437,7 @@ export class SuggestController implements IEditorContribution {
 
 		// clear only now - after all tasks are done
 		Promise.all(tasks).finally(() => {
-			this._reportSuggestionAcceptedTelemetry(model, event);
+			this._reportSuggestionAcceptedTelemetry(item, model, event);
 
 			this.model.clear();
 			cts.dispose();
@@ -442,7 +445,7 @@ export class SuggestController implements IEditorContribution {
 	}
 
 	private _telemetryGate: number = 0;
-	private _reportSuggestionAcceptedTelemetry(model: ITextModel, acceptedSuggestion: ISelectedSuggestion) {
+	private _reportSuggestionAcceptedTelemetry(item: CompletionItem /*| SnippetCompletion */, model: ITextModel, acceptedSuggestion: ISelectedSuggestion) {
 		if (this._telemetryGate++ % 100 !== 0) {
 			return;
 		}
@@ -457,6 +460,7 @@ export class SuggestController implements IEditorContribution {
 		// _debugDisplayName looks like `vscode.css-language-features(/-:)`, where the last bit is the trigger chars
 		// normalize it to just the extension ID and lowercase
 		const providerId = (acceptedSuggestion.item.provider._debugDisplayName ?? 'unknown').split('(', 1)[0].toLowerCase();
+		// const providerId = ('snippet' in item && item.snippet.extension) ? item.snippet.extension : (acceptedSuggestion.item.provider._debugDisplayName ?? 'unknown').split('(', 1)[0].toLowerCase();
 		this._telemetryService.publicLog2<AcceptedSuggestion, AcceptedSuggestionClassification>('suggest.acceptedSuggestion', {
 			providerId,
 			basenameHash: hash(basename(model.uri)).toString(16),

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -457,7 +457,7 @@ export class SuggestController implements IEditorContribution {
 		};
 		// _debugDisplayName looks like `vscode.css-language-features(/-:)`, where the last bit is the trigger chars
 		// normalize it to just the extension ID and lowercase
-		const providerId = item.extensionId ?? (acceptedSuggestion.item.provider._debugDisplayName ?? 'unknown').split('(', 1)[0].toLowerCase();
+		const providerId = item.extensionId ? item.extensionId.value : (acceptedSuggestion.item.provider._debugDisplayName ?? 'unknown').split('(', 1)[0].toLowerCase();
 		this._telemetryService.publicLog2<AcceptedSuggestion, AcceptedSuggestionClassification>('suggest.acceptedSuggestion', {
 			providerId,
 			kind: item.completion.kind,

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -45,9 +45,6 @@ import { ISelectedSuggestion, SuggestWidget } from './suggestWidget';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { basename, extname } from 'vs/base/common/resources';
 import { hash } from 'vs/base/common/hash';
-// FIXME: Not what want! What is a better way to access snippets property?
-// eslint-disable-next-line code-import-patterns
-// import { SnippetCompletion } from 'vs/workbench/contrib/snippets/browser/snippetCompletionProvider';
 
 // sticky suggest widget which doesn't disappear on focus out and such
 let _sticky = false;
@@ -444,25 +441,26 @@ export class SuggestController implements IEditorContribution {
 		});
 	}
 
-	private _telemetryGate: number = 0;
+	// private _telemetryGate: number = 0;
 	private _reportSuggestionAcceptedTelemetry(item: CompletionItem /*| SnippetCompletion */, model: ITextModel, acceptedSuggestion: ISelectedSuggestion) {
-		if (this._telemetryGate++ % 100 !== 0) {
-			return;
-		}
+		// if (this._telemetryGate++ % 100 !== 0) {
+		// 	return;
+		// }
 
-		type AcceptedSuggestion = { providerId: string; fileExtension: string; languageId: string; basenameHash: string };
+		type AcceptedSuggestion = { providerId: string; fileExtension: string; languageId: string; basenameHash: string; kind: number };
 		type AcceptedSuggestionClassification = {
 			providerId: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 			basenameHash: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 			fileExtension: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 			languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+			kind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 		};
 		// _debugDisplayName looks like `vscode.css-language-features(/-:)`, where the last bit is the trigger chars
 		// normalize it to just the extension ID and lowercase
-		const providerId = (acceptedSuggestion.item.provider._debugDisplayName ?? 'unknown').split('(', 1)[0].toLowerCase();
-		// const providerId = ('snippet' in item && item.snippet.extension) ? item.snippet.extension : (acceptedSuggestion.item.provider._debugDisplayName ?? 'unknown').split('(', 1)[0].toLowerCase();
+		const providerId = item.extensionId ?? (acceptedSuggestion.item.provider._debugDisplayName ?? 'unknown').split('(', 1)[0].toLowerCase();
 		this._telemetryService.publicLog2<AcceptedSuggestion, AcceptedSuggestionClassification>('suggest.acceptedSuggestion', {
 			providerId,
+			kind: item.completion.kind,
 			basenameHash: hash(basename(model.uri)).toString(16),
 			languageId: model.getLanguageId(),
 			fileExtension: extname(model.uri),

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6203,6 +6203,10 @@ declare namespace monaco.languages {
 		 * A command that should be run upon acceptance of this item.
 		 */
 		command?: Command;
+		/**
+		 * Identifier for the extension that contributed this completion.
+		 */
+		extensionId?: string;
 	}
 
 	export interface CompletionList {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6203,10 +6203,6 @@ declare namespace monaco.languages {
 		 * A command that should be run upon acceptance of this item.
 		 */
 		command?: Command;
-		/**
-		 * Identifier for the extension that contributed this completion.
-		 */
-		extensionId?: string;
 	}
 
 	export interface CompletionList {

--- a/src/vs/workbench/contrib/snippets/browser/snippetCompletionProvider.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetCompletionProvider.ts
@@ -18,6 +18,7 @@ import { isPatternInWord } from 'vs/base/common/filters';
 import { StopWatch } from 'vs/base/common/stopwatch';
 import { ILanguageConfigurationService } from 'vs/editor/common/languages/languageConfigurationRegistry';
 import { getWordAtText } from 'vs/editor/common/core/wordHelper';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 
 export class SnippetCompletion implements CompletionItem {
 
@@ -29,7 +30,7 @@ export class SnippetCompletion implements CompletionItem {
 	sortText: string;
 	kind: CompletionItemKind;
 	insertTextRules: CompletionItemInsertTextRule;
-	extensionId?: string;
+	extensionId?: ExtensionIdentifier;
 
 	constructor(
 		readonly snippet: Snippet,

--- a/src/vs/workbench/contrib/snippets/browser/snippetCompletionProvider.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetCompletionProvider.ts
@@ -29,6 +29,7 @@ export class SnippetCompletion implements CompletionItem {
 	sortText: string;
 	kind: CompletionItemKind;
 	insertTextRules: CompletionItemInsertTextRule;
+	extensionId?: string;
 
 	constructor(
 		readonly snippet: Snippet,
@@ -37,6 +38,7 @@ export class SnippetCompletion implements CompletionItem {
 		this.label = { label: snippet.prefix, description: snippet.name };
 		this.detail = localize('detail.snippet', "{0} ({1})", snippet.description || snippet.name, snippet.source);
 		this.insertText = snippet.codeSnippet;
+		this.extensionId = snippet.extensionId;
 		this.range = range;
 		this.sortText = `${snippet.snippetSource === SnippetSource.Extension ? 'z' : 'a'}-${snippet.prefix}`;
 		this.kind = CompletionItemKind.Snippet;

--- a/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
@@ -12,7 +12,7 @@ import { KnownSnippetVariableNames } from 'vs/editor/contrib/snippet/browser/sni
 import { isFalsyOrWhitespace } from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
 import { IFileService } from 'vs/platform/files/common/files';
-import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
+import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { IdleValue } from 'vs/base/common/async';
 import { IExtensionResourceLoaderService } from 'vs/workbench/services/extensionResourceLoader/common/extensionResourceLoader';
 import { relativePath } from 'vs/base/common/resources';
@@ -115,7 +115,7 @@ export class Snippet {
 		readonly source: string,
 		readonly snippetSource: SnippetSource,
 		readonly snippetIdentifier?: string,
-		readonly extensionId?: string
+		readonly extensionId?: ExtensionIdentifier,
 	) {
 		this.prefixLow = prefix.toLowerCase();
 		this._bodyInsights = new IdleValue(() => new SnippetBodyInsights(this.body));
@@ -334,7 +334,7 @@ export class SnippetFile {
 				source,
 				this.source,
 				this._extension && `${relativePath(this._extension.extensionLocation, this.location)}/${name}`,
-				this._extension?.identifier.value,
+				this._extension?.identifier,
 			));
 		}
 	}

--- a/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
@@ -114,7 +114,8 @@ export class Snippet {
 		readonly body: string,
 		readonly source: string,
 		readonly snippetSource: SnippetSource,
-		readonly snippetIdentifier?: string
+		readonly snippetIdentifier?: string,
+		readonly extension?: string
 	) {
 		this.prefixLow = prefix.toLowerCase();
 		this._bodyInsights = new IdleValue(() => new SnippetBodyInsights(this.body));
@@ -332,7 +333,8 @@ export class SnippetFile {
 				body,
 				source,
 				this.source,
-				this._extension && `${relativePath(this._extension.extensionLocation, this.location)}/${name}`
+				this._extension && `${relativePath(this._extension.extensionLocation, this.location)}/${name}`,
+				this._extension?.identifier.value,
 			));
 		}
 	}

--- a/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
@@ -115,7 +115,7 @@ export class Snippet {
 		readonly source: string,
 		readonly snippetSource: SnippetSource,
 		readonly snippetIdentifier?: string,
-		readonly extension?: string
+		readonly extensionId?: string
 	) {
 		this.prefixLow = prefix.toLowerCase();
 		this._bodyInsights = new IdleValue(() => new SnippetBodyInsights(this.body));


### PR DESCRIPTION
@jrieken I am trying to extend @JacksonKearl's instrumentation to understand extension snippets. I got the property into the Snippets instance but my TS foo fails to access the `snippets` object on the `CompletionItem | SnippetCompletion`. Maybe I am holding it wrong.

Can you confirm if this approach is generally sane and how I solve the TS puzzle to access `.snippets`.