### PR TITLE
Comments: Wrap non-Markdown content

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -114,7 +114,7 @@
 }
 
 .review-widget .body .review-comment .review-comment-contents .comment-body .comment-body-plainstring {
-	white-space: pre;
+	white-space: pre-wrap;
 }
 
 .review-widget .body .review-comment .review-comment-contents .comment-body {


### PR DESCRIPTION
In https://github.com/microsoft/vscode/issues/145380, the style for comments was changed to preserve indentation. However, when a line is too long, the text will be hidden instead of wrapping.

Using `pre-wrap` fixes that issue.
