### PR TITLE
Fix list pageup down

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1598,9 +1598,10 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 		let lastPageIndex = this.view.indexAt(this.view.getScrollTop() + this.view.renderHeight);
 		lastPageIndex = lastPageIndex === 0 ? 0 : lastPageIndex - 1;
 		const lastPageElement = this.view.element(lastPageIndex);
-		const currentlyFocusedElement = this.getFocusedElements()[0];
+		const currentlyFocusedElementIndex = this.getFocus()[0];
+		const currentlyFocusedElement = this.view.element(currentlyFocusedElementIndex);
 
-		if (currentlyFocusedElement !== lastPageElement) {
+		if (currentlyFocusedElement !== lastPageElement && lastPageIndex > currentlyFocusedElementIndex) {
 			const lastGoodPageIndex = this.findPreviousIndex(lastPageIndex, false, filter);
 
 			if (lastGoodPageIndex > -1 && currentlyFocusedElement !== this.view.element(lastGoodPageIndex)) {
@@ -1610,7 +1611,13 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 			}
 		} else {
 			const previousScrollTop = this.view.getScrollTop();
-			this.view.setScrollTop(previousScrollTop + this.view.renderHeight - this.view.elementHeight(lastPageIndex));
+			let nextpageScrollTop = previousScrollTop + this.view.renderHeight;
+			if (lastPageIndex > currentlyFocusedElementIndex) {
+				// scroll last page element to the top only if the last page element is below the focused element
+				nextpageScrollTop -= this.view.elementHeight(lastPageIndex);
+			}
+
+			this.view.setScrollTop(nextpageScrollTop);
 
 			if (this.view.getScrollTop() !== previousScrollTop) {
 				this.setFocus([]);
@@ -1633,9 +1640,10 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 		}
 
 		const firstPageElement = this.view.element(firstPageIndex);
-		const currentlyFocusedElement = this.getFocusedElements()[0];
+		const currentlyFocusedElementIndex = this.getFocus()[0];
+		const currentlyFocusedElement = this.view.element(currentlyFocusedElementIndex);
 
-		if (currentlyFocusedElement !== firstPageElement) {
+		if (currentlyFocusedElement !== firstPageElement && currentlyFocusedElementIndex >= firstPageIndex) {
 			const firstGoodPageIndex = this.findNextIndex(firstPageIndex, false, filter);
 
 			if (firstGoodPageIndex > -1 && currentlyFocusedElement !== this.view.element(firstGoodPageIndex)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #149502. Currently when page up/down over a list item whose height is larger than the viewport, the algorithm checking the "next" page is wrong, it will find a page of the other direction.
