### PR TITLE
Skip diagnostics for non-open md files

### DIFF
--- a/extensions/markdown-language-features/src/test/diagnostic.test.ts
+++ b/extensions/markdown-language-features/src/test/diagnostic.test.ts
@@ -75,6 +75,7 @@ class MemoryDiagnosticConfiguration implements DiagnosticConfiguration {
 }
 
 class MemoryDiagnosticReporter extends DiagnosticReporter {
+
 	private readonly diagnostics = new ResourceMap<readonly vscode.Diagnostic[]>();
 
 	override dispose(): void {
@@ -89,6 +90,10 @@ class MemoryDiagnosticReporter extends DiagnosticReporter {
 
 	set(uri: vscode.Uri, diagnostics: readonly vscode.Diagnostic[]): void {
 		this.diagnostics.set(uri, diagnostics);
+	}
+
+	areDiagnosticsEnabled(_uri: vscode.Uri): boolean {
+		return true;
 	}
 
 	delete(uri: vscode.Uri): void {

--- a/extensions/markdown-language-features/src/workspaceContents.ts
+++ b/extensions/markdown-language-features/src/workspaceContents.ts
@@ -147,6 +147,9 @@ export class VsCodeMdWorkspaceContents extends Disposable implements MdWorkspace
 
 		this._register(vscode.workspace.onDidOpenTextDocument(e => {
 			this._documentCache.delete(e.uri);
+			if (this.isRelevantMarkdownDocument(e)) {
+				this._onDidCreateMarkdownDocumentEmitter.fire(e);
+			}
 		}));
 
 		this._register(vscode.workspace.onDidChangeTextDocument(e => {


### PR DESCRIPTION
Currently we only show diagnostics for opened tabs. This means we shouldn't waste time computing diagnostics for non open files
