### PR TITLE
Fix category width in extensions for better presentation

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -452,6 +452,7 @@
 
 .extension-editor > .body > .content > .details > .additional-details-container .categories-container > .categories > .category,
 .extension-editor > .body > .content > .details > .additional-details-container .tags-container > .tags > .tag {
+	width: min-content;
 	display: inline-block;
 	border: 1px solid rgba(136, 136, 136, 0.45);
 	padding: 2px 4px;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #150209

Tried to fix it with a minimum of code, in my opinion it got better

<img width="774" alt="image" src="https://user-images.githubusercontent.com/5946242/172045275-1e1237f1-eebf-4afa-9285-9911742f1580.png">
