### PR TITLE
Add skipPaths option for markdown link validation

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -420,10 +420,10 @@
           "description": "%configuration.markdown.experimental.validate.enabled.description%",
           "default": false
         },
-        "markdown.experimental.validate.referenceLinks": {
+        "markdown.experimental.validate.referenceLinks.enabled": {
           "type": "string",
           "scope": "resource",
-          "markdownDescription": "%configuration.markdown.experimental.validate.referenceLinks.description%",
+          "markdownDescription": "%configuration.markdown.experimental.validate.referenceLinks.enabled.description%",
           "default": "warning",
           "enum": [
             "ignore",
@@ -431,10 +431,10 @@
             "error"
           ]
         },
-        "markdown.experimental.validate.headerLinks": {
+        "markdown.experimental.validate.headerLinks.enabled": {
           "type": "string",
           "scope": "resource",
-          "markdownDescription": "%configuration.markdown.experimental.validate.headerLinks.description%",
+          "markdownDescription": "%configuration.markdown.experimental.validate.headerLinks.enabled.description%",
           "default": "warning",
           "enum": [
             "ignore",
@@ -442,16 +442,24 @@
             "error"
           ]
         },
-        "markdown.experimental.validate.fileLinks": {
+        "markdown.experimental.validate.fileLinks.enabled": {
           "type": "string",
           "scope": "resource",
-          "markdownDescription": "%configuration.markdown.experimental.validate.fileLinks.description%",
+          "markdownDescription": "%configuration.markdown.experimental.validate.fileLinks.enabled.description%",
           "default": "warning",
           "enum": [
             "ignore",
             "warning",
             "error"
           ]
+        },
+        "markdown.experimental.validate.fileLinks.skipPaths": {
+          "type": "array",
+          "scope": "resource",
+          "markdownDescription": "%configuration.markdown.experimental.validate.fileLinks.skipPaths.description%",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -504,6 +512,7 @@
     "markdown-it": "^12.3.2",
     "markdown-it-front-matter": "^0.2.1",
     "morphdom": "^2.6.1",
+    "picomatch": "^2.3.1",
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-nls": "^5.0.0",
     "vscode-uri": "^3.0.3"
@@ -512,6 +521,7 @@
     "@types/dompurify": "^2.3.1",
     "@types/lodash.throttle": "^4.1.3",
     "@types/markdown-it": "12.2.3",
+    "@types/picomatch": "^2.3.0",
     "@types/vscode-notebook-renderer": "^1.60.0",
     "@types/vscode-webview": "^1.57.0",
     "lodash.throttle": "^4.1.1"

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -30,8 +30,9 @@
 	"configuration.markdown.suggest.paths.enabled.description": "Enable/disable path suggestions for markdown links",
 	"configuration.markdown.editor.drop.enabled": "Enable/disable dropping into the markdown editor to insert shift. Requires enabling `#workbenck.experimental.editor.dropIntoEditor.enabled#`.",
 	"configuration.markdown.experimental.validate.enabled.description": "Enable/disable all error reporting in Markdown files.",
-	"configuration.markdown.experimental.validate.referenceLinks.description": "Validate reference links in Markdown files, e.g. `[link][ref]`.  Requires enabling `#markdown.experimental.validate.enabled#`.",
-	"configuration.markdown.experimental.validate.headerLinks.description": "Validate links to headers in Markdown files, e.g. `[link](#header)`. Requires enabling `#markdown.experimental.validate.enabled#`.",
-	"configuration.markdown.experimental.validate.fileLinks.description": "Validate links to other files in Markdown files, e.g. `[link](/path/to/file.md)`. This checks that the target files exists. Requires enabling `#markdown.experimental.validate.enabled#`.",
+	"configuration.markdown.experimental.validate.referenceLinks.enabled.description": "Validate reference links in Markdown files, e.g. `[link][ref]`.  Requires enabling `#markdown.experimental.validate.enabled#`.",
+	"configuration.markdown.experimental.validate.headerLinks.enabled.description": "Validate links to headers in Markdown files, e.g. `[link](#header)`. Requires enabling `#markdown.experimental.validate.enabled#`.",
+	"configuration.markdown.experimental.validate.fileLinks.enabled.description": "Validate links to other files in Markdown files, e.g. `[link](/path/to/file.md)`. This checks that the target files exists. Requires enabling `#markdown.experimental.validate.enabled#`.",
+	"configuration.markdown.experimental.validate.fileLinks.skipPaths.description": "Configure glob patterns for links to treat as valid, even if they don't exist in the workspace. For example `/about` would make the link `[about](/about)` valid, while the glob `/assets/**/*.svg` would let you link to any `.svg` asset under the `assets` directory",
 	"workspaceTrust": "Required for loading styles configured in the workspace."
 }

--- a/extensions/markdown-language-features/src/extension.ts
+++ b/extensions/markdown-language-features/src/extension.ts
@@ -76,7 +76,7 @@ function registerMarkdownLanguageFeatures(
 		vscode.languages.registerRenameProvider(selector, new MdRenameProvider(referencesProvider, workspaceContents, githubSlugifier)),
 		vscode.languages.registerDefinitionProvider(selector, new MdDefinitionProvider(referencesProvider)),
 		MdPathCompletionProvider.register(selector, engine, linkProvider),
-		registerDiagnostics(engine, workspaceContents, linkProvider),
+		registerDiagnostics(selector, engine, workspaceContents, linkProvider, commandManager),
 		registerDropIntoEditor(selector),
 		registerFindFileReferences(commandManager, referencesProvider),
 	);

--- a/extensions/markdown-language-features/src/test/diagnostic.test.ts
+++ b/extensions/markdown-language-features/src/test/diagnostic.test.ts
@@ -26,6 +26,7 @@ async function getComputedDiagnostics(doc: InMemoryDocument, workspaceContents: 
 			validateFilePaths: DiagnosticLevel.warning,
 			validateOwnHeaders: DiagnosticLevel.warning,
 			validateReferences: DiagnosticLevel.warning,
+			skipPaths: [],
 		}, noopToken)
 	).diagnostics;
 }
