### PR TITLE
Allow paste API to replace metadata on copy

### DIFF
--- a/src/vs/editor/contrib/copyPaste/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/copyPaste/browser/copyPasteController.ts
@@ -148,7 +148,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 				if (handle && this._currentClipboardItem?.handle === handle) {
 					const toMergeDataTransfer = await this._currentClipboardItem.dataTransferPromise;
 					toMergeDataTransfer.forEach((value, key) => {
-						dataTransfer.append(key, value);
+						dataTransfer.replace(key, value);
 					});
 				}
 


### PR DESCRIPTION
This lets the paste api replace data, such as `text/plain` on copy

For #151047

