### PR TITLE
always `preserveFocus` when calling `_open.mergeEditor`

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
@@ -33,7 +33,7 @@ export class OpenMergeEditor extends Action2 {
 			validatedArgs.input2,
 			validatedArgs.output,
 		);
-		accessor.get(IEditorService).openEditor(input);
+		accessor.get(IEditorService).openEditor(input, { preserveFocus: true });
 	}
 }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/152948
