### PR TITLE
Fix typing for commentReply in commentThreadWidget.ts

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -231,7 +231,7 @@ export class CommentThreadWidget<T extends IRange | ICellRange = IRange> extends
 			this._pendingComment,
 			this,
 			this._containerDelegate.actionRunner
-		);
+		) as CommentReply<T>;
 
 		this._register(this._commentReply);
 	}


### PR DESCRIPTION
Base commit: 8cad47446f29c889b42f1678723fbc493d08d82f

Prior to this change TS was throwing in commentThreadWidget.ts
```
Type 'CommentReply<IRange | ICellRange>' is not assignable to type 'CommentReply<T>'.
  Type 'IRange | ICellRange' is not assignable to type 'T'.
    'IRange | ICellRange' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'IRange | ICellRange'.
      Type 'IRange' is not assignable to type 'T'.
        'IRange' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'IRange | ICellRange'.ts(2322)
```
Possibly introduced with adding generics.

Side note: Unsure what kind of issue to create here since the issue creation flow has the following options "bug report, feature request, security and Q&A", this isn't any of them?