### PR TITLE
Don't parse checkboxes as links in markdown

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/documentLinkProvider.ts
@@ -353,6 +353,12 @@ export class MdLinkProvider implements vscode.DocumentLinkProvider {
 				reference = match[5];
 				const offset = ((match.index ?? 0) + match[1].length) + 1;
 				linkStart = document.positionAt(offset);
+				const line = document.lineAt(linkStart.line);
+				// See if link looks like a checkbox
+				const checkboxMatch = line.text.match(/^\s*\-\s*\[x\]/i);
+				if (checkboxMatch && linkStart.character <= checkboxMatch[0].length) {
+					continue;
+				}
 				linkEnd = document.positionAt(offset + reference.length);
 			} else {
 				continue;

--- a/extensions/markdown-language-features/src/test/diagnostic.test.ts
+++ b/extensions/markdown-language-features/src/test/diagnostic.test.ts
@@ -268,4 +268,17 @@ suite('markdown: Diagnostics', () => {
 		const { diagnostics } = await manager.recomputeDiagnosticState(doc1, noopToken);
 		assert.deepStrictEqual(diagnostics.length, 0);
 	});
+
+	test('Should not detect checkboxes as invalid links', async () => {
+		const doc1 = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
+			`- [x]`,
+			`- [X]`,
+			`- [ ]`,
+		));
+
+		const contents = new InMemoryWorkspaceMarkdownDocuments([doc1]);
+		const manager = createDiagnosticsManager(contents, new MemoryDiagnosticConfiguration(true, ['/doc2.md']));
+		const { diagnostics } = await manager.recomputeDiagnosticState(doc1, noopToken);
+		assert.deepStrictEqual(diagnostics.length, 0);
+	});
 });

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -313,4 +313,33 @@ suite('markdown.DocumentLinkProvider', () => {
 		));
 		assert.strictEqual(links.length, 0);
 	});
+
+	test('Should not mark checkboxes as links', async () => {
+		const links = await getLinksForFile(joinLines(
+			'- [x]',
+			'- [X]',
+			'- []',
+			``,
+			`[x]: http://example.com`
+		));
+		assert.strictEqual(links.length, 1);
+		assertRangeEqual(links[0].range, new vscode.Range(4, 5, 4, 23));
+
+	});
+
+	test('Should still find links on line with checkbox', async () => {
+		const links = await getLinksForFile(joinLines(
+			'- [x] [x]',
+			'- [X] [x]',
+			'- [] [x]',
+			``,
+			`[x]: http://example.com`
+		));
+		assert.strictEqual(links.length, 4);
+
+		assertRangeEqual(links[0].range, new vscode.Range(0, 7, 0, 8));
+		assertRangeEqual(links[1].range, new vscode.Range(1, 7, 1, 8));
+		assertRangeEqual(links[2].range, new vscode.Range(2, 6, 2, 7));
+		assertRangeEqual(links[3].range, new vscode.Range(4, 5, 4, 23));
+	});
 });

--- a/extensions/markdown-language-features/src/test/references.test.ts
+++ b/extensions/markdown-language-features/src/test/references.test.ts
@@ -577,5 +577,19 @@ suite('markdown: find all references', () => {
 				{ uri: docUri, line: 2 },
 			);
 		});
+
+		test('Should not consider checkboxes as reference links', async () => {
+			const docUri = workspacePath('doc.md');
+			const doc = new InMemoryDocument(docUri, joinLines(
+				`- [x]`,
+				`- [X]`,
+				`- [ ]`,
+				``,
+				`[x]: https://example.com`
+			));
+
+			const refs = await getReferences(doc, new vscode.Position(0, 4), new InMemoryWorkspaceMarkdownDocuments([doc]));
+			assert.strictEqual(refs?.length!, 0);
+		});
 	});
 });


### PR DESCRIPTION
Fixes #150672


