### PR TITLE
Fixing some html tags detected as autolinks for diagnostics

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/documentLinkProvider.ts
@@ -47,6 +47,11 @@ function parseLink(
 		return { kind: 'external', uri: externalSchemeUri };
 	}
 
+	if (/^[a-z\-][a-z\-]+:/i.test(cleanLink)) {
+		// Looks like a uri
+		return { kind: 'external', uri: vscode.Uri.parse(cleanLink) };
+	}
+
 	// Assume it must be an relative or absolute file path
 	// Use a fake scheme to avoid parse warnings
 	const tempUri = vscode.Uri.parse(`vscode-resource:${link}`);

--- a/extensions/markdown-language-features/src/test/diagnostic.test.ts
+++ b/extensions/markdown-language-features/src/test/diagnostic.test.ts
@@ -158,4 +158,23 @@ suite('markdown: Diagnostics', () => {
 		const diagnostics = await manager.getDiagnostics(doc1, noopToken);
 		assert.deepStrictEqual(diagnostics.length, 0);
 	});
+
+	test('Should not generate diagnostics for email autolink', async () => {
+		const doc1 = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
+			`a <user@example.com> c`,
+		));
+
+		const diagnostics = await getComputedDiagnostics(doc1, new InMemoryWorkspaceMarkdownDocuments([doc1]));
+		assert.deepStrictEqual(diagnostics.length, 0);
+	});
+
+	test('Should not generate diagnostics for html tag that looks like an autolink', async () => {
+		const doc1 = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
+			`a <tag>b</tag> c`,
+			`a <scope:tag>b</scope:tag> c`,
+		));
+
+		const diagnostics = await getComputedDiagnostics(doc1, new InMemoryWorkspaceMarkdownDocuments([doc1]));
+		assert.deepStrictEqual(diagnostics.length, 0);
+	});
 });


### PR DESCRIPTION
For markdown such as `<scope:tag>b</scope:tag>`, we currently detect `<scope:tag>` as an uri (an autolink) and then try validating it as a file path

This change doesn't fix `<scope:tag>` being detected as a link (which is actually correct if there isn't a closing html tag), but does fix the us trying to validate it by marking the uri as external
