### PR TITLE
Expose progress in the web embedder API

### DIFF
--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -14,6 +14,7 @@ import type { IWorkspaceProvider } from 'vs/workbench/services/host/browser/brow
 import type { IProductConfiguration } from 'vs/base/common/product';
 import type { ICredentialsProvider } from 'vs/platform/credentials/common/credentials';
 import type { TunnelProviderFeatures } from 'vs/platform/tunnel/common/tunnel';
+import type { IProgress, IProgressOptions } from 'vs/platform/progress/common/progress';
 
 /**
  * The `IWorkbench` interface is the API facade for web embedders
@@ -61,6 +62,17 @@ export interface IWorkbench {
 		 * workbench.
 		 */
 		openUri(target: URI): Promise<boolean>;
+	};
+
+	/**
+	 * Show progress in the editor. Progress is shown while running the given callback
+	 * and while the promise it returned isn't resolved nor rejected.
+	 *
+	 * @param task A callback returning a promise.
+	 * @return A promise that resolves to the returned value of the given task result.
+	 */
+	window: {
+		withProgress(options: IProgressOptions, task: (progress: IProgress<{ message?: string; increment?: number }>) => Promise<unknown>): Promise<unknown>;
 	};
 
 	/**

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -14,7 +14,7 @@ import type { IWorkspaceProvider } from 'vs/workbench/services/host/browser/brow
 import type { IProductConfiguration } from 'vs/base/common/product';
 import type { ICredentialsProvider } from 'vs/platform/credentials/common/credentials';
 import type { TunnelProviderFeatures } from 'vs/platform/tunnel/common/tunnel';
-import type { IProgress, IProgressOptions } from 'vs/platform/progress/common/progress';
+import type { IProgress, IProgressCompositeOptions, IProgressDialogOptions, IProgressNotificationOptions, IProgressOptions, IProgressStep, IProgressWindowOptions } from 'vs/platform/progress/common/progress';
 
 /**
  * The `IWorkbench` interface is the API facade for web embedders
@@ -72,7 +72,11 @@ export interface IWorkbench {
 		 * @param task A callback returning a promise.
 		 * @return A promise that resolves to the returned value of the given task result.
 		 */
-		withProgress(options: IProgressOptions, task: (progress: IProgress<{ message?: string; increment?: number }>) => Promise<unknown>): Promise<unknown>;
+		withProgress<R>(
+			options: IProgressOptions | IProgressDialogOptions | IProgressNotificationOptions | IProgressWindowOptions | IProgressCompositeOptions,
+			task: (progress: IProgress<IProgressStep>) => Promise<R>,
+			onDidCancel?: (choice?: number) => void
+		): Promise<R>;
 	};
 
 	/**

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -74,8 +74,7 @@ export interface IWorkbench {
 		 */
 		withProgress<R>(
 			options: IProgressOptions | IProgressDialogOptions | IProgressNotificationOptions | IProgressWindowOptions | IProgressCompositeOptions,
-			task: (progress: IProgress<IProgressStep>) => Promise<R>,
-			onDidCancel?: (choice?: number) => void
+			task: (progress: IProgress<IProgressStep>) => Promise<R>
 		): Promise<R>;
 	};
 

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -64,14 +64,14 @@ export interface IWorkbench {
 		openUri(target: URI): Promise<boolean>;
 	};
 
-	/**
-	 * Show progress in the editor. Progress is shown while running the given callback
-	 * and while the promise it returned isn't resolved nor rejected.
-	 *
-	 * @param task A callback returning a promise.
-	 * @return A promise that resolves to the returned value of the given task result.
-	 */
 	window: {
+		/**
+		 * Show progress in the editor. Progress is shown while running the given callback
+		 * and while the promise it returned isn't resolved nor rejected.
+		 *
+		 * @param task A callback returning a promise.
+		 * @return A promise that resolves to the returned value of the given task result.
+		 */
 		withProgress(options: IProgressOptions, task: (progress: IProgress<{ message?: string; increment?: number }>) => Promise<unknown>): Promise<unknown>;
 	};
 

--- a/src/vs/workbench/browser/web.factory.ts
+++ b/src/vs/workbench/browser/web.factory.ts
@@ -12,7 +12,7 @@ import { mark, PerformanceMark } from 'vs/base/common/performance';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { DeferredPromise } from 'vs/base/common/async';
 import { asArray } from 'vs/base/common/arrays';
-import { IProgress, IProgressOptions } from 'vs/platform/progress/common/progress';
+import { IProgress, IProgressCompositeOptions, IProgressDialogOptions, IProgressNotificationOptions, IProgressOptions, IProgressStep, IProgressWindowOptions } from 'vs/platform/progress/common/progress';
 
 let created = false;
 const workbenchPromise = new DeferredPromise<IWorkbench>();
