### PR TITLE
Adresses #149130 by not causing and endless-loop when token end-offsets are not sorted.

### DIFF
--- a/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/tokenizer.ts
+++ b/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/tokenizer.ts
@@ -199,7 +199,7 @@ class NonPeekableTextBufferTokenizer {
 
 				const endOffset = lineTokens.getEndOffset(this.lineTokenOffset);
 				// Is there a bracket token next? Only consume text.
-				if (containsBracketType && isOther && endOffset !== this.lineCharOffset) {
+				if (containsBracketType && isOther && this.lineCharOffset < endOffset) {
 					const languageId = lineTokens.getLanguageId(this.lineTokenOffset);
 					const text = this.line.substring(this.lineCharOffset, endOffset);
 


### PR DESCRIPTION
This PR fixes symptoms of #149130.

It handles situations like this:
![image](https://user-images.githubusercontent.com/2931520/171595666-2698d18c-c5bc-4231-8603-650957aaa831.png)