### PR TITLE
Change profile options to use defaults or not

### DIFF
--- a/src/vs/platform/storage/common/storage.ts
+++ b/src/vs/platform/storage/common/storage.ts
@@ -550,6 +550,18 @@ export abstract class AbstractStorageService extends Disposable implements IStor
 		return this.switchToWorkspace(to, preserveData);
 	}
 
+	protected canSwitchProfile(from: IUserDataProfile, to: IUserDataProfile): boolean {
+		// Both profiles are same
+		if (from.id === to.id) {
+			return false;
+		}
+		// Both profiles are using default
+		if (to.isDefault || to.useDefaultFlags?.uiState === from.isDefault || from.useDefaultFlags?.uiState) {
+			return false;
+		}
+		return true;
+	}
+
 	protected switchData(oldStorage: Map<string, string>, newStorage: IStorage, scope: StorageScope, preserveData: boolean): void {
 		this.withPausedEmitters(() => {
 

--- a/src/vs/platform/storage/common/storage.ts
+++ b/src/vs/platform/storage/common/storage.ts
@@ -551,14 +551,14 @@ export abstract class AbstractStorageService extends Disposable implements IStor
 	}
 
 	protected canSwitchProfile(from: IUserDataProfile, to: IUserDataProfile): boolean {
-		// Both profiles are same
 		if (from.id === to.id) {
-			return false;
+			return false; // both profiles are same
 		}
-		// Both profiles are using default
+
 		if (to.isDefault || to.useDefaultFlags?.uiState === from.isDefault || from.useDefaultFlags?.uiState) {
-			return false;
+			return false; // both profiles are using default
 		}
+
 		return true;
 	}
 

--- a/src/vs/platform/storage/electron-sandbox/storageService.ts
+++ b/src/vs/platform/storage/electron-sandbox/storageService.ts
@@ -148,6 +148,9 @@ export class NativeStorageService extends AbstractStorageService {
 	}
 
 	protected async switchToProfile(toProfile: IUserDataProfile, preserveData: boolean): Promise<void> {
+		if (this.profileStorageProfile && !this.canSwitchProfile(this.profileStorageProfile, toProfile)) {
+			return;
+		}
 		const oldProfileStorage = this.profileStorage;
 		const oldItems = oldProfileStorage.items;
 

--- a/src/vs/platform/storage/electron-sandbox/storageService.ts
+++ b/src/vs/platform/storage/electron-sandbox/storageService.ts
@@ -151,6 +151,7 @@ export class NativeStorageService extends AbstractStorageService {
 		if (this.profileStorageProfile && !this.canSwitchProfile(this.profileStorageProfile, toProfile)) {
 			return;
 		}
+
 		const oldProfileStorage = this.profileStorage;
 		const oldItems = oldProfileStorage.items;
 

--- a/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
@@ -8,7 +8,7 @@ import { IChannel } from 'vs/base/parts/ipc/common/ipc';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ILogService } from 'vs/platform/log/common/log';
-import { ProfileOptions, IUserDataProfile, IUserDataProfilesService, reviveProfile, UserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { IUserDataProfile, IUserDataProfilesService, reviveProfile, UserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { ISingleFolderWorkspaceIdentifier, IWorkspaceIdentifier } from 'vs/platform/workspace/common/workspace';
 
 export class UserDataProfilesNativeService extends UserDataProfilesService implements IUserDataProfilesService {
@@ -36,8 +36,8 @@ export class UserDataProfilesNativeService extends UserDataProfilesService imple
 		}));
 	}
 
-	override async createProfile(profile: IUserDataProfile, options: ProfileOptions, workspaceIdentifier?: ISingleFolderWorkspaceIdentifier | IWorkspaceIdentifier): Promise<IUserDataProfile> {
-		const result = await this.channel.call<UriDto<IUserDataProfile>>('createProfile', [profile, options, workspaceIdentifier]);
+	override async createProfile(profile: IUserDataProfile, workspaceIdentifier?: ISingleFolderWorkspaceIdentifier | IWorkspaceIdentifier): Promise<IUserDataProfile> {
+		const result = await this.channel.call<UriDto<IUserDataProfile>>('createProfile', [profile, workspaceIdentifier]);
 		return reviveProfile(result, this.profilesHome.scheme);
 	}
 

--- a/src/vs/workbench/services/configuration/test/browser/configurationEditingService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationEditingService.test.ts
@@ -39,7 +39,7 @@ import { joinPath } from 'vs/base/common/resources';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { RemoteAgentService } from 'vs/workbench/services/remote/browser/remoteAgentService';
 import { getSingleFolderWorkspaceIdentifier } from 'vs/workbench/services/workspaces/browser/workspaces';
-import { DefaultOptions, toUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { toUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { hash } from 'vs/base/common/hash';
 import { FilePolicyService } from 'vs/platform/policy/common/filePolicyService';
@@ -110,7 +110,7 @@ suite('ConfigurationEditingService', () => {
 		environmentService = TestEnvironmentService;
 		environmentService.policyFile = joinPath(workspaceFolder, 'policies.json');
 		instantiationService.stub(IEnvironmentService, environmentService);
-		const profile = toUserDataProfile('temp', environmentService.userRoamingDataHome, DefaultOptions, true);
+		const profile = toUserDataProfile('temp', environmentService.userRoamingDataHome);
 		userDataProfileService = new UserDataProfileService(profile, profile);
 		const remoteAgentService = disposables.add(instantiationService.createInstance(RemoteAgentService, null));
 		disposables.add(fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, logService))));

--- a/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
@@ -44,7 +44,7 @@ import { RemoteAgentService } from 'vs/workbench/services/remote/browser/remoteA
 import { RemoteAuthorityResolverService } from 'vs/platform/remote/browser/remoteAuthorityResolverService';
 import { hash } from 'vs/base/common/hash';
 import { TestProductService } from 'vs/workbench/test/common/workbenchTestServices';
-import { DefaultOptions, toUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { toUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { NullPolicyService } from 'vs/platform/policy/common/policy';
 import { FilePolicyService } from 'vs/platform/policy/common/filePolicyService';
 import { runWithFakedTimers } from 'vs/base/test/common/timeTravelScheduler';
@@ -68,7 +68,7 @@ export class ConfigurationCache implements IConfigurationCache {
 const ROOT = URI.file('tests').with({ scheme: 'vscode-tests' });
 
 function aUserDataProfileService(environmentService: IEnvironmentService): IUserDataProfileService {
-	const profile = toUserDataProfile('temp', environmentService.userRoamingDataHome, DefaultOptions, true);
+	const profile = toUserDataProfile('temp', environmentService.userRoamingDataHome);
 	return new UserDataProfileService(profile, profile);
 }
 

--- a/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
+++ b/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
@@ -28,7 +28,7 @@ import { joinPath } from 'vs/base/common/resources';
 import { InMemoryFileSystemProvider } from 'vs/platform/files/common/inMemoryFilesystemProvider';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { VSBuffer } from 'vs/base/common/buffer';
-import { DefaultOptions, toUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { toUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { UserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfileService';
 import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 
@@ -66,7 +66,7 @@ suite('KeybindingsEditing', () => {
 		const configService = new TestConfigurationService();
 		configService.setUserConfiguration('files', { 'eol': '\n' });
 
-		const profile = toUserDataProfile('temp', environmentService.userRoamingDataHome, DefaultOptions, true);
+		const profile = toUserDataProfile('temp', environmentService.userRoamingDataHome);
 		userDataProfileService = new UserDataProfileService(profile, profile);
 
 		instantiationService = workbenchInstantiationService({

--- a/src/vs/workbench/services/storage/browser/storageService.ts
+++ b/src/vs/workbench/services/storage/browser/storageService.ts
@@ -166,6 +166,9 @@ export class BrowserStorageService extends AbstractStorageService {
 	}
 
 	protected async switchToProfile(toProfile: IUserDataProfile, preserveData: boolean): Promise<void> {
+		if (this.profileStorageProfile && !this.canSwitchProfile(this.profileStorageProfile, toProfile)) {
+			return;
+		}
 		const oldProfileStorage = assertIsDefined(this.profileStorage);
 		const oldItems = oldProfileStorage.items;
 

--- a/src/vs/workbench/services/storage/browser/storageService.ts
+++ b/src/vs/workbench/services/storage/browser/storageService.ts
@@ -169,6 +169,7 @@ export class BrowserStorageService extends AbstractStorageService {
 		if (this.profileStorageProfile && !this.canSwitchProfile(this.profileStorageProfile, toProfile)) {
 			return;
 		}
+
 		const oldProfileStorage = assertIsDefined(this.profileStorage);
 		const oldItems = oldProfileStorage.items;
 

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
@@ -16,22 +16,13 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
-import { EXTENSIONS_RESOURCE_NAME, IUserDataProfile, IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { EXTENSIONS_RESOURCE_NAME, IUserDataProfile, IUserDataProfilesService, UseDefaultProfileFlags } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { ISingleFolderWorkspaceIdentifier, IWorkspaceContextService, IWorkspaceIdentifier, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IExtensionManagementServerService, IWorkbenchExtensionManagementService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
-import { CreationOptions, IUserDataProfileManagementService, IUserDataProfileService, IUserDataProfileTemplate, PROFILES_CATEGORY } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
-
-const DefaultOptions: CreationOptions = {
-	settings: true,
-	keybindings: true,
-	tasks: true,
-	snippets: true,
-	extensions: true,
-	uiState: true
-};
+import { IUserDataProfileManagementService, IUserDataProfileService, IUserDataProfileTemplate, PROFILES_CATEGORY } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 
 export class UserDataProfileManagementService extends Disposable implements IUserDataProfileManagementService {
 	readonly _serviceBrand: undefined;
@@ -65,38 +56,26 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 		throw new Error('Invalid Profile');
 	}
 
-	async createAndEnterProfile(name: string, options: CreationOptions = DefaultOptions, fromExisting?: boolean): Promise<void> {
+	async createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean): Promise<void> {
 		const workspaceIdentifier = this.getWorkspaceIdentifier();
 		if (!workspaceIdentifier) {
 			throw new Error(localize('cannotCreateProfileInEmptyWorkbench', "Cannot create a profile in an empty workspace"));
 		}
 		const promises: Promise<any>[] = [];
-		const newProfile = this.userDataProfilesService.newProfile(name);
+		const newProfile = this.userDataProfilesService.newProfile(name, useDefaultFlags);
 		await this.fileService.createFolder(newProfile.location);
 		const extensionsProfileResourcePromise = this.checkAndCreateExtensionsProfileResource();
 		promises.push(extensionsProfileResourcePromise);
 		if (fromExisting) {
-			if (options?.uiState) {
-				// No op because, migration is handled by storage service while entering profile
-			}
-			if (options?.settings) {
-				promises.push(this.fileService.copy(this.userDataProfileService.currentProfile.settingsResource, newProfile.settingsResource));
-			}
-			if (options?.extensions) {
-				promises.push((async () => this.fileService.copy(await extensionsProfileResourcePromise, newProfile.extensionsResource))());
-			}
-			if (options?.keybindings) {
-				promises.push(this.fileService.copy(this.userDataProfileService.currentProfile.keybindingsResource, newProfile.keybindingsResource));
-			}
-			if (options?.tasks) {
-				promises.push(this.fileService.copy(this.userDataProfileService.currentProfile.tasksResource, newProfile.tasksResource));
-			}
-			if (options?.snippets) {
-				promises.push(this.fileService.copy(this.userDataProfileService.currentProfile.snippetsHome, newProfile.snippetsHome));
-			}
+			// Storage copy is handled by storage service while entering profile
+			promises.push(this.fileService.copy(this.userDataProfileService.currentProfile.settingsResource, newProfile.settingsResource));
+			promises.push((async () => this.fileService.copy(await extensionsProfileResourcePromise, newProfile.extensionsResource))());
+			promises.push(this.fileService.copy(this.userDataProfileService.currentProfile.keybindingsResource, newProfile.keybindingsResource));
+			promises.push(this.fileService.copy(this.userDataProfileService.currentProfile.tasksResource, newProfile.tasksResource));
+			promises.push(this.fileService.copy(this.userDataProfileService.currentProfile.snippetsHome, newProfile.snippetsHome));
 		}
 		await Promise.allSettled(promises);
-		const createdProfile = await this.userDataProfilesService.createProfile(newProfile, options, workspaceIdentifier);
+		const createdProfile = await this.userDataProfilesService.createProfile(newProfile, workspaceIdentifier);
 		await this.enterProfile(createdProfile, !!fromExisting);
 	}
 
@@ -125,7 +104,7 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 		await this.enterProfile(profile, false);
 	}
 
-	async createAndEnterProfileFromTemplate(name: string, template: IUserDataProfileTemplate, options: CreationOptions = DefaultOptions): Promise<void> {
+	async createAndEnterProfileFromTemplate(name: string, template: IUserDataProfileTemplate, useDefaultFlags: UseDefaultProfileFlags): Promise<void> {
 		const workspaceIdentifier = this.getWorkspaceIdentifier();
 		if (!workspaceIdentifier) {
 			throw new Error(localize('cannotCreateProfileInEmptyWorkbench', "Cannot create a profile in an empty workspace"));
@@ -135,7 +114,7 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 			title: localize('profiles.creating', "{0}: Creating...", PROFILES_CATEGORY),
 		}, async progress => {
 			const promises: Promise<any>[] = [];
-			const newProfile = this.userDataProfilesService.newProfile(name);
+			const newProfile = this.userDataProfilesService.newProfile(name, useDefaultFlags);
 			await this.fileService.createFolder(newProfile.location);
 			if (template.globalState) {
 				// todo: create global state
@@ -147,7 +126,7 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 				promises.push(this.fileService.writeFile(newProfile.extensionsResource, VSBuffer.fromString(template.extensions)));
 			}
 			await Promise.allSettled(promises);
-			return this.userDataProfilesService.createProfile(newProfile, options, workspaceIdentifier);
+			return this.userDataProfilesService.createProfile(newProfile, workspaceIdentifier);
 		});
 		await this.enterProfile(profile, false);
 	}

--- a/src/vs/workbench/services/userDataProfile/common/userDataProfile.ts
+++ b/src/vs/workbench/services/userDataProfile/common/userDataProfile.ts
@@ -8,16 +8,7 @@ import { Event } from 'vs/base/common/event';
 import { localize } from 'vs/nls';
 import { MenuId } from 'vs/platform/actions/common/actions';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { IUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
-
-export type CreationOptions = {
-	settings?: boolean;
-	keybindings?: boolean;
-	tasks?: boolean;
-	snippets?: boolean;
-	extensions?: boolean;
-	uiState?: boolean;
-};
+import { IUserDataProfile, UseDefaultProfileFlags } from 'vs/platform/userDataProfile/common/userDataProfile';
 
 export interface DidChangeUserDataProfileEvent {
 	readonly preserveData: boolean;
@@ -38,8 +29,8 @@ export const IUserDataProfileManagementService = createDecorator<IUserDataProfil
 export interface IUserDataProfileManagementService {
 	readonly _serviceBrand: undefined;
 
-	createAndEnterProfile(name: string, options?: CreationOptions, fromExisting?: boolean): Promise<void>;
-	createAndEnterProfileFromTemplate(name: string, template: IUserDataProfileTemplate, options?: CreationOptions): Promise<void>;
+	createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean): Promise<void>;
+	createAndEnterProfileFromTemplate(name: string, template: IUserDataProfileTemplate, useDefaultFlags?: UseDefaultProfileFlags): Promise<void>;
 	removeProfile(profile: IUserDataProfile): Promise<void>;
 	switchProfile(profile: IUserDataProfile): Promise<void>;
 


### PR DESCRIPTION
This PR fixes #152420

- flip profile options to flags for using defaults
- adopt storage service to switch profile only when the storage location has changed


