### PR TITLE
Improve notebook language detection CPU

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -112,17 +112,21 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				description: localize('workbench.editor.preferBasedLanguageDetection', "When enabled, a language detection model that takes into account editor history will be given higher precedence."),
 			},
 			'workbench.editor.languageDetectionHints': {
-				type: 'string',
-				default: 'always',
+				type: 'object',
+				default: { 'untitledEditors': true, 'notebookEditors': false },
 				tags: ['experimental'],
-				enum: ['always', 'notebookEditors', 'textEditors', 'never'],
 				description: localize('workbench.editor.showLanguageDetectionHints', "When enabled, shows a status bar quick fix when the editor language doesn't match detected content language."),
-				enumDescriptions: [
-					localize('workbench.editor.showLanguageDetectionHints.always', "Show show language detection quick fixes in both notebooks and untitled editors"),
-					localize('workbench.editor.showLanguageDetectionHints.notebook', "Only show language detection quick fixes in notebooks"),
-					localize('workbench.editor.showLanguageDetectionHints.editors', "Only show language detection quick fixes in untitled editors"),
-					localize('workbench.editor.showLanguageDetectionHints.never', "Never show language quick fixes"),
-				]
+				additionalProperties: false,
+				properties: {
+					untitledEditors: {
+						type: 'boolean',
+						description: localize('workbench.editor.showLanguageDetectionHints.editors', "Show in untitled text editors"),
+					},
+					notebookEditors: {
+						type: 'boolean',
+						description: localize('workbench.editor.showLanguageDetectionHints.notebook', "Show in notebook editors"),
+					}
+				}
 			},
 			'workbench.editor.tabCloseButton': {
 				'type': 'string',

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -113,7 +113,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			},
 			'workbench.editor.languageDetectionHints': {
 				type: 'object',
-				default: { 'untitledEditors': true, 'notebookEditors': false },
+				default: { 'untitledEditors': true, 'notebookEditors': true },
 				tags: ['experimental'],
 				description: localize('workbench.editor.showLanguageDetectionHints', "When enabled, shows a status bar quick fix when the editor language doesn't match detected content language."),
 				additionalProperties: false,

--- a/src/vs/workbench/contrib/languageDetection/browser/languageDetection.contribution.ts
+++ b/src/vs/workbench/contrib/languageDetection/browser/languageDetection.contribution.ts
@@ -11,7 +11,7 @@ import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWo
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
-import { ILanguageDetectionService } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
+import { ILanguageDetectionService, LanguageDetectionHintConfig } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
 import { ThrottledDelayer } from 'vs/base/common/async';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
@@ -75,8 +75,8 @@ class LanguageDetectionStatusContribution implements IWorkbenchContribution {
 		const editorModel = editor?.getModel();
 		const editorUri = editorModel?.uri;
 		const existingId = editorModel?.getLanguageId();
-		const enablementConfig = this._configurationService.getValue('workbench.editor.languageDetectionHints');
-		const enabled = enablementConfig === 'always' || enablementConfig === 'textEditors';
+		const enablementConfig = this._configurationService.getValue<LanguageDetectionHintConfig>('workbench.editor.languageDetectionHints');
+		const enabled = typeof enablementConfig === 'object' && enablementConfig?.untitledEditors;
 		const disableLightbulb = !enabled || editorUri?.scheme !== Schemas.untitled || !existingId;
 
 		if (disableLightbulb || !editorUri) {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
@@ -19,7 +19,7 @@ import { INotebookCellStatusBarService } from 'vs/workbench/contrib/notebook/com
 import { CellKind, CellStatusbarAlignment, INotebookCellStatusBarItem, INotebookCellStatusBarItemList, INotebookCellStatusBarItemProvider } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
-import { ILanguageDetectionService } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
+import { ILanguageDetectionService, LanguageDetectionHintConfig } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 
 class CellStatusBarLanguagePickerProvider implements INotebookCellStatusBarItemProvider {
@@ -79,8 +79,8 @@ class CellStatusBarLanguageDetectionProvider implements INotebookCellStatusBarIt
 		const cell = doc?.cells[index];
 		if (!cell) { return; }
 
-		const enablementConfig = this._configurationService.getValue('workbench.editor.languageDetectionHints');
-		const enabled = enablementConfig === 'always' || enablementConfig === 'notebookEditors';
+		const enablementConfig = this._configurationService.getValue<LanguageDetectionHintConfig>('workbench.editor.languageDetectionHints');
+		const enabled = typeof enablementConfig === 'object' && enablementConfig?.notebookEditors;
 		if (!enabled) {
 			return;
 		}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
@@ -113,7 +113,6 @@ class CellStatusBarLanguageDetectionProvider implements INotebookCellStatusBarIt
 			const kernel = this._notebookKernelService.getSelectedOrSuggestedKernel(doc);
 			if (kernel) {
 				const supportedLangs = [...kernel.supportedLanguages, 'markdown'];
-				console.log('running a detection!');
 				cached.guess = await this._languageDetectionService.detectLanguage(cell.uri, supportedLangs);
 			}
 		}

--- a/src/vs/workbench/services/languageDetection/common/languageDetectionWorkerService.ts
+++ b/src/vs/workbench/services/languageDetection/common/languageDetectionWorkerService.ts
@@ -25,6 +25,11 @@ export interface ILanguageDetectionService {
 	detectLanguage(resource: URI, supportedLangs?: string[]): Promise<string | undefined>;
 }
 
+export type LanguageDetectionHintConfig = {
+	untitledEditors: boolean;
+	notebookEditors: boolean;
+};
+
 //#region Telemetry events
 
 export const AutomaticLanguageDetectionLikelyWrongId = 'automaticlanguagedetection.likelywrong';


### PR DESCRIPTION
Reduces the running of language detection to once per document version, once per second, and only modified cells.

Fixes #148762.