### PR TITLE
Don't cache keytar until we know it works

### DIFF
--- a/src/vs/platform/credentials/common/credentialsMainService.ts
+++ b/src/vs/platform/credentials/common/credentialsMainService.ts
@@ -108,7 +108,6 @@ export abstract class BaseCredentialsMainService extends Disposable implements I
 			}
 
 			// throw last error
-			this.surfaceKeytarLoadError?.(error);
 			throw error;
 		};
 

--- a/src/vs/platform/credentials/common/credentialsMainService.ts
+++ b/src/vs/platform/credentials/common/credentialsMainService.ts
@@ -101,13 +101,14 @@ export abstract class BaseCredentialsMainService extends Disposable implements I
 					return;
 				} catch (e) {
 					error = e;
-					this.logService.warn('Error attempting to set a password: ', e);
+					this.logService.warn('Error attempting to set a password: ', e?.message ?? e);
 					attempts++;
 					await new Promise(resolve => setTimeout(resolve, 200));
 				}
 			}
 
 			// throw last error
+			this.surfaceKeytarLoadError?.(error);
 			throw error;
 		};
 

--- a/src/vs/platform/credentials/electron-main/credentialsMainService.ts
+++ b/src/vs/platform/credentials/electron-main/credentialsMainService.ts
@@ -36,15 +36,11 @@ export class CredentialsNativeMainService extends BaseCredentialsMainService {
 			return this._keytarCache;
 		}
 
-		try {
-			this._keytarCache = await import('keytar');
-			// Try using keytar to see if it throws or not.
-			await this._keytarCache.findCredentials('test-keytar-loads');
-			return this._keytarCache;
-		} catch (e) {
-			this._keytarCache = undefined;
-			throw e;
-		}
+		const keytarCache = await import('keytar');
+		// Try using keytar to see if it throws or not.
+		await keytarCache.findCredentials('test-keytar-loads');
+		this._keytarCache = keytarCache;
+		return this._keytarCache;
 	}
 
 	protected override surfaceKeytarLoadError = (err: any) => {

--- a/src/vs/platform/credentials/electron-main/credentialsMainService.ts
+++ b/src/vs/platform/credentials/electron-main/credentialsMainService.ts
@@ -36,10 +36,15 @@ export class CredentialsNativeMainService extends BaseCredentialsMainService {
 			return this._keytarCache;
 		}
 
-		this._keytarCache = await import('keytar');
-		// Try using keytar to see if it throws or not.
-		await this._keytarCache.findCredentials('test-keytar-loads');
-		return this._keytarCache;
+		try {
+			this._keytarCache = await import('keytar');
+			// Try using keytar to see if it throws or not.
+			await this._keytarCache.findCredentials('test-keytar-loads');
+			return this._keytarCache;
+		} catch (e) {
+			this._keytarCache = undefined;
+			throw e;
+		}
 	}
 
 	protected override surfaceKeytarLoadError = (err: any) => {


### PR DESCRIPTION
#146553's original issue is that we were too eager checking if a compatible keyring was installed when you don't need it to use vscode (only to use auth and secretstorage)...

in other words, if someone called getSessions silently (aka Settings Sync which does it at start up) that would show a notification to the user for the troubleshooting guide. But if the user has no intention of using Settings Sync, then they shouldn't see this notification.

They should only see a notification if they attempt to do a write operation (i.e. go through an auth flow).

keytar doesn't throw when you import it, only when you call a function on it, and I was calling this `await this._keytarCache.findCredentials('test-keytar-loads');` to test if keytar was in a good state... 

Fixes #146553
