### PR TITLE
Report a reset if there are no keys for object settings

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1322,7 +1322,8 @@ abstract class AbstractSettingObjectRenderer extends AbstractSettingRenderer imp
 			}
 
 			if (template.onChange) {
-				template.onChange(newValue);
+				const valueToReport = Object.keys(newValue).length ? newValue : undefined;
+				template.onChange(valueToReport);
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #146895

For example, let's say a user checks some boxes, and then unchecks all those boxes of the `gitlens.advanced.messages` setting.
Old behaviour: in their settings.json file, we would still save the value `{}`.
New behaviour: in their settings.json file, we now remove that key-value pair.

![A screencap showing that the scenario above follows the new behaviour](https://user-images.githubusercontent.com/7199958/162082146-cb0b07a9-26b6-4409-a5db-bcb9b43af845.gif)
