### PR TITLE
Have forceNewSession behave like createIfNone if no sessions are present

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -210,9 +210,6 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		const supportsMultipleAccounts = this.authenticationService.supportsMultipleAccounts(providerId);
 
 		// Error cases
-		if (options.forceNewSession && !sessions.length) {
-			throw new Error('No existing sessions found.');
-		}
 		if (options.forceNewSession && options.createIfNone) {
 			throw new Error('Invalid combination of options. Please remove one of the following: forceNewSession, createIfNone');
 		}
@@ -247,7 +244,11 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		if (options.createIfNone || options.forceNewSession) {
 			const providerName = this.authenticationService.getLabel(providerId);
 			const detail = (typeof options.forceNewSession === 'object') ? options.forceNewSession!.detail : undefined;
-			const isAllowed = await this.loginPrompt(providerName, extensionName, !!options.forceNewSession, detail);
+
+			// We only want to show the "recreating session" prompt if we are using forceNewSession & there are sessions
+			// that we will be "forcing through".
+			const recreatingSession = !!(options.forceNewSession && sessions.length);
+			const isAllowed = await this.loginPrompt(providerName, extensionName, recreatingSession, detail);
 			if (!isAllowed) {
 				throw new Error('User did not consent to login.');
 			}

--- a/src/vs/workbench/api/test/browser/extHostAuthentication.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostAuthentication.test.ts
@@ -211,7 +211,7 @@ suite('ExtHostAuthentication', () => {
 		assert.strictEqual(session.scopes[0], session2?.scopes[0]);
 	});
 
-	test('forceNewSession - true', async () => {
+	test('forceNewSession - true - existing session', async () => {
 		const scopes = ['foo'];
 		const session1 = await extHostAuthentication.getSession(
 			extensionDescription,
@@ -233,6 +233,20 @@ suite('ExtHostAuthentication', () => {
 		assert.strictEqual(session2?.id, '2');
 		assert.strictEqual(session2?.scopes[0], 'foo');
 		assert.notStrictEqual(session1.accessToken, session2?.accessToken);
+	});
+
+	// Should behave like createIfNone: true
+	test('forceNewSession - true - no existing session', async () => {
+		const scopes = ['foo'];
+		const session = await extHostAuthentication.getSession(
+			extensionDescription,
+			'test',
+			scopes,
+			{
+				forceNewSession: true
+			});
+		assert.strictEqual(session?.id, '1');
+		assert.strictEqual(session?.scopes[0], 'foo');
 	});
 
 	test('forceNewSession - detail', async () => {
@@ -349,21 +363,6 @@ suite('ExtHostAuthentication', () => {
 	//#endregion
 
 	//#region error cases
-
-	test('forceNewSession with no sessions', async () => {
-		try {
-			await extHostAuthentication.getSession(
-				extensionDescription,
-				'test',
-				['foo'],
-				{
-					forceNewSession: true
-				});
-			assert.fail('should have thrown an Error.');
-		} catch (e) {
-			assert.strictEqual(e.message, 'No existing sessions found.');
-		}
-	});
 
 	test('createIfNone and forceNewSession', async () => {
 		try {

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -14724,7 +14724,10 @@ declare module 'vscode' {
 		 * If true, a modal dialog will be shown asking the user to sign in again. This is mostly used for scenarios
 		 * where the token needs to be re minted because it has lost some authorization.
 		 *
-		 * Defaults to false.
+		 * If there are no existing sessions and forceNewSession is true, it will behave identically to
+		 * {@link AuthenticationGetSessionOptions.createIfNone createIfNone}.
+		 *
+		 * This defaults to false.
 		 */
 		forceNewSession?: boolean | { detail: string };
 


### PR DESCRIPTION
The idea is, `forceNewSession` should just do what `createIfNone` does if no session was found.