### PR TITLE
Skip encoding URI.toString in download service to avoid a malformed url

### DIFF
--- a/src/vs/platform/download/common/downloadService.ts
+++ b/src/vs/platform/download/common/downloadService.ts
@@ -25,7 +25,7 @@ export class DownloadService implements IDownloadService {
 			await this.fileService.copy(resource, target);
 			return;
 		}
-		const options = { type: 'GET', url: resource.toString() };
+		const options = { type: 'GET', url: resource.toString(true) };
 		const context = await this.requestService.request(options, cancellationToken);
 		if (context.res.statusCode === 200) {
 			await this.fileService.writeFile(target, context.stream);


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode-update-server/issues/95
