### PR TITLE
feat: inlay hints displayStyle

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2523,11 +2523,10 @@ export interface IEditorInlayHintsOptions {
 	fontFamily?: string;
 
 	/**
-	 * The display style to render inlay hints with.
-	 * Compact mode disables the borders and padding around the inlay hint.
-	 * Defaults to 'standard'.
+	 * Enables the padding around the inlay hint.
+	 * Defaults to false.
 	 */
-	displayStyle: 'standard' | 'compact';
+	padding?: boolean;
 }
 
 /**
@@ -2538,7 +2537,7 @@ export type EditorInlayHintsOptions = Readonly<Required<IEditorInlayHintsOptions
 class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, IEditorInlayHintsOptions, EditorInlayHintsOptions> {
 
 	constructor() {
-		const defaults: EditorInlayHintsOptions = { enabled: 'on', fontSize: 0, fontFamily: '', displayStyle: 'compact' };
+		const defaults: EditorInlayHintsOptions = { enabled: 'on', fontSize: 0, fontFamily: '', padding: false };
 		super(
 			EditorOption.inlayHints, 'inlayHints', defaults,
 			{
@@ -2564,16 +2563,11 @@ class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, IEditor
 					default: defaults.fontFamily,
 					markdownDescription: nls.localize('inlayHints.fontFamily', "Controls font family of inlay hints in the editor. When set to empty, the `#editor.fontFamily#` is used.")
 				},
-				// 'editor.inlayHints.displayStyle': {
-				// 	type: 'string',
-				// 	enum: ['standard', 'compact'],
-				// 	enumDescriptions: [
-				// 		nls.localize('inlayHints.displayStyle.standard', "Renders inlay hints with the default style."),
-				// 		nls.localize('inlayHints.displayStyle.compact', "Renders inlay hints without any padding, and removes the rounded borders."),
-				// 	],
-				// 	default: defaults.displayStyle,
-				// 	description: nls.localize('inlayHints.displayStyle', "Controls the display style of inlay hints.")
-				// }
+				'editor.inlayHints.padding': {
+					type: 'boolean',
+					default: defaults.padding,
+					description: nls.localize('inlayHints.padding', "Enables the padding around the inlay hints in the editor.")
+				}
 			}
 		);
 	}
@@ -2590,7 +2584,7 @@ class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, IEditor
 			enabled: stringSet<'on' | 'off' | 'offUnlessPressed' | 'onUnlessPressed'>(input.enabled, this.defaultValue.enabled, ['on', 'off', 'offUnlessPressed', 'onUnlessPressed']),
 			fontSize: EditorIntOption.clampedInt(input.fontSize, this.defaultValue.fontSize, 0, 100),
 			fontFamily: EditorStringOption.string(input.fontFamily, this.defaultValue.fontFamily),
-			displayStyle: stringSet<'standard' | 'compact'>(input.displayStyle, this.defaultValue.displayStyle, ['standard', 'compact'])
+			padding: boolean(input.padding, this.defaultValue.padding)
 		};
 	}
 }

--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
@@ -468,7 +468,7 @@ export class InlayHintsController implements IEditorContribution {
 
 
 		//
-		const { fontSize, fontFamily, displayStyle } = this._getLayoutInfo();
+		const { fontSize, fontFamily, padding } = this._getLayoutInfo();
 		const fontFamilyVar = '--code-editorInlayHintsFontFamily';
 		this._editor.getContainerDomNode().style.setProperty(fontFamilyVar, fontFamily);
 
@@ -493,6 +493,7 @@ export class InlayHintsController implements IEditorContribution {
 				const cssProperties: CssProperties = {
 					fontSize: `${fontSize}px`,
 					fontFamily: `var(${fontFamilyVar}), ${EDITOR_FONT_DEFAULTS.fontFamily}`,
+					verticalAlign: 'middle',
 				};
 
 				if (isNonEmptyArray(item.hint.textEdits)) {
@@ -510,9 +511,7 @@ export class InlayHintsController implements IEditorContribution {
 					}
 				}
 
-				if (displayStyle === 'standard') {
-					cssProperties.verticalAlign = 'middle';
-
+				if (padding) {
 					if (isFirst && isLast) {
 						// only element
 						cssProperties.padding = `1px ${Math.max(1, fontSize / 4) | 0}px`;
@@ -594,7 +593,7 @@ export class InlayHintsController implements IEditorContribution {
 			fontSize = editorFontSize;
 		}
 		const fontFamily = options.fontFamily || this._editor.getOption(EditorOption.fontFamily);
-		return { fontSize, fontFamily, displayStyle: options.displayStyle };
+		return { fontSize, fontFamily, padding: options.padding };
 	}
 
 	private _removeAllDecorations(): void {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3798,11 +3798,10 @@ declare namespace monaco.editor {
 		 */
 		fontFamily?: string;
 		/**
-		 * The display style to render inlay hints with.
-		 * Compact mode disables the borders and padding around the inlay hint.
-		 * Defaults to 'standard'.
+		 * Enables the padding around the inlay hint.
+		 * Defaults to false.
 		 */
-		displayStyle: 'standard' | 'compact';
+		padding?: boolean;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #148868

We now have two styles for inlay hints. `code` (default) and `widget`.
