### PR TITLE
Don't run on close until token issue can be fixed

### DIFF
--- a/.github/workflows/pr-chat.yml
+++ b/.github/workflows/pr-chat.yml
@@ -1,7 +1,7 @@
 name: PR Chat
 on:
   pull_request_target:
-    types: [opened, ready_for_review, closed]
+    types: [opened, ready_for_review]
 
 jobs:
   main:


### PR DESCRIPTION
Reverts #149751 because our Slack token type doesn't support history at the moment.