### PR TITLE
Rename types in the markdown extension

### DIFF
--- a/extensions/markdown-language-features/src/commands/renderDocument.ts
+++ b/extensions/markdown-language-features/src/commands/renderDocument.ts
@@ -5,7 +5,7 @@
 
 import { Command } from '../commandManager';
 import { MarkdownItEngine } from '../markdownEngine';
-import { SkinnyTextDocument } from '../workspaceContents';
+import { ITextDocument } from '../types/textDocument';
 
 export class RenderDocument implements Command {
 	public readonly id = 'markdown.api.render';
@@ -14,7 +14,7 @@ export class RenderDocument implements Command {
 		private readonly engine: MarkdownItEngine
 	) { }
 
-	public async execute(document: SkinnyTextDocument | string): Promise<string> {
+	public async execute(document: ITextDocument | string): Promise<string> {
 		return (await (this.engine.render(document))).html;
 	}
 }

--- a/extensions/markdown-language-features/src/languageFeatures/definitions.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/definitions.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
-import { SkinnyTextDocument } from '../workspaceContents';
+import { ITextDocument } from '../types/textDocument';
 import { MdReferencesProvider } from './references';
 
 export class MdVsCodeDefinitionProvider implements vscode.DefinitionProvider {
@@ -12,7 +12,7 @@ export class MdVsCodeDefinitionProvider implements vscode.DefinitionProvider {
 		private readonly referencesProvider: MdReferencesProvider,
 	) { }
 
-	async provideDefinition(document: SkinnyTextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Definition | undefined> {
+	async provideDefinition(document: ITextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Definition | undefined> {
 		const allRefs = await this.referencesProvider.getReferencesAtPosition(document, position, token);
 
 		return allRefs.find(ref => ref.kind === 'link' && ref.isDefinition)?.location;

--- a/extensions/markdown-language-features/src/languageFeatures/documentSymbols.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/documentSymbols.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { ILogger } from '../logging';
 import { MdTableOfContentsProvider, TocEntry } from '../tableOfContents';
-import { SkinnyTextDocument } from '../workspaceContents';
+import { ITextDocument } from '../types/textDocument';
 
 interface MarkdownSymbol {
 	readonly level: number;
@@ -21,13 +21,13 @@ export class MdDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 		private readonly logger: ILogger,
 	) { }
 
-	public async provideDocumentSymbolInformation(document: SkinnyTextDocument): Promise<vscode.SymbolInformation[]> {
+	public async provideDocumentSymbolInformation(document: ITextDocument): Promise<vscode.SymbolInformation[]> {
 		this.logger.verbose('DocumentSymbolProvider', `provideDocumentSymbolInformation - ${document.uri}`);
 		const toc = await this.tocProvider.getForDocument(document);
 		return toc.entries.map(entry => this.toSymbolInformation(entry));
 	}
 
-	public async provideDocumentSymbols(document: SkinnyTextDocument): Promise<vscode.DocumentSymbol[]> {
+	public async provideDocumentSymbols(document: ITextDocument): Promise<vscode.DocumentSymbol[]> {
 		const toc = await this.tocProvider.getForDocument(document);
 		const root: MarkdownSymbol = {
 			level: -Infinity,

--- a/extensions/markdown-language-features/src/languageFeatures/folding.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/folding.ts
@@ -7,7 +7,7 @@ import type Token = require('markdown-it/lib/token');
 import * as vscode from 'vscode';
 import { IMdParser } from '../markdownEngine';
 import { MdTableOfContentsProvider } from '../tableOfContents';
-import { SkinnyTextDocument } from '../workspaceContents';
+import { ITextDocument } from '../types/textDocument';
 
 const rangeLimit = 5000;
 
@@ -23,7 +23,7 @@ export class MdFoldingProvider implements vscode.FoldingRangeProvider {
 	) { }
 
 	public async provideFoldingRanges(
-		document: SkinnyTextDocument,
+		document: ITextDocument,
 		_: vscode.FoldingContext,
 		_token: vscode.CancellationToken
 	): Promise<vscode.FoldingRange[]> {
@@ -35,7 +35,7 @@ export class MdFoldingProvider implements vscode.FoldingRangeProvider {
 		return foldables.flat().slice(0, rangeLimit);
 	}
 
-	private async getRegions(document: SkinnyTextDocument): Promise<vscode.FoldingRange[]> {
+	private async getRegions(document: ITextDocument): Promise<vscode.FoldingRange[]> {
 		const tokens = await this.parser.tokenize(document);
 		const regionMarkers = tokens.filter(isRegionMarker)
 			.map(token => ({ line: token.map[0], isStart: isStartRegion(token.content) }));
@@ -55,7 +55,7 @@ export class MdFoldingProvider implements vscode.FoldingRangeProvider {
 			.filter((region: vscode.FoldingRange | null): region is vscode.FoldingRange => !!region);
 	}
 
-	private async getHeaderFoldingRanges(document: SkinnyTextDocument): Promise<vscode.FoldingRange[]> {
+	private async getHeaderFoldingRanges(document: ITextDocument): Promise<vscode.FoldingRange[]> {
 		const toc = await this.tocProvide.getForDocument(document);
 		return toc.entries.map(entry => {
 			let endLine = entry.sectionLocation.range.end.line;
@@ -66,7 +66,7 @@ export class MdFoldingProvider implements vscode.FoldingRangeProvider {
 		});
 	}
 
-	private async getBlockFoldingRanges(document: SkinnyTextDocument): Promise<vscode.FoldingRange[]> {
+	private async getBlockFoldingRanges(document: ITextDocument): Promise<vscode.FoldingRange[]> {
 		const tokens = await this.parser.tokenize(document);
 		const multiLineListItems = tokens.filter(isFoldableToken);
 		return multiLineListItems.map(listItem => {

--- a/extensions/markdown-language-features/src/languageFeatures/smartSelect.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/smartSelect.ts
@@ -6,7 +6,7 @@ import Token = require('markdown-it/lib/token');
 import * as vscode from 'vscode';
 import { IMdParser } from '../markdownEngine';
 import { MdTableOfContentsProvider, TocEntry } from '../tableOfContents';
-import { SkinnyTextDocument } from '../workspaceContents';
+import { ITextDocument } from '../types/textDocument';
 
 interface MarkdownItTokenWithMap extends Token {
 	map: [number, number];
@@ -19,24 +19,24 @@ export class MdSmartSelect implements vscode.SelectionRangeProvider {
 		private readonly tocProvider: MdTableOfContentsProvider,
 	) { }
 
-	public async provideSelectionRanges(document: SkinnyTextDocument, positions: vscode.Position[], _token: vscode.CancellationToken): Promise<vscode.SelectionRange[] | undefined> {
+	public async provideSelectionRanges(document: ITextDocument, positions: vscode.Position[], _token: vscode.CancellationToken): Promise<vscode.SelectionRange[] | undefined> {
 		const promises = await Promise.all(positions.map((position) => {
 			return this.provideSelectionRange(document, position, _token);
 		}));
 		return promises.filter(item => item !== undefined) as vscode.SelectionRange[];
 	}
 
-	private async provideSelectionRange(document: SkinnyTextDocument, position: vscode.Position, _token: vscode.CancellationToken): Promise<vscode.SelectionRange | undefined> {
+	private async provideSelectionRange(document: ITextDocument, position: vscode.Position, _token: vscode.CancellationToken): Promise<vscode.SelectionRange | undefined> {
 		const headerRange = await this.getHeaderSelectionRange(document, position);
 		const blockRange = await this.getBlockSelectionRange(document, position, headerRange);
 		const inlineRange = await this.getInlineSelectionRange(document, position, blockRange);
 		return inlineRange || blockRange || headerRange;
 	}
-	private async getInlineSelectionRange(document: SkinnyTextDocument, position: vscode.Position, blockRange?: vscode.SelectionRange): Promise<vscode.SelectionRange | undefined> {
+	private async getInlineSelectionRange(document: ITextDocument, position: vscode.Position, blockRange?: vscode.SelectionRange): Promise<vscode.SelectionRange | undefined> {
 		return createInlineRange(document, position, blockRange);
 	}
 
-	private async getBlockSelectionRange(document: SkinnyTextDocument, position: vscode.Position, headerRange?: vscode.SelectionRange): Promise<vscode.SelectionRange | undefined> {
+	private async getBlockSelectionRange(document: ITextDocument, position: vscode.Position, headerRange?: vscode.SelectionRange): Promise<vscode.SelectionRange | undefined> {
 		const tokens = await this.parser.tokenize(document);
 		const blockTokens = getBlockTokensForPosition(tokens, position, headerRange);
 
@@ -52,7 +52,7 @@ export class MdSmartSelect implements vscode.SelectionRangeProvider {
 		return currentRange;
 	}
 
-	private async getHeaderSelectionRange(document: SkinnyTextDocument, position: vscode.Position): Promise<vscode.SelectionRange | undefined> {
+	private async getHeaderSelectionRange(document: ITextDocument, position: vscode.Position): Promise<vscode.SelectionRange | undefined> {
 		const toc = await this.tocProvider.getForDocument(document);
 
 		const headerInfo = getHeadersForPosition(toc.entries, position);
@@ -107,7 +107,7 @@ function getBlockTokensForPosition(tokens: Token[], position: vscode.Position, p
 	return sortedTokens;
 }
 
-function createBlockRange(block: MarkdownItTokenWithMap, document: SkinnyTextDocument, cursorLine: number, parent?: vscode.SelectionRange): vscode.SelectionRange | undefined {
+function createBlockRange(block: MarkdownItTokenWithMap, document: ITextDocument, cursorLine: number, parent?: vscode.SelectionRange): vscode.SelectionRange | undefined {
 	if (block.type === 'fence') {
 		return createFencedRange(block, cursorLine, document, parent);
 	} else {
@@ -129,7 +129,7 @@ function createBlockRange(block: MarkdownItTokenWithMap, document: SkinnyTextDoc
 	}
 }
 
-function createInlineRange(document: SkinnyTextDocument, cursorPosition: vscode.Position, parent?: vscode.SelectionRange): vscode.SelectionRange | undefined {
+function createInlineRange(document: ITextDocument, cursorPosition: vscode.Position, parent?: vscode.SelectionRange): vscode.SelectionRange | undefined {
 	const lineText = document.lineAt(cursorPosition.line).text;
 	const boldSelection = createBoldRange(lineText, cursorPosition.character, cursorPosition.line, parent);
 	const italicSelection = createOtherInlineRange(lineText, cursorPosition.character, cursorPosition.line, true, parent);
@@ -146,7 +146,7 @@ function createInlineRange(document: SkinnyTextDocument, cursorPosition: vscode.
 	return inlineCodeBlockSelection || linkSelection || comboSelection || boldSelection || italicSelection;
 }
 
-function createFencedRange(token: MarkdownItTokenWithMap, cursorLine: number, document: SkinnyTextDocument, parent?: vscode.SelectionRange): vscode.SelectionRange {
+function createFencedRange(token: MarkdownItTokenWithMap, cursorLine: number, document: ITextDocument, parent?: vscode.SelectionRange): vscode.SelectionRange {
 	const startLine = token.map[0];
 	const endLine = token.map[1] - 1;
 	const onFenceLine = cursorLine === startLine || cursorLine === endLine;
@@ -236,7 +236,7 @@ function isBlockElement(token: Token): boolean {
 	return !['list_item_close', 'paragraph_close', 'bullet_list_close', 'inline', 'heading_close', 'heading_open'].includes(token.type);
 }
 
-function getFirstChildHeader(document: SkinnyTextDocument, header?: TocEntry, toc?: readonly TocEntry[]): vscode.Position | undefined {
+function getFirstChildHeader(document: ITextDocument, header?: TocEntry, toc?: readonly TocEntry[]): vscode.Position | undefined {
 	let childRange: vscode.Position | undefined;
 	if (header && toc) {
 		const children = toc.filter(t => header.sectionLocation.range.contains(t.sectionLocation.range) && t.sectionLocation.range.start.line > header.sectionLocation.range.start.line).sort((t1, t2) => t1.line - t2.line);

--- a/extensions/markdown-language-features/src/languageFeatures/workspaceSymbols.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/workspaceSymbols.ts
@@ -5,9 +5,9 @@
 
 import * as vscode from 'vscode';
 import { Disposable } from '../util/dispose';
-import { MdWorkspaceContents } from '../workspaceContents';
-import { MdDocumentSymbolProvider } from './documentSymbols';
 import { MdWorkspaceInfoCache } from '../util/workspaceCache';
+import { IMdWorkspace } from '../workspace';
+import { MdDocumentSymbolProvider } from './documentSymbols';
 
 export class MdWorkspaceSymbolProvider extends Disposable implements vscode.WorkspaceSymbolProvider {
 
@@ -15,11 +15,11 @@ export class MdWorkspaceSymbolProvider extends Disposable implements vscode.Work
 
 	public constructor(
 		symbolProvider: MdDocumentSymbolProvider,
-		workspaceContents: MdWorkspaceContents,
+		workspace: IMdWorkspace,
 	) {
 		super();
 
-		this._cache = this._register(new MdWorkspaceInfoCache(workspaceContents, doc => symbolProvider.provideDocumentSymbolInformation(doc)));
+		this._cache = this._register(new MdWorkspaceInfoCache(workspace, doc => symbolProvider.provideDocumentSymbolInformation(doc)));
 	}
 
 	public async provideWorkspaceSymbols(query: string): Promise<vscode.SymbolInformation[]> {
@@ -29,8 +29,8 @@ export class MdWorkspaceSymbolProvider extends Disposable implements vscode.Work
 }
 
 export function registerWorkspaceSymbolSupport(
-	workspaceContents: MdWorkspaceContents,
+	workspace: IMdWorkspace,
 	symbolProvider: MdDocumentSymbolProvider,
 ): vscode.Disposable {
-	return vscode.languages.registerWorkspaceSymbolProvider(new MdWorkspaceSymbolProvider(symbolProvider, workspaceContents));
+	return vscode.languages.registerWorkspaceSymbolProvider(new MdWorkspaceSymbolProvider(symbolProvider, workspace));
 }

--- a/extensions/markdown-language-features/src/preview/previewManager.ts
+++ b/extensions/markdown-language-features/src/preview/previewManager.ts
@@ -9,9 +9,9 @@ import { MarkdownContributionProvider } from '../markdownExtensions';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { Disposable, disposeAll } from '../util/dispose';
 import { isMarkdownFile } from '../util/file';
+import { MdDocumentRenderer } from './documentRenderer';
 import { DynamicMarkdownPreview, IManagedMarkdownPreview, StaticMarkdownPreview } from './preview';
 import { MarkdownPreviewConfigurationManager } from './previewConfig';
-import { MdDocumentRenderer } from './documentRenderer';
 import { scrollEditorToLine, StartingScrollFragment } from './scrolling';
 import { TopmostLineMonitor } from './topmostLineMonitor';
 

--- a/extensions/markdown-language-features/src/tableOfContents.ts
+++ b/extensions/markdown-language-features/src/tableOfContents.ts
@@ -7,10 +7,11 @@ import * as vscode from 'vscode';
 import { ILogger } from './logging';
 import { IMdParser } from './markdownEngine';
 import { githubSlugifier, Slug, Slugifier } from './slugify';
+import { ITextDocument } from './types/textDocument';
 import { Disposable } from './util/dispose';
 import { isMarkdownFile } from './util/file';
 import { MdDocumentInfoCache } from './util/workspaceCache';
-import { MdWorkspaceContents, SkinnyTextDocument } from './workspaceContents';
+import { IMdWorkspace } from './workspace';
 
 export interface TocEntry {
 	readonly slug: Slug;
@@ -64,12 +65,12 @@ export interface TocEntry {
 
 export class TableOfContents {
 
-	public static async create(parser: IMdParser, document: SkinnyTextDocument,): Promise<TableOfContents> {
+	public static async create(parser: IMdParser, document: ITextDocument,): Promise<TableOfContents> {
 		const entries = await this.buildToc(parser, document);
 		return new TableOfContents(entries, parser.slugifier);
 	}
 
-	public static async createForDocumentOrNotebook(parser: IMdParser, document: SkinnyTextDocument): Promise<TableOfContents> {
+	public static async createForDocumentOrNotebook(parser: IMdParser, document: ITextDocument): Promise<TableOfContents> {
 		if (document.uri.scheme === 'vscode-notebook-cell') {
 			const notebook = vscode.workspace.notebookDocuments
 				.find(notebook => notebook.getCells().some(cell => cell.document === document));
@@ -90,7 +91,7 @@ export class TableOfContents {
 		return this.create(parser, document);
 	}
 
-	private static async buildToc(parser: IMdParser, document: SkinnyTextDocument): Promise<TocEntry[]> {
+	private static async buildToc(parser: IMdParser, document: ITextDocument): Promise<TocEntry[]> {
 		const toc: TocEntry[] = [];
 		const tokens = await parser.tokenize(document);
 
@@ -183,11 +184,11 @@ export class MdTableOfContentsProvider extends Disposable {
 
 	constructor(
 		parser: IMdParser,
-		workspaceContents: MdWorkspaceContents,
+		workspace: IMdWorkspace,
 		private readonly logger: ILogger,
 	) {
 		super();
-		this._cache = this._register(new MdDocumentInfoCache<TableOfContents>(workspaceContents, doc => {
+		this._cache = this._register(new MdDocumentInfoCache<TableOfContents>(workspace, doc => {
 			this.logger.verbose('TableOfContentsProvider', `create - ${doc.uri}`);
 			return TableOfContents.create(parser, doc);
 		}));
@@ -197,7 +198,7 @@ export class MdTableOfContentsProvider extends Disposable {
 		return await this._cache.get(resource) ?? TableOfContents.empty;
 	}
 
-	public getForDocument(doc: SkinnyTextDocument): Promise<TableOfContents> {
+	public getForDocument(doc: ITextDocument): Promise<TableOfContents> {
 		return this._cache.getForDocument(doc);
 	}
 }

--- a/extensions/markdown-language-features/src/test/definitionProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/definitionProvider.test.ts
@@ -11,14 +11,14 @@ import { MdReferencesProvider } from '../languageFeatures/references';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { noopToken } from '../util/cancellation';
 import { InMemoryDocument } from '../util/inMemoryDocument';
-import { MdWorkspaceContents } from '../workspaceContents';
+import { IMdWorkspace } from '../workspace';
 import { createNewMarkdownEngine } from './engine';
-import { InMemoryWorkspaceMarkdownDocuments } from './inMemoryWorkspace';
+import { InMemoryMdWorkspace } from './inMemoryWorkspace';
 import { nulLogger } from './nulLogging';
 import { joinLines, workspacePath } from './util';
 
 
-function getDefinition(doc: InMemoryDocument, pos: vscode.Position, workspace: MdWorkspaceContents) {
+function getDefinition(doc: InMemoryDocument, pos: vscode.Position, workspace: IMdWorkspace) {
 	const engine = createNewMarkdownEngine();
 	const referencesProvider = new MdReferencesProvider(engine, workspace, new MdTableOfContentsProvider(engine, workspace, nulLogger), nulLogger);
 	const provider = new MdVsCodeDefinitionProvider(referencesProvider);
@@ -52,7 +52,7 @@ suite('markdown: Go to definition', () => {
 			`[ref]: http://example.com`,
 		));
 
-		const defs = await getDefinition(doc, new vscode.Position(0, 1), new InMemoryWorkspaceMarkdownDocuments([doc]));
+		const defs = await getDefinition(doc, new vscode.Position(0, 1), new InMemoryMdWorkspace([doc]));
 		assert.deepStrictEqual(defs, undefined);
 	});
 
@@ -64,7 +64,7 @@ suite('markdown: Go to definition', () => {
 			`[abc]: https://example.com`,
 		));
 
-		const defs = await getDefinition(doc, new vscode.Position(0, 12), new InMemoryWorkspaceMarkdownDocuments([doc]));
+		const defs = await getDefinition(doc, new vscode.Position(0, 12), new InMemoryMdWorkspace([doc]));
 		assertDefinitionsEqual(defs!,
 			{ uri: docUri, line: 2 },
 		);
@@ -81,19 +81,19 @@ suite('markdown: Go to definition', () => {
 		));
 
 		{
-			const defs = await getDefinition(doc, new vscode.Position(0, 2), new InMemoryWorkspaceMarkdownDocuments([doc]));
+			const defs = await getDefinition(doc, new vscode.Position(0, 2), new InMemoryMdWorkspace([doc]));
 			assertDefinitionsEqual(defs!,
 				{ uri: docUri, line: 4 },
 			);
 		}
 		{
-			const defs = await getDefinition(doc, new vscode.Position(2, 7), new InMemoryWorkspaceMarkdownDocuments([doc]));
+			const defs = await getDefinition(doc, new vscode.Position(2, 7), new InMemoryMdWorkspace([doc]));
 			assertDefinitionsEqual(defs!,
 				{ uri: docUri, line: 4 },
 			);
 		}
 		{
-			const defs = await getDefinition(doc, new vscode.Position(4, 2), new InMemoryWorkspaceMarkdownDocuments([doc]));
+			const defs = await getDefinition(doc, new vscode.Position(4, 2), new InMemoryMdWorkspace([doc]));
 			assertDefinitionsEqual(defs!,
 				{ uri: docUri, line: 4 },
 			);
@@ -108,7 +108,7 @@ suite('markdown: Go to definition', () => {
 			`[abc]: https://example.com`, // trigger here
 		));
 
-		const defs = await getDefinition(doc, new vscode.Position(2, 3), new InMemoryWorkspaceMarkdownDocuments([doc]));
+		const defs = await getDefinition(doc, new vscode.Position(2, 3), new InMemoryMdWorkspace([doc]));
 		assertDefinitionsEqual(defs!,
 			{ uri: docUri, line: 2 },
 		);
@@ -122,7 +122,7 @@ suite('markdown: Go to definition', () => {
 			`[abc]: https://example.com`,
 		));
 
-		const defs = await getDefinition(doc, new vscode.Position(0, 12), new InMemoryWorkspaceMarkdownDocuments([
+		const defs = await getDefinition(doc, new vscode.Position(0, 12), new InMemoryMdWorkspace([
 			doc,
 			new InMemoryDocument(workspacePath('other.md'), joinLines(
 				`[link 1][abc]`,

--- a/extensions/markdown-language-features/src/test/diagnostic.test.ts
+++ b/extensions/markdown-language-features/src/test/diagnostic.test.ts
@@ -14,9 +14,9 @@ import { noopToken } from '../util/cancellation';
 import { disposeAll } from '../util/dispose';
 import { InMemoryDocument } from '../util/inMemoryDocument';
 import { ResourceMap } from '../util/resourceMap';
-import { MdWorkspaceContents } from '../workspaceContents';
+import { IMdWorkspace } from '../workspace';
 import { createNewMarkdownEngine } from './engine';
-import { InMemoryWorkspaceMarkdownDocuments } from './inMemoryWorkspace';
+import { InMemoryMdWorkspace } from './inMemoryWorkspace';
 import { nulLogger } from './nulLogging';
 import { assertRangeEqual, joinLines, workspacePath } from './util';
 
@@ -29,7 +29,7 @@ const defaultDiagnosticsOptions = Object.freeze<DiagnosticOptions>({
 	ignoreLinks: [],
 });
 
-async function getComputedDiagnostics(doc: InMemoryDocument, workspace: MdWorkspaceContents, options: Partial<DiagnosticOptions> = {}): Promise<vscode.Diagnostic[]> {
+async function getComputedDiagnostics(doc: InMemoryDocument, workspace: IMdWorkspace, options: Partial<DiagnosticOptions> = {}): Promise<vscode.Diagnostic[]> {
 	const engine = createNewMarkdownEngine();
 	const linkProvider = new MdLinkProvider(engine, workspace, nulLogger);
 	const tocProvider = new MdTableOfContentsProvider(engine, workspace, nulLogger);
@@ -113,7 +113,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`text`,
 		));
 
-		const diagnostics = await getComputedDiagnostics(doc, new InMemoryWorkspaceMarkdownDocuments([doc]));
+		const diagnostics = await getComputedDiagnostics(doc, new InMemoryMdWorkspace([doc]));
 		assert.deepStrictEqual(diagnostics, []);
 	});
 
@@ -125,7 +125,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[bad-ref]: /no/such/file.md`,
 		));
 
-		const diagnostics = await getComputedDiagnostics(doc, new InMemoryWorkspaceMarkdownDocuments([doc]));
+		const diagnostics = await getComputedDiagnostics(doc, new InMemoryMdWorkspace([doc]));
 		assertDiagnosticsEqual(diagnostics, [
 			new vscode.Range(0, 6, 0, 22),
 			new vscode.Range(3, 11, 3, 27),
@@ -142,7 +142,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[bad-ref]: #no-such-header`,
 		));
 
-		const diagnostics = await getComputedDiagnostics(doc, new InMemoryWorkspaceMarkdownDocuments([doc]));
+		const diagnostics = await getComputedDiagnostics(doc, new InMemoryMdWorkspace([doc]));
 		assertDiagnosticsEqual(diagnostics, [
 			new vscode.Range(2, 6, 2, 21),
 			new vscode.Range(5, 11, 5, 26),
@@ -163,7 +163,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`# Other header`,
 		));
 
-		const diagnostics = await getComputedDiagnostics(doc1, new InMemoryWorkspaceMarkdownDocuments([doc1, doc2]));
+		const diagnostics = await getComputedDiagnostics(doc1, new InMemoryMdWorkspace([doc1, doc2]));
 		assertDiagnosticsEqual(diagnostics, [
 			new vscode.Range(5, 14, 5, 35),
 		]);
@@ -179,7 +179,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[good](doc#my-header)`,
 		));
 
-		const diagnostics = await getComputedDiagnostics(doc, new InMemoryWorkspaceMarkdownDocuments([doc]));
+		const diagnostics = await getComputedDiagnostics(doc, new InMemoryMdWorkspace([doc]));
 		assertDiagnosticsEqual(diagnostics, []);
 	});
 
@@ -191,7 +191,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[good]: http://example.com`,
 		));
 
-		const diagnostics = await getComputedDiagnostics(doc, new InMemoryWorkspaceMarkdownDocuments([doc]));
+		const diagnostics = await getComputedDiagnostics(doc, new InMemoryMdWorkspace([doc]));
 		assertDiagnosticsEqual(diagnostics, [
 			new vscode.Range(1, 11, 1, 18),
 		]);
@@ -203,7 +203,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[text][no-such-ref]`,
 		));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1]);
+		const workspace = new InMemoryMdWorkspace([doc1]);
 		const diagnostics = await getComputedDiagnostics(doc1, workspace, new MemoryDiagnosticConfiguration({ enabled: false }).getOptions(doc1.uri));
 		assertDiagnosticsEqual(diagnostics, []);
 	});
@@ -213,7 +213,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`a <user@example.com> c`,
 		));
 
-		const diagnostics = await getComputedDiagnostics(doc1, new InMemoryWorkspaceMarkdownDocuments([doc1]));
+		const diagnostics = await getComputedDiagnostics(doc1, new InMemoryMdWorkspace([doc1]));
 		assertDiagnosticsEqual(diagnostics, []);
 	});
 
@@ -223,7 +223,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`a <scope:tag>b</scope:tag> c`,
 		));
 
-		const diagnostics = await getComputedDiagnostics(doc1, new InMemoryWorkspaceMarkdownDocuments([doc1]));
+		const diagnostics = await getComputedDiagnostics(doc1, new InMemoryMdWorkspace([doc1]));
 		assertDiagnosticsEqual(diagnostics, []);
 	});
 
@@ -234,7 +234,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[text]: /no-such-file`,
 		));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1]);
+		const workspace = new InMemoryMdWorkspace([doc1]);
 		const diagnostics = await getComputedDiagnostics(doc1, workspace, { ignoreLinks: ['/no-such-file'] });
 		assertDiagnosticsEqual(diagnostics, []);
 	});
@@ -245,7 +245,7 @@ suite('markdown: Diagnostic Computer', () => {
 		));
 		const doc2 = new InMemoryDocument(workspacePath('doc2.md'), joinLines(''));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1, doc2]);
+		const workspace = new InMemoryMdWorkspace([doc1, doc2]);
 
 		const diagnostics = await getComputedDiagnostics(doc1, workspace, { validateMarkdownFileLinkFragments: DiagnosticLevel.ignore });
 		assertDiagnosticsEqual(diagnostics, []);
@@ -258,7 +258,7 @@ suite('markdown: Diagnostic Computer', () => {
 		));
 		const doc2 = new InMemoryDocument(workspacePath('doc2.md'), joinLines(''));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1, doc2]);
+		const workspace = new InMemoryMdWorkspace([doc1, doc2]);
 
 		{
 			const diagnostics = await getComputedDiagnostics(doc1, workspace, { validateFragmentLinks: DiagnosticLevel.ignore });
@@ -278,7 +278,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[text](/no-such-file#header)`,
 		));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1]);
+		const workspace = new InMemoryMdWorkspace([doc1]);
 
 		const diagnostics = await getComputedDiagnostics(doc1, workspace, { ignoreLinks: ['/no-such-file'] });
 		assertDiagnosticsEqual(diagnostics, []);
@@ -289,7 +289,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[text](/no-such-file#header)`,
 		));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1]);
+		const workspace = new InMemoryMdWorkspace([doc1]);
 
 		const diagnostics = await getComputedDiagnostics(doc1, workspace, { ignoreLinks: ['/no-such-file'] });
 		assertDiagnosticsEqual(diagnostics, []);
@@ -302,7 +302,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`![i](/images/sub/sub2/ccc.png)`,
 		));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1]);
+		const workspace = new InMemoryMdWorkspace([doc1]);
 		const diagnostics = await getComputedDiagnostics(doc1, workspace, { ignoreLinks: ['/images/**/*.png'] });
 		assertDiagnosticsEqual(diagnostics, []);
 	});
@@ -311,7 +311,7 @@ suite('markdown: Diagnostic Computer', () => {
 		const doc1 = new InMemoryDocument(workspacePath('doc1.md'), joinLines(
 			`![i](#no-such)`,
 		));
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1]);
+		const workspace = new InMemoryMdWorkspace([doc1]);
 
 		const diagnostics = await getComputedDiagnostics(doc1, workspace, { ignoreLinks: ['#no-such'] });
 		assertDiagnosticsEqual(diagnostics, []);
@@ -323,7 +323,7 @@ suite('markdown: Diagnostic Computer', () => {
 		));
 		const doc2 = new InMemoryDocument(workspacePath('doc2.md'), joinLines(''));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1, doc2]);
+		const workspace = new InMemoryMdWorkspace([doc1, doc2]);
 		{
 			const diagnostics = await getComputedDiagnostics(doc1, workspace, { ignoreLinks: ['/doc2.md#no-such'] });
 			assertDiagnosticsEqual(diagnostics, []);
@@ -340,7 +340,7 @@ suite('markdown: Diagnostic Computer', () => {
 		));
 		const doc2 = new InMemoryDocument(workspacePath('doc2.md'), joinLines(''));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1, doc2]);
+		const workspace = new InMemoryMdWorkspace([doc1, doc2]);
 
 		const diagnostics = await getComputedDiagnostics(doc1, workspace, { ignoreLinks: ['/doc2.md'] });
 		assertDiagnosticsEqual(diagnostics, []);
@@ -353,7 +353,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`- [ ]`,
 		));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1]);
+		const workspace = new InMemoryMdWorkspace([doc1]);
 
 		const diagnostics = await getComputedDiagnostics(doc1, workspace, { ignoreLinks: ['/doc2.md'] });
 		assertDiagnosticsEqual(diagnostics, []);
@@ -368,7 +368,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[link](no-such.md 'text')`,
 			`[link](no-such.md (text))`,
 		));
-		const diagnostics = await getComputedDiagnostics(doc, new InMemoryWorkspaceMarkdownDocuments([doc]));
+		const diagnostics = await getComputedDiagnostics(doc, new InMemoryMdWorkspace([doc]));
 		assertDiagnosticsEqual(diagnostics, [
 			new vscode.Range(0, 8, 0, 18),
 			new vscode.Range(1, 8, 1, 18),
@@ -387,7 +387,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[bad](/sub/doc#no-such)`,
 		));
 
-		const diagnostics = await getComputedDiagnostics(doc, new InMemoryWorkspaceMarkdownDocuments([doc]));
+		const diagnostics = await getComputedDiagnostics(doc, new InMemoryMdWorkspace([doc]));
 		assertDiagnosticsEqual(orderDiagnosticsByRange(diagnostics), [
 			new vscode.Range(0, 12, 0, 20),
 			new vscode.Range(1, 9, 1, 17),
@@ -404,7 +404,7 @@ suite('markdown: Diagnostic Computer', () => {
 			`[bad](/sub/doc#no-such)`,
 		));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1]);
+		const workspace = new InMemoryMdWorkspace([doc1]);
 
 		const diagnostics = await getComputedDiagnostics(doc1, workspace, {
 			validateFragmentLinks: DiagnosticLevel.ignore,
@@ -432,7 +432,7 @@ suite('Markdown: Diagnostics manager', () => {
 	});
 
 	function createDiagnosticsManager(
-		workspace: MdWorkspaceContents,
+		workspace: IMdWorkspace,
 		configuration = new MemoryDiagnosticConfiguration({}),
 		reporter: DiagnosticReporter = new DiagnosticCollectionReporter(),
 	) {
@@ -456,7 +456,7 @@ suite('Markdown: Diagnostics manager', () => {
 	test('Changing enable/disable should recompute diagnostics', async () => {
 		const doc1Uri = workspacePath('doc1.md');
 		const doc2Uri = workspacePath('doc2.md');
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([
+		const workspace = new InMemoryMdWorkspace([
 			new InMemoryDocument(doc1Uri, joinLines(
 				`[text](#no-such-1)`,
 			)),
@@ -510,7 +510,7 @@ suite('Markdown: Diagnostics manager', () => {
 			`[text](#no-such-2)`,
 		));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1, doc2]);
+		const workspace = new InMemoryMdWorkspace([doc1, doc2]);
 		const reporter = new MemoryDiagnosticReporter();
 
 		const manager = createDiagnosticsManager(workspace, new MemoryDiagnosticConfiguration({}), reporter);
@@ -566,7 +566,7 @@ suite('Markdown: Diagnostics manager', () => {
 			`# Header`
 		));
 
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([doc1, doc2]);
+		const workspace = new InMemoryMdWorkspace([doc1, doc2]);
 		const reporter = new MemoryDiagnosticReporter();
 
 		const manager = createDiagnosticsManager(workspace, new MemoryDiagnosticConfiguration({}), reporter);

--- a/extensions/markdown-language-features/src/test/documentInfoCache.test.ts
+++ b/extensions/markdown-language-features/src/test/documentInfoCache.test.ts
@@ -7,13 +7,13 @@ import * as assert from 'assert';
 import 'mocha';
 import { InMemoryDocument } from '../util/inMemoryDocument';
 import { MdDocumentInfoCache } from '../util/workspaceCache';
-import { InMemoryWorkspaceMarkdownDocuments } from './inMemoryWorkspace';
+import { InMemoryMdWorkspace } from './inMemoryWorkspace';
 import { workspacePath } from './util';
 
 suite('DocumentInfoCache', () => {
 	test('Repeated calls should only compute value once', async () => {
 		const doc = workspacePath('doc.md');
-		const workspace = new InMemoryWorkspaceMarkdownDocuments([
+		const workspace = new InMemoryMdWorkspace([
 			new InMemoryDocument(doc, '')
 		]);
 

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -10,14 +10,14 @@ import { MdLinkProvider, MdVsCodeLinkProvider } from '../languageFeatures/docume
 import { noopToken } from '../util/cancellation';
 import { InMemoryDocument } from '../util/inMemoryDocument';
 import { createNewMarkdownEngine } from './engine';
-import { InMemoryWorkspaceMarkdownDocuments } from './inMemoryWorkspace';
+import { InMemoryMdWorkspace } from './inMemoryWorkspace';
 import { nulLogger } from './nulLogging';
 import { assertRangeEqual, joinLines, workspacePath } from './util';
 
 
 function getLinksForFile(fileContents: string) {
 	const doc = new InMemoryDocument(workspacePath('x.md'), fileContents);
-	const workspace = new InMemoryWorkspaceMarkdownDocuments([doc]);
+	const workspace = new InMemoryMdWorkspace([doc]);
 
 	const engine = createNewMarkdownEngine();
 	const linkProvider = new MdLinkProvider(engine, workspace, nulLogger);

--- a/extensions/markdown-language-features/src/test/documentSymbolProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentSymbolProvider.test.ts
@@ -9,14 +9,14 @@ import { MdDocumentSymbolProvider } from '../languageFeatures/documentSymbols';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { InMemoryDocument } from '../util/inMemoryDocument';
 import { createNewMarkdownEngine } from './engine';
-import { InMemoryWorkspaceMarkdownDocuments } from './inMemoryWorkspace';
+import { InMemoryMdWorkspace } from './inMemoryWorkspace';
 import { nulLogger } from './nulLogging';
 import { workspacePath } from './util';
 
 
 function getSymbolsForFile(fileContents: string) {
 	const doc = new InMemoryDocument(workspacePath('test.md'), fileContents);
-	const workspace = new InMemoryWorkspaceMarkdownDocuments([doc]);
+	const workspace = new InMemoryMdWorkspace([doc]);
 	const engine = createNewMarkdownEngine();
 	const provider = new MdDocumentSymbolProvider(new MdTableOfContentsProvider(engine, workspace, nulLogger), nulLogger);
 	return provider.provideDocumentSymbols(doc);

--- a/extensions/markdown-language-features/src/test/engine.test.ts
+++ b/extensions/markdown-language-features/src/test/engine.test.ts
@@ -6,8 +6,8 @@
 import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
-import { createNewMarkdownEngine } from './engine';
 import { InMemoryDocument } from '../util/inMemoryDocument';
+import { createNewMarkdownEngine } from './engine';
 
 
 const testFileName = vscode.Uri.file('test.md');

--- a/extensions/markdown-language-features/src/test/fileReferences.test.ts
+++ b/extensions/markdown-language-features/src/test/fileReferences.test.ts
@@ -10,14 +10,14 @@ import { MdReference, MdReferencesProvider } from '../languageFeatures/reference
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { noopToken } from '../util/cancellation';
 import { InMemoryDocument } from '../util/inMemoryDocument';
-import { MdWorkspaceContents } from '../workspaceContents';
+import { IMdWorkspace } from '../workspace';
 import { createNewMarkdownEngine } from './engine';
-import { InMemoryWorkspaceMarkdownDocuments } from './inMemoryWorkspace';
+import { InMemoryMdWorkspace } from './inMemoryWorkspace';
 import { nulLogger } from './nulLogging';
 import { joinLines, workspacePath } from './util';
 
 
-function getFileReferences(resource: vscode.Uri, workspace: MdWorkspaceContents) {
+function getFileReferences(resource: vscode.Uri, workspace: IMdWorkspace) {
 	const engine = createNewMarkdownEngine();
 	const computer = new MdReferencesProvider(engine, workspace, new MdTableOfContentsProvider(engine, workspace, nulLogger), nulLogger);
 	return computer.getAllReferencesToFile(resource, noopToken);
@@ -41,7 +41,7 @@ suite('markdown: find file references', () => {
 		const docUri = workspacePath('doc.md');
 		const otherUri = workspacePath('other.md');
 
-		const refs = await getFileReferences(otherUri, new InMemoryWorkspaceMarkdownDocuments([
+		const refs = await getFileReferences(otherUri, new InMemoryMdWorkspace([
 			new InMemoryDocument(docUri, joinLines(
 				`# header`,
 				`[link 1](./other.md)`,
@@ -66,7 +66,7 @@ suite('markdown: find file references', () => {
 		const docUri = workspacePath('doc.md');
 		const otherUri = workspacePath('other.md');
 
-		const refs = await getFileReferences(otherUri, new InMemoryWorkspaceMarkdownDocuments([
+		const refs = await getFileReferences(otherUri, new InMemoryMdWorkspace([
 			new InMemoryDocument(docUri, joinLines(
 				`# header`,
 				`[link 1](./other.md)`,
@@ -93,7 +93,7 @@ suite('markdown: find file references', () => {
 		const docUri = workspacePath('doc.md');
 		const otherUri = workspacePath('other.md');
 
-		const refs = await getFileReferences(otherUri, new InMemoryWorkspaceMarkdownDocuments([
+		const refs = await getFileReferences(otherUri, new InMemoryMdWorkspace([
 			new InMemoryDocument(docUri, joinLines(
 				`# header`,
 				`[link 1](./other.md#sub-bla)`,

--- a/extensions/markdown-language-features/src/test/foldingProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/foldingProvider.test.ts
@@ -10,7 +10,7 @@ import { MdFoldingProvider } from '../languageFeatures/folding';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { InMemoryDocument } from '../util/inMemoryDocument';
 import { createNewMarkdownEngine } from './engine';
-import { InMemoryWorkspaceMarkdownDocuments } from './inMemoryWorkspace';
+import { InMemoryMdWorkspace } from './inMemoryWorkspace';
 import { nulLogger } from './nulLogging';
 import { joinLines } from './util';
 
@@ -221,7 +221,7 @@ suite('markdown.FoldingProvider', () => {
 
 async function getFoldsForDocument(contents: string) {
 	const doc = new InMemoryDocument(testFileName, contents);
-	const workspace = new InMemoryWorkspaceMarkdownDocuments([doc]);
+	const workspace = new InMemoryMdWorkspace([doc]);
 	const engine = createNewMarkdownEngine();
 	const provider = new MdFoldingProvider(engine, new MdTableOfContentsProvider(engine, workspace, nulLogger));
 	return await provider.provideFoldingRanges(doc, {}, new vscode.CancellationTokenSource().token);

--- a/extensions/markdown-language-features/src/test/inMemoryWorkspace.ts
+++ b/extensions/markdown-language-features/src/test/inMemoryWorkspace.ts
@@ -5,14 +5,15 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
+import { ITextDocument } from '../types/textDocument';
 import { ResourceMap } from '../util/resourceMap';
-import { MdWorkspaceContents, SkinnyTextDocument } from '../workspaceContents';
+import { IMdWorkspace } from '../workspace';
 
 
-export class InMemoryWorkspaceMarkdownDocuments implements MdWorkspaceContents {
-	private readonly _documents = new ResourceMap<SkinnyTextDocument>(uri => uri.fsPath);
+export class InMemoryMdWorkspace implements IMdWorkspace {
+	private readonly _documents = new ResourceMap<ITextDocument>(uri => uri.fsPath);
 
-	constructor(documents: SkinnyTextDocument[]) {
+	constructor(documents: ITextDocument[]) {
 		for (const doc of documents) {
 			this._documents.set(doc.uri, doc);
 		}
@@ -22,7 +23,7 @@ export class InMemoryWorkspaceMarkdownDocuments implements MdWorkspaceContents {
 		return Array.from(this._documents.values());
 	}
 
-	public async getOrLoadMarkdownDocument(resource: vscode.Uri): Promise<SkinnyTextDocument | undefined> {
+	public async getOrLoadMarkdownDocument(resource: vscode.Uri): Promise<ITextDocument | undefined> {
 		return this._documents.get(resource);
 	}
 
@@ -34,21 +35,21 @@ export class InMemoryWorkspaceMarkdownDocuments implements MdWorkspaceContents {
 		return this._documents.has(resource);
 	}
 
-	private readonly _onDidChangeMarkdownDocumentEmitter = new vscode.EventEmitter<SkinnyTextDocument>();
+	private readonly _onDidChangeMarkdownDocumentEmitter = new vscode.EventEmitter<ITextDocument>();
 	public onDidChangeMarkdownDocument = this._onDidChangeMarkdownDocumentEmitter.event;
 
-	private readonly _onDidCreateMarkdownDocumentEmitter = new vscode.EventEmitter<SkinnyTextDocument>();
+	private readonly _onDidCreateMarkdownDocumentEmitter = new vscode.EventEmitter<ITextDocument>();
 	public onDidCreateMarkdownDocument = this._onDidCreateMarkdownDocumentEmitter.event;
 
 	private readonly _onDidDeleteMarkdownDocumentEmitter = new vscode.EventEmitter<vscode.Uri>();
 	public onDidDeleteMarkdownDocument = this._onDidDeleteMarkdownDocumentEmitter.event;
 
-	public updateDocument(document: SkinnyTextDocument) {
+	public updateDocument(document: ITextDocument) {
 		this._documents.set(document.uri, document);
 		this._onDidChangeMarkdownDocumentEmitter.fire(document);
 	}
 
-	public createDocument(document: SkinnyTextDocument) {
+	public createDocument(document: ITextDocument) {
 		assert.ok(!this._documents.has(document.uri));
 
 		this._documents.set(document.uri, document);

--- a/extensions/markdown-language-features/src/test/pathCompletion.test.ts
+++ b/extensions/markdown-language-features/src/test/pathCompletion.test.ts
@@ -11,14 +11,14 @@ import { MdVsCodePathCompletionProvider } from '../languageFeatures/pathCompleti
 import { noopToken } from '../util/cancellation';
 import { InMemoryDocument } from '../util/inMemoryDocument';
 import { createNewMarkdownEngine } from './engine';
-import { InMemoryWorkspaceMarkdownDocuments } from './inMemoryWorkspace';
+import { InMemoryMdWorkspace } from './inMemoryWorkspace';
 import { nulLogger } from './nulLogging';
 import { CURSOR, getCursorPositions, joinLines, workspacePath } from './util';
 
 
 function getCompletionsAtCursor(resource: vscode.Uri, fileContents: string) {
 	const doc = new InMemoryDocument(resource, fileContents);
-	const workspace = new InMemoryWorkspaceMarkdownDocuments([doc]);
+	const workspace = new InMemoryMdWorkspace([doc]);
 
 	const engine = createNewMarkdownEngine();
 	const linkProvider = new MdLinkProvider(engine, workspace, nulLogger);

--- a/extensions/markdown-language-features/src/test/smartSelect.test.ts
+++ b/extensions/markdown-language-features/src/test/smartSelect.test.ts
@@ -9,7 +9,7 @@ import { MdSmartSelect } from '../languageFeatures/smartSelect';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { InMemoryDocument } from '../util/inMemoryDocument';
 import { createNewMarkdownEngine } from './engine';
-import { InMemoryWorkspaceMarkdownDocuments } from './inMemoryWorkspace';
+import { InMemoryMdWorkspace } from './inMemoryWorkspace';
 import { nulLogger } from './nulLogging';
 import { CURSOR, getCursorPositions, joinLines } from './util';
 
@@ -723,7 +723,7 @@ function assertLineNumbersEqual(selectionRange: vscode.SelectionRange, startLine
 
 function getSelectionRangesForDocument(contents: string, pos?: vscode.Position[]): Promise<vscode.SelectionRange[] | undefined> {
 	const doc = new InMemoryDocument(testFileName, contents);
-	const workspace = new InMemoryWorkspaceMarkdownDocuments([doc]);
+	const workspace = new InMemoryMdWorkspace([doc]);
 	const engine = createNewMarkdownEngine();
 	const provider = new MdSmartSelect(engine, new MdTableOfContentsProvider(engine, workspace, nulLogger));
 	const positions = pos ? pos : getCursorPositions(contents, doc);

--- a/extensions/markdown-language-features/src/test/tableOfContentsProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/tableOfContentsProvider.test.ts
@@ -7,14 +7,14 @@ import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
 import { TableOfContents } from '../tableOfContents';
+import { ITextDocument } from '../types/textDocument';
 import { InMemoryDocument } from '../util/inMemoryDocument';
-import { SkinnyTextDocument } from '../workspaceContents';
 import { createNewMarkdownEngine } from './engine';
 
 
 const testFileName = vscode.Uri.file('test.md');
 
-function createToc(doc: SkinnyTextDocument): Promise<TableOfContents> {
+function createToc(doc: ITextDocument): Promise<TableOfContents> {
 	const engine = createNewMarkdownEngine();
 	return TableOfContents.create(engine, doc);
 }

--- a/extensions/markdown-language-features/src/types/textDocument.ts
+++ b/extensions/markdown-language-features/src/types/textDocument.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+
+/**
+ * Minimal version of {@link vscode.TextLine}.
+ */
+export interface ITextLine {
+	readonly text: string;
+	readonly isEmptyOrWhitespace: boolean;
+}
+
+/**
+ * Minimal version of {@link vscode.TextDocument}.
+ */
+export interface ITextDocument {
+	readonly uri: vscode.Uri;
+	readonly version: number;
+	readonly lineCount: number;
+
+	getText(range?: vscode.Range): string;
+	lineAt(line: number): ITextLine;
+	positionAt(offset: number): vscode.Position;
+}

--- a/extensions/markdown-language-features/src/util/inMemoryDocument.ts
+++ b/extensions/markdown-language-features/src/util/inMemoryDocument.ts
@@ -5,13 +5,13 @@
 
 import * as vscode from 'vscode';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { SkinnyTextDocument, SkinnyTextLine } from '../workspaceContents';
+import { ITextDocument, ITextLine } from '../types/textDocument';
 
-export class InMemoryDocument implements SkinnyTextDocument {
+export class InMemoryDocument implements ITextDocument {
 
 	private readonly _doc: TextDocument;
 
-	private lines: SkinnyTextLine[] | undefined;
+	private lines: ITextLine[] | undefined;
 
 	constructor(
 		public readonly uri: vscode.Uri, contents: string,
@@ -25,7 +25,7 @@ export class InMemoryDocument implements SkinnyTextDocument {
 		return this._doc.lineCount;
 	}
 
-	lineAt(index: any): SkinnyTextLine {
+	lineAt(index: any): ITextLine {
 		if (!this.lines) {
 			this.lines = this._doc.getText().split(/\r?\n/).map(text => ({
 				text,

--- a/extensions/markdown-language-features/src/util/tableOfContentsWatcher.ts
+++ b/extensions/markdown-language-features/src/util/tableOfContentsWatcher.ts
@@ -5,7 +5,8 @@
 
 import * as vscode from 'vscode';
 import { MdTableOfContentsProvider, TableOfContents } from '../tableOfContents';
-import { MdWorkspaceContents, SkinnyTextDocument } from '../workspaceContents';
+import { ITextDocument } from '../types/textDocument';
+import { IMdWorkspace } from '../workspace';
 import { equals } from './arrays';
 import { Delayer } from './async';
 import { Disposable } from './dispose';
@@ -36,7 +37,7 @@ export class MdTableOfContentsWatcher extends Disposable {
 	private readonly delayer: Delayer<void>;
 
 	public constructor(
-		private readonly workspaceContents: MdWorkspaceContents,
+		private readonly workspace: IMdWorkspace,
 		private readonly tocProvider: MdTableOfContentsProvider,
 		private readonly delay: number,
 	) {
@@ -44,17 +45,17 @@ export class MdTableOfContentsWatcher extends Disposable {
 
 		this.delayer = this._register(new Delayer<void>(delay));
 
-		this._register(this.workspaceContents.onDidChangeMarkdownDocument(this.onDidChangeDocument, this));
-		this._register(this.workspaceContents.onDidCreateMarkdownDocument(this.onDidCreateDocument, this));
-		this._register(this.workspaceContents.onDidDeleteMarkdownDocument(this.onDidDeleteDocument, this));
+		this._register(this.workspace.onDidChangeMarkdownDocument(this.onDidChangeDocument, this));
+		this._register(this.workspace.onDidCreateMarkdownDocument(this.onDidCreateDocument, this));
+		this._register(this.workspace.onDidDeleteMarkdownDocument(this.onDidDeleteDocument, this));
 	}
 
-	private async onDidCreateDocument(document: SkinnyTextDocument) {
+	private async onDidCreateDocument(document: ITextDocument) {
 		const toc = await this.tocProvider.getForDocument(document);
 		this._files.set(document.uri, { toc });
 	}
 
-	private async onDidChangeDocument(document: SkinnyTextDocument) {
+	private async onDidChangeDocument(document: ITextDocument) {
 		if (this.delay > 0) {
 			this._pending.set(document.uri);
 			this.delayer.trigger(() => this.flushPending());

--- a/extensions/markdown-language-features/src/util/workspaceCache.ts
+++ b/extensions/markdown-language-features/src/util/workspaceCache.ts
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { ITextDocument } from '../types/textDocument';
+import { IMdWorkspace } from '../workspace';
 import { Disposable } from './dispose';
 import { Lazy, lazy } from './lazy';
 import { ResourceMap } from './resourceMap';
-import { MdWorkspaceContents, SkinnyTextDocument } from '../workspaceContents';
 
 class LazyResourceMap<T> {
 	private readonly _map = new ResourceMap<Lazy<Promise<T>>>();
@@ -43,16 +44,16 @@ class LazyResourceMap<T> {
 export class MdDocumentInfoCache<T> extends Disposable {
 
 	private readonly _cache = new LazyResourceMap<T>();
-	private readonly _loadingDocuments = new ResourceMap<Promise<SkinnyTextDocument | undefined>>();
+	private readonly _loadingDocuments = new ResourceMap<Promise<ITextDocument | undefined>>();
 
 	public constructor(
-		private readonly workspaceContents: MdWorkspaceContents,
-		private readonly getValue: (document: SkinnyTextDocument) => Promise<T>,
+		private readonly workspace: IMdWorkspace,
+		private readonly getValue: (document: ITextDocument) => Promise<T>,
 	) {
 		super();
 
-		this._register(this.workspaceContents.onDidChangeMarkdownDocument(doc => this.invalidate(doc)));
-		this._register(this.workspaceContents.onDidDeleteMarkdownDocument(this.onDidDeleteDocument, this));
+		this._register(this.workspace.onDidChangeMarkdownDocument(doc => this.invalidate(doc)));
+		this._register(this.workspace.onDidDeleteMarkdownDocument(this.onDidDeleteDocument, this));
 	}
 
 	public async get(resource: vscode.Uri): Promise<T | undefined> {
@@ -75,7 +76,7 @@ export class MdDocumentInfoCache<T> extends Disposable {
 		return this.resetEntry(doc)?.value;
 	}
 
-	public async getForDocument(document: SkinnyTextDocument): Promise<T> {
+	public async getForDocument(document: ITextDocument): Promise<T> {
 		const existing = this._cache.get(document.uri);
 		if (existing) {
 			return existing;
@@ -83,13 +84,13 @@ export class MdDocumentInfoCache<T> extends Disposable {
 		return this.resetEntry(document).value;
 	}
 
-	private loadDocument(resource: vscode.Uri): Promise<SkinnyTextDocument | undefined> {
+	private loadDocument(resource: vscode.Uri): Promise<ITextDocument | undefined> {
 		const existing = this._loadingDocuments.get(resource);
 		if (existing) {
 			return existing;
 		}
 
-		const p = this.workspaceContents.getOrLoadMarkdownDocument(resource);
+		const p = this.workspace.getOrLoadMarkdownDocument(resource);
 		this._loadingDocuments.set(resource, p);
 		p.finally(() => {
 			this._loadingDocuments.delete(resource);
@@ -97,13 +98,13 @@ export class MdDocumentInfoCache<T> extends Disposable {
 		return p;
 	}
 
-	private resetEntry(document: SkinnyTextDocument): Lazy<Promise<T>> {
+	private resetEntry(document: ITextDocument): Lazy<Promise<T>> {
 		const value = lazy(() => this.getValue(document));
 		this._cache.set(document.uri, value);
 		return value;
 	}
 
-	private invalidate(document: SkinnyTextDocument): void {
+	private invalidate(document: ITextDocument): void {
 		if (this._cache.has(document.uri)) {
 			this.resetEntry(document);
 		}
@@ -126,8 +127,8 @@ export class MdWorkspaceInfoCache<T> extends Disposable {
 	private _init?: Promise<void>;
 
 	public constructor(
-		private readonly workspaceContents: MdWorkspaceContents,
-		private readonly getValue: (document: SkinnyTextDocument) => Promise<T>,
+		private readonly workspace: IMdWorkspace,
+		private readonly getValue: (document: ITextDocument) => Promise<T>,
 	) {
 		super();
 	}
@@ -146,25 +147,25 @@ export class MdWorkspaceInfoCache<T> extends Disposable {
 		if (!this._init) {
 			this._init = this.populateCache();
 
-			this._register(this.workspaceContents.onDidChangeMarkdownDocument(this.onDidChangeDocument, this));
-			this._register(this.workspaceContents.onDidCreateMarkdownDocument(this.onDidChangeDocument, this));
-			this._register(this.workspaceContents.onDidDeleteMarkdownDocument(this.onDidDeleteDocument, this));
+			this._register(this.workspace.onDidChangeMarkdownDocument(this.onDidChangeDocument, this));
+			this._register(this.workspace.onDidCreateMarkdownDocument(this.onDidChangeDocument, this));
+			this._register(this.workspace.onDidDeleteMarkdownDocument(this.onDidDeleteDocument, this));
 		}
 		await this._init;
 	}
 
 	private async populateCache(): Promise<void> {
-		const markdownDocumentUris = await this.workspaceContents.getAllMarkdownDocuments();
+		const markdownDocumentUris = await this.workspace.getAllMarkdownDocuments();
 		for (const document of markdownDocumentUris) {
 			this.update(document);
 		}
 	}
 
-	private update(document: SkinnyTextDocument): void {
+	private update(document: ITextDocument): void {
 		this._cache.set(document.uri, lazy(() => this.getValue(document)));
 	}
 
-	private onDidChangeDocument(document: SkinnyTextDocument) {
+	private onDidChangeDocument(document: ITextDocument) {
 		this.update(document);
 	}
 


### PR DESCRIPTION
This renames some types and splits up some files as part of an exploration towards a proper LSP. Changes:

- `SkinnyTextDocument` -> `ITextDocument`
- Moved `ITextDocument` to own file
- `MdWorkspaceContents` -> `IMdWorkspace`

