### PR TITLE
Support fuzzy matching on the absolute paths of files/resources

### DIFF
--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -558,7 +558,14 @@ export function isSerializedFileMatch(arg: ISerializedSearchProgressItem): arg i
 
 export function isFilePatternMatch(candidate: IRawFileMatch, normalizedFilePatternLowercase: string): boolean {
 	const pathToMatch = candidate.searchPath ? candidate.searchPath : candidate.relativePath;
-	return fuzzyContains(pathToMatch, normalizedFilePatternLowercase);
+	if (fuzzyContains(pathToMatch, normalizedFilePatternLowercase)) {
+		return true;
+	}
+	// Also try matching against the absolute path of the file.
+	if (candidate.base) {
+		return fuzzyContains(paths.join(candidate.base, candidate.relativePath), normalizedFilePatternLowercase);
+	}
+	return false;
 }
 
 export interface ISerializedFileMatch {

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -417,6 +417,9 @@ const FileMatchItemAccessor = new class implements IItemAccessor<IRawFileMatch> 
 	}
 
 	getItemPath(match: IRawFileMatch): string {
+		if (match.base) {
+			return join(match.base, match.relativePath);  // e.g. /home/user/some/path/to/file/myFile.txt
+		}
 		return match.relativePath; // e.g. some/path/to/file/myFile.txt
 	}
 };

--- a/src/vs/workbench/services/search/test/node/search.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/search.integrationTest.ts
@@ -205,7 +205,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.strictEqual(count, 7);
+			assert.strictEqual(count, 11);
 			done();
 		});
 	});
@@ -224,7 +224,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.strictEqual(count, 3);
+			assert.strictEqual(count, 7);
 			done();
 		});
 	});


### PR DESCRIPTION
We now apply fuzzy matching on the (absolute) path of files/resources,
which allows fuzzy matching to work even if the user has a partial
absolute path or subpath which is rooted in folders outside of the
workspace folders.

I left a FIXME in the code  - I'm not sure if we should try to add a minimum score threshold or maybe think of another way to avoid really fuzzy matches (e.g. typing `someRelativelyLongString` and having tiny matches across tens of path components due to long absolute paths). Please let me know what you think.
