### PR TITLE
Wait for split to init before changing icon

### DIFF
--- a/test/smoke/src/areas/terminal/terminal-tabs.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-tabs.test.ts
@@ -55,6 +55,7 @@ export function setup() {
 		it('should update icon of the tab in the tabs list', async () => {
 			await terminal.createTerminal();
 			await terminal.runCommand(TerminalCommandId.Split);
+			await terminal.waitForTerminalText(lines => lines.some(line => line.length > 0), undefined, 1);
 			const icon = 'symbol-method';
 			await terminal.runCommandWithValue(TerminalCommandIdWithValue.ChangeIcon, icon);
 			await terminal.assertTerminalGroups([[{}, { icon }]]);


### PR DESCRIPTION
Fixes #151710

Theory is that the change icon command is run during initialization which triggers some race condition. We should wait for the split to be ready to make sure.