### PR TITLE
TS/JS Auto save updated imports after some file has moved/renamed

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/updatePathsOnRename.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/updatePathsOnRename.ts
@@ -234,7 +234,7 @@ class UpdateImportsOnFileRenameHandler extends Disposable {
 		document: vscode.TextDocument,
 		oldFilePath: string,
 		newFilePath: string,
-	): Promise<boolean> {
+	): Promise<false | vscode.Uri[]> {
 		const response = await this.client.interruptGetErr(() => {
 			this.fileConfigurationManager.setGlobalConfigurationFromDocument(document, nulToken);
 			const args: Proto.GetEditsForFileRenameRequestArgs = {
@@ -248,7 +248,7 @@ class UpdateImportsOnFileRenameHandler extends Disposable {
 		}
 
 		typeConverters.WorkspaceEdit.withFileCodeEdits(edits, this.client, response.body);
-		return true;
+		return response.body.map(x => this.client.toResource(x.fileName));
 	}
 
 	private groupRenames(renames: Iterable<RenameAction>): Iterable<Iterable<RenameAction>> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #148901

This is a somewhat temporary fix since it just changes the behavior of the TS/JS extension, not the underlying mechanisms of workspace edits.
