### PR TITLE
don't escape text edits as snippets

### DIFF
--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
@@ -19,7 +19,6 @@ import { ResourceMap } from 'vs/base/common/map';
 import { IModelService } from 'vs/editor/common/services/model';
 import { ResourceTextEdit } from 'vs/editor/browser/services/bulkEditService';
 import { CancellationToken } from 'vs/base/common/cancellation';
-import { SnippetParser } from 'vs/editor/contrib/snippet/browser/snippetParser';
 import { performSnippetEdits } from 'vs/editor/contrib/snippet/browser/snippetController2';
 
 type ValidationResult = { canApply: true } | { canApply: false; reason: URI };
@@ -94,8 +93,7 @@ class ModelEditTask implements IDisposable {
 	apply(): void {
 		if (this._edits.length > 0) {
 			this._edits = this._edits
-				.sort((a, b) => Range.compareRangesUsingStarts(a.range, b.range))
-				.map(edit => ({ ...edit, text: edit.text && SnippetParser.escape(edit.text) }));
+				.sort((a, b) => Range.compareRangesUsingStarts(a.range, b.range));
 			this.model.pushEditOperations(null, this._edits, () => null);
 		}
 		if (this._newEol !== undefined) {

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
@@ -20,15 +20,18 @@ import { IModelService } from 'vs/editor/common/services/model';
 import { ResourceTextEdit } from 'vs/editor/browser/services/bulkEditService';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { performSnippetEdits } from 'vs/editor/contrib/snippet/browser/snippetController2';
+import { SnippetParser } from 'vs/editor/contrib/snippet/browser/snippetParser';
 
 type ValidationResult = { canApply: true } | { canApply: false; reason: URI };
+
+type ISingleSnippetEditOperation = ISingleEditOperation & { insertAsSnippet?: boolean };
 
 class ModelEditTask implements IDisposable {
 
 	readonly model: ITextModel;
 
 	private _expectedModelVersionId: number | undefined;
-	protected _edits: (ISingleEditOperation & { insertAsSnippet?: boolean })[];
+	protected _edits: ISingleSnippetEditOperation[];
 	protected _newEol: EndOfLineSequence | undefined;
 
 	constructor(private readonly _modelReference: IReference<IResolvedTextEditorModel>) {
@@ -93,12 +96,27 @@ class ModelEditTask implements IDisposable {
 	apply(): void {
 		if (this._edits.length > 0) {
 			this._edits = this._edits
+				.map(this._transformSnippetStringToInsertText, this) // no editor -> no snippet mode
 				.sort((a, b) => Range.compareRangesUsingStarts(a.range, b.range));
 			this.model.pushEditOperations(null, this._edits, () => null);
 		}
 		if (this._newEol !== undefined) {
 			this.model.pushEOL(this._newEol);
 		}
+	}
+
+	protected _transformSnippetStringToInsertText(edit: ISingleSnippetEditOperation): ISingleSnippetEditOperation {
+		// transform a snippet edit (and only those) into a normal text edit
+		// for that we need to parse the snippet and get its actual text, e.g without placeholder
+		// or variable syntaxes
+		if (!edit.insertAsSnippet) {
+			return edit;
+		}
+		if (!edit.text) {
+			return edit;
+		}
+		const text = new SnippetParser().parse(edit.text, false, false).toString();
+		return { ...edit, insertAsSnippet: false, text };
 	}
 }
 
@@ -132,6 +150,7 @@ class EditorEditTask extends ModelEditTask {
 
 			} else {
 				this._edits = this._edits
+					.map(this._transformSnippetStringToInsertText, this) // mixed edits (snippet and normal) -> no snippet mode
 					.sort((a, b) => Range.compareRangesUsingStarts(a.range, b.range));
 				this._editor.executeEdits('', this._edits);
 			}


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/152746

When applying a workspace edit, "normal" edits don't need snippet escaping. That was my bad and flawed thinking. Instead, when a snippet edit is wanted but cannot be performed its text needs to be extracted. 