### PR TITLE
Dispose the management connection when the extension host exits after running tests or after a development session to avoid reconnection attempts

### DIFF
--- a/src/vs/workbench/services/extensions/electron-sandbox/electronExtensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/electronExtensionService.ts
@@ -594,6 +594,12 @@ export abstract class ElectronExtensionService extends AbstractExtensionService 
 		// Dispose everything associated with the extension host
 		this.stopExtensionHosts();
 
+		// Dispose the management connection to avoid reconnecting after the extension host exits
+		const connection = this._remoteAgentService.getConnection();
+		if (connection) {
+			connection.dispose();
+		}
+
 		if (this._isExtensionDevTestFromCli) {
 			// When CLI testing make sure to exit with proper exit code
 			this._nativeHostService.exit(code);

--- a/src/vs/workbench/services/remote/common/remoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/remoteAgentService.ts
@@ -68,6 +68,7 @@ export interface IRemoteAgentConnection {
 	readonly onReconnecting: Event<void>;
 	readonly onDidStateChange: Event<PersistentConnectionEvent>;
 
+	dispose(): void;
 	getChannel<T extends IChannel>(channelName: string): T;
 	withChannel<T extends IChannel, R>(channelName: string, callback: (channel: T) => Promise<R>): Promise<R>;
 	registerChannel<T extends IServerChannel<RemoteAgentConnectionContext>>(channelName: string, channel: T): void;


### PR DESCRIPTION
cc @aeschli
#147755