### PR TITLE
Fix drop data transfer overwriting everything with `uri-list` mime

### DIFF
--- a/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
+++ b/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
@@ -121,10 +121,8 @@ export class DropIntoEditorController extends Disposable implements IEditorContr
 				.map(input => input.resource!.toString());
 
 			if (editorData.length) {
-				const added = new VSDataTransfer();
 				const str = distinct(editorData).join('\n');
-				added.setString(Mimes.uriList.toLowerCase(), str);
-				return added;
+				textEditorDataTransfer.setString(Mimes.uriList.toLowerCase(), str);
 			}
 		}
 


### PR DESCRIPTION
When adding the `uri-list` mime type to a drop data transfer, by mistake we are dropping all the other mimes types. Instead we should just add this entry to the existing data transfer