### PR TITLE
Add note to description

### DIFF
--- a/extensions/emmet/package.nls.json
+++ b/extensions/emmet/package.nls.json
@@ -60,5 +60,5 @@
 	"emmetPreferencesOutputReverseAttributes": "If `true`, reverses attribute merging directions when resolving snippets.",
 	"emmetPreferencesOutputSelfClosingStyle": "Style of self-closing tags: html (`<br>`), xml (`<br/>`) or xhtml (`<br />`).",
 	"emmetPreferencesCssColorShort": "If `true`, color values like `#f` will be expanded to `#fff` instead of `#ffffff`.",
-	"emmetUseInlineCompletions": "If `true`, Emmet will use inline completions to suggest expansions."
+	"emmetUseInlineCompletions": "If `true`, Emmet will use inline completions to suggest expansions. To prevent the non-inline completion item provider from showing up as often while this setting is `true`, turn `#editor.quickSuggestions#` to `inline` or `off` for the `other` item."
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Ref #139247

This PR appends the following sentence to the `emmet.useInlineCompletions` setting:
```
To prevent the non-inline completion item provider from showing up as often 
while this setting is `true`, turn `#editor.quickSuggestions#` to 
`inline` or `off` for the `other` item.
```

![A screenshot showing the updated description of the Emmet inline completions setting](https://user-images.githubusercontent.com/7199958/174692654-14dcbdf3-da34-4dfc-80a0-3f01b6e961ba.PNG)

An alternative to updating the description is to change the setting itself so it gives the user the option to use the inline completion provider only, but for that case:
1. We'd need to change the setting from a boolean setting to an enum setting and add in enum values and descriptions.
2. We would still have to document the fact that the final behaviour depends a lot on the `editor.quickSuggestions` setting.

