### PR TITLE
Fix process.platform for picomatch

### DIFF
--- a/extensions/shared.webpack.config.js
+++ b/extensions/shared.webpack.config.js
@@ -151,6 +151,7 @@ const browserPlugins = [
 		]
 	}),
 	new DefinePlugin({
+		'process.platform': JSON.stringify('web'),
 		'process.env': JSON.stringify({}),
 		'process.env.BROWSER_ENV': JSON.stringify('true')
 	})


### PR DESCRIPTION
The `picomatch` library currently checks `process.platform` to see if they are running on windows. This check fails on web, which causes the markdown extension to not load

To fix this, I'm replacing `process.platform` with the string`'web'`

