### PR TITLE
Align text title and menu titles

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -57,41 +57,6 @@
 	-webkit-app-region: drag;
 }
 
-/* Command Center */
-.monaco-workbench .part.titlebar>.titlebar-container>.title-menu .action-item.quickopen {
-	color: var(--vscode-input-foreground);
-	border: 1px solid var(--vscode-dropdown-border);
-	height: 20px;
-	line-height: 20px;
-	width: 38vw;
-	max-width: 600px;
-	margin: 4px 4px;
-	flex-direction: row;
-	justify-content: center;
-	overflow: hidden;
-}
-
-.monaco-workbench .part.titlebar>.titlebar-container>.title-menu .action-item.quickopen:HOVER,
-.monaco-workbench .part.titlebar>.titlebar-container>.title-menu .action-item.quickopen .action-container .action-label:HOVER {
-	background-color: var(--vscode-dropdown-border);
-	line-height: 18px;
-}
-
-.monaco-workbench .part.titlebar>.titlebar-container>.title-menu .action-item.quickopen .action-container {
-	flex: 1 0 auto;
-	display: flex;
-	justify-content: center;
-}
-
-.monaco-workbench .part.titlebar>.titlebar-container>.title-menu .action-item.quickopen .action-container .keybinding {
-	font-size: 11px;
-	padding: 3px;
-}
-
-.monaco-workbench .part.titlebar>.titlebar-container>.title-menu .action-item.quickopen .dropdown-action-container {
-	margin-left: auto;
-}
-
 /* Window title text */
 .monaco-workbench .part.titlebar>.titlebar-container>.window-title {
 	flex: 0 1 auto;
@@ -120,13 +85,44 @@
 	cursor: default;
 }
 
-.monaco-workbench .part.titlebar>.titlebar-container.enable-title-menu>.window-title {
-	display: none;
-}
-
 .monaco-workbench.linux .part.titlebar>.titlebar-container>.window-title {
 	font-size: inherit;
 	/* see #55435 */
+}
+
+/* Window Title Menu */
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen {
+	color: var(--vscode-input-foreground);
+	border: 1px solid var(--vscode-dropdown-border);
+	height: 20px;
+	line-height: 20px;
+	width: 38vw;
+	max-width: 600px;
+	margin: 4px 4px;
+	flex-direction: row;
+	justify-content: center;
+	overflow: hidden;
+}
+
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen:HOVER,
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen .action-container .action-label:HOVER {
+	background-color: var(--vscode-dropdown-border);
+	line-height: 18px;
+}
+
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen .action-container {
+	flex: 1 0 auto;
+	display: flex;
+	justify-content: center;
+}
+
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen .action-container .keybinding {
+	font-size: 11px;
+	padding: 3px;
+}
+
+.monaco-workbench .part.titlebar>.titlebar-container>.title-menu .action-item.quickopen .dropdown-action-container {
+	margin-left: auto;
 }
 
 /* Menubar */

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -5,7 +5,6 @@
 
 import 'vs/css!./media/titlebarpart';
 import { localize } from 'vs/nls';
-import { dirname, basename } from 'vs/base/common/resources';
 import { Part } from 'vs/workbench/browser/part';
 import { ITitleService, ITitleProperties } from 'vs/workbench/services/title/common/titleService';
 import { getZoomFactor } from 'vs/base/browser/browser';
@@ -14,251 +13,27 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
 import { IAction, toAction } from 'vs/base/common/actions';
 import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
-import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { Disposable, DisposableStore, dispose, toDisposable } from 'vs/base/common/lifecycle';
-import { EditorResourceAccessor, Verbosity, SideBySideEditor } from 'vs/workbench/common/editor';
+import { DisposableStore, dispose, toDisposable } from 'vs/base/common/lifecycle';
 import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService';
