### PR TITLE
Allow cancelling webview's readFileStream calls

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
+++ b/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
@@ -65,7 +65,7 @@ export async function loadLocalResource(
 	const mime = getWebviewContentMimeType(requestUri); // Use the original path for the mime
 
 	try {
-		const result = await fileService.readFileStream(resourceToLoad, { etag: options.ifNoneMatch });
+		const result = await fileService.readFileStream(resourceToLoad, { etag: options.ifNoneMatch }, token);
 		return new WebviewResourceResponse.StreamSuccess(result.value, result.etag, result.mtime, mime);
 	} catch (err) {
 		if (err instanceof FileOperationError) {


### PR DESCRIPTION
This passes a cancellation token to `readFileStream` (this parameter was recently added). This ensures we stop reading the file if the webview is disposed of
