### PR TITLE
SCM - Add capability to disable the SCM action button

### DIFF
--- a/extensions/git/src/actionButton.ts
+++ b/extensions/git/src/actionButton.ts
@@ -13,7 +13,7 @@ const localize = nls.loadMessageBundle();
 
 interface ActionButtonState {
 	readonly HEAD: Branch | undefined;
-	readonly isSyncRunning: boolean;
+	readonly isActionRunning: boolean;
 	readonly repositoryHasNoChanges: boolean;
 }
 
@@ -33,7 +33,7 @@ export class ActionButtonCommand {
 	private disposables: Disposable[] = [];
 
 	constructor(readonly repository: Repository) {
-		this._state = { HEAD: undefined, isSyncRunning: false, repositoryHasNoChanges: false };
+		this._state = { HEAD: undefined, isActionRunning: false, repositoryHasNoChanges: false };
 
 		repository.onDidRunGitStatus(this.onDidRunGitStatus, this, this.disposables);
 		repository.onDidChangeOperations(this.onDidChangeOperations, this, this.disposables);
@@ -50,49 +50,63 @@ export class ActionButtonCommand {
 		let actionButton: SourceControlActionButton | undefined;
 		if (showActionButton === 'always' || (showActionButton === 'whenEmpty' && this.state.repositoryHasNoChanges && noPostCommitCommand)) {
 			if (this.state.HEAD.upstream) {
-				if (this.state.HEAD.ahead) {
-					const config = workspace.getConfiguration('git', Uri.file(this.repository.root));
-					const rebaseWhenSync = config.get<string>('rebaseWhenSync');
-
-					const ahead = `${this.state.HEAD.ahead}$(arrow-up)`;
-					const behind = this.state.HEAD.behind ? `${this.state.HEAD.behind}$(arrow-down) ` : '';
-					const icon = this.state.isSyncRunning ? '$(sync~spin)' : '$(sync)';
-
-					actionButton = {
-						command: {
-							command: this.state.isSyncRunning ? '' : rebaseWhenSync ? 'git.syncRebase' : 'git.sync',
-							title: localize('scm button sync title', "{0} {1}{2}", icon, behind, ahead),
-							tooltip: this.state.isSyncRunning ?
-								localize('syncing changes', "Synchronizing Changes...")
-								: this.repository.syncTooltip,
-							arguments: [this.repository.sourceControl],
-						},
-						description: localize('scm button sync description', "{0} Sync Changes {1}{2}", icon, behind, ahead)
-					};
-				}
+				// Sync Changes
+				actionButton = this.getSyncChangesActionButton();
 			} else {
-				actionButton = {
-					command: {
-						command: this.state.isSyncRunning ? '' : 'git.publish',
-						title: localize('scm button publish title', "$(cloud-upload) Publish Branch"),
-						tooltip: this.state.isSyncRunning ?
-							localize('scm button publish branch running', "Publishing Branch...") :
-							localize('scm button publish branch', "Publish Branch"),
-						arguments: [this.repository.sourceControl],
-					}
-				};
+				// Publish Branch
+				actionButton = this.getPublishBranchActionButton();
 			}
 		}
 
 		return actionButton;
 	}
 
+	private getPublishBranchActionButton(): SourceControlActionButton {
+		return {
+			command: {
+				command: 'git.publish',
+				title: localize('scm button publish title', "$(cloud-upload) Publish Branch"),
+				tooltip: this.state.isActionRunning ?
+					localize('scm button publish branch running', "Publishing Branch...") :
+					localize('scm button publish branch', "Publish Branch"),
+				arguments: [this.repository.sourceControl],
+			},
+			enabled: !this.state.isActionRunning
+		};
+	}
+
+	private getSyncChangesActionButton(): SourceControlActionButton | undefined {
+		if (this.state.HEAD?.ahead) {
+			const config = workspace.getConfiguration('git', Uri.file(this.repository.root));
+			const rebaseWhenSync = config.get<string>('rebaseWhenSync');
+
+			const ahead = `${this.state.HEAD.ahead}$(arrow-up)`;
+			const behind = this.state.HEAD.behind ? `${this.state.HEAD.behind}$(arrow-down) ` : '';
+			const icon = this.state.isActionRunning ? '$(sync~spin)' : '$(sync)';
+
+			return {
+				command: {
+					command: rebaseWhenSync ? 'git.syncRebase' : 'git.sync',
+					title: localize('scm button sync title', "{0} {1}{2}", icon, behind, ahead),
+					tooltip: this.state.isActionRunning ?
+						localize('syncing changes', "Synchronizing Changes...")
+						: this.repository.syncTooltip,
+					arguments: [this.repository.sourceControl],
+				},
+				description: localize('scm button sync description', "{0} Sync Changes {1}{2}", icon, behind, ahead),
+				enabled: !this.state.isActionRunning
+			};
+		}
+
+		return undefined;
+	}
+
 	private onDidChangeOperations(): void {
-		const isSyncRunning = this.repository.operations.isRunning(Operation.Sync) ||
+		const isActionRunning = this.repository.operations.isRunning(Operation.Sync) ||
 			this.repository.operations.isRunning(Operation.Push) ||
 			this.repository.operations.isRunning(Operation.Pull);
 
-		this.state = { ...this.state, isSyncRunning };
+		this.state = { ...this.state, isActionRunning: isActionRunning };
 	}
 
 	private onDidRunGitStatus(): void {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1144,6 +1144,7 @@ export interface SCMProviderFeatures {
 export interface SCMActionButtonDto {
 	command: ICommandDto;
 	description?: string;
+	enabled: boolean;
 }
 
 export interface SCMGroupFeatures {

--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -537,7 +537,8 @@ class ExtHostSourceControl implements vscode.SourceControl {
 		const internal = actionButton !== undefined ?
 			{
 				command: this._commands.converter.toInternal(actionButton.command, this._actionButtonDisposables.value),
-				description: actionButton.description
+				description: actionButton.description,
+				enabled: actionButton.enabled
 			} : undefined;
 		this.#proxy.$updateSourceControl(this.handle, { actionButton: internal ?? null });
 	}

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -2600,6 +2600,7 @@ export class SCMActionButton implements IDisposable {
 			this.button = new Button(this.container, { supportIcons: true, title: button.command.tooltip });
 		}
 
+		this.button.enabled = button.enabled;
 		this.button.label = button.command.title;
 		this.button.onDidClick(async () => {
 			try {

--- a/src/vs/workbench/contrib/scm/common/scm.ts
+++ b/src/vs/workbench/contrib/scm/common/scm.ts
@@ -100,6 +100,7 @@ export interface ISCMInputChangeEvent {
 export interface ISCMActionButtonDescriptor {
 	command: Command;
 	description?: string;
+	enabled: boolean;
 }
 
 export interface ISCMActionButton {

--- a/src/vscode-dts/vscode.proposed.scmActionButton.d.ts
+++ b/src/vscode-dts/vscode.proposed.scmActionButton.d.ts
@@ -9,6 +9,7 @@ declare module 'vscode' {
 	export interface SourceControlActionButton {
 		command: Command;
 		description?: string;
+		enabled: boolean;
 	}
 
 	export interface SourceControl {


### PR DESCRIPTION
This pull request adds the capability to disable the SCM action button (`Publish Branch` and `Sync Changes`). 
We are taking advantage of this capability to disable the SCM action button while there is an operation running. 