### PR TITLE
Inform the user the actual branch name that will be used in the branchName inputbox

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5,7 +5,7 @@
 
 import * as os from 'os';
 import * as path from 'path';
-import { Command, commands, Disposable, LineChange, MessageOptions, Position, ProgressLocation, QuickPickItem, Range, SourceControlResourceState, TextDocumentShowOptions, TextEditor, Uri, ViewColumn, window, workspace, WorkspaceEdit, WorkspaceFolder, TimelineItem, env, Selection, TextDocumentContentProvider } from 'vscode';
+import { Command, commands, Disposable, LineChange, MessageOptions, Position, ProgressLocation, QuickPickItem, Range, SourceControlResourceState, TextDocumentShowOptions, TextEditor, Uri, ViewColumn, window, workspace, WorkspaceEdit, WorkspaceFolder, TimelineItem, env, Selection, TextDocumentContentProvider, InputBoxValidationSeverity } from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import * as nls from 'vscode-nls';
 import { Branch, ForcePushMode, GitErrorCodes, Ref, RefType, Status, CommitOptions, RemoteSourcePublisher } from './api/git';
@@ -1787,8 +1787,17 @@ export class CommandCenter {
 			ignoreFocusOut: true,
 			validateInput: (name: string) => {
 				const validateName = new RegExp(branchValidationRegex);
-				if (validateName.test(sanitize(name))) {
-					return null;
+				const sanitizedName = sanitize(name);
+				if (validateName.test(sanitizedName)) {
+					// If the sanitized name that we will use is different than what is
+					// in the input box, show an info message to the user informing them
+					// the branch name that will be used.
+					return name === sanitizedName
+						? null
+						: {
+							message: localize('branch name does not match sanitized', "Will be created as '{0}'", sanitizedName),
+							severity: InputBoxValidationSeverity.Info
+						};
 				}
 
 				return localize('branch name format invalid', "Branch name needs to match regex: {0}", branchValidationRegex);

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1795,7 +1795,7 @@ export class CommandCenter {
 					return name === sanitizedName
 						? null
 						: {
-							message: localize('branch name does not match sanitized', "Will be created as '{0}'", sanitizedName),
+							message: localize('branch name does not match sanitized', "The new branch will be '{0}'", sanitizedName),
 							severity: InputBoxValidationSeverity.Info
 						};
 				}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Now that https://github.com/microsoft/vscode/pull/148961 is finalized...

When you type in characters in a branch name that will be sanitized out in the `Create New Branch` or `Create New Branch From` input box, you'll get this tip if your branch name contains an invalid character:
![image](https://user-images.githubusercontent.com/2644648/167220218-782aa51f-6771-4dee-b5b7-d710fd4fe5d6.png)

The idea was to match GitHub:
![image](https://user-images.githubusercontent.com/2644648/167220356-0953d24e-b0b2-4599-997b-c337138b903f.png)


NOTE: I didn't inform the user if they already had something in the input when they select `Create New Branch` from the quick pick because the InputBox is totally skipped.

Couple ideas:

* We could consider showing the input box with the info message if sanitation doesn't match what's in the input... but that would introduce another ENTER that the user would have to hit.
* We could make the quickpick more complex by having `Create New Branch...` say `Create New Branch (branch-name)...` on type which is possible but a bit annoying to implement

Because both of these ideas are tricky, I deferred them for now. This PR is a standalone improvement.

You can decide if this takes care of #144219 enough.
