### PR TITLE
joh/careful silverfish

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1478,7 +1478,7 @@
         {
           "command": "git.openChange",
           "group": "navigation",
-          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && !isInDiffEditor && resourceScheme == file && scmActiveResourceHasChanges"
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && !isInDiffEditor && !isMergeEditor && resourceScheme == file && scmActiveResourceHasChanges"
         },
         {
           "command": "git.stageSelectedRanges",

--- a/extensions/merge-conflict/package.json
+++ b/extensions/merge-conflict/package.json
@@ -77,6 +77,7 @@
         "title": "%command.next%",
         "original": "Next Conflict",
         "command": "merge-conflict.next",
+        "enablement": "!isMergeEditor",
         "icon": "$(arrow-down)"
       },
       {
@@ -84,6 +85,7 @@
         "title": "%command.previous%",
         "original": "Previous Conflict",
         "command": "merge-conflict.previous",
+        "enablement": "!isMergeEditor",
         "icon": "$(arrow-up)"
       },
       {
@@ -110,12 +112,12 @@
         {
           "command": "merge-conflict.previous",
           "group": "navigation@1",
-          "when": "mergeConflictsCount && mergeConflictsCount != 0"
+          "when": "!isMergeEditor && mergeConflictsCount && mergeConflictsCount != 0"
         },
         {
           "command": "merge-conflict.next",
           "group": "navigation@2",
-          "when": "mergeConflictsCount && mergeConflictsCount != 0"
+          "when": "!isMergeEditor && mergeConflictsCount && mergeConflictsCount != 0"
         }
       ]
     },

--- a/extensions/merge-conflict/src/services.ts
+++ b/extensions/merge-conflict/src/services.ts
@@ -48,6 +48,19 @@ export default class ServiceWrapper implements vscode.Disposable {
 	}
 
 	createExtensionConfiguration(): interfaces.IExtensionConfiguration {
+
+		// PRAGMATIC way to avoid conflicting with the new merge editor: when git opts into
+		// using the merge editor we disable this extension - for the merge editor but also
+		// for "other" editors
+		const gitConfig = vscode.workspace.getConfiguration('git');
+		if (gitConfig.get<boolean>('experimental.mergeEditor')) {
+			return {
+				enableCodeLens: false,
+				enableDecorations: false,
+				enableEditorOverview: false
+			};
+		}
+
 		const workspaceConfiguration = vscode.workspace.getConfiguration(ConfigurationSectionName);
 		const codeLensEnabled: boolean = workspaceConfiguration.get('codeLens.enabled', true);
 		const decoratorsEnabled: boolean = workspaceConfiguration.get('decorators.enabled', true);
@@ -64,4 +77,3 @@ export default class ServiceWrapper implements vscode.Disposable {
 		this.services = [];
 	}
 }
-


### PR DESCRIPTION
- don't show `openChange` command for merge editor
- disable and not-place the conflicting merge-conflict navigation commands for the merge editor
- disable (configurable) merge-conflict featues (code lens, decorations) when git is configured to use merge editor
