### PR TITLE
improve configure display language & add clear display language preference

### DIFF
--- a/src/vs/code/electron-browser/sharedProcess/contrib/localizationsUpdater.ts
+++ b/src/vs/code/electron-browser/sharedProcess/contrib/localizationsUpdater.ts
@@ -5,12 +5,12 @@
 
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { LanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
+import { NativeLanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
 
 export class LocalizationsUpdater extends Disposable {
 
 	constructor(
-		@ILanguagePackService private readonly localizationsService: LanguagePackService
+		@ILanguagePackService private readonly localizationsService: NativeLanguagePackService
 	) {
 		super();
 

--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -47,7 +47,7 @@ import { ServiceCollection } from 'vs/platform/instantiation/common/serviceColle
 import { MessagePortMainProcessService } from 'vs/platform/ipc/electron-browser/mainProcessService';
 import { IMainProcessService } from 'vs/platform/ipc/electron-sandbox/services';
 import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { LanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
+import { NativeLanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
 import { ConsoleLogger, ILoggerService, ILogService, MultiplexLogService } from 'vs/platform/log/common/log';
 import { FollowerLogService, LoggerChannelClient, LogLevelChannelClient } from 'vs/platform/log/common/logIpc';
 import { INativeHostService } from 'vs/platform/native/electron-sandbox/native';
@@ -311,7 +311,7 @@ class SharedProcessMain extends Disposable {
 		services.set(IExtensionTipsService, new SyncDescriptor(ExtensionTipsService));
 
 		// Localizations
-		services.set(ILanguagePackService, new SyncDescriptor(LanguagePackService));
+		services.set(ILanguagePackService, new SyncDescriptor(NativeLanguagePackService));
 
 		// Diagnostics
 		services.set(IDiagnosticsService, new SyncDescriptor(DiagnosticsService));

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -37,7 +37,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { LanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
+import { NativeLanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
 import { ConsoleLogger, getLogLevel, ILogger, ILogService, LogLevel, MultiplexLogService } from 'vs/platform/log/common/log';
 import { SpdLogLogger } from 'vs/platform/log/node/spdlogLog';
 import { FilePolicyService } from 'vs/platform/policy/common/filePolicyService';
@@ -161,7 +161,7 @@ class CliMain extends Disposable {
 		services.set(IExtensionManagementCLIService, new SyncDescriptor(ExtensionManagementCLIService));
 
 		// Localizations
-		services.set(ILanguagePackService, new SyncDescriptor(LanguagePackService));
+		services.set(ILanguagePackService, new SyncDescriptor(NativeLanguagePackService));
 
 		// Telemetry
 		const appenders: AppInsightsAppender[] = [];

--- a/src/vs/platform/languagePacks/common/languagePacks.ts
+++ b/src/vs/platform/languagePacks/common/languagePacks.ts
@@ -3,10 +3,84 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationTokenSource } from 'vs/base/common/cancellation';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { language } from 'vs/base/common/platform';
+import { IQuickPickItem } from 'vs/base/parts/quickinput/common/quickInput';
+import { localize } from 'vs/nls';
+import { IExtensionGalleryService, IGalleryExtension } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
 export const ILanguagePackService = createDecorator<ILanguagePackService>('languagePackService');
+
+export interface ILanguagePackItem extends IQuickPickItem {
+	readonly extensionId: string;
+	readonly galleryExtension?: IGalleryExtension;
+}
+
 export interface ILanguagePackService {
 	readonly _serviceBrand: undefined;
-	getInstalledLanguages(): Promise<string[]>;
+	getAvailableLanguages(): Promise<Array<ILanguagePackItem>>;
+	getInstalledLanguages(): Promise<Array<ILanguagePackItem>>;
+}
+
+export abstract class LanguagePackBaseService extends Disposable implements ILanguagePackService {
+	_serviceBrand: undefined;
+
+	constructor(@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService) {
+		super();
+	}
+
+	abstract getInstalledLanguages(): Promise<Array<ILanguagePackItem>>;
+
+	async getAvailableLanguages(): Promise<ILanguagePackItem[]> {
+		const timeout = new CancellationTokenSource();
+		setTimeout(() => timeout.cancel(), 1000);
+
+		let result;
+		try {
+			result = await this.extensionGalleryService.query({
+				text: 'category:"language packs"',
+				pageSize: 20
+			}, timeout.token);
+		} catch (_) {
+			// This method is best effort. So, we ignore any errors.
+			return [];
+		}
+
+		const languagePackExtensions = result.firstPage.filter(e => e.properties.localizedLanguages?.length && e.tags.some(t => t.startsWith('lp-')));
+		const allFromMarketplace: ILanguagePackItem[] = languagePackExtensions.map(lp => {
+			const languageName = lp.properties.localizedLanguages?.[0];
+			const locale = lp.tags.find(t => t.startsWith('lp-'))!.split('lp-')[1];
+			const baseQuickPick = this.createQuickPickItem({ locale, label: languageName });
+			return {
+				...baseQuickPick,
+				extensionId: lp.identifier.id,
+				galleryExtension: lp
+			};
+		});
+
+		allFromMarketplace.push({
+			...this.createQuickPickItem({ locale: 'en', label: 'English' }),
+			extensionId: 'default',
+		});
+
+		return allFromMarketplace;
+	}
+
+	protected createQuickPickItem(languageItem: { locale: string; label?: string | undefined }): IQuickPickItem {
+		const label = languageItem.label ?? languageItem.locale;
+		let description: string | undefined = languageItem.locale !== languageItem.label ? languageItem.locale : undefined;
+		if (languageItem.locale.toLowerCase() === language.toLowerCase()) {
+			if (!description) {
+				description = '';
+			}
+			description += localize('currentDisplayLanguage', " (Current)");
+		}
+		return {
+			id: languageItem.locale,
+			label,
+			description
+		};
+	}
 }

--- a/src/vs/server/node/remoteExtensionHostAgentCli.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentCli.ts
@@ -29,7 +29,7 @@ import { RemoteExtensionLogFileName } from 'vs/workbench/services/remote/common/
 import { IServerEnvironmentService, ServerEnvironmentService, ServerParsedArgs } from 'vs/server/node/serverEnvironmentService';
 import { ExtensionManagementCLIService } from 'vs/platform/extensionManagement/common/extensionManagementCLIService';
 import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { LanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
+import { NativeLanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
 import { getErrorMessage } from 'vs/base/common/errors';
 import { URI } from 'vs/base/common/uri';
 import { isAbsolute, join } from 'vs/base/common/path';
@@ -104,7 +104,7 @@ class CliMain extends Disposable {
 		services.set(IExtensionsScannerService, new SyncDescriptor(ExtensionsScannerService));
 		services.set(IExtensionManagementService, new SyncDescriptor(ExtensionManagementService));
 		services.set(IExtensionManagementCLIService, new SyncDescriptor(ExtensionManagementCLIService));
-		services.set(ILanguagePackService, new SyncDescriptor(LanguagePackService));
+		services.set(ILanguagePackService, new SyncDescriptor(NativeLanguagePackService));
 
 		return new InstantiationService(services);
 	}

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -36,7 +36,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { LanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
+import { NativeLanguagePackService } from 'vs/platform/languagePacks/node/languagePacks';
 import { AbstractLogger, DEFAULT_LOG_LEVEL, getLogLevel, ILogService, LogLevel, LogService, MultiplexLogService } from 'vs/platform/log/common/log';
 import { LogLevelChannel } from 'vs/platform/log/common/logIpc';
 import { SpdLogLogger } from 'vs/platform/log/node/spdlogLog';
@@ -159,7 +159,7 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	services.set(IExtensionManagementService, new SyncDescriptor(ExtensionManagementService));
 
 	const instantiationService: IInstantiationService = new InstantiationService(services);
-	services.set(ILanguagePackService, instantiationService.createInstance(LanguagePackService));
+	services.set(ILanguagePackService, instantiationService.createInstance(NativeLanguagePackService));
 
 	const extensionManagementCLIService = instantiationService.createInstance(ExtensionManagementCLIService);
 	services.set(IExtensionManagementCLIService, extensionManagementCLIService);

--- a/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
@@ -82,14 +82,11 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 			const selectedLanguage = qp.activeItems[0];
 			qp.hide();
 
-			if (
-				// Only Desktop has the concept of installing language packs so we only do this for Desktop
-				!isWeb &&
-				// Only if the language pack is not installed
-				!(await extensionManagementService.getInstalled()).find(e => e.identifier.id === selectedLanguage.extensionId)
-			) {
-				// install language pack
+			// Only Desktop has the concept of installing language packs so we only do this for Desktop
+			// and only if the language pack is not installed
+			if (!isWeb && !installedSet.has(selectedLanguage.id!)) {
 				try {
+					// Show the view so the user can see the language pack to be installed
 					let viewlet = await paneCompositePartService.openPaneComposite(EXTENSIONS_VIEWLET_ID, ViewContainerLocation.Sidebar);
 					(viewlet?.getViewPaneContainer() as IExtensionsViewPaneContainer).search(`@id:${selectedLanguage.extensionId}`);
 

--- a/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
@@ -54,7 +54,7 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 		qp.placeholder = localize('chooseLocale', "Select Display Language");
 
 		if (installedLanguages?.length) {
-			const items: Array<ILanguagePackItem | IQuickPickSeparator> = [{ type: 'separator', label: 'Installed languages' /*localize('installed', "Installed languages")*/ }];
+			const items: Array<ILanguagePackItem | IQuickPickSeparator> = [{ type: 'separator', label: localize('installed', "Installed languages") }];
 			qp.items = items.concat(installedLanguages);
 		}
 

--- a/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
@@ -4,88 +4,157 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { IEnvironmentService } from 'vs/platform/environment/common/environment';
-import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
-import { IJSONEditingService } from 'vs/workbench/services/configuration/common/jsonEditing';
+import { IQuickInputService, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
-import { INotificationService } from 'vs/platform/notification/common/notification';
-import { language } from 'vs/base/common/platform';
-import { IExtensionsViewPaneContainer, VIEWLET_ID as EXTENSIONS_VIEWLET_ID } from 'vs/workbench/contrib/extensions/common/extensions';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IProductService } from 'vs/platform/product/common/productService';
-import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
-import { ViewContainerLocation } from 'vs/workbench/common/views';
+import { CancellationTokenSource } from 'vs/base/common/cancellation';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { Action2, MenuId } from 'vs/platform/actions/common/actions';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { ILanguagePackItem, ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
+import { ILocaleService } from 'vs/workbench/services/localization/common/locale';
+import { IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
+import { IExtensionsViewPaneContainer, VIEWLET_ID as EXTENSIONS_VIEWLET_ID } from 'vs/workbench/contrib/extensions/common/extensions';
+import { ViewContainerLocation } from 'vs/workbench/common/views';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { isWeb } from 'vs/base/common/platform';
 
-export class ConfigureLocaleAction extends Action2 {
+const restart = localize('restart', "&&Restart");
+
+export class ConfigureDisplayLanguageAction extends Action2 {
+	public static readonly ID = 'workbench.action.configureLocale';
+	public static readonly LABEL = localize('configureLocale', "Configure Display Language");
+
 	constructor() {
 		super({
-			id: 'workbench.action.configureLocale',
-			title: { original: 'Configure Display Language', value: localize('configureLocale', "Configure Display Language") },
+			id: ConfigureDisplayLanguageAction.ID,
+			title: { original: 'Configure Display Language', value: ConfigureDisplayLanguageAction.LABEL },
 			menu: {
 				id: MenuId.CommandPalette
 			}
 		});
 	}
 
-	private async getLanguageOptions(localizationService: ILanguagePackService): Promise<IQuickPickItem[]> {
-		const availableLanguages = await localizationService.getInstalledLanguages();
-		availableLanguages.sort();
-
-		return availableLanguages
-			.map(language => { return { label: language }; })
-			.concat({ label: localize('installAdditionalLanguages', "Install Additional Languages...") });
-	}
-
-	public override async run(accessor: ServicesAccessor): Promise<void> {
-		const environmentService: IEnvironmentService = accessor.get(IEnvironmentService);
+	public async run(accessor: ServicesAccessor): Promise<void> {
 		const languagePackService: ILanguagePackService = accessor.get(ILanguagePackService);
 		const quickInputService: IQuickInputService = accessor.get(IQuickInputService);
-		const jsonEditingService: IJSONEditingService = accessor.get(IJSONEditingService);
 		const hostService: IHostService = accessor.get(IHostService);
-		const notificationService: INotificationService = accessor.get(INotificationService);
-		const paneCompositeService: IPaneCompositePartService = accessor.get(IPaneCompositePartService);
 		const dialogService: IDialogService = accessor.get(IDialogService);
 		const productService: IProductService = accessor.get(IProductService);
+		const localeService: ILocaleService = accessor.get(ILocaleService);
+		const extensionManagementService: IExtensionManagementService = accessor.get(IExtensionManagementService);
+		const paneCompositePartService: IPaneCompositePartService = accessor.get(IPaneCompositePartService);
+		const notificationService: INotificationService = accessor.get(INotificationService);
 
-		const languageOptions = await this.getLanguageOptions(languagePackService);
-		const currentLanguageIndex = languageOptions.findIndex(l => l.label === language);
+		const installedLanguages = await languagePackService.getInstalledLanguages();
 
-		try {
-			const selectedLanguage = await quickInputService.pick(languageOptions,
-				{
-					canPickMany: false,
-					placeHolder: localize('chooseDisplayLanguage', "Select Display Language"),
-					activeItem: languageOptions[currentLanguageIndex]
-				});
+		const qp = quickInputService.createQuickPick<ILanguagePackItem>();
+		qp.placeholder = localize('chooseLocale', "Select Display Language");
 
-			if (selectedLanguage === languageOptions[languageOptions.length - 1]) {
-				return paneCompositeService.openPaneComposite(EXTENSIONS_VIEWLET_ID, ViewContainerLocation.Sidebar, true)
-					.then(viewlet => viewlet?.getViewPaneContainer())
-					.then(viewlet => {
-						const extensionsViewlet = viewlet as IExtensionsViewPaneContainer;
-						extensionsViewlet.search('@category:"language packs"');
-						extensionsViewlet.focus();
-					});
+		if (installedLanguages?.length) {
+			const items: Array<ILanguagePackItem | IQuickPickSeparator> = [{ type: 'separator', label: 'Installed languages' /*localize('installed', "Installed languages")*/ }];
+			qp.items = items.concat(installedLanguages);
+		}
+
+		const disposables = new DisposableStore();
+		const source = new CancellationTokenSource();
+		disposables.add(qp.onDispose(() => {
+			source.cancel();
+			disposables.dispose();
+		}));
+
+		const installedSet = new Set<string>(installedLanguages?.map(language => language.id!) ?? []);
+		languagePackService.getAvailableLanguages().then(availableLanguages => {
+			const newLanguages = availableLanguages.filter(l => l.id && !installedSet.has(l.id));
+			if (newLanguages.length) {
+				qp.items = [
+					...qp.items,
+					{ type: 'separator', label: localize('available', "Available languages") },
+					...newLanguages
+				];
+			}
+			qp.busy = false;
+		});
+
+		disposables.add(qp.onDidAccept(async () => {
+			const selectedLanguage = qp.activeItems[0];
+			qp.hide();
+
+			if (
+				// Only Desktop has the concept of installing language packs so we only do this for Desktop
+				!isWeb &&
+				// Only if the language pack is not installed
+				!(await extensionManagementService.getInstalled()).find(e => e.identifier.id === selectedLanguage.extensionId)
+			) {
+				// install language pack
+				try {
+					let viewlet = await paneCompositePartService.openPaneComposite(EXTENSIONS_VIEWLET_ID, ViewContainerLocation.Sidebar);
+					(viewlet?.getViewPaneContainer() as IExtensionsViewPaneContainer).search(`@id:${selectedLanguage.extensionId}`);
+
+					// Only actually install a language pack from Microsoft
+					if (selectedLanguage.galleryExtension?.publisher.toLowerCase() !== 'ms-ceintl') {
+						return;
+					}
+
+					await extensionManagementService.installFromGallery(selectedLanguage.galleryExtension);
+				} catch (err) {
+					notificationService.error(err);
+					return;
+				}
 			}
 
-			if (selectedLanguage) {
-				await jsonEditingService.write(environmentService.argvResource, [{ path: ['locale'], value: selectedLanguage.label }], true);
-				const restart = await dialogService.confirm({
+			if (await localeService.setLocale(selectedLanguage.id!)) {
+				const restartDialog = await dialogService.confirm({
 					type: 'info',
 					message: localize('relaunchDisplayLanguageMessage', "A restart is required for the change in display language to take effect."),
 					detail: localize('relaunchDisplayLanguageDetail', "Press the restart button to restart {0} and change the display language.", productService.nameLong),
-					primaryButton: localize('restart', "&&Restart")
+					primaryButton: restart
 				});
 
-				if (restart.confirmed) {
+				if (restartDialog.confirmed) {
 					hostService.restart();
 				}
 			}
-		} catch (e) {
-			notificationService.error(e);
+		}));
+
+		qp.show();
+		qp.busy = true;
+	}
+}
+
+export class ClearDisplayLanguageAction extends Action2 {
+	public static readonly ID = 'workbench.action.clearLocalePreference';
+	public static readonly LABEL = localize('clearDisplayLanguage', "Clear Display Language Preference");
+
+	constructor() {
+		super({
+			id: ClearDisplayLanguageAction.ID,
+			title: { original: 'Clear Display Language Preference', value: ClearDisplayLanguageAction.LABEL },
+			menu: {
+				id: MenuId.CommandPalette
+			}
+		});
+	}
+
+	public async run(accessor: ServicesAccessor): Promise<void> {
+		const localeService: ILocaleService = accessor.get(ILocaleService);
+		const dialogService: IDialogService = accessor.get(IDialogService);
+		const productService: IProductService = accessor.get(IProductService);
+		const hostService: IHostService = accessor.get(IHostService);
+
+		if (await localeService.setLocale(undefined)) {
+			const restartDialog = await dialogService.confirm({
+				type: 'info',
+				message: localize('relaunchAfterClearDisplayLanguageMessage', "A restart is required for the change in display language to take effect."),
+				detail: localize('relaunchAfterClearDisplayLanguageDetail', "Press the restart button to restart {0} and change the display language.", productService.nameLong),
+				primaryButton: restart
+			});
+
+			if (restartDialog.confirmed) {
+				hostService.restart();
+			}
 		}
 	}
 }

--- a/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
@@ -24,10 +24,11 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
 import { ViewContainerLocation } from 'vs/workbench/common/views';
 import { registerAction2 } from 'vs/platform/actions/common/actions';
-import { ConfigureLocaleAction } from 'vs/workbench/contrib/localization/browser/localizationsActions';
+import { ClearDisplayLanguageAction, ConfigureDisplayLanguageAction } from 'vs/workbench/contrib/localization/browser/localizationsActions';
 
 // Register action to configure locale and related settings
-registerAction2(ConfigureLocaleAction);
+registerAction2(ConfigureDisplayLanguageAction);
+registerAction2(ClearDisplayLanguageAction);
 
 const LANGUAGEPACK_SUGGESTION_IGNORE_STORAGE_KEY = 'extensionsAssistant/languagePackSuggestionIgnore';
 
@@ -195,14 +196,13 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 
 	}
 
-	private isLanguageInstalled(language: string | undefined): Promise<boolean> {
-		return this.extensionManagementService.getInstalled()
-			.then(installed => installed.some(i =>
-				!!(i.manifest
-					&& i.manifest.contributes
-					&& i.manifest.contributes.localizations
-					&& i.manifest.contributes.localizations.length
-					&& i.manifest.contributes.localizations.some(l => l.languageId.toLowerCase() === language))));
+	private async isLanguageInstalled(language: string | undefined): Promise<boolean> {
+		const installed = await this.extensionManagementService.getInstalled();
+		return installed.some(i => !!(i.manifest
+			&& i.manifest.contributes
+			&& i.manifest.contributes.localizations
+			&& i.manifest.contributes.localizations.length
+			&& i.manifest.contributes.localizations.some(l => l.languageId.toLowerCase() === language)));
 	}
 
 	private installExtension(extension: IGalleryExtension): Promise<void> {

--- a/src/vs/workbench/services/localization/common/locale.ts
+++ b/src/vs/workbench/services/localization/common/locale.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+
+export const ILocaleService = createDecorator<ILocaleService>('localizationService');
+
+export interface ILocaleService {
+	readonly _serviceBrand: undefined;
+	setLocale(languagePackItem: string | undefined): Promise<boolean>;
+}

--- a/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
+++ b/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
@@ -21,7 +21,7 @@ export class NativeLocaleService implements ILocaleService {
 
 	async setLocale(locale: string | undefined): Promise<boolean> {
 		try {
-			if (locale === language || (!locale && (language === 'en' || language === 'en-US'))) {
+			if (locale === language || (!locale && language === 'en')) {
 				return false;
 			}
 			await this.jsonEditingService.write(this.environmentService.argvResource, [{ path: ['locale'], value: locale }], true);

--- a/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
+++ b/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { language } from 'vs/base/common/platform';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IJSONEditingService } from 'vs/workbench/services/configuration/common/jsonEditing';
+import { ILocaleService } from 'vs/workbench/services/localization/common/locale';
+
+export class NativeLocaleService implements ILocaleService {
+	_serviceBrand: undefined;
+
+	constructor(
+		@IJSONEditingService private readonly jsonEditingService: IJSONEditingService,
+		@IEnvironmentService private readonly environmentService: IEnvironmentService,
+		@INotificationService private readonly notificationService: INotificationService,
+	) { }
+
+	async setLocale(locale: string | undefined): Promise<boolean> {
+		try {
+			if (locale === language || (!locale && (language === 'en' || language === 'en-US'))) {
+				return false;
+			}
+			await this.jsonEditingService.write(this.environmentService.argvResource, [{ path: ['locale'], value: locale }], true);
+			return true;
+		} catch (err) {
+			this.notificationService.error(err);
+			return false;
+		}
+	}
+}
+
+registerSingleton(ILocaleService, NativeLocaleService, true);

--- a/src/vs/workbench/workbench.sandbox.main.ts
+++ b/src/vs/workbench/workbench.sandbox.main.ts
@@ -83,6 +83,7 @@ import 'vs/workbench/services/files/electron-sandbox/elevatedFileService';
 import 'vs/workbench/services/search/electron-sandbox/searchService';
 import 'vs/workbench/services/workingCopy/electron-sandbox/workingCopyHistoryService';
 import 'vs/workbench/services/userDataSync/browser/userDataSyncEnablementService';
+import 'vs/workbench/services/localization/electron-sandbox/localeService';
 
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IUserDataInitializationService, UserDataInitializationService } from 'vs/workbench/services/userData/browser/userDataInit';


### PR DESCRIPTION
Attempting to break apart https://github.com/microsoft/vscode/pull/150418 into smaller PRs...

#### Revamp `Configure Display Language`

This command use to only let you switch between installed language packs on desktop... and the quick pick would only show the locale:
![image](https://user-images.githubusercontent.com/2644648/170382996-0c45f9b9-4ae2-4f74-b346-8c71e857f20e.png)

This PR revamps that command so that languages (the quick pick items) are displayed in their native language and a new section called "Additional languages" is there if you want to install a language pack. Here's what that looks like:

https://user-images.githubusercontent.com/2644648/170383150-a2f412ce-8623-48da-8b44-8a00c1abb4a1.mp4

In the video you can see it show the extensions pane, install the language pack (if the language pack is owned by Microsoft - detail in the code), update the locale (in Desktop's case via runtime args), and show a dialog to reload the window.

#### Add a `Clear Display Language Preference` command

A less important command but all this does is clears whatever value is stored. This command will be more important in the web scenario but it also has value on Desktop.
