### PR TITLE
Move out Settings editor indicator label impl

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -40,7 +40,7 @@ import { IEditorMemento, IEditorOpenContext, IEditorPane } from 'vs/workbench/co
 import { attachSuggestEnabledInputBoxStyler, SuggestEnabledInput } from 'vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput';
 import { SettingsTarget, SettingsTargetsWidget } from 'vs/workbench/contrib/preferences/browser/preferencesWidgets';
 import { commonlyUsedData, tocData } from 'vs/workbench/contrib/preferences/browser/settingsLayout';
-import { AbstractSettingRenderer, HeightChangeParams, ISettingLinkClickEvent, ISettingOverrideClickEvent, resolveConfiguredUntrustedSettings, createTocTreeForExtensionSettings, resolveSettingsTree, SettingsTree, SettingTreeRenderers } from 'vs/workbench/contrib/preferences/browser/settingsTree';
+import { AbstractSettingRenderer, HeightChangeParams, ISettingLinkClickEvent, resolveConfiguredUntrustedSettings, createTocTreeForExtensionSettings, resolveSettingsTree, SettingsTree, SettingTreeRenderers } from 'vs/workbench/contrib/preferences/browser/settingsTree';
 import { ISettingsEditorViewState, parseQuery, SearchResultIdx, SearchResultModel, SettingsTreeElement, SettingsTreeGroupChild, SettingsTreeGroupElement, SettingsTreeModel, SettingsTreeSettingElement } from 'vs/workbench/contrib/preferences/browser/settingsTreeModels';
 import { createTOCIterator, TOCTree, TOCTreeModel } from 'vs/workbench/contrib/preferences/browser/tocTree';
 import { CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_ROW_FOCUS, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, ENABLE_LANGUAGE_FILTER, EXTENSION_SETTING_TAG, FEATURE_SETTING_TAG, ID_SETTING_TAG, IPreferencesSearchService, ISearchProvider, LANGUAGE_SETTING_TAG, MODIFIED_SETTING_TAG, POLICY_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, SETTINGS_EDITOR_COMMAND_SUGGEST_FILTERS, WORKSPACE_TRUST_SETTING_TAG } from 'vs/workbench/contrib/preferences/common/preferences';
