### PR TITLE
Create cell execution beforehand

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookExecutionStateServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookExecutionStateServiceImpl.ts
@@ -14,7 +14,6 @@ import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/no
 import { CellEditType, CellUri, ICellEditOperation, NotebookCellExecutionState, NotebookCellInternalMetadata, NotebookTextModelWillAddRemoveEvent } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { CellExecutionUpdateType, INotebookExecutionService } from 'vs/workbench/contrib/notebook/common/notebookExecutionService';
 import { ICellExecuteUpdate, ICellExecutionComplete, ICellExecutionStateChangedEvent, ICellExecutionStateUpdate, INotebookCellExecution, INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
-import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
 
 export class NotebookExecutionStateService extends Disposable implements INotebookExecutionStateService {
@@ -28,7 +27,6 @@ export class NotebookExecutionStateService extends Disposable implements INotebo
 	onDidChangeCellExecution = this._onDidChangeCellExecution.event;
 
 	constructor(
-		@INotebookKernelService private readonly _notebookKernelService: INotebookKernelService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ILogService private readonly _logService: ILogService,
 		@INotebookService private readonly _notebookService: INotebookService,
@@ -91,15 +89,10 @@ export class NotebookExecutionStateService extends Disposable implements INotebo
 		this._onDidChangeCellExecution.fire(new NotebookExecutionEvent(notebookUri, cellHandle));
 	}
 
-	createCellExecution(controllerId: string, notebookUri: URI, cellHandle: number): INotebookCellExecution {
+	createCellExecution(notebookUri: URI, cellHandle: number): INotebookCellExecution {
 		const notebook = this._notebookService.getNotebookTextModel(notebookUri);
 		if (!notebook) {
 			throw new Error(`Notebook not found: ${notebookUri.toString()}`);
-		}
-
-		const kernel = this._notebookKernelService.getMatchingKernel(notebook);
-		if (!kernel.selected || kernel.selected.id !== controllerId) {
-			throw new Error(`Kernel is not selected: ${kernel.selected?.id} !== ${controllerId}`);
 		}
 
 		let notebookExecutionMap = this._executions.get(notebookUri);

--- a/src/vs/workbench/contrib/notebook/common/notebookExecutionStateService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookExecutionStateService.ts
@@ -50,7 +50,7 @@ export interface INotebookExecutionStateService {
 	forceCancelNotebookExecutions(notebookUri: URI): void;
 	getCellExecutionStatesForNotebook(notebook: URI): INotebookCellExecution[];
 	getCellExecution(cellUri: URI): INotebookCellExecution | undefined;
-	createCellExecution(controllerId: string, notebook: URI, cellHandle: number): INotebookCellExecution;
+	createCellExecution(notebook: URI, cellHandle: number): INotebookCellExecution;
 }
 
 export interface INotebookCellExecution {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionStateService.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionStateService.test.ts
@@ -94,7 +94,7 @@ suite('NotebookExecutionStateService', () => {
 			const executionStateService: INotebookExecutionStateService = instantiationService.get(INotebookExecutionStateService);
 
 			const cell = insertCellAtIndex(viewModel, 0, 'var c = 3', 'javascript', CellKind.Code, {}, [], true, true);
-			executionStateService.createCellExecution(kernel.id, viewModel.uri, cell.handle);
+			executionStateService.createCellExecution(viewModel.uri, cell.handle);
 			assert.strictEqual(didCancel, false);
 			viewModel.notebookDocument.applyEdits([{
 				editType: CellEditType.Replace, index: 0, count: 1, cells: []
@@ -113,7 +113,7 @@ suite('NotebookExecutionStateService', () => {
 
 			const executionStateService: INotebookExecutionStateService = instantiationService.get(INotebookExecutionStateService);
 			const cell = insertCellAtIndex(viewModel, 0, 'var c = 3', 'javascript', CellKind.Code, {}, [], true, true);
-			const exe = executionStateService.createCellExecution(kernel.id, viewModel.uri, cell.handle);
+			const exe = executionStateService.createCellExecution(viewModel.uri, cell.handle);
 
 			let didFire = false;
 			disposables.add(executionStateService.onDidChangeCellExecution(e => {
@@ -154,7 +154,7 @@ suite('NotebookExecutionStateService', () => {
 				deferred.complete();
 			}));
 
-			executionStateService.createCellExecution(kernel.id, viewModel.uri, cell.handle);
+			executionStateService.createCellExecution(viewModel.uri, cell.handle);
 
 			return deferred.p;
 		});
@@ -170,7 +170,7 @@ suite('NotebookExecutionStateService', () => {
 
 			const executionStateService: INotebookExecutionStateService = instantiationService.get(INotebookExecutionStateService);
 			const cell = insertCellAtIndex(viewModel, 0, 'var c = 3', 'javascript', CellKind.Code, {}, [], true, true);
-			executionStateService.createCellExecution(kernel.id, viewModel.uri, cell.handle);
+			executionStateService.createCellExecution(viewModel.uri, cell.handle);
 			const exe = executionStateService.getCellExecution(cell.uri);
 			assert.ok(exe);
 

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -422,7 +422,7 @@ class TestNotebookExecutionStateService implements INotebookExecutionStateServic
 		return this._executions.get(cellUri);
 	}
 
-	createCellExecution(controllerId: string, notebook: URI, cellHandle: number): INotebookCellExecution {
+	createCellExecution(notebook: URI, cellHandle: number): INotebookCellExecution {
 		const onComplete = () => this._executions.delete(CellUri.generate(notebook, cellHandle));
 		const exe = new TestCellExecution(notebook, cellHandle, onComplete);
 		this._executions.set(CellUri.generate(notebook, cellHandle), exe);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Currently we only create cell execution objects when users pick a kernel. This PR will ensure that they are created first, and users will see the cells in pending state when they are selecting kernels or waiting for kernel to start.
