### PR TITLE
Fix #148150

### DIFF
--- a/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts
+++ b/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts
@@ -62,9 +62,15 @@ class Settings {
 		const minimapOpts = options.get(EditorOption.minimap);
 		const minimapEnabled = minimapOpts.enabled;
 		const minimapSide = minimapOpts.side;
-		const backgroundColor = minimapEnabled
-			? theme.getColor(editorOverviewRulerBackground) || TokenizationRegistry.getDefaultBackground()
-			: null;
+		const themeColor = theme.getColor(editorOverviewRulerBackground);
+		const defaultBackground = TokenizationRegistry.getDefaultBackground();
+		let backgroundColor: Color | null = null;
+
+		if (themeColor !== undefined) {
+			backgroundColor = themeColor;
+		} else if (minimapEnabled) {
+			backgroundColor = defaultBackground;
+		}
 
 		if (backgroundColor === null || minimapSide === 'left') {
 			this.backgroundColor = null;


### PR DESCRIPTION
With this change, the configured background color of the scrollbar will be used when the minimap is enabled.