### PR TITLE
Fix default override model value

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -122,7 +122,7 @@ export class SettingsTreeIndicatorsLabel {
 
 	updateDefaultOverrideIndicator(element: SettingsTreeSettingElement) {
 		this.defaultOverrideIndicatorElement.style.display = 'none';
-		const defaultValueSource = element.setting.defaultValueSource;
+		const defaultValueSource = element.defaultValueSource;
 		if (defaultValueSource) {
 			this.defaultOverrideIndicatorElement.style.display = 'inline';
 			if (typeof defaultValueSource !== 'string' && defaultValueSource.id !== element.setting.extensionInfo?.id) {
@@ -157,8 +157,8 @@ export function getIndicatorsLabelAriaLabel(element: SettingsTreeSettingElement,
 	}
 
 	// Add default override indicator text
-	if (element.setting.defaultValueSource) {
-		const defaultValueSource = element.setting.defaultValueSource;
+	if (element.defaultValueSource) {
+		const defaultValueSource = element.defaultValueSource;
 		if (typeof defaultValueSource !== 'string' && defaultValueSource.id !== element.setting.extensionInfo?.id) {
 			const extensionSource = defaultValueSource.displayName ?? defaultValueSource.id;
 			ariaLabelSections.push(localize('defaultOverriddenDetails', "Default setting value overridden by {0}", extensionSource));

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1115,7 +1115,7 @@ export class SettingComplexRenderer extends AbstractSettingRenderer implements I
 
 		template.elementDisposables.add(template.button.onDidClick(() => {
 			if (isLanguageTagSetting) {
-				this._onApplyFilter.fire(`@${LANGUAGE_SETTING_TAG}:${plainKey}`);
+				this._onApplyFilter.fire(`@${LANGUAGE_SETTING_TAG}${plainKey}`);
 			} else {
 				this._onDidOpenSettings.fire(dataElement.setting.key);
 			}

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -87,7 +87,7 @@ export interface ISetting {
 	enumItemLabels?: string[];
 	allKeysAreBoolean?: boolean;
 	editPresentation?: EditPresentationTypes;
-	defaultValueSource?: string | IExtensionInfo;
+	nonLanguageSpecificDefaultValueSource?: string | IExtensionInfo;
 	isLanguageTagSetting?: boolean;
 	categoryOrder?: number;
 	categoryLabel?: string;

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -751,7 +751,7 @@ export class DefaultSettings extends Disposable {
 					allKeysAreBoolean,
 					editPresentation: prop.editPresentation,
 					order: prop.order,
-					defaultValueSource,
+					nonLanguageSpecificDefaultValueSource: defaultValueSource,
 					isLanguageTagSetting,
 					categoryLabel,
 					categoryOrder


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/150231.
This PR also:
1. Changes one of the field names in the ISetting interface to emphasize that that interface holds the _non-language-specific_ default value source.
2. Fixes a bug where there was an extra colon; `LANGUAGE_SETTING_TAG` already ends with a colon.
