### PR TITLE
Restart a Javascript server.

### DIFF
--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -48,7 +48,7 @@
 	"typescript.referencesCodeLens.showOnAllFunctions": "Enable/disable references CodeLens on all functions in TypeScript files.",
 	"typescript.implementationsCodeLens.enabled": "Enable/disable implementations CodeLens. This CodeLens shows the implementers of an interface.",
 	"typescript.openTsServerLog.title": "Open TS Server log",
-	"typescript.restartTsServer": "Restart TS server",
+	"typescript.restartTsServer": "Restart TS and JS server",
 	"typescript.selectTypeScriptVersion.title": "Select TypeScript Version...",
 	"typescript.reportStyleChecksAsWarnings": "Report style checks as warnings.",
 	"typescript.npm": "Specifies the path to the npm executable used for [Automatic Type Acquisition](https://code.visualstudio.com/docs/nodejs/working-with-javascript#_typings-and-automatic-type-acquisition).",


### PR DESCRIPTION
Before there was an option to restart the Typescript server but this command also restarted the Javascript Server. I included this change as it was confusing before I released what the command did. This can help beginners whom do not realise that they can restart their Javascript server with the Restart TS Server Command.
