### PR TITLE
Use new method for settings in terminal split cwd smoke test

### DIFF
--- a/test/smoke/src/areas/terminal/terminal-splitCwd.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-splitCwd.test.ts
@@ -15,8 +15,9 @@ export function setup() {
 			const app = this.app as Application;
 			terminal = app.workbench.terminal;
 			settingsEditor = app.workbench.settingsEditor;
-			await settingsEditor.addUserSetting('terminal.integrated.splitCwd', '"inherited"');
-			await setTerminalTestSettings(app);
+			await setTerminalTestSettings(app, [
+				['terminal.integrated.splitCwd', '"inherited"']
+			]);
 		});
 
 		after(async function () {


### PR DESCRIPTION
I doubt this will fix the flake, but it's the right way to do things now.

Part of #152451
