### PR TITLE
Deprecate publicLog and point people towards the 2 variant

### DIFF
--- a/src/vs/platform/telemetry/common/telemetry.ts
+++ b/src/vs/platform/telemetry/common/telemetry.ts
@@ -32,13 +32,19 @@ export interface ITelemetryService {
 	readonly _serviceBrand: undefined;
 
 	/**
-	 * Sends a telemetry event that has been privacy approved.
-	 * Do not call this unless you have been given approval.
+	 * @deprecated Use publicLog2 and the typescript GDPR annotation where possible
 	 */
 	publicLog(eventName: string, data?: ITelemetryData, anonymizeFilePaths?: boolean): Promise<void>;
 
+	/**
+	 * Sends a telemetry event that has been privacy approved.
+	 * Do not call this unless you have been given approval.
+	 */
 	publicLog2<E extends ClassifiedEvent<T> = never, T extends GDPRClassification<T> = never>(eventName: string, data?: StrictPropertyCheck<T, E>, anonymizeFilePaths?: boolean): Promise<void>;
 
+	/**
+	 * @deprecated Use publicLogError2 and the typescript GDPR annotation where possible
+	 */
 	publicLogError(errorEventName: string, data?: ITelemetryData): Promise<void>;
 
 	publicLogError2<E extends ClassifiedEvent<T> = never, T extends GDPRClassification<T> = never>(eventName: string, data?: StrictPropertyCheck<T, E>): Promise<void>;


### PR DESCRIPTION
Some people still accidentally use `publicLog` in cases where `publicLog2` can be used. This just adds the deprecation strike through to point people in the right direction. Maybe we should eventually rename `publicLog2` to `publicLog` and then `publicLog` to `publicLogDeprecated` or something but that would break extensions who use `publicLog2`