### PR TITLE
WIP: fix: 1px mismatch in diff editor viewport dom

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -1276,7 +1276,7 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		const computedRatio = scrollHeight > 0 ? (computedRepresentableSize / scrollHeight) : 0;
 
 		const computedSliderSize = Math.max(0, Math.floor(layoutInfo.height * computedRatio));
-		const computedSliderPosition = Math.floor(scrollTop * computedRatio);
+		const computedSliderPosition = Math.ceil(scrollTop * computedRatio);
 
 		return {
 			height: computedSliderSize,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #152942

1. open a diff editor
2. scroll to bottom
3. there is 1px mismatch for the scroll controller and overview port
