### PR TITLE
Add support for angle bracket colorization in Typescript

### DIFF
--- a/extensions/typescript-basics/language-configuration.json
+++ b/extensions/typescript-basics/language-configuration.json
@@ -99,6 +99,24 @@
 			">"
 		]
 	],
+	"colorizedBracketPairs": [
+		[
+			"(",
+			")"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"{",
+			"}"
+		],
+		[
+			"<",
+			">"
+		]
+	],
 	"autoCloseBefore": ";:.,=}])>` \n\t",
 	"folding": {
 		"markers": {


### PR DESCRIPTION
Adds support for angle bracket colorization in Typescript.

This PR fixes #151196 
