### PR TITLE
joh/issue151136

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
@@ -16,7 +16,7 @@ import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { AbstractTextResourceEditorInput } from 'vs/workbench/common/editor/textResourceEditorInput';
 import { MergeEditorModel } from 'vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { ITextFileEditorModel, ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
+import { ILanguageSupport, ITextFileEditorModel, ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 
 export class MergeEditorInputData {
 	constructor(
@@ -27,7 +27,7 @@ export class MergeEditorInputData {
 	) { }
 }
 
-export class MergeEditorInput extends AbstractTextResourceEditorInput {
+export class MergeEditorInput extends AbstractTextResourceEditorInput implements ILanguageSupport {
 
 	static readonly ID = 'mergeEditor.Input';
 
@@ -140,6 +140,9 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput {
 		return Boolean(this._outTextModel?.isDirty());
 	}
 
+	setLanguageId(languageId: string, _setExplicitly?: boolean): void {
+		this._model?.setLanguageId(languageId);
+	}
 
 	// implement get/set languageId
 	// implement get/set encoding

--- a/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
@@ -20,6 +20,8 @@ import { LineRange } from 'vs/workbench/contrib/mergeEditor/browser/model/lineRa
 import { TextModelDiffChangeReason, TextModelDiffs, TextModelDiffState } from 'vs/workbench/contrib/mergeEditor/browser/model/textModelDiffs';
 import { concatArrays, leftJoin, elementAtOrUndefined } from 'vs/workbench/contrib/mergeEditor/browser/utils';
 import { ModifiedBaseRange, ModifiedBaseRangeState } from './modifiedBaseRange';
+import { IModelService } from 'vs/editor/common/services/model';
+import { ILanguageService } from 'vs/editor/common/languages/language';
 
 export const enum MergeEditorModelState {
 	initializing = 1,
@@ -134,7 +136,9 @@ export class MergeEditorModel extends EditorModel {
 		readonly input2Detail: string | undefined,
 		readonly input2Description: string | undefined,
 		readonly result: ITextModel,
-		@IEditorWorkerService private readonly editorWorkerService: IEditorWorkerService
+		@IEditorWorkerService private readonly editorWorkerService: IEditorWorkerService,
+		@IModelService private readonly modelService: IModelService,
+		@ILanguageService private readonly languageService: ILanguageService,
 	) {
 		super();
 
@@ -328,6 +332,10 @@ export class MergeEditorModel extends EditorModel {
 
 	public setHandled(baseRange: ModifiedBaseRange, handled: boolean, tx: ITransaction): void {
 		this.modifiedBaseRangeHandlingStateStores.get().get(baseRange)!.set(handled, tx);
+	}
+
+	public setLanguageId(languageId: string): void {
+		this.modelService.setMode(this.result, this.languageService.createById(languageId));
 	}
 }
 


### PR DESCRIPTION
- Implement `ILanguageSupport#setLanguageId` for merge editor input. With this the editor langauge status shows (but doesn't do anything yet)
- Improve `MergeEditor#getControl` so that the editor language status works (knows the editor/model to operate on). This opens a can of worms as other things start to work, e.g outline and breakcrumbs and that requires some "redirect magic" to ensure opening a symbol from outline/breakcrumbs stays within the merge editor...
