### PR TITLE
Server: register a dummy service worker

### DIFF
--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -508,4 +508,11 @@ function doCreateUri(path: string, queryValues: Map<string, string>): URI {
 		urlCallbackProvider: new LocalStorageURLCallbackProvider(config.callbackRoute),
 		credentialsProvider: config.remoteAuthority ? undefined : new LocalStorageCredentialsProvider() // with a remote, we don't use a local credentials provider
 	});
+
+	if ('serviceWorker' in navigator) {
+		navigator.serviceWorker
+			.register('/service-worker.js')
+			.then(() => { })
+			.catch(() => { });
+	}
 })();

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -131,6 +131,20 @@ export class RemoteExtensionHostAgentServer extends Disposable implements IServe
 			return serveError(req, res, 403, `Forbidden.`);
 		}
 
+		// Service worker
+		if (pathname === '/service-worker.js') {
+			res.writeHead(200, { 'Content-Type': 'text/javascript' });
+			return res.end(`
+				self.addEventListener('install', (e) => {
+					e.waitUntil(self.skipWaiting());
+				});
+				self.addEventListener('fetch', (e) => {
+					console.log(e.request.url);
+					e.respondWith(fetch(e.request));
+				});
+			`);
+		}
+
 		if (pathname === '/vscode-remote-resource') {
 			// Handle HTTP requests for resources rendered in the rich client (images, fonts, etc.)
 			// These resources could be files shipped with extensions or even workspace files.


### PR DESCRIPTION
Chrome does not allow PWAs without a matching service worker

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #151055
