### PR TITLE
Use `I` prefix for task interfaces

### DIFF
--- a/extensions/npm/src/commands.ts
+++ b/extensions/npm/src/commands.ts
@@ -10,7 +10,7 @@ import {
 	detectNpmScriptsForFolder,
 	findScriptAtPosition,
 	runScript,
-	FolderTaskItem
+	IFolderTaskItem
 } from './tasks';
 
 const localize = nls.loadMessageBundle();
@@ -37,17 +37,17 @@ export async function selectAndRunScriptFromFolder(context: vscode.ExtensionCont
 	}
 	const selectedFolder = selectedFolders[0];
 
-	let taskList: FolderTaskItem[] = await detectNpmScriptsForFolder(context, selectedFolder);
+	let taskList: IFolderTaskItem[] = await detectNpmScriptsForFolder(context, selectedFolder);
 
 	if (taskList && taskList.length > 0) {
-		const quickPick = vscode.window.createQuickPick<FolderTaskItem>();
+		const quickPick = vscode.window.createQuickPick<IFolderTaskItem>();
 		quickPick.title = 'Run NPM script in Folder';
 		quickPick.placeholder = 'Select an npm script';
 		quickPick.items = taskList;
 
 		const toDispose: vscode.Disposable[] = [];
 
-		let pickPromise = new Promise<FolderTaskItem | undefined>((c) => {
+		let pickPromise = new Promise<IFolderTaskItem | undefined>((c) => {
 			toDispose.push(quickPick.onDidAccept(() => {
 				toDispose.forEach(d => d.dispose());
 				c(quickPick.selectedItems[0]);

--- a/extensions/npm/src/npmMain.ts
+++ b/extensions/npm/src/npmMain.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { addJSONProviders } from './features/jsonContributions';
 import { runSelectedScript, selectAndRunScriptFromFolder } from './commands';
 import { NpmScriptsTreeDataProvider } from './npmView';
-import { getPackageManager, invalidateTasksCache, NpmTaskProvider, hasPackageJson } from './tasks';
+import { getPackageManager, invalidateTasksCache, INpmTaskProvider, hasPackageJson } from './tasks';
 import { invalidateHoverScriptsCache, NpmScriptHoverProvider } from './scriptHover';
 import { NpmScriptLensProvider } from './npmScriptLens';
 import * as which from 'which';
@@ -90,7 +90,7 @@ function canRunNpmInCurrentWorkspace() {
 	return false;
 }
 
-let taskProvider: NpmTaskProvider;
+let taskProvider: INpmTaskProvider;
 function registerTaskProvider(context: vscode.ExtensionContext): vscode.Disposable | undefined {
 	if (vscode.workspace.workspaceFolders) {
 		let watcher = vscode.workspace.createFileSystemWatcher('**/package.json');
@@ -102,7 +102,7 @@ function registerTaskProvider(context: vscode.ExtensionContext): vscode.Disposab
 		let workspaceWatcher = vscode.workspace.onDidChangeWorkspaceFolders((_e) => invalidateScriptCaches());
 		context.subscriptions.push(workspaceWatcher);
 
-		taskProvider = new NpmTaskProvider(context);
+		taskProvider = new INpmTaskProvider(context);
 		let disposable = vscode.tasks.registerTaskProvider('npm', taskProvider);
 		context.subscriptions.push(disposable);
 		return disposable;

--- a/extensions/npm/src/npmMain.ts
+++ b/extensions/npm/src/npmMain.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { addJSONProviders } from './features/jsonContributions';
 import { runSelectedScript, selectAndRunScriptFromFolder } from './commands';
 import { NpmScriptsTreeDataProvider } from './npmView';
-import { getPackageManager, invalidateTasksCache, INpmTaskProvider, hasPackageJson } from './tasks';
+import { getPackageManager, invalidateTasksCache, NpmTaskProvider, hasPackageJson } from './tasks';
 import { invalidateHoverScriptsCache, NpmScriptHoverProvider } from './scriptHover';
 import { NpmScriptLensProvider } from './npmScriptLens';
 import * as which from 'which';
@@ -90,7 +90,7 @@ function canRunNpmInCurrentWorkspace() {
 	return false;
 }
 
-let taskProvider: INpmTaskProvider;
+let taskProvider: NpmTaskProvider;
 function registerTaskProvider(context: vscode.ExtensionContext): vscode.Disposable | undefined {
 	if (vscode.workspace.workspaceFolders) {
 		let watcher = vscode.workspace.createFileSystemWatcher('**/package.json');
@@ -102,7 +102,7 @@ function registerTaskProvider(context: vscode.ExtensionContext): vscode.Disposab
 		let workspaceWatcher = vscode.workspace.onDidChangeWorkspaceFolders((_e) => invalidateScriptCaches());
 		context.subscriptions.push(workspaceWatcher);
 
-		taskProvider = new INpmTaskProvider(context);
+		taskProvider = new NpmTaskProvider(context);
 		let disposable = vscode.tasks.registerTaskProvider('npm', taskProvider);
 		context.subscriptions.push(disposable);
 		return disposable;

--- a/extensions/npm/src/npmView.ts
+++ b/extensions/npm/src/npmView.ts
@@ -15,7 +15,7 @@ import * as nls from 'vscode-nls';
 import { readScripts } from './readScripts';
 import {
 	createTask, getPackageManager, getTaskName, isAutoDetectionEnabled, isWorkspaceFolder, INpmTaskDefinition,
-	INpmTaskProvider,
+	NpmTaskProvider,
 	startDebugging,
 	ITaskWithLocation
 } from './tasks';
@@ -139,7 +139,7 @@ export class NpmScriptsTreeDataProvider implements TreeDataProvider<TreeItem> {
 	private _onDidChangeTreeData: EventEmitter<TreeItem | null> = new EventEmitter<TreeItem | null>();
 	readonly onDidChangeTreeData: Event<TreeItem | null> = this._onDidChangeTreeData.event;
 
-	constructor(private context: ExtensionContext, public taskProvider: INpmTaskProvider) {
+	constructor(private context: ExtensionContext, public taskProvider: NpmTaskProvider) {
 		const subscriptions = context.subscriptions;
 		this.extensionContext = context;
 		subscriptions.push(commands.registerCommand('npm.runScript', this.runScript, this));

--- a/extensions/npm/src/npmView.ts
+++ b/extensions/npm/src/npmView.ts
@@ -14,10 +14,10 @@ import {
 import * as nls from 'vscode-nls';
 import { readScripts } from './readScripts';
 import {
-	createTask, getPackageManager, getTaskName, isAutoDetectionEnabled, isWorkspaceFolder, NpmTaskDefinition,
-	NpmTaskProvider,
+	createTask, getPackageManager, getTaskName, isAutoDetectionEnabled, isWorkspaceFolder, INpmTaskDefinition,
+	INpmTaskProvider,
 	startDebugging,
-	TaskWithLocation
+	ITaskWithLocation
 } from './tasks';
 
 const localize = nls.loadMessageBundle();
@@ -78,7 +78,7 @@ class NpmScript extends TreeItem {
 	package: PackageJSON;
 	taskLocation?: Location;
 
-	constructor(_context: ExtensionContext, packageJson: PackageJSON, task: TaskWithLocation) {
+	constructor(_context: ExtensionContext, packageJson: PackageJSON, task: ITaskWithLocation) {
 		const name = packageJson.path.length > 0
 			? task.task.name.substring(0, task.task.name.length - packageJson.path.length - 2)
 			: task.task.name;
@@ -139,7 +139,7 @@ export class NpmScriptsTreeDataProvider implements TreeDataProvider<TreeItem> {
 	private _onDidChangeTreeData: EventEmitter<TreeItem | null> = new EventEmitter<TreeItem | null>();
 	readonly onDidChangeTreeData: Event<TreeItem | null> = this._onDidChangeTreeData.event;
 
-	constructor(private context: ExtensionContext, public taskProvider: NpmTaskProvider) {
+	constructor(private context: ExtensionContext, public taskProvider: INpmTaskProvider) {
 		const subscriptions = context.subscriptions;
 		this.extensionContext = context;
 		subscriptions.push(commands.registerCommand('npm.runScript', this.runScript, this));
@@ -284,7 +284,7 @@ export class NpmScriptsTreeDataProvider implements TreeDataProvider<TreeItem> {
 		});
 	}
 
-	private buildTaskTree(tasks: TaskWithLocation[]): TaskTree {
+	private buildTaskTree(tasks: ITaskWithLocation[]): TaskTree {
 		let folders: Map<String, Folder> = new Map();
 		let packages: Map<String, PackageJSON> = new Map();
 
@@ -301,7 +301,7 @@ export class NpmScriptsTreeDataProvider implements TreeDataProvider<TreeItem> {
 			}
 			const regularExpressions = (location && excludeConfig.has(location.uri.toString())) ? excludeConfig.get(location.uri.toString()) : undefined;
 
-			if (regularExpressions && regularExpressions.some((regularExpression) => (<NpmTaskDefinition>each.task.definition).script.match(regularExpression))) {
+			if (regularExpressions && regularExpressions.some((regularExpression) => (<INpmTaskDefinition>each.task.definition).script.match(regularExpression))) {
 				return;
 			}
 
@@ -311,7 +311,7 @@ export class NpmScriptsTreeDataProvider implements TreeDataProvider<TreeItem> {
 					folder = new Folder(each.task.scope);
 					folders.set(each.task.scope.name, folder);
 				}
-				let definition: NpmTaskDefinition = <NpmTaskDefinition>each.task.definition;
+				let definition: INpmTaskDefinition = <INpmTaskDefinition>each.task.definition;
 				let relativePath = definition.path ? definition.path : '';
 				let fullPath = path.join(each.task.scope.name, relativePath);
 				packageJson = packages.get(fullPath);

--- a/extensions/npm/src/tasks.ts
+++ b/extensions/npm/src/tasks.ts
@@ -17,38 +17,38 @@ import { readScripts } from './readScripts';
 
 const localize = nls.loadMessageBundle();
 
-export interface NpmTaskDefinition extends TaskDefinition {
+export interface INpmTaskDefinition extends TaskDefinition {
 	script: string;
 	path?: string;
 }
 
-export interface FolderTaskItem extends QuickPickItem {
+export interface IFolderTaskItem extends QuickPickItem {
 	label: string;
 	task: Task;
 }
 
 type AutoDetect = 'on' | 'off';
 
-let cachedTasks: TaskWithLocation[] | undefined = undefined;
+let cachedTasks: ITaskWithLocation[] | undefined = undefined;
 
 const INSTALL_SCRIPT = 'install';
 
-export interface TaskLocation {
+export interface ITaskLocation {
 	document: Uri;
 	line: Position;
 }
 
-export interface TaskWithLocation {
+export interface ITaskWithLocation {
 	task: Task;
 	location?: Location;
 }
 
-export class NpmTaskProvider implements TaskProvider {
+export class INpmTaskProvider implements TaskProvider {
 
 	constructor(private context: ExtensionContext) {
 	}
 
-	get tasksWithLocation(): Promise<TaskWithLocation[]> {
+	get tasksWithLocation(): Promise<ITaskWithLocation[]> {
 		return provideNpmScripts(this.context, false);
 	}
 
@@ -60,7 +60,7 @@ export class NpmTaskProvider implements TaskProvider {
 	public async resolveTask(_task: Task): Promise<Task | undefined> {
 		const npmTask = (<any>_task.definition).script;
 		if (npmTask) {
-			const kind: NpmTaskDefinition = (<any>_task.definition);
+			const kind: INpmTaskDefinition = (<any>_task.definition);
 			let packageJsonUri: Uri;
 			if (_task.scope === undefined || _task.scope === TaskScope.Global || _task.scope === TaskScope.Workspace) {
 				// scope is required to be a WorkspaceFolder for resolveTask
@@ -170,10 +170,10 @@ export async function hasNpmScripts(): Promise<boolean> {
 	}
 }
 
-async function detectNpmScripts(context: ExtensionContext, showWarning: boolean): Promise<TaskWithLocation[]> {
+async function detectNpmScripts(context: ExtensionContext, showWarning: boolean): Promise<ITaskWithLocation[]> {
 
-	let emptyTasks: TaskWithLocation[] = [];
-	let allTasks: TaskWithLocation[] = [];
+	let emptyTasks: ITaskWithLocation[] = [];
+	let allTasks: ITaskWithLocation[] = [];
 	let visitedPackageJsonFiles: Set<string> = new Set();
 
 	let folders = workspace.workspaceFolders;
@@ -201,9 +201,9 @@ async function detectNpmScripts(context: ExtensionContext, showWarning: boolean)
 }
 
 
-export async function detectNpmScriptsForFolder(context: ExtensionContext, folder: Uri): Promise<FolderTaskItem[]> {
+export async function detectNpmScriptsForFolder(context: ExtensionContext, folder: Uri): Promise<IFolderTaskItem[]> {
 
-	let folderTasks: FolderTaskItem[] = [];
+	let folderTasks: IFolderTaskItem[] = [];
 
 	try {
 		let relativePattern = new RelativePattern(folder.fsPath, '**/package.json');
@@ -223,7 +223,7 @@ export async function detectNpmScriptsForFolder(context: ExtensionContext, folde
 	}
 }
 
-export async function provideNpmScripts(context: ExtensionContext, showWarning: boolean): Promise<TaskWithLocation[]> {
+export async function provideNpmScripts(context: ExtensionContext, showWarning: boolean): Promise<ITaskWithLocation[]> {
 	if (!cachedTasks) {
 		cachedTasks = await detectNpmScripts(context, showWarning);
 	}
@@ -261,8 +261,8 @@ function isDebugScript(script: string): boolean {
 	return match !== null;
 }
 
-async function provideNpmScriptsForFolder(context: ExtensionContext, packageJsonUri: Uri, showWarning: boolean): Promise<TaskWithLocation[]> {
-	let emptyTasks: TaskWithLocation[] = [];
+async function provideNpmScriptsForFolder(context: ExtensionContext, packageJsonUri: Uri, showWarning: boolean): Promise<ITaskWithLocation[]> {
+	let emptyTasks: ITaskWithLocation[] = [];
 
 	let folder = workspace.getWorkspaceFolder(packageJsonUri);
 	if (!folder) {
@@ -273,7 +273,7 @@ async function provideNpmScriptsForFolder(context: ExtensionContext, packageJson
 		return emptyTasks;
 	}
 
-	const result: TaskWithLocation[] = [];
+	const result: ITaskWithLocation[] = [];
 
 	const packageManager = await getPackageManager(context, folder.uri, showWarning);
 
@@ -294,8 +294,8 @@ export function getTaskName(script: string, relativePath: string | undefined) {
 	return script;
 }
 
-export async function createTask(packageManager: string, script: NpmTaskDefinition | string, cmd: string[], folder: WorkspaceFolder, packageJsonUri: Uri, scriptValue?: string, matcher?: any): Promise<Task> {
-	let kind: NpmTaskDefinition;
+export async function createTask(packageManager: string, script: INpmTaskDefinition | string, cmd: string[], folder: WorkspaceFolder, packageJsonUri: Uri, scriptValue?: string, matcher?: any): Promise<Task> {
+	let kind: INpmTaskDefinition;
 	if (typeof script === 'string') {
 		kind = { type: 'npm', script: script };
 	} else {

--- a/extensions/npm/src/tasks.ts
+++ b/extensions/npm/src/tasks.ts
@@ -43,7 +43,7 @@ export interface ITaskWithLocation {
 	location?: Location;
 }
 
-export class INpmTaskProvider implements TaskProvider {
+export class NpmTaskProvider implements TaskProvider {
 
 	constructor(private context: ExtensionContext) {
 	}

--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.tasks.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.tasks.test.ts
@@ -147,7 +147,7 @@ import { assertNoRpc } from '../utils';
 		suite('CustomExecution', () => {
 			test('task should start and shutdown successfully', async () => {
 				window.terminals.forEach(terminal => terminal.dispose());
-				interface CustomTestingTaskDefinition extends TaskDefinition {
+				interface ICustomTestingTaskDefinition extends TaskDefinition {
 					/**
 					 * One of the task properties. This can be used to customize the task in the tasks.json
 					 */
@@ -179,7 +179,7 @@ import { assertNoRpc } from '../utils';
 					disposables.push(tasks.registerTaskProvider(taskType, {
 						provideTasks: () => {
 							const result: Task[] = [];
-							const kind: CustomTestingTaskDefinition = {
+							const kind: ICustomTestingTaskDefinition = {
 								type: taskType,
 								customProp1: 'testing task one'
 							};
@@ -235,7 +235,7 @@ import { assertNoRpc } from '../utils';
 			});
 
 			test('sync task should flush all data on close', async () => {
-				interface CustomTestingTaskDefinition extends TaskDefinition {
+				interface ICustomTestingTaskDefinition extends TaskDefinition {
 					/**
 					 * One of the task properties. This can be used to customize the task in the tasks.json
 					 */
@@ -250,7 +250,7 @@ import { assertNoRpc } from '../utils';
 					disposables.push(tasks.registerTaskProvider(taskType, {
 						provideTasks: () => {
 							const result: Task[] = [];
-							const kind: CustomTestingTaskDefinition = {
+							const kind: ICustomTestingTaskDefinition = {
 								type: taskType,
 								customProp1: 'testing task one'
 							};

--- a/src/vs/workbench/api/browser/mainThreadTask.ts
+++ b/src/vs/workbench/api/browser/mainThreadTask.ts
@@ -15,27 +15,27 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { IWorkspace, IWorkspaceContextService, IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 
 import {
-	ContributedTask, ConfiguringTask, KeyedTaskIdentifier, TaskExecution, Task, TaskEvent, TaskEventKind,
-	PresentationOptions, CommandOptions, CommandConfiguration, RuntimeType, CustomTask, TaskScope, TaskSource,
-	TaskSourceKind, ExtensionTaskSource, RunOptions, TaskSet, TaskDefinition, TaskGroup
+	ContributedTask, ConfiguringTask, KeyedTaskIdentifier, ITaskExecution, Task, ITaskEvent, TaskEventKind,
+	IPresentationOptions, CommandOptions, ICommandConfiguration, RuntimeType, CustomTask, TaskScope, TaskSource,
+	TaskSourceKind, IExtensionTaskSource, IRunOptions, ITaskSet, TaskGroup, TaskDefinition, PresentationOptions, RunOptions
 } from 'vs/workbench/contrib/tasks/common/tasks';
 
 
-import { ResolveSet, ResolvedVariables } from 'vs/workbench/contrib/tasks/common/taskSystem';
-import { ITaskService, TaskFilter, ITaskProvider } from 'vs/workbench/contrib/tasks/common/taskService';
+import { IResolveSet, IResolvedVariables } from 'vs/workbench/contrib/tasks/common/taskSystem';
+import { ITaskService, ITaskFilter, ITaskProvider } from 'vs/workbench/contrib/tasks/common/taskService';
 
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
 import { ExtHostContext, MainThreadTaskShape, ExtHostTaskShape, MainContext } from 'vs/workbench/api/common/extHost.protocol';
 import {
-	TaskDefinitionDTO, TaskExecutionDTO, ProcessExecutionOptionsDTO, TaskPresentationOptionsDTO,
-	ProcessExecutionDTO, ShellExecutionDTO, ShellExecutionOptionsDTO, CustomExecutionDTO, TaskDTO, TaskSourceDTO, TaskHandleDTO, TaskFilterDTO, TaskProcessStartedDTO, TaskProcessEndedDTO, TaskSystemInfoDTO,
-	RunOptionsDTO, TaskGroupDTO
+	ITaskDefinitionDTO, ITaskExecutionDTO, IProcessExecutionOptionsDTO, ITaskPresentationOptionsDTO,
+	IProcessExecutionDTO, IShellExecutionDTO, IShellExecutionOptionsDTO, ICustomExecutionDTO, ITaskDTO, ITaskSourceDTO, ITaskHandleDTO, ITaskFilterDTO, ITaskProcessStartedDTO, ITaskProcessEndedDTO, ITaskSystemInfoDTO,
+	IRunOptionsDTO, ITaskGroupDTO
 } from 'vs/workbench/api/common/shared/tasks';
 import { IConfigurationResolverService } from 'vs/workbench/services/configurationResolver/common/configurationResolver';
 import { ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
 
 namespace TaskExecutionDTO {
-	export function from(value: TaskExecution): TaskExecutionDTO {
+	export function from(value: ITaskExecution): ITaskExecutionDTO {
 		return {
 			id: value.id,
 			task: TaskDTO.from(value.task)
@@ -44,7 +44,7 @@ namespace TaskExecutionDTO {
 }
 
 namespace TaskProcessStartedDTO {
-	export function from(value: TaskExecution, processId: number): TaskProcessStartedDTO {
+	export function from(value: ITaskExecution, processId: number): ITaskProcessStartedDTO {
 		return {
 			id: value.id,
 			processId
@@ -53,7 +53,7 @@ namespace TaskProcessStartedDTO {
 }
 
 namespace TaskProcessEndedDTO {
-	export function from(value: TaskExecution, exitCode: number | undefined): TaskProcessEndedDTO {
+	export function from(value: ITaskExecution, exitCode: number | undefined): ITaskProcessEndedDTO {
 		return {
 			id: value.id,
 			exitCode
@@ -62,12 +62,12 @@ namespace TaskProcessEndedDTO {
 }
 
 namespace TaskDefinitionDTO {
-	export function from(value: KeyedTaskIdentifier): TaskDefinitionDTO {
+	export function from(value: KeyedTaskIdentifier): ITaskDefinitionDTO {
 		const result = Object.assign(Object.create(null), value);
 		delete result._key;
 		return result;
 	}
-	export function to(value: TaskDefinitionDTO, executeOnly: boolean): KeyedTaskIdentifier | undefined {
+	export function to(value: ITaskDefinitionDTO, executeOnly: boolean): KeyedTaskIdentifier | undefined {
 		let result = TaskDefinition.createTaskIdentifier(value, console);
 		if (result === undefined && executeOnly) {
 			result = {
@@ -80,13 +80,13 @@ namespace TaskDefinitionDTO {
 }
 
 namespace TaskPresentationOptionsDTO {
-	export function from(value: PresentationOptions | undefined): TaskPresentationOptionsDTO | undefined {
+	export function from(value: IPresentationOptions | undefined): ITaskPresentationOptionsDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
 		return Object.assign(Object.create(null), value);
 	}
-	export function to(value: TaskPresentationOptionsDTO | undefined): PresentationOptions {
+	export function to(value: ITaskPresentationOptionsDTO | undefined): IPresentationOptions {
 		if (value === undefined || value === null) {
 			return PresentationOptions.defaults;
 		}
@@ -95,13 +95,13 @@ namespace TaskPresentationOptionsDTO {
 }
 
 namespace RunOptionsDTO {
-	export function from(value: RunOptions): RunOptionsDTO | undefined {
+	export function from(value: IRunOptions): IRunOptionsDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
 		return Object.assign(Object.create(null), value);
 	}
-	export function to(value: RunOptionsDTO | undefined): RunOptions {
+	export function to(value: IRunOptionsDTO | undefined): IRunOptions {
 		if (value === undefined || value === null) {
 			return RunOptions.defaults;
 		}
@@ -110,7 +110,7 @@ namespace RunOptionsDTO {
 }
 
 namespace ProcessExecutionOptionsDTO {
-	export function from(value: CommandOptions): ProcessExecutionOptionsDTO | undefined {
+	export function from(value: CommandOptions): IProcessExecutionOptionsDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
@@ -119,7 +119,7 @@ namespace ProcessExecutionOptionsDTO {
 			env: value.env
 		};
 	}
-	export function to(value: ProcessExecutionOptionsDTO | undefined): CommandOptions {
+	export function to(value: IProcessExecutionOptionsDTO | undefined): CommandOptions {
 		if (value === undefined || value === null) {
 			return CommandOptions.defaults;
 		}
@@ -131,14 +131,14 @@ namespace ProcessExecutionOptionsDTO {
 }
 
 namespace ProcessExecutionDTO {
-	export function is(value: ShellExecutionDTO | ProcessExecutionDTO | CustomExecutionDTO): value is ProcessExecutionDTO {
-		const candidate = value as ProcessExecutionDTO;
+	export function is(value: IShellExecutionDTO | IProcessExecutionDTO | ICustomExecutionDTO): value is IProcessExecutionDTO {
+		const candidate = value as IProcessExecutionDTO;
 		return candidate && !!candidate.process;
 	}
-	export function from(value: CommandConfiguration): ProcessExecutionDTO {
+	export function from(value: ICommandConfiguration): IProcessExecutionDTO {
 		const process: string = Types.isString(value.name) ? value.name : value.name!.value;
 		const args: string[] = value.args ? value.args.map(value => Types.isString(value) ? value : value.value) : [];
-		const result: ProcessExecutionDTO = {
+		const result: IProcessExecutionDTO = {
 			process: process,
 			args: args
 		};
@@ -147,8 +147,8 @@ namespace ProcessExecutionDTO {
 		}
 		return result;
 	}
-	export function to(value: ProcessExecutionDTO): CommandConfiguration {
-		const result: CommandConfiguration = {
+	export function to(value: IProcessExecutionDTO): ICommandConfiguration {
+		const result: ICommandConfiguration = {
 			runtime: RuntimeType.Process,
 			name: value.process,
 			args: value.args,
@@ -160,11 +160,11 @@ namespace ProcessExecutionDTO {
 }
 
 namespace ShellExecutionOptionsDTO {
-	export function from(value: CommandOptions): ShellExecutionOptionsDTO | undefined {
+	export function from(value: CommandOptions): IShellExecutionOptionsDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
-		const result: ShellExecutionOptionsDTO = {
+		const result: IShellExecutionOptionsDTO = {
 			cwd: value.cwd || CommandOptions.defaults.cwd,
 			env: value.env
 		};
@@ -175,7 +175,7 @@ namespace ShellExecutionOptionsDTO {
 		}
 		return result;
 	}
-	export function to(value: ShellExecutionOptionsDTO): CommandOptions | undefined {
+	export function to(value: IShellExecutionOptionsDTO): CommandOptions | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
@@ -199,12 +199,12 @@ namespace ShellExecutionOptionsDTO {
 }
 
 namespace ShellExecutionDTO {
-	export function is(value: ShellExecutionDTO | ProcessExecutionDTO | CustomExecutionDTO): value is ShellExecutionDTO {
-		const candidate = value as ShellExecutionDTO;
+	export function is(value: IShellExecutionDTO | IProcessExecutionDTO | ICustomExecutionDTO): value is IShellExecutionDTO {
+		const candidate = value as IShellExecutionDTO;
 		return candidate && (!!candidate.commandLine || !!candidate.command);
 	}
-	export function from(value: CommandConfiguration): ShellExecutionDTO {
-		const result: ShellExecutionDTO = {};
+	export function from(value: ICommandConfiguration): IShellExecutionDTO {
+		const result: IShellExecutionDTO = {};
 		if (value.name && Types.isString(value.name) && (value.args === undefined || value.args === null || value.args.length === 0)) {
 			result.commandLine = value.name;
 		} else {
@@ -216,8 +216,8 @@ namespace ShellExecutionDTO {
 		}
 		return result;
 	}
-	export function to(value: ShellExecutionDTO): CommandConfiguration {
-		const result: CommandConfiguration = {
+	export function to(value: IShellExecutionDTO): ICommandConfiguration {
+		const result: ICommandConfiguration = {
 			runtime: RuntimeType.Shell,
 			name: value.commandLine ? value.commandLine : value.command,
 			args: value.args,
@@ -231,18 +231,18 @@ namespace ShellExecutionDTO {
 }
 
 namespace CustomExecutionDTO {
-	export function is(value: ShellExecutionDTO | ProcessExecutionDTO | CustomExecutionDTO): value is CustomExecutionDTO {
-		const candidate = value as CustomExecutionDTO;
+	export function is(value: IShellExecutionDTO | IProcessExecutionDTO | ICustomExecutionDTO): value is ICustomExecutionDTO {
+		const candidate = value as ICustomExecutionDTO;
 		return candidate && candidate.customExecution === 'customExecution';
 	}
 
-	export function from(value: CommandConfiguration): CustomExecutionDTO {
+	export function from(value: ICommandConfiguration): ICustomExecutionDTO {
 		return {
 			customExecution: 'customExecution'
 		};
 	}
 
-	export function to(value: CustomExecutionDTO): CommandConfiguration {
+	export function to(value: ICustomExecutionDTO): ICommandConfiguration {
 		return {
 			runtime: RuntimeType.CustomExecution,
 			presentation: undefined
@@ -251,8 +251,8 @@ namespace CustomExecutionDTO {
 }
 
 namespace TaskSourceDTO {
-	export function from(value: TaskSource): TaskSourceDTO {
-		const result: TaskSourceDTO = {
+	export function from(value: TaskSource): ITaskSourceDTO {
+		const result: ITaskSourceDTO = {
 			label: value.label
 		};
 		if (value.kind === TaskSourceKind.Extension) {
@@ -268,7 +268,7 @@ namespace TaskSourceDTO {
 		}
 		return result;
 	}
-	export function to(value: TaskSourceDTO, workspace: IWorkspaceContextService): ExtensionTaskSource {
+	export function to(value: ITaskSourceDTO, workspace: IWorkspaceContextService): IExtensionTaskSource {
 		let scope: TaskScope;
 		let workspaceFolder: IWorkspaceFolder | undefined;
 		if ((value.scope === undefined) || ((typeof value.scope === 'number') && (value.scope !== TaskScope.Global))) {
@@ -285,7 +285,7 @@ namespace TaskSourceDTO {
 			scope = TaskScope.Folder;
 			workspaceFolder = Types.withNullAsUndefined(workspace.getWorkspaceFolder(URI.revive(value.scope)));
 		}
-		const result: ExtensionTaskSource = {
+		const result: IExtensionTaskSource = {
 			kind: TaskSourceKind.Extension,
 			label: value.label,
 			extension: value.extensionId,
@@ -297,18 +297,18 @@ namespace TaskSourceDTO {
 }
 
 namespace TaskHandleDTO {
-	export function is(value: any): value is TaskHandleDTO {
-		const candidate: TaskHandleDTO = value;
+	export function is(value: any): value is ITaskHandleDTO {
+		const candidate: ITaskHandleDTO = value;
 		return candidate && Types.isString(candidate.id) && !!candidate.workspaceFolder;
 	}
 }
 
 namespace TaskDTO {
-	export function from(task: Task | ConfiguringTask): TaskDTO | undefined {
+	export function from(task: Task | ConfiguringTask): ITaskDTO | undefined {
 		if (task === undefined || task === null || (!CustomTask.is(task) && !ContributedTask.is(task) && !ConfiguringTask.is(task))) {
 			return undefined;
 		}
-		const result: TaskDTO = {
+		const result: ITaskDTO = {
 			_id: task._id,
 			name: task.configurationProperties.name,
 			definition: TaskDefinitionDTO.from(task.getDefinition(true)),
@@ -342,12 +342,12 @@ namespace TaskDTO {
 		return result;
 	}
 
-	export function to(task: TaskDTO | undefined, workspace: IWorkspaceContextService, executeOnly: boolean): ContributedTask | undefined {
+	export function to(task: ITaskDTO | undefined, workspace: IWorkspaceContextService, executeOnly: boolean): ContributedTask | undefined {
 		if (!task || (typeof task.name !== 'string')) {
 			return undefined;
 		}
 
-		let command: CommandConfiguration | undefined;
+		let command: ICommandConfiguration | undefined;
 		if (task.execution) {
 			if (ShellExecutionDTO.is(task.execution)) {
 				command = ShellExecutionDTO.to(task.execution);
@@ -390,7 +390,7 @@ namespace TaskDTO {
 }
 
 namespace TaskGroupDTO {
-	export function from(value: string | TaskGroup | undefined): TaskGroupDTO | undefined {
+	export function from(value: string | TaskGroup | undefined): ITaskGroupDTO | undefined {
 		if (value === undefined) {
 			return undefined;
 		}
@@ -402,10 +402,10 @@ namespace TaskGroupDTO {
 }
 
 namespace TaskFilterDTO {
-	export function from(value: TaskFilter): TaskFilterDTO {
+	export function from(value: ITaskFilter): ITaskFilterDTO {
 		return value;
 	}
-	export function to(value: TaskFilterDTO | undefined): TaskFilter | undefined {
+	export function to(value: ITaskFilterDTO | undefined): ITaskFilter | undefined {
 		return value;
 	}
 }
@@ -425,11 +425,11 @@ export class MainThreadTask implements MainThreadTaskShape {
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostTask);
 		this._providers = new Map();
-		this._taskService.onDidStateChange(async (event: TaskEvent) => {
+		this._taskService.onDidStateChange(async (event: ITaskEvent) => {
 			const task = event.__task!;
 			if (event.kind === TaskEventKind.Start) {
 				const execution = TaskExecutionDTO.from(task.getTaskExecution());
-				let resolvedDefinition: TaskDefinitionDTO = execution.task!.definition;
+				let resolvedDefinition: ITaskDefinitionDTO = execution.task!.definition;
 				if (execution.task?.execution && CustomExecutionDTO.is(execution.task.execution) && event.resolvedVariables) {
 					const dictionary: IStringDictionary<string> = {};
 					Array.from(event.resolvedVariables.entries()).forEach(entry => dictionary[entry[0]] = entry[1]);
@@ -454,7 +454,7 @@ export class MainThreadTask implements MainThreadTaskShape {
 		this._providers.clear();
 	}
 
-	$createTaskId(taskDTO: TaskDTO): Promise<string> {
+	$createTaskId(taskDTO: ITaskDTO): Promise<string> {
 		return new Promise((resolve, reject) => {
 			let task = TaskDTO.to(taskDTO, this._workspaceContextServer, true);
 			if (task) {
@@ -481,7 +481,7 @@ export class MainThreadTask implements MainThreadTaskShape {
 					return {
 						tasks,
 						extension: value.extension
-					} as TaskSet;
+					} as ITaskSet;
 				});
 			},
 			resolveTask: (task: ConfiguringTask) => {
@@ -514,9 +514,9 @@ export class MainThreadTask implements MainThreadTaskShape {
 		return Promise.resolve(undefined);
 	}
 
-	public $fetchTasks(filter?: TaskFilterDTO): Promise<TaskDTO[]> {
+	public $fetchTasks(filter?: ITaskFilterDTO): Promise<ITaskDTO[]> {
 		return this._taskService.tasks(TaskFilterDTO.to(filter)).then((tasks) => {
-			const result: TaskDTO[] = [];
+			const result: ITaskDTO[] = [];
 			for (let task of tasks) {
 				const item = TaskDTO.from(task);
 				if (item) {
@@ -543,7 +543,7 @@ export class MainThreadTask implements MainThreadTaskShape {
 		return workspace;
 	}
 
-	public async $getTaskExecution(value: TaskHandleDTO | TaskDTO): Promise<TaskExecutionDTO> {
+	public async $getTaskExecution(value: ITaskHandleDTO | ITaskDTO): Promise<ITaskExecutionDTO> {
 		if (TaskHandleDTO.is(value)) {
 			const workspace = this.getWorkspace(value.workspaceFolder);
 			if (workspace) {
@@ -569,8 +569,8 @@ export class MainThreadTask implements MainThreadTaskShape {
 
 	// Passing in a TaskHandleDTO will cause the task to get re-resolved, which is important for tasks are coming from the core,
 	// such as those gotten from a fetchTasks, since they can have missing configuration properties.
-	public $executeTask(value: TaskHandleDTO | TaskDTO): Promise<TaskExecutionDTO> {
-		return new Promise<TaskExecutionDTO>((resolve, reject) => {
+	public $executeTask(value: ITaskHandleDTO | ITaskDTO): Promise<ITaskExecutionDTO> {
+		return new Promise<ITaskExecutionDTO>((resolve, reject) => {
 			if (TaskHandleDTO.is(value)) {
 				const workspace = this.getWorkspace(value.workspaceFolder);
 				if (workspace) {
@@ -578,7 +578,7 @@ export class MainThreadTask implements MainThreadTaskShape {
 						if (!task) {
 							reject(new Error('Task not found'));
 						} else {
-							const result: TaskExecutionDTO = {
+							const result: ITaskExecutionDTO = {
 								id: value.id,
 								task: TaskDTO.from(task)
 							};
@@ -604,7 +604,7 @@ export class MainThreadTask implements MainThreadTaskShape {
 				this._taskService.run(task).then(undefined, reason => {
 					// eat the error, it has already been surfaced to the user and we don't care about it here
 				});
-				const result: TaskExecutionDTO = {
+				const result: ITaskExecutionDTO = {
 					id: task._id,
 					task: TaskDTO.from(task)
 				};
@@ -650,7 +650,7 @@ export class MainThreadTask implements MainThreadTaskShape {
 		});
 	}
 
-	public $registerTaskSystem(key: string, info: TaskSystemInfoDTO): void {
+	public $registerTaskSystem(key: string, info: ITaskSystemInfoDTO): void {
 		let platform: Platform.Platform;
 		switch (info.platform) {
 			case 'Web':
@@ -674,7 +674,7 @@ export class MainThreadTask implements MainThreadTaskShape {
 				return URI.from({ scheme: info.scheme, authority: info.authority, path });
 			},
 			context: this._extHostContext,
-			resolveVariables: (workspaceFolder: IWorkspaceFolder, toResolve: ResolveSet, target: ConfigurationTarget): Promise<ResolvedVariables | undefined> => {
+			resolveVariables: (workspaceFolder: IWorkspaceFolder, toResolve: IResolveSet, target: ConfigurationTarget): Promise<IResolvedVariables | undefined> => {
 				const vars: string[] = [];
 				toResolve.variables.forEach(item => vars.push(item));
 				return Promise.resolve(this._proxy.$resolveVariables(workspaceFolder.uri, { process: toResolve.process, variables: vars })).then(values => {
@@ -682,13 +682,13 @@ export class MainThreadTask implements MainThreadTaskShape {
 					forEach(values.variables, (entry) => {
 						partiallyResolvedVars.push(entry.value);
 					});
-					return new Promise<ResolvedVariables | undefined>((resolve, reject) => {
+					return new Promise<IResolvedVariables | undefined>((resolve, reject) => {
 						this._configurationResolverService.resolveWithInteraction(workspaceFolder, partiallyResolvedVars, 'tasks', undefined, target).then(resolvedVars => {
 							if (!resolvedVars) {
 								resolve(undefined);
 							}
 
-							const result: ResolvedVariables = {
+							const result: IResolvedVariables = {
 								process: undefined,
 								variables: new Map<string, string>()
 							};

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1111,14 +1111,14 @@ export interface MainThreadSearchShape extends IDisposable {
 }
 
 export interface MainThreadTaskShape extends IDisposable {
-	$createTaskId(task: tasks.TaskDTO): Promise<string>;
+	$createTaskId(task: tasks.ITaskDTO): Promise<string>;
 	$registerTaskProvider(handle: number, type: string): Promise<void>;
 	$unregisterTaskProvider(handle: number): Promise<void>;
-	$fetchTasks(filter?: tasks.TaskFilterDTO): Promise<tasks.TaskDTO[]>;
-	$getTaskExecution(value: tasks.TaskHandleDTO | tasks.TaskDTO): Promise<tasks.TaskExecutionDTO>;
-	$executeTask(task: tasks.TaskHandleDTO | tasks.TaskDTO): Promise<tasks.TaskExecutionDTO>;
+	$fetchTasks(filter?: tasks.ITaskFilterDTO): Promise<tasks.ITaskDTO[]>;
+	$getTaskExecution(value: tasks.ITaskHandleDTO | tasks.ITaskDTO): Promise<tasks.ITaskExecutionDTO>;
+	$executeTask(task: tasks.ITaskHandleDTO | tasks.ITaskDTO): Promise<tasks.ITaskExecutionDTO>;
 	$terminateTask(id: string): Promise<void>;
-	$registerTaskSystem(scheme: string, info: tasks.TaskSystemInfoDTO): void;
+	$registerTaskSystem(scheme: string, info: tasks.ITaskSystemInfoDTO): void;
 	$customExecutionComplete(id: string, result?: number): Promise<void>;
 	$registerSupportedExecutions(custom?: boolean, shell?: boolean, process?: boolean): Promise<void>;
 }
@@ -1841,12 +1841,12 @@ export interface ExtHostSCMShape {
 }
 
 export interface ExtHostTaskShape {
-	$provideTasks(handle: number, validTypes: { [key: string]: boolean }): Promise<tasks.TaskSetDTO>;
-	$resolveTask(handle: number, taskDTO: tasks.TaskDTO): Promise<tasks.TaskDTO | undefined>;
-	$onDidStartTask(execution: tasks.TaskExecutionDTO, terminalId: number, resolvedDefinition: tasks.TaskDefinitionDTO): void;
-	$onDidStartTaskProcess(value: tasks.TaskProcessStartedDTO): void;
-	$onDidEndTaskProcess(value: tasks.TaskProcessEndedDTO): void;
-	$OnDidEndTask(execution: tasks.TaskExecutionDTO): void;
+	$provideTasks(handle: number, validTypes: { [key: string]: boolean }): Promise<tasks.ITaskSetDTO>;
+	$resolveTask(handle: number, taskDTO: tasks.ITaskDTO): Promise<tasks.ITaskDTO | undefined>;
+	$onDidStartTask(execution: tasks.ITaskExecutionDTO, terminalId: number, resolvedDefinition: tasks.ITaskDefinitionDTO): void;
+	$onDidStartTaskProcess(value: tasks.ITaskProcessStartedDTO): void;
+	$onDidEndTaskProcess(value: tasks.ITaskProcessEndedDTO): void;
+	$OnDidEndTask(execution: tasks.ITaskExecutionDTO): void;
 	$resolveVariables(workspaceFolder: UriComponents, toResolve: { process?: { name: string; cwd?: string }; variables: string[] }): Promise<{ process?: string; variables: { [key: string]: string } }>;
 	$jsonTasksSupported(): Promise<boolean>;
 	$findExecutable(command: string, cwd?: string, paths?: string[]): Promise<string | undefined>;

--- a/src/vs/workbench/api/common/extHostTask.ts
+++ b/src/vs/workbench/api/common/extHostTask.ts
@@ -38,20 +38,20 @@ export interface IExtHostTask extends ExtHostTaskShape {
 	onDidEndTaskProcess: Event<vscode.TaskProcessEndEvent>;
 
 	registerTaskProvider(extension: IExtensionDescription, type: string, provider: vscode.TaskProvider): vscode.Disposable;
-	registerTaskSystem(scheme: string, info: tasks.TaskSystemInfoDTO): void;
+	registerTaskSystem(scheme: string, info: tasks.ITaskSystemInfoDTO): void;
 	fetchTasks(filter?: vscode.TaskFilter): Promise<vscode.Task[]>;
 	executeTask(extension: IExtensionDescription, task: vscode.Task): Promise<vscode.TaskExecution>;
 	terminateTask(execution: vscode.TaskExecution): Promise<void>;
 }
 
 export namespace TaskDefinitionDTO {
-	export function from(value: vscode.TaskDefinition): tasks.TaskDefinitionDTO | undefined {
+	export function from(value: vscode.TaskDefinition): tasks.ITaskDefinitionDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
 		return value;
 	}
-	export function to(value: tasks.TaskDefinitionDTO): vscode.TaskDefinition | undefined {
+	export function to(value: tasks.ITaskDefinitionDTO): vscode.TaskDefinition | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
@@ -60,13 +60,13 @@ export namespace TaskDefinitionDTO {
 }
 
 export namespace TaskPresentationOptionsDTO {
-	export function from(value: vscode.TaskPresentationOptions): tasks.TaskPresentationOptionsDTO | undefined {
+	export function from(value: vscode.TaskPresentationOptions): tasks.ITaskPresentationOptionsDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
 		return value;
 	}
-	export function to(value: tasks.TaskPresentationOptionsDTO): vscode.TaskPresentationOptions | undefined {
+	export function to(value: tasks.ITaskPresentationOptionsDTO): vscode.TaskPresentationOptions | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
@@ -75,13 +75,13 @@ export namespace TaskPresentationOptionsDTO {
 }
 
 export namespace ProcessExecutionOptionsDTO {
-	export function from(value: vscode.ProcessExecutionOptions): tasks.ProcessExecutionOptionsDTO | undefined {
+	export function from(value: vscode.ProcessExecutionOptions): tasks.IProcessExecutionOptionsDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
 		return value;
 	}
-	export function to(value: tasks.ProcessExecutionOptionsDTO): vscode.ProcessExecutionOptions | undefined {
+	export function to(value: tasks.IProcessExecutionOptionsDTO): vscode.ProcessExecutionOptions | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
@@ -90,19 +90,19 @@ export namespace ProcessExecutionOptionsDTO {
 }
 
 export namespace ProcessExecutionDTO {
-	export function is(value: tasks.ShellExecutionDTO | tasks.ProcessExecutionDTO | tasks.CustomExecutionDTO | undefined): value is tasks.ProcessExecutionDTO {
+	export function is(value: tasks.IShellExecutionDTO | tasks.IProcessExecutionDTO | tasks.ICustomExecutionDTO | undefined): value is tasks.IProcessExecutionDTO {
 		if (value) {
-			const candidate = value as tasks.ProcessExecutionDTO;
+			const candidate = value as tasks.IProcessExecutionDTO;
 			return candidate && !!candidate.process;
 		} else {
 			return false;
 		}
 	}
-	export function from(value: vscode.ProcessExecution): tasks.ProcessExecutionDTO | undefined {
+	export function from(value: vscode.ProcessExecution): tasks.IProcessExecutionDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
-		const result: tasks.ProcessExecutionDTO = {
+		const result: tasks.IProcessExecutionDTO = {
 			process: value.process,
 			args: value.args
 		};
@@ -111,7 +111,7 @@ export namespace ProcessExecutionDTO {
 		}
 		return result;
 	}
-	export function to(value: tasks.ProcessExecutionDTO): types.ProcessExecution | undefined {
+	export function to(value: tasks.IProcessExecutionDTO): types.ProcessExecution | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
@@ -120,13 +120,13 @@ export namespace ProcessExecutionDTO {
 }
 
 export namespace ShellExecutionOptionsDTO {
-	export function from(value: vscode.ShellExecutionOptions): tasks.ShellExecutionOptionsDTO | undefined {
+	export function from(value: vscode.ShellExecutionOptions): tasks.IShellExecutionOptionsDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
 		return value;
 	}
-	export function to(value: tasks.ShellExecutionOptionsDTO): vscode.ShellExecutionOptions | undefined {
+	export function to(value: tasks.IShellExecutionOptionsDTO): vscode.ShellExecutionOptions | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
@@ -135,19 +135,19 @@ export namespace ShellExecutionOptionsDTO {
 }
 
 export namespace ShellExecutionDTO {
-	export function is(value: tasks.ShellExecutionDTO | tasks.ProcessExecutionDTO | tasks.CustomExecutionDTO | undefined): value is tasks.ShellExecutionDTO {
+	export function is(value: tasks.IShellExecutionDTO | tasks.IProcessExecutionDTO | tasks.ICustomExecutionDTO | undefined): value is tasks.IShellExecutionDTO {
 		if (value) {
-			const candidate = value as tasks.ShellExecutionDTO;
+			const candidate = value as tasks.IShellExecutionDTO;
 			return candidate && (!!candidate.commandLine || !!candidate.command);
 		} else {
 			return false;
 		}
 	}
-	export function from(value: vscode.ShellExecution): tasks.ShellExecutionDTO | undefined {
+	export function from(value: vscode.ShellExecution): tasks.IShellExecutionDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
-		const result: tasks.ShellExecutionDTO = {
+		const result: tasks.IShellExecutionDTO = {
 		};
 		if (value.commandLine !== undefined) {
 			result.commandLine = value.commandLine;
@@ -160,7 +160,7 @@ export namespace ShellExecutionDTO {
 		}
 		return result;
 	}
-	export function to(value: tasks.ShellExecutionDTO): types.ShellExecution | undefined {
+	export function to(value: tasks.IShellExecutionDTO): types.ShellExecution | undefined {
 		if (value === undefined || value === null || (value.command === undefined && value.commandLine === undefined)) {
 			return undefined;
 		}
@@ -173,16 +173,16 @@ export namespace ShellExecutionDTO {
 }
 
 export namespace CustomExecutionDTO {
-	export function is(value: tasks.ShellExecutionDTO | tasks.ProcessExecutionDTO | tasks.CustomExecutionDTO | undefined): value is tasks.CustomExecutionDTO {
+	export function is(value: tasks.IShellExecutionDTO | tasks.IProcessExecutionDTO | tasks.ICustomExecutionDTO | undefined): value is tasks.ICustomExecutionDTO {
 		if (value) {
-			let candidate = value as tasks.CustomExecutionDTO;
+			let candidate = value as tasks.ICustomExecutionDTO;
 			return candidate && candidate.customExecution === 'customExecution';
 		} else {
 			return false;
 		}
 	}
 
-	export function from(value: vscode.CustomExecution): tasks.CustomExecutionDTO {
+	export function from(value: vscode.CustomExecution): tasks.ICustomExecutionDTO {
 		return {
 			customExecution: 'customExecution'
 		};
@@ -195,7 +195,7 @@ export namespace CustomExecutionDTO {
 
 
 export namespace TaskHandleDTO {
-	export function from(value: types.Task, workspaceService?: IExtHostWorkspace): tasks.TaskHandleDTO {
+	export function from(value: types.Task, workspaceService?: IExtHostWorkspace): tasks.ITaskHandleDTO {
 		let folder: UriComponents | string;
 		if (value.scope !== undefined && typeof value.scope !== 'number') {
 			folder = value.scope.uri;
@@ -213,7 +213,7 @@ export namespace TaskHandleDTO {
 	}
 }
 export namespace TaskGroupDTO {
-	export function from(value: vscode.TaskGroup): tasks.TaskGroupDTO | undefined {
+	export function from(value: vscode.TaskGroup): tasks.ITaskGroupDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
@@ -222,11 +222,11 @@ export namespace TaskGroupDTO {
 }
 
 export namespace TaskDTO {
-	export function fromMany(tasks: vscode.Task[], extension: IExtensionDescription): tasks.TaskDTO[] {
+	export function fromMany(tasks: vscode.Task[], extension: IExtensionDescription): tasks.ITaskDTO[] {
 		if (tasks === undefined || tasks === null) {
 			return [];
 		}
-		const result: tasks.TaskDTO[] = [];
+		const result: tasks.ITaskDTO[] = [];
 		for (let task of tasks) {
 			const converted = from(task, extension);
 			if (converted) {
@@ -236,11 +236,11 @@ export namespace TaskDTO {
 		return result;
 	}
 
-	export function from(value: vscode.Task, extension: IExtensionDescription): tasks.TaskDTO | undefined {
+	export function from(value: vscode.Task, extension: IExtensionDescription): tasks.ITaskDTO | undefined {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
-		let execution: tasks.ShellExecutionDTO | tasks.ProcessExecutionDTO | tasks.CustomExecutionDTO | undefined;
+		let execution: tasks.IShellExecutionDTO | tasks.IProcessExecutionDTO | tasks.ICustomExecutionDTO | undefined;
 		if (value.execution instanceof types.ProcessExecution) {
 			execution = ProcessExecutionDTO.from(value.execution);
 		} else if (value.execution instanceof types.ShellExecution) {
@@ -249,7 +249,7 @@ export namespace TaskDTO {
 			execution = CustomExecutionDTO.from(<types.CustomExecution>value.execution);
 		}
 
-		const definition: tasks.TaskDefinitionDTO | undefined = TaskDefinitionDTO.from(value.definition);
+		const definition: tasks.ITaskDefinitionDTO | undefined = TaskDefinitionDTO.from(value.definition);
 		let scope: number | UriComponents;
 		if (value.scope) {
 			if (typeof value.scope === 'number') {
@@ -264,7 +264,7 @@ export namespace TaskDTO {
 		if (!definition || !scope) {
 			return undefined;
 		}
-		const result: tasks.TaskDTO = {
+		const result: tasks.ITaskDTO = {
 			_id: (value as types.Task)._id!,
 			definition,
 			name: value.name,
@@ -284,7 +284,7 @@ export namespace TaskDTO {
 		};
 		return result;
 	}
-	export async function to(value: tasks.TaskDTO | undefined, workspace: IExtHostWorkspaceProvider, providedCustomExeutions: Map<string, types.CustomExecution>): Promise<types.Task | undefined> {
+	export async function to(value: tasks.ITaskDTO | undefined, workspace: IExtHostWorkspaceProvider, providedCustomExeutions: Map<string, types.CustomExecution>): Promise<types.Task | undefined> {
 		if (value === undefined || value === null) {
 			return undefined;
 		}
@@ -339,11 +339,11 @@ export namespace TaskDTO {
 }
 
 export namespace TaskFilterDTO {
-	export function from(value: vscode.TaskFilter | undefined): tasks.TaskFilterDTO | undefined {
+	export function from(value: vscode.TaskFilter | undefined): tasks.ITaskFilterDTO | undefined {
 		return value;
 	}
 
-	export function to(value: tasks.TaskFilterDTO): vscode.TaskFilter | undefined {
+	export function to(value: tasks.ITaskFilterDTO): vscode.TaskFilter | undefined {
 		if (!value) {
 			return undefined;
 		}
@@ -367,15 +367,15 @@ class TaskExecutionImpl implements vscode.TaskExecution {
 		this.#tasks.terminateTask(this);
 	}
 
-	public fireDidStartProcess(value: tasks.TaskProcessStartedDTO): void {
+	public fireDidStartProcess(value: tasks.ITaskProcessStartedDTO): void {
 	}
 
-	public fireDidEndProcess(value: tasks.TaskProcessEndedDTO): void {
+	public fireDidEndProcess(value: tasks.ITaskProcessEndedDTO): void {
 	}
 }
 
 export namespace TaskExecutionDTO {
-	export function from(value: vscode.TaskExecution): tasks.TaskExecutionDTO {
+	export function from(value: vscode.TaskExecution): tasks.ITaskExecutionDTO {
 		return {
 			id: (value as TaskExecutionImpl)._id,
 			task: undefined
@@ -453,7 +453,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		});
 	}
 
-	public registerTaskSystem(scheme: string, info: tasks.TaskSystemInfoDTO): void {
+	public registerTaskSystem(scheme: string, info: tasks.ITaskSystemInfoDTO): void {
 		this._proxy.$registerTaskSystem(scheme, info);
 	}
 
@@ -489,7 +489,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		return this._onDidExecuteTask.event;
 	}
 
-	public async $onDidStartTask(execution: tasks.TaskExecutionDTO, terminalId: number, resolvedDefinition: tasks.TaskDefinitionDTO): Promise<void> {
+	public async $onDidStartTask(execution: tasks.ITaskExecutionDTO, terminalId: number, resolvedDefinition: tasks.ITaskDefinitionDTO): Promise<void> {
 		const customExecution: types.CustomExecution | undefined = this._providedCustomExecutions2.get(execution.id);
 		if (customExecution) {
 			// Clone the custom execution to keep the original untouched. This is important for multiple runs of the same task.
@@ -507,7 +507,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		return this._onDidTerminateTask.event;
 	}
 
-	public async $OnDidEndTask(execution: tasks.TaskExecutionDTO): Promise<void> {
+	public async $OnDidEndTask(execution: tasks.ITaskExecutionDTO): Promise<void> {
 		const _execution = await this.getTaskExecution(execution);
 		this._taskExecutionPromises.delete(execution.id);
 		this._taskExecutions.delete(execution.id);
@@ -521,7 +521,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		return this._onDidTaskProcessStarted.event;
 	}
 
-	public async $onDidStartTaskProcess(value: tasks.TaskProcessStartedDTO): Promise<void> {
+	public async $onDidStartTaskProcess(value: tasks.ITaskProcessStartedDTO): Promise<void> {
 		const execution = await this.getTaskExecution(value.id);
 		this._onDidTaskProcessStarted.fire({
 			execution: execution,
@@ -533,7 +533,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		return this._onDidTaskProcessEnded.event;
 	}
 
-	public async $onDidEndTaskProcess(value: tasks.TaskProcessEndedDTO): Promise<void> {
+	public async $onDidEndTaskProcess(value: tasks.ITaskProcessEndedDTO): Promise<void> {
 		const execution = await this.getTaskExecution(value.id);
 		this._onDidTaskProcessEnded.fire({
 			execution: execution,
@@ -541,9 +541,9 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		});
 	}
 
-	protected abstract provideTasksInternal(validTypes: { [key: string]: boolean }, taskIdPromises: Promise<void>[], handler: HandlerData, value: vscode.Task[] | null | undefined): { tasks: tasks.TaskDTO[]; extension: IExtensionDescription };
+	protected abstract provideTasksInternal(validTypes: { [key: string]: boolean }, taskIdPromises: Promise<void>[], handler: HandlerData, value: vscode.Task[] | null | undefined): { tasks: tasks.ITaskDTO[]; extension: IExtensionDescription };
 
-	public $provideTasks(handle: number, validTypes: { [key: string]: boolean }): Promise<tasks.TaskSetDTO> {
+	public $provideTasks(handle: number, validTypes: { [key: string]: boolean }): Promise<tasks.ITaskSetDTO> {
 		const handler = this._handlers.get(handle);
 		if (!handler) {
 			return Promise.reject(new Error('no handler found'));
@@ -571,9 +571,9 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		});
 	}
 
-	protected abstract resolveTaskInternal(resolvedTaskDTO: tasks.TaskDTO): Promise<tasks.TaskDTO | undefined>;
+	protected abstract resolveTaskInternal(resolvedTaskDTO: tasks.ITaskDTO): Promise<tasks.ITaskDTO | undefined>;
 
-	public async $resolveTask(handle: number, taskDTO: tasks.TaskDTO): Promise<tasks.TaskDTO | undefined> {
+	public async $resolveTask(handle: number, taskDTO: tasks.ITaskDTO): Promise<tasks.ITaskDTO | undefined> {
 		const handler = this._handlers.get(handle);
 		if (!handler) {
 			return Promise.reject(new Error('no handler found'));
@@ -595,7 +595,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 
 		this.checkDeprecation(resolvedTask, handler);
 
-		const resolvedTaskDTO: tasks.TaskDTO | undefined = TaskDTO.from(resolvedTask, handler.extension);
+		const resolvedTaskDTO: tasks.ITaskDTO | undefined = TaskDTO.from(resolvedTask, handler.extension);
 		if (!resolvedTaskDTO) {
 			throw new Error('Unexpected: Task cannot be resolved.');
 		}
@@ -617,7 +617,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		return this._handleCounter++;
 	}
 
-	protected async addCustomExecution(taskDTO: tasks.TaskDTO, task: vscode.Task, isProvided: boolean): Promise<void> {
+	protected async addCustomExecution(taskDTO: tasks.ITaskDTO, task: vscode.Task, isProvided: boolean): Promise<void> {
 		const taskId = await this._proxy.$createTaskId(taskDTO);
 		if (!isProvided && !this._providedCustomExecutions2.has(taskId)) {
 			this._notProvidedCustomExecutions.add(taskId);
@@ -627,7 +627,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		this._providedCustomExecutions2.set(taskId, <types.CustomExecution>task.execution);
 	}
 
-	protected async getTaskExecution(execution: tasks.TaskExecutionDTO | string, task?: vscode.Task): Promise<TaskExecutionImpl> {
+	protected async getTaskExecution(execution: tasks.ITaskExecutionDTO | string, task?: vscode.Task): Promise<TaskExecutionImpl> {
 		if (typeof execution === 'string') {
 			const taskExecution = this._taskExecutionPromises.get(execution);
 			if (!taskExecution) {
@@ -641,7 +641,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 			return result;
 		}
 		const createdResult: Promise<TaskExecutionImpl> = new Promise((resolve, reject) => {
-			function resolvePromiseWithCreatedTask(that: ExtHostTaskBase, execution: tasks.TaskExecutionDTO, taskToCreate: vscode.Task | types.Task | undefined) {
+			function resolvePromiseWithCreatedTask(that: ExtHostTaskBase, execution: tasks.ITaskExecutionDTO, taskToCreate: vscode.Task | types.Task | undefined) {
 				if (!taskToCreate) {
 					reject('Unexpected: Task does not exist.');
 				} else {
@@ -673,7 +673,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		}
 	}
 
-	private customExecutionComplete(execution: tasks.TaskExecutionDTO): void {
+	private customExecutionComplete(execution: tasks.ITaskExecutionDTO): void {
 		const extensionCallback2: vscode.CustomExecution | undefined = this._activeCustomExecutions2.get(execution.id);
 		if (extensionCallback2) {
 			this._activeCustomExecutions2.delete(execution.id);
@@ -747,8 +747,8 @@ export class WorkerExtHostTask extends ExtHostTaskBase {
 		return execution;
 	}
 
-	protected provideTasksInternal(validTypes: { [key: string]: boolean }, taskIdPromises: Promise<void>[], handler: HandlerData, value: vscode.Task[] | null | undefined): { tasks: tasks.TaskDTO[]; extension: IExtensionDescription } {
-		const taskDTOs: tasks.TaskDTO[] = [];
+	protected provideTasksInternal(validTypes: { [key: string]: boolean }, taskIdPromises: Promise<void>[], handler: HandlerData, value: vscode.Task[] | null | undefined): { tasks: tasks.ITaskDTO[]; extension: IExtensionDescription } {
+		const taskDTOs: tasks.ITaskDTO[] = [];
 		if (value) {
 			for (let task of value) {
 				this.checkDeprecation(task, handler);
@@ -756,7 +756,7 @@ export class WorkerExtHostTask extends ExtHostTaskBase {
 					this._logService.warn(`The task [${task.source}, ${task.name}] uses an undefined task type. The task will be ignored in the future.`);
 				}
 
-				const taskDTO: tasks.TaskDTO | undefined = TaskDTO.from(task, handler.extension);
+				const taskDTO: tasks.ITaskDTO | undefined = TaskDTO.from(task, handler.extension);
 				if (taskDTO && CustomExecutionDTO.is(taskDTO.execution)) {
 					taskDTOs.push(taskDTO);
 					// The ID is calculated on the main thread task side, so, let's call into it here.
@@ -774,7 +774,7 @@ export class WorkerExtHostTask extends ExtHostTaskBase {
 		};
 	}
 
-	protected async resolveTaskInternal(resolvedTaskDTO: tasks.TaskDTO): Promise<tasks.TaskDTO | undefined> {
+	protected async resolveTaskInternal(resolvedTaskDTO: tasks.ITaskDTO): Promise<tasks.ITaskDTO | undefined> {
 		if (CustomExecutionDTO.is(resolvedTaskDTO.execution)) {
 			return resolvedTaskDTO;
 		} else {

--- a/src/vs/workbench/api/common/shared/tasks.ts
+++ b/src/vs/workbench/api/common/shared/tasks.ts
@@ -7,12 +7,12 @@ import { UriComponents } from 'vs/base/common/uri';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import type { Dto } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
-export interface TaskDefinitionDTO {
+export interface ITaskDefinitionDTO {
 	type: string;
 	[name: string]: any;
 }
 
-export interface TaskPresentationOptionsDTO {
+export interface ITaskPresentationOptionsDTO {
 	reveal?: number;
 	echo?: boolean;
 	focus?: boolean;
@@ -23,25 +23,25 @@ export interface TaskPresentationOptionsDTO {
 	close?: boolean;
 }
 
-export interface RunOptionsDTO {
+export interface IRunOptionsDTO {
 	reevaluateOnRerun?: boolean;
 }
 
-export interface ExecutionOptionsDTO {
+export interface IExecutionOptionsDTO {
 	cwd?: string;
 	env?: { [key: string]: string };
 }
 
-export interface ProcessExecutionOptionsDTO extends ExecutionOptionsDTO {
+export interface IProcessExecutionOptionsDTO extends IExecutionOptionsDTO {
 }
 
-export interface ProcessExecutionDTO {
+export interface IProcessExecutionDTO {
 	process: string;
 	args: string[];
-	options?: ProcessExecutionOptionsDTO;
+	options?: IProcessExecutionOptionsDTO;
 }
 
-export interface ShellQuotingOptionsDTO {
+export interface IShellQuotingOptionsDTO {
 	escape?: string | {
 		escapeChar: string;
 		charsToEscape: string;
@@ -50,86 +50,86 @@ export interface ShellQuotingOptionsDTO {
 	weak?: string;
 }
 
-export interface ShellExecutionOptionsDTO extends ExecutionOptionsDTO {
+export interface IShellExecutionOptionsDTO extends IExecutionOptionsDTO {
 	executable?: string;
 	shellArgs?: string[];
-	shellQuoting?: ShellQuotingOptionsDTO;
+	shellQuoting?: IShellQuotingOptionsDTO;
 }
 
-export interface ShellQuotedStringDTO {
+export interface IShellQuotedStringDTO {
 	value: string;
 	quoting: number;
 }
 
-export interface ShellExecutionDTO {
+export interface IShellExecutionDTO {
 	commandLine?: string;
-	command?: string | ShellQuotedStringDTO;
-	args?: Array<string | ShellQuotedStringDTO>;
-	options?: ShellExecutionOptionsDTO;
+	command?: string | IShellQuotedStringDTO;
+	args?: Array<string | IShellQuotedStringDTO>;
+	options?: IShellExecutionOptionsDTO;
 }
 
-export interface CustomExecutionDTO {
+export interface ICustomExecutionDTO {
 	customExecution: 'customExecution';
 }
 
-export interface TaskSourceDTO {
+export interface ITaskSourceDTO {
 	label: string;
 	extensionId?: string;
 	scope?: number | UriComponents;
 }
 
-export interface TaskHandleDTO {
+export interface ITaskHandleDTO {
 	id: string;
 	workspaceFolder: UriComponents | string;
 }
 
-export interface TaskGroupDTO {
+export interface ITaskGroupDTO {
 	isDefault?: boolean;
 	_id: string;
 }
 
-export interface TaskDTO {
+export interface ITaskDTO {
 	_id: string;
 	name?: string;
-	execution: ProcessExecutionDTO | ShellExecutionDTO | CustomExecutionDTO | undefined;
-	definition: TaskDefinitionDTO;
+	execution: IProcessExecutionDTO | IShellExecutionDTO | ICustomExecutionDTO | undefined;
+	definition: ITaskDefinitionDTO;
 	isBackground?: boolean;
-	source: TaskSourceDTO;
-	group?: TaskGroupDTO;
+	source: ITaskSourceDTO;
+	group?: ITaskGroupDTO;
 	detail?: string;
-	presentationOptions?: TaskPresentationOptionsDTO;
+	presentationOptions?: ITaskPresentationOptionsDTO;
 	problemMatchers: string[];
 	hasDefinedMatchers: boolean;
-	runOptions?: RunOptionsDTO;
+	runOptions?: IRunOptionsDTO;
 }
 
-export interface TaskSetDTO {
-	tasks: TaskDTO[];
+export interface ITaskSetDTO {
+	tasks: ITaskDTO[];
 	extension: Dto<IExtensionDescription>;
 }
 
-export interface TaskExecutionDTO {
+export interface ITaskExecutionDTO {
 	id: string;
-	task: TaskDTO | undefined;
+	task: ITaskDTO | undefined;
 }
 
-export interface TaskProcessStartedDTO {
+export interface ITaskProcessStartedDTO {
 	id: string;
 	processId: number;
 }
 
-export interface TaskProcessEndedDTO {
+export interface ITaskProcessEndedDTO {
 	id: string;
 	exitCode: number | undefined;
 }
 
 
-export interface TaskFilterDTO {
+export interface ITaskFilterDTO {
 	version?: string;
 	type?: string;
 }
 
-export interface TaskSystemInfoDTO {
+export interface ITaskSystemInfoDTO {
 	scheme: string;
 	authority: string;
 	platform: string;

--- a/src/vs/workbench/api/node/extHostTask.ts
+++ b/src/vs/workbench/api/node/extHostTask.ts
@@ -92,8 +92,8 @@ export class ExtHostTask extends ExtHostTaskBase {
 		}
 	}
 
-	protected provideTasksInternal(validTypes: { [key: string]: boolean }, taskIdPromises: Promise<void>[], handler: HandlerData, value: vscode.Task[] | null | undefined): { tasks: tasks.TaskDTO[]; extension: IExtensionDescription } {
-		const taskDTOs: tasks.TaskDTO[] = [];
+	protected provideTasksInternal(validTypes: { [key: string]: boolean }, taskIdPromises: Promise<void>[], handler: HandlerData, value: vscode.Task[] | null | undefined): { tasks: tasks.ITaskDTO[]; extension: IExtensionDescription } {
+		const taskDTOs: tasks.ITaskDTO[] = [];
 		if (value) {
 			for (let task of value) {
 				this.checkDeprecation(task, handler);
@@ -102,7 +102,7 @@ export class ExtHostTask extends ExtHostTaskBase {
 					this._logService.warn(`The task [${task.source}, ${task.name}] uses an undefined task type. The task will be ignored in the future.`);
 				}
 
-				const taskDTO: tasks.TaskDTO | undefined = TaskDTO.from(task, handler.extension);
+				const taskDTO: tasks.ITaskDTO | undefined = TaskDTO.from(task, handler.extension);
 				if (taskDTO) {
 					taskDTOs.push(taskDTO);
 
@@ -121,7 +121,7 @@ export class ExtHostTask extends ExtHostTaskBase {
 		};
 	}
 
-	protected async resolveTaskInternal(resolvedTaskDTO: tasks.TaskDTO): Promise<tasks.TaskDTO | undefined> {
+	protected async resolveTaskInternal(resolvedTaskDTO: tasks.ITaskDTO): Promise<tasks.ITaskDTO | undefined> {
 		return resolvedTaskDTO;
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
@@ -10,7 +10,7 @@ import { Markers } from 'vs/workbench/contrib/markers/common/markers';
 import { ITaskService, ITaskSummary } from 'vs/workbench/contrib/tasks/common/taskService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IWorkspaceFolder, IWorkspace } from 'vs/platform/workspace/common/workspace';
-import { TaskEvent, TaskEventKind, TaskIdentifier } from 'vs/workbench/contrib/tasks/common/tasks';
+import { ITaskEvent, TaskEventKind, ITaskIdentifier } from 'vs/workbench/contrib/tasks/common/tasks';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { withUndefinedAsNull } from 'vs/base/common/types';
 import { IMarkerService, MarkerSeverity } from 'vs/platform/markers/common/markers';
@@ -22,7 +22,7 @@ import { Action } from 'vs/base/common/actions';
 import { DEBUG_CONFIGURE_COMMAND_ID, DEBUG_CONFIGURE_LABEL } from 'vs/workbench/contrib/debug/browser/debugCommands';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 
-function once(match: (e: TaskEvent) => boolean, event: Event<TaskEvent>): Event<TaskEvent> {
+function once(match: (e: ITaskEvent) => boolean, event: Event<ITaskEvent>): Event<ITaskEvent> {
 	return (listener, thisArgs = null, disposables?) => {
 		const result = event(e => {
 			if (match(e)) {
@@ -59,7 +59,7 @@ export class DebugTaskRunner {
 		this.canceled = true;
 	}
 
-	async runTaskAndCheckErrors(root: IWorkspaceFolder | IWorkspace | undefined, taskId: string | TaskIdentifier | undefined): Promise<TaskRunResult> {
+	async runTaskAndCheckErrors(root: IWorkspaceFolder | IWorkspace | undefined, taskId: string | ITaskIdentifier | undefined): Promise<TaskRunResult> {
 		try {
 			this.canceled = false;
 			const taskSummary = await this.runTask(root, taskId);
@@ -149,7 +149,7 @@ export class DebugTaskRunner {
 		}
 	}
 
-	async runTask(root: IWorkspace | IWorkspaceFolder | undefined, taskId: string | TaskIdentifier | undefined): Promise<ITaskSummary | null> {
+	async runTask(root: IWorkspace | IWorkspaceFolder | undefined, taskId: string | ITaskIdentifier | undefined): Promise<ITaskSummary | null> {
 		if (!taskId) {
 			return Promise.resolve(null);
 		}

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -24,7 +24,7 @@ import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { IEditorPane } from 'vs/workbench/common/editor';
 import { DebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debugCompoundRoot';
 import { Source } from 'vs/workbench/contrib/debug/common/debugSource';
-import { TaskIdentifier } from 'vs/workbench/contrib/tasks/common/tasks';
+import { ITaskIdentifier } from 'vs/workbench/contrib/tasks/common/tasks';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 export const VIEWLET_ID = 'workbench.view.debug';
@@ -650,10 +650,10 @@ export interface IGlobalConfig {
 
 export interface IEnvConfig {
 	internalConsoleOptions?: 'neverOpen' | 'openOnSessionStart' | 'openOnFirstSessionStart';
-	preRestartTask?: string | TaskIdentifier;
-	postRestartTask?: string | TaskIdentifier;
-	preLaunchTask?: string | TaskIdentifier;
-	postDebugTask?: string | TaskIdentifier;
+	preRestartTask?: string | ITaskIdentifier;
+	postRestartTask?: string | ITaskIdentifier;
+	preLaunchTask?: string | ITaskIdentifier;
+	postDebugTask?: string | ITaskIdentifier;
 	debugServer?: number;
 	noDebug?: boolean;
 }
@@ -687,7 +687,7 @@ export interface IConfig extends IEnvConfig {
 export interface ICompound {
 	name: string;
 	stopAll?: boolean;
-	preLaunchTask?: string | TaskIdentifier;
+	preLaunchTask?: string | ITaskIdentifier;
 	configurations: (string | { name: string; folder: string })[];
 	presentation?: IConfigPresentation;
 }

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -7,9 +7,9 @@ import * as nls from 'vs/nls';
 import * as resources from 'vs/base/common/resources';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
-import { ITaskService, WorkspaceFolderTaskResult } from 'vs/workbench/contrib/tasks/common/taskService';
+import { ITaskService, IWorkspaceFolderTaskResult } from 'vs/workbench/contrib/tasks/common/taskService';
 import { forEach } from 'vs/base/common/collections';
-import { RunOnOptions, Task, TaskRunSource, TaskSource, TaskSourceKind, TASKS_CATEGORY, WorkspaceFileTaskSource, WorkspaceTaskSource } from 'vs/workbench/contrib/tasks/common/tasks';
+import { RunOnOptions, Task, TaskRunSource, TaskSource, TaskSourceKind, TASKS_CATEGORY, WorkspaceFileTaskSource, IWorkspaceTaskSource } from 'vs/workbench/contrib/tasks/common/tasks';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { IQuickPickItem, IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
@@ -77,7 +77,7 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		const taskKind = TaskSourceKind.toConfigurationTarget(source.kind);
 		switch (taskKind) {
 			case ConfigurationTarget.WORKSPACE_FOLDER: {
-				return resources.joinPath((<WorkspaceTaskSource>source).config.workspaceFolder!.uri, (<WorkspaceTaskSource>source).config.file);
+				return resources.joinPath((<IWorkspaceTaskSource>source).config.workspaceFolder!.uri, (<IWorkspaceTaskSource>source).config.file);
 			}
 			case ConfigurationTarget.WORKSPACE: {
 				return (<WorkspaceFileTaskSource>source).config.workspace?.configuration ?? undefined;
@@ -86,7 +86,7 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		return undefined;
 	}
 
-	private static findAutoTasks(taskService: ITaskService, workspaceTaskResult: Map<string, WorkspaceFolderTaskResult>): { tasks: Array<Task | Promise<Task | undefined>>; taskNames: Array<string>; locations: Map<string, URI> } {
+	private static findAutoTasks(taskService: ITaskService, workspaceTaskResult: Map<string, IWorkspaceFolderTaskResult>): { tasks: Array<Task | Promise<Task | undefined>>; taskNames: Array<string>; locations: Map<string, URI> } {
 		const tasks = new Array<Task | Promise<Task | undefined>>();
 		const taskNames = new Array<string>();
 		const locations = new Map<string, URI>();
@@ -129,7 +129,7 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 	}
 
 	public static async promptForPermission(taskService: ITaskService, storageService: IStorageService, notificationService: INotificationService, workspaceTrustManagementService: IWorkspaceTrustManagementService,
-		openerService: IOpenerService, workspaceTaskResult: Map<string, WorkspaceFolderTaskResult>) {
+		openerService: IOpenerService, workspaceTaskResult: Map<string, IWorkspaceFolderTaskResult>) {
 		const isWorkspaceTrusted = workspaceTrustManagementService.isWorkspaceTrusted;
 		if (!isWorkspaceTrusted) {
 			return;

--- a/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
@@ -20,7 +20,7 @@ import { StatusbarAlignment, IStatusbarService, IStatusbarEntryAccessor, IStatus
 
 import { IOutputChannelRegistry, Extensions as OutputExt } from 'vs/workbench/services/output/common/output';
 
-import { TaskEvent, TaskEventKind, TaskGroup, TASKS_CATEGORY, TASK_RUNNING_STATE } from 'vs/workbench/contrib/tasks/common/tasks';
+import { ITaskEvent, TaskEventKind, TaskGroup, TASKS_CATEGORY, TASK_RUNNING_STATE } from 'vs/workbench/contrib/tasks/common/tasks';
 import { ITaskService, ProcessExecutionSupportedContext, ShellExecutionSupportedContext } from 'vs/workbench/contrib/tasks/common/taskService';
 
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry, IWorkbenchContribution } from 'vs/workbench/common/contributions';
@@ -146,7 +146,7 @@ export class TaskStatusBarContributions extends Disposable implements IWorkbench
 		}
 	}
 
-	private ignoreEventForUpdateRunningTasksCount(event: TaskEvent): boolean {
+	private ignoreEventForUpdateRunningTasksCount(event: ITaskEvent): boolean {
 		if (!this.taskService.inTerminal()) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/tasks/browser/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/taskService.ts
@@ -7,8 +7,8 @@ import * as nls from 'vs/nls';
 import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { ITaskSystem } from 'vs/workbench/contrib/tasks/common/taskSystem';
 import { ExecutionEngine } from 'vs/workbench/contrib/tasks/common/tasks';
-import { AbstractTaskService, WorkspaceFolderConfigurationResult } from 'vs/workbench/contrib/tasks/browser/abstractTaskService';
-import { TaskFilter, ITaskService } from 'vs/workbench/contrib/tasks/common/taskService';
+import { AbstractTaskService, IWorkspaceFolderConfigurationResult } from 'vs/workbench/contrib/tasks/browser/abstractTaskService';
+import { ITaskFilter, ITaskService } from 'vs/workbench/contrib/tasks/common/taskService';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
 export class TaskService extends AbstractTaskService {
@@ -32,11 +32,11 @@ export class TaskService extends AbstractTaskService {
 		return this._taskSystem!;
 	}
 
-	protected computeLegacyConfiguration(workspaceFolder: IWorkspaceFolder): Promise<WorkspaceFolderConfigurationResult> {
+	protected computeLegacyConfiguration(workspaceFolder: IWorkspaceFolder): Promise<IWorkspaceFolderConfigurationResult> {
 		throw new Error(TaskService.ProcessTaskSystemSupportMessage);
 	}
 
-	protected versionAndEngineCompatible(filter?: TaskFilter): boolean {
+	protected versionAndEngineCompatible(filter?: ITaskFilter): boolean {
 		return this.executionEngine === ExecutionEngine.Terminal;
 	}
 }

--- a/src/vs/workbench/contrib/tasks/browser/taskTerminalStatus.ts
+++ b/src/vs/workbench/contrib/tasks/browser/taskTerminalStatus.ts
@@ -8,14 +8,14 @@ import { Codicon } from 'vs/base/common/codicons';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import Severity from 'vs/base/common/severity';
 import { AbstractProblemCollector, StartStopProblemCollector } from 'vs/workbench/contrib/tasks/common/problemCollectors';
-import { TaskEvent, TaskEventKind, TaskRunType } from 'vs/workbench/contrib/tasks/common/tasks';
+import { ITaskEvent, TaskEventKind, TaskRunType } from 'vs/workbench/contrib/tasks/common/tasks';
 import { ITaskService, Task } from 'vs/workbench/contrib/tasks/common/taskService';
 import { ITerminalInstance } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { ITerminalStatus } from 'vs/workbench/contrib/terminal/browser/terminalStatusList';
 import { MarkerSeverity } from 'vs/platform/markers/common/markers';
 import { spinningLoading } from 'vs/platform/theme/common/iconRegistry';
 
-interface TerminalData {
+interface ITerminalData {
 	terminal: ITerminalInstance;
 	task: Task;
 	status: ITerminalStatus;
@@ -36,7 +36,7 @@ const INFO_TASK_STATUS: ITerminalStatus = { id: TASK_TERMINAL_STATUS_ID, icon: C
 const INFO_INACTIVE_TASK_STATUS: ITerminalStatus = { id: TASK_TERMINAL_STATUS_ID, icon: Codicon.info, severity: Severity.Info, tooltip: nls.localize('taskTerminalStatus.infosInactive', "Task has infos and is waiting...") };
 
 export class TaskTerminalStatus extends Disposable {
-	private terminalMap: Map<string, TerminalData> = new Map();
+	private terminalMap: Map<string, ITerminalData> = new Map();
 
 	constructor(taskService: ITaskService) {
 		super();
@@ -56,7 +56,7 @@ export class TaskTerminalStatus extends Disposable {
 		this.terminalMap.set(task._id, { terminal, task, status, problemMatcher, taskRunEnded: false });
 	}
 
-	private terminalFromEvent(event: TaskEvent): TerminalData | undefined {
+	private terminalFromEvent(event: ITaskEvent): ITerminalData | undefined {
 		if (!event.__task) {
 			return undefined;
 		}
@@ -64,7 +64,7 @@ export class TaskTerminalStatus extends Disposable {
 		return this.terminalMap.get(event.__task._id);
 	}
 
-	private eventEnd(event: TaskEvent) {
+	private eventEnd(event: ITaskEvent) {
 		const terminalData = this.terminalFromEvent(event);
 		if (!terminalData) {
 			return;
@@ -82,7 +82,7 @@ export class TaskTerminalStatus extends Disposable {
 		}
 	}
 
-	private eventInactive(event: TaskEvent) {
+	private eventInactive(event: ITaskEvent) {
 		const terminalData = this.terminalFromEvent(event);
 		if (!terminalData || !terminalData.problemMatcher || terminalData.taskRunEnded) {
 			return;
@@ -99,7 +99,7 @@ export class TaskTerminalStatus extends Disposable {
 		}
 	}
 
-	private eventActive(event: TaskEvent) {
+	private eventActive(event: ITaskEvent) {
 		const terminalData = this.terminalFromEvent(event);
 		if (!terminalData) {
 			return;

--- a/src/vs/workbench/contrib/tasks/browser/tasksQuickAccess.ts
+++ b/src/vs/workbench/contrib/tasks/browser/tasksQuickAccess.ts
@@ -12,7 +12,7 @@ import { ITaskService, Task } from 'vs/workbench/contrib/tasks/common/taskServic
 import { CustomTask, ContributedTask, ConfiguringTask } from 'vs/workbench/contrib/tasks/common/tasks';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { DisposableStore } from 'vs/base/common/lifecycle';
-import { TaskQuickPick, TaskTwoLevelQuickPickEntry } from 'vs/workbench/contrib/tasks/browser/taskQuickPick';
+import { TaskQuickPick, ITaskTwoLevelQuickPickEntry } from 'vs/workbench/contrib/tasks/browser/taskQuickPick';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { isString } from 'vs/base/common/types';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -56,8 +56,8 @@ export class TasksQuickAccessProvider extends PickerQuickAccessProvider<IPickerQ
 				taskPicks.push(entry);
 			}
 
-			const task: Task | ConfiguringTask | string = (<TaskTwoLevelQuickPickEntry>entry).task!;
-			const quickAccessEntry: IPickerQuickAccessItem = <TaskTwoLevelQuickPickEntry>entry;
+			const task: Task | ConfiguringTask | string = (<ITaskTwoLevelQuickPickEntry>entry).task!;
+			const quickAccessEntry: IPickerQuickAccessItem = <ITaskTwoLevelQuickPickEntry>entry;
 			quickAccessEntry.highlights = { label: highlights };
 			quickAccessEntry.trigger = (index) => {
 				if ((index === 1) && (quickAccessEntry.buttons?.length === 2)) {

--- a/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts
@@ -14,7 +14,7 @@ import * as UUID from 'vs/base/common/uuid';
 
 import { ValidationStatus, IProblemReporter as IProblemReporterBase } from 'vs/base/common/parsers';
 import {
-	NamedProblemMatcher, ProblemMatcherParser, Config as ProblemMatcherConfig,
+	INamedProblemMatcher, ProblemMatcherParser, Config as ProblemMatcherConfig,
 	isNamedProblemMatcher, ProblemMatcherRegistry, ProblemMatcher
 } from 'vs/workbench/contrib/tasks/common/problemMatcher';
 
@@ -43,7 +43,7 @@ export const enum ShellQuoting {
 	weak = 3
 }
 
-export interface ShellQuotingOptions {
+export interface IShellQuotingOptions {
 	/**
 	 * The character used to do character escaping.
 	 */
@@ -63,13 +63,13 @@ export interface ShellQuotingOptions {
 	weak?: string;
 }
 
-export interface ShellConfiguration {
+export interface IShellConfiguration {
 	executable?: string;
 	args?: string[];
-	quoting?: ShellQuotingOptions;
+	quoting?: IShellQuotingOptions;
 }
 
-export interface CommandOptionsConfig {
+export interface ICommandOptionsConfig {
 	/**
 	 * The current working directory of the executed program or shell.
 	 * If omitted VSCode's current workspace root is used.
@@ -85,10 +85,10 @@ export interface CommandOptionsConfig {
 	/**
 	 * The shell configuration;
 	 */
-	shell?: ShellConfiguration;
+	shell?: IShellConfiguration;
 }
 
-export interface PresentationOptionsConfig {
+export interface IPresentationOptionsConfig {
 	/**
 	 * Controls whether the terminal executing a task is brought to front or not.
 	 * Defaults to `RevealKind.Always`.
@@ -137,25 +137,25 @@ export interface PresentationOptionsConfig {
 	close?: boolean;
 }
 
-export interface RunOptionsConfig {
+export interface IRunOptionsConfig {
 	reevaluateOnRerun?: boolean;
 	runOn?: string;
 	instanceLimit?: number;
 }
 
-export interface TaskIdentifier {
+export interface ITaskIdentifier {
 	type?: string;
 	[name: string]: any;
 }
 
-export namespace TaskIdentifier {
-	export function is(value: any): value is TaskIdentifier {
-		let candidate: TaskIdentifier = value;
+export namespace ITaskIdentifier {
+	export function is(value: any): value is ITaskIdentifier {
+		let candidate: ITaskIdentifier = value;
 		return candidate !== undefined && Types.isString(value.type);
 	}
 }
 
-export interface LegacyTaskProperties {
+export interface ILegacyTaskProperties {
 	/**
 	 * @deprecated Use `isBackground` instead.
 	 * Whether the executed command is kept alive and is watching the file system.
@@ -175,7 +175,7 @@ export interface LegacyTaskProperties {
 	isTestCommand?: boolean;
 }
 
-export interface LegacyCommandProperties {
+export interface ILegacyCommandProperties {
 
 	/**
 	 * Whether this is a shell or process
@@ -198,7 +198,7 @@ export interface LegacyCommandProperties {
 	/**
 	 * @deprecated Use presentation instead
 	 */
-	terminal?: PresentationOptionsConfig;
+	terminal?: IPresentationOptionsConfig;
 
 	/**
 	 * @deprecated Use inline commands.
@@ -220,7 +220,7 @@ export interface LegacyCommandProperties {
 	 *
 	 * Defaults to false if omitted.
 	 */
-	isShellCommand?: boolean | ShellConfiguration;
+	isShellCommand?: boolean | IShellConfiguration;
 }
 
 export type CommandString = string | string[] | { value: string | string[]; quoting: 'escape' | 'strong' | 'weak' };
@@ -241,7 +241,7 @@ export namespace CommandString {
 	}
 }
 
-export interface BaseCommandProperties {
+export interface IBaseCommandProperties {
 
 	/**
 	 * The command to be executed. Can be an external program or a shell
@@ -252,7 +252,7 @@ export interface BaseCommandProperties {
 	/**
 	 * The command options used when the command is executed. Can be omitted.
 	 */
-	options?: CommandOptionsConfig;
+	options?: ICommandOptionsConfig;
 
 	/**
 	 * The arguments passed to the command or additional arguments passed to the
@@ -262,30 +262,30 @@ export interface BaseCommandProperties {
 }
 
 
-export interface CommandProperties extends BaseCommandProperties {
+export interface ICommandProperties extends IBaseCommandProperties {
 
 	/**
 	 * Windows specific command properties
 	 */
-	windows?: BaseCommandProperties;
+	windows?: IBaseCommandProperties;
 
 	/**
 	 * OSX specific command properties
 	 */
-	osx?: BaseCommandProperties;
+	osx?: IBaseCommandProperties;
 
 	/**
 	 * linux specific command properties
 	 */
-	linux?: BaseCommandProperties;
+	linux?: IBaseCommandProperties;
 }
 
-export interface GroupKind {
+export interface IGroupKind {
 	kind?: string;
 	isDefault?: boolean | string;
 }
 
-export interface ConfigurationProperties {
+export interface IConfigurationProperties {
 	/**
 	 * The task's name
 	 */
@@ -315,7 +315,7 @@ export interface ConfigurationProperties {
 	/**
 	 * Defines the group the task belongs too.
 	 */
-	group?: string | GroupKind;
+	group?: string | IGroupKind;
 
 	/**
 	 * A description of the task.
@@ -325,7 +325,7 @@ export interface ConfigurationProperties {
 	/**
 	 * The other tasks the task depend on
 	 */
-	dependsOn?: string | TaskIdentifier | Array<string | TaskIdentifier>;
+	dependsOn?: string | ITaskIdentifier | Array<string | ITaskIdentifier>;
 
 	/**
 	 * The order the dependsOn tasks should be executed in.
@@ -335,12 +335,12 @@ export interface ConfigurationProperties {
 	/**
 	 * Controls the behavior of the used terminal
 	 */
-	presentation?: PresentationOptionsConfig;
+	presentation?: IPresentationOptionsConfig;
 
 	/**
 	 * Controls shell options.
 	 */
-	options?: CommandOptionsConfig;
+	options?: ICommandOptionsConfig;
 
 	/**
 	 * The problem matcher(s) to use to capture problems in the tasks
@@ -351,10 +351,10 @@ export interface ConfigurationProperties {
 	/**
 	 * Task run options. Control run related properties.
 	 */
-	runOptions?: RunOptionsConfig;
+	runOptions?: IRunOptionsConfig;
 }
 
-export interface CustomTask extends CommandProperties, ConfigurationProperties {
+export interface ICustomTask extends ICommandProperties, IConfigurationProperties {
 	/**
 	 * Custom tasks have the type CUSTOMIZED_TASK_TYPE
 	 */
@@ -362,7 +362,7 @@ export interface CustomTask extends CommandProperties, ConfigurationProperties {
 
 }
 
-export interface ConfiguringTask extends ConfigurationProperties {
+export interface IConfiguringTask extends IConfigurationProperties {
 	/**
 	 * The contributed type of the task
 	 */
@@ -372,7 +372,7 @@ export interface ConfiguringTask extends ConfigurationProperties {
 /**
  * The base task runner configuration
  */
-export interface BaseTaskRunnerConfiguration {
+export interface IBaseTaskRunnerConfiguration {
 
 	/**
 	 * The command to be executed. Can be an external program or a shell
@@ -398,7 +398,7 @@ export interface BaseTaskRunnerConfiguration {
 	/**
 	 * The command options used when the command is executed. Can be omitted.
 	 */
-	options?: CommandOptionsConfig;
+	options?: ICommandOptionsConfig;
 
 	/**
 	 * The arguments passed to the command. Can be omitted.
@@ -424,12 +424,12 @@ export interface BaseTaskRunnerConfiguration {
 	/**
 	 * The group
 	 */
-	group?: string | GroupKind;
+	group?: string | IGroupKind;
 
 	/**
 	 * Controls the behavior of the used terminal
 	 */
-	presentation?: PresentationOptionsConfig;
+	presentation?: IPresentationOptionsConfig;
 
 	/**
 	 * If set to false the task name is added as an additional argument to the
@@ -475,12 +475,12 @@ export interface BaseTaskRunnerConfiguration {
 	 * The configuration of the available tasks. A tasks.json file can either
 	 * contain a global problemMatcher property or a tasks property but not both.
 	 */
-	tasks?: Array<CustomTask | ConfiguringTask>;
+	tasks?: Array<ICustomTask | IConfiguringTask>;
 
 	/**
 	 * Problem matcher declarations.
 	 */
-	declares?: ProblemMatcherConfig.NamedProblemMatcher[];
+	declares?: ProblemMatcherConfig.INamedProblemMatcher[];
 
 	/**
 	 * Optional user input variables.
@@ -492,7 +492,7 @@ export interface BaseTaskRunnerConfiguration {
  * A configuration of an external build system. BuildConfiguration.buildSystem
  * must be set to 'program'
  */
-export interface ExternalTaskRunnerConfiguration extends BaseTaskRunnerConfiguration {
+export interface IExternalTaskRunnerConfiguration extends IBaseTaskRunnerConfiguration {
 
 	_runner?: string;
 
@@ -509,17 +509,17 @@ export interface ExternalTaskRunnerConfiguration extends BaseTaskRunnerConfigura
 	/**
 	 * Windows specific task configuration
 	 */
-	windows?: BaseTaskRunnerConfiguration;
+	windows?: IBaseTaskRunnerConfiguration;
 
 	/**
 	 * Mac specific task configuration
 	 */
-	osx?: BaseTaskRunnerConfiguration;
+	osx?: IBaseTaskRunnerConfiguration;
 
 	/**
 	 * Linux specific task configuration
 	 */
-	linux?: BaseTaskRunnerConfiguration;
+	linux?: IBaseTaskRunnerConfiguration;
 }
 
 enum ProblemMatcherKind {
@@ -552,21 +552,21 @@ function fillProperty<T, K extends keyof T>(target: T, source: Partial<T>, key: 
 }
 
 
-interface ParserType<T> {
+interface IParserType<T> {
 	isEmpty(value: T | undefined): boolean;
 	assignProperties(target: T | undefined, source: T | undefined): T | undefined;
 	fillProperties(target: T | undefined, source: T | undefined): T | undefined;
-	fillDefaults(value: T | undefined, context: ParseContext): T | undefined;
+	fillDefaults(value: T | undefined, context: IParseContext): T | undefined;
 	freeze(value: T): Readonly<T> | undefined;
 }
 
-interface MetaData<T, U> {
+interface IMetaData<T, U> {
 	property: keyof T;
-	type?: ParserType<U>;
+	type?: IParserType<U>;
 }
 
 
-function _isEmpty<T>(this: void, value: T | undefined, properties: MetaData<T, any>[] | undefined, allowEmptyArray: boolean = false): boolean {
+function _isEmpty<T>(this: void, value: T | undefined, properties: IMetaData<T, any>[] | undefined, allowEmptyArray: boolean = false): boolean {
 	if (value === undefined || value === null || properties === undefined) {
 		return true;
 	}
@@ -583,7 +583,7 @@ function _isEmpty<T>(this: void, value: T | undefined, properties: MetaData<T, a
 	return true;
 }
 
-function _assignProperties<T>(this: void, target: T | undefined, source: T | undefined, properties: MetaData<T, any>[]): T | undefined {
+function _assignProperties<T>(this: void, target: T | undefined, source: T | undefined, properties: IMetaData<T, any>[]): T | undefined {
 	if (!source || _isEmpty(source, properties)) {
 		return target;
 	}
@@ -605,7 +605,7 @@ function _assignProperties<T>(this: void, target: T | undefined, source: T | und
 	return target;
 }
 
-function _fillProperties<T>(this: void, target: T | undefined, source: T | undefined, properties: MetaData<T, any>[] | undefined, allowEmptyArray: boolean = false): T | undefined {
+function _fillProperties<T>(this: void, target: T | undefined, source: T | undefined, properties: IMetaData<T, any>[] | undefined, allowEmptyArray: boolean = false): T | undefined {
 	if (!source || _isEmpty(source, properties)) {
 		return target;
 	}
@@ -627,7 +627,7 @@ function _fillProperties<T>(this: void, target: T | undefined, source: T | undef
 	return target;
 }
 
-function _fillDefaults<T>(this: void, target: T | undefined, defaults: T | undefined, properties: MetaData<T, any>[], context: ParseContext): T | undefined {
+function _fillDefaults<T>(this: void, target: T | undefined, defaults: T | undefined, properties: IMetaData<T, any>[], context: IParseContext): T | undefined {
 	if (target && Object.isFrozen(target)) {
 		return target;
 	}
@@ -657,7 +657,7 @@ function _fillDefaults<T>(this: void, target: T | undefined, defaults: T | undef
 	return target;
 }
 
-function _freeze<T>(this: void, target: T, properties: MetaData<T, any>[]): Readonly<T> | undefined {
+function _freeze<T>(this: void, target: T, properties: IMetaData<T, any>[]): Readonly<T> | undefined {
 	if (target === undefined || target === null) {
 		return undefined;
 	}
@@ -692,8 +692,8 @@ export namespace RunOnOptions {
 }
 
 export namespace RunOptions {
-	const properties: MetaData<Tasks.RunOptions, void>[] = [{ property: 'reevaluateOnRerun' }, { property: 'runOn' }, { property: 'instanceLimit' }];
-	export function fromConfiguration(value: RunOptionsConfig | undefined): Tasks.RunOptions {
+	const properties: IMetaData<Tasks.IRunOptions, void>[] = [{ property: 'reevaluateOnRerun' }, { property: 'runOn' }, { property: 'instanceLimit' }];
+	export function fromConfiguration(value: IRunOptionsConfig | undefined): Tasks.IRunOptions {
 		return {
 			reevaluateOnRerun: value ? value.reevaluateOnRerun : true,
 			runOn: value ? RunOnOptions.fromString(value.runOn) : Tasks.RunOnOptions.default,
@@ -701,20 +701,20 @@ export namespace RunOptions {
 		};
 	}
 
-	export function assignProperties(target: Tasks.RunOptions, source: Tasks.RunOptions | undefined): Tasks.RunOptions {
+	export function assignProperties(target: Tasks.IRunOptions, source: Tasks.IRunOptions | undefined): Tasks.IRunOptions {
 		return _assignProperties(target, source, properties)!;
 	}
 
-	export function fillProperties(target: Tasks.RunOptions, source: Tasks.RunOptions | undefined): Tasks.RunOptions {
+	export function fillProperties(target: Tasks.IRunOptions, source: Tasks.IRunOptions | undefined): Tasks.IRunOptions {
 		return _fillProperties(target, source, properties)!;
 	}
 }
 
-export interface ParseContext {
+export interface IParseContext {
 	workspaceFolder: IWorkspaceFolder;
 	workspace: IWorkspace | undefined;
 	problemReporter: IProblemReporter;
-	namedProblemMatchers: IStringDictionary<NamedProblemMatcher>;
+	namedProblemMatchers: IStringDictionary<INamedProblemMatcher>;
 	uuidMap: UUIDMap;
 	engine: Tasks.ExecutionEngine;
 	schemaVersion: Tasks.JsonSchemaVersion;
@@ -726,18 +726,18 @@ export interface ParseContext {
 
 namespace ShellConfiguration {
 
-	const properties: MetaData<Tasks.ShellConfiguration, void>[] = [{ property: 'executable' }, { property: 'args' }, { property: 'quoting' }];
+	const properties: IMetaData<Tasks.IShellConfiguration, void>[] = [{ property: 'executable' }, { property: 'args' }, { property: 'quoting' }];
 
-	export function is(value: any): value is ShellConfiguration {
-		let candidate: ShellConfiguration = value;
+	export function is(value: any): value is IShellConfiguration {
+		let candidate: IShellConfiguration = value;
 		return candidate && (Types.isString(candidate.executable) || Types.isStringArray(candidate.args));
 	}
 
-	export function from(this: void, config: ShellConfiguration | undefined, context: ParseContext): Tasks.ShellConfiguration | undefined {
+	export function from(this: void, config: IShellConfiguration | undefined, context: IParseContext): Tasks.IShellConfiguration | undefined {
 		if (!is(config)) {
 			return undefined;
 		}
-		let result: ShellConfiguration = {};
+		let result: IShellConfiguration = {};
 		if (config.executable !== undefined) {
 			result.executable = config.executable;
 		}
@@ -751,23 +751,23 @@ namespace ShellConfiguration {
 		return result;
 	}
 
-	export function isEmpty(this: void, value: Tasks.ShellConfiguration): boolean {
+	export function isEmpty(this: void, value: Tasks.IShellConfiguration): boolean {
 		return _isEmpty(value, properties, true);
 	}
 
-	export function assignProperties(this: void, target: Tasks.ShellConfiguration | undefined, source: Tasks.ShellConfiguration | undefined): Tasks.ShellConfiguration | undefined {
+	export function assignProperties(this: void, target: Tasks.IShellConfiguration | undefined, source: Tasks.IShellConfiguration | undefined): Tasks.IShellConfiguration | undefined {
 		return _assignProperties(target, source, properties);
 	}
 
-	export function fillProperties(this: void, target: Tasks.ShellConfiguration, source: Tasks.ShellConfiguration): Tasks.ShellConfiguration | undefined {
+	export function fillProperties(this: void, target: Tasks.IShellConfiguration, source: Tasks.IShellConfiguration): Tasks.IShellConfiguration | undefined {
 		return _fillProperties(target, source, properties, true);
 	}
 
-	export function fillDefaults(this: void, value: Tasks.ShellConfiguration, context: ParseContext): Tasks.ShellConfiguration {
+	export function fillDefaults(this: void, value: Tasks.IShellConfiguration, context: IParseContext): Tasks.IShellConfiguration {
 		return value;
 	}
 
-	export function freeze(this: void, value: Tasks.ShellConfiguration): Readonly<Tasks.ShellConfiguration> | undefined {
+	export function freeze(this: void, value: Tasks.IShellConfiguration): Readonly<Tasks.IShellConfiguration> | undefined {
 		if (!value) {
 			return undefined;
 		}
@@ -777,10 +777,10 @@ namespace ShellConfiguration {
 
 namespace CommandOptions {
 
-	const properties: MetaData<Tasks.CommandOptions, Tasks.ShellConfiguration>[] = [{ property: 'cwd' }, { property: 'env' }, { property: 'shell', type: ShellConfiguration }];
-	const defaults: CommandOptionsConfig = { cwd: '${workspaceFolder}' };
+	const properties: IMetaData<Tasks.CommandOptions, Tasks.IShellConfiguration>[] = [{ property: 'cwd' }, { property: 'env' }, { property: 'shell', type: ShellConfiguration }];
+	const defaults: ICommandOptionsConfig = { cwd: '${workspaceFolder}' };
 
-	export function from(this: void, options: CommandOptionsConfig, context: ParseContext): Tasks.CommandOptions | undefined {
+	export function from(this: void, options: ICommandOptionsConfig, context: IParseContext): Tasks.CommandOptions | undefined {
 		let result: Tasks.CommandOptions = {};
 		if (options.cwd !== undefined) {
 			if (Types.isString(options.cwd)) {
@@ -828,7 +828,7 @@ namespace CommandOptions {
 		return _fillProperties(target, source, properties);
 	}
 
-	export function fillDefaults(value: Tasks.CommandOptions | undefined, context: ParseContext): Tasks.CommandOptions | undefined {
+	export function fillDefaults(value: Tasks.CommandOptions | undefined, context: IParseContext): Tasks.CommandOptions | undefined {
 		return _fillDefaults(value, defaults, properties, context);
 	}
 
@@ -840,13 +840,13 @@ namespace CommandOptions {
 namespace CommandConfiguration {
 
 	export namespace PresentationOptions {
-		const properties: MetaData<Tasks.PresentationOptions, void>[] = [{ property: 'echo' }, { property: 'reveal' }, { property: 'revealProblems' }, { property: 'focus' }, { property: 'panel' }, { property: 'showReuseMessage' }, { property: 'clear' }, { property: 'group' }, { property: 'close' }];
+		const properties: IMetaData<Tasks.IPresentationOptions, void>[] = [{ property: 'echo' }, { property: 'reveal' }, { property: 'revealProblems' }, { property: 'focus' }, { property: 'panel' }, { property: 'showReuseMessage' }, { property: 'clear' }, { property: 'group' }, { property: 'close' }];
 
-		interface PresentationOptionsShape extends LegacyCommandProperties {
-			presentation?: PresentationOptionsConfig;
+		interface IPresentationOptionsShape extends ILegacyCommandProperties {
+			presentation?: IPresentationOptionsConfig;
 		}
 
-		export function from(this: void, config: PresentationOptionsShape, context: ParseContext): Tasks.PresentationOptions | undefined {
+		export function from(this: void, config: IPresentationOptionsShape, context: IParseContext): Tasks.IPresentationOptions | undefined {
 			let echo: boolean;
 			let reveal: Tasks.RevealKind;
 			let revealProblems: Tasks.RevealProblemKind;
@@ -902,24 +902,24 @@ namespace CommandConfiguration {
 			return { echo: echo!, reveal: reveal!, revealProblems: revealProblems!, focus: focus!, panel: panel!, showReuseMessage: showReuseMessage!, clear: clear!, group, close: close };
 		}
 
-		export function assignProperties(target: Tasks.PresentationOptions, source: Tasks.PresentationOptions | undefined): Tasks.PresentationOptions | undefined {
+		export function assignProperties(target: Tasks.IPresentationOptions, source: Tasks.IPresentationOptions | undefined): Tasks.IPresentationOptions | undefined {
 			return _assignProperties(target, source, properties);
 		}
 
-		export function fillProperties(target: Tasks.PresentationOptions, source: Tasks.PresentationOptions | undefined): Tasks.PresentationOptions | undefined {
+		export function fillProperties(target: Tasks.IPresentationOptions, source: Tasks.IPresentationOptions | undefined): Tasks.IPresentationOptions | undefined {
 			return _fillProperties(target, source, properties);
 		}
 
-		export function fillDefaults(value: Tasks.PresentationOptions, context: ParseContext): Tasks.PresentationOptions | undefined {
+		export function fillDefaults(value: Tasks.IPresentationOptions, context: IParseContext): Tasks.IPresentationOptions | undefined {
 			let defaultEcho = context.engine === Tasks.ExecutionEngine.Terminal ? true : false;
 			return _fillDefaults(value, { echo: defaultEcho, reveal: Tasks.RevealKind.Always, revealProblems: Tasks.RevealProblemKind.Never, focus: false, panel: Tasks.PanelKind.Shared, showReuseMessage: true, clear: false }, properties, context);
 		}
 
-		export function freeze(value: Tasks.PresentationOptions): Readonly<Tasks.PresentationOptions> | undefined {
+		export function freeze(value: Tasks.IPresentationOptions): Readonly<Tasks.IPresentationOptions> | undefined {
 			return _freeze(value, properties);
 		}
 
-		export function isEmpty(this: void, value: Tasks.PresentationOptions): boolean {
+		export function isEmpty(this: void, value: Tasks.IPresentationOptions): boolean {
 			return _isEmpty(value, properties);
 		}
 	}
@@ -948,25 +948,25 @@ namespace CommandConfiguration {
 		}
 	}
 
-	interface BaseCommandConfigurationShape extends BaseCommandProperties, LegacyCommandProperties {
+	interface IBaseCommandConfigurationShape extends IBaseCommandProperties, ILegacyCommandProperties {
 	}
 
-	interface CommandConfigurationShape extends BaseCommandConfigurationShape {
-		windows?: BaseCommandConfigurationShape;
-		osx?: BaseCommandConfigurationShape;
-		linux?: BaseCommandConfigurationShape;
+	interface ICommandConfigurationShape extends IBaseCommandConfigurationShape {
+		windows?: IBaseCommandConfigurationShape;
+		osx?: IBaseCommandConfigurationShape;
+		linux?: IBaseCommandConfigurationShape;
 	}
 
-	const properties: MetaData<Tasks.CommandConfiguration, any>[] = [
+	const properties: IMetaData<Tasks.ICommandConfiguration, any>[] = [
 		{ property: 'runtime' }, { property: 'name' }, { property: 'options', type: CommandOptions },
 		{ property: 'args' }, { property: 'taskSelector' }, { property: 'suppressTaskName' },
 		{ property: 'presentation', type: PresentationOptions }
 	];
 
-	export function from(this: void, config: CommandConfigurationShape, context: ParseContext): Tasks.CommandConfiguration | undefined {
-		let result: Tasks.CommandConfiguration = fromBase(config, context)!;
+	export function from(this: void, config: ICommandConfigurationShape, context: IParseContext): Tasks.ICommandConfiguration | undefined {
+		let result: Tasks.ICommandConfiguration = fromBase(config, context)!;
 
-		let osConfig: Tasks.CommandConfiguration | undefined = undefined;
+		let osConfig: Tasks.ICommandConfiguration | undefined = undefined;
 		if (config.windows && context.platform === Platform.Windows) {
 			osConfig = fromBase(config.windows, context);
 		} else if (config.osx && context.platform === Platform.Mac) {
@@ -980,7 +980,7 @@ namespace CommandConfiguration {
 		return isEmpty(result) ? undefined : result;
 	}
 
-	function fromBase(this: void, config: BaseCommandConfigurationShape, context: ParseContext): Tasks.CommandConfiguration | undefined {
+	function fromBase(this: void, config: IBaseCommandConfigurationShape, context: IParseContext): Tasks.ICommandConfiguration | undefined {
 		let name: Tasks.CommandString | undefined = ShellString.from(config.command);
 		let runtime: Tasks.RuntimeType;
 		if (Types.isString(config.type)) {
@@ -995,7 +995,7 @@ namespace CommandConfiguration {
 			runtime = !!config.isShellCommand ? Tasks.RuntimeType.Shell : Tasks.RuntimeType.Process;
 		}
 
-		let result: Tasks.CommandConfiguration = {
+		let result: Tasks.ICommandConfiguration = {
 			name: name,
 			runtime: runtime!,
 			presentation: PresentationOptions.from(config, context)!
@@ -1020,7 +1020,7 @@ namespace CommandConfiguration {
 		if (config.options !== undefined) {
 			result.options = CommandOptions.from(config.options, context);
 			if (result.options && result.options.shell === undefined && isShellConfiguration) {
-				result.options.shell = ShellConfiguration.from(config.isShellCommand as ShellConfiguration, context);
+				result.options.shell = ShellConfiguration.from(config.isShellCommand as IShellConfiguration, context);
 				if (context.engine !== Tasks.ExecutionEngine.Terminal) {
 					context.taskLoadIssues.push(nls.localize('ConfigurationParser.noShell', 'Warning: shell configuration is only supported when executing tasks in the terminal.'));
 				}
@@ -1037,15 +1037,15 @@ namespace CommandConfiguration {
 		return isEmpty(result) ? undefined : result;
 	}
 
-	export function hasCommand(value: Tasks.CommandConfiguration): boolean {
+	export function hasCommand(value: Tasks.ICommandConfiguration): boolean {
 		return value && !!value.name;
 	}
 
-	export function isEmpty(value: Tasks.CommandConfiguration | undefined): boolean {
+	export function isEmpty(value: Tasks.ICommandConfiguration | undefined): boolean {
 		return _isEmpty(value, properties);
 	}
 
-	export function assignProperties(target: Tasks.CommandConfiguration, source: Tasks.CommandConfiguration, overwriteArgs: boolean): Tasks.CommandConfiguration {
+	export function assignProperties(target: Tasks.ICommandConfiguration, source: Tasks.ICommandConfiguration, overwriteArgs: boolean): Tasks.ICommandConfiguration {
 		if (isEmpty(source)) {
 			return target;
 		}
@@ -1068,11 +1068,11 @@ namespace CommandConfiguration {
 		return target;
 	}
 
-	export function fillProperties(target: Tasks.CommandConfiguration, source: Tasks.CommandConfiguration): Tasks.CommandConfiguration | undefined {
+	export function fillProperties(target: Tasks.ICommandConfiguration, source: Tasks.ICommandConfiguration): Tasks.ICommandConfiguration | undefined {
 		return _fillProperties(target, source, properties);
 	}
 
-	export function fillGlobals(target: Tasks.CommandConfiguration, source: Tasks.CommandConfiguration | undefined, taskName: string | undefined): Tasks.CommandConfiguration {
+	export function fillGlobals(target: Tasks.ICommandConfiguration, source: Tasks.ICommandConfiguration | undefined, taskName: string | undefined): Tasks.ICommandConfiguration {
 		if ((source === undefined) || isEmpty(source)) {
 			return target;
 		}
@@ -1106,7 +1106,7 @@ namespace CommandConfiguration {
 		return target;
 	}
 
-	export function fillDefaults(value: Tasks.CommandConfiguration | undefined, context: ParseContext): void {
+	export function fillDefaults(value: Tasks.ICommandConfiguration | undefined, context: IParseContext): void {
 		if (!value || Object.isFrozen(value)) {
 			return;
 		}
@@ -1125,20 +1125,20 @@ namespace CommandConfiguration {
 		}
 	}
 
-	export function freeze(value: Tasks.CommandConfiguration): Readonly<Tasks.CommandConfiguration> | undefined {
+	export function freeze(value: Tasks.ICommandConfiguration): Readonly<Tasks.ICommandConfiguration> | undefined {
 		return _freeze(value, properties);
 	}
 }
 
 export namespace ProblemMatcherConverter {
 
-	export function namedFrom(this: void, declares: ProblemMatcherConfig.NamedProblemMatcher[] | undefined, context: ParseContext): IStringDictionary<NamedProblemMatcher> {
-		let result: IStringDictionary<NamedProblemMatcher> = Object.create(null);
+	export function namedFrom(this: void, declares: ProblemMatcherConfig.INamedProblemMatcher[] | undefined, context: IParseContext): IStringDictionary<INamedProblemMatcher> {
+		let result: IStringDictionary<INamedProblemMatcher> = Object.create(null);
 
 		if (!Types.isArray(declares)) {
 			return result;
 		}
-		(<ProblemMatcherConfig.NamedProblemMatcher[]>declares).forEach((value) => {
+		(<ProblemMatcherConfig.INamedProblemMatcher[]>declares).forEach((value) => {
 			let namedProblemMatcher = (new ProblemMatcherParser(context.problemReporter)).parse(value);
 			if (isNamedProblemMatcher(namedProblemMatcher)) {
 				result[namedProblemMatcher.name] = namedProblemMatcher;
@@ -1149,7 +1149,7 @@ export namespace ProblemMatcherConverter {
 		return result;
 	}
 
-	export function fromWithOsConfig(this: void, external: ConfigurationProperties & { [key: string]: any }, context: ParseContext): TaskConfigurationValueWithErrors<ProblemMatcher[]> {
+	export function fromWithOsConfig(this: void, external: IConfigurationProperties & { [key: string]: any }, context: IParseContext): TaskConfigurationValueWithErrors<ProblemMatcher[]> {
 		let result: TaskConfigurationValueWithErrors<ProblemMatcher[]> = {};
 		if (external.windows && external.windows.problemMatcher && context.platform === Platform.Windows) {
 			result = from(external.windows.problemMatcher, context);
@@ -1163,7 +1163,7 @@ export namespace ProblemMatcherConverter {
 		return result;
 	}
 
-	export function from(this: void, config: ProblemMatcherConfig.ProblemMatcherType | undefined, context: ParseContext): TaskConfigurationValueWithErrors<ProblemMatcher[]> {
+	export function from(this: void, config: ProblemMatcherConfig.ProblemMatcherType | undefined, context: IParseContext): TaskConfigurationValueWithErrors<ProblemMatcher[]> {
 		let result: ProblemMatcher[] = [];
 		if (config === undefined) {
 			return { value: result };
@@ -1207,7 +1207,7 @@ export namespace ProblemMatcherConverter {
 		}
 	}
 
-	function resolveProblemMatcher(this: void, value: string | ProblemMatcherConfig.ProblemMatcher, context: ParseContext): TaskConfigurationValueWithErrors<ProblemMatcher> {
+	function resolveProblemMatcher(this: void, value: string | ProblemMatcherConfig.ProblemMatcher, context: IParseContext): TaskConfigurationValueWithErrors<ProblemMatcher> {
 		if (Types.isString(value)) {
 			let variableName = <string>value;
 			if (variableName.length > 1 && variableName[0] === '$') {
@@ -1216,7 +1216,7 @@ export namespace ProblemMatcherConverter {
 				if (global) {
 					return { value: Objects.deepClone(global) };
 				}
-				let localProblemMatcher: ProblemMatcher & Partial<NamedProblemMatcher> = context.namedProblemMatchers[variableName];
+				let localProblemMatcher: ProblemMatcher & Partial<INamedProblemMatcher> = context.namedProblemMatchers[variableName];
 				if (localProblemMatcher) {
 					localProblemMatcher = Objects.deepClone(localProblemMatcher);
 					// remove the name
@@ -1238,7 +1238,7 @@ const partialSource: Partial<Tasks.TaskSource> = {
 };
 
 export namespace GroupKind {
-	export function from(this: void, external: string | GroupKind | undefined): Tasks.TaskGroup | undefined {
+	export function from(this: void, external: string | IGroupKind | undefined): Tasks.TaskGroup | undefined {
 		if (external === undefined) {
 			return undefined;
 		} else if (Types.isString(external) && Tasks.TaskGroup.is(external)) {
@@ -1252,7 +1252,7 @@ export namespace GroupKind {
 		return undefined;
 	}
 
-	export function to(group: Tasks.TaskGroup | string): GroupKind | string {
+	export function to(group: Tasks.TaskGroup | string): IGroupKind | string {
 		if (Types.isString(group)) {
 			return group;
 		} else if (!group.isDefault) {
@@ -1266,7 +1266,7 @@ export namespace GroupKind {
 }
 
 namespace TaskDependency {
-	function uriFromSource(context: ParseContext, source: TaskConfigSource): URI | string {
+	function uriFromSource(context: IParseContext, source: TaskConfigSource): URI | string {
 		switch (source) {
 			case TaskConfigSource.User: return Tasks.USER_TASKS_GROUP_KEY;
 			case TaskConfigSource.TasksJson: return context.workspaceFolder.uri;
@@ -1274,13 +1274,13 @@ namespace TaskDependency {
 		}
 	}
 
-	export function from(this: void, external: string | TaskIdentifier, context: ParseContext, source: TaskConfigSource): Tasks.TaskDependency | undefined {
+	export function from(this: void, external: string | ITaskIdentifier, context: IParseContext, source: TaskConfigSource): Tasks.ITaskDependency | undefined {
 		if (Types.isString(external)) {
 			return { uri: uriFromSource(context, source), task: external };
-		} else if (TaskIdentifier.is(external)) {
+		} else if (ITaskIdentifier.is(external)) {
 			return {
 				uri: uriFromSource(context, source),
-				task: Tasks.TaskDefinition.createTaskIdentifier(external as Tasks.TaskIdentifier, context.problemReporter)
+				task: Tasks.TaskDefinition.createTaskIdentifier(external as Tasks.ITaskIdentifier, context.problemReporter)
 			};
 		} else {
 			return undefined;
@@ -1302,7 +1302,7 @@ namespace DependsOrder {
 
 namespace ConfigurationProperties {
 
-	const properties: MetaData<Tasks.ConfigurationProperties, any>[] = [
+	const properties: IMetaData<Tasks.IConfigurationProperties, any>[] = [
 
 		{ property: 'name' }, { property: 'identifier' }, { property: 'group' }, { property: 'isBackground' },
 		{ property: 'promptOnClose' }, { property: 'dependsOn' },
@@ -1310,12 +1310,12 @@ namespace ConfigurationProperties {
 		{ property: 'options' }
 	];
 
-	export function from(this: void, external: ConfigurationProperties & { [key: string]: any }, context: ParseContext,
-		includeCommandOptions: boolean, source: TaskConfigSource, properties?: IJSONSchemaMap): TaskConfigurationValueWithErrors<Tasks.ConfigurationProperties> {
+	export function from(this: void, external: IConfigurationProperties & { [key: string]: any }, context: IParseContext,
+		includeCommandOptions: boolean, source: TaskConfigSource, properties?: IJSONSchemaMap): TaskConfigurationValueWithErrors<Tasks.IConfigurationProperties> {
 		if (!external) {
 			return {};
 		}
-		let result: Tasks.ConfigurationProperties & { [key: string]: any } = {};
+		let result: Tasks.IConfigurationProperties & { [key: string]: any } = {};
 
 		if (properties) {
 			for (const propertyName of Object.keys(properties)) {
@@ -1343,7 +1343,7 @@ namespace ConfigurationProperties {
 		result.group = GroupKind.from(external.group);
 		if (external.dependsOn !== undefined) {
 			if (Types.isArray(external.dependsOn)) {
-				result.dependsOn = external.dependsOn.reduce((dependencies: Tasks.TaskDependency[], item): Tasks.TaskDependency[] => {
+				result.dependsOn = external.dependsOn.reduce((dependencies: Tasks.ITaskDependency[], item): Tasks.ITaskDependency[] => {
 					const dependency = TaskDependency.from(item, context, source);
 					if (dependency) {
 						dependencies.push(dependency);
@@ -1356,7 +1356,7 @@ namespace ConfigurationProperties {
 			}
 		}
 		result.dependsOrder = DependsOrder.from(external.dependsOrder);
-		if (includeCommandOptions && (external.presentation !== undefined || (external as LegacyCommandProperties).terminal !== undefined)) {
+		if (includeCommandOptions && (external.presentation !== undefined || (external as ILegacyCommandProperties).terminal !== undefined)) {
 			result.presentation = CommandConfiguration.PresentationOptions.from(external, context);
 		}
 		if (includeCommandOptions && (external.options !== undefined)) {
@@ -1372,7 +1372,7 @@ namespace ConfigurationProperties {
 		return isEmpty(result) ? {} : { value: result, errors: configProblemMatcher.errors };
 	}
 
-	export function isEmpty(this: void, value: Tasks.ConfigurationProperties): boolean {
+	export function isEmpty(this: void, value: Tasks.IConfigurationProperties): boolean {
 		return _isEmpty(value, properties);
 	}
 }
@@ -1385,16 +1385,16 @@ namespace ConfiguringTask {
 	const npm = 'vscode.npm.';
 	const typescript = 'vscode.typescript.';
 
-	interface CustomizeShape {
+	interface ICustomizeShape {
 		customize: string;
 	}
 
-	export function from(this: void, external: ConfiguringTask, context: ParseContext, index: number, source: TaskConfigSource, registry?: Partial<ITaskDefinitionRegistry>): Tasks.ConfiguringTask | undefined {
+	export function from(this: void, external: IConfiguringTask, context: IParseContext, index: number, source: TaskConfigSource, registry?: Partial<ITaskDefinitionRegistry>): Tasks.ConfiguringTask | undefined {
 		if (!external) {
 			return undefined;
 		}
 		let type = external.type;
-		let customize = (external as CustomizeShape).customize;
+		let customize = (external as ICustomizeShape).customize;
 		if (!type && !customize) {
 			context.problemReporter.error(nls.localize('ConfigurationParser.noTaskType', 'Error: tasks configuration must have a type property. The configuration will be ignored.\n{0}\n', JSON.stringify(external, null, 4)));
 			return undefined;
@@ -1405,7 +1405,7 @@ namespace ConfiguringTask {
 			context.problemReporter.error(message);
 			return undefined;
 		}
-		let identifier: Tasks.TaskIdentifier | undefined;
+		let identifier: Tasks.ITaskIdentifier | undefined;
 		if (Types.isString(customize)) {
 			if (customize.indexOf(grunt) === 0) {
 				identifier = { type: 'grunt', task: customize.substring(grunt.length) };
@@ -1420,7 +1420,7 @@ namespace ConfiguringTask {
 			}
 		} else {
 			if (Types.isString(external.type)) {
-				identifier = external as Tasks.TaskIdentifier;
+				identifier = external as Tasks.ITaskIdentifier;
 			}
 		}
 		if (identifier === undefined) {
@@ -1438,7 +1438,7 @@ namespace ConfiguringTask {
 			));
 			return undefined;
 		}
-		let configElement: Tasks.TaskSourceConfigElement = {
+		let configElement: Tasks.ITaskSourceConfigElement = {
 			workspaceFolder: context.workspaceFolder,
 			file: '.vscode/tasks.json',
 			index,
@@ -1447,7 +1447,7 @@ namespace ConfiguringTask {
 		let taskSource: Tasks.FileBasedTaskSource;
 		switch (source) {
 			case TaskConfigSource.User: {
-				taskSource = Object.assign({} as Tasks.UserTaskSource, partialSource, { kind: Tasks.TaskSourceKind.User, config: configElement });
+				taskSource = Object.assign({} as Tasks.IUserTaskSource, partialSource, { kind: Tasks.TaskSourceKind.User, config: configElement });
 				break;
 			}
 			case TaskConfigSource.WorkspaceFile: {
@@ -1455,7 +1455,7 @@ namespace ConfiguringTask {
 				break;
 			}
 			default: {
-				taskSource = Object.assign({} as Tasks.WorkspaceTaskSource, partialSource, { kind: Tasks.TaskSourceKind.Workspace, config: configElement });
+				taskSource = Object.assign({} as Tasks.IWorkspaceTaskSource, partialSource, { kind: Tasks.TaskSourceKind.Workspace, config: configElement });
 				break;
 			}
 		}
@@ -1496,7 +1496,7 @@ namespace ConfiguringTask {
 }
 
 namespace CustomTask {
-	export function from(this: void, external: CustomTask, context: ParseContext, index: number, source: TaskConfigSource): Tasks.CustomTask | undefined {
+	export function from(this: void, external: ICustomTask, context: IParseContext, index: number, source: TaskConfigSource): Tasks.CustomTask | undefined {
 		if (!external) {
 			return undefined;
 		}
@@ -1520,7 +1520,7 @@ namespace CustomTask {
 		let taskSource: Tasks.FileBasedTaskSource;
 		switch (source) {
 			case TaskConfigSource.User: {
-				taskSource = Object.assign({} as Tasks.UserTaskSource, partialSource, { kind: Tasks.TaskSourceKind.User, config: { index, element: external, file: '.vscode/tasks.json', workspaceFolder: context.workspaceFolder } });
+				taskSource = Object.assign({} as Tasks.IUserTaskSource, partialSource, { kind: Tasks.TaskSourceKind.User, config: { index, element: external, file: '.vscode/tasks.json', workspaceFolder: context.workspaceFolder } });
 				break;
 			}
 			case TaskConfigSource.WorkspaceFile: {
@@ -1528,7 +1528,7 @@ namespace CustomTask {
 				break;
 			}
 			default: {
-				taskSource = Object.assign({} as Tasks.WorkspaceTaskSource, partialSource, { kind: Tasks.TaskSourceKind.Workspace, config: { index, element: external, file: '.vscode/tasks.json', workspaceFolder: context.workspaceFolder } });
+				taskSource = Object.assign({} as Tasks.IWorkspaceTaskSource, partialSource, { kind: Tasks.TaskSourceKind.Workspace, config: { index, element: external, file: '.vscode/tasks.json', workspaceFolder: context.workspaceFolder } });
 				break;
 			}
 		}
@@ -1553,7 +1553,7 @@ namespace CustomTask {
 		}
 		let supportLegacy: boolean = true; //context.schemaVersion === Tasks.JsonSchemaVersion.V2_0_0;
 		if (supportLegacy) {
-			let legacy: LegacyTaskProperties = external as LegacyTaskProperties;
+			let legacy: ILegacyTaskProperties = external as ILegacyTaskProperties;
 			if (result.configurationProperties.isBackground === undefined && legacy.isWatching !== undefined) {
 				result.configurationProperties.isBackground = !!legacy.isWatching;
 			}
@@ -1565,7 +1565,7 @@ namespace CustomTask {
 				}
 			}
 		}
-		let command: Tasks.CommandConfiguration = CommandConfiguration.from(external, context)!;
+		let command: Tasks.ICommandConfiguration = CommandConfiguration.from(external, context)!;
 		if (command) {
 			result.command = command;
 		}
@@ -1577,7 +1577,7 @@ namespace CustomTask {
 		return result;
 	}
 
-	export function fillGlobals(task: Tasks.CustomTask, globals: Globals): void {
+	export function fillGlobals(task: Tasks.CustomTask, globals: IGlobals): void {
 		// We only merge a command from a global definition if there is no dependsOn
 		// or there is a dependsOn and a defined command.
 		if (CommandConfiguration.hasCommand(task.command) || task.configurationProperties.dependsOn === undefined) {
@@ -1593,7 +1593,7 @@ namespace CustomTask {
 		}
 	}
 
-	export function fillDefaults(task: Tasks.CustomTask, context: ParseContext): void {
+	export function fillDefaults(task: Tasks.CustomTask, context: IParseContext): void {
 		CommandConfiguration.fillDefaults(task.command, context);
 		if (task.configurationProperties.promptOnClose === undefined) {
 			task.configurationProperties.promptOnClose = task.configurationProperties.isBackground !== undefined ? !task.configurationProperties.isBackground : true;
@@ -1621,7 +1621,7 @@ namespace CustomTask {
 			}
 		);
 		result.addTaskLoadMessages(configuredProps.taskLoadMessages);
-		let resultConfigProps: Tasks.ConfigurationProperties = result.configurationProperties;
+		let resultConfigProps: Tasks.IConfigurationProperties = result.configurationProperties;
 
 		assignProperty(resultConfigProps, configuredProps.configurationProperties, 'group');
 		assignProperty(resultConfigProps, configuredProps.configurationProperties, 'isBackground');
@@ -1634,7 +1634,7 @@ namespace CustomTask {
 		result.command.options = CommandOptions.assignProperties(result.command.options, configuredProps.configurationProperties.options);
 		result.runOptions = RunOptions.assignProperties(result.runOptions, configuredProps.runOptions);
 
-		let contributedConfigProps: Tasks.ConfigurationProperties = contributedTask.configurationProperties;
+		let contributedConfigProps: Tasks.IConfigurationProperties = contributedTask.configurationProperties;
 		fillProperty(resultConfigProps, contributedConfigProps, 'group');
 		fillProperty(resultConfigProps, contributedConfigProps, 'isBackground');
 		fillProperty(resultConfigProps, contributedConfigProps, 'dependsOn');
@@ -1654,14 +1654,14 @@ namespace CustomTask {
 	}
 }
 
-export interface TaskParseResult {
+export interface ITaskParseResult {
 	custom: Tasks.CustomTask[];
 	configured: Tasks.ConfiguringTask[];
 }
 
 export namespace TaskParser {
 
-	function isCustomTask(value: CustomTask | ConfiguringTask): value is CustomTask {
+	function isCustomTask(value: ICustomTask | IConfiguringTask): value is ICustomTask {
 		let type = value.type;
 		let customize = (value as any).customize;
 		return customize === undefined && (type === undefined || type === null || type === Tasks.CUSTOMIZED_TASK_TYPE || type === 'shell' || type === 'process');
@@ -1672,8 +1672,8 @@ export namespace TaskParser {
 		process: ProcessExecutionSupportedContext
 	};
 
-	export function from(this: void, externals: Array<CustomTask | ConfiguringTask> | undefined, globals: Globals, context: ParseContext, source: TaskConfigSource, registry?: Partial<ITaskDefinitionRegistry>): TaskParseResult {
-		let result: TaskParseResult = { custom: [], configured: [] };
+	export function from(this: void, externals: Array<ICustomTask | IConfiguringTask> | undefined, globals: IGlobals, context: IParseContext, source: TaskConfigSource, registry?: Partial<ITaskDefinitionRegistry>): ITaskParseResult {
+		let result: ITaskParseResult = { custom: [], configured: [] };
 		if (!externals) {
 			return result;
 		}
@@ -1795,8 +1795,8 @@ export namespace TaskParser {
 	}
 }
 
-export interface Globals {
-	command?: Tasks.CommandConfiguration;
+export interface IGlobals {
+	command?: Tasks.ICommandConfiguration;
 	problemMatcher?: ProblemMatcher[];
 	promptOnClose?: boolean;
 	suppressTaskName?: boolean;
@@ -1804,9 +1804,9 @@ export interface Globals {
 
 namespace Globals {
 
-	export function from(config: ExternalTaskRunnerConfiguration, context: ParseContext): Globals {
+	export function from(config: IExternalTaskRunnerConfiguration, context: IParseContext): IGlobals {
 		let result = fromBase(config, context);
-		let osGlobals: Globals | undefined = undefined;
+		let osGlobals: IGlobals | undefined = undefined;
 		if (config.windows && context.platform === Platform.Windows) {
 			osGlobals = fromBase(config.windows, context);
 		} else if (config.osx && context.platform === Platform.Mac) {
@@ -1826,8 +1826,8 @@ namespace Globals {
 		return result;
 	}
 
-	export function fromBase(this: void, config: BaseTaskRunnerConfiguration, context: ParseContext): Globals {
-		let result: Globals = {};
+	export function fromBase(this: void, config: IBaseTaskRunnerConfiguration, context: IParseContext): IGlobals {
+		let result: IGlobals = {};
 		if (config.suppressTaskName !== undefined) {
 			result.suppressTaskName = !!config.suppressTaskName;
 		}
@@ -1840,11 +1840,11 @@ namespace Globals {
 		return result;
 	}
 
-	export function isEmpty(value: Globals): boolean {
+	export function isEmpty(value: IGlobals): boolean {
 		return !value || value.command === undefined && value.promptOnClose === undefined && value.suppressTaskName === undefined;
 	}
 
-	export function assignProperties(target: Globals, source: Globals): Globals {
+	export function assignProperties(target: IGlobals, source: IGlobals): IGlobals {
 		if (isEmpty(source)) {
 			return target;
 		}
@@ -1856,7 +1856,7 @@ namespace Globals {
 		return target;
 	}
 
-	export function fillDefaults(value: Globals, context: ParseContext): void {
+	export function fillDefaults(value: IGlobals, context: IParseContext): void {
 		if (!value) {
 			return;
 		}
@@ -1869,7 +1869,7 @@ namespace Globals {
 		}
 	}
 
-	export function freeze(value: Globals): void {
+	export function freeze(value: IGlobals): void {
 		Object.freeze(value);
 		if (value.command) {
 			CommandConfiguration.freeze(value.command);
@@ -1879,7 +1879,7 @@ namespace Globals {
 
 export namespace ExecutionEngine {
 
-	export function from(config: ExternalTaskRunnerConfiguration): Tasks.ExecutionEngine {
+	export function from(config: IExternalTaskRunnerConfiguration): Tasks.ExecutionEngine {
 		let runner = config.runner || config._runner;
 		let result: Tasks.ExecutionEngine | undefined;
 		if (runner) {
@@ -1907,7 +1907,7 @@ export namespace JsonSchemaVersion {
 
 	const _default: Tasks.JsonSchemaVersion = Tasks.JsonSchemaVersion.V2_0_0;
 
-	export function from(config: ExternalTaskRunnerConfiguration): Tasks.JsonSchemaVersion {
+	export function from(config: IExternalTaskRunnerConfiguration): Tasks.JsonSchemaVersion {
 		let version = config.version;
 		if (!version) {
 			return _default;
@@ -1923,7 +1923,7 @@ export namespace JsonSchemaVersion {
 	}
 }
 
-export interface ParseResult {
+export interface IParseResult {
 	validationStatus: ValidationStatus;
 	custom: Tasks.CustomTask[];
 	configured: Tasks.ConfiguringTask[];
@@ -2016,10 +2016,10 @@ class ConfigurationParser {
 		this.uuidMap = uuidMap;
 	}
 
-	public run(fileConfig: ExternalTaskRunnerConfiguration, source: TaskConfigSource, contextKeyService: IContextKeyService): ParseResult {
+	public run(fileConfig: IExternalTaskRunnerConfiguration, source: TaskConfigSource, contextKeyService: IContextKeyService): IParseResult {
 		let engine = ExecutionEngine.from(fileConfig);
 		let schemaVersion = JsonSchemaVersion.from(fileConfig);
-		let context: ParseContext = {
+		let context: IParseContext = {
 			workspaceFolder: this.workspaceFolder,
 			workspace: this.workspace,
 			problemReporter: this.problemReporter,
@@ -2040,14 +2040,14 @@ class ConfigurationParser {
 		};
 	}
 
-	private createTaskRunnerConfiguration(fileConfig: ExternalTaskRunnerConfiguration, context: ParseContext, source: TaskConfigSource): TaskParseResult {
+	private createTaskRunnerConfiguration(fileConfig: IExternalTaskRunnerConfiguration, context: IParseContext, source: TaskConfigSource): ITaskParseResult {
 		let globals = Globals.from(fileConfig, context);
 		if (this.problemReporter.status.isFatal()) {
 			return { custom: [], configured: [] };
 		}
 		context.namedProblemMatchers = ProblemMatcherConverter.namedFrom(fileConfig.declares, context);
 		let globalTasks: Tasks.CustomTask[] | undefined = undefined;
-		let externalGlobalTasks: Array<ConfiguringTask | CustomTask> | undefined = undefined;
+		let externalGlobalTasks: Array<IConfiguringTask | ICustomTask> | undefined = undefined;
 		if (fileConfig.windows && context.platform === Platform.Windows) {
 			globalTasks = TaskParser.from(fileConfig.windows.tasks, globals, context, source).custom;
 			externalGlobalTasks = fileConfig.windows.tasks;
@@ -2070,7 +2070,7 @@ class ConfigurationParser {
 			);
 		}
 
-		let result: TaskParseResult = { custom: [], configured: [] };
+		let result: ITaskParseResult = { custom: [], configured: [] };
 		if (fileConfig.tasks) {
 			result = TaskParser.from(fileConfig.tasks, globals, context, source);
 		}
@@ -2084,7 +2084,7 @@ class ConfigurationParser {
 			let name = Tasks.CommandString.value(globals.command.name);
 			let task: Tasks.CustomTask = new Tasks.CustomTask(
 				context.uuidMap.getUUID(name),
-				Object.assign({} as Tasks.WorkspaceTaskSource, source, { config: { index: -1, element: fileConfig, workspaceFolder: context.workspaceFolder } }),
+				Object.assign({} as Tasks.IWorkspaceTaskSource, source, { config: { index: -1, element: fileConfig, workspaceFolder: context.workspaceFolder } }),
 				name,
 				Tasks.CUSTOMIZED_TASK_TYPE,
 				{
@@ -2121,7 +2121,7 @@ class ConfigurationParser {
 
 let uuidMaps: Map<TaskConfigSource, Map<string, UUIDMap>> = new Map();
 let recentUuidMaps: Map<TaskConfigSource, Map<string, UUIDMap>> = new Map();
-export function parse(workspaceFolder: IWorkspaceFolder, workspace: IWorkspace | undefined, platform: Platform, configuration: ExternalTaskRunnerConfiguration, logger: IProblemReporter, source: TaskConfigSource, contextKeyService: IContextKeyService, isRecents: boolean = false): ParseResult {
+export function parse(workspaceFolder: IWorkspaceFolder, workspace: IWorkspace | undefined, platform: Platform, configuration: IExternalTaskRunnerConfiguration, logger: IProblemReporter, source: TaskConfigSource, contextKeyService: IContextKeyService, isRecents: boolean = false): IParseResult {
 	let recentOrOtherMaps = isRecents ? recentUuidMaps : uuidMaps;
 	let selectedUuidMaps = recentOrOtherMaps.get(source);
 	if (!selectedUuidMaps) {

--- a/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
@@ -47,14 +47,14 @@ const taskDefinitionSchema: IJSONSchema = {
 };
 
 namespace Configuration {
-	export interface TaskDefinition {
+	export interface ITaskDefinition {
 		type?: string;
 		required?: string[];
 		properties?: IJSONSchemaMap;
 		when?: string;
 	}
 
-	export function from(value: TaskDefinition, extensionId: ExtensionIdentifier, messageCollector: ExtensionMessageCollector): Tasks.TaskDefinition | undefined {
+	export function from(value: ITaskDefinition, extensionId: ExtensionIdentifier, messageCollector: ExtensionMessageCollector): Tasks.ITaskDefinition | undefined {
 		if (!value) {
 			return undefined;
 		}
@@ -81,7 +81,7 @@ namespace Configuration {
 }
 
 
-const taskDefinitionsExtPoint = ExtensionsRegistry.registerExtensionPoint<Configuration.TaskDefinition[]>({
+const taskDefinitionsExtPoint = ExtensionsRegistry.registerExtensionPoint<Configuration.ITaskDefinition[]>({
 	extensionPoint: 'taskDefinitions',
 	jsonSchema: {
 		description: nls.localize('TaskDefinitionExtPoint', 'Contributes task kinds'),
@@ -93,15 +93,15 @@ const taskDefinitionsExtPoint = ExtensionsRegistry.registerExtensionPoint<Config
 export interface ITaskDefinitionRegistry {
 	onReady(): Promise<void>;
 
-	get(key: string): Tasks.TaskDefinition;
-	all(): Tasks.TaskDefinition[];
+	get(key: string): Tasks.ITaskDefinition;
+	all(): Tasks.ITaskDefinition[];
 	getJsonSchema(): IJSONSchema;
 	onDefinitionsChanged: Event<void>;
 }
 
 export class TaskDefinitionRegistryImpl implements ITaskDefinitionRegistry {
 
-	private taskTypes: IStringDictionary<Tasks.TaskDefinition>;
+	private taskTypes: IStringDictionary<Tasks.ITaskDefinition>;
 	private readyPromise: Promise<void>;
 	private _schema: IJSONSchema | undefined;
 	private _onDefinitionsChanged: Emitter<void> = new Emitter();
@@ -143,11 +143,11 @@ export class TaskDefinitionRegistryImpl implements ITaskDefinitionRegistry {
 		return this.readyPromise;
 	}
 
-	public get(key: string): Tasks.TaskDefinition {
+	public get(key: string): Tasks.ITaskDefinition {
 		return this.taskTypes[key];
 	}
 
-	public all(): Tasks.TaskDefinition[] {
+	public all(): Tasks.ITaskDefinition[] {
 		return Object.keys(this.taskTypes).map(key => this.taskTypes[key]);
 	}
 

--- a/src/vs/workbench/contrib/tasks/common/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskService.ts
@@ -10,12 +10,12 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 import { IDisposable } from 'vs/base/common/lifecycle';
 
 import { IWorkspaceFolder, IWorkspace } from 'vs/platform/workspace/common/workspace';
-import { Task, ContributedTask, CustomTask, TaskSet, TaskSorter, TaskEvent, TaskIdentifier, ConfiguringTask, TaskRunSource } from 'vs/workbench/contrib/tasks/common/tasks';
-import { ITaskSummary, TaskTerminateResponse, TaskSystemInfo } from 'vs/workbench/contrib/tasks/common/taskSystem';
+import { Task, ContributedTask, CustomTask, ITaskSet, TaskSorter, ITaskEvent, ITaskIdentifier, ConfiguringTask, TaskRunSource } from 'vs/workbench/contrib/tasks/common/tasks';
+import { ITaskSummary, ITaskTerminateResponse, ITaskSystemInfo } from 'vs/workbench/contrib/tasks/common/taskSystem';
 import { IStringDictionary } from 'vs/base/common/collections';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 
-export { ITaskSummary, Task, TaskTerminateResponse };
+export { ITaskSummary, Task, ITaskTerminateResponse as TaskTerminateResponse };
 
 export const CustomExecutionSupportedContext = new RawContextKey<boolean>('customExecutionSupported', true, nls.localize('tasks.customExecutionSupported', "Whether CustomExecution tasks are supported. Consider using in the when clause of a \'taskDefinition\' contribution."));
 export const ShellExecutionSupportedContext = new RawContextKey<boolean>('shellExecutionSupported', false, nls.localize('tasks.shellExecutionSupported', "Whether ShellExecution tasks are supported. Consider using in the when clause of a \'taskDefinition\' contribution."));
@@ -24,57 +24,57 @@ export const ProcessExecutionSupportedContext = new RawContextKey<boolean>('proc
 export const ITaskService = createDecorator<ITaskService>('taskService');
 
 export interface ITaskProvider {
-	provideTasks(validTypes: IStringDictionary<boolean>): Promise<TaskSet>;
+	provideTasks(validTypes: IStringDictionary<boolean>): Promise<ITaskSet>;
 	resolveTask(task: ConfiguringTask): Promise<ContributedTask | undefined>;
 }
 
-export interface ProblemMatcherRunOptions {
+export interface IProblemMatcherRunOptions {
 	attachProblemMatcher?: boolean;
 }
 
-export interface CustomizationProperties {
+export interface ICustomizationProperties {
 	group?: string | { kind?: string; isDefault?: boolean };
 	problemMatcher?: string | string[];
 	isBackground?: boolean;
 }
 
-export interface TaskFilter {
+export interface ITaskFilter {
 	version?: string;
 	type?: string;
 }
 
-interface WorkspaceTaskResult {
-	set: TaskSet | undefined;
+interface IWorkspaceTaskResult {
+	set: ITaskSet | undefined;
 	configurations: {
 		byIdentifier: IStringDictionary<ConfiguringTask>;
 	} | undefined;
 	hasErrors: boolean;
 }
 
-export interface WorkspaceFolderTaskResult extends WorkspaceTaskResult {
+export interface IWorkspaceFolderTaskResult extends IWorkspaceTaskResult {
 	workspaceFolder: IWorkspaceFolder;
 }
 
 export interface ITaskService {
 	readonly _serviceBrand: undefined;
-	onDidStateChange: Event<TaskEvent>;
+	onDidStateChange: Event<ITaskEvent>;
 	supportsMultipleTaskExecutions: boolean;
 
 	configureAction(): Action;
-	run(task: Task | undefined, options?: ProblemMatcherRunOptions): Promise<ITaskSummary | undefined>;
+	run(task: Task | undefined, options?: IProblemMatcherRunOptions): Promise<ITaskSummary | undefined>;
 	inTerminal(): boolean;
 	getActiveTasks(): Promise<Task[]>;
 	getBusyTasks(): Promise<Task[]>;
-	terminate(task: Task): Promise<TaskTerminateResponse>;
-	tasks(filter?: TaskFilter): Promise<Task[]>;
+	terminate(task: Task): Promise<ITaskTerminateResponse>;
+	tasks(filter?: ITaskFilter): Promise<Task[]>;
 	taskTypes(): string[];
-	getWorkspaceTasks(runSource?: TaskRunSource): Promise<Map<string, WorkspaceFolderTaskResult>>;
+	getWorkspaceTasks(runSource?: TaskRunSource): Promise<Map<string, IWorkspaceFolderTaskResult>>;
 	readRecentTasks(): Promise<(Task | ConfiguringTask)[]>;
 	removeRecentlyUsedTask(taskRecentlyUsedKey: string): void;
 	/**
 	 * @param alias The task's name, label or defined identifier.
 	 */
-	getTask(workspaceFolder: IWorkspace | IWorkspaceFolder | string, alias: string | TaskIdentifier, compareId?: boolean): Promise<Task | undefined>;
+	getTask(workspaceFolder: IWorkspace | IWorkspaceFolder | string, alias: string | ITaskIdentifier, compareId?: boolean): Promise<Task | undefined>;
 	tryResolveTask(configuringTask: ConfiguringTask): Promise<Task | undefined>;
 	createSorter(): TaskSorter;
 
@@ -84,7 +84,7 @@ export interface ITaskService {
 
 	registerTaskProvider(taskProvider: ITaskProvider, type: string): IDisposable;
 
-	registerTaskSystem(scheme: string, taskSystemInfo: TaskSystemInfo): void;
+	registerTaskSystem(scheme: string, taskSystemInfo: ITaskSystemInfo): void;
 	onDidChangeTaskSystemInfo: Event<void>;
 	readonly hasTaskSystemInfo: boolean;
 	registerSupportedExecutions(custom?: boolean, shell?: boolean, process?: boolean): void;

--- a/src/vs/workbench/contrib/tasks/common/taskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskSystem.ts
@@ -9,7 +9,7 @@ import { TerminateResponse } from 'vs/base/common/processes';
 import { Event } from 'vs/base/common/event';
 import { Platform } from 'vs/base/common/platform';
 import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
-import { Task, TaskEvent, KeyedTaskIdentifier } from './tasks';
+import { Task, ITaskEvent, KeyedTaskIdentifier } from './tasks';
 import { ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
 
 export const enum TaskErrors {
@@ -69,11 +69,11 @@ export interface ITaskResolver {
 	resolve(uri: URI | string, identifier: string | KeyedTaskIdentifier | undefined): Promise<Task | undefined>;
 }
 
-export interface TaskTerminateResponse extends TerminateResponse {
+export interface ITaskTerminateResponse extends TerminateResponse {
 	task: Task | undefined;
 }
 
-export interface ResolveSet {
+export interface IResolveSet {
 	process?: {
 		name: string;
 		cwd?: string;
@@ -82,25 +82,25 @@ export interface ResolveSet {
 	variables: Set<string>;
 }
 
-export interface ResolvedVariables {
+export interface IResolvedVariables {
 	process?: string;
 	variables: Map<string, string>;
 }
 
-export interface TaskSystemInfo {
+export interface ITaskSystemInfo {
 	platform: Platform;
 	context: any;
 	uriProvider: (this: void, path: string) => URI;
-	resolveVariables(workspaceFolder: IWorkspaceFolder, toResolve: ResolveSet, target: ConfigurationTarget): Promise<ResolvedVariables | undefined>;
+	resolveVariables(workspaceFolder: IWorkspaceFolder, toResolve: IResolveSet, target: ConfigurationTarget): Promise<IResolvedVariables | undefined>;
 	findExecutable(command: string, cwd?: string, paths?: string[]): Promise<string | undefined>;
 }
 
-export interface TaskSystemInfoResolver {
-	(workspaceFolder: IWorkspaceFolder | undefined): TaskSystemInfo | undefined;
+export interface ITaskSystemInfoResolver {
+	(workspaceFolder: IWorkspaceFolder | undefined): ITaskSystemInfo | undefined;
 }
 
 export interface ITaskSystem {
-	onDidStateChange: Event<TaskEvent>;
+	onDidStateChange: Event<ITaskEvent>;
 	run(task: Task, resolver: ITaskResolver): ITaskExecuteResult;
 	rerun(): ITaskExecuteResult | undefined;
 	isActive(): Promise<boolean>;
@@ -109,8 +109,8 @@ export interface ITaskSystem {
 	getLastInstance(task: Task): Task | undefined;
 	getBusyTasks(): Task[];
 	canAutoTerminate(): boolean;
-	terminate(task: Task): Promise<TaskTerminateResponse>;
-	terminateAll(): Promise<TaskTerminateResponse[]>;
+	terminate(task: Task): Promise<ITaskTerminateResponse>;
+	terminateAll(): Promise<ITaskTerminateResponse[]>;
 	revealTask(task: Task): boolean;
 	customExecutionComplete(task: Task, result: number): Promise<void>;
 	isTaskVisible(task: Task): boolean;

--- a/src/vs/workbench/contrib/tasks/common/taskTemplates.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskTemplates.ts
@@ -7,13 +7,13 @@ import * as nls from 'vs/nls';
 
 import { IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 
-export interface TaskEntry extends IQuickPickItem {
+export interface ITaskEntry extends IQuickPickItem {
 	sort?: string;
 	autoDetect: boolean;
 	content: string;
 }
 
-const dotnetBuild: TaskEntry = {
+const dotnetBuild: ITaskEntry = {
 	id: 'dotnetCore',
 	label: '.NET Core',
 	sort: 'NET Core',
@@ -47,7 +47,7 @@ const dotnetBuild: TaskEntry = {
 	].join('\n')
 };
 
-const msbuild: TaskEntry = {
+const msbuild: ITaskEntry = {
 	id: 'msbuild',
 	label: 'MSBuild',
 	autoDetect: false,
@@ -82,7 +82,7 @@ const msbuild: TaskEntry = {
 	].join('\n')
 };
 
-const command: TaskEntry = {
+const command: ITaskEntry = {
 	id: 'externalCommand',
 	label: 'Others',
 	autoDetect: false,
@@ -103,7 +103,7 @@ const command: TaskEntry = {
 	].join('\n')
 };
 
-const maven: TaskEntry = {
+const maven: ITaskEntry = {
 	id: 'maven',
 	label: 'maven',
 	sort: 'MVN',
@@ -132,8 +132,8 @@ const maven: TaskEntry = {
 	].join('\n')
 };
 
-let _templates: TaskEntry[] | null = null;
-export function getTemplates(): TaskEntry[] {
+let _templates: ITaskEntry[] | null = null;
+export function getTemplates(): ITaskEntry[] {
 	if (!_templates) {
 		_templates = [dotnetBuild, msbuild, maven].sort((a, b) => {
 			return (a.sort || a.label).localeCompare(b.sort || b.label);

--- a/src/vs/workbench/contrib/tasks/common/tasks.ts
+++ b/src/vs/workbench/contrib/tasks/common/tasks.ts
@@ -60,7 +60,7 @@ export namespace ShellQuoting {
 	}
 }
 
-export interface ShellQuotingOptions {
+export interface IShellQuotingOptions {
 	/**
 	 * The character used to do character escaping.
 	 */
@@ -80,7 +80,7 @@ export interface ShellQuotingOptions {
 	weak?: string;
 }
 
-export interface ShellConfiguration {
+export interface IShellConfiguration {
 	/**
 	 * The shell executable.
 	 */
@@ -94,7 +94,7 @@ export interface ShellConfiguration {
 	/**
 	 * Which kind of quotes the shell supports.
 	 */
-	quoting?: ShellQuotingOptions;
+	quoting?: IShellQuotingOptions;
 }
 
 export interface CommandOptions {
@@ -102,7 +102,7 @@ export interface CommandOptions {
 	/**
 	 * The shell to use if the task is a shell command.
 	 */
-	shell?: ShellConfiguration;
+	shell?: IShellConfiguration;
 
 	/**
 	 * The current working directory of the executed program or shell.
@@ -223,7 +223,7 @@ export namespace PanelKind {
 	}
 }
 
-export interface PresentationOptions {
+export interface IPresentationOptions {
 	/**
 	 * Controls whether the task output is reveal in the user interface.
 	 * Defaults to `RevealKind.Always`.
@@ -276,7 +276,7 @@ export interface PresentationOptions {
 }
 
 export namespace PresentationOptions {
-	export const defaults: PresentationOptions = {
+	export const defaults: IPresentationOptions = {
 		echo: true, reveal: RevealKind.Always, revealProblems: RevealProblemKind.Never, focus: false, panel: PanelKind.Shared, showReuseMessage: true, clear: false
 	};
 }
@@ -310,12 +310,12 @@ export namespace RuntimeType {
 	}
 }
 
-export interface QuotedString {
+export interface IQuotedString {
 	value: string;
 	quoting: ShellQuoting;
 }
 
-export type CommandString = string | QuotedString;
+export type CommandString = string | IQuotedString;
 
 export namespace CommandString {
 	export function value(value: CommandString): string {
@@ -327,7 +327,7 @@ export namespace CommandString {
 	}
 }
 
-export interface CommandConfiguration {
+export interface ICommandConfiguration {
 
 	/**
 	 * The task type
@@ -363,7 +363,7 @@ export interface CommandConfiguration {
 	/**
 	 * Describes how the task is presented in the UI.
 	 */
-	presentation?: PresentationOptions;
+	presentation?: IPresentationOptions;
 }
 
 export namespace TaskGroup {
@@ -420,7 +420,7 @@ export namespace TaskSourceKind {
 	}
 }
 
-export interface TaskSourceConfigElement {
+export interface ITaskSourceConfigElement {
 	workspaceFolder?: IWorkspaceFolder;
 	workspace?: IWorkspace;
 	file: string;
@@ -428,57 +428,57 @@ export interface TaskSourceConfigElement {
 	element: any;
 }
 
-interface BaseTaskSource {
+interface IBaseTaskSource {
 	readonly kind: string;
 	readonly label: string;
 }
 
-export interface WorkspaceTaskSource extends BaseTaskSource {
+export interface IWorkspaceTaskSource extends IBaseTaskSource {
 	readonly kind: 'workspace';
-	readonly config: TaskSourceConfigElement;
+	readonly config: ITaskSourceConfigElement;
 	readonly customizes?: KeyedTaskIdentifier;
 }
 
-export interface ExtensionTaskSource extends BaseTaskSource {
+export interface IExtensionTaskSource extends IBaseTaskSource {
 	readonly kind: 'extension';
 	readonly extension?: string;
 	readonly scope: TaskScope;
 	readonly workspaceFolder: IWorkspaceFolder | undefined;
 }
 
-export interface ExtensionTaskSourceTransfer {
+export interface IExtensionTaskSourceTransfer {
 	__workspaceFolder: UriComponents;
 	__definition: { type: string;[name: string]: any };
 }
 
-export interface InMemoryTaskSource extends BaseTaskSource {
+export interface IInMemoryTaskSource extends IBaseTaskSource {
 	readonly kind: 'inMemory';
 }
 
-export interface UserTaskSource extends BaseTaskSource {
+export interface IUserTaskSource extends IBaseTaskSource {
 	readonly kind: 'user';
-	readonly config: TaskSourceConfigElement;
+	readonly config: ITaskSourceConfigElement;
 	readonly customizes?: KeyedTaskIdentifier;
 }
 
-export interface WorkspaceFileTaskSource extends BaseTaskSource {
+export interface WorkspaceFileTaskSource extends IBaseTaskSource {
 	readonly kind: 'workspaceFile';
-	readonly config: TaskSourceConfigElement;
+	readonly config: ITaskSourceConfigElement;
 	readonly customizes?: KeyedTaskIdentifier;
 }
 
-export type TaskSource = WorkspaceTaskSource | ExtensionTaskSource | InMemoryTaskSource | UserTaskSource | WorkspaceFileTaskSource;
-export type FileBasedTaskSource = WorkspaceTaskSource | UserTaskSource | WorkspaceFileTaskSource;
-export interface TaskIdentifier {
+export type TaskSource = IWorkspaceTaskSource | IExtensionTaskSource | IInMemoryTaskSource | IUserTaskSource | WorkspaceFileTaskSource;
+export type FileBasedTaskSource = IWorkspaceTaskSource | IUserTaskSource | WorkspaceFileTaskSource;
+export interface ITaskIdentifier {
 	type: string;
 	[name: string]: any;
 }
 
-export interface KeyedTaskIdentifier extends TaskIdentifier {
+export interface KeyedTaskIdentifier extends ITaskIdentifier {
 	_key: string;
 }
 
-export interface TaskDependency {
+export interface ITaskDependency {
 	uri: URI | string;
 	task: string | KeyedTaskIdentifier | undefined;
 }
@@ -488,7 +488,7 @@ export const enum DependsOrder {
 	sequence = 'sequence'
 }
 
-export interface ConfigurationProperties {
+export interface IConfigurationProperties {
 
 	/**
 	 * The task's name
@@ -508,7 +508,7 @@ export interface ConfigurationProperties {
 	/**
 	 * The presentation options
 	 */
-	presentation?: PresentationOptions;
+	presentation?: IPresentationOptions;
 
 	/**
 	 * The command options;
@@ -528,7 +528,7 @@ export interface ConfigurationProperties {
 	/**
 	 * The other tasks this task depends on.
 	 */
-	dependsOn?: TaskDependency[];
+	dependsOn?: ITaskDependency[];
 
 	/**
 	 * The order the dependsOn tasks should be executed in.
@@ -551,14 +551,14 @@ export enum RunOnOptions {
 	folderOpen = 2
 }
 
-export interface RunOptions {
+export interface IRunOptions {
 	reevaluateOnRerun?: boolean;
 	runOn?: RunOnOptions;
 	instanceLimit?: number;
 }
 
 export namespace RunOptions {
-	export const defaults: RunOptions = { reevaluateOnRerun: true, runOn: RunOnOptions.default, instanceLimit: 1 };
+	export const defaults: IRunOptions = { reevaluateOnRerun: true, runOn: RunOnOptions.default, instanceLimit: 1 };
 }
 
 export abstract class CommonTask {
@@ -575,16 +575,16 @@ export abstract class CommonTask {
 
 	type?: string;
 
-	runOptions: RunOptions;
+	runOptions: IRunOptions;
 
-	configurationProperties: ConfigurationProperties;
+	configurationProperties: IConfigurationProperties;
 
-	_source: BaseTaskSource;
+	_source: IBaseTaskSource;
 
 	private _taskLoadMessages: string[] | undefined;
 
-	protected constructor(id: string, label: string | undefined, type: string | undefined, runOptions: RunOptions,
-		configurationProperties: ConfigurationProperties, source: BaseTaskSource) {
+	protected constructor(id: string, label: string | undefined, type: string | undefined, runOptions: IRunOptions,
+		configurationProperties: IConfigurationProperties, source: IBaseTaskSource) {
 		this._id = id;
 		if (label) {
 			this._label = label;
@@ -612,12 +612,12 @@ export abstract class CommonTask {
 	protected abstract getFolderId(): string | undefined;
 
 	public getCommonTaskId(): string {
-		interface RecentTaskKey {
+		interface IRecentTaskKey {
 			folder: string | undefined;
 			id: string;
 		}
 
-		const key: RecentTaskKey = { folder: this.getFolderId(), id: this._id };
+		const key: IRecentTaskKey = { folder: this.getFolderId(), id: this._id };
 		return JSON.stringify(key);
 	}
 
@@ -659,8 +659,8 @@ export abstract class CommonTask {
 		}
 	}
 
-	public getTaskExecution(): TaskExecution {
-		let result: TaskExecution = {
+	public getTaskExecution(): ITaskExecution {
+		let result: ITaskExecution = {
 			id: this._id,
 			task: <any>this
 		};
@@ -697,10 +697,10 @@ export class CustomTask extends CommonTask {
 	/**
 	 * The command configuration
 	 */
-	command: CommandConfiguration = {};
+	command: ICommandConfiguration = {};
 
-	public constructor(id: string, source: FileBasedTaskSource, label: string, type: string, command: CommandConfiguration | undefined,
-		hasDefinedMatchers: boolean, runOptions: RunOptions, configurationProperties: ConfigurationProperties) {
+	public constructor(id: string, source: FileBasedTaskSource, label: string, type: string, command: ICommandConfiguration | undefined,
+		hasDefinedMatchers: boolean, runOptions: IRunOptions, configurationProperties: IConfigurationProperties) {
 		super(id, label, undefined, runOptions, configurationProperties, source);
 		this._source = source;
 		this.hasDefinedMatchers = hasDefinedMatchers;
@@ -774,7 +774,7 @@ export class CustomTask extends CommonTask {
 	}
 
 	public override getRecentlyUsedKey(): string | undefined {
-		interface CustomKey {
+		interface ICustomKey {
 			type: string;
 			folder: string;
 			id: string;
@@ -787,7 +787,7 @@ export class CustomTask extends CommonTask {
 		if (this._source.kind !== TaskSourceKind.Workspace) {
 			id += this._source.kind;
 		}
-		let key: CustomKey = { type: CUSTOMIZED_TASK_TYPE, folder: workspaceFolder, id };
+		let key: ICustomKey = { type: CUSTOMIZED_TASK_TYPE, folder: workspaceFolder, id };
 		return JSON.stringify(key);
 	}
 
@@ -822,7 +822,7 @@ export class ConfiguringTask extends CommonTask {
 	configures: KeyedTaskIdentifier;
 
 	public constructor(id: string, source: FileBasedTaskSource, label: string | undefined, type: string | undefined,
-		configures: KeyedTaskIdentifier, runOptions: RunOptions, configurationProperties: ConfigurationProperties) {
+		configures: KeyedTaskIdentifier, runOptions: IRunOptions, configurationProperties: IConfigurationProperties) {
 		super(id, label, type, runOptions, configurationProperties, source);
 		this._source = source;
 		this.configures = configures;
@@ -853,7 +853,7 @@ export class ConfiguringTask extends CommonTask {
 	}
 
 	public override getRecentlyUsedKey(): string | undefined {
-		interface CustomKey {
+		interface ICustomKey {
 			type: string;
 			folder: string;
 			id: string;
@@ -866,7 +866,7 @@ export class ConfiguringTask extends CommonTask {
 		if (this._source.kind !== TaskSourceKind.Workspace) {
 			id += this._source.kind;
 		}
-		let key: CustomKey = { type: CUSTOMIZED_TASK_TYPE, folder: workspaceFolder, id };
+		let key: ICustomKey = { type: CUSTOMIZED_TASK_TYPE, folder: workspaceFolder, id };
 		return JSON.stringify(key);
 	}
 }
@@ -877,7 +877,7 @@ export class ContributedTask extends CommonTask {
 	 * Indicated the source of the task (e.g. tasks.json or extension)
 	 * Set in the super constructor
 	 */
-	override _source!: ExtensionTaskSource;
+	override _source!: IExtensionTaskSource;
 
 	instance: number | undefined;
 
@@ -888,11 +888,11 @@ export class ContributedTask extends CommonTask {
 	/**
 	 * The command configuration
 	 */
-	command: CommandConfiguration;
+	command: ICommandConfiguration;
 
-	public constructor(id: string, source: ExtensionTaskSource, label: string, type: string | undefined, defines: KeyedTaskIdentifier,
-		command: CommandConfiguration, hasDefinedMatchers: boolean, runOptions: RunOptions,
-		configurationProperties: ConfigurationProperties) {
+	public constructor(id: string, source: IExtensionTaskSource, label: string, type: string | undefined, defines: KeyedTaskIdentifier,
+		command: ICommandConfiguration, hasDefinedMatchers: boolean, runOptions: IRunOptions,
+		configurationProperties: IConfigurationProperties) {
 		super(id, label, type, runOptions, configurationProperties, source);
 		this.defines = defines;
 		this.hasDefinedMatchers = hasDefinedMatchers;
@@ -926,14 +926,14 @@ export class ContributedTask extends CommonTask {
 	}
 
 	public override getRecentlyUsedKey(): string | undefined {
-		interface ContributedKey {
+		interface IContributedKey {
 			type: string;
 			scope: number;
 			folder?: string;
 			id: string;
 		}
 
-		let key: ContributedKey = { type: 'contributed', scope: this._source.scope, id: this._id };
+		let key: IContributedKey = { type: 'contributed', scope: this._source.scope, id: this._id };
 		key.folder = this.getFolderId();
 		return JSON.stringify(key);
 	}
@@ -955,14 +955,14 @@ export class InMemoryTask extends CommonTask {
 	/**
 	 * Indicated the source of the task (e.g. tasks.json or extension)
 	 */
-	override _source: InMemoryTaskSource;
+	override _source: IInMemoryTaskSource;
 
 	instance: number | undefined;
 
 	override type!: 'inMemory';
 
-	public constructor(id: string, source: InMemoryTaskSource, label: string, type: string,
-		runOptions: RunOptions, configurationProperties: ConfigurationProperties) {
+	public constructor(id: string, source: IInMemoryTaskSource, label: string, type: string,
+		runOptions: IRunOptions, configurationProperties: IConfigurationProperties) {
 		super(id, label, type, runOptions, configurationProperties, source);
 		this._source = source;
 	}
@@ -994,7 +994,7 @@ export class InMemoryTask extends CommonTask {
 
 export type Task = CustomTask | ContributedTask | InMemoryTask;
 
-export interface TaskExecution {
+export interface ITaskExecution {
 	id: string;
 	task: Task;
 }
@@ -1013,12 +1013,12 @@ export const enum JsonSchemaVersion {
 	V2_0_0 = 2
 }
 
-export interface TaskSet {
+export interface ITaskSet {
 	tasks: Task[];
 	extension?: IExtensionDescription;
 }
 
-export interface TaskDefinition {
+export interface ITaskDefinition {
 	extensionId: string;
 	taskType: string;
 	required: string[];
@@ -1078,7 +1078,7 @@ export const enum TaskRunType {
 	Background = 'background'
 }
 
-export interface TaskEvent {
+export interface ITaskEvent {
 	kind: TaskEventKind;
 	taskId?: string;
 	taskName?: string;
@@ -1099,13 +1099,13 @@ export const enum TaskRunSource {
 }
 
 export namespace TaskEvent {
-	export function create(kind: TaskEventKind.ProcessStarted | TaskEventKind.ProcessEnded, task: Task, processIdOrExitCode?: number): TaskEvent;
-	export function create(kind: TaskEventKind.Start, task: Task, terminalId?: number, resolvedVariables?: Map<string, string>): TaskEvent;
-	export function create(kind: TaskEventKind.AcquiredInput | TaskEventKind.DependsOnStarted | TaskEventKind.Start | TaskEventKind.Active | TaskEventKind.Inactive | TaskEventKind.Terminated | TaskEventKind.End, task: Task): TaskEvent;
-	export function create(kind: TaskEventKind.Changed): TaskEvent;
-	export function create(kind: TaskEventKind, task?: Task, processIdOrExitCodeOrTerminalId?: number, resolvedVariables?: Map<string, string>): TaskEvent {
+	export function create(kind: TaskEventKind.ProcessStarted | TaskEventKind.ProcessEnded, task: Task, processIdOrExitCode?: number): ITaskEvent;
+	export function create(kind: TaskEventKind.Start, task: Task, terminalId?: number, resolvedVariables?: Map<string, string>): ITaskEvent;
+	export function create(kind: TaskEventKind.AcquiredInput | TaskEventKind.DependsOnStarted | TaskEventKind.Start | TaskEventKind.Active | TaskEventKind.Inactive | TaskEventKind.Terminated | TaskEventKind.End, task: Task): ITaskEvent;
+	export function create(kind: TaskEventKind.Changed): ITaskEvent;
+	export function create(kind: TaskEventKind, task?: Task, processIdOrExitCodeOrTerminalId?: number, resolvedVariables?: Map<string, string>): ITaskEvent {
 		if (task) {
-			let result: TaskEvent = {
+			let result: ITaskEvent = {
 				kind: kind,
 				taskId: task._id,
 				taskName: task.configurationProperties.name,
@@ -1146,7 +1146,7 @@ export namespace KeyedTaskIdentifier {
 		}
 		return result;
 	}
-	export function create(value: TaskIdentifier): KeyedTaskIdentifier {
+	export function create(value: ITaskIdentifier): KeyedTaskIdentifier {
 		const resultKey = sortedStringify(value);
 		let result = { _key: resultKey, type: value.taskType };
 		Object.assign(result, value);
@@ -1155,7 +1155,7 @@ export namespace KeyedTaskIdentifier {
 }
 
 export namespace TaskDefinition {
-	export function createTaskIdentifier(external: TaskIdentifier, reporter: { error(message: string): void }): KeyedTaskIdentifier | undefined {
+	export function createTaskIdentifier(external: ITaskIdentifier, reporter: { error(message: string): void }): KeyedTaskIdentifier | undefined {
 		let definition = TaskDefinitionRegistry.get(external.type);
 		if (definition === undefined) {
 			// We have no task definition so we can't sanitize the literal. Take it as is

--- a/src/vs/workbench/contrib/tasks/electron-sandbox/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/electron-sandbox/taskService.ts
@@ -10,7 +10,7 @@ import { ITaskSystem } from 'vs/workbench/contrib/tasks/common/taskSystem';
 import { ExecutionEngine } from 'vs/workbench/contrib/tasks/common/tasks';
 import * as TaskConfig from '../common/taskConfiguration';
 import { AbstractTaskService } from 'vs/workbench/contrib/tasks/browser/abstractTaskService';
-import { TaskFilter, ITaskService } from 'vs/workbench/contrib/tasks/common/taskService';
+import { ITaskFilter, ITaskService } from 'vs/workbench/contrib/tasks/common/taskService';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { TerminalTaskSystem } from 'vs/workbench/contrib/tasks/browser/terminalTaskSystem';
 import { IConfirmationResult, IDialogService } from 'vs/platform/dialogs/common/dialogs';
@@ -44,9 +44,9 @@ import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from 
 import { ITerminalProfileResolverService } from 'vs/workbench/contrib/terminal/common/terminal';
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
 
-interface WorkspaceFolderConfigurationResult {
+interface IWorkspaceFolderConfigurationResult {
 	workspaceFolder: IWorkspaceFolder;
-	config: TaskConfig.ExternalTaskRunnerConfiguration | undefined;
+	config: TaskConfig.IExternalTaskRunnerConfiguration | undefined;
 	hasErrors: boolean;
 }
 
@@ -133,7 +133,7 @@ export class TaskService extends AbstractTaskService {
 		return this._taskSystem;
 	}
 
-	protected computeLegacyConfiguration(workspaceFolder: IWorkspaceFolder): Promise<WorkspaceFolderConfigurationResult> {
+	protected computeLegacyConfiguration(workspaceFolder: IWorkspaceFolder): Promise<IWorkspaceFolderConfigurationResult> {
 		let { config, hasParseErrors } = this.getConfiguration(workspaceFolder);
 		if (hasParseErrors) {
 			return Promise.resolve({ workspaceFolder: workspaceFolder, hasErrors: true, config: undefined });
@@ -145,7 +145,7 @@ export class TaskService extends AbstractTaskService {
 		}
 	}
 
-	protected versionAndEngineCompatible(filter?: TaskFilter): boolean {
+	protected versionAndEngineCompatible(filter?: ITaskFilter): boolean {
 		let range = filter && filter.version ? filter.version : undefined;
 		let engine = this.executionEngine;
 

--- a/src/vs/workbench/contrib/tasks/test/browser/taskTerminalStatus.test.ts
+++ b/src/vs/workbench/contrib/tasks/test/browser/taskTerminalStatus.test.ts
@@ -9,17 +9,17 @@ import { TestConfigurationService } from 'vs/platform/configuration/test/common/
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { ACTIVE_TASK_STATUS, FAILED_TASK_STATUS, SUCCEEDED_TASK_STATUS, TaskTerminalStatus } from 'vs/workbench/contrib/tasks/browser/taskTerminalStatus';
 import { AbstractProblemCollector } from 'vs/workbench/contrib/tasks/common/problemCollectors';
-import { CommonTask, TaskEvent, TaskEventKind, TaskRunType } from 'vs/workbench/contrib/tasks/common/tasks';
+import { CommonTask, ITaskEvent, TaskEventKind, TaskRunType } from 'vs/workbench/contrib/tasks/common/tasks';
 import { ITaskService, Task } from 'vs/workbench/contrib/tasks/common/taskService';
 import { ITerminalInstance } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { ITerminalStatus, ITerminalStatusList, TerminalStatusList } from 'vs/workbench/contrib/terminal/browser/terminalStatusList';
 
 class TestTaskService implements Partial<ITaskService> {
-	private readonly _onDidStateChange: Emitter<TaskEvent> = new Emitter();
-	public get onDidStateChange(): Event<TaskEvent> {
+	private readonly _onDidStateChange: Emitter<ITaskEvent> = new Emitter();
+	public get onDidStateChange(): Event<ITaskEvent> {
 		return this._onDidStateChange.event;
 	}
-	public triggerStateChange(event: TaskEvent): void {
+	public triggerStateChange(event: ITaskEvent): void {
 		this._onDidStateChange.fire(event);
 	}
 }

--- a/src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts
+++ b/src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts
@@ -67,7 +67,7 @@ suite('ProblemPatternParser', () => {
 
 	suite('single-pattern definitions', () => {
 		test('parses a pattern defined by only a regexp', () => {
-			let problemPattern: matchers.Config.ProblemPattern = {
+			let problemPattern: matchers.Config.IProblemPattern = {
 				regexp: 'test'
 			};
 			let parsed = parser.parse(problemPattern);
@@ -82,7 +82,7 @@ suite('ProblemPatternParser', () => {
 			});
 		});
 		test('does not sets defaults for line and character if kind is File', () => {
-			let problemPattern: matchers.Config.ProblemPattern = {
+			let problemPattern: matchers.Config.IProblemPattern = {
 				regexp: 'test',
 				kind: 'file'
 			};


### PR DESCRIPTION
@alexr00 the context for this issue is when I was writing tests, it was unclear to me whether things were interfaces or classes at first glance since we have this as a convention in terminal land.

With the current implementation, it wasn't possible to do this for these: 
`TaskGroup, TaskDefinition, TaskEvent, ProblemMatcher, CommandOptions`. 

Doing so resulted in `'ITaskDefinition' only refers to a type, but is being used as a value here.` 

If you have helpful context or think we shouldn't do this for some reason, please let me know. 

This PR fixes #150211
