### PR TITLE
Keep block cursor as wide as a typical character when it sits on a tab

### DIFF
--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursor.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursor.ts
@@ -172,7 +172,13 @@ export class ViewCursor {
 		}
 
 		const range = firstVisibleRangeForCharacter.ranges[0];
-		const width = range.width < 1 ? this._typicalHalfwidthCharacterWidth : range.width;
+		const width = (
+			nextGrapheme === '\t'
+				? this._typicalHalfwidthCharacterWidth
+				: (range.width < 1
+					? this._typicalHalfwidthCharacterWidth
+					: range.width)
+		);
 
 		let textContentClassName = '';
 		if (this._cursorStyle === TextEditorCursorStyle.Block) {


### PR DESCRIPTION
Fixes #151959