### PR TITLE
Add patch for enabling new TS plugins on web approach

### DIFF
--- a/extensions/typescript-language-features/extension-browser.webpack.config.js
+++ b/extensions/typescript-language-features/extension-browser.webpack.config.js
@@ -8,6 +8,8 @@
 'use strict';
 const CopyPlugin = require('copy-webpack-plugin');
 const Terser = require('terser');
+const fs = require('fs');
+const path = require('path');
 
 const defaultConfig = require('../shared.webpack.config');
 const withBrowserDefaults = defaultConfig.browser;
@@ -64,9 +66,11 @@ module.exports = withBrowserDefaults({
 				{
 					from: '../node_modules/typescript/lib/tsserver.js',
 					to: 'typescript/tsserver.web.js',
-					transform: (content) => {
-						return Terser.minify(content.toString()).then(output => output.code);
+					transform: async (content) => {
+						const prefix = fs.readFileSync(path.join(__dirname, '..', 'node_modules', 'typescript', 'lib', 'tsserverWeb.js'));
+						const output = await Terser.minify(content.toString());
 
+						return prefix + '\n' + output.code;
 					},
 					transformPath: (targetPath) => {
 						return targetPath.replace('tsserver.js', 'tsserver.web.js');

--- a/extensions/typescript-language-features/extension-browser.webpack.config.js
+++ b/extensions/typescript-language-features/extension-browser.webpack.config.js
@@ -67,7 +67,8 @@ module.exports = withBrowserDefaults({
 					from: '../node_modules/typescript/lib/tsserver.js',
 					to: 'typescript/tsserver.web.js',
 					transform: async (content) => {
-						const prefix = fs.readFileSync(path.join(__dirname, '..', 'node_modules', 'typescript', 'lib', 'tsserverWeb.js'));
+						const dynamicImportCompatPath = path.join(__dirname, '..', 'node_modules', 'typescript', 'lib', 'dynamicImportCompat.js');
+						const prefix = fs.existsSync(dynamicImportCompatPath) ? fs.readFileSync(dynamicImportCompatPath) : undefined;
 						const output = await Terser.minify(content.toString());
 
 						return prefix + '\n' + output.code;


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/pull/47377

To run plugins on web, we need to shim out `dynamicImport`. This is done in a file call `dynamicImportCompat.js`, which is added by the linked PR

Fixes #140455

