### PR TITLE
Prefer third party renderer over builtin one.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
@@ -317,8 +317,8 @@ export class NotebookOutputRendererInfoStore {
 		const enum ReuseOrder {
 			PreviouslySelected = 1 << 8,
 			SameExtensionAsNotebook = 2 << 8,
-			BuiltIn = 3 << 8,
-			OtherRenderer = 4 << 8,
+			OtherRenderer = 3 << 8,
+			BuiltIn = 4 << 8,
 		}
 
 		const preferred = notebookProviderInfo && this.preferredMimetype.getValue()[notebookProviderInfo.id]?.[mimeType];


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #148724

To increase the discoverbility of third party renderers, we now experiment with preferring renderers from extensions other builtin ones. Will see whether this introduces more confusion and decide if we should show notifications to ask users to pick renderer manually.
