### PR TITLE
Disable inline completions by default for Emmet

### DIFF
--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -129,7 +129,7 @@
         },
         "emmet.useInlineCompletions": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "markdownDescription": "%emmetUseInlineCompletions%"
         },
         "emmet.preferences": {


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/issues/139247

Currently, due to Emmet not being able to detect the local language properly, especially in JSX files, having inline completions enabled by default sometimes results in extremely incorrect previews showing up.

This PR changes the setting to be disabled by default before the release.