### PR TITLE
Pass collection as third paramter to `DataTransfer.forEach`

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2473,9 +2473,11 @@ export class DataTransfer {
 		this.#items.set(mimeType, [value]);
 	}
 
-	forEach(callbackfn: (value: DataTransferItem, key: string) => void, thisArg?: unknown): void {
+	forEach(callbackfn: (value: DataTransferItem, key: string, dataTransfer: DataTransfer) => void, thisArg?: unknown): void {
 		for (const [mime, items] of this.#items) {
-			items.forEach(item => callbackfn(item, mime), thisArg);
+			for (const item of items) {
+				callbackfn.call(thisArg, item, mime, this);
+			}
 		}
 	}
 }

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -10114,7 +10114,7 @@ declare module 'vscode' {
 		 * @param callbackfn Callback for iteration through the data transfer items.
 		 * @param thisArg The `this` context used when invoking the handler function.
 		 */
-		forEach(callbackfn: (value: DataTransferItem, key: string) => void, thisArg?: any): void;
+		forEach(callbackfn: (value: DataTransferItem, key: string, dataTransfer: DataTransfer) => void, thisArg?: any): void;
 	}
 
 	/**


### PR DESCRIPTION
For #151657

This aligns the signature with our other `forEach` functions in `vscode.d.ts`

Also fixes `callbackfn` not actually using `thisArg`

