### PR TITLE
xterm-addon-webgl@0.12.0-beta.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "xterm-addon-search": "0.9.0-beta.39",
     "xterm-addon-serialize": "0.7.0-beta.12",
     "xterm-addon-unicode11": "0.4.0-beta.3",
-    "xterm-addon-webgl": "0.12.0-beta.38",
+    "xterm-addon-webgl": "0.12.0-beta.39",
     "xterm-headless": "4.19.0-beta.60",
     "yauzl": "^2.9.2",
     "yazl": "^2.4.3"

--- a/remote/package.json
+++ b/remote/package.json
@@ -30,7 +30,7 @@
     "xterm-addon-search": "0.9.0-beta.39",
     "xterm-addon-serialize": "0.7.0-beta.12",
     "xterm-addon-unicode11": "0.4.0-beta.3",
-    "xterm-addon-webgl": "0.12.0-beta.38",
+    "xterm-addon-webgl": "0.12.0-beta.39",
     "xterm-headless": "4.19.0-beta.60",
     "yauzl": "^2.9.2",
     "yazl": "^2.4.3"

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -15,6 +15,6 @@
 		"xterm": "4.19.0-beta.60",
 		"xterm-addon-search": "0.9.0-beta.39",
 		"xterm-addon-unicode11": "0.4.0-beta.3",
-		"xterm-addon-webgl": "0.12.0-beta.38"
+		"xterm-addon-webgl": "0.12.0-beta.39"
 	}
 }

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -141,10 +141,10 @@ xterm-addon-unicode11@0.4.0-beta.3:
   resolved "https://registry.yarnpkg.com/xterm-addon-unicode11/-/xterm-addon-unicode11-0.4.0-beta.3.tgz#f350184155fafd5ad0d6fbf31d13e6ca7dea1efa"
   integrity sha512-FryZAVwbUjKTmwXnm1trch/2XO60F5JsDvOkZhzobV1hm10sFLVuZpFyHXiUx7TFeeFsvNP+S77LAtWoeT5z+Q==
 
-xterm-addon-webgl@0.12.0-beta.38:
-  version "0.12.0-beta.38"
-  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.12.0-beta.38.tgz#59fc8f3711e38b9a238fd460cd070007b7904e7a"
-  integrity sha512-fqRhfwUx/WZlDLFsZX26irLYTdRGMf1xuRwoqfr4KiFoQvHye55U8VJ4WLHdWglN2Kzh8PbINk5HfMhIwYHe9Q==
+xterm-addon-webgl@0.12.0-beta.39:
+  version "0.12.0-beta.39"
+  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.12.0-beta.39.tgz#f5fafd2c4d1ec046ff6b57edf850234948cf630a"
+  integrity sha512-116gk9KYqbMyCcjedDYhqg3RKl0CI19I1l/+u8JdJb6bucv835Hj60W2it5AAsmvw726FEXwhMoOaY3gs+n1/g==
 
 xterm@4.19.0-beta.60:
   version "4.19.0-beta.60"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -947,10 +947,10 @@ xterm-addon-unicode11@0.4.0-beta.3:
   resolved "https://registry.yarnpkg.com/xterm-addon-unicode11/-/xterm-addon-unicode11-0.4.0-beta.3.tgz#f350184155fafd5ad0d6fbf31d13e6ca7dea1efa"
   integrity sha512-FryZAVwbUjKTmwXnm1trch/2XO60F5JsDvOkZhzobV1hm10sFLVuZpFyHXiUx7TFeeFsvNP+S77LAtWoeT5z+Q==
 
-xterm-addon-webgl@0.12.0-beta.38:
-  version "0.12.0-beta.38"
-  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.12.0-beta.38.tgz#59fc8f3711e38b9a238fd460cd070007b7904e7a"
-  integrity sha512-fqRhfwUx/WZlDLFsZX26irLYTdRGMf1xuRwoqfr4KiFoQvHye55U8VJ4WLHdWglN2Kzh8PbINk5HfMhIwYHe9Q==
+xterm-addon-webgl@0.12.0-beta.39:
+  version "0.12.0-beta.39"
+  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.12.0-beta.39.tgz#f5fafd2c4d1ec046ff6b57edf850234948cf630a"
+  integrity sha512-116gk9KYqbMyCcjedDYhqg3RKl0CI19I1l/+u8JdJb6bucv835Hj60W2it5AAsmvw726FEXwhMoOaY3gs+n1/g==
 
 xterm-headless@4.19.0-beta.60:
   version "4.19.0-beta.60"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12271,10 +12271,10 @@ xterm-addon-unicode11@0.4.0-beta.3:
   resolved "https://registry.yarnpkg.com/xterm-addon-unicode11/-/xterm-addon-unicode11-0.4.0-beta.3.tgz#f350184155fafd5ad0d6fbf31d13e6ca7dea1efa"
   integrity sha512-FryZAVwbUjKTmwXnm1trch/2XO60F5JsDvOkZhzobV1hm10sFLVuZpFyHXiUx7TFeeFsvNP+S77LAtWoeT5z+Q==
 
-xterm-addon-webgl@0.12.0-beta.38:
-  version "0.12.0-beta.38"
-  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.12.0-beta.38.tgz#59fc8f3711e38b9a238fd460cd070007b7904e7a"
-  integrity sha512-fqRhfwUx/WZlDLFsZX26irLYTdRGMf1xuRwoqfr4KiFoQvHye55U8VJ4WLHdWglN2Kzh8PbINk5HfMhIwYHe9Q==
+xterm-addon-webgl@0.12.0-beta.39:
+  version "0.12.0-beta.39"
+  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.12.0-beta.39.tgz#f5fafd2c4d1ec046ff6b57edf850234948cf630a"
+  integrity sha512-116gk9KYqbMyCcjedDYhqg3RKl0CI19I1l/+u8JdJb6bucv835Hj60W2it5AAsmvw726FEXwhMoOaY3gs+n1/g==
 
 xterm-headless@4.19.0-beta.60:
   version "4.19.0-beta.60"


### PR DESCRIPTION
This is one of those odd cases where the latest (.40) is actually older than the
one before because the merged happened close by.

This brings in the light-height webgl powerline fix xtermjs/xterm.js#3862
