### PR TITLE
Create new shell integration test suite that uses recordings instead of depending on processes/environment

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -925,6 +925,17 @@ export interface IXtermTerminal {
 	 * Clears the active search result decorations
 	 */
 	clearActiveSearchDecoration(): void;
+
+}
+
+export interface IInternalXtermTerminal {
+	/**
+	 * Writes text directly to the terminal, bypassing the process.
+	 *
+	 * **WARNING:** This should never be used outside of the terminal component and only for
+	 * developer purposed inside the terminal component.
+	 */
+	_writeText(data: string): void; // eslint-disable-line @typescript-eslint/naming-convention
 }
 
 export interface IRequestAddInstanceToGroupEvent {

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -34,7 +34,7 @@ import { PICK_WORKSPACE_FOLDER_COMMAND_ID } from 'vs/workbench/browser/actions/w
 import { CLOSE_EDITOR_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
 import { ResourceContextKey } from 'vs/workbench/common/contextkeys';
 import { FindInFilesCommand, IFindInFilesArgs } from 'vs/workbench/contrib/search/browser/searchActions';
-import { Direction, ICreateTerminalOptions, ITerminalEditorService, ITerminalGroupService, ITerminalInstance, ITerminalInstanceService, ITerminalService } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { Direction, ICreateTerminalOptions, IInternalXtermTerminal, ITerminalEditorService, ITerminalGroupService, ITerminalInstance, ITerminalInstanceService, ITerminalService } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { TerminalQuickAccessProvider } from 'vs/workbench/contrib/terminal/browser/terminalQuickAccess';
 import { IRemoteTerminalAttachTarget, ITerminalConfigHelper, ITerminalProfileService, TerminalCommandId, TERMINAL_ACTION_CATEGORY } from 'vs/workbench/contrib/terminal/common/terminal';
 import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
@@ -52,6 +52,7 @@ import { ITerminalQuickPickItem } from 'vs/workbench/contrib/terminal/browser/te
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { getIconId, getColorClass, getUriClasses } from 'vs/workbench/contrib/terminal/browser/terminalIcon';
 import { getCommandHistory } from 'vs/workbench/contrib/terminal/common/history';
+import { CATEGORIES } from 'vs/workbench/common/actions';
 
 export const switchTerminalActionViewItemSeparator = '\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500';
 export const switchTerminalShowTabsTitle = localize('showTerminalTabs', "Show Tabs");
@@ -2104,6 +2105,46 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			getCommandHistory(accessor).clear();
+		}
+	});
+	registerAction2(class extends Action2 {
+		constructor() {
+			super({
+				id: TerminalCommandId.WriteDataToTerminal,
+				title: { value: localize('workbench.action.terminal.writeDataToTerminal', "Write Data to Terminal"), original: 'Write Data to Terminal' },
+				f1: true,
+				category: CATEGORIES.Developer.value
+			});
+		}
+		async run(accessor: ServicesAccessor) {
+			const terminalService = accessor.get(ITerminalService);
+			const terminalGroupService = accessor.get(ITerminalGroupService);
+			const quickInputService = accessor.get(IQuickInputService);
+
+			const instance = await terminalService.getActiveOrCreateInstance();
+			await terminalGroupService.showPanel();
+			await instance.processReady;
+			if (!instance.xterm) {
+				throw new Error('Cannot write data to terminal if xterm isn\'t initialized');
+			}
+			const data = await quickInputService.input({
+				value: '',
+				placeHolder: 'Enter data, use \\x to escape',
+				prompt: localize('workbench.action.terminal.writeDataToTerminal.prompt', "Enter data to write directly to the terminal, bypassing the pty"),
+			});
+			if (!data) {
+				return;
+			}
+			let escapedData = data;
+			while (true) {
+				const match = escapedData.match(/\\x([0-9a-fA-F]{2})/);
+				if (!match?.index || match.length < 2) {
+					break;
+				}
+				escapedData = escapedData.slice(0, match.index) + String.fromCharCode(parseInt(match[1], 16)) + escapedData.slice(match.index + 4);
+			}
+			const xterm = instance.xterm as any as IInternalXtermTerminal;
+			xterm._writeText(escapedData);
 		}
 	});
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -2135,10 +2135,12 @@ export function registerTerminalActions() {
 			if (!data) {
 				return;
 			}
-			let escapedData = data;
+			let escapedData = data
+				.replace(/\\n/g, '\n')
+				.replace(/\\r/g, '\r');
 			while (true) {
 				const match = escapedData.match(/\\x([0-9a-fA-F]{2})/);
-				if (!match?.index || match.length < 2) {
+				if (match === null || match.index === undefined || match.length < 2) {
 					break;
 				}
 				escapedData = escapedData.slice(0, match.index) + String.fromCharCode(parseInt(match[1], 16)) + escapedData.slice(match.index + 4);

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -194,6 +194,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 	}
 
 	registerCommandDecoration(command: ITerminalCommand, beforeCommandExecution?: boolean): IDecoration | undefined {
+		console.log('registerCommandDecoration');
 		if (!this._terminal) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -194,7 +194,6 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 	}
 
 	registerCommandDecoration(command: ITerminalCommand, beforeCommandExecution?: boolean): IDecoration | undefined {
-		console.log('registerCommandDecoration');
 		if (!this._terminal) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -179,9 +179,6 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 		this.raw.loadAddon(this._shellIntegrationAddon);
 	}
 
-	// private _createDecorationAddon(): void {
-	// }
-
 	async getSelectionAsHtml(command?: ITerminalCommand): Promise<string> {
 		if (!this._serializeAddon) {
 			const Addon = await this._getSerializeAddonConstructor();

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -61,7 +61,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 	// Always on addons
 	private _commandNavigationAddon: CommandNavigationAddon;
 	private _shellIntegrationAddon: ShellIntegrationAddon;
-	private _decorationAddon: DecorationAddon | undefined;
+	private _decorationAddon: DecorationAddon;
 
 	// Optional addons
 	private _searchAddon?: SearchAddonType;
@@ -155,17 +155,13 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 			if (e.affectsConfiguration(TerminalSettingId.UnicodeVersion)) {
 				this._updateUnicodeVersion();
 			}
-			if (e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationsEnabled) ||
-				e.affectsConfiguration(TerminalSettingId.ShellIntegrationEnabled)) {
-				this._updateShellIntegrationAddons();
-			}
 		}));
 
 		this.add(this._themeService.onDidColorThemeChange(theme => this._updateTheme(theme)));
 		this.add(this._viewDescriptorService.onDidChangeLocation(({ views }) => {
 			if (views.some(v => v.id === TERMINAL_VIEW_ID)) {
 				this._updateTheme();
-				this._decorationAddon?.refreshLayouts();
+				this._decorationAddon.refreshLayouts();
 			}
 		}));
 
