### PR TITLE
Improve a11y for Settings editor markdown links

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -452,15 +452,16 @@
 	margin: 0px;
 }
 
-.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-trust-description a:focus
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-trust-description a:focus,
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a:focus {
 	outline: 1px solid -webkit-focus-ring-color;
 	outline-offset: -1px;
 	text-decoration: underline;
 }
 
-.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-trust-description a:hover
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-trust-description a:hover,
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-markdown a:hover {
+	cursor: pointer;
 	text-decoration: underline;
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #148747

1. Add commas so that we don't try to interpret the two lines of rules as a single CSS rule. I'm not sure if there's a way to add a linting rule for this. It took a while to realize why the CSS wasn't being applied at all.
2. Add a `cursor: pointer` line so that when users hover over a link in the Settings editor, the cursor changes to a pointer hand.
