### PR TITLE
Fixes #149460 by returning null for unconfigured brackets.

### DIFF
--- a/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsImpl.ts
+++ b/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsImpl.ts
@@ -127,7 +127,11 @@ export class BracketPairsTextModelPart extends Disposable implements IBracketPai
 		if (this.canBuildAST) {
 			const closingBracketInfo = this.languageConfigurationService
 				.getLanguageConfiguration(languageId)
-				.bracketsNew.getClosingBracketInfo(_bracket)!;
+				.bracketsNew.getClosingBracketInfo(_bracket);
+
+			if (!closingBracketInfo) {
+				return null;
+			}
 
 			const bracketPair = findLast(this.getBracketPairsInRange(Range.fromPositions(_position, _position)) || [], (b) =>
 				closingBracketInfo.closes(b.openingBracketInfo)


### PR DESCRIPTION

This PR fixes #149460 
