### PR TITLE
Add action to ping when 1.999.0 tag pushed

### DIFF
--- a/.github/workflows/bad-tag.yml
+++ b/.github/workflows/bad-tag.yml
@@ -1,0 +1,22 @@
+name: Bad Tag
+on:
+  create
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    if: github.event.ref == '1.999.0'
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "microsoft/vscode-github-triage-actions"
+          ref: stable
+          path: ./actions
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Bad Tag
+        uses: ./actions/tag-alert
+        with:
+          token: ${{secrets.VSCODE_ISSUE_TRIAGE_BOT_PAT}}
+          tag-name: '1.999.0'


### PR DESCRIPTION
Requires https://github.com/microsoft/vscode-github-triage-actions/pull/57

Fixes https://github.com/microsoft/vscode/issues/149080