### PR TITLE
Deprecated extensions support

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -282,9 +282,20 @@ export const enum StatisticType {
 	Uninstall = 'uninstall'
 }
 
+export interface IDeprecationInfo {
+	readonly disallowInstall?: boolean;
+	readonly extension?: {
+		readonly id: string;
+		readonly displayName: string;
+		readonly autoMigrate?: { readonly storage: boolean };
+		readonly preRelease?: boolean;
+	};
+	readonly settings?: readonly string[];
+}
+
 export interface IExtensionsControlManifest {
-	malicious: IExtensionIdentifier[];
-	deprecated?: IStringDictionary<boolean | { id: string; displayName: string; migrateStorage?: boolean; preRelease?: boolean }>;
+	readonly malicious: IExtensionIdentifier[];
+	readonly deprecated: IStringDictionary<IDeprecationInfo>;
 }
 
 export const enum InstallOperation {
@@ -349,7 +360,7 @@ export interface DidUninstallExtensionEvent {
 
 export enum ExtensionManagementErrorCode {
 	Unsupported = 'Unsupported',
-	UnsupportedPreRelease = 'UnsupportedPreRelease',
+	Deprecated = 'Deprecated',
 	Malicious = 'Malicious',
 	Incompatible = 'Incompatible',
 	IncompatiblePreRelease = 'IncompatiblePreRelease',

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -658,7 +658,7 @@ export class ExtensionEditor extends EditorPane {
 			}
 		};
 		reset(template.recommendation);
-		if (extension.deprecated || extension.state === ExtensionState.Installed) {
+		if (extension.deprecationInfo || extension.state === ExtensionState.Installed) {
 			return;
 		}
 		updateRecommendationText(false);

--- a/src/vs/workbench/contrib/extensions/browser/extensionsList.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsList.ts
@@ -188,7 +188,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		const updateEnablement = async () => {
 			let isDisabled = false;
 			if (extension.state === ExtensionState.Uninstalled) {
-				isDisabled = !!extension.deprecated || !(await this.extensionsWorkbenchService.canInstall(extension));
+				isDisabled = !!extension.deprecationInfo || !(await this.extensionsWorkbenchService.canInstall(extension));
 			} else if (extension.local && !isLanguagePackExtension(extension.local.manifest)) {
 				const runningExtensions = await this.extensionService.getExtensions();
 				const runningExtension = runningExtensions.filter(e => areSameExtensions({ id: e.identifier.value, uuid: e.uuid }, extension.identifier))[0];

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
@@ -185,7 +185,7 @@ export class RecommendationWidget extends ExtensionWidget {
 
 	render(): void {
 		this.clear();
-		if (!this.extension || this.extension.state === ExtensionState.Installed || this.extension.deprecated) {
+		if (!this.extension || this.extension.state === ExtensionState.Installed || this.extension.deprecationInfo) {
 			return;
 		}
 		const extRecommendations = this.extensionRecommendationsService.getAllRecommendationsWithReason();
@@ -549,7 +549,7 @@ export class ExtensionHoverWidget extends ExtensionWidget {
 		if (extension.state === ExtensionState.Installed) {
 			return undefined;
 		}
-		if (extension.deprecated) {
+		if (extension.deprecationInfo) {
 			return undefined;
 		}
 		const recommendation = this.extensionRecommendationsService.getAllRecommendationsWithReason()[extension.identifier.id.toLowerCase()];

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -6,7 +6,7 @@
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Event } from 'vs/base/common/event';
 import { IPager } from 'vs/base/common/paging';
-import { IQueryOptions, ILocalExtension, IGalleryExtension, IExtensionIdentifier, InstallOptions, InstallVSIXOptions, IExtensionInfo, IExtensionQueryOptions } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IQueryOptions, ILocalExtension, IGalleryExtension, IExtensionIdentifier, InstallOptions, InstallVSIXOptions, IExtensionInfo, IExtensionQueryOptions, IDeprecationInfo } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { EnablementState, IExtensionManagementServer } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Disposable } from 'vs/base/common/lifecycle';
@@ -78,7 +78,7 @@ export interface IExtension {
 	readonly local?: ILocalExtension;
 	gallery?: IGalleryExtension;
 	readonly isMalicious: boolean;
-	readonly deprecated: boolean | { id: string; displayName: string };
+	readonly deprecationInfo?: IDeprecationInfo;
 }
 
 export const SERVICE_ID = 'extensionsWorkbenchService';

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionRecommendationsService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionRecommendationsService.test.ts
@@ -218,7 +218,7 @@ suite('ExtensionRecommendationsService Test', () => {
 			onDidUninstallExtension: didUninstallEvent.event,
 			async getInstalled() { return []; },
 			async canInstall() { return true; },
-			async getExtensionsControlManifest() { return { malicious: [] }; },
+			async getExtensionsControlManifest() { return { malicious: [], deprecated: {} }; },
 			async getTargetPlatform() { return getTargetPlatform(platform, arch); }
 		});
 		instantiationService.stub(IExtensionService, <Partial<IExtensionService>>{

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
@@ -100,7 +100,7 @@ async function setupTest() {
 		onUninstallExtension: uninstallEvent.event,
 		onDidUninstallExtension: didUninstallEvent.event,
 		async getInstalled() { return []; },
-		async getExtensionsControlManifest() { return { malicious: [] }; },
+		async getExtensionsControlManifest() { return { malicious: [], deprecated: {} }; },
 		async updateMetadata(local: ILocalExtension, metadata: IGalleryMetadata) {
 			local.identifier.uuid = metadata.id;
 			local.publisherDisplayName = metadata.publisherDisplayName;
@@ -2424,7 +2424,7 @@ function createExtensionManagementService(installed: ILocalExtension[] = []): IE
 			return local;
 		},
 		async getTargetPlatform() { return getTargetPlatform(platform, arch); },
-		async getExtensionsControlManifest() { return <IExtensionsControlManifest>{ malicious: [] }; },
+		async getExtensionsControlManifest() { return <IExtensionsControlManifest>{ malicious: [], deprecated: {} }; },
 	};
 }
 

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsViews.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsViews.test.ts
@@ -98,7 +98,7 @@ suite('ExtensionsListView Tests', () => {
 			onDidUninstallExtension: didUninstallEvent.event,
 			async getInstalled() { return []; },
 			async canInstall() { return true; },
-			async getExtensionsControlManifest() { return { malicious: [] }; },
+			async getExtensionsControlManifest() { return { malicious: [], deprecated: {} }; },
 			async getTargetPlatform() { return getTargetPlatform(platform, arch); }
 		});
 		instantiationService.stub(IRemoteAgentService, RemoteAgentService);

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
@@ -95,7 +95,7 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 			onUninstallExtension: uninstallEvent.event,
 			onDidUninstallExtension: didUninstallEvent.event,
 			async getInstalled() { return []; },
-			async getExtensionsControlManifest() { return { malicious: [] }; },
+			async getExtensionsControlManifest() { return { malicious: [], deprecated: {} }; },
 			async updateMetadata(local: ILocalExtension, metadata: IGalleryMetadata) {
 				local.identifier.uuid = metadata.id;
 				local.publisherDisplayName = metadata.publisherDisplayName;
@@ -1489,7 +1489,7 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 				return local;
 			},
 			getTargetPlatform: async () => getTargetPlatform(platform, arch),
-			async getExtensionsControlManifest() { return <IExtensionsControlManifest>{ malicious: [] }; },
+			async getExtensionsControlManifest() { return <IExtensionsControlManifest>{ malicious: [], deprecated: {} }; },
 		};
 	}
 });

--- a/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
@@ -21,7 +21,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { localizeManifest } from 'vs/platform/extensionManagement/common/extensionNls';
 import { localize } from 'vs/nls';
 import * as semver from 'vs/base/common/semver/semver';
-import { isBoolean, isString } from 'vs/base/common/types';
+import { isString } from 'vs/base/common/types';
 import { getErrorMessage } from 'vs/base/common/errors';
 import { ResourceMap } from 'vs/base/common/map';
 import { IExtensionManifestPropertiesService } from 'vs/workbench/services/extensions/common/extensionManifestPropertiesService';
@@ -140,11 +140,11 @@ export class WebExtensionsScannerService extends Disposable implements IWebExten
 				this.logService.info(`Checking additional builtin extensions: Ignoring '${extension.id}' because it is reported to be malicious.`);
 				continue;
 			}
-			const deprecated = extensionsControlManifest.deprecated ? extensionsControlManifest.deprecated[extension.id.toLowerCase()] : undefined;
-			if (deprecated && !isBoolean(deprecated)) {
-				const preReleaseExtensionId = deprecated.id;
+			const deprecationInfo = extensionsControlManifest.deprecated[extension.id.toLowerCase()];
+			if (deprecationInfo?.extension?.autoMigrate) {
+				const preReleaseExtensionId = deprecationInfo.extension.id;
 				this.logService.info(`Checking additional builtin extensions: '${extension.id}' is deprecated, instead using '${preReleaseExtensionId}'`);
-				result.push({ id: preReleaseExtensionId, preRelease: !!deprecated.preRelease });
+				result.push({ id: preReleaseExtensionId, preRelease: !!extension.preRelease });
 			} else {
 				result.push(extension);
 			}

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -394,7 +394,7 @@ export class ExtensionManagementService extends Disposable implements IWorkbench
 		if (this.extensionManagementServerService.webExtensionManagementServer) {
 			return this.extensionManagementServerService.webExtensionManagementServer.extensionManagementService.getExtensionsControlManifest();
 		}
-		return Promise.resolve({ malicious: [] });
+		return Promise.resolve({ malicious: [], deprecated: {} });
 	}
 
 	private getServer(extension: ILocalExtension): IExtensionManagementServer | null {


### PR DESCRIPTION
- separate deprecated and prerelease migration extensions in the control file
- Merge deprecated and prerelease migration extensions
- Support deprecated extensions with settings
- Do not auto migrate deprecated extensions
- Support disallowing install for deprecated extensions

