### PR TITLE
Disable terminal smoke tests on desktop/remote

### DIFF
--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -400,7 +400,7 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupSearchTests(logger);
 	setupNotebookTests(logger);
 	setupLanguagesTests(logger);
-	setupTerminalTests(logger);
+	if (opts.web) { setupTerminalTests(logger); } // Not stable on desktop/remote https://github.com/microsoft/vscode/issues/146811
 	setupStatusbarTests(logger);
 	if (quality !== Quality.Dev && quality !== Quality.OSS) { setupExtensionTests(logger); }
 	setupMultirootTests(logger);


### PR DESCRIPTION
Fixes #152451
