### PR TITLE
Add CursorMove trigger kind

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -775,6 +775,11 @@ export enum InlineCompletionTriggerKind {
 	 * Return multiple completion items to enable cycling through them.
 	 */
 	Explicit = 1,
+
+	/**
+	 * Completion was triggered automatically while moving the cursor.
+	 */
+	CursorMove = 2,
 }
 
 export interface InlineCompletionContext {

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -384,7 +384,11 @@ export enum InlineCompletionTriggerKind {
 	 * Completion was triggered explicitly by a user gesture.
 	 * Return multiple completion items to enable cycling through them.
 	 */
-	Explicit = 1
+	Explicit = 1,
+	/**
+	 * Completion was triggered automatically while moving the cursor.
+	 */
+	CursorMove = 2
 }
 /**
  * Virtual Key Codes, the value does not hold any inherent meaning.

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
@@ -72,14 +72,14 @@ export class InlineCompletionsModel extends Disposable implements GhostTextWidge
 					'acceptSelectedSuggestion',
 				]);
 				if (commands.has(e.commandId) && editor.hasTextFocus()) {
-					this.handleUserInput();
+					this.handleUserInput(InlineCompletionTriggerKind.Explicit);
 				}
 			})
 		);
 
 		this._register(
 			this.editor.onDidType((e) => {
-				this.handleUserInput();
+				this.handleUserInput(InlineCompletionTriggerKind.Automatic);
 			})
 		);
 
@@ -109,7 +109,7 @@ export class InlineCompletionsModel extends Disposable implements GhostTextWidge
 		);
 	}
 
-	private handleUserInput() {
+	private handleUserInput(triggerKind: InlineCompletionTriggerKind) {
 		if (this.session && !this.session.isValid) {
 			this.hide();
 		}
@@ -118,7 +118,7 @@ export class InlineCompletionsModel extends Disposable implements GhostTextWidge
 				return;
 			}
 			// Wait for the cursor update that happens in the same iteration loop iteration
-			this.startSessionIfTriggered();
+			this.startSessionIfTriggered(triggerKind);
 		}, 0);
 	}
 
@@ -149,7 +149,7 @@ export class InlineCompletionsModel extends Disposable implements GhostTextWidge
 		}
 	}
 
-	private startSessionIfTriggered(): void {
+	private startSessionIfTriggered(triggerKind: InlineCompletionTriggerKind): void {
 		const suggestOptions = this.editor.getOption(EditorOption.inlineSuggest);
 		if (!suggestOptions.enabled) {
 			return;
@@ -159,7 +159,7 @@ export class InlineCompletionsModel extends Disposable implements GhostTextWidge
 			return;
 		}
 
-		this.trigger(InlineCompletionTriggerKind.Automatic);
+		this.trigger(triggerKind);
 	}
 
 	public trigger(triggerKind: InlineCompletionTriggerKind): void {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6333,7 +6333,11 @@ declare namespace monaco.languages {
 		 * Completion was triggered explicitly by a user gesture.
 		 * Return multiple completion items to enable cycling through them.
 		 */
-		Explicit = 1
+		Explicit = 1,
+		/**
+		 * Completion was triggered automatically while moving the cursor.
+		 */
+		CursorMove = 2
 	}
 
 	export interface InlineCompletionContext {

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1055,6 +1055,7 @@ class InlineCompletionAdapter extends InlineCompletionAdapterBase {
 	private readonly languageTriggerKindToVSCodeTriggerKind: Record<languages.InlineCompletionTriggerKind, InlineCompletionTriggerKind> = {
 		[languages.InlineCompletionTriggerKind.Automatic]: InlineCompletionTriggerKind.Automatic,
 		[languages.InlineCompletionTriggerKind.Explicit]: InlineCompletionTriggerKind.Invoke,
+		[languages.InlineCompletionTriggerKind.CursorMove]: InlineCompletionTriggerKind.CursorMove,
 	};
 
 	override async provideInlineCompletions(resource: URI, position: IPosition, context: languages.InlineCompletionContext, token: CancellationToken): Promise<extHostProtocol.IdentifiableInlineCompletions | undefined> {
@@ -1161,6 +1162,7 @@ class InlineCompletionAdapterNew extends InlineCompletionAdapterBase {
 	private readonly languageTriggerKindToVSCodeTriggerKind: Record<languages.InlineCompletionTriggerKind, vscode.InlineCompletionTriggerKindNew> = {
 		[languages.InlineCompletionTriggerKind.Automatic]: InlineCompletionTriggerKindNew.Automatic,
 		[languages.InlineCompletionTriggerKind.Explicit]: InlineCompletionTriggerKindNew.Invoke,
+		[languages.InlineCompletionTriggerKind.CursorMove]: InlineCompletionTriggerKindNew.CursorMove,
 	};
 
 	override async provideInlineCompletions(resource: URI, position: IPosition, context: languages.InlineCompletionContext, token: CancellationToken): Promise<extHostProtocol.IdentifiableInlineCompletions | undefined> {

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2677,11 +2677,13 @@ export class EvaluatableExpression implements vscode.EvaluatableExpression {
 export enum InlineCompletionTriggerKind {
 	Invoke = 0,
 	Automatic = 1,
+	CursorMove = 2,
 }
 
 export enum InlineCompletionTriggerKindNew {
 	Invoke = 0,
 	Automatic = 1,
+	CursorMove = 2,
 }
 
 @es5ClassCompat

--- a/src/vscode-dts/vscode.proposed.inlineCompletions.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineCompletions.d.ts
@@ -115,6 +115,11 @@ declare module 'vscode' {
 		 * It is sufficient to return a single completion item in this case.
 		 */
 		Automatic = 1,
+
+		/**
+		 * Completion was triggered automatically while moving the cursor.
+		 */
+		CursorMove = 2,
 	}
 
 	/**

--- a/src/vscode-dts/vscode.proposed.inlineCompletionsNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineCompletionsNew.d.ts
@@ -100,6 +100,11 @@ declare module 'vscode' {
 		 * It is sufficient to return a single completion item in this case.
 		 */
 		Automatic = 1,
+
+		/**
+		 * Completion was triggered automatically while moving the cursor.
+		 */
+		CursorMove = 2,
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR contributes to #150684 by introducing CursorMove enum value and allowing to start triggering inline completion when user moves the cursor around the document without typing in the future.
