### PR TITLE
Add onEnterRule for SassDoc documentation

### DIFF
--- a/extensions/scss/language-configuration.json
+++ b/extensions/scss/language-configuration.json
@@ -32,5 +32,14 @@
 		"increaseIndentPattern": "(^.*\\{[^}]*$)",
 		"decreaseIndentPattern": "^\\s*\\}"
 	},
-	"wordPattern": "(#?-?\\d*\\.\\d\\w*%?)|(::?[\\w-]*(?=[^,{;]*[,{]))|(([@$#.!])?[\\w-?]+%?|[@#!$.])"
+	"wordPattern": "(#?-?\\d*\\.\\d\\w*%?)|(::?[\\w-]*(?=[^,{;]*[,{]))|(([@$#.!])?[\\w-?]+%?|[@#!$.])",
+	"onEnterRules": [
+		{
+			"beforeText": "^[\\s]*///.*$",
+			"action": {
+				"indent": "none",
+				"appendText": "/// "
+			}
+		}
+	]
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #150598

The proposed change extends the language configuration for SCSS with an `onEnterRule` to make the SassDoc editing experience closer to that of JSDoc.

An example test is shown in the second video attached to #150598.

This SCSS can be used to test the change.

```scss
/// Describe some-function, explaining what it does and how to use it. Try to add a new line after this.
@function some-function() {
    @return 2px;
}

.a {
    /// Confirm that SassDoc that is indented works as expected. Try to add a new line after this.
    $some-variable: 1px;  /// Try to add a new line after this. The rule should not kick in.
}

```