@@ -127,9 +127,13 @@ export namespace window {
 	/**
 	 * {@linkcode IWorkbench.window IWorkbench.window.withProgress}
 	 */
-	export async function withProgress(options: IProgressOptions, task: (progress: IProgress<{ message?: string; increment?: number }>) => Promise<unknown>): Promise<unknown> {
+	export async function withProgress<R>(
+		options: IProgressOptions | IProgressDialogOptions | IProgressNotificationOptions | IProgressWindowOptions | IProgressCompositeOptions,
+		task: (progress: IProgress<IProgressStep>) => Promise<R>,
+		onDidCancel?: (choice?: number) => void
+	): Promise<R> {
 		const workbench = await workbenchPromise.p;
 
-		return workbench.window.withProgress(options, task);
+		return workbench.window.withProgress(options, task, onDidCancel);
 	}
 }

--- a/src/vs/workbench/browser/web.factory.ts
+++ b/src/vs/workbench/browser/web.factory.ts
@@ -129,11 +129,10 @@ export namespace window {
 	 */
 	export async function withProgress<R>(
 		options: IProgressOptions | IProgressDialogOptions | IProgressNotificationOptions | IProgressWindowOptions | IProgressCompositeOptions,
-		task: (progress: IProgress<IProgressStep>) => Promise<R>,
-		onDidCancel?: (choice?: number) => void
+		task: (progress: IProgress<IProgressStep>) => Promise<R>
 	): Promise<R> {
 		const workbench = await workbenchPromise.p;
 
-		return workbench.window.withProgress(options, task, onDidCancel);
+		return workbench.window.withProgress(options, task);
 	}
 }

--- a/src/vs/workbench/browser/web.factory.ts
+++ b/src/vs/workbench/browser/web.factory.ts
@@ -12,6 +12,7 @@ import { mark, PerformanceMark } from 'vs/base/common/performance';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { DeferredPromise } from 'vs/base/common/async';
 import { asArray } from 'vs/base/common/arrays';
+import { IProgress, IProgressOptions } from 'vs/platform/progress/common/progress';
 
 let created = false;
 const workbenchPromise = new DeferredPromise<IWorkbench>();
@@ -118,5 +119,17 @@ export namespace env {
 		const workbench = await workbenchPromise.p;
 
 		return workbench.env.openUri(target);
+	}
+}
+
+export namespace window {
+
+	/**
+	 * {@linkcode IWorkbench.window IWorkbench.window.withProgress}
+	 */
+	export async function withProgress(options: IProgressOptions, task: (progress: IProgress<{ message?: string; increment?: number }>) => Promise<unknown>): Promise<unknown> {
+		const workbench = await workbenchPromise.p;
+
+		return workbench.window.withProgress(options, task);
 	}
 }

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -69,6 +69,7 @@ import { IndexedDB } from 'vs/base/browser/indexedDB';
 import { BrowserCredentialsService } from 'vs/workbench/services/credentials/browser/credentialsService';
 import { IWorkspace } from 'vs/workbench/services/host/browser/browserHostService';
 import { WebFileSystemAccess } from 'vs/platform/files/browser/webFileSystemAccess';
+import { IProgressService } from 'vs/platform/progress/common/progress';
 
 export class BrowserMain extends Disposable {
 
@@ -116,6 +117,7 @@ export class BrowserMain extends Disposable {
 			const timerService = accessor.get(ITimerService);
 			const openerService = accessor.get(IOpenerService);
 			const productService = accessor.get(IProductService);
+			const progessService = accessor.get(IProgressService);
 
 			return {
 				commands: {
@@ -131,6 +133,9 @@ export class BrowserMain extends Disposable {
 					async openUri(uri: URI): Promise<boolean> {
 						return openerService.open(uri, {});
 					}
+				},
+				window: {
+					withProgress: (options, task) => progessService.withProgress(options, task)
 				},
 				shutdown: () => lifecycleService.shutdown()
 			};

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -135,7 +135,7 @@ export class BrowserMain extends Disposable {
 					}
 				},
 				window: {
-					withProgress: (options, task, onDidCancel) => progessService.withProgress(options, task, onDidCancel)
+					withProgress: (options, task) => progessService.withProgress(options, task)
 				},
 				shutdown: () => lifecycleService.shutdown()
 			};

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -135,7 +135,7 @@ export class BrowserMain extends Disposable {
 					}
 				},
 				window: {
-					withProgress: (options, task) => progessService.withProgress(options, task)
+					withProgress: (options, task, onDidCancel) => progessService.withProgress(options, task, onDidCancel)
 				},
 				shutdown: () => lifecycleService.shutdown()
 			};

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -166,7 +166,7 @@ import 'vs/workbench/contrib/offline/browser/offline.contribution';
 //
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-import { create, commands, env } from 'vs/workbench/browser/web.factory';
+import { create, commands, env, window } from 'vs/workbench/browser/web.factory';
 import { IWorkbench, ICommand, ICommonTelemetryPropertiesResolver, IDefaultEditor, IDefaultLayout, IDefaultView, IDevelopmentOptions, IExternalUriResolver, IExternalURLOpener, IHomeIndicator, IInitialColorTheme, IPosition, IProductQualityChangeHandler, IRange, IResourceUriProvider, ISettingsSyncOptions, IShowPortCandidate, ITunnel, ITunnelFactory, ITunnelOptions, ITunnelProvider, IWelcomeBanner, IWelcomeBannerAction, IWindowIndicator, IWorkbenchConstructionOptions, Menu } from 'vs/workbench/browser/web.api';
 import { UriComponents, URI } from 'vs/base/common/uri';
 import { IWebSocketFactory, IWebSocket } from 'vs/platform/remote/browser/browserSocketFactory';
@@ -247,6 +247,9 @@ export {
 	ICommand,
 	commands,
 	Menu,
+
+	// Window
+	window,
 
 	// Branding
 	IHomeIndicator,


### PR DESCRIPTION
Ref: https://github.com/microsoft/vscode-dev/issues/555

Exposes the ProgressService in the web embedders to allow embedders to show progress in set up.