### PR TITLE
implement `IEditorInput#confirm` 

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
@@ -91,6 +91,8 @@ export class MergeEditorModel extends EditorModel {
 		return map.size - handledCount;
 	});
 
+	public readonly hasUnhandledConflicts = this.unhandledConflictsCount.map(value => value > 0);
+
 	public readonly input1ResultMapping = derivedObservable('input1ResultMapping', reader => {
 		const resultDiffs = this.resultDiffs.read(reader);
 		const modifiedBaseRanges = DocumentMapping.betweenOutputs(this.input1LinesDiffs.read(reader), resultDiffs, this.input1.getLineCount());


### PR DESCRIPTION
implement `IEditorInput#confirm` to confirm with users that it is OK to close a merge editor despite unresolved conflicts. As a side-effect keep the merge editor dirty while it is unsed and while it has unresolved conflicts

fixes https://github.com/microsoft/vscode/issues/151024
