### PR TITLE
Fix markdown ext errors accessing disposed webview

### DIFF
--- a/extensions/markdown-language-features/src/preview/previewContentProvider.ts
+++ b/extensions/markdown-language-features/src/preview/previewContentProvider.ts
@@ -66,7 +66,8 @@ export class MarkdownContentProvider {
 		resourceProvider: WebviewResourceProvider,
 		previewConfigurations: MarkdownPreviewConfigurationManager,
 		initialLine: number | undefined = undefined,
-		state?: any
+		state: any | undefined,
+		token: vscode.CancellationToken
 	): Promise<MarkdownContentProviderOutput> {
 		const sourceUri = markdownDocument.uri;
 		const config = previewConfigurations.loadAndCacheConfiguration(sourceUri);
@@ -89,6 +90,10 @@ export class MarkdownContentProvider {
 		const csp = this.getCsp(resourceProvider, sourceUri, nonce);
 
 		const body = await this.markdownBody(markdownDocument, resourceProvider);
+		if (token.isCancellationRequested) {
+			return { html: '', containingImages: [] };
+		}
+
 		const html = `<!DOCTYPE html>
 			<html style="${escapeAttribute(this.getSettingsOverrideStyles(config))}">
 			<head>


### PR DESCRIPTION
When reloading windows that need to restore a markdown preview, sometimes I'll see an error when the markdown preview tries accessing a disposed of webview. This seems to be cause caused by `provideTextDocumentContent`, where we end up disposing of the webview before an `await` resumes execution