### PR TITLE
Change modified in to use custom hover

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconHoverDelegate.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconHoverDelegate.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
+import { IUpdatableHoverOptions } from 'vs/base/browser/ui/iconLabel/iconLabelHover';
 import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { IDisposable } from 'vs/base/common/lifecycle';
 
@@ -12,7 +13,7 @@ export interface IHoverDelegateTarget extends IDisposable {
 	x?: number;
 }
 
-export interface IHoverDelegateOptions {
+export interface IHoverDelegateOptions extends IUpdatableHoverOptions {
 	content: IMarkdownString | string | HTMLElement;
 	target: IHoverDelegateTarget | HTMLElement;
 	hoverPosition?: HoverPosition;

--- a/src/vs/base/browser/ui/iconLabel/iconLabelHover.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabelHover.ts
@@ -33,6 +33,21 @@ export function setupNativeHover(htmlElement: HTMLElement, tooltip: string | ITo
 export type IHoverContent = string | ITooltipMarkdownString | HTMLElement | undefined;
 type IResolvedHoverContent = IMarkdownString | string | HTMLElement | undefined;
 
+/**
+ * Copied from src\vs\workbench\services\hover\browser\hover.ts
+ * @deprecated Use IHoverService
+ */
+export interface IHoverAction {
+	label: string;
+	commandId: string;
+	iconClass?: string;
+	run(target: HTMLElement): void;
+}
+
+export interface IUpdatableHoverOptions {
+	actions?: IHoverAction[];
+	linkHandler?(url: string): void;
+}
 
 export interface ICustomHover extends IDisposable {
 
@@ -49,7 +64,7 @@ export interface ICustomHover extends IDisposable {
 	/**
 	 * Updates the contents of the hover.
 	 */
-	update(tooltip: IHoverContent): void;
+	update(tooltip: IHoverContent, options?: IUpdatableHoverOptions): void;
 }
 
 
@@ -61,7 +76,7 @@ class UpdatableHoverWidget implements IDisposable {
 	constructor(private hoverDelegate: IHoverDelegate, private target: IHoverDelegateTarget | HTMLElement, private fadeInAnimation: boolean) {
 	}
 
-	async update(content: IHoverContent, focus?: boolean): Promise<void> {
+	async update(content: IHoverContent, focus?: boolean, options?: IUpdatableHoverOptions): Promise<void> {
 		if (this._cancellationTokenSource) {
 			// there's an computation ongoing, cancel it
 			this._cancellationTokenSource.dispose(true);
@@ -99,10 +114,10 @@ class UpdatableHoverWidget implements IDisposable {
 			}
 		}
 
-		this.show(resolvedContent, focus);
+		this.show(resolvedContent, focus, options);
 	}
 
-	private show(content: IResolvedHoverContent, focus?: boolean): void {
+	private show(content: IResolvedHoverContent, focus?: boolean, options?: IUpdatableHoverOptions): void {
 		const oldHoverWidget = this._hoverWidget;
 
 		if (this.hasContent(content)) {
@@ -111,7 +126,8 @@ class UpdatableHoverWidget implements IDisposable {
 				target: this.target,
 				showPointer: this.hoverDelegate.placement === 'element',
 				hoverPosition: HoverPosition.BELOW,
-				skipFadeInAnimation: !this.fadeInAnimation || !!oldHoverWidget // do not fade in if the hover is already showing
+				skipFadeInAnimation: !this.fadeInAnimation || !!oldHoverWidget, // do not fade in if the hover is already showing
+				...options
 			};
 
 			this._hoverWidget = this.hoverDelegate.showHover(hoverOptions, focus);
@@ -142,7 +158,7 @@ class UpdatableHoverWidget implements IDisposable {
 	}
 }
 
-export function setupCustomHover(hoverDelegate: IHoverDelegate, htmlElement: HTMLElement, content: IHoverContent): ICustomHover {
+export function setupCustomHover(hoverDelegate: IHoverDelegate, htmlElement: HTMLElement, content: IHoverContent, options?: IUpdatableHoverOptions): ICustomHover {
 	let hoverPreparation: IDisposable | undefined;
 
 	let hoverWidget: UpdatableHoverWidget | undefined;
@@ -163,7 +179,7 @@ export function setupCustomHover(hoverDelegate: IHoverDelegate, htmlElement: HTM
 		return new TimeoutTimer(async () => {
 			if (!hoverWidget || hoverWidget.isDisposed) {
 				hoverWidget = new UpdatableHoverWidget(hoverDelegate, target || htmlElement, delay > 0);
-				await hoverWidget.update(content, focus);
+				await hoverWidget.update(content, focus, options);
 			}
 		}, delay);
 	};
@@ -208,9 +224,9 @@ export function setupCustomHover(hoverDelegate: IHoverDelegate, htmlElement: HTM
 		hide: () => {
 			hideHover(true, true);
 		},
-		update: async newContent => {
+		update: async (newContent, hoverOptions) => {
 			content = newContent;
-			await hoverWidget?.update(content);
+			await hoverWidget?.update(content, undefined, hoverOptions);
 		},
 		dispose: () => {
 			mouseOverDomEmitter.dispose();

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -351,8 +351,7 @@
 	font-style: italic;
 }
 
-.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-ignored .codicon,
-.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .setting-item-default-overridden .codicon {
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .codicon {
 	vertical-align: middle;
 	padding-left: 1px;
 }

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -112,10 +112,10 @@ export class SettingsTreeIndicatorsLabel {
 			this.scopeOverridesElement.style.display = 'inline';
 			if (element.overriddenScopeList.length === 1) {
 				// Just show all the text in the label.
-				const configuredInText = element.isConfigured ?
+				const prefaceText = element.isConfigured ?
 					localize('alsoConfiguredIn', "Also modified in") :
 					localize('configuredIn', "Modified in");
-				this.scopeOverridesLabel.text = `${configuredInText}: `;
+				this.scopeOverridesLabel.text = `${prefaceText}: `;
 
 				const firstScope = element.overriddenScopeList[0];
 				const view = DOM.append(this.scopeOverridesElement, $('a.modified-scope', undefined, firstScope));
@@ -136,17 +136,17 @@ export class SettingsTreeIndicatorsLabel {
 					localize('configuredElsewhere', "Modified elsewhere");
 				this.scopeOverridesLabel.text = scopeOverridesLabelText;
 
-				const scopeOverridesContent = $('.scope-overrides-hover-content');
-				const scopeOverridesHoverMessagePreface = element.isConfigured ?
+				const content = $('.scope-overrides-hover-content');
+				const prefaceText = element.isConfigured ?
 					localize('alsoModifiedInScopes', "The setting has also been modified in the following scopes:") :
 					localize('modifiedInScopes', "The setting has been modified in the following scopes:");
-				const prefaceParagraph = DOM.append(scopeOverridesContent, $('p', { 'style': 'padding: 4px 8px;' }, scopeOverridesHoverMessagePreface));
-				const listMessage = DOM.append(prefaceParagraph, $('ul'));
+				const preface = DOM.append(content, $('p', { 'style': 'padding: 4px 8px;' }, prefaceText));
+				const list = DOM.append(preface, $('ul'));
 				for (const scope of element.overriddenScopeList) {
-					const listBullet = DOM.append(listMessage, $('li'));
+					const listBullet = DOM.append(list, $('li'));
 					DOM.append(listBullet, $('span.modified-scope', undefined, scope));
 				}
-				setupCustomHover(this.hoverDelegate, this.scopeOverridesElement, scopeOverridesContent);
+				setupCustomHover(this.hoverDelegate, this.scopeOverridesElement, content);
 			}
 		}
 		this.render();

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -144,17 +144,7 @@ export class SettingsTreeIndicatorsLabel {
 				const listMessage = DOM.append(prefaceParagraph, $('ul'));
 				for (const scope of element.overriddenScopeList) {
 					const listBullet = DOM.append(listMessage, $('li'));
-					// TODO: Turn this into a link after improving onDidClickOverrideElement
-					const scopeLink = DOM.append(listBullet, $('span.modified-scope', undefined, scope));
-					elementDisposables.add(
-						DOM.addStandardDisposableListener(scopeLink, DOM.EventType.CLICK, (e: IMouseEvent) => {
-							onDidClickOverrideElement.fire({
-								targetKey: element.setting.key,
-								scope
-							});
-							e.preventDefault();
-							e.stopPropagation();
-						}));
+					DOM.append(listBullet, $('span.modified-scope', undefined, scope));
 				}
 				setupCustomHover(this.hoverDelegate, this.scopeOverridesElement, scopeOverridesContent);
 			}


### PR DESCRIPTION
Ref #151787

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR changes the "Modified in/Also modified in" label to say "(Also) modified elsewhere" when there are two or more scopes in which the setting has been modified. 

When the "Modified elsewhere" label is displayed, there is also a custom hover that shows a list of scopes in which the setting has been modified. 

For now, the hover shows a list of spans rather than a list of links, but I plan on upgrading the link handler event for clicking on a scope in general, and then using links instead.

![A screenshot showing the new Modified elsewhere label along with the custom hover](https://user-images.githubusercontent.com/7199958/174194365-4089a061-1a93-4f24-a81b-aa87c6097262.PNG)

