### PR TITLE
Always show overview ruler decorations before command execution

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -220,7 +220,9 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 		}
 		const decoration = this._terminal.registerDecoration({
 			marker: command.marker,
-			overviewRulerOptions: beforeCommandExecution ? undefined : { color, position: command.exitCode ? 'right' : 'left' }
+			overviewRulerOptions: beforeCommandExecution
+				? { color, position: 'left' }
+				: { color, position: command.exitCode ? 'right' : 'left' }
 		});
 		if (!decoration) {
 			return undefined;


### PR DESCRIPTION
Originally we hid the overview ruler decoration for command currently being input
and executed. This ended up causing problems for commands that took a while to run
and task decoration support as they would not get a mark in the overview ruler
until the command finished. For simplicity let's just always show this, so there
will basically always be a grey mark at the very bottom for the cursor line, but
that is at least consistent and then we don't need to juggle different overview
ruler options depending on the state of the command.

Fixes #152663

---

Task showing the in progress overview ruler decoration:

![image](https://user-images.githubusercontent.com/2193314/175565689-4a810223-a732-4497-a6ce-4721a6a62d7f.png)

Terminal showing input line overview ruler decoration:

![image](https://user-images.githubusercontent.com/2193314/175565765-a101abab-08fb-4730-b13c-b1fe339f9ec6.png)
