### PR TITLE
Add experimental tag to experimental extension settings

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -2450,7 +2450,10 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "%config.experimental.mergeEditor%",
-          "scope": "window"
+          "scope": "window",
+          "tags": [
+            "experimental"
+          ]
         }
       }
     },

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -417,15 +417,21 @@
         },
         "markdown.experimental.editor.pasteLinks.enabled": {
           "type": "boolean",
-          "default": false,
+          "scope": "resource",
           "markdownDescription": "%configuration.markdown.editor.pasteLinks.enabled%",
-          "scope": "resource"
+          "default": false,
+          "tags": [
+            "experimental"
+          ]
         },
         "markdown.experimental.validate.enabled": {
           "type": "boolean",
           "scope": "resource",
           "description": "%configuration.markdown.experimental.validate.enabled.description%",
-          "default": false
+          "default": false,
+          "tags": [
+            "experimental"
+          ]
         },
         "markdown.experimental.validate.referenceLinks.enabled": {
           "type": "string",
@@ -436,6 +442,9 @@
             "ignore",
             "warning",
             "error"
+          ],
+          "tags": [
+            "experimental"
           ]
         },
         "markdown.experimental.validate.headerLinks.enabled": {
@@ -447,6 +456,9 @@
             "ignore",
             "warning",
             "error"
+          ],
+          "tags": [
+            "experimental"
           ]
         },
         "markdown.experimental.validate.fileLinks.enabled": {
@@ -458,6 +470,9 @@
             "ignore",
             "warning",
             "error"
+          ],
+          "tags": [
+            "experimental"
           ]
         },
         "markdown.experimental.validate.ignoreLinks": {
@@ -466,7 +481,10 @@
           "markdownDescription": "%configuration.markdown.experimental.validate.ignoreLinks.description%",
           "items": {
             "type": "string"
-          }
+          },
+          "tags": [
+            "experimental"
+          ]
         }
       }
     },

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -1103,7 +1103,10 @@
           "type": "boolean",
           "default": false,
           "description": "%configuration.tsserver.experimental.enableProjectDiagnostics%",
-          "scope": "window"
+          "scope": "window",
+          "tags": [
+            "experimental"
+          ]
         },
         "typescript.tsserver.watchOptions": {
           "type": "object",


### PR DESCRIPTION
Found while testing #150389

This makes a few more extension settings with the `experimental` tag so that show up if you search `@tag:experimental`


