### PR TITLE
Add Expand all button in explorer view

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -8,7 +8,7 @@ import { URI } from 'vs/base/common/uri';
 import * as perf from 'vs/base/common/performance';
 import { IAction, WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification } from 'vs/base/common/actions';
 import { memoize } from 'vs/base/common/decorators';
-import { IFilesConfiguration, ExplorerFolderContext, FilesExplorerFocusedContext, ExplorerFocusedContext, ExplorerRootContext, ExplorerResourceReadonlyContext, ExplorerResourceCut, ExplorerResourceMoveableToTrash, ExplorerCompressedFocusContext, ExplorerCompressedFirstFocusContext, ExplorerCompressedLastFocusContext, ExplorerResourceAvailableEditorIdsContext, VIEW_ID, VIEWLET_ID, ExplorerResourceNotReadonlyContext } from 'vs/workbench/contrib/files/common/files';
+import { IFilesConfiguration, ExplorerFolderContext, FilesExplorerFocusedContext, ExplorerFocusedContext, ExplorerRootContext, ExplorerResourceReadonlyContext, ExplorerResourceCut, ExplorerResourceMoveableToTrash, ExplorerCompressedFocusContext, ExplorerCompressedFirstFocusContext, ExplorerCompressedLastFocusContext, ExplorerResourceAvailableEditorIdsContext, VIEW_ID, VIEWLET_ID, ExplorerResourceNotReadonlyContext, ViewHasSomeCollapsibleRootItemContext } from 'vs/workbench/contrib/files/common/files';
 import { FileCopiedContext, NEW_FILE_COMMAND_ID, NEW_FOLDER_COMMAND_ID } from 'vs/workbench/contrib/files/browser/fileActions';
 import * as DOM from 'vs/base/browser/dom';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
@@ -67,13 +67,19 @@ interface IExplorerViewStyles {
 	listDropBackground?: Color;
 }
 
-function hasExpandedRootChild(tree: WorkbenchCompressibleAsyncDataTree<ExplorerItem | ExplorerItem[], ExplorerItem, FuzzyScore>, treeInput: ExplorerItem[]): boolean {
-	for (const folder of treeInput) {
-		if (tree.hasNode(folder) && !tree.isCollapsed(folder)) {
-			for (const [, child] of folder.children.entries()) {
-				if (tree.hasNode(child) && tree.isCollapsible(child) && !tree.isCollapsed(child)) {
-					return true;
-				}
+// Accepts a single or multiple workspace folders
+function hasExpandedRootChild(tree: WorkbenchCompressibleAsyncDataTree<ExplorerItem | ExplorerItem[], ExplorerItem, FuzzyScore>, treeInput: ExplorerItem | ExplorerItem[]): boolean {
+	const inputsToCheck = [];
+	if (Array.isArray(treeInput)) {
+		inputsToCheck.push(...treeInput.filter(folder => tree.hasNode(folder) && !tree.isCollapsed(folder)));
+	} else {
+		inputsToCheck.push(treeInput);
+	}
+
+	for (const folder of inputsToCheck) {
+		for (const [, child] of folder.children.entries()) {
+			if (tree.hasNode(child) && tree.isCollapsible(child) && !tree.isCollapsed(child)) {
+				return true;
 			}
 		}
 	}
@@ -161,6 +167,8 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 	private compressedFocusFirstContext: IContextKey<boolean>;
 	private compressedFocusLastContext: IContextKey<boolean>;
 
+	private viewHasSomeCollapsibleRootItem: IContextKey<boolean>;
+
 	private horizontalScrolling: boolean | undefined;
 
 	private dragHandler!: DelayedDragHandler;
@@ -207,6 +215,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 		this.compressedFocusContext = ExplorerCompressedFocusContext.bindTo(contextKeyService);
 		this.compressedFocusFirstContext = ExplorerCompressedFirstFocusContext.bindTo(contextKeyService);
 		this.compressedFocusLastContext = ExplorerCompressedLastFocusContext.bindTo(contextKeyService);
+		this.viewHasSomeCollapsibleRootItem = ViewHasSomeCollapsibleRootItemContext.bindTo(contextKeyService);
 
 		this.explorerService.registerView(this);
 	}
@@ -493,6 +502,9 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 			}
 		}));
 
