### PR TITLE
Add more sanitization around the attributes in MD generated HTML

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -108,13 +108,13 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 		let attributes: string[] = [];
 		if (href) {
 			({ href, dimensions } = parseHrefAndDimensions(href));
-			attributes.push(`src="${href}"`);
+			attributes.push(`src="${href.replace(/"/g, '&quot;')}"`);
 		}
 		if (text) {
-			attributes.push(`alt="${text}"`);
+			attributes.push(`alt="${text.replace(/"/g, '&quot;')}"`);
 		}
 		if (title) {
-			attributes.push(`title="${title}"`);
+			attributes.push(`title="${title.replace(/"/g, '&quot;')}"`);
 		}
 		if (dimensions.length) {
 			attributes = attributes.concat(dimensions);
@@ -134,7 +134,7 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 		if (markdown.baseUri) {
 			href = resolveWithBaseUri(URI.from(markdown.baseUri), href);
 		}
-		title = typeof title === 'string' ? removeMarkdownEscapes(title) : '';
+		title = typeof title === 'string' ? removeMarkdownEscapes(title).replace(/"/g, '&quot;') : '';
 		href = removeMarkdownEscapes(href);
 		if (
 			!href


### PR DESCRIPTION
When generating a link, we URL encode the value passed in as the href value.

We don't need to do it quite to aggressively elsewhere, but it would be good to add a bit of extra protection against html code being injected here.
