### PR TITLE
Debug console items don't use cursor:pointer on windows

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/media/repl.css
+++ b/src/vs/workbench/contrib/debug/browser/media/repl.css
@@ -43,8 +43,8 @@
 	white-space: pre; /* Preserve whitespace but don't wrap */
 }
 
-.monaco-workbench.mac .repl .repl-tree .monaco-tl-twistie.collapsible + .monaco-tl-contents,
-.monaco-workbench.mac .repl .repl-tree .monaco-tl-twistie {
+.monaco-workbench .repl .repl-tree .monaco-tl-twistie.collapsible + .monaco-tl-contents,
+.monaco-workbench .repl .repl-tree .monaco-tl-twistie {
 	cursor: pointer;
 }
 


### PR DESCRIPTION
Fixes #151021
