### PR TITLE
Dispose custom hover after clicking link

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -6,7 +6,7 @@
 import * as DOM from 'vs/base/browser/dom';
 import { IMouseEvent } from 'vs/base/browser/mouseEvent';
 import { IHoverDelegate, IHoverDelegateOptions } from 'vs/base/browser/ui/iconLabel/iconHoverDelegate';
-import { ITooltipMarkdownString, IUpdatableHoverOptions, setupCustomHover } from 'vs/base/browser/ui/iconLabel/iconLabelHover';
+import { ICustomHover, ITooltipMarkdownString, IUpdatableHoverOptions, setupCustomHover } from 'vs/base/browser/ui/iconLabel/iconLabelHover';
 import { SimpleIconLabel } from 'vs/base/browser/ui/iconLabel/simpleIconLabel';
 import { Emitter } from 'vs/base/common/event';
 import { DisposableStore } from 'vs/base/common/lifecycle';
@@ -153,15 +153,17 @@ export class SettingsTreeIndicatorsLabel {
 					},
 					markdownNotSupportedFallback: contentFallback
 				};
+				let hover: ICustomHover | undefined = undefined;
 				const options: IUpdatableHoverOptions = {
 					linkHandler: (scope: string) => {
 						onDidClickOverrideElement.fire({
 							targetKey: element.setting.key,
 							scope
 						});
+						hover!.dispose();
 					}
 				};
-				setupCustomHover(this.hoverDelegate, this.scopeOverridesElement, content, options);
+				hover = setupCustomHover(this.hoverDelegate, this.scopeOverridesElement, content, options);
 			}
 		}
 		this.render();


### PR DESCRIPTION
Ref #151787

By disposing the custom hover after clicking the link, the hover stops showing up after the link is clicked, which is the desired behaviour.