### PR TITLE
support vscode.dev link generation in notebook editor

### DIFF
--- a/extensions/github/src/links.ts
+++ b/extensions/github/src/links.ts
@@ -127,7 +127,7 @@ export function getPermalink(gitAPI: GitAPI, useSelection: boolean, hostPrefix?:
 
 	const commitHash = gitRepo.state.HEAD?.commit;
 	const fileSegments = fileAndPosition.type === LinkType.File
-		? ((useSelection && uri) ? `${uri.path.substring(gitRepo.rootUri.path.length)}${rangeString(fileAndPosition.range)}` : '')
+		? (useSelection ? `${uri.path.substring(gitRepo.rootUri.path.length)}${rangeString(fileAndPosition.range)}` : '')
 		: (useSelection ? `${uri.path.substring(gitRepo.rootUri.path.length)}${notebookCellRangeString(fileAndPosition.cellIndex, fileAndPosition.range)}` : '');
 
 	return `${hostPrefix}/${repo.owner}/${repo.repo}/blob/${commitHash

--- a/extensions/github/src/links.ts
+++ b/extensions/github/src/links.ts
@@ -22,14 +22,46 @@ export function getRepositoryForFile(gitAPI: GitAPI, file: vscode.Uri): Reposito
 	return undefined;
 }
 
-function getFileAndPosition(): { uri: vscode.Uri | undefined; range: vscode.Range | undefined } {
+enum LinkType {
+	File = 1,
+	Notebook = 2
+}
+
+interface IFilePosition {
+	type: LinkType.File;
+	uri: vscode.Uri;
+	range: vscode.Range | undefined;
+}
+
+interface INotebookPosition {
+	type: LinkType.Notebook;
+	uri: vscode.Uri;
+	cellIndex: number;
+	range: vscode.Range | undefined;
+}
+
+function getFileAndPosition(): IFilePosition | INotebookPosition | undefined {
 	let uri: vscode.Uri | undefined;
 	let range: vscode.Range | undefined;
 	if (vscode.window.activeTextEditor) {
 		uri = vscode.window.activeTextEditor.document.uri;
-		range = vscode.window.activeTextEditor.selection;
+
+		if (uri.scheme === 'vscode-notebook-cell' && vscode.window.activeNotebookEditor?.notebook.uri.fsPath === uri.fsPath) {
+			const cell = vscode.window.activeNotebookEditor.notebook.getCells().find(cell => cell.document.uri.fragment === uri?.fragment);
+			const cellIndex = cell?.index ?? vscode.window.activeNotebookEditor.selection.start;
+			const range = cell !== undefined ? vscode.window.activeTextEditor.selection : undefined;
+			return { type: LinkType.Notebook, uri, cellIndex, range };
+		} else {
+			range = vscode.window.activeTextEditor.selection;
+			return { type: LinkType.File, uri, range };
+		}
 	}
-	return { uri, range };
+
+	if (vscode.window.activeNotebookEditor) {
+		return { type: LinkType.Notebook, uri: vscode.window.activeNotebookEditor.notebook.uri, cellIndex: vscode.window.activeNotebookEditor.selection.start, range: undefined };
+	}
+
+	return undefined;
 }
 
 function rangeString(range: vscode.Range | undefined) {
@@ -43,9 +75,30 @@ function rangeString(range: vscode.Range | undefined) {
 	return hash;
 }
 
+export function notebookCellRangeString(index: number | undefined, range: vscode.Range | undefined) {
+	if (index === undefined) {
+		return '';
+	}
+
+	if (!range) {
+		return `#C${index + 1}`;
+	}
+
+	let hash = `#C${index + 1}:L${range.start.line + 1}`;
+	if (range.start.line !== range.end.line) {
+		hash += `-L${range.end.line + 1}`;
+	}
+	return hash;
+}
+
 export function getPermalink(gitAPI: GitAPI, useSelection: boolean, hostPrefix?: string): string | undefined {
 	hostPrefix = hostPrefix ?? 'https://github.com';
-	const { uri, range } = getFileAndPosition();
+	const fileAndPosition = getFileAndPosition();
+	if (!fileAndPosition) {
+		return;
+	}
+	const uri = fileAndPosition.uri;
+
 	// Use the first repo if we cannot determine a repo from the uri.
 	const gitRepo = (uri ? getRepositoryForFile(gitAPI, uri) : gitAPI.repositories[0]) ?? gitAPI.repositories[0];
 	if (!gitRepo) {
@@ -69,7 +122,9 @@ export function getPermalink(gitAPI: GitAPI, useSelection: boolean, hostPrefix?:
 	}
 
 	const commitHash = gitRepo.state.HEAD?.commit;
-	const fileSegments = (useSelection && uri) ? `${uri.path.substring(gitRepo.rootUri.path.length)}${rangeString(range)}` : '';
+	const fileSegments = fileAndPosition.type === LinkType.File
+		? ((useSelection && uri) ? `${uri.path.substring(gitRepo.rootUri.path.length)}${rangeString(fileAndPosition.range)}` : '')
+		: (useSelection ? `${uri.path.substring(gitRepo.rootUri.path.length)}${notebookCellRangeString(fileAndPosition.cellIndex, fileAndPosition.range)}` : '');
 
 	return `${hostPrefix}/${repo.owner}/${repo.repo}/blob/${commitHash
 		}${fileSegments}`;

--- a/extensions/github/src/links.ts
+++ b/extensions/github/src/links.ts
@@ -47,17 +47,21 @@ function getFileAndPosition(): IFilePosition | INotebookPosition | undefined {
 		uri = vscode.window.activeTextEditor.document.uri;
 
 		if (uri.scheme === 'vscode-notebook-cell' && vscode.window.activeNotebookEditor?.notebook.uri.fsPath === uri.fsPath) {
+			// if the active editor is a notebook editor and the focus is inside any a cell text editor
+			// generate deep link for text selection for the notebook cell.
 			const cell = vscode.window.activeNotebookEditor.notebook.getCells().find(cell => cell.document.uri.fragment === uri?.fragment);
 			const cellIndex = cell?.index ?? vscode.window.activeNotebookEditor.selection.start;
 			const range = cell !== undefined ? vscode.window.activeTextEditor.selection : undefined;
 			return { type: LinkType.Notebook, uri, cellIndex, range };
 		} else {
+			// the active editor is a text editor
 			range = vscode.window.activeTextEditor.selection;
 			return { type: LinkType.File, uri, range };
 		}
 	}
 
 	if (vscode.window.activeNotebookEditor) {
+		// if the active editor is a notebook editor but the focus is not inside any cell text editor, generate deep link for the cell selection in the notebook document.
 		return { type: LinkType.Notebook, uri: vscode.window.activeNotebookEditor.notebook.uri, cellIndex: vscode.window.activeNotebookEditor.selection.start, range: undefined };
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/controller/coreActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/coreActions.ts
@@ -431,6 +431,6 @@ MenuRegistry.appendMenuItem(MenuId.EditorContext, {
 
 MenuRegistry.appendMenuItem(MenuId.NotebookCellTitle, {
 	title: localize('miShare', "Share"),
-	submenu: MenuId.MenubarShare,
+	submenu: MenuId.EditorContextShare,
 	group: CellOverflowToolbarGroups.Share
 });

--- a/src/vs/workbench/contrib/notebook/browser/controller/coreActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/coreActions.ts
@@ -42,7 +42,8 @@ export const enum CellToolbarOrder {
 export const enum CellOverflowToolbarGroups {
 	Copy = '1_copy',
 	Insert = '2_insert',
-	Edit = '3_edit'
+	Edit = '3_edit',
+	Share = '4_share'
 }
 
 export interface INotebookActionContext {
@@ -426,4 +427,10 @@ MenuRegistry.appendMenuItem(MenuId.EditorContext, {
 	title: localize('notebookMenu.cellTitle', "Notebook Cell"),
 	group: CellOverflowToolbarGroups.Insert,
 	when: NOTEBOOK_EDITOR_FOCUSED
+});
+
+MenuRegistry.appendMenuItem(MenuId.NotebookCellTitle, {
+	title: localize('miShare', "Share"),
+	submenu: MenuId.MenubarShare,
+	group: CellOverflowToolbarGroups.Share
 });


### PR DESCRIPTION
Fix #153944

Generate notebook deep links when the active editor is a notebook editor. The command is available in both cell text editor (monaco)'s context menu, cell title toolbar and cell context menu (right click on whitespace on a cell).