### PR TITLE
fixes #148899

### DIFF
--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -378,9 +378,11 @@ export abstract class BasePanelPart extends CompositePart<PaneComposite> impleme
 			contextKey.set(true);
 			this.compositeBar.addComposite({ id: viewContainer.id, name: viewContainer.title, order: viewContainer.order, requestedIndex: viewContainer.requestedIndex });
 
-			const activeComposite = this.getActiveComposite();
-			if (activeComposite === undefined || activeComposite.getId() === viewContainer.id) {
-				this.compositeBar.activateComposite(viewContainer.id);
+			if (this.layoutService.isVisible(this.partId)) {
+				const activeComposite = this.getActiveComposite();
+				if (activeComposite === undefined || activeComposite.getId() === viewContainer.id) {
+					this.compositeBar.activateComposite(viewContainer.id);
+				}
 			}
 
 			this.layoutCompositeBar();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #148899

See issue for problem. The fix I've chosen will not activate a newly activated composite while the part is hidden. This is in line with what happens when we hide the part where we deactivate the active composite.

What happens in the repro is:
1. The panel is hidden
2. The interactive window is opened which triggers a new view container in the panel (new composite) via context keys.
3. The new view container is activated even though the panel is hidden (the panel is not shown)
4. The interactive window is closed which deactivates the active composite (which it should not have because it is hidden)
5. The composite bar has to reset to the default view (terminal) which triggers a show panel