### PR TITLE
Try prevent duplicate placeholder decorations showing

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -297,6 +297,12 @@ export class CommandDetectionCapability implements ICommandDetectionCapability {
 	}
 
 	handleCommandStart(): void {
+		// Only update the column if the line has already been set
+		if (this._currentCommand.commandStartMarker?.line === this._terminal.buffer.active.cursorY) {
+			this._currentCommand.commandStartX = this._terminal.buffer.active.cursorX;
+			this._logService.debug('CommandDetectionCapability#handleCommandStart', this._currentCommand.commandStartX, this._currentCommand.commandStartMarker?.line);
+			return;
+		}
 		if (this._isWindowsPty) {
 			this._handleCommandStartWindows();
 			return;

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -215,14 +215,14 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 		if (!decoration) {
 			return undefined;
 		}
-
+		if (beforeCommandExecution) {
+			this._placeholderDecoration = decoration;
+		}
 		decoration.onRender(element => {
 			if (element.classList.contains(DecorationSelector.OverviewRuler)) {
 				return;
 			}
-			if (beforeCommandExecution && !this._placeholderDecoration) {
-				this._placeholderDecoration = decoration;
-			} else if (!this._decorations.get(decoration.marker.id)) {
+			if (!this._decorations.get(decoration.marker.id)) {
 				decoration.onDispose(() => this._decorations.delete(decoration.marker.id));
 				this._decorations.set(decoration.marker.id,
 					{


### PR DESCRIPTION
This adds these protections:

- Placeholders are now always disposed of before a new one is created,
this was the main reason for these issues.
- Prevent the command started event firing if it has already fired on
the same line.

Fixes #151228
