### PR TITLE
Renames files.excludeGitIgnore -> explorer.excludeGitIgnore

### DIFF
--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -1218,7 +1218,6 @@ export interface IFilesConfiguration {
 		autoSaveDelay: number;
 		eol: string;
 		enableTrash: boolean;
-		excludeGitIgnore: boolean;
 		hotExit: string;
 		saveConflictResolution: 'askUser' | 'overwriteFileOnDisk';
 	};

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -186,12 +186,6 @@ configurationRegistry.registerConfiguration({
 			'markdownDescription': nls.localize('autoGuessEncoding', "When enabled, the editor will attempt to guess the character set encoding when opening files. This setting can also be configured per language. Note, this setting is not respected by text search. Only `#files.encoding#` is respected."),
 			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE
 		},
-		'files.excludeGitIgnore': {
-			type: 'boolean',
-			markdownDescription: nls.localize('excludeGitignore', "Controls whether entries in .gitignore should be parsed and excluded from the explorer. Similar to `#files.exclude#`."),
-			default: false,
-			scope: ConfigurationScope.RESOURCE
-		},
 		'files.eol': {
 			'type': 'string',
 			'enum': [
@@ -476,6 +470,12 @@ configurationRegistry.registerConfiguration({
 			],
 			'description': nls.localize('copyRelativePathSeparator', "The path separation character used when copying relative file paths."),
 			'default': 'auto'
+		},
+		'explorer.excludeGitIgnore': {
+			type: 'boolean',
+			markdownDescription: nls.localize('excludeGitignore', "Controls whether entries in .gitignore should be parsed and excluded from the explorer. Similar to `#files.exclude#`."),
+			default: false,
+			scope: ConfigurationScope.RESOURCE
 		},
 		'explorer.fileNesting.enabled': {
 			'type': 'boolean',

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -622,7 +622,7 @@ export class FilesFilter implements ITreeFilter<ExplorerItem, FuzzyScore> {
 	) {
 		this.toDispose.push(this.contextService.onDidChangeWorkspaceFolders(() => this.updateConfiguration()));
 		this.toDispose.push(this.configurationService.onDidChangeConfiguration((e) => {
-			if (e.affectsConfiguration('files.exclude') || e.affectsConfiguration('files.excludeGitIgnore')) {
+			if (e.affectsConfiguration('files.exclude') || e.affectsConfiguration('explorer.excludeGitIgnore')) {
 				this.updateConfiguration();
 			}
 		}));
@@ -683,7 +683,7 @@ export class FilesFilter implements ITreeFilter<ExplorerItem, FuzzyScore> {
 		this.contextService.getWorkspace().folders.forEach(folder => {
 			const configuration = this.configurationService.getValue<IFilesConfiguration>({ resource: folder.uri });
 			const excludesConfig: glob.IExpression = configuration?.files?.exclude || Object.create(null);
-			const parseIgnoreFile: boolean = configuration.files.excludeGitIgnore;
+			const parseIgnoreFile: boolean = configuration.explorer.excludeGitIgnore;
 
 			// If we should be parsing ignoreFiles for this workspace and don't have an ignore tree initialize one
 			if (parseIgnoreFile && !this.ignoreTreesPerRoot.has(folder.uri.toString())) {

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -98,6 +98,7 @@ export interface IFilesConfiguration extends PlatformIFilesConfiguration, IWorkb
 			badges: boolean;
 		};
 		incrementalNaming: 'simple' | 'smart';
+		excludeGitIgnore: boolean;
 		fileNesting: {
 			enabled: boolean;
 			expand: boolean;


### PR DESCRIPTION
Since this setting only applies to the explorer it is being renamed from `files.excludeGitIgnore` to `expllorer.excludeGitIgnore`