### PR TITLE
Decode clicked uris in markdown notebook cells

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -686,7 +686,7 @@ var requirejs = (function() {
 						linkToOpen = data.href;
 					} else if (!/^[\w\-]+:/.test(data.href)) {
 						const fragmentStartIndex = data.href.lastIndexOf('#');
-						const path = fragmentStartIndex >= 0 ? data.href.slice(0, fragmentStartIndex) : data.href;
+						const path = decodeURI(fragmentStartIndex >= 0 ? data.href.slice(0, fragmentStartIndex) : data.href);
 						if (this.documentUri.scheme === Schemas.untitled) {
 							const folders = this.workspaceContextService.getWorkspace().folders;
 							if (!folders.length) {


### PR DESCRIPTION
Fixes #148519

These links end up being encoded by the markdown renderer. We need to decode them before trying to use them here
