### PR TITLE
Send telemetry data on the base data object

### DIFF
--- a/src/vs/platform/telemetry/common/1dsAppender.ts
+++ b/src/vs/platform/telemetry/common/1dsAppender.ts
@@ -108,11 +108,12 @@ export abstract class AbstractOneDataSystemAppender implements ITelemetryAppende
 		}
 		data = mixin(data, this._defaultData);
 		data = validateTelemetryData(data);
+		const name = this._eventPrefix + '/' + eventName;
 
 		try {
 			this._withAIClient((aiClient) => aiClient.track({
-				name: this._eventPrefix + '/' + eventName,
-				data,
+				name,
+				baseData: { name, properties: data?.properties, measurements: data?.measurements }
 			}));
 		} catch { }
 	}


### PR DESCRIPTION
Data team needs the telemetry on the baseData object rather than the data object for the pipeline