### PR TITLE
re #147183. Support editor options in IDefaultEditor

### DIFF
--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -186,6 +186,8 @@ export interface IPathData {
 
 	/**
 	 * An optional selection to apply in the file
+	 *
+	 * @deprecated Use options instead
 	 */
 	readonly selection?: {
 		readonly startLineNumber: number;
@@ -207,8 +209,12 @@ export interface IPathData {
 	// if it exists
 	readonly openOnlyIfExists?: boolean;
 
-	// Specifies an optional id to override the editor
-	// used to edit the resource, e.g. custom editor.
+	/**
+	 * Specifies an optional id to override the editor
+	 * used to edit the resource, e.g. custom editor.
+	 *
+	 * @deprecated Use options.override instead
+	 */
 	readonly editorOverrideId?: string;
 }
 

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -8,6 +8,7 @@ import { isLinux, isMacintosh, isNative, isWeb } from 'vs/base/common/platform';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { ISandboxConfiguration } from 'vs/base/parts/sandbox/common/sandboxTypes';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
 import { FileType } from 'vs/platform/files/common/files';
 import { LogLevel } from 'vs/platform/log/common/log';
@@ -177,6 +178,11 @@ export interface IPathData {
 
 	// the file path to open within the instance
 	readonly fileUri?: UriComponents;
+
+	/**
+	 * Optional editor options to apply in the file
+	 */
+	readonly options?: IEditorOptions;
 
 	/**
 	 * An optional selection to apply in the file

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -626,7 +626,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 							endColumn: isNumber(file.selection.end.line) ? (isNumber(file.selection.end.column) ? file.selection.end.column : 1) : undefined,
 						} : undefined,
 						openOnlyIfExists: file.openOnlyIfExists,
-						editorOverrideId: file.openWith
+						editorOverrideId: file.openWith,
+						options: file.options
 					};
 				})
 			};

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -17,6 +17,7 @@ import type { TunnelProviderFeatures } from 'vs/platform/tunnel/common/tunnel';
 import type { IProgress, IProgressCompositeOptions, IProgressDialogOptions, IProgressNotificationOptions, IProgressOptions, IProgressStep, IProgressWindowOptions } from 'vs/platform/progress/common/progress';
 import { IObservableValue } from 'vs/base/common/observableValue';
 import { TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
+import { IEditorOptions } from 'vs/platform/editor/common/editor';
 
 /**
  * The `IWorkbench` interface is the API facade for web embedders
@@ -580,9 +581,16 @@ export interface IRange {
 
 export interface IDefaultEditor {
 	readonly uri: UriComponents;
+	/**
+	 * @deprecated Use options instead
+	 */
 	readonly selection?: IRange;
 	readonly openOnlyIfExists?: boolean;
+	/**
+	 * @deprecated Use options.override instead
+	 */
 	readonly openWith?: string;
+	readonly options?: IEditorOptions;
 }
 
 export interface IDefaultLayout {

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1340,12 +1340,14 @@ export async function pathsToEditors(paths: IPathData[] | undefined, fileService
 			return;
 		}
 
-		const options = {
+		const options: IEditorOptions = {
 			...path.options,
-			selection: exists ? path.selection : undefined,
+			...{
+				selection: exists ? path.selection : undefined
+			},
 			pinned: true,
 			override: path.editorOverrideId
-		} as IEditorOptions;
+		};
 
 		let input: IResourceEditorInput | IUntitledTextResourceEditorInput;
 		if (!exists) {

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -9,7 +9,7 @@ import { assertIsDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { ICodeEditorViewState, IDiffEditor, IDiffEditorViewState, IEditorViewState } from 'vs/editor/common/editorCommon';
-import { IEditorOptions, ITextEditorOptions, IResourceEditorInput, ITextResourceEditorInput, IBaseTextResourceEditorInput, IBaseUntypedEditorInput } from 'vs/platform/editor/common/editor';
+import { IEditorOptions, IResourceEditorInput, ITextResourceEditorInput, IBaseTextResourceEditorInput, IBaseUntypedEditorInput } from 'vs/platform/editor/common/editor';
 import type { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { IInstantiationService, IConstructorSignature, ServicesAccessor, BrandedService } from 'vs/platform/instantiation/common/instantiation';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1340,11 +1340,12 @@ export async function pathsToEditors(paths: IPathData[] | undefined, fileService
 			return;
 		}
 
-		const options: ITextEditorOptions = {
+		const options = {
+			...path.options,
 			selection: exists ? path.selection : undefined,
 			pinned: true,
 			override: path.editorOverrideId
-		};
+		} as IEditorOptions;
 
 		let input: IResourceEditorInput | IUntitledTextResourceEditorInput;
 		if (!exists) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #147183. It attempts to introduce `IEditorOptions` to `IDefaultLayout`, which can be transported to any workbench editor. It will allow embedders to construct a notebook editor options for notebook resources.
