### PR TITLE
add additional telemetry for connection latency and duration

### DIFF
--- a/src/vs/platform/telemetry/common/remoteTelemetryChannel.ts
+++ b/src/vs/platform/telemetry/common/remoteTelemetryChannel.ts
@@ -45,6 +45,10 @@ export class ServerTelemetryChannel extends Disposable implements IServerChannel
 
 				return Promise.resolve();
 			}
+
+			case 'ping': {
+				return;
+			}
 		}
 		// Command we cannot handle so we throw an error
 		throw new Error(`IPC Command ${command} not found`);

--- a/src/vs/workbench/contrib/remote/common/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/common/remote.contribution.ts
@@ -185,14 +185,17 @@ class InitialRemoteConnectionHealthContribution implements IWorkbenchContributio
 				owner: 'alexdima';
 				comment: 'The initial connection succeeded';
 				web: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
+				connectionTimeMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time, in ms, until connected'; isMeasurement: true };
 				remoteName: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
 			};
 			type RemoteConnectionSuccessEvent = {
 				web: boolean;
+				connectionTimeMs: number | undefined;
 				remoteName: string | undefined;
 			};
 			this._telemetryService.publicLog2<RemoteConnectionSuccessEvent, RemoteConnectionSuccessClassification>('remoteConnectionSuccess', {
 				web: isWeb,
+				connectionTimeMs: this.getInitialConnectLatency(),
 				remoteName: getRemoteName(this._environmentService.remoteAuthority)
 			});
 
@@ -203,20 +206,28 @@ class InitialRemoteConnectionHealthContribution implements IWorkbenchContributio
 				comment: 'The initial connection failed';
 				web: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
 				remoteName: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
+				connectionTimeMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time, in ms, until connection failure'; isMeasurement: true };
 				message: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
 			};
 			type RemoteConnectionFailureEvent = {
 				web: boolean;
 				remoteName: string | undefined;
+				connectionTimeMs: number | undefined;
 				message: string;
 			};
 			this._telemetryService.publicLog2<RemoteConnectionFailureEvent, RemoteConnectionFailureClassification>('remoteConnectionFailure', {
 				web: isWeb,
+				connectionTimeMs: this.getInitialConnectLatency(),
 				remoteName: getRemoteName(this._environmentService.remoteAuthority),
 				message: err ? err.message : ''
 			});
 
 		}
+	}
+
+	private getInitialConnectLatency() {
+		const [entry] = performance.getEntriesByName('code/remote/initialConnect', 'measure');
+		return entry?.duration;
 	}
 }
 

--- a/src/vs/workbench/contrib/remote/common/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/common/remote.contribution.ts
@@ -31,6 +31,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { getRemoteName } from 'vs/platform/remote/common/remoteHosts';
 import { IDownloadService } from 'vs/platform/download/common/download';
 import { DownloadServiceChannel } from 'vs/platform/download/common/downloadIpc';
+import { timeout } from 'vs/base/common/async';
 
 export class LabelContribution implements IWorkbenchContribution {
 	constructor(
@@ -165,6 +166,9 @@ class RemoteInvalidWorkspaceDetector extends Disposable implements IWorkbenchCon
 	}
 }
 
+const EXT_HOST_LATENCY_SAMPLES = 5;
+const EXT_HOST_LATENCY_DELAY = 2_000;
+
 class InitialRemoteConnectionHealthContribution implements IWorkbenchContribution {
 
 	constructor(
@@ -199,6 +203,8 @@ class InitialRemoteConnectionHealthContribution implements IWorkbenchContributio
 				remoteName: getRemoteName(this._environmentService.remoteAuthority)
 			});
 
+			await this._measureExtHostLatency();
+
 		} catch (err) {
 
 			type RemoteConnectionFailureClassification = {
@@ -223,6 +229,38 @@ class InitialRemoteConnectionHealthContribution implements IWorkbenchContributio
 			});
 
 		}
