### PR TITLE
Fix tm regex for XML comment <%-- --%>

### DIFF
--- a/extensions/xml/syntaxes/xml.tmLanguage.json
+++ b/extensions/xml/syntaxes/xml.tmLanguage.json
@@ -356,10 +356,10 @@
 					"captures": {
 						"0": {
 							"name": "punctuation.definition.comment.xml"
-						},
-						"end": "--%>",
-						"name": "comment.block.xml"
-					}
+						}
+					},
+					"end": "--%>",
+					"name": "comment.block.xml"
 				},
 				{
 					"begin": "<!--",


### PR DESCRIPTION
Fix tm regex for XML comment <%-- --%>. The end rule key and the name key are in the captures key, but should be up one level in the comments patterns.

Using version 1.66.2.

Repro:
Add the <%-- style comment patterns to a XML file.

<%--
This comment and all following content is not syntax colored.
--%>

All following lines are not processed for syntax coloring because the end rule key is missing for the comments patterns.

Test:
With the fixed regex, the comment will be correctly syntax colored as well as all the following xml content.