### PR TITLE
rename ref-viewlet's publisher back to `vscode`

### DIFF
--- a/extensions/references-view/package.json
+++ b/extensions/references-view/package.json
@@ -4,7 +4,7 @@
   "description": "%description%",
   "icon": "media/icon.png",
   "version": "1.0.0",
-  "publisher": "ms-vscode",
+  "publisher": "vscode",
   "license": "MIT",
   "engines": {
     "vscode": "^1.67.0"


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/142168