### PR TITLE
Fix `<a>` without href stripping html

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -265,7 +265,7 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 				|| /^command:(\/\/\/)?_workbench\.downloadResource/i.test(href)
 			) {
 				// drop the link
-				a.replaceWith(a.textContent ?? '');
+				a.replaceWith(...a.childNodes);
 			} else {
 				let resolvedHref = _href(href, false);
 				if (markdown.baseUri) {

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -173,6 +173,14 @@ suite('MarkdownRenderer', () => {
 </tbody></table>
 `);
 		});
+
+		test('render icon in <a> without href (#152170)', () => {
+			const mds = new MarkdownString(undefined, { supportThemeIcons: true, supportHtml: true });
+			mds.appendMarkdown(`<a>$(sync)</a>`);
+
+			const result: HTMLElement = renderMarkdown(mds).element;
+			assert.strictEqual(result.innerHTML, `<p><span class="codicon codicon-sync"></span></p>`);
+		});
 	});
 
 	suite('ThemeIcons Support Off', () => {


### PR DESCRIPTION
Fixes #152170


`textContent` strips all html content. Instead we should replace the parent with its actual child nodes