### PR TITLE
Adopt notebookWorkspaceEdit proposal internally

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -9,8 +9,7 @@
 		"vscode": "^1.57.0"
 	},
 	"enabledApiProposals": [
-		"notebookEditor",
-		"notebookEditorEdit"
+		"notebookEditor"
 	],
 	"activationEvents": [
 		"*"

--- a/extensions/ipynb/src/cellIdService.ts
+++ b/extensions/ipynb/src/cellIdService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionContext, NotebookDocument, NotebookDocumentChangeEvent, workspace, WorkspaceEdit } from 'vscode';
+import { ExtensionContext, NotebookDocument, NotebookDocumentChangeEvent, NotebookEdit, workspace, WorkspaceEdit } from 'vscode';
 import { v4 as uuid } from 'uuid';
 import { getCellMetadata } from './serializers';
 import { CellMetadata } from './common';
@@ -34,7 +34,7 @@ function onDidChangeNotebookCells(e: NotebookDocumentChangeEvent) {
 			// Don't edit the metadata directly, always get a clone (prevents accidental singletons and directly editing the objects).
 			const updatedMetadata: CellMetadata = { ...JSON.parse(JSON.stringify(cellMetadata || {})) };
 			updatedMetadata.id = id;
-			edit.replaceNotebookCellMetadata(cell.notebook.uri, cell.index, { ...(cell.metadata), custom: updatedMetadata });
+			edit.set(cell.notebook.uri, [NotebookEdit.updateCellMetadata(cell.index, { ...(cell.metadata), custom: updatedMetadata })]);
 			workspace.applyEdit(edit);
 		});
 	});

--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -94,7 +94,7 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 
 			const edit = new vscode.WorkspaceEdit();
-			edit.replaceNotebookMetadata(resource, {
+			edit.set(resource, [vscode.NotebookEdit.updateNotebookMetadata({
 				...document.metadata,
 				custom: {
 					...(document.metadata.custom ?? {}),
@@ -103,7 +103,7 @@ export function activate(context: vscode.ExtensionContext) {
 						...metadata
 					},
 				}
-			});
+			})]);
 			return vscode.workspace.applyEdit(edit);
 		},
 	};

--- a/extensions/ipynb/tsconfig.json
+++ b/extensions/ipynb/tsconfig.json
@@ -10,6 +10,6 @@
 		"src/**/*",
 		"../../src/vscode-dts/vscode.d.ts",
 		"../../src/vscode-dts/vscode.proposed.notebookEditor.d.ts",
-		"../../src/vscode-dts/vscode.proposed.notebookEditorEdit.d.ts"
+		"../../src/vscode-dts/vscode.proposed.notebookWorkspaceEdit.d.ts"
 	]
 }

--- a/extensions/vscode-notebook-tests/package.json
+++ b/extensions/vscode-notebook-tests/package.json
@@ -17,7 +17,6 @@
     "notebookDeprecated",
     "notebookEditor",
     "notebookEditorDecorationType",
-    "notebookEditorEdit",
     "notebookLiveShare",
     "notebookMessaging",
     "notebookMime"


### PR DESCRIPTION
This switches us to use the new `notebookWorkspaceEdit` proposal instead of the now deprecated `notebookEditorEdit` proposal


