### PR TITLE
unset IFS before evaluating each function in `$PROMPT_COMMAND`

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -109,15 +109,16 @@ __vsc_prompt_cmd_original() {
 		IFS=' '
 	fi
 	builtin read -ra ADDR <<<"$__vsc_original_prompt_command"
-	for ((i = 0; i < ${#ADDR[@]}; i++)); do
-		builtin eval ${ADDR[i]}
-	done
 	if [[ ${__vsc_original_ifs+set} ]]; then
 		IFS="$__vsc_original_ifs"
 		unset __vsc_original_ifs
 	else
 		unset IFS
 	fi
+	for ((i = 0; i < ${#ADDR[@]}; i++)); do
+		# unset IFS
+		builtin eval ${ADDR[i]}
+	done
 	__vsc_precmd
 }
 


### PR DESCRIPTION
So as to avoid interfering with IFS used in that function

This PR fixes #146377
