### PR TITLE
Check edit session schema version before applying it

### DIFF
--- a/src/vs/workbench/contrib/sessionSync/browser/sessionSync.contribution.ts
+++ b/src/vs/workbench/contrib/sessionSync/browser/sessionSync.contribution.ts
@@ -10,7 +10,7 @@ import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { localize } from 'vs/nls';
-import { ISessionSyncWorkbenchService, Change, ChangeType, Folder, EditSession, FileType, EDIT_SESSION_SYNC_TITLE } from 'vs/workbench/services/sessionSync/common/sessionSync';
+import { ISessionSyncWorkbenchService, Change, ChangeType, Folder, EditSession, FileType, EDIT_SESSION_SYNC_TITLE, EditSessionSchemaVersion } from 'vs/workbench/services/sessionSync/common/sessionSync';
 import { ISCMRepository, ISCMService } from 'vs/workbench/contrib/scm/common/scm';
 import { IFileService } from 'vs/platform/files/common/files';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
@@ -26,6 +26,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { ILogService } from 'vs/platform/log/common/log';
+import { IProductService } from 'vs/platform/product/common/productService';
 
 registerSingleton(ISessionSyncWorkbenchService, SessionSyncWorkbenchService);
 
@@ -51,6 +52,7 @@ export class SessionSyncContribution extends Disposable implements IWorkbenchCon
 		@INotificationService private readonly notificationService: INotificationService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@ILogService private readonly logService: ILogService,
+		@IProductService private readonly productService: IProductService,
 		@IConfigurationService private configurationService: IConfigurationService,
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
 	) {
@@ -123,6 +125,11 @@ export class SessionSyncContribution extends Disposable implements IWorkbenchCon
 	async applyEditSession() {
 		const editSession = await this.sessionSyncWorkbenchService.read();
 		if (!editSession) {
+			return;
+		}
+
+		if (editSession.version > EditSessionSchemaVersion) {
+			this.notificationService.error(localize('client too old', "Please upgrade to a newer version of {0} to apply this edit session.", this.productService.nameLong));
 			return;
 		}
 

--- a/src/vs/workbench/services/sessionSync/common/sessionSync.ts
+++ b/src/vs/workbench/services/sessionSync/common/sessionSync.ts
@@ -46,7 +46,9 @@ export interface Folder {
 	workingChanges: Change[];
 }
 
+export const EditSessionSchemaVersion = 1;
+
 export interface EditSession {
-	version: 1;
+	version: number;
 	folders: Folder[];
 }


### PR DESCRIPTION
Re: https://github.com/microsoft/vscode/issues/141293

If the client doesn't know how to handle the edit session's schema version number, we should inform the user that we can't apply it and bail out.