### PR TITLE
[typescript-language-features] Pass through all `typescript.unstable.*` settings

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
@@ -174,6 +174,7 @@ export default class FileConfigurationManager extends Disposable {
 			document);
 
 		const preferences: Proto.UserPreferences = {
+			...config.get('unstable'),
 			quotePreference: this.getQuoteStylePreference(preferencesConfig),
 			importModuleSpecifierPreference: getImportModuleSpecifierPreference(preferencesConfig),
 			importModuleSpecifierEnding: getImportModuleSpecifierEndingPreference(preferencesConfig),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This allows users to pass settings to TS Server by specifying them in `typescript.unstable` config JSON. This primarily saves TS devs from having to build and run local edits to VS Code to test TS Server features that need to be enabled by an editor setting, but is also useful for letting users try out the same features in TS nightlies or even PR builds.
