### PR TITLE
use remote cli when in remote terminal

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -288,6 +288,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 			all = es.merge(all, gulp.src('resources/linux/code.png', { base: '.' }));
 		} else if (platform === 'darwin') {
 			const shortcut = gulp.src('resources/darwin/bin/code.sh')
+				.pipe(replace('@@APPNAME@@', product.applicationName))
 				.pipe(rename('bin/code'));
 
 			all = es.merge(all, shortcut);
@@ -336,7 +337,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		} else if (platform === 'linux') {
 			result = es.merge(result, gulp.src('resources/linux/bin/code.sh', { base: '.' })
 				.pipe(replace('@@PRODNAME@@', product.nameLong))
-				.pipe(replace('@@NAME@@', product.applicationName))
+				.pipe(replace('@@APPNAME@@', product.applicationName))
 				.pipe(rename('bin/' + product.applicationName)));
 		}
 

--- a/resources/darwin/bin/code.sh
+++ b/resources/darwin/bin/code.sh
@@ -3,6 +3,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
+# when run in remote terminal, use the remote cli
+if [ -n "$VSCODE_IPC_HOOK_CLI" ]; then
+	REMOTE_CLI="$(which -a '@@APPNAME@@' | grep /remote-cli/)"
+	if [ -n "$REMOTE_CLI" ]; then
+		"$REMOTE_CLI" "$@"
+		exit $?
+	fi
+fi
+
 function app_realpath() {
 	SOURCE=$1
 	while [ -h "$SOURCE" ]; do

--- a/resources/linux/bin/code.sh
+++ b/resources/linux/bin/code.sh
@@ -3,9 +3,18 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
+# when run in remote terminal, use the remote cli
+if [ -n "$VSCODE_IPC_HOOK_CLI" ]; then
+	REMOTE_CLI="$(which -a '@@APPNAME@@' | grep /remote-cli/)"
+	if [ -n "$REMOTE_CLI" ]; then
+		"$REMOTE_CLI" "$@"
+		exit $?
+	fi
+fi
+
 # test that VSCode wasn't installed inside WSL
 if grep -qi Microsoft /proc/version && [ -z "$DONT_PROMPT_WSL_INSTALL" ]; then
-	echo "To use @@PRODNAME@@ with the Windows Subsystem for Linux, please install @@PRODNAME@@ in Windows and uninstall the Linux version in WSL. You can then use the \`@@NAME@@\` command in a WSL terminal just as you would in a normal command prompt." 1>&2
+	echo "To use @@PRODNAME@@ with the Windows Subsystem for Linux, please install @@PRODNAME@@ in Windows and uninstall the Linux version in WSL. You can then use the \`@@APPNAME@@\` command in a WSL terminal just as you would in a normal command prompt." 1>&2
 	printf "Do you want to continue anyway? [y/N] " 1>&2
 	read -r YN
 	YN=$(printf '%s' "$YN" | tr '[:upper:]' '[:lower:]')
@@ -44,11 +53,11 @@ else
 		VSCODE_PATH="$(dirname "$(readlink -f "$0")")/.."
 	else
 		# else use the standard install location
-		VSCODE_PATH="/usr/share/@@NAME@@"
+		VSCODE_PATH="/usr/share/@@APPNAME@@"
 	fi
 fi
 
-ELECTRON="$VSCODE_PATH/@@NAME@@"
+ELECTRON="$VSCODE_PATH/@@APPNAME@@"
 CLI="$VSCODE_PATH/resources/app/out/cli.js"
 ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" --ms-enable-electron-run-as-node "$@"
 exit $?


### PR DESCRIPTION
Fixes microsoft/vscode-remote-release#6625

Replaces https://github.com/microsoft/vscode/pull/150131

This fix is for Linux/Mac only. On Linux, the shell login script adds `/usr/local/bin` to the front of the path. The Mac reorders the PATH segments, see #99878. On remote systems that also have desktop code installed, this causes the desktop code shell script to be found before the remote cli code script.

The fix is to have the Desktop code / code-insiders shell script detect if it is invoked in a remote terminal and forward he call the remote cli command

- To detect if we are in a remote terminal we use the `VSCODE_IPC_HOOK_CLI` env variable.
- To find the remote cli, we look in the PATH if a second code command is found under a path `remote-cli`

On Windows, the remote code command is always first.