### PR TITLE
Fixes #148893: Use the change accessor pattern to avoid leaking decorations via `deltaDecorations`

### DIFF
--- a/src/vs/editor/contrib/multicursor/browser/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/browser/multicursor.ts
@@ -986,7 +986,9 @@ export class SelectionHighlighter extends Disposable implements IEditorContribut
 		this.state = newState;
 
 		if (!this.state) {
-			this.decorations = this.editor.deltaDecorations(this.decorations, []);
+			this.editor.changeDecorations((accessor) => {
+				this.decorations = accessor.deltaDecorations(this.decorations, []);
+			});
 			return;
 		}
 
@@ -1042,7 +1044,9 @@ export class SelectionHighlighter extends Disposable implements IEditorContribut
 			};
 		});
 
-		this.decorations = this.editor.deltaDecorations(this.decorations, decorations);
+		this.editor.changeDecorations((accessor) => {
+			this.decorations = accessor.deltaDecorations(this.decorations, decorations);
+		});
 	}
 
 	private static readonly _SELECTION_HIGHLIGHT_OVERVIEW = ModelDecorationOptions.register({


### PR DESCRIPTION
Invoking `editor.deltaDecorations` might emit an event which might lead to recursion. In case the caller of `editor.deltaDecorations` recurses, decorations will be leaked. We can avoid this using the change accessor pattern where events are emitted only after the change accessor function returns.