### PR TITLE
Git - "Commit & Push" command now publishes the branch if there is no tracking remote

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1625,7 +1625,7 @@ export class CommandCenter {
 
 		const postCommitCommand = config.get<'none' | 'push' | 'sync'>('postCommitCommand');
 		if ((opts.postCommitCommand === undefined && postCommitCommand === 'push') || opts.postCommitCommand === 'push') {
-			await this._push(repository, { pushType: PushType.Push, silent: true });
+			await this._push(repository, { pushType: PushType.Push });
 		}
 		if ((opts.postCommitCommand === undefined && postCommitCommand === 'sync') || opts.postCommitCommand === 'sync') {
 			await this.sync(repository);


### PR DESCRIPTION
Fix #153511