### PR TITLE
Always Use `/` for md paths inserted on drop

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/dropIntoEditor.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/dropIntoEditor.ts
@@ -57,7 +57,7 @@ export function registerDropIntoEditor(selector: vscode.DocumentSelector) {
 			const snippet = new vscode.SnippetString();
 			uris.forEach((uri, i) => {
 				const mdPath = document.uri.scheme === uri.scheme
-					? encodeURI(path.relative(URI.Utils.dirname(document.uri).fsPath, uri.fsPath))
+					? encodeURI(path.relative(URI.Utils.dirname(document.uri).fsPath, uri.fsPath).replace(/\\/g, '/'))
 					: uri.toString(false);
 
 				const ext = URI.Utils.extname(uri).toLowerCase();


### PR DESCRIPTION
Fixes #149010

Makes sure we don't use backslash style paths on windows