### PR TITLE
Comments panel: use the date of the last reply

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
@@ -225,9 +225,9 @@ export class CommentNodeRenderer implements IListRenderer<ITreeNode<CommentNode>
 
 		templateData.repliesMetadata.container.style.display = '';
 		templateData.repliesMetadata.count.textContent = this.getCountString(commentCount);
-		templateData.repliesMetadata.lastReplyDetail.textContent = nls.localize('lastReplyFrom', "Last reply from {0}", node.element.replies[node.element.replies.length - 1].comment.userName);
-		templateData.repliesMetadata.timestamp.setTimestamp(originalComment.comment.timestamp ? new Date(originalComment.comment.timestamp) : undefined);
-
+		const lastComment = node.element.replies[node.element.replies.length - 1].comment;
+		templateData.repliesMetadata.lastReplyDetail.textContent = nls.localize('lastReplyFrom', "Last reply from {0}", lastComment.userName);
+		templateData.repliesMetadata.timestamp.setTimestamp(lastComment.timestamp ? new Date(lastComment.timestamp) : undefined);
 	}
 
 	private getCommentThreadWidgetStateColor(state: CommentThreadState | undefined, theme: IColorTheme): Color | undefined {


### PR DESCRIPTION
After the text "Last reply from", the date should refer to the date of
that comment (not the date of the thread, which already appears above).

Tested:
![image](https://user-images.githubusercontent.com/485572/164723572-1ca3c053-7f7c-456b-a9c1-f93f11795cff.png)


This PR fixes #147921

cc @alexr00 