### PR TITLE
Make tree view always write `text/uri-list`

### DIFF
--- a/src/vs/editor/browser/dnd.ts
+++ b/src/vs/editor/browser/dnd.ts
@@ -41,8 +41,8 @@ const INTERNAL_DND_MIME_TYPES = Object.freeze([
 	DataTransfers.RESOURCES,
 ]);
 
-export function addExternalEditorsDropData(dataTransfer: VSDataTransfer, dragEvent: DragEvent) {
-	if (dragEvent.dataTransfer && !dataTransfer.has(Mimes.uriList)) {
+export function addExternalEditorsDropData(dataTransfer: VSDataTransfer, dragEvent: DragEvent, overwriteUriList = false) {
+	if (dragEvent.dataTransfer && (overwriteUriList || !dataTransfer.has(Mimes.uriList))) {
 		const editorData = extractEditorsDropData(dragEvent)
 			.filter(input => input.resource)
 			.map(input => input.resource!.toString());

--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -1495,7 +1495,7 @@ export class CustomTreeViewDragAndDrop implements ITreeDragAndDrop<ITreeItem> {
 		}
 
 		const originalDataTransfer = toVSDataTransfer(originalEvent.dataTransfer);
-		addExternalEditorsDropData(originalDataTransfer, originalEvent);
+		addExternalEditorsDropData(originalDataTransfer, originalEvent, true);
 
 		const outDataTransfer = new VSDataTransfer();
 		for (const [type, item] of originalDataTransfer.entries()) {


### PR DESCRIPTION
Fixes #152836

This forces the treeview to always write `text/uri-list` when it can. Previouly we only wrote it when there was not already a `text/uri-list` on the data transfer

I have no clue where the original `text/uri-list` is coming from and it only seems to get set on windows
