### PR TITLE
When in between two columns, prefer the column which is closer to the mouse horizontal offset

### DIFF
--- a/src/vs/editor/browser/controller/mouseTarget.ts
+++ b/src/vs/editor/browser/controller/mouseTarget.ts
@@ -823,7 +823,21 @@ export class MouseTargetFactory {
 			const curr = points[i];
 			if (prev.offset <= request.mouseContentHorizontalOffset && request.mouseContentHorizontalOffset <= curr.offset) {
 				const rng = new EditorRange(lineNumber, prev.column, lineNumber, curr.column);
-				return request.fulfillContentText(pos, rng, { mightBeForeignElement: !mouseIsOverSpanNode || !!injectedText, injectedText });
+
+				// See https://github.com/microsoft/vscode/issues/152819
+				// Due to the use of zwj, the browser's hit test result is skewed towards the left
+				// Here we try to correct that if the mouse horizontal offset is closer to the right than the left
+
+				const prevDelta = Math.abs(prev.offset - request.mouseContentHorizontalOffset);
+				const nextDelta = Math.abs(curr.offset - request.mouseContentHorizontalOffset);
+
+				const resultPos = (
+					prevDelta < nextDelta
+						? new Position(lineNumber, prev.column)
+						: new Position(lineNumber, curr.column)
+				);
+
+				return request.fulfillContentText(resultPos, rng, { mightBeForeignElement: !mouseIsOverSpanNode || !!injectedText, injectedText });
 			}
 		}
 		return request.fulfillContentText(pos, null, { mightBeForeignElement: !mouseIsOverSpanNode || !!injectedText, injectedText });


### PR DESCRIPTION
Fixes #152819