### PR TITLE
explore allowing snippet text edits as workspace edit

### DIFF
--- a/src/vs/editor/browser/services/bulkEditService.ts
+++ b/src/vs/editor/browser/services/bulkEditService.ts
@@ -45,9 +45,9 @@ export class ResourceEdit {
 export class ResourceTextEdit extends ResourceEdit {
 	constructor(
 		readonly resource: URI,
-		readonly textEdit: TextEdit,
+		readonly textEdit: TextEdit & { insertAsSnippet?: boolean },
 		readonly versionId?: number,
-		metadata?: WorkspaceEditMetadata
+		metadata?: WorkspaceEditMetadata,
 	) {
 		super(metadata);
 	}

--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -6,8 +6,7 @@
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { EditorAction2, EditorCommand, registerEditorCommand, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
-import { IBulkEditService, ResourceTextEdit } from 'vs/editor/browser/services/bulkEditService';
+import { EditorCommand, registerEditorCommand, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
 import { ISelection } from 'vs/editor/common/core/selection';
@@ -21,9 +20,7 @@ import { Choice, SnippetParser } from 'vs/editor/contrib/snippet/browser/snippet
 import { showSimpleSuggestions } from 'vs/editor/contrib/suggest/browser/suggest';
 import { OvertypingCapturer } from 'vs/editor/contrib/suggest/browser/suggestOvertypingCapturer';
 import { localize } from 'vs/nls';
-import { registerAction2 } from 'vs/platform/actions/common/actions';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ILogService } from 'vs/platform/log/common/log';
 import { SnippetSession } from './snippetSession';
@@ -392,39 +389,3 @@ export function performSnippetEdits(editor: ICodeEditor, edits: ISnippetEdit[]) 
 	controller.insert(newText, { undoStopBefore: false });
 	return controller.isInSnippet();
 }
-
-
-registerAction2(class extends EditorAction2 {
-
-	constructor() {
-		super({
-			id: 'snippet',
-			title: 'Extract constant snippet',
-			f1: true
-		});
-	}
-
-	async runEditorCommand(accessor: ServicesAccessor, editor: ICodeEditor, ...args: any[]) {
-		if (!editor.hasModel()) {
-			return;
-		}
-		const bulkEdit = accessor.get(IBulkEditService);
-		await bulkEdit.apply([
-			new ResourceTextEdit(editor.getModel().uri, {
-				range: new Range(1, 1, 1, 1),
-				text: `const \${1:foo} = 123;`,
-				insertAsSnippet: true
-			}),
-			new ResourceTextEdit(editor.getModel().uri, {
-				range: new Range(3, 4, 3, 7),
-				text: `\${1:foo}`,
-				insertAsSnippet: true
-			}),
-			new ResourceTextEdit(editor.getModel().uri, {
-				range: new Range(3, 8, 3, 8),
-				text: `\$0`,
-				insertAsSnippet: true
-			}),
-		]);
-	}
-});

--- a/src/vs/editor/contrib/snippet/browser/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetSession.ts
@@ -49,7 +49,7 @@ export class OneSnippet {
 		this._placeholderGroupsIdx = -1;
 	}
 
-	public initialize(textChange: TextChange): void {
+	initialize(textChange: TextChange): void {
 		this._offset = textChange.newPosition;
 	}
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -856,7 +856,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				return extHostWorkspace.saveAll(includeUntitled);
 			},
 			applyEdit(edit: vscode.WorkspaceEdit): Thenable<boolean> {
-				return extHostBulkEdits.applyWorkspaceEdit(edit);
+				return extHostBulkEdits.applyWorkspaceEdit(edit, extension);
 			},
 			createFileSystemWatcher: (pattern, ignoreCreate, ignoreChange, ignoreDelete): vscode.FileSystemWatcher => {
 				return extHostFileSystemEvent.createFileSystemWatcher(extHostWorkspace, extension, pattern, ignoreCreate, ignoreChange, ignoreDelete);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1606,7 +1606,7 @@ export interface IWorkspaceFileEditDto {
 export interface IWorkspaceTextEditDto {
 	_type: WorkspaceEditType.Text;
 	resource: UriComponents;
-	edit: languages.TextEdit;
+	edit: languages.TextEdit & { insertAsSnippet?: boolean };
 	modelVersionId?: number;
 	metadata?: IWorkspaceEditEntryMetadataDto;
 }

--- a/src/vs/workbench/api/common/extHostBulkEdits.ts
+++ b/src/vs/workbench/api/common/extHostBulkEdits.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { MainContext, MainThreadBulkEditsShape } from 'vs/workbench/api/common/extHost.protocol';
 import { ExtHostDocumentsAndEditors } from 'vs/workbench/api/common/extHostDocumentsAndEditors';
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
 import { WorkspaceEdit } from 'vs/workbench/api/common/extHostTypeConverters';
+import { isProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
 import type * as vscode from 'vscode';
 
 export class ExtHostBulkEdits {
@@ -26,8 +28,9 @@ export class ExtHostBulkEdits {
 		};
 	}
 
-	applyWorkspaceEdit(edit: vscode.WorkspaceEdit): Promise<boolean> {
-		const dto = WorkspaceEdit.from(edit, this._versionInformationProvider);
+	applyWorkspaceEdit(edit: vscode.WorkspaceEdit, extension: IExtensionDescription): Promise<boolean> {
+		const allowSnippetTextEdit = isProposedApiEnabled(extension, 'snippetWorkspaceEdit');
+		const dto = WorkspaceEdit.from(edit, this._versionInformationProvider, allowSnippetTextEdit);
 		return this._proxy.$tryApplyWorkspaceEdit(dto);
 	}
 }

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -598,14 +598,21 @@ export namespace WorkspaceEdit {
 					});
 
 				} else if (entry._type === types.FileEditType.Text) {
+
 					// text edits
-					result.edits.push(<extHostProtocol.IWorkspaceTextEditDto>{
+					const dto = <extHostProtocol.IWorkspaceTextEditDto>{
 						_type: extHostProtocol.WorkspaceEditType.Text,
 						resource: entry.uri,
-						edit: { ...TextEdit.from(entry.edit), insertAsSnippet: allowSnippetTextEdit && entry.edit.newText2 instanceof types.SnippetString },
+						edit: TextEdit.from(entry.edit),
 						modelVersionId: !toCreate.has(entry.uri) ? versionInfo?.getTextDocumentVersion(entry.uri) : undefined,
 						metadata: entry.metadata
-					});
+					};
+					if (allowSnippetTextEdit && entry.edit.newText2 instanceof types.SnippetString) {
+						dto.edit.insertAsSnippet = true;
+						dto.edit.text = entry.edit.newText2.value;
+					}
+					result.edits.push(dto);
+
 				} else if (entry._type === types.FileEditType.Cell) {
 					result.edits.push(<extHostProtocol.IWorkspaceCellEditDto>{
 						_type: extHostProtocol.WorkspaceEditType.Cell,

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -569,7 +569,7 @@ export namespace WorkspaceEdit {
 		getNotebookDocumentVersion(uri: URI): number | undefined;
 	}
 
-	export function from(value: vscode.WorkspaceEdit, versionInfo?: IVersionInformationProvider): extHostProtocol.IWorkspaceEditDto {
+	export function from(value: vscode.WorkspaceEdit, versionInfo?: IVersionInformationProvider, allowSnippetTextEdit?: boolean): extHostProtocol.IWorkspaceEditDto {
 		const result: extHostProtocol.IWorkspaceEditDto = {
 			edits: []
 		};
@@ -602,7 +602,7 @@ export namespace WorkspaceEdit {
 					result.edits.push(<extHostProtocol.IWorkspaceTextEditDto>{
 						_type: extHostProtocol.WorkspaceEditType.Text,
 						resource: entry.uri,
-						edit: TextEdit.from(entry.edit),
+						edit: { ...TextEdit.from(entry.edit), insertAsSnippet: allowSnippetTextEdit && entry.edit.newText2 instanceof types.SnippetString },
 						modelVersionId: !toCreate.has(entry.uri) ? versionInfo?.getTextDocumentVersion(entry.uri) : undefined,
 						metadata: entry.metadata
 					});

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -549,6 +549,7 @@ export class TextEdit {
 
 	protected _range: Range;
 	protected _newText: string | null;
+	newText2?: string | SnippetString;
 	protected _newEol?: EndOfLine;
 
 	get range(): Range {

--- a/src/vs/workbench/api/test/browser/extHostBulkEdits.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostBulkEdits.test.ts
@@ -12,6 +12,7 @@ import { SingleProxyRPCProtocol, TestRPCProtocol } from 'vs/workbench/api/test/c
 import { NullLogService } from 'vs/platform/log/common/log';
 import { assertType } from 'vs/base/common/types';
 import { ExtHostBulkEdits } from 'vs/workbench/api/common/extHostBulkEdits';
+import { nullExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
 
 suite('ExtHostBulkEdits.applyWorkspaceEdit', () => {
 
@@ -46,7 +47,7 @@ suite('ExtHostBulkEdits.applyWorkspaceEdit', () => {
 	test('uses version id if document available', async () => {
 		const edit = new extHostTypes.WorkspaceEdit();
 		edit.replace(resource, new extHostTypes.Range(0, 0, 0, 0), 'hello');
-		await bulkEdits.applyWorkspaceEdit(edit);
+		await bulkEdits.applyWorkspaceEdit(edit, nullExtensionDescription);
 		assert.strictEqual(workspaceResourceEdits.edits.length, 1);
 		const [first] = workspaceResourceEdits.edits;
 		assertType(first._type === WorkspaceEditType.Text);
@@ -56,7 +57,7 @@ suite('ExtHostBulkEdits.applyWorkspaceEdit', () => {
 	test('does not use version id if document is not available', async () => {
 		const edit = new extHostTypes.WorkspaceEdit();
 		edit.replace(URI.parse('foo:bar2'), new extHostTypes.Range(0, 0, 0, 0), 'hello');
-		await bulkEdits.applyWorkspaceEdit(edit);
+		await bulkEdits.applyWorkspaceEdit(edit, nullExtensionDescription);
 		assert.strictEqual(workspaceResourceEdits.edits.length, 1);
 		const [first] = workspaceResourceEdits.edits;
 		assertType(first._type === WorkspaceEditType.Text);

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
@@ -19,6 +19,8 @@ import { ResourceMap } from 'vs/base/common/map';
 import { IModelService } from 'vs/editor/common/services/model';
 import { ResourceTextEdit } from 'vs/editor/browser/services/bulkEditService';
 import { CancellationToken } from 'vs/base/common/cancellation';
+import { SnippetParser } from 'vs/editor/contrib/snippet/browser/snippetParser';
+import { performSnippetEdits } from 'vs/editor/contrib/snippet/browser/snippetController2';
 
 type ValidationResult = { canApply: true } | { canApply: false; reason: URI };
 
@@ -27,7 +29,7 @@ class ModelEditTask implements IDisposable {
 	readonly model: ITextModel;
 
 	private _expectedModelVersionId: number | undefined;
-	protected _edits: ISingleEditOperation[];
+	protected _edits: (ISingleEditOperation & { insertAsSnippet?: boolean })[];
 	protected _newEol: EndOfLineSequence | undefined;
 
 	constructor(private readonly _modelReference: IReference<IResolvedTextEditorModel>) {
@@ -75,7 +77,7 @@ class ModelEditTask implements IDisposable {
 		} else {
 			range = Range.lift(textEdit.range);
 		}
-		this._edits.push(EditOperation.replaceMove(range, textEdit.text));
+		this._edits.push({ ...EditOperation.replaceMove(range, textEdit.text), insertAsSnippet: textEdit.insertAsSnippet });
 	}
 
 	validate(): ValidationResult {
@@ -91,7 +93,9 @@ class ModelEditTask implements IDisposable {
 
 	apply(): void {
 		if (this._edits.length > 0) {
-			this._edits = this._edits.sort((a, b) => Range.compareRangesUsingStarts(a.range, b.range));
+			this._edits = this._edits
+				.sort((a, b) => Range.compareRangesUsingStarts(a.range, b.range))
+				.map(edit => ({ ...edit, text: edit.text && SnippetParser.escape(edit.text) }));
 			this.model.pushEditOperations(null, this._edits, () => null);
 		}
 		if (this._newEol !== undefined) {
@@ -121,10 +125,19 @@ class EditorEditTask extends ModelEditTask {
 			super.apply();
 			return;
 		}
-
 		if (this._edits.length > 0) {
-			this._edits = this._edits.sort((a, b) => Range.compareRangesUsingStarts(a.range, b.range));
-			this._editor.executeEdits('', this._edits);
+
+			const insertAsSnippet = this._edits.every(edit => edit.insertAsSnippet);
+			if (insertAsSnippet) {
+				// todo@jrieken what ABOUT EOL?
+				performSnippetEdits(this._editor, this._edits.map(edit => ({ range: Range.lift(edit.range!), snippet: edit.text! })));
+
+			} else {
+				this._edits = this._edits
+					.sort((a, b) => Range.compareRangesUsingStarts(a.range, b.range))
+					.map(edit => ({ ...edit, text: edit.text && SnippetParser.escape(edit.text) }));
+				this._editor.executeEdits('', this._edits);
+			}
 		}
 		if (this._newEol !== undefined) {
 			if (this._editor.hasModel()) {
@@ -193,7 +206,7 @@ export class BulkTextEdits {
 				let makeMinimal = false;
 				if (this._editor?.getModel()?.uri.toString() === ref.object.textEditorModel.uri.toString()) {
 					task = new EditorEditTask(ref, this._editor);
-					makeMinimal = true;
+					makeMinimal = true && false;
 				} else {
 					task = new ModelEditTask(ref);
 				}

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
@@ -206,7 +206,7 @@ export class BulkTextEdits {
 				let makeMinimal = false;
 				if (this._editor?.getModel()?.uri.toString() === ref.object.textEditorModel.uri.toString()) {
 					task = new EditorEditTask(ref, this._editor);
-					makeMinimal = true && false;
+					makeMinimal = true && false; // todo@jrieken HACK
 				} else {
 					task = new ModelEditTask(ref);
 				}

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -51,6 +51,7 @@ export const allApiProposals = Object.freeze({
 	scmInput: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmInput.d.ts',
 	scmSelectedProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmSelectedProvider.d.ts',
 	scmValidation: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmValidation.d.ts',
+	snippetWorkspaceEdit: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.snippetWorkspaceEdit.d.ts',
 	taskPresentationGroup: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.taskPresentationGroup.d.ts',
 	telemetry: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.telemetry.d.ts',
 	terminalDataWriteEvent: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalDataWriteEvent.d.ts',

--- a/src/vscode-dts/vscode.proposed.snippetWorkspaceEdit.d.ts
+++ b/src/vscode-dts/vscode.proposed.snippetWorkspaceEdit.d.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/145374
+
+	export interface TextEdit {
+
+		// will be merged with newText
+		// will NOT be supported everywhere, only: `workspace.applyEdit`
+		newText2?: string | SnippetString;
+	}
+}


### PR DESCRIPTION
This PR explore allowing to use snippets inside workspace edits. The following restrictions apply

* only a single resource/editor can be put into snippet mode
* all snippet edits for an editor are understood as one snippet session
* a workspace edit can also change other files but for now the snippet-editor is snippet only