### PR TITLE
Allow stage/revertSelectedRanges keybinding not just in diffEditor

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -596,7 +596,7 @@
         "command": "git.stageSelectedRanges",
         "key": "ctrl+k ctrl+alt+s",
         "mac": "cmd+k cmd+alt+s",
-        "when": "isInDiffEditor || editorHasSelection"
+        "when": "isInDiffEditor || editorTextFocus"
       },
       {
         "command": "git.unstageSelectedRanges",
@@ -608,7 +608,7 @@
         "command": "git.revertSelectedRanges",
         "key": "ctrl+k ctrl+r",
         "mac": "cmd+k cmd+r",
-        "when": "isInDiffEditor || editorHasSelection"
+        "when": "isInDiffEditor || editorTextFocus"
       }
     ],
     "menus": {

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -596,7 +596,7 @@
         "command": "git.stageSelectedRanges",
         "key": "ctrl+k ctrl+alt+s",
         "mac": "cmd+k cmd+alt+s",
-        "when": "isInDiffEditor"
+        "when": "isInDiffEditor || editorHasSelection"
       },
       {
         "command": "git.unstageSelectedRanges",
@@ -608,7 +608,7 @@
         "command": "git.revertSelectedRanges",
         "key": "ctrl+k ctrl+r",
         "mac": "cmd+k cmd+r",
-        "when": "isInDiffEditor"
+        "when": "isInDiffEditor || editorHasSelection"
       }
     ],
     "menus": {


### PR DESCRIPTION
#93706 introduced default keybindings for `stageSelectedRanges`, `unstageSelectedRanges` and `revertSelectedRanges` as per issue #93564, but they don't work in the regular editor, while running the command from the command palette gives the intended result. 
Therefore, I propose to extend the [`when` clauses](https://code.visualstudio.com/api/references/when-clause-contexts) of  `stageSelectedRanges` and `revertSelectedRanges`.  `unstageSelectedRanges` remains unchanged, since it seems to have no effect in a regular editor.

Note: I tried to be as conservative and left `isInDiffEditor` intact, but that's probably not needed.