### PR TITLE
Escape {} properly in bash debug terminal

### DIFF
--- a/src/vs/workbench/contrib/debug/node/terminals.ts
+++ b/src/vs/workbench/contrib/debug/node/terminals.ts
@@ -161,7 +161,7 @@ export function prepareCommand(shell: string, args: string[], cwd?: string, env?
 		case ShellType.bash: {
 
 			quote = (s: string) => {
-				s = s.replace(/(["'\\\$!><#()\[\]*&^| ;])/g, '\\$1');
+				s = s.replace(/(["'\\\$!><#()\[\]*&^| ;{}`])/g, '\\$1');
 				return s.length === 0 ? `""` : s;
 			};
 

--- a/src/vs/workbench/contrib/debug/test/node/terminals.test.ts
+++ b/src/vs/workbench/contrib/debug/test/node/terminals.test.ts
@@ -11,7 +11,7 @@ suite('Debug - prepareCommand', () => {
 	test('bash', () => {
 		assert.strictEqual(
 			prepareCommand('bash', ['{$} (']).trim(),
-			'{\\$}\\ \\(');
+			'\\{\\$\\}\\ \\(');
 		assert.strictEqual(
 			prepareCommand('bash', ['hello', 'world', '--flag=true']).trim(),
 			'hello world --flag=true');


### PR DESCRIPTION
Fixes #150774
