### PR TITLE
Enable strictNullChecks for implicit projects

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -686,7 +686,7 @@
         },
         "js/ts.implicitProjectConfig.checkJs": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "markdownDescription": "%configuration.implicitProjectConfig.checkJs%",
           "scope": "window"
         },
@@ -705,7 +705,7 @@
         },
         "js/ts.implicitProjectConfig.strictNullChecks": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "%configuration.implicitProjectConfig.strictNullChecks%",
           "scope": "window"
         },

--- a/extensions/typescript-language-features/src/utils/configuration.ts
+++ b/extensions/typescript-language-features/src/utils/configuration.ts
@@ -82,7 +82,7 @@ export class ImplicitProjectConfiguration {
 
 	private static readCheckJs(configuration: vscode.WorkspaceConfiguration): boolean {
 		return configuration.get<boolean>('js/ts.implicitProjectConfig.checkJs')
-			?? configuration.get<boolean>('javascript.implicitProjectConfig.checkJs', true);
+			?? configuration.get<boolean>('javascript.implicitProjectConfig.checkJs', false);
 	}
 
 	private static readExperimentalDecorators(configuration: vscode.WorkspaceConfiguration): boolean {
@@ -91,7 +91,7 @@ export class ImplicitProjectConfiguration {
 	}
 
 	private static readImplicitStrictNullChecks(configuration: vscode.WorkspaceConfiguration): boolean {
-		return configuration.get<boolean>('js/ts.implicitProjectConfig.strictNullChecks', false);
+		return configuration.get<boolean>('js/ts.implicitProjectConfig.strictNullChecks', true);
 	}
 
 	private static readImplicitStrictFunctionTypes(configuration: vscode.WorkspaceConfiguration): boolean {


### PR DESCRIPTION
Mistakenly enabled checkJS instead of strictNullChecks

Seems like the cause of #149814 (although installing the types is likely the most useful fix in that case)