### PR TITLE
Remove `print value` from Swift Code Snippets

### DIFF
--- a/extensions/swift/snippets/swift.code-snippets
+++ b/extensions/swift/snippets/swift.code-snippets
@@ -4,11 +4,6 @@
 		"body": "print(\"$1\")\n$0",
 		"description": "print(\"...\")"
 	},
-	"print value": {
-		"prefix": "printv",
-		"body": "print(\"\\($1)\")\n$0",
-		"description": "print(\"\\(...)\")"
-	},
 	"while": {
 		"prefix": "while",
 		"body": [


### PR DESCRIPTION
The code snippet is useless, as it is not needed in Swift. Doing `print(value)` achieves the same as `print("\(value)")` but cleaner.