### PR TITLE
Prepare to support Typescript Inlay Hints for Tuple Labels

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -321,21 +321,49 @@
         "typescript.inlayHints.tupleElementAccess.enabled": {
           "type": "boolean",
           "default": false,
+          "markdownDescription": "%configuration.inlayHints.tupleElementAccess.enabled%",
           "scope": "resource"
         },
         "typescript.inlayHints.tupleLiteral.enabled": {
           "type": "boolean",
           "default": false,
+          "markdownDescription": "%configuration.inlayHints.tupleLiteral.enabled%",
           "scope": "resource"
         },
         "typescript.inlayHints.tupleBinding.enabled": {
           "type": "boolean",
           "default": false,
+          "markdownDescription": "%configuration.inlayHints.tupleBinding.enabled%",
           "scope": "resource"
         },
         "typescript.inlayHints.tupleBinding.suppressWhenVariableMatchesName": {
           "type": "boolean",
           "default": true,
+          "markdownDescription": "%configuration.inlayHints.tupleBinding.suppressWhenVariableMatchesName%",
+          "scope": "resource"
+        },
+        "javascript.inlayHints.tupleElementAccess.enabled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "%configuration.inlayHints.tupleElementAccess.enabled.js%",
+          "scope": "resource"
+        },
+        "javascript.inlayHints.tupleLiteral.enabled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "%configuration.inlayHints.tupleLiteral.enabled.js%",
+          "scope": "resource"
+        },
+        "javascript.inlayHints.tupleBinding.enabled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "%configuration.inlayHints.tupleBinding.enabled.js%",
+          "scope": "resource"
+        },
+        "javascript.inlayHints.tupleBinding.suppressWhenVariableMatchesName": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "%configuration.inlayHints.tupleBinding.suppressWhenVariableMatchesName%",
           "scope": "resource"
         },
         "javascript.inlayHints.parameterNames.enabled": {

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -318,6 +318,26 @@
           "markdownDescription": "%configuration.inlayHints.enumMemberValues.enabled%",
           "scope": "resource"
         },
+        "typescript.inlayHints.tupleElementAccess.enabled": {
+          "type": "boolean",
+          "default": false,
+          "scope": "resource"
+        },
+        "typescript.inlayHints.tupleLiteral.enabled": {
+          "type": "boolean",
+          "default": false,
+          "scope": "resource"
+        },
+        "typescript.inlayHints.tupleBinding.enabled": {
+          "type": "boolean",
+          "default": false,
+          "scope": "resource"
+        },
+        "typescript.inlayHints.tupleBinding.suppressWhenVariableMatchesName": {
+          "type": "boolean",
+          "default": true,
+          "scope": "resource"
+        },
         "javascript.inlayHints.parameterNames.enabled": {
           "type": "string",
           "enum": [

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -112,6 +112,31 @@
 		"message": "Enable/disable inlay hints for member values in enum declarations:\n```typescript\n\nenum MyValue {\n\tA /* = 0 */;\n\tB /* = 1 */;\n}\n \n```\nRequires using TypeScript 4.4+ in the workspace.",
 		"comment": "The text inside the ``` block is code and should not be localized."
 	},
+	"configuration.inlayHints.tupleElementAccess.enabled": {
+		"message": "Enable/disable inlay hints for tuple labels when accessing a tuple element:\n```typescript\n\ntype Foo = [bar: number, baz: number];\n\nlet foo: Foo;\nfoo[/* bar: */ 0];\nfoo[/* baz: */ 1];\n \n```\nRequires using TypeScript 4.7+ in the workspace.",
+		"comment": "The text inside the ``` block is code and should not be localized."
+	},
+	"configuration.inlayHints.tupleLiteral.enabled": {
+		"message": "Enable/disable inlay hints for tuple labels when creating a tuple literal:\n```typescript\n\ntype Foo = [bar: number, baz: number];\n\nlet foo: Foo = [/* bar: */ 0, /* baz: */ 1];\n \n```\nRequires using TypeScript 4.7+ in the workspace.",
+		"comment": "The text inside the ``` block is code and should not be localized."
+	},
+	"configuration.inlayHints.tupleBinding.enabled": {
+		"message": "Enable/disable inlay hints for tuple labels when binding a tuple into a destructured array:\n```typescript\n\ntype Foo = [bar: number, baz: number];\n\nlet foo: Foo;\nlet [/* bar: */ a, /* baz: */ b] = foo;\n \n```\nRequires using TypeScript 4.7+ in the workspace.",
+		"comment": "The text inside the ``` block is code and should not be localized."
+	},
+	"configuration.inlayHints.tupleElementAccess.enabled.js": {
+		"message": "Enable/disable inlay hints for tuple labels when accessing a tuple element:\n```javascript\n\n/**\n * @type {[bar: number, baz: number]}\n */\nlet foo;\nfoo[/* bar: */ 0];\nfoo[/* baz: */ 1];\n \n```\nRequires using TypeScript 4.7+ in the workspace.",
+		"comment": "The text inside the ``` block is code and should not be localized."
+	},
+	"configuration.inlayHints.tupleLiteral.enabled.js": {
+		"message": "Enable/disable inlay hints for tuple labels when creating a tuple literal:\n```javascript\n\n/**\n * @type {[bar: number, baz: number]}\n */\nlet foo = [/* bar: */ 0, /* baz: */ 1];\n \n```\nRequires using TypeScript 4.7+ in the workspace.",
+		"comment": "The text inside the ``` block is code and should not be localized."
+	},
+	"configuration.inlayHints.tupleBinding.enabled.js": {
+		"message": "Enable/disable inlay hints for tuple labels when binding a tuple into a destructured array:\n```javascript\n\n/**\n * @type {[bar: number, baz: number]}\n */\nlet foo;\nlet [/* bar: */ a, /* baz: */ b] = foo;\n \n```\nRequires using TypeScript 4.7+ in the workspace.",
+		"comment": "The text inside the ``` block is code and should not be localized."
+	},
+	"configuration.inlayHints.tupleBinding.suppressWhenVariableMatchesName": "Suppress tuple label hints during tuple binding when the label matches the variable name in the destructured array.",
 	"taskDefinition.tsconfig.description": "The tsconfig file that defines the TS build.",
 	"javascript.suggestionActions.enabled": "Enable/disable suggestion diagnostics for JavaScript files in the editor.",
 	"typescript.suggestionActions.enabled": "Enable/disable suggestion diagnostics for TypeScript files in the editor.",

--- a/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
@@ -214,6 +214,10 @@ export class InlayHintSettingNames {
 	static readonly propertyDeclarationTypesEnabled = 'inlayHints.propertyDeclarationTypes.enabled';
 	static readonly functionLikeReturnTypesEnabled = 'inlayHints.functionLikeReturnTypes.enabled';
 	static readonly enumMemberValuesEnabled = 'inlayHints.enumMemberValues.enabled';
+	static readonly tupleElementAccessEnabled = 'inlayHints.tupleElementAccess.enabled';
+	static readonly tupleLiteralEnabled = 'inlayHints.tupleLiteral.enabled';
+	static readonly tupleBindingEnabled = 'inlayHints.tupleBinding.enabled';
+	static readonly tupleBindingSupressWhenVariableMatchesName = 'inlayHints.tupleBinding.suppressWhenVariableMatchesName';
 }
 
 export function getInlayHintsPreferences(config: vscode.WorkspaceConfiguration) {
@@ -225,6 +229,10 @@ export function getInlayHintsPreferences(config: vscode.WorkspaceConfiguration) 
 		includeInlayPropertyDeclarationTypeHints: config.get<boolean>(InlayHintSettingNames.propertyDeclarationTypesEnabled, false),
 		includeInlayFunctionLikeReturnTypeHints: config.get<boolean>(InlayHintSettingNames.functionLikeReturnTypesEnabled, false),
 		includeInlayEnumMemberValueHints: config.get<boolean>(InlayHintSettingNames.enumMemberValuesEnabled, false),
+		includeInlayTupleElementAccessLabelHints: config.get<boolean>(InlayHintSettingNames.tupleElementAccessEnabled, false),
+		includeInlayTupleLiteralLabelHints: config.get<boolean>(InlayHintSettingNames.tupleLiteralEnabled, false),
+		includeInlayTupleBindingLabelHints: config.get<boolean>(InlayHintSettingNames.tupleBindingEnabled, false),
+		includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel: config.get<boolean>(InlayHintSettingNames.tupleBindingSupressWhenVariableMatchesName, true),
 	} as const;
 }
 

