### PR TITLE
Add keybindings for search editor file filters

### DIFF
--- a/src/vs/editor/contrib/find/browser/findModel.ts
+++ b/src/vs/editor/contrib/find/browser/findModel.ts
@@ -51,14 +51,6 @@ export const TogglePreserveCaseKeybinding: IKeybindings = {
 	primary: KeyMod.Alt | KeyCode.KeyP,
 	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyP }
 };
-export const FocusFilesToIncludeKeybinding: IKeybindings = {
-	primary: KeyMod.Alt | KeyCode.KeyF,
-	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyF }
-};
-export const FocusFilesToExcludeKeybinding: IKeybindings = {
-	primary: KeyMod.Alt | KeyMod.Shift | KeyCode.KeyF,
-	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyMod.Shift | KeyCode.KeyF }
-};
 
 export const FIND_IDS = {
 	StartFindAction: 'actions.find',

--- a/src/vs/editor/contrib/find/browser/findModel.ts
+++ b/src/vs/editor/contrib/find/browser/findModel.ts
@@ -51,6 +51,14 @@ export const TogglePreserveCaseKeybinding: IKeybindings = {
 	primary: KeyMod.Alt | KeyCode.KeyP,
 	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyP }
 };
+export const FocusFilesToIncludeKeybinding: IKeybindings = {
+	primary: KeyMod.Alt | KeyCode.KeyF,
+	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyF }
+};
+export const FocusFilesToExcludeKeybinding: IKeybindings = {
+	primary: KeyMod.Alt | KeyMod.Shift | KeyCode.KeyF,
+	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyMod.Shift | KeyCode.KeyF }
+};
 
 export const FIND_IDS = {
 	StartFindAction: 'actions.find',

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -8,7 +8,7 @@ import { extname, isEqual } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { Range } from 'vs/editor/common/core/range';
-import { ToggleCaseSensitiveKeybinding, ToggleRegexKeybinding, ToggleWholeWordKeybinding } from 'vs/editor/contrib/find/browser/findModel';
+import { FocusFilesToExcludeKeybinding, FocusFilesToIncludeKeybinding, ToggleCaseSensitiveKeybinding, ToggleRegexKeybinding, ToggleWholeWordKeybinding } from 'vs/editor/contrib/find/browser/findModel';
 import { localize } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
@@ -41,6 +41,8 @@ import { Disposable } from 'vs/base/common/lifecycle';
 const OpenInEditorCommandId = 'search.action.openInEditor';
 const OpenNewEditorToSideCommandId = 'search.action.openNewEditorToSide';
 const FocusQueryEditorWidgetCommandId = 'search.action.focusQueryEditorWidget';
+const FocusQueryEditorFilesToIncludeCommandId = 'search.action.FocusQueryEditorFilesToInclude';
+const FocusQueryEditorFilesToExcludeCommandId = 'search.action.FocusQueryEditorFilesToExclude';
 
 const ToggleSearchEditorCaseSensitiveCommandId = 'toggleSearchEditorCaseSensitive';
 const ToggleSearchEditorWholeWordCommandId = 'toggleSearchEditorWholeWord';
@@ -370,6 +372,50 @@ registerAction2(class extends Action2 {
 		const input = editorService.activeEditor;
 		if (input instanceof SearchEditorInput) {
 			(editorService.activeEditorPane as SearchEditor).focusSearchInput();
+		}
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: FocusQueryEditorFilesToIncludeCommandId,
+			title: { value: localize('search.action.FocusQueryEditorFilesToIncludeCommandId', "Focus Search Editor Files to Include"), original: 'Focus Search Editor Files to Include' },
+			category,
+			f1: true,
+			precondition: SearchEditorConstants.InSearchEditor,
+			keybinding: Object.assign({
+				weight: KeybindingWeight.WorkbenchContrib,
+			}, FocusFilesToIncludeKeybinding)
+		});
+	}
+	async run(accessor: ServicesAccessor) {
+		const editorService = accessor.get(IEditorService);
+		const input = editorService.activeEditor;
+		if (input instanceof SearchEditorInput) {
+			(editorService.activeEditorPane as SearchEditor).focusFilesToIncludeInput();
+		}
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: FocusQueryEditorFilesToExcludeCommandId,
+			title: { value: localize('search.action.FocusQueryEditorFilesToExcludeCommandId', "Focus Search Editor Files to Exclude"), original: 'Focus Search Editor Files to Exclude' },
+			category,
+			f1: true,
+			precondition: SearchEditorConstants.InSearchEditor,
+			keybinding: Object.assign({
+				weight: KeybindingWeight.WorkbenchContrib,
+			}, FocusFilesToExcludeKeybinding)
+		});
+	}
+	async run(accessor: ServicesAccessor) {
+		const editorService = accessor.get(IEditorService);
+		const input = editorService.activeEditor;
+		if (input instanceof SearchEditorInput) {
+			(editorService.activeEditorPane as SearchEditor).focusFilesToExcludeInput();
 		}
 	}
 });

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -8,7 +8,7 @@ import { extname, isEqual } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { Range } from 'vs/editor/common/core/range';
-import { FocusFilesToExcludeKeybinding, FocusFilesToIncludeKeybinding, ToggleCaseSensitiveKeybinding, ToggleRegexKeybinding, ToggleWholeWordKeybinding } from 'vs/editor/contrib/find/browser/findModel';
+import { ToggleCaseSensitiveKeybinding, ToggleRegexKeybinding, ToggleWholeWordKeybinding } from 'vs/editor/contrib/find/browser/findModel';
 import { localize } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
