### PR TITLE
Enable translations of extension manifests on the marketplace

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionNls.ts
+++ b/src/vs/platform/extensionManagement/common/extensionNls.ts
@@ -12,7 +12,7 @@ export interface ITranslations {
 	[key: string]: string | { message: string; comment: string[] };
 }
 
-export function localizeManifest(manifest: IExtensionManifest, translations: ITranslations): IExtensionManifest {
+export function localizeManifest(manifest: IExtensionManifest, translations: ITranslations, fallbackTranslations?: ITranslations): IExtensionManifest {
 	const patcher = (value: string): string | undefined => {
 		if (typeof value !== 'string') {
 			return undefined;
@@ -24,7 +24,7 @@ export function localizeManifest(manifest: IExtensionManifest, translations: ITr
 			return undefined;
 		}
 
-		const translation = translations[match[1]] ?? value;
+		const translation = translations?.[match[1]] ?? fallbackTranslations?.[match[1]] ?? value;
 		return typeof translation === 'string' ? translation : (typeof translation.message === 'string' ? translation.message : value);
 	};
 

--- a/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
@@ -58,7 +58,7 @@ interface IStoredWebExtension {
 	readonly readmeUri?: UriComponents;
 	readonly changelogUri?: UriComponents;
 	// deprecated in favor of packageNLSUris & fallbackPackageNLSUri
-	packageNLSUri?: UriComponents;
+	readonly packageNLSUri?: UriComponents;
 	readonly packageNLSUris?: IStringDictionary<UriComponents>;
 	readonly fallbackPackageNLSUri?: UriComponents;
 	readonly metadata?: Metadata;

--- a/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
@@ -674,14 +674,14 @@ export class WebExtensionsScannerService extends Disposable implements IWebExten
 		const webExtensions = await this.withWebExtensions(this.installedExtensionsResource);
 
 		// TODO: @TylerLeonhardt/@Sandy081: Delete after 6 months
-		if (webExtensions.some(e => e.packageNLSUri)) {
+		if (webExtensions.some(e => !e.packageNLSUris && e.packageNLSUri)) {
 			return this.withWebExtensions(this.installedExtensionsResource, async (extensions) => {
 				for (const e of webExtensions) {
 					if (!e.packageNLSUris && e.packageNLSUri) {
 						e.fallbackPackageNLSUri = e.packageNLSUri;
 						const extensionResources = await this.listExtensionResources(e.location);
 						e.packageNLSUris = this.getNLSResourceMapFromResources(extensionResources);
-						// e.packageNLSUri = undefined;
+						e.packageNLSUri = undefined;
 					}
 				}
 				return webExtensions;


### PR DESCRIPTION
This is the low hanging fruit of the "translations of extensions for the web". Basically, we search for a `package.nls.{locale}.json` file and apply that. The `package.nls.json` file then becomes the fallback for any strings that were not translated.