@@ -43,6 +44,7 @@ class MemoryDiagnosticConfiguration implements DiagnosticConfiguration {
 
 	constructor(
 		private readonly enabled: boolean = true,
+		private readonly skipPaths: string[] = [],
 	) { }
 
 	getOptions(_resource: vscode.Uri): DiagnosticOptions {
@@ -52,6 +54,7 @@ class MemoryDiagnosticConfiguration implements DiagnosticConfiguration {
 				validateFilePaths: DiagnosticLevel.ignore,
 				validateOwnHeaders: DiagnosticLevel.ignore,
 				validateReferences: DiagnosticLevel.ignore,
+				skipPaths: this.skipPaths,
 			};
 		}
 		return {
@@ -59,6 +62,7 @@ class MemoryDiagnosticConfiguration implements DiagnosticConfiguration {
 			validateFilePaths: DiagnosticLevel.warning,
 			validateOwnHeaders: DiagnosticLevel.warning,
 			validateReferences: DiagnosticLevel.warning,
+			skipPaths: this.skipPaths,
 		};
 	}
 }
@@ -177,6 +181,63 @@ suite('markdown: Diagnostics', () => {
 		));
 
 		const diagnostics = await getComputedDiagnostics(doc1, new InMemoryWorkspaceMarkdownDocuments([doc1]));
