### PR TITLE
Switch web endpoint back to vortex.

### DIFF
--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -26,7 +26,7 @@ class WebAppInsightsAppender implements ITelemetryAppender {
 	private _telemetryCache: { eventName: string; data: any }[] = [];
 
 	constructor(private _eventPrefix: string, aiKey: string) {
-		const endpointUrl = 'https://mobile.events.data.microsoft.com/collect/v1';
+		const endpointUrl = 'https://vortex.data.microsoft.com/collect/v1';
 		import('@microsoft/applicationinsights-web').then(aiLibrary => {
 			this._aiClient = new aiLibrary.ApplicationInsights({
 				config: {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes telemetry in vscode.dev


Appears that the collector endpoint has some CORS issues that still need to be worked out on web. This takes the vortex endpoint back in as a candidate. Will leave collector endpoint in stable for now with hopes that the CORS issues will be fixed for 1.68.
