### PR TITLE
Fix auto tasks in the browser

### DIFF
--- a/src/vs/workbench/api/common/extHostTask.ts
+++ b/src/vs/workbench/api/common/extHostTask.ts
@@ -715,8 +715,8 @@ export class WorkerExtHostTask extends ExtHostTaskBase {
 		@IExtHostApiDeprecationService deprecationService: IExtHostApiDeprecationService
 	) {
 		super(extHostRpc, initData, workspaceService, editorService, configurationService, extHostTerminalService, logService, deprecationService);
-		this.registerTaskSystem(Schemas.vscodeRemote, {
-			scheme: Schemas.vscodeRemote,
+		this.registerTaskSystem(Schemas.inMemory, {
+			scheme: Schemas.inMemory,
 			authority: '',
 			platform: Platform.PlatformToString(Platform.Platform.Web)
 		});

--- a/src/vs/workbench/api/common/extHostTask.ts
+++ b/src/vs/workbench/api/common/extHostTask.ts
@@ -715,8 +715,8 @@ export class WorkerExtHostTask extends ExtHostTaskBase {
 		@IExtHostApiDeprecationService deprecationService: IExtHostApiDeprecationService
 	) {
 		super(extHostRpc, initData, workspaceService, editorService, configurationService, extHostTerminalService, logService, deprecationService);
-		this.registerTaskSystem(Schemas.inMemory, {
-			scheme: Schemas.inMemory,
+		this.registerTaskSystem(Schemas.vscodeRemote, {
+			scheme: Schemas.vscodeRemote,
 			authority: '',
 			platform: Platform.PlatformToString(Platform.Platform.Web)
 		});

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -205,7 +205,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	private _showIgnoreMessage?: boolean;
 	private _providers: Map<number, ITaskProvider>;
 	private _providerTypes: Map<number, string>;
-	protected _taskSystemInfos: Map<string, TaskSystemInfo>;
+	protected _taskSystemInfos: Map<string, TaskSystemInfo[]>;
 
 	protected _workspaceTasksPromise?: Promise<Map<string, WorkspaceFolderTaskResult>>;
 
@@ -265,7 +265,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		this._outputChannel = this.outputService.getChannel(AbstractTaskService.OutputChannelId)!;
 		this._providers = new Map<number, ITaskProvider>();
 		this._providerTypes = new Map<number, string>();
-		this._taskSystemInfos = new Map<string, TaskSystemInfo>();
+		this._taskSystemInfos = new Map<string, TaskSystemInfo[]>();
 		this._register(this.contextService.onDidChangeWorkspaceFolders(() => {
 			let folderSetup = this.computeWorkspaceFolderSetup();
 			if (this.executionEngine !== folderSetup[2]) {
@@ -567,25 +567,41 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	}
 
 	get hasTaskSystemInfo(): boolean {
+		let infosCount = Array.from(this._taskSystemInfos.values()).flat().length;
 		// If there's a remoteAuthority, then we end up with 2 taskSystemInfos,
 		// one for each extension host.
 		if (this.environmentService.remoteAuthority) {
-			return this._taskSystemInfos.size > 1;
+			return infosCount > 1;
 		}
-		return this._taskSystemInfos.size > 0;
+		return infosCount > 0;
 	}
 
 	public registerTaskSystem(key: string, info: TaskSystemInfo): void {
-		if (!this._taskSystemInfos.has(key) || info.platform !== Platform.Platform.Web) {
-			this._taskSystemInfos.set(key, info);
-			if (this.hasTaskSystemInfo) {
-				this._onDidChangeTaskSystemInfo.fire();
+		// Ideally the Web caller of registerRegisterTaskSystem would use the correct key.
+		// However, the caller doesn't know about the workspace folders at the time of the call, even though we know about them here.
+		if (info.platform === Platform.Platform.Web) {
+			key = this.workspaceFolders.length ? this.workspaceFolders[0].uri.scheme : key;
+		}
+		if (!this._taskSystemInfos.has(key)) {
+			this._taskSystemInfos.set(key, [info]);
+		} else {
+			const infos = this._taskSystemInfos.get(key)!;
+			if (info.platform === Platform.Platform.Web) {
+				// Web infos should be pushed last.
+				infos.push(info);
+			} else {
+				infos.unshift(info);
 			}
+		}
+
+		if (this.hasTaskSystemInfo) {
+			this._onDidChangeTaskSystemInfo.fire();
 		}
 	}
 
 	private getTaskSystemInfo(key: string): TaskSystemInfo | undefined {
-		return this._taskSystemInfos.get(key);
+		const infos = this._taskSystemInfos.get(key);
+		return (infos && infos.length) ? infos[0] : undefined;
 	}
 
 	public extensionCallbackTaskComplete(task: Task, result: number): Promise<void> {
@@ -1791,9 +1807,9 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 					const infos = Array.from(this._taskSystemInfos.entries());
 					const notFile = infos.filter(info => info[0] !== Schemas.file);
 					if (notFile.length > 0) {
-						return notFile[0][1];
+						return notFile[0][1][0];
 					}
-					return infos[0][1];
+					return infos[0][1][0];
 				} else {
 					return undefined;
 				}

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -576,6 +576,11 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	}
 
 	public registerTaskSystem(key: string, info: TaskSystemInfo): void {
+		// Ideally the Web caller of registerRegisterTaskSystem would use the correct key.
+		// However, the caller doesn't know about the workspace folders at the time of the call, even though we know about them here.
+		if (info.platform === Platform.Platform.Web) {
+			key = this.workspaceFolders.length ? this.workspaceFolders[0].uri.scheme : key;
+		}
 		if (!this._taskSystemInfos.has(key) || info.platform !== Platform.Platform.Web) {
 			this._taskSystemInfos.set(key, info);
 			if (this.hasTaskSystemInfo) {

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -576,11 +576,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	}
 
 	public registerTaskSystem(key: string, info: TaskSystemInfo): void {
-		// Ideally the Web caller of registerRegisterTaskSystem would use the correct key.
-		// However, the caller doesn't know about the workspace folders at the time of the call, even though we know about them here.
-		if (info.platform === Platform.Platform.Web) {
-			key = this.workspaceFolders.length ? this.workspaceFolders[0].uri.scheme : key;
-		}
 		if (!this._taskSystemInfos.has(key) || info.platform !== Platform.Platform.Web) {
 			this._taskSystemInfos.set(key, info);
 			if (this.hasTaskSystemInfo) {


### PR DESCRIPTION
The issue here is that we often have 2 extensions hosts: 1 remote and 1 local. Both extension hosts register a task system info. In browser + server case, we have 1 remote and 1 worker. In this case, both task system infos register with the scheme vscode-remote. This was causing the task service to only keep 1 of the infos because the first would get overwritten by the second.