### PR TITLE
joh/bloody egret

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -110,7 +110,7 @@ const tasks = compilations.map(function (tsconfigFile) {
 		overrideOptions.inlineSources = Boolean(build);
 		overrideOptions.base = path.dirname(absolutePath);
 
-		const compilation = tsb.create(absolutePath, overrideOptions, false, err => reporter(err.toString()));
+		const compilation = tsb.create(absolutePath, overrideOptions, { verbose: false }, err => reporter(err.toString()));
 
 		const pipeline = function () {
 			const input = es.through();

--- a/build/lib/compilation.js
+++ b/build/lib/compilation.js
@@ -42,7 +42,7 @@ function createCompile(src, build, emitError) {
     if (!build) {
         overrideOptions.inlineSourceMap = true;
     }
-    const compilation = tsb.create(projectPath, overrideOptions, false, err => reporter(err));
+    const compilation = tsb.create(projectPath, overrideOptions, { verbose: false }, err => reporter(err));
     function pipeline(token) {
         const bom = require('gulp-bom');
         const utf8Filter = util.filter(data => /(\/|\\)test(\/|\\).*utf8/.test(data.path));

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -50,7 +50,7 @@ function createCompile(src: string, build: boolean, emitError?: boolean) {
 		overrideOptions.inlineSourceMap = true;
 	}
 
-	const compilation = tsb.create(projectPath, overrideOptions, false, err => reporter(err));
+	const compilation = tsb.create(projectPath, overrideOptions, { verbose: false }, err => reporter(err));
 
 	function pipeline(token?: util.ICancellationToken) {
 		const bom = require('gulp-bom') as typeof import('gulp-bom');

--- a/build/lib/tsb/builder.js
+++ b/build/lib/tsb/builder.js
@@ -30,7 +30,7 @@ function createTypeScriptBuilder(config, projectFile, cmd) {
     }
     let host = new LanguageServiceHost(cmd, projectFile, _log), service = ts.createLanguageService(host, ts.createDocumentRegistry()), lastBuildVersion = Object.create(null), lastDtsHash = Object.create(null), userWantsDeclarations = cmd.options.declaration, oldErrors = Object.create(null), headUsed = process.memoryUsage().heapUsed, emitSourceMapsInStream = true;
     // always emit declaraction files
-    host.getCompilationSettings().declaration = true;
+    host.getCompilationSettings().declaration = !config.transpileOnly;
     function file(file) {
         // support gulp-sourcemaps
         if (file.sourceMap) {
@@ -149,8 +149,10 @@ function createTypeScriptBuilder(config, projectFile, cmd) {
         for (let fileName of host.getScriptFileNames()) {
             if (lastBuildVersion[fileName] !== host.getScriptVersion(fileName)) {
                 toBeEmitted.push(fileName);
-                toBeCheckedSyntactically.push(fileName);
-                toBeCheckedSemantically.push(fileName);
+                if (!config.transpileOnly) {
+                    toBeCheckedSyntactically.push(fileName);
+                    toBeCheckedSemantically.push(fileName);
+                }
             }
         }
         return new Promise(resolve => {
@@ -177,7 +179,7 @@ function createTypeScriptBuilder(config, projectFile, cmd) {
                         // remember when this was build
                         newLastBuildVersion.set(fileName, host.getScriptVersion(fileName));
                         // remeber the signature
-                        if (value.signature && lastDtsHash[fileName] !== value.signature) {
+                        if (!config.transpileOnly && value.signature && lastDtsHash[fileName] !== value.signature) {
                             lastDtsHash[fileName] = value.signature;
                             filesWithChangedSignature.push(fileName);
                         }

--- a/build/lib/tsb/builder.ts
+++ b/build/lib/tsb/builder.ts
@@ -14,6 +14,7 @@ import * as Vinyl from 'vinyl';
 
 export interface IConfiguration {
 	verbose: boolean;
+	transpileOnly?: boolean;
 	_emitWithoutBasePath?: boolean;
 }
 
@@ -55,8 +56,7 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 		emitSourceMapsInStream = true;
 
 	// always emit declaraction files
-	host.getCompilationSettings().declaration = true;
-
+	host.getCompilationSettings().declaration = !config.transpileOnly;
 
 	function file(file: Vinyl): void {
 		// support gulp-sourcemaps
@@ -196,8 +196,11 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 			if (lastBuildVersion[fileName] !== host.getScriptVersion(fileName)) {
 
 				toBeEmitted.push(fileName);
-				toBeCheckedSyntactically.push(fileName);
-				toBeCheckedSemantically.push(fileName);
+
+				if (!config.transpileOnly) {
+					toBeCheckedSyntactically.push(fileName);
+					toBeCheckedSemantically.push(fileName);
+				}
 			}
 		}
 
@@ -233,7 +236,7 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 						newLastBuildVersion.set(fileName, host.getScriptVersion(fileName));
 
 						// remeber the signature
-						if (value.signature && lastDtsHash[fileName] !== value.signature) {
+						if (!config.transpileOnly && value.signature && lastDtsHash[fileName] !== value.signature) {
 							lastDtsHash[fileName] = value.signature;
 							filesWithChangedSignature.push(fileName);
 						}

--- a/build/lib/tsb/builder.ts
+++ b/build/lib/tsb/builder.ts
@@ -7,14 +7,12 @@ import { statSync, readFileSync } from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import * as utils from './utils';
-import * as log from 'fancy-log';
 import * as colors from 'ansi-colors';
 import * as ts from 'typescript';
 import * as Vinyl from 'vinyl';
 
 export interface IConfiguration {
-	verbose: boolean;
-	transpileOnly?: boolean;
+	logFn: (topic: string, message: string) => void;
 	_emitWithoutBasePath?: boolean;
 }
 
@@ -40,11 +38,7 @@ function normalize(path: string): string {
 
 export function createTypeScriptBuilder(config: IConfiguration, projectFile: string, cmd: ts.ParsedCommandLine): ITypeScriptBuilder {
 
-	function _log(topic: string, message: string): void {
-		if (config.verbose) {
-			log(colors.cyan(topic), message);
-		}
-	}
+	const _log = config.logFn;
 
 	let host = new LanguageServiceHost(cmd, projectFile, _log),
 		service = ts.createLanguageService(host, ts.createDocumentRegistry()),
@@ -56,7 +50,7 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 		emitSourceMapsInStream = true;
 
 	// always emit declaraction files
-	host.getCompilationSettings().declaration = !config.transpileOnly;
+	host.getCompilationSettings().declaration = true;
 
 	function file(file: Vinyl): void {
 		// support gulp-sourcemaps
@@ -196,11 +190,8 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 			if (lastBuildVersion[fileName] !== host.getScriptVersion(fileName)) {
 
 				toBeEmitted.push(fileName);
-
-				if (!config.transpileOnly) {
-					toBeCheckedSyntactically.push(fileName);
-					toBeCheckedSemantically.push(fileName);
-				}
+				toBeCheckedSyntactically.push(fileName);
+				toBeCheckedSemantically.push(fileName);
 			}
 		}
 
@@ -236,7 +227,7 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 						newLastBuildVersion.set(fileName, host.getScriptVersion(fileName));
 
 						// remeber the signature
-						if (!config.transpileOnly && value.signature && lastDtsHash[fileName] !== value.signature) {
+						if (value.signature && lastDtsHash[fileName] !== value.signature) {
 							lastDtsHash[fileName] = value.signature;
 							filesWithChangedSignature.push(fileName);
 						}
@@ -358,15 +349,13 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 			oldErrors = newErrors;
 
 			// print stats
-			if (config.verbose) {
-				const headNow = process.memoryUsage().heapUsed;
-				const MB = 1024 * 1024;
-				log('[tsb]',
-					'time:', colors.yellow((Date.now() - t1) + 'ms'),
-					'mem:', colors.cyan(Math.ceil(headNow / MB) + 'MB'), colors.bgCyan('delta: ' + Math.ceil((headNow - headUsed) / MB))
-				);
-				headUsed = headNow;
-			}
+			const headNow = process.memoryUsage().heapUsed;
+			const MB = 1024 * 1024;
+			_log(
+				'[tsb]',
+				`time:  ${colors.yellow((Date.now() - t1) + 'ms')} + \nmem:  ${colors.cyan(Math.ceil(headNow / MB) + 'MB')} ${colors.bgCyan('delta: ' + Math.ceil((headNow - headUsed) / MB))}`
+			);
+			headUsed = headNow;
 		});
 	}
 

--- a/build/lib/tsb/index.js
+++ b/build/lib/tsb/index.js
@@ -89,7 +89,7 @@ function create(projectPath, existingOptions, config, onError = _defaultOnError)
                 contents: Buffer.from(out.outputText),
             });
             this.push(outFile);
-            logFn('Transpile', file.path);
+            logFn('Transpiled', file.path);
         });
     }
     const result = (token) => {

--- a/build/lib/tsb/index.js
+++ b/build/lib/tsb/index.js
@@ -13,6 +13,8 @@ const stream_1 = require("stream");
 const path_1 = require("path");
 const utils_1 = require("./utils");
 const fs_1 = require("fs");
+const log = require("fancy-log");
+const colors = require("ansi-colors");
 class EmptyDuplex extends stream_1.Duplex {
     _write(_chunk, _encoding, callback) { callback(); }
     _read() { this.push(null); }
@@ -23,7 +25,7 @@ function createNullCompiler() {
     return result;
 }
 const _defaultOnError = (err) => console.log(JSON.stringify(err, null, 4));
-function create(projectPath, existingOptions, verbose = false, onError = _defaultOnError) {
+function create(projectPath, existingOptions, config, onError = _defaultOnError) {
     function printDiagnostic(diag) {
         if (!diag.file || !diag.start) {
             onError(ts.flattenDiagnosticMessageText(diag.messageText, '\n'));
@@ -43,8 +45,14 @@ function create(projectPath, existingOptions, verbose = false, onError = _defaul
         cmdLine.errors.forEach(printDiagnostic);
         return createNullCompiler();
     }
-    const _builder = builder.createTypeScriptBuilder({ verbose }, projectPath, cmdLine);
-    function createStream(token) {
+    function logFn(topic, message) {
+        if (config.verbose) {
+            log(colors.cyan(topic), message);
+        }
+    }
+    // FULL COMPILE stream doing transpile, syntax and semantic diagnostics
+    function createCompileStream(token) {
+        const _builder = builder.createTypeScriptBuilder({ logFn }, projectPath, cmdLine);
         return through(function (file) {
             // give the file to the compiler
             if (file.isStream()) {
@@ -57,7 +65,38 @@ function create(projectPath, existingOptions, verbose = false, onError = _defaul
             _builder.build(file => this.queue(file), printDiagnostic, token).catch(e => console.error(e)).then(() => this.queue(null));
         });
     }
-    const result = (token) => createStream(token);
+    // TRANSPILE ONLY stream doing just TS to JS conversion
+    function createTranspileStream() {
+        return through(function (file) {
+            // give the file to the compiler
+            if (file.isStream()) {
+                this.emit('error', 'no support for streams');
+                return;
+            }
+            if (!file.contents) {
+                return;
+            }
+            const out = ts.transpileModule(String(file.contents), {
+                compilerOptions: { ...cmdLine.options, declaration: false, sourceMap: false }
+            });
+            if (out.diagnostics) {
+                out.diagnostics.forEach(printDiagnostic);
+            }
+            const outFile = new Vinyl({
+                path: file.path.replace(/\.ts$/, '.js'),
+                cwd: file.cwd,
+                base: file.base,
+                contents: Buffer.from(out.outputText),
+            });
+            this.push(outFile);
+            logFn('Transpile', file.path);
+        });
+    }
+    const result = (token) => {
+        return config.transplileOnly
+            ? createTranspileStream()
+            : createCompileStream(token);
+    };
     result.src = (opts) => {
         let _pos = 0;
         let _fileNames = cmdLine.fileNames.slice(0);


### PR DESCRIPTION
- add a `transpileOnly` option to gulp-tsb
- add transpile only stream to tsb, using `ts.transpile`.

Part of https://github.com/microsoft/vscode/issues/150025, uses https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#a-simple-transform-function