### PR TITLE
assign builtin flag for overridden remote builtin extensions

### DIFF
--- a/scripts/test-remote-integration.sh
+++ b/scripts/test-remote-integration.sh
@@ -63,7 +63,7 @@ else
 	export ELECTRON_ENABLE_LOGGING=1
 
 	# Running from a build, we need to enable the vscode-test-resolver extension
-	EXTRA_INTEGRATION_TEST_ARGUMENTS="--extensions-dir=$EXT_PATH  --enable-proposed-api=vscode.vscode-test-resolver --enable-proposed-api=vscode.vscode-api-tests --enable-proposed-api=vscode.markdown-language-features --enable-proposed-api=vscode.git"
+	EXTRA_INTEGRATION_TEST_ARGUMENTS="--extensions-dir=$EXT_PATH  --enable-proposed-api=vscode.vscode-test-resolver --enable-proposed-api=vscode.vscode-api-tests"
 
 	echo "Storing crash reports into '$VSCODECRASHDIR'."
 	echo "Storing log files into '$VSCODELOGSDIR'."


### PR DESCRIPTION
Re-use deduping logic so that builtin flag is assigned for overridden remote builtin extensions. This fixes removing `--enable-proposed-api` flag while running remote builtin extension tests