### PR TITLE
Enable md paste actions by default

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -419,7 +419,7 @@
           "type": "boolean",
           "scope": "resource",
           "markdownDescription": "%configuration.markdown.editor.pasteLinks.enabled%",
-          "default": false,
+          "default": true,
           "tags": [
             "experimental"
           ]

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -29,7 +29,7 @@
 	"configuration.markdown.links.openLocation.beside": "Open links beside the active editor.",
 	"configuration.markdown.suggest.paths.enabled.description": "Enable/disable path suggestions for markdown links",
 	"configuration.markdown.editor.drop.enabled": "Enable/disable dropping into the markdown editor to insert shift. Requires enabling `#workbench.experimental.editor.dropIntoEditor.enabled#`.",
-	"configuration.markdown.editor.pasteLinks.enabled": "Enable/disable pasting files into a Markdown editor inserts Markdown links.",
+	"configuration.markdown.editor.pasteLinks.enabled": "Enable/disable pasting files into a Markdown editor inserts Markdown links. Requires enabling `#editor.experimental.pasteActions.enabled#`.",
 	"configuration.markdown.experimental.validate.enabled.description": "Enable/disable all error reporting in Markdown files.",
 	"configuration.markdown.experimental.validate.referenceLinks.enabled.description": "Validate reference links in Markdown files, e.g. `[link][ref]`.  Requires enabling `#markdown.experimental.validate.enabled#`.",
 	"configuration.markdown.experimental.validate.fragmentLinks.enabled.description": "Validate fragment links to headers in the current Markdown file, e.g. `[link](#header)`. Requires enabling `#markdown.experimental.validate.enabled#`.",

--- a/extensions/markdown-language-features/src/languageFeatures/copyPaste.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyPaste.ts
@@ -15,7 +15,7 @@ export function registerPasteSupport(selector: vscode.DocumentSelector) {
 			dataTransfer: vscode.DataTransfer,
 			token: vscode.CancellationToken,
 		): Promise<vscode.DocumentPasteEdit | undefined> {
-			const enabled = vscode.workspace.getConfiguration('markdown', document).get('experimental.editor.pasteLinks.enabled', false);
+			const enabled = vscode.workspace.getConfiguration('markdown', document).get('experimental.editor.pasteLinks.enabled', true);
 			if (!enabled) {
 				return;
 			}


### PR DESCRIPTION
Turns on pasting of links for easier testing. However `editor.experimental.pasteActions.enabled` is still off by default so this won't be enabled by default

