### PR TITLE
Fix ranges and validation setting for MD own path + header links

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/diagnostics.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/diagnostics.ts
@@ -394,7 +394,7 @@ export class DiagnosticComputer {
 		return {
 			links,
 			diagnostics: (await Promise.all([
-				this.validateFileLinks(doc, options, links, token),
+				this.validateFileLinks(options, links, token),
 				Array.from(this.validateReferenceLinks(options, links)),
 				this.validateFragmentLinks(doc, options, links, token),
 			])).flat()
@@ -415,6 +415,7 @@ export class DiagnosticComputer {
 		const diagnostics: vscode.Diagnostic[] = [];
 		for (const link of links) {
 			if (link.href.kind === 'internal'
+				&& link.source.text.startsWith('#')
 				&& link.href.path.toString() === doc.uri.toString()
 				&& link.href.fragment
 				&& !toc.lookup(link.href.fragment)
@@ -449,14 +450,15 @@ export class DiagnosticComputer {
 		}
 	}
 
-	private async validateFileLinks(doc: SkinnyTextDocument, options: DiagnosticOptions, links: readonly MdLink[], token: vscode.CancellationToken): Promise<vscode.Diagnostic[]> {
+	private async validateFileLinks(options: DiagnosticOptions, links: readonly MdLink[], token: vscode.CancellationToken): Promise<vscode.Diagnostic[]> {
 		const pathErrorSeverity = toSeverity(options.validateFileLinks);
 		if (typeof pathErrorSeverity === 'undefined') {
 			return [];
 		}
 		const fragmentErrorSeverity = toSeverity(typeof options.validateMarkdownFileLinkFragments === 'undefined' ? options.validateFragmentLinks : options.validateMarkdownFileLinkFragments);
 
-		const linkSet = new FileLinkMap(links);
+		// We've already validated our own fragment links in `validateOwnHeaderLinks`
+		const linkSet = new FileLinkMap(links.filter(link => !link.source.text.startsWith('#')));
 		if (linkSet.size === 0) {
 			return [];
 		}
@@ -472,11 +474,6 @@ export class DiagnosticComputer {
 					}
 
 					const hrefDoc = await tryFindMdDocumentForLink({ kind: 'internal', path: path, fragment: '' }, this.workspaceContents);
-					if (hrefDoc && hrefDoc.uri.toString() === doc.uri.toString()) {
-						// We've already validated our own links in `validateOwnHeaderLinks`
-						return;
-					}
-
 					if (!hrefDoc && !await this.workspaceContents.pathExists(path)) {
 						const msg = localize('invalidPathLink', 'File does not exist at path: {0}', path.fsPath);
 						for (const link of links) {

--- a/extensions/markdown-language-features/src/test/diagnostic.test.ts
+++ b/extensions/markdown-language-features/src/test/diagnostic.test.ts
@@ -8,8 +8,6 @@ import 'mocha';
 import * as vscode from 'vscode';
 import { DiagnosticComputer, DiagnosticConfiguration, DiagnosticLevel, DiagnosticManager, DiagnosticOptions } from '../languageFeatures/diagnostics';
 import { MdLinkComputer } from '../languageFeatures/documentLinkProvider';
-import { MdReferencesProvider } from '../languageFeatures/references';
-import { githubSlugifier } from '../slugify';
 import { noopToken } from '../util/cancellation';
 import { InMemoryDocument } from '../util/inMemoryDocument';
 import { MdWorkspaceContents } from '../workspaceContents';
@@ -37,8 +35,7 @@ async function getComputedDiagnostics(doc: InMemoryDocument, workspaceContents: 
 function createDiagnosticsManager(workspaceContents: MdWorkspaceContents, configuration = new MemoryDiagnosticConfiguration({})) {
 	const engine = createNewMarkdownEngine();
 	const linkComputer = new MdLinkComputer(engine);
-	const referencesProvider = new MdReferencesProvider(linkComputer, workspaceContents, engine, githubSlugifier);
-	return new DiagnosticManager(engine, workspaceContents, new DiagnosticComputer(engine, workspaceContents, linkComputer), configuration, referencesProvider);
+	return new DiagnosticManager(new DiagnosticComputer(engine, workspaceContents, linkComputer), configuration);
 }
 
 function assertDiagnosticsEqual(actual: readonly vscode.Diagnostic[], expectedRanges: readonly vscode.Range[]) {


### PR DESCRIPTION
Previously for a `file.md`, links to headers in that file that use paths, such as `[link](./file.md#some-header)` were validated using `markdown.experimental.validate.fragmentLinks.enabled`

This is confusing as that setting was only meant to be used for links such as`[link](#some-header`). It also resulted in the diagnostic having the incorrect range

This change instead makes these links be validated by `markdown.experimental.validate.fileLinks.markdownFragmentLinks`

