### PR TITLE
testing: first pass at related code api

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1765,6 +1765,7 @@ export namespace TestItem {
 			busy: false,
 			tags: item.tags.map(t => TestTag.namespace(ctrlId, t.id)),
 			range: editorRange.Range.lift(Range.from(item.range)),
+			relatedCode: item.relatedCode?.map(r => ({ uri: URI.revive(r.uri), range: editorRange.Range.lift(Range.from(r.range)) })) || null,
 			description: item.description || null,
 			sortText: item.sortText || null,
 			error: item.error ? (MarkdownString.fromStrict(item.error) || null) : null,

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -248,6 +248,10 @@ export interface ITestTagDisplayInfo {
 
 /**
  * The TestItem from .d.ts, as a plain object without children.
+ *
+ * If you want to add a new property here (new API from vscode.TestItem), make
+ * sure to also add it to `TestItemWritableProps` and ITestItemUpdate's
+ * serialization, and follow the compile errors to add it everywhere else.
  */
 export interface ITestItem {
 	/** ID of the test given by the test controller */
@@ -258,10 +262,14 @@ export interface ITestItem {
 	children?: never;
 	uri: URI | undefined;
 	range: Range | null;
+	relatedCode: { uri: URI; range: Range }[] | null;
 	description: string | null;
 	error: string | IMarkdownString | null;
 	sortText: string | null;
 }
+
+/** Subset of the ITestItem which is writable after the item's creation. */
+export type TestItemWritableProps = Pick<ITestItem, 'range' | 'label' | 'description' | 'sortText' | 'busy' | 'error' | 'tags' | 'relatedCode'>;
 
 export namespace ITestItem {
 	export interface Serialized {
@@ -272,6 +280,7 @@ export namespace ITestItem {
 		children?: never;
 		uri: UriComponents | undefined;
 		range: IRange | null;
+		relatedCode: { uri: UriComponents; range: IRange }[] | null;
 		description: string | null;
 		error: string | IMarkdownString | null;
 		sortText: string | null;
@@ -285,6 +294,7 @@ export namespace ITestItem {
 		children: undefined,
 		uri: item.uri?.toJSON(),
 		range: item.range?.toJSON() || null,
+		relatedCode: item.relatedCode || null,
 		description: item.description,
 		error: item.error,
 		sortText: item.sortText
@@ -298,6 +308,7 @@ export namespace ITestItem {
 		children: undefined,
 		uri: serialized.uri ? URI.revive(serialized.uri) : undefined,
 		range: serialized.range ? Range.lift(serialized.range) : null,
+		relatedCode: serialized.relatedCode?.map(r => ({ uri: URI.revive(r.uri), range: Range.lift(r.range) })) || null,
 		description: serialized.description,
 		error: serialized.error,
 		sortText: serialized.sortText
@@ -376,6 +387,7 @@ export namespace ITestItemUpdate {
 			if (u.item.description !== undefined) { item.description = u.item.description; }
 			if (u.item.error !== undefined) { item.error = u.item.error; }
 			if (u.item.sortText !== undefined) { item.sortText = u.item.sortText; }
+			if (u.item.relatedCode !== undefined) { item.relatedCode = u.item.relatedCode; }
 		}
 
 		return { extId: u.extId, expand: u.expand, item };
@@ -392,6 +404,7 @@ export namespace ITestItemUpdate {
 			if (u.item.description !== undefined) { item.description = u.item.description; }
 			if (u.item.error !== undefined) { item.error = u.item.error; }
 			if (u.item.sortText !== undefined) { item.sortText = u.item.sortText; }
+			if (u.item.relatedCode !== undefined) { item.relatedCode = u.item.relatedCode?.map(r => ({ uri: URI.revive(r.uri), range: Range.lift(r.range) })) || null; }
 		}
 
 		return { extId: u.extId, expand: u.expand, item };
@@ -611,6 +624,8 @@ export class IncrementalChangeCollector<T> {
  */
 export abstract class AbstractIncrementalTestCollection<T extends IncrementalTestCollectionItem>  {
 	private readonly _tags = new Map<string, ITestTagDisplayInfo>();
+	/** Map of test IDs that have related code in each file. */
+	private readonly _relatedCode = new Map</* uri */string, Set< /* test id */string>>();
 
 	/**
 	 * Map of item IDs to test item objects.
@@ -660,6 +675,12 @@ export abstract class AbstractIncrementalTestCollection<T extends IncrementalTes
 						changes.add(created);
 					}
 
+					if (internalTest.item.relatedCode) {
+						for (const { uri } of internalTest.item.relatedCode) {
+							this.addTestToRelatedCode(uri.toString(), internalTest.item.extId);
+						}
+					}
+
 					if (internalTest.expand === TestItemExpandState.BusyExpanding) {
 						this.busyControllerCount++;
 					}
@@ -679,6 +700,21 @@ export abstract class AbstractIncrementalTestCollection<T extends IncrementalTes
 						}
 						if (patch.expand === TestItemExpandState.BusyExpanding) {
 							this.busyControllerCount++;
+						}
+					}
+
+					if (patch.item?.relatedCode !== undefined) {
+						const previous = new Set(existing.item.relatedCode?.map(c => c.uri.toString()));
+						const current = new Set(patch.item.relatedCode?.map(c => c.uri.toString()));
+						for (const uri of previous) {
+							if (!current.has(uri)) {
+								this.removeTestFromRelatedCode(uri.toString(), patch.extId);
+							}
+						}
+						for (const uri of current) {
+							if (!previous.has(uri)) {
+								this.addTestToRelatedCode(uri.toString(), patch.extId);
+							}
 						}
 					}
 
@@ -708,6 +744,12 @@ export abstract class AbstractIncrementalTestCollection<T extends IncrementalTes
 								queue.push(existing.children);
 								this.items.delete(itemId);
 								changes.remove(existing, existing !== toRemove);
+
+								if (existing.item.relatedCode) {
+									for (const { uri } of existing.item.relatedCode) {
+										this.removeTestFromRelatedCode(uri.toString(), existing.item.extId);
+									}
+								}
 
 								if (existing.expand === TestItemExpandState.BusyExpanding) {
 									this.busyControllerCount--;
@@ -766,4 +808,20 @@ export abstract class AbstractIncrementalTestCollection<T extends IncrementalTes
 	 * Creates a new item for the collection from the internal test item.
 	 */
 	protected abstract createItem(internal: InternalTestItem, parent?: T): T;
+
+	private removeTestFromRelatedCode(uri: string, testId: string) {
+		const s = this._relatedCode.get(uri);
+		if (s?.delete(testId) && !s.size) {
+			this._relatedCode.delete(uri);
+		}
+	}
+
+	private addTestToRelatedCode(uri: string, testId: string) {
+		const s = this._relatedCode.get(uri);
+		if (s) {
+			s.add(testId);
+		} else {
+			this._relatedCode.set(uri, new Set([testId]));
+		}
+	}
 }

--- a/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByLocation.test.ts
+++ b/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByLocation.test.ts
@@ -116,6 +116,7 @@ suite('Workbench - Testing Explorer Hierarchal by Location Projection', () => {
 				sortText: null,
 				tags: [],
 				uri: undefined,
+				relatedCode: null,
 			},
 			parent: 'id-root',
 			tasks: [],

--- a/src/vs/workbench/contrib/testing/test/common/testStubs.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testStubs.ts
@@ -53,6 +53,7 @@ export class TestTestItem implements ITestItemLike {
 			label,
 			range: null,
 			sortText: null,
+			relatedCode: null,
 			tags: [],
 			uri,
 		};

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -55,6 +55,7 @@ export const allApiProposals = Object.freeze({
 	terminalNameChangeEvent: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalNameChangeEvent.d.ts',
 	testCoverage: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.testCoverage.d.ts',
 	testObserver: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.testObserver.d.ts',
+	testRelatedCode: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.testRelatedCode.d.ts',
 	textDocumentNotebook: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.textDocumentNotebook.d.ts',
 	textEditorDrop: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.textEditorDrop.d.ts',
 	textSearchProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.textSearchProvider.d.ts',

--- a/src/vscode-dts/vscode.proposed.testRelatedCode.d.ts
+++ b/src/vscode-dts/vscode.proposed.testRelatedCode.d.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/126932
+
+	export interface TestItem {
+		/**
+		 * Ranges of implementation code related to this test. This is used to
+		 * provide navigation between a test and its implementation, as well as
+		 * commands to run tests related to the an implementation location.
+		 */
+		relatedCode?: readonly Location[];
+	}
+}


### PR DESCRIPTION
This adds `relatedCode?: readonly Location[];` on the TestItem as discussed in https://github.com/microsoft/vscode/issues/126932, and wires up test decorations to that.

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/2230985/167928201-93b3ef14-95ea-4532-bd1c-b39a9b397b49.png">
