### PR TITLE
fix: `git` commit allows empty message despite `useEditorAsCommitInput` is enable

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1398,7 +1398,7 @@ export class Repository {
 	}
 
 	async commit(message: string | undefined, opts: CommitOptions = Object.create(null)): Promise<void> {
-		const args = ['commit', '--quiet'];
+		const args = ['commit', '--quiet', '--allow-empty-message'];
 		const options: SpawnOptions = {};
 
 		if (message) {
@@ -1428,7 +1428,6 @@ export class Repository {
 				}
 			}
 
-			args.push('--allow-empty-message');
 		}
 
 		if (opts.signoff) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

- This PR fixes #152702
