### PR TITLE
Git - Add minItems/maxItems for branch dictionary setting

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1927,6 +1927,8 @@
               "%config.branchRandomNameDictionary.numbers%"
             ]
           },
+          "minItems": 1,
+          "maxItems": 5,
           "default": [
             "adjectives",
             "animals"


### PR DESCRIPTION
Fix #151110