### PR TITLE
In addition to WebviewPanel, let WebviewView also support transferring of TypedArrays

### DIFF
--- a/src/vs/workbench/api/common/extHostWebviewView.ts
+++ b/src/vs/workbench/api/common/extHostWebviewView.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
-import { ExtHostWebview, ExtHostWebviews, toExtensionData } from 'vs/workbench/api/common/extHostWebview';
+import { ExtHostWebview, ExtHostWebviews, toExtensionData, shouldSerializeBuffersForPostMessage } from 'vs/workbench/api/common/extHostWebview';
 import { checkProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
 import { ViewBadge } from 'vs/workbench/api/common/extHostTypeConverters';
 import type * as vscode from 'vscode';
@@ -173,7 +173,7 @@ export class ExtHostWebviewViews implements extHostProtocol.ExtHostWebviewViewsS
 		this._viewProviders.set(viewType, { provider, extension });
 		this._proxy.$registerWebviewViewProvider(toExtensionData(extension), viewType, {
 			retainContextWhenHidden: webviewOptions?.retainContextWhenHidden,
-			serializeBuffersForPostMessage: false,
+			serializeBuffersForPostMessage: shouldSerializeBuffersForPostMessage(extension),
 		});
 
 		return new extHostTypes.Disposable(() => {


### PR DESCRIPTION
This PR fixes #115807

#### Currently webviews created with `window.createWebviewPanel` can send ArrayBuffer via postMessage, but webviews registered via `window.registerWebviewViewProvider` cannot. The two cases behave inconsistently

@mjbvz 
@Tyriar 

```typescript
const html = `
    <!doctype html>
    <html>
        <head>
            <meta charset='utf-8' />
            <title>Webview</title>
        </head>
        <body>
            <script>
                let vscode = acquireVsCodeApi()
                
                const buffer = new ArrayBuffer(10)
                
                vscode.postMessage(buffer, [buffer])
            </script>
        </body>
    </html>
`

// WebviewView, registered as a webview view in view container
window.registerWebviewViewProvider(
    'bufferview',
    {
        async resolveWebviewView (view, ctx, canceller) {
            view.webview.options = {
                enableScripts: true,
            }
            
            view.webview.onDidReceiveMessage(event => {
                event instanceof ArrayBuffer // false, event is currently { }
            })
            
            view.webview.html = html
        }
    }
)


// WebviewPanel
let panel = window.createWebviewPanel(
    'bufferpanel',
    'bufferpanel',
    {
        preserveFocus: true,
        viewColumn: ViewColumn.Two,
    },
    {
        enableScripts: true,
    }
)

panel.webview.onDidReceiveMessage(event => {
    event instanceof ArrayBuffer // true
})

panel.webview.html = html
```