### PR TITLE
Simplify default override indicator impl

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -125,13 +125,15 @@ export class SettingsTreeIndicatorsLabel {
 		const defaultValueSource = element.defaultValueSource;
 		if (defaultValueSource) {
 			this.defaultOverrideIndicatorElement.style.display = 'inline';
+			let sourceToDisplay = '';
 			if (typeof defaultValueSource !== 'string' && defaultValueSource.id !== element.setting.extensionInfo?.id) {
-				const extensionSource = defaultValueSource.displayName ?? defaultValueSource.id;
-				this.defaultOverrideIndicatorLabel.title = localize('defaultOverriddenDetails', "Default setting value overridden by {0}", extensionSource);
-				this.defaultOverrideIndicatorLabel.text = localize('defaultOverrideLabelText', "$(replace) {0}", extensionSource);
+				sourceToDisplay = defaultValueSource.displayName ?? defaultValueSource.id;
 			} else if (typeof defaultValueSource === 'string') {
-				this.defaultOverrideIndicatorLabel.title = localize('defaultOverriddenDetails', "Default setting value overridden by {0}", defaultValueSource);
-				this.defaultOverrideIndicatorLabel.text = localize('defaultOverrideLabelText', "$(replace) {0}", defaultValueSource);
+				sourceToDisplay = defaultValueSource;
+			}
+			if (sourceToDisplay) {
+				this.defaultOverrideIndicatorLabel.title = localize('defaultOverriddenDetails', "Default setting value overridden by {0}", sourceToDisplay);
+				this.defaultOverrideIndicatorLabel.text = `$(replace) ${sourceToDisplay}`;
 			}
 		}
 		this.render();


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode/issues/151164

The PR:
1. Reduces repetitiveness by firstly saving the extension source to use for the default override indicator into a label.
2. Stops using localization for the label display text, because the display text doesn't have anything that needs to be localized.