### PR TITLE
chore: bump js-debug

### DIFF
--- a/product.json
+++ b/product.json
@@ -61,7 +61,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.67.0",
+			"version": "1.67.2",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
This contains the following two changes: https://github.com/microsoft/vscode-js-debug/compare/v1.67.0...v1.67.2

- Fixed sourcemaps not loading from data URIs -- came in from a PR on Monday that I didn't catch https://github.com/microsoft/vscode-js-debug/issues/1248
- Fixed the debugger not working on Node 12 -- thanks to @rzhao271. Not sure what precisely caused this, but something we did started causing TS to emit new syntax that old Node couldn't understand. Adjust the tsconfig target based on the [target mapping](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping) to fix this.