### PR TITLE
Support TS's includeInlayVariableTypeHintsWhenTypeMatchesName setting

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -301,6 +301,12 @@
           "markdownDescription": "%configuration.inlayHints.variableTypes.enabled%",
           "scope": "resource"
         },
+        "typescript.inlayHints.variableTypes.supressWhenTypeMatchesName": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "%configuration.inlayHints.variableTypes.supressWhenTypeMatchesName%",
+          "scope": "resource"
+        },
         "typescript.inlayHints.propertyDeclarationTypes.enabled": {
           "type": "boolean",
           "default": false,
@@ -351,6 +357,12 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "%configuration.inlayHints.variableTypes.enabled%",
+          "scope": "resource"
+        },
+        "javascript.inlayHints.variableTypes.supressWhenTypeMatchesName": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "%configuration.inlayHints.variableTypes.supressWhenTypeMatchesName%",
           "scope": "resource"
         },
         "javascript.inlayHints.propertyDeclarationTypes.enabled": {

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -301,10 +301,10 @@
           "markdownDescription": "%configuration.inlayHints.variableTypes.enabled%",
           "scope": "resource"
         },
-        "typescript.inlayHints.variableTypes.supressWhenTypeMatchesName": {
+        "typescript.inlayHints.variableTypes.suppressWhenTypeMatchesName": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "%configuration.inlayHints.variableTypes.supressWhenTypeMatchesName%",
+          "markdownDescription": "%configuration.inlayHints.variableTypes.suppressWhenTypeMatchesName%",
           "scope": "resource"
         },
         "typescript.inlayHints.propertyDeclarationTypes.enabled": {
@@ -359,10 +359,10 @@
           "markdownDescription": "%configuration.inlayHints.variableTypes.enabled%",
           "scope": "resource"
         },
-        "javascript.inlayHints.variableTypes.supressWhenTypeMatchesName": {
+        "javascript.inlayHints.variableTypes.suppressWhenTypeMatchesName": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "%configuration.inlayHints.variableTypes.supressWhenTypeMatchesName%",
+          "markdownDescription": "%configuration.inlayHints.variableTypes.suppressWhenTypeMatchesName%",
           "scope": "resource"
         },
         "javascript.inlayHints.propertyDeclarationTypes.enabled": {

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -97,7 +97,7 @@
 		"message": "Enable/disable inlay hints for implicit variable types:\n```typescript\n\nconst foo /* :number */ = Date.now();\n \n```\nRequires using TypeScript 4.4+ in the workspace.",
 		"comment": "The text inside the ``` block is code and should not be localized."
 	},
-	"configuration.inlayHints.variableTypes.supressWhenTypeMatchesName": "Suppress type hints on variables whose name is identical to the type name. Requires using TypeScript 4.8+ in the workspace.",
+	"configuration.inlayHints.variableTypes.suppressWhenTypeMatchesName": "Suppress type hints on variables whose name is identical to the type name. Requires using TypeScript 4.8+ in the workspace.",
 	"configuration.inlayHints.propertyDeclarationTypes.enabled": {
 		"message": "Enable/disable inlay hints for implicit types on property declarations:\n```typescript\n\nclass Foo {\n\tprop /* :number */ = Date.now();\n}\n \n```\nRequires using TypeScript 4.4+ in the workspace.",
 		"comment": "The text inside the ``` block is code and should not be localized."

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -88,10 +88,7 @@
 		"message": "Enable/disable inlay hints for parameter names:\n```typescript\n\nparseInt(/* str: */ '123', /* radix: */ 8)\n \n```\nRequires using TypeScript 4.4+ in the workspace.",
 		"comment": "The text inside the ``` block is code and should not be localized."
 	},
