### PR TITLE
Fix notebook links to other docs in edited markdown cells

### DIFF
--- a/extensions/markdown-language-features/src/tableOfContents.ts
+++ b/extensions/markdown-language-features/src/tableOfContents.ts
@@ -10,6 +10,7 @@ import { githubSlugifier, Slug, Slugifier } from './slugify';
 import { ITextDocument } from './types/textDocument';
 import { Disposable } from './util/dispose';
 import { isMarkdownFile } from './util/file';
+import { Schemes } from './util/schemes';
 import { MdDocumentInfoCache } from './util/workspaceCache';
 import { IMdWorkspace } from './workspace';
 
@@ -71,7 +72,7 @@ export class TableOfContents {
 	}
 
 	public static async createForDocumentOrNotebook(parser: IMdParser, document: ITextDocument): Promise<TableOfContents> {
-		if (document.uri.scheme === 'vscode-notebook-cell') {
+		if (document.uri.scheme === Schemes.notebookCell) {
 			const notebook = vscode.workspace.notebookDocuments
 				.find(notebook => notebook.getCells().some(cell => cell.document === document));
 

--- a/extensions/markdown-language-features/src/util/schemes.ts
+++ b/extensions/markdown-language-features/src/util/schemes.ts
@@ -14,6 +14,7 @@ export const Schemes = {
 	data: 'data:',
 	vscode: 'vscode:',
 	'vscode-insiders': 'vscode-insiders:',
+	notebookCell: 'vscode-notebook-cell',
 };
 
 const knownSchemes = [


### PR DESCRIPTION
Fixes #148199

This makes us resolve links in notebooks relative to the notebook document instead of relative to the cell itself
