### PR TITLE
clip -> clipPath

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -179,8 +179,8 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 		this._container.style.height = `${dimension ? dimension.height : frameRect.height}px`;
 
 		if (clippingContainer) {
-			const clip = computeClippingRect(frameRect, clippingContainer);
-			this._container.style.clip = `rect(${clip.top}px, ${clip.right}px, ${clip.bottom}px, ${clip.left}px)`;
+			const { top, left, right, bottom } = computeClippingRect(frameRect, clippingContainer);
+			this._container.style.clipPath = `polygon(${left}px ${top}px, ${right}px ${top}px, ${right}px ${bottom}px, ${left}px ${bottom}px)`;
 		}
 	}
 

--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -283,8 +283,8 @@ export class WebviewViewPane extends ViewPane {
 		}
 
 		if (this._rootContainer) {
-			const clip = computeClippingRect(this._container, this._rootContainer);
-			webviewEntry.container.style.clip = `rect(${clip.top}px, ${clip.right}px, ${clip.bottom}px, ${clip.left}px)`;
+			const { top, left, right, bottom } = computeClippingRect(this._container, this._rootContainer);
+			webviewEntry.container.style.clipPath = `polygon(${left}px ${top}px, ${right}px ${top}px, ${right}px ${bottom}px, ${left}px ${bottom}px)`;
 		}
 	}
 


### PR DESCRIPTION
This migrates us from the deprecated `clip` css property to the modern `clip-path` property

As part of this, we also have to switch to `polygon` to define the rectangular clip path
