### PR TITLE
Fix terminal profiles smoke tests

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
@@ -241,10 +241,11 @@ export class TerminalGroupService extends Disposable implements ITerminalGroupSe
 			if (this.activeGroupIndex > index) {
 				this.setActiveGroupByIndex(this.activeGroupIndex - 1);
 			}
-			// Ensure the active group is still valid
-			if (this.activeGroupIndex >= this.groups.length) {
-				this.setActiveGroupByIndex(this.groups.length - 1);
-			}
+		}
+		// Ensure the active group is still valid, this should set the activeGroupIndex to -1 if
+		// there are no groups
+		if (this.activeGroupIndex >= this.groups.length) {
+			this.setActiveGroupByIndex(this.groups.length - 1);
 		}
 
 		this._onDidChangeInstances.fire();


### PR DESCRIPTION
This if statement needs to be run even if it was the active group, otherwise
active group index remains at 0 when there are no terminals which causes
problems when a new terminal is created.

Part of #150541
