### PR TITLE
Include authority in TS in-memory scheme

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -674,7 +674,9 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 				}
 			default:
 				{
-					return this.inMemoryResourcePrefix + '/' + resource.scheme
+					return this.inMemoryResourcePrefix
+						+ '/' + resource.scheme
+						+ '/' + resource.authority
 						+ (resource.path.startsWith('/') ? resource.path : '/' + resource.path)
 						+ (resource.fragment ? '#' + resource.fragment : '');
 				}
@@ -724,7 +726,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		if (filepath.startsWith(this.inMemoryResourcePrefix)) {
 			const parts = filepath.match(/^\^\/([^\/]+)\/(.+)$/);
 			if (parts) {
-				const resource = vscode.Uri.parse(parts[1] + ':/' + parts[2]);
+				const resource = vscode.Uri.parse(parts[1] + '://' + parts[2]);
 				return this.bufferSyncSupport.toVsCodeResource(resource);
 			}
 		}


### PR DESCRIPTION
For #146853

Make sure we include the uri authority when serializing and then restoring the file paths we send to TSServer (similarly to how we already handle the uri scheme)

