### PR TITLE
Better message for markdown reference links

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/diagnostics.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/diagnostics.ts
@@ -448,7 +448,7 @@ export class DiagnosticComputer {
 			if (link.href.kind === 'reference' && !definitionSet.lookup(link.href.ref)) {
 				yield new vscode.Diagnostic(
 					link.source.hrefRange,
-					localize('invalidReferenceLink', 'No link reference found: \'{0}\'', link.href.ref),
+					localize('invalidReferenceLink', 'No link definition found: \'{0}\'', link.href.ref),
 					severity);
 			}
 		}

--- a/extensions/markdown-language-features/src/languageFeatures/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/documentLinkProvider.ts
@@ -271,9 +271,11 @@ export class MdLinkProvider implements vscode.DocumentLinkProvider {
 			case 'reference': {
 				const def = definitionSet.lookup(link.href.ref);
 				if (def) {
-					return new vscode.DocumentLink(
+					const documentLink = new vscode.DocumentLink(
 						link.source.hrefRange,
 						vscode.Uri.parse(`command:_markdown.moveCursorToPosition?${encodeURIComponent(JSON.stringify([def.source.hrefRange.start.line, def.source.hrefRange.start.character]))}`));
+					documentLink.tooltip = localize('documentLink.referenceTooltip', 'Go to link definition');
+					return documentLink;
 				} else {
 					return undefined;
 				}


### PR DESCRIPTION
Fixes #151017

Also improves the diagnostic message for invalid reference links to make it clear we are talking about a missing link definition

