### PR TITLE
Source extensions properly, fixes #148192

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -275,8 +275,15 @@ export class SettingsEditor2 extends EditorPane {
 			SettingsEditor2.SUGGESTIONS.push(`@${LANGUAGE_SETTING_TAG}`);
 		}
 
-		extensionManagementService.getInstalled(ExtensionType.System).then(extensions => {
-			this.installedExtensionIds = extensions.map(extension => extension.identifier.id);
+		Promise.all([extensionManagementService.getInstalled(ExtensionType.System), extensionManagementService.getInstalled(ExtensionType.User)]).then(extensions => {
+			const filteredExtensionIds = [];
+			for (const group of extensions) {
+				const filteredExtensions = group
+					.filter(ext => ext.manifest && ext.manifest.contributes && ext.manifest.contributes.configuration)
+					.map(ext => ext.identifier.id);
+				filteredExtensionIds.push(...filteredExtensions);
+			}
+			this.installedExtensionIds = filteredExtensionIds;
 		});
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -60,7 +60,6 @@ import { Color } from 'vs/base/common/color';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { SettingsSearchFilterDropdownMenuActionViewItem } from 'vs/workbench/contrib/preferences/browser/settingsSearchMenu';
 import { IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
-import { ExtensionType } from 'vs/platform/extensions/common/extensions';
 
 export const enum SettingsFocusContext {
 	Search,
@@ -275,15 +274,10 @@ export class SettingsEditor2 extends EditorPane {
 			SettingsEditor2.SUGGESTIONS.push(`@${LANGUAGE_SETTING_TAG}`);
 		}
 
-		Promise.all([extensionManagementService.getInstalled(ExtensionType.System), extensionManagementService.getInstalled(ExtensionType.User)]).then(extensions => {
-			const filteredExtensionIds = [];
-			for (const group of extensions) {
-				const filteredExtensions = group
-					.filter(ext => ext.manifest && ext.manifest.contributes && ext.manifest.contributes.configuration)
-					.map(ext => ext.identifier.id);
-				filteredExtensionIds.push(...filteredExtensions);
-			}
-			this.installedExtensionIds = filteredExtensionIds;
+		extensionManagementService.getInstalled().then(extensions => {
+			this.installedExtensionIds = extensions
+				.filter(ext => ext.manifest && ext.manifest.contributes && ext.manifest.contributes.configuration)
+				.map(ext => ext.identifier.id);
 		});
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #148192

When a user presses the filter button in the Settings editor search widget and selects the "Extensions" option, it used to be that we would list all built-in extensions, even ones that didn't provide any settings. Another problem was we would not list any user-installed extensions. Now, we list built-in extensions and user-installed extensions, but only ones that contribute settings (i.e. have a contributes.configuration section).
