### PR TITLE
Re work configuring a display language and enable core translations for web serverful

### DIFF
--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -80,7 +80,8 @@ if (typeof navigator === 'object' && !isElectronRenderer) {
 	_isIOS = (_userAgent.indexOf('Macintosh') >= 0 || _userAgent.indexOf('iPad') >= 0 || _userAgent.indexOf('iPhone') >= 0) && !!navigator.maxTouchPoints && navigator.maxTouchPoints > 0;
 	_isLinux = _userAgent.indexOf('Linux') >= 0;
 	_isWeb = true;
-	_locale = navigator.language;
+	const storedLocale = window.localStorage.getItem('vscode.nls.configuration.language');
+	_locale = storedLocale || navigator.language;
 	_language = _locale;
 }
 

--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -72,6 +72,11 @@ interface INavigator {
 }
 declare const navigator: INavigator;
 
+interface IWindow {
+	localStorage: { getItem: (key: string) => string | null };
+}
+declare const window: IWindow;
+
 // Web environment
 if (typeof navigator === 'object' && !isElectronRenderer) {
 	_userAgent = navigator.userAgent;

--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -74,6 +74,7 @@ export interface IProductConfiguration {
 		readonly resourceUrlTemplate: string;
 		readonly controlUrl: string;
 		readonly recommendationsUrl: string;
+		readonly nlsBaseUrl: string;
 	};
 
 	readonly extensionTips?: { [id: string]: string };

--- a/src/vs/code/browser/workbench/workbench.html
+++ b/src/vs/code/browser/workbench/workbench.html
@@ -40,6 +40,20 @@
 		Object.keys(self.webPackagePaths).map(function (key, index) {
 			self.webPackagePaths[key] = `${baseUrl}/node_modules/${key}/${self.webPackagePaths[key]}`;
 		});
+
+		// Set up nls if the user is not using the default language (English)
+		const nlsConfig = {};
+		const storedLocale = window.localStorage.getItem('vscode.nls.configuration.language');
+		const locale = storedLocale || navigator.language;
+		if (!locale.startsWith('en')) {
+			nlsConfig['vs/nls'] = {
+				availableLanguages: {
+					'*': locale
+				},
+				baseUrl: '{{WORKBENCH_NLS_BASE_URL}}'
+			};
+		}
+
 		require.config({
 			baseUrl: `${baseUrl}/out`,
 			recordStats: true,
@@ -48,7 +62,8 @@
 					return value;
 				}
 			}),
-			paths: self.webPackagePaths
+			paths: self.webPackagePaths,
+			...nlsConfig
 		});
 	</script>
 	<script>

