### PR TITLE
Fix 152790 : Invalid regex message obscures search

### DIFF
--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -525,10 +525,10 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			}, 0));
 
 			// validate query again as it's being dismissed when we hide the find widget.
-			// timeout set to 250ms for proper alignment of error message
+			// timeout set to 300ms for proper alignment of error message
 			this._revealTimeouts.push(setTimeout(() => {
 				this._findInput.validate();
-			}, 250));
+			}, 300));
 
 			this._codeEditor.layoutOverlayWidget(this);
 

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -525,9 +525,10 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			}, 0));
 
 			// validate query again as it's being dismissed when we hide the find widget.
+			// timeout set to 250ms for proper alignment of error message
 			this._revealTimeouts.push(setTimeout(() => {
 				this._findInput.validate();
-			}, 200));
+			}, 250));
 
 			this._codeEditor.layoutOverlayWidget(this);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #152790 : [Invalid regex message obscures search](https://github.com/microsoft/vscode/issues/152790)

**Root cause of bug :**
- The error message was getting displayed even before the find/search widget takes place after transition/animation which resulted in improper positioning of the error message.

**Change done :** 
- Increased the timeout set for validation from 200ms to 300ms [ file : `findWidget.ts `]

**Tests performed on UI :**
- Checked the reopening of find widget with invalid regex on editor using Ctrl + F key combination [Ctrl+F, invalid regex, Esc, Ctrl+F again as mentioned in bug]
- Checked the find widget on editor using Ctrl + F and Ctrl + V key combination used rapidly with invalid regex

**Working behavior after fix :** 
- The error message gets aligned properly below the find widget. 

**Test machine details :** 
Version: 1.69.0
Electron: 18.3.4
Chromium: 100.0.4896.160
Node.js: 16.13.2
V8: 10.0.139.17-electron.0
OS: Linux x64 5.10.0-14-amd64