### PR TITLE
Adding __id to the output metadata in .ipynb files

### DIFF
--- a/extensions/ipynb/src/common.ts
+++ b/extensions/ipynb/src/common.ts
@@ -39,6 +39,11 @@ export interface CellOutputMetadata {
 	 * (this is something we have added)
 	 */
 	__isJson?: boolean;
+
+	/**
+	 * A unique identifier to track a specific output.
+	 */
+	__id?: string;
 }
 
 

--- a/extensions/ipynb/src/deserializers.ts
+++ b/extensions/ipynb/src/deserializers.ts
@@ -6,6 +6,7 @@
 import * as nbformat from '@jupyterlab/nbformat';
 import { extensions, NotebookCellData, NotebookCellExecutionSummary, NotebookCellKind, NotebookCellOutput, NotebookCellOutputItem, NotebookData } from 'vscode';
 import { CellMetadata, CellOutputMetadata } from './common';
+import * as uuid from "uuid/v4";
 
 const jupyterLanguageToMonacoLanguageMapping = new Map([
 	['c#', 'csharp'],
@@ -167,6 +168,7 @@ function getNotebookCellMetadata(cell: nbformat.IBaseCell): CellMetadata {
 function getOutputMetadata(output: nbformat.IOutput): CellOutputMetadata {
 	// Add on transient data if we have any. This should be removed by our save functions elsewhere.
 	const metadata: CellOutputMetadata = {
+		__id: uuid(),
 		outputType: output.output_type
 	};
 	if (output.transient) {


### PR DESCRIPTION
This PR ensures that the outputs have an Id that we can use to track changes to each separate output UI as we render them in the vscode-jupyter extension.

Related to:
- https://github.com/microsoft/vscode-notebook-renderers/pull/114
- https://github.com/microsoft/vscode-jupyter/pull/10468

How does this look? Feedback appreciated!