### PR TITLE
Force update on Markdown preview webview visible

### DIFF
--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -155,12 +155,6 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			}
 		}));
 
-		this._register(this._webviewPanel.onDidChangeViewState(event => {
-			if (event.webviewPanel.visible) {
-				this.refresh(true);
-			}
-		}));
-
 		const watcher = this._register(vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(resource, '*')));
 		this._register(watcher.onDidChange(uri => {
 			if (this.isPreviewOf(uri)) {
@@ -643,7 +637,12 @@ export class DynamicMarkdownPreview extends Disposable implements ManagedMarkdow
 		const webview = vscode.window.createWebviewPanel(
 			DynamicMarkdownPreview.viewType,
 			DynamicMarkdownPreview.getPreviewTitle(input.resource, input.locked),
-			previewColumn, { enableFindWidget: true, });
+			previewColumn,
+			{
+				enableFindWidget: true,
+				retainContextWhenHidden: true,
+			},
+		);
 
 		webview.iconPath = contentProvider.iconPath;
 

--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -155,6 +155,12 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			}
 		}));
 
+		this._register(this._webviewPanel.onDidChangeViewState(event => {
+			if (event.webviewPanel.visible) {
+				this.refresh(true);
+			}
+		}));
+
 		const watcher = this._register(vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(resource, '*')));
 		this._register(watcher.onDidChange(uri => {
 			if (this.isPreviewOf(uri)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #147718

The cause of the issue seems to be that when the preview webview becomes visible from invisible, the content is initialized using the webview's `html`. But when the webview's content is updated, it's updated using JavaScript in the webview, which doesn't update the `html` property.

The fix forces the webview to refresh when the webview becomes visible. Honestly, it's not the most elegant fix. I'm open to suggestions on how to fix the root cause better.

# Test
https://user-images.githubusercontent.com/70373/169742979-68501e89-53a6-4291-8b57-147f50d69b92.mp4




