### PR TITLE
Add owners to all telemetry events

### DIFF
--- a/src/vs/base/common/actions.ts
+++ b/src/vs/base/common/actions.ts
@@ -14,6 +14,7 @@ export interface ITelemetryData {
 }
 
 export type WorkbenchActionExecutedClassification = {
+	owner: 'bpasero';
 	id: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 	from: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 };

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1105,7 +1105,7 @@ export class CodeApplication extends Disposable {
 				code: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The type of shared process crash to understand the nature of the crash better.' };
 				visible: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether shared process window was visible or not.' };
 				shuttingdown: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the application is shutting down when the crash happens.' };
-				owner: 'bpaser';
+				owner: 'bpasero';
 				comment: 'Event which fires whenever an error occurs in the shared process';
 
 			};

--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -338,6 +338,7 @@ export abstract class EditorAction extends EditorCommand {
 
 	protected reportTelemetry(accessor: ServicesAccessor, editor: ICodeEditor) {
 		type EditorActionInvokedClassification = {
+			owner: 'alexdima';
 			name: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 			id: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 		};

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -451,11 +451,11 @@ export class SuggestController implements IEditorContribution {
 		type AcceptedSuggestionClassification = {
 			owner: 'jrieken';
 			comment: 'Information accepting completion items';
-			providerId: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comments: 'Provider of the completions item' };
-			basenameHash: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comments: 'Hash of the basename of the file into which the completion was inserted' };
-			fileExtension: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comments: 'File extension of the file into which the completion was inserted' };
-			languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comments: 'Language type of the file into which the completion was inserted' };
-			kind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comments: 'The completion item kind' };
+			providerId: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'Provider of the completions item' };
+			basenameHash: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'Hash of the basename of the file into which the completion was inserted' };
+			fileExtension: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'File extension of the file into which the completion was inserted' };
+			languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Language type of the file into which the completion was inserted' };
+			kind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The completion item kind' };
 		};
 		// _debugDisplayName looks like `vscode.css-language-features(/-:)`, where the last bit is the trigger chars
 		// normalize it to just the extension ID and lowercase

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -235,6 +235,7 @@ const DefaultQueryState: IQueryState = {
 };
 
 type GalleryServiceQueryClassification = {
+	owner: 'sandy081';
 	readonly filterTypes: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 	readonly flags: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 	readonly sortBy: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
@@ -272,6 +273,7 @@ type GalleryServiceQueryEvent = QueryTelemetryData & {
 };
 
 type GalleryServiceAdditionalQueryClassification = {
+	owner: 'sandy081';
 	readonly duration: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; 'isMeasurement': true };
 	readonly count: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 };
@@ -1124,6 +1126,7 @@ abstract class AbstractExtensionGalleryService implements IExtensionGalleryServi
 
 			const message = getErrorMessage(err);
 			type GalleryServiceCDNFallbackClassification = {
+				owner: 'sandy081';
 				url: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 				message: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 			};

--- a/src/vs/platform/extensionManagement/electron-sandbox/extensionTipsService.ts
+++ b/src/vs/platform/extensionManagement/electron-sandbox/extensionTipsService.ts
@@ -27,6 +27,7 @@ import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storag
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 type ExeExtensionRecommendationsClassification = {
+	owner: 'sandy081';
 	extensionId: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 	exeName: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 };