-import { IWorkspaceContextService, WorkbenchState, IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { IThemeService, registerThemingParticipant, ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { TITLE_BAR_ACTIVE_BACKGROUND, TITLE_BAR_ACTIVE_FOREGROUND, TITLE_BAR_INACTIVE_FOREGROUND, TITLE_BAR_INACTIVE_BACKGROUND, TITLE_BAR_BORDER, WORKBENCH_BACKGROUND } from 'vs/workbench/common/theme';
 import { isMacintosh, isWindows, isLinux, isWeb } from 'vs/base/common/platform';
-import { URI } from 'vs/base/common/uri';
 import { Color } from 'vs/base/common/color';
-import { trim } from 'vs/base/common/strings';
 import { EventType, EventHelper, Dimension, isAncestor, append, $, addDisposableListener, runAtThisOrScheduleAtNextAnimationFrame, prepend, clearNode } from 'vs/base/browser/dom';
 import { CustomMenubarControl } from 'vs/workbench/browser/parts/titlebar/menubarControl';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { template } from 'vs/base/common/labels';
-import { ILabelService } from 'vs/platform/label/common/label';
 import { Emitter } from 'vs/base/common/event';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { Parts, IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
-import { RunOnceScheduler } from 'vs/base/common/async';
 import { createActionViewItem, createAndFillInContextMenuActions, DropdownWithDefaultActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { IMenuService, IMenu, MenuId, SubmenuItemAction, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
-import { IProductService } from 'vs/platform/product/common/productService';
-import { Schemas } from 'vs/base/common/network';
-import { withNullAsUndefined } from 'vs/base/common/types';
 import { Codicon } from 'vs/base/common/codicons';
-import { getVirtualWorkspaceLocation } from 'vs/platform/workspace/common/virtualWorkspace';
 import { getIconRegistry } from 'vs/platform/theme/common/iconRegistry';
 import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-
-class WindowTitle extends Disposable {
-
-	private static readonly NLS_UNSUPPORTED = localize('patchedWindowTitle', "[Unsupported]");
-	private static readonly NLS_USER_IS_ADMIN = isWindows ? localize('userIsAdmin', "[Administrator]") : localize('userIsSudo', "[Superuser]");
-	private static readonly NLS_EXTENSION_HOST = localize('devExtensionWindowTitlePrefix', "[Extension Development Host]");
-	private static readonly TITLE_DIRTY = '\u25cf ';
-
-	private readonly properties: ITitleProperties = { isPure: true, isAdmin: false, prefix: undefined };
-	private readonly activeEditorListeners = this._register(new DisposableStore());
-	private readonly titleUpdater = this._register(new RunOnceScheduler(() => this.doUpdateTitle(), 0));
-
-	private readonly onDidChangeEmitter = new Emitter<void>();
-	readonly onDidChange = this.onDidChangeEmitter.event;
-
-	private title: string | undefined;
-
-	constructor(
-		@IConfigurationService protected readonly configurationService: IConfigurationService,
-		@IEditorService private readonly editorService: IEditorService,
-		@IBrowserWorkbenchEnvironmentService protected readonly environmentService: IBrowserWorkbenchEnvironmentService,
-		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
-		@IInstantiationService protected readonly instantiationService: IInstantiationService,
-		@ILabelService private readonly labelService: ILabelService,
-		@IProductService private readonly productService: IProductService,
-	) {
-		super();
-		this.registerListeners();
-	}
-
-	get value() {
-		return this.title ?? '';
-	}
-
-	private registerListeners(): void {
-		this._register(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationChanged(e)));
-		this._register(this.editorService.onDidActiveEditorChange(() => this.onActiveEditorChange()));
-		this._register(this.contextService.onDidChangeWorkspaceFolders(() => this.titleUpdater.schedule()));
-		this._register(this.contextService.onDidChangeWorkbenchState(() => this.titleUpdater.schedule()));
-		this._register(this.contextService.onDidChangeWorkspaceName(() => this.titleUpdater.schedule()));
-		this._register(this.labelService.onDidChangeFormatters(() => this.titleUpdater.schedule()));
-	}
-
-
-	private onConfigurationChanged(event: IConfigurationChangeEvent): void {
-		if (event.affectsConfiguration('window.title') || event.affectsConfiguration('window.titleSeparator')) {
-			this.titleUpdater.schedule();
-		}
-	}
-
-	private onActiveEditorChange(): void {
-
-		// Dispose old listeners
-		this.activeEditorListeners.clear();
-
-		// Calculate New Window Title
-		this.titleUpdater.schedule();
-
-		// Apply listener for dirty and label changes
-		const activeEditor = this.editorService.activeEditor;
-		if (activeEditor) {
-			this.activeEditorListeners.add(activeEditor.onDidChangeDirty(() => this.titleUpdater.schedule()));
-			this.activeEditorListeners.add(activeEditor.onDidChangeLabel(() => this.titleUpdater.schedule()));
-		}
-	}
-
-	private doUpdateTitle(): void {
-		const title = this.getWindowTitle();
-		if (title !== this.title) {
-			// Always set the native window title to identify us properly to the OS
-			let nativeTitle = title;
-			if (!trim(nativeTitle)) {
-				nativeTitle = this.productService.nameLong;
-			}
-			window.document.title = nativeTitle;
-			this.title = title;
-			this.onDidChangeEmitter.fire();
-		}
-	}
-
-	private getWindowTitle(): string {
-		let title = this.doGetWindowTitle();
-
-		if (this.properties.prefix) {
-			title = `${this.properties.prefix} ${title || this.productService.nameLong}`;
-		}
-
-		if (this.properties.isAdmin) {
-			title = `${title || this.productService.nameLong} ${WindowTitle.NLS_USER_IS_ADMIN}`;
-		}
-
-		if (!this.properties.isPure) {
-			title = `${title || this.productService.nameLong} ${WindowTitle.NLS_UNSUPPORTED}`;
-		}
-
-		if (this.environmentService.isExtensionDevelopment) {
-			title = `${WindowTitle.NLS_EXTENSION_HOST} - ${title || this.productService.nameLong}`;
-		}
-
-		// Replace non-space whitespace
-		title = title.replace(/[^\S ]/g, ' ');
-
-		return title;
-	}
-
-	updateProperties(properties: ITitleProperties): void {
-		const isAdmin = typeof properties.isAdmin === 'boolean' ? properties.isAdmin : this.properties.isAdmin;
-		const isPure = typeof properties.isPure === 'boolean' ? properties.isPure : this.properties.isPure;
-		const prefix = typeof properties.prefix === 'string' ? properties.prefix : this.properties.prefix;
-
-		if (isAdmin !== this.properties.isAdmin || isPure !== this.properties.isPure || prefix !== this.properties.prefix) {
-			this.properties.isAdmin = isAdmin;
-			this.properties.isPure = isPure;
-			this.properties.prefix = prefix;
-
-			this.titleUpdater.schedule();
-		}
-	}
-
-	/**
-	 * Possible template values:
-	 *
-	 * {activeEditorLong}: e.g. /Users/Development/myFolder/myFileFolder/myFile.txt
-	 * {activeEditorMedium}: e.g. myFolder/myFileFolder/myFile.txt
-	 * {activeEditorShort}: e.g. myFile.txt
-	 * {activeFolderLong}: e.g. /Users/Development/myFolder/myFileFolder
-	 * {activeFolderMedium}: e.g. myFolder/myFileFolder
-	 * {activeFolderShort}: e.g. myFileFolder
-	 * {rootName}: e.g. myFolder1, myFolder2, myFolder3
-	 * {rootPath}: e.g. /Users/Development
-	 * {folderName}: e.g. myFolder
-	 * {folderPath}: e.g. /Users/Development/myFolder
-	 * {appName}: e.g. VS Code
-	 * {remoteName}: e.g. SSH
-	 * {dirty}: indicator
-	 * {separator}: conditional separator
-	 */
-	private doGetWindowTitle(): string {
-		const editor = this.editorService.activeEditor;
-		const workspace = this.contextService.getWorkspace();
-
-		// Compute root
-		let root: URI | undefined;
-		if (workspace.configuration) {
-			root = workspace.configuration;
-		} else if (workspace.folders.length) {
-			root = workspace.folders[0].uri;
-		}
-
-		// Compute active editor folder
-		const editorResource = EditorResourceAccessor.getOriginalUri(editor, { supportSideBySide: SideBySideEditor.PRIMARY });
-		let editorFolderResource = editorResource ? dirname(editorResource) : undefined;
-		if (editorFolderResource?.path === '.') {
-			editorFolderResource = undefined;
-		}
-
-		// Compute folder resource
-		// Single Root Workspace: always the root single workspace in this case
-		// Otherwise: root folder of the currently active file if any
-		let folder: IWorkspaceFolder | undefined = undefined;
-		if (this.contextService.getWorkbenchState() === WorkbenchState.FOLDER) {
-			folder = workspace.folders[0];
-		} else if (editorResource) {
-			folder = withNullAsUndefined(this.contextService.getWorkspaceFolder(editorResource));
-		}
-
-		// Compute remote
-		// vscode-remtoe: use as is
-		// otherwise figure out if we have a virtual folder opened
-		let remoteName: string | undefined = undefined;
-		if (this.environmentService.remoteAuthority && !isWeb) {
-			remoteName = this.labelService.getHostLabel(Schemas.vscodeRemote, this.environmentService.remoteAuthority);
-		} else {
-			const virtualWorkspaceLocation = getVirtualWorkspaceLocation(workspace);
-			if (virtualWorkspaceLocation) {
-				remoteName = this.labelService.getHostLabel(virtualWorkspaceLocation.scheme, virtualWorkspaceLocation.authority);
-			}
-		}
-
-		// Variables
-		const activeEditorShort = editor ? editor.getTitle(Verbosity.SHORT) : '';
-		const activeEditorMedium = editor ? editor.getTitle(Verbosity.MEDIUM) : activeEditorShort;
-		const activeEditorLong = editor ? editor.getTitle(Verbosity.LONG) : activeEditorMedium;
-		const activeFolderShort = editorFolderResource ? basename(editorFolderResource) : '';
-		const activeFolderMedium = editorFolderResource ? this.labelService.getUriLabel(editorFolderResource, { relative: true }) : '';
-		const activeFolderLong = editorFolderResource ? this.labelService.getUriLabel(editorFolderResource) : '';
-		const rootName = this.labelService.getWorkspaceLabel(workspace);
-		const rootPath = root ? this.labelService.getUriLabel(root) : '';
-		const folderName = folder ? folder.name : '';
-		const folderPath = folder ? this.labelService.getUriLabel(folder.uri) : '';
-		const dirty = editor?.isDirty() && !editor.isSaving() ? WindowTitle.TITLE_DIRTY : '';
-		const appName = this.productService.nameLong;
-		const separator = this.configurationService.getValue<string>('window.titleSeparator');
-		const titleTemplate = this.configurationService.getValue<string>('window.title');
-
-		return template(titleTemplate, {
-			activeEditorShort,
-			activeEditorLong,
-			activeEditorMedium,
-			activeFolderShort,
-			activeFolderMedium,
-			activeFolderLong,
-			rootName,
-			rootPath,
-			folderName,
-			folderPath,
-			dirty,
-			appName,
-			remoteName,
-			separator: { label: separator }
-		});
-	}
-}
+import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
 
 export class TitlebarPart extends Part implements ITitleService {
 
@@ -288,7 +63,7 @@ export class TitlebarPart extends Part implements ITitleService {
 	private layoutToolbar: ToolBar | undefined;
 	protected lastLayoutDimensions: Dimension | undefined;
 
-	private readonly titleMenuDisposables = this._register(new DisposableStore());
+	private readonly titleDisposables = this._register(new DisposableStore());
 	private titleBarStyle: 'native' | 'custom';
 
 	private isInactive: boolean = false;
@@ -397,14 +172,14 @@ export class TitlebarPart extends Part implements ITitleService {
 	}
 
 	private updateTitle(): void {
-		this.titleMenuDisposables.clear();
+		this.titleDisposables.clear();
 		const enableTitleMenu = this.configurationService.getValue<boolean>('window.experimental.titleMenu');
 		this.title.classList.toggle('title-menu', enableTitleMenu);
 
 		if (!enableTitleMenu) {
 			// Text Title
 			this.title.innerText = this.windowTitle.value;
-			this._register(this.windowTitle.onDidChange(() => this.title.innerText = this.windowTitle.value));
+			this.titleDisposables.add(this.windowTitle.onDidChange(() => this.title.innerText = this.windowTitle.value));
 
 		} else {
 			// Menu Title
@@ -430,17 +205,17 @@ export class TitlebarPart extends Part implements ITitleService {
 					return undefined;
 				}
 			});
-			const titleMenu = this.titleMenuDisposables.add(this.menuService.createMenu(MenuId.TitleMenu, this.contextKeyService));
-			const titleMenuDisposables = this.titleMenuDisposables.add(new DisposableStore());
+			const titleMenu = this.titleDisposables.add(this.menuService.createMenu(MenuId.TitleMenu, this.contextKeyService));
+			const titleMenuDisposables = this.titleDisposables.add(new DisposableStore());
 			const updateTitleMenu = () => {
 				titleMenuDisposables.clear();
 				const actions: IAction[] = [];
 				titleMenuDisposables.add(createAndFillInContextMenuActions(titleMenu, undefined, actions));
 				titleToolbar.setActions(actions);
 			};
-			this.titleMenuDisposables.add(titleMenu.onDidChange(updateTitleMenu));
-			this.titleMenuDisposables.add(this.keybindingService.onDidUpdateKeybindings(updateTitleMenu));
-			this.titleMenuDisposables.add(toDisposable(() => clearNode(this.title)));
+			this.titleDisposables.add(titleMenu.onDidChange(updateTitleMenu));
+			this.titleDisposables.add(this.keybindingService.onDidUpdateKeybindings(updateTitleMenu));
+			this.titleDisposables.add(toDisposable(() => clearNode(this.title)));
 			updateTitleMenu();
 		}
 	}

--- a/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -1,0 +1,238 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from 'vs/nls';
+import { dirname, basename } from 'vs/base/common/resources';
+import { ITitleProperties } from 'vs/workbench/services/title/common/titleService';
+import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { EditorResourceAccessor, Verbosity, SideBySideEditor } from 'vs/workbench/common/editor';
+import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService';
+import { IWorkspaceContextService, WorkbenchState, IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
+import { isWindows, isWeb } from 'vs/base/common/platform';
+import { URI } from 'vs/base/common/uri';
+import { trim } from 'vs/base/common/strings';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { template } from 'vs/base/common/labels';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { Emitter } from 'vs/base/common/event';
+import { RunOnceScheduler } from 'vs/base/common/async';
+import { IProductService } from 'vs/platform/product/common/productService';
+import { Schemas } from 'vs/base/common/network';
+import { withNullAsUndefined } from 'vs/base/common/types';
+import { getVirtualWorkspaceLocation } from 'vs/platform/workspace/common/virtualWorkspace';
+
+export class WindowTitle extends Disposable {
+
+	private static readonly NLS_UNSUPPORTED = localize('patchedWindowTitle', "[Unsupported]");
+	private static readonly NLS_USER_IS_ADMIN = isWindows ? localize('userIsAdmin', "[Administrator]") : localize('userIsSudo', "[Superuser]");
+	private static readonly NLS_EXTENSION_HOST = localize('devExtensionWindowTitlePrefix', "[Extension Development Host]");
+	private static readonly TITLE_DIRTY = '\u25cf ';
+
+	private readonly properties: ITitleProperties = { isPure: true, isAdmin: false, prefix: undefined };
+	private readonly activeEditorListeners = this._register(new DisposableStore());
+	private readonly titleUpdater = this._register(new RunOnceScheduler(() => this.doUpdateTitle(), 0));
+
+	private readonly onDidChangeEmitter = new Emitter<void>();
+	readonly onDidChange = this.onDidChangeEmitter.event;
+
+	private title: string | undefined;
+
+	constructor(
+		@IConfigurationService protected readonly configurationService: IConfigurationService,
+		@IEditorService private readonly editorService: IEditorService,
+		@IBrowserWorkbenchEnvironmentService protected readonly environmentService: IBrowserWorkbenchEnvironmentService,
+		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
+		@IInstantiationService protected readonly instantiationService: IInstantiationService,
+		@ILabelService private readonly labelService: ILabelService,
+		@IProductService private readonly productService: IProductService
+	) {
+		super();
+		this.registerListeners();
+	}
+
+	get value() {
+		return this.title ?? '';
+	}
+
+	private registerListeners(): void {
+		this._register(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationChanged(e)));
+		this._register(this.editorService.onDidActiveEditorChange(() => this.onActiveEditorChange()));
+		this._register(this.contextService.onDidChangeWorkspaceFolders(() => this.titleUpdater.schedule()));
+		this._register(this.contextService.onDidChangeWorkbenchState(() => this.titleUpdater.schedule()));
+		this._register(this.contextService.onDidChangeWorkspaceName(() => this.titleUpdater.schedule()));
+		this._register(this.labelService.onDidChangeFormatters(() => this.titleUpdater.schedule()));
+	}
+
+	private onConfigurationChanged(event: IConfigurationChangeEvent): void {
+		if (event.affectsConfiguration('window.title') || event.affectsConfiguration('window.titleSeparator')) {
+			this.titleUpdater.schedule();
+		}
+	}
+
+	private onActiveEditorChange(): void {
+
+		// Dispose old listeners
+		this.activeEditorListeners.clear();
+
+		// Calculate New Window Title
+		this.titleUpdater.schedule();
+
+		// Apply listener for dirty and label changes
+		const activeEditor = this.editorService.activeEditor;
+		if (activeEditor) {
+			this.activeEditorListeners.add(activeEditor.onDidChangeDirty(() => this.titleUpdater.schedule()));
+			this.activeEditorListeners.add(activeEditor.onDidChangeLabel(() => this.titleUpdater.schedule()));
+		}
+	}
+
+	private doUpdateTitle(): void {
+		const title = this.getWindowTitle();
+		if (title !== this.title) {
+			// Always set the native window title to identify us properly to the OS
+			let nativeTitle = title;
+			if (!trim(nativeTitle)) {
+				nativeTitle = this.productService.nameLong;
+			}
+			window.document.title = nativeTitle;
+			this.title = title;
+			this.onDidChangeEmitter.fire();
+		}
+	}
+
+	private getWindowTitle(): string {
+		let title = this.doGetWindowTitle();
+
+		if (this.properties.prefix) {
+			title = `${this.properties.prefix} ${title || this.productService.nameLong}`;
+		}
+
+		if (this.properties.isAdmin) {
+			title = `${title || this.productService.nameLong} ${WindowTitle.NLS_USER_IS_ADMIN}`;
+		}
+
+		if (!this.properties.isPure) {
+			title = `${title || this.productService.nameLong} ${WindowTitle.NLS_UNSUPPORTED}`;
+		}
+
+		if (this.environmentService.isExtensionDevelopment) {
+			title = `${WindowTitle.NLS_EXTENSION_HOST} - ${title || this.productService.nameLong}`;
+		}
+
+		// Replace non-space whitespace
+		title = title.replace(/[^\S ]/g, ' ');
+
+		return title;
+	}
+
+	updateProperties(properties: ITitleProperties): void {
+		const isAdmin = typeof properties.isAdmin === 'boolean' ? properties.isAdmin : this.properties.isAdmin;
+		const isPure = typeof properties.isPure === 'boolean' ? properties.isPure : this.properties.isPure;
+		const prefix = typeof properties.prefix === 'string' ? properties.prefix : this.properties.prefix;
+
+		if (isAdmin !== this.properties.isAdmin || isPure !== this.properties.isPure || prefix !== this.properties.prefix) {
+			this.properties.isAdmin = isAdmin;
+			this.properties.isPure = isPure;
+			this.properties.prefix = prefix;
+
+			this.titleUpdater.schedule();
+		}
+	}
+
+	/**
+	 * Possible template values:
+	 *
+	 * {activeEditorLong}: e.g. /Users/Development/myFolder/myFileFolder/myFile.txt
+	 * {activeEditorMedium}: e.g. myFolder/myFileFolder/myFile.txt
+	 * {activeEditorShort}: e.g. myFile.txt
+	 * {activeFolderLong}: e.g. /Users/Development/myFolder/myFileFolder
+	 * {activeFolderMedium}: e.g. myFolder/myFileFolder
+	 * {activeFolderShort}: e.g. myFileFolder
+	 * {rootName}: e.g. myFolder1, myFolder2, myFolder3
+	 * {rootPath}: e.g. /Users/Development
+	 * {folderName}: e.g. myFolder
+	 * {folderPath}: e.g. /Users/Development/myFolder
+	 * {appName}: e.g. VS Code
+	 * {remoteName}: e.g. SSH
+	 * {dirty}: indicator
+	 * {separator}: conditional separator
+	 */
+	private doGetWindowTitle(): string {
+		const editor = this.editorService.activeEditor;
+		const workspace = this.contextService.getWorkspace();
+
+		// Compute root
+		let root: URI | undefined;
+		if (workspace.configuration) {
+			root = workspace.configuration;
+		} else if (workspace.folders.length) {
+			root = workspace.folders[0].uri;
+		}
+
+		// Compute active editor folder
+		const editorResource = EditorResourceAccessor.getOriginalUri(editor, { supportSideBySide: SideBySideEditor.PRIMARY });
+		let editorFolderResource = editorResource ? dirname(editorResource) : undefined;
+		if (editorFolderResource?.path === '.') {
+			editorFolderResource = undefined;
+		}
+
+		// Compute folder resource
+		// Single Root Workspace: always the root single workspace in this case
+		// Otherwise: root folder of the currently active file if any
+		let folder: IWorkspaceFolder | undefined = undefined;
+		if (this.contextService.getWorkbenchState() === WorkbenchState.FOLDER) {
+			folder = workspace.folders[0];
+		} else if (editorResource) {
+			folder = withNullAsUndefined(this.contextService.getWorkspaceFolder(editorResource));
+		}
+
+		// Compute remote
+		// vscode-remtoe: use as is
+		// otherwise figure out if we have a virtual folder opened
+		let remoteName: string | undefined = undefined;
+		if (this.environmentService.remoteAuthority && !isWeb) {
+			remoteName = this.labelService.getHostLabel(Schemas.vscodeRemote, this.environmentService.remoteAuthority);
+		} else {
+			const virtualWorkspaceLocation = getVirtualWorkspaceLocation(workspace);
+			if (virtualWorkspaceLocation) {
+				remoteName = this.labelService.getHostLabel(virtualWorkspaceLocation.scheme, virtualWorkspaceLocation.authority);
+			}
+		}
+
+		// Variables
+		const activeEditorShort = editor ? editor.getTitle(Verbosity.SHORT) : '';
+		const activeEditorMedium = editor ? editor.getTitle(Verbosity.MEDIUM) : activeEditorShort;
+		const activeEditorLong = editor ? editor.getTitle(Verbosity.LONG) : activeEditorMedium;
+		const activeFolderShort = editorFolderResource ? basename(editorFolderResource) : '';
+		const activeFolderMedium = editorFolderResource ? this.labelService.getUriLabel(editorFolderResource, { relative: true }) : '';
+		const activeFolderLong = editorFolderResource ? this.labelService.getUriLabel(editorFolderResource) : '';
+		const rootName = this.labelService.getWorkspaceLabel(workspace);
+		const rootPath = root ? this.labelService.getUriLabel(root) : '';
+		const folderName = folder ? folder.name : '';
+		const folderPath = folder ? this.labelService.getUriLabel(folder.uri) : '';
+		const dirty = editor?.isDirty() && !editor.isSaving() ? WindowTitle.TITLE_DIRTY : '';
+		const appName = this.productService.nameLong;
+		const separator = this.configurationService.getValue<string>('window.titleSeparator');
+		const titleTemplate = this.configurationService.getValue<string>('window.title');
+
+		return template(titleTemplate, {
+			activeEditorShort,
+			activeEditorLong,
+			activeEditorMedium,
+			activeFolderShort,
+			activeFolderMedium,
+			activeFolderLong,
+			rootName,
+			rootPath,
+			folderName,
+			folderPath,
+			dirty,
+			appName,
+			remoteName,
+			separator: { label: separator }
+		});
+	}
+}

--- a/src/vs/workbench/electron-sandbox/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/electron-sandbox/parts/titlebar/titlebarPart.ts
@@ -7,7 +7,6 @@ import { getZoomFactor } from 'vs/base/browser/browser';
 import { $, addDisposableListener, append, EventType, hide, prepend, show } from 'vs/base/browser/dom';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
-import { ILabelService } from 'vs/platform/label/common/label';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/environment/electron-sandbox/environmentService';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
@@ -15,11 +14,8 @@ import { isMacintosh, isWindows, isLinux } from 'vs/base/common/platform';
 import { IMenuService } from 'vs/platform/actions/common/actions';
 import { TitlebarPart as BrowserTitleBarPart } from 'vs/workbench/browser/parts/titlebar/titlebarPart';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
-import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
-import { IProductService } from 'vs/platform/product/common/productService';
 import { INativeHostService } from 'vs/platform/native/electron-sandbox/native';
 import { getTitleBarStyle } from 'vs/platform/window/common/window';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -50,22 +46,18 @@ export class TitlebarPart extends BrowserTitleBarPart {
 	constructor(
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@IConfigurationService configurationService: IConfigurationService,
-		@IEditorService editorService: IEditorService,
 		@INativeWorkbenchEnvironmentService environmentService: INativeWorkbenchEnvironmentService,
-		@IWorkspaceContextService contextService: IWorkspaceContextService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IThemeService themeService: IThemeService,
-		@ILabelService labelService: ILabelService,
 		@IStorageService storageService: IStorageService,
 		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService,
 		@IMenuService menuService: IMenuService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IHostService hostService: IHostService,
-		@IProductService productService: IProductService,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
 		@IKeybindingService keybindingService: IKeybindingService,
 	) {
-		super(contextMenuService, configurationService, editorService, environmentService, contextService, instantiationService, themeService, labelService, storageService, layoutService, menuService, contextKeyService, hostService, productService, keybindingService);
+		super(contextMenuService, configurationService, environmentService, instantiationService, themeService, storageService, layoutService, menuService, contextKeyService, hostService, keybindingService);
 
 		this.environmentService = environmentService;
 	}


### PR DESCRIPTION
* Extracts the logic that determines the window title into a UI-less buisness object (`WindowTitle`)
* Move the "menu title" under the same DOM node as the plain "text title" so that layouting rules are aligned
