### PR TITLE
chore: update electron@17.4.6

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,4 +1,4 @@
 disturl "https://electronjs.org/headers"
-target "17.4.5"
+target "17.4.6"
 runtime "electron"
 build_from_source "true"

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -60,12 +60,12 @@
 				"git": {
 					"name": "electron",
 					"repositoryUrl": "https://github.com/electron/electron",
-					"commitHash": "fb3abffd16dc30cb959417191fc86d4f33d40263"
+					"commitHash": "3a1945bd6c62459a457bd8d0b922259234816e22"
 				}
 			},
 			"isOnlyProductionDependency": true,
 			"license": "MIT",
-			"version": "17.4.5"
+			"version": "17.4.6"
 		},
 		{
 			"component": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "cssnano": "^4.1.11",
     "debounce": "^1.0.0",
     "deemon": "^1.4.0",
-    "electron": "17.4.5",
+    "electron": "17.4.6",
     "eslint": "8.7.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-jsdoc": "^19.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4287,10 +4287,10 @@ electron-to-chromium@^1.4.17:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.45.tgz#cf1144091d6683cbd45a231954a745f02fb24598"
   integrity sha512-czF9eYVuOmlY/vxyMQz2rGlNSjZpxNQYBe1gmQv7al171qOIhgyO9k7D5AKlgeTCSPKk+LHhj5ZyIdmEub9oNg==
 
-electron@17.4.5:
-  version "17.4.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.5.tgz#a1d9c22fc7acfeced4f56caef68bb53988aceb97"
-  integrity sha512-OuJH+cVko69/o/zxsQXpjoLaIEQLZ/yVSd82bShRBdKc3JVfVo2cCejjpeizq/Q4VjWyT494BodDSS2hz/47cQ==
+electron@17.4.6:
+  version "17.4.6"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.6.tgz#4837b3adb2636992a33da734a77794dd932fb05c"
+  integrity sha512-9aPjlyWoVxchD/iw5KcbQ7ZaC5ezxsObBrMbGjpdMmDL5dktI0EkT6x2l2CYPZCi4rQG/6qlPfTZJeVPIIwI2Q==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
Addresses the following from https://github.com/microsoft/vscode/pull/150167#issue-1244882967

```
* args/execArgv shapes are different compared to nodejs
* on('spawn') / on('exit') are never fired
```