### PR TITLE
Drag & drop from tree item with no valid data still triggers editor drop zone and split view drop zone behaviours

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
+++ b/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
@@ -349,8 +349,9 @@ class DropOverlay extends Themable {
 						editors.push(...treeDropData.map(editor => ({ ...editor, options: { ...editor.options, pinned: true } })));
 					}
 				}
-
-				this.editorService.openEditors(editors, ensureTargetGroup(), { validateTrust: true });
+				if (editors.length) {
+					this.editorService.openEditors(editors, ensureTargetGroup(), { validateTrust: true });
+				}
 			}
 
 			this.treeItemsTransfer.clearData(DraggedTreeItemsIdentifier.prototype);


### PR DESCRIPTION
Fixes #148622
