### PR TITLE
Adds cancellation to md diagnostic computation

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -423,7 +423,7 @@
         "markdown.experimental.validate.referenceLinks": {
           "type": "string",
           "scope": "resource",
-          "description": "%configuration.markdown.experimental.validate.referenceLinks.description%",
+          "markdownDescription": "%configuration.markdown.experimental.validate.referenceLinks.description%",
           "default": "warning",
           "enum": [
             "ignore",
@@ -434,7 +434,7 @@
         "markdown.experimental.validate.headerLinks": {
           "type": "string",
           "scope": "resource",
-          "description": "%configuration.markdown.experimental.validate.headerLinks.description%",
+          "markdownDescription": "%configuration.markdown.experimental.validate.headerLinks.description%",
           "default": "warning",
           "enum": [
             "ignore",
@@ -445,7 +445,7 @@
         "markdown.experimental.validate.fileLinks": {
           "type": "string",
           "scope": "resource",
-          "description": "%configuration.markdown.experimental.validate.fileLinks.description%",
+          "markdownDescription": "%configuration.markdown.experimental.validate.fileLinks.description%",
           "default": "warning",
           "enum": [
             "ignore",

--- a/extensions/markdown-language-features/src/util/async.ts
+++ b/extensions/markdown-language-features/src/util/async.ts
@@ -25,6 +25,10 @@ export class Delayer<T> {
 		this.task = null;
 	}
 
+	dispose() {
+		this.cancelTimeout();
+	}
+
 	public trigger(task: ITask<T>, delay: number = this.defaultDelay): Promise<T | null> {
 		this.task = task;
 		if (delay >= 0) {


### PR DESCRIPTION
This tracks inflight diagnostic computation and tries to cancel them if a new request comes in for the same document (usually because the document has changed or has been closed). Previously we never canceled these (see how `noopToken` was being used)

Also fixes the validate setting descriptions to be rendered as markdown 
