### PR TITLE
ci: build arm64 server with centos7-devtoolset8

### DIFF
--- a/build/azure-pipelines/linux/product-build-linux-client.yml
+++ b/build/azure-pipelines/linux/product-build-linux-client.yml
@@ -148,7 +148,7 @@ steps:
       rm -rf remote/node_modules
       tar -xzf $(Build.ArtifactStagingDirectory)/reh_node_modules-$(VSCODE_ARCH).tar.gz --directory $(Build.SourcesDirectory)/remote
     displayName: Extract server node_modules output
-    condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'x64'))
+    condition: and(succeeded(), ne(variables['VSCODE_ARCH'], 'armhf'))
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/product-build-linux-server.yml
+++ b/build/azure-pipelines/linux/product-build-linux-server.yml
@@ -10,6 +10,16 @@ steps:
       KeyVaultName: vscode
       SecretsFilter: "github-distro-mixin-password,ESRP-PKI,esrp-aad-username,esrp-aad-password"
 
+  - task: Docker@1
+    displayName: "Pull Docker image"
+    inputs:
+      azureSubscriptionEndpoint: "vscode-builds-subscription"
+      azureContainerRegistry: vscodehub.azurecr.io
+      command: "Run an image"
+      imageName: "vscode-linux-build-agent:centos7-devtoolset8-arm64"
+      containerCommand: uname
+    condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'arm64'))
+
   - script: |
       set -e
       cat << EOF > ~/.netrc
@@ -45,20 +55,21 @@ steps:
 
   - script: |
       set -e
-      export npm_config_arch=$(NPM_ARCH)
-
-      for i in {1..3}; do # try 3 times, for Terrapin
-        yarn --cwd remote --frozen-lockfile --check-files && break
-        if [ $i -eq 3 ]; then
-          echo "Yarn failed too many times" >&2
-          exit 1
-        fi
-        echo "Yarn failed $i, trying again..."
-      done
+      $(pwd)/build/azure-pipelines/linux/scripts/install-remote-dependencies.sh
     displayName: Install dependencies
     env:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'x64'))
+
+  - script: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    displayName: Register Docker QEMU
+    condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'arm64'))
+
+  - script: |
+      set -e
+      docker run -e VSCODE_QUALITY -v $(pwd):/root/vscode -v ~/.netrc:/root/.netrc vscodehub.azurecr.io/vscode-linux-build-agent:centos7-devtoolset8-arm64 /root/vscode/build/azure-pipelines/linux/scripts/install-remote-dependencies.sh
+    displayName: Install dependencies via qemu
+    condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'arm64'))
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/scripts/install-remote-dependencies.sh
+++ b/build/azure-pipelines/linux/scripts/install-remote-dependencies.sh
@@ -2,4 +2,13 @@
 set -e
 
 echo "Installing remote dependencies"
-(cd remote && rm -rf node_modules && yarn --verbose)
+(cd remote && rm -rf node_modules)
+
+for i in {1..3}; do # try 3 times, for Terrapin
+  yarn --cwd remote --frozen-lockfile --check-files && break
+  if [ $i -eq 3 ]; then
+    echo "Yarn failed too many times" >&2
+    exit 1
+  fi
+  echo "Yarn failed $i, trying again..."
+done

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -207,6 +207,13 @@ stages:
                 steps:
                   - template: linux/product-build-linux-server.yml
 
+          - ${{ if eq(parameters.VSCODE_BUILD_LINUX, true) }}:
+              - job: arm64
+                variables:
+                  VSCODE_ARCH: arm64
+                steps:
+                  - template: linux/product-build-linux-server.yml
+
   - ${{ if and(eq(parameters.VSCODE_COMPILE_ONLY, false), eq(variables['VSCODE_BUILD_STAGE_LINUX'], true)) }}:
       - stage: Linux
         dependsOn:


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-remote-release/issues/2998
Fixes https://github.com/microsoft/vscode-remote-release/issues/103

Based on https://github.com/nodejs/node/blob/v16.x/BUILDING.md#official-binary-platforms-and-toolchains

Brings requirement to `glibc >= 2.17` and `libstdc++ >= 6.0.20 (GLIBCXX_3.4.20)`