### PR TITLE
Adjust removable value, fixes #139175

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -153,9 +153,8 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 	);
 
 	return Object.keys(data).map(key => {
+		const defaultValue = elementDefaultValue[key];
 		if (isDefined(objectProperties) && key in objectProperties) {
-			const defaultValue = elementDefaultValue[key];
-
 			if (element.setting.allKeysAreBoolean) {
 				return {
 					key: {
@@ -188,6 +187,9 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 			} as IObjectDataItem;
 		}
 
+		// The row is removable if it doesn't have a default value assigned.
+		// Otherwise, it is not removable, but its value can be reset to the default.
+		const removable = !defaultValue;
 		const schema = patternsAndSchemas.find(({ pattern }) => pattern.test(key))?.schema;
 		if (schema) {
 			const valueEnumOptions = getEnumOptionsFromSchema(schema);
@@ -199,7 +201,7 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 					options: valueEnumOptions,
 				},
 				keyDescription: schema.description,
-				removable: true,
+				removable,
 			} as IObjectDataItem;
 		}
 
@@ -217,7 +219,7 @@ function getObjectDisplayValue(element: SettingsTreeSettingElement): IObjectData
 				options: additionalValueEnums,
 			},
 			keyDescription: typeof objectAdditionalProperties === 'object' ? objectAdditionalProperties.description : undefined,
-			removable: true,
+			removable,
 		} as IObjectDataItem;
 	}).filter(item => !isUndefinedOrNull(item.value.data));
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #139175 

It used to be that sometimes, default key-value pairs in object settings would display as removable even though they weren't.

Now, those settings are displayed as resettable but not removable, which is the correct behaviour.

![Example showing object setting key-value pair with default value being resettable but not removable](https://user-images.githubusercontent.com/7199958/173127977-12925e65-1615-4514-94ef-2117936530fd.PNG)

Also, yes, this PR implies that for workspace settings, object setting key-value pairs get reset to the default value rather than the user value in the Settings editor, which can be confusing to users. There is already a separate issue tracking that problem.