### PR TITLE
Update pr-chat.yml to pull_request_target

### DIFF
--- a/.github/workflows/pr-chat.yml
+++ b/.github/workflows/pr-chat.yml
@@ -1,6 +1,6 @@
 name: PR Chat
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review]
 
 jobs:


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target, basically `pull_request_target` runs in the context of the `main` branch (or whatever is being merged into) and thus gets access to secrets even when PR is coming from a fork

Requires https://github.com/microsoft/vscode-github-triage-actions/pull/60!