### PR TITLE
Set z-index of watermark

### DIFF
--- a/src/vs/workbench/contrib/watermark/browser/media/watermark.css
+++ b/src/vs/workbench/contrib/watermark/browser/media/watermark.css
@@ -23,6 +23,8 @@
 	text-align: center;
 	white-space: nowrap;
 	overflow: hidden;
+	/* Watermark should show even over opaque backgrounds */
+	z-index: 1000;
 }
 
 .monaco-workbench .part.editor > .content.empty > .watermark > .watermark-box {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #151184


Some downsides here being that we have a preset color for dark and light themes (high contrast variants inherit from editor foreground color) meaning even though it is now above a bad empty foreground color can lead to the text being very hard to read. Not sure what our best fix there. I think the reason for not using editor foreground everywhere in the watermark is we wanted a muted appearance to the hint. 
