### PR TITLE
fix: show `npm install` when no script in `package.json`

### DIFF
--- a/extensions/npm/src/tasks.ts
+++ b/extensions/npm/src/tasks.ts
@@ -273,14 +273,16 @@ async function provideNpmScriptsForFolder(context: ExtensionContext, packageJson
 	if (!folder) {
 		return emptyTasks;
 	}
+	const packageManager = await getPackageManager(context, folder.uri, showWarning);
 	const scripts = await getScripts(packageJsonUri);
 	if (!scripts) {
+		if (!workspace.getConfiguration('npm', folder).get<string[]>('scriptExplorerExclude', []).find(e => e.includes(INSTALL_SCRIPT))) {
+			emptyTasks.push({ task: await createTask(packageManager, INSTALL_SCRIPT, [INSTALL_SCRIPT], folder, packageJsonUri, 'install dependencies from package', []) });
+		}
 		return emptyTasks;
 	}
 
 	const result: ITaskWithLocation[] = [];
-
-	const packageManager = await getPackageManager(context, folder.uri, showWarning);
 
 	for (const { name, value, nameRange } of scripts.scripts) {
 		const task = await createTask(packageManager, name, ['run', name], folder!, packageJsonUri, value, undefined);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

- This PR fixes #152618

<img width="683" alt="Screen Shot 2022-06-21 at 9 42 41 PM" src="https://user-images.githubusercontent.com/20318608/174814420-1415337f-1ec5-4e24-84ae-431a94dedefd.png">

