### PR TITLE
testing: fix layout issues for long test labels

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -19,10 +19,11 @@
 .test-output-peek-tree .test-peek-item .name {
 	display: flex;
 	align-items: center;
-}
-
-.test-explorer .test-item .label {
-	white-space: pre-wrap;
+	flex-grow: 1;
+	gap: 0.15em;
+	width: 0;
+	overflow: hidden;
+	white-space: nowrap;
 }
 
 .test-explorer .test-item,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/152959
Fixes https://github.com/microsoft/vscode/issues/152622

Some regressions caused by a PR (adding pre-wrap in an attempt to space icons). Instead use flex gap, and fixup sizing for the actions

<img width="296" alt="image" src="https://user-images.githubusercontent.com/2230985/176730968-57dab05b-2b84-4a21-9947-bb98b7e2e150.png">