@@ -41,8 +41,8 @@ import { Disposable } from 'vs/base/common/lifecycle';
 const OpenInEditorCommandId = 'search.action.openInEditor';
 const OpenNewEditorToSideCommandId = 'search.action.openNewEditorToSide';
 const FocusQueryEditorWidgetCommandId = 'search.action.focusQueryEditorWidget';
-const FocusQueryEditorFilesToIncludeCommandId = 'search.action.FocusQueryEditorFilesToInclude';
-const FocusQueryEditorFilesToExcludeCommandId = 'search.action.FocusQueryEditorFilesToExclude';
+const FocusQueryEditorFilesToIncludeCommandId = 'search.action.focusFilesToInclude';
+const FocusQueryEditorFilesToExcludeCommandId = 'search.action.focusFilesToExclude';
 
 const ToggleSearchEditorCaseSensitiveCommandId = 'toggleSearchEditorCaseSensitive';
 const ToggleSearchEditorWholeWordCommandId = 'toggleSearchEditorWholeWord';
@@ -380,13 +380,10 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: FocusQueryEditorFilesToIncludeCommandId,
-			title: { value: localize('search.action.FocusQueryEditorFilesToIncludeCommandId', "Focus Search Editor Files to Include"), original: 'Focus Search Editor Files to Include' },
+			title: { value: localize('search.action.focusFilesToInclude', "Focus Search Editor Files to Include"), original: 'Focus Search Editor Files to Include' },
 			category,
 			f1: true,
 			precondition: SearchEditorConstants.InSearchEditor,
-			keybinding: Object.assign({
-				weight: KeybindingWeight.WorkbenchContrib,
-			}, FocusFilesToIncludeKeybinding)
 		});
 	}
 	async run(accessor: ServicesAccessor) {
@@ -402,13 +399,10 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: FocusQueryEditorFilesToExcludeCommandId,
-			title: { value: localize('search.action.FocusQueryEditorFilesToExcludeCommandId', "Focus Search Editor Files to Exclude"), original: 'Focus Search Editor Files to Exclude' },
+			title: { value: localize('search.action.focusFilesToExclude', "Focus Search Editor Files to Exclude"), original: 'Focus Search Editor Files to Exclude' },
 			category,
 			f1: true,
 			precondition: SearchEditorConstants.InSearchEditor,
-			keybinding: Object.assign({
-				weight: KeybindingWeight.WorkbenchContrib,
-			}, FocusFilesToExcludeKeybinding)
 		});
 	}
 	async run(accessor: ServicesAccessor) {

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
@@ -276,15 +276,17 @@ export class SearchEditor extends AbstractTextCodeEditor<SearchEditorViewState> 
 	}
 
 	focusFilesToIncludeInput() {
-		if (this.showingIncludesExcludes) {
-			this.inputPatternIncludes.focus();
+		if (!this.showingIncludesExcludes) {
+			this.toggleIncludesExcludes(true);
 		}
+		this.inputPatternIncludes.focus();
 	}
 
 	focusFilesToExcludeInput() {
-		if (this.showingIncludesExcludes) {
-			this.inputPatternExcludes.focus();
+		if (!this.showingIncludesExcludes) {
+			this.toggleIncludesExcludes(true);
 		}
+		this.inputPatternExcludes.focus();
 	}
 
 	focusNextInput() {

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
@@ -275,6 +275,18 @@ export class SearchEditor extends AbstractTextCodeEditor<SearchEditorViewState> 
 		this.queryEditorWidget.searchInput.focus();
 	}
 
+	focusFilesToIncludeInput() {
+		if (this.showingIncludesExcludes) {
+			this.inputPatternIncludes.focus();
+		}
+	}
+
+	focusFilesToExcludeInput() {
+		if (this.showingIncludesExcludes) {
+			this.inputPatternExcludes.focus();
+		}
+	}
+
 	focusNextInput() {
 		if (this.queryEditorWidget.searchInputHasFocus()) {
 			if (this.showingIncludesExcludes) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #153684

This adds keybindings to quickly focus on files to include/exclude.  I tried to follow the pattern for the toggle X keybindings, so I went with Cmd+Alt+F and Cmd+Alt+Shift+F.  I used "F" for "files".

To test, open the search editor and use those keybindings.