### PR TITLE
Allow debug extensions to show diagnostic information in the breakpoints view

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -3,48 +3,52 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as resources from 'vs/base/common/resources';
 import * as dom from 'vs/base/browser/dom';
+import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { Gesture } from 'vs/base/browser/touch';
+import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
+import { IconLabel } from 'vs/base/browser/ui/iconLabel/iconLabel';
+import { InputBox } from 'vs/base/browser/ui/inputbox/inputBox';
+import { IListContextMenuEvent, IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
+import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
+import { Orientation } from 'vs/base/browser/ui/splitview/splitview';
 import { Action, IAction } from 'vs/base/common/actions';
-import { IDebugService, IBreakpoint, CONTEXT_BREAKPOINTS_FOCUSED, State, DEBUG_SCHEME, IFunctionBreakpoint, IExceptionBreakpoint, IEnablement, IDebugModel, IDataBreakpoint, BREAKPOINTS_VIEW_ID, CONTEXT_BREAKPOINT_ITEM_TYPE, CONTEXT_BREAKPOINT_SUPPORTS_CONDITION, CONTEXT_BREAKPOINTS_EXIST, CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_IN_DEBUG_MODE, IBaseBreakpoint, IBreakpointEditorContribution, BREAKPOINT_EDITOR_CONTRIBUTION_ID, CONTEXT_BREAKPOINT_INPUT_FOCUSED, IInstructionBreakpoint } from 'vs/workbench/contrib/debug/common/debug';
-import { ExceptionBreakpoint, FunctionBreakpoint, Breakpoint, DataBreakpoint, InstructionBreakpoint } from 'vs/workbench/contrib/debug/common/debugModel';
+import { equals } from 'vs/base/common/arrays';
+import { RunOnceScheduler } from 'vs/base/common/async';
+import { Codicon } from 'vs/base/common/codicons';
+import { MarkdownString } from 'vs/base/common/htmlContent';
+import { KeyCode } from 'vs/base/common/keyCodes';
+import { dispose, IDisposable } from 'vs/base/common/lifecycle';
+import * as resources from 'vs/base/common/resources';
+import { Constants } from 'vs/base/common/uint';
+import { isCodeEditor } from 'vs/editor/browser/editorBrowser';
+import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
+import { localize } from 'vs/nls';
+import { createAndFillInActionBarActions, createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { Action2, IMenu, IMenuService, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { ContextKeyExpr, IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
+import { TextEditorSelectionRevealType } from 'vs/platform/editor/common/editor';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { IThemeService, ThemeIcon } from 'vs/platform/theme/common/themeService';
-import { Constants } from 'vs/base/common/uint';
-import { dispose, IDisposable } from 'vs/base/common/lifecycle';
-import { IListVirtualDelegate, IListContextMenuEvent, IListRenderer } from 'vs/base/browser/ui/list/list';
-import { IEditorPane } from 'vs/workbench/common/editor';
-import { InputBox } from 'vs/base/browser/ui/inputbox/inputBox';
-import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
-import { KeyCode } from 'vs/base/common/keyCodes';
-import { WorkbenchList } from 'vs/platform/list/browser/listService';
-import { IViewletViewOptions } from 'vs/workbench/browser/parts/views/viewsViewlet';
-import { attachInputBoxStyler } from 'vs/platform/theme/common/styler';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IEditorService, SIDE_GROUP, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
-import { ViewPane, ViewAction } from 'vs/workbench/browser/parts/views/viewPane';
 import { ILabelService } from 'vs/platform/label/common/label';
-import { IContextKeyService, IContextKey, ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
-import { Gesture } from 'vs/base/browser/touch';
-import { IViewDescriptorService } from 'vs/workbench/common/views';
-import { TextEditorSelectionRevealType } from 'vs/platform/editor/common/editor';
+import { WorkbenchList } from 'vs/platform/list/browser/listService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { Orientation } from 'vs/base/browser/ui/splitview/splitview';
-import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
+import { attachInputBoxStyler } from 'vs/platform/theme/common/styler';
+import { IThemeService, ThemeIcon } from 'vs/platform/theme/common/themeService';
+import { ViewAction, ViewPane } from 'vs/workbench/browser/parts/views/viewPane';
+import { IViewletViewOptions } from 'vs/workbench/browser/parts/views/viewsViewlet';
+import { IEditorPane } from 'vs/workbench/common/editor';
+import { IViewDescriptorService } from 'vs/workbench/common/views';
 import * as icons from 'vs/workbench/contrib/debug/browser/debugIcons';
-import { registerAction2, Action2, MenuId, IMenu, IMenuService } from 'vs/platform/actions/common/actions';
-import { localize } from 'vs/nls';
-import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
-import { createAndFillInContextMenuActions, createAndFillInActionBarActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
-import { isCodeEditor } from 'vs/editor/browser/editorBrowser';
-import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
-import { Codicon } from 'vs/base/common/codicons';
-import { equals } from 'vs/base/common/arrays';
-import { DisassemblyViewInput } from 'vs/workbench/contrib/debug/common/disassemblyViewInput';
 import { DisassemblyView } from 'vs/workbench/contrib/debug/browser/disassemblyView';
+import { BREAKPOINTS_VIEW_ID, BREAKPOINT_EDITOR_CONTRIBUTION_ID, CONTEXT_BREAKPOINTS_EXIST, CONTEXT_BREAKPOINTS_FOCUSED, CONTEXT_BREAKPOINT_INPUT_FOCUSED, CONTEXT_BREAKPOINT_ITEM_TYPE, CONTEXT_BREAKPOINT_SUPPORTS_CONDITION, CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_IN_DEBUG_MODE, DebuggerUiMessage, DEBUG_SCHEME, IBaseBreakpoint, IBreakpoint, IBreakpointEditorContribution, IDataBreakpoint, IDebugModel, IDebugService, IEnablement, IExceptionBreakpoint, IFunctionBreakpoint, IInstructionBreakpoint, State } from 'vs/workbench/contrib/debug/common/debug';
+import { Breakpoint, DataBreakpoint, ExceptionBreakpoint, FunctionBreakpoint, InstructionBreakpoint } from 'vs/workbench/contrib/debug/common/debugModel';
+import { DisassemblyViewInput } from 'vs/workbench/contrib/debug/common/disassemblyViewInput';
+import { ACTIVE_GROUP, IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
+import { IHoverService } from 'vs/workbench/services/hover/browser/hover';
 
 const $ = dom.$;
 
@@ -82,6 +86,9 @@ export class BreakpointsView extends ViewPane {
 	breakpointInputFocused: IContextKey<boolean>;
 	private autoFocusedIndex = -1;
 
+	private hintContainer: IconLabel | undefined;
+	private hintDelayer: RunOnceScheduler;
+
 	constructor(
 		options: IViewletViewOptions,
 		@IContextMenuService contextMenuService: IContextMenuService,
@@ -97,7 +104,8 @@ export class BreakpointsView extends ViewPane {
 		@IOpenerService openerService: IOpenerService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@ILabelService private readonly labelService: ILabelService,
-		@IMenuService menuService: IMenuService
+		@IMenuService menuService: IMenuService,
+		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
 
@@ -107,7 +115,9 @@ export class BreakpointsView extends ViewPane {
 		this.breakpointSupportsCondition = CONTEXT_BREAKPOINT_SUPPORTS_CONDITION.bindTo(contextKeyService);
 		this.breakpointInputFocused = CONTEXT_BREAKPOINT_INPUT_FOCUSED.bindTo(contextKeyService);
 		this._register(this.debugService.getModel().onDidChangeBreakpoints(() => this.onBreakpointsChange()));
+		this._register(this.debugService.getViewModel().onDidFocusSession(() => this.updateBreakpointsHint()));
 		this._register(this.debugService.onDidChangeState(() => this.onStateChange()));
+		this.hintDelayer = this._register(new RunOnceScheduler(() => this.updateBreakpointsHint(true), 4000));
 	}
 
 	override renderBody(container: HTMLElement): void {
@@ -194,6 +204,19 @@ export class BreakpointsView extends ViewPane {
 		}));
 	}
 
+	protected override renderHeaderTitle(container: HTMLElement, title: string): void {
+		super.renderHeaderTitle(container, title);
+
+		const iconLabelContainer = dom.append(container, $('span.breakpoint-warning'));
+		this.hintContainer = this._register(new IconLabel(iconLabelContainer, {
+			supportIcons: true, hoverDelegate: {
+				showHover: (options, focus?) => this.hoverService.showHover({ content: options.content, target: this.hintContainer!.element }, focus),
+				delay: <number>this.configurationService.getValue('workbench.hover.delay')
+			}
+		}));
+		dom.hide(this.hintContainer.element);
+	}
+
 	override focus(): void {
 		super.focus();
 		if (this.list) {
@@ -257,6 +280,29 @@ export class BreakpointsView extends ViewPane {
 		this.maximumBodySize = this.orientation === Orientation.VERTICAL && containerModel.visibleViewDescriptors.length > 1 ? getExpandedBodySize(this.debugService.getModel(), Number.POSITIVE_INFINITY) : Number.POSITIVE_INFINITY;
 	}
 
+	private updateBreakpointsHint(delayed = false): void {
+		if (!this.hintContainer) {
+			return;
+		}
+
+		const hasSomeUnverified = this.debugService.getModel().getBreakpoints().some(bp => !bp.verified);
+
+		const currentType = this.debugService.getViewModel().focusedSession?.configuration.type;
+		const message = currentType && this.debugService.getAdapterManager().getDebuggerUiMessages(currentType)[DebuggerUiMessage.UnverifiedBreakpoints];
+
+		if (message && hasSomeUnverified) {
+			if (delayed) {
+				const mdown = new MarkdownString(undefined, { isTrusted: true }).appendMarkdown(message);
+				this.hintContainer.setLabel('$(warning)', undefined, { title: { markdown: mdown, markdownNotSupportedFallback: message } });
+				dom.show(this.hintContainer.element);
+			} else {
+				this.hintDelayer.schedule();
+			}
+		} else {
+			dom.hide(this.hintContainer.element);
+		}
+	}
+
 	private onBreakpointsChange(): void {
 		if (this.isBodyVisible()) {
 			this.updateSize();
@@ -270,6 +316,7 @@ export class BreakpointsView extends ViewPane {
 					this.list.focusNth(Math.min(lastFocusIndex, this.list.length - 1));
 				}
 			}
+			this.updateBreakpointsHint();
 		} else {
 			this.needsRefresh = true;
 		}
@@ -304,6 +351,7 @@ export class BreakpointsView extends ViewPane {
 				}
 				this.autoFocusedIndex = -1;
 			}
+			this.updateBreakpointsHint();
 		} else {
 			this.needsStateChange = true;
 		}

--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -23,7 +23,7 @@ import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { Breakpoints } from 'vs/workbench/contrib/debug/common/breakpoints';
-import { CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_DEBUG_EXTENSION_AVAILABLE, IAdapterDescriptor, IAdapterManager, IConfig, IDebugAdapter, IDebugAdapterDescriptorFactory, IDebugAdapterFactory, IDebugConfiguration, IDebugSession, INTERNAL_CONSOLE_OPTIONS_SCHEMA } from 'vs/workbench/contrib/debug/common/debug';
+import { CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_DEBUG_EXTENSION_AVAILABLE, DebuggerUiMessage, IAdapterDescriptor, IAdapterManager, IConfig, IDebugAdapter, IDebugAdapterDescriptorFactory, IDebugAdapterFactory, IDebugConfiguration, IDebugSession, INTERNAL_CONSOLE_OPTIONS_SCHEMA } from 'vs/workbench/contrib/debug/common/debug';
 import { Debugger } from 'vs/workbench/contrib/debug/common/debugger';
 import { breakpointsExtPoint, debuggersExtPoint, launchSchema, presentationSchema } from 'vs/workbench/contrib/debug/common/debugSchemas';
 import { TaskDefinitionRegistry } from 'vs/workbench/contrib/tasks/common/taskDefinitionRegistry';
@@ -271,6 +271,15 @@ export class AdapterManager extends Disposable implements IAdapterManager {
 		}
 
 		return undefined;
+	}
+
+	getDebuggerUiMessages(type: string): { [key in DebuggerUiMessage]?: string } {
+		const dbgr = this.getDebugger(type);
+		if (dbgr) {
+			return dbgr.uiMessages || {};
+		}
+
+		return {};
 	}
 
 	get onDidRegisterDebugger(): Event<void> {

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -317,3 +317,12 @@
 	overflow: hidden;
 	text-overflow: ellipsis
 }
+
+.debug-pane .pane-header .breakpoint-warning {
+	margin-left: 3px;
+}
+
+.debug-pane .pane-header .breakpoint-warning .monaco-icon-label .codicon {
+	display: flex;
+	align-items: center;
+}

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -772,6 +772,7 @@ export interface IDebuggerContribution extends IPlatformSpecificAdapterContribut
 	configurationSnippets?: IJSONSchemaSnippet[];
 	variables?: { [key: string]: string };
 	when?: string;
+	uiMessages?: { [key in DebuggerUiMessage]: string };
 }
 
 export interface IBreakpointContribution {
@@ -847,6 +848,10 @@ export interface IConfigurationManager {
 	resolveConfigurationByProviders(folderUri: uri | undefined, type: string | undefined, debugConfiguration: any, token: CancellationToken): Promise<any>;
 }
 
+export enum DebuggerUiMessage {
+	UnverifiedBreakpoints = 'unverifiedBreakpoints'
+}
+
 export interface IAdapterManager {
 
 	onDidRegisterDebugger: Event<void>;
@@ -855,6 +860,7 @@ export interface IAdapterManager {
 	getDebugAdapterDescriptor(session: IDebugSession): Promise<IAdapterDescriptor | undefined>;
 	getDebuggerLabel(type: string): string | undefined;
 	isDebuggerInterestedInLanguage(language: string): boolean;
+	getDebuggerUiMessages(type: string): { [key in DebuggerUiMessage]?: string };
 
 	activateDebuggers(activationEvent: string, debugType?: string): Promise<void>;
 	registerDebugAdapterFactory(debugTypes: string[], debugAdapterFactory: IDebugAdapterFactory): IDisposable;

--- a/src/vs/workbench/contrib/debug/common/debugger.ts
+++ b/src/vs/workbench/contrib/debug/common/debugger.ts
@@ -147,6 +147,10 @@ export class Debugger implements IDebugger {
 		return !this.debuggerWhen || this.contextKeyService.contextMatchesRules(this.debuggerWhen);
 	}
 
+	get uiMessages() {
+		return this.debuggerContribution.uiMessages;
+	}
+
 	hasInitialConfiguration(): boolean {
 		return !!this.debuggerContribution.initialConfigurations;
 	}


### PR DESCRIPTION
Fixes #142870
