### PR TITLE
Allow snippets' final placeholder ($0) to have choices

### DIFF
--- a/src/vs/editor/contrib/snippet/browser/snippetParser.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetParser.ts
@@ -777,7 +777,7 @@ export class SnippetParser {
 				placeholder.children.forEach(parent.appendChild, parent);
 				return true;
 			}
-		} else if (placeholder.index > 0 && this._accept(TokenType.Pipe)) {
+		} else if (this._accept(TokenType.Pipe)) {
 			// ${1|one,two,three|}
 			const choice = new Choice();
 

--- a/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
@@ -284,9 +284,11 @@ suite('SnippetParser', () => {
 	});
 
 	test('Parser, placeholder with choice; for $0 (#150745)', () => {
-		const input = '${0|one,two,three|}';
+		const p = new SnippetParser();
+		const snippet = p.parse('${0|one,two,three|}');
+		assertMarker(snippet, Placeholder);
 		const expected = [Placeholder, Text, Text, Text];
-		new SnippetParser().parse(input).walk(marker => {
+		snippet.walk(marker => {
 			assert.strictEqual(marker, expected.shift());
 			return true;
 		});

--- a/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
@@ -641,12 +641,6 @@ suite('SnippetParser', () => {
 		});
 	});
 
-	test('Snippets: make parser ignore `${0|choice|}`, #31599', function () {
-		assertTextAndMarker('${0|foo,bar|}', '${0|foo,bar|}', Text);
-		assertTextAndMarker('${1|foo,bar|}', 'foo', Placeholder);
-	});
-
-
 	test('Transform -> FormatString#resolve', function () {
 
 		// shorthand functions

--- a/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
@@ -283,6 +283,15 @@ suite('SnippetParser', () => {
 		});
 	});
 
+	test('Parser, placeholder with choice; for $0 (#150745)', () => {
+		const input = '${0|one,two,three|}';
+		const expected = [Placeholder, Text, Text, Text];
+		new SnippetParser().parse(input).walk(marker => {
+			assert.strictEqual(marker, expected.shift());
+			return true;
+		});
+	});
+
 	test('Snippet choices: unable to escape comma and pipe, #31521', function () {
 		assertTextAndMarker('console.log(${1|not\\, not, five, 5, 1   23|});', 'console.log(not, not);', Text, Placeholder, Text);
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #150745

:warning: As already mentioned in the original issue, this fix is in conflict with an old issue, #31599.