### PR TITLE
Add web command to request usb access

### DIFF
--- a/src/vs/workbench/browser/actions/workspaceCommands.ts
+++ b/src/vs/workbench/browser/actions/workspaceCommands.ts
@@ -24,6 +24,7 @@ import { IOpenEmptyWindowOptions, IOpenWindowOptions, IWindowOpenable } from 'vs
 import { IRecent, IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { ILocalizedString } from 'vs/platform/action/common/action';
+import { isWeb } from 'vs/base/common/platform';
 
 export const ADD_ROOT_FOLDER_COMMAND_ID = 'addRootFolder';
 export const ADD_ROOT_FOLDER_LABEL: ILocalizedString = { value: localize('addFolderToWorkspace', "Add Folder to Workspace..."), original: 'Add Folder to Workspace...' };
@@ -306,3 +307,9 @@ CommandsRegistry.registerCommand('_workbench.getRecentlyOpened', async function 
 
 	return workspacesService.getRecentlyOpened();
 });
+
+if (isWeb) {
+	CommandsRegistry.registerCommand('workbench.experimental.requestUsbDevice', async (_accessor: ServicesAccessor): Promise<void> => {
+		await (navigator as any).usb.requestDevice({ filters: [] });
+	});
+}

--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -130,6 +130,7 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 		const iframe = document.createElement('iframe');
 		iframe.setAttribute('class', 'web-worker-ext-host-iframe');
 		iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+		iframe.setAttribute('allow', 'usb');
 		iframe.setAttribute('aria-hidden', 'true');
 		iframe.style.display = 'none';
 


### PR DESCRIPTION
This experimental command triggers a request for usb devices. After the user selects these, extensions under the extension host can access them using `navigator.usb.getDevices(...)`

