### PR TITLE
Stop removing app insights in the meantime

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -122,11 +122,6 @@ vscode-windows-ca-certs/**/*
 node-addon-api/**/*
 prebuild-install/**/*
 
-@microsoft/applicationinsights*/**
-@microsoft/dynamicproto-js/**
-!@microsoft/applicationinsights-shims/**
-!@microsoft/applicationinsights-web/dist/applicationinsights-web.min.js
-
 # other node modules
 
 **/docs/**

--- a/build/.webignore
+++ b/build/.webignore
@@ -33,7 +33,3 @@ xterm-addon-webgl/out/**
 # This makes sure the model is included in the package
 !@vscode/vscode-languagedetection/model/**
 
-@microsoft/applicationinsights*/**
-@microsoft/dynamicproto-js/**
-!@microsoft/applicationinsights-shims/**
-!@microsoft/applicationinsights-web/dist/applicationinsights-web.min.js


### PR DESCRIPTION
This PR stops removing parts of app insights from the build while we figure out 1DS