### PR TITLE
only allow primitive types in history navigation widget context

### DIFF
--- a/src/vs/base/browser/history.ts
+++ b/src/vs/base/browser/history.ts
@@ -3,10 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Event } from 'vs/base/common/event';
+
 export interface IHistoryNavigationWidget {
+
+	readonly element: HTMLElement;
 
 	showPreviousValue(): void;
 
 	showNextValue(): void;
+
+	onDidFocus: Event<void>;
+
+	onDidBlur: Event<void>;
 
 }

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -128,6 +128,12 @@ export class InputBox extends Widget {
 	private _onDidHeightChange = this._register(new Emitter<number>());
 	public readonly onDidHeightChange: Event<number> = this._onDidHeightChange.event;
 
+	private readonly _onDidFocus = this._register(new Emitter<void>());
+	readonly onDidFocus = this._onDidFocus.event;
+
+	private readonly _onDidBlur = this._register(new Emitter<void>());
+	readonly onDidBlur = this._onDidBlur.event;
+
 	constructor(container: HTMLElement, contextViewProvider: IContextViewProvider | undefined, options?: IInputOptions) {
 		super();
 
@@ -238,6 +244,7 @@ export class InputBox extends Widget {
 		if (this.options.showPlaceholderOnFocus) {
 			this.input.setAttribute('placeholder', '');
 		}
+		this._onDidBlur.fire();
 	}
 
 	private onFocus(): void {
@@ -245,6 +252,7 @@ export class InputBox extends Widget {
 		if (this.options.showPlaceholderOnFocus) {
 			this.input.setAttribute('placeholder', this.placeholder || '');
 		}
+		this._onDidFocus.fire();
 	}
 
 	public setPlaceHolder(placeHolder: string): void {

--- a/src/vs/platform/history/browser/contextScopedHistoryWidget.ts
+++ b/src/vs/platform/history/browser/contextScopedHistoryWidget.ts
@@ -9,51 +9,69 @@ import { FindInput, IFindInputOptions } from 'vs/base/browser/ui/findinput/findI
 import { IReplaceInputOptions, ReplaceInput } from 'vs/base/browser/ui/findinput/replaceInput';
 import { HistoryInputBox, IHistoryInputOptions } from 'vs/base/browser/ui/inputbox/inputBox';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
-import { ContextKeyExpr, IContextKey, IContextKeyService, IContextKeyServiceTarget, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { localize } from 'vs/nls';
+import { DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 
 export const historyNavigationVisible = new RawContextKey<boolean>('suggestWidgetVisible', false, localize('suggestWidgetVisible', "Whether suggestion are visible"));
 
-export const HistoryNavigationWidgetContext = 'historyNavigationWidget';
+const HistoryNavigationWidgetFocusContext = 'historyNavigationWidgetFocus';
 const HistoryNavigationForwardsEnablementContext = 'historyNavigationForwardsEnabled';
 const HistoryNavigationBackwardsEnablementContext = 'historyNavigationBackwardsEnabled';
 
-function bindContextScopedWidget(contextKeyService: IContextKeyService, widget: IContextScopedWidget, contextKey: string): void {
-	new RawContextKey<IContextScopedWidget>(contextKey, widget).bindTo(contextKeyService);
-}
-
-function createWidgetScopedContextKeyService(contextKeyService: IContextKeyService, widget: IContextScopedWidget): IContextKeyService {
-	return contextKeyService.createScoped(widget.target);
-}
-
-function getContextScopedWidget<T extends IContextScopedWidget>(contextKeyService: IContextKeyService, contextKey: string): T | undefined {
-	return contextKeyService.getContext(document.activeElement).getValue(contextKey);
-}
-
-interface IContextScopedWidget {
-	readonly target: IContextKeyServiceTarget;
-}
-
-export interface IContextScopedHistoryNavigationWidget extends IContextScopedWidget {
-	historyNavigator: IHistoryNavigationWidget;
-}
-
-export interface IHistoryNavigationContext {
+export interface IHistoryNavigationContext extends IDisposable {
 	scopedContextKeyService: IContextKeyService;
 	historyNavigationForwardsEnablement: IContextKey<boolean>;
 	historyNavigationBackwardsEnablement: IContextKey<boolean>;
 }
 
-export function createAndBindHistoryNavigationWidgetScopedContextKeyService(contextKeyService: IContextKeyService, widget: IContextScopedHistoryNavigationWidget): IHistoryNavigationContext {
-	const scopedContextKeyService = createWidgetScopedContextKeyService(contextKeyService, widget);
-	bindContextScopedWidget(scopedContextKeyService, widget, HistoryNavigationWidgetContext);
+let lastFocusedWidget: IHistoryNavigationWidget | undefined = undefined;
+const widgets: IHistoryNavigationWidget[] = [];
+
+export function registerAndCreateHistoryNavigationContext(contextKeyService: IContextKeyService, widget: IHistoryNavigationWidget): IHistoryNavigationContext {
+	if (widgets.includes(widget)) {
+		throw new Error('Cannot register the same widget multiple times');
+	}
+
+	widgets.push(widget);
+	const disposableStore = new DisposableStore();
+	const scopedContextKeyService = disposableStore.add(contextKeyService.createScoped(widget.element));
+	const historyNavigationWidgetFocus = new RawContextKey<boolean>(HistoryNavigationWidgetFocusContext, false).bindTo(contextKeyService);
 	const historyNavigationForwardsEnablement = new RawContextKey<boolean>(HistoryNavigationForwardsEnablementContext, true).bindTo(scopedContextKeyService);
 	const historyNavigationBackwardsEnablement = new RawContextKey<boolean>(HistoryNavigationBackwardsEnablementContext, true).bindTo(scopedContextKeyService);
+
+	const onDidFocus = () => {
+		historyNavigationWidgetFocus.set(true);
+		lastFocusedWidget = widget;
+	};
+
+	const onDidBlur = () => {
+		historyNavigationWidgetFocus.set(false);
+		if (lastFocusedWidget === widget) {
+			lastFocusedWidget = undefined;
+		}
+	};
+
+	// Check for currently being focused
+	if (widget.element === document.activeElement) {
+		onDidFocus();
+	}
+
+	disposableStore.add(widget.onDidFocus(() => onDidFocus()));
+	disposableStore.add(widget.onDidBlur(() => onDidBlur()));
+	disposableStore.add(toDisposable(() => {
+		widgets.splice(widgets.indexOf(widget), 1);
+		onDidBlur();
+	}));
+
 	return {
 		scopedContextKeyService,
 		historyNavigationForwardsEnablement,
 		historyNavigationBackwardsEnablement,
+		dispose() {
+			disposableStore.dispose();
+		}
 	};
 }
 
@@ -63,7 +81,7 @@ export class ContextScopedHistoryInputBox extends HistoryInputBox {
 		@IContextKeyService contextKeyService: IContextKeyService
 	) {
 		super(container, contextViewProvider, options);
-		this._register(createAndBindHistoryNavigationWidgetScopedContextKeyService(contextKeyService, <IContextScopedHistoryNavigationWidget>{ target: this.element, historyNavigator: this }).scopedContextKeyService);
+		this._register(registerAndCreateHistoryNavigationContext(contextKeyService, this));
 	}
 
 }
@@ -74,7 +92,7 @@ export class ContextScopedFindInput extends FindInput {
 		@IContextKeyService contextKeyService: IContextKeyService, showFindOptions: boolean = false
 	) {
 		super(container, contextViewProvider, showFindOptions, options);
-		this._register(createAndBindHistoryNavigationWidgetScopedContextKeyService(contextKeyService, <IContextScopedHistoryNavigationWidget>{ target: this.inputBox.element, historyNavigator: this.inputBox }).scopedContextKeyService);
+		this._register(registerAndCreateHistoryNavigationContext(contextKeyService, this.inputBox));
 	}
 }
 
@@ -84,7 +102,7 @@ export class ContextScopedReplaceInput extends ReplaceInput {
 		@IContextKeyService contextKeyService: IContextKeyService, showReplaceOptions: boolean = false
 	) {
 		super(container, contextViewProvider, showReplaceOptions, options);
-		this._register(createAndBindHistoryNavigationWidgetScopedContextKeyService(contextKeyService, <IContextScopedHistoryNavigationWidget>{ target: this.inputBox.element, historyNavigator: this.inputBox }).scopedContextKeyService);
+		this._register(registerAndCreateHistoryNavigationContext(contextKeyService, this.inputBox));
 	}
 
 }
@@ -93,17 +111,15 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'history.showPrevious',
 	weight: KeybindingWeight.WorkbenchContrib,
 	when: ContextKeyExpr.and(
-		ContextKeyExpr.has(HistoryNavigationWidgetContext),
+		ContextKeyExpr.has(HistoryNavigationWidgetFocusContext),
 		ContextKeyExpr.equals(HistoryNavigationBackwardsEnablementContext, true),
 		historyNavigationVisible.isEqualTo(false),
 	),
 	primary: KeyCode.UpArrow,
 	secondary: [KeyMod.Alt | KeyCode.UpArrow],
 	handler: (accessor) => {
-		const widget = getContextScopedWidget<IContextScopedHistoryNavigationWidget>(accessor.get(IContextKeyService), HistoryNavigationWidgetContext);
-		if (widget) {
-			const historyInputBox: IHistoryNavigationWidget = widget.historyNavigator;
-			historyInputBox.showPreviousValue();
+		if (lastFocusedWidget) {
+			lastFocusedWidget.showPreviousValue();
 		}
 	}
 });
@@ -112,17 +128,15 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'history.showNext',
 	weight: KeybindingWeight.WorkbenchContrib,
 	when: ContextKeyExpr.and(
-		ContextKeyExpr.has(HistoryNavigationWidgetContext),
+		ContextKeyExpr.has(HistoryNavigationWidgetFocusContext),
 		ContextKeyExpr.equals(HistoryNavigationForwardsEnablementContext, true),
 		historyNavigationVisible.isEqualTo(false),
 	),
 	primary: KeyCode.DownArrow,
 	secondary: [KeyMod.Alt | KeyCode.DownArrow],
 	handler: (accessor) => {
-		const widget = getContextScopedWidget<IContextScopedHistoryNavigationWidget>(accessor.get(IContextKeyService), HistoryNavigationWidgetContext);
-		if (widget) {
-			const historyInputBox: IHistoryNavigationWidget = widget.historyNavigator;
-			historyInputBox.showNextValue();
+		if (lastFocusedWidget) {
+			lastFocusedWidget.showNextValue();
 		}
 	}
 });

--- a/src/vs/platform/history/browser/contextScopedHistoryWidget.ts
+++ b/src/vs/platform/history/browser/contextScopedHistoryWidget.ts
@@ -37,7 +37,7 @@ export function registerAndCreateHistoryNavigationContext(contextKeyService: ICo
 	widgets.push(widget);
 	const disposableStore = new DisposableStore();
 	const scopedContextKeyService = disposableStore.add(contextKeyService.createScoped(widget.element));
-	const historyNavigationWidgetFocus = new RawContextKey<boolean>(HistoryNavigationWidgetFocusContext, false).bindTo(contextKeyService);
+	const historyNavigationWidgetFocus = new RawContextKey<boolean>(HistoryNavigationWidgetFocusContext, false).bindTo(scopedContextKeyService);
 	const historyNavigationForwardsEnablement = new RawContextKey<boolean>(HistoryNavigationForwardsEnablementContext, true).bindTo(scopedContextKeyService);
 	const historyNavigationBackwardsEnablement = new RawContextKey<boolean>(HistoryNavigationBackwardsEnablementContext, true).bindTo(scopedContextKeyService);
 

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -42,7 +42,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ContextKeyExpr, IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
-import { createAndBindHistoryNavigationWidgetScopedContextKeyService } from 'vs/platform/history/browser/contextScopedHistoryWidget';
+import { registerAndCreateHistoryNavigationContext } from 'vs/platform/history/browser/contextScopedHistoryWidget';
 import { showHistoryKeybindingHint } from 'vs/platform/history/browser/historyWidgetKeybindingHint';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
@@ -637,12 +637,11 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 		this.replInputContainer = dom.append(container, $('.repl-input-wrapper'));
 		dom.append(this.replInputContainer, $('.repl-input-chevron' + ThemeIcon.asCSSSelector(debugConsoleEvaluationPrompt)));
 
-		const { scopedContextKeyService, historyNavigationBackwardsEnablement, historyNavigationForwardsEnablement } = createAndBindHistoryNavigationWidgetScopedContextKeyService(this.contextKeyService, { target: container, historyNavigator: this });
+		const { scopedContextKeyService, historyNavigationBackwardsEnablement, historyNavigationForwardsEnablement } = this._register(registerAndCreateHistoryNavigationContext(this.contextKeyService, this));
 		this.setHistoryNavigationEnablement = enabled => {
 			historyNavigationBackwardsEnablement.set(enabled);
 			historyNavigationForwardsEnablement.set(enabled);
 		};
-		this._register(scopedContextKeyService);
 		CONTEXT_IN_DEBUG_REPL.bindTo(scopedContextKeyService).set(true);
 
 		this.scopedInstantiationService = this.instantiationService.createChild(new ServiceCollection([IContextKeyService, scopedContextKeyService]));

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
@@ -15,7 +15,7 @@ import 'vs/css!./notebookFindReplaceWidget';
 import { FindReplaceState, FindReplaceStateChangedEvent } from 'vs/editor/contrib/find/browser/findState';
 import { findNextMatchIcon, findPreviousMatchIcon, findReplaceAllIcon, findReplaceIcon, SimpleButton } from 'vs/editor/contrib/find/browser/findWidget';
 import * as nls from 'vs/nls';
-import { ContextScopedReplaceInput, createAndBindHistoryNavigationWidgetScopedContextKeyService, IContextScopedHistoryNavigationWidget } from 'vs/platform/history/browser/contextScopedHistoryWidget';
+import { ContextScopedReplaceInput, registerAndCreateHistoryNavigationContext } from 'vs/platform/history/browser/contextScopedHistoryWidget';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { editorWidgetBackground, editorWidgetForeground, inputActiveOptionBackground, inputActiveOptionBorder, inputActiveOptionForeground, inputBackground, inputBorder, inputForeground, inputValidationErrorBackground, inputValidationErrorBorder, inputValidationErrorForeground, inputValidationInfoBackground, inputValidationInfoBorder, inputValidationInfoForeground, inputValidationWarningBackground, inputValidationWarningBorder, inputValidationWarningForeground, widgetShadow } from 'vs/platform/theme/common/colorRegistry';
@@ -162,7 +162,7 @@ class NotebookFindInput extends FindInput {
 		parent: HTMLElement | null, contextViewProvider: IContextViewProvider, showOptionButtons: boolean, options: IFindInputOptions) {
 		super(parent, contextViewProvider, showOptionButtons, options);
 
-		this._register(createAndBindHistoryNavigationWidgetScopedContextKeyService(contextKeyService, <IContextScopedHistoryNavigationWidget>{ target: this.inputBox.element, historyNavigator: this.inputBox }).scopedContextKeyService);
+		this._register(registerAndCreateHistoryNavigationContext(contextKeyService, this.inputBox));
 		this._filtersAction = new Action('notebookFindFilterAction', NOTEBOOK_FIND_FILTERS, 'notebook-filters ' + ThemeIcon.asClassName(filterIcon));
 		this._filtersAction.checked = false;
 		this._filterButtonContainer = dom.$('.find-filter-button');

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -563,7 +563,7 @@ export class SettingsEditor2 extends EditorPane {
 			focusContextKey: this.searchFocusContextKey,
 			// TODO: Aria-live
 		}));
-		this._register(this.searchWidget.onFocus(() => {
+		this._register(this.searchWidget.onDidFocus(() => {
 			this._currentFocusContext = SettingsFocusContext.Search;
 		}));
 


### PR DESCRIPTION
This is necessary for the [PR](https://github.com/microsoft/vscode/pull/147926) that is to allow only primitive types in context keys

- Remove setting history navigation widget in the context
- Maintain a list of history navigation widgets
- Remember the last focused history navigation widget
- Use that while running navigation commands