### PR TITLE
Changing dependency syntax in extensions/markdown-math

### DIFF
--- a/extensions/markdown-math/package.json
+++ b/extensions/markdown-math/package.json
@@ -90,7 +90,7 @@
     "build-notebook": "node ./esbuild"
   },
   "dependencies": {
-    "@iktakahiro/markdown-it-katex": "https://github.com/mjbvz/markdown-it-katex.git"
+    "@iktakahiro/markdown-it-katex": "mjbvz/markdown-it-katex"
   },
   "devDependencies": {
     "@types/markdown-it": "^0.0.0",

--- a/extensions/markdown-math/yarn.lock
+++ b/extensions/markdown-math/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@iktakahiro/markdown-it-katex@https://github.com/mjbvz/markdown-it-katex.git":
+"@iktakahiro/markdown-it-katex@mjbvz/markdown-it-katex":
   version "4.0.1"
-  resolved "https://github.com/mjbvz/markdown-it-katex.git#2e3736e4b916ee64ed92ebfabeaa94643612665a"
+  resolved "https://codeload.github.com/mjbvz/markdown-it-katex/tar.gz/2e3736e4b916ee64ed92ebfabeaa94643612665a"
   dependencies:
     katex "^0.13.0"
 


### PR DESCRIPTION
Changing dependency syntax in extensions/markdown-math
for yarn not to call git, but to use a simple cacheable file instead.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #149291
