### PR TITLE
don't dispose of addon on relaunch of terminal 

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -114,6 +114,10 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 		if (this._commandDetectionListeners) {
 			dispose(this._commandDetectionListeners);
 		}
+		this.clearDecorations();
+	}
+
+	public clearDecorations(): void {
 		this._placeholderDecoration?.dispose();
 		this._placeholderDecoration?.marker.dispose();
 		for (const value of this._decorations.values()) {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -258,8 +258,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 	}
 
 	clearDecorations(): void {
-		this._decorationAddon?.dispose();
-		this._decorationAddon = undefined;
+		this._decorationAddon?.clearDecorations();
 	}
 
 	forceRefresh() {


### PR DESCRIPTION
fix #146855

properly fixed this time 😓 . the name `clearDecorations` did not describe what it actually did 

https://user-images.githubusercontent.com/29464607/171688823-68edef81-d36e-4090-94c6-3ca0ea3d32c0.mov