+		this._register(this.tree.onDidChangeCollapseState(() => this.updateAnyCollapsedContext()));
+		this.updateAnyCollapsedContext();
+
 		this._register(this.tree.onMouseDblClick(e => {
 			if (e.element === null) {
 				// click in empty area -> create a new file #116676
@@ -769,6 +781,23 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 		}
 	}
 
+	expandAll(): void {
+		if (this.explorerService.isEditable(undefined)) {
+			this.tree.domFocus();
+		}
+
+		const treeInput = this.tree.getInput();
+		if (Array.isArray(treeInput)) {
+			treeInput.forEach(folder => {
+				folder.children.forEach(child => this.tree.hasNode(child) && this.tree.expand(child, true));
+			});
+
+			return;
+		}
+
+		this.tree.expandAll();
+	}
+
 	collapseAll(): void {
 		if (this.explorerService.isEditable(undefined)) {
 			this.tree.domFocus();
@@ -835,6 +864,14 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 	private updateCompressedNavigationContextKeys(controller: ICompressedNavigationController): void {
 		this.compressedFocusFirstContext.set(controller.index === 0);
 		this.compressedFocusLastContext.set(controller.index === controller.count - 1);
+	}
+
+	private updateAnyCollapsedContext(): void {
+		const treeInput = this.tree.getInput();
+		if (treeInput === undefined) {
+			return;
+		}
+		this.viewHasSomeCollapsibleRootItem.set(hasExpandedRootChild(this.tree, treeInput));
 	}
 
 	styleListDropBackground(styles: IExplorerViewStyles): void {
@@ -951,7 +988,7 @@ registerAction2(class extends Action2 {
 			menu: {
 				id: MenuId.ViewTitle,
 				group: 'navigation',
-				when: ContextKeyExpr.equals('view', VIEW_ID),
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('view', VIEW_ID), ViewHasSomeCollapsibleRootItemContext),
 				order: 40
 			}
 		});
@@ -961,5 +998,28 @@ registerAction2(class extends Action2 {
 		const viewsService = accessor.get(IViewsService);
 		const explorerView = viewsService.getViewWithId(VIEW_ID) as ExplorerView;
 		explorerView.collapseAll();
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.files.action.expandExplorerFolders',
+			title: { value: nls.localize('expandExplorerFolders', "Expand Folders in Explorer"), original: 'Expand Folders in Explorer' },
+			f1: true,
+			icon: Codicon.expandAll,
+			menu: {
+				id: MenuId.ViewTitle,
+				group: 'navigation',
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('view', VIEW_ID), ViewHasSomeCollapsibleRootItemContext.toNegated()),
+				order: 40
+			}
+		});
+	}
+
+	run(accessor: ServicesAccessor) {
+		const viewsService = accessor.get(IViewsService);
+		const explorerView = viewsService.getViewWithId(VIEW_ID) as ExplorerView;
+		explorerView.expandAll();
 	}
 });

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -56,6 +56,8 @@ export const ExplorerCompressedFocusContext = new RawContextKey<boolean>('explor
 export const ExplorerCompressedFirstFocusContext = new RawContextKey<boolean>('explorerViewletCompressedFirstFocus', true, { type: 'boolean', description: localize('explorerViewletCompressedFirstFocus', "True when the focus is inside a compact item's first part in the EXPLORER view.") });
 export const ExplorerCompressedLastFocusContext = new RawContextKey<boolean>('explorerViewletCompressedLastFocus', true, { type: 'boolean', description: localize('explorerViewletCompressedLastFocus', "True when the focus is inside a compact item's last part in the EXPLORER view.") });
 
+export const ViewHasSomeCollapsibleRootItemContext = new RawContextKey<boolean>('viewHasSomeCollapsibleItem', false, { type: 'boolean', description: localize('viewHasSomeCollapsibleItem', "True when a workspace in the EXPLORER view has some collapsible root child.") });
+
 export const FilesExplorerFocusCondition = ContextKeyExpr.and(ExplorerViewletVisibleContext, FilesExplorerFocusedContext, ContextKeyExpr.not(InputFocusedContextKey));
 export const ExplorerFocusCondition = ContextKeyExpr.and(ExplorerViewletVisibleContext, ExplorerFocusedContext, ContextKeyExpr.not(InputFocusedContextKey));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #88682

Demo:

https://user-images.githubusercontent.com/20613660/176315086-ea0f3a8f-9fcd-418a-a0b3-9cc7f459c2a8.mp4


Added changes:
* New `RawContextKey` `ViewHasSomeCollapsibleRootItemContext` that tracks tree status for swapping buttons
* `hasExpandedRootChild` updated to work with a non-workspace tree as well
* `updateAnyCollapsedContext` updates `ViewHasSomeCollapsibleRootItemContext` using `onDidChangeCollapseState`
* new `Action2` that is mostly a copy of "Collapse All"

This button behaves like the exact opposite of the "Collapse All" button, and only shows when all root folders in all open workspace folders are collapsed (does not check closed workspace folders)
* However just like "Collapse All", running "Expand All" will affect root folders within closed workspace folders (should this behaviour be changed)

Other considerations:
* Performance impact of `onDidChangeCollapseState`, this seems to run for every visible item once, so for a large workspace triggers lots of calls when using "Expand All" or "Collapse All". Could go by the comment of @JacksonKearl to make "Expand All" be the Alt-click action of "Collapse All" so the button does not have to update. (Although I don't know how to get the MouseEvent from inside the Action2 `run` function)
* Make both expand/collapse button not run on closed Workspace folders