### PR TITLE
Fixes #147936

### DIFF
--- a/extensions/markdown-language-features/esbuild-preview.js
+++ b/extensions/markdown-language-features/esbuild-preview.js
@@ -28,7 +28,7 @@ function build() {
 		bundle: true,
 		minify: true,
 		sourcemap: false,
-		format: 'esm',
+		format: 'iife',
 		outdir: outDir,
 		platform: 'browser',
 		target: ['es2020'],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #147936.

By changing output esbuild setting for Markdown preview scripts to `iife`, prevents global namespace pollution and reduces possibility of breaking the preview by contributions from other extensions.
