### PR TITLE
Add option to always reveal tests after state change

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -554,6 +554,11 @@ export class TestingExplorerViewModel extends Disposable {
 			followRunningTests = getTestingConfiguration(configurationService, TestingConfigKeys.FollowRunningTest);
 		}));
 
+		let alwaysRevealTestAfterStateChange = getTestingConfiguration(configurationService, TestingConfigKeys.AlwaysRevealTestOnStateChange);
+		this._register(configurationService.onDidChangeConfiguration(() => {
+			alwaysRevealTestAfterStateChange = getTestingConfiguration(configurationService, TestingConfigKeys.AlwaysRevealTestOnStateChange);
+		}));
+
 		this._register(testResults.onTestChanged(evt => {
 			if (!followRunningTests) {
 				return;
@@ -569,7 +574,7 @@ export class TestingExplorerViewModel extends Disposable {
 				return;
 			}
 
-			this.revealById(evt.item.item.extId, false, false);
+			this.revealById(evt.item.item.extId, alwaysRevealTestAfterStateChange, false);
 		}));
 
 		this._register(testResults.onResultsChanged(() => {

--- a/src/vs/workbench/contrib/testing/common/configuration.ts
+++ b/src/vs/workbench/contrib/testing/common/configuration.ts
@@ -130,7 +130,7 @@ export const testingConfiguation: IConfigurationNode = {
 			description: localize('testing.openTesting', "Controls when the testing view should open.")
 		},
 		[TestingConfigKeys.AlwaysRevealTestOnStateChange]: {
-			description: localize('testing.alwaysRevealTestOnStateChange', "Always reveal the test in the tree view when its state has changed"),
+			markdownDescription: localize('testing.alwaysRevealTestOnStateChange', "Always reveal the executed test when `#testing.followRunningTest#` is on. If this setting is turned off, only failed tests will be revealed."),
 			type: 'boolean',
 			default: false,
 		},

--- a/src/vs/workbench/contrib/testing/common/configuration.ts
+++ b/src/vs/workbench/contrib/testing/common/configuration.ts
@@ -17,6 +17,7 @@ export const enum TestingConfigKeys {
 	DefaultGutterClickAction = 'testing.defaultGutterClickAction',
 	GutterEnabled = 'testing.gutterEnabled',
 	SaveBeforeTest = 'testing.saveBeforeTest',
+	AlwaysRevealTestOnStateChange = 'testing.alwaysRevealTestOnStateChange'
 }
 
 export const enum AutoOpenTesting {
@@ -128,6 +129,11 @@ export const testingConfiguation: IConfigurationNode = {
 			default: 'openOnTestStart',
 			description: localize('testing.openTesting', "Controls when the testing view should open.")
 		},
+		[TestingConfigKeys.AlwaysRevealTestOnStateChange]: {
+			description: localize('testing.alwaysRevealTestOnStateChange', "Always reveal the test in the tree view when its state has changed"),
+			type: 'boolean',
+			default: false,
+		},
 	}
 };
 
@@ -141,6 +147,7 @@ export interface ITestingConfiguration {
 	[TestingConfigKeys.GutterEnabled]: boolean;
 	[TestingConfigKeys.SaveBeforeTest]: boolean;
 	[TestingConfigKeys.OpenTesting]: AutoOpenTesting;
+	[TestingConfigKeys.AlwaysRevealTestOnStateChange]: boolean;
 }
 
 export const getTestingConfiguration = <K extends TestingConfigKeys>(config: IConfigurationService, key: K) => config.getValue<ITestingConfiguration[K]>(key);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #151847

A new configuration parameter, named `testing.alwaysRevealTestOnStateChange`, is added. When enabled, after a test's state has changed, the tree view expands to reveal the corresponding item. The default value of the new parameter is set to `false`, which keeps the existing behavior in place.