### PR TITLE
fix(service-worker): allow webview resources to be served from same domain

### DIFF
--- a/src/vs/workbench/common/webview.ts
+++ b/src/vs/workbench/common/webview.ts
@@ -22,7 +22,7 @@ export const webviewResourceBaseHost = 'vscode-cdn.net';
 
 export const webviewRootResourceAuthority = `vscode-resource.${webviewResourceBaseHost}`;
 
-export const webviewGenericCspSource = `https://*.${webviewResourceBaseHost}`;
+export const webviewGenericCspSource = `'self' https://*.${webviewResourceBaseHost}`;
 
 /**
  * Construct a uri that can load resources inside a webview

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -189,8 +189,10 @@ sw.addEventListener('fetch', (event) => {
 	}
 
 	// If we're making a request against the remote authority, we want to go
-	// back through VS Code itself so that we are authenticated properly
-	if (requestUrl.host === remoteAuthority) {
+	// through VS Code itself so that we are authenticated properly.  If the
+	// service worker is hosted on the same origin we will have cookies and
+	// authentication will not be an issue.
+	if (requestUrl.origin !== sw.origin && requestUrl.host === remoteAuthority) {
 		switch (event.request.method) {
 			case 'GET':
 			case 'HEAD':


### PR DESCRIPTION
## Description
The previous implementation (https://github.com/microsoft/vscode/commit/93a2a2fa12dd3ae0629eec01c05a28cb60ac1c4b) did not consider what would happen if
webview resources were served from the same domain. By first comparing
the requestUrl.orgin with the sw.orgin (similar to how it's done for
localhost), this is no longer a problem.

And since the requests have the same origin, authentication will never
be an issue as cookies will exist.

## How to test
1. In `webClientServer`, set `webviewEndpoint` [here](https://github.com/microsoft/vscode/blob/main/src/vs/server/node/webClientServer.ts#L280)
to `remoteAuthority + '/static/out/vs/workbench/contrib/webview/browser/pre'`
2. Run Code Web locally
3. Open an image in Code Web and see the preview

This PR fixes N/A
