### PR TITLE
Make `jsx: react` the default for implicit js/ts projects

### DIFF
--- a/extensions/typescript-language-features/src/utils/tsconfig.ts
+++ b/extensions/typescript-language-features/src/utils/tsconfig.ts
@@ -26,7 +26,7 @@ const defaultProjectConfig = Object.freeze<Proto.ExternalProjectCompilerOptions>
 	module: 'ESNext' as Proto.ModuleKind,
 	moduleResolution: 'Node' as Proto.ModuleResolutionKind,
 	target: 'ES2020' as Proto.ScriptTarget,
-	jsx: 'preserve' as Proto.JsxEmit,
+	jsx: 'react' as Proto.JsxEmit,
 });
 
 export function inferredProjectCompilerOptions(


### PR DESCRIPTION
Fixes #152150

This fixes imports of `react` getting removed with TS 4.7 in implicit projects

