### PR TITLE
Add horizontal scrolling to disassembly view

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -595,7 +595,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		}
 	}
 
-	private eventuallyUpdateScrollWidth(): void {
+	eventuallyUpdateScrollWidth(): void {
 		if (!this.horizontalScrolling) {
 			this.scrollableElementWidthDelayer.cancel();
 			return;
@@ -886,6 +886,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 
 			this.cache.release(item.row);
 			item.row = null;
+			item.width = undefined;
 		}
 
 		if (this.horizontalScrolling) {

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1439,6 +1439,10 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 		this.view.updateWidth(index);
 	}
 
+	eventuallyUpdateScrollWidth(): void {
+		this.view.eventuallyUpdateScrollWidth();
+	}
+
 	updateElementHeight(index: number, size: number): void {
 		this.view.updateElementHeight(index, size, null);
 	}

--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -560,6 +560,8 @@ export class SplitView<TLayoutContext = undefined> extends Disposable {
 		this._register(this.onDidScroll(e => {
 			this.viewContainer.scrollTop = e.scrollTop;
 			this.viewContainer.scrollLeft = e.scrollLeft;
+			this.sashContainer.style.top = `${-e.scrollTop}px`;
+			this.sashContainer.style.left = `${-e.scrollLeft}px`;
 		}));
 
 		append(this.el, this.scrollableElement.getDomNode());
@@ -1321,6 +1323,14 @@ export class SplitView<TLayoutContext = undefined> extends Disposable {
 		}
 
 		return undefined;
+	}
+
+	public setScrollPosition(pos: number): void {
+		if (this.orientation === Orientation.HORIZONTAL) {
+			this.scrollableElement.setScrollPosition({ scrollLeft: pos });
+		} else {
+			this.scrollableElement.setScrollPosition({ scrollTop: pos });
+		}
 	}
 
 	override dispose(): void {

--- a/src/vs/base/browser/ui/table/table.ts
+++ b/src/vs/base/browser/ui/table/table.ts
@@ -17,6 +17,8 @@ export interface ITableColumn<TRow, TCell> {
 	readonly onDidChangeWidthConstraints?: Event<void>;
 
 	project(row: TRow): TCell;
+
+	readonly fixed?: boolean;
 }
 
 export interface ITableVirtualDelegate<TRow> {
@@ -24,7 +26,9 @@ export interface ITableVirtualDelegate<TRow> {
 	getHeight(row: TRow): number;
 }
 
-export interface ITableRenderer<TCell, TTemplateData> extends IListRenderer<TCell, TTemplateData> { }
+export interface ITableRenderer<TCell, TTemplateData> extends IListRenderer<TCell, TTemplateData> {
+	getContentWidth?(visibleTemplates: TTemplateData[]): number;
+}
 
 export interface ITableEvent<TRow> extends IListEvent<TRow> { }
 export interface ITableMouseEvent<TRow> extends IListMouseEvent<TRow> { }


### PR DESCRIPTION
This PR fixes #129762

1. Add fixed column feature to Table
    The fixed columns are contained in a separate table widget.
    Limitation: the hover highlight and row selection are not synchronized between two table

2. Add fit content width feature to Table
    A column with minimumWidth set to POSITIVE_INFINITY is treated as fit-content-width column
    TableListRenderer.renderElement() will call getContentWidth on the renderer of the column and update column width if necessary. Each table could customize content width computation by implementing getContentWidth.

3. Enable these features on disassembly view
    Mark breakpoint column as fixed.
    Instruction column renderer uses CSS "width: fit-content" to detect the content width. The width is stored in IDisassembledInstructionEntry to avoid duplicated operation when one line is rendered again.
    Instruction column uses an expand-only policy: InstructionRenderer will remember the maximum width used.

Edit:
What I did:
1. Add a horizontal scrollbar when the line in disassembly view is wider than screen
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/5312474/164603827-db570b9a-eb38-4a62-92bf-212dfd4d3dbd.png">

2. And the breakpoint column is fixed at left when scrolling
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/5312474/164603738-6d3f558e-5972-4bfe-8b83-34dda498a996.png">
