### PR TITLE
update bash status correctly

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -124,7 +124,7 @@ __vsc_prompt_cmd_original() {
 		unset IFS
 	fi
 	for ((i = 0; i < ${#ADDR[@]}; i++)); do
-		# unset IFS
+		(exit ${__vsc_status})
 		builtin eval ${ADDR[i]}
 	done
 	__vsc_precmd

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -96,6 +96,7 @@ if [[ -n "$__vsc_original_trap" ]]; then
 fi
 
 __vsc_preexec() {
+	__vsc_status="$?"
 	eval ${__vsc_original_trap}
 	PS1="$__vsc_prior_prompt"
 	if [ -z "${__vsc_in_command_execution-}" ]; then
@@ -110,7 +111,6 @@ __vsc_prompt_cmd_original() {
 	if [[ ${IFS+set} ]]; then
 		__vsc_original_ifs="$IFS"
 	fi
-	__vsc_status="$?"
 	if [[ "$__vsc_original_prompt_command" =~ .+\;.+ ]]; then
 		IFS=';'
 	else


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Error status was not correct for `bash` because any exit code from the command was getting overwritten by the successful run of the function we were running before saving it.

The status was not correct when used within a function of `PROMPT_COMMAND` because as we ran each of those, it would overwrite the previous value. 

The way to "set" the status to what we trapped before running this is by faking it with `(exit __trapped_value)` so that any functions in `PROMPT_COMMAND` get the exit code from the truly last run command.

This PR fixes #150320 and fixes #150243

Notice in the gif how my powerlevel10k decorations now update based on what I run (using status) and the correct command decoration gets used.

https://user-images.githubusercontent.com/29464607/170146352-f15b73b2-3bc9-4005-bcac-273128a1e196.mov


