### PR TITLE
Fix #142756

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
@@ -929,7 +929,7 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 
 		matches.forEach(match => {
 			match.matches.forEach((singleMatch, index) => {
-				if ((singleMatch as OutputFindMatch).index !== undefined) {
+				if ((singleMatch as OutputFindMatch).index === undefined) {
 					textEdits.push({
 						edit: { range: (singleMatch as FindMatch).range, text: texts[index] },
 						resource: match.cell.uri


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #142756.

When running replace all in notebook, we check if a find match is on input or output, and only allow replacement on input. it's an oversight that we did the wrong check.
