### PR TITLE
Update foreground color of extension list item descriptions

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -149,6 +149,7 @@
 
 .extension-list-item > .details > .description {
 	padding-right: 11px;
+	color: var(--vscode-descriptionForeground);
 }
 
 .extension-list-item > .details > .footer {

--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -152,6 +152,11 @@
 	color: var(--vscode-descriptionForeground);
 }
 
+.hc-black .extension-list-item > .details > .description,
+.hc-light .extension-list-item > .details > .description {
+	color: unset;
+}
+
 .extension-list-item > .details > .footer {
 	display: flex;
 	justify-content: flex-end;


### PR DESCRIPTION
Uses `descriptionForeground` for extension list item descriptions to help distinguish between primary/secondary text elements.

Does not apply to high contrast themes.

<img width="1236" alt="CleanShot 2022-05-13 at 10 19 16@2x" src="https://user-images.githubusercontent.com/25163139/168335329-45231b95-f7a6-466b-a460-15c7410eb586.png">
