### PR TITLE
Avoid using `deltaDecorations` in cases where it could recurse

### DIFF
--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -1255,6 +1255,10 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		this._modelData.viewModel.executeCommands(commands, source);
 	}
 
+	public createDecorationsCollection(): EditorDecorationsCollection {
+		return new EditorDecorationsCollection(this);
+	}
+
 	public changeDecorations(callback: (changeAccessor: IModelDecorationsChangeAccessor) => any): any {
 		if (!this._modelData) {
 			// callback will not be called
@@ -2128,6 +2132,31 @@ class CodeEditorWidgetFocusTracker extends Disposable {
 		if (this._domFocusTracker.refreshState) {
 			this._domFocusTracker.refreshState();
 		}
+	}
+}
+
+class EditorDecorationsCollection implements editorCommon.IEditorDecorationsCollection {
+
+	private _decorationIds: string[];
+
+	constructor(
+		private readonly _editor: editorBrowser.ICodeEditor
+	) {
+		this._decorationIds = [];
+	}
+
+	public clear(): void {
+		if (this._decorationIds.length === 0) {
+			// nothing to do
+			return;
+		}
+		this.set([]);
+	}
+
+	public set(decorations: IModelDeltaDecoration[]): void {
+		this._editor.changeDecorations((accessor) => {
+			this._decorationIds = accessor.deltaDecorations(this._decorationIds, decorations);
+		});
 	}
 }
 

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -14,7 +14,7 @@ import { Color } from 'vs/base/common/color';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { Emitter, EmitterOptions, Event, EventDeliveryQueue } from 'vs/base/common/event';
 import { hash } from 'vs/base/common/hash';
-import { Disposable, IDisposable, dispose } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable, dispose, DisposableStore } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { EditorConfiguration, IEditorConstructionOptions } from 'vs/editor/browser/config/editorConfiguration';
 import * as editorBrowser from 'vs/editor/browser/editorBrowser';
