### PR TITLE
Ensure 1DS can load on the web

### DIFF
--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -336,6 +336,13 @@ function acquireWebNodePaths() {
         }
         nodePaths[key] = entryPoint;
     }
+    // @TODO lramos15 can we make this dynamic like the rest of the node paths
+    // Add these paths as well for 1DS SDK dependencies.
+    // Not sure why given the 1DS entrypoint then requires these modules
+    // they are not fetched from the right location and instead are fetched from out/
+    nodePaths['@microsoft/dynamicproto-js'] = 'lib/dist/umd/dynamicproto-js.min.js';
+    nodePaths['@microsoft/applicationinsights-shims'] = 'dist/umd/applicationinsights-shims.min.js';
+    nodePaths['@microsoft/applicationinsights-core-js'] = 'browser/applicationinsights-core-js.min.js';
     return nodePaths;
 }
 exports.acquireWebNodePaths = acquireWebNodePaths;

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -415,6 +415,13 @@ export function acquireWebNodePaths() {
 		nodePaths[key] = entryPoint;
 	}
 
+	// @TODO lramos15 can we make this dynamic like the rest of the node paths
+	// Add these paths as well for 1DS SDK dependencies.
+	// Not sure why given the 1DS entrypoint then requires these modules
+	// they are not fetched from the right location and instead are fetched from out/
+	nodePaths['@microsoft/dynamicproto-js'] = 'lib/dist/umd/dynamicproto-js.min.js';
+	nodePaths['@microsoft/applicationinsights-shims'] = 'dist/umd/applicationinsights-shims.min.js';
+	nodePaths['@microsoft/applicationinsights-core-js'] = 'browser/applicationinsights-core-js.min.js';
 	return nodePaths;
 }
 


### PR DESCRIPTION
This PR fixes the errors in the insiders.vscode.dev console 
<img width="840" alt="image" src="https://user-images.githubusercontent.com/4544166/174677117-4bda2a68-e6fd-4e38-98fa-b003dfc24fd6.png">


What seems to be happening is 1ds-core-js is in the remote/web package.json and therefore is dynamically added to the loader correctly. However, its dependencies (such as `application-insights-core-js`) seem to resolve just to the root out directory and therefore fail to import so the 1ds package fails to load.

This workaround tells the loader how to resolve 1DS's dependencies and places them in the dynamically built `webPackagePaths.js`. The reason I do not love this solution is because I would expect that the modules listed in package.json are able to correctly resolve their dependencies. I'm not sure if there is anything special about 1DS's SDK and how it handles dependencies which causes this weird import behavior as our other web modules and the vanilla AI JS SDK do not have this problem.


/cc @alexdima @joaomoreno @MSNev for possible insights on a better solution.