### PR TITLE
Focus editor for tab after dragged over for 1500 millis

### DIFF
--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -898,6 +898,16 @@ export class TabsTitleControl extends TitleControl {
 				this.updateDropFeedback(tab, true, index);
 			},
 
+			onDragOver: (e, dragDuration) => {
+				if (dragDuration && dragDuration >= 1500 && this.group.activeEditor !== this.group.getEditorByIndex(index)) {
+					let target = this.group.getEditorByIndex(index);
+					if (target) {
+						this.group.openEditor(target);
+					}
+				}
+				this.updateDropFeedback(tab, true, index);
+			},
+
 			onDragLeave: () => {
 				tab.classList.remove('dragged-over');
 				this.updateDropFeedback(tab, false, index);

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -97,6 +97,8 @@ export class TabsTitleControl extends TitleControl {
 
 	private static readonly TAB_HEIGHT = 35;
 
+	private static readonly DRAG_OVER_OPEN_TAB_THRESHOLD = 1500;
+
 	private static readonly MOUSE_WHEEL_EVENT_THRESHOLD = 150;
 	private static readonly MOUSE_WHEEL_DISTANCE_THRESHOLD = 1.5;
 
@@ -898,14 +900,13 @@ export class TabsTitleControl extends TitleControl {
 				this.updateDropFeedback(tab, true, index);
 			},
 
-			onDragOver: (e, dragDuration) => {
-				if (dragDuration && dragDuration >= 1500 && this.group.activeEditor !== this.group.getEditorByIndex(index)) {
-					let target = this.group.getEditorByIndex(index);
-					if (target) {
-						this.group.openEditor(target);
+			onDragOver: (_, dragDuration) => {
+				if (dragDuration >= TabsTitleControl.DRAG_OVER_OPEN_TAB_THRESHOLD) {
+					const draggedOverTab = this.group.getEditorByIndex(index);
+					if (draggedOverTab && this.group.activeEditor !== draggedOverTab) {
+						this.group.openEditor(draggedOverTab, { preserveFocus: true });
 					}
 				}
-				this.updateDropFeedback(tab, true, index);
 			},
 
 			onDragLeave: () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR implements #148664

This PR fulfills the requirements, but I think it could be better.
Perhaps we need a setting to indicate if this feature should be active 
and also how long the delay should be before we focus the other editor?
