### PR TITLE
Fix missing horizontal bracket guides when editor.wrappingIndent == "same"

### DIFF
--- a/src/vs/editor/common/viewModel/viewModelLines.ts
+++ b/src/vs/editor/common/viewModel/viewModelLines.ts
@@ -573,72 +573,69 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 			);
 
 			for (const viewLineInfo of group.viewLines) {
-				if (viewLineInfo.isWrappedLineContinuation && this.getMinColumnOfViewLine(viewLineInfo) === 1) {
-					// Don't add indent guides when the wrapped line continuation has no wrapping-indentation.
-					resultPerViewLine.push([]);
-				} else {
-					const bracketGuides = bracketGuidesPerModelLine[viewLineInfo.modelLineNumber - modelRangeStartLineNumber];
 
-					// visibleColumns stay as they are (this is a bug and needs to be fixed, but it is not a regression)
-					// model-columns must be converted to view-model columns.
-					const result = bracketGuides.map(g => {
-						if (g.forWrappedLinesAfterColumn !== -1) {
-							const p = this.modelLineProjections[viewLineInfo.modelLineNumber - 1].getViewPositionOfModelPosition(0, g.forWrappedLinesAfterColumn);
-							if (p.lineNumber >= viewLineInfo.modelLineWrappedLineIdx) {
-								return undefined;
-							}
-						}
+				const bracketGuides = bracketGuidesPerModelLine[viewLineInfo.modelLineNumber - modelRangeStartLineNumber];
 
-						if (g.forWrappedLinesBeforeOrAtColumn !== -1) {
-							const p = this.modelLineProjections[viewLineInfo.modelLineNumber - 1].getViewPositionOfModelPosition(0, g.forWrappedLinesBeforeOrAtColumn);
-							if (p.lineNumber < viewLineInfo.modelLineWrappedLineIdx) {
-								return undefined;
-							}
-						}
-
-						if (!g.horizontalLine) {
-							return g;
-						}
-
-						let column = -1;
-						if (g.column !== -1) {
-							const p = this.modelLineProjections[viewLineInfo.modelLineNumber - 1].getViewPositionOfModelPosition(0, g.column);
-							if (p.lineNumber === viewLineInfo.modelLineWrappedLineIdx) {
-								column = p.column;
-							} else if (p.lineNumber < viewLineInfo.modelLineWrappedLineIdx) {
-								column = this.getMinColumnOfViewLine(viewLineInfo);
-							} else if (p.lineNumber > viewLineInfo.modelLineWrappedLineIdx) {
-								return undefined;
-							}
-						}
-
-						const viewPosition = this.convertModelPositionToViewPosition(viewLineInfo.modelLineNumber, g.horizontalLine.endColumn);
-						const p = this.modelLineProjections[viewLineInfo.modelLineNumber - 1].getViewPositionOfModelPosition(0, g.horizontalLine.endColumn);
-						if (p.lineNumber === viewLineInfo.modelLineWrappedLineIdx) {
-							return new IndentGuide(g.visibleColumn, column, g.className,
-								new IndentGuideHorizontalLine(g.horizontalLine.top,
-									viewPosition.column),
-								- 1,
-								-1,
-							);
-						} else if (p.lineNumber < viewLineInfo.modelLineWrappedLineIdx) {
+				// visibleColumns stay as they are (this is a bug and needs to be fixed, but it is not a regression)
+				// model-columns must be converted to view-model columns.
+				const result = bracketGuides.map(g => {
+					if (g.forWrappedLinesAfterColumn !== -1) {
+						const p = this.modelLineProjections[viewLineInfo.modelLineNumber - 1].getViewPositionOfModelPosition(0, g.forWrappedLinesAfterColumn);
+						if (p.lineNumber >= viewLineInfo.modelLineWrappedLineIdx) {
 							return undefined;
-						} else {
-							if (g.visibleColumn !== -1) {
-								// Don't repeat horizontal lines that use visibleColumn for unrelated lines.
-								return undefined;
-							}
-							return new IndentGuide(g.visibleColumn, column, g.className,
-								new IndentGuideHorizontalLine(g.horizontalLine.top,
-									this.getMaxColumnOfViewLine(viewLineInfo)
-								),
-								-1,
-								-1,
-							);
 						}
-					});
-					resultPerViewLine.push(result.filter((r): r is IndentGuide => !!r));
-				}
+					}
+
+					if (g.forWrappedLinesBeforeOrAtColumn !== -1) {
+						const p = this.modelLineProjections[viewLineInfo.modelLineNumber - 1].getViewPositionOfModelPosition(0, g.forWrappedLinesBeforeOrAtColumn);
+						if (p.lineNumber < viewLineInfo.modelLineWrappedLineIdx) {
+							return undefined;
+						}
+					}
+
+					if (!g.horizontalLine) {
+						return g;
+					}
+
+					let column = -1;
+					if (g.column !== -1) {
+						const p = this.modelLineProjections[viewLineInfo.modelLineNumber - 1].getViewPositionOfModelPosition(0, g.column);
+						if (p.lineNumber === viewLineInfo.modelLineWrappedLineIdx) {
+							column = p.column;
+						} else if (p.lineNumber < viewLineInfo.modelLineWrappedLineIdx) {
+							column = this.getMinColumnOfViewLine(viewLineInfo);
+						} else if (p.lineNumber > viewLineInfo.modelLineWrappedLineIdx) {
+							return undefined;
+						}
+					}
+
+					const viewPosition = this.convertModelPositionToViewPosition(viewLineInfo.modelLineNumber, g.horizontalLine.endColumn);
+					const p = this.modelLineProjections[viewLineInfo.modelLineNumber - 1].getViewPositionOfModelPosition(0, g.horizontalLine.endColumn);
+					if (p.lineNumber === viewLineInfo.modelLineWrappedLineIdx) {
+						return new IndentGuide(g.visibleColumn, column, g.className,
+							new IndentGuideHorizontalLine(g.horizontalLine.top,
+								viewPosition.column),
+							- 1,
+							-1,
+						);
+					} else if (p.lineNumber < viewLineInfo.modelLineWrappedLineIdx) {
+						return undefined;
+					} else {
+						if (g.visibleColumn !== -1) {
+							// Don't repeat horizontal lines that use visibleColumn for unrelated lines.
+							return undefined;
+						}
+						return new IndentGuide(g.visibleColumn, column, g.className,
+							new IndentGuideHorizontalLine(g.horizontalLine.top,
+								this.getMaxColumnOfViewLine(viewLineInfo)
+							),
+							-1,
+							-1,
+						);
+					}
+				});
+				resultPerViewLine.push(result.filter((r): r is IndentGuide => !!r));
+
 			}
 		}
 


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #149074

The if statement removed prevents any guides in case of wrapped line with no wrapping-indentation (i.e. when the starting column of the new line is the first).
This prevented the rendering of horizontal guides.
Removing the statement also does not lead to wrongfully diplayed vertical guides (see example below).
![example-guides](https://user-images.githubusercontent.com/105170638/174410261-365e194f-331e-4bec-bc1d-c9448ea7bf55.png)

