### PR TITLE
Enable alwaysStrict for build scripts

### DIFF
--- a/build/azure-pipelines/common/computeNodeModulesCacheKey.js
+++ b/build/azure-pipelines/common/computeNodeModulesCacheKey.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs");
 const path = require("path");

--- a/build/azure-pipelines/common/computeNodeModulesCacheKey.ts
+++ b/build/azure-pipelines/common/computeNodeModulesCacheKey.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';

--- a/build/azure-pipelines/common/createAsset.js
+++ b/build/azure-pipelines/common/createAsset.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs");
 const crypto = require("crypto");

--- a/build/azure-pipelines/common/createAsset.ts
+++ b/build/azure-pipelines/common/createAsset.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as fs from 'fs';
 import { Readable } from 'stream';
 import * as crypto from 'crypto';

--- a/build/azure-pipelines/common/createBuild.js
+++ b/build/azure-pipelines/common/createBuild.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const identity_1 = require("@azure/identity");
 const cosmos_1 = require("@azure/cosmos");

--- a/build/azure-pipelines/common/createBuild.ts
+++ b/build/azure-pipelines/common/createBuild.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import { ClientSecretCredential } from '@azure/identity';
 import { CosmosClient } from '@azure/cosmos';
 import { retry } from './retry';

--- a/build/azure-pipelines/common/listNodeModules.js
+++ b/build/azure-pipelines/common/listNodeModules.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs");
 const path = require("path");

--- a/build/azure-pipelines/common/listNodeModules.ts
+++ b/build/azure-pipelines/common/listNodeModules.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/build/azure-pipelines/common/releaseBuild.js
+++ b/build/azure-pipelines/common/releaseBuild.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const identity_1 = require("@azure/identity");
 const cosmos_1 = require("@azure/cosmos");

--- a/build/azure-pipelines/common/releaseBuild.ts
+++ b/build/azure-pipelines/common/releaseBuild.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import { ClientSecretCredential } from '@azure/identity';
 import { CosmosClient } from '@azure/cosmos';
 import { retry } from './retry';

