### PR TITLE
Comments panel: do not truncate the author name

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/media/panel.css
+++ b/src/vs/workbench/contrib/comments/browser/media/panel.css
@@ -49,8 +49,7 @@
 
 .comments-panel .comments-panel-container .tree-container .comment-thread-container .comment-snippet-container .count,
 .comments-panel .comments-panel-container .tree-container .comment-thread-container .comment-metadata-container .user {
-	overflow: hidden;
-	text-overflow: ellipsis;
+	min-width: fit-content;
 }
 
 .comments-panel .comments-panel-container .tree-container .comment-thread-container .comment-snippet-container .text {


### PR DESCRIPTION
When the line is too long, truncate the end of the comment instead.

This PR fixes #147920

cc @alexr00 