@@ -176,16 +172,15 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 		this._updateUnicodeVersion();
 		this._commandNavigationAddon = this._instantiationService.createInstance(CommandNavigationAddon, _capabilities);
 		this.raw.loadAddon(this._commandNavigationAddon);
-		this._shellIntegrationAddon = this._instantiationService.createInstance(ShellIntegrationAddon, disableShellIntegrationReporting, this._telemetryService);
-		this.raw.loadAddon(this._shellIntegrationAddon);
-		this._updateShellIntegrationAddons();
-	}
-
-	private _createDecorationAddon(): void {
 		this._decorationAddon = this._instantiationService.createInstance(DecorationAddon, this._capabilities);
 		this._decorationAddon.onDidRequestRunCommand(e => this._onDidRequestRunCommand.fire(e));
 		this.raw.loadAddon(this._decorationAddon);
+		this._shellIntegrationAddon = this._instantiationService.createInstance(ShellIntegrationAddon, disableShellIntegrationReporting, this._telemetryService);
+		this.raw.loadAddon(this._shellIntegrationAddon);
 	}
+
+	// private _createDecorationAddon(): void {
+	// }
 
 	async getSelectionAsHtml(command?: ITerminalCommand): Promise<string> {
 		if (!this._serializeAddon) {
@@ -609,24 +604,6 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 		}
 		if (this.raw.unicode.activeVersion !== this._configHelper.config.unicodeVersion) {
 			this.raw.unicode.activeVersion = this._configHelper.config.unicodeVersion;
-		}
-	}
-
-	private _updateShellIntegrationAddons(): void {
-		const shellIntegrationEnabled = this._configurationService.getValue(TerminalSettingId.ShellIntegrationEnabled);
-		const decorationsEnabled = this._configurationService.getValue(TerminalSettingId.ShellIntegrationDecorationsEnabled);
-		if (shellIntegrationEnabled) {
-			if (decorationsEnabled && !this._decorationAddon) {
-				this._createDecorationAddon();
-			} else if (this._decorationAddon && !decorationsEnabled) {
-				this._decorationAddon.dispose();
-				this._decorationAddon = undefined;
-			}
-			return;
-		}
-		if (this._decorationAddon) {
-			this._decorationAddon.dispose();
-			this._decorationAddon = undefined;
 		}
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -16,7 +16,7 @@ import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { IShellIntegration, TerminalLocation, TerminalSettingId } from 'vs/platform/terminal/common/terminal';
 import { ITerminalFont, TERMINAL_VIEW_ID } from 'vs/workbench/contrib/terminal/common/terminal';
 import { isSafari } from 'vs/base/browser/browser';
-import { ICommandTracker, IXtermTerminal } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { ICommandTracker, IInternalXtermTerminal, IXtermTerminal } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { TerminalStorageKeys } from 'vs/workbench/contrib/terminal/common/terminalStorageKeys';
@@ -50,7 +50,7 @@ let SerializeAddon: typeof SerializeAddonType;
  * Wraps the xterm object with additional functionality. Interaction with the backing process is out
  * of the scope of this class.
  */
-export class XtermTerminal extends DisposableStore implements IXtermTerminal {
+export class XtermTerminal extends DisposableStore implements IXtermTerminal, IInternalXtermTerminal {
 	/** The raw xterm.js instance */
 	readonly raw: RawXtermTerminal;
 
@@ -628,5 +628,10 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 			this._decorationAddon.dispose();
 			this._decorationAddon = undefined;
 		}
+	}
+
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	_writeText(data: string): void {
+		this.raw.write(data);
 	}
 }

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -564,6 +564,7 @@ export const enum TerminalCommandId {
 	MoveToTerminalPanel = 'workbench.action.terminal.moveToTerminalPanel',
 	SetDimensions = 'workbench.action.terminal.setDimensions',
 	ClearCommandHistory = 'workbench.action.terminal.clearCommandHistory',
+	WriteDataToTerminal = 'workbench.action.terminal.writeDataToTerminal',
 }
 
 export const DEFAULT_COMMANDS_TO_SKIP_SHELL: string[] = [

--- a/test/automation/src/terminal.ts
+++ b/test/automation/src/terminal.ts
@@ -37,7 +37,8 @@ export enum TerminalCommandIdWithValue {
 	ChangeIcon = 'workbench.action.terminal.changeIcon',
 	NewWithProfile = 'workbench.action.terminal.newWithProfile',
 	SelectDefaultProfile = 'workbench.action.terminal.selectDefaultShell',
-	AttachToSession = 'workbench.action.terminal.attachToSession'
+	AttachToSession = 'workbench.action.terminal.attachToSession',
+	WriteDataToTerminal = 'workbench.action.terminal.writeDataToTerminal'
 }
 
 /**
@@ -112,6 +113,9 @@ export class Terminal {
 		}
 		await this.code.dispatchKeybinding(altKey ? 'Alt+Enter' : 'enter');
 		await this.quickinput.waitForQuickInputClosed();
+		if (commandId === TerminalCommandIdWithValue.NewWithProfile) {
+			await this._waitForTerminal();
+		}
 	}
 
 	async runCommandInTerminal(commandText: string, skipEnter?: boolean): Promise<void> {

--- a/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
@@ -16,7 +16,6 @@ export function setup() {
 			app = this.app as Application;
 			terminal = app.workbench.terminal;
 			settingsEditor = app.workbench.settingsEditor;
-			await setTerminalTestSettings(app, [['terminal.integrated.shellIntegration.enabled', 'true']]);
 		});
 
 		afterEach(async function () {
@@ -31,8 +30,15 @@ export function setup() {
 			await terminal.runCommandWithValue(TerminalCommandIdWithValue.NewWithProfile, process.platform === 'win32' ? 'PowerShell' : 'bash');
 		}
 
+		async function createSimpleProfile() {
+			await terminal.runCommandWithValue(TerminalCommandIdWithValue.NewWithProfile, process.platform === 'win32' ? 'Command Prompt' : 'sh');
+		}
+
 		// TODO: Some agents may not have pwsh installed?
-		(process.platform === 'win32' ? describe.skip : describe)(`Shell integration`, function () {
+		(process.platform === 'win32' ? describe.skip : describe)(`Process-based tests`, function () {
+			before(async function () {
+				await setTerminalTestSettings(app, [['terminal.integrated.shellIntegration.enabled', 'true']]);
+			});
 			describe('Decorations', function () {
 				describe('Should show default icons', function () {
 
@@ -66,5 +72,66 @@ export function setup() {
 				});
 			});
 		});
+
+		describe('Write data-based tests', () => {
+			before(async function () {
+				await setTerminalTestSettings(app);
+			});
+			beforeEach(async function () {
+				// Create the simplest system profile to get as little process interaction as possible
+				await createSimpleProfile();
+				// Erase all content and reset cursor to top
+				await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${csi('2J')}${csi('H')}`);
+			});
+			describe('VS Code sequences', () => {
+				it('should handle the simple case', async () => {
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${vsc('A')}Prompt> ${vsc('B')}exitcode 0`);
+					await terminal.assertCommandDecorations({ placeholder: 1, success: 0, error: 0 });
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `\\r\\n${vsc('C')}Success\\r\\n${vsc('D;0')}`);
+					await terminal.assertCommandDecorations({ placeholder: 0, success: 1, error: 0 });
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${vsc('A')}Prompt> ${vsc('B')}exitcode 1`);
+					await terminal.assertCommandDecorations({ placeholder: 1, success: 1, error: 0 });
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `\\r\\n${vsc('C')}Failure\\r\\n${vsc('D;1')}`);
+					await terminal.assertCommandDecorations({ placeholder: 0, success: 1, error: 1 });
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${vsc('A')}Prompt> ${vsc('B')}exitcode 1`);
+					await terminal.assertCommandDecorations({ placeholder: 1, success: 1, error: 1 });
+				});
+			});
+			// TODO: This depends on https://github.com/microsoft/vscode/issues/146587
+			describe.skip('Final Term sequences', () => {
+				it('should handle the simple case', async () => {
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${ft('A')}Prompt> ${ft('B')}exitcode 0`);
+					await terminal.assertCommandDecorations({ placeholder: 1, success: 0, error: 0 });
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `\\r\\n${ft('C')}Success\\r\\n${ft('D;0')}`);
+					await terminal.assertCommandDecorations({ placeholder: 0, success: 1, error: 0 });
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${ft('A')}Prompt> ${ft('B')}exitcode 1`);
+					await terminal.assertCommandDecorations({ placeholder: 1, success: 1, error: 0 });
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `\\r\\n${ft('C')}Failure\\r\\n${ft('D;1')}`);
+					await terminal.assertCommandDecorations({ placeholder: 0, success: 1, error: 1 });
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${ft('A')}Prompt> ${ft('B')}exitcode 1`);
+					await terminal.assertCommandDecorations({ placeholder: 1, success: 1, error: 1 });
+				});
+			});
+		});
 	});
+}
+
+function ft(data: string) {
+	return setTextParams(`133;${data}`);
+}
+
+function vsc(data: string) {
+	return setTextParams(`633;${data}`);
+}
+
+function setTextParams(data: string) {
+	return osc(`${data}\\x07`);
+}
+
+function osc(data: string) {
+	return `\\x1b]${data}`;
+}
+
+function csi(data: string) {
+	return `\\x1b[${data}`;
 }

--- a/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
@@ -30,10 +30,6 @@ export function setup() {
 			await terminal.runCommandWithValue(TerminalCommandIdWithValue.NewWithProfile, process.platform === 'win32' ? 'PowerShell' : 'bash');
 		}
 
-		async function createSimpleProfile() {
-			await terminal.runCommandWithValue(TerminalCommandIdWithValue.NewWithProfile, process.platform === 'win32' ? 'Command Prompt' : 'sh');
-		}
-
 		// TODO: Some agents may not have pwsh installed?
 		(process.platform === 'win32' ? describe.skip : describe)(`Process-based tests`, function () {
 			before(async function () {
@@ -82,7 +78,7 @@ export function setup() {
 			});
 			beforeEach(async function () {
 				// Create the simplest system profile to get as little process interaction as possible
-				await createSimpleProfile();
+				await terminal.createTerminal();
 				// Erase all content and reset cursor to top
 				await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${csi('2J')}${csi('H')}`);
 			});

--- a/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
@@ -22,10 +22,6 @@ export function setup() {
 			await app.workbench.terminal.runCommand(TerminalCommandId.KillAll);
 		});
 
-		after(async function () {
-			await settingsEditor.clearUserSettings();
-		});
-
 		async function createShellIntegrationProfile() {
 			await terminal.runCommandWithValue(TerminalCommandIdWithValue.NewWithProfile, process.platform === 'win32' ? 'PowerShell' : 'bash');
 		}
@@ -34,6 +30,9 @@ export function setup() {
 		(process.platform === 'win32' ? describe.skip : describe)(`Process-based tests`, function () {
 			before(async function () {
 				await setTerminalTestSettings(app, [['terminal.integrated.shellIntegration.enabled', 'true']]);
+			});
+			after(async function () {
+				await settingsEditor.clearUserSettings();
 			});
 			describe('Decorations', function () {
 				describe('Should show default icons', function () {
@@ -75,6 +74,9 @@ export function setup() {
 		describe('Write data-based tests', () => {
 			before(async function () {
 				await setTerminalTestSettings(app);
+			});
+			after(async function () {
+				await settingsEditor.clearUserSettings();
 			});
 			beforeEach(async function () {
 				// Create the simplest system profile to get as little process interaction as possible

--- a/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
@@ -73,6 +73,9 @@ export function setup() {
 			});
 		});
 
+		// These are integration tests that only test the UI side by simulating process writes.
+		// Because of this, they do not test the shell integration scripts, only what the scripts
+		// are expected to write.
 		describe('Write data-based tests', () => {
 			before(async function () {
 				await setTerminalTestSettings(app);
@@ -93,7 +96,7 @@ export function setup() {
 					await terminal.assertCommandDecorations({ placeholder: 1, success: 1, error: 0 });
 					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `\\r\\n${vsc('C')}Failure\\r\\n${vsc('D;1')}`);
 					await terminal.assertCommandDecorations({ placeholder: 0, success: 1, error: 1 });
-					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${vsc('A')}Prompt> ${vsc('B')}exitcode 1`);
+					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${vsc('A')}Prompt> ${vsc('B')}`);
 					await terminal.assertCommandDecorations({ placeholder: 1, success: 1, error: 1 });
 				});
 			});


### PR DESCRIPTION
Part of #152658

These tests don't test the shell integration scripts but should eliminate flakiness and allow testing of recordings expected to come through from shells, exercising all the code on the vscode side. A functional change is also made here to allow the display of command decorations even when shell integration is disabled, this is required not just for the tests but for the manual install of shell integration scripts (https://github.com/microsoft/vscode/issues/151933) and for alternative shell integration sequence support (https://github.com/microsoft/vscode/issues/146587).