### PR TITLE
Improve language filter placement, fixes #145711

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -839,10 +839,9 @@ export class SettingsEditor2 extends EditorPane {
 		}));
 		this._register(this.settingRenderers.onApplyLanguageFilter((lang: string) => {
 			if (this.searchWidget) {
-				// Prepend the language filter
+				// Prepend the language filter to the query.
 				const newQuery = `@${LANGUAGE_SETTING_TAG}${lang} ${this.searchWidget.getValue().trimStart()}`;
-				this.searchWidget.setValue(newQuery);
-				this.searchWidget.focus();
+				this.focusSearch(newQuery, false);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -838,7 +838,23 @@ export class SettingsEditor2 extends EditorPane {
 			}
 		}));
 		this._register(this.settingRenderers.onApplyLanguageFilter((lang: string) => {
-			this.focusSearch(`@${LANGUAGE_SETTING_TAG}${lang}`);
+			if (this.searchWidget) {
+				const splitSearchQuery = this.searchWidget.getValue().trimEnd().split(' ');
+				const filter = `@${LANGUAGE_SETTING_TAG}${lang}`;
+
+				// If the query contained the word markdown before,
+				// and we want it to be @lang:markdown, we should just replace
+				// that part of the query directly.
+				const index = splitSearchQuery.findIndex(word => word === lang);
+				if (index !== -1) {
+					splitSearchQuery[index] = filter;
+				} else {
+					splitSearchQuery.push(filter);
+				}
+
+				this.searchWidget.setValue(splitSearchQuery.join(' '));
+				this.searchWidget.focus();
+			}
 		}));
 
 		this.settingsTree = this._register(this.instantiationService.createInstance(SettingsTree,

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -839,20 +839,9 @@ export class SettingsEditor2 extends EditorPane {
 		}));
 		this._register(this.settingRenderers.onApplyLanguageFilter((lang: string) => {
 			if (this.searchWidget) {
-				const splitSearchQuery = this.searchWidget.getValue().trimEnd().split(' ');
-				const filter = `@${LANGUAGE_SETTING_TAG}${lang}`;
-
-				// If the query contained the word markdown before,
-				// and we want it to be @lang:markdown, we should just replace
-				// that part of the query directly.
-				const index = splitSearchQuery.findIndex(word => word === lang);
-				if (index !== -1) {
-					splitSearchQuery[index] = filter;
-				} else {
-					splitSearchQuery.push(filter);
-				}
-
-				this.searchWidget.setValue(splitSearchQuery.join(' '));
+				// Prepend the language filter
+				const newQuery = `@${LANGUAGE_SETTING_TAG}${lang} ${this.searchWidget.getValue().trimStart()}`;
+				this.searchWidget.setValue(newQuery);
 				this.searchWidget.focus();
 			}
 		}));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #145711

1. Search for a query such that a language config setting such as markdown shows up (the description of that setting will read "Configure settings to be overridden for the markdown language.") Two search queries that help with this step are `editor.wordwrap` and `markdown` (both case-sensitive).
2. For the `markdown` query, when pressing on the "Edit settings for markdown" link, the search query should become `@lang:markdown`.
3. For the `editor.wordwrap` query, when pressing on the "Edit settings for markdown" link, the search query should become `editor.wordwrap @lang:markdown`.