### PR TITLE
Poor scrolling behavior after notebook model reset

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -448,9 +448,9 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		this.items[index].size = size;
 
 		this.render(lastRenderRange, Math.max(0, this.lastRenderTop + heightDiff), this.lastRenderHeight, undefined, undefined, true);
-		this.setScrollTop(this.lastRenderTop);
 
 		this.eventuallyUpdateScrollDimensions();
+		this.setScrollTop(this.lastRenderTop);
 
 		if (this.supportDynamicHeights) {
 			this._rerender(this.lastRenderTop, this.lastRenderHeight);

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -450,7 +450,6 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		this.render(lastRenderRange, Math.max(0, this.lastRenderTop + heightDiff), this.lastRenderHeight, undefined, undefined, true);
 		this.setScrollTop(this.lastRenderTop);
 
-		// Must update scrollHeight before scrollTop, in case scrollTop won't fit in the old scrollHeight
 		this.eventuallyUpdateScrollDimensions();
 
 		if (this.supportDynamicHeights) {

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -448,10 +448,10 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		this.items[index].size = size;
 
 		this.render(lastRenderRange, Math.max(0, this.lastRenderTop + heightDiff), this.lastRenderHeight, undefined, undefined, true);
+		this.setScrollTop(this.lastRenderTop);
 
 		// Must update scrollHeight before scrollTop, in case scrollTop won't fit in the old scrollHeight
 		this.eventuallyUpdateScrollDimensions();
-		this.setScrollTop(this.lastRenderTop);
 
 		if (this.supportDynamicHeights) {
 			this._rerender(this.lastRenderTop, this.lastRenderHeight);

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -449,6 +449,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 
 		this.render(lastRenderRange, Math.max(0, this.lastRenderTop + heightDiff), this.lastRenderHeight, undefined, undefined, true);
 
+		// Must update scrollHeight before scrollTop, in case scrollTop won't fit in the old scrollHeight
 		this.eventuallyUpdateScrollDimensions();
 		this.setScrollTop(this.lastRenderTop);
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1165,14 +1165,14 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		this._backgroundMarkdownRendering();
 	}
 
-	private _isScheduled = false;
+	private _backgroundMarkdownRenderRunning = false;
 	private _backgroundMarkdownRendering() {
-		if (this._isScheduled) {
+		if (this._backgroundMarkdownRenderRunning) {
 			return;
 		}
 
+		this._backgroundMarkdownRenderRunning = true;
 		runWhenIdle((deadline) => {
-			this._isScheduled = false;
 			this._backgroundMarkdownRenderingWithDeadline(deadline);
 		});
 	}
@@ -1181,6 +1181,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		const endTime = Date.now() + deadline.timeRemaining();
 
 		const execute = () => {
+			this._backgroundMarkdownRenderRunning = false;
 			if (this._isDisposed) {
 				return;
 			}
@@ -1194,6 +1195,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 				return;
 			}
 
+			this._backgroundMarkdownRenderRunning = true;
 			this.createMarkupPreview(firstMarkupCell);
 
 			if (Date.now() < endTime) {
@@ -1508,6 +1510,10 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 				dispose(deletedCells);
 			});
+
+			if (e.splices.some(s => s[2].some(cell => cell.cellKind === CellKind.Markup))) {
+				this._backgroundMarkdownRendering();
+			}
 		}));
 
 		if (this._dimension) {
@@ -2235,6 +2241,11 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		let deferred = new DeferredPromise<void>();
 		const doLayout = () => {
 			if (this._isDisposed) {
+				return;
+			}
+
+			if (!this.viewModel?.hasCell(cell)) {
+				// Cell removed in the meantime?
 				return;
 			}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts
@@ -257,7 +257,7 @@ export class CodeCell extends Disposable {
 		}));
 
 		this._register(this.templateData.editor.onDidChangeCursorSelection((e) => {
-			if (e.source === 'restoreState') {
+			if (e.source === 'restoreState' || e.oldModelVersionId === 0) {
 				// do not reveal the cell into view if this selection change was caused by restoring editors...
 				return;
 			}

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
@@ -627,6 +627,10 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 		}
 
 		const modelIndex = this._viewModel.getCellIndex(cell);
+		if (modelIndex === -1) {
+			return -1;
+		}
+
 		if (!this.hiddenRangesPrefixSum) {
 			return modelIndex;
 		}
@@ -965,7 +969,6 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 			// update element above viewport
 			const oldHeight = this.elementHeight(element);
 			const delta = oldHeight - size;
-			// const date = new Date();
 			if (this._webviewElement) {
 				Event.once(this.view.onWillScroll)(() => {
 					const webviewTop = parseInt(this._webviewElement!.domNode.style.top, 10);

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
@@ -156,6 +156,8 @@ export abstract class BaseCellViewModel extends Disposable {
 		this._onDidChangeState.fire({ outputCollapsedChanged: true });
 	}
 
+	private _isDisposed = false;
+
 	constructor(
 		readonly viewType: string,
 		readonly model: NotebookCellTextModel,
@@ -550,6 +552,10 @@ export abstract class BaseCellViewModel extends Disposable {
 	async resolveTextModel(): Promise<model.ITextModel> {
 		if (!this._textModelRef || !this.textModel) {
 			this._textModelRef = await this._modelService.createModelReference(this.uri);
+			if (this._isDisposed) {
+				return this.textModel!;
+			}
+
 			if (!this._textModelRef) {
 				throw new Error(`Cannot resolve text model for ${this.uri}`);
 			}
@@ -590,6 +596,7 @@ export abstract class BaseCellViewModel extends Disposable {
 	}
 
 	override dispose() {
+		this._isDisposed = true;
 		super.dispose();
 
 		dispose(this._editorListeners);


### PR DESCRIPTION
For #148164

1. Kick off markdown rendering in background after markdown cells are added
2. Fix issue with cell editor trying to reveal itself when it gets rendered
3. Fix cell being resized after it is disposed, causing some issues