### PR TITLE
fixes #152509

### DIFF
--- a/src/vs/workbench/contrib/workspace/browser/media/workspaceTrustEditor.css
+++ b/src/vs/workbench/contrib/workspace/browser/media/workspaceTrustEditor.css
@@ -7,7 +7,8 @@
 	font-family: 'codicon';
 	content: '\eb53';
 	background-image: none;
-	font-size: 150%;
+	font-size: 16px;
+	line-height: 37px !important;
 }
 
 .workspace-trust-editor {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #152509

The icon seems a little top-leaning. I had to oversize the line height to get a reasonable alignment. The image below is with the oversized line height.

<img width="859" alt="image" src="https://user-images.githubusercontent.com/6561887/175119344-4d998ab0-e971-4c13-b90d-ceb2913a1e8b.png">

This image is without:
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/6561887/175119511-52723e40-8968-4790-b59c-54e0b84749bd.png">

