### PR TITLE
Split markdown linkComputer from linkProvider

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/pathCompletions.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/pathCompletions.ts
@@ -9,7 +9,7 @@ import { MarkdownEngine } from '../markdownEngine';
 import { TableOfContents } from '../tableOfContents';
 import { resolveUriToMarkdownFile } from '../util/openDocumentLink';
 import { SkinnyTextDocument } from '../workspaceContents';
-import { MdLinkProvider } from './documentLinkProvider';
+import { MdLinkComputer } from './documentLinkProvider';
 
 enum CompletionContextKind {
 	/** `[...](|)` */
@@ -81,14 +81,14 @@ export class MdPathCompletionProvider implements vscode.CompletionItemProvider {
 	public static register(
 		selector: vscode.DocumentSelector,
 		engine: MarkdownEngine,
-		linkProvider: MdLinkProvider,
+		linkComputer: MdLinkComputer,
 	): vscode.Disposable {
-		return vscode.languages.registerCompletionItemProvider(selector, new MdPathCompletionProvider(engine, linkProvider), '.', '/', '#');
+		return vscode.languages.registerCompletionItemProvider(selector, new MdPathCompletionProvider(engine, linkComputer), '.', '/', '#');
 	}
 
 	constructor(
 		private readonly engine: MarkdownEngine,
-		private readonly linkProvider: MdLinkProvider,
+		private readonly linkComputer: MdLinkComputer,
 	) { }
 
 	public async provideCompletionItems(document: SkinnyTextDocument, position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext): Promise<vscode.CompletionItem[]> {
@@ -240,7 +240,7 @@ export class MdPathCompletionProvider implements vscode.CompletionItemProvider {
 		const insertionRange = new vscode.Range(context.linkTextStartPosition, position);
 		const replacementRange = new vscode.Range(insertionRange.start, position.translate({ characterDelta: context.linkSuffix.length }));
 
-		const definitions = await this.linkProvider.getLinkDefinitions(document);
+		const definitions = await this.linkComputer.getLinkDefinitions(document);
 		for (const def of definitions) {
 			yield {
 				kind: vscode.CompletionItemKind.Reference,

--- a/extensions/markdown-language-features/src/languageFeatures/references.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/references.ts
@@ -10,7 +10,7 @@ import { TableOfContents, TocEntry } from '../tableOfContents';
 import { noopToken } from '../util/cancellation';
 import { Disposable } from '../util/dispose';
 import { MdWorkspaceContents, SkinnyTextDocument } from '../workspaceContents';
-import { InternalHref, MdLink, MdLinkProvider } from './documentLinkProvider';
+import { InternalHref, MdLink, MdLinkComputer } from './documentLinkProvider';
 import { MdWorkspaceCache } from './workspaceCache';
 
 
@@ -64,14 +64,14 @@ export class MdReferencesProvider extends Disposable implements vscode.Reference
 	private readonly _linkCache: MdWorkspaceCache<readonly MdLink[]>;
 
 	public constructor(
-		private readonly linkProvider: MdLinkProvider,
+		private readonly linkComputer: MdLinkComputer,
 		private readonly workspaceContents: MdWorkspaceContents,
 		private readonly engine: MarkdownEngine,
 		private readonly slugifier: Slugifier,
 	) {
 		super();
 
-		this._linkCache = this._register(new MdWorkspaceCache(workspaceContents, doc => linkProvider.getAllLinks(doc, noopToken)));
+		this._linkCache = this._register(new MdWorkspaceCache(workspaceContents, doc => linkComputer.getAllLinks(doc, noopToken)));
 	}
 
 	async provideReferences(document: SkinnyTextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken): Promise<vscode.Location[] | undefined> {
@@ -129,7 +129,7 @@ export class MdReferencesProvider extends Disposable implements vscode.Reference
 	}
 
 	private async getReferencesToLinkAtPosition(document: SkinnyTextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<MdReference[]> {
-		const docLinks = await this.linkProvider.getAllLinks(document, token);
+		const docLinks = await this.linkComputer.getAllLinks(document, token);
 
 		for (const link of docLinks) {
 			if (link.kind === 'definition') {

--- a/extensions/markdown-language-features/src/test/definitionProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/definitionProvider.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
 import { MdDefinitionProvider } from '../languageFeatures/definitionProvider';
-import { MdLinkProvider } from '../languageFeatures/documentLinkProvider';
+import { MdLinkComputer } from '../languageFeatures/documentLinkProvider';
 import { MdReferencesProvider } from '../languageFeatures/references';
 import { githubSlugifier } from '../slugify';
 import { noopToken } from '../util/cancellation';
@@ -20,8 +20,8 @@ import { joinLines, workspacePath } from './util';
 
 function getDefinition(doc: InMemoryDocument, pos: vscode.Position, workspaceContents: MdWorkspaceContents) {
 	const engine = createNewMarkdownEngine();
-	const linkProvider = new MdLinkProvider(engine);
-	const referencesProvider = new MdReferencesProvider(linkProvider, workspaceContents, engine, githubSlugifier);
+	const linkComputer = new MdLinkComputer(engine);
+	const referencesProvider = new MdReferencesProvider(linkComputer, workspaceContents, engine, githubSlugifier);
 	const provider = new MdDefinitionProvider(referencesProvider);
 	return provider.provideDefinition(doc, pos, noopToken);
 }

--- a/extensions/markdown-language-features/src/test/diagnostic.test.ts
+++ b/extensions/markdown-language-features/src/test/diagnostic.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
 import { DiagnosticComputer, DiagnosticConfiguration, DiagnosticLevel, DiagnosticManager, DiagnosticOptions } from '../languageFeatures/diagnostics';
-import { MdLinkProvider } from '../languageFeatures/documentLinkProvider';
+import { MdLinkComputer } from '../languageFeatures/documentLinkProvider';
 import { noopToken } from '../util/cancellation';
 import { InMemoryDocument } from '../util/inMemoryDocument';
 import { MdWorkspaceContents } from '../workspaceContents';
@@ -18,8 +18,8 @@ import { assertRangeEqual, joinLines, workspacePath } from './util';
 
 async function getComputedDiagnostics(doc: InMemoryDocument, workspaceContents: MdWorkspaceContents): Promise<vscode.Diagnostic[]> {
 	const engine = createNewMarkdownEngine();
-	const linkProvider = new MdLinkProvider(engine);
-	const computer = new DiagnosticComputer(engine, workspaceContents, linkProvider);
+	const linkComputer = new MdLinkComputer(engine);
+	const computer = new DiagnosticComputer(engine, workspaceContents, linkComputer);
 	return (
 		await computer.getDiagnostics(doc, {
 			enabled: true,
@@ -34,8 +34,8 @@ async function getComputedDiagnostics(doc: InMemoryDocument, workspaceContents: 
 
 function createDiagnosticsManager(workspaceContents: MdWorkspaceContents, configuration = new MemoryDiagnosticConfiguration({})) {
 	const engine = createNewMarkdownEngine();
-	const linkProvider = new MdLinkProvider(engine);
-	return new DiagnosticManager(new DiagnosticComputer(engine, workspaceContents, linkProvider), configuration);
+	const linkComputer = new MdLinkComputer(engine);
+	return new DiagnosticManager(new DiagnosticComputer(engine, workspaceContents, linkComputer), configuration);
 }
 
 function assertDiagnosticsEqual(actual: readonly vscode.Diagnostic[], expectedRanges: readonly vscode.Range[]) {

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
-import { MdLinkProvider } from '../languageFeatures/documentLinkProvider';
+import { MdLinkComputer, MdLinkProvider } from '../languageFeatures/documentLinkProvider';
 import { noopToken } from '../util/cancellation';
 import { InMemoryDocument } from '../util/inMemoryDocument';
 import { createNewMarkdownEngine } from './engine';
@@ -17,7 +17,8 @@ const testFile = vscode.Uri.joinPath(vscode.workspace.workspaceFolders![0].uri, 
 
 function getLinksForFile(fileContents: string) {
 	const doc = new InMemoryDocument(testFile, fileContents);
-	const provider = new MdLinkProvider(createNewMarkdownEngine());
+	const linkComputer = new MdLinkComputer(createNewMarkdownEngine());
+	const provider = new MdLinkProvider(linkComputer);
 	return provider.provideDocumentLinks(doc, noopToken);
 }
 

--- a/extensions/markdown-language-features/src/test/fileReferences.test.ts
+++ b/extensions/markdown-language-features/src/test/fileReferences.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
-import { MdLinkProvider } from '../languageFeatures/documentLinkProvider';
+import { MdLinkComputer } from '../languageFeatures/documentLinkProvider';
 import { MdReference, MdReferencesProvider } from '../languageFeatures/references';
 import { githubSlugifier } from '../slugify';
 import { noopToken } from '../util/cancellation';
@@ -19,8 +19,8 @@ import { joinLines, workspacePath } from './util';
 
 function getFileReferences(resource: vscode.Uri, workspaceContents: MdWorkspaceContents) {
 	const engine = createNewMarkdownEngine();
-	const linkProvider = new MdLinkProvider(engine);
-	const provider = new MdReferencesProvider(linkProvider, workspaceContents, engine, githubSlugifier);
+	const linkComputer = new MdLinkComputer(engine);
+	const provider = new MdReferencesProvider(linkComputer, workspaceContents, engine, githubSlugifier);
 	return provider.getAllReferencesToFile(resource, noopToken);
 }
 

--- a/extensions/markdown-language-features/src/test/pathCompletion.test.ts
+++ b/extensions/markdown-language-features/src/test/pathCompletion.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
-import { MdLinkProvider } from '../languageFeatures/documentLinkProvider';
+import { MdLinkComputer } from '../languageFeatures/documentLinkProvider';
 import { MdPathCompletionProvider } from '../languageFeatures/pathCompletions';
 import { noopToken } from '../util/cancellation';
 import { InMemoryDocument } from '../util/inMemoryDocument';
@@ -17,8 +17,8 @@ import { CURSOR, getCursorPositions, joinLines, workspacePath } from './util';
 function getCompletionsAtCursor(resource: vscode.Uri, fileContents: string) {
 	const doc = new InMemoryDocument(resource, fileContents);
 	const engine = createNewMarkdownEngine();
-	const linkProvider = new MdLinkProvider(engine);
-	const provider = new MdPathCompletionProvider(engine, linkProvider);
+	const linkComputer = new MdLinkComputer(engine);
+	const provider = new MdPathCompletionProvider(engine, linkComputer);
 	const cursorPositions = getCursorPositions(fileContents, doc);
 	return provider.provideCompletionItems(doc, cursorPositions[0], noopToken, {
 		triggerCharacter: undefined,

--- a/extensions/markdown-language-features/src/test/references.test.ts
+++ b/extensions/markdown-language-features/src/test/references.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
-import { MdLinkProvider } from '../languageFeatures/documentLinkProvider';
+import { MdLinkComputer } from '../languageFeatures/documentLinkProvider';
 import { MdReferencesProvider } from '../languageFeatures/references';
 import { githubSlugifier } from '../slugify';
 import { noopToken } from '../util/cancellation';
@@ -19,8 +19,8 @@ import { joinLines, workspacePath } from './util';
 
 function getReferences(doc: InMemoryDocument, pos: vscode.Position, workspaceContents: MdWorkspaceContents) {
 	const engine = createNewMarkdownEngine();
-	const linkProvider = new MdLinkProvider(engine);
-	const provider = new MdReferencesProvider(linkProvider, workspaceContents, engine, githubSlugifier);
+	const linkComputer = new MdLinkComputer(engine);
+	const provider = new MdReferencesProvider(linkComputer, workspaceContents, engine, githubSlugifier);
 	return provider.provideReferences(doc, pos, { includeDeclaration: true }, noopToken);
 }
 

--- a/extensions/markdown-language-features/src/test/rename.test.ts
+++ b/extensions/markdown-language-features/src/test/rename.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
-import { MdLinkProvider } from '../languageFeatures/documentLinkProvider';
+import { MdLinkComputer } from '../languageFeatures/documentLinkProvider';
 import { MdReferencesProvider } from '../languageFeatures/references';
 import { MdRenameProvider, MdWorkspaceEdit } from '../languageFeatures/rename';
 import { githubSlugifier } from '../slugify';
@@ -23,8 +23,8 @@ import { assertRangeEqual, joinLines, workspacePath } from './util';
  */
 function prepareRename(doc: InMemoryDocument, pos: vscode.Position, workspaceContents: MdWorkspaceContents): Promise<undefined | { readonly range: vscode.Range; readonly placeholder: string }> {
 	const engine = createNewMarkdownEngine();
-	const linkProvider = new MdLinkProvider(engine);
-	const referencesProvider = new MdReferencesProvider(linkProvider, workspaceContents, engine, githubSlugifier);
+	const linkComputer = new MdLinkComputer(engine);
+	const referencesProvider = new MdReferencesProvider(linkComputer, workspaceContents, engine, githubSlugifier);
 	const renameProvider = new MdRenameProvider(referencesProvider, workspaceContents, githubSlugifier);
 	return renameProvider.prepareRename(doc, pos, noopToken);
 }
@@ -34,8 +34,8 @@ function prepareRename(doc: InMemoryDocument, pos: vscode.Position, workspaceCon
  */
 function getRenameEdits(doc: InMemoryDocument, pos: vscode.Position, newName: string, workspaceContents: MdWorkspaceContents): Promise<MdWorkspaceEdit | undefined> {
 	const engine = createNewMarkdownEngine();
-	const linkProvider = new MdLinkProvider(engine);
-	const referencesProvider = new MdReferencesProvider(linkProvider, workspaceContents, engine, githubSlugifier);
+	const linkComputer = new MdLinkComputer(engine);
+	const referencesProvider = new MdReferencesProvider(linkComputer, workspaceContents, engine, githubSlugifier);
 	const renameProvider = new MdRenameProvider(referencesProvider, workspaceContents, githubSlugifier);
 	return renameProvider.provideRenameEditsImpl(doc, pos, newName, noopToken);
 }


### PR DESCRIPTION
Instead of passing around a full `vscode.DocumentLinkProvider`, we should pass just the more minimal interface that consumers need

