### PR TITLE
Add editor monitoring methods in monaco api

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -13,7 +13,7 @@ import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService
 import { DiffNavigator, IDiffNavigator } from 'vs/editor/browser/widget/diffNavigator';
 import { ApplyUpdateResult, ConfigurationChangedEvent, EditorOptions } from 'vs/editor/common/config/editorOptions';
 import { BareFontInfo, FontInfo } from 'vs/editor/common/config/fontInfo';
-import { EditorType } from 'vs/editor/common/editorCommon';
+import { EditorType, IDiffEditor } from 'vs/editor/common/editorCommon';
 import { FindMatch, ITextModel, TextModelResolvedOptions } from 'vs/editor/common/model';
 import * as languages from 'vs/editor/common/languages';
 import { ILanguageConfigurationService } from 'vs/editor/common/languages/languageConfigurationRegistry';
@@ -50,6 +50,33 @@ export function onDidCreateEditor(listener: (codeEditor: ICodeEditor) => void): 
 	return codeEditorService.onCodeEditorAdd((editor) => {
 		listener(<ICodeEditor>editor);
 	});
+}
+
+/**
+ * Emitted when an diff editor is created.
+ * @event
+ */
+export function onDidCreateDiffEditor(listener: (diffEditor: IDiffEditor) => void): IDisposable {
+	const codeEditorService = StandaloneServices.get(ICodeEditorService);
+	return codeEditorService.onDiffEditorAdd((editor) => {
+		listener(<IDiffEditor>editor);
+	});
+}
+
+/**
+ * Get all the created editors.
+ */
+export function getEditors(): readonly ICodeEditor[] {
+	const codeEditorService = StandaloneServices.get(ICodeEditorService);
+	return codeEditorService.listCodeEditors();
+}
+
+/**
+ * Get all the created diff editors.
+ */
+export function getDiffEditors(): readonly IDiffEditor[] {
+	const codeEditorService = StandaloneServices.get(ICodeEditorService);
+	return codeEditorService.listDiffEditors();
 }
 
 /**
@@ -283,7 +310,10 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 	return {
 		// methods
 		create: <any>create,
+		getEditors: <any>getEditors,
+		getDiffEditors: <any>getDiffEditors,
 		onDidCreateEditor: <any>onDidCreateEditor,
+		onDidCreateDiffEditor: <any>onDidCreateDiffEditor,
 		createDiffEditor: <any>createDiffEditor,
 		createDiffNavigator: <any>createDiffNavigator,
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -891,6 +891,22 @@ declare namespace monaco.editor {
 	export function onDidCreateEditor(listener: (codeEditor: ICodeEditor) => void): IDisposable;
 
 	/**
+	 * Emitted when an diff editor is created.
+	 * @event
+	 */
+	export function onDidCreateDiffEditor(listener: (diffEditor: IDiffEditor) => void): IDisposable;
+
+	/**
+	 * Get all the created editors.
+	 */
+	export function getEditors(): readonly ICodeEditor[];
+
+	/**
+	 * Get all the created diff editors.
+	 */
+	export function getDiffEditors(): readonly IDiffEditor[];
+
+	/**
 	 * Create a new diff editor under `domElement`.
 	 * `domElement` should be empty (not contain other dom nodes).
 	 * The editor will read the size of `domElement`.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/monaco-editor/issues/3095

The monaco api exposes a `onDidCreateEditor` method to listen for editor creation, but do not allow to get currently open editors nor to listen on diff editor creation. This PR adds these features.
