### PR TITLE
Add indicator, fixes #148672

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -18,8 +18,9 @@ import { FOLDER_SCOPES, WORKSPACE_SCOPES, REMOTE_MACHINE_SCOPES, LOCAL_MACHINE_S
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Emitter } from 'vs/base/common/event';
-import { ConfigurationScope, EditPresentationTypes } from 'vs/platform/configuration/common/configurationRegistry';
+import { ConfigurationScope, EditPresentationTypes, Extensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 import { ILanguageService } from 'vs/editor/common/languages/language';
+import { Registry } from 'vs/platform/registry/common/platform';
 
 export const ONLINE_SERVICES_SETTING_TAG = 'usesOnlineServices';
 
@@ -221,6 +222,12 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 			this.value = displayValue;
 			this.scopeValue = isConfigured && overrideValues[targetSelector];
 			this.defaultValue = overrideValues.defaultValue ?? inspected.defaultValue;
+
+			const registryValues = Registry.as<IConfigurationRegistry>(Extensions.Configuration).getConfigurationDefaultsOverrides();
+			const overrideValueSource = registryValues.get(`[${languageSelector}]`)?.valuesSources?.get(this.setting.key);
+			if (overrideValueSource) {
+				this.setting.defaultValueSource = overrideValueSource;
+			}
 		} else {
 			this.value = displayValue;
 			this.scopeValue = isConfigured && inspected[targetSelector];

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -707,15 +707,17 @@ export class DefaultSettings extends Disposable {
 					});
 				}
 
-				const registeredConfigurationProp = prop as IRegisteredConfigurationPropertySchema;
-				let defaultValueSource: string | IExtensionInfo | undefined;
-				if (registeredConfigurationProp && registeredConfigurationProp.defaultValueSource) {
-					defaultValueSource = registeredConfigurationProp.defaultValueSource;
-				}
-
 				let isLanguageTagSetting = false;
 				if (OVERRIDE_PROPERTY_REGEX.test(key)) {
 					isLanguageTagSetting = true;
+				}
+
+				let defaultValueSource: string | IExtensionInfo | undefined;
+				if (!isLanguageTagSetting) {
+					const registeredConfigurationProp = prop as IRegisteredConfigurationPropertySchema;
+					if (registeredConfigurationProp && registeredConfigurationProp.defaultValueSource) {
+						defaultValueSource = registeredConfigurationProp.defaultValueSource;
+					}
 				}
 
 				result.push({


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #148672

We can finally obtain the correct extension source for extension-contributed language-specific default value overrides. Therefore, the PR adds in the default value source in the case of language-specific settings, so that the default override indicator can be displayed for language-specific settings where applicable.

![A screenshot showing a default override indicator on the editor.wordWrap setting with the Markdown language filter](https://user-images.githubusercontent.com/7199958/167952111-5ae88654-9743-4a9b-b2fe-23d6280140a5.PNG)

