### PR TITLE
environment - canonicalize value of `homedir()`

### DIFF
--- a/src/vs/platform/environment/node/environmentService.ts
+++ b/src/vs/platform/environment/node/environmentService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { homedir, tmpdir } from 'os';
+import { realpathSync } from 'vs/base/node/extpath';
 import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
 import { AbstractNativeEnvironmentService } from 'vs/platform/environment/common/environmentService';
 import { getUserDataPath } from 'vs/platform/environment/node/userDataPath';
@@ -13,7 +14,7 @@ export class NativeEnvironmentService extends AbstractNativeEnvironmentService {
 
 	constructor(args: NativeParsedArgs, productService: IProductService) {
 		super(args, {
-			homeDir: homedir(),
+			homeDir: realpathSync(homedir()),
 			tmpDir: tmpdir(),
 			userDataDir: getUserDataPath(args)
 		}, productService);


### PR DESCRIPTION
In some environments, it is common for a user's home directory to be a
symbolic link (symlink) to a different filesystem location. For
example, for user 'jane' the value of the HOME environment variable is
'/home/jane' but '/home/jane' is actually a symbolic link to
'/some/place/else/homes/jane'. This setup is very common on high
performance computing (HPC) systems.

When such a user opens a folder in VS Code, the 'Open Folder' dialog
defaults to the user' HOME, i.e. '/home/jane'. If the user opens a
folder located somwhere in their home, this directory is opened by VS
Code unresolved, i.e. '/home/jane/project'.

When the users opens a file by Ctrl-clicking a file link in the
integrated terminal, the resolved file path is opened, i.e.
'/some/place/else/homes/jane/project/file'. This is suboptimal because
if 'file' was already opened in the workspace, opening it from the
integrated terminal opens a second tab instead of focusing on the
already opened tab, as VS Code does not recognize it is the same file.
This is made worse by the fact that some language extensions that
provide 'Outline' functionality do not work at all in this newly opened
tab from the resolved file path.

To fix this, canonicalize the value of a user's home directory early in
the environment initialization, by calling 'realpathSync' on the path
returned by Node's 'homedir()' in the constructor of
NativeEnvironmentService. This results in the resolved value of a user's
home directory being the default location for the 'Open Folder'
dialog. Since now the already opened 'file' and 'file' opened from the
integrated terminal have the same path, VS Code does recognize they are
indeed the same file, and focuses on the already opened tab instead of
opening a second tab.

Test this by temporarily changing the value of HOME (USERPROFILE on
Windows) to point to a symlink and verifying that the userHome property
of a newly created NativeEnvironmentService is returned as resolved.
Note that for some reason, in order for 'fs.rmSync' to correctly clean
up the symlink after the test, it has to be called with 'recursive:
true'.

Fixes: https://github.com/microsoft/vscode/issues/118973
Fixes: https://github.com/microsoft/vscode/issues/129023