### PR TITLE
Clarify markdown validate settings

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -447,10 +447,10 @@
             "experimental"
           ]
         },
-        "markdown.experimental.validate.headerLinks.enabled": {
+        "markdown.experimental.validate.fragmentLinks.enabled": {
           "type": "string",
           "scope": "resource",
-          "markdownDescription": "%configuration.markdown.experimental.validate.headerLinks.enabled.description%",
+          "markdownDescription": "%configuration.markdown.experimental.validate.fragmentLinks.enabled.description%",
           "default": "warning",
           "enum": [
             "ignore",
@@ -466,6 +466,19 @@
           "scope": "resource",
           "markdownDescription": "%configuration.markdown.experimental.validate.fileLinks.enabled.description%",
           "default": "warning",
+          "enum": [
+            "ignore",
+            "warning",
+            "error"
+          ],
+          "tags": [
+            "experimental"
+          ]
+        },
+        "markdown.experimental.validate.fileLinks.markdownFragmentLinks": {
+          "type": "string",
+          "scope": "resource",
+          "markdownDescription": "%configuration.markdown.experimental.validate.fileLinks.markdownFragmentLinks.description%",
           "enum": [
             "ignore",
             "warning",

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -32,8 +32,9 @@
 	"configuration.markdown.editor.pasteLinks.enabled": "Enable/disable pasting files into a Markdown editor inserts Markdown links.",
 	"configuration.markdown.experimental.validate.enabled.description": "Enable/disable all error reporting in Markdown files.",
 	"configuration.markdown.experimental.validate.referenceLinks.enabled.description": "Validate reference links in Markdown files, e.g. `[link][ref]`.  Requires enabling `#markdown.experimental.validate.enabled#`.",
-	"configuration.markdown.experimental.validate.headerLinks.enabled.description": "Validate links to headers in Markdown files, e.g. `[link](#header)`. Requires enabling `#markdown.experimental.validate.enabled#`.",
+	"configuration.markdown.experimental.validate.fragmentLinks.enabled.description": "Validate fragment links to headers in the current Markdown file, e.g. `[link](#header)`. Requires enabling `#markdown.experimental.validate.enabled#`.",
 	"configuration.markdown.experimental.validate.fileLinks.enabled.description": "Validate links to other files in Markdown files, e.g. `[link](/path/to/file.md)`. This checks that the target files exists. Requires enabling `#markdown.experimental.validate.enabled#`.",
+	"configuration.markdown.experimental.validate.fileLinks.markdownFragmentLinks.description": "Validate the fragment part of links to headers in other files in Markdown files, e.g. `[link](/path/to/file.md#header)`. Inherits the setting value from `#markdown.experimental.validate.fragmentLinks.enabled#` by default.",
 	"configuration.markdown.experimental.validate.ignoreLinks.description": "Configure links that should not be validated. For example `/about` would not validate the link `[about](/about)`, while the glob `/assets/**/*.svg` would let you skip validation for any link to `.svg` files under the `assets` directory.",
 	"workspaceTrust": "Required for loading styles configured in the workspace."
 }


### PR DESCRIPTION
Fixes #150949

- Rename the `headerLinks` setting to `fragmentLinks`
- Add new `fileLink.markdownFragmentsLinks ` setting to validate the headers on file links to markdown files (inherits the default setting value from `fragmentLinks`)

