### PR TITLE
joh/useless centipede

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,6 +73,7 @@
 	],
 	"git.branchProtectionPrompt": "alwaysCommitToNewBranch",
 	"git.branchRandomName.enable": true,
+	"git.mergeEditor": true,
 	"remote.extensionKind": {
 		"msjsdiag.debugger-for-chrome": "workspace"
 	},

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -2500,14 +2500,11 @@
           "markdownDescription": "%config.logLevel%",
           "scope": "window"
         },
-        "git.experimental.mergeEditor": {
+        "git.mergeEditor": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "%config.experimental.mergeEditor%",
-          "scope": "window",
-          "tags": [
-            "experimental"
-          ]
+          "markdownDescription": "%config.mergeEditor%",
+          "scope": "window"
         }
       }
     },

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -243,7 +243,7 @@
 	"config.logLevel.error": "Log only error, and critical information",
 	"config.logLevel.critical": "Log only critical information",
 	"config.logLevel.off": "Log nothing",
-	"config.experimental.mergeEditor": "Open the _experimental_ merge editor for files that are currently under conflict.",
+	"config.mergeEditor": "Open the merge editor for files that are currently under conflict.",
 	"submenu.explorer": "Git",
 	"submenu.commit": "Commit",
 	"submenu.commit.amend": "Amend",

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -616,7 +616,7 @@ class ResourceCommandResolver {
 
 		if (!resource.leftUri) {
 			const bothModified = resource.type === Status.BOTH_MODIFIED;
-			if (resource.rightUri && bothModified && workspace.getConfiguration('git').get<boolean>('experimental.mergeEditor', false)) {
+			if (resource.rightUri && bothModified && workspace.getConfiguration('git').get<boolean>('mergeEditor', false)) {
 				return {
 					command: '_git.openMergeEditor',
 					title: localize('open.merge', "Open Merge"),
@@ -935,7 +935,7 @@ export class Repository implements Disposable {
 		updateIndexGroupVisibility();
 
 		workspace.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('git.experimental.mergeEditor')) {
+			if (e.affectsConfiguration('git.mergeEditor')) {
 				this.mergeGroup.resourceStates = this.mergeGroup.resourceStates.map(r => r.clone());
 			}
 		}, undefined, this.disposables);

--- a/extensions/merge-conflict/src/services.ts
+++ b/extensions/merge-conflict/src/services.ts
@@ -53,7 +53,7 @@ export default class ServiceWrapper implements vscode.Disposable {
 		// using the merge editor we disable this extension - for the merge editor but also
 		// for "other" editors
 		const gitConfig = vscode.workspace.getConfiguration('git');
-		if (gitConfig.get<boolean>('experimental.mergeEditor')) {
+		if (gitConfig.get<boolean>('mergeEditor')) {
 			return {
 				enableCodeLens: false,
 				enableDecorations: false,


### PR DESCRIPTION
- rename setting to `git.mergeEditor`, no more experimental
- enable merge editor for the team
