### PR TITLE
Don't sync label formatters across machines

### DIFF
--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -143,7 +143,7 @@ export class LabelService extends Disposable implements ILabelService {
 		this.userHome = pathService.defaultUriScheme === Schemas.file ? this.pathService.userHome({ preferLocal: true }) : undefined;
 
 		const memento = this.storedFormattersMemento = new Memento('cachedResourceFormatters', storageService);
-		this.storedFormatters = memento.getMemento(StorageScope.GLOBAL, StorageTarget.USER);
+		this.storedFormatters = memento.getMemento(StorageScope.GLOBAL, StorageTarget.MACHINE);
 		this.formatters = this.storedFormatters?.formatters || [];
 
 		// Remote environment is potentially long running


### PR DESCRIPTION
Fixes #150970

I didn't test this as it's hard to test without it being in product but it seems like this should fix. Since the scope is different I believe the old contents will not be used do there's no migration needed to fix (can confirm after update).