### PR TITLE
Comment loss when clicking "Go to review"

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentReply.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentReply.ts
@@ -275,7 +275,6 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 	}
 
 	private hideReplyArea() {
-		this.commentEditor.setValue('');
 		this.commentEditor.getDomNode()!.style.outline = '';
 		this._pendingComment = '';
 		this.form.classList.remove('expand');


### PR DESCRIPTION
There's already code in place to restore in-progress comments. However, when one of the actions is clicked, we clear the text from the editor model. Fix is to not do that.

Fixes #148629
