### PR TITLE
Adjust padding and outline of Settings editor scope widget tabs

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -109,13 +109,21 @@
 	/* padding must be on action-label because it has the bottom-border, because that's where the .checked class is */
 }
 
+.settings-editor > .settings-header > .settings-header-controls .settings-tabs-widget > .monaco-action-bar .action-item.focused {
+	outline-offset: -1.5px;
+}
+
 .settings-editor > .settings-header > .settings-header-controls .settings-tabs-widget > .monaco-action-bar .action-item .action-label {
 	text-transform: none;
 	font-size: 13px;
-	padding-bottom: 7px;
+	padding-bottom: 6.5px;
 	padding-top: 7px;
 	padding-left: 8px;
 	padding-right: 8px;
+}
+
+.settings-editor > .settings-header > .settings-header-controls .settings-tabs-widget > .monaco-action-bar .action-item .action-label .dropdown-icon {
+	padding-top: 2px;
 }
 
 .settings-editor > .settings-header > .settings-header-controls .settings-tabs-widget > .monaco-action-bar .action-item .action-label:not(.checked):not(:focus) {


### PR DESCRIPTION
Fixes #146491

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes the layout of the Settings editor scope widget tabs for workspaces, especially multi-root ones.
Before, on a multi-root workspace, the underlines would not show until a user used the arrow keys to focus on a new tab, in which case a misaligned underline would show.
Now, the underline shows correctly. I also adjusted the outline offset to have more even outlines when the user focuses on the folder tab.

Before:
![Screencap showing the incorrect before behaviour](https://user-images.githubusercontent.com/7199958/172730066-d4425ef9-8fe9-4086-903a-f4b964ec8565.gif)

After:
![Screencap showing the correct behaviour](https://user-images.githubusercontent.com/7199958/172730062-c9620142-74b2-4314-af90-a765a24a1beb.gif)

