### PR TITLE
Disallow trailing commas in devcontainer files

### DIFF
--- a/extensions/configuration-editing/schemas/devContainer.schema.generated.json
+++ b/extensions/configuration-editing/schemas/devContainer.schema.generated.json
@@ -2,7 +2,7 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"description": "Defines a dev container",
 	"allowComments": true,
-	"allowTrailingCommas": true,
+	"allowTrailingCommas": false,
 	"oneOf": [
 		{
 			"type": "object",

--- a/extensions/configuration-editing/schemas/devContainer.schema.src.json
+++ b/extensions/configuration-editing/schemas/devContainer.schema.src.json
@@ -2,7 +2,7 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"description": "Defines a dev container",
 	"allowComments": true,
-	"allowTrailingCommas": true,
+	"allowTrailingCommas": false,
 	"definitions": {
 		"devContainerCommon": {
 			"type": "object",


### PR DESCRIPTION
Align the JSON Schema spec with JSONC, which allows JS-style comments but does not allow trailing commas.

https://github.com/microsoft/dev-container-spec/pull/24

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
