### PR TITLE
Disable a breakpoint on shift+click

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -245,7 +245,6 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 						// Do not show dialog on linux due to electron issue freezing the mouse #50026
 						const logPoint = breakpoints.every(bp => !!bp.logMessage);
 						const breakpointType = logPoint ? nls.localize('logPoint', "Logpoint") : nls.localize('breakpoint', "Breakpoint");
-						const enabled = breakpoints.some(bp => bp.enabled);
 
 						const disabledBreakpointDialogMessage = nls.localize(
 							'breakpointHasConditionDisabled',

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -236,14 +236,16 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 
 				if (breakpoints.length) {
 					const isShiftPressed = e.event.shiftKey;
+					const enabled = breakpoints.some(bp => bp.enabled);
 
-					// Show the dialog if there is a potential condition to be accidently lost.
-					// Do not show dialog on linux due to electron issue freezing the mouse #50026
-					if (!env.isLinux && breakpoints.some(bp => !!bp.condition || !!bp.logMessage || !!bp.hitCondition)) {
+					if (isShiftPressed) {
+						breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
+					} else if (!env.isLinux && breakpoints.some(bp => !!bp.condition || !!bp.logMessage || !!bp.hitCondition)) {
+						// Show the dialog if there is a potential condition to be accidently lost.
+						// Do not show dialog on linux due to electron issue freezing the mouse #50026
 						const logPoint = breakpoints.every(bp => !!bp.logMessage);
 						const breakpointType = logPoint ? nls.localize('logPoint', "Logpoint") : nls.localize('breakpoint', "Breakpoint");
 						const enabled = breakpoints.some(bp => bp.enabled);
-						const isDisableAction = enabled && isShiftPressed;
 
 						const disabledBreakpointDialogMessage = nls.localize(
 							'breakpointHasConditionDisabled',
@@ -258,20 +260,16 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 							logPoint ? nls.localize('message', "message") : nls.localize('condition', "condition")
 						);
 
-						const dialogActionChoicePromise = isDisableAction
-							? Promise.resolve({ choice: 1 })
-							: this.dialogService.show(
-								severity.Info,
-								enabled ? enabledBreakpointDialogMessage : disabledBreakpointDialogMessage,
-								[
-									nls.localize('removeLogPoint', "Remove {0}", breakpointType),
-									nls.localize('disableLogPoint', "{0} {1}", enabled ? nls.localize('disable', "Disable") : nls.localize('enable', "Enable"), breakpointType),
-									nls.localize('cancel', "Cancel")
-								],
-								{ cancelId: 2 },
-							);
-
-						const { choice } = await dialogActionChoicePromise;
+						const { choice } = await this.dialogService.show(
+							severity.Info,
+							enabled ? enabledBreakpointDialogMessage : disabledBreakpointDialogMessage,
+							[
+								nls.localize('removeLogPoint', "Remove {0}", breakpointType),
+								nls.localize('disableLogPoint', "{0} {1}", enabled ? nls.localize('disable', "Disable") : nls.localize('enable', "Enable"), breakpointType),
+								nls.localize('cancel', "Cancel")
+							],
+							{ cancelId: 2 },
+						);
 
 						if (choice === 0) {
 							breakpoints.forEach(bp => this.debugService.removeBreakpoints(bp.getId()));
@@ -280,9 +278,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 							breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
 						}
 					} else {
-						const enabled = breakpoints.some(bp => bp.enabled);
-
-						if (!enabled || isShiftPressed) {
+						if (!enabled) {
 							breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
 						} else {
 							breakpoints.forEach(bp => this.debugService.removeBreakpoints(bp.getId()));

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -267,7 +267,9 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 						}
 					} else {
 						const enabled = breakpoints.some(bp => bp.enabled);
-						if (!enabled) {
+						const isShiftPressed = e.event.shiftKey;
+
+						if (!enabled || isShiftPressed) {
 							breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
 						} else {
 							breakpoints.forEach(bp => this.debugService.removeBreakpoints(bp.getId()));

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -38,7 +38,6 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 import { noBreakWhitespace } from 'vs/base/common/strings';
 
 const $ = dom.$;
-const TOGGLE_BREAKPOINT_BUTTON_INDEX = 1;
 
 interface IBreakpointDecoration {
 	decorationId: string;
@@ -260,7 +259,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 						);
 
 						const dialogActionChoicePromise = isDisableAction
-							? Promise.resolve(TOGGLE_BREAKPOINT_BUTTON_INDEX)
+							? Promise.resolve({ choice: 1 })
 							: this.dialogService.show(
 								severity.Info,
 								enabled ? enabledBreakpointDialogMessage : disabledBreakpointDialogMessage,
@@ -270,14 +269,14 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 									nls.localize('cancel', "Cancel")
 								],
 								{ cancelId: 2 },
-							).then(({ choice }) => choice);
+							);
 
-						const choice = await dialogActionChoicePromise;
+						const { choice } = await dialogActionChoicePromise;
 
 						if (choice === 0) {
 							breakpoints.forEach(bp => this.debugService.removeBreakpoints(bp.getId()));
 						}
-						if (choice === TOGGLE_BREAKPOINT_BUTTON_INDEX) {
+						if (choice === 1) {
 							breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
 						}
 					} else {

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -38,6 +38,7 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 import { noBreakWhitespace } from 'vs/base/common/strings';
 
 const $ = dom.$;
+const TOGGLE_BREAKPOINT_BUTTON_INDEX = 1;
 
 interface IBreakpointDecoration {
 	decorationId: string;
@@ -242,28 +243,30 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 					if (!env.isLinux && breakpoints.some(bp => !!bp.condition || !!bp.logMessage || !!bp.hitCondition)) {
 						const logPoint = breakpoints.every(bp => !!bp.logMessage);
 						const breakpointType = logPoint ? nls.localize('logPoint', "Logpoint") : nls.localize('breakpoint', "Breakpoint");
-						const disable = breakpoints.some(bp => bp.enabled);
-						const isDisableAction = disable && isShiftPressed;
+						const enabled = breakpoints.some(bp => bp.enabled);
+						const isDisableAction = enabled && isShiftPressed;
 
-						const enabling = nls.localize('breakpointHasConditionDisabled',
+						const disabledBreakpointDialogMessage = nls.localize(
+							'breakpointHasConditionDisabled',
 							"This {0} has a {1} that will get lost on remove. Consider enabling the {0} instead.",
 							breakpointType.toLowerCase(),
 							logPoint ? nls.localize('message', "message") : nls.localize('condition', "condition")
 						);
-						const disabling = nls.localize('breakpointHasConditionEnabled',
+						const enabledBreakpointDialogMessage = nls.localize(
+							'breakpointHasConditionEnabled',
 							"This {0} has a {1} that will get lost on remove. Consider disabling the {0} instead.",
 							breakpointType.toLowerCase(),
 							logPoint ? nls.localize('message', "message") : nls.localize('condition', "condition")
 						);
 
 						const dialogActionChoicePromise = isDisableAction
-							? Promise.resolve(1)
+							? Promise.resolve(TOGGLE_BREAKPOINT_BUTTON_INDEX)
 							: this.dialogService.show(
 								severity.Info,
-								disable ? disabling : enabling,
+								enabled ? enabledBreakpointDialogMessage : disabledBreakpointDialogMessage,
 								[
 									nls.localize('removeLogPoint', "Remove {0}", breakpointType),
-									nls.localize('disableLogPoint', "{0} {1}", disable ? nls.localize('disable', "Disable") : nls.localize('enable', "Enable"), breakpointType),
+									nls.localize('disableLogPoint', "{0} {1}", enabled ? nls.localize('disable', "Disable") : nls.localize('enable', "Enable"), breakpointType),
 									nls.localize('cancel', "Cancel")
 								],
 								{ cancelId: 2 },
@@ -274,8 +277,8 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 						if (choice === 0) {
 							breakpoints.forEach(bp => this.debugService.removeBreakpoints(bp.getId()));
 						}
-						if (choice === 1) {
-							breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!disable, bp));
+						if (choice === TOGGLE_BREAKPOINT_BUTTON_INDEX) {
+							breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
 						}
 					} else {
 						const enabled = breakpoints.some(bp => bp.enabled);

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -235,12 +235,15 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 				const breakpoints = this.debugService.getModel().getBreakpoints({ uri, lineNumber });
 
 				if (breakpoints.length) {
+					const isShiftPressed = e.event.shiftKey;
+
 					// Show the dialog if there is a potential condition to be accidently lost.
 					// Do not show dialog on linux due to electron issue freezing the mouse #50026
 					if (!env.isLinux && breakpoints.some(bp => !!bp.condition || !!bp.logMessage || !!bp.hitCondition)) {
 						const logPoint = breakpoints.every(bp => !!bp.logMessage);
 						const breakpointType = logPoint ? nls.localize('logPoint', "Logpoint") : nls.localize('breakpoint', "Breakpoint");
 						const disable = breakpoints.some(bp => bp.enabled);
+						const isDisableAction = disable && isShiftPressed;
 
 						const enabling = nls.localize('breakpointHasConditionDisabled',
 							"This {0} has a {1} that will get lost on remove. Consider enabling the {0} instead.",
@@ -253,11 +256,20 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 							logPoint ? nls.localize('message', "message") : nls.localize('condition', "condition")
 						);
 
-						const { choice } = await this.dialogService.show(severity.Info, disable ? disabling : enabling, [
-							nls.localize('removeLogPoint', "Remove {0}", breakpointType),
-							nls.localize('disableLogPoint', "{0} {1}", disable ? nls.localize('disable', "Disable") : nls.localize('enable', "Enable"), breakpointType),
-							nls.localize('cancel', "Cancel")
-						], { cancelId: 2 });
+						const dialogActionChoicePromise = isDisableAction
+							? Promise.resolve(1)
+							: this.dialogService.show(
+								severity.Info,
+								disable ? disabling : enabling,
+								[
+									nls.localize('removeLogPoint', "Remove {0}", breakpointType),
+									nls.localize('disableLogPoint', "{0} {1}", disable ? nls.localize('disable', "Disable") : nls.localize('enable', "Enable"), breakpointType),
+									nls.localize('cancel', "Cancel")
+								],
+								{ cancelId: 2 },
+							).then(({ choice }) => choice);
+
+						const choice = await dialogActionChoicePromise;
 
 						if (choice === 0) {
 							breakpoints.forEach(bp => this.debugService.removeBreakpoints(bp.getId()));
@@ -267,7 +279,6 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 						}
 					} else {
 						const enabled = breakpoints.some(bp => bp.enabled);
-						const isShiftPressed = e.event.shiftKey;
 
 						if (!enabled || isShiftPressed) {
 							breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));


### PR DESCRIPTION
Hey vscode team,

This PR fixes #147597 and adds an ability to disable a breakpoint on shift+click. Demo recording is attached.

https://user-images.githubusercontent.com/3923527/164318290-6560728c-08e7-489d-ba9e-0fd2764b3995.mov