### PR TITLE
Exclude empty links from md results

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/documentLinks.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/documentLinks.ts
@@ -219,7 +219,7 @@ const linkPattern = new RegExp(
 	r`\(\s*)` + // <-- close prefix match
 	/**/r`(` +
 	/*****/r`[^\s\(\)\<](?:[^\s\(\)]|\([^\s\(\)]*?\))*|` + // Link without whitespace, or...
-	/*****/r`<[^<>]*>` + // In angle brackets
+	/*****/r`<[^<>]+>` + // In angle brackets
 	/**/r`)` +
 
 	// Title

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -461,6 +461,17 @@ suite('Markdown: MdLinkComputer', () => {
 			new vscode.Range(5, 7, 5, 17),
 		]);
 	});
+
+	test('Should not include link with empty angle bracket', async () => {
+		const links = await getLinksForFile(joinLines(
+			`[](<>)`,
+			`[link](<>)`,
+			`[link](<> "text")`,
+			`[link](<> 'text')`,
+			`[link](<> (text))`,
+		));
+		assertLinksEqual(links, []);
+	});
 });
 
 


### PR DESCRIPTION
These are technically valid links but we don't care about them since they take up no space in the text

