### PR TITLE
Update module ignores to include AI shims required by 1DS

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -124,6 +124,7 @@ prebuild-install/**/*
 
 @microsoft/applicationinsights*/**
 @microsoft/dynamicproto-js/**
+!@microsoft/applicationinsights-shims/dist/**
 !@microsoft/applicationinsights-web/dist/applicationinsights-web.min.js
 
 # other node modules

--- a/build/.webignore
+++ b/build/.webignore
@@ -35,4 +35,5 @@ xterm-addon-webgl/out/**
 
 @microsoft/applicationinsights*/**
 @microsoft/dynamicproto-js/**
+!@microsoft/applicationinsights-shims/dist/**
 !@microsoft/applicationinsights-web/dist/applicationinsights-web.min.js


### PR DESCRIPTION
Looks like 1DS isn't working in core because AI shims are missing