### PR TITLE
Format date strings with the right locale

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -6,7 +6,7 @@
 import 'vs/css!./media/extensionEditor';
 import { localize } from 'vs/nls';
 import * as arrays from 'vs/base/common/arrays';
-import { OS } from 'vs/base/common/platform';
+import { OS, locale } from 'vs/base/common/platform';
 import { Event, Emitter } from 'vs/base/common/event';
 import { Cache, CacheResult } from 'vs/base/common/cache';
 import { Action, IAction } from 'vs/base/common/actions';
@@ -997,11 +997,11 @@ export class ExtensionEditor extends EditorPane {
 			append(moreInfo,
 				$('.more-info-entry', undefined,
 					$('div', undefined, localize('release date', "Released on")),
-					$('div', undefined, new Date(gallery.releaseDate).toLocaleString(undefined, { hourCycle: 'h23' }))
+					$('div', undefined, new Date(gallery.releaseDate).toLocaleString(locale, { hourCycle: 'h23' }))
 				),
 				$('.more-info-entry', undefined,
 					$('div', undefined, localize('last updated', "Last updated")),
-					$('div', undefined, new Date(gallery.lastUpdated).toLocaleString(undefined, { hourCycle: 'h23' }))
+					$('div', undefined, new Date(gallery.lastUpdated).toLocaleString(locale, { hourCycle: 'h23' }))
 				)
 			);
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode/issues/140434

It's also a retake of @icepaq 's PR https://github.com/microsoft/vscode/pull/141353, which has the discussion history.

This PR fixes the issue that the dates in the Extension details page are not formatted with the locale used in VS Code. The fix is fairly straightforward - get the locale string from `vs/base/common/platform` and pass it to `Date.prototype.toLocaleString()`. 

# How to Test

1. Add the following member to `product.json` to enable extension marketplace in the OSS dev build
```	
"extensionsGallery": {
  "serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",
  "cacheUrl": "https://vscode.blob.core.windows.net/gallery/index",
  "itemUrl": "https://marketplace.visualstudio.com/items"
},
```
2. Use "Configure Display Language" to change the locale used in VS Code. I've tested with `en`, `es`, and `zh-cn`, covering date formats `MM/DD/YYYY`, `DD/MM/YYYY`, and `YYYY/MM/DD`.
3. Go to the Extensions tab
4. Search for an extension (eg, "Prettier")
5. Ensure that the "Released on" and "Last updated" fields are rendered in the format specified by the locale.

||en|es|zh-cn|
|--|--|--|--|
|Format|`MM/DD/YYYY`|`DD/MM/YYYY`|`YYYY/MM/DD`|
||![image](https://user-images.githubusercontent.com/70373/169716617-0788a2db-50b0-42fc-a265-e1411d1763ca.png)|![image](https://user-images.githubusercontent.com/70373/169717097-77667fab-c36a-41d1-a6bf-8b93e5108e30.png)|![image](https://user-images.githubusercontent.com/70373/169716625-2880d37f-59b8-40c9-853a-d0fd3bbcb059.png)|


