### PR TITLE
Allow symbol search with multiple words

### DIFF
--- a/src/vs/base/common/fuzzyScorer.ts
+++ b/src/vs/base/common/fuzzyScorer.ts
@@ -5,7 +5,7 @@
 
 import { CharCode } from './charCode.js';
 import { compareAnything } from './comparers.js';
-import { createMatches as createFuzzyMatches, fuzzyScore, IMatch, isUpper, matchesPrefix } from './filters.js';
+import { createMatches as createFuzzyMatches, fuzzyScore, IMatch, isUpper, matchesContiguousSubString, matchesPrefix } from './filters.js';
 import { hash } from './hash.js';
 import { sep } from './path.js';
 import { isLinux, isWindows } from './platform.js';
@@ -320,8 +320,12 @@ function doScoreFuzzy2Multiple(target: string, query: IPreparedQueryPiece[], pat
 }
 
 function doScoreFuzzy2Single(target: string, query: IPreparedQueryPiece, patternStart: number, wordStart: number): FuzzyScore2 {
-	const score = fuzzyScore(query.original, query.originalLowercase, patternStart, target, target.toLowerCase(), wordStart, { firstMatchCanBeWeak: true, boostFullMatch: true });
+
+	const score = fuzzyScore(query.expectContiguousMatch ? query.normalized : query.original, query.expectContiguousMatch ? query.normalizedLowercase : query.originalLowercase, patternStart, target, target.toLowerCase(), wordStart, { firstMatchCanBeWeak: true, boostFullMatch: true });
 	if (!score) {
+		return NO_SCORE2;
+	}
+	if (query.expectContiguousMatch && matchesContiguousSubString(query.normalized, target) === null) {
 		return NO_SCORE2;
 	}
 

--- a/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
@@ -146,6 +146,12 @@ export class SymbolsQuickAccessProvider extends PickerQuickAccessProvider<ISymbo
 					[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabelWithIcon, { ...query, values: undefined /* disable multi-query support */ }, 0, symbolLabelIconOffset);
 					if (typeof symbolScore === 'number') {
 						skipContainerQuery = true; // since we consumed the query, skip any container matching
+					} else {
+						// Try multi-query
+						[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabelWithIcon, query, 0, symbolLabelIconOffset);
+						if (typeof symbolScore === 'number') {
+							skipContainerQuery = true; // since we consumed the query, skip any container matching
+						}
 					}
 				}
 


### PR DESCRIPTION
This PR fixes #109548

To test, create a typescript file with this:
```typescript
function oneTwoThree() {}
```

They use "Go to Symbol" and search for `#one three`.
