### PR TITLE
joh/issue152834

### DIFF
--- a/extensions/references-view/src/references-view.d.ts
+++ b/extensions/references-view/src/references-view.d.ts
@@ -6,14 +6,14 @@
 import * as vscode from 'vscode';
 
 /**
- * This interface describes the shape for the references viewlet API. It consists 
- * of a single `setInput` function which must be called with a full implementation 
+ * This interface describes the shape for the references viewlet API. It consists
+ * of a single `setInput` function which must be called with a full implementation
  * of the `SymbolTreeInput`-interface. To acquire this API use the default mechanics, e.g:
- * 
+ *
  * ```ts
  * // get references viewlet API
- * const api = await vscode.extensions.getExtension<SymbolTree>('ms-vscode.references-view').activate();
- * 
+ * const api = await vscode.extensions.getExtension<SymbolTree>('vscode.references-view').activate();
+ *
  * // instantiate and set input which updates the view
  * const myInput: SymbolTreeInput<MyItems> = ...
  * api.setInput(myInput)
@@ -22,8 +22,8 @@ import * as vscode from 'vscode';
 export interface SymbolTree {
 
 	/**
-	 * Set the contents of the references viewlet. 
-	 * 
+	 * Set the contents of the references viewlet.
+	 *
 	 * @param input A symbol tree input object
 	 */
 	setInput(input: SymbolTreeInput<unknown>): void;
@@ -31,7 +31,7 @@ export interface SymbolTree {
 
 /**
  * A symbol tree input is the entry point for populating the references viewlet.
- * Inputs must be anchored at a code location, they must have a title, and they 
+ * Inputs must be anchored at a code location, they must have a title, and they
  * must resolve to a model.
  */
 export interface SymbolTreeInput<T> {
@@ -54,17 +54,17 @@ export interface SymbolTreeInput<T> {
 	readonly location: vscode.Location;
 
 	/**
-	 * Resolve this input to a model that contains the actual data. When there are no result 
+	 * Resolve this input to a model that contains the actual data. When there are no result
 	 * than `undefined` or `null` should be returned.
 	 */
 	resolve(): vscode.ProviderResult<SymbolTreeModel<T>>;
 
 	/**
 	 * This function is called when re-running from history. The symbols tree has tracked
-	 * the original location of this input and that is now passed to this input. The 
+	 * the original location of this input and that is now passed to this input. The
 	 * implementation of this function should return a clone where the `location`-property
 	 * uses the provided `location`
-	 * 
+	 *
 	 * @param location The location at which the new input should be anchored.
 	 * @returns A new input which location is anchored at the position.
 	 */
@@ -94,7 +94,7 @@ export interface SymbolTreeModel<T> {
 	navigation?: SymbolItemNavigation<T>;
 
 	/**
-	 * Optional support for editor highlights. WHen implemented, the editor will highlight 
+	 * Optional support for editor highlights. WHen implemented, the editor will highlight
 	 * symbol ranges in the source code.
 	 */
 	highlights?: SymbolItemEditorHighlights<T>;

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -92,6 +92,7 @@ import { ExtHostInteractive } from 'vs/workbench/api/common/extHostInteractive';
 import { combinedDisposable } from 'vs/base/common/lifecycle';
 import { checkProposedApiEnabled, ExtensionIdentifierSet, isProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
 import { DebugConfigurationProviderTriggerKind } from 'vs/workbench/contrib/debug/common/debug';
+import { equalsIgnoreCase } from 'vs/base/common/strings';
 
 export interface IExtensionRegistries {
 	mine: ExtensionDescriptionRegistry;
@@ -392,6 +393,11 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 
 		const extensions: typeof vscode.extensions = {
 			getExtension(extensionId: string, includeFromDifferentExtensionHosts?: boolean): vscode.Extension<any> | undefined {
+				if (equalsIgnoreCase(extensionId, 'ms-vscode.references-view')) {
+					extHostApiDeprecation.report(`The extension 'ms-vscode.references-view' has been renamed.`, extension, `Use 'vscode.references-view' instead.`);
+					extensionId = 'vscode.references-view';
+				}
+
 				if (!isProposedApiEnabled(extension, 'extensionsAny')) {
 					includeFromDifferentExtensionHosts = false;
 				}


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/152834 but I am planning on removing this aliasing very soon after

- update sample
- dynamically alias `ms-vscode.references-view` onto `vscode.references-view`
