### PR TITLE
Bundle accidentally updated extensions

### DIFF
--- a/product.json
+++ b/product.json
@@ -31,7 +31,7 @@
 	"builtInExtensions": [
 		{
 			"name": "ms-vscode.references-view",
-			"version": "0.0.86",
+			"version": "0.0.89",
 			"repo": "https://github.com/microsoft/vscode-references-view",
 			"metadata": {
 				"id": "dc489f46-520d-4556-ae85-1f9eab3c412d",

--- a/product.json
+++ b/product.json
@@ -46,7 +46,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug-companion",
-			"version": "1.0.16",
+			"version": "1.0.17",
 			"repo": "https://github.com/microsoft/vscode-js-debug-companion",
 			"metadata": {
 				"id": "99cb0b7f-7354-4278-b8da-6cc79972169d",


### PR DESCRIPTION
Built-in, marketplace extensions, now auto-update after publish. @connor4312 and forgot about this and published later versions which are now installed for 1.66. To prevent the same update cycle for 1.66.1 we should simple bundle them