### PR TITLE
Fix snippet parser tests assertion

### DIFF
--- a/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
@@ -97,12 +97,12 @@ suite('SnippetParser', () => {
 	function assertMarker(input: TextmateSnippet | Marker[] | string, ...ctors: Function[]) {
 		let marker: Marker[];
 		if (input instanceof TextmateSnippet) {
-			marker = input.children;
+			marker = [...input.children];
 		} else if (typeof input === 'string') {
 			const p = new SnippetParser();
 			marker = p.parse(input).children;
 		} else {
-			marker = input;
+			marker = [...input];
 		}
 		while (marker.length > 0) {
 			const m = marker.pop();

--- a/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
@@ -273,12 +273,13 @@ suite('SnippetParser', () => {
 		assertTextAndMarker('${1|one,two,three,|}', '${1|one,two,three,|}', Text);
 		assertTextAndMarker('${1|one,', '${1|one,', Text);
 
-		const p = new SnippetParser();
-		const snippet = p.parse('${1|one,two,three|}');
-		assertMarker(snippet, Placeholder);
-		const expected = [Placeholder, Text, Text, Text];
+		const snippet = new SnippetParser().parse('${1|one,two,three|}');
+		const expected: ((m: Marker) => boolean)[] = [
+			m => m instanceof Placeholder,
+			m => m instanceof Choice && m.options.length === 3 && m.options.every(x => x instanceof Text),
+		];
 		snippet.walk(marker => {
-			assert.strictEqual(marker, expected.shift());
+			assert.ok(expected.shift()!(marker));
 			return true;
 		});
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes these within the snippet parser tests:

- The `assertMarker` method was altering the arguments sent to it (by popping the entire `children` array). So, potential assertions after a call to this method were subject to unpredicted results.
- The assertion below ([snippetParser.test.ts#L276][link]) didn't work as expected because of the `assertMarker` method dropping any children and leaving nothing for the `walk` to encounter. So, the `assert.strictEqual` was actually never called. Let alone the `strictEquals` would still fail, even if the types match.
- The resulting `Marker`s from the `walk` are only two: a `Placeholder` and a `Choice`. So the options of the choice should be asserted in another way.

```ts
const p = new SnippetParser();
const snippet = p.parse('${1|one,two,three|}');
assertMarker(snippet, Placeholder);
const expected = [Placeholder, Text, Text, Text];
snippet.walk(marker => {
	assert.strictEqual(marker, expected.shift());
	return true;
});
```

[link]: https://github.com/microsoft/vscode/blob/00574df08aac536a4262ce0ff975bd04a2768e80/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts#L276