### PR TITLE
Adjust md external header link diagnostic range

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/diagnostics.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/diagnostics.ts
@@ -496,7 +496,8 @@ export class DiagnosticComputer {
 							for (const link of fragmentLinks) {
 								if (!toc.lookup(link.fragment) && !this.isIgnoredLink(options, link.source.pathText) && !this.isIgnoredLink(options, link.source.text)) {
 									const msg = localize('invalidLinkToHeaderInOtherFile', 'Header does not exist in file: {0}', link.fragment);
-									diagnostics.push(new LinkDoesNotExistDiagnostic(link.source.hrefRange, msg, fragmentErrorSeverity, link.source.text));
+									const range = link.source.fragmentRange?.with({ start: link.source.fragmentRange.start.translate(0, -1) }) ?? link.source.hrefRange;
+									diagnostics.push(new LinkDoesNotExistDiagnostic(range, msg, fragmentErrorSeverity, link.source.text));
 								}
 							}
 						}

--- a/extensions/markdown-language-features/src/test/diagnostic.test.ts
+++ b/extensions/markdown-language-features/src/test/diagnostic.test.ts
@@ -131,7 +131,7 @@ suite('markdown: Diagnostics', () => {
 
 		const diagnostics = await getComputedDiagnostics(doc1, new InMemoryWorkspaceMarkdownDocuments([doc1, doc2]));
 		assertDiagnosticsEqual(diagnostics, [
-			new vscode.Range(5, 6, 5, 35),
+			new vscode.Range(5, 14, 5, 35),
 		]);
 	});
 
@@ -236,7 +236,9 @@ suite('markdown: Diagnostics', () => {
 			// But we should be able to override the default
 			const manager = createDiagnosticsManager(contents, new MemoryDiagnosticConfiguration({ validateFragmentLinks: DiagnosticLevel.ignore, validateMarkdownFileLinkFragments: DiagnosticLevel.warning }));
 			const { diagnostics } = await manager.recomputeDiagnosticState(doc1, noopToken);
-			assert.deepStrictEqual(diagnostics.length, 1);
+			assertDiagnosticsEqual(diagnostics, [
+				new vscode.Range(1, 13, 1, 21),
+			]);
 		}
 	});
 


### PR DESCRIPTION
Fixes #151998

Makes errors for invalid headers on file links only cover the fragment range instead of the entire link range

