### PR TITLE
fix menubar visibility events when moving menubar

### DIFF
--- a/src/vs/base/browser/ui/menu/menubar.ts
+++ b/src/vs/base/browser/ui/menu/menubar.ts
@@ -746,7 +746,7 @@ export class MenuBar extends Disposable {
 		this._onFocusStateChange.fire(this.focusState >= MenubarState.FOCUSED);
 	}
 
-	private get isVisible(): boolean {
+	get isVisible(): boolean {
 		return this.focusState >= MenubarState.VISIBLE;
 	}
 

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -698,6 +698,11 @@ export class CustomMenubarControl extends MenubarControl {
 			}));
 
 			this.reinstallDisposables.add(attachMenuStyler(this.menubar, this.themeService));
+
+			// Fire visibility change for the first install if menu is shown
+			if (this.menubar.isVisible) {
+				this.onDidVisibilityChange(true);
+			}
 		} else {
 			this.menubar?.update(this.getMenuBarOptions());
 		}

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -180,7 +180,9 @@ export class TitlebarPart extends Part implements ITitleService {
 
 	protected onMenubarVisibilityChanged(visible: boolean): void {
 		if (isWeb || isWindows || isLinux) {
-			this.adjustTitleMarginToCenter();
+			if (this.lastLayoutDimensions) {
+				this.layout(this.lastLayoutDimensions.width, this.lastLayoutDimensions.height);
+			}
 
 			this._onMenubarVisibilityChange.fire(visible);
 		}
@@ -197,6 +199,8 @@ export class TitlebarPart extends Part implements ITitleService {
 			this.menubar.remove();
 			this.menubar = undefined;
 		}
+
+		this.onMenubarVisibilityChanged(false);
 	}
 
 	protected installMenubar(): void {
@@ -210,9 +214,9 @@ export class TitlebarPart extends Part implements ITitleService {
 		this.menubar = this.rootContainer.insertBefore($('div.menubar'), this.title);
 		this.menubar.setAttribute('role', 'menubar');
 
-		this.customMenubar.create(this.menubar);
-
 		this._register(this.customMenubar.onVisibilityChange(e => this.onMenubarVisibilityChanged(e)));
+
+		this.customMenubar.create(this.menubar);
 	}
 
 	private updateTitle(): void {


### PR DESCRIPTION
fixes #151063

note that because the current behavior is to always use the compact menu with the command center, the original issue is not easily reproducible 

cc @jrieken 