### PR TITLE
Refactor telemetry appenders to reduce duplicated code

### DIFF
--- a/src/tsconfig.monaco.json
+++ b/src/tsconfig.monaco.json
@@ -30,7 +30,7 @@
 		"node_modules/*",
 		"vs/platform/files/browser/htmlFileSystemProvider.ts",
 		"vs/platform/files/browser/webFileSystemAccess.ts",
-		"vs/platform/telemetry/browser/*",
+		"vs/platform/telemetry/*",
 		"vs/platform/assignment/*"
 	]
 }

--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -104,7 +104,7 @@ import { IUserDataProfilesService, UserDataProfilesService } from 'vs/platform/u
 import { ExtensionsProfileScannerService, IExtensionsProfileScannerService } from 'vs/platform/extensionManagement/common/extensionsProfileScannerService';
 import { PolicyChannelClient } from 'vs/platform/policy/common/policyIpc';
 import { IPolicyService, NullPolicyService } from 'vs/platform/policy/common/policy';
-import { OneDataSystemAppender } from 'vs/platform/telemetry/node/1dsAppender';
+import { OneDataSystemWebAppender } from 'vs/platform/telemetry/browser/1dsAppender';
 
 class SharedProcessMain extends Disposable {
 
@@ -282,7 +282,7 @@ class SharedProcessMain extends Disposable {
 			const { installSourcePath } = environmentService;
 			const internalTesting = configurationService.getValue<boolean>('telemetry.internalTesting');
 			if (internalTesting && productService.aiConfig?.ariaKey) {
-				const collectorAppender = new OneDataSystemAppender('monacoworkbench', null, productService.aiConfig.ariaKey);
+				const collectorAppender = new OneDataSystemWebAppender('monacoworkbench', null, productService.aiConfig.ariaKey);
 				this._register(toDisposable(() => collectorAppender.flush())); // Ensure the 1DS appender is disposed so that it flushes remaining data
 				appenders.push(collectorAppender);
 			} else if (productService.aiConfig && productService.aiConfig.asimovKey) {

--- a/src/vs/platform/telemetry/browser/1dsAppender.ts
+++ b/src/vs/platform/telemetry/browser/1dsAppender.ts
@@ -3,125 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { AppInsightsCore, IExtendedConfiguration } from '@microsoft/1ds-core-js';
-import type { PostChannel } from '@microsoft/1ds-post-js';
-import { onUnexpectedError } from 'vs/base/common/errors';
-import { mixin } from 'vs/base/common/objects';
-import { ITelemetryAppender, validateTelemetryData } from 'vs/platform/telemetry/common/telemetryUtils';
+import type { AppInsightsCore } from '@microsoft/1ds-core-js';
+import { AbstractOneDataSystemAppender } from 'vs/platform/telemetry/common/1dsAppender';
 
-const endpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0';
 
-async function getClient(instrumentationKey: string): Promise<AppInsightsCore> {
-	const oneDs = await import('@microsoft/1ds-core-js');
-	const postPlugin = await import('@microsoft/1ds-post-js');
-	const appInsightsCore = new oneDs.AppInsightsCore();
-	const collectorChannelPlugin: PostChannel = new postPlugin.PostChannel();
-	// Configure the app insights core to send to collector++ and disable logging of debug info
-	const coreConfig: IExtendedConfiguration = {
-		instrumentationKey,
-		endpointUrl,
-		loggingLevelTelemetry: 0,
-		loggingLevelConsole: 0,
-		disableCookiesUsage: true,
-		disableDbgExt: true,
-		disableInstrumentationKeyValidation: true,
-		channels: [[
-			collectorChannelPlugin
-		]]
-	};
-
-	appInsightsCore.initialize(coreConfig, []);
-
-	appInsightsCore.addTelemetryInitializer((envelope) => {
-		envelope['ext'] = envelope['ext'] ?? {};
-		envelope['ext']['utc'] = envelope['ext']['utc'] ?? {};
-		// Sets it to be internal only based on Windows UTC flagging
-		envelope['ext']['utc']['flags'] = 0x0000811ECD;
-	});
-
-	return appInsightsCore;
-}
-
-// TODO @lramos15 maybe make more in line with src/vs/platform/telemetry/browser/appInsightsAppender.ts with caching support
-export class OneDataSystemWebAppender implements ITelemetryAppender {
-
-	private _aiCoreOrKey: AppInsightsCore | string | undefined;
-	private _asyncAiCore: Promise<AppInsightsCore> | null;
-
+export class OneDataSystemWebAppender extends AbstractOneDataSystemAppender {
 	constructor(
-		private _eventPrefix: string,
-		private _defaultData: { [key: string]: any } | null,
+		eventPrefix: string,
+		defaultData: { [key: string]: any } | null,
 		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
 	) {
-		if (!this._defaultData) {
-			this._defaultData = Object.create(null);
-		}
-
-		if (typeof iKeyOrClientFactory === 'function') {
-			this._aiCoreOrKey = iKeyOrClientFactory();
-		} else {
-			this._aiCoreOrKey = iKeyOrClientFactory;
-		}
-		this._asyncAiCore = null;
+		super(eventPrefix, defaultData, iKeyOrClientFactory);
 
 		// If we cannot fetch the endpoint it means it is down and we should not send any telemetry.
 		// This is most likely due to ad blockers
-		fetch(endpointUrl, { method: 'POST' }).catch(err => {
+		fetch(this.endPointUrl, { method: 'POST' }).catch(err => {
 			this._aiCoreOrKey = undefined;
 		});
-	}
-
-	private _withAIClient(callback: (aiCore: AppInsightsCore) => void): void {
-		if (!this._aiCoreOrKey) {
-			return;
-		}
-
-		if (typeof this._aiCoreOrKey !== 'string') {
-			callback(this._aiCoreOrKey);
-			return;
-		}
-
-		if (!this._asyncAiCore) {
-			this._asyncAiCore = getClient(this._aiCoreOrKey);
-		}
-
-		this._asyncAiCore.then(
-			(aiClient) => {
-				callback(aiClient);
-			},
-			(err) => {
-				onUnexpectedError(err);
-				console.error(err);
-			}
-		);
-	}
-
-	log(eventName: string, data?: any): void {
-		if (!this._aiCoreOrKey) {
-			return;
-		}
-		data = mixin(data, this._defaultData);
-		data = validateTelemetryData(data);
-
-		try {
-			this._withAIClient((aiClient) => aiClient.track({
-				name: this._eventPrefix + '/' + eventName,
-				data: { ...data.properties, ...data.measurements },
-			}));
-		} catch { }
-	}
-
-	flush(): Promise<any> {
-		if (this._aiCoreOrKey) {
-			return new Promise(resolve => {
-				this._withAIClient((aiClient) => {
-					aiClient.unload(true, () => {
-						this._aiCoreOrKey = undefined;
-						resolve(undefined);
-					});
-				});
-			});
-		}
-		return Promise.resolve(undefined);
 	}
 }

--- a/src/vs/platform/telemetry/common/1dsAppender.ts
+++ b/src/vs/platform/telemetry/common/1dsAppender.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { AppInsightsCore, IExtendedConfiguration } from '@microsoft/1ds-core-js';
+import type { IChannelConfiguration, IXHROverride, PostChannel } from '@microsoft/1ds-post-js';
+import { onUnexpectedError } from 'vs/base/common/errors';
+import { mixin } from 'vs/base/common/objects';
+import { ITelemetryAppender, validateTelemetryData } from 'vs/platform/telemetry/common/telemetryUtils';
+
+const endpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0';
+
+async function getClient(instrumentationKey: string, xhrOverride?: IXHROverride): Promise<AppInsightsCore> {
+	const oneDs = await import('@microsoft/1ds-core-js');
+	const postPlugin = await import('@microsoft/1ds-post-js');
+	const appInsightsCore = new oneDs.AppInsightsCore();
+	const collectorChannelPlugin: PostChannel = new postPlugin.PostChannel();
+	// Configure the app insights core to send to collector++ and disable logging of debug info
+	const coreConfig: IExtendedConfiguration = {
+		instrumentationKey,
+		endpointUrl,
+		loggingLevelTelemetry: 0,
+		loggingLevelConsole: 0,
+		disableCookiesUsage: true,
+		disableDbgExt: true,
+		disableInstrumentationKeyValidation: true,
+		channels: [[
+			collectorChannelPlugin
+		]]
+	};
+
+	if (xhrOverride) {
+		coreConfig.extensionConfig = {};
+		// Configure the channel to use a XHR Request override since it's not available in node
+		const channelConfig: IChannelConfiguration = {
+			alwaysUseXhrOverride: true,
+			httpXHROverride: xhrOverride
+		};
+		coreConfig.extensionConfig[collectorChannelPlugin.identifier] = channelConfig;
+	}
+
+	appInsightsCore.initialize(coreConfig, []);
+
+	appInsightsCore.addTelemetryInitializer((envelope) => {
+		envelope['ext'] = envelope['ext'] ?? {};
+		envelope['ext']['utc'] = envelope['ext']['utc'] ?? {};
+		// Sets it to be internal only based on Windows UTC flagging
+		envelope['ext']['utc']['flags'] = 0x0000811ECD;
+	});
+
+	return appInsightsCore;
+}
+
+// TODO @lramos15 maybe make more in line with src/vs/platform/telemetry/browser/appInsightsAppender.ts with caching support
+export abstract class AbstractOneDataSystemAppender implements ITelemetryAppender {
+
+	protected _aiCoreOrKey: AppInsightsCore | string | undefined;
+	private _asyncAiCore: Promise<AppInsightsCore> | null;
+	protected readonly endPointUrl = endpointUrl;
+
+	constructor(
+		private _eventPrefix: string,
+		private _defaultData: { [key: string]: any } | null,
+		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
+		private _xhrOverride?: IXHROverride
+	) {
+		if (!this._defaultData) {
+			this._defaultData = Object.create(null);
+		}
+
+		if (typeof iKeyOrClientFactory === 'function') {
+			this._aiCoreOrKey = iKeyOrClientFactory();
+		} else {
+			this._aiCoreOrKey = iKeyOrClientFactory;
+		}
+		this._asyncAiCore = null;
+	}
+
+	private _withAIClient(callback: (aiCore: AppInsightsCore) => void): void {
+		if (!this._aiCoreOrKey) {
+			return;
+		}
+
+		if (typeof this._aiCoreOrKey !== 'string') {
+			callback(this._aiCoreOrKey);
+			return;
+		}
+
+		if (!this._asyncAiCore) {
+			this._asyncAiCore = getClient(this._aiCoreOrKey, this._xhrOverride);
+		}
+
+		this._asyncAiCore.then(
+			(aiClient) => {
+				callback(aiClient);
+			},
+			(err) => {
+				onUnexpectedError(err);
+				console.error(err);
+			}
+		);
+	}
+
+	log(eventName: string, data?: any): void {
+		if (!this._aiCoreOrKey) {
+			return;
+		}
+		data = mixin(data, this._defaultData);
+		data = validateTelemetryData(data);
+
+		try {
+			this._withAIClient((aiClient) => aiClient.track({
+				name: this._eventPrefix + '/' + eventName,
+				data: { ...data.properties, ...data.measurements },
+			}));
+		} catch { }
+	}
+
+	flush(): Promise<any> {
+		if (this._aiCoreOrKey) {
+			return new Promise(resolve => {
+				this._withAIClient((aiClient) => {
+					aiClient.unload(true, () => {
+						this._aiCoreOrKey = undefined;
+						resolve(undefined);
+					});
+				});
+			});
+		}
+		return Promise.resolve(undefined);
+	}
+}

--- a/src/vs/platform/telemetry/common/1dsAppender.ts
+++ b/src/vs/platform/telemetry/common/1dsAppender.ts
@@ -66,7 +66,7 @@ export abstract class AbstractOneDataSystemAppender implements ITelemetryAppende
 		private _xhrOverride?: IXHROverride
 	) {
 		if (!this._defaultData) {
-			this._defaultData = Object.create(null);
+			this._defaultData = {};
 		}
 
 		if (typeof iKeyOrClientFactory === 'function') {
@@ -112,7 +112,7 @@ export abstract class AbstractOneDataSystemAppender implements ITelemetryAppende
 		try {
 			this._withAIClient((aiClient) => aiClient.track({
 				name: this._eventPrefix + '/' + eventName,
-				data: { ...data.properties, ...data.measurements },
+				data,
 			}));
 		} catch { }
 	}

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -154,10 +154,10 @@ export interface Measurements {
 
 export function validateTelemetryData(data?: any): { properties: Properties; measurements: Measurements } {
 
-	const properties: Properties = Object.create(null);
-	const measurements: Measurements = Object.create(null);
+	const properties: Properties = {};
+	const measurements: Measurements = {};
 
-	const flat = Object.create(null);
+	const flat: Record<string, any> = {};
 	flatten(data, flat);
 
 	for (let prop in flat) {


### PR DESCRIPTION
This PRs creates an abstract appender to remove the duplicate code.

I decided to use the web appender for the shared process too because it appears easy to debug and then when everything is flowing correctly we can add the node appender to the right places like the CLI.