### PR TITLE
fix jsx text foreground in tomorrow-night theme

### DIFF
--- a/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-color-theme.json
+++ b/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-color-theme.json
@@ -65,7 +65,7 @@
 			}
 		},
 		{
-			"scope": ["meta.embedded", "source.groovy.embedded"],
+			"scope": ["meta.embedded", "source.groovy.embedded", "meta.jsx.children"],
 			"settings": {
 				//"background": "#002451",
 				"foreground": "#FFFFFF"


### PR DESCRIPTION
@aeschli

This PR fixes #147146

Before:

![](https://user-images.githubusercontent.com/41773861/162580709-c2d74ae9-f2f5-49af-9384-e5e16942e15e.png)

Now: 

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/41773861/172522289-9e51e986-c5fe-4efa-9ab2-127f069ebfdc.png">

