### PR TITLE
Introduce negate pattern in `files.exclude`

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -711,7 +711,7 @@ export class FilesFilter implements ITreeFilter<ExplorerItem, FuzzyScore> {
 			const excludesConfigCopy = deepClone(excludesConfig); // do not keep the config, as it gets mutated under our hoods
 
 			// Prepare include list created from negate pattern (same as in .gitignore) in files.exclude
-			let includesConfig: glob.IExpression = Object.create(null);
+			const includesConfig: glob.IExpression = Object.create(null);
 			for (const key in excludesConfig) {
 				if (key.length > 1 && key[0] === '!') {
 					// populate include list from negated excludes


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #869 

Check `files.exclude` setting and extract all negate patterns from it into separate "include files" list.
To allow `!` as a first character of file name to be excluded, user should use backslash: 
```javascript
"files.exclude": {
	"*.js": true,
	"!gulpfile.js": true,
	"\\!my_exclude_file.txt": true  // needs double backslash to backslash the backslash :)
},
```
