### PR TITLE
Fix ignorefile parsing on windows

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -739,7 +739,7 @@ export class FilesFilter implements ITreeFilter<ExplorerItem, FuzzyScore> {
 		// Maybe we need a cancellation token here in case it's super long?
 		const content = await this.fileService.readFile(ignoreFileResource);
 		const ignoreParent = ignoreTree.findSubstr(dirUri);
-		const ignoreFile = new IgnoreFile(content.value.toString(), dirUri.path + path.sep, ignoreParent);
+		const ignoreFile = new IgnoreFile(content.value.toString(), dirUri.path, ignoreParent);
 		ignoreTree.set(dirUri, ignoreFile);
 		// If we haven't seen this resource before then we need to add it to the list of resources we're tracking
 		if (!this.ignoreFileResourcesPerRoot.get(root)?.has(ignoreFileResource)) {

--- a/src/vs/workbench/services/search/common/ignoreFile.ts
+++ b/src/vs/workbench/services/search/common/ignoreFile.ts
@@ -11,6 +11,12 @@ export class IgnoreFile {
 	private isPathIgnored: (path: string, isDir: boolean, parent?: IgnoreFile) => boolean;
 
 	constructor(contents: string, location: string, parent?: IgnoreFile) {
+		if (location[location.length - 1] === '\\') {
+			throw Error('Unexpected path format, do not use trailing backslashes');
+		}
+		if (location[location.length - 1] !== '/') {
+			location += '/';
+		}
 		this.isPathIgnored = this.parseIgnoreFile(contents, location, parent);
 	}
 


### PR DESCRIPTION
We use slashes internally for separators so using the path separator was a bug. Pull the path specific logic into IgnoreFile util so callers don't need to know implementation details.
