### PR TITLE
Use explicit empty authority for JS/TS resources

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -95,6 +95,7 @@ namespace ServerState {
 export default class TypeScriptServiceClient extends Disposable implements ITypeScriptServiceClient {
 
 	private readonly pathSeparator: string;
+	private readonly emptyAuthority = 'ts-nul-authority';
 	private readonly inMemoryResourcePrefix = '^';
 
 	private readonly workspaceState: vscode.Memento;
@@ -676,7 +677,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 				{
 					return this.inMemoryResourcePrefix
 						+ '/' + resource.scheme
-						+ '/' + resource.authority
+						+ '/' + (resource.authority || this.emptyAuthority)
 						+ (resource.path.startsWith('/') ? resource.path : '/' + resource.path)
 						+ (resource.fragment ? '#' + resource.fragment : '');
 				}
@@ -724,9 +725,9 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		}
 
 		if (filepath.startsWith(this.inMemoryResourcePrefix)) {
-			const parts = filepath.match(/^\^\/([^\/]+)\/(.+)$/);
+			const parts = filepath.match(/^\^\/([^\/]+)\/([^\/]*)\/(.+)$/);
 			if (parts) {
-				const resource = vscode.Uri.parse(parts[1] + '://' + parts[2]);
+				const resource = vscode.Uri.parse(parts[1] + '://' + (parts[2] === this.emptyAuthority ? '' : parts[2]) + '/' + parts[3]);
 				return this.bufferSyncSupport.toVsCodeResource(resource);
 			}
 		}


### PR DESCRIPTION
Fixes #149123

10c8c1c2cce90256dc84597034c18b391a8b189f made sure we sync over the authority of in-memory resources over to TS Server. However if a resource does not have an authority, this resulted in a url with `scheme//path` instead of `scheme/authority/path`

TS would then normalize the uri to `scheme/path`, resulting in us considering this as a district resource from `scheme//path`

This fix adds an explicit empty authority that we use in this case instead

