### PR TITLE
Markdown ignoreLink should apply to paths in header links

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/diagnostics.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/diagnostics.ts
@@ -494,7 +494,7 @@ export class DiagnosticComputer {
 						if (fragmentLinks.length) {
 							const toc = await TableOfContents.create(this.engine, hrefDoc);
 							for (const link of fragmentLinks) {
-								if (!toc.lookup(link.fragment) && !this.isIgnoredLink(options, link.source.text)) {
+								if (!toc.lookup(link.fragment) && !this.isIgnoredLink(options, link.source.pathText) && !this.isIgnoredLink(options, link.source.text)) {
 									const msg = localize('invalidLinkToHeaderInOtherFile', 'Header does not exist in file: {0}', link.fragment);
 									diagnostics.push(new LinkDoesNotExistDiagnostic(link.source.hrefRange, msg, severity, link.source.text));
 								}

--- a/extensions/markdown-language-features/src/test/diagnostic.test.ts
+++ b/extensions/markdown-language-features/src/test/diagnostic.test.ts
@@ -256,4 +256,16 @@ suite('markdown: Diagnostics', () => {
 			assert.deepStrictEqual(diagnostics.length, 0);
 		}
 	});
+
+	test('ignoreLinks should support ignore header links if file is ignored', async () => {
+		const doc1 = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
+			`![i](/doc2.md#no-such)`,
+		));
+		const doc2 = new InMemoryDocument(workspacePath('doc2.md'), joinLines(''));
+
+		const contents = new InMemoryWorkspaceMarkdownDocuments([doc1, doc2]);
+		const manager = createDiagnosticsManager(contents, new MemoryDiagnosticConfiguration(true, ['/doc2.md']));
+		const { diagnostics } = await manager.recomputeDiagnosticState(doc1, noopToken);
+		assert.deepStrictEqual(diagnostics.length, 0);
+	});
 });


### PR DESCRIPTION
This change lets you ignore all links to a given file, even if those links include a header. For example: `[text](/path/to/file#some-header)` can be ignored using `/path/to/file`

