### PR TITLE
Validate that semantic tokens edits reference valid offsets

### DIFF
--- a/src/vs/editor/common/services/modelService.ts
+++ b/src/vs/editor/common/services/modelService.ts
@@ -710,6 +710,14 @@ class SemanticColoringFeature extends Disposable {
 		}));
 		this._register(themeService.onDidColorThemeChange(handleSettingOrThemeChange));
 	}
+
+	override dispose(): void {
+		// Dispose all watchers
+		for (const watcher of Object.values(this._watchers)) {
+			watcher.dispose();
+		}
+		super.dispose();
+	}
 }
 
 class SemanticStyling extends Disposable {
@@ -900,6 +908,8 @@ export class ModelSemanticColoring extends Disposable {
 	}
 
 	private static _copy(src: Uint32Array, srcOffset: number, dest: Uint32Array, destOffset: number, length: number): void {
+		// protect against overflows
+		length = Math.min(length, dest.length - destOffset, src.length - srcOffset);
 		for (let i = 0; i < length; i++) {
 			dest[destOffset + i] = src[srcOffset + i];
 		}
@@ -959,6 +969,13 @@ export class ModelSemanticColoring extends Disposable {
 				let destLastStart = destData.length;
 				for (let i = tokens.edits.length - 1; i >= 0; i--) {
 					const edit = tokens.edits[i];
+
+					if (edit.start > srcData.length) {
+						styling.warnInvalidEditStart(currentResponse.resultId, tokens.resultId, i, edit.start, srcData.length);
+						// The edits are invalid and there's no way to recover
+						this._model.tokenization.setSemanticTokens(null, true);
+						return;
+					}
 
 					const copyCount = srcLastStart - (edit.start + edit.deleteCount);
 					if (copyCount > 0) {

--- a/src/vs/editor/common/services/semanticTokensProviderStyling.ts
+++ b/src/vs/editor/common/services/semanticTokensProviderStyling.ts
@@ -16,8 +16,9 @@ export const enum SemanticTokensProviderStylingConstants {
 export class SemanticTokensProviderStyling {
 
 	private readonly _hashTable: HashTable;
-	private _hasWarnedOverlappingTokens: boolean;
-	private _hasWarnedInvalidLengthTokens: boolean;
+	private _hasWarnedOverlappingTokens = false;
+	private _hasWarnedInvalidLengthTokens = false;
+	private _hasWarnedInvalidEditStart = false;
 
 	constructor(
 		private readonly _legend: SemanticTokensLegend,
@@ -26,8 +27,6 @@ export class SemanticTokensProviderStyling {
 		@ILogService private readonly _logService: ILogService
 	) {
 		this._hashTable = new HashTable();
-		this._hasWarnedOverlappingTokens = false;
-		this._hasWarnedInvalidLengthTokens = false;
 	}
 
 	public getMetadata(tokenTypeIndex: number, tokenModifierSet: number, languageId: string): number {
@@ -113,6 +112,13 @@ export class SemanticTokensProviderStyling {
 		if (!this._hasWarnedInvalidLengthTokens) {
 			this._hasWarnedInvalidLengthTokens = true;
 			console.warn(`Semantic token with invalid length detected at lineNumber ${lineNumber}, column ${startColumn}`);
+		}
+	}
+
+	public warnInvalidEditStart(previousResultId: string | undefined, resultId: string | undefined, editIndex: number, editStart: number, maxExpectedStart: number): void {
+		if (!this._hasWarnedInvalidEditStart) {
+			this._hasWarnedInvalidEditStart = true;
+			console.warn(`Invalid semantic tokens edit detected (previousResultId: ${previousResultId}, resultId: ${resultId}) at edit #${editIndex}: The provided start offset ${editStart} is outside the previous data (length ${maxExpectedStart}).`);
 		}
 	}
 

--- a/src/vs/editor/test/common/services/modelService.test.ts
+++ b/src/vs/editor/test/common/services/modelService.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import { CharCode } from 'vs/base/common/charCode';
+import { Event } from 'vs/base/common/event';
 import * as platform from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
 import { EditOperation } from 'vs/editor/common/core/editOperation';
@@ -492,6 +493,56 @@ suite('ModelSemanticColoring', () => {
 
 			// assert that it got called twice
 			assert.strictEqual(callCount, 2);
+		});
+	});
+
+	test('issue #149412: VS Code hangs when bad semantic token data is received', async () => {
+		await runWithFakedTimers({}, async () => {
+
+			disposables.add(languageService.registerLanguage({ id: 'testMode' }));
+
+			let lastResult: SemanticTokens | SemanticTokensEdits | null = null;
+
+			disposables.add(languageFeaturesService.documentSemanticTokensProvider.register('testMode', new class implements DocumentSemanticTokensProvider {
+				getLegend(): SemanticTokensLegend {
+					return { tokenTypes: ['class'], tokenModifiers: [] };
+				}
+				async provideDocumentSemanticTokens(model: ITextModel, lastResultId: string | null, token: CancellationToken): Promise<SemanticTokens | SemanticTokensEdits | null> {
+					if (!lastResultId) {
+						// this is the first call
+						lastResult = {
+							resultId: '1',
+							data: new Uint32Array([4294967293, 0, 7, 16, 0, 1, 4, 3, 11, 1])
+						};
+					} else {
+						// this is the second call
+						lastResult = {
+							resultId: '2',
+							edits: [{
+								start: 4294967276,
+								deleteCount: 0,
+								data: new Uint32Array([2, 0, 3, 11, 0])
+							}]
+						};
+					}
+					return lastResult;
+				}
+				releaseDocumentSemanticTokens(resultId: string | undefined): void {
+				}
+			}));
+
+			const textModel = disposables.add(modelService.createModel('', languageService.createById('testMode')));
+
+			// wait for the semantic tokens to be fetched
+			await Event.toPromise(textModel.onDidChangeTokens);
+			assert.strictEqual(lastResult!.resultId, '1');
+
+			// edit the text
+			textModel.applyEdits([{ range: new Range(1, 1, 1, 1), text: 'foo' }]);
+
+			// wait for the semantic tokens to be fetched again
+			await Event.toPromise(textModel.onDidChangeTokens);
+			assert.strictEqual(lastResult!.resultId, '2');
 		});
 	});
 


### PR DESCRIPTION
The actual hang was caused by a loop that was running for a very long time in `ModelSemanticColoring._copy`. The passed in `length` was 4 billion and it wouldn't do anything, so now we protect against that.

But the root problem was that we received an edit which referenced an offset outside the array. So now we also validate edits and in case they don't make sense simply drop all semantic tokens.

Fixes #149412