### PR TITLE
sandbox - more sandboxed usages in ext host starter

### DIFF
--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -43,7 +43,6 @@ export interface INodeProcess {
 	versions?: {
 		electron?: string;
 	};
-	sandboxed?: boolean;
 	type?: string;
 	cwd: () => string;
 }
@@ -65,7 +64,6 @@ if (typeof globals.vscode !== 'undefined' && typeof globals.vscode.process !== '
 
 const isElectronProcess = typeof nodeProcess?.versions?.electron === 'string';
 const isElectronRenderer = isElectronProcess && nodeProcess?.type === 'renderer';
-export const isElectronSandboxed = isElectronRenderer && nodeProcess?.sandboxed;
 
 interface INavigator {
 	userAgent: string;

--- a/src/vs/base/common/processes.ts
+++ b/src/vs/base/common/processes.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IProcessEnvironment } from 'vs/base/common/platform';
+import { IProcessEnvironment, isLinux, isMacintosh } from 'vs/base/common/platform';
 
 /**
  * Options to be passed to the external program or shell.
@@ -123,4 +123,33 @@ export function sanitizeProcessEnvironment(env: IProcessEnvironment, ...preserve
 				}
 			}
 		});
+}
+
+/**
+ * Remove dangerous environment variables that have caused crashes
+ * in forked processes (i.e. in ELECTRON_RUN_AS_NODE processes)
+ *
+ * @param env The env object to change
+ */
+export function removeDangerousEnvVariables(env: IProcessEnvironment | undefined): void {
+	if (!env) {
+		return;
+	}
+
+	// Unset `DEBUG`, as an invalid value might lead to process crashes
+	// See https://github.com/microsoft/vscode/issues/130072
+	delete env['DEBUG'];
+
+	if (isMacintosh) {
+		// Unset `DYLD_LIBRARY_PATH`, as it leads to process crashes
+		// See https://github.com/microsoft/vscode/issues/104525
+		// See https://github.com/microsoft/vscode/issues/105848
+		delete env['DYLD_LIBRARY_PATH'];
+	}
+
+	if (isLinux) {
+		// Unset `LD_PRELOAD`, as it might lead to process crashes
+		// See https://github.com/microsoft/vscode/issues/134177
+		delete env['LD_PRELOAD'];
+	}
 }

--- a/src/vs/base/node/processes.ts
+++ b/src/vs/base/node/processes.ts
@@ -87,35 +87,6 @@ function terminateProcess(process: cp.ChildProcess, cwd?: string): Promise<Termi
 	return Promise.resolve({ success: true });
 }
 
-/**
- * Remove dangerous environment variables that have caused crashes
- * in forked processes (i.e. in ELECTRON_RUN_AS_NODE processes)
- *
- * @param env The env object to change
- */
-export function removeDangerousEnvVariables(env: NodeJS.ProcessEnv | undefined): void {
-	if (!env) {
-		return;
-	}
-
-	// Unset `DEBUG`, as an invalid value might lead to process crashes
-	// See https://github.com/microsoft/vscode/issues/130072
-	delete env['DEBUG'];
-
-	if (Platform.isMacintosh) {
-		// Unset `DYLD_LIBRARY_PATH`, as it leads to process crashes
-		// See https://github.com/microsoft/vscode/issues/104525
-		// See https://github.com/microsoft/vscode/issues/105848
-		delete env['DYLD_LIBRARY_PATH'];
-	}
-
-	if (Platform.isLinux) {
-		// Unset `LD_PRELOAD`, as it might lead to process crashes
-		// See https://github.com/microsoft/vscode/issues/134177
-		delete env['LD_PRELOAD'];
-	}
-}
-
 export function getWindowsShell(env = process.env as Platform.IProcessEnvironment): string {
 	return env['comspec'] || 'cmd.exe';
 }

--- a/src/vs/base/parts/ipc/node/ipc.cp.ts
+++ b/src/vs/base/parts/ipc/node/ipc.cp.ts
@@ -12,7 +12,8 @@ import * as errors from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { dispose, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { deepClone } from 'vs/base/common/objects';
-import { createQueuedSender, removeDangerousEnvVariables } from 'vs/base/node/processes';
+import { createQueuedSender } from 'vs/base/node/processes';
+import { removeDangerousEnvVariables } from 'vs/base/common/processes';
 import { ChannelClient as IPCClient, ChannelServer as IPCServer, IChannel, IChannelClient } from 'vs/base/parts/ipc/common/ipc';
 
 /**

--- a/src/vs/base/parts/sandbox/electron-browser/preload.js
+++ b/src/vs/base/parts/sandbox/electron-browser/preload.js
@@ -24,18 +24,6 @@
 	}
 
 	/**
-	 * @param {string} type
-	 * @returns {type is 'uncaughtException'}
-	 */
-	function validateProcessEventType(type) {
-		if (type !== 'uncaughtException') {
-			throw new Error(`Unsupported process event '${type}'`);
-		}
-
-		return true;
-	}
-
-	/**
 	 * @param {string} key the name of the process argument to parse
 	 * @returns {string | undefined}
 	 */
@@ -264,6 +252,7 @@
 			get platform() { return process.platform; },
 			get arch() { return process.arch; },
 			get env() { return { ...process.env }; },
+			get pid() { return process.pid; },
 			get versions() { return process.versions; },
 			get type() { return 'renderer'; },
 			get execPath() { return process.execPath; },
@@ -293,15 +282,11 @@
 			/**
 			 * @param {string} type
 			 * @param {Function} callback
-			 * @returns {ISandboxNodeProcess}
+			 * @returns {void}
 			 */
 			on(type, callback) {
-				if (validateProcessEventType(type)) {
-					// @ts-ignore
-					process.on(type, callback);
-
-					return this;
-				}
+				// @ts-ignore
+				process.on(type, callback);
 			}
 		},
 

