### PR TITLE
TreeDataProvider: iconPath is ignored for items with resourceUri

### DIFF
--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -1089,9 +1089,9 @@ class TreeRenderer extends Disposable implements ITreeRenderer<ITreeItem, FuzzyS
 			return false;
 		}
 
-		if (hasResource && (this.isFileKindThemeIcon(icon) || !this.shouldShowFileIcons())) {
+		if (hasResource && this.isFileKindThemeIcon(icon) && !this.shouldShowFileIcons()) {
 			return false;
-		} else if (hasResource && (this.isFolderThemeIcon(icon) || !this.shouldShowFolderIcons())) {
+		} else if (hasResource && this.isFolderThemeIcon(icon) && !this.shouldShowFolderIcons()) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Fixes #151087
