### PR TITLE
No flicker anymore for output update

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/docs/notebook.layout.md
+++ b/src/vs/workbench/contrib/notebook/browser/docs/notebook.layout.md
@@ -136,10 +136,6 @@ Code cell outputs and markdown cells are both rendered in the underlying webview
 
 Whether users would see flickering or overlap of outputs, monaco editor and markdown cells depends on the latency between 3.2 and 3.3.
 
-### What's the catch
-
-Setting `overflow: hidden` turns out to be imperfect. When we replace outputs (or just in place rerender), due to the existence of `overflow: hidden`, the whole output container will be invisible for a super short period (as height changes to zero and we have a `max-height = 0`) and then show up again. This will cause unexpected flash https://github.com/microsoft/vscode/issues/132143#issuecomment-958495698. You won't see this without `overflow: hidden` as the browser is smart enough to know how to replace the old with the new DOM node without noticeable delay.
-
 
 ## Re-executing code cell followed by markdown cells
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The output rendering are now all handled in the webview, and the renderers would handle output item update. This means we are not going to see the flash/blinking anymore (previously these are two operations: clear and render).