### PR TITLE
Mark notebookContentProvider proposal as deprecated

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -934,6 +934,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			},
 			registerNotebookContentProvider: (viewType: string, provider: vscode.NotebookContentProvider, options?: vscode.NotebookDocumentContentOptions, registration?: vscode.NotebookRegistrationData) => {
 				checkProposedApiEnabled(extension, 'notebookContentProvider');
+
+				extHostApiDeprecation.report('workspace.registerNotebookContentProvider', extension,
+					`The notebookContentProvider API is not on track for finalization and will be removed.`);
+
 				return extHostNotebook.registerNotebookContentProvider(extension, viewType, provider, options, isProposedApiEnabled(extension, 'notebookLiveShare') ? registration : undefined);
 			},
 			onDidChangeConfiguration: (listener: (_: any) => any, thisArgs?: any, disposables?: extHostTypes.Disposable[]) => {

--- a/src/vscode-dts/vscode.proposed.notebookContentProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookContentProvider.d.ts
@@ -5,8 +5,9 @@
 
 declare module 'vscode' {
 
-	// https://github.com/microsoft/vscode/issues/106744
+	// https://github.com/microsoft/vscode/issues/147248
 
+	/** @deprecated */
 	interface NotebookDocumentBackup {
 		/**
 		 * Unique identifier for the backup.
@@ -24,10 +25,12 @@ declare module 'vscode' {
 		delete(): void;
 	}
 
+	/** @deprecated */
 	interface NotebookDocumentBackupContext {
 		readonly destination: Uri;
 	}
 
+	/** @deprecated */
 	interface NotebookDocumentOpenContext {
 		readonly backupId?: string;
 		readonly untitledDocumentData?: Uint8Array;
@@ -35,6 +38,8 @@ declare module 'vscode' {
 
 	// todo@API use openNotebookDOCUMENT to align with openCustomDocument etc?
 	// todo@API rename to NotebookDocumentContentProvider
+	/** @deprecated */
+
 	export interface NotebookContentProvider {
 
 		readonly options?: NotebookDocumentContentOptions;
@@ -60,6 +65,7 @@ declare module 'vscode' {
 
 		// TODO@api use NotebookDocumentFilter instead of just notebookType:string?
 		// TODO@API options duplicates the more powerful variant on NotebookContentProvider
+		/** @deprecated */
 		export function registerNotebookContentProvider(notebookType: string, provider: NotebookContentProvider, options?: NotebookDocumentContentOptions): Disposable;
 	}
 }


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/147248

Marks the top level types in this proposal as deprecated. Also hooks up `registerNotebookContentProvider` to report deprecated API usage