--- a/build/azure-pipelines/common/retry.js
+++ b/build/azure-pipelines/common/retry.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.retry = void 0;
 async function retry(fn) {

--- a/build/azure-pipelines/common/retry.ts
+++ b/build/azure-pipelines/common/retry.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 export async function retry<T>(fn: () => Promise<T>): Promise<T> {
 	let lastError: Error | undefined;
 

--- a/build/azure-pipelines/mixin.js
+++ b/build/azure-pipelines/mixin.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const json = require("gulp-json-editor");
 const buffer = require('gulp-buffer');

--- a/build/azure-pipelines/mixin.ts
+++ b/build/azure-pipelines/mixin.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as json from 'gulp-json-editor';
 const buffer = require('gulp-buffer');
 import * as filter from 'gulp-filter';

--- a/build/azure-pipelines/publish-types/check-version.js
+++ b/build/azure-pipelines/publish-types/check-version.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const cp = require("child_process");
 let tag = '';

--- a/build/azure-pipelines/publish-types/check-version.ts
+++ b/build/azure-pipelines/publish-types/check-version.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as cp from 'child_process';
 
 let tag = '';

--- a/build/azure-pipelines/publish-types/update-types.js
+++ b/build/azure-pipelines/publish-types/update-types.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs");
 const cp = require("child_process");

--- a/build/azure-pipelines/publish-types/update-types.ts
+++ b/build/azure-pipelines/publish-types/update-types.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as fs from 'fs';
 import * as cp from 'child_process';
 import * as path from 'path';

--- a/build/azure-pipelines/upload-cdn.js
+++ b/build/azure-pipelines/upload-cdn.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const es = require("event-stream");
 const Vinyl = require("vinyl");

--- a/build/azure-pipelines/upload-cdn.ts
+++ b/build/azure-pipelines/upload-cdn.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as es from 'event-stream';
 import * as Vinyl from 'vinyl';
 import * as vfs from 'vinyl-fs';

--- a/build/azure-pipelines/upload-configuration.js
+++ b/build/azure-pipelines/upload-configuration.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getSettingsSearchBuildId = exports.shouldSetupSettingsSearch = void 0;
 const path = require("path");

--- a/build/azure-pipelines/upload-configuration.ts
+++ b/build/azure-pipelines/upload-configuration.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as path from 'path';
 import * as os from 'os';
 import * as cp from 'child_process';

--- a/build/azure-pipelines/upload-nlsmetadata.js
+++ b/build/azure-pipelines/upload-nlsmetadata.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const es = require("event-stream");
 const vfs = require("vinyl-fs");

--- a/build/azure-pipelines/upload-nlsmetadata.ts
+++ b/build/azure-pipelines/upload-nlsmetadata.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as es from 'event-stream';
 import * as Vinyl from 'vinyl';
 import * as vfs from 'vinyl-fs';

--- a/build/azure-pipelines/upload-sourcemaps.js
+++ b/build/azure-pipelines/upload-sourcemaps.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const path = require("path");
 const es = require("event-stream");

--- a/build/azure-pipelines/upload-sourcemaps.ts
+++ b/build/azure-pipelines/upload-sourcemaps.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as path from 'path';
 import * as es from 'event-stream';
 import * as Vinyl from 'vinyl';

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const vscode_universal_bundler_1 = require("vscode-universal-bundler");
 const cross_spawn_promise_1 = require("@malept/cross-spawn-promise");

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import { makeUniversalApp } from 'vscode-universal-bundler';
 import { spawn } from '@malept/cross-spawn-promise';
 import * as fs from 'fs-extra';

--- a/build/darwin/sign.js
+++ b/build/darwin/sign.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 const codesign = require("electron-osx-sign");
 const path = require("path");

--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as codesign from 'electron-osx-sign';
 import * as path from 'path';
 import * as util from '../lib/util';

--- a/build/lib/asar.js
+++ b/build/lib/asar.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createAsar = void 0;
 const path = require("path");

--- a/build/lib/asar.ts
+++ b/build/lib/asar.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as path from 'path';
 import * as es from 'event-stream';
 const pickle = require('chromium-pickle-js');

--- a/build/lib/compilation.js
+++ b/build/lib/compilation.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.watchApiProposalNamesTask = exports.compileApiProposalNamesTask = exports.watchTask = exports.compileTask = void 0;
 const es = require("event-stream");

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as es from 'event-stream';
 import * as fs from 'fs';
 import * as gulp from 'gulp';

--- a/build/lib/dependencies.js
+++ b/build/lib/dependencies.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getProductionDependencies = void 0;
 const path = require("path");

--- a/build/lib/dependencies.ts
+++ b/build/lib/dependencies.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as path from 'path';
 import * as cp from 'child_process';
 import * as _ from 'underscore';

--- a/build/lib/electron.js
+++ b/build/lib/electron.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.config = void 0;
 const fs = require("fs");

--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vfs from 'vinyl-fs';

--- a/build/lib/eslint/code-no-look-behind-regex.js
+++ b/build/lib/eslint/code-no-look-behind-regex.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/build/lib/eslint/code-no-look-behind-regex.ts
+++ b/build/lib/eslint/code-no-look-behind-regex.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as eslint from 'eslint';
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import * as ESTree from 'estree';

--- a/build/lib/eslint/code-no-unused-expressions.js
+++ b/build/lib/eslint/code-no-unused-expressions.js
@@ -1,14 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-// FORKED FROM https://github.com/eslint/eslint/blob/b23ad0d789a909baf8d7c41a35bc53df932eaf30/lib/rules/no-unused-expressions.js
-// and added support for `OptionalCallExpression`, see https://github.com/facebook/create-react-app/issues/8107 and https://github.com/eslint/eslint/issues/12642
-/**
- * @fileoverview Flag expressions in statement position that do not side effect
- * @author Michael Ficarra
- */
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/build/lib/eslint/code-no-unused-expressions.ts
+++ b/build/lib/eslint/code-no-unused-expressions.ts
@@ -11,8 +11,6 @@
  * @author Michael Ficarra
  */
 
-'use strict';
-
 import * as eslint from 'eslint';
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import * as ESTree from 'estree';

--- a/build/lib/git.js
+++ b/build/lib/git.js
@@ -1,10 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getVersion = void 0;
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.getVersion = void 0;
 const path = require("path");
 const fs = require("fs");
 /**

--- a/build/lib/git.ts
+++ b/build/lib/git.ts
@@ -2,8 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
-
 import * as path from 'path';
 import * as fs from 'fs';
 

--- a/build/lib/optimize.js
+++ b/build/lib/optimize.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.minifyTask = exports.optimizeTask = exports.loaderConfig = void 0;
 const es = require("event-stream");

--- a/build/lib/optimize.ts
+++ b/build/lib/optimize.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as es from 'event-stream';
 import * as gulp from 'gulp';
 import * as concat from 'gulp-concat';

--- a/build/lib/preLaunch.js
+++ b/build/lib/preLaunch.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 // @ts-check
 const path = require("path");

--- a/build/lib/preLaunch.ts
+++ b/build/lib/preLaunch.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 // @ts-check
 
 import * as path from 'path';

--- a/build/lib/reporter.js
+++ b/build/lib/reporter.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createReporter = void 0;
 const es = require("event-stream");

--- a/build/lib/reporter.ts
+++ b/build/lib/reporter.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as es from 'event-stream';
 import * as _ from 'underscore';
 import * as fancyLog from 'fancy-log';

--- a/build/lib/snapshotLoader.js
+++ b/build/lib/snapshotLoader.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 var snaps;
 (function (snaps) {
     const fs = require('fs');

--- a/build/lib/snapshotLoader.ts
+++ b/build/lib/snapshotLoader.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 namespace snaps {
 
 	const fs = require('fs');

--- a/build/lib/stats.js
+++ b/build/lib/stats.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createStatsStream = void 0;
 const es = require("event-stream");

--- a/build/lib/stats.ts
+++ b/build/lib/stats.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as es from 'event-stream';
 import * as fancyLog from 'fancy-log';
 import * as ansiColors from 'ansi-colors';

--- a/build/lib/task.js
+++ b/build/lib/task.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.define = exports.parallel = exports.series = void 0;
 const fancyLog = require("fancy-log");

--- a/build/lib/task.ts
+++ b/build/lib/task.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as fancyLog from 'fancy-log';
 import * as ansiColors from 'ansi-colors';
 

--- a/build/lib/treeshaking.js
+++ b/build/lib/treeshaking.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.shake = exports.toStringShakeLevel = exports.ShakeLevel = void 0;
 const fs = require("fs");
@@ -839,3 +839,4 @@ function getTokenAtPosition(ts, sourceFile, position, allowPositionInLeadingTriv
         return current;
     }
 }
+//#endregion

--- a/build/lib/treeshaking.ts
+++ b/build/lib/treeshaking.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as fs from 'fs';
 import * as path from 'path';
 import type * as ts from 'typescript';

--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.buildWebNodePaths = exports.createExternalLoaderConfig = exports.acquireWebNodePaths = exports.getElectronVersion = exports.streamToPromise = exports.versionStringToNumber = exports.filter = exports.rebase = exports.getVersion = exports.ensureDir = exports.rreddir = exports.rimraf = exports.rewriteSourceMappingURL = exports.stripSourceMappingURL = exports.loadSourcemaps = exports.cleanNodeModules = exports.skipDirectories = exports.toFileUri = exports.setExecutableBit = exports.fixWin32DirectoryPermissions = exports.debounce = exports.incremental = void 0;
 const es = require("event-stream");

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as es from 'event-stream';
 import _debounce = require('debounce');
 import * as _filter from 'gulp-filter';

--- a/build/linux/libcxx-fetcher.js
+++ b/build/linux/libcxx-fetcher.js
@@ -1,11 +1,11 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-// Can be removed once https://github.com/electron/electron-rebuild/pull/703 is available.
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.downloadLibcxxObjects = exports.downloadLibcxxHeaders = void 0;
+// Can be removed once https://github.com/electron/electron-rebuild/pull/703 is available.
 const debug = require("debug");
 const extract = require("extract-zip");
 const fs = require("fs-extra");

--- a/build/linux/libcxx-fetcher.ts
+++ b/build/linux/libcxx-fetcher.ts
@@ -5,8 +5,6 @@
 
 // Can be removed once https://github.com/electron/electron-rebuild/pull/703 is available.
 
-'use strict';
-
 import * as debug from 'debug';
 import * as extract from 'extract-zip';
 import * as fs from 'fs-extra';

--- a/build/linux/rpm/dependencies-generator.js
+++ b/build/linux/rpm/dependencies-generator.js
@@ -1,8 +1,8 @@
+"use strict";
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getDependencies = void 0;
 const child_process_1 = require("child_process");

--- a/build/linux/rpm/dependencies-generator.ts
+++ b/build/linux/rpm/dependencies-generator.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import { spawnSync } from 'child_process';
 import { constants, statSync } from 'fs';
 import path = require('path');

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -3,6 +3,7 @@
 		"target": "es2020",
 		"lib": ["ES2020"],
 		"module": "commonjs",
+		"alwaysStrict": true,
 		"removeComments": false,
 		"preserveConstEnums": true,
 		"sourceMap": false,


### PR DESCRIPTION
Turns on `alwaysStrict` and removes `'use strict';` from our `.ts` files
