### PR TITLE
Fix telemetry not sending

### DIFF
--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -105,7 +105,6 @@ import { ExtensionsProfileScannerService, IExtensionsProfileScannerService } fro
 import { PolicyChannelClient } from 'vs/platform/policy/common/policyIpc';
 import { IPolicyService, NullPolicyService } from 'vs/platform/policy/common/policy';
 import { OneDataSystemAppender } from 'vs/platform/telemetry/node/1dsAppender';
-// import { OneDataSystemAppender } from 'vs/platform/telemetry/node/1dsAppender';
 
 class SharedProcessMain extends Disposable {
 

--- a/src/vs/platform/telemetry/browser/1dsAppender.ts
+++ b/src/vs/platform/telemetry/browser/1dsAppender.ts
@@ -106,8 +106,7 @@ export class OneDataSystemWebAppender implements ITelemetryAppender {
 		try {
 			this._withAIClient((aiClient) => aiClient.track({
 				name: this._eventPrefix + '/' + eventName,
-				data,
-
+				data: { ...data.properties, ...data.measurements },
 			}));
 		} catch { }
 	}

--- a/src/vs/platform/telemetry/node/1dsAppender.ts
+++ b/src/vs/platform/telemetry/node/1dsAppender.ts
@@ -21,6 +21,7 @@ async function getClient(instrumentationKey: string): Promise<AppInsightsCore> {
 		endpointUrl: 'https://mobile.events.data.microsoft.com/OneCollector/1.0',
 		loggingLevelTelemetry: 0,
 		loggingLevelConsole: 0,
+		extensionConfig: {},
 		channels: [[
 			collectorChannelPlugin
 		]]
@@ -135,7 +136,7 @@ export class OneDataSystemAppender implements ITelemetryAppender {
 		try {
 			this._withAIClient((aiClient) => aiClient.track({
 				name: this._eventPrefix + '/' + eventName,
-				data,
+				data: { ...data.properties, ...data.measurements },
 
 			}));
 		} catch { }


### PR DESCRIPTION
1DS doesn't seem to handle nested data well. The requests just fail silently. This spreads the data again to ensure events get sent. Also we were using web API in the shared process this enables the HTTP shim. Sadly the HTTP shim causes network tracing to be disabled.
