### PR TITLE
Add suggestions for ext filter in the Settings editor search widget

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsSearchMenu.ts
@@ -107,7 +107,7 @@ export class SettingsSearchFilterDropdownMenuActionViewItem extends DropdownMenu
 				localize('extSettingsSearch', "Extension ID..."),
 				localize('extSettingsSearchTooltip', "Add extension ID filter"),
 				`@${EXTENSION_SETTING_TAG}`,
-				false
+				true
 			),
 			this.createAction(
 				'featuresSettingsSearch',


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/issues/145710

This PR adds suggestions for the `@ext` filter in the Settings editor search widget, so now when a user types `@ext:`, or when they select the "Extension ID..." option from the funnel button, a list of installed extension IDs will pop up as suggestions to choose from.