### PR TITLE
Use correct terminal dimensions when restoring a terminal

### DIFF
--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -766,8 +766,8 @@ class XtermSerializer implements ITerminalSerializer {
 		return {
 			events: [
 				{
-					cols: this._xterm.getOption('cols'),
-					rows: this._xterm.getOption('rows'),
+					cols: this._xterm.cols,
+					rows: this._xterm.rows,
 					data: serialized
 				}
 			],


### PR DESCRIPTION
Fixes #146059

---

Created https://github.com/xtermjs/xterm.js/issues/3825 to help prevent this sort of thing in the future.