### PR TITLE
Use full titlebar height for menubar button hit area (Fix #150170)

### DIFF
--- a/src/vs/base/browser/ui/menu/menubar.css
+++ b/src/vs/base/browser/ui/menu/menubar.css
@@ -68,9 +68,11 @@
 .menubar .toolbar-toggle-more {
 	width: 22px;
 	height: 22px;
+	padding: 0 8px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	vertical-align: sub;
 }
 
 .menubar.compact .toolbar-toggle-more {
@@ -82,11 +84,6 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-}
-
-.menubar .toolbar-toggle-more {
-	padding: 0;
-	vertical-align: sub;
 }
 
 .menubar.compact .toolbar-toggle-more::before {

--- a/src/vs/base/browser/ui/menu/menubar.css
+++ b/src/vs/base/browser/ui/menu/menubar.css
@@ -10,9 +10,7 @@
 	flex-shrink: 1;
 	box-sizing: border-box;
 	height: 100%;
-	padding: 4px 0;
 	overflow: hidden;
-	flex-wrap: wrap;
 }
 
 .fullscreen .menubar:not(.compact) {
@@ -21,10 +19,9 @@
 }
 
 .menubar > .menubar-menu-button {
+	display: flex;
 	align-items: center;
 	box-sizing: border-box;
-	padding: 0px 8px;
-	border-radius: 5px;
 	cursor: default;
 	-webkit-app-region: no-drag;
 	zoom: 1;
@@ -41,6 +38,11 @@
 	width: 100%;
 	height: 100%;
 	padding: 0px;
+}
+
+.menubar-menu-title {
+	padding: 0px 8px;
+	border-radius: 5px;
 }
 
 .menubar .menubar-menu-items-holder {
@@ -64,8 +66,11 @@
 }
 
 .menubar .toolbar-toggle-more {
-	width: 20px;
-	height: 100%;
+	width: 22px;
+	height: 22px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .menubar.compact .toolbar-toggle-more {

--- a/src/vs/base/browser/ui/menu/menubar.css
+++ b/src/vs/base/browser/ui/menu/menubar.css
@@ -29,6 +29,13 @@
 	outline: 0 !important;
 }
 
+.monaco-workbench .menubar:not(.compact) > .menubar-menu-button:focus .menubar-menu-title {
+	outline-width: 1px;
+	outline-style: solid;
+	outline-offset: -1px;
+	outline-color: var(--vscode-focusBorder);
+}
+
 .menubar.compact {
 	flex-shrink: 0;
 	overflow: visible; /* to avoid the compact menu to be repositioned when clicking */

--- a/src/vs/base/browser/ui/menu/menubar.css
+++ b/src/vs/base/browser/ui/menu/menubar.css
@@ -26,7 +26,7 @@
 	-webkit-app-region: no-drag;
 	zoom: 1;
 	white-space: nowrap;
-	outline: 0;
+	outline: 0 !important;
 }
 
 .menubar.compact {
@@ -91,9 +91,9 @@
 }
 
 /* Match behavior of outline for activity bar icons */
-.menubar.compact > .menubar-menu-button.open,
-.menubar.compact > .menubar-menu-button:focus,
-.menubar.compact > .menubar-menu-button:hover {
+.menubar.compact > .menubar-menu-button.open .menubar-menu-title,
+.menubar.compact > .menubar-menu-button:focus .menubar-menu-title,
+.menubar.compact > .menubar-menu-button:hover .menubar-menu-title{
 	outline-width: 1px !important;
 	outline-offset: -8px !important;
 }

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -481,9 +481,9 @@ export class CustomMenubarControl extends MenubarControl {
 			const menubarSelectedBgColor = theme.getColor(MENUBAR_SELECTION_BACKGROUND);
 			if (menubarSelectedBgColor) {
 				collector.addRule(`
-					.monaco-workbench .menubar:not(.compact) > .menubar-menu-button.open,
-					.monaco-workbench .menubar:not(.compact) > .menubar-menu-button:focus,
-					.monaco-workbench .menubar:not(:focus-within):not(.compact) > .menubar-menu-button:hover {
+					.monaco-workbench .menubar:not(.compact) > .menubar-menu-button.open .menubar-menu-title,
+					.monaco-workbench .menubar:not(.compact) > .menubar-menu-button:focus .menubar-menu-title,
+					.monaco-workbench .menubar:not(:focus-within):not(.compact) > .menubar-menu-button:hover .menubar-menu-title {
 						background-color: ${menubarSelectedBgColor};
 					}
 				`);
@@ -492,18 +492,18 @@ export class CustomMenubarControl extends MenubarControl {
 			const menubarSelectedBorderColor = theme.getColor(MENUBAR_SELECTION_BORDER);
 			if (menubarSelectedBorderColor) {
 				collector.addRule(`
-					.monaco-workbench .menubar > .menubar-menu-button:hover {
+					.monaco-workbench .menubar > .menubar-menu-button:hover .menubar-menu-title  {
 						outline: dashed 1px;
 					}
 
-					.monaco-workbench .menubar > .menubar-menu-button.open,
-					.monaco-workbench .menubar > .menubar-menu-button:focus {
+					.monaco-workbench .menubar > .menubar-menu-button.open .menubar-menu-title,
+					.monaco-workbench .menubar > .menubar-menu-button:focus .menubar-menu-title {
 						outline: solid 1px;
 					}
 
-					.monaco-workbench .menubar > .menubar-menu-button.open,
-					.monaco-workbench .menubar > .menubar-menu-button:focus,
-					.monaco-workbench .menubar > .menubar-menu-button:hover {
+					.monaco-workbench .menubar > .menubar-menu-button.open .menubar-menu-title,
+					.monaco-workbench .menubar > .menubar-menu-button:focus .menubar-menu-title,
+					.monaco-workbench .menubar > .menubar-menu-button:hover .menubar-menu-title {
 						outline-color: ${menubarSelectedBorderColor};
 					}
 				`);

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -505,6 +505,7 @@ export class CustomMenubarControl extends MenubarControl {
 					.monaco-workbench .menubar > .menubar-menu-button:focus .menubar-menu-title,
 					.monaco-workbench .menubar > .menubar-menu-button:hover .menubar-menu-title {
 						outline-color: ${menubarSelectedBorderColor};
+						outline-offset: -1px;
 					}
 				`);
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #150170 by ensuring the menubar buttons fill the available vertical height of the titlebar. To keep the new Windows-style button padding style, styling is moved to the text element.

The overall effect is that users can keep the large button hit area while only seeing the new smaller visual hit area highlight on hover/focus.

To do:
- [x] Fix outline since it still applies to the parent button element 
