### PR TITLE
debug: bump js-debug companion

### DIFF
--- a/product.json
+++ b/product.json
@@ -46,7 +46,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug-companion",
-			"version": "1.0.17",
+			"version": "1.0.18",
 			"repo": "https://github.com/microsoft/vscode-js-debug-companion",
 			"metadata": {
 				"id": "99cb0b7f-7354-4278-b8da-6cc79972169d",


### PR DESCRIPTION
This contains the following changes: https://github.com/microsoft/vscode-js-debug-companion/compare/v1.0.17...v1.0.18

Fixes https://github.com/microsoft/vscode-js-debug/issues/1249. Initially was going to let it be in the next release, but the change is small enough and impact large enough that we can take it as a candidate