@@ -60,6 +60,7 @@ import { Color } from 'vs/base/common/color';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { SettingsSearchFilterDropdownMenuActionViewItem } from 'vs/workbench/contrib/preferences/browser/settingsSearchMenu';
 import { IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { ISettingOverrideClickEvent } from 'vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators';
 
 export const enum SettingsFocusContext {
 	Search,

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -122,9 +122,9 @@ export class SettingsTreeIndicatorsLabel {
 
 	updateDefaultOverrideIndicator(element: SettingsTreeSettingElement) {
 		this.defaultOverrideIndicatorElement.style.display = 'none';
-		if (element.defaultValueSource) {
+		const defaultValueSource = element.setting.defaultValueSource;
+		if (defaultValueSource) {
 			this.defaultOverrideIndicatorElement.style.display = 'inline';
-			const defaultValueSource = element.defaultValueSource;
 			if (typeof defaultValueSource !== 'string' && defaultValueSource.id !== element.setting.extensionInfo?.id) {
 				const extensionSource = defaultValueSource.displayName ?? defaultValueSource.id;
 				this.defaultOverrideIndicatorLabel.title = localize('defaultOverriddenDetails', "Default setting value overridden by {0}", extensionSource);

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from 'vs/base/browser/dom';
+import { IMouseEvent } from 'vs/base/browser/mouseEvent';
+import { SimpleIconLabel } from 'vs/base/browser/ui/iconLabel/simpleIconLabel';
+import { Emitter } from 'vs/base/common/event';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { localize } from 'vs/nls';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { getIgnoredSettings } from 'vs/platform/userDataSync/common/settingsMerge';
+import { getDefaultIgnoredSettings } from 'vs/platform/userDataSync/common/userDataSync';
+import { SettingsTreeSettingElement } from 'vs/workbench/contrib/preferences/browser/settingsTreeModels';
+
+const $ = DOM.$;
+
+export interface ISettingOverrideClickEvent {
+	scope: string;
+	targetKey: string;
+}
+
+/**
+ * Renders the indicators next to a setting, such as Sync Ignored, Also Modified In, etc.
+ */
+export class SettingsTreeIndicatorsLabel {
+	/**
+	 * This element wraps around the other elements.
+	 */
+	private labelElement: HTMLElement;
+	private scopeOverridesElement: HTMLElement;
+	private syncIgnoredElement: HTMLElement;
+	private defaultOverrideIndicatorElement: HTMLElement;
+	private defaultOverrideIndicatorLabel: SimpleIconLabel;
+
+	constructor(container: HTMLElement) {
+		this.labelElement = DOM.append(container, $('.misc-label'));
+		this.labelElement.style.display = 'inline';
+
+		this.scopeOverridesElement = this.createScopeOverridesElement();
+		this.syncIgnoredElement = this.createSyncIgnoredElement();
+		const { element: defaultOverrideElement, label: defaultOverrideLabel } = this.createDefaultOverrideIndicator();
+		this.defaultOverrideIndicatorElement = defaultOverrideElement;
+		this.defaultOverrideIndicatorLabel = defaultOverrideLabel;
+	}
+
+	private createScopeOverridesElement(): HTMLElement {
+		const otherOverridesElement = $('span.setting-item-overrides');
+		return otherOverridesElement;
+	}
+
+	private createSyncIgnoredElement(): HTMLElement {
+		const syncIgnoredElement = $('span.setting-item-ignored');
+		const syncIgnoredLabel = new SimpleIconLabel(syncIgnoredElement);
+		syncIgnoredLabel.text = `$(sync-ignored) ${localize('extensionSyncIgnoredLabel', 'Sync: Ignored')}`;
+		syncIgnoredLabel.title = localize('syncIgnoredTitle', "Settings sync does not sync this setting");
+		return syncIgnoredElement;
+	}
+
+	private createDefaultOverrideIndicator(): { element: HTMLElement; label: SimpleIconLabel } {
+		const defaultOverrideIndicator = $('span.setting-item-default-overridden');
+		const defaultOverrideLabel = new SimpleIconLabel(defaultOverrideIndicator);
+		return { element: defaultOverrideIndicator, label: defaultOverrideLabel };
+	}
+
+	private render() {
+		const elementsToShow = [this.scopeOverridesElement, this.syncIgnoredElement, this.defaultOverrideIndicatorElement].filter(element => {
+			return element.style.display !== 'none';
+		});
+
+		this.labelElement.innerText = '';
+		this.labelElement.style.display = 'none';
+		if (elementsToShow.length) {
+			this.labelElement.style.display = 'inline';
+			DOM.append(this.labelElement, $('span', undefined, '('));
+			for (let i = 0; i < elementsToShow.length - 1; i++) {
+				DOM.append(this.labelElement, elementsToShow[i]);
+				DOM.append(this.labelElement, $('span.comma', undefined, ', '));
+			}
+			DOM.append(this.labelElement, elementsToShow[elementsToShow.length - 1]);
+			DOM.append(this.labelElement, $('span', undefined, ')'));
+		}
+	}
+
+	updateSyncIgnored(element: SettingsTreeSettingElement, ignoredSettings: string[]) {
+		this.syncIgnoredElement.style.display = ignoredSettings.includes(element.setting.key) ? 'inline' : 'none';
+		this.render();
+	}
+
+	updateScopeOverrides(element: SettingsTreeSettingElement, elementDisposables: DisposableStore, onDidClickOverrideElement: Emitter<ISettingOverrideClickEvent>) {
+		this.scopeOverridesElement.innerText = '';
+		this.scopeOverridesElement.style.display = 'none';
+		if (element.overriddenScopeList.length) {
+			this.scopeOverridesElement.style.display = 'inline';
+			const otherOverridesLabel = element.isConfigured ?
+				localize('alsoConfiguredIn', "Also modified in") :
+				localize('configuredIn', "Modified in");
+
+			DOM.append(this.scopeOverridesElement, $('span', undefined, `${otherOverridesLabel}: `));
+
+			for (let i = 0; i < element.overriddenScopeList.length; i++) {
+				const view = DOM.append(this.scopeOverridesElement, $('a.modified-scope', undefined, element.overriddenScopeList[i]));
+
+				if (i !== element.overriddenScopeList.length - 1) {
+					DOM.append(this.scopeOverridesElement, $('span', undefined, ', '));
+				}
+
+				elementDisposables.add(
+					DOM.addStandardDisposableListener(view, DOM.EventType.CLICK, (e: IMouseEvent) => {
+						onDidClickOverrideElement.fire({
+							targetKey: element.setting.key,
+							scope: element.overriddenScopeList[i]
+						});
+						e.preventDefault();
+						e.stopPropagation();
+					}));
+			}
+		}
+		this.render();
+	}
+
+	updateDefaultOverrideIndicator(element: SettingsTreeSettingElement) {
+		this.defaultOverrideIndicatorElement.style.display = 'none';
+		if (element.defaultValueSource) {
+			this.defaultOverrideIndicatorElement.style.display = 'inline';
+			const defaultValueSource = element.defaultValueSource;
+			if (typeof defaultValueSource !== 'string' && defaultValueSource.id !== element.setting.extensionInfo?.id) {
+				const extensionSource = defaultValueSource.displayName ?? defaultValueSource.id;
+				this.defaultOverrideIndicatorLabel.title = localize('defaultOverriddenDetails', "Default setting value overridden by {0}", extensionSource);
+				this.defaultOverrideIndicatorLabel.text = localize('defaultOverrideLabelText', "$(replace) {0}", extensionSource);
+			} else if (typeof defaultValueSource === 'string') {
+				this.defaultOverrideIndicatorLabel.title = localize('defaultOverriddenDetails', "Default setting value overridden by {0}", defaultValueSource);
+				this.defaultOverrideIndicatorLabel.text = localize('defaultOverrideLabelText', "$(replace) {0}", defaultValueSource);
+			}
+		}
+		this.render();
+	}
+}
+
+export function getIndicatorsLabelAriaLabel(element: SettingsTreeSettingElement, configurationService: IConfigurationService): string {
+	const ariaLabelSections: string[] = [];
+
+	// Add other overrides text
+	const otherOverridesStart = element.isConfigured ?
+		localize('alsoConfiguredIn', "Also modified in") :
+		localize('configuredIn', "Modified in");
+	const otherOverridesList = element.overriddenScopeList.join(', ');
+	if (element.overriddenScopeList.length) {
+		ariaLabelSections.push(`${otherOverridesStart} ${otherOverridesList}`);
+	}
+
+	// Add sync ignored text
+	const ignoredSettings = getIgnoredSettings(getDefaultIgnoredSettings(), configurationService);
+	if (ignoredSettings.includes(element.setting.key)) {
+		ariaLabelSections.push(localize('syncIgnoredTitle', "Settings sync does not sync this setting"));
+	}
+
+	// Add default override indicator text
+	if (element.setting.defaultValueSource) {
+		const defaultValueSource = element.setting.defaultValueSource;
+		if (typeof defaultValueSource !== 'string' && defaultValueSource.id !== element.setting.extensionInfo?.id) {
+			const extensionSource = defaultValueSource.displayName ?? defaultValueSource.id;
+			ariaLabelSections.push(localize('defaultOverriddenDetails', "Default setting value overridden by {0}", extensionSource));
+		} else if (typeof defaultValueSource === 'string') {
+			ariaLabelSections.push(localize('defaultOverriddenDetails', "Default setting value overridden by {0}", defaultValueSource));
+		}
+	}
+
+	const ariaLabel = ariaLabelSections.join('. ');
+	return ariaLabel;
+}

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -62,6 +62,7 @@ import { SettingsTarget } from 'vs/workbench/contrib/preferences/browser/prefere
 import { MarkdownRenderer } from 'vs/editor/contrib/markdownRenderer/browser/markdownRenderer';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { focusedRowBackground, focusedRowBorder, rowHoverBackground, settingsHeaderForeground, settingsNumberInputBackground, settingsNumberInputBorder, settingsNumberInputForeground, settingsSelectBackground, settingsSelectBorder, settingsSelectForeground, settingsSelectListBorder, settingsTextInputBackground, settingsTextInputBorder, settingsTextInputForeground } from 'vs/workbench/contrib/preferences/common/settingsEditorColorRegistry';
+import { getIndicatorsLabelAriaLabel, ISettingOverrideClickEvent, SettingsTreeIndicatorsLabel } from 'vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators';
 
 const $ = DOM.$;
 
@@ -588,7 +589,7 @@ interface ISettingItemTemplate<T = any> extends IDisposableTemplate {
 	descriptionElement: HTMLElement;
 	controlElement: HTMLElement;
 	deprecationWarningElement: HTMLElement;
-	miscLabel: SettingsTreeMiscLabel;
+	indicatorsLabel: SettingsTreeIndicatorsLabel;
 	toolbar: ToolBar;
 	elementDisposables: DisposableStore;
 }
@@ -663,11 +664,6 @@ export interface ISettingChangeEvent {
 
 export interface ISettingLinkClickEvent {
 	source: SettingsTreeSettingElement;
-	targetKey: string;
-}
-
-export interface ISettingOverrideClickEvent {
-	scope: string;
 	targetKey: string;
 }
 
@@ -783,7 +779,8 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		const categoryElement = DOM.append(labelCategoryContainer, $('span.setting-item-category'));
 		const labelElementContainer = DOM.append(labelCategoryContainer, $('span.setting-item-label'));
 		const labelElement = new SimpleIconLabel(labelElementContainer);
-		const miscLabel = new SettingsTreeMiscLabel(titleElement);
+		const indicatorsLabel = new SettingsTreeIndicatorsLabel(titleElement);
+
 		const descriptionElement = DOM.append(container, $('.setting-item-description'));
 		const modifiedIndicatorElement = DOM.append(container, $('.setting-item-modified-indicator'));
 		modifiedIndicatorElement.title = localize('modified', "The setting has been configured in the current scope.");
@@ -810,7 +807,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 			descriptionElement,
 			controlElement,
 			deprecationWarningElement,
-			miscLabel,
+			indicatorsLabel,
 			toolbar
 		};
 
@@ -914,7 +911,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 			template.descriptionElement.innerText = element.description;
 		}
 
-		template.miscLabel.updateOtherOverrides(element, template.elementDisposables, this._onDidClickOverrideElement);
+		template.indicatorsLabel.updateScopeOverrides(element, template.elementDisposables, this._onDidClickOverrideElement);
 
 		const onChange = (value: any) => this._onDidChangeSetting.fire({ key: element.setting.key, value, type: template.context!.valueType, manualReset: false });
 		const deprecationText = element.setting.deprecationMessage || '';
@@ -931,10 +928,10 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 
 		this.renderValue(element, <ISettingItemTemplate>template, onChange);
 
-		template.miscLabel.updateSyncIgnored(element, this.ignoredSettings);
-		template.miscLabel.updateDefaultOverrideIndicator(element);
+		template.indicatorsLabel.updateSyncIgnored(element, this.ignoredSettings);
+		template.indicatorsLabel.updateDefaultOverrideIndicator(element);
 		template.elementDisposables.add(this.onDidChangeIgnoredSettings(() => {
-			template.miscLabel.updateSyncIgnored(element, this.ignoredSettings);
+			template.indicatorsLabel.updateSyncIgnored(element, this.ignoredSettings);
 		}));
 
 		template.policyWarningElement.hidden = !element.hasPolicyValue;
@@ -1819,7 +1816,7 @@ export class SettingBoolRenderer extends AbstractSettingRenderer implements ITre
 		const categoryElement = DOM.append(titleElement, $('span.setting-item-category'));
 		const labelElementContainer = DOM.append(titleElement, $('span.setting-item-label'));
 		const labelElement = new SimpleIconLabel(labelElementContainer);
-		const miscLabel = new SettingsTreeMiscLabel(titleElement);
+		const indicatorsLabel = new SettingsTreeIndicatorsLabel(titleElement);
 
 		const descriptionAndValueElement = DOM.append(container, $('.setting-item-value-description'));
 		const controlElement = DOM.append(descriptionAndValueElement, $('.setting-item-bool-control'));
@@ -1870,7 +1867,7 @@ export class SettingBoolRenderer extends AbstractSettingRenderer implements ITre
 			policyWarningElement,
 			descriptionElement,
 			deprecationWarningElement,
-			miscLabel,
+			indicatorsLabel,
 			toolbar
 		};
 
@@ -2142,120 +2139,6 @@ function escapeInvisibleChars(enumValue: string): string {
 		.replace(/\r/g, '\\r');
 }
 
-/**
- * Controls logic and rendering of the label next to each setting header.
- * For example, the "Modified by" and "Overridden by" labels go here.
- */
-class SettingsTreeMiscLabel {
-	private labelElement: HTMLElement;
-	private otherOverridesElement: HTMLElement;
-	private syncIgnoredElement: HTMLElement;
-	private defaultOverrideIndicatorElement: HTMLElement;
-	private defaultOverrideIndicatorLabel: SimpleIconLabel;
-
-	constructor(container: HTMLElement) {
-		this.labelElement = DOM.append(container, $('.misc-label'));
-		this.labelElement.style.display = 'inline';
-
-		this.otherOverridesElement = this.createOtherOverridesElement();
-		this.syncIgnoredElement = this.createSyncIgnoredElement();
-		const { element, label } = this.createDefaultOverrideIndicator();
-		this.defaultOverrideIndicatorElement = element;
-		this.defaultOverrideIndicatorLabel = label;
-	}
-
-	private createOtherOverridesElement(): HTMLElement {
-		const otherOverridesElement = $('span.setting-item-overrides');
-		return otherOverridesElement;
-	}
-
-	private createSyncIgnoredElement(): HTMLElement {
-		const syncIgnoredElement = $('span.setting-item-ignored');
-		const syncIgnoredLabel = new SimpleIconLabel(syncIgnoredElement);
-		syncIgnoredLabel.text = `$(sync-ignored) ${localize('extensionSyncIgnoredLabel', 'Sync: Ignored')}`;
-		syncIgnoredLabel.title = localize('syncIgnoredTitle', "Settings sync does not sync this setting");
-		return syncIgnoredElement;
-	}
-
-	private createDefaultOverrideIndicator(): { element: HTMLElement; label: SimpleIconLabel } {
-		const defaultOverrideIndicator = $('span.setting-item-default-overridden');
-		const defaultOverrideLabel = new SimpleIconLabel(defaultOverrideIndicator);
-		return { element: defaultOverrideIndicator, label: defaultOverrideLabel };
-	}
-
-	private render() {
-		const elementsToShow = [this.otherOverridesElement, this.syncIgnoredElement, this.defaultOverrideIndicatorElement].filter(element => {
-			return element.style.display !== 'none';
-		});
-
-		this.labelElement.innerText = '';
-		this.labelElement.style.display = 'none';
-		if (elementsToShow.length) {
-			this.labelElement.style.display = 'inline';
-			DOM.append(this.labelElement, $('span', undefined, '('));
-			for (let i = 0; i < elementsToShow.length - 1; i++) {
-				DOM.append(this.labelElement, elementsToShow[i]);
-				DOM.append(this.labelElement, $('span.comma', undefined, ', '));
-			}
-			DOM.append(this.labelElement, elementsToShow[elementsToShow.length - 1]);
-			DOM.append(this.labelElement, $('span', undefined, ')'));
-		}
-	}
-
-	updateSyncIgnored(element: SettingsTreeSettingElement, ignoredSettings: string[]) {
-		this.syncIgnoredElement.style.display = ignoredSettings.includes(element.setting.key) ? 'inline' : 'none';
-		this.render();
-	}
-
-	updateOtherOverrides(element: SettingsTreeSettingElement, elementDisposables: DisposableStore, onDidClickOverrideElement: Emitter<ISettingOverrideClickEvent>) {
-		this.otherOverridesElement.innerText = '';
-		this.otherOverridesElement.style.display = 'none';
-		if (element.overriddenScopeList.length) {
-			this.otherOverridesElement.style.display = 'inline';
-			const otherOverridesLabel = element.isConfigured ?
-				localize('alsoConfiguredIn', "Also modified in") :
-				localize('configuredIn', "Modified in");
-
-			DOM.append(this.otherOverridesElement, $('span', undefined, `${otherOverridesLabel}: `));
-
-			for (let i = 0; i < element.overriddenScopeList.length; i++) {
-				const view = DOM.append(this.otherOverridesElement, $('a.modified-scope', undefined, element.overriddenScopeList[i]));
-
-				if (i !== element.overriddenScopeList.length - 1) {
-					DOM.append(this.otherOverridesElement, $('span', undefined, ', '));
-				}
-
-				elementDisposables.add(
-					DOM.addStandardDisposableListener(view, DOM.EventType.CLICK, (e: IMouseEvent) => {
-						onDidClickOverrideElement.fire({
-							targetKey: element.setting.key,
-							scope: element.overriddenScopeList[i]
-						});
-						e.preventDefault();
-						e.stopPropagation();
-					}));
-			}
-		}
-		this.render();
-	}
-
-	updateDefaultOverrideIndicator(element: SettingsTreeSettingElement) {
-		this.defaultOverrideIndicatorElement.style.display = 'none';
-		if (element.setting.defaultValueSource) {
-			this.defaultOverrideIndicatorElement.style.display = 'inline';
-			const defaultValueSource = element.setting.defaultValueSource;
-			if (typeof defaultValueSource !== 'string' && defaultValueSource.id !== element.setting.extensionInfo?.id) {
-				const extensionSource = defaultValueSource.displayName ?? defaultValueSource.id;
-				this.defaultOverrideIndicatorLabel.title = localize('defaultOverriddenDetails', "Default value overridden by {0}", extensionSource);
-				this.defaultOverrideIndicatorLabel.text = localize('defaultOverrideLabelText', "$(wrench) Overridden by: {0}", extensionSource);
-			} else if (typeof defaultValueSource === 'string') {
-				this.defaultOverrideIndicatorLabel.title = localize('defaultOverriddenDetails', "Default value overridden by {0}", defaultValueSource);
-				this.defaultOverrideIndicatorLabel.text = localize('defaultOverrideLabelText', "$(wrench) Overridden by: {0}", defaultValueSource);
-			}
-		}
-		this.render();
-	}
-}
 
 export class SettingsTreeFilter implements ITreeFilter<SettingsTreeElement> {
 	constructor(
@@ -2419,9 +2302,9 @@ class SettingsTreeAccessibilityProvider implements IListAccessibilityProvider<Se
 				ariaLabelSections.push(modifiedText);
 			}
 
-			const miscLabelAriaLabel = this.getMiscLabelAriaLabel(element);
-			if (miscLabelAriaLabel.length) {
-				ariaLabelSections.push(`${miscLabelAriaLabel}.`);
+			const indicatorsLabelAriaLabel = getIndicatorsLabelAriaLabel(element, this.configurationService);
+			if (indicatorsLabelAriaLabel.length) {
+				ariaLabelSections.push(`${indicatorsLabelAriaLabel}.`);
 			}
 
 			const descriptionWithoutSettingLinks = fixSettingLinks(element.description, false);
@@ -2438,39 +2321,6 @@ class SettingsTreeAccessibilityProvider implements IListAccessibilityProvider<Se
 
 	getWidgetAriaLabel() {
 		return localize('settings', "Settings");
-	}
-
-	private getMiscLabelAriaLabel(element: SettingsTreeSettingElement): string {
-		const ariaLabelSections: string[] = [];
-
-		// Add other overrides text
-		const otherOverridesStart = element.isConfigured ?
-			localize('alsoConfiguredIn', "Also modified in") :
-			localize('configuredIn', "Modified in");
-		const otherOverridesList = element.overriddenScopeList.join(', ');
-		if (element.overriddenScopeList.length) {
-			ariaLabelSections.push(`${otherOverridesStart} ${otherOverridesList}`);
-		}
-
-		// Add sync ignored text
-		const ignoredSettings = getIgnoredSettings(getDefaultIgnoredSettings(), this.configurationService);
-		if (ignoredSettings.includes(element.setting.key)) {
-			ariaLabelSections.push(localize('syncIgnoredTitle', "Settings sync does not sync this setting"));
-		}
-
-		// Add default override indicator text
-		if (element.setting.defaultValueSource) {
-			const defaultValueSource = element.setting.defaultValueSource;
-			if (typeof defaultValueSource !== 'string' && defaultValueSource.id !== element.setting.extensionInfo?.id) {
-				const extensionSource = defaultValueSource.displayName ?? defaultValueSource.id;
-				ariaLabelSections.push(localize('defaultOverriddenDetails', "Default value overridden by {0}", extensionSource));
-			} else if (typeof defaultValueSource === 'string') {
-				ariaLabelSections.push(localize('defaultOverriddenDetails', "Default value overridden by {0}", defaultValueSource));
-			}
-		}
-
-		const ariaLabel = ariaLabelSections.join('. ');
-		return ariaLabel;
 	}
 }
 


### PR DESCRIPTION
This PR reduces technical debt by 
1. Moving the SettingsTreeMiscLabel, along with a function that generates the aria label for that element, to their own file.
2. Renaming the SettingsTreeMiscLabel to SettingsTreeIndicatorsLabel instead so that its purpose is more obvious.

The Settings tree indicators label is highlighted below:
![A screenshot showing the Also Modified label highlighted. The label next to the setting name that says "Also Modified in", "Sync Ignored", etc., is the Settings tree indicators label](https://user-images.githubusercontent.com/7199958/169914425-1473a163-c912-4483-9385-9edd5591b64f.PNG)

