### PR TITLE
Close #143241: Testing UI filter survives window reload

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts
@@ -66,9 +66,8 @@ export class TestingExplorerFilter extends BaseActionViewItem {
 		container.appendChild(wrapper);
 
 		const history = this.history.get([]);
-		const previousValue = history ? history[history.length - 1] : null;
-		if (previousValue) {
-			this.state.setText(previousValue);
+		if (history.length) {
+			this.state.setText(history[history.length - 1]);
 		}
 
 		const input = this.input = this._register(this.instantiationService.createInstance(ContextScopedSuggestEnabledInputWithHistory, {
@@ -95,7 +94,7 @@ export class TestingExplorerFilter extends BaseActionViewItem {
 				value: this.state.text.value,
 				placeholderText: localize('testExplorerFilter', "Filter (e.g. text, !exclude, @tag)"),
 			},
-			history: history
+			history
 		}));
 		this._register(attachSuggestEnabledInputBoxStyler(input, this.themeService));
 

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts
@@ -65,6 +65,12 @@ export class TestingExplorerFilter extends BaseActionViewItem {
 		const wrapper = this.wrapper = dom.$('.testing-filter-wrapper');
 		container.appendChild(wrapper);
 
+		const history = this.history.get([]);
+		const previousValue = history ? history[history.length - 1] : null;
+		if (previousValue) {
+			this.state.setText(previousValue);
+		}
+
 		const input = this.input = this._register(this.instantiationService.createInstance(ContextScopedSuggestEnabledInputWithHistory, {
 			id: 'testing.explorer.filter',
 			ariaLabel: localize('testExplorerFilterLabel', "Filter text for tests in the explorer"),
@@ -89,7 +95,7 @@ export class TestingExplorerFilter extends BaseActionViewItem {
 				value: this.state.text.value,
 				placeholderText: localize('testExplorerFilter', "Filter (e.g. text, !exclude, @tag)"),
 			},
-			history: this.history.get([])
+			history: history
 		}));
 		this._register(attachSuggestEnabledInputBoxStyler(input, this.themeService));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #143241. Upon loading the Testing UI, if the filter history contains a previous filter, it is loaded as the current value of the search bar, and only tests matching the filter are shown. Else, the search bar is empty, and all tests are shown. Below is a demo:

https://user-images.githubusercontent.com/58230338/163103028-e0c56d06-649e-40c3-9e0e-bfe0c6fdd2d7.mp4



