### PR TITLE
Better handling of text/uri-list in built-in extensions

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/dropIntoEditor.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/dropIntoEditor.ts
@@ -44,7 +44,7 @@ export async function tryGetUriListSnippet(document: vscode.TextDocument, dataTr
 	}
 
 	const uris: vscode.Uri[] = [];
-	for (const resource of urlList.split('\r\n')) {
+	for (const resource of urlList.split('\n')) {
 		try {
 			uris.push(vscode.Uri.parse(resource));
 		} catch {

--- a/extensions/references-view/src/tree.ts
+++ b/extensions/references-view/src/tree.ts
@@ -213,7 +213,7 @@ class TreeDndDelegate implements vscode.TreeDragAndDropController<undefined> {
 				}
 			}
 			if (urls.length > 0) {
-				data.set('text/uri-list', new vscode.DataTransferItem(urls.join('\n')));
+				data.set('text/uri-list', new vscode.DataTransferItem(urls.join('\r\n')));
 			}
 		}
 	}

--- a/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
+++ b/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
@@ -119,7 +119,7 @@ class DefaultOnDropProvider implements DocumentOnDropEditProvider {
 	) { }
 
 	async provideDocumentOnDropEdits(_model: ITextModel, _position: IPosition, dataTransfer: VSDataTransfer, _token: CancellationToken): Promise<DocumentOnDropEdit | undefined> {
-		const urlListEntry = dataTransfer.get('text/uri-list');
+		const urlListEntry = dataTransfer.get(Mimes.uriList);
 		if (urlListEntry) {
 			const urlList = await urlListEntry.asString();
 			const snippet = this.getUriListInsertText(urlList);

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -10127,7 +10127,7 @@ declare module 'vscode' {
 		 * @param mimeType The mime type to get the data transfer item for, such as `text/plain` or `image/png`.
 		 *
 		 * Special mime types:
-		 * - `text/uri-list` — A string with `toString()`ed Uris separated by newlines. To specify a cursor position in the file,
+		 * - `text/uri-list` — A string with `toString()`ed Uris separated by `\r\n`. To specify a cursor position in the file,
 		 * set the Uri's fragment to `L3,5`, where 3 is the line number and 5 is the column number.
 		 */
 		get(mimeType: string): DataTransferItem | undefined;


### PR DESCRIPTION
- When splitting `text/uri-list`, we should split on `\n` to handle against spec versions of `text/uri-list` (i.e. strings that use `\n` instead of `\r\n`)
- However when constructing a `text/uri-list`, we should use `\r\n` to align with the spec
