### PR TITLE
Align menubar button hover backgrounds with title bar elements

### DIFF
--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke, errorForeground, listActiveSelectionBackground, listActiveSelectionForeground, editorForeground } from 'vs/platform/theme/common/colorRegistry';
+import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke, errorForeground, listActiveSelectionBackground, listActiveSelectionForeground, editorForeground, toolbarHoverBackground } from 'vs/platform/theme/common/colorRegistry';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { Color } from 'vs/base/common/color';
 import { ColorScheme } from 'vs/platform/theme/common/theme';
@@ -763,8 +763,8 @@ export const MENUBAR_SELECTION_FOREGROUND = registerColor('menubar.selectionFore
 }, localize('menubarSelectionForeground', "Foreground color of the selected menu item in the menubar."));
 
 export const MENUBAR_SELECTION_BACKGROUND = registerColor('menubar.selectionBackground', {
-	dark: transparent(Color.white, 0.1),
-	light: transparent(Color.black, 0.1),
+	dark: toolbarHoverBackground,
+	light: toolbarHoverBackground,
 	hcDark: null,
 	hcLight: null,
 }, localize('menubarSelectionBackground', "Background color of the selected menu item in the menubar."));


### PR DESCRIPTION
Fixes an issue where the menubar buttons feature a different background color on hover compared with all other title bar elements.

## Before

![CleanShot 2022-05-19 at 10 33 41](https://user-images.githubusercontent.com/25163139/169362511-850b39d6-eb83-4699-b2d0-318f88cfec0a.gif)

## After

![CleanShot 2022-05-19 at 10 31 53](https://user-images.githubusercontent.com/25163139/169362553-4de1728b-387b-48ac-95f2-5be7255b83ac.gif)
