### PR TITLE
Update list of enabled APIs

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -9,7 +9,8 @@
 		"vscode": "^1.57.0"
 	},
 	"enabledApiProposals": [
-		"notebookEditor"
+		"notebookEditor",
+    "notebookWorkspaceEdit"
 	],
 	"activationEvents": [
 		"*"


### PR DESCRIPTION
We use `notebookWorkspaceEdit` even though it's not enforced