--- a/src/vs/base/parts/sandbox/electron-sandbox/globals.ts
+++ b/src/vs/base/parts/sandbox/electron-sandbox/globals.ts
@@ -35,6 +35,11 @@ export interface ISandboxNodeProcess extends INodeProcess {
 	readonly sandboxed: boolean;
 
 	/**
+	 * The `process.pid` property returns the PID of the process.
+	 */
+	readonly pid: number;
+
+	/**
 	 * A list of versions for the current node.js/electron configuration.
 	 */
 	readonly versions: { [key: string]: string | undefined };

--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -153,6 +153,7 @@ export interface ICommonNativeHostService {
 
 	// Connectivity
 	resolveProxy(url: string): Promise<string | undefined>;
+	findFreePort(startPort: number, giveUpAfter: number, timeout: number, stride?: number): Promise<number>;
 
 	// Registry (windows only)
 	windowsGetStringRegKey(hive: 'HKEY_CURRENT_USER' | 'HKEY_LOCAL_MACHINE' | 'HKEY_CLASSES_ROOT' | 'HKEY_USERS' | 'HKEY_CURRENT_CONFIG', path: string, name: string): Promise<string | undefined>;

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -19,6 +19,7 @@ import { URI } from 'vs/base/common/uri';
 import { realpath } from 'vs/base/node/extpath';
 import { virtualMachineHint } from 'vs/base/node/id';
 import { Promises, SymlinkSupport } from 'vs/base/node/pfs';
+import { findFreePort } from 'vs/base/node/ports';
 import { MouseInputEvent } from 'vs/base/parts/sandbox/common/electronTypes';
 import { localize } from 'vs/nls';
 import { ISerializableCommandAction } from 'vs/platform/action/common/action';
@@ -734,6 +735,10 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		} else {
 			return undefined;
 		}
+	}
+
+	findFreePort(windowId: number | undefined, startPort: number, giveUpAfter: number, timeout: number, stride = 1): Promise<number> {
+		return findFreePort(startPort, giveUpAfter, timeout, stride);
 	}
 
 	//#endregion

--- a/src/vs/platform/sharedProcess/electron-browser/sharedProcessWorkerMain.ts
+++ b/src/vs/platform/sharedProcess/electron-browser/sharedProcessWorkerMain.ts
@@ -12,7 +12,7 @@ import { Event, Emitter } from 'vs/base/common/event';
 import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { deepClone } from 'vs/base/common/objects';
 import { withNullAsUndefined } from 'vs/base/common/types';
-import { removeDangerousEnvVariables } from 'vs/base/node/processes';
+import { removeDangerousEnvVariables } from 'vs/base/common/processes';
 import { hash, ISharedProcessWorkerConfiguration, ISharedProcessWorkerProcessExit } from 'vs/platform/sharedProcess/common/sharedProcessWorkerService';
 import { SharedProcessWorkerMessages, ISharedProcessToWorkerMessage, ISharedProcessWorkerEnvironment, IWorkerToSharedProcessMessage } from 'vs/platform/sharedProcess/electron-browser/sharedProcessWorker';
 

