### PR TITLE
Add nvm-exec support

### DIFF
--- a/extensions/npm/README.md
+++ b/extensions/npm/README.md
@@ -35,6 +35,7 @@ The extension fetches data from https://registry.npmjs.org and https://registry.
 - `npm.autoDetect` - Enable detecting scripts as tasks, the default is `on`.
 - `npm.runSilent` - Run npm script with the `--silent` option, the default is `false`.
 - `npm.packageManager` - The package manager used to run the scripts: `auto`, `npm`, `yarn` or `pnpm`, the default is `auto`, which detects your package manager based on your files.
+- `npm.useNvm` - Use [`nvm`](https://github.com/nvm-sh/nvm#readme) to run npm, the default is `false`.
 - `npm.exclude` - Glob patterns for folders that should be excluded from automatic script detection. The pattern is matched against the **absolute path** of the package.json. For example, to exclude all test folders use '&ast;&ast;/test/&ast;&ast;'.
 - `npm.enableScriptExplorer` - Enable an explorer view for npm scripts.
 - `npm.scriptExplorerAction` - The default click action: `open` or `run`, the default is `open`.

--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -112,6 +112,10 @@
       {
         "command": "npm.packageManager",
         "title": "%command.packageManager%"
+      },
+      {
+        "command": "npm.packageManagerLaunchArgs",
+        "title": "%command.packageManagerLaunchArgs%"
       }
     ],
     "menus": {
@@ -246,6 +250,12 @@
           ],
           "default": "auto",
           "description": "%config.npm.packageManager%"
+        },
+        "npm.useNvm": {
+          "type": "boolean",
+          "default": false,
+          "scope": "resource",
+          "markdownDescription": "%config.npm.useNvm%"
         },
         "npm.exclude": {
           "type": [

--- a/extensions/npm/package.nls.json
+++ b/extensions/npm/package.nls.json
@@ -9,6 +9,7 @@
 	"config.npm.packageManager.yarn": "Use yarn as the package manager for running scripts.",
 	"config.npm.packageManager.pnpm": "Use pnpm as the package manager for running scripts.",
 	"config.npm.packageManager.auto": "Auto-detect which package manager to use for running scripts based on lock files and installed package managers.",
+	"config.npm.useNvm": "Use nvm to run npm",
 	"config.npm.exclude": "Configure glob patterns for folders that should be excluded from automatic script detection.",
 	"config.npm.enableScriptExplorer": "Enable an explorer view for npm scripts when there is no top-level 'package.json' file.",
 	"config.npm.scriptExplorerAction": "The default click action used in the npm scripts explorer: `open` or `run`, the default is `open`.",
@@ -26,5 +27,6 @@
 	"command.runInstall": "Run Install",
 	"command.runSelectedScript": "Run Script",
 	"command.runScriptFromFolder": "Run NPM Script in Folder...",
-	"command.packageManager": "Get Configured Package Manager"
+	"command.packageManager": "Get Configured Package Manager",
+	"command.packageManagerLaunchArgs": "Get Args for Launching Configured Package Manager"
 }

--- a/extensions/npm/src/npmMain.ts
+++ b/extensions/npm/src/npmMain.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { addJSONProviders } from './features/jsonContributions';
 import { runSelectedScript, selectAndRunScriptFromFolder } from './commands';
 import { NpmScriptsTreeDataProvider } from './npmView';
-import { getPackageManager, invalidateTasksCache, NpmTaskProvider, hasPackageJson } from './tasks';
+import { getPackageManager, invalidateTasksCache, NpmTaskProvider, hasPackageJson, getPackageManagerLaunchArgs } from './tasks';
 import { invalidateHoverScriptsCache, NpmScriptHoverProvider } from './scriptHover';
 import { NpmScriptLensProvider } from './npmScriptLens';
 import * as which from 'which';
@@ -66,6 +66,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(vscode.commands.registerCommand('npm.packageManager', (args) => {
 		if (args instanceof vscode.Uri) {
 			return getPackageManager(context, args);
+		}
+		return '';
+	}));
+	context.subscriptions.push(vscode.commands.registerCommand('npm.packageManagerLaunchArgs', (args) => {
+		if (args instanceof vscode.Uri) {
+			return getPackageManagerLaunchArgs(context, args);
 		}
 		return '';
 	}));

--- a/extensions/npm/src/npmScriptLens.ts
+++ b/extensions/npm/src/npmScriptLens.ts
@@ -17,6 +17,7 @@ import {
 import * as nls from 'vscode-nls';
 import { findPreferredPM } from './preferred-pm';
 import { readScripts } from './readScripts';
+import { getNvmExecPath } from './tasks';
 
 const localize = nls.loadMessageBundle();
 
@@ -88,6 +89,7 @@ export class NpmScriptLensProvider implements CodeLensProvider, Disposable {
 
 		if (this.lensLocation === 'all') {
 			const packageManager = await findPreferredPM(Uri.joinPath(document.uri, '..').fsPath);
+			const nvmExecPath = getNvmExecPath(workspace.getWorkspaceFolder(document.uri)?.uri);
 			return tokens.scripts.map(
 				({ name, nameRange }) =>
 					new CodeLens(
@@ -95,7 +97,7 @@ export class NpmScriptLensProvider implements CodeLensProvider, Disposable {
 						{
 							title,
 							command: 'extension.js-debug.createDebuggerTerminal',
-							arguments: [`${packageManager.name} run ${name}`, workspace.getWorkspaceFolder(document.uri), { cwd }],
+							arguments: [`${nvmExecPath ? `${nvmExecPath} ` : ''}${packageManager.name} run ${name}`, workspace.getWorkspaceFolder(document.uri), { cwd }],
 						},
 					),
 			);


### PR DESCRIPTION
This PR fixes #150938 by adding support for [`nvm`](https://github.com/nvm-sh/nvm#readme) in the `npm` extension. The support is enabled with a config setting, without which there is no behaviour change. This change enables support for `nvm`'s `.nvmrc` files, which control the version of node per project or per folder. The approach could be changed to automatically enable `nvm` if `.nvmrc` files are detected, but that would introduce a behaviour change for those users.

Notable changes include:

* an `npm.useNvm` config setting
* an `npm.packageManagerLaunchArgs` command to enhance the existing `npm.packageManager` command, so the `npm` extension can return an array of commands to launch the package manager, possibly including using `nvm-exec` (the `js-debug` extension would need updating to use this, and I can make a PR if this PR makes the cut!)

Testing:

1. Have `nvm` installed
2. Open an existing node project containing a `package.json`
3. Add a 'test-nvm' script containing "node --version"
4. Create, if there isn't one already, an `.nvmrc` file in the root of the project, containing a node version (e.g. 16.15.0) 
5. Use _Run Build Task_ to run the "test-nvm" script that will have been detected.
6. Observe the version of node matches the version in `.nvmrc` if you have this PR installed, or matches your default version of node if not.
7. If you have this PR installed; change the version of node in `.nvmrc` and repeat the previous step to observe the reported node version changing.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


