### PR TITLE
Add settings editor search funnel button

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -55,7 +55,7 @@
 	top: 0;
 	right: 0;
 	height: 100%;
-	width: 30px;
+	width: 43px;
 }
 
 .settings-editor > .settings-header > .search-container > .settings-clear-widget .action-label {

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -39,7 +39,7 @@
 
 .settings-editor > .settings-header > .search-container > .settings-count-widget {
 	position: absolute;
-	right: 35px;
+	right: 46px;
 	top: 0px;
 	margin: 4px 0px;
 }

--- a/src/vs/workbench/contrib/preferences/browser/preferencesIcons.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesIcons.ts
@@ -25,4 +25,5 @@ export const settingsRemoveIcon = registerIcon('settings-remove', Codicon.close,
 export const settingsDiscardIcon = registerIcon('settings-discard', Codicon.discard, localize('preferencesDiscardIcon', 'Icon for the discard action in the Settings UI.'));
 
 export const preferencesClearInputIcon = registerIcon('preferences-clear-input', Codicon.clearAll, localize('preferencesClearInput', 'Icon for clear input in the Settings and keybinding UI.'));
+export const preferencesFilterIcon = registerIcon('preferences-filter', Codicon.filter, localize('settingsFilter', 'Icon for the button that suggests filters for the Settings UI.'));
 export const preferencesOpenSettingsIcon = registerIcon('preferences-open-settings', Codicon.goToFile, localize('preferencesOpenSettings', 'Icon for open settings commands.'));

--- a/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
@@ -7,6 +7,7 @@ import { AnchorAlignment } from 'vs/base/browser/ui/contextview/contextview';
 import { DropdownMenuActionViewItem } from 'vs/base/browser/ui/dropdown/dropdownActionViewItem';
 import { IAction, IActionRunner } from 'vs/base/common/actions';
 import { localize } from 'vs/nls';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { SuggestEnabledInput } from 'vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput';
 import { EXTENSION_SETTING_TAG, FEATURE_SETTING_TAG, GENERAL_TAG_SETTING_TAG, ID_SETTING_TAG, LANGUAGE_SETTING_TAG, MODIFIED_SETTING_TAG } from 'vs/workbench/contrib/preferences/common/preferences';
@@ -16,7 +17,8 @@ export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenu
 		action: IAction,
 		actionRunner: IActionRunner | undefined,
 		private readonly searchWidget: SuggestEnabledInput,
-		@IContextMenuService contextMenuService: IContextMenuService
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@ICommandService private readonly commandService: ICommandService
 	) {
 		super(action,
 			{ getActions: () => this.getActions() },
@@ -34,11 +36,15 @@ export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenu
 		super.render(container);
 	}
 
-	private appendToSearchWidgetValue(s: string) {
-		this.searchWidget.setValue(this.searchWidget.getValue().trimEnd() + ' ' + s);
+	private doSearchWidgetAction(queryToAppend: string, triggerSuggest: boolean) {
+		this.searchWidget.setValue(this.searchWidget.getValue().trimEnd() + ' ' + queryToAppend);
+		this.searchWidget.focus();
+		if (triggerSuggest) {
+			this.commandService.executeCommand('editor.action.triggerSuggest');
+		}
 	}
 
-	private createAction(id: string, label: string, tooltip: string, queryToAppend: string): IAction {
+	private createAction(id: string, label: string, tooltip: string, queryToAppend: string, triggerSuggest: boolean): IAction {
 		return {
 			id,
 			label,
@@ -46,48 +52,73 @@ export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenu
 			class: undefined,
 			enabled: true,
 			checked: false,
-			run: () => { this.appendToSearchWidgetValue(queryToAppend); },
+			run: () => { this.doSearchWidgetAction(queryToAppend, triggerSuggest); },
+			dispose: () => { }
+		};
+	}
+
+	private createModifiedAction(): IAction {
+		// The modified action works slightly differently than the other actions.
+		// It is more like a checkbox on/off toggle.
+		const queryContainsModifiedTag = this.searchWidget.getValue().split(' ').some(word => word === `@${MODIFIED_SETTING_TAG}`);
+		return {
+			id: 'modifiedSettingsSearch',
+			label: localize('modifiedSettingsSearch', "Modified"),
+			tooltip: localize('modifiedSettingsSearchTooltip', "View modified settings only"),
+			class: undefined,
+			enabled: true,
+			checked: queryContainsModifiedTag,
+			run: () => {
+				// Append the tag, otherwise remove it from the query.
+				if (!queryContainsModifiedTag) {
+					this.searchWidget.setValue(this.searchWidget.getValue().trimEnd() + ` @${MODIFIED_SETTING_TAG}`);
+				} else {
+					const queryWithoutModifiedTag = this.searchWidget.getValue().split(' ').filter(word => word !== `@${MODIFIED_SETTING_TAG}`).join(' ');
+					this.searchWidget.setValue(queryWithoutModifiedTag);
+				}
+				this.searchWidget.focus();
+			},
 			dispose: () => { }
 		};
 	}
 
 	getActions(): IAction[] {
 		return [
-			this.createAction(
-				'modifiedSettingsSearch',
-				localize('modifiedSettingsSearch', "Modified"),
-				localize('modifiedSettingsSearchTooltip', "View modified settings only"),
-				`@${MODIFIED_SETTING_TAG} `
-			),
+			this.createModifiedAction(),
 			this.createAction(
 				'extSettingsSearch',
 				localize('extSettingsSearch', "Extension ID"),
 				localize('extSettingsSearchTooltip', "Add extension ID filter"),
-				`@${EXTENSION_SETTING_TAG}`
+				`@${EXTENSION_SETTING_TAG}`,
+				false
 			),
 			this.createAction(
 				'featuresSettingsSearch',
 				localize('featureSettingsSearch', "Feature"),
 				localize('featureSettingsSearchTooltip', "Add feature filter"),
-				`@${FEATURE_SETTING_TAG}`
+				`@${FEATURE_SETTING_TAG}`,
+				true
 			),
 			this.createAction(
 				'idSettingsSearch',
 				localize('idSettingsSearch', "Setting ID"),
 				localize('idSettingsSearchTooltip', "Add setting ID filter"),
-				`@${ID_SETTING_TAG}`
+				`@${ID_SETTING_TAG}`,
+				false
 			),
 			this.createAction(
 				'langSettingsSearch',
 				localize('langSettingsSearch', "Language"),
 				localize('langSettingsSearchTooltip', "Add language ID filter"),
-				`@${LANGUAGE_SETTING_TAG}`
+				`@${LANGUAGE_SETTING_TAG}`,
+				true
 			),
 			this.createAction(
 				'tagSettingsSearch',
 				localize('tagSettingsSearch', "Tag"),
 				localize('tagSettingsSearchTooltip', "Add tag filter"),
-				`@${GENERAL_TAG_SETTING_TAG}`
+				`@${GENERAL_TAG_SETTING_TAG}`,
+				true
 			),
 		];
 	}

--- a/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AnchorAlignment } from 'vs/base/browser/ui/contextview/contextview';
+import { DropdownMenuActionViewItem } from 'vs/base/browser/ui/dropdown/dropdownActionViewItem';
+import { IAction, IActionRunner } from 'vs/base/common/actions';
+import { localize } from 'vs/nls';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { SuggestEnabledInput } from 'vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput';
+
+export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenuActionViewItem {
+	constructor(
+		action: IAction,
+		actionRunner: IActionRunner | undefined,
+		private readonly searchWidget: SuggestEnabledInput,
+		@IContextMenuService contextMenuService: IContextMenuService
+	) {
+		super(action,
+			{ getActions: () => this.getActions() },
+			contextMenuService,
+			{
+				actionRunner,
+				classNames: action.class,
+				anchorAlignmentProvider: () => AnchorAlignment.RIGHT,
+				menuAsChild: true
+			}
+		);
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+	}
+
+	private appendToSearchWidgetValue(s: string) {
+		this.searchWidget.setValue(this.searchWidget.getValue().trimEnd() + ' ' + s);
+	}
+
+	getActions(): IAction[] {
+		return [
+			{
+				id: 'modifiedSettingsSearch',
+				label: localize('modified', "Modified"),
+				tooltip: localize('modifiedTooltip', "View modified settings"),
+				class: undefined,
+				enabled: true,
+				checked: false,
+				run: () => { this.appendToSearchWidgetValue('@modified'); },
+				dispose: () => { }
+			}
+		];
+	}
+}

--- a/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
@@ -9,6 +9,7 @@ import { IAction, IActionRunner } from 'vs/base/common/actions';
 import { localize } from 'vs/nls';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { SuggestEnabledInput } from 'vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput';
+import { EXTENSION_SETTING_TAG, FEATURE_SETTING_TAG, GENERAL_TAG_SETTING_TAG, ID_SETTING_TAG, LANGUAGE_SETTING_TAG, MODIFIED_SETTING_TAG } from 'vs/workbench/contrib/preferences/common/preferences';
 
 export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenuActionViewItem {
 	constructor(
@@ -37,18 +38,57 @@ export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenu
 		this.searchWidget.setValue(this.searchWidget.getValue().trimEnd() + ' ' + s);
 	}
 
+	private createAction(id: string, label: string, tooltip: string, queryToAppend: string): IAction {
+		return {
+			id,
+			label,
+			tooltip,
+			class: undefined,
+			enabled: true,
+			checked: false,
+			run: () => { this.appendToSearchWidgetValue(queryToAppend); },
+			dispose: () => { }
+		};
+	}
+
 	getActions(): IAction[] {
 		return [
-			{
-				id: 'modifiedSettingsSearch',
-				label: localize('modified', "Modified"),
-				tooltip: localize('modifiedTooltip', "View modified settings"),
-				class: undefined,
-				enabled: true,
-				checked: false,
-				run: () => { this.appendToSearchWidgetValue('@modified'); },
-				dispose: () => { }
-			}
+			this.createAction(
+				'modifiedSettingsSearch',
+				localize('modifiedSettingsSearch', "Modified"),
+				localize('modifiedSettingsSearchTooltip', "View modified settings only"),
+				`@${MODIFIED_SETTING_TAG} `
+			),
+			this.createAction(
+				'extSettingsSearch',
+				localize('extSettingsSearch', "Extension ID"),
+				localize('extSettingsSearchTooltip', "Add extension ID filter"),
+				`@${EXTENSION_SETTING_TAG}`
+			),
+			this.createAction(
+				'featuresSettingsSearch',
+				localize('featureSettingsSearch', "Feature"),
+				localize('featureSettingsSearchTooltip', "Add feature filter"),
+				`@${FEATURE_SETTING_TAG}`
+			),
+			this.createAction(
+				'idSettingsSearch',
+				localize('idSettingsSearch', "Setting ID"),
+				localize('idSettingsSearchTooltip', "Add setting ID filter"),
+				`@${ID_SETTING_TAG}`
+			),
+			this.createAction(
+				'langSettingsSearch',
+				localize('langSettingsSearch', "Language"),
+				localize('langSettingsSearchTooltip', "Add language ID filter"),
+				`@${LANGUAGE_SETTING_TAG}`
+			),
+			this.createAction(
+				'tagSettingsSearch',
+				localize('tagSettingsSearch', "Tag"),
+				localize('tagSettingsSearchTooltip', "Add tag filter"),
+				`@${GENERAL_TAG_SETTING_TAG}`
+			),
 		];
 	}
 }

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -77,6 +77,7 @@ export const EXTENSION_SETTING_TAG = 'ext:';
 export const FEATURE_SETTING_TAG = 'feature:';
 export const ID_SETTING_TAG = 'id:';
 export const LANGUAGE_SETTING_TAG = 'lang:';
+export const GENERAL_TAG_SETTING_TAG = 'tag:';
 export const WORKSPACE_TRUST_SETTING_TAG = 'workspaceTrust';
 export const REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG = 'requireTrustedWorkspace';
 export const KEYBOARD_LAYOUT_OPEN_PICKER = 'workbench.action.openKeyboardLayoutPicker';

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -42,6 +42,7 @@ export interface ISearchProvider {
 
 export const SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS = 'settings.action.clearSearchResults';
 export const SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU = 'settings.action.showContextMenu';
+export const SETTINGS_EDITOR_COMMAND_SUGGEST_FILTERS = 'settings.action.suggestFilters';
 
 export const CONTEXT_SETTINGS_EDITOR = new RawContextKey<boolean>('inSettingsEditor', false);
 export const CONTEXT_SETTINGS_JSON_EDITOR = new RawContextKey<boolean>('inSettingsJSONEditor', false);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/145710

This PR adds a funnel button to the right of the Settings editor search bar, so that users can click around to add tags, rather than manually type in tags. When users click on the funnel button, a dropdown of filter types appears.

For most filter types in the dropdown, clicking on it adds the appropriate tag to the search widget query, and refocuses the search widget.

For some filter types, clicking on it adds the appropriate tag to the search widget query, refocuses the search widget, but also pops open the suggestions. This behaviour occurs when there are pre-filled suggestions available, such as for the language and feature tags.

For the modified filter type, clicking on it adds the modified tag to the search widget query if it doesn't already exist. Otherwise, it removes that tag from the search widget query. The modified filter type option also displays with a checkmark whenever the modified tag appears in the search widget query.

![A screencap showing the settings editor funnel interaction with the modified and lang tags](https://user-images.githubusercontent.com/7199958/162846721-5078fbc6-8eaa-4aa2-979c-31d1c01c6349.gif)
