### PR TITLE
Add markdown to proposed enabled extension for remote tests

### DIFF
--- a/scripts/test-remote-integration.sh
+++ b/scripts/test-remote-integration.sh
@@ -63,7 +63,7 @@ else
 	export ELECTRON_ENABLE_LOGGING=1
 
 	# Running from a build, we need to enable the vscode-test-resolver extension
-	EXTRA_INTEGRATION_TEST_ARGUMENTS="--extensions-dir=$EXT_PATH  --enable-proposed-api=vscode.vscode-test-resolver --enable-proposed-api=vscode.vscode-api-tests"
+	EXTRA_INTEGRATION_TEST_ARGUMENTS="--extensions-dir=$EXT_PATH  --enable-proposed-api=vscode.vscode-test-resolver --enable-proposed-api=vscode.vscode-api-tests --enable-proposed-api=vscode.markdown-language-features"
 
 	echo "Storing crash reports into '$VSCODECRASHDIR'."
 	echo "Storing log files into '$VSCODELOGSDIR'."


### PR DESCRIPTION
Same fix as https://github.com/microsoft/vscode/pull/146176. I think this got removed during some refactoring