### PR TITLE
add customizations.codespaces.repositories.permissions

### DIFF
--- a/extensions/configuration-editing/schemas/devContainer.schema.generated.json
+++ b/extensions/configuration-editing/schemas/devContainer.schema.generated.json
@@ -429,6 +429,127 @@
 								}
 							},
 							"additionalProperties": false
+						},
+						"codespaces": {
+							"type": "object",
+							"properties": {
+								"repositories": {
+									"type": "object",
+									"description": "Configuration relative to a GitHub repository",
+									"pattern": "^[a-zA-Z0-9-_.]+[.]*/[a-zA-Z0-9-_*]+[.]*$",
+									"errorMessage": "Expected format: 'owner/repo' (eg: 'microsoft/vscode'). A wildcard (*) is permitted for the repo name. (eg: 'microsoft/*').",
+									"oneOf": [
+										{
+											"properties": {
+												"permissions": {
+													"type": "object",
+													"description": "Addional repository permissions. See https://aka.ms/ghcs/multi-repo-auth for more info.",
+													"anyOf": [
+														{
+															"actions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"checks": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"contents": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"deployments": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"discussions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"issues": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"packages": {
+																"type": "string",
+																"enum": [
+																	"read"
+																]
+															},
+															"pages": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"pull_requests": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"repository_projects": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"statuses": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"workflows": {
+																"type": "string",
+																"enum": [
+																	"write"
+																]
+															}
+														}
+													],
+													"additionalProperties": false
+												}
+											}
+										},
+										{
+											"properties": {
+												"permissions": {
+													"type": "string",
+													"enum": [
+														"read-all",
+														"write-all"
+													]
+												}
+											}
+										}
+									],
+									"additionalProperties": false
+								}
+							},
+							"additionalProperties": false
 						}
 					},
 					"additionalProperties": {
@@ -865,6 +986,127 @@
 								}
 							},
 							"additionalProperties": false
+						},
+						"codespaces": {
+							"type": "object",
+							"properties": {
+								"repositories": {
+									"type": "object",
+									"description": "Configuration relative to a GitHub repository",
+									"pattern": "^[a-zA-Z0-9-_.]+[.]*/[a-zA-Z0-9-_*]+[.]*$",
+									"errorMessage": "Expected format: 'owner/repo' (eg: 'microsoft/vscode'). A wildcard (*) is permitted for the repo name. (eg: 'microsoft/*').",
+									"oneOf": [
+										{
+											"properties": {
+												"permissions": {
+													"type": "object",
+													"description": "Addional repository permissions. See https://aka.ms/ghcs/multi-repo-auth for more info.",
+													"anyOf": [
+														{
+															"actions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"checks": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"contents": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"deployments": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"discussions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"issues": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"packages": {
+																"type": "string",
+																"enum": [
+																	"read"
+																]
+															},
+															"pages": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"pull_requests": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"repository_projects": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"statuses": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"workflows": {
+																"type": "string",
+																"enum": [
+																	"write"
+																]
+															}
+														}
+													],
+													"additionalProperties": false
+												}
+											}
+										},
+										{
+											"properties": {
+												"permissions": {
+													"type": "string",
+													"enum": [
+														"read-all",
+														"write-all"
+													]
+												}
+											}
+										}
+									],
+									"additionalProperties": false
+								}
+							},
+							"additionalProperties": false
 						}
 					},
 					"additionalProperties": {
@@ -1267,6 +1509,127 @@
 								}
 							},
 							"additionalProperties": false
+						},
+						"codespaces": {
+							"type": "object",
+							"properties": {
+								"repositories": {
+									"type": "object",
+									"description": "Configuration relative to a GitHub repository",
+									"pattern": "^[a-zA-Z0-9-_.]+[.]*/[a-zA-Z0-9-_*]+[.]*$",
+									"errorMessage": "Expected format: 'owner/repo' (eg: 'microsoft/vscode'). A wildcard (*) is permitted for the repo name. (eg: 'microsoft/*').",
+									"oneOf": [
+										{
+											"properties": {
+												"permissions": {
+													"type": "object",
+													"description": "Addional repository permissions. See https://aka.ms/ghcs/multi-repo-auth for more info.",
+													"anyOf": [
+														{
+															"actions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"checks": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"contents": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"deployments": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"discussions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"issues": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"packages": {
+																"type": "string",
+																"enum": [
+																	"read"
+																]
+															},
+															"pages": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"pull_requests": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"repository_projects": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"statuses": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"workflows": {
+																"type": "string",
+																"enum": [
+																	"write"
+																]
+															}
+														}
+													],
+													"additionalProperties": false
+												}
+											}
+										},
+										{
+											"properties": {
+												"permissions": {
+													"type": "string",
+													"enum": [
+														"read-all",
+														"write-all"
+													]
+												}
+											}
+										}
+									],
+									"additionalProperties": false
+								}
+							},
+							"additionalProperties": false
 						}
 					},
 					"additionalProperties": {
@@ -1643,6 +2006,127 @@
 								}
 							},
 							"additionalProperties": false