+		assert.deepStrictEqual(diagnostics.length, 0);
+	});
+
+	test('Should allow ignoring invalid file link using glob', async () => {
+		const doc1 = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
+			`[text](/no-such-file)`,
+			`![img](/no-such-file)`,
+			`[text]: /no-such-file`,
+		));
+
+		const manager = createDiagnosticsManager(new InMemoryWorkspaceMarkdownDocuments([doc1]), new MemoryDiagnosticConfiguration(true, ['/no-such-file']));
+		const { diagnostics } = await manager.recomputeDiagnosticState(doc1, noopToken);
+		assert.deepStrictEqual(diagnostics.length, 0);
+	});
+
+	test('skipPaths should allow skipping non-existent file', async () => {
+		const doc1 = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
+			`[text](/no-such-file#header)`,
+		));
+
+		const manager = createDiagnosticsManager(new InMemoryWorkspaceMarkdownDocuments([doc1]), new MemoryDiagnosticConfiguration(true, ['/no-such-file']));
+		const { diagnostics } = await manager.recomputeDiagnosticState(doc1, noopToken);
+		assert.deepStrictEqual(diagnostics.length, 0);
+	});
+
+	test('skipPaths should not consider link fragment', async () => {
+		const doc1 = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
+			`[text](/no-such-file#header)`,
+		));
+
+		const manager = createDiagnosticsManager(new InMemoryWorkspaceMarkdownDocuments([doc1]), new MemoryDiagnosticConfiguration(true, ['/no-such-file']));
+		const { diagnostics } = await manager.recomputeDiagnosticState(doc1, noopToken);
+		assert.deepStrictEqual(diagnostics.length, 0);
+	});
+
+	test('skipPaths should support globs', async () => {
+		const doc1 = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
+			`![i](/images/aaa.png)`,
+			`![i](/images/sub/bbb.png)`,
+			`![i](/images/sub/sub2/ccc.png)`,
+		));
+
+		const manager = createDiagnosticsManager(new InMemoryWorkspaceMarkdownDocuments([doc1]), new MemoryDiagnosticConfiguration(true, ['/images/**/*.png']));
+		const { diagnostics } = await manager.recomputeDiagnosticState(doc1, noopToken);
+		assert.deepStrictEqual(diagnostics.length, 0);
+	});
+
+	test('skipPaths should resolve relative to file', async () => {
+		const doc1 = new InMemoryDocument(workspacePath('sub', 'doc1.md'), joinLines(
+			`![i](images/aaa.png)`,
+			`![i](images/sub/bbb.png)`,
+			`![i](images/sub/sub2/ccc.png)`,
+			`![i](/images/sub/sub2/ccc.png)`,
+		));
+
+		const manager = createDiagnosticsManager(new InMemoryWorkspaceMarkdownDocuments([doc1]), new MemoryDiagnosticConfiguration(true, ['images/**/*.png']));
+		const { diagnostics } = await manager.recomputeDiagnosticState(doc1, noopToken);
 		assert.deepStrictEqual(diagnostics.length, 0);
 	});
 });

--- a/extensions/markdown-language-features/yarn.lock
+++ b/extensions/markdown-language-features/yarn.lock
@@ -39,6 +39,11 @@
   resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
   integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
 
+"@types/picomatch@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@types/picomatch/-/picomatch-2.3.0.tgz#75db5e75a713c5a83d5b76780c3da84a82806003"
+  integrity sha512-O397rnSS9iQI4OirieAtsDqvCj4+3eY1J+EPdNTKuHuRWIfUoGyzX294o8C4KJYaLqgSrd2o60c5EqCU8Zv02g==
+
 "@types/trusted-types@*":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
@@ -116,6 +121,11 @@ morphdom@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/morphdom/-/morphdom-2.6.1.tgz#e868e24f989fa3183004b159aed643e628b4306e"
   integrity sha512-Y8YRbAEP3eKykroIBWrjcfMw7mmwJfjhqdpSvoqinu8Y702nAwikpXcNFDiIkyvfCLxLM9Wu95RZqo4a9jFBaA==
+
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
For #146303

The new `markdown.experimental.validate.fileLinks.skipPaths` setting lets you specify a list of paths (as globs) that should not be validated

This is useful since markdown is used in a range of environments, and sometimes you may need to link to paths that don't exist on disk but will exist upon deployment

A few other changes here:

- Adds a quick fix that adds paths to `skipPaths`
- Rename existing settings to use the `.enabled` prefix

