### PR TITLE
Don't try parsing non-markdown files

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/rename.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/rename.ts
@@ -11,7 +11,7 @@ import { Disposable } from '../util/dispose';
 import { resolveDocumentLink } from '../util/openDocumentLink';
 import { MdWorkspaceContents, SkinnyTextDocument } from '../workspaceContents';
 import { InternalHref } from './documentLinkProvider';
-import { MdHeaderReference, MdLinkReference, MdReference, MdReferencesProvider, tryFindMdDocumentForLink } from './references';
+import { MdHeaderReference, MdLinkReference, MdReference, MdReferencesProvider, tryResolveLinkPath } from './references';
 
 const localize = nls.loadMessageBundle();
 
@@ -153,8 +153,7 @@ export class MdVsCodeRenameProvider extends Disposable implements vscode.RenameP
 		const edit = new vscode.WorkspaceEdit();
 		const fileRenames: MdFileRenameEdit[] = [];
 
-		const targetDoc = await tryFindMdDocumentForLink(triggerHref, this.workspaceContents);
-		const targetUri = targetDoc?.uri ?? triggerHref.path;
+		const targetUri = await tryResolveLinkPath(triggerHref.path, this.workspaceContents) ?? triggerHref.path;
 
 		const rawNewFilePath = resolveDocumentLink(newName, triggerDocument);
 		let resolvedNewFilePath = rawNewFilePath;

--- a/extensions/markdown-language-features/src/languageFeatures/workspaceCache.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/workspaceCache.ts
@@ -61,7 +61,7 @@ export class MdDocumentInfoCache<T> extends Disposable {
 			return existing;
 		}
 
-		const doc = await this.workspaceContents.getMarkdownDocument(resource);
+		const doc = await this.workspaceContents.getOrLoadMarkdownDocument(resource);
 		return doc && this.onDidChangeDocument(doc, true)?.value;
 	}
 

--- a/extensions/markdown-language-features/src/test/inMemoryWorkspace.ts
+++ b/extensions/markdown-language-features/src/test/inMemoryWorkspace.ts
@@ -22,8 +22,12 @@ export class InMemoryWorkspaceMarkdownDocuments implements MdWorkspaceContents {
 		return Array.from(this._documents.values());
 	}
 
-	public async getMarkdownDocument(resource: vscode.Uri): Promise<SkinnyTextDocument | undefined> {
+	public async getOrLoadMarkdownDocument(resource: vscode.Uri): Promise<SkinnyTextDocument | undefined> {
 		return this._documents.get(resource);
+	}
+
+	public hasMarkdownDocument(resolvedHrefPath: vscode.Uri): boolean {
+		return this._documents.has(resolvedHrefPath);
 	}
 
 	public async pathExists(resource: vscode.Uri): Promise<boolean> {

--- a/extensions/markdown-language-features/src/util/file.ts
+++ b/extensions/markdown-language-features/src/util/file.ts
@@ -4,7 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as URI from 'vscode-uri';
+
+const markdownFileExtensions = Object.freeze<string[]>([
+	'.md',
+	'.mkd',
+	'.mdwn',
+	'.mdown',
+	'.markdown',
+	'.markdn',
+	'.mdtxt',
+	'.mdtext',
+	'.workbook',
+]);
 
 export function isMarkdownFile(document: vscode.TextDocument) {
 	return document.languageId === 'markdown';
+}
+
+export function looksLikeMarkdownPath(resolvedHrefPath: vscode.Uri) {
+	return markdownFileExtensions.includes(URI.Utils.extname(resolvedHrefPath).toLowerCase());
 }

--- a/extensions/markdown-language-features/src/util/schemes.ts
+++ b/extensions/markdown-language-features/src/util/schemes.ts
@@ -32,15 +32,3 @@ export function getUriForLinkWithKnownExternalScheme(link: string): vscode.Uri |
 export function isOfScheme(scheme: string, link: string): boolean {
 	return link.toLowerCase().startsWith(scheme);
 }
-
-export const MarkdownFileExtensions: readonly string[] = [
-	'.md',
-	'.mkd',
-	'.mdwn',
-	'.mdown',
-	'.markdown',
-	'.markdn',
-	'.mdtxt',
-	'.mdtext',
-	'.workbook',
-];


### PR DESCRIPTION
This fixes our references and diagnostics to not try parsing non-markdown files as if they were markdown