+	}
+
+	private async _measureExtHostLatency() {
+		// Get the minimum latency, since latency spikes could be caused by a busy extension host.
+		let bestLatency = Infinity;
+		for (let i = 0; i < EXT_HOST_LATENCY_SAMPLES; i++) {
+			const rtt = await this._remoteAgentService.getRoundTripTime();
+			if (rtt === undefined) {
+				return;
+			}
+			bestLatency = Math.min(bestLatency, rtt / 2);
+			await timeout(EXT_HOST_LATENCY_DELAY);
+		}
+
+		type RemoteConnectionFailureClassification = {
+			owner: 'connor4312';
+			comment: 'The latency to the remote extension host';
+			web: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether this is running on web' };
+			remoteName: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Anonymized remote name' };
+			latencyMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Latency to the remote, in milliseconds'; isMeasurement: true };
+		};
+		type RemoteConnectionFailureEvent = {
+			web: boolean;
+			remoteName: string | undefined;
+			latencyMs: number;
+		};
+
+		this._telemetryService.publicLog2<RemoteConnectionFailureEvent, RemoteConnectionFailureClassification>('remoteConnectionFailure', {
+			web: isWeb,
+			remoteName: getRemoteName(this._environmentService.remoteAuthority),
+			latencyMs: bestLatency
+		});
 	}
 
 	private getInitialConnectLatency() {

--- a/src/vs/workbench/contrib/remote/common/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/common/remote.contribution.ts
@@ -199,7 +199,7 @@ class InitialRemoteConnectionHealthContribution implements IWorkbenchContributio
 			};
 			this._telemetryService.publicLog2<RemoteConnectionSuccessEvent, RemoteConnectionSuccessClassification>('remoteConnectionSuccess', {
 				web: isWeb,
-				connectionTimeMs: this.getInitialConnectLatency(),
+				connectionTimeMs: await this._remoteAgentService.getConnection()?.getInitialConnectionTimeMs(),
 				remoteName: getRemoteName(this._environmentService.remoteAuthority)
 			});
 
@@ -223,7 +223,7 @@ class InitialRemoteConnectionHealthContribution implements IWorkbenchContributio
 			};
 			this._telemetryService.publicLog2<RemoteConnectionFailureEvent, RemoteConnectionFailureClassification>('remoteConnectionFailure', {
 				web: isWeb,
-				connectionTimeMs: this.getInitialConnectLatency(),
+				connectionTimeMs: await this._remoteAgentService.getConnection()?.getInitialConnectionTimeMs(),
 				remoteName: getRemoteName(this._environmentService.remoteAuthority),
 				message: err ? err.message : ''
 			});
@@ -261,11 +261,6 @@ class InitialRemoteConnectionHealthContribution implements IWorkbenchContributio
 			remoteName: getRemoteName(this._environmentService.remoteAuthority),
 			latencyMs: bestLatency
 		});
-	}
-
-	private getInitialConnectLatency() {
-		const [entry] = performance.getEntriesByName('code/remote/initialConnect', 'measure');
-		return entry?.duration;
 	}
 }
 

--- a/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
@@ -164,8 +164,6 @@ export class RemoteAgentConnection extends Disposable implements IRemoteAgentCon
 	readonly remoteAuthority: string;
 	private _connection: Promise<Client<RemoteAgentConnectionContext>> | null;
 