--- a/src/vs/code/electron-browser/sharedProcess/contrib/localizationsUpdater.ts
+++ b/src/vs/code/electron-browser/sharedProcess/contrib/localizationsUpdater.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from 'vs/base/common/lifecycle';
-import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { LanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
+import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePack';
+import { NativeLanguagePackService } from 'vs/platform/languagePacks/node/languagePackService';
 
 export class LocalizationsUpdater extends Disposable {
 
 	constructor(
-		@ILanguagePackService private readonly localizationsService: LanguagePackService
+		@ILanguagePackService private readonly localizationsService: NativeLanguagePackService
 	) {
 		super();
 

--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -46,8 +46,8 @@ import { InstantiationService } from 'vs/platform/instantiation/common/instantia
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { MessagePortMainProcessService } from 'vs/platform/ipc/electron-browser/mainProcessService';
 import { IMainProcessService } from 'vs/platform/ipc/electron-sandbox/services';
-import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { LanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
+import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePack';
+import { NativeLanguagePackService } from 'vs/platform/languagePacks/node/languagePackService';
 import { ConsoleLogger, ILoggerService, ILogService, MultiplexLogService } from 'vs/platform/log/common/log';
 import { FollowerLogService, LoggerChannelClient, LogLevelChannelClient } from 'vs/platform/log/common/logIpc';
 import { INativeHostService } from 'vs/platform/native/electron-sandbox/native';
@@ -311,7 +311,7 @@ class SharedProcessMain extends Disposable {
 		services.set(IExtensionTipsService, new SyncDescriptor(ExtensionTipsService));
 
 		// Localizations
-		services.set(ILanguagePackService, new SyncDescriptor(LanguagePackService));
+		services.set(ILanguagePackService, new SyncDescriptor(NativeLanguagePackService));
 
 		// Diagnostics
 		services.set(IDiagnosticsService, new SyncDescriptor(DiagnosticsService));

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -36,8 +36,8 @@ import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
-import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { LanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
+import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePack';
+import { NativeLanguagePackService } from 'vs/platform/languagePacks/node/languagePackService';
 import { ConsoleLogger, getLogLevel, ILogger, ILogService, LogLevel, MultiplexLogService } from 'vs/platform/log/common/log';
 import { SpdLogLogger } from 'vs/platform/log/node/spdlogLog';
 import { FilePolicyService } from 'vs/platform/policy/common/filePolicyService';
@@ -161,7 +161,7 @@ class CliMain extends Disposable {
 		services.set(IExtensionManagementCLIService, new SyncDescriptor(ExtensionManagementCLIService));
 
 		// Localizations
-		services.set(ILanguagePackService, new SyncDescriptor(LanguagePackService));
+		services.set(ILanguagePackService, new SyncDescriptor(NativeLanguagePackService));
 
 		// Telemetry
 		const appenders: AppInsightsAppender[] = [];

--- a/src/vs/platform/languagePacks/browser/languagePackService.ts
+++ b/src/vs/platform/languagePacks/browser/languagePackService.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ILanguagePackItem, LanguagePackBaseService } from 'vs/platform/languagePacks/common/languagePack';
+
+export class WebLanguagePackService extends LanguagePackBaseService {
+	// For web, there is no concept of an "installed" language since
+	// we load language packs from the unpkg service directly.
+	getInstalledLanguages(): Promise<ILanguagePackItem[]> {
+		return Promise.resolve([]);
+	}
+}

--- a/src/vs/platform/languagePacks/common/languagePack.ts
+++ b/src/vs/platform/languagePacks/common/languagePack.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationTokenSource } from 'vs/base/common/cancellation';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { language } from 'vs/base/common/platform';
+import { IQuickPickItem } from 'vs/base/parts/quickinput/common/quickInput';
+import { localize } from 'vs/nls';
+import { IExtensionGalleryService, IGalleryExtension } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+
+export const ILanguagePackService = createDecorator<ILanguagePackService>('languagePackService');
+
+export interface ILanguagePackItem extends IQuickPickItem {
+	readonly extensionId: string;
+	readonly galleryExtension?: IGalleryExtension;
+}
+
+export interface ILanguagePackService {
+	readonly _serviceBrand: undefined;
+	getAvailableLanguages(): Promise<Array<ILanguagePackItem>>;
+	getInstalledLanguages(): Promise<Array<ILanguagePackItem>>;
+}
+
+export abstract class LanguagePackBaseService extends Disposable implements ILanguagePackService {
+	_serviceBrand: undefined;
+
+	constructor(@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService) {
+		super();
+	}
+
+	abstract getInstalledLanguages(): Promise<Array<ILanguagePackItem>>;
+
+	async getAvailableLanguages(): Promise<ILanguagePackItem[]> {
+		const timeout = new CancellationTokenSource();
+		setTimeout(() => timeout.cancel(), 1000);
+
+		let result;
+		try {
+			result = await this.extensionGalleryService.query({
+				text: 'category:"language packs"',
+				pageSize: 20
+			}, timeout.token);
+		} catch (_) {
+			// This method is best effort. So, we ignore any errors.
+			return [];
+		}
+
+		const languagePackExtensions = result.firstPage.filter(e => e.properties.localizedLanguages?.length && e.tags.some(t => t.startsWith('lp-')));
+		const allFromMarketplace: ILanguagePackItem[] = languagePackExtensions.map(lp => {
+			const languageName = lp.properties.localizedLanguages?.[0];
+			const locale = lp.tags.find(t => t.startsWith('lp-'))!.split('lp-')[1];
+			const baseQuickPick = this.createQuickPickItem({ locale, label: languageName });
+			return {
+				...baseQuickPick,
+				extensionId: lp.identifier.id,
+				galleryExtension: lp
+			};
+		});
+
+		allFromMarketplace.push({
+			...this.createQuickPickItem({ locale: 'en', label: 'English' }),
+			extensionId: 'default',
+		});
+
+		return allFromMarketplace;
+	}
+
+	protected createQuickPickItem(languageItem: { locale: string; label?: string | undefined }): IQuickPickItem {
+		const label = languageItem.label ?? languageItem.locale;
+		let description: string | undefined = languageItem.locale !== languageItem.label ? languageItem.locale : undefined;
+		if (languageItem.locale.toLowerCase() === language.toLowerCase()) {
+			if (!description) {
+				description = '';
+			}
+			description += localize('currentDisplayLanguage', " (Current)");
+		}
+		return {
+			id: languageItem.locale,
+			label,
+			description
+		};
+	}
+}

--- a/src/vs/platform/languagePacks/node/languagePackService.ts
+++ b/src/vs/platform/languagePacks/node/languagePackService.ts
@@ -4,21 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createHash } from 'crypto';
-import { distinct, equals } from 'vs/base/common/arrays';
+import { equals } from 'vs/base/common/arrays';
 import { Queue } from 'vs/base/common/async';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { join } from 'vs/base/common/path';
 import { Promises } from 'vs/base/node/pfs';
 import { INativeEnvironmentService } from 'vs/platform/environment/common/environment';
-import { IExtensionIdentifier, IExtensionManagementService, ILocalExtension } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IExtensionGalleryService, IExtensionIdentifier, IExtensionManagementService, ILocalExtension } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
-import { ILocalizationContribution } from 'vs/platform/extensions/common/extensions';
-import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
 import { ILogService } from 'vs/platform/log/common/log';
+import { ILocalizationContribution } from 'vs/platform/extensions/common/extensions';
+import { ILanguagePackItem, LanguagePackBaseService } from 'vs/platform/languagePacks/common/languagePack';
 
 interface ILanguagePack {
 	hash: string;
+	label: string | undefined;
 	extensions: {
 		extensionIdentifier: IExtensionIdentifier;
 		version: string;
@@ -26,7 +27,7 @@ interface ILanguagePack {
 	translations: { [id: string]: string };
 }
 
-export class LanguagePackService extends Disposable implements ILanguagePackService {
+export class NativeLanguagePackService extends LanguagePackBaseService {
 
 	declare readonly _serviceBrand: undefined;
 
@@ -35,9 +36,10 @@ export class LanguagePackService extends Disposable implements ILanguagePackServ
 	constructor(
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
 		@INativeEnvironmentService environmentService: INativeEnvironmentService,
+		@IExtensionGalleryService extensionGalleryService: IExtensionGalleryService,
 		@ILogService private readonly logService: ILogService
 	) {
-		super();
+		super(extensionGalleryService);
 		this.cache = this._register(new LanguagePacksCache(environmentService, logService));
 		this.extensionManagementService.registerParticipant({
 			postInstall: async (extension: ILocalExtension): Promise<void> => {
@@ -49,11 +51,21 @@ export class LanguagePackService extends Disposable implements ILanguagePackServ
 		});
 	}
 
-	async getInstalledLanguages(): Promise<string[]> {
+	async getInstalledLanguages(): Promise<Array<ILanguagePackItem>> {
 		const languagePacks = await this.cache.getLanguagePacks();
-		// Contributed languages are those installed via extension packs, so does not include English
-		const languages = ['en', ...Object.keys(languagePacks)];
-		return distinct(languages);
+		const languages = Object.keys(languagePacks).map(locale => {
+			const languagePack = languagePacks[locale];
+			const baseQuickPick = this.createQuickPickItem({ locale, label: languagePack.label });
+			return {
+				...baseQuickPick,
+				extensionId: languagePack.extensions[0].extensionIdentifier.id,
+			};
+		});
+		languages.push({
+			...this.createQuickPickItem({ locale: 'en', label: 'English' }),
+			extensionId: 'default',
+		});
+		return languages;
 	}
 
 	private async postInstallExtension(extension: ILocalExtension): Promise<void> {
@@ -126,7 +138,12 @@ class LanguagePacksCache extends Disposable {
 			if (extension.location.scheme === Schemas.file && isValidLocalization(localizationContribution)) {
 				let languagePack = languagePacks[localizationContribution.languageId];
 				if (!languagePack) {
-					languagePack = { hash: '', extensions: [], translations: {} };
+					languagePack = {
+						hash: '',
+						extensions: [],
+						translations: {},
+						label: localizationContribution.localizedLanguageName ?? localizationContribution.languageName
+					};
 					languagePacks[localizationContribution.languageId] = languagePack;
 				}
 				let extensionInLanguagePack = languagePack.extensions.filter(e => areSameExtensions(e.extensionIdentifier, extensionIdentifier))[0];

--- a/src/vs/server/node/remoteExtensionHostAgentCli.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentCli.ts
@@ -28,8 +28,8 @@ import { SpdLogLogger } from 'vs/platform/log/node/spdlogLog';
 import { RemoteExtensionLogFileName } from 'vs/workbench/services/remote/common/remoteAgentService';
 import { IServerEnvironmentService, ServerEnvironmentService, ServerParsedArgs } from 'vs/server/node/serverEnvironmentService';
 import { ExtensionManagementCLIService } from 'vs/platform/extensionManagement/common/extensionManagementCLIService';
-import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { LanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
+import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePack';
+import { NativeLanguagePackService } from 'vs/platform/languagePacks/node/languagePackService';
 import { getErrorMessage } from 'vs/base/common/errors';
 import { URI } from 'vs/base/common/uri';
 import { isAbsolute, join } from 'vs/base/common/path';
@@ -104,7 +104,7 @@ class CliMain extends Disposable {
 		services.set(IExtensionsScannerService, new SyncDescriptor(ExtensionsScannerService));
 		services.set(IExtensionManagementService, new SyncDescriptor(ExtensionManagementService));
 		services.set(IExtensionManagementCLIService, new SyncDescriptor(ExtensionManagementCLIService));
-		services.set(ILanguagePackService, new SyncDescriptor(LanguagePackService));
+		services.set(ILanguagePackService, new SyncDescriptor(NativeLanguagePackService));
 
 		return new InstantiationService(services);
 	}

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -35,8 +35,8 @@ import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
-import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { LanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
+import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePack';
+import { NativeLanguagePackService } from 'vs/platform/languagePacks/node/languagePackService';
 import { AbstractLogger, DEFAULT_LOG_LEVEL, getLogLevel, ILogService, LogLevel, LogService, MultiplexLogService } from 'vs/platform/log/common/log';
 import { LogLevelChannel } from 'vs/platform/log/common/logIpc';
 import { SpdLogLogger } from 'vs/platform/log/node/spdlogLog';
@@ -159,7 +159,7 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	services.set(IExtensionManagementService, new SyncDescriptor(ExtensionManagementService));
 
 	const instantiationService: IInstantiationService = new InstantiationService(services);
-	services.set(ILanguagePackService, instantiationService.createInstance(LanguagePackService));
+	services.set(ILanguagePackService, instantiationService.createInstance(NativeLanguagePackService));
 
 	const extensionManagementCLIService = instantiationService.createInstance(ExtensionManagementCLIService);
 	services.set(IExtensionManagementCLIService, extensionManagementCLIService);

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -320,10 +320,15 @@ export class WebClientServer {
 			callbackRoute: this._callbackRoute
 		};
 
+		let nlsBaseUrl = this._productService.extensionsGallery?.nlsBaseUrl;
+		if (!nlsBaseUrl?.endsWith('/')) {
+			nlsBaseUrl += '/';
+		}
 		const values: { [key: string]: string } = {
 			WORKBENCH_WEB_CONFIGURATION: asJSON(workbenchWebConfiguration),
 			WORKBENCH_AUTH_SESSION: authSessionInfo ? asJSON(authSessionInfo) : '',
 			WORKBENCH_WEB_BASE_URL: this._staticRoute,
+			WORKBENCH_NLS_BASE_URL: nlsBaseUrl ? `${nlsBaseUrl}${this._productService.commit}/${this._productService.version}/` : '',
 		};
 
 
@@ -340,7 +345,7 @@ export class WebClientServer {
 			'default-src \'self\';',
 			'img-src \'self\' https: data: blob:;',
 			'media-src \'self\';',
-			`script-src 'self' 'unsafe-eval' ${this._getScriptCspHashes(data).join(' ')} 'sha256-fh3TwPMflhsEIpR8g1OYTIMVWhXTLcjQ9kh2tIpmv54=' http://${remoteAuthority};`, // the sha is the same as in src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+			`script-src 'self' 'unsafe-eval' ${this._getScriptCspHashes(data).join(' ')} 'sha256-fh3TwPMflhsEIpR8g1OYTIMVWhXTLcjQ9kh2tIpmv54=' http://${remoteAuthority} ${nlsBaseUrl ?? ''};`, // the sha is the same as in src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 			'child-src \'self\';',
 			`frame-src 'self' https://*.vscode-cdn.net data:;`,
 			'worker-src \'self\' data:;',

--- a/src/vs/workbench/contrib/localization/browser/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/browser/localization.contribution.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerAction2 } from 'vs/platform/actions/common/actions';
+import { ClearDisplayLanguageAction, ConfigureDisplayLanguageAction } from 'vs/workbench/contrib/localization/browser/localizationsActions';
+
+// Register action to configure locale and related settings
+registerAction2(ConfigureDisplayLanguageAction);
+registerAction2(ClearDisplayLanguageAction);

--- a/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
@@ -4,88 +4,158 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { IEnvironmentService } from 'vs/platform/environment/common/environment';
-import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
-import { IJSONEditingService } from 'vs/workbench/services/configuration/common/jsonEditing';
+import { IQuickInputService, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
-import { INotificationService } from 'vs/platform/notification/common/notification';
-import { language } from 'vs/base/common/platform';
-import { IExtensionsViewPaneContainer, VIEWLET_ID as EXTENSIONS_VIEWLET_ID } from 'vs/workbench/contrib/extensions/common/extensions';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IProductService } from 'vs/platform/product/common/productService';
-import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
-import { ViewContainerLocation } from 'vs/workbench/common/views';
+import { CancellationTokenSource } from 'vs/base/common/cancellation';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { Action2, MenuId } from 'vs/platform/actions/common/actions';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { ILanguagePackItem, ILanguagePackService } from 'vs/platform/languagePacks/common/languagePack';
+import { ILocaleService } from 'vs/workbench/services/localization/common/locale';
+import { IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
+import { IExtensionsViewPaneContainer, VIEWLET_ID as EXTENSIONS_VIEWLET_ID } from 'vs/workbench/contrib/extensions/common/extensions';
+import { ViewContainerLocation } from 'vs/workbench/common/views';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { isWeb } from 'vs/base/common/platform';
 
-export class ConfigureLocaleAction extends Action2 {
+const restart = localize('restart', "&&Restart");
+
+export class ConfigureDisplayLanguageAction extends Action2 {
+	public static readonly ID = 'workbench.action.configureLocale';
+	public static readonly LABEL = localize('configureLocale', "Configure Display Language");
+
 	constructor() {
 		super({
-			id: 'workbench.action.configureLocale',
-			title: { original: 'Configure Display Language', value: localize('configureLocale', "Configure Display Language") },
+			id: ConfigureDisplayLanguageAction.ID,
+			title: { original: 'Configure Display Language', value: ConfigureDisplayLanguageAction.LABEL },
 			menu: {
 				id: MenuId.CommandPalette
 			}
 		});
 	}
 
-	private async getLanguageOptions(localizationService: ILanguagePackService): Promise<IQuickPickItem[]> {
-		const availableLanguages = await localizationService.getInstalledLanguages();
-		availableLanguages.sort();
-
-		return availableLanguages
-			.map(language => { return { label: language }; })
-			.concat({ label: localize('installAdditionalLanguages', "Install Additional Languages...") });
-	}
-
-	public override async run(accessor: ServicesAccessor): Promise<void> {
-		const environmentService: IEnvironmentService = accessor.get(IEnvironmentService);
-		const languagePackService: ILanguagePackService = accessor.get(ILanguagePackService);
+	public async run(accessor: ServicesAccessor): Promise<void> {
+		const languagePackSerivce: ILanguagePackService = accessor.get(ILanguagePackService);
 		const quickInputService: IQuickInputService = accessor.get(IQuickInputService);
-		const jsonEditingService: IJSONEditingService = accessor.get(IJSONEditingService);
 		const hostService: IHostService = accessor.get(IHostService);
-		const notificationService: INotificationService = accessor.get(INotificationService);
-		const paneCompositeService: IPaneCompositePartService = accessor.get(IPaneCompositePartService);
 		const dialogService: IDialogService = accessor.get(IDialogService);
 		const productService: IProductService = accessor.get(IProductService);
+		const localeService: ILocaleService = accessor.get(ILocaleService);
+		const extensionManagementService: IExtensionManagementService = accessor.get(IExtensionManagementService);
+		const paneCompositePartService: IPaneCompositePartService = accessor.get(IPaneCompositePartService);
+		const notificationService: INotificationService = accessor.get(INotificationService);
 
-		const languageOptions = await this.getLanguageOptions(languagePackService);
-		const currentLanguageIndex = languageOptions.findIndex(l => l.label === language);
+		const installedLanguages = await languagePackSerivce.getInstalledLanguages();
 
-		try {
-			const selectedLanguage = await quickInputService.pick(languageOptions,
-				{
-					canPickMany: false,
-					placeHolder: localize('chooseDisplayLanguage', "Select Display Language"),
-					activeItem: languageOptions[currentLanguageIndex]
-				});
+		const qp = quickInputService.createQuickPick<ILanguagePackItem>();
+		qp.placeholder = localize('chooseLocale', "Select Display Language");
 
-			if (selectedLanguage === languageOptions[languageOptions.length - 1]) {
-				return paneCompositeService.openPaneComposite(EXTENSIONS_VIEWLET_ID, ViewContainerLocation.Sidebar, true)
-					.then(viewlet => viewlet?.getViewPaneContainer())
-					.then(viewlet => {
-						const extensionsViewlet = viewlet as IExtensionsViewPaneContainer;
-						extensionsViewlet.search('@category:"language packs"');
-						extensionsViewlet.focus();
-					});
+		if (installedLanguages?.length) {
+			const items: Array<ILanguagePackItem | IQuickPickSeparator> = [{ type: 'separator', label: 'Installed languages' /*localize('installed', "Installed languages")*/ }];
+			qp.items = items.concat(installedLanguages);
+		}
+
+		const disposables = new DisposableStore();
+		const source = new CancellationTokenSource();
+		disposables.add(qp.onDispose(() => {
+			source.cancel();
+			disposables.dispose();
+		}));
+
+		const installedSet = new Set<string>(installedLanguages?.map(language => language.id!) ?? []);
+		languagePackSerivce.getAvailableLanguages().then(availableLanguages => {
+			const newLanguages = availableLanguages.filter(l => l.id && !installedSet.has(l.id));
+			if (newLanguages.length) {
+				qp.items = [
+					...qp.items,
+					{ type: 'separator', label: localize('available', "Available languages") },
+					...newLanguages
+				];
+			}
+			qp.busy = false;
+		});
+
+		disposables.add(qp.onDidAccept(async () => {
+			const selectedLanguage = qp.activeItems[0];
+			qp.hide();
+
+			if (
+				// Only Desktop has the concept of installing language packs so we only do this for Desktop
+				!isWeb &&
+				// Only if the language pack is not installed
+				!(await extensionManagementService.getInstalled()).find(e => e.identifier.id === selectedLanguage.extensionId)
+			) {
+				// install language pack
+				try {
+					let viewlet = await paneCompositePartService.openPaneComposite(EXTENSIONS_VIEWLET_ID, ViewContainerLocation.Sidebar);
+					(viewlet?.getViewPaneContainer() as IExtensionsViewPaneContainer).search(`@id:${selectedLanguage.extensionId}`);
+
+					// Only actually install a language pack from Microsoft
+					if (selectedLanguage.galleryExtension?.publisher.toLowerCase() !== 'ms-ceintl') {
+						return;
+					}
+
+					await extensionManagementService.installFromGallery(selectedLanguage.galleryExtension);
+				} catch (err) {
+					notificationService.error(err);
+					return;
+				}
 			}
 
-			if (selectedLanguage) {
-				await jsonEditingService.write(environmentService.argvResource, [{ path: ['locale'], value: selectedLanguage.label }], true);
-				const restart = await dialogService.confirm({
+			if (await localeService.setLocale(selectedLanguage.id!)) {
+				const restartDialog = await dialogService.confirm({
 					type: 'info',
 					message: localize('relaunchDisplayLanguageMessage', "A restart is required for the change in display language to take effect."),
 					detail: localize('relaunchDisplayLanguageDetail', "Press the restart button to restart {0} and change the display language.", productService.nameLong),
-					primaryButton: localize('restart', "&&Restart")
+					primaryButton: restart
 				});
 
-				if (restart.confirmed) {
+				if (restartDialog.confirmed) {
 					hostService.restart();
 				}
 			}
-		} catch (e) {
-			notificationService.error(e);
+		}));
+
+		qp.show();
+		qp.busy = true;
+	}
+}
+
+export class ClearDisplayLanguageAction extends Action2 {
+	public static readonly ID = 'workbench.action.clearLocalePreference';
+	public static readonly LABEL = localize('clearDisplayLanguage', "Clear Display Language Preference");
+
+	constructor() {
+		super({
+			id: ClearDisplayLanguageAction.ID,
+			title: { original: 'Clear Display Language Preference', value: ClearDisplayLanguageAction.LABEL },
+			menu: {
+				id: MenuId.CommandPalette
+			}
+		});
+	}
+
+	public async run(accessor: ServicesAccessor): Promise<void> {
+		const localeService: ILocaleService = accessor.get(ILocaleService);
+		const dialogService: IDialogService = accessor.get(IDialogService);
+		const productService: IProductService = accessor.get(IProductService);
+		const hostService: IHostService = accessor.get(IHostService);
+
+		if (await localeService.setLocale(undefined)) {
+			const restartDialog = await dialogService.confirm({
+				type: 'info',
+				message: localize('relaunchAfterClearDisplayLanguageMessage', "A restart is required for the change in display language to take effect."),
+				detail: localize('relaunchAfterClearDisplayLanguageDetail', "Press the restart button to restart {0} and change the display language.", productService.nameLong),
+				primaryButton: restart
+			});
+
+			if (restartDialog.confirmed) {
+				hostService.restart();
+			}
 		}
+
 	}
 }

--- a/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
@@ -23,11 +23,6 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
 import { ViewContainerLocation } from 'vs/workbench/common/views';
-import { registerAction2 } from 'vs/platform/actions/common/actions';
-import { ConfigureLocaleAction } from 'vs/workbench/contrib/localization/browser/localizationsActions';
-
-// Register action to configure locale and related settings
-registerAction2(ConfigureLocaleAction);
 
 const LANGUAGEPACK_SUGGESTION_IGNORE_STORAGE_KEY = 'extensionsAssistant/languagePackSuggestionIgnore';
 

--- a/src/vs/workbench/services/localization/browser/localeService.ts
+++ b/src/vs/workbench/services/localization/browser/localeService.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { language } from 'vs/base/common/platform';
+import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { ILocaleService } from 'vs/workbench/services/localization/common/locale';
+
+export class WebLocaleService implements ILocaleService {
+	_serviceBrand: undefined;
+
+	setLocale(locale: string | undefined): Promise<boolean> {
+		if (locale === language || (!locale && language === navigator.language)) {
+			return Promise.resolve(false);
+		}
+
+		if (locale) {
+			window.localStorage.setItem('vscode.nls.configuration.language', locale);
+		} else {
+			window.localStorage.removeItem('vscode.nls.configuration.language');
+		}
+		return Promise.resolve(true);
+	}
+}
+
+registerSingleton(ILocaleService, WebLocaleService, true);

--- a/src/vs/workbench/services/localization/common/locale.ts
+++ b/src/vs/workbench/services/localization/common/locale.ts
@@ -5,8 +5,9 @@
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
-export const ILanguagePackService = createDecorator<ILanguagePackService>('languagePackService');
-export interface ILanguagePackService {
+export const ILocaleService = createDecorator<ILocaleService>('localizationService');
+
+export interface ILocaleService {
 	readonly _serviceBrand: undefined;
-	getInstalledLanguages(): Promise<string[]>;
+	setLocale(languagePackItem: string | undefined): Promise<boolean>;
 }

--- a/src/vs/workbench/services/localization/electron-sandbox/languagePackService.ts
+++ b/src/vs/workbench/services/localization/electron-sandbox/languagePackService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
+import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePack';
 import { registerSharedProcessRemoteService } from 'vs/platform/ipc/electron-sandbox/services';
 
 registerSharedProcessRemoteService(ILanguagePackService, 'languagePacks', { supportsDelayedInstantiation: true });

--- a/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
+++ b/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { language } from 'vs/base/common/platform';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IJSONEditingService } from 'vs/workbench/services/configuration/common/jsonEditing';
+import { ILocaleService } from 'vs/workbench/services/localization/common/locale';
+
+export class NativeLocaleService implements ILocaleService {
+	_serviceBrand: undefined;
+
+	constructor(
+		@IJSONEditingService private readonly jsonEditingService: IJSONEditingService,
+		@IEnvironmentService private readonly environmentService: IEnvironmentService,
+		@INotificationService private readonly notificationService: INotificationService,
+	) { }
+
+	async setLocale(locale: string | undefined): Promise<boolean> {
+		try {
+			if (locale === language || (!locale && (language === 'en' || language === 'en-US'))) {
+				return false;
+			}
+			await this.jsonEditingService.write(this.environmentService.argvResource, [{ path: ['locale'], value: locale }], true);
+			return true;
+		} catch (err) {
+			this.notificationService.error(err);
+			return false;
+		}
+	}
+}
+
+registerSingleton(ILocaleService, NativeLocaleService, true);

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -98,6 +98,7 @@ import 'vs/workbench/services/assignment/common/assignmentService';
 import 'vs/workbench/services/outline/browser/outlineService';
 import 'vs/workbench/services/languageDetection/browser/languageDetectionWorkerServiceImpl';
 import 'vs/editor/common/services/languageFeaturesService';
+import 'vs/workbench/services/localization/browser/localeService';
 
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionGalleryService';
@@ -170,6 +171,9 @@ import 'vs/workbench/contrib/interactive/browser/interactive.contribution';
 
 // Testing
 import 'vs/workbench/contrib/testing/browser/testing.contribution';
+
+// Localizations
+import 'vs/workbench/contrib/localization/browser/localization.contribution';
 
 // Logs
 import 'vs/workbench/contrib/logs/common/logs.contribution';

--- a/src/vs/workbench/workbench.sandbox.main.ts
+++ b/src/vs/workbench/workbench.sandbox.main.ts
@@ -59,6 +59,7 @@ import 'vs/workbench/services/extensionManagement/electron-sandbox/extensionUrlT
 import 'vs/workbench/services/credentials/electron-sandbox/credentialsService';
 import 'vs/workbench/services/encryption/electron-sandbox/encryptionService';
 import 'vs/workbench/services/localization/electron-sandbox/languagePackService';
+import 'vs/workbench/services/localization/electron-sandbox/localeService';
 import 'vs/workbench/services/telemetry/electron-sandbox/telemetryService';
 import 'vs/workbench/services/extensions/electron-sandbox/extensionHostStarter';
 import 'vs/platform/extensionManagement/electron-sandbox/extensionsScannerService';

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -87,6 +87,8 @@ import { ITitleService } from 'vs/workbench/services/title/common/titleService';
 import { TitlebarPart } from 'vs/workbench/browser/parts/titlebar/titlebarPart';
 import { ITimerService, TimerService } from 'vs/workbench/services/timer/browser/timerService';
 import { IDiagnosticsService, NullDiagnosticsService } from 'vs/platform/diagnostics/common/diagnostics';
+import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePack';
+import { WebLanguagePackService } from 'vs/platform/languagePacks/browser/languagePackService';
 
 registerSingleton(IWorkbenchExtensionManagementService, ExtensionManagementService);
 registerSingleton(IAccessibilityService, AccessibilityService, true);
@@ -103,6 +105,7 @@ registerSingleton(IExtensionTipsService, ExtensionTipsService);
 registerSingleton(ITimerService, TimerService);
 registerSingleton(ICustomEndpointTelemetryService, NullEndpointTelemetryService, true);
 registerSingleton(IDiagnosticsService, NullDiagnosticsService, true);
+registerSingleton(ILanguagePackService, WebLanguagePackService);
 
 //#endregion
 


### PR DESCRIPTION
This is a doosy unfortunately due to many many many layering problems that required more and more refactoring. At a high level, this does 4 things:

#### Server distro

The 3rd commit enables server distro to use the new `baseUrl` configuration of the `nlsLoader` so that if `nlsBaseUrl` is defined in a product.json, you can get translations for core strings similar to how insiders.vscode.dev works today.


https://user-images.githubusercontent.com/2644648/170383888-c6efc558-9ef8-4fa4-802b-592653990349.mp4

#### Revamp `Configure Display Language`

This command use to only let you switch between installed language packs on desktop... and the quick pick would only show the locale:
![image](https://user-images.githubusercontent.com/2644648/170382996-0c45f9b9-4ae2-4f74-b346-8c71e857f20e.png)

This PR revamps that command so that languages (the quick pick items) are displayed in their native language and a new section called "Additional languages" is there if you want to install a language pack. Here's what that looks like:

https://user-images.githubusercontent.com/2644648/170383150-a2f412ce-8623-48da-8b44-8a00c1abb4a1.mp4

In the video you can see it show the extensions pane, install the language pack (if the language pack is owned by Microsoft - detail in the code), update the locale (in Desktop's case via runtime args), and show a dialog to reload the window.

#### Browser implementation

This PR also provides a Browser implementation of the `Configure Display Language` command which uses locale storage to update the locale:

https://user-images.githubusercontent.com/2644648/170383874-130859dc-2663-4eab-a2d0-5326d0525d5a.mp4

#### Add a `Clear Display Language Preference` command

A less important command but all this does is clears whatever value is stored


### Follow up

* Update product.json with a value for `nlsBaseUrl`
* Update vscode.dev to honor this localStorage update