### PR TITLE
feat: add authoritySuffix for remote labels

### DIFF
--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -74,7 +74,7 @@ const resourceLabelFormattersExtPoint = ExtensionsRegistry.registerExtensionPoin
 });
 
 const sepRegexp = /\//g;
-const labelMatchingRegexp = /\$\{(scheme|authority|path|(query)\.(.+?))\}/g;
+const labelMatchingRegexp = /\$\{(scheme|authoritySuffix|authority|path|(query)\.(.+?))\}/g;
 
 function hasDriveLetterIgnorePlatform(path: string): boolean {
 	return !!(path && path[2] === ':');
@@ -351,6 +351,10 @@ export class LabelService extends Disposable implements ILabelService {
 			switch (token) {
 				case 'scheme': return resource.scheme;
 				case 'authority': return resource.authority;
+				case 'authoritySuffix': {
+					const i = resource.authority.indexOf('+');
+					return i === -1 ? resource.authority : resource.authority.slice(i + 1);
+				}
 				case 'path':
 					return formatting.stripPathStartingSeparator
 						? resource.path.slice(resource.path[0] === formatting.separator ? 1 : 0)


### PR DESCRIPTION
For https://github.com/microsoft/vscode-cli/issues/250

I want to show a nicer name in the remote, but we should exclude the
`categorizer+name` prefix from the authority. The "+" is a standard
authority separator we use for SSH, WSL, etc.
