### PR TITLE
Fix toggle high contrast action

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneThemeService.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeService.ts
@@ -222,6 +222,7 @@ export class StandaloneThemeService extends Disposable implements IStandaloneThe
 	private readonly _environment: IEnvironmentService = Object.create(null);
 	private readonly _knownThemes: Map<string, StandaloneTheme>;
 	private _autoDetectHighContrast: boolean;
+	private _forceHighContrast: boolean | null;
 	private _codiconCSS: string;
 	private _themeCSS: string;
 	private _allCSS: string;
@@ -237,6 +238,7 @@ export class StandaloneThemeService extends Disposable implements IStandaloneThe
 		super();
 
 		this._autoDetectHighContrast = true;
+		this._forceHighContrast = null;
 
 		this._knownThemes = new Map<string, StandaloneTheme>();
 		this._knownThemes.set(VS_THEME_NAME, newBuiltInTheme(VS_THEME_NAME));
@@ -340,7 +342,11 @@ export class StandaloneThemeService extends Disposable implements IStandaloneThe
 	}
 
 	public isHighContrastEnabled(): boolean {
-		return this._autoDetectHighContrast && window.matchMedia(`(forced-colors: active)`).matches;
+		if (this._forceHighContrast !== null) {
+			return this._forceHighContrast;
+		} else {
+			return this._autoDetectHighContrast && window.matchMedia(`(forced-colors: active)`).matches;
+		}
 	}
 
 	private _updateActualTheme(): void {
@@ -359,6 +365,11 @@ export class StandaloneThemeService extends Disposable implements IStandaloneThe
 
 	public setAutoDetectHighContrast(autoDetectHighContrast: boolean): void {
 		this._autoDetectHighContrast = autoDetectHighContrast;
+		this._updateActualTheme();
+	}
+
+	public setForceHighContrast(forceHighContrast: boolean | null): void {
+		this._forceHighContrast = forceHighContrast;
 		this._updateActualTheme();
 	}
 

--- a/src/vs/editor/standalone/browser/standaloneThemeService.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeService.ts
@@ -339,9 +339,13 @@ export class StandaloneThemeService extends Disposable implements IStandaloneThe
 		this._updateActualTheme();
 	}
 
+	public isHighContrastEnabled(): boolean {
+		return this._autoDetectHighContrast && window.matchMedia(`(forced-colors: active)`).matches;
+	}
+
 	private _updateActualTheme(): void {
 		const theme = (
-			this._autoDetectHighContrast && window.matchMedia(`(forced-colors: active)`).matches
+			this.isHighContrastEnabled()
 				? this._knownThemes.get(HC_BLACK_THEME_NAME)!
 				: this._desiredTheme
 		);

--- a/src/vs/editor/standalone/browser/toggleHighContrast/toggleHighContrast.ts
+++ b/src/vs/editor/standalone/browser/toggleHighContrast/toggleHighContrast.ts
@@ -7,11 +7,8 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, ServicesAccessor, registerEditorAction } from 'vs/editor/browser/editorExtensions';
 import { IStandaloneThemeService } from 'vs/editor/standalone/common/standaloneTheme';
 import { ToggleHighContrastNLS } from 'vs/editor/common/standaloneStrings';
-import { isHighContrast } from 'vs/platform/theme/common/theme';
 
 class ToggleHighContrast extends EditorAction {
-
-	private _originalThemeName: string | null;
 
 	constructor() {
 		super({
@@ -20,19 +17,11 @@ class ToggleHighContrast extends EditorAction {
 			alias: 'Toggle High Contrast Theme',
 			precondition: undefined
 		});
-		this._originalThemeName = null;
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
 		const standaloneThemeService = accessor.get(IStandaloneThemeService);
-		if (isHighContrast(standaloneThemeService.getColorTheme().type)) {
-			// We must toggle back to the integrator's theme
-			standaloneThemeService.setTheme(this._originalThemeName || 'vs');
-			this._originalThemeName = null;
-		} else {
-			this._originalThemeName = standaloneThemeService.getColorTheme().themeName;
-			standaloneThemeService.setTheme('hc-black');
-		}
+		standaloneThemeService.setForceHighContrast(!standaloneThemeService.isHighContrastEnabled());
 	}
 }
 

--- a/src/vs/editor/standalone/common/standaloneTheme.ts
+++ b/src/vs/editor/standalone/common/standaloneTheme.ts
@@ -33,6 +33,8 @@ export interface IStandaloneThemeService extends IThemeService {
 
 	setAutoDetectHighContrast(autoDetectHighContrast: boolean): void;
 
+	setForceHighContrast(forceHighContrast: boolean | null): void;
+
 	isHighContrastEnabled(): boolean;
 
 	defineTheme(themeName: string, themeData: IStandaloneThemeData): void;

--- a/src/vs/editor/standalone/common/standaloneTheme.ts
+++ b/src/vs/editor/standalone/common/standaloneTheme.ts
@@ -33,6 +33,8 @@ export interface IStandaloneThemeService extends IThemeService {
 
 	setAutoDetectHighContrast(autoDetectHighContrast: boolean): void;
 
+	isHighContrastEnabled(): boolean;
+
 	defineTheme(themeName: string, themeData: IStandaloneThemeData): void;
 
 	getColorTheme(): IStandaloneTheme;

--- a/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
+++ b/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
@@ -46,6 +46,9 @@ suite('TokenizationSupport2Adapter', () => {
 		public defineTheme(themeName: string, themeData: IStandaloneThemeData): void {
 			throw new Error('Not implemented');
 		}
+		public setForceHighContrast(forceHighContrast: boolean | null): void {
+			throw new Error('Not implemented');
+		}
 		public isHighContrastEnabled(): boolean {
 			throw new Error('Not implemented');
 		}

--- a/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
+++ b/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
@@ -46,6 +46,9 @@ suite('TokenizationSupport2Adapter', () => {
 		public defineTheme(themeName: string, themeData: IStandaloneThemeData): void {
 			throw new Error('Not implemented');
 		}
+		public isHighContrastEnabled(): boolean {
+			throw new Error('Not implemented');
+		}
 		public getColorTheme(): IStandaloneTheme {
 			return {
 				label: 'mock',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/monaco-editor/issues/3086

This PR remove the previous theme stored in the `ToggleHighContrast` action and limit the high contrast management in the theme service
