### PR TITLE
stripComments: remove trailing comma

### DIFF
--- a/build/lib/i18n.js
+++ b/build/lib/i18n.js
@@ -295,9 +295,10 @@ function stripComments(content) {
     // Second group matches a single quoted string
     // Third group matches a multi line comment
     // Forth group matches a single line comment
-    const regexp = /("[^"\\]*(?:\\.[^"\\]*)*")|('[^'\\]*(?:\\.[^'\\]*)*')|(\/\*[^\/\*]*(?:(?:\*|\/)[^\/\*]*)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))/g;
-    const result = content.replace(regexp, (match, _m1, _m2, m3, m4) => {
-        // Only one of m1, m2, m3, m4 matches
+    // Fifth group matches a trailing comma
+    const regexp = /("[^"\\]*(?:\\.[^"\\]*)*")|('[^'\\]*(?:\\.[^'\\]*)*')|(\/\*[^\/\*]*(?:(?:\*|\/)[^\/\*]*)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))|(,\s*[}\]])/g;
+    const result = content.replace(regexp, (match, _m1, _m2, m3, m4, m5) => {
+        // Only one of m1, m2, m3, m4, m5 matches
         if (m3) {
             // A block comment. Replace with nothing
             return '';
@@ -312,6 +313,10 @@ function stripComments(content) {
             else {
                 return '';
             }
+        }
+        else if (m5) {
+            // Remove the trailing comma
+            return match.substring(1);
         }
         else {
             // We match a string

--- a/build/lib/i18n.ts
+++ b/build/lib/i18n.ts
@@ -412,9 +412,10 @@ function stripComments(content: string): string {
 	// Second group matches a single quoted string
 	// Third group matches a multi line comment
 	// Forth group matches a single line comment
-	const regexp = /("[^"\\]*(?:\\.[^"\\]*)*")|('[^'\\]*(?:\\.[^'\\]*)*')|(\/\*[^\/\*]*(?:(?:\*|\/)[^\/\*]*)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))/g;
-	const result = content.replace(regexp, (match, _m1: string, _m2: string, m3: string, m4: string) => {
-		// Only one of m1, m2, m3, m4 matches
+	// Fifth group matches a trailing comma
+	const regexp = /("[^"\\]*(?:\\.[^"\\]*)*")|('[^'\\]*(?:\\.[^'\\]*)*')|(\/\*[^\/\*]*(?:(?:\*|\/)[^\/\*]*)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))|(,\s*[}\]])/g;
+	const result = content.replace(regexp, (match, _m1: string, _m2: string, m3: string, m4: string, m5: string) => {
+		// Only one of m1, m2, m3, m4, m5 matches
 		if (m3) {
 			// A block comment. Replace with nothing
 			return '';
@@ -427,6 +428,9 @@ function stripComments(content: string): string {
 			} else {
 				return '';
 			}
+		} else if (m5) {
+			// Remove the trailing comma
+			return match.substring(1);
 		} else {
 			// We match a string
 			return match;

--- a/src/vs/base/common/stripComments.js
+++ b/src/vs/base/common/stripComments.js
@@ -13,7 +13,8 @@
 		// Second group matches a single quoted string
 		// Third group matches a multi line comment
 		// Forth group matches a single line comment
-		const regexp = /("[^"\\]*(?:\\.[^"\\]*)*")|('[^'\\]*(?:\\.[^'\\]*)*')|(\/\*[^\/\*]*(?:(?:\*|\/)[^\/\*]*)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))/g;
+		// Fifth group matches a trailing comma
+		const regexp = /("[^"\\]*(?:\\.[^"\\]*)*")|('[^'\\]*(?:\\.[^'\\]*)*')|(\/\*[^\/\*]*(?:(?:\*|\/)[^\/\*]*)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))|(,\s*[}\]])/g;
 
 		/**
 		 *
@@ -21,8 +22,8 @@
 		 * @returns {string}
 		 */
 		function stripComments(content) {
-			return content.replace(regexp, function (match, _m1, _m2, m3, m4) {
-				// Only one of m1, m2, m3, m4 matches
+			return content.replace(regexp, function (match, _m1, _m2, m3, m4, m5) {
+				// Only one of m1, m2, m3, m4, m5 matches
 				if (m3) {
 					// A block comment. Replace with nothing
 					return '';
@@ -36,6 +37,9 @@
 					else {
 						return '';
 					}
+				} else if (m5) {
+					// Remove the trailing comma
+					return match.substring(1);
 				} else {
 					// We match a string
 					return match;

--- a/src/vs/base/test/common/stripComments.test.ts
+++ b/src/vs/base/test/common/stripComments.test.ts
@@ -122,4 +122,26 @@ suite('Strip Comments', () => {
 		].join('\n');
 		assert.strictEqual(stripComments(content), expected);
 	});
+	test('Trailing comma in object', () => {
+		const content: string = [
+			"{",
+			`  "a": 10,`,
+			"}"
+		].join('\n');
+		const expected: string = [
+			"{",
+			`  "a": 10`,
+			"}"
+		].join('\n');
+		assert.strictEqual(stripComments(content), expected);
+	});
+	test('Trailing comma in array', () => {
+		const content: string = [
+			`[ "a", "b", "c", ]`
+		].join('\n');
+		const expected: string = [
+			`[ "a", "b", "c" ]`
+		].join('\n');
+		assert.strictEqual(stripComments(content), expected);
+	});
 });


### PR DESCRIPTION
For #151534

`stripComments` ro remove trailing commas if there are only whitespaces between comma and closing bracket/brace.

(That leaves the case where there's a comment after the trailing comma)