### PR TITLE
Keep webview from stealing focus from save dialog

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1336,12 +1336,10 @@ var requirejs = (function() {
 			this.webview?.focus();
 		}
 
-		setTimeout(() => { // Need this, or focus decoration is not shown. No clue.
-			this._sendMessageToWebview({
-				type: 'focus-output',
-				cellId,
-			});
-		}, 50);
+		this._sendMessageToWebview({
+			type: 'focus-output',
+			cellId,
+		});
 	}
 
 	async find(query: string, options: { wholeWord?: boolean; caseSensitive?: boolean; includeMarkup: boolean; includeOutput: boolean }): Promise<IFindMatch[]> {


### PR DESCRIPTION
Not sure why this timeout was needed two years ago, but the behavior is the same now. The behavior is not perfect anyway.
Fixes #151390
