### PR TITLE
improve search field hint text

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -789,7 +789,7 @@ const quickAccessRegistry = Registry.as<IQuickAccessRegistry>(QuickAccessExtensi
 quickAccessRegistry.registerQuickAccessProvider({
 	ctor: AnythingQuickAccessProvider,
 	prefix: AnythingQuickAccessProvider.PREFIX,
-	placeholder: nls.localize('anythingQuickAccessPlaceholder', "Search files by name (append {0} to go to line or {1} to go to symbol)", AbstractGotoLineQuickAccessProvider.PREFIX, GotoSymbolQuickAccessProvider.PREFIX),
+	placeholder: nls.localize('anythingQuickAccessPlaceholder', "Search files by name (or {0}line_number, {1}file_symbol, {2}workspace_symbol)", AbstractGotoLineQuickAccessProvider.PREFIX, GotoSymbolQuickAccessProvider.PREFIX, SymbolsQuickAccessProvider.PREFIX),
 	contextKey: defaultQuickAccessContextKeyValue,
 	helpEntries: [{ description: nls.localize('anythingQuickAccess', "Go to File"), needsEditor: false }]
 });


### PR DESCRIPTION
previous:  `Search files by name (append : to go to line or @ to go to symbol)`
proposed: `Search files by name (or :line_number, @file_symbol, #workspace_symbol)`

"append" of the original text was misleading, and the prefix for workspace symbol was omitted
