### PR TITLE
Revert "Correctly resolve the icon asap when defaultProfile is null"

### DIFF
--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -183,10 +183,9 @@ async function transformToTerminalProfiles(
 			validatedProfile.color = profile.color;
 			resultProfiles.push(validatedProfile);
 		} else {
-			logService?.debug('Terminal profile not validated', profileName, originalPaths);
+			logService?.trace('profile not validated', profileName, originalPaths);
 		}
 	}
-	logService?.debug('Validated terminal profiles', resultProfiles);
 	return resultProfiles;
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -385,6 +385,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		});
 		this._fixedRows = _shellLaunchConfig.attachPersistentProcess?.fixedDimensions?.rows;
 		this._fixedCols = _shellLaunchConfig.attachPersistentProcess?.fixedDimensions?.cols;
+		this._icon = _shellLaunchConfig.attachPersistentProcess?.icon || _shellLaunchConfig.icon;
 
 		// the resource is already set when it's been moved from another window
 		this._resource = resource || getTerminalUri(this._workspaceContextService.getWorkspace().id, this.instanceId, this.title);
@@ -430,12 +431,10 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		// Resolve just the icon ahead of time so that it shows up immediately in the tabs. This is
 		// disabled in remote because this needs to be sync and the OS may differ on the remote
 		// which would result in the wrong profile being selected and the wrong icon being
-		// permanently attached to the terminal. This also doesn't work when the default profile
-		// setting is set to null, that's handled after the process is created.
+		// permanently attached to the terminal.
 		if (!this.shellLaunchConfig.executable && !workbenchEnvironmentService.remoteAuthority) {
 			this._terminalProfileResolverService.resolveIcon(this._shellLaunchConfig, OS);
 		}
-		this._icon = _shellLaunchConfig.attachPersistentProcess?.icon || _shellLaunchConfig.icon;
 
 		// When a custom pty is used set the name immediately so it gets passed over to the exthost
 		// and is available when Pseudoterminal.open fires.
@@ -1555,7 +1554,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			this.xterm?.raw.resize(this._cols || Constants.DefaultCols, this._rows || Constants.DefaultRows);
 		}
 
-		const originalIcon = this.shellLaunchConfig.icon;
+		const hadIcon = !!this.shellLaunchConfig.icon;
+
 		await this._processManager.createProcess(this._shellLaunchConfig, this._cols || Constants.DefaultCols, this._rows || Constants.DefaultRows, this._accessibilityService.isScreenReaderOptimized()).then(error => {
 			if (error) {
 				this._onProcessExit(error, error.code === ShellIntegrationExitCode);
@@ -1564,8 +1564,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		if (this.xterm?.shellIntegration) {
 			this.capabilities.add(this.xterm?.shellIntegration.capabilities);
 		}
-		if (originalIcon !== this.shellLaunchConfig.icon || this.shellLaunchConfig.color) {
-			this._icon = this._shellLaunchConfig.attachPersistentProcess?.icon || this._shellLaunchConfig.icon;
+		if (!hadIcon && this.shellLaunchConfig.icon || this.shellLaunchConfig.color) {
 			this._onIconChanged.fire(this);
 		}
 	}


### PR DESCRIPTION
This reverts commit 2196474722524ea13028d6ab09f559c3b9c23ad4.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
