### PR TITLE
Make quick suggest setting settings editor friendly

### DIFF
--- a/src/vs/editor/browser/config/migrateOptions.ts
+++ b/src/vs/editor/browser/config/migrateOptions.ts
@@ -163,3 +163,11 @@ registerEditorSettingMigration('suggest.filteredTypes', (value, read, write) => 
 		write('suggest.filteredTypes', undefined);
 	}
 });
+
+registerEditorSettingMigration('quickSuggestions', (input, read, write) => {
+	if (typeof input === 'boolean') {
+		const value = input ? 'on' : 'off';
+		const newValue = { comments: value, strings: value, other: value };
+		write('quickSuggestions', newValue);
+	}
+});

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2927,35 +2927,28 @@ class EditorQuickSuggestions extends BaseEditorOption<EditorOption.quickSuggesti
 				enumDescriptions: [nls.localize('on', "Quick suggestions show inside the suggest widget"), nls.localize('inline', "Quick suggestions show as ghost text"), nls.localize('off', "Quick suggestions are disabled")]
 			}
 		];
-		super(
-			EditorOption.quickSuggestions, 'quickSuggestions', defaults,
-			{
-				anyOf: [{
-					type: 'boolean',
-				}, {
-					type: 'object',
-					properties: {
-						strings: {
-							anyOf: types,
-							default: defaults.strings,
-							description: nls.localize('quickSuggestions.strings', "Enable quick suggestions inside strings.")
-						},
-						comments: {
-							anyOf: types,
-							default: defaults.comments,
-							description: nls.localize('quickSuggestions.comments', "Enable quick suggestions inside comments.")
-						},
-						other: {
-							anyOf: types,
-							default: defaults.other,
-							description: nls.localize('quickSuggestions.other', "Enable quick suggestions outside of strings and comments.")
-						},
-					}
-				}],
-				default: defaults,
-				markdownDescription: nls.localize('quickSuggestions', "Controls whether suggestions should automatically show up while typing.")
-			}
-		);
+		super(EditorOption.quickSuggestions, 'quickSuggestions', defaults, {
+			type: 'object',
+			properties: {
+				strings: {
+					anyOf: types,
+					default: defaults.strings,
+					description: nls.localize('quickSuggestions.strings', "Enable quick suggestions inside strings.")
+				},
+				comments: {
+					anyOf: types,
+					default: defaults.comments,
+					description: nls.localize('quickSuggestions.comments', "Enable quick suggestions inside comments.")
+				},
+				other: {
+					anyOf: types,
+					default: defaults.other,
+					description: nls.localize('quickSuggestions.other', "Enable quick suggestions outside of strings and comments.")
+				},
+			},
+			default: defaults,
+			markdownDescription: nls.localize('quickSuggestions', "Controls whether suggestions should automatically show up while typing.")
+		});
 		this.defaultValue = defaults;
 	}
 

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2929,6 +2929,7 @@ class EditorQuickSuggestions extends BaseEditorOption<EditorOption.quickSuggesti
 		];
 		super(EditorOption.quickSuggestions, 'quickSuggestions', defaults, {
 			type: 'object',
+			additionalProperties: false,
 			properties: {
 				strings: {
 					anyOf: types,
@@ -2947,7 +2948,7 @@ class EditorQuickSuggestions extends BaseEditorOption<EditorOption.quickSuggesti
 				},
 			},
 			default: defaults,
-			markdownDescription: nls.localize('quickSuggestions', "Controls whether suggestions should automatically show up while typing.")
+			markdownDescription: nls.localize('quickSuggestions', "Controls whether suggestions should automatically show up while typing. This can be controlled for typing in comments, strings, and other code. Quick suggestion can be configured to show as ghost text or with the suggest widget.")
 		});
 		this.defaultValue = defaults;
 	}

--- a/src/vs/editor/test/browser/config/editorConfiguration.test.ts
+++ b/src/vs/editor/test/browser/config/editorConfiguration.test.ts
@@ -326,6 +326,11 @@ suite('migrateOptions', () => {
 			}
 		});
 	});
+	test('quickSuggestions', () => {
+		assert.deepStrictEqual(migrate({ quickSuggestions: true }), { quickSuggestions: { comments: 'on', strings: 'on', other: 'on' } });
+		assert.deepStrictEqual(migrate({ quickSuggestions: false }), { quickSuggestions: { comments: 'off', strings: 'off', other: 'off' } });
+		assert.deepStrictEqual(migrate({ quickSuggestions: { comments: 'on', strings: 'off' } }), { quickSuggestions: { comments: 'on', strings: 'off' } });
+	});
 	test('hover', () => {
 		assert.deepStrictEqual(migrate({ hover: true }), { hover: { enabled: true } });
 		assert.deepStrictEqual(migrate({ hover: false }), { hover: { enabled: false } });


### PR DESCRIPTION
- make `quickSuggestions` settings just an object, no more anyOf, add editor-specific migration logic for this setting
- mark object as "closed", add more doc

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/148163