@@ -2137,7 +2137,8 @@ class CodeEditorWidgetFocusTracker extends Disposable {
 
 class EditorDecorationsCollection implements editorCommon.IEditorDecorationsCollection {
 
-	private _decorationIds: string[];
+	private _decorationIds: string[] = [];
+	private _isChangingDecorations: boolean = false;
 
 	public get length(): number {
 		return this._decorationIds.length;
@@ -2145,8 +2146,15 @@ class EditorDecorationsCollection implements editorCommon.IEditorDecorationsColl
 
 	constructor(
 		private readonly _editor: editorBrowser.ICodeEditor
-	) {
-		this._decorationIds = [];
+	) { }
+
+	public onDidChange(listener: (e: IModelDecorationsChangedEvent) => any, thisArgs?: any, disposables?: IDisposable[] | DisposableStore): IDisposable {
+		return this._editor.onDidChangeModelDecorations((e) => {
+			if (this._isChangingDecorations) {
+				return;
+			}
+			listener.call(thisArgs, e);
+		}, disposables);
 	}
 
 	public getRange(index: number): Range | null {
@@ -2180,9 +2188,14 @@ class EditorDecorationsCollection implements editorCommon.IEditorDecorationsColl
 	}
 
 	public set(newDecorations: IModelDeltaDecoration[]): void {
-		this._editor.changeDecorations((accessor) => {
-			this._decorationIds = accessor.deltaDecorations(this._decorationIds, newDecorations);
-		});
+		try {
+			this._isChangingDecorations = true;
+			this._editor.changeDecorations((accessor) => {
+				this._decorationIds = accessor.deltaDecorations(this._decorationIds, newDecorations);
+			});
+		} finally {
+			this._isChangingDecorations = false;
+		}
 	}
 }
 

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -2139,10 +2139,36 @@ class EditorDecorationsCollection implements editorCommon.IEditorDecorationsColl
 
 	private _decorationIds: string[];
 
+	public get length(): number {
+		return this._decorationIds.length;
+	}
+
 	constructor(
 		private readonly _editor: editorBrowser.ICodeEditor
 	) {
 		this._decorationIds = [];
+	}
+
+	public getRange(index: number): Range | null {
+		if (!this._editor.hasModel()) {
+			return null;
+		}
+		return this._editor.getModel().getDecorationRange(this._decorationIds[index]);
+	}
+
+	public getRanges(): Range[] {
+		if (!this._editor.hasModel()) {
+			return [];
+		}
+		const model = this._editor.getModel();
+		const result: Range[] = [];
+		for (const decorationId of this._decorationIds) {
+			const range = model.getDecorationRange(decorationId);
+			if (range) {
+				result.push(range);
+			}
+		}
+		return result;
 	}
 
 	public clear(): void {
@@ -2153,9 +2179,9 @@ class EditorDecorationsCollection implements editorCommon.IEditorDecorationsColl
 		this.set([]);
 	}
 
-	public set(decorations: IModelDeltaDecoration[]): void {
+	public set(newDecorations: IModelDeltaDecoration[]): void {
 		this._editor.changeDecorations((accessor) => {
-			this._decorationIds = accessor.deltaDecorations(this._decorationIds, decorations);
+			this._decorationIds = accessor.deltaDecorations(this._decorationIds, newDecorations);
 		});
 	}
 }

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -920,6 +920,10 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		this._modifiedEditor.trigger(source, handlerId, payload);
 	}
 
+	public createDecorationsCollection(): editorCommon.IEditorDecorationsCollection {
+		return this._modifiedEditor.createDecorationsCollection();
+	}
+
 	public changeDecorations(callback: (changeAccessor: IModelDecorationsChangeAccessor) => any): any {
 		return this._modifiedEditor.changeDecorations(callback);
 	}

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -14,6 +14,7 @@ import { ISelection, Selection } from 'vs/editor/common/core/selection';
 import { IModelDecorationsChangeAccessor, ITextModel, OverviewRulerLane, TrackedRangeStickiness, IValidEditOperation, IModelDeltaDecoration } from 'vs/editor/common/model';
 import { ThemeColor } from 'vs/platform/theme/common/themeService';
 import { IDimension } from 'vs/editor/common/core/dimension';
+import { IModelDecorationsChangedEvent } from 'vs/editor/common/textModelEvents';
 
 /**
  * A builder and helper for edit operations for a command.
@@ -520,6 +521,11 @@ export interface ICompositeCodeEditor {
  * A collection of decorations
  */
 export interface IEditorDecorationsCollection {
+	/**
+	 * An event emitted when decorations change in the editor,
+	 * but the change is not caused by us setting or clearing the collection.
+	 */
+	onDidChange: Event<IModelDecorationsChangedEvent>;
 	/**
 	 * Get the decorations count.
 	 */

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -11,7 +11,7 @@ import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { ISelection, Selection } from 'vs/editor/common/core/selection';
-import { IModelDecorationsChangeAccessor, ITextModel, OverviewRulerLane, TrackedRangeStickiness, IValidEditOperation } from 'vs/editor/common/model';
+import { IModelDecorationsChangeAccessor, ITextModel, OverviewRulerLane, TrackedRangeStickiness, IValidEditOperation, IModelDeltaDecoration } from 'vs/editor/common/model';
 import { ThemeColor } from 'vs/platform/theme/common/themeService';
 import { IDimension } from 'vs/editor/common/core/dimension';
 
@@ -460,6 +460,13 @@ export interface IEditor {
 	setModel(model: IEditorModel | null): void;
 
 	/**
+	 * Create a collection of decorations. All decorations added through this collection
+	 * will get the ownerId of the editor (meaning they will not show up in other editors).
+	 * These decorations will be automatically cleared when the editor's model changes.
+	 */
+	createDecorationsCollection(): IEditorDecorationsCollection;
+
+	/**
 	 * Change the decorations. All decorations added through this changeAccessor
 	 * will get the ownerId of the editor (meaning they will not show up in other
 	 * editors).
@@ -509,6 +516,19 @@ export interface ICompositeCodeEditor {
 	// readonly editors: readonly ICodeEditor[] maybe supported with uris
 }
 
+/**
+ * A collection of decorations
+ */
+export interface IEditorDecorationsCollection {
+	/**
+	 * Remove all previous decorations and add `decorations`.
+	 */
+	set(decorations: IModelDeltaDecoration[]): void;
+	/**
+	 * Remove all previous decorations.
+	 */
+	clear(): void;
+}
 
 /**
  * An editor contribution that gets created every time a new editor gets created and gets disposed when the editor gets disposed.

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -521,9 +521,21 @@ export interface ICompositeCodeEditor {
  */
 export interface IEditorDecorationsCollection {
 	/**
-	 * Remove all previous decorations and add `decorations`.
+	 * Get the decorations count.
 	 */
-	set(decorations: IModelDeltaDecoration[]): void;
+	length: number;
+	/**
+	 * Get the range for a decoration.
+	 */
+	getRange(index: number): Range | null;
+	/**
+	 * Get all ranges for decorations.
+	 */
+	getRanges(): Range[];
+	/**
+	 * Replace all previous decorations with `newDecorations`.
+	 */
+	set(newDecorations: IModelDeltaDecoration[]): void;
 	/**
 	 * Remove all previous decorations.
 	 */

--- a/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts
@@ -17,7 +17,7 @@ import { registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { Position } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
-import { IEditorContribution } from 'vs/editor/common/editorCommon';
+import { IEditorContribution, IEditorDecorationsCollection } from 'vs/editor/common/editorCommon';
 import { IModelDeltaDecoration, ITextModel } from 'vs/editor/common/model';
 import { LocationLink } from 'vs/editor/common/languages';
 import { ILanguageService } from 'vs/editor/common/languages/language';
@@ -42,7 +42,7 @@ export class GotoDefinitionAtPositionEditorContribution implements IEditorContri
 	private readonly editor: ICodeEditor;
 	private readonly toUnhook = new DisposableStore();
 	private readonly toUnhookForKeyboard = new DisposableStore();
-	private linkDecorations: string[] = [];
+	private readonly linkDecorations: IEditorDecorationsCollection;
 	private currentWordAtPosition: IWordAtPosition | null = null;
 	private previousPromise: CancelablePromise<LocationLink[] | null> | null = null;
 
@@ -53,6 +53,7 @@ export class GotoDefinitionAtPositionEditorContribution implements IEditorContri
 		@ILanguageFeaturesService private readonly languageFeaturesService: ILanguageFeaturesService,
 	) {
 		this.editor = editor;
+		this.linkDecorations = this.editor.createDecorationsCollection();
 
 		let linkGesture = new ClickLinkGesture(editor);
 		this.toUnhook.add(linkGesture);
@@ -268,13 +269,11 @@ export class GotoDefinitionAtPositionEditorContribution implements IEditorContri
 			}
 		};
 
-		this.linkDecorations = this.editor.deltaDecorations(this.linkDecorations, [newDecorations]);
+		this.linkDecorations.set([newDecorations]);
 	}
 
 	private removeLinkDecorations(): void {
-		if (this.linkDecorations.length > 0) {
-			this.linkDecorations = this.editor.deltaDecorations(this.linkDecorations, []);
-		}
+		this.linkDecorations.clear();
 	}
 
 	private isEnabled(mouseEvent: ClickLinkMouseEvent, withKey?: ClickLinkKeyboardEvent): boolean {

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -14,7 +14,7 @@ import { ContentWidgetPositionPreference, IActiveCodeEditor, ICodeEditor, IConte
 import { ConfigurationChangedEvent, EditorOption } from 'vs/editor/common/config/editorOptions';
 import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
-import { IModelDecoration, IModelDeltaDecoration } from 'vs/editor/common/model';
+import { IModelDecoration } from 'vs/editor/common/model';
 import { ModelDecorationOptions } from 'vs/editor/common/model/textModel';
 import { TokenizationRegistry } from 'vs/editor/common/languages';
 import { HoverOperation, HoverStartMode, IHoverComputer } from 'vs/editor/contrib/hover/browser/hoverOperation';
@@ -25,8 +25,6 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { Context as SuggestContext } from 'vs/editor/contrib/suggest/browser/suggest';
 import { AsyncIterableObject } from 'vs/base/common/async';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
-import { Emitter } from 'vs/base/common/event';
-import { IModelDecorationsChangedEvent } from 'vs/editor/common/textModelEvents';
 
 const $ = dom.$;
 
@@ -34,7 +32,7 @@ export class ContentHoverController extends Disposable {
 
 	private readonly _participants: IEditorHoverParticipant[];
 	private readonly _widget = this._register(this._instantiationService.createInstance(ContentHoverWidget, this._editor));
-	private readonly _decorationsChangerListener = this._register(new EditorDecorationsChangerListener(this._editor));
+	private readonly _decorations = this._editor.createDecorationsCollection();
 	private readonly _computer: ContentHoverComputer;
 	private readonly _hoverOperation: HoverOperation<IHoverPart>;
 
@@ -64,7 +62,7 @@ export class ContentHoverController extends Disposable {
 		this._register(this._hoverOperation.onResult((result) => {
 			this._withResult(result.value, result.isComplete, result.hasLoadingMessage);
 		}));
-		this._register(this._decorationsChangerListener.onDidChangeModelDecorations(() => this._onModelDecorationsChanged()));
+		this._register(this._decorations.onDidChange(() => this._onModelDecorationsChanged()));
 		this._register(dom.addStandardDisposableListener(this._widget.getDomNode(), 'keydown', (e) => {
 			if (e.equals(KeyCode.Escape)) {
 				this.hide();
@@ -238,12 +236,12 @@ export class ContentHoverController extends Disposable {
 
 		if (fragment.hasChildNodes()) {
 			if (highlightRange) {
-				const highlightDecorations = this._decorationsChangerListener.deltaDecorations([], [{
+				this._decorations.set([{
 					range: highlightRange,
 					options: ContentHoverController._DECORATION_OPTIONS
 				}]);
 				disposables.add(toDisposable(() => {
-					this._decorationsChangerListener.deltaDecorations(highlightDecorations, []);
+					this._decorations.clear();
 				}));
 			}
 
@@ -264,38 +262,6 @@ export class ContentHoverController extends Disposable {
 		description: 'content-hover-highlight',
 		className: 'hoverHighlight'
 	});
-}
-
-/**
- * Allows listening to `ICodeEditor.onDidChangeModelDecorations` and ignores the change caused by itself.
- */
-class EditorDecorationsChangerListener extends Disposable {
-
-	private readonly _onDidChangeModelDecorations = this._register(new Emitter<IModelDecorationsChangedEvent>());
-	public readonly onDidChangeModelDecorations = this._onDidChangeModelDecorations.event;
-
-	private _isChangingDecorations: boolean = false;
-
-	constructor(
-		private readonly _editor: ICodeEditor
-	) {
-		super();
-		this._register(this._editor.onDidChangeModelDecorations((e) => {
-			if (this._isChangingDecorations) {
-				return;
-			}
-			this._onDidChangeModelDecorations.fire(e);
-		}));
-	}
-
-	public deltaDecorations(oldDecorations: string[], newDecorations: IModelDeltaDecoration[]): string[] {
-		try {
-			this._isChangingDecorations = true;
-			return this._editor.deltaDecorations(oldDecorations, newDecorations);
-		} finally {
-			this._isChangingDecorations = false;
-		}
-	}
 }
 
 class ContentHoverVisibleData {

--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -17,7 +17,7 @@ import { CursorChangeReason, ICursorPositionChangedEvent } from 'vs/editor/commo
 import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
-import { IEditorContribution } from 'vs/editor/common/editorCommon';
+import { IEditorContribution, IEditorDecorationsCollection } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { IModelDeltaDecoration, ITextModel, MinimapPosition, OverviewRulerLane, TrackedRangeStickiness } from 'vs/editor/common/model';
 import { ModelDecorationOptions } from 'vs/editor/common/model/textModel';
@@ -56,7 +56,7 @@ export function getOccurrencesAtPosition(registry: LanguageFeatureRegistry<Docum
 
 interface IOccurenceAtPositionRequest {
 	readonly result: Promise<DocumentHighlight[]>;
-	isValid(model: ITextModel, selection: Selection, decorationIds: string[]): boolean;
+	isValid(model: ITextModel, selection: Selection, decorations: IEditorDecorationsCollection): boolean;
 	cancel(): void;
 }
 
@@ -88,7 +88,7 @@ abstract class OccurenceAtPositionRequest implements IOccurenceAtPositionRequest
 		return null;
 	}
 
-	public isValid(model: ITextModel, selection: Selection, decorationIds: string[]): boolean {
+	public isValid(model: ITextModel, selection: Selection, decorations: IEditorDecorationsCollection): boolean {
 
 		const lineNumber = selection.startLineNumber;
 		const startColumn = selection.startColumn;
@@ -99,8 +99,8 @@ abstract class OccurenceAtPositionRequest implements IOccurenceAtPositionRequest
 
 		// Even if we are on a different word, if that word is in the decorations ranges, the request is still valid
 		// (Same symbol)
-		for (let i = 0, len = decorationIds.length; !requestIsValid && i < len; i++) {
-			let range = model.getDecorationRange(decorationIds[i]);
+		for (let i = 0, len = decorations.length; !requestIsValid && i < len; i++) {
+			const range = decorations.getRange(i);
 			if (range && range.startLineNumber === lineNumber) {
 				if (range.startColumn <= startColumn && range.endColumn >= endColumn) {
 					requestIsValid = true;
@@ -160,12 +160,12 @@ class TextualOccurenceAtPositionRequest extends OccurenceAtPositionRequest {
 		});
 	}
 
-	public override isValid(model: ITextModel, selection: Selection, decorationIds: string[]): boolean {
+	public override isValid(model: ITextModel, selection: Selection, decorations: IEditorDecorationsCollection): boolean {
 		const currentSelectionIsEmpty = selection.isEmpty();
 		if (this._selectionIsEmpty !== currentSelectionIsEmpty) {
 			return false;
 		}
-		return super.isValid(model, selection, decorationIds);
+		return super.isValid(model, selection, decorations);
 	}
 }
 
@@ -187,7 +187,7 @@ class WordHighlighter {
 	private readonly providers: LanguageFeatureRegistry<DocumentHighlightProvider>;
 	private occurrencesHighlight: boolean;
 	private readonly model: ITextModel;
-	private _decorationIds: string[];
+	private readonly decorations: IEditorDecorationsCollection;
 	private readonly toUnhook = new DisposableStore();
 
 	private workerRequestTokenId: number = 0;
@@ -234,7 +234,7 @@ class WordHighlighter {
 			}
 		}));
 
-		this._decorationIds = [];
+		this.decorations = this.editor.createDecorationsCollection();
 		this.workerRequestTokenId = 0;
 		this.workerRequest = null;
 		this.workerRequestCompleted = false;
@@ -244,7 +244,7 @@ class WordHighlighter {
 	}
 
 	public hasDecorations(): boolean {
-		return (this._decorationIds.length > 0);
+		return (this.decorations.length > 0);
 	}
 
 	public restore(): void {
@@ -255,9 +255,8 @@ class WordHighlighter {
 	}
 
 	private _getSortedHighlights(): Range[] {
-		return arrays.coalesce(
-			this._decorationIds
-				.map((id) => this.model.getDecorationRange(id))
+		return (
+			this.decorations.getRanges()
 				.sort(Range.compareRangesUsingStarts)
 		);
 	}
@@ -301,9 +300,9 @@ class WordHighlighter {
 	}
 
 	private _removeDecorations(): void {
-		if (this._decorationIds.length > 0) {
+		if (this.decorations.length > 0) {
 			// remove decorations
-			this._decorationIds = this.editor.deltaDecorations(this._decorationIds, []);
+			this.decorations.clear();
 			this._hasWordHighlights.set(false);
 		}
 	}
@@ -384,7 +383,7 @@ class WordHighlighter {
 		// - 250ms later after the last cursor move event, render the occurrences
 		// - no flickering!
 
-		const workerRequestIsValid = (this.workerRequest && this.workerRequest.isValid(this.model, editorSelection, this._decorationIds));
+		const workerRequestIsValid = (this.workerRequest && this.workerRequest.isValid(this.model, editorSelection, this.decorations));
 
 		// There are 4 cases:
 		// a) old workerRequest is valid & completed, renderDecorationsTimer fired
@@ -453,7 +452,7 @@ class WordHighlighter {
 			}
 		}
 
-		this._decorationIds = this.editor.deltaDecorations(this._decorationIds, decorations);
+		this.decorations.set(decorations);
 		this._hasWordHighlights.set(this.hasDecorations());
 	}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2537,9 +2537,21 @@ declare namespace monaco.editor {
 	 */
 	export interface IEditorDecorationsCollection {
 		/**
-		 * Remove all previous decorations and add `decorations`.
+		 * Get the decorations count.
 		 */
-		set(decorations: IModelDeltaDecoration[]): void;
+		length: number;
+		/**
+		 * Get the range for a decoration.
+		 */
+		getRange(index: number): Range | null;
+		/**
+		 * Get all ranges for decorations.
+		 */
+		getRanges(): Range[];
+		/**
+		 * Replace all previous decorations with `newDecorations`.
+		 */
+		set(newDecorations: IModelDeltaDecoration[]): void;
 		/**
 		 * Remove all previous decorations.
 		 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2537,6 +2537,11 @@ declare namespace monaco.editor {
 	 */
 	export interface IEditorDecorationsCollection {
 		/**
+		 * An event emitted when decorations change in the editor,
+		 * but the change is not caused by us setting or clearing the collection.
+		 */
+		onDidChange: IEvent<IModelDecorationsChangedEvent>;
+		/**
 		 * Get the decorations count.
 		 */
 		length: number;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2524,6 +2524,26 @@ declare namespace monaco.editor {
 		 * It is safe to call setModel(null) to simply detach the current model from the editor.
 		 */
 		setModel(model: IEditorModel | null): void;
+		/**
+		 * Create a collection of decorations. All decorations added through this collection
+		 * will get the ownerId of the editor (meaning they will not show up in other editors).
+		 * These decorations will be automatically cleared when the editor's model changes.
+		 */
+		createDecorationsCollection(): IEditorDecorationsCollection;
+	}
+
+	/**
+	 * A collection of decorations
+	 */
+	export interface IEditorDecorationsCollection {
+		/**
+		 * Remove all previous decorations and add `decorations`.
+		 */
+		set(decorations: IModelDeltaDecoration[]): void;
+		/**
+		 * Remove all previous decorations.
+		 */
+		clear(): void;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -264,7 +264,9 @@ export class FileMatch extends Disposable implements IFileMatch {
 	private unbindModel(): void {
 		if (this._model) {
 			this._updateScheduler.cancel();
-			this._model.deltaDecorations(this._modelDecorations, []);
+			this._model.changeDecorations((accessor) => {
+				this._modelDecorations = accessor.deltaDecorations(this._modelDecorations, []);
+			});
 			this._model = null;
 			this._modelListener!.dispose();
 		}
@@ -335,14 +337,17 @@ export class FileMatch extends Disposable implements IFileMatch {
 			return;
 		}
 
-		if (this.parent().showHighlights) {
-			this._modelDecorations = this._model.deltaDecorations(this._modelDecorations, this.matches().map(match => <IModelDeltaDecoration>{
-				range: match.range(),
-				options: FileMatch.getDecorationOption(this.isMatchSelected(match))
-			}));
-		} else {
-			this._modelDecorations = this._model.deltaDecorations(this._modelDecorations, []);
-		}
+		this._model.changeDecorations((accessor) => {
+			const newDecorations = (
+				this.parent().showHighlights
+					? this.matches().map(match => <IModelDeltaDecoration>{
+						range: match.range(),
+						options: FileMatch.getDecorationOption(this.isMatchSelected(match))
+					})
+					: []
+			);
+			this._modelDecorations = accessor.deltaDecorations(this._modelDecorations, newDecorations);
+		});
 	}
 
 	id(): string {
@@ -1222,7 +1227,10 @@ export class RangeHighlightDecorations implements IDisposable {
 
 	removeHighlightRange() {
 		if (this._model && this._decorationId) {
-			this._model.deltaDecorations([this._decorationId], []);
+			const decorationId = this._decorationId;
+			this._model.changeDecorations((accessor) => {
+				accessor.removeDecoration(decorationId);
+			});
 		}
 		this._decorationId = null;
 	}
@@ -1242,7 +1250,9 @@ export class RangeHighlightDecorations implements IDisposable {
 
 	private doHighlightRange(model: ITextModel, range: Range) {
 		this.removeHighlightRange();
-		this._decorationId = model.deltaDecorations([], [{ range: range, options: RangeHighlightDecorations._RANGE_HIGHLIGHT_DECORATION }])[0];
+		model.changeDecorations((accessor) => {
+			this._decorationId = accessor.addDecoration(range, RangeHighlightDecorations._RANGE_HIGHLIGHT_DECORATION);
+		});
 		this.setModel(model);
 	}
 


### PR DESCRIPTION
Change the way decorations are created / updated / removed to patterns which avoid recursion.
 
Fixes #148423
Fixes #149636
Fixes #149640
Fixes #149642