### PR TITLE
Use English as the default instead of navigator.language

### DIFF
--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -68,7 +68,6 @@ const isElectronRenderer = isElectronProcess && nodeProcess?.type === 'renderer'
 
 interface INavigator {
 	userAgent: string;
-	language: string;
 	maxTouchPoints?: number;
 }
 declare const navigator: INavigator;
@@ -90,7 +89,7 @@ if (typeof navigator === 'object' && !isElectronRenderer) {
 		nls.localize({ key: 'ensureLoaderPluginIsLoaded', comment: ['{Locked}'] }, '_')
 	);
 
-	_locale = configuredLocale || navigator.language;
+	_locale = configuredLocale || LANGUAGE_DEFAULT;
 
 	_language = _locale;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/vscode-internalbacklog/issues/2978

So that English is properly chosen as the current language being used for the session if we don't have a language pack for the navigator.language language.