### PR TITLE
Fix #151817

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -762,8 +762,9 @@ export class FilesFilter implements ITreeFilter<ExplorerItem, FuzzyScore> {
 		// Add newly visited .gitignore files to the ignore tree
 		if (stat.name === '.gitignore') {
 			this.processIgnoreFile(stat.root.resource.toString(), stat.resource, false);
-			// Never hide .gitignore files
-			return true;
+			// Never hide .gitignore files if explorer.excludeGitIgnore setting is enabled
+			// We can tell it's enabled if there is an ignore tree for the workspace root
+			return !!this.ignoreTreesPerRoot.get(stat.root.resource.toString());
 		}
 
 		return this.isVisible(stat, parentVisibility);


### PR DESCRIPTION
If the user hasn't enabled `explorer.excludeGitIgnore` don't prevent gitIgnore files form being hidden