### PR TITLE
Add `thisArg` to `DataTransfer.forEach`

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2473,9 +2473,9 @@ export class DataTransfer {
 		this.#items.set(mimeType, [value]);
 	}
 
-	forEach(callbackfn: (value: DataTransferItem, key: string) => void): void {
+	forEach(callbackfn: (value: DataTransferItem, key: string) => void, thisArg?: unknown): void {
 		for (const [mime, items] of this.#items) {
-			items.forEach(item => callbackfn(item, mime));
+			items.forEach(item => callbackfn(item, mime), thisArg);
 		}
 	}
 }

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -10110,9 +10110,11 @@ declare module 'vscode' {
 
 		/**
 		 * Allows iteration through the data transfer items.
+		 *
 		 * @param callbackfn Callback for iteration through the data transfer items.
+		 * @param thisArg The `this` context used when invoking the handler function.
 		 */
-		forEach(callbackfn: (value: DataTransferItem, key: string) => void): void;
+		forEach(callbackfn: (value: DataTransferItem, key: string) => void, thisArg?: unknown): void;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #151657

All of our other `forEach` functions take a `this` arg which is used when invoking the callback. This just aligns `DataTransfer.forEach`
