### PR TITLE
Fix releasing alt sometimes not hiding locked hovers

### DIFF
--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -38,7 +38,11 @@ export class HoverService implements IHoverService {
 		const hoverDisposables = new DisposableStore();
 		const hover = this._instantiationService.createInstance(HoverWidget, options);
 		hover.onDispose(() => {
-			this._currentHoverOptions = undefined;
+			// Only clear the current options if it's the current hover, the current options help
+			// reduce flickering when the same hover is shown multiple times
+			if (this._currentHoverOptions === options) {
+				this._currentHoverOptions = undefined;
+			}
 			hoverDisposables.dispose();
 		});
 		const provider = this._contextViewService as IContextViewProvider;

--- a/src/vs/workbench/services/hover/browser/hoverWidget.ts
+++ b/src/vs/workbench/services/hover/browser/hoverWidget.ts
@@ -507,7 +507,7 @@ export class HoverWidget extends Widget {
 }
 
 class CompositeMouseTracker extends Widget {
-	private _isMouseIn: boolean = false;
+	private _isMouseIn: boolean = true;
 	private _mouseTimeout: number | undefined;
 
 	private readonly _onMouseOut = this._register(new Emitter<void>());


### PR DESCRIPTION
- CompositeMouseTracker.isMouseIn's initial state is now true, this means
releasing alt without moving the mouse will not hide the hover
- The current hover options are now only cleared when the hover being
disposed is the active hover, this was the main cause of the problem because
if current hover options is undefined while there is an active hover weird
things could happen

Fixes #150842
