### PR TITLE
Add experimental Continue Edit Session API command

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -876,6 +876,13 @@ export class CodeApplication extends Disposable {
 				// or if no window is open (macOS only)
 				shouldOpenInNewWindow ||= isMacintosh && windowsMainService.getWindowCount() === 0;
 
+				// Pass along edit session id
+				if (params.get('edit-session-id') !== null) {
+					environmentService.editSessionId = params.get('edit-session-id') ?? undefined;
+					params.delete('edit-session-id');
+					uri = uri.with({ query: params.toString() });
+				}
+
 				// Check for URIs to open in window
 				const windowOpenableFromProtocolLink = app.getWindowOpenableFromProtocolLink(uri);
 				logService.trace('app#handleURL: windowOpenableFromProtocolLink = ', windowOpenableFromProtocolLink);

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -64,6 +64,9 @@ export interface IEnvironmentService {
 	userDataSyncLogResource: URI;
 	sync: 'on' | 'off' | undefined;
 
+	// --- continue edit session
+	editSessionId?: string;
+
 	// --- extension development
 	debugExtensionHost: IExtensionHostDebugParams;
 	isExtensionDevelopment: boolean;

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -436,6 +436,12 @@ const newCommands: ApiCommand[] = [
 		'vscode.revealTestInExplorer', '_revealTestInExplorer', 'Reveals a test instance in the explorer',
 		[ApiCommandArgument.TestItem],
 		ApiCommandResult.Void
+	),
+	// --- continue edit session
+	new ApiCommand(
+		'vscode.experimental.editSession.continue', '_workbench.experimental.sessionSync.actions.continueEditSession', 'Continue the current edit session in a different workspace',
+		[ApiCommandArgument.Uri.with('workspaceUri', 'The target workspace to continue the current edit session in')],
+		ApiCommandResult.Void
 	)
 ];
 

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -170,6 +170,11 @@ export interface IWorkbenchConstructionOptions {
 	readonly codeExchangeProxyEndpoints?: { [providerId: string]: string };
 
 	/**
+	 * The identifier of an edit session associated with the current workspace.
+	 */
+	readonly editSessionId?: string;
+
+	/**
 	 * [TEMPORARY]: This will be removed soon.
 	 * Endpoints to be used for proxying repository tarball download calls in the browser.
 	 */

--- a/src/vs/workbench/contrib/sessionSync/browser/sessionSync.contribution.ts
+++ b/src/vs/workbench/contrib/sessionSync/browser/sessionSync.contribution.ts
@@ -68,7 +68,7 @@ export class SessionSyncContribution extends Disposable implements IWorkbenchCon
 		super();
 
 		if (this.environmentService.editSessionId !== undefined) {
-			void this.applyEditSession(this.environmentService.editSessionId);
+			void this.applyEditSession(this.environmentService.editSessionId).then(() => this.environmentService.editSessionId = undefined);
 		}
 
 		this.configurationService.onDidChangeConfiguration((e) => {
@@ -111,6 +111,8 @@ export class SessionSyncContribution extends Disposable implements IWorkbenchCon
 				workspaceUri = workspaceUri.with({
 					query: workspaceUri.query.length > 0 ? (workspaceUri + `&${queryParamName}=${ref}`) : `${queryParamName}=${ref}`
 				});
+
+				that.environmentService.editSessionId = ref;
 
 				// Open the URI
 				that.logService.info(`Edit sessions: opening ${workspaceUri.toString()}`);

--- a/src/vs/workbench/contrib/sessionSync/browser/sessionSync.contribution.ts
+++ b/src/vs/workbench/contrib/sessionSync/browser/sessionSync.contribution.ts
@@ -28,6 +28,7 @@ import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 
 registerSingleton(ISessionSyncWorkbenchService, SessionSyncWorkbenchService);
 
@@ -59,11 +60,16 @@ export class SessionSyncContribution extends Disposable implements IWorkbenchCon
 		@INotificationService private readonly notificationService: INotificationService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@ILogService private readonly logService: ILogService,
+		@IEnvironmentService private readonly environmentService: IEnvironmentService,
 		@IProductService private readonly productService: IProductService,
 		@IConfigurationService private configurationService: IConfigurationService,
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
 	) {
 		super();
+
+		if (this.environmentService.editSessionId !== undefined) {
+			void this.applyEditSession(this.environmentService.editSessionId);
+		}
 
 		this.configurationService.onDidChangeConfiguration((e) => {
 			if (e.affectsConfiguration('workbench.experimental.sessionSync.enabled')) {

--- a/src/vs/workbench/contrib/sessionSync/test/browser/sessionSync.test.ts
+++ b/src/vs/workbench/contrib/sessionSync/test/browser/sessionSync.test.ts
@@ -26,6 +26,8 @@ import { URI } from 'vs/base/common/uri';
 import { joinPath } from 'vs/base/common/resources';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
+import { TestEnvironmentService } from 'vs/workbench/test/browser/workbenchTestServices';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 
 const folderName = 'test-folder';
 const folderUri = URI.file(`/${folderName}`);
@@ -53,6 +55,7 @@ suite('Edit session sync', () => {
 		instantiationService.stub(ISessionSyncWorkbenchService, new class extends mock<ISessionSyncWorkbenchService>() { });
 		instantiationService.stub(IProgressService, ProgressService);
 		instantiationService.stub(ISCMService, SCMService);
+		instantiationService.stub(IEnvironmentService, TestEnvironmentService);
 		instantiationService.stub(IConfigurationService, new TestConfigurationService({ workbench: { experimental: { sessionSync: { enabled: true } } } }));
 		instantiationService.stub(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() {
 			override getWorkspace() {

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -205,6 +205,9 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 	@memoize
 	get disableWorkspaceTrust(): boolean { return !this.options.enableWorkspaceTrust; }
 
+	@memoize
+	get editSessionId(): string | undefined { return this.options.editSessionId; }
+
 	private payload: Map<string, string> | undefined;
 
 	constructor(

--- a/src/vs/workbench/services/sessionSync/browser/sessionSyncWorkbenchService.ts
+++ b/src/vs/workbench/services/sessionSync/browser/sessionSyncWorkbenchService.ts
@@ -60,14 +60,15 @@ export class SessionSyncWorkbenchService extends Disposable implements ISessionS
 	/**
 	 *
 	 * @param editSession An object representing edit session state to be restored.
+	 * @returns The ref of the stored edit session state.
 	 */
-	async write(editSession: EditSession): Promise<void> {
+	async write(editSession: EditSession): Promise<string> {
 		this.initialized = await this.waitAndInitialize();
 		if (!this.initialized) {
 			throw new Error('Please sign in to store your edit session.');
 		}
 
-		await this.storeClient?.write('editSessions', JSON.stringify(editSession), null);
+		return this.storeClient!.write('editSessions', JSON.stringify(editSession), null);
 	}
 
 	/**

--- a/src/vs/workbench/services/sessionSync/common/sessionSync.ts
+++ b/src/vs/workbench/services/sessionSync/common/sessionSync.ts
@@ -13,7 +13,7 @@ export interface ISessionSyncWorkbenchService {
 	_serviceBrand: undefined;
 
 	read(ref: string | undefined): Promise<EditSession | undefined>;
-	write(editSession: EditSession): Promise<void>;
+	write(editSession: EditSession): Promise<string>;
 }
 
 export enum ChangeType {


### PR DESCRIPTION
Re: https://github.com/microsoft/vscode/issues/141293

This PR allows extensions which invoke our API command with a target URI (such as RemoteHub) to automatically export and apply uncommitted changes from the current workspace to the target URI.

This PR introduces:
- An API command `vscode.experimental.editSessions.continue` which accepts a target URI to open, stores the edit session for this URI, and appends the edit session identifier to the URI params to associate it with the destination URI
- An edit session query parameter which is read from:
  - protocol URL (web -> desktop)
  - embedder API (desktop/web -> web)
  and applied to the destination folder.

Additionally, this PR:
- marks all related commands experimental
- improves the contrib logging