### PR TITLE
Break at the start of multiple `BREAK_BEFORE` chars and at the end of multiple `BREAK_AFTER` chars

### DIFF
--- a/src/vs/editor/common/viewModel/monospaceLineBreaksComputer.ts
+++ b/src/vs/editor/common/viewModel/monospaceLineBreaksComputer.ts
@@ -411,7 +411,7 @@ function createLineBreaks(classifier: WrappingCharacterClassifier, _lineText: st
 	for (let i = startOffset; i < len; i++) {
 		const charStartOffset = i;
 		const charCode = lineText.charCodeAt(i);
-		let charCodeClass: number;
+		let charCodeClass: CharacterClass;
 		let charWidth: number;
 
 		if (strings.isHighSurrogate(charCode)) {
@@ -489,9 +489,9 @@ function canBreak(prevCharCode: number, prevCharCodeClass: CharacterClass, charC
 	return (
 		charCode !== CharCode.Space
 		&& (
-			(prevCharCodeClass === CharacterClass.BREAK_AFTER)
+			(prevCharCodeClass === CharacterClass.BREAK_AFTER && charCodeClass !== CharacterClass.BREAK_AFTER) // break at the end of multiple BREAK_AFTER
+			|| (prevCharCodeClass !== CharacterClass.BREAK_BEFORE && charCodeClass === CharacterClass.BREAK_BEFORE) // break at the start of multiple BREAK_BEFORE
 			|| (prevCharCodeClass === CharacterClass.BREAK_IDEOGRAPHIC && charCodeClass !== CharacterClass.BREAK_AFTER)
-			|| (charCodeClass === CharacterClass.BREAK_BEFORE)
 			|| (charCodeClass === CharacterClass.BREAK_IDEOGRAPHIC && prevCharCodeClass !== CharacterClass.BREAK_BEFORE)
 		)
 	);

--- a/src/vs/editor/test/common/viewModel/monospaceLineBreaksComputer.test.ts
+++ b/src/vs/editor/test/common/viewModel/monospaceLineBreaksComputer.test.ts
@@ -116,9 +116,9 @@ suite('Editor ViewModel - MonospaceLineBreaksComputer', () => {
 		assertLineBreaks(factory, 4, 5, 'aaa))|).aaa');
 		assertLineBreaks(factory, 4, 5, 'aaa))|).|aaaa');
 		assertLineBreaks(factory, 4, 5, 'aaa)|().|aaa');
-		assertLineBreaks(factory, 4, 5, 'aaa(|().|aaa');
-		assertLineBreaks(factory, 4, 5, 'aa.(|().|aaa');
-		assertLineBreaks(factory, 4, 5, 'aa.(.|).aaa');
+		assertLineBreaks(factory, 4, 5, 'aaa|(().|aaa');
+		assertLineBreaks(factory, 4, 5, 'aa.|(().|aaa');
+		assertLineBreaks(factory, 4, 5, 'aa.|(.).|aaa');
 	});
 
 	function assertLineBreakDataEqual(a: ModelLineProjectionData | null, b: ModelLineProjectionData | null): void {
@@ -291,6 +291,11 @@ suite('Editor ViewModel - MonospaceLineBreaksComputer', () => {
 	test('issue #33366: Word wrap algorithm behaves differently around punctuation', () => {
 		const factory = new MonospaceLineBreaksComputerFactory(EditorOptions.wordWrapBreakBeforeCharacters.defaultValue, EditorOptions.wordWrapBreakAfterCharacters.defaultValue);
 		assertLineBreaks(factory, 4, 23, 'this is a line of |text, text that sits |on a line', WrappingIndent.Same);
+	});
+
+	test('issue #152773: Word wrap algorithm behaves differently with bracket followed by comma', () => {
+		const factory = new MonospaceLineBreaksComputerFactory(EditorOptions.wordWrapBreakBeforeCharacters.defaultValue, EditorOptions.wordWrapBreakAfterCharacters.defaultValue);
+		assertLineBreaks(factory, 4, 24, 'this is a line of |(text), text that sits |on a line', WrappingIndent.Same);
 	});
 
 	test('issue #112382: Word wrap doesn\'t work well with control characters', () => {


### PR DESCRIPTION
Fixes #152773