### PR TITLE
`\t` should jump to next indent tab stop and not just add the tab width

### DIFF
--- a/src/vs/editor/common/core/indentation.ts
+++ b/src/vs/editor/common/core/indentation.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as strings from 'vs/base/common/strings';
+import { CursorColumns } from 'vs/editor/common/core/cursorColumns';
 
 function _normalizeIndentationFromWhitespace(str: string, indentSize: number, insertSpaces: boolean): string {
 	let spacesCnt = 0;
 	for (let i = 0; i < str.length; i++) {
 		if (str.charAt(i) === '\t') {
-			spacesCnt += indentSize;
+			spacesCnt = CursorColumns.nextIndentTabStop(spacesCnt, indentSize);
 		} else {
 			spacesCnt++;
 		}

--- a/src/vs/editor/contrib/snippet/test/browser/snippetSession.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetSession.test.ts
@@ -63,7 +63,7 @@ suite('SnippetSession', function () {
 		assertNormalized(new Position(1, 1), 'foo\rbar', 'foo\nbar');
 		assertNormalized(new Position(1, 1), 'foo\rbar', 'foo\nbar');
 		assertNormalized(new Position(2, 5), 'foo\r\tbar', 'foo\n        bar');
-		assertNormalized(new Position(2, 3), 'foo\r\tbar', 'foo\n      bar');
+		assertNormalized(new Position(2, 3), 'foo\r\tbar', 'foo\n    bar');
 		assertNormalized(new Position(2, 5), 'foo\r\tbar\nfoo', 'foo\n        bar\n    foo');
 
 		//Indentation issue with choice elements that span multiple lines #46266

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -3225,6 +3225,33 @@ suite('Editor Controller', () => {
 		});
 	});
 
+	test('issue #148256: Pressing Enter creates line with bad indent with insertSpaces: true', () => {
+		usingCursor({
+			text: [
+				'  \t'
+			],
+		}, (editor, model, viewModel) => {
+			moveTo(editor, viewModel, 1, 4, false);
+			viewModel.type('\n', 'keyboard');
+			assert.strictEqual(model.getValue(), '  \t\n    ');
+		});
+	});
+
+	test('issue #148256: Pressing Enter creates line with bad indent with insertSpaces: false', () => {
+		usingCursor({
+			text: [
+				'  \t'
+			]
+		}, (editor, model, viewModel) => {
+			model.updateOptions({
+				insertSpaces: false
+			});
+			moveTo(editor, viewModel, 1, 4, false);
+			viewModel.type('\n', 'keyboard');
+			assert.strictEqual(model.getValue(), '  \t\n\t');
+		});
+	});
+
 	test('removeAutoWhitespace off', () => {
 		usingCursor({
 			text: [

--- a/src/vs/editor/test/common/model/textModel.test.ts
+++ b/src/vs/editor/test/common/model/textModel.test.ts
@@ -915,10 +915,11 @@ suite('Editor Model - TextModel', () => {
 		assert.strictEqual(model.normalizeIndentation('  '), '  ');
 		assert.strictEqual(model.normalizeIndentation(' '), ' ');
 		assert.strictEqual(model.normalizeIndentation(''), '');
-		assert.strictEqual(model.normalizeIndentation(' \t   '), '\t\t');
-		assert.strictEqual(model.normalizeIndentation(' \t  '), '\t   ');
-		assert.strictEqual(model.normalizeIndentation(' \t '), '\t  ');
-		assert.strictEqual(model.normalizeIndentation(' \t'), '\t ');
+		assert.strictEqual(model.normalizeIndentation(' \t    '), '\t\t');
+		assert.strictEqual(model.normalizeIndentation(' \t   '), '\t   ');
+		assert.strictEqual(model.normalizeIndentation(' \t  '), '\t  ');
+		assert.strictEqual(model.normalizeIndentation(' \t '), '\t ');
+		assert.strictEqual(model.normalizeIndentation(' \t'), '\t');
 
 		assert.strictEqual(model.normalizeIndentation('\ta'), '\ta');
 		assert.strictEqual(model.normalizeIndentation('    a'), '\ta');
@@ -926,10 +927,11 @@ suite('Editor Model - TextModel', () => {
 		assert.strictEqual(model.normalizeIndentation('  a'), '  a');
 		assert.strictEqual(model.normalizeIndentation(' a'), ' a');
 		assert.strictEqual(model.normalizeIndentation('a'), 'a');
-		assert.strictEqual(model.normalizeIndentation(' \t   a'), '\t\ta');
-		assert.strictEqual(model.normalizeIndentation(' \t  a'), '\t   a');
-		assert.strictEqual(model.normalizeIndentation(' \t a'), '\t  a');
-		assert.strictEqual(model.normalizeIndentation(' \ta'), '\t a');
+		assert.strictEqual(model.normalizeIndentation(' \t    a'), '\t\ta');
+		assert.strictEqual(model.normalizeIndentation(' \t   a'), '\t   a');
+		assert.strictEqual(model.normalizeIndentation(' \t  a'), '\t  a');
+		assert.strictEqual(model.normalizeIndentation(' \t a'), '\t a');
+		assert.strictEqual(model.normalizeIndentation(' \ta'), '\ta');
 
 		model.dispose();
 	});
@@ -943,10 +945,11 @@ suite('Editor Model - TextModel', () => {
 		assert.strictEqual(model.normalizeIndentation('  a'), '  a');
 		assert.strictEqual(model.normalizeIndentation(' a'), ' a');
 		assert.strictEqual(model.normalizeIndentation('a'), 'a');
-		assert.strictEqual(model.normalizeIndentation(' \t   a'), '        a');
-		assert.strictEqual(model.normalizeIndentation(' \t  a'), '       a');
-		assert.strictEqual(model.normalizeIndentation(' \t a'), '      a');
-		assert.strictEqual(model.normalizeIndentation(' \ta'), '     a');
+		assert.strictEqual(model.normalizeIndentation(' \t    a'), '        a');
+		assert.strictEqual(model.normalizeIndentation(' \t   a'), '       a');
+		assert.strictEqual(model.normalizeIndentation(' \t  a'), '      a');
+		assert.strictEqual(model.normalizeIndentation(' \t a'), '     a');
+		assert.strictEqual(model.normalizeIndentation(' \ta'), '    a');
 
 		model.dispose();
 	});


### PR DESCRIPTION
Before, something like `<space><space><tab>` was interpreted as being equivalent to `<space><space><space><space><space><space>`. This doesn't make sense, as `\t` jumps to the next tab stop, so it should be equivalent to `<space><space><space><space>`

Fixes #148256