+						},
+						"codespaces": {
+							"type": "object",
+							"properties": {
+								"repositories": {
+									"type": "object",
+									"description": "Configuration relative to a GitHub repository",
+									"pattern": "^[a-zA-Z0-9-_.]+[.]*/[a-zA-Z0-9-_*]+[.]*$",
+									"errorMessage": "Expected format: 'owner/repo' (eg: 'microsoft/vscode'). A wildcard (*) is permitted for the repo name. (eg: 'microsoft/*').",
+									"oneOf": [
+										{
+											"properties": {
+												"permissions": {
+													"type": "object",
+													"description": "Addional repository permissions. See https://aka.ms/ghcs/multi-repo-auth for more info.",
+													"anyOf": [
+														{
+															"actions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"checks": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"contents": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"deployments": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"discussions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"issues": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"packages": {
+																"type": "string",
+																"enum": [
+																	"read"
+																]
+															},
+															"pages": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"pull_requests": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"repository_projects": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"statuses": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"workflows": {
+																"type": "string",
+																"enum": [
+																	"write"
+																]
+															}
+														}
+													],
+													"additionalProperties": false
+												}
+											}
+										},
+										{
+											"properties": {
+												"permissions": {
+													"type": "string",
+													"enum": [
+														"read-all",
+														"write-all"
+													]
+												}
+											}
+										}
+									],
+									"additionalProperties": false
+								}
+							},
+							"additionalProperties": false
 						}
 					},
 					"additionalProperties": {
@@ -1981,6 +2465,127 @@
 								"devPort": {
 									"type": "integer",
 									"description": "The port VS Code can use to connect to its backend."
+								}
+							},
+							"additionalProperties": false
+						},
+						"codespaces": {
+							"type": "object",
+							"properties": {
+								"repositories": {
+									"type": "object",
+									"description": "Configuration relative to a GitHub repository",
+									"pattern": "^[a-zA-Z0-9-_.]+[.]*/[a-zA-Z0-9-_*]+[.]*$",
+									"errorMessage": "Expected format: 'owner/repo' (eg: 'microsoft/vscode'). A wildcard (*) is permitted for the repo name. (eg: 'microsoft/*').",
+									"oneOf": [
+										{
+											"properties": {
+												"permissions": {
+													"type": "object",
+													"description": "Addional repository permissions. See https://aka.ms/ghcs/multi-repo-auth for more info.",
+													"anyOf": [
+														{
+															"actions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"checks": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"contents": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"deployments": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"discussions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"issues": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"packages": {
+																"type": "string",
+																"enum": [
+																	"read"
+																]
+															},
+															"pages": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"pull_requests": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"repository_projects": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"statuses": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"workflows": {
+																"type": "string",
+																"enum": [
+																	"write"
+																]
+															}
+														}
+													],
+													"additionalProperties": false
+												}
+											}
+										},
+										{
+											"properties": {
+												"permissions": {
+													"type": "string",
+													"enum": [
+														"read-all",
+														"write-all"
+													]
+												}
+											}
+										}
+									],
+									"additionalProperties": false
 								}
 							},
 							"additionalProperties": false

--- a/extensions/configuration-editing/schemas/devContainer.schema.src.json
+++ b/extensions/configuration-editing/schemas/devContainer.schema.src.json
@@ -331,6 +331,126 @@
 									"description": "The port VS Code can use to connect to its backend."
 								}
 							}
+						},
+						"codespaces": {
+							"type": "object",
+							"properties": {
+								"repositories": {
+									"type": "object",
+									"description": "Configuration relative to a GitHub repository",
+									"pattern": "^[a-zA-Z0-9-_.]+[.]*\/[a-zA-Z0-9-_*]+[.]*$",
+									"errorMessage": "Expected format: 'owner/repo' (eg: 'microsoft/vscode'). A wildcard (*) is permitted for the repo name. (eg: 'microsoft/*').",
+									"oneOf": [
+										{
+											"properties": {
+												"permissions": {
+													"type": "object",
+													"description": "Addional repository permissions. See https://aka.ms/ghcs/multi-repo-auth for more info.",
+													"anyOf": [
+														{
+															"actions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"checks": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"contents": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"deployments": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"discussions": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"issues": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"packages": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"pages": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"pull_requests": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"repository_projects": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"statuses": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															},
+															"workflows": {
+																"type": "string",
+																"enum": [
+																	"read",
+																	"write"
+																]
+															}
+														}
+													]
+												}
+											}
+										},
+										{
+											"properties": {
+												"permissions": {
+													"type": "string",
+													"enum": [
+														"read-all",
+														"write-all"
+													]
+												}
+											}
+										}
+									]
+								}
+							}
 						}
 					},
 					"additionalProperties": {

--- a/extensions/configuration-editing/schemas/devContainer.schema.src.json
+++ b/extensions/configuration-editing/schemas/devContainer.schema.src.json
@@ -393,8 +393,7 @@
 															"packages": {
 																"type": "string",
 																"enum": [
-																	"read",
-																	"write"
+																	"read"
 																]
 															},
 															"pages": {
@@ -428,7 +427,6 @@
 															"workflows": {
 																"type": "string",
 																"enum": [
-																	"read",
 																	"write"
 																]
 															}


### PR DESCRIPTION
Adds schema hints for the Codespaces property under "customizations".

Information on the property: https://aka.ms/ghcs/multi-repo-auth

cc/ @chrmarti / @Chuxel