### PR TITLE
Use more standard values for scheme constants

### DIFF
--- a/extensions/markdown-language-features/src/commands/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/commands/openDocumentLink.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { Command } from '../commandManager';
 import { MdTableOfContentsProvider } from '../tableOfContents';
 import { openDocumentLink } from '../util/openDocumentLink';
+import { Schemes } from '../util/schemes';
 
 type UriComponents = {
 	readonly scheme?: string;
@@ -59,7 +60,7 @@ export class OpenDocumentLinkCommand implements Command {
 }
 
 function reviveUri(parts: any) {
-	if (parts.scheme === 'file') {
+	if (parts.scheme === Schemes.file) {
 		return vscode.Uri.file(parts.path);
 	}
 	return vscode.Uri.parse('').with(parts);

--- a/extensions/markdown-language-features/src/languageFeatures/pathCompletions.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/pathCompletions.ts
@@ -9,6 +9,7 @@ import { IMdParser } from '../markdownEngine';
 import { TableOfContents } from '../tableOfContents';
 import { ITextDocument } from '../types/textDocument';
 import { resolveUriToMarkdownFile } from '../util/openDocumentLink';
+import { Schemes } from '../util/schemes';
 import { IMdWorkspace } from '../workspace';
 import { MdLinkProvider } from './documentLinks';
 
@@ -324,7 +325,7 @@ export class MdVsCodePathCompletionProvider implements vscode.CompletionItemProv
 
 	private resolvePath(root: vscode.Uri, ref: string): vscode.Uri | undefined {
 		try {
-			if (root.scheme === 'file') {
+			if (root.scheme === Schemes.file) {
 				return vscode.Uri.file(resolve(dirname(root.fsPath), ref));
 			} else {
 				return root.with({

--- a/extensions/markdown-language-features/src/util/schemes.ts
+++ b/extensions/markdown-language-features/src/util/schemes.ts
@@ -5,21 +5,21 @@
 
 import * as vscode from 'vscode';
 
-export const Schemes = {
-	http: 'http:',
-	https: 'https:',
-	file: 'file:',
+export const Schemes = Object.freeze({
+	http: 'http',
+	https: 'https',
+	file: 'file',
 	untitled: 'untitled',
-	mailto: 'mailto:',
-	data: 'data:',
-	vscode: 'vscode:',
-	'vscode-insiders': 'vscode-insiders:',
+	mailto: 'mailto',
+	data: 'data',
+	vscode: 'vscode',
+	'vscode-insiders': 'vscode-insiders',
 	notebookCell: 'vscode-notebook-cell',
-};
+});
 
 const knownSchemes = [
 	...Object.values(Schemes),
-	`${vscode.env.uriScheme}:`
+	`${vscode.env.uriScheme}`
 ];
 
 export function getUriForLinkWithKnownExternalScheme(link: string): vscode.Uri | undefined {
@@ -31,5 +31,5 @@ export function getUriForLinkWithKnownExternalScheme(link: string): vscode.Uri |
 }
 
 export function isOfScheme(scheme: string, link: string): boolean {
-	return link.toLowerCase().startsWith(scheme);
+	return link.toLowerCase().startsWith(scheme + ':');
 }


### PR DESCRIPTION
This drops the `:` from the scheme constants as it was easy to misuse this


