### PR TITLE
Set up console forwarding in the extension host separately of `bootstrap-fork.js`

### DIFF
--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -44,7 +44,6 @@ export async function buildUserEnvironment(startParamsEnv: { [key: string]: stri
 		...{
 			VSCODE_LOG_NATIVE: String(isDebug),
 			VSCODE_AMD_ENTRYPOINT: 'vs/workbench/api/node/extensionHostProcess',
-			VSCODE_PIPE_LOGGING: 'true',
 			VSCODE_VERBOSE_LOGGING: 'true',
 			VSCODE_HANDLES_UNCAUGHT_ERRORS: 'true',
 			VSCODE_LOG_STACK: 'false',

--- a/src/vs/workbench/api/worker/extHostExtensionService.ts
+++ b/src/vs/workbench/api/worker/extHostExtensionService.ts
@@ -141,6 +141,7 @@ function ensureSuffix(path: string, suffix: string): string {
 	return path.endsWith(suffix) ? path : path + suffix;
 }
 
+// TODO@Alex: remove duplication
 // copied from bootstrap-fork.js
 function wrapConsoleMethods(service: MainThreadConsoleShape, callToNative: boolean) {
 	wrap('info', 'log');

--- a/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
@@ -228,7 +228,6 @@ export class SandboxLocalProcessExtensionHost implements IExtensionHost {
 
 		const env = objects.mixin(processEnv, {
 			VSCODE_AMD_ENTRYPOINT: 'vs/workbench/api/node/extensionHostProcess',
-			VSCODE_PIPE_LOGGING: 'true',
 			VSCODE_VERBOSE_LOGGING: true,
 			VSCODE_LOG_NATIVE: this._isExtensionDevHost,
 			VSCODE_HANDLES_UNCAUGHT_ERRORS: true,


### PR DESCRIPTION
This is a refactoring stepping stone. 
* move all of the logic that was previously in `bootstrap-fork.js` to `extHostConsoleForwarder.ts` which is now exercised explicitly by the nodejs extension host.
* since `VSCODE_LOG_NATIVE` and `VSCODE_LOG_STACK` were only exercised by the extension host, remove support for them from `bootstrap-fork.js`