### PR TITLE
Revert "Adopt `setTimeout0()` which doesn't suffer from the 4ms artificial delay that browsers set when the nesting level is > 5. (#149723)"

### DIFF
--- a/src/vs/base/test/common/timeTravelScheduler.ts
+++ b/src/vs/base/test/common/timeTravelScheduler.ts
@@ -5,7 +5,6 @@
 
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
-import { setTimeout0 } from 'vs/base/common/platform';
 
 interface PriorityQueue<T> {
 	length: number;
@@ -179,7 +178,7 @@ export class AsyncSchedulerProcessor extends Disposable {
 			if (this.useSetImmediate) {
 				originalGlobalValues.setImmediate(() => this.process());
 			} else {
-				setTimeout0(() => this.process());
+				originalGlobalValues.setTimeout(() => this.process());
 			}
 		});
 	}


### PR DESCRIPTION
This reverts commit 2c97c8064722c44a10cf548990d3457864b6c89f.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
