### PR TITLE
Do not set `editSessionId` in source workspace

### DIFF
--- a/src/vs/workbench/contrib/sessionSync/browser/sessionSync.contribution.ts
+++ b/src/vs/workbench/contrib/sessionSync/browser/sessionSync.contribution.ts
@@ -113,8 +113,6 @@ export class SessionSyncContribution extends Disposable implements IWorkbenchCon
 					workspaceUri = workspaceUri.with({
 						query: workspaceUri.query.length > 0 ? (workspaceUri + `&${queryParamName}=${encodedRef}`) : `${queryParamName}=${encodedRef}`
 					});
-
-					that.environmentService.editSessionId = ref;
 				} else {
 					that.logService.warn(`Edit Sessions: Failed to store edit session when invoking ${continueEditSessionCommand.id}.`);
 				}


### PR DESCRIPTION
Re: https://github.com/microsoft/vscode/issues/141293

Fix an issue where after invoking continue on, the created edit session becomes associated with the current workspace instead of the destination workspace