### PR TITLE
Fixes #148568

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1785,12 +1785,12 @@ export class Repository {
 		} catch (err) {
 			if (/^error: failed to push some refs to\b/m.test(err.stderr || '')) {
 				err.gitErrorCode = GitErrorCodes.PushRejected;
+			} else if (/Permission.*denied/.test(err.stderr || '')) {
+				err.gitErrorCode = GitErrorCodes.PermissionDenied;
 			} else if (/Could not read from remote repository/.test(err.stderr || '')) {
 				err.gitErrorCode = GitErrorCodes.RemoteConnectionError;
 			} else if (/^fatal: The current branch .* has no upstream branch/.test(err.stderr || '')) {
 				err.gitErrorCode = GitErrorCodes.NoUpstreamBranch;
-			} else if (/Permission.*denied/.test(err.stderr || '')) {
-				err.gitErrorCode = GitErrorCodes.PermissionDenied;
 			}
 
 			throw err;


### PR DESCRIPTION
Fixes #148568

Somehow @connor4312's git prints an error which contains two cases we detect:

```
> git push -u origin test-branch
ERROR: Permission to joaomoreno/test-pr-templates.git denied to connor4312.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

We should _catch_ the `Permission.*denied` message before the `Could not read from remote repository`.