### PR TITLE
Fix accidental grammar mistake to .d.ts

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -16031,7 +16031,7 @@ declare module 'vscode' {
 		readonly viewColumn: ViewColumn;
 
 		/**
-		 * The active {@link Tab tab} in the group. This is the tab which contents are currently
+		 * The active {@link Tab tab} in the group. This is the tab whose contents are currently
 		 * being rendered.
 		 *
 		 * *Note* that there can be one active tab per group but there can only be one {@link TabGroups.activeTabGroup active group}.


### PR DESCRIPTION
Looks like @jrieken brought in an [accidental grammar change](https://github.com/microsoft/vscode/pull/147926#discussion_r866186867) to the tabs API in the `.d.ts`. This just returns the word to its previous status 