### PR TITLE
Remove info icons from Settings editor indicators + other small fixes

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -351,6 +351,12 @@
 	font-style: italic;
 }
 
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title > .misc-label .setting-item-overrides:hover,
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title > .misc-label .setting-item-ignored:hover,
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title > .misc-label .setting-item-default-overridden:hover {
+	text-decoration: underline;
+}
+
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .codicon {
 	vertical-align: middle;
 	padding-left: 1px;

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -37,6 +37,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 	private scopeOverridesElement: HTMLElement;
 	private scopeOverridesLabel: SimpleIconLabel;
 	private syncIgnoredElement: HTMLElement;
+	private syncIgnoredHover: ICustomHover | undefined;
 	private defaultOverrideIndicatorElement: HTMLElement;
 	private hoverDelegate: IHoverDelegate;
 	private hover: ICustomHover | undefined;
@@ -60,6 +61,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 			showHover: (options: IHoverDelegateOptions, focus?: boolean) => {
 				return hoverService.showHover(options, focus);
 			},
+			onDidHideHover: () => { },
 			delay: configurationService.getValue<number>('workbench.hover.delay'),
 			placement: 'element'
 		};
@@ -74,16 +76,16 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 	private createSyncIgnoredElement(): HTMLElement {
 		const syncIgnoredElement = $('span.setting-item-ignored');
 		const syncIgnoredLabel = new SimpleIconLabel(syncIgnoredElement);
-		syncIgnoredLabel.text = '$(info) ' + localize('extensionSyncIgnoredLabel', 'Not synced');
+		syncIgnoredLabel.text = localize('extensionSyncIgnoredLabel', 'Not synced');
 		const syncIgnoredHoverContent = localize('syncIgnoredTitle', "This setting is ignored during sync");
-		setupCustomHover(this.hoverDelegate, syncIgnoredElement, syncIgnoredHoverContent);
+		this.syncIgnoredHover = setupCustomHover(this.hoverDelegate, syncIgnoredElement, syncIgnoredHoverContent);
 		return syncIgnoredElement;
 	}
 
 	private createDefaultOverrideIndicator(): HTMLElement {
 		const defaultOverrideIndicator = $('span.setting-item-default-overridden');
 		const defaultOverrideLabel = new SimpleIconLabel(defaultOverrideIndicator);
-		defaultOverrideLabel.text = '$(info) ' + localize('defaultOverriddenLabel', "Default value changed");
+		defaultOverrideLabel.text = localize('defaultOverriddenLabel', "Default value changed");
 		return defaultOverrideIndicator;
 	}
 
@@ -125,6 +127,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 
 	dispose() {
 		this.hover?.dispose();
+		this.syncIgnoredHover?.dispose();
 	}
 
 	updateScopeOverrides(element: SettingsTreeSettingElement, elementDisposables: DisposableStore, onDidClickOverrideElement: Emitter<ISettingOverrideClickEvent>) {
@@ -167,8 +170,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 				// show the text in a custom hover only if
 				// the feature flag isn't on.
 				this.scopeOverridesElement.style.display = 'inline';
-				let scopeOverridesLabelText = '$(info) ';
-				scopeOverridesLabelText += element.isConfigured ?
+				const scopeOverridesLabelText = element.isConfigured ?
 					localize('alsoConfiguredElsewhere', "Also modified elsewhere") :
 					localize('configuredElsewhere', "Modified elsewhere");
 				this.scopeOverridesLabel.text = scopeOverridesLabelText;


### PR DESCRIPTION
Fixes #153420 
Fixes #153574 
Fixes #153576
Fixes #153578
Fixes #153586
Fixes https://github.com/microsoft/vscode/issues/153638

- Remove info icons
- Add underline when hovering over indicators
- Handle sync ignored hover properly

![A screencap showing the removed info icons and that there's an underline that shows up when hovering over indicators](https://user-images.githubusercontent.com/7199958/176320627-53b89918-0849-446c-b7be-1a3d7308b912.gif)
