### PR TITLE
Prevent terminals being attached to by multiple windows

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -210,7 +210,7 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 		this._dimensions.rows = rows;
 		this._isScreenReaderModeEnabled = isScreenReaderModeEnabled;
 
-		let newProcess: ITerminalChildProcess;
+		let newProcess: ITerminalChildProcess | undefined;
 
 		if (shellLaunchConfig.customPtyImplementation) {
 			this._processType = ProcessType.PsuedoTerminal;
@@ -251,10 +251,12 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 					if (result) {
 						newProcess = result;
 					} else {
-						this._logService.trace(`Attach to process failed for terminal ${shellLaunchConfig.attachPersistentProcess}`);
-						return undefined;
+						// Warn and just create a new terminal if attach failed for some reason
+						this._logService.warn(`Attach to process failed for terminal`, shellLaunchConfig.attachPersistentProcess);
+						shellLaunchConfig.attachPersistentProcess = undefined;
 					}
-				} else {
+				}
+				if (!newProcess) {
 					await this._terminalProfileResolverService.resolveShellLaunchConfig(shellLaunchConfig, {
 						remoteAuthority: this.remoteAuthority,
 						os: this.os
@@ -294,10 +296,12 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 					if (result) {
 						newProcess = result;
 					} else {
-						this._logService.trace(`Attach to process failed for terminal ${shellLaunchConfig.attachPersistentProcess}`);
-						return undefined;
+						// Warn and just create a new terminal if attach failed for some reason
+						this._logService.warn(`Attach to process failed for terminal`, shellLaunchConfig.attachPersistentProcess);
+						shellLaunchConfig.attachPersistentProcess = undefined;
 					}
-				} else {
+				}
+				if (!newProcess) {
 					newProcess = await this._launchLocalProcess(backend, shellLaunchConfig, cols, rows, this.userHome, isScreenReaderModeEnabled, variableResolver);
 				}
 				if (!this._isDisposed) {
@@ -335,7 +339,7 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 
 				if (this._preLaunchInputQueue.length > 0 && this._process) {
 					// Send any queued data that's waiting
-					newProcess.input(this._preLaunchInputQueue.join(''));
+					newProcess!.input(this._preLaunchInputQueue.join(''));
 					this._preLaunchInputQueue.length = 0;
 				}
 			}),


### PR DESCRIPTION
I was no able to reproduce the issue where users were seeing a terminal get reconnected
to from multiple windows. This is a defensive change that does the following:

- When a persistent process is being attached to, check if it is disconnected. If so,
confirm that it is orphaned, continue if so and throw if not.
- Silently recreate a new process with warning logs if an attach fails.

Fixes #133542
