### PR TITLE
Update menubar button styles (Fix #149834)

### DIFF
--- a/src/vs/base/browser/ui/menu/menubar.css
+++ b/src/vs/base/browser/ui/menu/menubar.css
@@ -32,10 +32,6 @@
 	outline: 0;
 }
 
-.menubar-menu-title {
-	line-height: 22px;
-}
-
 .menubar.compact {
 	flex-shrink: 0;
 	overflow: visible; /* to avoid the compact menu to be repositioned when clicking */

--- a/src/vs/base/browser/ui/menu/menubar.css
+++ b/src/vs/base/browser/ui/menu/menubar.css
@@ -9,7 +9,8 @@
 	display: flex;
 	flex-shrink: 1;
 	box-sizing: border-box;
-	height: 30px;
+	height: 100%;
+	padding: 4px 0;
 	overflow: hidden;
 	flex-wrap: wrap;
 }
@@ -23,11 +24,16 @@
 	align-items: center;
 	box-sizing: border-box;
 	padding: 0px 8px;
+	border-radius: 5px;
 	cursor: default;
 	-webkit-app-region: no-drag;
 	zoom: 1;
 	white-space: nowrap;
 	outline: 0;
+}
+
+.menubar-menu-title {
+	line-height: 22px;
 }
 
 .menubar.compact {

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -42,7 +42,7 @@
 .monaco-workbench.windows .part.titlebar>.titlebar-container,
 .monaco-workbench.linux .part.titlebar>.titlebar-container {
 	height: 30px;
-	line-height: 30px;
+	line-height: 22px;
 	justify-content: left;
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #149834 by making styling updates to the menubar buttons in the `classic` menubar setting.

## Before

<img width="603" alt="CleanShot 2022-05-18 at 09 00 26@2x" src="https://user-images.githubusercontent.com/25163139/169088734-728874cc-4f49-4bda-9186-fdbe18b20645.png">

## After 

<img width="632" alt="CleanShot 2022-05-18 at 08 55 38@2x" src="https://user-images.githubusercontent.com/25163139/169088630-d93eb939-c583-42bb-a051-986fcfb9e9a4.png">

## Demo

![CleanShot 2022-05-16 at 20 45 59](https://user-images.githubusercontent.com/25163139/169088801-4c54029e-e2a9-45d2-b5f8-3fc977bceb74.gif)

