### PR TITLE
Annotate error fragment

### DIFF
--- a/src/vs/platform/telemetry/common/errorTelemetry.ts
+++ b/src/vs/platform/telemetry/common/errorTelemetry.ts
@@ -10,14 +10,16 @@ import { safeStringify } from 'vs/base/common/objects';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 type ErrorEventFragment = {
-	callstack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
-	msg?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
-	file?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
-	line?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; isMeasurement: true };
-	column?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; isMeasurement: true };
-	uncaught_error_name?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
-	uncaught_error_msg?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth' };
-	count?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; isMeasurement: true };
+	owner: 'lramos15, sbatten'
+	comment: 'Whenever an error in VS Code is thrown.'
+	callstack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth', comment: 'The callstack of the error.' };
+	msg?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth', comment: 'The message of the error. Normally the first line int the callstack.' };
+	file?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth', comment: 'The file the error originated from.'};
+	line?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; isMeasurement: true, comment: 'The line the error originate on.' };
+	column?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; isMeasurement: true, comment: 'The column of the line which the error orginated on.'};
+	uncaught_error_name?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth', comment: 'If the error is uncaught what is the error type' };
+	uncaught_error_msg?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth', comment: 'If the error is uncaught this is just msg but for uncaught errors.' };
+	count?: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; isMeasurement: true, comment: 'How many times this error has been thrown' };
 };
 export interface ErrorEvent {
 	callstack: string;


### PR DESCRIPTION
As part of our efforts to annotate telemetry this annotates one of the team events the error fragment.


I assigned Steven and I to it since we own the error site.

(This PR is mostly a test for the codereview bot).