### PR TITLE
Add gulp tasks for transpile only

### DIFF
--- a/build/gulpfile.compile.js
+++ b/build/gulpfile.compile.js
@@ -15,7 +15,7 @@ const compileBuildTask = task.define('compile-build',
 	task.series(
 		util.rimraf('out-build'),
 		util.buildWebNodePaths('out-build'),
-		compilation.compileTask('src', 'out-build', true)
+		compilation.compileTask('src', 'out-build', true, false)
 	)
 );
 gulp.task(compileBuildTask);

--- a/build/gulpfile.editor.js
+++ b/build/gulpfile.editor.js
@@ -77,7 +77,7 @@ const extractEditorSrcTask = task.define('extract-editor-src', () => {
 	});
 });
 
-const compileEditorAMDTask = task.define('compile-editor-amd', compilation.compileTask('out-editor-src', 'out-editor-build', true));
+const compileEditorAMDTask = task.define('compile-editor-amd', compilation.compileTask('out-editor-src', 'out-editor-build', true, false));
 
 const optimizeEditorAMDTask = task.define('optimize-editor-amd', common.optimizeTask({
 	src: 'out-editor-build',

--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -100,7 +100,7 @@ const tasks = compilations.map(function (tsconfigFile) {
 		headerOut = relativeDirname.substr(index + 1) + '/out';
 	}
 
-	function createPipeline(build, emitError) {
+	function createPipeline(build, emitError, transpileOnly) {
 		const nlsDev = require('vscode-nls-dev');
 		const tsb = require('./lib/tsb');
 		const sourcemaps = require('gulp-sourcemaps');
@@ -110,7 +110,11 @@ const tasks = compilations.map(function (tsconfigFile) {
 		overrideOptions.inlineSources = Boolean(build);
 		overrideOptions.base = path.dirname(absolutePath);
 
-		const compilation = tsb.create(absolutePath, overrideOptions, { verbose: false }, err => reporter(err.toString()));
+		if (transpileOnly) {
+			overrideOptions.rootDir = path.join(root, 'src');
+		}
+
+		const compilation = tsb.create(absolutePath, overrideOptions, { verbose: false, transpileOnly }, err => reporter(err.toString()));
 
 		const pipeline = function () {
 			const input = es.through();
@@ -152,6 +156,16 @@ const tasks = compilations.map(function (tsconfigFile) {
 
 	const cleanTask = task.define(`clean-extension-${name}`, util.rimraf(out));
 
+	const transpileTask = task.define(`transpile-extension:${name}`, task.series(cleanTask, () => {
+		const pipeline = createPipeline(false, true, true);
+		const nonts = gulp.src(src, srcOpts).pipe(filter(['**', '!**/*.ts']));
+		const input = es.merge(nonts, pipeline.tsProjectSrc());
+
+		return input
+			.pipe(pipeline())
+			.pipe(gulp.dest(out));
+	}));
+
 	const compileTask = task.define(`compile-extension:${name}`, task.series(cleanTask, () => {
 		const pipeline = createPipeline(false, true);
 		const nonts = gulp.src(src, srcOpts).pipe(filter(['**', '!**/*.ts']));
@@ -184,11 +198,15 @@ const tasks = compilations.map(function (tsconfigFile) {
 	}));
 
 	// Tasks
+	gulp.task(transpileTask);
 	gulp.task(compileTask);
 	gulp.task(watchTask);
 
-	return { compileTask, watchTask, compileBuildTask };
+	return { transpileTask, compileTask, watchTask, compileBuildTask };
 });
+
+const transpileExtensionsTask = task.define('transpile-extensions', task.parallel(...tasks.map(t => t.transpileTask)));
+gulp.task(transpileExtensionsTask);
 
 const compileExtensionsTask = task.define('compile-extensions', task.parallel(...tasks.map(t => t.compileTask)));
 gulp.task(compileExtensionsTask);

--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -114,7 +114,7 @@ const tasks = compilations.map(function (tsconfigFile) {
 			overrideOptions.rootDir = path.join(root, 'src');
 		}
 
-		const compilation = tsb.create(absolutePath, overrideOptions, { verbose: false, transpileOnly }, err => reporter(err.toString()));
+		const compilation = tsb.create(absolutePath, overrideOptions, { verbose: false, transpileOnly, transpileOnlyIncludesDts: transpileOnly }, err => reporter(err.toString()));
 
 		const pipeline = function () {
 			const input = es.through();

--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -110,10 +110,6 @@ const tasks = compilations.map(function (tsconfigFile) {
 		overrideOptions.inlineSources = Boolean(build);
 		overrideOptions.base = path.dirname(absolutePath);
 
-		if (transpileOnly) {
-			overrideOptions.rootDir = path.join(root, 'src');
-		}
-
 		const compilation = tsb.create(absolutePath, overrideOptions, { verbose: false, transpileOnly, transpileOnlyIncludesDts: transpileOnly }, err => reporter(err.toString()));
 
 		const pipeline = function () {

--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -19,8 +19,12 @@ const { compileExtensionsTask, watchExtensionsTask, compileExtensionMediaTask } 
 gulp.task(compileApiProposalNamesTask);
 gulp.task(watchApiProposalNamesTask);
 
+// Transpile only
+const transpileClientTask = task.define('transpile-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), compileTask('src', 'out', false, true)));
+gulp.task(transpileClientTask);
+
 // Fast compile for development time
-const compileClientTask = task.define('compile-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), compileApiProposalNamesTask, compileTask('src', 'out', false)));
+const compileClientTask = task.define('compile-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), compileApiProposalNamesTask, compileTask('src', 'out', false, false)));
 gulp.task(compileClientTask);
 
 const watchClientTask = task.define('watch-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), task.parallel(watchTask('out', false), watchApiProposalNamesTask)));

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -19,6 +19,7 @@ import * as os from 'os';
 import ts = require('typescript');
 import * as File from 'vinyl';
 import * as task from './task';
+import * as tsb from './tsb';
 
 const watch = require('./watch');
 
@@ -39,8 +40,8 @@ function getTypeScriptCompilerOptions(src: string): ts.CompilerOptions {
 	return options;
 }
 
-function createCompile(src: string, build: boolean, emitError?: boolean) {
-	const tsb = require('./tsb') as typeof import('./tsb');
+function createCompile(src: string, build: boolean, emitError: boolean, transpileOnly: boolean) {
+	// const tsb = require('./tsb') as typeof import('./tsb');
 	const sourcemaps = require('gulp-sourcemaps') as typeof import('gulp-sourcemaps');
 
 
@@ -50,7 +51,7 @@ function createCompile(src: string, build: boolean, emitError?: boolean) {
 		overrideOptions.inlineSourceMap = true;
 	}
 
-	const compilation = tsb.create(projectPath, overrideOptions, { verbose: false }, err => reporter(err));
+	const compilation = tsb.create(projectPath, overrideOptions, { verbose: false, transpileOnly }, err => reporter(err));
 
 	function pipeline(token?: util.ICancellationToken) {
 		const bom = require('gulp-bom') as typeof import('gulp-bom');
@@ -86,7 +87,7 @@ function createCompile(src: string, build: boolean, emitError?: boolean) {
 	return pipeline;
 }
 
-export function compileTask(src: string, out: string, build: boolean): () => NodeJS.ReadWriteStream {
+export function compileTask(src: string, out: string, build: boolean, transpileOnly: boolean): () => NodeJS.ReadWriteStream {
 
 	return function () {
 
@@ -94,7 +95,7 @@ export function compileTask(src: string, out: string, build: boolean): () => Nod
 			throw new Error('compilation requires 4GB of RAM');
 		}
 
-		const compile = createCompile(src, build, true);
+		const compile = createCompile(src, build, true, transpileOnly);
 		const srcPipe = gulp.src(`${src}/**`, { base: `${src}` });
 		const generator = new MonacoGenerator(false);
 		if (src === 'src') {
@@ -111,7 +112,7 @@ export function compileTask(src: string, out: string, build: boolean): () => Nod
 export function watchTask(out: string, build: boolean): () => NodeJS.ReadWriteStream {
 
 	return function () {
-		const compile = createCompile('src', build);
+		const compile = createCompile('src', build, false, false);
 
 		const src = gulp.src('src/**', { base: 'src' });
 		const watchSrc = watch('src/**', { base: 'src', readDelay: 200 });

--- a/build/lib/tsb/index.js
+++ b/build/lib/tsb/index.js
@@ -84,7 +84,7 @@ function create(projectPath, existingOptions, config, onError = _defaultOnError)
         });
     }
     let result;
-    if (config.transplileOnly) {
+    if (config.transpileOnly) {
         const transpiler = new transpiler_1.Transpiler(logFn, { compilerOptions: cmdLine.options });
         result = (() => createTranspileStream(transpiler));
     }

--- a/build/lib/tsb/index.js
+++ b/build/lib/tsb/index.js
@@ -73,7 +73,7 @@ function create(projectPath, existingOptions, config, onError = _defaultOnError)
                 this.emit('error', 'no support for streams');
                 return;
             }
-            if (!file.contents || file.path.endsWith('.d.ts')) {
+            if (!file.contents) {
                 return;
             }
             if (!transpiler.onOutfile) {

--- a/build/lib/tsb/index.js
+++ b/build/lib/tsb/index.js
@@ -92,12 +92,7 @@ function create(projectPath, existingOptions, config, onError = _defaultOnError)
     }
     let result;
     if (config.transpileOnly) {
-        const transpiler = new transpiler_1.Transpiler(logFn, printDiagnostic, {
-            compilerOptions: {
-                rootDir: cmdLine.options.rootDir ?? (0, path_1.dirname)(projectPath),
-                ...cmdLine.options
-            },
-        });
+        const transpiler = new transpiler_1.Transpiler(logFn, printDiagnostic, cmdLine);
         result = (() => createTranspileStream(transpiler));
     }
     else {

--- a/build/lib/tsb/index.js
+++ b/build/lib/tsb/index.js
@@ -76,7 +76,7 @@ function create(projectPath, existingOptions, config, onError = _defaultOnError)
                 this.emit('error', 'no support for streams');
                 return;
             }
-            if (!file.contents) {
+            if (!file.contents || file.path.endsWith('.d.ts')) {
                 return;
             }
             const out = ts.transpileModule(String(file.contents), {
@@ -85,10 +85,12 @@ function create(projectPath, existingOptions, config, onError = _defaultOnError)
             if (out.diagnostics) {
                 out.diagnostics.forEach(printDiagnostic);
             }
+            const outBase = cmdLine.options.outDir;
+            const outRelative = (0, path_1.relative)(cmdLine.options.rootDir, file.path);
+            const outPath = (0, path_1.join)(outBase, outRelative.replace(/\.ts$/, '.js'));
             const outFile = new Vinyl({
-                path: file.path.replace(/\.ts$/, '.js'),
-                cwd: file.cwd,
-                base: file.base,
+                path: outPath,
+                base: outBase,
                 contents: Buffer.from(out.outputText),
             });
             this.push(outFile);

--- a/build/lib/tsb/index.js
+++ b/build/lib/tsb/index.js
@@ -76,6 +76,9 @@ function create(projectPath, existingOptions, config, onError = _defaultOnError)
             if (!file.contents) {
                 return;
             }
+            if (!config.transpileOnlyIncludesDts && file.path.endsWith('.d.ts')) {
+                return;
+            }
             if (!transpiler.onOutfile) {
                 transpiler.onOutfile = file => this.queue(file);
             }

--- a/build/lib/tsb/index.ts
+++ b/build/lib/tsb/index.ts
@@ -36,7 +36,7 @@ const _defaultOnError = (err: string) => console.log(JSON.stringify(err, null, 4
 export function create(
 	projectPath: string,
 	existingOptions: Partial<ts.CompilerOptions>,
-	config: { verbose?: boolean; transpileOnly?: boolean },
+	config: { verbose?: boolean; transpileOnly?: boolean; transpileOnlyIncludesDts?: boolean },
 	onError: (message: string) => void = _defaultOnError
 ): IncrementalCompiler {
 
@@ -103,6 +103,9 @@ export function create(
 				return;
 			}
 			if (!file.contents) {
+				return;
+			}
+			if (!config.transpileOnlyIncludesDts && file.path.endsWith('.d.ts')) {
 				return;
 			}
 

--- a/build/lib/tsb/index.ts
+++ b/build/lib/tsb/index.ts
@@ -126,12 +126,7 @@ export function create(
 
 	let result: IncrementalCompiler;
 	if (config.transpileOnly) {
-		const transpiler = new Transpiler(logFn, printDiagnostic, {
-			compilerOptions: {
-				rootDir: cmdLine.options.rootDir ?? dirname(projectPath),
-				...cmdLine.options
-			},
-		});
+		const transpiler = new Transpiler(logFn, printDiagnostic, cmdLine);
 		result = <any>(() => createTranspileStream(transpiler));
 	} else {
 		const _builder = builder.createTypeScriptBuilder({ logFn }, projectPath, cmdLine);

--- a/build/lib/tsb/index.ts
+++ b/build/lib/tsb/index.ts
@@ -102,7 +102,7 @@ export function create(
 				this.emit('error', 'no support for streams');
 				return;
 			}
-			if (!file.contents || file.path.endsWith('.d.ts')) {
+			if (!file.contents) {
 				return;
 			}
 

--- a/build/lib/tsb/index.ts
+++ b/build/lib/tsb/index.ts
@@ -8,7 +8,7 @@ import * as through from 'through';
 import * as builder from './builder';
 import * as ts from 'typescript';
 import { Readable, Writable, Duplex } from 'stream';
-import { dirname } from 'path';
+import { dirname, join, relative } from 'path';
 import { strings } from './utils';
 import { readFileSync, statSync } from 'fs';
 import * as log from 'fancy-log';
@@ -109,7 +109,7 @@ export function create(
 				return;
 			}
 
-			if (!file.contents) {
+			if (!file.contents || file.path.endsWith('.d.ts')) {
 				return;
 			}
 
@@ -121,10 +121,13 @@ export function create(
 				out.diagnostics.forEach(printDiagnostic);
 			}
 
+			const outBase = cmdLine.options.outDir!;
+			const outRelative = relative(cmdLine.options.rootDir!, file.path);
+			const outPath = join(outBase, outRelative.replace(/\.ts$/, '.js'));
+
 			const outFile = new Vinyl({
-				path: file.path.replace(/\.ts$/, '.js'),
-				cwd: file.cwd,
-				base: file.base,
+				path: outPath,
+				base: outBase,
 				contents: Buffer.from(out.outputText),
 			});
 

--- a/build/lib/tsb/index.ts
+++ b/build/lib/tsb/index.ts
@@ -36,7 +36,7 @@ const _defaultOnError = (err: string) => console.log(JSON.stringify(err, null, 4
 export function create(
 	projectPath: string,
 	existingOptions: Partial<ts.CompilerOptions>,
-	config: { verbose?: boolean; transplileOnly?: boolean },
+	config: { verbose?: boolean; transpileOnly?: boolean },
 	onError: (message: string) => void = _defaultOnError
 ): IncrementalCompiler {
 
@@ -121,7 +121,7 @@ export function create(
 
 
 	let result: IncrementalCompiler;
-	if (config.transplileOnly) {
+	if (config.transpileOnly) {
 		const transpiler = new Transpiler(logFn, { compilerOptions: cmdLine.options });
 		result = <any>(() => createTranspileStream(transpiler));
 	} else {

--- a/build/lib/tsb/transpiler.js
+++ b/build/lib/tsb/transpiler.js
@@ -1,0 +1,135 @@
+"use strict";
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Transpiler = void 0;
+const ts = require("typescript");
+const threads = require("node:worker_threads");
+const Vinyl = require("vinyl");
+const path_1 = require("path");
+const node_os_1 = require("node:os");
+function transpile(tsSrc, options) {
+    const out = ts.transpileModule(tsSrc, options);
+    return {
+        jsSrc: out.outputText,
+        diag: out.diagnostics && out.diagnostics.length > 0 ? out.diagnostics : undefined
+    };
+}
+if (!threads.isMainThread) {
+    // WORKER
+    threads.parentPort?.addListener('message', (req) => {
+        const out = transpile(req.tsSrc, req.options);
+        threads.parentPort.postMessage(out);
+    });
+}
+class TranspileWorker {
+    constructor() {
+        this.id = TranspileWorker.pool++;
+        this._worker = new threads.Worker(__filename);
+        this._durations = [];
+        this._worker.addListener('message', (value) => {
+            if (!this._pending) {
+                console.error('RECEIVING data WITHOUT request');
+                return;
+            }
+            const [resolve, reject, file, options, t1] = this._pending;
+            if (value.diagnostics && value.diagnostics.length > 0) {
+                reject(value.diagnostics);
+                return;
+            }
+            const outBase = options.compilerOptions.outDir;
+            const outRelative = (0, path_1.relative)(options.compilerOptions.rootDir, file.path);
+            const outPath = (0, path_1.join)(outBase, outRelative.replace(/\.ts$/, '.js'));
+            const outFile = new Vinyl({
+                path: outPath,
+                base: outBase,
+                contents: Buffer.from(value.jsSrc),
+            });
+            this._pending = undefined;
+            this._durations.push(Date.now() - t1);
+            resolve(outFile);
+        });
+    }
+    terminate() {
+        // console.log(`Worker#${this.id} ENDS after ${this._durations.length} jobs (total: ${this._durations.reduce((p, c) => p + c, 0)}, avg: ${this._durations.reduce((p, c) => p + c, 0) / this._durations.length})`);
+        this._worker.terminate();
+    }
+    get isBusy() {
+        return this._pending !== undefined;
+    }
+    next(file, options) {
+        if (this._pending !== undefined) {
+            throw new Error('BUSY');
+        }
+        return new Promise((resolve, reject) => {
+            this._pending = [resolve, reject, file, options, Date.now()];
+            const req = { tsSrc: String(file.contents), options };
+            this._worker.postMessage(req);
+        });
+    }
+}
+TranspileWorker.pool = 1;
+class Transpiler {
+    constructor(logFn, options) {
+        this.logFn = logFn;
+        this.options = options;
+        // private _worker: TranspileWorker[] = [];
+        this._queue = [];
+        this._workerPool = [];
+        this._allJobs = [];
+        logFn('Transpile', `will use ${Transpiler.P} transpile worker`);
+    }
+    async join() {
+        // wait for all penindg jobs
+        await Promise.allSettled(this._allJobs);
+        this._allJobs.length = 0;
+        // terminate all worker
+        this._workerPool.forEach(w => w.terminate());
+        this._workerPool.length = 0;
+    }
+    transpile(file, out, onError) {
+        const len = this._queue.push(file);
+        if (len < 2 * Transpiler.P) {
+            return;
+        }
+        // LAZYily create worker
+        if (this._workerPool.length === 0) {
+            for (let i = 0; i < Transpiler.P; i++) {
+                this._workerPool.push(new TranspileWorker());
+            }
+        }
+        const freeWorker = this._workerPool.filter(w => !w.isBusy);
+        if (freeWorker.length === 0) {
+            // OK, they will pick up work themselves
+            return;
+        }
+        for (const worker of freeWorker) {
+            if (this._queue.length === 0) {
+                break;
+            }
+            const job = new Promise(resolve => {
+                const consume = () => {
+                    const inFile = this._queue.pop();
+                    if (!inFile) {
+                        // DONE
+                        resolve(undefined);
+                        return;
+                    }
+                    // work on the NEXT file
+                    worker.next(inFile, this.options).then(outFile => {
+                        out(outFile);
+                        consume();
+                    }).catch(err => {
+                        onError(err);
+                    });
+                };
+                consume();
+            });
+            this._allJobs.push(job);
+        }
+    }
+}
+exports.Transpiler = Transpiler;
+Transpiler.P = (0, node_os_1.cpus)().length * .5;

--- a/build/lib/tsb/transpiler.js
+++ b/build/lib/tsb/transpiler.js
@@ -70,7 +70,7 @@ class TranspileWorker {
                         : 0 /* SuffixTypes.Unknown */;
                 // check if output of a DTS-files isn't just "empty" and iff so
                 // skip this file
-                if (suffixLen === 5 /* SuffixTypes.Dts */ && jsSrc === _defaultEmptyJsSrc) {
+                if (suffixLen === 5 /* SuffixTypes.Dts */ && _isDefaultEmpty(jsSrc)) {
                     continue;
                 }
                 const outBase = options.compilerOptions.outDir ?? file.base;
@@ -181,9 +181,9 @@ class Transpiler {
 }
 exports.Transpiler = Transpiler;
 Transpiler.P = Math.floor((0, node_os_1.cpus)().length * .5);
-const _defaultEmptyJsSrc = `"use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-//# sourceMappingURL=module.js.map`;
+function _isDefaultEmpty(src) {
+    return src
+        .replace('"use strict";', '')
+        .replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, '$1')
+        .trim().length === 0;
+}

--- a/build/lib/tsb/transpiler.js
+++ b/build/lib/tsb/transpiler.js
@@ -146,13 +146,21 @@ class Transpiler {
         this._workerPool.length = 0;
     }
     transpile(file) {
+        if (this._cmdLine.options.noEmit) {
+            // not doing ANYTHING here
+            return;
+        }
         const newLen = this._queue.push(file);
         if (newLen > Transpiler.P ** 2) {
             this._consumeQueue();
         }
     }
     _consumeQueue() {
-        // LAZYily create worker
+        if (this._queue.length === 0) {
+            // no work...
+            return;
+        }
+        // kinda LAZYily create workers
         if (this._workerPool.length === 0) {
             for (let i = 0; i < Transpiler.P; i++) {
                 this._workerPool.push(new TranspileWorker(file => this._tsApiInternalOutfileName.getForInfile(file)));

--- a/build/lib/tsb/transpiler.js
+++ b/build/lib/tsb/transpiler.js
@@ -12,7 +12,7 @@ const path_1 = require("path");
 const node_os_1 = require("node:os");
 function transpile(tsSrc, options) {
     const isAmd = /\n(import|export)/m.test(tsSrc);
-    if (!isAmd) {
+    if (!isAmd && options.compilerOptions?.module === ts.ModuleKind.AMD) {
         // enforce NONE module-system for not-amd cases
         options = { ...options, ...{ compilerOptions: { ...options.compilerOptions, module: ts.ModuleKind.None } } };
     }
@@ -59,9 +59,12 @@ class TranspileWorker {
                     diag.push(...diag);
                     continue;
                 }
+                const suffixLen = file.path.endsWith('.d.ts') ? 5
+                    : file.path.endsWith('.ts') ? 3
+                        : 0;
                 const outBase = options.compilerOptions.outDir ?? file.base;
                 const outRelative = (0, path_1.relative)(options.compilerOptions.rootDir, file.path);
-                const outPath = (0, path_1.join)(outBase, outRelative.replace(/\.ts$/, '.js'));
+                const outPath = (0, path_1.join)(outBase, outRelative.slice(0, -suffixLen) + '.js');
                 outFiles.push(new Vinyl({
                     path: outPath,
                     base: outBase ?? file.base,

--- a/build/lib/tsb/transpiler.js
+++ b/build/lib/tsb/transpiler.js
@@ -11,6 +11,10 @@ const Vinyl = require("vinyl");
 const path_1 = require("path");
 const node_os_1 = require("node:os");
 function transpile(tsSrc, options) {
+    const isAmd = /\n(import|export)/m.test(tsSrc);
+    if (!isAmd) {
+        options.compilerOptions.module = ts.ModuleKind.None;
+    }
     const out = ts.transpileModule(tsSrc, options);
     return {
         jsSrc: out.outputText,

--- a/build/lib/tsb/transpiler.js
+++ b/build/lib/tsb/transpiler.js
@@ -59,9 +59,20 @@ class TranspileWorker {
                     diag.push(...diag);
                     continue;
                 }
-                const suffixLen = file.path.endsWith('.d.ts') ? 5
-                    : file.path.endsWith('.ts') ? 3
-                        : 0;
+                let SuffixTypes;
+                (function (SuffixTypes) {
+                    SuffixTypes[SuffixTypes["Dts"] = 5] = "Dts";
+                    SuffixTypes[SuffixTypes["Ts"] = 3] = "Ts";
+                    SuffixTypes[SuffixTypes["Unknown"] = 0] = "Unknown";
+                })(SuffixTypes || (SuffixTypes = {}));
+                const suffixLen = file.path.endsWith('.d.ts') ? 5 /* SuffixTypes.Dts */
+                    : file.path.endsWith('.ts') ? 3 /* SuffixTypes.Ts */
+                        : 0 /* SuffixTypes.Unknown */;
+                // check if output of a DTS-files isn't just "empty" and iff so
+                // skip this file
+                if (suffixLen === 5 /* SuffixTypes.Dts */ && jsSrc === _defaultEmptyJsSrc) {
+                    continue;
+                }
                 const outBase = options.compilerOptions.outDir ?? file.base;
                 const outRelative = (0, path_1.relative)(options.compilerOptions.rootDir, file.path);
                 const outPath = (0, path_1.join)(outBase, outRelative.slice(0, -suffixLen) + '.js');
@@ -170,3 +181,9 @@ class Transpiler {
 }
 exports.Transpiler = Transpiler;
 Transpiler.P = Math.floor((0, node_os_1.cpus)().length * .5);
+const _defaultEmptyJsSrc = `"use strict";
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+//# sourceMappingURL=module.js.map`;

--- a/build/lib/tsb/transpiler.ts
+++ b/build/lib/tsb/transpiler.ts
@@ -1,0 +1,173 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as ts from 'typescript';
+import * as threads from 'node:worker_threads';
+import * as Vinyl from 'vinyl';
+import { join, relative } from 'path';
+import { cpus } from 'node:os';
+
+interface TranspileReq {
+	readonly tsSrc: string;
+	readonly options: ts.TranspileOptions;
+}
+
+interface TranspileRes {
+	readonly jsSrc: string;
+	readonly diagnostics?: ts.Diagnostic[];
+}
+
+function transpile(tsSrc: string, options: ts.TranspileOptions): { jsSrc: string; diag?: ts.Diagnostic[] } {
+	const out = ts.transpileModule(tsSrc, options);
+	return {
+		jsSrc: out.outputText,
+		diag: out.diagnostics && out.diagnostics.length > 0 ? out.diagnostics : undefined
+	};
+}
+
+if (!threads.isMainThread) {
+	// WORKER
+	threads.parentPort?.addListener('message', (req: TranspileReq) => {
+		const out: TranspileRes = transpile(req.tsSrc, req.options);
+		threads.parentPort!.postMessage(out);
+	});
+}
+
+class TranspileWorker {
+
+	private static pool = 1;
+
+	readonly id = TranspileWorker.pool++;
+
+	private _worker = new threads.Worker(__filename);
+	private _pending?: [resolve: Function, reject: Function, file: Vinyl, options: ts.TranspileOptions, t1: number];
+	private _durations: number[] = [];
+
+	constructor() {
+
+		this._worker.addListener('message', (value: TranspileRes) => {
+			if (!this._pending) {
+				console.error('RECEIVING data WITHOUT request');
+				return;
+			}
+
+			const [resolve, reject, file, options, t1] = this._pending;
+
+			if (value.diagnostics && value.diagnostics.length > 0) {
+				reject(value.diagnostics);
+				return;
+			}
+
+			const outBase = options.compilerOptions!.outDir!;
+			const outRelative = relative(options.compilerOptions!.rootDir!, file.path);
+			const outPath = join(outBase, outRelative.replace(/\.ts$/, '.js'));
+			const outFile = new Vinyl({
+				path: outPath,
+				base: outBase,
+				contents: Buffer.from(value.jsSrc),
+			});
+			this._pending = undefined;
+			this._durations.push(Date.now() - t1);
+			resolve(outFile);
+		});
+	}
+
+	terminate() {
+		// console.log(`Worker#${this.id} ENDS after ${this._durations.length} jobs (total: ${this._durations.reduce((p, c) => p + c, 0)}, avg: ${this._durations.reduce((p, c) => p + c, 0) / this._durations.length})`);
+		this._worker.terminate();
+	}
+
+	get isBusy() {
+		return this._pending !== undefined;
+	}
+
+	next(file: Vinyl, options: ts.TranspileOptions) {
+		if (this._pending !== undefined) {
+			throw new Error('BUSY');
+		}
+		return new Promise<Vinyl>((resolve, reject) => {
+			this._pending = [resolve, reject, file, options, Date.now()];
+			const req: TranspileReq = { tsSrc: String(file.contents), options };
+			this._worker.postMessage(req);
+		});
+	}
+}
+
+export class Transpiler {
+
+	static P = cpus().length * .5;
+	// private _worker: TranspileWorker[] = [];
+	private _queue: Vinyl[] = [];
+
+	private _workerPool: TranspileWorker[] = [];
+	private _allJobs: Promise<any>[] = [];
+
+	constructor(
+		readonly logFn: (topic: string, message: string) => void,
+		readonly options: ts.TranspileOptions
+	) {
+		logFn('Transpile', `will use ${Transpiler.P} transpile worker`);
+	}
+
+	async join() {
+		// wait for all penindg jobs
+		await Promise.allSettled(this._allJobs);
+		this._allJobs.length = 0;
+		// terminate all worker
+		this._workerPool.forEach(w => w.terminate());
+		this._workerPool.length = 0;
+	}
+
+	transpile(file: Vinyl, out: (file: Vinyl) => void, onError: (err: any) => void) {
+
+		const len = this._queue.push(file);
+		if (len < 2 * Transpiler.P) {
+			return;
+		}
+
+		// LAZYily create worker
+		if (this._workerPool.length === 0) {
+			for (let i = 0; i < Transpiler.P; i++) {
+				this._workerPool.push(new TranspileWorker());
+			}
+		}
+
+		const freeWorker = this._workerPool.filter(w => !w.isBusy);
+
+		if (freeWorker.length === 0) {
+			// OK, they will pick up work themselves
+			return;
+		}
+
+		for (const worker of freeWorker) {
+			if (this._queue.length === 0) {
+				break;
+			}
+
+			const job = new Promise(resolve => {
+
+				const consume = () => {
+					const inFile = this._queue.pop();
+					if (!inFile) {
+						// DONE
+						resolve(undefined);
+						return;
+					}
+					// work on the NEXT file
+					worker.next(inFile, this.options).then(outFile => {
+						out(outFile);
+						consume();
+					}).catch(err => {
+						onError(err);
+					});
+				};
+
+				consume();
+			});
+
+			this._allJobs.push(job);
+		}
+	}
+}

--- a/build/lib/tsb/transpiler.ts
+++ b/build/lib/tsb/transpiler.ts
@@ -93,7 +93,7 @@ class TranspileWorker {
 
 				// check if output of a DTS-files isn't just "empty" and iff so
 				// skip this file
-				if (suffixLen === SuffixTypes.Dts && jsSrc === _defaultEmptyJsSrc) {
+				if (suffixLen === SuffixTypes.Dts && _isDefaultEmpty(jsSrc)) {
 					continue;
 				}
 
@@ -232,10 +232,9 @@ export class Transpiler {
 	}
 }
 
-
-const _defaultEmptyJsSrc = `"use strict";
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-//# sourceMappingURL=module.js.map`;
+function _isDefaultEmpty(src: string): boolean {
+	return src
+		.replace('"use strict";', '')
+		.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, '$1')
+		.trim().length === 0;
+}

--- a/build/lib/tsb/transpiler.ts
+++ b/build/lib/tsb/transpiler.ts
@@ -20,6 +20,11 @@ interface TranspileRes {
 }
 
 function transpile(tsSrc: string, options: ts.TranspileOptions): { jsSrc: string; diag?: ts.Diagnostic[] } {
+
+	const isAmd = /\n(import|export)/m.test(tsSrc);
+	if (!isAmd) {
+		options.compilerOptions!.module = ts.ModuleKind.None;
+	}
 	const out = ts.transpileModule(tsSrc, options);
 	return {
 		jsSrc: out.outputText,

--- a/build/lib/tsb/transpiler.ts
+++ b/build/lib/tsb/transpiler.ts
@@ -173,6 +173,12 @@ export class Transpiler {
 
 
 	transpile(file: Vinyl) {
+
+		if (this._cmdLine.options.noEmit) {
+			// not doing ANYTHING here
+			return;
+		}
+
 		const newLen = this._queue.push(file);
 		if (newLen > Transpiler.P ** 2) {
 			this._consumeQueue();
@@ -181,7 +187,12 @@ export class Transpiler {
 
 	private _consumeQueue(): void {
 
-		// LAZYily create worker
+		if (this._queue.length === 0) {
+			// no work...
+			return;
+		}
+
+		// kinda LAZYily create workers
 		if (this._workerPool.length === 0) {
 			for (let i = 0; i < Transpiler.P; i++) {
 				this._workerPool.push(new TranspileWorker(file => this._tsApiInternalOutfileName.getForInfile(file)));
@@ -189,7 +200,6 @@ export class Transpiler {
 		}
 
 		const freeWorker = this._workerPool.filter(w => !w.isBusy);
-
 		if (freeWorker.length === 0) {
 			// OK, they will pick up work themselves
 			return;

--- a/build/lib/tsb/transpiler.ts
+++ b/build/lib/tsb/transpiler.ts
@@ -82,10 +82,20 @@ class TranspileWorker {
 					diag.push(...diag);
 					continue;
 				}
+				const enum SuffixTypes {
+					Dts = 5,
+					Ts = 3,
+					Unknown = 0
+				}
+				const suffixLen = file.path.endsWith('.d.ts') ? SuffixTypes.Dts
+					: file.path.endsWith('.ts') ? SuffixTypes.Ts
+						: SuffixTypes.Unknown;
 
-				const suffixLen = file.path.endsWith('.d.ts') ? 5
-					: file.path.endsWith('.ts') ? 3
-						: 0;
+				// check if output of a DTS-files isn't just "empty" and iff so
+				// skip this file
+				if (suffixLen === SuffixTypes.Dts && jsSrc === _defaultEmptyJsSrc) {
+					continue;
+				}
 
 				const outBase = options.compilerOptions.outDir ?? file.base;
 				const outRelative = relative(options.compilerOptions.rootDir, file.path);
@@ -221,3 +231,11 @@ export class Transpiler {
 		}
 	}
 }
+
+
+const _defaultEmptyJsSrc = `"use strict";
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+//# sourceMappingURL=module.js.map`;

--- a/extensions/debug-auto-launch/src/extension.ts
+++ b/extensions/debug-auto-launch/src/extension.ts
@@ -8,6 +8,12 @@ import { createServer, Server } from 'net';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 
+const enum State {
+	Disabled = 'disabled',
+	OnlyWithFlag = 'onlyWithFlag',
+	Smart = 'smart',
+	Always = 'always',
+}
 const localize = nls.loadMessageBundle();
 const TEXT_STATUSBAR_LABEL = {
 	[State.Disabled]: localize('status.text.auto.attach.disabled', 'Auto Attach: Disabled'),
@@ -62,12 +68,6 @@ const SETTINGS_CAUSE_REFRESH = new Set(
 	['autoAttachSmartPattern', SETTING_STATE].map(s => `${SETTING_SECTION}.${s}`),
 );
 
-const enum State {
-	Disabled = 'disabled',
-	OnlyWithFlag = 'onlyWithFlag',
-	Smart = 'smart',
-	Always = 'always',
-}
 
 let currentState: Promise<{ context: vscode.ExtensionContext; state: State | null }>;
 let statusItem: vscode.StatusBarItem | undefined; // and there is no status bar item


### PR DESCRIPTION
This PR adds two new gulp tasks: `transpile-client` and `transpile-extensions`. It uses TypeScripts `transpileModule` to create JS from TS, no d.ts file, no source maps (would be possible), and no semantic analysis. 
