### PR TITLE
Display dialog when opening `vscode://` urls

### DIFF
--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -18,6 +18,7 @@ import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { registerWindowDriver } from 'vs/platform/driver/browser/driver';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { IOpenerService, matchesScheme } from 'vs/platform/opener/common/opener';
+import { IProductService } from 'vs/platform/product/common/productService';
 import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { BrowserLifecycleService } from 'vs/workbench/services/lifecycle/browser/lifecycleService';
@@ -30,6 +31,7 @@ export class BrowserWindow extends Disposable {
 		@ILifecycleService private readonly lifecycleService: BrowserLifecycleService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@ILabelService private readonly labelService: ILabelService,
+		@IProductService private readonly productService: IProductService,
 		@IBrowserWorkbenchEnvironmentService private readonly environmentService: IBrowserWorkbenchEnvironmentService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService
 	) {
@@ -189,29 +191,33 @@ export class BrowserWindow extends Disposable {
 				// but make sure to signal this as an expected unload and disable unload
 				// handling explicitly to prevent the workbench from going down.
 				else {
-					this.lifecycleService.withExpectedShutdown({ disableShutdownHandling: true }, () => window.location.href = href);
+					const invokeProtocolHandler = () => {
+						this.lifecycleService.withExpectedShutdown({ disableShutdownHandling: true }, () => window.location.href = href);
+					};
+
+					invokeProtocolHandler();
 
 					// We cannot know whether the protocol handler succeeded.
-					// Display guidance in case it did not, e.g. VS Code is not installed.
-					if (matchesScheme(href, Schemas.vscode) || matchesScheme(href, 'vscode-insiders')) {
+					// Display guidance in case it did not, e.g. the app is not installed locally.
+					if (matchesScheme(href, this.productService.urlProtocol)) {
 						const showResult = await this.dialogService.show(
 							Severity.Info,
 							localize('you can close this tab', "All done. You can close this tab now."),
 							[
 								localize('continue here', "Continue here"),
 								localize('try again', "Try again"),
-								localize('install vs code', "Install VS Code")
+								localize('install application', "Install {0}", this.productService.nameLong)
 							],
 							{
 								cancelId: 0,
-								detail: localize('opened vs code desktop detail', "We tried opening VS Code on your computer.")
+								detail: localize('opened desktop application detail', "We tried opening {0} on your computer.", this.productService.nameLong)
 							},
 						);
 
 						if (showResult.choice === 1) {
-							this.lifecycleService.withExpectedShutdown({ disableShutdownHandling: true }, () => window.location.href = href);
+							invokeProtocolHandler();
 						} else if (showResult.choice === 2) {
-							await this.openerService.open(URI.parse(`https://code.visualstudio.com/download`));
+							await this.openerService.open(URI.parse(`http://aka.ms/vscode-install`));
 						}
 					}
 				}

--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -202,15 +202,15 @@ export class BrowserWindow extends Disposable {
 					if (matchesScheme(href, this.productService.urlProtocol)) {
 						const showResult = await this.dialogService.show(
 							Severity.Info,
-							localize('you can close this tab', "All done. You can close this tab now."),
+							localize('openExternalDialogTitle', "All done. You can close this tab now."),
 							[
-								localize('continue here', "Continue here"),
-								localize('try again', "Try again"),
-								localize('install application', "Install {0}", this.productService.nameLong)
+								localize('openExternalDialogButtonContinue', "Continue here"),
+								localize('openExternalDialogButtonRetry', "Try again"),
+								localize('openExternalDialogButtonInstall', "Install {0}", this.productService.nameLong)
 							],
 							{
 								cancelId: 0,
-								detail: localize('opened desktop application detail', "We tried opening {0} on your computer.", this.productService.nameLong)
+								detail: localize('openExternalDialogDetail', "We tried opening {0} on your computer.", this.productService.nameLong)
 							},
 						);
 

--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -190,6 +190,30 @@ export class BrowserWindow extends Disposable {
 				// handling explicitly to prevent the workbench from going down.
 				else {
 					this.lifecycleService.withExpectedShutdown({ disableShutdownHandling: true }, () => window.location.href = href);
+
+					// We cannot know whether the protocol handler succeeded.
+					// Display guidance in case it did not, e.g. VS Code is not installed.
+					if (matchesScheme(href, Schemas.vscode) || matchesScheme(href, 'vscode-insiders')) {
+						const showResult = await this.dialogService.show(
+							Severity.Info,
+							localize('you can close this tab', "All done. You can close this tab now."),
+							[
+								localize('continue here', "Continue here"),
+								localize('try again', "Try again"),
+								localize('install vs code', "Install VS Code")
+							],
+							{
+								cancelId: 0,
+								detail: localize('opened vs code desktop detail', "We tried opening VS Code on your computer.")
+							},
+						);
+
+						if (showResult.choice === 1) {
+							this.lifecycleService.withExpectedShutdown({ disableShutdownHandling: true }, () => window.location.href = href);
+						} else if (showResult.choice === 2) {
+							await this.openerService.open(URI.parse(`https://code.visualstudio.com/download`));
+						}
+					}
 				}
 
 				return true;

--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -204,19 +204,19 @@ export class BrowserWindow extends Disposable {
 							Severity.Info,
 							localize('openExternalDialogTitle', "All done. You can close this tab now."),
 							[
-								localize('openExternalDialogButtonContinue', "Continue here"),
 								localize('openExternalDialogButtonRetry', "Try again"),
-								localize('openExternalDialogButtonInstall', "Install {0}", this.productService.nameLong)
+								localize('openExternalDialogButtonInstall', "Install {0}", this.productService.nameLong),
+								localize('openExternalDialogButtonContinue', "Continue here")
 							],
 							{
-								cancelId: 0,
+								cancelId: 2,
 								detail: localize('openExternalDialogDetail', "We tried opening {0} on your computer.", this.productService.nameLong)
 							},
 						);
 
-						if (showResult.choice === 1) {
+						if (showResult.choice === 0) {
 							invokeProtocolHandler();
-						} else if (showResult.choice === 2) {
+						} else if (showResult.choice === 1) {
 							await this.openerService.open(URI.parse(`http://aka.ms/vscode-install`));
 						}
 					}


### PR DESCRIPTION
If no handler is installed, opening a protocol url will no-op, so we want to guide the user to download and install VS Code

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/147870
