### PR TITLE
calling `executeCommand` for a locally known extension cmd should fire activation event

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadCommands.ts
@@ -74,6 +74,15 @@ export class MainThreadCommands implements MainThreadCommandsShape {
 		}
 	}
 
+	$fireCommandActivationEvent(id: string): void {
+		const activationEvent = `onCommand:${id}`;
+		if (!this._extensionService.activationEventIsDone(activationEvent)) {
+			// this is NOT awaited because we only use it as drive-by-activation
+			// for commands that are already known inside the extension host
+			this._extensionService.activateByEvent(activationEvent);
+		}
+	}
+
 	async $executeCommand<T>(id: string, args: any[] | SerializableObjectWithBuffers<any[]>, retry: boolean): Promise<T | undefined> {
 		if (args instanceof SerializableObjectWithBuffers) {
 			args = args.value;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -92,6 +92,7 @@ export interface MainThreadClipboardShape extends IDisposable {
 export interface MainThreadCommandsShape extends IDisposable {
 	$registerCommand(id: string): void;
 	$unregisterCommand(id: string): void;
+	$fireCommandActivationEvent(id: string): void;
 	$executeCommand(id: string, args: any[] | SerializableObjectWithBuffers<any[]>, retry: boolean): Promise<unknown | undefined>;
 	$getCommands(): Promise<string[]>;
 }

--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -169,8 +169,11 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 	private async _doExecuteCommand<T>(id: string, args: any[], retry: boolean): Promise<T> {
 
 		if (this._commands.has(id)) {
-			// we stay inside the extension host and support
-			// to pass any kind of parameters around
+			// - We stay inside the extension host and support
+			// 	 to pass any kind of parameters around.
+			// - We still emit the corresponding activation event
+			//   BUT we don't await that event
+			this.#proxy.$fireCommandActivationEvent(id);
 			return this._executeContributedCommand<T>(id, args, false);
 
 		} else {

--- a/src/vs/workbench/api/test/browser/extHostCommands.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostCommands.test.ts
@@ -90,4 +90,28 @@ suite('ExtHostCommands', function () {
 		assert.strictEqual(result, 17);
 		assert.strictEqual(count, 2);
 	});
+
+	test('onCommand:abc activates extensions when executed from command palette, but not when executed programmatically with vscode.commands.executeCommand #150293', async function () {
+
+		const activationEvents: string[] = [];
+
+		const shape = new class extends mock<MainThreadCommandsShape>() {
+			override $registerCommand(id: string): void {
+				//
+			}
+			override $fireCommandActivationEvent(id: string): void {
+				activationEvents.push(id);
+			}
+		};
+		const commands = new ExtHostCommands(
+			SingleProxyRPCProtocol(shape),
+			new NullLogService()
+		);
+
+		commands.registerCommand(true, 'extCmd', (args: any): any => args);
+
+		const result = await commands.executeCommand('extCmd', this);
+		assert.strictEqual(result, this);
+		assert.deepStrictEqual(activationEvents, ['extCmd']);
+	});
 });


### PR DESCRIPTION
We should always fire the event but when the command is already known (locally) we don't await that.

fixes https://github.com/microsoft/vscode/issues/150293