--- a/src/vs/platform/files/browser/indexedDBFileSystemProvider.ts
+++ b/src/vs/platform/files/browser/indexedDBFileSystemProvider.ts
@@ -16,6 +16,7 @@ import { createFileSystemProviderError, FileChangeType, IFileDeleteOptions, IFil
 import { DBClosedError, IndexedDB } from 'vs/base/browser/indexedDB';
 
 export type IndexedDBFileSystemProviderErrorDataClassification = {
+	owner: 'sandy081';
 	readonly scheme: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 	readonly operation: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 	readonly code: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -84,8 +84,10 @@ export function configurationTelemetry(telemetryService: ITelemetryService, conf
 	return configurationService.onDidChangeConfiguration(event => {
 		if (event.source !== ConfigurationTarget.DEFAULT) {
 			type UpdateConfigurationClassification = {
-				configurationSource: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
-				configurationKeys: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+				owner: 'lramos15, sbatten';
+				comment: 'Event which fires when user updates telemetry configuration';
+				configurationSource: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'What configuration file was updated i.e user or workspace' };
+				configurationKeys: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'What configuration keys were updated' };
 			};
 			type UpdateConfigurationEvent = {
 				configurationSource: string;

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -144,7 +144,7 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 	private _handleVSCodeSequence(data: string): boolean {
 		const didHandle = this._doHandleVSCodeSequence(data);
 		if (!this._hasUpdatedTelemetry && didHandle) {
-			this._telemetryService?.publicLog2<{ classification: 'SystemMetaData'; purpose: 'FeatureInsight' }>('terminal/shellIntegrationActivationSucceeded');
+			this._telemetryService?.publicLog2<{}, { owner: 'meganrogge' }>('terminal/shellIntegrationActivationSucceeded');
 			this._hasUpdatedTelemetry = true;
 			if (this._activationTimeout !== undefined) {
 				clearTimeout(this._activationTimeout);
@@ -232,7 +232,7 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 	private async _ensureCapabilitiesOrAddFailureTelemetry(): Promise<void> {
 		this._activationTimeout = setTimeout(() => {
 			if (!this.capabilities.get(TerminalCapability.CommandDetection) && !this.capabilities.get(TerminalCapability.CwdDetection)) {
-				this._telemetryService?.publicLog2<{ classification: 'SystemMetaData'; purpose: 'FeatureInsight' }>('terminal/shellIntegrationActivationTimeout');
+				this._telemetryService?.publicLog2<{}, { owner: 'meganrogge' }>('terminal/shellIntegrationActivationTimeout');
 				this._logService.warn('Shell integration failed to add capabilities within 10 seconds');
 			}
 			this._hasUpdatedTelemetry = true;

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -19,6 +19,7 @@ export function createUpdateURL(platform: string, quality: string, productServic
 }
 
 export type UpdateNotAvailableClassification = {
+	owner: 'joaomoreno';
 	explicit: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 };
 

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -92,6 +92,7 @@ export class DarwinUpdateService extends AbstractUpdateService {
 		}
 
 		type UpdateDownloadedClassification = {
+			owner: 'joaomoreno';
 			version: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 		};
 		this.telemetryService.publicLog2<{ version: String }, UpdateDownloadedClassification>('update:downloaded', { version: update.version });

--- a/src/vs/platform/userDataSync/common/abstractSynchronizer.ts
+++ b/src/vs/platform/userDataSync/common/abstractSynchronizer.ts
@@ -29,6 +29,7 @@ import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity'
 import { Change, getLastSyncResourceUri, IRemoteUserData, IResourcePreview as IBaseResourcePreview, ISyncData, ISyncResourceHandle, ISyncResourcePreview as IBaseSyncResourcePreview, IUserData, IUserDataInitializer, IUserDataManifest, IUserDataSyncBackupStoreService, IUserDataSyncConfiguration, IUserDataSynchroniser, IUserDataSyncLogService, IUserDataSyncEnablementService, IUserDataSyncStoreService, IUserDataSyncUtilService, MergeState, PREVIEW_DIR_NAME, SyncResource, SyncStatus, UserDataSyncError, UserDataSyncErrorCode, USER_DATA_SYNC_CONFIGURATION_SCOPE, USER_DATA_SYNC_SCHEME } from 'vs/platform/userDataSync/common/userDataSync';
 
 type SyncSourceClassification = {
+	owner: 'sandy081';
 	source?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 };
 

--- a/src/vs/platform/userDataSync/common/userDataAutoSyncService.ts
+++ b/src/vs/platform/userDataSync/common/userDataAutoSyncService.ts
@@ -22,10 +22,12 @@ import { IUserDataSyncAccountService } from 'vs/platform/userDataSync/common/use
 import { IUserDataSyncMachinesService } from 'vs/platform/userDataSync/common/userDataSyncMachines';
 
 type AutoSyncClassification = {
+	owner: 'sandy081';
 	sources: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 };
 
 type AutoSyncErrorClassification = {
+	owner: 'sandy081';
 	code: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 	service: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 };
@@ -194,7 +196,7 @@ export class UserDataAutoSyncService extends Disposable implements IUserDataAuto
 
 			// Reset
 			if (everywhere) {
-				this.telemetryService.publicLog2('sync/turnOffEveryWhere');
+				this.telemetryService.publicLog2<{}, { owner: 'sandy081' }>('sync/turnOffEveryWhere');
 				await this.userDataSyncService.reset();
 			} else {
 				await this.userDataSyncService.resetLocal();

--- a/src/vs/platform/userDataSync/common/userDataSyncEnablementService.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncEnablementService.ts
@@ -12,6 +12,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ALL_SYNC_RESOURCES, getEnablementKey, IUserDataSyncEnablementService, IUserDataSyncStoreManagementService, SyncResource } from 'vs/platform/userDataSync/common/userDataSync';
 
 type SyncEnablementClassification = {
+	owner: 'sandy081';
 	enabled?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 };
 

--- a/src/vs/platform/userDataSync/common/userDataSyncService.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncService.ts
@@ -28,6 +28,7 @@ import { TasksSynchroniser } from 'vs/platform/userDataSync/common/tasksSync';
 import { ALL_SYNC_RESOURCES, Change, createSyncHeaders, IManualSyncTask, IResourcePreview, ISyncResourceHandle, ISyncResourcePreview, ISyncTask, IUserDataManifest, IUserDataSyncConfiguration, IUserDataSyncEnablementService, IUserDataSynchroniser, IUserDataSyncLogService, IUserDataSyncService, IUserDataSyncStoreManagementService, IUserDataSyncStoreService, MergeState, SyncResource, SyncStatus, UserDataSyncError, UserDataSyncErrorCode, UserDataSyncStoreError, USER_DATA_SYNC_CONFIGURATION_SCOPE } from 'vs/platform/userDataSync/common/userDataSync';
 
 type SyncErrorClassification = {
+	owner: 'sandy081';
 	code: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 	service: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 	serverCode?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -757,10 +757,10 @@ export async function createServer(address: string | net.AddressInfo | null, arg
 		type ServerStartClassification = {
 			owner: 'alexdima';
 			comment: 'The server has started up';
-			startTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
-			startedTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
-			codeLoadedTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
-			readyTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
+			startTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The time the server started at.' };
+			startedTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The time the server began listening for connections.' };
+			codeLoadedTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The time which the code loaded on the server' };
+			readyTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The time when the server was completely ready' };
 		};
 		type ServerStartEvent = {
 			startTime: number;

--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -424,6 +424,7 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 	private _logExtensionActivationTimes(extensionDescription: IExtensionDescription, reason: ExtensionActivationReason, outcome: string, activationTimes?: ExtensionActivationTimes) {
 		const event = getTelemetryActivationEvent(extensionDescription, reason);
 		type ExtensionActivationTimesClassification = {
+			owner: 'jrieken';
 			outcome: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 		} & TelemetryActivationEventFragment & ExtensionActivationTimesFragment;
 
@@ -447,7 +448,9 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 
 	private _doActivateExtension(extensionDescription: IExtensionDescription, reason: ExtensionActivationReason): Promise<ActivatedExtension> {
 		const event = getTelemetryActivationEvent(extensionDescription, reason);
-		type ActivatePluginClassification = {} & TelemetryActivationEventFragment;
+		type ActivatePluginClassification = {
+			owner: 'jrieken';
+		} & TelemetryActivationEventFragment;
 		this._mainThreadTelemetryProxy.$publicLog2<TelemetryActivationEvent, ActivatePluginClassification>('activatePlugin', event);
 		const entryPoint = this._getEntryPoint(extensionDescription);
 		if (!entryPoint) {

--- a/src/vs/workbench/api/common/extHostRequireInterceptor.ts
+++ b/src/vs/workbench/api/common/extHostRequireInterceptor.ts
@@ -249,6 +249,7 @@ class KeytarNodeModuleFactory implements INodeModuleFactory {
 	public load(_request: string, parent: URI): any {
 		const ext = this._extensionPaths.findSubstr(parent);
 		type ShimmingKeytarClassification = {
+			owner: 'jrieken';
 			extension: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 		};
 		this._mainThreadTelemetry.$publicLog2<{ extension: string }, ShimmingKeytarClassification>('shimming.keytar', { extension: ext?.identifier.value ?? 'unknown_extension' });
@@ -346,6 +347,7 @@ class OpenNodeModuleFactory implements INodeModuleFactory {
 			return;
 		}
 		type ShimmingOpenClassification = {
+			owner: 'jrieken';
 			extension: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 		};
 		this._mainThreadTelemetry.$publicLog2<{ extension: string }, ShimmingOpenClassification>('shimming.open', { extension: this._extensionId });
@@ -356,6 +358,7 @@ class OpenNodeModuleFactory implements INodeModuleFactory {
 			return;
 		}
 		type ShimmingOpenCallNoForwardClassification = {
+			owner: 'jrieken';
 			extension: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 		};
 		this._mainThreadTelemetry.$publicLog2<{ extension: string }, ShimmingOpenCallNoForwardClassification>('shimming.open.call.noForward', { extension: this._extensionId });

--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -722,7 +722,10 @@ export class ExtHostSCM implements ExtHostSCMShape {
 		this.logService.trace('ExtHostSCM#createSourceControl', extension.identifier.value, id, label, rootUri);
 
 		type TEvent = { extensionId: string };
-		type TMeta = { extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' } };
+		type TMeta = {
+			owner: 'joaomoreno';
+			extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
+		};
 		this._telemetry.$publicLog2<TEvent, TMeta>('api/scm/createSourceControl', {
 			extensionId: extension.identifier.value,
 		});

--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -102,6 +102,7 @@ export class ViewContainerActivityAction extends ActivityAction {
 
 	private logAction(action: string) {
 		type ActivityBarActionClassification = {
+			owner: 'sbatten';
 			viewletId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 			action: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 		};

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -968,6 +968,7 @@ function registerCloseEditorCommands() {
 			]);
 
 			type WorkbenchEditorReopenClassification = {
+				owner: 'rebornix';
 				scheme: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 				ext: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 				from: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };

--- a/src/vs/workbench/browser/parts/views/viewPane.ts
+++ b/src/vs/workbench/browser/parts/views/viewPane.ts
@@ -51,6 +51,7 @@ export interface IViewPaneOptions extends IPaneOptions {
 }
 
 type WelcomeActionClassification = {
+	owner: 'sandy081';
 	viewId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 	uri: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 };

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -821,6 +821,7 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 		if (this.viewContainerModel.activeViewDescriptors.some(viewDescriptor => viewDescriptor.id === viewId)) {
 			const visible = !this.viewContainerModel.isVisible(viewId);
 			type ViewsToggleVisibilityClassification = {
+				owner: 'sandy081';
 				viewId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 				visible: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 			};

--- a/src/vs/workbench/contrib/experiments/common/experimentService.ts
+++ b/src/vs/workbench/contrib/experiments/common/experimentService.ts
@@ -306,6 +306,7 @@ export class ExperimentService extends Disposable implements IExperimentService 
 			const promises = rawExperiments.map(experiment => this.evaluateExperiment(experiment));
 			return Promise.all(promises).then(() => {
 				type ExperimentsClassification = {
+					owner: 'sbatten';
 					experiments: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 				};
 				this.telemetryService.publicLog2<{ experiments: string[] }, ExperimentsClassification>('experiments', { experiments: this._experiments.map(e => e.id) });

--- a/src/vs/workbench/contrib/extensions/browser/dynamicWorkspaceRecommendations.ts
+++ b/src/vs/workbench/contrib/extensions/browser/dynamicWorkspaceRecommendations.ts
@@ -16,6 +16,7 @@ import { ExtensionRecommendationReason } from 'vs/workbench/services/extensionRe
 import { localize } from 'vs/nls';
 
 type DynamicWorkspaceRecommendationsClassification = {
+	owner: 'sandy081';
 	count: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 	cache: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 };

--- a/src/vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService.ts
@@ -27,12 +27,14 @@ import { EnablementState, IWorkbenchExtensionManagementService, IWorkbenchExtens
 import { IExtensionIgnoredRecommendationsService } from 'vs/workbench/services/extensionRecommendations/common/extensionRecommendations';
 
 type ExtensionRecommendationsNotificationClassification = {
+	owner: 'sandy081';
 	userReaction: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 	extensionId?: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 	source: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 };
 
 type ExtensionWorkspaceRecommendationsNotificationClassification = {
+	owner: 'sandy081';
 	userReaction: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 };
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
@@ -29,6 +29,7 @@ import { IExtensionsWorkbenchService } from 'vs/workbench/contrib/extensions/com
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 
 type IgnoreRecommendationClassification = {
+	owner: 'sandy081';
 	recommendationReason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 	extensionId: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 };

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
@@ -61,6 +61,7 @@ import { isOfflineError } from 'vs/base/parts/request/common/request';
 const FORCE_FEATURE_EXTENSIONS = ['vscode.git', 'vscode.git-base', 'vscode.search-result'];
 
 type WorkspaceRecommendationsClassification = {
+	owner: 'sandy081';
 	count: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; 'isMeasurement': true };
 };
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -57,6 +57,7 @@ interface InstalledExtensionsEvent {
 	readonly count: number;
 }
 interface ExtensionsLoadClassification extends GDPRClassification<InstalledExtensionsEvent> {
+	owner: 'digitarald';
 	readonly extensionIds: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 	readonly count: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 }

--- a/src/vs/workbench/contrib/extensions/browser/fileBasedRecommendations.ts
+++ b/src/vs/workbench/contrib/extensions/browser/fileBasedRecommendations.ts
@@ -37,6 +37,7 @@ import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 
 type FileExtensionSuggestionClassification = {
+	owner: 'sandy081';
 	userReaction: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 	fileExtension: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 };

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -245,6 +245,7 @@ export class NotebookEditor extends EditorPane implements IEditorPaneWithSelecti
 			mark(input.resource, 'editorLoaded');
 
 			type WorkbenchNotebookOpenClassification = {
+				owner: 'rebornix';
 				scheme: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 				ext: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 				viewType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1130,6 +1130,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 				});
 			}
 			type WorkbenchNotebookOpenClassification = {
+				owner: 'rebornix';
 				scheme: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 				ext: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 				viewType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -51,6 +51,7 @@ import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 
 type KeybindingEditorActionClassification = {
+	owner: 'sandy081';
 	action: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 	command: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 };

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
@@ -139,7 +139,7 @@ export const openNewSearchEditor =
 			}
 		}
 
-		telemetryService.publicLog2('searchEditor/openNewSearchEditor');
+		telemetryService.publicLog2<{}, { owner: 'roblourens' }>('searchEditor/openNewSearchEditor');
 
 		const seedSearchStringFromSelection = _args.location === 'new' || configurationService.getValue<IEditorOptions>('editor').find!.seedSearchStringFromSelection;
 		const args: OpenSearchEditorArgs = { query: seedSearchStringFromSelection ? selected : undefined };
@@ -189,7 +189,7 @@ export const createEditorFromSearchResult =
 		const sortOrder = configurationService.getValue<ISearchConfigurationProperties>('search').sortOrder;
 
 
-		telemetryService.publicLog2('searchEditor/createEditorFromSearchResult');
+		telemetryService.publicLog2<{}, { owner: 'roblourens' }>('searchEditor/createEditorFromSearchResult');
 
 		const labelFormatter = (uri: URI): string => labelService.getUriLabel(uri, { relative: true });
 

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorInput.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorInput.ts
@@ -184,7 +184,7 @@ export class SearchEditorInput extends EditorInput {
 	override async saveAs(group: GroupIdentifier, options?: ITextFileSaveOptions): Promise<EditorInput | undefined> {
 		const path = await this.fileDialogService.pickFileToSave(await this.suggestFileName(), options?.availableFileSystems);
 		if (path) {
-			this.telemetryService.publicLog2('searchEditor/saveSearchResults');
+			this.telemetryService.publicLog2<{}, { owner: 'roblourens' }>('searchEditor/saveSearchResults');
 			const toWrite = await this.serializeForDisk();
 			if (await this.textFileService.create([{ resource: path, value: toWrite, options: { overwrite: true } }])) {
 				this.setDirty(false);

--- a/src/vs/workbench/contrib/tags/electron-sandbox/workspaceTags.ts
+++ b/src/vs/workbench/contrib/tags/electron-sandbox/workspaceTags.ts
@@ -67,7 +67,7 @@ export class WorkspaceTags implements IWorkbenchContribution {
 			value = 'Unknown';
 		}
 
-		this.telemetryService.publicLog2<{ edition: string }, { edition: { classification: 'SystemMetaData'; purpose: 'BusinessInsight' } }>('windowsEdition', { edition: value });
+		this.telemetryService.publicLog2<{ edition: string }, { owner: 'sbatten'; edition: { classification: 'SystemMetaData'; purpose: 'BusinessInsight' } }>('windowsEdition', { edition: value });
 	}
 
 	private async getWorkspaceInformation(): Promise<IWorkspaceInformation> {

--- a/src/vs/workbench/contrib/telemetry/browser/telemetry.contribution.ts
+++ b/src/vs/workbench/contrib/telemetry/browser/telemetry.contribution.ts
@@ -72,6 +72,7 @@ export class TelemetryContribution extends Disposable implements IWorkbenchContr
 		};
 
 		type WorkspaceLoadClassification = {
+			owner: 'bpasero';
 			userAgent: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 			emptyWorkbench: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 			windowSize: WindowSizeFragment;
@@ -134,12 +135,15 @@ export class TelemetryContribution extends Disposable implements IWorkbenchContr
 		const settingsType = this.getTypeIfSettings(e.model.resource);
 		if (settingsType) {
 			type SettingsReadClassification = {
+				owner: 'bpasero';
 				settingsType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 			};
 
 			this.telemetryService.publicLog2<{ settingsType: string }, SettingsReadClassification>('settingsRead', { settingsType }); // Do not log read to user settings.json and .vscode folder as a fileGet event as it ruins our JSON usage data
 		} else {
-			type FileGetClassification = {} & FileTelemetryDataFragment;
+			type FileGetClassification = {
+				owner: 'bpasero';
+			} & FileTelemetryDataFragment;
 
 			this.telemetryService.publicLog2<TelemetryData, FileGetClassification>('fileGet', this.getTelemetryData(e.model.resource, e.reason));
 		}
@@ -149,11 +153,14 @@ export class TelemetryContribution extends Disposable implements IWorkbenchContr
 		const settingsType = this.getTypeIfSettings(e.model.resource);
 		if (settingsType) {
 			type SettingsWrittenClassification = {
+				owner: 'bpasero';
 				settingsType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 			};
 			this.telemetryService.publicLog2<{ settingsType: string }, SettingsWrittenClassification>('settingsWritten', { settingsType }); // Do not log write to user settings.json and .vscode folder as a filePUT event as it ruins our JSON usage data
 		} else {
-			type FilePutClassfication = {} & FileTelemetryDataFragment;
+			type FilePutClassfication = {
+				owner: 'bpasero';
+			} & FileTelemetryDataFragment;
 			this.telemetryService.publicLog2<TelemetryData, FilePutClassfication>('filePUT', this.getTelemetryData(e.model.resource, e.reason));
 		}
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1634,7 +1634,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}
 
 		if (failedShellIntegrationInjection) {
-			this._telemetryService.publicLog2<{ classification: 'SystemMetaData'; purpose: 'FeatureInsight' }>('terminal/shellIntegrationFailureProcessExit');
+			this._telemetryService.publicLog2<{}, { owner: 'meganrogge' }>('terminal/shellIntegrationFailureProcessExit');
 		}
 
 		// First onExit to consumers, this can happen after the terminal has already been disposed.

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -335,7 +335,7 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 						this._hasChildProcesses = value;
 						break;
 					case ProcessPropertyType.FailedShellIntegrationActivation:
-						this._telemetryService?.publicLog2<{ classification: 'SystemMetaData'; purpose: 'FeatureInsight' }>('terminal/shellIntegrationActivationFailureCustomArgs');
+						this._telemetryService?.publicLog2<{}, { owner: 'meganrogge' }>('terminal/shellIntegrationActivationFailureCustomArgs');
 						break;
 				}
 				this._onDidChangeProperty.fire({ type, value });

--- a/src/vs/workbench/contrib/userDataSync/browser/userDataSync.ts
+++ b/src/vs/workbench/contrib/userDataSync/browser/userDataSync.ts
@@ -66,6 +66,7 @@ const CONTEXT_CONFLICTS_SOURCES = new RawContextKey<string>('conflictsSources', 
 type ConfigureSyncQuickPickItem = { id: SyncResource; label: string; description?: string };
 
 type SyncConflictsClassification = {
+	owner: 'sandy081';
 	source: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 	action?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 };

--- a/src/vs/workbench/services/accessibility/electron-sandbox/accessibilityService.ts
+++ b/src/vs/workbench/services/accessibility/electron-sandbox/accessibilityService.ts
@@ -22,6 +22,7 @@ interface AccessibilityMetrics {
 	enabled: boolean;
 }
 type AccessibilityMetricsClassification = {
+	owner: 'isidorn';
 	enabled: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 };
 

--- a/src/vs/workbench/services/extensions/browser/extensionUrlHandler.ts
+++ b/src/vs/workbench/services/extensions/browser/extensionUrlHandler.ts
@@ -82,6 +82,7 @@ export interface ExtensionUrlHandlerEvent {
 }
 
 export interface ExtensionUrlHandlerClassification extends GDPRClassification<ExtensionUrlHandlerEvent> {
+	owner: 'joaomoreno';
 	readonly extensionId: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 }
 

--- a/src/vs/workbench/services/languageDetection/browser/languageDetectionWorkerServiceImpl.ts
+++ b/src/vs/workbench/services/languageDetection/browser/languageDetectionWorkerServiceImpl.ts
@@ -203,6 +203,7 @@ export class LanguageDetectionWorkerHost {
 	async sendTelemetryEvent(languages: string[], confidences: number[], timeSpent: number): Promise<void> {
 		type LanguageDetectionStats = { languages: string; confidences: string; timeSpent: number };
 		type LanguageDetectionStatsClassification = {
+			owner: 'TylerLeonhardt';
 			languages: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 			confidences: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 			timeSpent: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
@@ -337,6 +338,7 @@ export class LanguageDetectionWorkerClient extends EditorWorkerClient {
 		}
 
 		type LanguageDetectionPerfClassification = {
+			owner: 'TylerLeonhardt';
 			timeSpent: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 			detection: { classification: 'SystemMetaData'; purpose: 'FeatureInsight' };
 		};

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -304,6 +304,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 
 	async openGlobalKeybindingSettings(textual: boolean, options?: IKeybindingsEditorOptions): Promise<void> {
 		type OpenKeybindingsClassification = {
+			owner: 'sandy081';
 			textual: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 		};
 		this.telemetryService.publicLog2<{ textual: boolean }, OpenKeybindingsClassification>('openKeybindings', { textual });

--- a/src/vs/workbench/services/search/common/searchService.ts
+++ b/src/vs/workbench/services/search/common/searchService.ts
@@ -288,6 +288,7 @@ export class SearchService extends Disposable implements ISearchService {
 				const cacheStats: ICachedSearchStats = fileSearchStats.detailStats as ICachedSearchStats;
 
 				type CachedSearchCompleteClassifcation = {
+					owner: 'roblourens';
 					reason?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
 					resultCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true };
 					workspaceFolderCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true };
@@ -330,6 +331,7 @@ export class SearchService extends Disposable implements ISearchService {
 				const searchEngineStats: ISearchEngineStats = fileSearchStats.detailStats as ISearchEngineStats;
 
 				type SearchCompleteClassification = {
+					owner: 'roblourens';
 					reason?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
 					resultCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true };
 					workspaceFolderCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true };
@@ -387,6 +389,7 @@ export class SearchService extends Disposable implements ISearchService {
 			}
 
 			type TextSearchCompleteClassification = {
+				owner: 'roblourens';
 				reason?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth' };
 				workspaceFolderCount: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true };
 				endToEndTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true };

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -579,6 +579,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 			const key = themeType + themeData.extensionId;
 			if (!this.themeExtensionsActivated.get(key)) {
 				type ActivatePluginClassification = {
+					owner: 'aeschli';
 					id: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 					name: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight' };
 					isBuiltin: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };

--- a/src/vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService.ts
+++ b/src/vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService.ts
@@ -37,11 +37,13 @@ import { ICredentialsService } from 'vs/platform/credentials/common/credentials'
 import { CancellationError } from 'vs/base/common/errors';
 
 type UserAccountClassification = {
+	owner: 'sandy081';
 	id: { classification: 'EndUserPseudonymizedInformation'; purpose: 'BusinessInsight' };
 	providerId: { classification: 'EndUserPseudonymizedInformation'; purpose: 'BusinessInsight' };
 };
 
 type FirstTimeSyncClassification = {
+	owner: 'sandy081';
 	action: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true };
 };
 
@@ -617,7 +619,7 @@ export class UserDataSyncWorkbenchService extends Disposable implements IUserDat
 	}
 
 	private async onDidSuccessiveAuthFailures(): Promise<void> {
-		this.telemetryService.publicLog2('sync/successiveAuthFailures');
+		this.telemetryService.publicLog2<{}, { owner: 'sandy081' }>('sync/successiveAuthFailures');
 		this.currentSessionId = undefined;
 		await this.update();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR goes through our telemetry classifications and adds owners to everything. This will greatly speed up the adoption of the comment and owner metadata.

/cc @microsoft/vscode Just a reminder to complete this work (even if you already completed it previously please do the following just to ensure no events of yours were missed as I went through all of them)
1. Search for your github alias in the codebase
2. Ensure that "owner" and "comment" are inside the event classification object
3. Ensure each property of the event classification also has a comment
4. Assign @lramos15 as the reviewer to the PR.
5. 🎉 Thanks for making VS Code telemetry more transparent.
