### PR TITLE
chore: update distro

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.69.0",
-  "distro": "a44d562925abc5db8eb21089d4a69ae544b3ec69",
+  "distro": "daf000367ee34d716c5dbdf836b11c06c407ef5f",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
Update for chromium license change in distro, changelog https://github.com/microsoft/vscode-distro/compare/a44d562925abc5db8eb21089d4a69ae544b3ec69...daf000367ee34d716c5dbdf836b11c06c407ef5f

There are also two additional commits apart from my license update commit, which I am not sure is intended for `release/1.69` /cc @isidorn 