### PR TITLE
Fix escaped links being recognized as md links

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/documentLinkProvider.ts
@@ -195,7 +195,7 @@ const r = String.raw;
  */
 const linkPattern = new RegExp(
 	// text
-	r`(\[` + // open prefix match -->
+	r`((?:^|[^\\])\[` + // open prefix match -->
 	/**/r`(?:` +
 	/*****/r`[^\[\]\\]|` + // Non-bracket chars, or...
 	/*****/r`\\.|` + // Escaped char, or...
@@ -213,7 +213,7 @@ const linkPattern = new RegExp(
 	// Title
 	/**/r`\s*(?:"[^"]*"|'[^']*'|\([^\(\)]*\))?\s*` +
 	r`\)`,
-	'g');
+	'gm');
 
 /**
 * Matches `[text][ref]` or `[shorthand]`

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -444,4 +444,11 @@ suite('Markdown: DocumentLinkProvider', () => {
 			new vscode.Range(5, 7, 5, 17),
 		]);
 	});
+
+	test('Should not include links with escaped leading paren', async () => {
+		const links = await getLinksForFile(joinLines(
+			`\\[text](http://example.com)`
+		));
+		assertLinksEqual(links, []);
+	});
 });


### PR DESCRIPTION
Fixes microsoft/vscode-markdown-languageservice#15