### PR TITLE
Adds `"` and `/` as punctuators for slugifying markdown headers

### DIFF
--- a/extensions/markdown-language-features/src/slugify.ts
+++ b/extensions/markdown-language-features/src/slugify.ts
@@ -24,7 +24,7 @@ export const githubSlugifier: Slugifier = new class implements Slugifier {
 				.toLowerCase()
 				.replace(/\s+/g, '-') // Replace whitespace with -
 				// allow-any-unicode-next-line
-				.replace(/[\]\[\!\'\#\$\%\&\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~\`。，、；：？！…—·ˉ¨‘’“”々～‖∶＂＇｀｜〃〔〕〈〉《》「」『』．〖〗【】（）［］｛｝]/g, '') // Remove known punctuators
+				.replace(/[\]\[\!\/\'\"\#\$\%\&\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~\`。，、；：？！…—·ˉ¨‘’“”々～‖∶＂＇｀｜〃〔〕〈〉《》「」『』．〖〗【】（）［］｛｝]/g, '') // Remove known punctuators
 				.replace(/^\-+/, '') // Remove leading -
 				.replace(/\-+$/, '') // Remove trailing -
 		);


### PR DESCRIPTION
We already include `'` and `/` makes sense to treat as a puctuator too for markdown headers such as `# Do A / B`
