### PR TITLE
Fix inlay hints being offset by 1px in some cases

### DIFF
--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
@@ -468,7 +468,7 @@ export class InlayHintsController implements IEditorContribution {
 
 
 		//
-		const { fontSize, fontFamily, padding } = this._getLayoutInfo();
+		const { fontSize, fontFamily, padding, isUniform } = this._getLayoutInfo();
 		const fontFamilyVar = '--code-editorInlayHintsFontFamily';
 		this._editor.getContainerDomNode().style.setProperty(fontFamilyVar, fontFamily);
 
@@ -493,7 +493,7 @@ export class InlayHintsController implements IEditorContribution {
 				const cssProperties: CssProperties = {
 					fontSize: `${fontSize}px`,
 					fontFamily: `var(${fontFamilyVar}), ${EDITOR_FONT_DEFAULTS.fontFamily}`,
-					verticalAlign: 'middle',
+					verticalAlign: isUniform ? 'baseline' : 'middle',
 				};
 
 				if (isNonEmptyArray(item.hint.textEdits)) {
@@ -587,13 +587,23 @@ export class InlayHintsController implements IEditorContribution {
 
 	private _getLayoutInfo() {
 		const options = this._editor.getOption(EditorOption.inlayHints);
+		const padding = options.padding;
+
 		const editorFontSize = this._editor.getOption(EditorOption.fontSize);
+		const editorFontFamily = this._editor.getOption(EditorOption.fontFamily);
+
 		let fontSize = options.fontSize;
 		if (!fontSize || fontSize < 5 || fontSize > editorFontSize) {
 			fontSize = editorFontSize;
 		}
-		const fontFamily = options.fontFamily || this._editor.getOption(EditorOption.fontFamily);
-		return { fontSize, fontFamily, padding: options.padding };
+
+		const fontFamily = options.fontFamily || editorFontFamily;
+
+		const isUniform = !padding
+			&& fontFamily === editorFontFamily
+			&& fontSize === editorFontSize;
+
+		return { fontSize, fontFamily, padding, isUniform };
 	}
 
 	private _removeAllDecorations(): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #153419

VS Code previously applied the `vertical-align: middle` CSS rule to all hints, even those that have the same font style as the editor's. This results in inlay hints being 1px lower than they should be.

![2022-06-22_17-39-32_Code](https://user-images.githubusercontent.com/25177071/176107161-a6efb7c9-cdd5-4fc3-a10f-9ee6f5b8382f.png)

This pull request adds the `isUniform` flag to `_getLayoutInfo()`'s output. It indicates if the inlay hint styles and editor styles match. If they do, the `vertical-align` rule is set to `baseline`, effectively disabling it.