### PR TITLE
Fix #146166: Snippet transform preserves existing camel/Pascal case

### DIFF
--- a/src/vs/editor/contrib/snippet/browser/snippetParser.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetParser.ts
@@ -395,8 +395,7 @@ export class FormatString extends Marker {
 			return value;
 		}
 		return match.map(word => {
-			return word.charAt(0).toUpperCase()
-				+ word.substr(1).toLowerCase();
+			return word.charAt(0).toUpperCase() + word.substr(1);
 		})
 			.join('');
 	}
@@ -408,11 +407,9 @@ export class FormatString extends Marker {
 		}
 		return match.map((word, index) => {
 			if (index === 0) {
-				return word.toLowerCase();
-			} else {
-				return word.charAt(0).toUpperCase()
-					+ word.substr(1).toLowerCase();
+				return word.charAt(0).toLowerCase() + word.substr(1);
 			}
+			return word.charAt(0).toUpperCase() + word.substr(1);
 		})
 			.join('');
 	}

--- a/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
@@ -656,8 +656,14 @@ suite('SnippetParser', () => {
 		assert.strictEqual(new FormatString(1, 'capitalize').resolve('bar no repeat'), 'Bar no repeat');
 		assert.strictEqual(new FormatString(1, 'pascalcase').resolve('bar-foo'), 'BarFoo');
 		assert.strictEqual(new FormatString(1, 'pascalcase').resolve('bar-42-foo'), 'Bar42Foo');
+		assert.strictEqual(new FormatString(1, 'pascalcase').resolve('snake_AndPascalCase'), 'SnakeAndPascalCase');
+		assert.strictEqual(new FormatString(1, 'pascalcase').resolve('kebab-AndPascalCase'), 'KebabAndPascalCase');
+		assert.strictEqual(new FormatString(1, 'pascalcase').resolve('_justPascalCase'), 'JustPascalCase');
 		assert.strictEqual(new FormatString(1, 'camelcase').resolve('bar-foo'), 'barFoo');
 		assert.strictEqual(new FormatString(1, 'camelcase').resolve('bar-42-foo'), 'bar42Foo');
+		assert.strictEqual(new FormatString(1, 'camelcase').resolve('snake_AndCamelCase'), 'snakeAndCamelCase');
+		assert.strictEqual(new FormatString(1, 'camelcase').resolve('kebab-AndCamelCase'), 'kebabAndCamelCase');
+		assert.strictEqual(new FormatString(1, 'camelcase').resolve('_JustCamelCase'), 'justCamelCase');
 		assert.strictEqual(new FormatString(1, 'notKnown').resolve('input'), 'input');
 
 		// if


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #146166 so that existing camel/Pascal case within a snake_case or kebab-case name is preserved. For example, transforming `stub_PathServiceToken` to camel case now produces `stubPathServiceToken`, rather than `stubPathservicetoken`. Corresponding tests have been added to demonstrate this new behavior.

However, this adjusted implementation introduces some ambiguity I'd like to discuss. In the previous camel case implementation, the name `portland-OR-temp` would be transformed into `portlandOrTemp`. Now, it would become `portlandORTemp`, preserving the upper-case `OR`. Is this behavior desirable? I assumed this approach would best preserve user intent, but I understand preferences for the consistency of the former approach.