--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -19,7 +19,7 @@ import { IExtHostReadyMessage, IExtHostSocketMessage, IExtHostReduceGraceTimeMes
 import { IServerEnvironmentService } from 'vs/server/node/serverEnvironmentService';
 import { IProcessEnvironment, isWindows } from 'vs/base/common/platform';
 import { logRemoteEntry } from 'vs/workbench/services/extensions/common/remoteConsoleUtil';
-import { removeDangerousEnvVariables } from 'vs/base/node/processes';
+import { removeDangerousEnvVariables } from 'vs/base/common/processes';
 import { IExtensionHostStatusService } from 'vs/server/node/extensionHostStatusService';
 
 export async function buildUserEnvironment(startParamsEnv: { [key: string]: string | null } = {}, withUserShellEnvironment: boolean, language: string, isDebug: boolean, environmentService: IServerEnvironmentService, logService: ILogService): Promise<IProcessEnvironment> {

--- a/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/localProcessExtensionHost.ts
@@ -4,14 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Server, Socket, createServer } from 'net';
-import { findFreePort } from 'vs/base/node/ports';
 import { createRandomIPCHandle, NodeSocket } from 'vs/base/parts/ipc/node/ipc.net';
 
 import * as nls from 'vs/nls';
 import { timeout } from 'vs/base/common/async';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
 import { Emitter, Event } from 'vs/base/common/event';
-import { toDisposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import * as objects from 'vs/base/common/objects';
 import * as platform from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
@@ -42,9 +41,10 @@ import { IOutputChannelRegistry, Extensions } from 'vs/workbench/services/output
 import { IShellEnvironmentService } from 'vs/workbench/services/environment/electron-sandbox/shellEnvironmentService';
 import { IExtensionHostProcessOptions, IExtensionHostStarter } from 'vs/platform/extensions/common/extensionHostStarter';
 import { SerializedError } from 'vs/base/common/errors';
-import { removeDangerousEnvVariables } from 'vs/base/node/processes';
+import { removeDangerousEnvVariables } from 'vs/base/common/processes';
 import { StopWatch } from 'vs/base/common/stopwatch';
 import { ExtensionDescriptionRegistry } from 'vs/workbench/services/extensions/common/extensionDescriptionRegistry';
+import { process } from 'vs/base/parts/sandbox/electron-sandbox/globals';
 
 export interface ILocalProcessExtensionHostInitData {
 	readonly autoStart: boolean;
@@ -171,7 +171,7 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 
 		this._toDispose.add(this._onExit);
 		this._toDispose.add(this._lifecycleService.onWillShutdown(e => this._onWillShutdown(e)));
-		this._toDispose.add(this._lifecycleService.onDidShutdown(reason => this.terminate()));
+		this._toDispose.add(this._lifecycleService.onDidShutdown(() => this.terminate()));
 		this._toDispose.add(this._extensionHostDebugService.onClose(event => {
 			if (this._isExtensionDevHost && this._environmentService.debugExtensionHost.debugId === event.sessionId) {
 				this._nativeHostService.closeWindow();
@@ -181,12 +181,6 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 			if (this._isExtensionDevHost && this._environmentService.debugExtensionHost.debugId === event.sessionId) {
 				this._hostService.reload();
 			}
-		}));
-
-		const globalExitListener = () => this.terminate();
-		process.once('exit', globalExitListener);
-		this._toDispose.add(toDisposable(() => {
-			process.removeListener('exit' as 'loaded', globalExitListener); // https://github.com/electron/electron/issues/21475
 		}));
 	}
 
@@ -380,7 +374,7 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 		}
 
 		const expected = this._environmentService.debugExtensionHost.port;
-		const port = await findFreePort(expected, 10 /* try 10 ports */, 5000 /* try up to 5 seconds */, 2048 /* skip 2048 ports between attempts */);
+		const port = await this._nativeHostService.findFreePort(expected, 10 /* try 10 ports */, 5000 /* try up to 5 seconds */, 2048 /* skip 2048 ports between attempts */);
 
 		if (!this._isExtensionDevTestFromCli) {
 			if (!port) {
@@ -639,7 +633,7 @@ export class LocalProcessExtensionHost implements IExtensionHost {
 		return withNullAsUndefined(this._inspectPort);
 	}
 
-	public terminate(): void {
+	private terminate(): void {
 		if (this._terminating) {
 			return;
 		}

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -245,6 +245,7 @@ export class TestNativeHostService implements INativeHostService {
 	async toggleDevTools(): Promise<void> { }
 	async toggleSharedProcessWindow(): Promise<void> { }
 	async resolveProxy(url: string): Promise<string | undefined> { return undefined; }
+	async findFreePort(startPort: number, giveUpAfter: number, timeout: number, stride?: number): Promise<number> { return -1; }
 	async readClipboardText(type?: 'selection' | 'clipboard' | undefined): Promise<string> { return ''; }
 	async writeClipboardText(text: string, type?: 'selection' | 'clipboard' | undefined): Promise<void> { }
 	async readClipboardFindText(): Promise<string> { return ''; }


### PR DESCRIPTION
This further reduces node.js dependencies of `localProcessExtensionHost.ts` so that the only remaining piece is the IPC communication itself.

@alexdima I think most changes are compatible:
* `removeDangerousEnvVariables` moved to `common`
* `process.pid` used from preload script
* `findFreePort` moved to main process via native host service

The only piece that I cannot preserve is this:

```ts
const globalExitListener = () => this.terminate();
process.once('exit', globalExitListener);
this._toDispose.add(toDisposable(() => {
	process.removeListener('exit' as 'loaded', globalExitListener); // https://github.com/electron/electron/issues/21475
}));
```

I see no way of forwarding `process.on("exit")` from the preload script into the workbench when `contextBridge` is enabled (which will be enabled once sandbox is enabled). This maybe by design and I was wondering if we still need this code at all? Isn't the lifecycle of the extension host main governed by:
* the lifecycle service from the window when the window shuts down orderly
* a check from the extension host in case the window process dies (via the `parentPid` property)

I actually believe that when the window crashes (i.e. is not shutdown orderly), the window will not be able to run any code such as terminating the extension host, so that code might not be doing anything today anyway.

//cc @deepak1556 @rzhao271 