### PR TITLE
Preserve spaces in testing labels using icons (#152630)

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -21,6 +21,10 @@
 	align-items: center;
 }
 
+.test-explorer .test-item .label {
+	white-space: pre-wrap;
+}
+
 .test-explorer .test-item,
 .test-output-peek-tree .test-peek-item {
 	display: flex;


### PR DESCRIPTION
This PR fixes #152630
