### PR TITLE
Extend anythingQuickAccess to provide a quickAccess file search that ignores exclusions

### DIFF
--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccessWithoutExclusions.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccessWithoutExclusions.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { ILanguageService } from 'vs/editor/common/languages/language';
+import { IModelService } from 'vs/editor/common/services/model';
+import { ITextModelService } from 'vs/editor/common/services/resolverService';
+import { localize } from 'vs/nls';
+import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IFileService } from 'vs/platform/files/common/files';
+import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
+import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
+import { AnythingQuickAccessProvider } from 'vs/workbench/contrib/search/browser/anythingQuickAccess';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { IFilesConfigurationService } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
+import { IHistoryService } from 'vs/workbench/services/history/common/history';
+import { IPathService } from 'vs/workbench/services/path/common/pathService';
+import { IFileQueryBuilderOptions } from 'vs/workbench/services/search/common/queryBuilder';
+import { IFileQuery, ISearchService } from 'vs/workbench/services/search/common/search';
+import { IWorkingCopyService } from 'vs/workbench/services/workingCopy/common/workingCopyService';
+
+class GoToFileWithoutExclusionsAction extends Action2 {
+
+	static readonly ID = 'workbench.action.quickOpenWithoutExclusions';
+
+	constructor() {
+		super({
+			id: GoToFileWithoutExclusionsAction.ID,
+			title: {
+				value: localize('gotoFileWithoutExclusions', "Go to File (Without ignore files and search excludes)..."),
+				original: 'Go to File (Without ignore files and search excludes)...'
+			},
+			f1: true,
+			keybinding: {
+				when: undefined,
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyP
+			},
+			menu: [{
+				id: MenuId.MenubarGoMenu,
+				group: '4_symbol_nav',
+				order: 1
+			}]
+		});
+	}
+
+	run(accessor: ServicesAccessor) {
+		accessor.get(IQuickInputService).quickAccess.show(AnythingQuickAccessWithoutExclusionsProvider.PREFIX);
+	}
+}
+
+registerAction2(GoToFileWithoutExclusionsAction);
+
+export class AnythingQuickAccessWithoutExclusionsProvider extends AnythingQuickAccessProvider {
+	static override PREFIX = '!';
+
+	protected override createFileQuery(options: IFileQueryBuilderOptions): IFileQuery {
+		const query = this.fileQueryBuilder.file(this.contextService.getWorkspace().folders, options);
+		query.folderQueries.forEach(f => {
+			if (f.excludePattern) {
+				f.excludePattern = undefined;
+			}
+		});
+		return query;
+	}
+
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ISearchService searchService: ISearchService,
+		@IWorkspaceContextService contextService: IWorkspaceContextService,
+		@IPathService pathService: IPathService,
+		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+		@IFileService fileService: IFileService,
+		@ILabelService labelService: ILabelService,
+		@IModelService modelService: IModelService,
+		@ILanguageService languageService: ILanguageService,
+		@IWorkingCopyService workingCopyService: IWorkingCopyService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IEditorService editorService: IEditorService,
+		@IHistoryService historyService: IHistoryService,
+		@IFilesConfigurationService filesConfigurationService: IFilesConfigurationService,
+		@ITextModelService textModelService: ITextModelService,
+		@IUriIdentityService uriIdentityService: IUriIdentityService
+	) {
+		super(
+			instantiationService,
+			searchService,
+			contextService,
+			pathService,
+			environmentService,
+			fileService,
+			labelService,
+			modelService,
+			languageService,
+			workingCopyService,
+			configurationService,
+			editorService,
+			historyService,
+			filesConfigurationService,
+			textModelService,
+			uriIdentityService,
+			AnythingQuickAccessWithoutExclusionsProvider.PREFIX);
+	}
+}

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -56,6 +56,7 @@ import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
 import { ISearchConfiguration, SearchSortOrder, SEARCH_EXCLUDE_CONFIG, VIEWLET_ID, VIEW_ID } from 'vs/workbench/services/search/common/search';
 import { Extensions, IConfigurationMigrationRegistry } from 'vs/workbench/common/configuration';
+import { AnythingQuickAccessWithoutExclusionsProvider } from 'vs/workbench/contrib/search/browser/anythingQuickAccessWithoutExclusions';
 
 registerSingleton(ISearchWorkbenchService, SearchWorkbenchService, true);
 registerSingleton(ISearchHistoryService, SearchHistoryService, true);
@@ -794,6 +795,14 @@ quickAccessRegistry.registerQuickAccessProvider({
 	placeholder: nls.localize('anythingQuickAccessPlaceholder', "Search files by name (append {0} to go to line or {1} to go to symbol)", AbstractGotoLineQuickAccessProvider.PREFIX, GotoSymbolQuickAccessProvider.PREFIX),
 	contextKey: defaultQuickAccessContextKeyValue,
 	helpEntries: [{ description: nls.localize('anythingQuickAccess', "Go to File"), commandId: 'workbench.action.quickOpen' }]
+});
+
+quickAccessRegistry.registerQuickAccessProvider({
+	ctor: AnythingQuickAccessWithoutExclusionsProvider,
+	prefix: AnythingQuickAccessWithoutExclusionsProvider.PREFIX,
+	placeholder: nls.localize('anythingQuickAccessWithoutExclusionsPlaceholder', "Search files by name (without ignore files and search excludes)"),
+	contextKey: defaultQuickAccessContextKeyValue,
+	helpEntries: [{ description: nls.localize('anythingQuickAccessWithoutExclusions', "Go to File (without ignore files and search excludes)"), commandId: 'workbench.action.quickOpen' }]
 });
 
 quickAccessRegistry.registerQuickAccessProvider({


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15604

Video demo:

https://user-images.githubusercontent.com/20613660/175842621-b7fd9810-bae1-4658-bbc0-8b465dc91316.mp4

 This PR comes with 4 changes:
* Modifying `anythingQuickAccess` to make several properties `protected`, making the constructor prefix an argument, and refactoring the `IFileQuery` creation to pass through a helper function
* Creating `anythingQuickAccessWithoutExclusions` and overriding the prefix and `createFileQuery` function such that any query passing through is stripped of all excludes in `folderQueries`. `IFileQuery` itself has a `excludePattern` field but checking it during debugging it seems to be `undefined` for a default search.
* Creating and registering an `Action2` for the new class that uses `Ctrl` + `Alt` + `P` as the command and `!` as the prefix (should this stay in the same class?)
* Registering the new class as a `QuickAccessProvider` (here I feel like another PR could be needed to show the placeholder when the input is just the prefix but not empty, there is a placeholder also defined for `SymbolsQuickAccessProvider` but its never used either

