### PR TITLE
Use secondary buttons in Comments widget

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentFormActions.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentFormActions.ts
@@ -27,12 +27,14 @@ export class CommentFormActions implements IDisposable {
 		this._buttonElements.forEach(b => b.remove());
 
 		const groups = menu.getActions({ shouldForwardArgs: true });
+		let isPrimary: boolean = true;
 		for (const group of groups) {
 			const [, actions] = group;
 
 			this._actions = actions;
-			actions.forEach(action => {
-				const button = new Button(this.container);
+			for (const action of actions) {
+				const button = new Button(this.container, { secondary: !isPrimary });
+				isPrimary = false;
 				this._buttonElements.push(button.element);
 
 				this._toDispose.add(button);
@@ -41,7 +43,7 @@ export class CommentFormActions implements IDisposable {
 
 				button.enabled = action.enabled;
 				button.label = action.label;
-			});
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -298,11 +298,6 @@
 	padding: 10px 0;
 }
 
-.review-widget .body .edit-container .form-actions {
-	display: flex;
-	justify-content: flex-end;
-}
-
 .review-widget .body .edit-textarea {
 	height: 90px;
 	margin: 5px 0 10px 0;
@@ -316,7 +311,7 @@
 	margin-bottom: 5px;
 }
 
-.review-widget .body .comment-form .monaco-text-button {
+.review-widget .body .form-actions .monaco-text-button {
 	float: right;
 }
 


### PR DESCRIPTION
Also, fix a bug in the ordering of reply comment buttons order since they don't match the order of the new comment buttons.
Fixes #149157

