### PR TITLE
Specify tsconfig.tsbuildinfo is json

### DIFF
--- a/extensions/typescript-basics/package.json
+++ b/extensions/typescript-basics/package.json
@@ -51,6 +51,12 @@
           "tsconfig-*.json",
           "jsconfig-*.json"
         ]
+      },
+      {
+        "id": "json",
+        "filenames": [
+          "tsconfig.tsbuildinfo"
+        ]
       }
     ],
     "grammars": [


### PR DESCRIPTION
`tsconfig.tsbuildinfo` is a JSON file that is generated by the following TypeScript command:

```sh
tsc --build
```

It is typically ignored in version control, but still it makes sense to mark it as JSON as part of the TypeScript extension.