### PR TITLE
Always set text/uri-list

### DIFF
--- a/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
+++ b/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
@@ -100,15 +100,13 @@ export class DropIntoEditorController extends Disposable implements IEditorContr
 		}
 
 		const textEditorDataTransfer = toVSDataTransfer(dragEvent.dataTransfer);
-		if (!textEditorDataTransfer.has(Mimes.uriList)) {
-			const editorData = (await this._instantiationService.invokeFunction(extractEditorsDropData, dragEvent))
-				.filter(input => input.resource)
-				.map(input => input.resource!.toString());
+		const editorData = (await this._instantiationService.invokeFunction(extractEditorsDropData, dragEvent))
+			.filter(input => input.resource)
+			.map(input => input.resource!.toString());
 
-			if (editorData.length) {
-				const str = distinct(editorData).join('\n');
-				textEditorDataTransfer.replace(Mimes.uriList, createStringDataTransferItem(str));
-			}
+		if (editorData.length) {
+			const str = distinct(editorData).join('\n');
+			textEditorDataTransfer.replace(Mimes.uriList, createStringDataTransferItem(str));
 		}
 
 		return textEditorDataTransfer;


### PR DESCRIPTION
Fixes #150996

When dragging files from the explorer on windows, something seems to cause `text/uri-list` to get set on the datatransfer automatically. I don't understand why this happens as it doesn't happen on MacOS in my testing 

The generated `text/uri-list` is incorrect in this case though. It contains all the uris joined together without spaces, instead of separated by new lines

This fix makes us always recompute and set `text/uri-list`

