### PR TITLE
Update text editor drop proposal

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/dropIntoEditor.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/dropIntoEditor.ts
@@ -25,16 +25,15 @@ const imageFileExtensions = new Set<string>([
 
 export function registerDropIntoEditor(selector: vscode.DocumentSelector) {
 	return vscode.languages.registerDocumentOnDropEditProvider(selector, new class implements vscode.DocumentOnDropEditProvider {
-		async provideDocumentOnDropEdits(document: vscode.TextDocument, position: vscode.Position, dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken): Promise<vscode.SnippetTextEdit | undefined> {
+		async provideDocumentOnDropEdits(document: vscode.TextDocument, _position: vscode.Position, dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken): Promise<vscode.DocumentDropEdit | undefined> {
 			const enabled = vscode.workspace.getConfiguration('markdown', document).get('editor.drop.enabled', true);
 			if (!enabled) {
 				return undefined;
 			}
 
-			const replacementRange = new vscode.Range(position, position);
 			const snippet = await tryGetUriListSnippet(document, dataTransfer, token);
 			if (snippet) {
-				return new vscode.SnippetTextEdit(replacementRange, snippet);
+				return { insertText: snippet };
 			}
 			return undefined;
 		}

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -725,7 +725,7 @@ export interface CodeActionProvider {
  * @internal
  */
 export interface DocumentPasteEdit {
-	insertSnippet: string;
+	insertText: string | { snippet: string };
 	additionalEdit?: WorkspaceEdit;
 }
 
@@ -1133,11 +1133,6 @@ export interface DocumentSymbolProvider {
 }
 
 export type TextEdit = { range: IRange; text: string; eol?: model.EndOfLineSequence };
-
-export interface SnippetTextEdit {
-	range: IRange;
-	snippet: string;
-}
 
 /**
  * Interface used to format a model
@@ -1811,10 +1806,17 @@ export enum ExternalUriOpenerPriority {
 	Preferred = 3,
 }
 
+/**
+ * @internal
+ */
+export interface DocumentOnDropEdit {
+	insertText: string | { snippet: string };
+	additionalEdit?: WorkspaceEdit;
+}
 
 /**
  * @internal
  */
 export interface DocumentOnDropEditProvider {
-	provideDocumentOnDropEdits(model: model.ITextModel, position: IPosition, dataTransfer: VSDataTransfer, token: CancellationToken): ProviderResult<SnippetTextEdit>;
+	provideDocumentOnDropEdits(model: model.ITextModel, position: IPosition, dataTransfer: VSDataTransfer, token: CancellationToken): ProviderResult<DocumentOnDropEdit>;
 }

--- a/src/vs/editor/contrib/copyPaste/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/copyPaste/browser/copyPasteController.ts
@@ -21,6 +21,7 @@ import { ITextModel } from 'vs/editor/common/model';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { CodeEditorStateFlag, EditorStateCancellationTokenSource } from 'vs/editor/contrib/editorState/browser/editorState';
 import { performSnippetEdit } from 'vs/editor/contrib/snippet/browser/snippetController2';
+import { SnippetParser } from 'vs/editor/contrib/snippet/browser/snippetParser';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
@@ -34,7 +35,7 @@ const defaultPasteEditProvider = new class implements DocumentPasteEditProvider 
 		if (textDataTransfer) {
 			const text = await textDataTransfer.asString();
 			return {
-				insertSnippet: text
+				insertText: text
 			};
 		}
 
@@ -177,7 +178,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 					}
 
 					if (edit) {
-						performSnippetEdit(editor, edit.insertSnippet, selections);
+						performSnippetEdit(editor, typeof edit.insertText === 'string' ? SnippetParser.escape(edit.insertText) : edit.insertText.snippet, selections);
 
 						if (edit.additionalEdit) {
 							await this._bulkEditService.apply(ResourceEdit.convert(edit.additionalEdit), { editor });

--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -12,7 +12,7 @@ import { Range } from 'vs/editor/common/core/range';
 import { ISelection } from 'vs/editor/common/core/selection';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
-import { CompletionItem, CompletionItemKind, CompletionItemProvider, SnippetTextEdit } from 'vs/editor/common/languages';
+import { CompletionItem, CompletionItemKind, CompletionItemProvider } from 'vs/editor/common/languages';
 import { ILanguageConfigurationService } from 'vs/editor/common/languages/languageConfigurationRegistry';
 import { ITextModel } from 'vs/editor/common/model';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
@@ -336,20 +336,13 @@ registerEditorCommand(new CommandCtor({
 
 // ---
 
-export function performSnippetEdit(editor: ICodeEditor, snippet: string, selections: ISelection[]): boolean;
-export function performSnippetEdit(editor: ICodeEditor, edit: SnippetTextEdit): boolean;
-export function performSnippetEdit(editor: ICodeEditor, editOrSnippet: string | SnippetTextEdit, selections?: ISelection[]): boolean {
+export function performSnippetEdit(editor: ICodeEditor, snippet: string, selections: ISelection[]): boolean {
 	const controller = SnippetController2.get(editor);
 	if (!controller) {
 		return false;
 	}
 	editor.focus();
-	if (typeof editOrSnippet === 'string') {
-		editor.setSelections(selections ?? []);
-		controller.insert(editOrSnippet);
-	} else {
-		editor.setSelection(editOrSnippet.range);
-		controller.insert(editOrSnippet.snippet);
-	}
+	editor.setSelections(selections ?? []);
+	controller.insert(snippet);
 	return controller.isInSnippet();
 }

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6758,11 +6758,6 @@ declare namespace monaco.languages {
 		eol?: editor.EndOfLineSequence;
 	};
 
-	export interface SnippetTextEdit {
-		range: IRange;
-		snippet: string;
-	}
-
 	/**
 	 * Interface used to format a model
 	 */

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1267,7 +1267,6 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			SignatureHelpTriggerKind: extHostTypes.SignatureHelpTriggerKind,
 			SignatureInformation: extHostTypes.SignatureInformation,
 			SnippetString: extHostTypes.SnippetString,
-			SnippetTextEdit: extHostTypes.SnippetTextEdit,
 			SourceBreakpoint: extHostTypes.SourceBreakpoint,
 			StandardTokenType: extHostTypes.StandardTokenType,
 			StatusBarAlignment: extHostTypes.StatusBarAlignment,

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1714,7 +1714,12 @@ export interface IInlineValueContextDto {
 export type ITypeHierarchyItemDto = Dto<TypeHierarchyItem>;
 
 export interface IPasteEditDto {
-	insertSnippet: string;
+	insertText: string | { snippet: string };
+	additionalEdit?: IWorkspaceEditDto;
+}
+
+export interface IDocumentOnDropEditDto {
+	insertText: string | { snippet: string };
 	additionalEdit?: IWorkspaceEditDto;
 }
 
@@ -1776,7 +1781,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideTypeHierarchySupertypes(handle: number, sessionId: string, itemId: string, token: CancellationToken): Promise<ITypeHierarchyItemDto[] | undefined>;
 	$provideTypeHierarchySubtypes(handle: number, sessionId: string, itemId: string, token: CancellationToken): Promise<ITypeHierarchyItemDto[] | undefined>;
 	$releaseTypeHierarchy(handle: number, sessionId: string): void;
-	$provideDocumentOnDropEdits(handle: number, requestId: number, resource: UriComponents, position: IPosition, dataTransferDto: DataTransferDTO, token: CancellationToken): Promise<Dto<languages.SnippetTextEdit> | undefined>;
+	$provideDocumentOnDropEdits(handle: number, requestId: number, resource: UriComponents, position: IPosition, dataTransferDto: DataTransferDTO, token: CancellationToken): Promise<IDocumentOnDropEditDto | undefined>;
 }
 
 export interface ExtHostQuickOpenShape {

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -562,15 +562,6 @@ export namespace TextEdit {
 	}
 }
 
-export namespace SnippetTextEdit {
-	export function from(edit: vscode.SnippetTextEdit): languages.SnippetTextEdit {
-		return {
-			range: Range.from(edit.range),
-			snippet: edit.snippet.value
-		};
-	}
-}
-
 export namespace WorkspaceEdit {
 
 	export interface IVersionInformationProvider {

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -647,17 +647,6 @@ export class NotebookEdit implements vscode.NotebookEdit {
 	}
 }
 
-export class SnippetTextEdit implements vscode.SnippetTextEdit {
-
-	range: vscode.Range;
-	snippet: vscode.SnippetString;
-
-	constructor(range: Range, snippet: SnippetString) {
-		this.range = range;
-		this.snippet = snippet;
-	}
-}
-
 export interface IFileOperationOptions {
 	overwrite?: boolean;
 	ignoreIfExists?: boolean;

--- a/src/vscode-dts/vscode.proposed.textEditorDrop.d.ts
+++ b/src/vscode-dts/vscode.proposed.textEditorDrop.d.ts
@@ -7,12 +7,6 @@ declare module 'vscode' {
 
 	// https://github.com/microsoft/vscode/issues/142990
 
-	export class SnippetTextEdit {
-		snippet: SnippetString;
-		range: Range;
-		constructor(range: Range, snippet: SnippetString);
-	}
-
 	/**
 	 * Provider which handles dropping of resources into a text editor.
 	 *
@@ -27,10 +21,25 @@ declare module 'vscode' {
 		 * @param dataTransfer A {@link DataTransfer} object that holds data about what is being dragged and dropped.
 		 * @param token A cancellation token.
 		 *
-		 * @return A {@link SnippetTextEdit} or a thenable that resolves to such. The lack of a result can be
+		 * @return A {@link DocumentDropEdit} or a thenable that resolves to such. The lack of a result can be
 		 * signaled by returning `undefined` or `null`.
 		 */
-		provideDocumentOnDropEdits(document: TextDocument, position: Position, dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<SnippetTextEdit>;
+		provideDocumentOnDropEdits(document: TextDocument, position: Position, dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentDropEdit>;
+	}
+
+	/**
+	 * An edit operation applied on drop.
+	 */
+	export interface DocumentDropEdit {
+		/**
+		 * The text or snippet to insert at the drop location.
+		 */
+		readonly insertText: string | SnippetString;
+
+		/**
+		 * An optional additional edit to apply on drop.
+		 */
+		readonly additionalEdit?: WorkspaceEdit;
 	}
 
 	export namespace languages {


### PR DESCRIPTION
This updates the text editor drop proposal (#142990). This change introduces `DocumentDropEdit` which removes the need for `SnippetTextEdit`. This interface may also be extended in the future with additional metadata
