### PR TITLE
Add DataTransferItem.kind

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1330,6 +1330,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			TextSearchCompleteMessageType: TextSearchCompleteMessageType,
 			DataTransfer: extHostTypes.DataTransfer,
 			DataTransferItem: extHostTypes.DataTransferItem,
+			DataTransferItemKind: extHostTypes.DataTransferItemKind,
 			CoveredCount: extHostTypes.CoveredCount,
 			FileCoverage: extHostTypes.FileCoverage,
 			StatementCoverage: extHostTypes.StatementCoverage,

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1965,6 +1965,8 @@ export namespace DataTransferItem {
 		const file = item.fileData;
 		if (file) {
 			return new class extends types.DataTransferItem {
+				override get kind() { return types.DataTransferItemKind.File; }
+
 				override asFile(): vscode.DataTransferFile {
 					return {
 						name: file.name,

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2438,8 +2438,16 @@ export enum TreeItemCollapsibleState {
 	Expanded = 2
 }
 
+export enum DataTransferItemKind {
+	String = 1,
+	File = 2,
+}
+
 @es5ClassCompat
 export class DataTransferItem {
+
+	get kind(): DataTransferItemKind { return DataTransferItemKind.String; }
+
 	async asString(): Promise<string> {
 		return typeof this.value === 'string' ? this.value : JSON.stringify(this.value);
 	}

--- a/src/vscode-dts/vscode.proposed.dataTransferFiles.d.ts
+++ b/src/vscode-dts/vscode.proposed.dataTransferFiles.d.ts
@@ -7,6 +7,15 @@ declare module 'vscode' {
 
 	// https://github.com/microsoft/vscode/issues/147481
 
+	enum DataTransferItemKind {
+		String = 1,
+		File = 2,
+	}
+
+	interface DataTransferItem {
+		readonly kind: DataTransferItemKind;
+	}
+
 	/**
 	 * A file associated with a {@linkcode DataTransferItem}.
 	 */


### PR DESCRIPTION
Fixes #150963

The new `.kind` property makes it easier to tell the type of a data transfer item