### PR TITLE
fix non-serializable type in editor view state

### DIFF
--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -583,9 +583,10 @@ export class ViewModel extends Disposable implements IViewModel {
 		const firstPosition = this.coordinatesConverter.convertViewPositionToModelPosition(new Position(firstViewLineNumber, this.getLineMinColumn(firstViewLineNumber)));
 		const firstPositionDeltaTop = this.viewLayout.getVerticalOffsetForLineNumber(firstViewLineNumber) - scrollTop;
 
+		// all properties must be serializable
 		return {
 			scrollLeft: compatViewState.scrollLeft,
-			firstPosition: firstPosition,
+			firstPosition: { ...firstPosition },
 			firstPositionDeltaTop: firstPositionDeltaTop
 		};
 	}

--- a/src/vs/workbench/test/browser/parts/editor/editor.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editor.test.ts
@@ -21,7 +21,6 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { SideBySideEditorInput } from 'vs/workbench/common/editor/sideBySideEditorInput';
 import { EditorResolution, IResourceEditorInput } from 'vs/platform/editor/common/editor';
 import { ICodeEditorViewState, IDiffEditorViewState } from 'vs/editor/common/editorCommon';
-import { Position } from 'vs/editor/common/core/position';
 
 suite('Workbench editor utils', () => {
 
@@ -375,7 +374,10 @@ suite('Workbench editor utils', () => {
 			cursorState: [],
 			viewState: {
 				scrollLeft: 0,
-				firstPosition: new Position(1, 1),
+				firstPosition: {
+					lineNumber: 1,
+					column: 1,
+				},
 				firstPositionDeltaTop: 1
 			}
 		};


### PR DESCRIPTION
This fixes using the type `Position` in the editor view state.

The value returned by `IViewModel.saveState()` is supposed to be serializable. The `firstPosition` property currently is assigned an object with type `Position`. However, strictly speaking, objects that are not plain JavaScript objects are not serializable. When deserialized, we will get a plain JavaScript object rather than a `Position` object.

To fix it, we just use a spread to create a new JavaScript object with the same properties as the Position object.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
