### PR TITLE
Add action to hide all tests

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -111,6 +111,21 @@ export class UnhideTestAction extends Action2 {
 	}
 }
 
+export class UnhideAllTestsAction extends Action2 {
+	constructor() {
+		super({
+			id: TestCommandId.UnhideAllTestsAction,
+			title: localize('unhideAllTests', 'Unhide All Tests'),
+		});
+	}
+
+	public override run(accessor: ServicesAccessor) {
+		const service = accessor.get(ITestService);
+		service.excluded.clear();
+		return Promise.resolve();
+	}
+}
+
 const testItemInlineAndInContext = (order: ActionOrder, when?: ContextKeyExpression) => [
 	{
 		id: MenuId.TestItem,
@@ -1190,4 +1205,5 @@ export const allTestActions = [
 	TestingViewAsTreeAction,
 	ToggleInlineTestOutput,
 	UnhideTestAction,
+	UnhideAllTestsAction,
 ];

--- a/src/vs/workbench/contrib/testing/common/constants.ts
+++ b/src/vs/workbench/contrib/testing/common/constants.ts
@@ -89,4 +89,5 @@ export const enum TestCommandId {
 	ToggleAutoRun = 'testing.toggleautoRun',
 	ToggleInlineTestOutput = 'testing.toggleInlineTestOutput',
 	UnhideTestAction = 'testing.unhideTest',
+	UnhideAllTestsAction = 'testing.unhideAllTests',
 }


### PR DESCRIPTION
This PR fixes #147759.
Added new action to unhide all tests. Example task:
```
{
    "label": "testing.unhideTest",
    "type": "shell",
     "command":"${command:testing.unhideAllTests}",
    "group": "test"
}
```
