### PR TITLE
Add languages indicator to Settings editor settings

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -344,8 +344,9 @@
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-ignored .codicon,
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-language-overrides .codicon,
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-default-overridden .codicon {
-	vertical-align: text-top;
+	vertical-align: middle;
 	padding-left: 1px;
 }
 
@@ -353,7 +354,8 @@
 	vertical-align: text-top;
 }
 
-.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-overrides a.modified-scope {
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-overrides a.modified-scope,
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-language-overrides a.language-link {
 	text-decoration: underline;
 	cursor: pointer;
 }

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -343,9 +343,7 @@
 	font-style: italic;
 }
 
-.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-ignored .codicon,
-.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-language-overrides .codicon,
-.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-default-overridden .codicon {
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .codicon {
 	vertical-align: middle;
 	padding-left: 1px;
 }

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -868,10 +868,15 @@ export class SettingsEditor2 extends EditorPane {
 				// the element was not found
 			}
 		}));
-		this._register(this.settingRenderers.onApplyFilter((filter: string) => {
-			if (this.searchWidget && !this.searchWidget.getValue().includes(filter)) {
-				// Prepend the filter to the query.
-				const newQuery = `${filter} ${this.searchWidget.getValue().trimStart()}`;
+		this._register(this.settingRenderers.onApplyFilters((filters: string[]) => {
+			if (this.searchWidget) {
+				const newFilters: Set<string> = new Set<string>();
+				for (const filter of filters) {
+					if (!this.searchWidget.getValue().includes(filter)) {
+						newFilters.add(filter);
+					}
+				}
+				const newQuery = `${this.searchWidget.getValue().trimEnd()} ${Array.from(newFilters).sort().join(' ')}`;
 				this.focusSearch(newQuery, false);
 			}
 		}));

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -33,6 +33,7 @@ export class SettingsTreeIndicatorsLabel {
 	private languageOverridesElement: HTMLElement;
 	private languageOverridesLabel: SimpleIconLabel;
 	private scopeOverridesElement: HTMLElement;
+	private scopeOverridesLabel: SimpleIconLabel;
 	private syncIgnoredElement: HTMLElement;
 	private defaultOverrideIndicatorElement: HTMLElement;
 	private defaultOverrideIndicatorLabel: SimpleIconLabel;
@@ -44,7 +45,9 @@ export class SettingsTreeIndicatorsLabel {
 		const { element: languageOverridesElement, label: languageOverridesLabel } = this.createLanguageOverridesIndicator();
 		this.languageOverridesElement = languageOverridesElement;
 		this.languageOverridesLabel = languageOverridesLabel;
-		this.scopeOverridesElement = this.createScopeOverridesElement();
+		const { element: scopeOverridesElement, label: scopeOverridesLabel } = this.createScopeOverridesIndicator();
+		this.scopeOverridesElement = scopeOverridesElement;
+		this.scopeOverridesLabel = scopeOverridesLabel;
 		this.syncIgnoredElement = this.createSyncIgnoredElement();
 		const { element: defaultOverrideElement, label: defaultOverrideLabel } = this.createDefaultOverrideIndicator();
 		this.defaultOverrideIndicatorElement = defaultOverrideElement;
@@ -57,9 +60,10 @@ export class SettingsTreeIndicatorsLabel {
 		return { element: languageOverridesElement, label: languageOverridesLabel };
 	}
 
-	private createScopeOverridesElement(): HTMLElement {
+	private createScopeOverridesIndicator(): { element: HTMLElement; label: SimpleIconLabel } {
 		const otherOverridesElement = $('span.setting-item-overrides');
-		return otherOverridesElement;
+		const otherOverridesLabel = new SimpleIconLabel(otherOverridesElement);
+		return { element: otherOverridesElement, label: otherOverridesLabel };
 	}
 
 	private createSyncIgnoredElement(): HTMLElement {
@@ -144,6 +148,13 @@ export class SettingsTreeIndicatorsLabel {
 			const otherOverridesLabel = element.isConfigured ?
 				localize('alsoConfiguredIn', "Also modified in") :
 				localize('configuredIn', "Modified in");
+			let otherOverridesTitle = element.isConfigured ?
+				localize('alsoConfiguredIn', "Also modified in") :
+				localize('configuredIn', "Modified in");
+			otherOverridesTitle += ' ' + element.overriddenScopeList.join(', ');
+
+			this.scopeOverridesLabel.text = '$(note) ';
+			this.scopeOverridesLabel.title = otherOverridesTitle;
 
 			DOM.append(this.scopeOverridesElement, $('span', undefined, `${otherOverridesLabel}: `));
 			for (let i = 0; i < element.overriddenScopeList.length; i++) {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -108,7 +108,9 @@ export class SettingsTreeIndicatorsLabel {
 		const hasLanguageSpecificValuesOrOverrides = element.languageDefaultOverrides.size || element.languageOverridenScopeLists.size;
 		if (!element.languageSelector && hasLanguageSpecificValuesOrOverrides) {
 			this.languageOverridesElement.style.display = 'inline';
-			this.languageOverridesLabel.text = '$(bracket) ';
+
+			const languageOverriddenLabelStarter = localize('languageOverridesLabel', "Overridden for: ");
+			this.languageOverridesLabel.text = `$(bracket) ${languageOverriddenLabelStarter}`;
 
 			// Get the list of languages that have default value overrides or user-configured values.
 			const overrideSources: Set<string> = new Set<string>();
@@ -145,18 +147,14 @@ export class SettingsTreeIndicatorsLabel {
 		this.scopeOverridesElement.style.display = 'none';
 		if (element.overriddenScopeList.length) {
 			this.scopeOverridesElement.style.display = 'inline';
-			const otherOverridesLabel = element.isConfigured ?
+			const modifiedInText = element.isConfigured ?
 				localize('alsoConfiguredIn', "Also modified in") :
 				localize('configuredIn', "Modified in");
-			let otherOverridesTitle = element.isConfigured ?
-				localize('alsoConfiguredIn', "Also modified in") :
-				localize('configuredIn', "Modified in");
-			otherOverridesTitle += ' ' + element.overriddenScopeList.join(', ');
+			const otherOverridesTitle = modifiedInText + ' ' + element.overriddenScopeList.join(', ');
 
-			this.scopeOverridesLabel.text = '$(note) ';
+			this.scopeOverridesLabel.text = `$(note) ${modifiedInText}: `;
 			this.scopeOverridesLabel.title = otherOverridesTitle;
 
-			DOM.append(this.scopeOverridesElement, $('span', undefined, `${otherOverridesLabel}: `));
 			for (let i = 0; i < element.overriddenScopeList.length; i++) {
 				const view = DOM.append(this.scopeOverridesElement, $('a.modified-scope', undefined, element.overriddenScopeList[i]));
 
@@ -186,10 +184,10 @@ export class SettingsTreeIndicatorsLabel {
 			if (typeof defaultValueSource !== 'string' && defaultValueSource.id !== element.setting.extensionInfo?.id) {
 				const extensionSource = defaultValueSource.displayName ?? defaultValueSource.id;
 				this.defaultOverrideIndicatorLabel.title = localize('defaultOverriddenDetails', "Default setting value overridden by {0}", extensionSource);
-				this.defaultOverrideIndicatorLabel.text = localize('defaultOverrideLabelText', "$(replace) {0}", extensionSource);
+				this.defaultOverrideIndicatorLabel.text = localize('defaultOverrideLabelText', "$(replace) Default overridden by: {0}", extensionSource);
 			} else if (typeof defaultValueSource === 'string') {
 				this.defaultOverrideIndicatorLabel.title = localize('defaultOverriddenDetails', "Default setting value overridden by {0}", defaultValueSource);
-				this.defaultOverrideIndicatorLabel.text = localize('defaultOverrideLabelText', "$(replace) {0}", defaultValueSource);
+				this.defaultOverrideIndicatorLabel.text = localize('defaultOverrideLabelText', "$(replace) Default overridden by: {0}", defaultValueSource);
 			}
 		}
 		this.render();

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -736,8 +736,8 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 	protected readonly _onDidChangeSettingHeight = this._register(new Emitter<HeightChangeParams>());
 	readonly onDidChangeSettingHeight: Event<HeightChangeParams> = this._onDidChangeSettingHeight.event;
 
-	protected readonly _onApplyFilter = this._register(new Emitter<string>());
-	readonly onApplyFilter: Event<string> = this._onApplyFilter.event;
+	protected readonly _onApplyFilters = this._register(new Emitter<string[]>());
+	readonly onApplyFilters: Event<string[]> = this._onApplyFilters.event;
 
 	private readonly markdownRenderer: MarkdownRenderer;
 
@@ -854,12 +854,12 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		toDispose.add(DOM.addStandardDisposableListener(linkElement, DOM.EventType.CLICK, (e: MouseEvent) => {
 			e.preventDefault();
 			e.stopPropagation();
-			this._onApplyFilter.fire(`@${POLICY_SETTING_TAG}`);
+			this._onApplyFilters.fire([`@${POLICY_SETTING_TAG}`]);
 		}));
 		toDispose.add(DOM.addStandardDisposableListener(linkElement, DOM.EventType.KEY_DOWN, (e: IKeyboardEvent) => {
 			if (e.equals(KeyCode.Enter) || e.equals(KeyCode.Space)) {
 				e.stopPropagation();
-				this._onApplyFilter.fire(`@${POLICY_SETTING_TAG}`);
+				this._onApplyFilters.fire([`@${POLICY_SETTING_TAG}`]);
 			}
 		}));
 		return policyWarningElement;
@@ -930,6 +930,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 
 		template.indicatorsLabel.updateSyncIgnored(element, this.ignoredSettings);
 		template.indicatorsLabel.updateDefaultOverrideIndicator(element);
+		template.indicatorsLabel.updateLanguageOverrides(element, template.toDispose, this._onApplyFilters);
 		template.elementDisposables.add(this.onDidChangeIgnoredSettings(() => {
 			template.indicatorsLabel.updateSyncIgnored(element, this.ignoredSettings);
 		}));
@@ -1115,7 +1116,7 @@ export class SettingComplexRenderer extends AbstractSettingRenderer implements I
 
 		template.elementDisposables.add(template.button.onDidClick(() => {
 			if (isLanguageTagSetting) {
-				this._onApplyFilter.fire(`@${LANGUAGE_SETTING_TAG}${plainKey}`);
+				this._onApplyFilters.fire([`@${LANGUAGE_SETTING_TAG}${plainKey}`]);
 			} else {
 				this._onDidOpenSettings.fire(dataElement.setting.key);
 			}
@@ -1954,7 +1955,7 @@ export class SettingTreeRenderers {
 
 	readonly onDidChangeSettingHeight: Event<HeightChangeParams>;
 
-	readonly onApplyFilter: Event<string>;
+	readonly onApplyFilters: Event<string[]>;
 
 	readonly allRenderers: ITreeRenderer<SettingsTreeElement, never, any>[];
 
@@ -2003,7 +2004,7 @@ export class SettingTreeRenderers {
 		this.onDidClickSettingLink = Event.any(...settingRenderers.map(r => r.onDidClickSettingLink));
 		this.onDidFocusSetting = Event.any(...settingRenderers.map(r => r.onDidFocusSetting));
 		this.onDidChangeSettingHeight = Event.any(...settingRenderers.map(r => r.onDidChangeSettingHeight));
-		this.onApplyFilter = Event.any(...settingRenderers.map(r => r.onApplyFilter));
+		this.onApplyFilters = Event.any(...settingRenderers.map(r => r.onApplyFilters));
 
 		this.allRenderers = [
 			...settingRenderers,

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -128,12 +128,6 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 	 * The default value
 	 */
 	defaultValue?: any;
-	/**
-	 * The source of the default value to display.
-	 * This value also accounts for extension-contributed language-specific default value overrides,
-	 * whereas setting.defaultValueSource only accounts for non-language-specific default value overrides.
-	 */
-	defaultValueSource: string | IExtensionInfo | undefined;
 
 	/**
 	 * The source of the default value to display.


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode/issues/145731, by adding a new label for language overrides. This label currently shows when a setting has an extension-contributed language-specific default setting value override, but it should also show when a setting has a language-specific value in general.

This PR is not yet ready to merge. I have created some smaller debt-reduction PRs to merge first that are independent of this feature.
