### PR TITLE
Expose outputItem in notebook markdown eve

### DIFF
--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -207,7 +207,9 @@ export const activate: ActivationFunction<void> = (ctx) => {
 				previewNode.classList.remove('emptyMarkdownCell');
 				const markdownText = outputInfo.mime.startsWith('text/x-') ? `\`\`\`${outputInfo.mime.substr(7)}\n${text}\n\`\`\``
 					: (outputInfo.mime.startsWith('application/') ? `\`\`\`${outputInfo.mime.substr(12)}\n${text}\n\`\`\`` : text);
-				const unsanitizedRenderedMarkdown = markdownIt.render(markdownText);
+				const unsanitizedRenderedMarkdown = markdownIt.render(markdownText, {
+					outputItem: outputInfo,
+				});
 				previewNode.innerHTML = (ctx.workspace.isTrusted
 					? unsanitizedRenderedMarkdown
 					: DOMPurify.sanitize(unsanitizedRenderedMarkdown, sanitizerOptions)) as string;


### PR DESCRIPTION
For #121256

This change adds the current `ouputItem` to the notebook markdown renderer's environment

Renders that extend our markdown renderer can use this to access output item metadata for example

