### PR TITLE
Edit showFoldingControls to have a never setting

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -563,7 +563,7 @@ export interface IEditorOptions {
 	 * Controls whether the fold actions in the gutter stay always visible or hide unless the mouse is over the gutter.
 	 * Defaults to 'mouseover'.
 	 */
-	showFoldingControls?: 'always' | 'mouseover';
+	showFoldingControls?: 'always' | 'never' | 'mouseover';
 	/**
 	 * Controls whether clicking on the empty content after a folded line will unfold the line.
 	 * Defaults to false.
@@ -2331,6 +2331,7 @@ export class EditorLayoutInfoComputer extends ComputedEditorOption<EditorOption.
 
 		const rawLineDecorationsWidth = options.get(EditorOption.lineDecorationsWidth);
 		const folding = options.get(EditorOption.folding);
+		const showFoldingDecoration = options.get(EditorOption.showFoldingControls) !== 'never';
 
 		let lineDecorationsWidth: number;
 		if (typeof rawLineDecorationsWidth === 'string' && /^\d+(\.\d+)?ch$/.test(rawLineDecorationsWidth)) {
@@ -2339,7 +2340,7 @@ export class EditorLayoutInfoComputer extends ComputedEditorOption<EditorOption.
 		} else {
 			lineDecorationsWidth = EditorIntOption.clampedInt(rawLineDecorationsWidth, 0, 0, 1000);
 		}
-		if (folding) {
+		if (folding && showFoldingDecoration) {
 			lineDecorationsWidth += 16;
 		}
 
@@ -5039,11 +5040,12 @@ export const EditorOptions = {
 	)),
 	showFoldingControls: register(new EditorStringEnumOption(
 		EditorOption.showFoldingControls, 'showFoldingControls',
-		'mouseover' as 'always' | 'mouseover',
-		['always', 'mouseover'] as const,
+		'mouseover' as 'always' | 'never' | 'mouseover',
+		['always', 'never', 'mouseover'] as const,
 		{
 			enumDescriptions: [
 				nls.localize('showFoldingControls.always', "Always show the folding controls."),
+				nls.localize('showFoldingControls.never', "Never show the folding controls and reduce the gutter size."),
 				nls.localize('showFoldingControls.mouseover', "Only show the folding controls when the mouse is over the gutter."),
 			],
 			description: nls.localize('showFoldingControls', "Controls when the folding controls on the gutter are shown.")

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -127,7 +127,7 @@ export class FoldingController extends Disposable implements IEditorContribution
 		this.mouseDownInfo = null;
 
 		this.foldingDecorationProvider = new FoldingDecorationProvider(editor);
-		this.foldingDecorationProvider.autoHideFoldingControls = options.get(EditorOption.showFoldingControls) === 'mouseover';
+		this.foldingDecorationProvider.showFoldingControls = options.get(EditorOption.showFoldingControls);
 		this.foldingDecorationProvider.showFoldingHighlights = options.get(EditorOption.foldingHighlight);
 		this.foldingEnabled = CONTEXT_FOLDING_ENABLED.bindTo(this.contextKeyService);
 		this.foldingEnabled.set(this._isEnabled);
@@ -159,7 +159,7 @@ export class FoldingController extends Disposable implements IEditorContribution
 			}
 			if (e.hasChanged(EditorOption.showFoldingControls) || e.hasChanged(EditorOption.foldingHighlight)) {
 				const options = this.editor.getOptions();
-				this.foldingDecorationProvider.autoHideFoldingControls = options.get(EditorOption.showFoldingControls) === 'mouseover';
+				this.foldingDecorationProvider.showFoldingControls = options.get(EditorOption.showFoldingControls);
 				this.foldingDecorationProvider.showFoldingHighlights = options.get(EditorOption.foldingHighlight);
 				this.triggerFoldingModelChanged();
 			}

--- a/src/vs/editor/contrib/folding/browser/foldingDecorations.ts
+++ b/src/vs/editor/contrib/folding/browser/foldingDecorations.ts
@@ -52,7 +52,7 @@ export class FoldingDecorationProvider implements IDecorationProvider {
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges
 	});
 
-	public autoHideFoldingControls: boolean = true;
+	public showFoldingControls: 'always' | 'never' | 'mouseover' = 'mouseover';
 
 	public showFoldingHighlights: boolean = true;
 
@@ -60,12 +60,12 @@ export class FoldingDecorationProvider implements IDecorationProvider {
 	}
 
 	getDecorationOption(isCollapsed: boolean, isHidden: boolean): ModelDecorationOptions {
-		if (isHidden) {
+		if (isHidden || this.showFoldingControls === 'never') {
 			return FoldingDecorationProvider.HIDDEN_RANGE_DECORATION;
 		}
 		if (isCollapsed) {
 			return this.showFoldingHighlights ? FoldingDecorationProvider.COLLAPSED_HIGHLIGHTED_VISUAL_DECORATION : FoldingDecorationProvider.COLLAPSED_VISUAL_DECORATION;
-		} else if (this.autoHideFoldingControls) {
+		} else if (this.showFoldingControls === 'mouseover') {
 			return FoldingDecorationProvider.EXPANDED_AUTO_HIDE_VISUAL_DECORATION;
 		} else {
 			return FoldingDecorationProvider.EXPANDED_VISUAL_DECORATION;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3325,7 +3325,7 @@ declare namespace monaco.editor {
 		 * Controls whether the fold actions in the gutter stay always visible or hide unless the mouse is over the gutter.
 		 * Defaults to 'mouseover'.
 		 */
-		showFoldingControls?: 'always' | 'mouseover';
+		showFoldingControls?: 'always' | 'never' | 'mouseover';
 		/**
 		 * Controls whether clicking on the empty content after a folded line will unfold the line.
 		 * Defaults to false.
@@ -4539,7 +4539,7 @@ declare namespace monaco.editor {
 		selectionClipboard: IEditorOption<EditorOption.selectionClipboard, boolean>;
 		selectionHighlight: IEditorOption<EditorOption.selectionHighlight, boolean>;
 		selectOnLineNumbers: IEditorOption<EditorOption.selectOnLineNumbers, boolean>;
-		showFoldingControls: IEditorOption<EditorOption.showFoldingControls, 'always' | 'mouseover'>;
+		showFoldingControls: IEditorOption<EditorOption.showFoldingControls, 'always' | 'never' | 'mouseover'>;
 		showUnused: IEditorOption<EditorOption.showUnused, boolean>;
 		showDeprecated: IEditorOption<EditorOption.showDeprecated, boolean>;
 		inlayHints: IEditorOption<EditorOption.inlayHints, Readonly<Required<IEditorInlayHintsOptions>>>;

--- a/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
@@ -859,7 +859,7 @@ export class CommentController implements IEditorContribution {
 				}
 
 				const options = this.editor.getOptions();
-				if (options.get(EditorOption.folding)) {
+				if (options.get(EditorOption.folding) && options.get(EditorOption.showFoldingControls) !== 'never') {
 					lineDecorationsWidth -= 16;
 				}
 				lineDecorationsWidth += 9;

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -846,9 +846,10 @@ configurationRegistry.registerConfiguration({
 		[NotebookSetting.showFoldingControls]: {
 			description: nls.localize('notebook.showFoldingControls.description', "Controls when the Markdown header folding arrow is shown."),
 			type: 'string',
-			enum: ['always', 'mouseover'],
+			enum: ['always', 'never', 'mouseover'],
 			enumDescriptions: [
 				nls.localize('showFoldingControls.always', "The folding controls are always visible."),
+				nls.localize('showFoldingControls.never', "Never show the folding controls and reduce the gutter size."),
 				nls.localize('showFoldingControls.mouseover', "The folding controls are visible only on mouseover."),
 			],
 			default: 'mouseover',

--- a/src/vs/workbench/contrib/notebook/common/notebookOptions.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookOptions.ts
@@ -59,7 +59,7 @@ export interface NotebookLayoutConfiguration {
 	globalToolbar: boolean;
 	consolidatedOutputButton: boolean;
 	consolidatedRunButton: boolean;
-	showFoldingControls: 'always' | 'mouseover';
+	showFoldingControls: 'always' | 'never' | 'mouseover';
 	dragAndDropEnabled: boolean;
 	fontSize: number;
 	outputFontSize: number;
@@ -385,7 +385,7 @@ export class NotebookOptions extends Disposable {
 	}
 
 	private _computeShowFoldingControlsOption() {
-		return this.configurationService.getValue<'always' | 'mouseover'>(NotebookSetting.showFoldingControls) ?? 'mouseover';
+		return this.configurationService.getValue<'always' | 'never' | 'mouseover'>(NotebookSetting.showFoldingControls) ?? 'mouseover';
 	}
 
 	private _computeFocusIndicatorOption() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #58708

Demo:

https://user-images.githubusercontent.com/20613660/176559025-2964f7c7-02da-4a73-be13-7d4fac621861.mp4


* Add 'never' as a setting with a description to both `editor.showFoldingControls` and `notebook.showFoldingControls`
* Ensure `lineDecorationWidth` is updated with the setting
* Don't show visible folding decorations when set to `never` 

Of consideration:
* Should the setting actually remove the folding decorations instead of using the `hidden` one? Does anything depend on the decorations assumed to be there?
* I edited `commentsEditorContribution` for the gutter size but I don't actually know what this does/how to open this "comment editor"
* What kind of tests could be added for this?