### PR TITLE
fallback in else of loader & remove csp addition

### DIFF
--- a/src/vs/nls.ts
+++ b/src/vs/nls.ts
@@ -216,6 +216,13 @@ export function load(name: string, req: AMDLoader.IRelativeRequire, load: AMDLoa
 			}
 		})();
 	} else {
-		req([name + suffix], messagesLoaded);
+		req([name + suffix], messagesLoaded, (err: Error) => {
+			if (suffix === '.nls') {
+				console.error('Failed trying to load default language strings', err);
+				return;
+			}
+			console.error(`Failed to load message bundle for language ${language}. Falling back to the default language:`, err);
+			req([name + '.nls'], messagesLoaded);
+		});
 	}
 }

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -321,15 +321,12 @@ export class WebClientServer {
 			callbackRoute: this._callbackRoute
 		};
 
-		let nlsBaseUrl = this._productService.extensionsGallery?.nlsBaseUrl;
-		if (!nlsBaseUrl?.endsWith('/')) {
-			nlsBaseUrl += '/';
-		}
+		const nlsBaseUrl = this._productService.extensionsGallery?.nlsBaseUrl;
 		const values: { [key: string]: string } = {
 			WORKBENCH_WEB_CONFIGURATION: asJSON(workbenchWebConfiguration),
 			WORKBENCH_AUTH_SESSION: authSessionInfo ? asJSON(authSessionInfo) : '',
 			WORKBENCH_WEB_BASE_URL: this._staticRoute,
-			WORKBENCH_NLS_BASE_URL: nlsBaseUrl ? `${nlsBaseUrl}${this._productService.commit}/${this._productService.version}/` : '',
+			WORKBENCH_NLS_BASE_URL: nlsBaseUrl ? `${nlsBaseUrl}${!nlsBaseUrl.endsWith('/') ? '/' : ''}${this._productService.commit}/${this._productService.version}/` : '',
 		};
 
 
@@ -346,7 +343,7 @@ export class WebClientServer {
 			'default-src \'self\';',
 			'img-src \'self\' https: data: blob:;',
 			'media-src \'self\';',
-			`script-src 'self' 'unsafe-eval' ${this._getScriptCspHashes(data).join(' ')} 'sha256-fh3TwPMflhsEIpR8g1OYTIMVWhXTLcjQ9kh2tIpmv54=' http://${remoteAuthority} ${nlsBaseUrl ?? ''};`, // the sha is the same as in src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+			`script-src 'self' 'unsafe-eval' ${this._getScriptCspHashes(data).join(' ')} 'sha256-fh3TwPMflhsEIpR8g1OYTIMVWhXTLcjQ9kh2tIpmv54=' http://${remoteAuthority};`, // the sha is the same as in src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 			'child-src \'self\';',
 			`frame-src 'self' https://*.vscode-cdn.net data:;`,
 			'worker-src \'self\' data:;',


### PR DESCRIPTION
* Adds a fallback handler in the else block
* removes the script-src that isn't needed since we not fetch the unpkg service instead of require

As an aside, @alexdima it looks like the `err` pass in to the errorback from the loader looks like this:
![image](https://user-images.githubusercontent.com/2644648/175645713-2203445e-1295-4cf8-ae16-2ad203ef94d4.png)

`Error [object Event]` doesn't seem right... maybe the loader is wrapping this object incorrectly?