### PR TITLE
Update UTC flags properly for 1DS

### DIFF
--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -283,7 +283,7 @@ class SharedProcessMain extends Disposable {
 			const { installSourcePath } = environmentService;
 			const internalTesting = configurationService.getValue<boolean>('telemetry.internalTesting');
 			if (internalTesting && productService.aiConfig?.ariaKey) {
-				const collectorAppender = new OneDataSystemWebAppender('monacoworkbench', null, productService.aiConfig.ariaKey);
+				const collectorAppender = new OneDataSystemWebAppender(configurationService, 'monacoworkbench', null, productService.aiConfig.ariaKey);
 				this._register(toDisposable(() => collectorAppender.flush())); // Ensure the 1DS appender is disposed so that it flushes remaining data
 				appenders.push(collectorAppender);
 			} else if (productService.aiConfig && productService.aiConfig.asimovKey) {

--- a/src/vs/platform/telemetry/browser/1dsAppender.ts
+++ b/src/vs/platform/telemetry/browser/1dsAppender.ts
@@ -4,16 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { AppInsightsCore } from '@microsoft/1ds-core-js';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { AbstractOneDataSystemAppender } from 'vs/platform/telemetry/common/1dsAppender';
 
 
 export class OneDataSystemWebAppender extends AbstractOneDataSystemAppender {
 	constructor(
+		configurationService: IConfigurationService,
 		eventPrefix: string,
 		defaultData: { [key: string]: any } | null,
 		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
 	) {
-		super(eventPrefix, defaultData, iKeyOrClientFactory);
+		super(configurationService, eventPrefix, defaultData, iKeyOrClientFactory);
 
 		// If we cannot fetch the endpoint it means it is down and we should not send any telemetry.
 		// This is most likely due to ad blockers

--- a/src/vs/platform/telemetry/common/1dsAppender.ts
+++ b/src/vs/platform/telemetry/common/1dsAppender.ts
@@ -7,11 +7,12 @@ import type { AppInsightsCore, IExtendedConfiguration } from '@microsoft/1ds-cor
 import type { IChannelConfiguration, IXHROverride, PostChannel } from '@microsoft/1ds-post-js';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { mixin } from 'vs/base/common/objects';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ITelemetryAppender, validateTelemetryData } from 'vs/platform/telemetry/common/telemetryUtils';
 
 const endpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0';
 
-async function getClient(instrumentationKey: string, xhrOverride?: IXHROverride): Promise<AppInsightsCore> {
+async function getClient(instrumentationKey: string, addInternalFlag?: boolean, xhrOverride?: IXHROverride): Promise<AppInsightsCore> {
 	const oneDs = await import('@microsoft/1ds-core-js');
 	const postPlugin = await import('@microsoft/1ds-post-js');
 	const appInsightsCore = new oneDs.AppInsightsCore();
@@ -43,10 +44,12 @@ async function getClient(instrumentationKey: string, xhrOverride?: IXHROverride)
 	appInsightsCore.initialize(coreConfig, []);
 
 	appInsightsCore.addTelemetryInitializer((envelope) => {
-		envelope['ext'] = envelope['ext'] ?? {};
-		envelope['ext']['utc'] = envelope['ext']['utc'] ?? {};
-		// Sets it to be internal only based on Windows UTC flagging
-		envelope['ext']['utc']['flags'] = 0x0000811ECD;
+		if (addInternalFlag) {
+			envelope['ext'] = envelope['ext'] ?? {};
+			envelope['ext']['utc'] = envelope['ext']['utc'] ?? {};
+			// Sets it to be internal only based on Windows UTC flagging
+			envelope['ext']['utc']['flags'] = 0x0000811ECD;
+		}
 	});
 
 	return appInsightsCore;
@@ -60,6 +63,7 @@ export abstract class AbstractOneDataSystemAppender implements ITelemetryAppende
 	protected readonly endPointUrl = endpointUrl;
 
 	constructor(
+		private readonly _configurationService: IConfigurationService,
 		private _eventPrefix: string,
 		private _defaultData: { [key: string]: any } | null,
 		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
@@ -88,7 +92,8 @@ export abstract class AbstractOneDataSystemAppender implements ITelemetryAppende
 		}
 
 		if (!this._asyncAiCore) {
-			this._asyncAiCore = getClient(this._aiCoreOrKey, this._xhrOverride);
+			const isInternal = this._configurationService.getValue<boolean>('telemetry.internalTesting');
+			this._asyncAiCore = getClient(this._aiCoreOrKey, isInternal, this._xhrOverride);
 		}
 
 		this._asyncAiCore.then(

--- a/src/vs/platform/telemetry/node/1dsAppender.ts
+++ b/src/vs/platform/telemetry/node/1dsAppender.ts
@@ -6,12 +6,14 @@
 import type { AppInsightsCore } from '@microsoft/1ds-core-js';
 import type { IPayloadData, IXHROverride } from '@microsoft/1ds-post-js';
 import * as https from 'https';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { AbstractOneDataSystemAppender } from 'vs/platform/telemetry/common/1dsAppender';
 
 
 export class OneDataSystemAppender extends AbstractOneDataSystemAppender {
 
 	constructor(
+		configurationService: IConfigurationService,
 		eventPrefix: string,
 		defaultData: { [key: string]: any } | null,
 		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
@@ -46,6 +48,6 @@ export class OneDataSystemAppender extends AbstractOneDataSystemAppender {
 			}
 		};
 
-		super(eventPrefix, defaultData, iKeyOrClientFactory, customHttpXHROverride);
+		super(configurationService, eventPrefix, defaultData, iKeyOrClientFactory, customHttpXHROverride);
 	}
 }

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -43,7 +43,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 			const internalTesting = configurationService.getValue<boolean>('telemetry.internalTesting');
 			const appenders = [];
 			if (internalTesting || productService.aiConfig?.preferAria) {
-				const telemetryProvider: ITelemetryAppender = remoteAgentService.getConnection() !== null ? { log: remoteAgentService.logTelemetry.bind(remoteAgentService), flush: remoteAgentService.flushTelemetry.bind(remoteAgentService) } : new OneDataSystemWebAppender('monacoworkbench', null, productService.aiConfig?.ariaKey);
+				const telemetryProvider: ITelemetryAppender = remoteAgentService.getConnection() !== null ? { log: remoteAgentService.logTelemetry.bind(remoteAgentService), flush: remoteAgentService.flushTelemetry.bind(remoteAgentService) } : new OneDataSystemWebAppender(configurationService, 'monacoworkbench', null, productService.aiConfig?.ariaKey);
 				appenders.push(telemetryProvider);
 			} else {
 				const telemetryProvider: ITelemetryAppender = remoteAgentService.getConnection() !== null ? { log: remoteAgentService.logTelemetry.bind(remoteAgentService), flush: remoteAgentService.flushTelemetry.bind(remoteAgentService) } : new WebAppInsightsAppender('monacoworkbench', productService.aiConfig?.asimovKey);


### PR DESCRIPTION
UTC flags need to be properly populated on the 1DS data payloads to properly route to the correct clusters. This is a candidate because vscode.dev is switching data pipelines at the end of the week and improper data flagging will lead to no data being recorded.