### PR TITLE
Call `setPointerCapture` with all pointer types

### DIFF
--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -89,11 +89,9 @@ export class MouseHandler extends ViewEventHandler {
 		// because their `e.detail` is always 0.
 		// We will therefore save the pointer id for the mouse and then reuse it in the `mousedown` event
 		// for `element.setPointerCapture`.
-		let mousePointerId: number = 0;
-		this._register(mouseEvents.onPointerDown(this.viewHelper.viewDomNode, (e, pointerType, pointerId) => {
-			if (pointerType === 'mouse') {
-				mousePointerId = pointerId;
-			}
+		let capturePointerId: number = 0;
+		this._register(mouseEvents.onPointerDown(this.viewHelper.viewDomNode, (e, pointerId) => {
+			capturePointerId = pointerId;
 		}));
 		// The `pointerup` listener registered by `GlobalEditorPointerMoveMonitor` does not get invoked 100% of the times.
 		// I speculate that this is because the `pointerup` listener is only registered during the `mousedown` event, and perhaps
@@ -103,7 +101,7 @@ export class MouseHandler extends ViewEventHandler {
 		this._register(dom.addDisposableListener(this.viewHelper.viewDomNode, dom.EventType.POINTER_UP, (e: PointerEvent) => {
 			this._mouseDownOperation.onPointerUp();
 		}));
-		this._register(mouseEvents.onMouseDown(this.viewHelper.viewDomNode, (e) => this._onMouseDown(e, mousePointerId)));
+		this._register(mouseEvents.onMouseDown(this.viewHelper.viewDomNode, (e) => this._onMouseDown(e, capturePointerId)));
 
 		const onMouseWheel = (browserEvent: IMouseWheelEvent) => {
 			this.viewController.emitMouseWheel(browserEvent);

--- a/src/vs/editor/browser/editorDom.ts
+++ b/src/vs/editor/browser/editorDom.ts
@@ -166,9 +166,9 @@ export class EditorMouseEventFactory {
 		});
 	}
 
-	public onPointerDown(target: HTMLElement, callback: (e: EditorMouseEvent, pointerType: string, pointerId: number) => void): IDisposable {
+	public onPointerDown(target: HTMLElement, callback: (e: EditorMouseEvent, pointerId: number) => void): IDisposable {
 		return dom.addDisposableListener(target, dom.EventType.POINTER_DOWN, (e: PointerEvent) => {
-			callback(this._create(e), e.pointerType, e.pointerId);
+			callback(this._create(e), e.pointerId);
 		});
 	}
 


### PR DESCRIPTION
Fixes #146444

Some pen devices also generate `mousedown` and `mousemove` events. Before adopting `setPointerCapture`, these could be used to do editor selection. With this change, we will relax the condition under which we call `setPointerCapture` and also end up calling it with other pointer types (like pens).