### PR TITLE
joh/unexpected eagle

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorModel.ts
@@ -333,6 +333,13 @@ class ResultEdits {
 					false,
 					1000
 				).then(e => {
+
+					if (resultTextModel.isDisposed()) {
+						// this can happen because on "discard" the model is first reset to
+						// its old contents and then disposed
+						return;
+					}
+
 					const diffs =
 						e?.changes.map((c) =>
 							LineDiff.fromLineChange(c, baseTextModel, resultTextModel)


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/150817

- async event handler must check if model is still alive
- make `ResultEdits` disposable and dispose when `MergeEditorModel` is being disposed
