### PR TITLE
Polish notebook workspace edit

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -616,22 +616,34 @@ export class NotebookEdit implements vscode.NotebookEdit {
 		return new NotebookEdit(range, newCells);
 	}
 
+	static insertCells(index: number, newCells: vscode.NotebookCellData[]): vscode.NotebookEdit {
+		return new NotebookEdit(new NotebookRange(index, index), newCells);
+	}
+
 	static deleteCells(range: NotebookRange): NotebookEdit {
 		return new NotebookEdit(range, []);
 	}
 
 	static updateCellMetadata(index: number, newMetadata: { [key: string]: any }): NotebookEdit {
-		return new NotebookEdit(new NotebookRange(index, index), [], newMetadata);
+		const edit = new NotebookEdit(new NotebookRange(index, index), []);
+		edit.newCellMetadata = newMetadata;
+		return edit;
 	}
 
-	readonly range: NotebookRange;
-	readonly newCells: NotebookCellData[];
-	readonly newCellMetadata?: { [key: string]: any };
+	static updateNotebookMetadata(newMetadata: { [key: string]: any }): NotebookEdit {
+		const edit = new NotebookEdit(new NotebookRange(0, 0), []);
+		edit.newNotebookMetadata = newMetadata;
+		return edit;
+	}
 
-	constructor(range: NotebookRange, newCells: NotebookCellData[], newCellMetadata?: { [key: string]: any }) {
+	range: NotebookRange;
+	newCells: NotebookCellData[];
+	newCellMetadata?: { [key: string]: any };
+	newNotebookMetadata?: { [key: string]: any };
+
+	constructor(range: NotebookRange, newCells: NotebookCellData[]) {
 		this.range = range;
 		this.newCells = newCells;
-		this.newCellMetadata = newCellMetadata;
 	}
 }
 

--- a/src/vscode-dts/vscode.proposed.notebookWorkspaceEdit.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookWorkspaceEdit.d.ts
@@ -21,44 +21,59 @@ declare module 'vscode' {
 		static replaceCells(range: NotebookRange, newCells: NotebookCellData[]): NotebookEdit;
 
 		/**
-		 * Utility to create a edit that deletes cells in a notebook.
+		 * Utility to create an edit that replaces cells in a notebook.
+		 *
+		 * @param index The index to insert cells at.
+		 * @param newCells The new notebook cells.
+		 */
+		static insertCells(index: number, newCells: NotebookCellData[]): NotebookEdit;
+
+		/**
+		 * Utility to create an edit that deletes cells in a notebook.
 		 *
 		 * @param range The range of cells to delete.
 		 */
 		static deleteCells(range: NotebookRange): NotebookEdit;
 
 		/**
-		 * Utility to update a cells metadata.
+		 * Utility to create an edit that update a cell's metadata.
 		 *
 		 * @param index The index of the cell to update.
-		 * @param newMetadata The new metadata for the cell.
+		 * @param newCellMetadata The new metadata for the cell.
 		 */
-		static updateCellMetadata(index: number, newMetadata: { [key: string]: any }): NotebookEdit;
+		static updateCellMetadata(index: number, newCellMetadata: { [key: string]: any }): NotebookEdit;
 
 		/**
-		 * Range of the cells being edited
+		 * Utility to create an edit that updates the notebook's metadata.
+		 *
+		 * @param newNotebookMetadata The new metadata for the notebook.
 		 */
-		readonly range: NotebookRange;
+		static updateNotebookMetadata(newNotebookMetadata: { [key: string]: any }): NotebookEdit;
+
+		/**
+		 * Range of the cells being edited. May be empty.
+		 */
+		range: NotebookRange;
 
 		/**
 		 * New cells being inserted. May be empty.
 		 */
-		readonly newCells: NotebookCellData[];
+		newCells: NotebookCellData[];
 
 		/**
 		 * Optional new metadata for the cells.
 		 */
-		readonly newCellMetadata?: { [key: string]: any };
+		newCellMetadata?: { [key: string]: any };
 
-		constructor(range: NotebookRange, newCells: NotebookCellData[], newCellMetadata?: { [key: string]: any });
+		/**
+		 * Optional new metadata for the notebook.
+		 */
+		newNotebookMetadata?: { [key: string]: any };
+
+		constructor(range: NotebookRange, newCells: NotebookCellData[]);
 	}
 
 	export interface WorkspaceEdit {
-		/**
-		 * Replaces the metadata for a notebook document.
-		 */
-		replaceNotebookMetadata(uri: Uri, value: { [key: string]: any }): void;
-
 		/**
 		 * Set (and replace) edits for a resource.
 		 *


### PR DESCRIPTION
For #149181

- Add `insertCells` helper
- Add a `newNotebookMetadata` property for setting the metadata for the entire notebook
- Add a `NotebookEdit.updateNotebookMetadata` helper
- Remove the previous `WorkspaceEdit.updateNotebookMetadata` function since you can now use `NotebookEdit.updateNotebookMetadata`

