### PR TITLE
Switch to use objects instead of namespaces

### DIFF
--- a/src/vs/base/common/mime.ts
+++ b/src/vs/base/common/mime.ts
@@ -5,14 +5,14 @@
 
 import { extname } from 'vs/base/common/path';
 
-export namespace Mimes {
-	export const text = 'text/plain';
-	export const binary = 'application/octet-stream';
-	export const unknown = 'application/unknown';
-	export const markdown = 'text/markdown';
-	export const latex = 'text/latex';
-	export const uriList = 'text/uri-list';
-}
+export const Mimes = Object.freeze({
+	text: 'text/plain',
+	binary: 'application/octet-stream',
+	unknown: 'application/unknown',
+	markdown: 'text/markdown',
+	latex: 'text/latex',
+	uriList: 'text/uri-list',
+});
 
 interface MapExtToMediaMimes {
 	[index: string]: string;

--- a/src/vs/workbench/contrib/customEditor/common/extensionPoint.ts
+++ b/src/vs/workbench/contrib/customEditor/common/extensionPoint.ts
@@ -9,12 +9,12 @@ import { CustomEditorPriority, CustomEditorSelector } from 'vs/workbench/contrib
 import { ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
 import { languagesExtPoint } from 'vs/workbench/services/language/common/languageService';
 
-namespace Fields {
-	export const viewType = 'viewType';
-	export const displayName = 'displayName';
-	export const selector = 'selector';
-	export const priority = 'priority';
-}
+const Fields = Object.freeze({
+	viewType: 'viewType',
+	displayName: 'displayName',
+	selector: 'selector',
+	priority: 'priority',
+});
 
 export interface ICustomEditorsExtensionPoint {
 	readonly [Fields.viewType]: string;

--- a/src/vs/workbench/contrib/notebook/browser/extensionPoint.ts
+++ b/src/vs/workbench/contrib/notebook/browser/extensionPoint.ts
@@ -8,12 +8,12 @@ import * as nls from 'vs/nls';
 import { ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
 import { NotebookEditorPriority, NotebookRendererEntrypoint, RendererMessagingSpec } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 
-namespace NotebookEditorContribution {
-	export const type = 'type';
-	export const displayName = 'displayName';
-	export const selector = 'selector';
-	export const priority = 'priority';
-}
+const NotebookEditorContribution = Object.freeze({
+	type: 'type',
+	displayName: 'displayName',
+	selector: 'selector',
+	priority: 'priority',
+});
 
 export interface INotebookEditorContribution {
 	readonly [NotebookEditorContribution.type]: string;
@@ -22,16 +22,15 @@ export interface INotebookEditorContribution {
 	readonly [NotebookEditorContribution.priority]?: string;
 }
 
-namespace NotebookRendererContribution {
-
-	export const id = 'id';
-	export const displayName = 'displayName';
-	export const mimeTypes = 'mimeTypes';
-	export const entrypoint = 'entrypoint';
-	export const hardDependencies = 'dependencies';
-	export const optionalDependencies = 'optionalDependencies';
-	export const requiresMessaging = 'requiresMessaging';
-}
+const NotebookRendererContribution = Object.freeze({
+	id: 'id',
+	displayName: 'displayName',
+	mimeTypes: 'mimeTypes',
+	entrypoint: 'entrypoint',
+	hardDependencies: 'dependencies',
+	optionalDependencies: 'optionalDependencies',
+	requiresMessaging: 'requiresMessaging',
+});
 
 export interface INotebookRendererContribution {
 	readonly [NotebookRendererContribution.id]?: string;


### PR DESCRIPTION
Minor change to switch a few case away from using namespaces for storing sets of constants. Objects (or static classes) are prefered for this
