### PR TITLE
Fix editor eating ContextMenu key when contexmenu is disabled

### DIFF
--- a/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
@@ -62,6 +62,9 @@ export class ContextMenuController implements IEditorContribution {
 			}
 		}));
 		this._toDispose.add(this._editor.onKeyDown((e: IKeyboardEvent) => {
+			if (!this._editor.getOption(EditorOption.contextmenu)) {
+				return; // Context menu is turned off through configuration
+			}
 			if (e.keyCode === KeyCode.ContextMenu) {
 				// Chrome is funny like that
 				e.preventDefault();


### PR DESCRIPTION
The `EditorOption.contextmenu` setting is supposed to disable the context menu so users can provide their own implementation. However, it is eating the context menu keydown event so the user-defined context menu can only be activated with the mouse and not the keyboard.

This fixes the issue by checking the setting when the keydown event fires.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
