### PR TITLE
Detect terminal links with space, then line:col

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLocalLinkDetector.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLocalLinkDetector.ts
@@ -49,6 +49,7 @@ export const winLocalLinkClause = '((' + winPathPrefix + '|(' + winExcludedPathC
 /** As xterm reads from DOM, space in that case is nonbreaking char ASCII code - 160,
 replacing space with nonBreakningSpace or space ASCII code - 32. */
 export const lineAndColumnClause = [
+	'(([^:\\s\\(\\)<>\'\"\\[\\]]*) ((\\d+))(:(\\d+)))', // (file path) 336:9 [see #140780]
 	'((\\S*)[\'"], line ((\\d+)( column (\\d+))?))', // "(file path)", line 45 [see #40468]
 	'((\\S*)[\'"],((\\d+)(:(\\d+))?))', // "(file path)",45 [see #78205]
 	'((\\S*) on line ((\\d+)(, column (\\d+))?))', // (file path) on line 8, column 13

--- a/src/vs/workbench/contrib/terminal/test/browser/links/terminalLocalLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/links/terminalLocalLinkDetector.test.ts
@@ -66,6 +66,7 @@ const supportedLinkFormats: LinkFormatInfo[] = [
 	{ urlFormat: '{0} ({1}, {2})', line: '5', column: '3' },
 	{ urlFormat: '{0}:{1}', line: '5' },
 	{ urlFormat: '{0}:{1}:{2}', line: '5', column: '3' },
+	{ urlFormat: '{0} {1}:{2}', line: '5', column: '3' },
 	{ urlFormat: '{0}[{1}]', line: '5' },
 	{ urlFormat: '{0} [{1}]', line: '5' },
 	{ urlFormat: '{0}[{1},{2}]', line: '5', column: '3' },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #140780

To test, you can open a terminal and run `echo ./myFile.txt 10:5` (replacing the filename with one that exists).  When you click to open the file, it should open to line 10, column 5.