### PR TITLE
Add resourceMap helper for markdown extension

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/references.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/references.ts
@@ -97,7 +97,7 @@ export class MdReferencesProvider extends Disposable implements vscode.Reference
 	}
 
 	private async getReferencesToHeader(document: SkinnyTextDocument, header: TocEntry): Promise<MdReference[]> {
-		const links = (await this._linkCache.getAll()).flat();
+		const links = (await this._linkCache.values()).flat();
 
 		const references: MdReference[] = [];
 
@@ -150,7 +150,7 @@ export class MdReferencesProvider extends Disposable implements vscode.Reference
 	}
 
 	private async getReferencesToLink(sourceLink: MdLink, triggerPosition: vscode.Position, token: vscode.CancellationToken): Promise<MdReference[]> {
-		const allLinksInWorkspace = (await this._linkCache.getAll()).flat();
+		const allLinksInWorkspace = (await this._linkCache.values()).flat();
 		if (token.isCancellationRequested) {
 			return [];
 		}
@@ -227,7 +227,7 @@ export class MdReferencesProvider extends Disposable implements vscode.Reference
 	}
 
 	public async getAllReferencesToFile(resource: vscode.Uri, _token: vscode.CancellationToken): Promise<MdReference[]> {
-		const allLinksInWorkspace = (await this._linkCache.getAll()).flat();
+		const allLinksInWorkspace = (await this._linkCache.values()).flat();
 		return Array.from(this.findAllLinksToFile(resource, allLinksInWorkspace, undefined));
 	}
 

--- a/extensions/markdown-language-features/src/languageFeatures/workspaceSymbolProvider.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/workspaceSymbolProvider.ts
@@ -23,7 +23,7 @@ export class MdWorkspaceSymbolProvider extends Disposable implements vscode.Work
 	}
 
 	public async provideWorkspaceSymbols(query: string): Promise<vscode.SymbolInformation[]> {
-		const allSymbols = (await this._cache.getAll()).flat();
+		const allSymbols = (await this._cache.values()).flat();
 		return allSymbols.filter(symbolInformation => symbolInformation.name.toLowerCase().indexOf(query.toLowerCase()) !== -1);
 	}
 }

--- a/extensions/markdown-language-features/src/util/resourceMap.ts
+++ b/extensions/markdown-language-features/src/util/resourceMap.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export class ResourceMap<T> {
+
+	private readonly map = new Map<string, { readonly uri: vscode.Uri; readonly value: T }>();
+
+	public set(uri: vscode.Uri, value: T): this {
+		this.map.set(this.toKey(uri), { uri, value });
+		return this;
+	}
+
+	public get(resource: vscode.Uri): T | undefined {
+		return this.map.get(this.toKey(resource))?.value;
+	}
+
+	public has(resource: vscode.Uri): boolean {
+		return this.map.has(this.toKey(resource));
+	}
+
+	public get size(): number {
+		return this.map.size;
+	}
+
+	public clear(): void {
+		this.map.clear();
+	}
+
+	public delete(resource: vscode.Uri): boolean {
+		return this.map.delete(this.toKey(resource));
+	}
+
+	public *values(): IterableIterator<T> {
+		for (const entry of this.map.values()) {
+			yield entry.value;
+		}
+	}
+
+	public *keys(): IterableIterator<vscode.Uri> {
+		for (const entry of this.map.values()) {
+			yield entry.uri;
+		}
+	}
+
+	public *entries(): IterableIterator<[vscode.Uri, T]> {
+		for (const entry of this.map.values()) {
+			yield [entry.uri, entry.value];
+		}
+	}
+
+	public [Symbol.iterator](): IterableIterator<[vscode.Uri, T]> {
+		return this.entries();
+	}
+
+	private toKey(resource: vscode.Uri) {
+		return resource.toString();
+	}
+}


### PR DESCRIPTION
This change introduces a `ResoruceMap` map type that is essentially `Map<vscode.Uri, T>`

It also fixes a potential race condition with `MdWorkspaceCache` where two quick calls would both trigger init
