### PR TITLE
🐛 Fix single tilde (~) strikethrough in markdown syntax

### DIFF
--- a/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json
+++ b/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json
@@ -2918,7 +2918,7 @@
 					"name": "punctuation.definition.strikethrough.markdown"
 				}
 			},
-			"match": "(~+)((?:[^~]|(?!(?<!~)\\1(?!~))~)*+)(\\1)",
+			"match": "(~{2,})((?:[^~]|(?!(?<!~)\\1(?!~))~)*+)(\\1)",
 			"name": "markup.strikethrough.markdown"
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #146610
