### PR TITLE
joh/positive bobcat

### DIFF
--- a/build/gulpfile.compile.js
+++ b/build/gulpfile.compile.js
@@ -15,7 +15,7 @@ const compileBuildTask = task.define('compile-build',
 	task.series(
 		util.rimraf('out-build'),
 		util.buildWebNodePaths('out-build'),
-		compilation.compileTask('src', 'out-build', true, false)
+		compilation.compileTask('src', 'out-build', true)
 	)
 );
 gulp.task(compileBuildTask);

--- a/build/gulpfile.editor.js
+++ b/build/gulpfile.editor.js
@@ -84,7 +84,7 @@ const extractEditorSrcTask = task.define('extract-editor-src', () => {
 	});
 });
 
-const compileEditorAMDTask = task.define('compile-editor-amd', compilation.compileTask('out-editor-src', 'out-editor-build', true, false));
+const compileEditorAMDTask = task.define('compile-editor-amd', compilation.compileTask('out-editor-src', 'out-editor-build', true));
 
 const optimizeEditorAMDTask = task.define('optimize-editor-amd', common.optimizeTask({
 	src: 'out-editor-build',

--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -11,7 +11,7 @@ require('events').EventEmitter.defaultMaxListeners = 100;
 const gulp = require('gulp');
 const util = require('./lib/util');
 const task = require('./lib/task');
-const { compileTask, watchTask, compileApiProposalNamesTask, watchApiProposalNamesTask } = require('./lib/compilation');
+const { transpileTask, compileTask, watchTask, compileApiProposalNamesTask, watchApiProposalNamesTask } = require('./lib/compilation');
 const { monacoTypecheckTask/* , monacoTypecheckWatchTask */ } = require('./gulpfile.editor');
 const { compileExtensionsTask, watchExtensionsTask, compileExtensionMediaTask } = require('./gulpfile.extensions');
 
@@ -20,11 +20,11 @@ gulp.task(compileApiProposalNamesTask);
 gulp.task(watchApiProposalNamesTask);
 
 // Transpile only
-const transpileClientTask = task.define('transpile-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), compileTask('src', 'out', false, true)));
+const transpileClientTask = task.define('transpile-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), transpileTask('src', 'out')));
 gulp.task(transpileClientTask);
 
 // Fast compile for development time
-const compileClientTask = task.define('compile-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), compileApiProposalNamesTask, compileTask('src', 'out', false, false)));
+const compileClientTask = task.define('compile-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), compileApiProposalNamesTask, compileTask('src', 'out', false)));
 gulp.task(compileClientTask);
 
 const watchClientTask = task.define('watch-client', task.series(util.rimraf('out'), util.buildWebNodePaths('out'), task.parallel(watchTask('out', false), watchApiProposalNamesTask)));

--- a/build/lib/tsb/index.js
+++ b/build/lib/tsb/index.js
@@ -92,7 +92,7 @@ function create(projectPath, existingOptions, config, onError = _defaultOnError)
     }
     let result;
     if (config.transpileOnly) {
-        const transpiler = new transpiler_1.Transpiler(logFn, printDiagnostic, cmdLine);
+        const transpiler = new transpiler_1.Transpiler(logFn, printDiagnostic, projectPath, cmdLine);
         result = (() => createTranspileStream(transpiler));
     }
     else {

--- a/build/lib/tsb/index.ts
+++ b/build/lib/tsb/index.ts
@@ -126,7 +126,7 @@ export function create(
 
 	let result: IncrementalCompiler;
 	if (config.transpileOnly) {
-		const transpiler = new Transpiler(logFn, printDiagnostic, cmdLine);
+		const transpiler = new Transpiler(logFn, printDiagnostic, projectPath, cmdLine);
 		result = <any>(() => createTranspileStream(transpiler));
 	} else {
 		const _builder = builder.createTypeScriptBuilder({ logFn }, projectPath, cmdLine);


### PR DESCRIPTION
- use a different _internal_ API to get the output file names for a TS input file and its config... way faster than creating a program and using its internal API but needs some massage...
- have `compilation#transpileTask` as a separate place for tweaks
