### PR TITLE
Resolve env vars in settings.json

### DIFF
--- a/src/vs/platform/configuration/common/configuration.ts
+++ b/src/vs/platform/configuration/common/configuration.ts
@@ -271,8 +271,7 @@ export function getConfigurationValue<T>(config: any, settingPath: string, defau
 	}
 
 	const path = settingPath.split('.');
-	let result = accessSetting(config, path);
-	//result = resolveWithEnvironment({ ...process.env }, undefined, result);
+	const result = accessSetting(config, path);
 
 	return typeof result === 'undefined' ? defaultValue : result;
 }


### PR DESCRIPTION
### Feature contribution
- Resolves environment variables in `.vscode/settings.json` of the form `${env:...}`

### Use cases
- To be able to enter path for shared config file in `vscode-eslint`
   Fixes https://github.com/microsoft/vscode-eslint/issues/1425
- Many others requested since 2016
   Fixes https://github.com/microsoft/vscode/issues/2809#issuecomment-1031011012 


### Implementation
  - In `src/vs/platform/configuration/common/configuration.ts` [addToValueTree()](https://github.com/microsoft/vscode/blob/main/src/vs/platform/configuration/common/configuration.ts#L188), added 
  - Borrowed logic from `src/vs/workbench/services/configurationResolver/common/variableResolver.ts` for [`resolveWithEnvironment()`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/services/configurationResolver/common/variableResolver.ts#L71) since importing it results in violated imports warning:
     `Imports violates 'vs/base/common/** or vs/base/parts/*/common/** or vs/platform/*/common/** ...`
-  Logic kept identical except for small alterations:
  - `replaceAsync()` replaced by `replaceSync()` to keep `addToValueTree()`/ `toValueTree()` synchronous
  - `evaluateSingleVariable()` simplified to only cover for 'env' case but could be extended
### Tests
- [addToValueTree: add key with value ${env:...}](https://github.com/mjochum/vscode/blob/settingsVars/src/vs/platform/configuration/test/common/configuration.test.ts#L123)
 `{ 'a': 1, 'b': '${env:VALUE_FOR_B} }' => { 'a': 1, 'b': '2' }`
- [addToValueTree: add key with value string containing ${env:...}](https://github.com/mjochum/vscode/blob/settingsVars/src/vs/platform/configuration/test/common/configuration.test.ts#L133)
  `{'a': 'string1', 'b': 'string${env:VALUE_FOR_B}'} => {'a': 'string1', 'b': 'string2}`