### PR TITLE
ci: fix 403 when downloading ripgrep prebuilt for alpine stage

### DIFF
--- a/build/azure-pipelines/linux/product-build-alpine.yml
+++ b/build/azure-pipelines/linux/product-build-alpine.yml
@@ -118,7 +118,9 @@ steps:
 
   - script: |
       set -e
-      docker run -e VSCODE_QUALITY -v $(pwd):/root/vscode -v ~/.netrc:/root/.netrc vscodehub.azurecr.io/vscode-linux-build-agent:alpine-$(VSCODE_ARCH) /root/vscode/build/azure-pipelines/linux/scripts/install-remote-dependencies.sh
+      docker run -e VSCODE_QUALITY -e GITHUB_TOKEN -v $(pwd):/root/vscode -v ~/.netrc:/root/.netrc vscodehub.azurecr.io/vscode-linux-build-agent:alpine-$(VSCODE_ARCH) /root/vscode/build/azure-pipelines/linux/scripts/install-remote-dependencies.sh
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Prebuild
 
   - script: |


### PR DESCRIPTION
Refs failing alpine builds at https://dev.azure.com/monacotools/Monaco/_build/results?buildId=170295&view=results