### PR TITLE
Reduce number of times MD docs are re-tokenized

### DIFF
--- a/extensions/markdown-language-features/src/commands/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/commands/openDocumentLink.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { Command } from '../commandManager';
-import { MarkdownEngine } from '../markdownEngine';
+import { MdTableOfContentsProvider } from '../tableOfContents';
 import { openDocumentLink } from '../util/openDocumentLink';
 
 type UriComponents = {
@@ -48,13 +48,13 @@ export class OpenDocumentLinkCommand implements Command {
 	}
 
 	public constructor(
-		private readonly engine: MarkdownEngine
+		private readonly tocProvider: MdTableOfContentsProvider,
 	) { }
 
 	public async execute(args: OpenDocumentLinkArgs) {
 		const fromResource = vscode.Uri.parse('').with(args.fromResource);
 		const targetResource = reviveUri(args.parts).with({ fragment: args.fragment });
-		return openDocumentLink(this.engine, targetResource, fromResource);
+		return openDocumentLink(this.tocProvider, targetResource, fromResource);
 	}
 }
 

--- a/extensions/markdown-language-features/src/commands/refreshPreview.ts
+++ b/extensions/markdown-language-features/src/commands/refreshPreview.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Command } from '../commandManager';
-import { MarkdownEngine } from '../markdownEngine';
+import { MarkdownItEngine } from '../markdownEngine';
 import { MarkdownPreviewManager } from '../preview/previewManager';
 
 export class RefreshPreviewCommand implements Command {
@@ -12,7 +12,7 @@ export class RefreshPreviewCommand implements Command {
 
 	public constructor(
 		private readonly webviewManager: MarkdownPreviewManager,
-		private readonly engine: MarkdownEngine
+		private readonly engine: MarkdownItEngine
 	) { }
 
 	public execute() {

--- a/extensions/markdown-language-features/src/commands/reloadPlugins.ts
+++ b/extensions/markdown-language-features/src/commands/reloadPlugins.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Command } from '../commandManager';
-import { MarkdownEngine } from '../markdownEngine';
+import { MarkdownItEngine } from '../markdownEngine';
 import { MarkdownPreviewManager } from '../preview/previewManager';
 
 export class ReloadPlugins implements Command {
@@ -12,7 +12,7 @@ export class ReloadPlugins implements Command {
 
 	public constructor(
 		private readonly webviewManager: MarkdownPreviewManager,
-		private readonly engine: MarkdownEngine,
+		private readonly engine: MarkdownItEngine,
 	) { }
 
 	public execute(): void {

--- a/extensions/markdown-language-features/src/commands/renderDocument.ts
+++ b/extensions/markdown-language-features/src/commands/renderDocument.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Command } from '../commandManager';
-import { MarkdownEngine } from '../markdownEngine';
+import { MarkdownItEngine } from '../markdownEngine';
 import { SkinnyTextDocument } from '../workspaceContents';
 
 export class RenderDocument implements Command {
 	public readonly id = 'markdown.api.render';
 
 	public constructor(
-		private readonly engine: MarkdownEngine
+		private readonly engine: MarkdownItEngine
 	) { }
 
 	public async execute(document: SkinnyTextDocument | string): Promise<string> {

--- a/extensions/markdown-language-features/src/languageFeatures/diagnostics.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/diagnostics.ts
@@ -7,7 +7,6 @@ import * as picomatch from 'picomatch';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { CommandManager } from '../commandManager';
-import { MarkdownEngine } from '../markdownEngine';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { MdTableOfContentsWatcher } from '../test/tableOfContentsWatcher';
 import { Delayer } from '../util/async';
@@ -300,12 +299,12 @@ export class DiagnosticManager extends Disposable {
 	public readonly ready: Promise<void>;
 
 	constructor(
-		engine: MarkdownEngine,
 		private readonly workspaceContents: MdWorkspaceContents,
 		private readonly computer: DiagnosticComputer,
 		private readonly configuration: DiagnosticConfiguration,
 		private readonly reporter: DiagnosticReporter,
 		private readonly referencesProvider: MdReferencesProvider,
+		tocProvider: MdTableOfContentsProvider,
 		delay = 300,
 	) {
 		super();
@@ -340,7 +339,7 @@ export class DiagnosticManager extends Disposable {
 			}
 		}));
 
-		this.tableOfContentsWatcher = this._register(new MdTableOfContentsWatcher(engine, workspaceContents));
+		this.tableOfContentsWatcher = this._register(new MdTableOfContentsWatcher(workspaceContents, tocProvider));
 		this._register(this.tableOfContentsWatcher.onTocChanged(async e => {
 			// When the toc of a document changes, revalidate every file that linked to it too
 			const triggered = new ResourceMap<void>();
@@ -625,7 +624,6 @@ class AddToIgnoreLinksQuickFixProvider implements vscode.CodeActionProvider {
 
 export function registerDiagnosticSupport(
 	selector: vscode.DocumentSelector,
-	engine: MarkdownEngine,
 	workspaceContents: MdWorkspaceContents,
 	linkProvider: MdLinkProvider,
 	commandManager: CommandManager,
@@ -634,12 +632,12 @@ export function registerDiagnosticSupport(
 ): vscode.Disposable {
 	const configuration = new VSCodeDiagnosticConfiguration();
 	const manager = new DiagnosticManager(
-		engine,
 		workspaceContents,
 		new DiagnosticComputer(workspaceContents, linkProvider, tocProvider),
 		configuration,
 		new DiagnosticCollectionReporter(),
-		referenceProvider);
+		referenceProvider,
+		tocProvider);
 	return vscode.Disposable.from(
 		configuration,
 		manager,

--- a/extensions/markdown-language-features/src/languageFeatures/pathCompletions.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/pathCompletions.ts
@@ -5,7 +5,7 @@
 
 import { dirname, resolve } from 'path';
 import * as vscode from 'vscode';
-import { MarkdownEngine } from '../markdownEngine';
+import { IMdParser } from '../markdownEngine';
 import { TableOfContents } from '../tableOfContents';
 import { resolveUriToMarkdownFile } from '../util/openDocumentLink';
 import { SkinnyTextDocument } from '../workspaceContents';
@@ -82,7 +82,7 @@ function tryDecodeUriComponent(str: string): string {
 export class MdVsCodePathCompletionProvider implements vscode.CompletionItemProvider {
 
 	constructor(
-		private readonly engine: MarkdownEngine,
+		private readonly parser: IMdParser,
 		private readonly linkProvider: MdLinkProvider,
 	) { }
 
@@ -249,7 +249,7 @@ export class MdVsCodePathCompletionProvider implements vscode.CompletionItemProv
 	}
 
 	private async *provideHeaderSuggestions(document: SkinnyTextDocument, position: vscode.Position, context: CompletionContext, insertionRange: vscode.Range): AsyncIterable<vscode.CompletionItem> {
-		const toc = await TableOfContents.createForDocumentOrNotebook(this.engine, document);
+		const toc = await TableOfContents.createForDocumentOrNotebook(this.parser, document);
 		for (const entry of toc.entries) {
 			const replacementRange = new vscode.Range(insertionRange.start, position.translate({ characterDelta: context.linkSuffix.length }));
 			yield {
@@ -349,8 +349,8 @@ export class MdVsCodePathCompletionProvider implements vscode.CompletionItemProv
 
 export function registerPathCompletionSupport(
 	selector: vscode.DocumentSelector,
-	engine: MarkdownEngine,
+	parser: IMdParser,
 	linkProvider: MdLinkProvider,
 ): vscode.Disposable {
-	return vscode.languages.registerCompletionItemProvider(selector, new MdVsCodePathCompletionProvider(engine, linkProvider), '.', '/', '#');
+	return vscode.languages.registerCompletionItemProvider(selector, new MdVsCodePathCompletionProvider(parser, linkProvider), '.', '/', '#');
 }

--- a/extensions/markdown-language-features/src/languageFeatures/references.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/references.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
 import * as uri from 'vscode-uri';
-import { MarkdownEngine } from '../markdownEngine';
+import { IMdParser } from '../markdownEngine';
 import { MdTableOfContentsProvider, TocEntry } from '../tableOfContents';
 import { noopToken } from '../util/cancellation';
 import { Disposable } from '../util/dispose';
@@ -68,13 +68,13 @@ export class MdReferencesProvider extends Disposable {
 	private readonly _linkComputer: MdLinkComputer;
 
 	public constructor(
-		private readonly engine: MarkdownEngine,
+		private readonly parser: IMdParser,
 		private readonly workspaceContents: MdWorkspaceContents,
 		private readonly tocProvider: MdTableOfContentsProvider,
 	) {
 		super();
 
-		this._linkComputer = new MdLinkComputer(engine);
+		this._linkComputer = new MdLinkComputer(parser);
 		this._linkCache = this._register(new MdWorkspaceInfoCache(workspaceContents, doc => this._linkComputer.getAllLinks(doc, noopToken)));
 	}
 
@@ -114,7 +114,7 @@ export class MdReferencesProvider extends Disposable {
 		for (const link of links) {
 			if (link.href.kind === 'internal'
 				&& this.looksLikeLinkToDoc(link.href, document.uri)
-				&& this.engine.slugifier.fromHeading(link.href.fragment).value === header.slug.value
+				&& this.parser.slugifier.fromHeading(link.href.fragment).value === header.slug.value
 			) {
 				references.push({
 					kind: 'link',
@@ -204,7 +204,7 @@ export class MdReferencesProvider extends Disposable {
 					continue;
 				}
 
-				if (this.engine.slugifier.fromHeading(link.href.fragment).equals(this.engine.slugifier.fromHeading(sourceLink.href.fragment))) {
+				if (this.parser.slugifier.fromHeading(link.href.fragment).equals(this.parser.slugifier.fromHeading(sourceLink.href.fragment))) {
 					const isTriggerLocation = sourceLink.source.resource.fsPath === link.source.resource.fsPath && sourceLink.source.hrefRange.isEqual(link.source.hrefRange);
 					references.push({
 						kind: 'link',

--- a/extensions/markdown-language-features/src/languageFeatures/smartSelect.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/smartSelect.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import Token = require('markdown-it/lib/token');
 import * as vscode from 'vscode';
-import { MarkdownEngine } from '../markdownEngine';
+import { IMdParser } from '../markdownEngine';
 import { MdTableOfContentsProvider, TocEntry } from '../tableOfContents';
 import { SkinnyTextDocument } from '../workspaceContents';
 
@@ -15,7 +15,7 @@ interface MarkdownItTokenWithMap extends Token {
 export class MdSmartSelect implements vscode.SelectionRangeProvider {
 
 	constructor(
-		private readonly engine: MarkdownEngine,
+		private readonly parser: IMdParser,
 		private readonly tocProvider: MdTableOfContentsProvider,
 	) { }
 
@@ -37,9 +37,7 @@ export class MdSmartSelect implements vscode.SelectionRangeProvider {
 	}
 
 	private async getBlockSelectionRange(document: SkinnyTextDocument, position: vscode.Position, headerRange?: vscode.SelectionRange): Promise<vscode.SelectionRange | undefined> {
-
-		const tokens = await this.engine.parse(document);
-
+		const tokens = await this.parser.tokenize(document);
 		const blockTokens = getBlockTokensForPosition(tokens, position, headerRange);
 
 		if (blockTokens.length === 0) {
@@ -253,8 +251,8 @@ function getFirstChildHeader(document: SkinnyTextDocument, header?: TocEntry, to
 
 export function registerSmartSelectSupport(
 	selector: vscode.DocumentSelector,
-	engine: MarkdownEngine,
+	parser: IMdParser,
 	tocProvider: MdTableOfContentsProvider,
 ): vscode.Disposable {
-	return vscode.languages.registerSelectionRangeProvider(selector, new MdSmartSelect(engine, tocProvider));
+	return vscode.languages.registerSelectionRangeProvider(selector, new MdSmartSelect(parser, tocProvider));
 }

--- a/extensions/markdown-language-features/src/languageFeatures/workspaceCache.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/workspaceCache.ts
@@ -65,6 +65,15 @@ export class MdDocumentInfoCache<T> extends Disposable {
 		return doc && this.onDidChangeDocument(doc, true)?.value;
 	}
 
+	public async getForDocument(document: SkinnyTextDocument): Promise<T> {
+		const existing = this._cache.get(document.uri);
+		if (existing) {
+			return existing;
+		}
+
+		return this.onDidChangeDocument(document, true)!.value;
+	}
+
 	public async entries(): Promise<Array<[vscode.Uri, T]>> {
 		return this._cache.entries();
 	}

--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -3,15 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import MarkdownIt = require('markdown-it');
-import Token = require('markdown-it/lib/token');
+import type MarkdownIt = require('markdown-it');
+import type Token = require('markdown-it/lib/token');
 import * as vscode from 'vscode';
+import { MdDocumentInfoCache } from './languageFeatures/workspaceCache';
 import { MarkdownContributionProvider } from './markdownExtensions';
 import { Slugifier } from './slugify';
+import { Disposable } from './util/dispose';
 import { stringHash } from './util/hash';
 import { WebviewResourceProvider } from './util/resources';
 import { isOfScheme, Schemes } from './util/schemes';
-import { SkinnyTextDocument } from './workspaceContents';
+import { MdWorkspaceContents, SkinnyTextDocument } from './workspaceContents';
 
 const UNICODE_NEWLINE_REGEX = /\u2028|\u2029/g;
 
@@ -91,7 +93,12 @@ interface RenderEnv {
 	resourceProvider: WebviewResourceProvider | undefined;
 }
 
-export class MarkdownEngine {
+export interface IMdParser {
+	readonly slugifier: Slugifier;
+	tokenize(document: SkinnyTextDocument): Promise<Token[]>;
+}
+
+export class MarkdownItEngine implements IMdParser {
 
 	private md?: Promise<MarkdownIt>;
 
@@ -213,7 +220,7 @@ export class MarkdownEngine {
 		};
 	}
 
-	public async parse(document: SkinnyTextDocument): Promise<Token[]> {
+	public async tokenize(document: SkinnyTextDocument): Promise<Token[]> {
 		const config = this.getConfig(document.uri);
 		const engine = await this.getEngine(config);
 		return this.tokenizeDocument(document, config, engine);
@@ -425,5 +432,29 @@ function normalizeHighlightLang(lang: string | undefined) {
 
 		default:
 			return lang;
+	}
+}
+
+export class MdParsingProvider extends Disposable implements IMdParser {
+
+	private readonly _cache: MdDocumentInfoCache<Token[]>;
+
+	public readonly slugifier: Slugifier;
+
+	constructor(
+		engine: MarkdownItEngine,
+		workspaceContents: MdWorkspaceContents,
+	) {
+		super();
+
+		this.slugifier = engine.slugifier;
+
+		this._cache = this._register(new MdDocumentInfoCache<Token[]>(workspaceContents, doc => {
+			return engine.tokenize(doc);
+		}));
+	}
+
+	public tokenize(document: SkinnyTextDocument): Promise<Token[]> {
+		return this._cache.getForDocument(document);
 	}
 }

--- a/extensions/markdown-language-features/src/preview/previewContentProvider.ts
+++ b/extensions/markdown-language-features/src/preview/previewContentProvider.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import * as uri from 'vscode-uri';
 import { Logger } from '../logger';
-import { MarkdownEngine } from '../markdownEngine';
+import { MarkdownItEngine } from '../markdownEngine';
 import { MarkdownContributionProvider } from '../markdownExtensions';
 import { WebviewResourceProvider } from '../util/resources';
 import { MarkdownPreviewConfiguration, MarkdownPreviewConfigurationManager } from './previewConfig';
@@ -47,7 +47,7 @@ export interface MarkdownContentProviderOutput {
 
 export class MarkdownContentProvider {
 	constructor(
-		private readonly engine: MarkdownEngine,
+		private readonly engine: MarkdownItEngine,
 		private readonly context: vscode.ExtensionContext,
 		private readonly cspArbiter: ContentSecurityPolicyArbiter,
 		private readonly contributionProvider: MarkdownContributionProvider,

--- a/extensions/markdown-language-features/src/preview/previewManager.ts
+++ b/extensions/markdown-language-features/src/preview/previewManager.ts
@@ -5,8 +5,8 @@
 
 import * as vscode from 'vscode';
 import { Logger } from '../logger';
-import { MarkdownEngine } from '../markdownEngine';
 import { MarkdownContributionProvider } from '../markdownExtensions';
+import { MdTableOfContentsProvider } from '../tableOfContents';
 import { Disposable, disposeAll } from '../util/dispose';
 import { isMarkdownFile } from '../util/file';
 import { DynamicMarkdownPreview, ManagedMarkdownPreview, StaticMarkdownPreview } from './preview';
@@ -71,7 +71,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 		private readonly _contentProvider: MarkdownContentProvider,
 		private readonly _logger: Logger,
 		private readonly _contributions: MarkdownContributionProvider,
-		private readonly _engine: MarkdownEngine,
+		private readonly _tocProvider: MdTableOfContentsProvider,
 	) {
 		super();
 
@@ -166,7 +166,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 			this._logger,
 			this._topmostLineMonitor,
 			this._contributions,
-			this._engine);
+			this._tocProvider);
 
 		this.registerDynamicPreview(preview);
 	}
@@ -184,7 +184,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 			this._topmostLineMonitor,
 			this._logger,
 			this._contributions,
-			this._engine,
+			this._tocProvider,
 			lineNumber
 		);
 		this.registerStaticPreview(preview);
@@ -209,7 +209,7 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 			this._logger,
 			this._topmostLineMonitor,
 			this._contributions,
-			this._engine);
+			this._tocProvider);
 
 		this.setPreviewActiveContext(true);
 		this._activePreview = preview;

--- a/extensions/markdown-language-features/src/tableOfContents.ts
+++ b/extensions/markdown-language-features/src/tableOfContents.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { MdDocumentInfoCache } from './languageFeatures/workspaceCache';
-import { MarkdownEngine } from './markdownEngine';
+import { IMdParser } from './markdownEngine';
 import { githubSlugifier, Slug, Slugifier } from './slugify';
 import { Disposable } from './util/dispose';
 import { isMarkdownFile } from './util/file';
@@ -63,12 +63,12 @@ export interface TocEntry {
 
 export class TableOfContents {
 
-	public static async create(engine: MarkdownEngine, document: SkinnyTextDocument,): Promise<TableOfContents> {
-		const entries = await this.buildToc(engine, document);
-		return new TableOfContents(entries, engine.slugifier);
+	public static async create(parser: IMdParser, document: SkinnyTextDocument,): Promise<TableOfContents> {
+		const entries = await this.buildToc(parser, document);
+		return new TableOfContents(entries, parser.slugifier);
 	}
 
-	public static async createForDocumentOrNotebook(engine: MarkdownEngine, document: SkinnyTextDocument): Promise<TableOfContents> {
+	public static async createForDocumentOrNotebook(parser: IMdParser, document: SkinnyTextDocument): Promise<TableOfContents> {
 		if (document.uri.scheme === 'vscode-notebook-cell') {
 			const notebook = vscode.workspace.notebookDocuments
 				.find(notebook => notebook.getCells().some(cell => cell.document === document));
@@ -78,20 +78,20 @@ export class TableOfContents {
 
 				for (const cell of notebook.getCells()) {
 					if (cell.kind === vscode.NotebookCellKind.Markup && isMarkdownFile(cell.document)) {
-						entries.push(...(await this.buildToc(engine, cell.document)));
+						entries.push(...(await this.buildToc(parser, cell.document)));
 					}
 				}
 
-				return new TableOfContents(entries, engine.slugifier);
+				return new TableOfContents(entries, parser.slugifier);
 			}
 		}
 
-		return this.create(engine, document);
+		return this.create(parser, document);
 	}
 
-	private static async buildToc(engine: MarkdownEngine, document: SkinnyTextDocument): Promise<TocEntry[]> {
+	private static async buildToc(parser: IMdParser, document: SkinnyTextDocument): Promise<TocEntry[]> {
 		const toc: TocEntry[] = [];
-		const tokens = await engine.parse(document);
+		const tokens = await parser.tokenize(document);
 
 		const existingSlugEntries = new Map<string, { count: number }>();
 
@@ -103,11 +103,11 @@ export class TableOfContents {
 			const lineNumber = heading.map[0];
 			const line = document.lineAt(lineNumber);
 
-			let slug = engine.slugifier.fromHeading(line.text);
+			let slug = parser.slugifier.fromHeading(line.text);
 			const existingSlugEntry = existingSlugEntries.get(slug.value);
 			if (existingSlugEntry) {
 				++existingSlugEntry.count;
-				slug = engine.slugifier.fromHeading(slug.value + '-' + existingSlugEntry.count);
+				slug = parser.slugifier.fromHeading(slug.value + '-' + existingSlugEntry.count);
 			} else {
 				existingSlugEntries.set(slug.value, { count: 0 });
 			}
@@ -181,16 +181,20 @@ export class MdTableOfContentsProvider extends Disposable {
 	private readonly _cache: MdDocumentInfoCache<TableOfContents>;
 
 	constructor(
-		engine: MarkdownEngine,
+		parser: IMdParser,
 		workspaceContents: MdWorkspaceContents,
 	) {
 		super();
 		this._cache = this._register(new MdDocumentInfoCache<TableOfContents>(workspaceContents, doc => {
-			return TableOfContents.create(engine, doc);
+			return TableOfContents.create(parser, doc);
 		}));
 	}
 
 	public async get(resource: vscode.Uri): Promise<TableOfContents> {
-		return (await this._cache.get(resource)) ?? TableOfContents.empty;
+		return await this._cache.get(resource) ?? TableOfContents.empty;
+	}
+
+	public getForDocument(doc: SkinnyTextDocument): Promise<TableOfContents> {
+		return this._cache.getForDocument(doc);
 	}
 }

--- a/extensions/markdown-language-features/src/test/diagnostic.test.ts
+++ b/extensions/markdown-language-features/src/test/diagnostic.test.ts
@@ -435,12 +435,12 @@ suite('Markdown: Diagnostics manager', () => {
 		const tocProvider = new MdTableOfContentsProvider(engine, workspace);
 		const referencesProvider = new MdReferencesProvider(engine, workspace, tocProvider);
 		const manager = new DiagnosticManager(
-			engine,
 			workspace,
 			new DiagnosticComputer(workspace, linkProvider, tocProvider),
 			configuration,
 			reporter,
 			referencesProvider,
+			tocProvider,
 			0);
 		_disposables.push(manager, referencesProvider);
 		return manager;

--- a/extensions/markdown-language-features/src/test/engine.ts
+++ b/extensions/markdown-language-features/src/test/engine.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { MarkdownEngine } from '../markdownEngine';
+import { MarkdownItEngine } from '../markdownEngine';
 import { MarkdownContributionProvider, MarkdownContributions } from '../markdownExtensions';
 import { githubSlugifier } from '../slugify';
 import { Disposable } from '../util/dispose';
@@ -15,6 +15,6 @@ const emptyContributions = new class extends Disposable implements MarkdownContr
 	readonly onContributionsChanged = this._register(new vscode.EventEmitter<this>()).event;
 };
 
-export function createNewMarkdownEngine(): MarkdownEngine {
-	return new MarkdownEngine(emptyContributions, githubSlugifier);
+export function createNewMarkdownEngine(): MarkdownItEngine {
+	return new MarkdownItEngine(emptyContributions, githubSlugifier);
 }

--- a/extensions/markdown-language-features/src/test/smartSelect.test.ts
+++ b/extensions/markdown-language-features/src/test/smartSelect.test.ts
@@ -6,11 +6,11 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { MdSmartSelect } from '../languageFeatures/smartSelect';
-import { createNewMarkdownEngine } from './engine';
-import { InMemoryDocument } from '../util/inMemoryDocument';
-import { CURSOR, getCursorPositions, joinLines } from './util';
 import { MdTableOfContentsProvider } from '../tableOfContents';
+import { InMemoryDocument } from '../util/inMemoryDocument';
+import { createNewMarkdownEngine } from './engine';
 import { InMemoryWorkspaceMarkdownDocuments } from './inMemoryWorkspace';
+import { CURSOR, getCursorPositions, joinLines } from './util';
 
 const testFileName = vscode.Uri.file('test.md');
 


### PR DESCRIPTION
This change reduces the number of times we retokenize a markdown file by doing the following:

- Use `MdTableOfContentsProvider` in more places
- Introduce a `IMarkdownParser` interface that lets us drop in a caching version of the tokenizer

