### PR TITLE
ci: fix 32-bit builds of native modules

### DIFF
--- a/build/azure-pipelines/linux/product-build-linux-client.yml
+++ b/build/azure-pipelines/linux/product-build-linux-client.yml
@@ -104,6 +104,16 @@ steps:
   - script: |
       set -e
       export npm_config_arch=$(NPM_ARCH)
+      # node-gyp@9.0.0 shipped with node@16.15.0 starts using config.gypi
+      # from the custom headers path if dist-url option was set instead of
+      # using the config value from the process. Electron builds with pointer compression
+      # enabled for x64 and arm64, but incorrectly ships a single copy of config.gypi
+      # with v8_enable_pointer_compression option always set for all target architectures.
+      # We use the force_process_config option to use the config.gypi from the
+      # nodejs process executing npm for 32-bit architectures.
+      if [ "$NPM_ARCH" = "armv7l" ]; then
+        export npm_config_force_process_config="true"
+      fi
 
       if [ -z "$CC" ] || [ -z "$CXX" ]; then
         # Download clang based on chromium revision used by vscode

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -86,6 +86,14 @@ steps:
       . build/azure-pipelines/win32/retry.ps1
       $ErrorActionPreference = "Stop"
       $env:npm_config_arch="$(VSCODE_ARCH)"
+      # node-gyp@9.0.0 shipped with node@16.15.0 starts using config.gypi
+      # from the custom headers path if dist-url option was set instead of
+      # using the config value from the process. Electron builds with pointer compression
+      # enabled for x64 and arm64, but incorrectly ships a single copy of config.gypi
+      # with v8_enable_pointer_compression option always set for all target architectures.
+      # We use the force_process_config option to use the config.gypi from the
+      # nodejs process executing npm for 32-bit architectures.
+      if ('$(VSCODE_ARCH)' -eq 'ia32') { $env:npm_config_force_process_config="true" }
       $env:CHILD_CONCURRENCY="1"
       retry { exec { yarn --frozen-lockfile --check-files } }
     env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.68.0",
-  "distro": "0cfb470e9eff5c2a4bc6b5a37be833abcb72ed84",
+  "distro": "91d2cd9434a5815a375ae165349f2929d74ed03c",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.68.0",
-  "distro": "91d2cd9434a5815a375ae165349f2929d74ed03c",
+  "distro": "312bc01624f373fd39ff25675ed1aebfcf50e5a5",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
Depends on https://github.com/microsoft/vscode-distro/pull/350

Temporary workaround until headers are fixed in upstream https://github.com/electron/electron/pull/34136/commits/7ecd8cd2878fdcb75e838e1c972f1b3ced77b88f