--- a/extensions/typescript-language-features/src/languageFeatures/inlayHints.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/inlayHints.ts
@@ -22,6 +22,10 @@ const inlayHintSettingNames = [
 	InlayHintSettingNames.propertyDeclarationTypesEnabled,
 	InlayHintSettingNames.functionLikeReturnTypesEnabled,
 	InlayHintSettingNames.enumMemberValuesEnabled,
+	InlayHintSettingNames.tupleElementAccessEnabled,
+	InlayHintSettingNames.tupleLiteralEnabled,
+	InlayHintSettingNames.tupleBindingEnabled,
+	InlayHintSettingNames.tupleBindingSupressWhenVariableMatchesName,
 ];
 
 class TypeScriptInlayHintsProvider extends Disposable implements vscode.InlayHintsProvider {
@@ -91,6 +95,9 @@ function fromProtocolInlayHintKind(kind: Proto.InlayHintKind): vscode.InlayHintK
 		case 'Parameter': return vscode.InlayHintKind.Parameter;
 		case 'Type': return vscode.InlayHintKind.Type;
 		case 'Enum': return undefined;
+		// TODO: wait for typescript server proto definition changes
+		// @ts-expect-error
+		case 'Tuple': return vscode.InlayHintKind.Parameter;
 		default: return undefined;
 	}
 }
@@ -105,7 +112,11 @@ function areInlayHintsEnabledForFile(language: LanguageDescription, document: vs
 		preferences.includeInlayFunctionLikeReturnTypeHints ||
 		preferences.includeInlayFunctionParameterTypeHints ||
 		preferences.includeInlayPropertyDeclarationTypeHints ||
-		preferences.includeInlayVariableTypeHints;
+		preferences.includeInlayVariableTypeHints ||
+		preferences.includeInlayTupleElementAccessLabelHints ||
+		preferences.includeInlayTupleLiteralLabelHints ||
+		preferences.includeInlayTupleBindingLabelHints ||
+		preferences.includeInlayTupleBindingLabelHintsWhenVariableNameDoesntMatchLabel;
 }
 
 export function register(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #147617

TODO:
- [ ] Update the configuration descriptions that contains `Requires Typescript 4.7+ in the workspace.` if needed.
- [ ] Remove `@ts-error-expect` once the typescript version is updated. See `extensions/typescript-language-features/src/languageFeatures/inlayHints.ts#L99`.