-	initialConnectionLatencyMs?: number;
-
 	constructor(
 		remoteAuthority: string,
 		private readonly _commit: string | undefined,

--- a/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
@@ -128,9 +128,9 @@ export abstract class AbstractRemoteAgentService extends Disposable implements I
 	getRoundTripTime(): Promise<number | undefined> {
 		return this._withTelemetryChannel(
 			async channel => {
-				const start = performance.now();
+				const start = Date.now();
 				await RemoteExtensionEnvironmentChannelClient.ping(channel);
-				return performance.now() - start;
+				return Date.now() - start;
 			},
 			undefined
 		);
@@ -233,11 +233,11 @@ export class RemoteAgentConnection extends Disposable implements IRemoteAgentCon
 			ipcLogger: false ? new IPCLogger(`Local \u2192 Remote`, `Remote \u2192 Local`) : null
 		};
 		let connection: ManagementPersistentConnection;
-		let start = performance.now();
+		let start = Date.now();
 		try {
 			connection = this._register(await connectRemoteAgentManagement(options, this.remoteAuthority, `renderer`));
 		} finally {
-			this._initialConnectionMs = performance.now() - start;
+			this._initialConnectionMs = Date.now() - start;
 		}
 
 		connection.protocol.onDidDispose(() => {

--- a/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
@@ -125,6 +125,17 @@ export abstract class AbstractRemoteAgentService extends Disposable implements I
 		);
 	}
 
+	getRoundTripTime(): Promise<number | undefined> {
+		return this._withTelemetryChannel(
+			async channel => {
+				const start = performance.now();
+				await RemoteExtensionEnvironmentChannelClient.ping(channel);
+				return performance.now() - start;
+			},
+			undefined
+		);
+	}
+
 	private _withChannel<R>(callback: (channel: IChannel, connection: IRemoteAgentConnection) => Promise<R>, fallback: R): Promise<R> {
 		const connection = this.getConnection();
 		if (!connection) {

--- a/src/vs/workbench/services/remote/common/remoteAgentEnvironmentChannel.ts
+++ b/src/vs/workbench/services/remote/common/remoteAgentEnvironmentChannel.ts
@@ -138,4 +138,8 @@ export class RemoteExtensionEnvironmentChannelClient {
 	static flushTelemetry(channel: IChannel): Promise<void> {
 		return channel.call<void>('flushTelemetry');
 	}
+
+	static async ping(channel: IChannel): Promise<void> {
+		await channel.call<void>('ping');
+	}
 }

--- a/src/vs/workbench/services/remote/common/remoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/remoteAgentService.ts
@@ -64,7 +64,6 @@ export interface IExtensionHostExitInfo {
 
 export interface IRemoteAgentConnection {
 	readonly remoteAuthority: string;
-	readonly initialConnectionLatencyMs?: number;
 
 	readonly onReconnecting: Event<void>;
 	readonly onDidStateChange: Event<PersistentConnectionEvent>;

--- a/src/vs/workbench/services/remote/common/remoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/remoteAgentService.ts
@@ -58,6 +58,7 @@ export interface IExtensionHostExitInfo {
 
 export interface IRemoteAgentConnection {
 	readonly remoteAuthority: string;
+	readonly initialConnectionLatencyMs?: number;
 
 	readonly onReconnecting: Event<void>;
 	readonly onDidStateChange: Event<PersistentConnectionEvent>;

--- a/src/vs/workbench/services/remote/common/remoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/remoteAgentService.ts
@@ -71,4 +71,5 @@ export interface IRemoteAgentConnection {
 	getChannel<T extends IChannel>(channelName: string): T;
 	withChannel<T extends IChannel, R>(channelName: string, callback: (channel: T) => Promise<R>): Promise<R>;
 	registerChannel<T extends IServerChannel<RemoteAgentConnectionContext>>(channelName: string, channel: T): void;
+	getInitialConnectionTimeMs(): Promise<number>;
 }

--- a/src/vs/workbench/services/remote/common/remoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/remoteAgentService.ts
@@ -36,6 +36,12 @@ export interface IRemoteAgentService {
 	 */
 	getExtensionHostExitInfo(reconnectionToken: string): Promise<IExtensionHostExitInfo | null>;
 
+	/**
+	 * Gets the round trip time from the remote extension host. Note that this
+	 * may be delayed if the extension host is busy.
+	 */
+	getRoundTripTime(): Promise<number | undefined>;
+
 	whenExtensionsReady(): Promise<void>;
 	/**
 	 * Scan remote extensions.

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1918,4 +1918,5 @@ export class TestRemoteAgentService implements IRemoteAgentService {
 	async updateTelemetryLevel(telemetryLevel: TelemetryLevel): Promise<void> { }
 	async logTelemetry(eventName: string, data?: ITelemetryData): Promise<void> { }
 	async flushTelemetry(): Promise<void> { }
+	async getRoundTripTime(): Promise<number | undefined> { return undefined; }
 }


### PR DESCRIPTION
This adds a new `connectionTimeMs` to record the initial socket connection latency. This is done in a _slightly_ roundabout way using performance markers, since the TelemetryService doesn't exist at the time when we start creating the connection. So we put our markers in the ground and then look for them later once the connection is established (or fails.)

The second commit adds a new command the measures the approximate latency to the remote extension host. As discussed, this might be delayed if the remote extension host is busy, but should be a decent signal if we sample a few of them and take the best measurement.
