### PR TITLE
fix selected state for select box items

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1311,7 +1311,7 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 		private _options: IListOptions<T> = DefaultOptions
 	) {
 		const role = this._options.accessibilityProvider && this._options.accessibilityProvider.getWidgetRole ? this._options.accessibilityProvider?.getWidgetRole() : 'list';
-		this.selection = new SelectionTrait(role !== 'listbox');
+		this.selection = new SelectionTrait(role !== 'list');
 
 		mixin(_options, defaultStyles, false);
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -287,6 +287,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		// Mirror options in drop-down
 		// Populate select list for non-native select mode
 		this.selectList?.splice(0, this.selectList.length, this.options);
+		this.selectList?.setSelection([this.selected]);
 	}
 
 	public select(index: number): void {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -287,7 +287,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		// Mirror options in drop-down
 		// Populate select list for non-native select mode
 		this.selectList?.splice(0, this.selectList.length, this.options);
-		this.selectList?.setSelection([this.selected]);
+		this.selectList?.setSelection(this.selected !== -1 ? [this.selected] : []);
 	}
 
 	public select(index: number): void {


### PR DESCRIPTION
This pr fixes: #152228
fixes the issue that the aria-selected attribute of the options in the select box list is not set properly.


1. the selectionTrait was disabled for listbox role, which I believe is a mistake. as per https://www.w3.org/WAI/PF/HTML/wiki/RoleAttribute , list role is not selectable and listbox role is.
![image](https://user-images.githubusercontent.com/13777222/173969736-8ea22b2c-04c6-41ad-a92f-9e9ae7dccb1f.png)

2. set the selection properly for the list before it is displayed

Use the output channel select box as an example, with the changes in this PR:

![image](https://user-images.githubusercontent.com/13777222/173964841-6b5f6af5-32f4-4f23-8220-aceda120bc69.png)

I highlighted a few of them using white line in screenshot below
![image](https://user-images.githubusercontent.com/13777222/173965089-68a51bea-f2a6-4df2-bd5f-51aee0e9cdb5.png)