### PR TITLE
Engineering - standardize macOS support jobs

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin-sign.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-sign.yml
@@ -13,33 +13,65 @@ steps:
       KeyVaultName: vscode
       SecretsFilter: "ESRP-PKI,esrp-aad-username,esrp-aad-password"
 
+  - script: |
+      mkdir -p .build
+      node build/azure-pipelines/common/computeNodeModulesCacheKey.js x64 $ENABLE_TERRAPIN > .build/yarnlockhash
+    displayName: Prepare yarn cache flags
+
   - task: Cache@2
     inputs:
-      key: "buildNodeModules | $(Agent.OS) | $(VSCODE_ARCH) | build/yarn.lock"
-      path: build/node_modules
-      cacheHitVar: BUILD_NODE_MODULES_RESTORED
-    displayName: Restore build node_modules cache
+      key: "nodeModules | $(Agent.OS) | .build/yarnlockhash"
+      path: .build/node_modules_cache
+      cacheHitVar: NODE_MODULES_RESTORED
+    displayName: Restore node_modules cache
+
+  - script: |
+      set -e
+      tar -xzf .build/node_modules_cache/cache.tgz
+    displayName: Extract node_modules cache
+
+  - script: |
+      set -e
+      npm install -g node-gyp@latest
+      node-gyp --version
+    displayName: Update node-gyp
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
   - script: |
       set -e
       npx https://aka.ms/enablesecurefeed standAlone
     timeoutInMinutes: 5
     retryCountOnTaskFailure: 3
-    condition: and(succeeded(), eq(variables['ENABLE_TERRAPIN'], 'true'), ne(variables.BUILD_NODE_MODULES_RESTORED, 'true'))
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), eq(variables['ENABLE_TERRAPIN'], 'true'))
     displayName: Switch to Terrapin packages
 
   - script: |
       set -e
+      export npm_config_arch=$(VSCODE_ARCH)
+      export npm_config_node_gyp=$(which node-gyp)
+
       for i in {1..3}; do # try 3 times, for Terrapin
-        yarn --cwd build --frozen-lockfile --check-files && break
+        yarn --frozen-lockfile --check-files && break
         if [ $i -eq 3 ]; then
           echo "Yarn failed too many times" >&2
           exit 1
         fi
         echo "Yarn failed $i, trying again..."
       done
-    displayName: Install build dependencies
-    condition: and(succeeded(), ne(variables.BUILD_NODE_MODULES_RESTORED, 'true'))
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Install dependencies
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - script: |
+      set -e
+      node build/azure-pipelines/common/listNodeModules.js .build/node_modules_list.txt
+      mkdir -p .build/node_modules_cache
+      tar -czf .build/node_modules_cache/cache.tgz --files-from .build/node_modules_list.txt
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+    displayName: Create node_modules archive
 
   - download: current
     artifact: unsigned_vscode_client_darwin_$(VSCODE_ARCH)_archive

--- a/build/azure-pipelines/darwin/product-build-darwin-sign.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-sign.yml
@@ -11,7 +11,32 @@ steps:
     inputs:
       azureSubscription: "vscode-builds-subscription"
       KeyVaultName: vscode
-      SecretsFilter: "ESRP-PKI,esrp-aad-username,esrp-aad-password"
+      SecretsFilter: "github-distro-mixin-password,ESRP-PKI,esrp-aad-username,esrp-aad-password"
+
+  - script: |
+      set -e
+      cat << EOF > ~/.netrc
+      machine github.com
+      login vscode
+      password $(github-distro-mixin-password)
+      EOF
+
+      git config user.email "vscode@microsoft.com"
+      git config user.name "VSCode"
+    displayName: Prepare tooling
+
+  - script: |
+      set -e
+      git fetch https://github.com/$(VSCODE_MIXIN_REPO).git $VSCODE_DISTRO_REF
+      echo "##vso[task.setvariable variable=VSCODE_DISTRO_COMMIT;]$(git rev-parse FETCH_HEAD)"
+      git checkout FETCH_HEAD
+    condition: and(succeeded(), ne(variables.VSCODE_DISTRO_REF, ' '))
+    displayName: Checkout override commit
+
+  - script: |
+      set -e
+      git pull --no-rebase https://github.com/$(VSCODE_MIXIN_REPO).git $(node -p "require('./package.json').distro")
+    displayName: Merge distro
 
   - script: |
       mkdir -p .build

--- a/build/azure-pipelines/darwin/product-build-darwin-sign.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-sign.yml
@@ -29,6 +29,7 @@ steps:
       set -e
       tar -xzf .build/node_modules_cache/cache.tgz
     displayName: Extract node_modules cache
+    condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
 
   - script: |
       set -e

--- a/build/azure-pipelines/darwin/product-build-darwin-sign.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-sign.yml
@@ -1,7 +1,4 @@
 steps:
-  - checkout: self
-    fetchDepth: 1
-
   - task: NodeTool@0
     inputs:
       versionSpec: "16.x"

--- a/build/azure-pipelines/darwin/product-build-darwin-universal.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-universal.yml
@@ -54,6 +54,49 @@ steps:
 
   - script: |
       set -e
+      npm install -g node-gyp@latest
+      node-gyp --version
+    displayName: Update node-gyp
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - script: |
+      set -e
+      npx https://aka.ms/enablesecurefeed standAlone
+    timeoutInMinutes: 5
+    retryCountOnTaskFailure: 3
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), eq(variables['ENABLE_TERRAPIN'], 'true'))
+    displayName: Switch to Terrapin packages
+
+  - script: |
+      set -e
+      export npm_config_arch=$(VSCODE_ARCH)
+      export npm_config_node_gyp=$(which node-gyp)
+
+      for i in {1..3}; do # try 3 times, for Terrapin
+        yarn --frozen-lockfile --check-files && break
+        if [ $i -eq 3 ]; then
+          echo "Yarn failed too many times" >&2
+          exit 1
+        fi
+        echo "Yarn failed $i, trying again..."
+      done
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Install dependencies
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - script: |
+      set -e
+      node build/azure-pipelines/common/listNodeModules.js .build/node_modules_list.txt
+      mkdir -p .build/node_modules_cache
+      tar -czf .build/node_modules_cache/cache.tgz --files-from .build/node_modules_list.txt
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+    displayName: Create node_modules archive
+
+  - script: |
+      set -e
       node build/azure-pipelines/mixin
     displayName: Mix in quality
 

--- a/build/azure-pipelines/darwin/product-build-darwin-universal.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-universal.yml
@@ -51,6 +51,7 @@ steps:
       set -e
       tar -xzf .build/node_modules_cache/cache.tgz
     displayName: Extract node_modules cache
+    condition: and(succeeded(), eq(variables.NODE_MODULES_RESTORED, 'true'))
 
   - script: |
       set -e


### PR DESCRIPTION
Signing jobs and the job to create the universal package now use the "node_modules" cache. 