### PR TITLE
Adding aria-selected attribute to custom dropdown list items

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBox.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBox.ts
@@ -53,6 +53,7 @@ export interface ISelectOptionItem {
 	descriptionIsMarkdown?: boolean;
 	descriptionMarkdownActionHandler?: IContentActionHandler;
 	isDisabled?: boolean;
+	isSelected?: boolean;
 }
 
 export interface ISelectBoxStyles extends IListStyles {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -32,6 +32,7 @@ interface ISelectListTemplateData {
 	detail: HTMLElement;
 	decoratorRight: HTMLElement;
 	disposables: IDisposable[];
+	isSelected: boolean;
 }
 
 class SelectListRenderer implements IListRenderer<ISelectOptionItem, ISelectListTemplateData> {
@@ -69,6 +70,8 @@ class SelectListRenderer implements IListRenderer<ISelectOptionItem, ISelectList
 			// Make sure we do class removal from prior template rendering
 			data.root.classList.remove('option-disabled');
 		}
+
+		data.root.ariaSelected = element.isSelected ? 'true' : 'false';
 	}
 
 	disposeTemplate(templateData: ISelectListTemplateData): void {
@@ -306,6 +309,10 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		this.selectElement.selectedIndex = this.selected;
 		if (!!this.options[this.selected] && !!this.options[this.selected].text) {
 			this.selectElement.title = this.options[this.selected].text;
+			this.options.forEach(option => {
+				option.isSelected = false;
+			});
+			this.options[this.selected].isSelected = true;
 		}
 	}
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -307,11 +307,13 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		}
 
 		this.selectElement.selectedIndex = this.selected;
+
+		this.options.forEach(option => {
+			option.isSelected = false;
+		});
+
 		if (!!this.options[this.selected] && !!this.options[this.selected].text) {
 			this.selectElement.title = this.options[this.selected].text;
-			this.options.forEach(option => {
-				option.isSelected = false;
-			});
 			this.options[this.selected].isSelected = true;
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

I am adding aria-selected attribute to the dropdown list items. Screen reader then stops announcing selected item as unselected.
This PR fixes #152228 

Before:
```
<div class="monaco-list-row focused" role="option" data-index="12" data-last-element="false" data-parity="even" aria-setsize="37" aria-posinset="13" id="list_id_19_12" aria-label="VS Code API Tests (workspace)" draggable="false" style="top: 216px; height: 18px; line-height: 18px;"><div class="option-text">VS Code API Tests (workspace)</div><div class="option-detail"></div><div class="option-decorator-right"></div></div>
```

After: 
Selected item:
```
<div class="monaco-list-row" role="option" data-index="13" data-last-element="false" data-parity="odd" aria-setsize="37" aria-posinset="14" id="list_id_5_13" aria-label="VS Code Tokenizer Tests" aria-selected="true" draggable="false" style="top: 234px; height: 18px; line-height: 18px;"><div class="option-text">VS Code Tokenizer Tests</div><div class="option-detail"></div><div class="option-decorator-right"></div></div>
```

Unselected item:
```
<div class="monaco-list-row" role="option" data-index="14" data-last-element="false" data-parity="even" aria-setsize="37" aria-posinset="15" id="list_id_5_14" aria-label="VS Code Emmet Tests" aria-selected="false" draggable="false" style="top: 252px; height: 18px; line-height: 18px;"><div class="option-text">VS Code Emmet Tests</div><div class="option-detail"></div><div class="option-decorator-right"></div></div>
```