-	"configuration.inlayHints.parameterNames.suppressWhenArgumentMatchesName": {
-		"message": "Suppress parameter name hints on arguments whose text is identical to the parameter name.",
-		"comment": "The text inside the ``` block is code and should not be localized."
-	},
+	"configuration.inlayHints.parameterNames.suppressWhenArgumentMatchesName": "Suppress parameter name hints on arguments whose text is identical to the parameter name.",
 	"configuration.inlayHints.parameterTypes.enabled": {
 		"message": "Enable/disable inlay hints for implicit parameter types:\n```typescript\n\nel.addEventListener('click', e /* :MouseEvent */ => ...)\n \n```\nRequires using TypeScript 4.4+ in the workspace.",
 		"comment": "The text inside the ``` block is code and should not be localized."
@@ -100,6 +97,7 @@
 		"message": "Enable/disable inlay hints for implicit variable types:\n```typescript\n\nconst foo /* :number */ = Date.now();\n \n```\nRequires using TypeScript 4.4+ in the workspace.",
 		"comment": "The text inside the ``` block is code and should not be localized."
 	},
+	"configuration.inlayHints.variableTypes.supressWhenTypeMatchesName": "Suppress type hints on variables whose name is identical to the type name. Requires using TypeScript 4.8+ in the workspace.",
 	"configuration.inlayHints.propertyDeclarationTypes.enabled": {
 		"message": "Enable/disable inlay hints for implicit types on property declarations:\n```typescript\n\nclass Foo {\n\tprop /* :number */ = Date.now();\n}\n \n```\nRequires using TypeScript 4.4+ in the workspace.",
 		"comment": "The text inside the ``` block is code and should not be localized."

--- a/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
@@ -210,7 +210,7 @@ export class InlayHintSettingNames {
 	static readonly parameterNamesSuppressWhenArgumentMatchesName = 'inlayHints.parameterNames.suppressWhenArgumentMatchesName';
 	static readonly parameterNamesEnabled = 'inlayHints.parameterTypes.enabled';
 	static readonly variableTypesEnabled = 'inlayHints.variableTypes.enabled';
-	static readonly variableTypesSupressWhenTypeMatchesName = 'inlayHints.variableTypes.supressWhenTypeMatchesName';
+	static readonly variableTypesSuppressWhenTypeMatchesName = 'inlayHints.variableTypes.suppressWhenTypeMatchesName';
 	static readonly propertyDeclarationTypesEnabled = 'inlayHints.propertyDeclarationTypes.enabled';
 	static readonly functionLikeReturnTypesEnabled = 'inlayHints.functionLikeReturnTypes.enabled';
 	static readonly enumMemberValuesEnabled = 'inlayHints.enumMemberValues.enabled';
@@ -222,7 +222,7 @@ export function getInlayHintsPreferences(config: vscode.WorkspaceConfiguration) 
 		includeInlayParameterNameHintsWhenArgumentMatchesName: !config.get<boolean>(InlayHintSettingNames.parameterNamesSuppressWhenArgumentMatchesName, true),
 		includeInlayFunctionParameterTypeHints: config.get<boolean>(InlayHintSettingNames.parameterNamesEnabled, false),
 		includeInlayVariableTypeHints: config.get<boolean>(InlayHintSettingNames.variableTypesEnabled, false),
-		includeInlayVariableTypeHintsWhenTypeMatchesName: !config.get<boolean>(InlayHintSettingNames.variableTypesSupressWhenTypeMatchesName, true),
+		includeInlayVariableTypeHintsWhenTypeMatchesName: !config.get<boolean>(InlayHintSettingNames.variableTypesSuppressWhenTypeMatchesName, true),
 		includeInlayPropertyDeclarationTypeHints: config.get<boolean>(InlayHintSettingNames.propertyDeclarationTypesEnabled, false),
 		includeInlayFunctionLikeReturnTypeHints: config.get<boolean>(InlayHintSettingNames.functionLikeReturnTypesEnabled, false),
 		includeInlayEnumMemberValueHints: config.get<boolean>(InlayHintSettingNames.enumMemberValuesEnabled, false),

--- a/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
@@ -210,6 +210,7 @@ export class InlayHintSettingNames {
 	static readonly parameterNamesSuppressWhenArgumentMatchesName = 'inlayHints.parameterNames.suppressWhenArgumentMatchesName';
 	static readonly parameterNamesEnabled = 'inlayHints.parameterTypes.enabled';
 	static readonly variableTypesEnabled = 'inlayHints.variableTypes.enabled';
+	static readonly variableTypesSupressWhenTypeMatchesName = 'inlayHints.variableTypes.supressWhenTypeMatchesName';
 	static readonly propertyDeclarationTypesEnabled = 'inlayHints.propertyDeclarationTypes.enabled';
 	static readonly functionLikeReturnTypesEnabled = 'inlayHints.functionLikeReturnTypes.enabled';
 	static readonly enumMemberValuesEnabled = 'inlayHints.enumMemberValues.enabled';
@@ -221,6 +222,7 @@ export function getInlayHintsPreferences(config: vscode.WorkspaceConfiguration) 
 		includeInlayParameterNameHintsWhenArgumentMatchesName: !config.get<boolean>(InlayHintSettingNames.parameterNamesSuppressWhenArgumentMatchesName, true),
 		includeInlayFunctionParameterTypeHints: config.get<boolean>(InlayHintSettingNames.parameterNamesEnabled, false),
 		includeInlayVariableTypeHints: config.get<boolean>(InlayHintSettingNames.variableTypesEnabled, false),
+		includeInlayVariableTypeHintsWhenTypeMatchesName: !config.get<boolean>(InlayHintSettingNames.variableTypesSupressWhenTypeMatchesName, true),
 		includeInlayPropertyDeclarationTypeHints: config.get<boolean>(InlayHintSettingNames.propertyDeclarationTypesEnabled, false),
 		includeInlayFunctionLikeReturnTypeHints: config.get<boolean>(InlayHintSettingNames.functionLikeReturnTypesEnabled, false),
 		includeInlayEnumMemberValueHints: config.get<boolean>(InlayHintSettingNames.enumMemberValuesEnabled, false),

--- a/extensions/typescript-language-features/src/languageFeatures/inlayHints.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/inlayHints.ts
@@ -15,14 +15,15 @@ import { Position } from '../utils/typeConverters';
 import FileConfigurationManager, { getInlayHintsPreferences, InlayHintSettingNames } from './fileConfigurationManager';
 
 
-const inlayHintSettingNames = [
+const inlayHintSettingNames = Object.freeze([
 	InlayHintSettingNames.parameterNamesSuppressWhenArgumentMatchesName,
 	InlayHintSettingNames.parameterNamesEnabled,
 	InlayHintSettingNames.variableTypesEnabled,
+	InlayHintSettingNames.variableTypesSupressWhenTypeMatchesName,
 	InlayHintSettingNames.propertyDeclarationTypesEnabled,
 	InlayHintSettingNames.functionLikeReturnTypesEnabled,
 	InlayHintSettingNames.enumMemberValuesEnabled,
-];
+]);
 
 class TypeScriptInlayHintsProvider extends Disposable implements vscode.InlayHintsProvider {
 

--- a/extensions/typescript-language-features/src/languageFeatures/inlayHints.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/inlayHints.ts
@@ -19,7 +19,7 @@ const inlayHintSettingNames = Object.freeze([
 	InlayHintSettingNames.parameterNamesSuppressWhenArgumentMatchesName,
 	InlayHintSettingNames.parameterNamesEnabled,
 	InlayHintSettingNames.variableTypesEnabled,
-	InlayHintSettingNames.variableTypesSupressWhenTypeMatchesName,
+	InlayHintSettingNames.variableTypesSuppressWhenTypeMatchesName,
 	InlayHintSettingNames.propertyDeclarationTypesEnabled,
 	InlayHintSettingNames.functionLikeReturnTypesEnabled,
 	InlayHintSettingNames.enumMemberValuesEnabled,


### PR DESCRIPTION
From https://github.com/microsoft/TypeScript/pull/48529

Let users control is variable type inlay hints are suppresed if the variable name matches the type name, such as:

```ts
const range = new Range();
```

Requires TS 4.8+ (currently nightly) so may change before the final 4.8 release 