### PR TITLE
Add WebviewInitInfo type

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadCodeInsets.ts
+++ b/src/vs/workbench/api/browser/mainThreadCodeInsets.ts
@@ -89,9 +89,14 @@ export class MainThreadEditorInsets implements MainThreadEditorInsetsShape {
 
 		const disposables = new DisposableStore();
 
-		const webview = this._webviewService.createWebviewElement('mainThreadCodeInsets_' + handle, {
-			enableFindWidget: false,
-		}, reviveWebviewContentOptions(options), { id: extensionId, location: URI.revive(extensionLocation) });
+		const webview = this._webviewService.createWebviewElement({
+			id: 'mainThreadCodeInsets_' + handle,
+			options: {
+				enableFindWidget: false,
+			},
+			contentOptions: reviveWebviewContentOptions(options),
+			extension: { id: extensionId, location: URI.revive(extensionLocation) }
+		});
 
 		const webviewZone = new EditorWebviewZone(editor, line, height, webview);
 

--- a/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
@@ -165,7 +165,13 @@ export class MainThreadWebviewPanels extends Disposable implements extHostProtoc
 
 		const extension = reviveWebviewExtension(extensionData);
 
-		const webview = this._webviewWorkbenchService.createWebview(handle, this.webviewPanelViewType.fromExternal(viewType), initData.title, mainThreadShowOptions, reviveWebviewOptions(initData.panelOptions), reviveWebviewContentOptions(initData.webviewOptions), extension);
+		const webview = this._webviewWorkbenchService.createWebview({
+			id: handle,
+			options: reviveWebviewOptions(initData.panelOptions),
+			contentOptions: reviveWebviewContentOptions(initData.webviewOptions),
+			extension
+		}, this.webviewPanelViewType.fromExternal(viewType), initData.title, mainThreadShowOptions);
+
 		this.addWebviewInput(handle, webview, { serializeBuffersForPostMessage: initData.serializeBuffersForPostMessage });
 
 		const payload = {

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -38,7 +38,12 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 			const untitledString = accessor.get(IUntitledTextEditorService).getValue(resource);
 			let untitledDocumentData = untitledString ? VSBuffer.fromString(untitledString) : undefined;
 			const id = generateUuid();
-			const webview = accessor.get(IWebviewService).createWebviewOverlay(id, { customClasses: options?.customClasses }, {}, undefined);
+			const webview = accessor.get(IWebviewService).createWebviewOverlay({
+				id,
+				options: { customClasses: options?.customClasses },
+				contentOptions: {},
+				extension: undefined,
+			});
 			const input = instantiationService.createInstance(CustomEditorInput, resource, viewType, id, webview, { untitledDocumentData: untitledDocumentData, oldResource: options?.oldResource });
 			if (typeof group !== 'undefined') {
 				input.updateGroup(group);

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
@@ -108,11 +108,16 @@ export class CustomEditorInputSerializer extends WebviewEditorInputSerializer {
 }
 
 function reviveWebview(webviewService: IWebviewService, data: { id: string; state: any; webviewOptions: WebviewOptions; contentOptions: WebviewContentOptions; extension?: WebviewExtensionDescription }) {
-	const webview = webviewService.createWebviewOverlay(data.id, {
-		purpose: WebviewContentPurpose.CustomEditor,
-		enableFindWidget: data.webviewOptions.enableFindWidget,
-		retainContextWhenHidden: data.webviewOptions.retainContextWhenHidden
-	}, data.contentOptions, data.extension);
+	const webview = webviewService.createWebviewOverlay({
+		id: data.id,
+		options: {
+			purpose: WebviewContentPurpose.CustomEditor,
+			enableFindWidget: data.webviewOptions.enableFindWidget,
+			retainContextWhenHidden: data.webviewOptions.retainContextWhenHidden
+		},
+		contentOptions: data.contentOptions,
+		extension: data.extension,
+	});
 	webview.state = data.state;
 	return webview;
 }

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -744,10 +744,15 @@ export class ExtensionEditor extends EditorPane {
 				return Promise.resolve(null);
 			}
 
-			const webview = this.contentDisposables.add(this.webviewService.createWebviewOverlay(generateUuid(), {
-				enableFindWidget: true,
-				tryRestoreScrollPosition: true,
-			}, {}, undefined));
+			const webview = this.contentDisposables.add(this.webviewService.createWebviewOverlay({
+				id: generateUuid(),
+				options: {
+					enableFindWidget: true,
+					tryRestoreScrollPosition: true,
+				},
+				contentOptions: {},
+				extension: undefined,
+			}));
 
 			webview.initialScrollProgress = this.initialScrollProgress.get(webviewIndex) || 0;
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -884,15 +884,20 @@ var requirejs = (function() {
 			...workspaceFolders,
 			...this.getBuiltinLocalResourceRoots(),
 		];
-		const webview = webviewService.createWebviewElement(this.id, {
-			purpose: WebviewContentPurpose.NotebookRenderer,
-			enableFindWidget: false,
-			transformCssVariables: transformWebviewThemeVars,
-		}, {
-			allowMultipleAPIAcquire: true,
-			allowScripts: true,
-			localResourceRoots: this.localResourceRootsCache,
-		}, undefined);
+		const webview = webviewService.createWebviewElement({
+			id: this.id,
+			options: {
+				purpose: WebviewContentPurpose.NotebookRenderer,
+				enableFindWidget: false,
+				transformCssVariables: transformWebviewThemeVars,
+			},
+			contentOptions: {
+				allowMultipleAPIAcquire: true,
+				allowScripts: true,
+				localResourceRoots: this.localResourceRootsCache,
+			},
+			extension: undefined
+		});
 
 		webview.html = content;
 		return webview;

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -79,18 +79,20 @@ export class ReleaseNotesManager {
 			this._webviewWorkbenchService.revealWebview(this._currentReleaseNotes, activeEditorPane ? activeEditorPane.group : this._editorGroupService.activeGroup, false);
 		} else {
 			this._currentReleaseNotes = this._webviewWorkbenchService.createWebview(
-				generateUuid(),
+				{
+					id: generateUuid(),
+					options: {
+						tryRestoreScrollPosition: true,
+						enableFindWidget: true,
+					},
+					contentOptions: {
+						localResourceRoots: []
+					},
+					extension: undefined
+				},
 				'releaseNotes',
 				title,
-				{ group: ACTIVE_GROUP, preserveFocus: false },
-				{
-					tryRestoreScrollPosition: true,
-					enableFindWidget: true,
-				},
-				{
-					localResourceRoots: []
-				},
-				undefined);
+				{ group: ACTIVE_GROUP, preserveFocus: false });
 
 			this._currentReleaseNotes.webview.onDidClickLink(uri => this.onDidClickLink(URI.parse(uri)));
 			this._currentReleaseNotes.onWillDispose(() => { this._currentReleaseNotes = undefined; });

--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -12,6 +12,7 @@ import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/c
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IWebviewService, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_ENABLED, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE, IWebview, WebviewContentOptions, IWebviewElement, WebviewExtensionDescription, WebviewMessageReceivedEvent, WebviewOptions, IOverlayWebview } from 'vs/workbench/contrib/webview/browser/webview';
+import { WebviewInitInfo } from 'vs/workbench/contrib/webview/browser/webviewElement';
 
 /**
  * Webview that is absolutely positioned over another element and that can creates and destroys an underlying webview as needed.
@@ -41,20 +42,20 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 	private _findWidgetVisible: IContextKey<boolean> | undefined;
 	private _findWidgetEnabled: IContextKey<boolean> | undefined;
 
+	public readonly id: string;
+
 	public constructor(
-		public readonly id: string,
-		initialOptions: WebviewOptions,
-		initialContentOptions: WebviewContentOptions,
-		extension: WebviewExtensionDescription | undefined,
+		initInfo: WebviewInitInfo,
 		@ILayoutService private readonly _layoutService: ILayoutService,
 		@IWebviewService private readonly _webviewService: IWebviewService,
 		@IContextKeyService private readonly _baseContextKeyService: IContextKeyService
 	) {
 		super();
 
-		this._extension = extension;
-		this._options = initialOptions;
-		this._contentOptions = initialContentOptions;
+		this.id = initInfo.id;
+		this._extension = initInfo.extension;
+		this._options = initInfo.options;
+		this._contentOptions = initInfo.contentOptions;
 	}
 
 	public get isFocused() {
@@ -99,8 +100,8 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 			// Webviews cannot be reparented in the dom as it will destroy their contents.
 			// Mount them to a high level node to avoid this.
 			this._layoutService.container.appendChild(this._container);
-
 		}
+
 		return this._container;
 	}
 
@@ -185,7 +186,7 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 		}
 
 		if (!this._webview.value) {
-			const webview = this._webviewService.createWebviewElement(this.id, this._options, this._contentOptions, this.extension);
+			const webview = this._webviewService.createWebviewElement({ id: this.id, options: this._options, contentOptions: this._contentOptions, extension: this.extension });
 			this._webview.value = webview;
 			webview.state = this._state;
 

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -14,6 +14,7 @@ import { IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IWebviewPortMapping } from 'vs/platform/webview/common/webviewPortMapping';
+import { WebviewInitInfo } from 'vs/workbench/contrib/webview/browser/webviewElement';
 
 /**
  * Set when the find widget in a webview in a webview is visible.
@@ -53,12 +54,7 @@ export interface IWebviewService {
 	/**
 	 * Create a basic webview dom element.
 	 */
-	createWebviewElement(
-		id: string,
-		options: WebviewOptions,
-		contentOptions: WebviewContentOptions,
-		extension: WebviewExtensionDescription | undefined,
-	): IWebviewElement;
+	createWebviewElement(initInfo: WebviewInitInfo): IWebviewElement;
 
 	/**
 	 * Create a lazily created webview element that is overlaid on top of another element.
@@ -66,12 +62,7 @@ export interface IWebviewService {
 	 * Allows us to avoid re-parenting the webview (which destroys its contents) when
 	 * moving webview around the workbench.
 	 */
-	createWebviewOverlay(
-		id: string,
-		options: WebviewOptions,
-		contentOptions: WebviewContentOptions,
-		extension: WebviewExtensionDescription | undefined,
-	): IOverlayWebview;
+	createWebviewOverlay(initInfo: WebviewInitInfo): IOverlayWebview;
 }
 
 export const enum WebviewContentPurpose {

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -118,9 +118,9 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 	public readonly id: string;
 
 	/**
-	 * Unique identifier of this webview element.
+	 * Unique identifier of this webview iframe element.
 	 */
-	private readonly frameId: string;
+	private readonly iframeId: string;
 
 	private readonly encodedWebviewOriginPromise: Promise<string>;
 	private encodedWebviewOrigin: string | undefined;
@@ -193,8 +193,8 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 		super();
 
 		this.id = initInfo.id;
-		this.frameId = generateUuid();
-		this.encodedWebviewOriginPromise = parentOriginHash(window.origin, this.frameId).then(id => this.encodedWebviewOrigin = id);
+		this.iframeId = generateUuid();
+		this.encodedWebviewOriginPromise = parentOriginHash(window.origin, this.iframeId).then(id => this.encodedWebviewOrigin = id);
 
 		this.options = initInfo.options;
 		this.extension = initInfo.extension;
@@ -215,7 +215,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 
 
 		const subscription = this._register(addDisposableListener(window, 'message', (e: MessageEvent) => {
-			if (!this.encodedWebviewOrigin || e?.data?.target !== this.frameId) {
+			if (!this.encodedWebviewOrigin || e?.data?.target !== this.iframeId) {
 				return;
 			}
 
@@ -483,7 +483,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 	private initElement(encodedWebviewOrigin: string, extension: WebviewExtensionDescription | undefined, options: WebviewOptions) {
 		// The extensionId and purpose in the URL are used for filtering in js-debug:
 		const params: { [key: string]: string } = {
-			id: this.frameId,
+			id: this.iframeId,
 			swVersion: String(this._expectedServiceWorkerVersion),
 			extensionId: extension?.id.value ?? '',
 			platform: this.platform,

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -113,14 +113,14 @@ export interface WebviewInitInfo {
 export class WebviewElement extends Disposable implements IWebview, WebviewFindDelegate {
 
 	/**
-	 * Unique identifier of this webview.
+	 * External identifier of this webview.
 	 */
 	public readonly id: string;
 
 	/**
-	 * The webview's origin (the origin where the webview itself is served from). May be shared by multiple webviews.
+	 * Unique identifier of this webview element.
 	 */
-	public readonly origin: string;
+	private readonly frameId: string;
 
 	private readonly encodedWebviewOriginPromise: Promise<string>;
 	private encodedWebviewOrigin: string | undefined;
@@ -193,8 +193,8 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 		super();
 
 		this.id = initInfo.id;
-		this.origin = generateUuid();
-		this.encodedWebviewOriginPromise = parentOriginHash(window.origin, this.origin).then(id => this.encodedWebviewOrigin = id);
+		this.frameId = generateUuid();
+		this.encodedWebviewOriginPromise = parentOriginHash(window.origin, this.frameId).then(id => this.encodedWebviewOrigin = id);
 
 		this.options = initInfo.options;
 		this.extension = initInfo.extension;
@@ -215,7 +215,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 
 
 		const subscription = this._register(addDisposableListener(window, 'message', (e: MessageEvent) => {
-			if (!this.encodedWebviewOrigin || e?.data?.target !== this.origin) {
+			if (!this.encodedWebviewOrigin || e?.data?.target !== this.frameId) {
 				return;
 			}
 
@@ -483,7 +483,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 	private initElement(encodedWebviewOrigin: string, extension: WebviewExtensionDescription | undefined, options: WebviewOptions) {
 		// The extensionId and purpose in the URL are used for filtering in js-debug:
 		const params: { [key: string]: string } = {
-			id: this.origin,
+			id: this.frameId,
 			swVersion: String(this._expectedServiceWorkerVersion),
 			extensionId: extension?.id.value ?? '',
 			platform: this.platform,

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -100,11 +100,28 @@ namespace WebviewState {
 	export type State = typeof Ready | Initializing;
 }
 
+export interface WebviewInitInfo {
+	readonly id: string;
+
+	readonly options: WebviewOptions;
+	readonly contentOptions: WebviewContentOptions;
+
+	readonly extension: WebviewExtensionDescription | undefined;
+}
+
+
 export class WebviewElement extends Disposable implements IWebview, WebviewFindDelegate {
 
+	/**
+	 * Unique identifier of this webview.
+	 */
 	public readonly id: string;
 
-	private readonly iframeId: string;
+	/**
+	 * The webview's origin (the origin where the webview itself is served from). May be shared by multiple webviews.
+	 */
+	public readonly origin: string;
+
 	private readonly encodedWebviewOriginPromise: Promise<string>;
 	private encodedWebviewOrigin: string | undefined;
 
@@ -153,11 +170,12 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 
 	private _disposed = false;
 
+
+	public extension: WebviewExtensionDescription | undefined;
+	private readonly options: WebviewOptions;
+
 	constructor(
-		id: string,
-		private readonly options: WebviewOptions,
-		contentOptions: WebviewContentOptions,
-		public extension: WebviewExtensionDescription | undefined,
+		initInfo: WebviewInitInfo,
 		protected readonly webviewThemeDataProvider: WebviewThemeDataProvider,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IContextMenuService contextMenuService: IContextMenuService,
@@ -174,13 +192,16 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 	) {
 		super();
 
-		this.id = id;
-		this.iframeId = generateUuid();
-		this.encodedWebviewOriginPromise = parentOriginHash(window.origin, this.iframeId).then(id => this.encodedWebviewOrigin = id);
+		this.id = initInfo.id;
+		this.origin = generateUuid();
+		this.encodedWebviewOriginPromise = parentOriginHash(window.origin, this.origin).then(id => this.encodedWebviewOrigin = id);
+
+		this.options = initInfo.options;
+		this.extension = initInfo.extension;
 
 		this.content = {
 			html: '',
-			options: contentOptions,
+			options: initInfo.contentOptions,
 			state: undefined
 		};
 
@@ -190,11 +211,11 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 			this._tunnelService
 		));
 
-		this._element = this.createElement(options, contentOptions);
+		this._element = this.createElement(initInfo.options, initInfo.contentOptions);
 
 
 		const subscription = this._register(addDisposableListener(window, 'message', (e: MessageEvent) => {
-			if (!this.encodedWebviewOrigin || e?.data?.target !== this.iframeId) {
+			if (!this.encodedWebviewOrigin || e?.data?.target !== this.origin) {
 				return;
 			}
 
@@ -355,14 +376,14 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 			this.startBlockingIframeDragEvents();
 		}));
 
-		if (options.enableFindWidget) {
+		if (initInfo.options.enableFindWidget) {
 			this._webviewFindWidget = this._register(instantiationService.createInstance(WebviewFindWidget, this));
 			this.styledFindWidget();
 		}
 
 		this.encodedWebviewOriginPromise.then(encodedWebviewOrigin => {
 			if (!this._disposed) {
-				this.initElement(encodedWebviewOrigin, extension, options);
+				this.initElement(encodedWebviewOrigin, this.extension, this.options);
 			}
 		});
 	}
@@ -462,7 +483,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 	private initElement(encodedWebviewOrigin: string, extension: WebviewExtensionDescription | undefined, options: WebviewOptions) {
 		// The extensionId and purpose in the URL are used for filtering in js-debug:
 		const params: { [key: string]: string } = {
-			id: this.iframeId,
+			id: this.origin,
 			swVersion: String(this._expectedServiceWorkerVersion),
 			extensionId: extension?.id.value ?? '',
 			platform: this.platform,

--- a/src/vs/workbench/contrib/webview/browser/webviewService.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewService.ts
@@ -7,8 +7,8 @@ import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
-import { IWebviewService, IWebview, WebviewContentOptions, IWebviewElement, WebviewExtensionDescription, WebviewOptions, IOverlayWebview } from 'vs/workbench/contrib/webview/browser/webview';
-import { WebviewElement } from 'vs/workbench/contrib/webview/browser/webviewElement';
+import { IOverlayWebview, IWebview, IWebviewElement, IWebviewService } from 'vs/workbench/contrib/webview/browser/webview';
+import { WebviewElement, WebviewInitInfo } from 'vs/workbench/contrib/webview/browser/webviewElement';
 import { OverlayWebview } from './overlayWebview';
 
 export class WebviewService extends Disposable implements IWebviewService {
@@ -43,24 +43,14 @@ export class WebviewService extends Disposable implements IWebviewService {
 	private readonly _onDidChangeActiveWebview = this._register(new Emitter<IWebview | undefined>());
 	public readonly onDidChangeActiveWebview = this._onDidChangeActiveWebview.event;
 
-	createWebviewElement(
-		id: string,
-		options: WebviewOptions,
-		contentOptions: WebviewContentOptions,
-		extension: WebviewExtensionDescription | undefined,
-	): IWebviewElement {
-		const webview = this._instantiationService.createInstance(WebviewElement, id, options, contentOptions, extension, this._webviewThemeDataProvider);
+	createWebviewElement(initInfo: WebviewInitInfo): IWebviewElement {
+		const webview = this._instantiationService.createInstance(WebviewElement, initInfo, this._webviewThemeDataProvider);
 		this.registerNewWebview(webview);
 		return webview;
 	}
 
-	createWebviewOverlay(
-		id: string,
-		options: WebviewOptions,
-		contentOptions: WebviewContentOptions,
-		extension: WebviewExtensionDescription | undefined,
-	): IOverlayWebview {
-		const webview = this._instantiationService.createInstance(OverlayWebview, id, options, contentOptions, extension);
+	createWebviewOverlay(initInfo: WebviewInitInfo): IOverlayWebview {
+		const webview = this._instantiationService.createInstance(OverlayWebview, initInfo);
 		this.registerNewWebview(webview);
 		return webview;
 	}

--- a/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
@@ -23,8 +23,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ITunnelService } from 'vs/platform/tunnel/common/tunnel';
 import { FindInFrameOptions, IWebviewManagerService } from 'vs/platform/webview/common/webviewManagerService';
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
-import { WebviewContentOptions, WebviewExtensionDescription, WebviewOptions } from 'vs/workbench/contrib/webview/browser/webview';
-import { WebviewElement, WebviewMessageChannels } from 'vs/workbench/contrib/webview/browser/webviewElement';
+import { WebviewElement, WebviewInitInfo, WebviewMessageChannels } from 'vs/workbench/contrib/webview/browser/webviewElement';
 import { WindowIgnoreMenuShortcutsManager } from 'vs/workbench/contrib/webview/electron-sandbox/windowIgnoreMenuShortcutsManager';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 
@@ -44,10 +43,7 @@ export class ElectronWebviewElement extends WebviewElement {
 	protected override get platform() { return 'electron'; }
 
 	constructor(
-		id: string,
-		options: WebviewOptions,
-		contentOptions: WebviewContentOptions,
-		extension: WebviewExtensionDescription | undefined,
+		initInfo: WebviewInitInfo,
 		webviewThemeDataProvider: WebviewThemeDataProvider,
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@ITunnelService tunnelService: ITunnelService,
@@ -64,7 +60,7 @@ export class ElectronWebviewElement extends WebviewElement {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IAccessibilityService accessibilityService: IAccessibilityService,
 	) {
-		super(id, options, contentOptions, extension, webviewThemeDataProvider,
+		super(initInfo, webviewThemeDataProvider,
 			configurationService, contextMenuService, menuService, notificationService, environmentService,
 			fileService, logService, remoteAuthorityResolverService, telemetryService, tunnelService, instantiationService, accessibilityService);
 
@@ -80,7 +76,7 @@ export class ElectronWebviewElement extends WebviewElement {
 			this._webviewKeyboardHandler.didBlur();
 		}));
 
-		if (options.enableFindWidget) {
+		if (initInfo.options.enableFindWidget) {
 			this._register(this.onDidHtmlChange((newContent) => {
 				if (this._findStarted && this._cachedHtmlContent !== newContent) {
 					this.stopFind(false);

--- a/src/vs/workbench/contrib/webview/electron-sandbox/webviewService.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/webviewService.ts
@@ -3,19 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IWebviewElement, WebviewContentOptions, WebviewExtensionDescription, WebviewOptions } from 'vs/workbench/contrib/webview/browser/webview';
+import { IWebviewElement } from 'vs/workbench/contrib/webview/browser/webview';
+import { WebviewInitInfo } from 'vs/workbench/contrib/webview/browser/webviewElement';
 import { WebviewService } from 'vs/workbench/contrib/webview/browser/webviewService';
 import { ElectronWebviewElement } from 'vs/workbench/contrib/webview/electron-sandbox/webviewElement';
 
 export class ElectronWebviewService extends WebviewService {
 
-	override createWebviewElement(
-		id: string,
-		options: WebviewOptions,
-		contentOptions: WebviewContentOptions,
-		extension: WebviewExtensionDescription | undefined,
-	): IWebviewElement {
-		const webview = this._instantiationService.createInstance(ElectronWebviewElement, id, options, contentOptions, extension, this._webviewThemeDataProvider);
+	override createWebviewElement(initInfo: WebviewInitInfo): IWebviewElement {
+		const webview = this._instantiationService.createInstance(ElectronWebviewElement, initInfo, this._webviewThemeDataProvider);
 		this.registerNewWebview(webview);
 		return webview;
 	}

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewEditorInputSerializer.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewEditorInputSerializer.ts
@@ -74,14 +74,16 @@ export class WebviewEditorInputSerializer implements IEditorSerializer {
 	): WebviewInput {
 		const data = this.fromJson(JSON.parse(serializedEditorInput));
 		return this._webviewWorkbenchService.reviveWebview({
-			id: data.id,
+			webviewInitInfo: {
+				id: data.id,
+				options: data.webviewOptions,
+				contentOptions: data.contentOptions,
+				extension: data.extension,
+			},
 			viewType: data.viewType,
 			title: data.title,
 			iconPath: data.iconPath,
 			state: data.state,
-			webviewOptions: data.webviewOptions,
-			contentOptions: data.contentOptions,
-			extension: data.extension,
 			group: data.group
 		});
 	}

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.ts
@@ -15,7 +15,8 @@ import { createDecorator, IInstantiationService } from 'vs/platform/instantiatio
 import { GroupIdentifier } from 'vs/workbench/common/editor';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
-import { IOverlayWebview, IWebviewService, WebviewContentOptions, WebviewExtensionDescription, WebviewOptions } from 'vs/workbench/contrib/webview/browser/webview';
+import { IOverlayWebview, IWebviewService } from 'vs/workbench/contrib/webview/browser/webview';
+import { WebviewInitInfo } from 'vs/workbench/contrib/webview/browser/webviewElement';
 import { WebviewIconManager, WebviewIcons } from 'vs/workbench/contrib/webviewPanel/browser/webviewIconManager';
 import { IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { ACTIVE_GROUP_TYPE, IEditorService, SIDE_GROUP_TYPE } from 'vs/workbench/services/editor/common/editorService';
@@ -34,24 +35,18 @@ export interface IWebviewWorkbenchService {
 	readonly iconManager: WebviewIconManager;
 
 	createWebview(
-		id: string,
+		webviewInitInfo: WebviewInitInfo,
 		viewType: string,
 		title: string,
 		showOptions: ICreateWebViewShowOptions,
-		webviewOptions: WebviewOptions,
-		contentOptions: WebviewContentOptions,
-		extension: WebviewExtensionDescription | undefined,
 	): WebviewInput;
 
 	reviveWebview(options: {
-		id: string;
+		webviewInitInfo: WebviewInitInfo;
 		viewType: string;
 		title: string;
 		iconPath: WebviewIcons | undefined;
 		state: any;
-		webviewOptions: WebviewOptions;
-		contentOptions: WebviewContentOptions;
-		extension: WebviewExtensionDescription | undefined;
 		group: number | undefined;
 	}): WebviewInput;
 
@@ -218,16 +213,13 @@ export class WebviewEditorService extends Disposable implements IWebviewWorkbenc
 	}
 
 	public createWebview(
-		id: string,
+		webviewInitInfo: WebviewInitInfo,
 		viewType: string,
 		title: string,
 		showOptions: ICreateWebViewShowOptions,
-		webviewOptions: WebviewOptions,
-		contentOptions: WebviewContentOptions,
-		extension: WebviewExtensionDescription | undefined,
 	): WebviewInput {
-		const webview = this._webviewService.createWebviewOverlay(id, webviewOptions, contentOptions, extension);
-		const webviewInput = this._instantiationService.createInstance(WebviewInput, id, viewType, title, webview, this.iconManager);
+		const webview = this._webviewService.createWebviewOverlay(webviewInitInfo);
+		const webviewInput = this._instantiationService.createInstance(WebviewInput, webviewInitInfo.id, viewType, title, webview, this.iconManager);
 		this._editorService.openEditor(webviewInput, {
 			pinned: true,
 			preserveFocus: showOptions.preserveFocus,
@@ -268,20 +260,17 @@ export class WebviewEditorService extends Disposable implements IWebviewWorkbenc
 	}
 
 	public reviveWebview(options: {
-		id: string;
+		webviewInitInfo: WebviewInitInfo;
 		viewType: string;
 		title: string;
 		iconPath: WebviewIcons | undefined;
 		state: any;
-		webviewOptions: WebviewOptions;
-		contentOptions: WebviewContentOptions;
-		extension: WebviewExtensionDescription | undefined;
 		group: number | undefined;
 	}): WebviewInput {
-		const webview = this._webviewService.createWebviewOverlay(options.id, options.webviewOptions, options.contentOptions, options.extension);
+		const webview = this._webviewService.createWebviewOverlay(options.webviewInitInfo);
 		webview.state = options.state;
 
-		const webviewInput = this._instantiationService.createInstance(LazilyResolvedWebviewEditorInput, options.id, options.viewType, options.title, webview);
+		const webviewInput = this._instantiationService.createInstance(LazilyResolvedWebviewEditorInput, options.webviewInitInfo.id, options.viewType, options.title, webview);
 		webviewInput.iconPath = options.iconPath;
 
 		if (typeof options.group === 'number') {

--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -167,12 +167,12 @@ export class WebviewViewPane extends ViewPane {
 		this._activated = true;
 
 		const webviewId = generateUuid();
-		const webview = this.webviewService.createWebviewOverlay(
-			webviewId,
-			{ purpose: WebviewContentPurpose.WebviewView },
-			{},
-			this.extensionId ? { id: this.extensionId } : undefined
-		);
+		const webview = this.webviewService.createWebviewOverlay({
+			id: webviewId,
+			options: { purpose: WebviewContentPurpose.WebviewView },
+			contentOptions: {},
+			extension: this.extensionId ? { id: this.extensionId } : undefined
+		});
 		webview.state = this.viewState[storageKeys.webviewState];
 		this._webview.value = webview;
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -529,7 +529,7 @@ export class GettingStartedPage extends EditorPane {
 			this.stepsContent.classList.remove('markdown');
 
 			const media = stepToExpand.media;
-			const webview = this.stepDisposables.add(this.webviewService.createWebviewElement(this.webviewID, {}, {}, undefined));
+			const webview = this.stepDisposables.add(this.webviewService.createWebviewElement({ id: this.webviewID, options: {}, contentOptions: {}, extension: undefined }));
 			webview.mountTo(this.stepMediaComponent);
 
 			webview.html = await this.detailsRenderer.renderSVG(media.path);
@@ -570,7 +570,7 @@ export class GettingStartedPage extends EditorPane {
 
 			const media = stepToExpand.media;
 
-			const webview = this.stepDisposables.add(this.webviewService.createWebviewElement(this.webviewID, {}, { localResourceRoots: [media.root], allowScripts: true }, undefined));
+			const webview = this.stepDisposables.add(this.webviewService.createWebviewElement({ id: this.webviewID, options: {}, contentOptions: { localResourceRoots: [media.root], allowScripts: true }, extension: undefined }));
 			webview.mountTo(this.stepMediaComponent);
 
 			const rawHTML = await this.detailsRenderer.renderMarkdown(media.path, media.base);


### PR DESCRIPTION
This cleanup PR adds a new `WebviewInitInfo` type that brings together the core information needed to create a webview

I've then updated the various webview APIs to use this new type

