### PR TITLE
Accept capitalization in HTTP upgrade header in web

### DIFF
--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -192,7 +192,7 @@ export class RemoteExtensionHostAgentServer extends Disposable implements IServe
 			}
 		}
 
-		if (req.headers['upgrade'] !== 'websocket') {
+		if (req.headers['upgrade'] === undefined || req.headers['upgrade'].toLowerCase() !== 'websocket') {
 			socket.end('HTTP/1.1 400 Bad Request');
 			return;
 		}


### PR DESCRIPTION
This PR makes VS Code web accept capitalization in HTTP upgrade header instead of only accepting `Upgrade: websocket`.

This solves a bug where the websocket connection fails with status 1006 when running VS Code web behind an Apache proxy that is using mod_proxy_wstunnel since mod_proxy_wstunnel sends the header `Upgrade: WebSocket`. 
Relevant discussion about this bug can be found [here](https://github.com/coder/code-server/issues/4723#issuecomment-1105319574).