### PR TITLE
Move some term keys back to application scope

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1046,7 +1046,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			const EXCLUDED_KEYS = ['RightArrow', 'LeftArrow', 'UpArrow', 'DownArrow', 'Space', 'Meta', 'Control', 'Shift', 'Alt', '', 'Delete', 'Backspace', 'Tab'];
 
 			// only keep track of input if prompt hasn't already been shown
-			if (this._storageService.getBoolean(SHOW_TERMINAL_CONFIG_PROMPT_KEY, StorageScope.PROFILE, true) &&
+			if (this._storageService.getBoolean(SHOW_TERMINAL_CONFIG_PROMPT_KEY, StorageScope.APPLICATION, true) &&
 				!EXCLUDED_KEYS.includes(event.key) &&
 				!event.ctrlKey &&
 				!event.shiftKey &&
@@ -1058,7 +1058,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			// within commandsToSkipShell, either alert or skip processing by xterm.js
 			if (resolveResult && resolveResult.commandId && this._skipTerminalCommands.some(k => k === resolveResult.commandId) && !this._configHelper.config.sendKeybindingsToShell) {
 				// don't alert when terminal is opened or closed
-				if (this._storageService.getBoolean(SHOW_TERMINAL_CONFIG_PROMPT_KEY, StorageScope.PROFILE, true) &&
+				if (this._storageService.getBoolean(SHOW_TERMINAL_CONFIG_PROMPT_KEY, StorageScope.APPLICATION, true) &&
 					this._hasHadInput &&
 					!TERMINAL_CREATION_COMMANDS.includes(resolveResult.commandId)) {
 					this._notificationService.prompt(
@@ -1073,7 +1073,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 							} as IPromptChoice
 						]
 					);
-					this._storageService.store(SHOW_TERMINAL_CONFIG_PROMPT_KEY, false, StorageScope.PROFILE, StorageTarget.USER);
+					this._storageService.store(SHOW_TERMINAL_CONFIG_PROMPT_KEY, false, StorageScope.APPLICATION, StorageTarget.USER);
 				}
 				event.preventDefault();
 				return false;

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -452,7 +452,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 			// }, 5000);
 		} catch (e) {
 			this._logService.warn(`Webgl could not be loaded. Falling back to the canvas renderer type.`, e);
-			const neverMeasureRenderTime = this._storageService.getBoolean(TerminalStorageKeys.NeverMeasureRenderTime, StorageScope.PROFILE, false);
+			const neverMeasureRenderTime = this._storageService.getBoolean(TerminalStorageKeys.NeverMeasureRenderTime, StorageScope.APPLICATION, false);
 			// if it's already set to dom, no need to measure render time
 			if (!neverMeasureRenderTime && this._configHelper.config.gpuAcceleration !== 'off') {
 				this._measureRenderTime();
@@ -529,7 +529,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal {
 						{
 							label: localize('dontShowAgain', "Don't Show Again"),
 							isSecondary: true,
-							run: () => this._storageService.store(TerminalStorageKeys.NeverMeasureRenderTime, true, StorageScope.PROFILE, StorageTarget.MACHINE)
+							run: () => this._storageService.store(TerminalStorageKeys.NeverMeasureRenderTime, true, StorageScope.APPLICATION, StorageTarget.MACHINE)
 						} as IPromptChoice
 					];
 					this._notificationService.prompt(

--- a/src/vs/workbench/contrib/terminal/common/history.ts
+++ b/src/vs/workbench/contrib/terminal/common/history.ts
@@ -92,7 +92,7 @@ export class TerminalPersistedHistory<T> extends Disposable implements ITerminal
 		// Listen to cache changes from other windows
 		this._storageService.onDidChangeValue(e => {
 			if (e.key === this._getTimestampStorageKey() && !this._isStale) {
-				this._isStale = this._storageService.getNumber(this._getTimestampStorageKey(), StorageScope.PROFILE, 0) !== this._timestamp;
+				this._isStale = this._storageService.getNumber(this._getTimestampStorageKey(), StorageScope.APPLICATION, 0) !== this._timestamp;
 			}
 		});
 	}
@@ -133,7 +133,7 @@ export class TerminalPersistedHistory<T> extends Disposable implements ITerminal
 	}
 
 	private _loadState() {
-		this._timestamp = this._storageService.getNumber(this._getTimestampStorageKey(), StorageScope.PROFILE, 0);
+		this._timestamp = this._storageService.getNumber(this._getTimestampStorageKey(), StorageScope.APPLICATION, 0);
 
 		// Load global entries plus
 		const serialized = this._loadPersistedState();
@@ -145,7 +145,7 @@ export class TerminalPersistedHistory<T> extends Disposable implements ITerminal
 	}
 
 	private _loadPersistedState(): ISerializedCache<T> | undefined {
-		const raw = this._storageService.get(this._getEntriesStorageKey(), StorageScope.PROFILE);
+		const raw = this._storageService.get(this._getEntriesStorageKey(), StorageScope.APPLICATION);
 		if (raw === undefined || raw.length === 0) {
 			return undefined;
 		}
@@ -162,9 +162,9 @@ export class TerminalPersistedHistory<T> extends Disposable implements ITerminal
 	private _saveState() {
 		const serialized: ISerializedCache<T> = { entries: [] };
 		this._entries.forEach((value, key) => serialized.entries.push({ key, value }));
-		this._storageService.store(this._getEntriesStorageKey(), JSON.stringify(serialized), StorageScope.PROFILE, StorageTarget.MACHINE);
+		this._storageService.store(this._getEntriesStorageKey(), JSON.stringify(serialized), StorageScope.APPLICATION, StorageTarget.MACHINE);
 		this._timestamp = Date.now();
-		this._storageService.store(this._getTimestampStorageKey(), this._timestamp, StorageScope.PROFILE, StorageTarget.MACHINE);
+		this._storageService.store(this._getTimestampStorageKey(), this._timestamp, StorageScope.APPLICATION, StorageTarget.MACHINE);
 	}
 
 	private _getHistoryLimit() {


### PR DESCRIPTION
Part of #152679

- `SHOW_TERMINAL_CONFIG_PROMPT_KEY` is for setting up an application setting
- `TerminalStorageKeys.NeverMeasureRenderTime` is a per machine setting for checking GPU support
- `_getTimestampStorageKey` and `_getEntriesStorageKey` is for recording terminal history which is arguable whether it should be profile, I think aligning with how regular shell history works is best though