### PR TITLE
Settings editor search widget polish

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -500,11 +500,11 @@ export class SettingsEditor2 extends EditorPane {
 	clearSearchFilters(): void {
 		let query = this.searchWidget.getValue();
 
-		SettingsEditor2.SUGGESTIONS.forEach(suggestion => {
-			query = query.replace(suggestion, '');
+		const splitQuery = query.split(' ').filter(word => {
+			return word.length && !SettingsEditor2.SUGGESTIONS.some(suggestion => word.startsWith(suggestion));
 		});
 
-		this.searchWidget.setValue(query.trim());
+		this.searchWidget.setValue(splitQuery.join(' '));
 	}
 
 	private updateInputAriaLabel() {
@@ -534,9 +534,10 @@ export class SettingsEditor2 extends EditorPane {
 				// for the ':' trigger, only return suggestions if there was a '@' before it in the same word.
 				const queryParts = query.split(/\s/g);
 				if (queryParts[queryParts.length - 1].startsWith(`@${LANGUAGE_SETTING_TAG}`)) {
-					return this.languageService.getRegisteredLanguageIds().map(languageId => {
+					const sortedLanguages = this.languageService.getRegisteredLanguageIds().map(languageId => {
 						return `@${LANGUAGE_SETTING_TAG}${languageId} `;
 					}).sort();
+					return sortedLanguages.filter(langFilter => !query.includes(langFilter));
 				} else if (queryParts[queryParts.length - 1].startsWith('@')) {
 					return SettingsEditor2.SUGGESTIONS.filter(tag => !query.includes(tag)).map(tag => tag.endsWith(':') ? tag : tag + ' ');
 				}

--- a/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
@@ -90,39 +90,39 @@ export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenu
 			this.createModifiedAction(),
 			this.createAction(
 				'extSettingsSearch',
-				localize('extSettingsSearch', "Extension ID"),
+				localize('extSettingsSearch', "Extension ID..."),
 				localize('extSettingsSearchTooltip', "Add extension ID filter"),
 				`@${EXTENSION_SETTING_TAG}`,
 				false
 			),
 			this.createAction(
 				'featuresSettingsSearch',
-				localize('featureSettingsSearch', "Feature"),
+				localize('featureSettingsSearch', "Feature..."),
 				localize('featureSettingsSearchTooltip', "Add feature filter"),
 				`@${FEATURE_SETTING_TAG}`,
 				true
 			),
 			this.createAction(
-				'idSettingsSearch',
-				localize('idSettingsSearch', "Setting ID"),
-				localize('idSettingsSearchTooltip', "Add setting ID filter"),
-				`@${ID_SETTING_TAG}`,
-				false
+				'tagSettingsSearch',
+				localize('tagSettingsSearch', "Tag..."),
+				localize('tagSettingsSearchTooltip', "Add tag filter"),
+				`@${GENERAL_TAG_SETTING_TAG}`,
+				true
 			),
 			this.createAction(
 				'langSettingsSearch',
-				localize('langSettingsSearch', "Language"),
+				localize('langSettingsSearch', "Language..."),
 				localize('langSettingsSearchTooltip', "Add language ID filter"),
 				`@${LANGUAGE_SETTING_TAG}`,
 				true
 			),
 			this.createAction(
-				'tagSettingsSearch',
-				localize('tagSettingsSearch', "Tag"),
-				localize('tagSettingsSearchTooltip', "Add tag filter"),
-				`@${GENERAL_TAG_SETTING_TAG}`,
-				true
-			),
+				'idSettingsSearch',
+				localize('idSettingsSearch', "Setting ID..."),
+				localize('idSettingsSearchTooltip', "Add setting ID filter"),
+				`@${ID_SETTING_TAG}`,
+				false
+			)
 		];
 	}
 }


### PR DESCRIPTION
This PR applies the following feedback to the Settings editor search widget funnel button:
- For the options that append on a filter, we want to add "..." to their labels.
- We still want to keep the "Settings ID..." option, but we can lower its priority by placing it at the end.

This PR also fixes the following issues:
- Search filters such as `@lang:c @tag:sync @modified @feature:debug` were not being cleared properly (I almost accidentally pinged four users, here).
- Even when there was already a language filter for a certain language X, when a user appended `@lang:` to the search box, language X was still being suggested.