### PR TITLE
Revert "rename references-view publisher to vscode so that NLS works, fixes https://github.com/microsoft/vscode/issues/142168 (#151696)"

### DIFF
--- a/extensions/references-view/package.json
+++ b/extensions/references-view/package.json
@@ -4,7 +4,7 @@
   "description": "%description%",
   "icon": "media/icon.png",
   "version": "1.0.0",
-  "publisher": "vscode",
+  "publisher": "ms-vscode",
   "license": "MIT",
   "engines": {
     "vscode": "^1.67.0"


### PR DESCRIPTION
This reverts commit 66f8ae48b059b7591ed36787fd60803c4058487c.
