### PR TITLE
Ensure tab api properly states unpin status.

### DIFF
--- a/src/vs/workbench/common/editor/editorGroupModel.ts
+++ b/src/vs/workbench/common/editor/editorGroupModel.ts
@@ -567,7 +567,7 @@ export class EditorGroupModel extends Disposable {
 			kind: GroupModelChangeKind.EDITOR_MOVE,
 			editor,
 			oldEditorIndex: index,
-			editorIndex: toIndex,
+			editorIndex: toIndex
 		};
 		this._onDidModelChange.fire(event);
 
@@ -735,7 +735,8 @@ export class EditorGroupModel extends Disposable {
 		this.pin(editor);
 
 		// Move editor to be the last sticky editor
-		this.moveEditor(editor, this.sticky + 1);
+		const newEditorIndex = this.sticky + 1;
+		this.moveEditor(editor, newEditorIndex);
 
 		// Adjust sticky index
 		this.sticky++;
@@ -744,7 +745,7 @@ export class EditorGroupModel extends Disposable {
 		const event: IGroupEditorChangeEvent = {
 			kind: GroupModelChangeKind.EDITOR_STICKY,
 			editor,
-			editorIndex: this.sticky
+			editorIndex: newEditorIndex
 		};
 		this._onDidModelChange.fire(event);
 	}
@@ -768,7 +769,8 @@ export class EditorGroupModel extends Disposable {
 		}
 
 		// Move editor to be the first non-sticky editor
-		this.moveEditor(editor, this.sticky);
+		const newEditorIndex = this.sticky;
+		this.moveEditor(editor, newEditorIndex);
 
 		// Adjust sticky index
 		this.sticky--;
@@ -777,7 +779,7 @@ export class EditorGroupModel extends Disposable {
 		const event: IGroupEditorChangeEvent = {
 			kind: GroupModelChangeKind.EDITOR_STICKY,
 			editor,
-			editorIndex
+			editorIndex: newEditorIndex
 		};
 		this._onDidModelChange.fire(event);
 	}

--- a/src/vs/workbench/test/browser/parts/editor/editorGroupModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editorGroupModel.test.ts
@@ -2232,6 +2232,40 @@ suite('EditorGroupModel', () => {
 		assert.strictEqual(group.indexOf(input4), 2);
 	});
 
+	test('Sticky/Unsticky Editors sends correct editor index', function () {
+		const group = createEditorGroupModel();
+
+		const input1 = input();
+		const input2 = input();
+		const input3 = input();
+
+		group.openEditor(input1, { pinned: true, active: true });
+		group.openEditor(input2, { pinned: true, active: true });
+		group.openEditor(input3, { pinned: false, active: true });
+
+		assert.strictEqual(group.stickyCount, 0);
+
+		const events = groupListener(group);
+
+		group.stick(input3);
+
+		assert.strictEqual(events.sticky[0].editorIndex, 0);
+		assert.strictEqual(group.isSticky(input3), true);
+		assert.strictEqual(group.stickyCount, 1);
+
+		group.stick(input2);
+
+		assert.strictEqual(events.sticky[1].editorIndex, 1);
+		assert.strictEqual(group.isSticky(input2), true);
+		assert.strictEqual(group.stickyCount, 2);
+
+		group.unstick(input3);
+		assert.strictEqual(events.unsticky[0].editorIndex, 1);
+		assert.strictEqual(group.isSticky(input3), false);
+		assert.strictEqual(group.isSticky(input2), true);
+		assert.strictEqual(group.stickyCount, 1);
+	});
+
 	test('onDidMoveEditor Event', () => {
 		const group1 = createEditorGroupModel();
 		const group2 = createEditorGroupModel();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #145773

Pulling in part two of the fix to #145773 by @bpasero as it didn't make the branching cut off. This is relatively safe as we already have the change in for pinning but now if you unpin the state isn't correct as well. Ben also graciously wrote some tests to allow for higher confidence.