### PR TITLE
joh/normal crow

### DIFF
--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -37,6 +37,9 @@
 			"ES2020.String",
 			"ES2020.Symbol.WellKnown",
 			"ES2020.Intl",
+			"ES2021.Promise",
+			"ES2021.String",
+			"ES2021.WeakRef",
 			"DOM",
 			"DOM.Iterable",
 			"WebWorker.ImportScripts"

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,7 +5,7 @@
 		"preserveConstEnums": true,
 		"sourceMap": false,
 		"outDir": "../out/vs",
-		"target": "es2020",
+		"target": "es2021",
 		"types": [
 			"keytar",
 			"mocha",


### PR DESCRIPTION
- enable `"ES2021.Promise", "ES2021.String", "ES2021.WeakRef"` as lib-dependencies as our runtimes have caught up
- set JS compile target to `2021`
