### PR TITLE
Also ignore star checkboxes

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/documentLinkProvider.ts
@@ -355,7 +355,7 @@ export class MdLinkProvider implements vscode.DocumentLinkProvider {
 				linkStart = document.positionAt(offset);
 				const line = document.lineAt(linkStart.line);
 				// See if link looks like a checkbox
-				const checkboxMatch = line.text.match(/^\s*\-\s*\[x\]/i);
+				const checkboxMatch = line.text.match(/^\s*[\-\*]\s*\[x\]/i);
 				if (checkboxMatch && linkStart.character <= checkboxMatch[0].length) {
 					continue;
 				}

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -318,12 +318,15 @@ suite('markdown.DocumentLinkProvider', () => {
 		const links = await getLinksForFile(joinLines(
 			'- [x]',
 			'- [X]',
-			'- []',
+			'- [ ]',
+			'* [x]',
+			'* [X]',
+			'* [ ]',
 			``,
 			`[x]: http://example.com`
 		));
 		assert.strictEqual(links.length, 1);
-		assertRangeEqual(links[0].range, new vscode.Range(4, 5, 4, 23));
+		assertRangeEqual(links[0].range, new vscode.Range(7, 5, 7, 23));
 
 	});
 


### PR DESCRIPTION
Fixes #150672

This makes our md link detection also ignore checkboxes like `* [x]` instead of just `- [x]`

