### PR TITLE
Deprecate collections.forEach

### DIFF
--- a/src/vs/base/common/collections.ts
+++ b/src/vs/base/common/collections.ts
@@ -33,18 +33,15 @@ export function values<T>(from: IStringDictionary<T> | INumberDictionary<T>): T[
 }
 
 /**
- * Iterates over each entry in the provided dictionary. The iterator allows
- * to remove elements and will stop when the callback returns {{false}}.
+ * Iterates over each entry in the provided dictionary. The iterator will stop when the callback returns `false`.
+ *
+ * @deprecated Use `Object.entries(x)` with a `for...of` loop.
  */
-export function forEach<T>(from: IStringDictionary<T> | INumberDictionary<T>, callback: (entry: { key: any; value: T }, remove: () => void) => any): void {
-	for (const key in from) {
-		if (hasOwnProperty.call(from, key)) {
-			const result = callback({ key: key, value: (from as any)[key] }, function () {
-				delete (from as any)[key];
-			});
-			if (result === false) {
-				return;
-			}
+export function forEach<T>(from: IStringDictionary<T> | INumberDictionary<T>, callback: (entry: { key: any; value: T }) => any): void {
+	for (const [key, value] of Object.entries(from)) {
+		const result = callback({ key, value });
+		if (result === false) {
+			return;
 		}
 	}
 }

--- a/src/vs/base/test/common/collections.test.ts
+++ b/src/vs/base/test/common/collections.test.ts
@@ -24,9 +24,6 @@ suite('Collections', () => {
 
 		collections.forEach(dict, () => false);
 
-		collections.forEach(dict, (x, remove) => remove());
-		assert.strictEqual(dict['toString'], undefined);
-
 		// don't iterate over properties that are not on the object itself
 		const test = Object.create({ 'derived': true });
 		collections.forEach(test, () => assert(false));


### PR DESCRIPTION
This marks `collections.forEach` as deprecated. We should use `Object.entries` instead

I've also removed the `remove` functionality since no callers were using it and updated the implementation to use `Object.entries`

