### PR TITLE
use extension id as key not folder name which is more accurate

### DIFF
--- a/build/azure-pipelines/upload-nlsmetadata.js
+++ b/build/azure-pipelines/upload-nlsmetadata.js
@@ -9,6 +9,8 @@ const vfs = require("vinyl-fs");
 const merge = require("gulp-merge-json");
 const gzip = require("gulp-gzip");
 const identity_1 = require("@azure/identity");
+const path = require("path");
+const fs_1 = require("fs");
 const azure = require('gulp-azure-storage');
 const commit = process.env['VSCODE_DISTRO_COMMIT'] || process.env['BUILD_SOURCEVERSION'];
 const credential = new identity_1.ClientSecretCredential(process.env['AZURE_TENANT_ID'], process.env['AZURE_CLIENT_ID'], process.env['AZURE_CLIENT_SECRET']);
@@ -62,7 +64,11 @@ function main() {
                         break;
                     }
                 }
-                const key = 'vscode.' + file.relative.split('/')[0];
+                // Get extension id and use that as the key
+                const folderPath = path.join(file.base, file.relative.split('/')[0]);
+                const manifest = (0, fs_1.readFileSync)(path.join(folderPath, 'package.json'), 'utf-8');
+                const manifestJson = JSON.parse(manifest);
+                const key = manifestJson.publisher + '.' + manifestJson.name;
                 return { [key]: parsedJson };
             },
         }))

--- a/build/azure-pipelines/upload-nlsmetadata.ts
+++ b/build/azure-pipelines/upload-nlsmetadata.ts
@@ -9,6 +9,8 @@ import * as vfs from 'vinyl-fs';
 import * as merge from 'gulp-merge-json';
 import * as gzip from 'gulp-gzip';
 import { ClientSecretCredential } from '@azure/identity';
+import path = require('path');
+import { readFileSync } from 'fs';
 const azure = require('gulp-azure-storage');
 
 const commit = process.env['VSCODE_DISTRO_COMMIT'] || process.env['BUILD_SOURCEVERSION'];
@@ -79,7 +81,12 @@ function main(): Promise<void> {
 							break;
 						}
 					}
-					const key = 'vscode.' + file.relative.split('/')[0];
+
+					// Get extension id and use that as the key
+					const folderPath = path.join(file.base, file.relative.split('/')[0]);
+					const manifest = readFileSync(path.join(folderPath, 'package.json'), 'utf-8');
+					const manifestJson = JSON.parse(manifest);
+					const key = manifestJson.publisher + '.' + manifestJson.name;
 					return { [key]: parsedJson };
 				},
 			}))


### PR DESCRIPTION
this fixes a couple of extensions whos extension ids are not the same as their folder... I was also lazily tacking on `vscode.` to the folder name... which isn't true for `ms-vscode.js-debug`

For example:

vscode.typescript is actually in a folder called typescript-basics...
