### PR TITLE
Use optional method calls in more places

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3129,9 +3129,7 @@ export class CommandCenter {
 				if (result) {
 					const resultFn = choices.get(result);
 
-					if (resultFn) {
-						resultFn();
-					}
+					resultFn?.();
 				}
 			});
 		};

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -556,9 +556,7 @@ export class Git {
 	private async _exec(args: string[], options: SpawnOptions = {}): Promise<IExecutionResult<string>> {
 		const child = this.spawn(args, options);
 
-		if (options.onSpawn) {
-			options.onSpawn(child);
-		}
+		options.onSpawn?.(child);
 
 		if (options.input) {
 			child.stdin!.end(options.input, 'utf8');

--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -251,9 +251,7 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 	// The settings have changed. Is send on server activation as well.
 	connection.onDidChangeConfiguration((change) => {
 		let settings = <Settings>change.settings;
-		if (runtime.configureHttpRequests) {
-			runtime.configureHttpRequests(settings?.http?.proxy, !!settings.http?.proxyStrictSSL);
-		}
+		runtime.configureHttpRequests?.(settings?.http?.proxy, !!settings.http?.proxyStrictSSL);
 		jsonConfigurationSettings = settings.json?.schemas;
 		validateEnabled = !!settings.json?.validate?.enable;
 		updateConfiguration();

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1733,9 +1733,7 @@ export class DragAndDropObserver extends Disposable {
 		this._register(addDisposableListener(this.element, EventType.DRAG_OVER, (e: DragEvent) => {
 			e.preventDefault(); // needed so that the drop event fires (https://stackoverflow.com/questions/21339924/drop-event-not-firing-in-chrome)
 
-			if (this.callbacks.onDragOver) {
-				this.callbacks.onDragOver(e, e.timeStamp - this.dragStartTime);
-			}
+			this.callbacks.onDragOver?.(e, e.timeStamp - this.dragStartTime);
 		}));
 
 		this._register(addDisposableListener(this.element, EventType.DRAG_LEAVE, (e: DragEvent) => {

--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -220,9 +220,7 @@ export class ContextView extends Disposable {
 		this.doLayout();
 
 		// Focus
-		if (this.delegate.focus) {
-			this.delegate.focus();
-		}
+		this.delegate.focus?.();
 	}
 
 	getViewElement(): HTMLElement {

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -857,9 +857,7 @@ class LeafNode implements ISplitView<ILayoutContext>, IDisposable {
 	set boundarySashes(boundarySashes: IRelativeBoundarySashes) {
 		this._boundarySashes = boundarySashes;
 
-		if (this.view.setBoundarySashes) {
-			this.view.setBoundarySashes(toAbsoluteBoundarySashes(boundarySashes, this.orientation));
-		}
+		this.view.setBoundarySashes?.(toAbsoluteBoundarySashes(boundarySashes, this.orientation));
 	}
 
 	layout(size: number, offset: number, ctx: ILayoutContext | undefined): void {
@@ -897,9 +895,7 @@ class LeafNode implements ISplitView<ILayoutContext>, IDisposable {
 	}
 
 	setVisible(visible: boolean): void {
-		if (this.view.setVisible) {
-			this.view.setVisible(visible);
-		}
+		this.view.setVisible?.(visible);
 	}
 
 	dispose(): void {

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1032,9 +1032,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		this.currentDragData = new ElementsDragAndDropData(elements);
 		StaticDND.CurrentDragAndDropData = new ExternalElementsDragAndDropData(elements);
 
-		if (this.dnd.onDragStart) {
-			this.dnd.onDragStart(this.currentDragData, event);
-		}
+		this.dnd.onDragStart?.(this.currentDragData, event);
 	}
 
 	private onDragOver(event: IListDragEvent<T>): boolean {
@@ -1169,9 +1167,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		this.currentDragData = undefined;
 		StaticDND.CurrentDragAndDropData = undefined;
 
-		if (this.dnd.onDragEnd) {
-			this.dnd.onDragEnd(event);
-		}
+		this.dnd.onDragEnd?.(event);
 	}
 
 	private clearDragOverFeedback(): void {
@@ -1379,16 +1375,12 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		if (renderer) {
 			renderer.renderElement(item.element, index, row.templateData, undefined);
 
-			if (renderer.disposeElement) {
-				renderer.disposeElement(item.element, index, row.templateData, undefined);
-			}
+			renderer.disposeElement?.(item.element, index, row.templateData, undefined);
 		}
 
 		item.size = row.domNode.offsetHeight;
 
-		if (this.virtualDelegate.setDynamicHeight) {
-			this.virtualDelegate.setDynamicHeight(item.element, item.size);
-		}
+		this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
 
 		item.lastDynamicHeightWidth = this.renderWidth;
 		this.rowsContainer.removeChild(row.domNode);
@@ -1429,9 +1421,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 				if (item.row) {
 					const renderer = this.renderers.get(item.row.templateId);
 					if (renderer) {
-						if (renderer.disposeElement) {
-							renderer.disposeElement(item.element, -1, item.row.templateData, undefined);
-						}
+						renderer.disposeElement?.(item.element, -1, item.row.templateData, undefined);
 						renderer.disposeTemplate(item.row.templateData);
 					}
 				}

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1109,9 +1109,7 @@ class PipelineRenderer<T> implements IListRenderer<T, any> {
 		let i = 0;
 
 		for (const renderer of this.renderers) {
-			if (renderer.disposeElement) {
-				renderer.disposeElement(element, index, templateData[i], height);
-			}
+			renderer.disposeElement?.(element, index, templateData[i], height);
 
 			i += 1;
 		}
@@ -1182,9 +1180,7 @@ class ListViewDragAndDrop<T> implements IListViewDragAndDrop<T> {
 	}
 
 	onDragStart(data: IDragAndDropData, originalEvent: DragEvent): void {
-		if (this.dnd.onDragStart) {
-			this.dnd.onDragStart(data, originalEvent);
-		}
+		this.dnd.onDragStart?.(data, originalEvent);
 	}
 
 	onDragOver(data: IDragAndDropData, targetElement: T, targetIndex: number, originalEvent: DragEvent): boolean | IListDragOverReaction {
@@ -1196,9 +1192,7 @@ class ListViewDragAndDrop<T> implements IListViewDragAndDrop<T> {
 	}
 
 	onDragEnd(originalEvent: DragEvent): void {
-		if (this.dnd.onDragEnd) {
-			this.dnd.onDragEnd(originalEvent);
-		}
+		this.dnd.onDragEnd?.(originalEvent);
 	}
 
 	drop(data: IDragAndDropData, targetElement: T, targetIndex: number, originalEvent: DragEvent): void {
@@ -1328,9 +1322,7 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 		if (this.accessibilityProvider) {
 			baseRenderers.push(new AccessibiltyRenderer<T>(this.accessibilityProvider));
 
-			if (this.accessibilityProvider.onDidChangeActiveDescendant) {
-				this.accessibilityProvider.onDidChangeActiveDescendant(this.onDidChangeActiveDescendant, this, this.disposables);
-			}
+			this.accessibilityProvider.onDidChangeActiveDescendant?.(this.onDidChangeActiveDescendant, this, this.disposables);
 		}
 
 		renderers = renderers.map(r => new PipelineRenderer(r.templateId, [...baseRenderers, r]));

--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -231,9 +231,7 @@ abstract class ViewItem<TLayoutContext> {
 
 		this.container.classList.toggle('visible', visible);
 
-		if (this.view.setVisible) {
-			this.view.setVisible(visible);
-		}
+		this.view.setVisible?.(visible);
 	}
 
 	get minimumSize(): number { return this.visible ? this.view.minimumSize : 0; }

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -70,9 +70,7 @@ class TreeNodeListDragAndDrop<T, TFilterData, TRef> implements IListDragAndDrop<
 	}
 
 	onDragStart(data: IDragAndDropData, originalEvent: DragEvent): void {
-		if (this.dnd.onDragStart) {
-			this.dnd.onDragStart(asTreeDragAndDropData(data), originalEvent);
-		}
+		this.dnd.onDragStart?.(asTreeDragAndDropData(data), originalEvent);
 	}
 
 	onDragOver(data: IDragAndDropData, targetNode: ITreeNode<T, TFilterData> | undefined, targetIndex: number | undefined, originalEvent: DragEvent, raw = true): boolean | IListDragOverReaction {
@@ -137,9 +135,7 @@ class TreeNodeListDragAndDrop<T, TFilterData, TRef> implements IListDragAndDrop<
 	}
 
 	onDragEnd(originalEvent: DragEvent): void {
-		if (this.dnd.onDragEnd) {
-			this.dnd.onDragEnd(originalEvent);
-		}
+		this.dnd.onDragEnd?.(originalEvent);
 	}
 }
 
@@ -220,9 +216,7 @@ export class ComposedTreeDelegate<T, N extends { element: T }> implements IListV
 	}
 
 	setDynamicHeight(element: N, height: number): void {
-		if (this.delegate.setDynamicHeight) {
-			this.delegate.setDynamicHeight(element.element, height);
-		}
+		this.delegate.setDynamicHeight?.(element.element, height);
 	}
 }
 
@@ -350,9 +344,7 @@ class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListRenderer
 
 		Event.map(onDidChangeCollapseState, e => e.node)(this.onDidChangeNodeTwistieState, this, this.disposables);
 
-		if (renderer.onDidChangeTwistieState) {
-			renderer.onDidChangeTwistieState(this.onDidChangeTwistieState, this, this.disposables);
-		}
+		renderer.onDidChangeTwistieState?.(this.onDidChangeTwistieState, this, this.disposables);
 	}
 
 	updateOptions(options: ITreeRendererOptions = {}): void {
@@ -414,9 +406,7 @@ class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListRenderer
 	disposeElement(node: ITreeNode<T, TFilterData>, index: number, templateData: ITreeListTemplateData<TTemplateData>, height: number | undefined): void {
 		templateData.indentGuidesDisposable.dispose();
 
-		if (this.renderer.disposeElement) {
-			this.renderer.disposeElement(node, index, templateData.templateData, height);
-		}
+		this.renderer.disposeElement?.(node, index, templateData.templateData, height);
 
 		if (typeof height === 'number') {
 			this.renderedNodes.delete(node);

--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -119,9 +119,7 @@ class AsyncDataTreeRenderer<TInput, T, TFilterData, TTemplateData> implements IT
 	}
 
 	disposeElement(node: ITreeNode<IAsyncDataTreeNode<TInput, T>, TFilterData>, index: number, templateData: IDataTreeListTemplateData<TTemplateData>, height: number | undefined): void {
-		if (this.renderer.disposeElement) {
-			this.renderer.disposeElement(this.nodeMapper.map(node) as ITreeNode<T, TFilterData>, index, templateData.templateData, height);
-		}
+		this.renderer.disposeElement?.(this.nodeMapper.map(node) as ITreeNode<T, TFilterData>, index, templateData.templateData, height);
 	}
 
 	disposeTemplate(templateData: IDataTreeListTemplateData<TTemplateData>): void {
@@ -196,9 +194,7 @@ class AsyncDataTreeNodeListDragAndDrop<TInput, T> implements IListDragAndDrop<IA
 	}
 
 	onDragStart(data: IDragAndDropData, originalEvent: DragEvent): void {
-		if (this.dnd.onDragStart) {
-			this.dnd.onDragStart(asAsyncDataTreeDragAndDropData(data), originalEvent);
-		}
+		this.dnd.onDragStart?.(asAsyncDataTreeDragAndDropData(data), originalEvent);
 	}
 
 	onDragOver(data: IDragAndDropData, targetNode: IAsyncDataTreeNode<TInput, T> | undefined, targetIndex: number | undefined, originalEvent: DragEvent, raw = true): boolean | IListDragOverReaction {
@@ -210,9 +206,7 @@ class AsyncDataTreeNodeListDragAndDrop<TInput, T> implements IListDragAndDrop<IA
 	}
 
 	onDragEnd(originalEvent: DragEvent): void {
-		if (this.dnd.onDragEnd) {
-			this.dnd.onDragEnd(originalEvent);
-		}
+		this.dnd.onDragEnd?.(originalEvent);
 	}
 }
 
@@ -1086,15 +1080,11 @@ class CompressibleAsyncDataTreeRenderer<TInput, T, TFilterData, TTemplateData> i
 	}
 
 	disposeElement(node: ITreeNode<IAsyncDataTreeNode<TInput, T>, TFilterData>, index: number, templateData: IDataTreeListTemplateData<TTemplateData>, height: number | undefined): void {
-		if (this.renderer.disposeElement) {
-			this.renderer.disposeElement(this.nodeMapper.map(node) as ITreeNode<T, TFilterData>, index, templateData.templateData, height);
-		}
+		this.renderer.disposeElement?.(this.nodeMapper.map(node) as ITreeNode<T, TFilterData>, index, templateData.templateData, height);
 	}
 
 	disposeCompressedElements(node: ITreeNode<ICompressedTreeNode<IAsyncDataTreeNode<TInput, T>>, TFilterData>, index: number, templateData: IDataTreeListTemplateData<TTemplateData>, height: number | undefined): void {
-		if (this.renderer.disposeCompressedElements) {
-			this.renderer.disposeCompressedElements(this.compressibleNodeMapperProvider().map(node) as ITreeNode<ICompressedTreeNode<T>, TFilterData>, index, templateData.templateData, height);
-		}
+		this.renderer.disposeCompressedElements?.(this.compressibleNodeMapperProvider().map(node) as ITreeNode<ICompressedTreeNode<T>, TFilterData>, index, templateData.templateData, height);
 	}
 
 	disposeTemplate(templateData: IDataTreeListTemplateData<TTemplateData>): void {

--- a/src/vs/base/browser/ui/tree/dataTree.ts
+++ b/src/vs/base/browser/ui/tree/dataTree.ts
@@ -140,9 +140,7 @@ export class DataTree<TInput, T, TFilterData = void> extends AbstractTree<T | nu
 				insertedElements.add(id);
 				this.nodesByIdentity.set(id, node);
 
-				if (outerOnDidCreateNode) {
-					outerOnDidCreateNode(node);
-				}
+				outerOnDidCreateNode?.(node);
 			};
 
 			onDidDeleteNode = (node: ITreeNode<T, TFilterData>) => {

--- a/src/vs/base/browser/ui/tree/indexTreeModel.ts
+++ b/src/vs/base/browser/ui/tree/indexTreeModel.ts
@@ -554,9 +554,7 @@ export class IndexTreeModel<T extends Exclude<any, undefined>, TFilterData = voi
 			node.renderNodeCount = renderNodeCount;
 		}
 
-		if (onDidCreateNode) {
-			onDidCreateNode(node);
-		}
+		onDidCreateNode?.(node);
 
 		return node;
 	}

--- a/src/vs/base/browser/ui/tree/objectTree.ts
+++ b/src/vs/base/browser/ui/tree/objectTree.ts
@@ -140,13 +140,9 @@ class CompressibleRenderer<T extends NonNullable<any>, TFilterData, TTemplateDat
 
 	disposeElement(node: ITreeNode<T, TFilterData>, index: number, templateData: CompressibleTemplateData<T, TFilterData, TTemplateData>, height: number | undefined): void {
 		if (templateData.compressedTreeNode) {
-			if (this.renderer.disposeCompressedElements) {
-				this.renderer.disposeCompressedElements(templateData.compressedTreeNode, index, templateData.data, height);
-			}
+			this.renderer.disposeCompressedElements?.(templateData.compressedTreeNode, index, templateData.data, height);
 		} else {
-			if (this.renderer.disposeElement) {
-				this.renderer.disposeElement(node, index, templateData.data, height);
-			}
+			this.renderer.disposeElement?.(node, index, templateData.data, height);
 		}
 	}
 

--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -354,9 +354,7 @@ export class Delayer<T> implements IDisposable {
 		this.cancelTimeout();
 
 		if (this.completionPromise) {
-			if (this.doReject) {
-				this.doReject(new CancellationError());
-			}
+			this.doReject?.(new CancellationError());
 			this.completionPromise = null;
 		}
 	}
@@ -885,9 +883,7 @@ export class RunOnceScheduler {
 	}
 
 	protected doRun(): void {
-		if (this.runner) {
-			this.runner();
-		}
+		this.runner?.();
 	}
 }
 
@@ -960,9 +956,7 @@ export class ProcessTimeRunOnceScheduler {
 		// time elapsed
 		clearInterval(this.intervalToken);
 		this.intervalToken = -1;
-		if (this.runner) {
-			this.runner();
-		}
+		this.runner?.();
 	}
 }
 
@@ -985,9 +979,7 @@ export class RunOnceWorker<T> extends RunOnceScheduler {
 		const units = this.units;
 		this.units = [];
 
-		if (this.runner) {
-			this.runner(units);
-		}
+		this.runner?.(units);
 	}
 
 	override dispose(): void {

--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -690,9 +690,7 @@ export class Emitter<T> {
 				}
 
 				const result = listener.subscription.set(() => {
-					if (removeMonitor) {
-						removeMonitor();
-					}
+					removeMonitor?.();
 					if (!this._disposed) {
 						removeListener();
 						if (this._options && this._options.onLastListenerRemove) {

--- a/src/vs/base/common/worker/simpleWorker.ts
+++ b/src/vs/base/common/worker/simpleWorker.ts
@@ -283,9 +283,7 @@ export class SimpleWorkerClient<W extends object, H extends object> extends Disp
 			(err: any) => {
 				// in Firefox, web workers fail lazily :(
 				// we will reject the proxy
-				if (lazyProxyReject) {
-					lazyProxyReject(err);
-				}
+				lazyProxyReject?.(err);
 			}
 		));
 

--- a/src/vs/base/parts/contextmenu/electron-sandbox/contextmenu.ts
+++ b/src/vs/base/parts/contextmenu/electron-sandbox/contextmenu.ts
@@ -15,9 +15,7 @@ export function popup(items: IContextMenuItem[], options?: IPopupOptions, onHide
 	const onClickChannel = `vscode:onContextMenu${contextMenuId}`;
 	const onClickChannelHandler = (event: unknown, itemId: number, context: IContextMenuEvent) => {
 		const item = processedItems[itemId];
-		if (item.click) {
-			item.click(context);
-		}
+		item.click?.(context);
 	};
 
 	ipcRenderer.once(onClickChannel, onClickChannelHandler);
@@ -28,9 +26,7 @@ export function popup(items: IContextMenuItem[], options?: IPopupOptions, onHide
 
 		ipcRenderer.removeListener(onClickChannel, onClickChannelHandler);
 
-		if (onHide) {
-			onHide();
-		}
+		onHide?.();
 	});
 
 	ipcRenderer.send(CONTEXT_MENU_CHANNEL, contextMenuId, items.map(item => createItem(item, processedItems)), onClickChannel, options);

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -707,9 +707,7 @@ export class ChannelClient implements IChannelClient, IDisposable {
 
 		const handler = this.handlers.get(response.id);
 
-		if (handler) {
-			handler(response);
-		}
+		handler?.(response);
 	}
 
 	@memoize

--- a/src/vs/base/parts/ipc/node/ipc.cp.ts
+++ b/src/vs/base/parts/ipc/node/ipc.cp.ts
@@ -26,9 +26,7 @@ export class Server<TContext extends string> extends IPCServer<TContext> {
 		super({
 			send: r => {
 				try {
-					if (process.send) {
-						process.send((<Buffer>r.buffer).toString('base64'));
-					}
+					process.send?.((<Buffer>r.buffer).toString('base64'));
 				} catch (e) { /* not much to do */ }
 			},
 			onMessage: Event.fromNodeEventEmitter(process, 'message', msg => VSBuffer.wrap(Buffer.from(msg, 'base64')))

--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1406,9 +1406,7 @@ export class QuickInputController extends Disposable {
 		return new Promise<R>((doResolve, reject) => {
 			let resolve = (result: R) => {
 				resolve = doResolve;
-				if (options.onKeyMods) {
-					options.onKeyMods(input.keyMods);
-				}
+				options.onKeyMods?.(input.keyMods);
 				doResolve(result);
 			};
 			if (token.isCancellationRequested) {

--- a/src/vs/base/parts/storage/node/storage.ts
+++ b/src/vs/base/parts/storage/node/storage.ts
@@ -440,14 +440,10 @@ class SQLiteStorageDatabaseLogger {
 	}
 
 	trace(msg: string): void {
-		if (this.logTrace) {
-			this.logTrace(msg);
-		}
+		this.logTrace?.(msg);
 	}
 
 	error(error: string | Error): void {
-		if (this.logError) {
-			this.logError(error);
-		}
+		this.logError?.(error);
 	}
 }

--- a/src/vs/base/test/common/troubleshooting.ts
+++ b/src/vs/base/test/common/troubleshooting.ts
@@ -47,13 +47,9 @@ export function endTrackingDisposables(): void {
 }
 
 export function beginLoggingFS(withStacks: boolean = false): void {
-	if ((<any>self).beginLoggingFS) {
-		(<any>self).beginLoggingFS(withStacks);
-	}
+	(<any>self).beginLoggingFS?.(withStacks);
 }
 
 export function endLoggingFS(): void {
-	if ((<any>self).endLoggingFS) {
-		(<any>self).endLoggingFS();
-	}
+	(<any>self).endLoggingFS?.();
 }

--- a/src/vs/editor/browser/view/viewUserInputEvents.ts
+++ b/src/vs/editor/browser/view/viewUserInputEvents.ts
@@ -33,69 +33,47 @@ export class ViewUserInputEvents {
 	}
 
 	public emitKeyDown(e: IKeyboardEvent): void {
-		if (this.onKeyDown) {
-			this.onKeyDown(e);
-		}
+		this.onKeyDown?.(e);
 	}
 
 	public emitKeyUp(e: IKeyboardEvent): void {
-		if (this.onKeyUp) {
-			this.onKeyUp(e);
-		}
+		this.onKeyUp?.(e);
 	}
 
 	public emitContextMenu(e: IEditorMouseEvent): void {
-		if (this.onContextMenu) {
-			this.onContextMenu(this._convertViewToModelMouseEvent(e));
-		}
+		this.onContextMenu?.(this._convertViewToModelMouseEvent(e));
 	}
 
 	public emitMouseMove(e: IEditorMouseEvent): void {
-		if (this.onMouseMove) {
-			this.onMouseMove(this._convertViewToModelMouseEvent(e));
-		}
+		this.onMouseMove?.(this._convertViewToModelMouseEvent(e));
 	}
 
 	public emitMouseLeave(e: IPartialEditorMouseEvent): void {
-		if (this.onMouseLeave) {
-			this.onMouseLeave(this._convertViewToModelMouseEvent(e));
-		}
+		this.onMouseLeave?.(this._convertViewToModelMouseEvent(e));
 	}
 
 	public emitMouseDown(e: IEditorMouseEvent): void {
-		if (this.onMouseDown) {
-			this.onMouseDown(this._convertViewToModelMouseEvent(e));
-		}
+		this.onMouseDown?.(this._convertViewToModelMouseEvent(e));
 	}
 
 	public emitMouseUp(e: IEditorMouseEvent): void {
-		if (this.onMouseUp) {
-			this.onMouseUp(this._convertViewToModelMouseEvent(e));
-		}
+		this.onMouseUp?.(this._convertViewToModelMouseEvent(e));
 	}
 
 	public emitMouseDrag(e: IEditorMouseEvent): void {
-		if (this.onMouseDrag) {
-			this.onMouseDrag(this._convertViewToModelMouseEvent(e));
-		}
+		this.onMouseDrag?.(this._convertViewToModelMouseEvent(e));
 	}
 
 	public emitMouseDrop(e: IPartialEditorMouseEvent): void {
-		if (this.onMouseDrop) {
-			this.onMouseDrop(this._convertViewToModelMouseEvent(e));
-		}
+		this.onMouseDrop?.(this._convertViewToModelMouseEvent(e));
 	}
 
 	public emitMouseDropCanceled(): void {
-		if (this.onMouseDropCanceled) {
-			this.onMouseDropCanceled();
-		}
+		this.onMouseDropCanceled?.();
 	}
 
 	public emitMouseWheel(e: IMouseWheelEvent): void {
-		if (this.onMouseWheel) {
-			this.onMouseWheel(e);
-		}
+		this.onMouseWheel?.(e);
 	}
 
 	private _convertViewToModelMouseEvent(e: IEditorMouseEvent): IEditorMouseEvent;

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -2136,9 +2136,7 @@ class CodeEditorWidgetFocusTracker extends Disposable {
 	}
 
 	public refreshState(): void {
-		if (this._domFocusTracker.refreshState) {
-			this._domFocusTracker.refreshState();
-		}
+		this._domFocusTracker.refreshState?.();
 	}
 }
 

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -1348,9 +1348,7 @@ export class SimpleButton extends Widget {
 				e.preventDefault();
 				return;
 			}
-			if (this._opts.onKeyDown) {
-				this._opts.onKeyDown(e);
-			}
+			this._opts.onKeyDown?.(e);
 		});
 	}
 

--- a/src/vs/editor/contrib/folding/browser/indentRangeProvider.ts
+++ b/src/vs/editor/contrib/folding/browser/indentRangeProvider.ts
@@ -74,9 +74,7 @@ export class RangesCollector {
 			}
 			return new FoldingRegions(startIndexes, endIndexes);
 		} else {
-			if (this._notifyTooManyRegions) {
-				this._notifyTooManyRegions(this._foldingRangesLimit);
-			}
+			this._notifyTooManyRegions?.(this._foldingRangesLimit);
 			let entries = 0;
 			let maxIndent = this._indentOccurrences.length;
 			for (let i = 0; i < this._indentOccurrences.length; i++) {

--- a/src/vs/editor/contrib/folding/browser/syntaxRangeProvider.ts
+++ b/src/vs/editor/contrib/folding/browser/syntaxRangeProvider.ts
@@ -121,9 +121,7 @@ export class RangesCollector {
 			}
 			return new FoldingRegions(startIndexes, endIndexes, this._types);
 		} else {
-			if (this._notifyTooManyRegions) {
-				this._notifyTooManyRegions(this._foldingRangesLimit);
-			}
+			this._notifyTooManyRegions?.(this._foldingRangesLimit);
 			let entries = 0;
 			let maxLevel = this._nestingLevelCounts.length;
 			for (let i = 0; i < this._nestingLevelCounts.length; i++) {

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
@@ -243,9 +243,7 @@ export class InlineCompletionsSession extends BaseGhostTextWidgetModel {
 				lastCompletionItem = currentCompletion.sourceInlineCompletion;
 
 				const provider = currentCompletion.sourceProvider;
-				if (provider.handleItemDidShow) {
-					provider.handleItemDidShow(currentCompletion.sourceInlineCompletions, lastCompletionItem);
-				}
+				provider.handleItemDidShow?.(currentCompletion.sourceInlineCompletions, lastCompletionItem);
 			}
 		}));
 

--- a/src/vs/editor/contrib/rename/browser/renameInputField.ts
+++ b/src/vs/editor/contrib/rename/browser/renameInputField.ts
@@ -146,15 +146,11 @@ export class RenameInputField implements IContentWidget {
 	private _currentCancelInput?: (focusEditor: boolean) => void;
 
 	acceptInput(wantsPreview: boolean): void {
-		if (this._currentAcceptInput) {
-			this._currentAcceptInput(wantsPreview);
-		}
+		this._currentAcceptInput?.(wantsPreview);
 	}
 
 	cancelInput(focusEditor: boolean): void {
-		if (this._currentCancelInput) {
-			this._currentCancelInput(focusEditor);
-		}
+		this._currentCancelInput?.(focusEditor);
 	}
 
 	getInput(where: IRange, value: string, selectionStart: number, selectionEnd: number, supportPreview: boolean, token: CancellationToken): Promise<RenameInputFieldResult | boolean> {

--- a/src/vs/editor/contrib/unicodeHighlighter/browser/bannerController.ts
+++ b/src/vs/editor/contrib/unicodeHighlighter/browser/bannerController.ts
@@ -39,9 +39,7 @@ export class BannerController extends Disposable {
 			...item,
 			onClose: () => {
 				this.hide();
-				if (item.onClose) {
-					item.onClose();
-				}
+				item.onClose?.();
 			}
 		});
 		this._editor.setBanner(this.banner.element, BANNER_ELEMENT_HEIGHT);

--- a/src/vs/platform/contextview/browser/contextMenuHandler.ts
+++ b/src/vs/platform/contextview/browser/contextMenuHandler.ts
@@ -129,9 +129,7 @@ export class ContextMenuHandler {
 			},
 
 			onHide: (didCancel?: boolean) => {
-				if (delegate.onHide) {
-					delegate.onHide(!!didCancel);
-				}
+				delegate.onHide?.(!!didCancel);
 
 				if (this.block) {
 					this.block.remove();

--- a/src/vs/platform/contextview/browser/contextMenuService.ts
+++ b/src/vs/platform/contextview/browser/contextMenuService.ts
@@ -47,9 +47,7 @@ export class ContextMenuService extends Disposable implements IContextMenuServic
 		this.contextMenuHandler.showContextMenu({
 			...delegate,
 			onHide: (didCancel) => {
-				if (delegate.onHide) {
-					delegate.onHide(didCancel);
-				}
+				delegate.onHide?.(didCancel);
 
 				this._onDidHideContextMenu.fire();
 			}

--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -816,9 +816,7 @@ export class Menubar {
 		const originalClick = options.click;
 		options.click = (item, window, event) => {
 			this.reportMenuActionTelemetry(commandId);
-			if (originalClick) {
-				originalClick(item, window, event);
-			}
+			originalClick?.(item, window, event);
 		};
 
 		return options;

--- a/src/vs/platform/remote/electron-sandbox/remoteAuthorityResolverService.ts
+++ b/src/vs/platform/remote/electron-sandbox/remoteAuthorityResolverService.ts
@@ -71,9 +71,7 @@ export class RemoteAuthorityResolverService extends Disposable implements IRemot
 		const key = uri.toString();
 		if (!this._canonicalURIRequests.has(key)) {
 			const request = new PendingPromise<URI, URI>(uri);
-			if (this._canonicalURIProvider) {
-				this._canonicalURIProvider(request.input).then((uri) => request.resolve(uri), (err) => request.reject(err));
-			}
+			this._canonicalURIProvider?.(request.input).then((uri) => request.resolve(uri), (err) => request.reject(err));
 			this._canonicalURIRequests.set(key, request);
 		}
 		return this._canonicalURIRequests.get(key)!.promise;

--- a/src/vs/workbench/api/browser/mainThreadSearch.ts
+++ b/src/vs/workbench/api/browser/mainThreadSearch.ts
@@ -94,9 +94,7 @@ class SearchOperation {
 			this.matches.set(match.resource.toString(), match);
 		}
 
-		if (this.progress) {
-			this.progress(match);
-		}
+		this.progress?.(match);
 	}
 }
 

--- a/src/vs/workbench/api/common/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/common/extHostQuickOpen.ts
@@ -136,9 +136,7 @@ export function createExtHostQuickOpen(mainContext: IMainContext, workspace: IEx
 		}
 
 		$onItemSelected(handle: number): void {
-			if (this._onDidSelectItem) {
-				this._onDidSelectItem(handle);
-			}
+			this._onDidSelectItem?.(handle);
 		}
 
 		// ---- input

--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -546,9 +546,7 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 	}
 
 	$handleTextSearchResult(result: IRawFileMatch2, requestId: number): void {
-		if (this._activeSearchCallbacks[requestId]) {
-			this._activeSearchCallbacks[requestId](result);
-		}
+		this._activeSearchCallbacks[requestId]?.(result);
 	}
 
 	saveAll(includeUntitled?: boolean): Promise<boolean> {

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -197,9 +197,7 @@ function _createExtHostProtocol(): Promise<IMessagePassingProtocol> {
 
 			// Now that we have managed to install a message listener, ask the other side to send us the socket
 			const req: IExtHostReadyMessage = { type: 'VSCODE_EXTHOST_IPC_READY' };
-			if (process.send) {
-				process.send(req);
-			}
+			process.send?.(req);
 		});
 
 	} else {

--- a/src/vs/workbench/api/test/common/testRPCProtocol.ts
+++ b/src/vs/workbench/api/test/common/testRPCProtocol.ts
@@ -57,9 +57,7 @@ export class TestRPCProtocol implements IExtHostContext, IExtHostRpcService {
 	private set _callCount(value: number) {
 		this._callCountValue = value;
 		if (this._callCountValue === 0) {
-			if (this._completeIdle) {
-				this._completeIdle();
-			}
+			this._completeIdle?.();
 			this._idle = undefined;
 		}
 	}

--- a/src/vs/workbench/browser/dnd.ts
+++ b/src/vs/workbench/browser/dnd.ts
@@ -609,9 +609,7 @@ export class CompositeDragAndDropObserver extends Disposable {
 					return;
 				}
 
-				if (callbacks.onDragLeave) {
-					callbacks.onDragLeave({ eventData: e, dragAndDropData: data! });
-				}
+				callbacks.onDragLeave?.({ eventData: e, dragAndDropData: data! });
 			},
 			onDrop: e => {
 				if (callbacks.onDrop) {

--- a/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane.ts
@@ -272,9 +272,7 @@ export class BulkEditPane extends ViewPane {
 	}
 
 	private _done(accept: boolean): void {
-		if (this._currentResolve) {
-			this._currentResolve(accept ? this._currentInput?.getWorkspaceEdit() : undefined);
-		}
+		this._currentResolve?.(accept ? this._currentInput?.getWorkspaceEdit() : undefined);
 		this._currentInput = undefined;
 		this._setState(State.Message);
 		this._sessionDisposables.clear();

--- a/src/vs/workbench/contrib/comments/browser/commentReply.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentReply.ts
@@ -250,9 +250,7 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 		}));
 
 		this._commentFormActions = new CommentFormActions(container, async (action: IAction) => {
-			if (this._actionRunDelegate) {
-				this._actionRunDelegate();
-			}
+			this._actionRunDelegate?.();
 
 			action.run({
 				thread: this._commentThread,

--- a/src/vs/workbench/contrib/debug/common/abstractDebugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/common/abstractDebugAdapter.ts
@@ -155,14 +155,10 @@ export abstract class AbstractDebugAdapter implements IDebugAdapter {
 
 			switch (message.type) {
 				case 'event':
-					if (this.eventCallback) {
-						this.eventCallback(<DebugProtocol.Event>message);
-					}
+					this.eventCallback?.(<DebugProtocol.Event>message);
 					break;
 				case 'request':
-					if (this.requestCallback) {
-						this.requestCallback(<DebugProtocol.Request>message);
-					}
+					this.requestCallback?.(<DebugProtocol.Request>message);
 					break;
 				case 'response': {
 					const response = <DebugProtocol.Response>message;

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1519,9 +1519,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 				this.progressService.withProgress({ location: ProgressLocation.Extensions }, () => new Promise(resolve => this._activityCallBack = resolve));
 			}
 		} else {
-			if (this._activityCallBack) {
-				this._activityCallBack();
-			}
+			this._activityCallBack?.();
 			this._activityCallBack = null;
 		}
 	}

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellToolbars.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellToolbars.ts
@@ -164,9 +164,7 @@ export class CellTitleToolbarPart extends CellPart {
 
 			if (deferredUpdate && !visible) {
 				this._register(disposableTimeout(() => {
-					if (deferredUpdate) {
-						deferredUpdate();
-					}
+					deferredUpdate?.();
 				}));
 
 				deferredUpdate = undefined;

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
@@ -405,9 +405,7 @@ export class NotebookEditorToolbar extends Disposable {
 
 			if (deferredUpdate && !visible) {
 				setTimeout(() => {
-					if (deferredUpdate) {
-						deferredUpdate();
-					}
+					deferredUpdate?.();
 				}, 0);
 				deferredUpdate = undefined;
 			}

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1166,9 +1166,7 @@ export class SettingArrayRenderer extends AbstractSettingRenderer implements ITr
 		common.toDispose.add(
 			listWidget.onDidChangeList(e => {
 				const newList = this.computeNewList(template, e);
-				if (template.onChange) {
-					template.onChange(newList);
-				}
+				template.onChange?.(newList);
 			})
 		);
 
@@ -1349,9 +1347,7 @@ abstract class AbstractSettingObjectRenderer extends AbstractSettingRenderer imp
 				template.objectDropdownWidget!.setValue(newItems);
 			}
 
-			if (template.onChange) {
-				template.onChange(newValue);
-			}
+			template.onChange?.(newValue);
 		}
 	}
 
@@ -1539,9 +1535,7 @@ abstract class AbstractSettingTextRenderer extends AbstractSettingRenderer imple
 		}));
 		common.toDispose.add(
 			inputBox.onDidChange(e => {
-				if (template.onChange) {
-					template.onChange(e);
-				}
+				template.onChange?.(e);
 			}));
 		common.toDispose.add(inputBox);
 		inputBox.inputElement.classList.add(AbstractSettingRenderer.CONTROL_CLASS);
@@ -1652,9 +1646,7 @@ export class SettingEnumRenderer extends AbstractSettingRenderer implements ITre
 
 		common.toDispose.add(
 			selectBox.onDidSelect(e => {
-				if (template.onChange) {
-					template.onChange(e.index);
-				}
+				template.onChange?.(e.index);
 			}));
 
 		const enumDescriptionElement = common.containerElement.insertBefore($('.setting-item-enumDescription'), common.descriptionElement.nextSibling);
@@ -1758,9 +1750,7 @@ export class SettingNumberRenderer extends AbstractSettingRenderer implements IT
 		}));
 		common.toDispose.add(
 			inputBox.onDidChange(e => {
-				if (template.onChange) {
-					template.onChange(e);
-				}
+				template.onChange?.(e);
 			}));
 		common.toDispose.add(inputBox);
 		inputBox.inputElement.classList.add(AbstractSettingRenderer.CONTROL_CLASS);

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -1077,9 +1077,7 @@ export class SearchModel extends Disposable {
 			progressEmitter.fire();
 			this.onSearchProgress(p);
 
-			if (onProgress) {
-				onProgress(p);
-			}
+			onProgress?.(p);
 		});
 
 		const dispose = () => tokenSource.dispose();

--- a/src/vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart.ts
+++ b/src/vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart.ts
@@ -291,9 +291,7 @@ export class WalkThroughPart extends EditorPane {
 					this.updateSizeClasses();
 					this.decorateContent();
 					this.contentDisposables.push(this.keybindingService.onDidUpdateKeybindings(() => this.decorateContent()));
-					if (input.onReady) {
-						input.onReady(this.content.firstElementChild as HTMLElement, store);
-					}
+					input.onReady?.(this.content.firstElementChild as HTMLElement, store);
 					this.scrollbar.scanDomNode();
 					this.loadTextEditorViewState(input);
 					this.updatedScrollPosition();
@@ -371,9 +369,7 @@ export class WalkThroughPart extends EditorPane {
 						this.multiCursorModifier();
 					}
 				}));
-				if (input.onReady) {
-					input.onReady(innerContent, store);
-				}
+				input.onReady?.(innerContent, store);
 				this.scrollbar.scanDomNode();
 				this.loadTextEditorViewState(input);
 				this.updatedScrollPosition();

--- a/src/vs/workbench/services/contextmenu/electron-sandbox/contextmenuService.ts
+++ b/src/vs/workbench/services/contextmenu/electron-sandbox/contextmenuService.ts
@@ -83,9 +83,7 @@ class NativeContextMenuService extends Disposable implements IContextMenuService
 		const actions = delegate.getActions();
 		if (actions.length) {
 			const onHide = once(() => {
-				if (delegate.onHide) {
-					delegate.onHide(false);
-				}
+				delegate.onHide?.(false);
 
 				dom.ModifierKeyEmitter.getInstance().resetKeyStatus();
 				this._onDidHideContextMenu.fire();

--- a/src/vs/workbench/services/extensions/common/rpcProtocol.ts
+++ b/src/vs/workbench/services/extensions/common/rpcProtocol.ts
@@ -406,9 +406,7 @@ export class RPCProtocol extends Disposable implements IRPCProtocol {
 			this._logger.logIncoming(msgLength, req, RequestInitiator.OtherSide, `receiveCancel`);
 		}
 		const callId = String(req);
-		if (this._cancelInvokedHandlers[callId]) {
-			this._cancelInvokedHandlers[callId]();
-		}
+		this._cancelInvokedHandlers[callId]?.();
 	}
 
 	private _receiveReply(msgLength: number, req: number, value: any): void {

--- a/src/vs/workbench/services/search/common/searchService.ts
+++ b/src/vs/workbench/services/search/common/searchService.ts
@@ -134,9 +134,7 @@ export class SearchService extends Disposable implements ISearchService {
 					return;
 				}
 
-				if (onProgress) {
-					onProgress(item);
-				}
+				onProgress?.(item);
 			};
 
 			const exists = await Promise.all(query.folderQueries.map(query => this.fileService.exists(query.folder)));

--- a/src/vs/workbench/services/textfile/common/textEditorService.ts
+++ b/src/vs/workbench/services/textfile/common/textEditorService.ts
@@ -227,9 +227,7 @@ export class TextEditorService extends Disposable implements ITextEditorService 
 		// Return early if already cached
 		let input = this.editorInputCache.get(resource);
 		if (input) {
-			if (cachedFn) {
-				cachedFn(input);
-			}
+			cachedFn?.(input);
 
 			return input;
 		}


### PR DESCRIPTION
Replaces code like:

```ts
if (foo.bar) {
    foo.bar(cat);
}
```

with the more concise:

```ts
foo.bar?.(cat)
```

I've been sometimes making this change while navigating around our codebase, but figured it would be better to handle most of the simple cases in a single pass

