### PR TITLE
Refine title menu

### DIFF
--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -6,7 +6,7 @@
 .quick-input-widget {
 	position: absolute;
 	width: 600px;
-	z-index: 2000;
+	z-index: 4000;
 	padding: 0 1px 1px 1px;
 	left: 50%;
 	margin-left: -300px;

--- a/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
+++ b/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
@@ -44,7 +44,8 @@ export class EditorScopedQuickInputService extends QuickInputService {
 				get container() { return widget.getDomNode(); },
 				get dimension() { return editor.getLayoutInfo(); },
 				get onDidLayout() { return editor.onDidLayoutChange; },
-				focus: () => editor.focus()
+				focus: () => editor.focus(),
+				offset: { top: 0, quickPickTop: 0 }
 			};
 		} else {
 			this.host = undefined;

--- a/src/vs/editor/standalone/browser/standaloneLayoutService.ts
+++ b/src/vs/editor/standalone/browser/standaloneLayoutService.ts
@@ -5,7 +5,7 @@
 
 import * as dom from 'vs/base/browser/dom';
 import { Event } from 'vs/base/common/event';
-import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
+import { ILayoutService, ILayoutOffsetInfo } from 'vs/platform/layout/browser/layoutService';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
@@ -40,9 +40,12 @@ class StandaloneLayoutService implements ILayoutService {
 		this._codeEditorService.getFocusedCodeEditor()?.focus();
 	}
 
+	readonly offset: ILayoutOffsetInfo = { top: 0, quickPickTop: 0 };
+
 	constructor(
 		@ICodeEditorService private _codeEditorService: ICodeEditorService
 	) { }
+
 }
 
 export class EditorScopedLayoutService extends StandaloneLayoutService {

--- a/src/vs/platform/layout/browser/layoutService.ts
+++ b/src/vs/platform/layout/browser/layoutService.ts
@@ -9,6 +9,17 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 
 export const ILayoutService = createDecorator<ILayoutService>('layoutService');
 
+export interface ILayoutOffsetInfo {
+	/**
+	 * Generic top offset
+	 */
+	readonly top: number;
+	/**
+	 * Quick pick specific top offset.
+	 */
+	readonly quickPickTop: number;
+}
+
 export interface ILayoutService {
 
 	readonly _serviceBrand: undefined;
@@ -40,7 +51,7 @@ export interface ILayoutService {
 	/**
 	 * An offset to use for positioning elements inside the container.
 	 */
-	readonly offset?: { top: number };
+	readonly offset: ILayoutOffsetInfo;
 
 	/**
 	 * An event that is emitted when the container is layed out. The

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -84,10 +84,10 @@ export class QuickInputService extends Themable implements IQuickInputService {
 			...options
 		}));
 
-		controller.layout(host.dimension, host.offset?.top ?? 0);
+		controller.layout(host.dimension, host.offset.quickPickTop);
 
 		// Layout changes
-		this._register(host.onDidLayout(dimension => controller.layout(dimension, host.offset?.top ?? 0)));
+		this._register(host.onDidLayout(dimension => controller.layout(dimension, host.offset.quickPickTop)));
 
 		// Context keys
 		this._register(controller.onShow(() => this.resetContextKeys()));

--- a/src/vs/workbench/browser/actions/quickAccessActions.ts
+++ b/src/vs/workbench/browser/actions/quickAccessActions.ts
@@ -140,11 +140,14 @@ registerAction2(class QuickAccessAction extends Action2 {
 				mac: globalQuickAccessKeybinding.mac
 			},
 			f1: true,
-			menu: {
+			menu: [{
 				id: MenuId.TitleMenuQuickPick,
 				group: '1/workspaceNav',
 				order: 1
-			}
+			}, {
+				id: MenuId.TitleMenu,
+				order: 100
+			}]
 		});
 	}
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -144,16 +144,13 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	get dimension(): IDimension { return this._dimension; }
 
 	get offset() {
-		return {
-			top: (() => {
-				let offset = 0;
-				if (this.isVisible(Parts.TITLEBAR_PART)) {
-					offset = this.getPart(Parts.TITLEBAR_PART).maximumHeight;
-				}
-
-				return offset;
-			})()
-		};
+		let top = 0;
+		let quickPickTop = 0;
+		if (this.isVisible(Parts.TITLEBAR_PART)) {
+			top = this.getPart(Parts.TITLEBAR_PART).maximumHeight;
+			quickPickTop = this.titleService.titleMenuVisible ? 0 : top;
+		}
+		return { top, quickPickTop };
 	}
 
 	//#endregion
@@ -270,6 +267,9 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		if ((isWindows || isLinux || isWeb) && getTitleBarStyle(this.configurationService) === 'custom') {
 			this._register(this.titleService.onMenubarVisibilityChange(visible => this.onMenubarToggled(visible)));
 		}
+
+		// Title Menu changes
+		this._register(this.titleService.onDidChangeTitleMenuVisibility(() => this._onDidLayout.fire(this._dimension)));
 
 		// Theme changes
 		this._register(this.themeService.onDidColorThemeChange(() => this.updateStyles()));

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -113,6 +113,7 @@
 	display: inline-block;
 	width: 100%;
 	text-align: center;
+	font-size: 12px;
 }
 
 .monaco-workbench .part.titlebar>.titlebar-container>.window-title>.title-menu .action-item.quickopen .action-label:HOVER {

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -91,8 +91,8 @@
 
 .monaco-workbench .part.titlebar>.titlebar-container>.window-title>.title-menu .action-item.quickopen {
 	display: flex;
-	color: var(--vscode-input-foreground);
-	border: 1px solid var(--vscode-dropdown-border);
+	color: var(--vscode-titleMenu-foreground);
+	border: 1px solid var(--vscode-titleMenu-border);
 	border-radius: 5px;
 	height: 20px;
 	line-height: 18px;
@@ -105,7 +105,7 @@
 }
 
 .monaco-workbench .part.titlebar>.titlebar-container>.window-title>.title-menu .action-item.quickopen:HOVER {
-	background-color: var(--vscode-dropdown-border);
+	background-color: var(--vscode-titleMenu-activeBackground);
 	line-height: 18px;
 }
 
@@ -116,7 +116,7 @@
 }
 
 .monaco-workbench .part.titlebar>.titlebar-container>.window-title>.title-menu .action-item.quickopen .action-label:HOVER {
-	background-color: var(--vscode-dropdown-border);
+	background-color: var(--vscode-titleMenu-activeBackground);
 }
 
 /* Menubar */

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -86,10 +86,12 @@
 }
 
 .monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen {
+	display: flex;
 	color: var(--vscode-input-foreground);
 	border: 1px solid var(--vscode-dropdown-border);
+	border-radius: 5px;
 	height: 20px;
-	line-height: 20px;
+	line-height: 18px;
 	width: 38vw;
 	max-width: 600px;
 	margin: 4px 4px;
@@ -98,25 +100,19 @@
 	overflow: hidden;
 }
 
-.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen:HOVER,
-.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen .action-container .action-label:HOVER {
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen:HOVER {
 	background-color: var(--vscode-dropdown-border);
 	line-height: 18px;
 }
 
-.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen .action-container {
-	flex: 1 0 auto;
-	display: flex;
-	justify-content: center;
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen .action-label {
+	display: inline-block;
+	width: 100%;
+	text-align: center;
 }
 
-.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen .action-container .keybinding {
-	font-size: 11px;
-	padding: 3px;
-}
-
-.monaco-workbench .part.titlebar>.titlebar-container>.title-menu .action-item.quickopen .dropdown-action-container {
-	margin-left: auto;
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen .action-label:HOVER {
+	background-color: var(--vscode-dropdown-border);
 }
 
 /* Menubar */

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -80,12 +80,16 @@
 }
 
 /* Window Title Menu */
-.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu {
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title>.title-menu {
 	z-index: 3000;
 	-webkit-app-region: no-drag;
 }
 
-.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen {
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title>.title-menu.hide {
+	display: none;
+}
+
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title>.title-menu .action-item.quickopen {
 	display: flex;
 	color: var(--vscode-input-foreground);
 	border: 1px solid var(--vscode-dropdown-border);
@@ -100,18 +104,18 @@
 	overflow: hidden;
 }
 
-.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen:HOVER {
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title>.title-menu .action-item.quickopen:HOVER {
 	background-color: var(--vscode-dropdown-border);
 	line-height: 18px;
 }
 
-.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen .action-label {
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title>.title-menu .action-item.quickopen .action-label {
 	display: inline-block;
 	width: 100%;
 	text-align: center;
 }
 
-.monaco-workbench .part.titlebar>.titlebar-container>.window-title.title-menu .action-item.quickopen .action-label:HOVER {
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title>.title-menu .action-item.quickopen .action-label:HOVER {
 	background-color: var(--vscode-dropdown-border);
 }
 

--- a/src/vs/workbench/browser/parts/titlebar/titleMenuControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titleMenuControl.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
+import { IAction } from 'vs/base/common/actions';
+import { Codicon } from 'vs/base/common/codicons';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { localize } from 'vs/nls';
+import { createActionViewItem, createAndFillInContextMenuActions, MenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { IMenuService, MenuId, MenuItemAction, MenuRegistry } from 'vs/platform/actions/common/actions';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
+
+export class TitleMenuControl {
+
+	private readonly _disposables = new DisposableStore();
+
+	readonly element: HTMLElement = document.createElement('div');
+
+	constructor(
+		windowTitle: WindowTitle,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IMenuService menuService: IMenuService,
+		@IQuickInputService quickInputService: IQuickInputService,
+	) {
+		this.element.classList.add('title-menu');
+		const titleToolbar = new ToolBar(this.element, contextMenuService, {
+			actionViewItemProvider: (action) => {
+
+				if (action instanceof MenuItemAction && action.id === 'workbench.action.quickOpen') {
+
+					class InputLikeViewItem extends MenuEntryActionViewItem {
+						override render(container: HTMLElement): void {
+							super.render(container);
+							container.classList.add('quickopen');
+							this._store.add(windowTitle.onDidChange(this._updateFromWindowTitle, this));
+							this._updateFromWindowTitle();
+						}
+						private _updateFromWindowTitle() {
+							if (this.label) {
+								this.label.innerText = localize('search', "Search {0}", windowTitle.workspaceName);
+								this.label.title = windowTitle.value;
+							}
+						}
+					}
+					return instantiationService.createInstance(InputLikeViewItem, action, undefined);
+				}
+
+				return createActionViewItem(instantiationService, action);
+			}
+		});
+		const titleMenu = this._disposables.add(menuService.createMenu(MenuId.TitleMenu, contextKeyService));
+		const titleMenuDisposables = this._disposables.add(new DisposableStore());
+		const updateTitleMenu = () => {
+			titleMenuDisposables.clear();
+			const actions: IAction[] = [];
+			titleMenuDisposables.add(createAndFillInContextMenuActions(titleMenu, undefined, actions));
+			titleToolbar.setActions(actions);
+		};
+		updateTitleMenu();
+		this._disposables.add(titleMenu.onDidChange(updateTitleMenu));
+		this._disposables.add(quickInputService.onShow(() => this.element.classList.toggle('hide', true)));
+		this._disposables.add(quickInputService.onHide(() => this.element.classList.toggle('hide', false)));
+	}
+
+	dispose(): void {
+		this._disposables.dispose();
+	}
+}
+
+MenuRegistry.appendMenuItem(MenuId.TitleMenu, {
+	submenu: MenuId.TitleMenuQuickPick,
+	title: localize('title', "Quick Pick"),
+	icon: Codicon.search,
+	order: Number.MAX_SAFE_INTEGER
+});

--- a/src/vs/workbench/browser/parts/titlebar/titleMenuControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titleMenuControl.ts
@@ -14,7 +14,9 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+import * as colors from 'vs/platform/theme/common/colorRegistry';
 import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
+import { MENUBAR_SELECTION_BACKGROUND, MENUBAR_SELECTION_FOREGROUND } from 'vs/workbench/common/theme';
 
 export class TitleMenuControl {
 
@@ -75,9 +77,45 @@ export class TitleMenuControl {
 	}
 }
 
+// --- quick pick submenu
+
 MenuRegistry.appendMenuItem(MenuId.TitleMenu, {
 	submenu: MenuId.TitleMenuQuickPick,
 	title: localize('title', "Quick Pick"),
 	icon: Codicon.search,
 	order: Number.MAX_SAFE_INTEGER
 });
+
+
+// --- theme colors
+
+colors.registerColor(
+	'titleMenu.foreground',
+	{ dark: colors.inputForeground, hcDark: colors.inputForeground, light: colors.inputForeground, hcLight: colors.inputForeground },
+	localize('titleMenu-foreground', "Foreground color of the title menu"),
+	false
+);
+colors.registerColor(
+	'titleMenu.background',
+	{ dark: colors.inputForeground, hcDark: colors.inputForeground, light: colors.inputForeground, hcLight: colors.inputForeground },
+	localize('titleMenu-background', "Background color of the title menu"),
+	false
+);
+const activeBackground = colors.registerColor(
+	'titleMenu.activeBackground',
+	{ dark: MENUBAR_SELECTION_BACKGROUND, hcDark: MENUBAR_SELECTION_BACKGROUND, light: MENUBAR_SELECTION_BACKGROUND, hcLight: MENUBAR_SELECTION_BACKGROUND },
+	localize('titleMenu-activeBackground', "Active background color of the title menu"),
+	false
+);
+colors.registerColor(
+	'titleMenu.border',
+	{ dark: activeBackground, hcDark: activeBackground, light: activeBackground, hcLight: activeBackground },
+	localize('titleMenu-border', "Border color of the title menu"),
+	false
+);
+colors.registerColor(
+	'titleMenu.activeForeground',
+	{ dark: MENUBAR_SELECTION_FOREGROUND, hcDark: MENUBAR_SELECTION_FOREGROUND, light: MENUBAR_SELECTION_FOREGROUND, hcLight: MENUBAR_SELECTION_FOREGROUND },
+	localize('titleMenu-activeForeground', "Active foreground color of the title menu"),
+	false
+);

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -13,28 +13,33 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
 import { IAction, toAction } from 'vs/base/common/actions';
 import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
-import { DisposableStore, dispose, toDisposable } from 'vs/base/common/lifecycle';
+import { DisposableStore, dispose } from 'vs/base/common/lifecycle';
 import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService';
 import { IThemeService, registerThemingParticipant, ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { TITLE_BAR_ACTIVE_BACKGROUND, TITLE_BAR_ACTIVE_FOREGROUND, TITLE_BAR_INACTIVE_FOREGROUND, TITLE_BAR_INACTIVE_BACKGROUND, TITLE_BAR_BORDER, WORKBENCH_BACKGROUND } from 'vs/workbench/common/theme';
 import { isMacintosh, isWindows, isLinux, isWeb } from 'vs/base/common/platform';
 import { Color } from 'vs/base/common/color';
-import { EventType, EventHelper, Dimension, isAncestor, append, $, addDisposableListener, runAtThisOrScheduleAtNextAnimationFrame, prepend, clearNode } from 'vs/base/browser/dom';
+import { EventType, EventHelper, Dimension, isAncestor, append, $, addDisposableListener, runAtThisOrScheduleAtNextAnimationFrame, prepend, reset } from 'vs/base/browser/dom';
 import { CustomMenubarControl } from 'vs/workbench/browser/parts/titlebar/menubarControl';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { Emitter } from 'vs/base/common/event';
+import { Emitter, Event } from 'vs/base/common/event';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { Parts, IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
-import { createActionViewItem, createAndFillInContextMenuActions, MenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
-import { IMenuService, IMenu, MenuId, MenuRegistry, MenuItemAction } from 'vs/platform/actions/common/actions';
+import { createActionViewItem, createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { IMenuService, IMenu, MenuId } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { Codicon } from 'vs/base/common/codicons';
 import { getIconRegistry } from 'vs/platform/theme/common/iconRegistry';
 import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
+import { TitleMenuControl } from 'vs/workbench/browser/parts/titlebar/titleMenuControl';
 
 export class TitlebarPart extends Part implements ITitleService {
+
+	private static readonly configTitleMenu = 'window.experimental.titleMenu';
+
+	declare readonly _serviceBrand: undefined;
 
 	//#region IView
 
@@ -48,7 +53,8 @@ export class TitlebarPart extends Part implements ITitleService {
 	private _onMenubarVisibilityChange = this._register(new Emitter<boolean>());
 	readonly onMenubarVisibilityChange = this._onMenubarVisibilityChange.event;
 
-	declare readonly _serviceBrand: undefined;
+	private readonly _onDidChangeTitleMenuVisibility = new Emitter<void>();
+	readonly onDidChangeTitleMenuVisibility: Event<void> = this._onDidChangeTitleMenuVisibility.event;
 
 	protected rootContainer!: HTMLElement;
 	protected windowControls: HTMLElement | undefined;
@@ -96,6 +102,10 @@ export class TitlebarPart extends Part implements ITitleService {
 		this.windowTitle.updateProperties(properties);
 	}
 
+	get titleMenuVisible() {
+		return this.configurationService.getValue<boolean>(TitlebarPart.configTitleMenu);
+	}
+
 	private registerListeners(): void {
 		this._register(this.hostService.onDidChangeFocus(focused => focused ? this.onFocus() : this.onBlur()));
 		this._register(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationChanged(e)));
@@ -127,9 +137,10 @@ export class TitlebarPart extends Part implements ITitleService {
 			this.layoutControls.classList.toggle('show-layout-control', this.layoutControlEnabled);
 		}
 
-		if (event.affectsConfiguration('window.experimental.titleMenu')) {
+		if (event.affectsConfiguration(TitlebarPart.configTitleMenu)) {
 			this.updateTitle();
 			this.adjustTitleMarginToCenter();
+			this._onDidChangeTitleMenuVisibility.fire();
 		}
 	}
 
@@ -172,10 +183,7 @@ export class TitlebarPart extends Part implements ITitleService {
 
 	private updateTitle(): void {
 		this.titleDisposables.clear();
-		const enableTitleMenu = this.configurationService.getValue<boolean>('window.experimental.titleMenu');
-		this.title.classList.toggle('title-menu', enableTitleMenu);
-
-		if (!enableTitleMenu) {
+		if (!this.titleMenuVisible) {
 			// Text Title
 			this.title.innerText = this.windowTitle.value;
 			this.titleDisposables.add(this.windowTitle.onDidChange(() => {
@@ -184,44 +192,9 @@ export class TitlebarPart extends Part implements ITitleService {
 			}));
 		} else {
 			// Menu Title
-			clearNode(this.title);
-			const that = this;
-			const titleToolbar = new ToolBar(this.title, this.contextMenuService, {
-				actionViewItemProvider: (action) => {
-
-					if (action instanceof MenuItemAction && action.id === 'workbench.action.quickOpen') {
-
-						class InputLikeViewItem extends MenuEntryActionViewItem {
-							override render(container: HTMLElement): void {
-								super.render(container);
-								container.classList.add('quickopen');
-								this._store.add(that.windowTitle.onDidChange(this._updateFromWindowTitle, this));
-								this._updateFromWindowTitle();
-							}
-							private _updateFromWindowTitle() {
-								if (this.label) {
-									this.label.innerText = localize('search', "Search {0}", that.windowTitle.workspaceName);
-									this.label.title = that.windowTitle.value;
-								}
-							}
-						}
-						return that.instantiationService.createInstance(InputLikeViewItem, action, undefined);
-					}
-
-					return createActionViewItem(this.instantiationService, action);
-				}
-			});
-			const titleMenu = this.titleDisposables.add(this.menuService.createMenu(MenuId.TitleMenu, this.contextKeyService));
-			const titleMenuDisposables = this.titleDisposables.add(new DisposableStore());
-			const updateTitleMenu = () => {
-				titleMenuDisposables.clear();
-				const actions: IAction[] = [];
-				titleMenuDisposables.add(createAndFillInContextMenuActions(titleMenu, undefined, actions));
-				titleToolbar.setActions(actions);
-			};
-			this.titleDisposables.add(titleMenu.onDidChange(updateTitleMenu));
-			this.titleDisposables.add(toDisposable(() => clearNode(this.title)));
-			updateTitleMenu();
+			const titleMenu = this.instantiationService.createInstance(TitleMenuControl, this.windowTitle);
+			reset(this.title, titleMenu.element);
+			this.titleDisposables.add(titleMenu);
 		}
 	}
 
@@ -494,11 +467,4 @@ registerThemingParticipant((theme, collector) => {
 			}
 		`);
 	}
-});
-
-MenuRegistry.appendMenuItem(MenuId.TitleMenu, {
-	submenu: MenuId.TitleMenuQuickPick,
-	title: localize('title', "Select Mode"),
-	icon: Codicon.search,
-	order: Number.MAX_SAFE_INTEGER
 });

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -32,7 +32,6 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { Codicon } from 'vs/base/common/codicons';
 import { getIconRegistry } from 'vs/platform/theme/common/iconRegistry';
 import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
 
 export class TitlebarPart extends Part implements ITitleService {
@@ -83,7 +82,6 @@ export class TitlebarPart extends Part implements ITitleService {
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IHostService private readonly hostService: IHostService,
-		@IKeybindingService private readonly keybindingService: IKeybindingService,
 	) {
 		super(Parts.TITLEBAR_PART, { hasTitle: false }, themeService, storageService, layoutService);
 		this.windowTitle = this._register(instantiationService.createInstance(WindowTitle));
@@ -222,7 +220,6 @@ export class TitlebarPart extends Part implements ITitleService {
 				titleToolbar.setActions(actions);
 			};
 			this.titleDisposables.add(titleMenu.onDidChange(updateTitleMenu));
-			this.titleDisposables.add(this.keybindingService.onDidUpdateKeybindings(updateTitleMenu));
 			this.titleDisposables.add(toDisposable(() => clearNode(this.title)));
 			updateTitleMenu();
 		}

--- a/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -58,6 +58,10 @@ export class WindowTitle extends Disposable {
 		return this.title ?? '';
 	}
 
+	get workspaceName() {
+		return this.labelService.getWorkspaceLabel(this.contextService.getWorkspace());
+	}
+
 	private registerListeners(): void {
 		this._register(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationChanged(e)));
 		this._register(this.editorService.onDidActiveEditorChange(() => this.onActiveEditorChange()));

--- a/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
@@ -71,7 +71,7 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 		super(themeService);
 
 		this.$el = dom.$('div.debug-toolbar');
-		this.$el.style.top = `${layoutService.offset?.top ?? 0}px`;
+		this.$el.style.top = `${layoutService.offset.top}px`;
 
 		this.dragArea = dom.append(this.$el, dom.$('div.drag-area' + ThemeIcon.asCSSSelector(icons.debugGripper)));
 
@@ -161,7 +161,7 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 				// Prevent default to stop editor selecting text #8524
 				mouseMoveEvent.preventDefault();
 				// Reduce x by width of drag handle to reduce jarring #16604
-				this.setCoordinates(mouseMoveEvent.posx - 14, mouseMoveEvent.posy - (this.layoutService.offset?.top ?? 0));
+				this.setCoordinates(mouseMoveEvent.posx - 14, mouseMoveEvent.posy - (this.layoutService.offset.top));
 			});
 
 			const mouseUpListener = dom.addDisposableGenericMouseUpListener(window, (e: MouseEvent) => {
@@ -207,7 +207,7 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 	}
 
 	private setYCoordinate(y = this.yCoordinate): void {
-		const titlebarOffset = this.layoutService.offset?.top ?? 0;
+		const titlebarOffset = this.layoutService.offset.top;
 		this.$el.style.top = `${titlebarOffset + y}px`;
 		this.yCoordinate = y;
 	}

--- a/src/vs/workbench/contrib/welcomeOverlay/browser/welcomeOverlay.ts
+++ b/src/vs/workbench/contrib/welcomeOverlay/browser/welcomeOverlay.ts
@@ -169,7 +169,7 @@ class WelcomeOverlay extends Disposable {
 	}
 
 	private create(): void {
-		const offset = this.layoutService.offset?.top ?? 0;
+		const offset = this.layoutService.offset.top;
 		this._overlay = dom.append(this.layoutService.container, $('.welcomeOverlay'));
 		this._overlay.style.top = `${offset}px`;
 		this._overlay.style.height = `calc(100% - ${offset}px)`;

--- a/src/vs/workbench/electron-sandbox/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/electron-sandbox/parts/titlebar/titlebarPart.ts
@@ -21,7 +21,6 @@ import { getTitleBarStyle } from 'vs/platform/window/common/window';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { Codicon } from 'vs/base/common/codicons';
 import { NativeMenubarControl } from 'vs/workbench/electron-sandbox/parts/titlebar/menubarControl';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 
 export class TitlebarPart extends BrowserTitleBarPart {
 	private maxRestoreControl: HTMLElement | undefined;
@@ -55,9 +54,8 @@ export class TitlebarPart extends BrowserTitleBarPart {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IHostService hostService: IHostService,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
-		@IKeybindingService keybindingService: IKeybindingService,
 	) {
-		super(contextMenuService, configurationService, environmentService, instantiationService, themeService, storageService, layoutService, menuService, contextKeyService, hostService, keybindingService);
+		super(contextMenuService, configurationService, environmentService, instantiationService, themeService, storageService, layoutService, menuService, contextKeyService, hostService);
 
 		this.environmentService = environmentService;
 	}

--- a/src/vs/workbench/services/title/common/titleService.ts
+++ b/src/vs/workbench/services/title/common/titleService.ts
@@ -24,6 +24,16 @@ export interface ITitleService {
 	readonly onMenubarVisibilityChange: Event<boolean>;
 
 	/**
+	 *  Title menu is visible
+	 */
+	readonly titleMenuVisible: boolean;
+
+	/**
+	 * An event when the title menu is enabled/disabled
+	 */
+	readonly onDidChangeTitleMenuVisibility: Event<void>;
+
+	/**
 	 * Update some environmental title properties.
 	 */
 	updateProperties(properties: ITitleProperties): void;

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -159,6 +159,7 @@ import { IDiagnosticInfoOptions, IDiagnosticInfo } from 'vs/platform/diagnostics
 import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { ISocketFactory } from 'vs/platform/remote/common/remoteAgentConnection';
 import { IRemoteAgentEnvironment } from 'vs/platform/remote/common/remoteAgentEnvironment';
+import { ILayoutOffsetInfo } from 'vs/platform/layout/browser/layoutService';
 
 export function createFileEditorInput(instantiationService: IInstantiationService, resource: URI): FileEditorInput {
 	return instantiationService.createInstance(FileEditorInput, resource, undefined, undefined, undefined, undefined, undefined, undefined);
@@ -567,6 +568,7 @@ export class TestLayoutService implements IWorkbenchLayoutService {
 	openedDefaultEditors = false;
 
 	dimension: IDimension = { width: 800, height: 600 };
+	offset: ILayoutOffsetInfo = { top: 0, quickPickTop: 0 };
 
 	hasContainer = true;
 	container: HTMLElement = window.document.body;


### PR DESCRIPTION
* show workspace title inside "input like button", move other quick pick options into normal dropdown menu
* cleanup: no more need for keybindings service
* make `ILayoutService#offset` return general `top` and specific `quickPickTop` 
* improve ergonomics of `ILayoutService#offset`
* Use new `quickPickTop` to overlay title bar part when title menu is enabled 
* hide title menu whenever quick pick shows to avoid unwanted overlap 
* extract title menu into its own file
* define and use theme colors for title menu
