### PR TITLE
Debt: Clean up in Profiles

### DIFF
--- a/src/vs/code/electron-browser/sharedProcess/contrib/extensionsCleaner.ts
+++ b/src/vs/code/electron-browser/sharedProcess/contrib/extensionsCleaner.ts
@@ -34,7 +34,7 @@ export class ExtensionsCleaner extends Disposable {
 	) {
 		super();
 
-		extensionManagementService.removeUninstalledExtensions(this.userDataProfilesService.profiles.length === 0);
+		extensionManagementService.removeUninstalledExtensions(this.userDataProfilesService.profiles.length === 1);
 		migrateUnsupportedExtensions(extensionManagementService, extensionGalleryService, extensionStorageService, extensionEnablementService, logService);
 		ExtensionStorageService.removeOutdatedExtensionVersions(extensionManagementService, storageService);
 		this._register(instantiationService.createInstance(ProfileExtensionsCleaner));
@@ -66,7 +66,7 @@ class ProfileExtensionsCleaner extends Disposable {
 			this.logService.error(error);
 		}
 
-		if (all.length === 0) {
+		if (all.length === 1) {
 			// Exit profile mode
 			this.profileModeDisposables.clear();
 			// Listen for entering into profile mode

--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -31,7 +31,7 @@ import { INativeEnvironmentService } from 'vs/platform/environment/common/enviro
 import { SharedProcessEnvironmentService } from 'vs/platform/sharedProcess/node/sharedProcessEnvironmentService';
 import { GlobalExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionEnablementService';
 import { ExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionGalleryService';
-import { IExtensionGalleryService, IExtensionManagementService, IExtensionTipsService, IGlobalExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IDefaultExtensionsProfileInitService, IExtensionGalleryService, IExtensionManagementService, IExtensionTipsService, IGlobalExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ExtensionManagementChannel, ExtensionTipsChannel } from 'vs/platform/extensionManagement/common/extensionManagementIpc';
 import { ExtensionTipsService } from 'vs/platform/extensionManagement/electron-sandbox/extensionTipsService';
 import { ExtensionManagementService, INativeServerExtensionManagementService } from 'vs/platform/extensionManagement/node/extensionManagementService';
@@ -106,6 +106,7 @@ import { PolicyChannelClient } from 'vs/platform/policy/common/policyIpc';
 import { IPolicyService, NullPolicyService } from 'vs/platform/policy/common/policy';
 import { UserDataProfilesNativeService } from 'vs/platform/userDataProfile/electron-sandbox/userDataProfile';
 import { OneDataSystemWebAppender } from 'vs/platform/telemetry/browser/1dsAppender';
+import { DefaultExtensionsProfileInitService } from 'vs/platform/extensionManagement/electron-sandbox/defaultExtensionsProfileInit';
 
 class SharedProcessMain extends Disposable {
 
@@ -316,6 +317,7 @@ class SharedProcessMain extends Disposable {
 		services.set(IExtensionsProfileScannerService, new SyncDescriptor(ExtensionsProfileScannerService));
 		services.set(IExtensionsScannerService, new SyncDescriptor(ExtensionsScannerService));
 		services.set(INativeServerExtensionManagementService, new SyncDescriptor(ExtensionManagementService));
+		services.set(IDefaultExtensionsProfileInitService, new SyncDescriptor(DefaultExtensionsProfileInitService));
 
 		// Extension Gallery
 		services.set(IExtensionGalleryService, new SyncDescriptor(ExtensionGalleryService));
@@ -426,6 +428,9 @@ class SharedProcessMain extends Disposable {
 		// Worker
 		const sharedProcessWorkerChannel = ProxyChannel.fromService(accessor.get(ISharedProcessWorkerService));
 		this.server.registerChannel(ipcSharedProcessWorkerChannelName, sharedProcessWorkerChannel);
+
+		// Default Extensions Profile Init
+		this.server.registerChannel('IDefaultExtensionsProfileInitService', ProxyChannel.fromService(accessor.get(IDefaultExtensionsProfileInitService)));
 	}
 
 	private registerErrorHandler(logService: ILogService): void {

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -528,3 +528,10 @@ export interface IExtensionManagementCLIService {
 	uninstallExtensions(extensions: (string | URI)[], force: boolean, output?: CLIOutput): Promise<void>;
 	locateExtension(extensions: string[], output?: CLIOutput): Promise<void>;
 }
+
+export const IDefaultExtensionsProfileInitService = createDecorator<IDefaultExtensionsProfileInitService>('IDefaultExtensionsProfileInitService');
+export interface IDefaultExtensionsProfileInitService {
+	readonly _serviceBrand: undefined;
+	initialize(): Promise<void>;
+	uninitialize(): Promise<void>;
+}

--- a/src/vs/platform/extensionManagement/electron-main/defaultExtensionsProfileInit.ts
+++ b/src/vs/platform/extensionManagement/electron-main/defaultExtensionsProfileInit.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+import { IDefaultExtensionsProfileInitService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IUserDataProfilesMainService } from 'vs/platform/userDataProfile/electron-main/userDataProfile';
+
+export class DefaultExtensionsProfileInitHandler extends Disposable {
+	constructor(
+		@IDefaultExtensionsProfileInitService private readonly defaultExtensionsProfileInitService: IDefaultExtensionsProfileInitService,
+		@IUserDataProfilesMainService userDataProfilesService: IUserDataProfilesMainService,
+	) {
+		super();
+		this._register(userDataProfilesService.onWillCreateProfile(e => {
+			if (userDataProfilesService.profiles.length === 0) {
+				e.join(this.defaultExtensionsProfileInitService.initialize());
+			}
+		}));
+		this._register(userDataProfilesService.onDidChangeProfiles(e => {
+			if (userDataProfilesService.profiles.length === 0) {
+				this.defaultExtensionsProfileInitService.uninitialize();
+			}
+		}));
+	}
+}

--- a/src/vs/platform/extensionManagement/electron-main/defaultExtensionsProfileInit.ts
+++ b/src/vs/platform/extensionManagement/electron-main/defaultExtensionsProfileInit.ts
@@ -14,12 +14,12 @@ export class DefaultExtensionsProfileInitHandler extends Disposable {
 	) {
 		super();
 		this._register(userDataProfilesService.onWillCreateProfile(e => {
-			if (userDataProfilesService.profiles.length === 0) {
+			if (userDataProfilesService.profiles.length === 1) {
 				e.join(this.defaultExtensionsProfileInitService.initialize());
 			}
 		}));
 		this._register(userDataProfilesService.onDidChangeProfiles(e => {
-			if (userDataProfilesService.profiles.length === 0) {
+			if (userDataProfilesService.profiles.length === 1) {
 				this.defaultExtensionsProfileInitService.uninitialize();
 			}
 		}));

--- a/src/vs/platform/extensionManagement/electron-sandbox/defaultExtensionsProfileInit.ts
+++ b/src/vs/platform/extensionManagement/electron-sandbox/defaultExtensionsProfileInit.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+import { joinPath } from 'vs/base/common/resources';
+import { URI } from 'vs/base/common/uri';
+import { IDefaultExtensionsProfileInitService, IExtensionManagementService, ILocalExtension, Metadata } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IExtensionsProfileScannerService } from 'vs/platform/extensionManagement/common/extensionsProfileScannerService';
+import { ExtensionType } from 'vs/platform/extensions/common/extensions';
+import { IFileService } from 'vs/platform/files/common/files';
+import { EXTENSIONS_RESOURCE_NAME, IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
+
+export class DefaultExtensionsProfileInitService extends Disposable implements IDefaultExtensionsProfileInitService {
+
+	readonly _serviceBrand: undefined;
+
+	constructor(
+		@IUserDataProfilesService private readonly userDataProfilesService: IUserDataProfilesService,
+		@IFileService private readonly fileService: IFileService,
+		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
+		@IExtensionsProfileScannerService private readonly extensionsProfileScannerService: IExtensionsProfileScannerService,
+	) {
+		super();
+	}
+
+	async initialize(): Promise<void> {
+		/* Create and populate the default extensions profile resource */
+		const extensionsProfileResource = this.getDefaultExtensionsProfileResource();
+		try { await this.fileService.del(extensionsProfileResource); } catch (error) { /* ignore */ }
+		const userExtensions = await this.extensionManagementService.getInstalled(ExtensionType.User);
+		const extensions: [ILocalExtension, Metadata | undefined][] = await Promise.all(userExtensions.map(async e => ([e, await this.extensionManagementService.getMetadata(e)])));
+		await this.extensionsProfileScannerService.addExtensionsToProfile(extensions, extensionsProfileResource);
+	}
+
+	async uninitialize(): Promise<void> {
+		/* Remove the default extensions profile resource */
+		try { await this.fileService.del(this.getDefaultExtensionsProfileResource()); } catch (error) { /* ignore */ }
+	}
+
+	private getDefaultExtensionsProfileResource(): URI {
+		return this.userDataProfilesService.defaultProfile.extensionsResource ?? joinPath(this.userDataProfilesService.defaultProfile.location, EXTENSIONS_RESOURCE_NAME);
+	}
+}

--- a/src/vs/platform/extensionManagement/test/node/extensionsScannerService.test.ts
+++ b/src/vs/platform/extensionManagement/test/node/extensionsScannerService.test.ts
@@ -17,7 +17,6 @@ import { InMemoryFileSystemProvider } from 'vs/platform/files/common/inMemoryFil
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { ILogService, NullLogService } from 'vs/platform/log/common/log';
 import { IProductService } from 'vs/platform/product/common/productService';
-import { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService';
 import { IUserDataProfilesService, UserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 
 let translations: Translations = Object.create(null);
@@ -70,9 +69,7 @@ suite('NativeExtensionsScanerService Test', () => {
 			extensionsPath: userExtensionsLocation.fsPath,
 		});
 		instantiationService.stub(IProductService, { version: '1.66.0' });
-		const uriIdentityService = new UriIdentityService(fileService);
-		const userDataProfilesService = new UserDataProfilesService(environmentService, fileService, logService);
-		instantiationService.stub(IExtensionsProfileScannerService, new ExtensionsProfileScannerService(fileService, uriIdentityService, userDataProfilesService, logService));
+		instantiationService.stub(IExtensionsProfileScannerService, new ExtensionsProfileScannerService(fileService, logService));
 		instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, logService));
 		await fileService.createFolder(systemExtensionsLocation);
 		await fileService.createFolder(userExtensionsLocation);

--- a/src/vs/platform/userDataProfile/common/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/common/userDataProfile.ts
@@ -42,8 +42,6 @@ export interface IUserDataProfile {
 	readonly useDefaultFlags?: UseDefaultProfileFlags;
 }
 
-export type CustomUserDataProfile = IUserDataProfile & { readonly extensionsResource: URI; readonly isDefault: false };
-
 export function isUserDataProfile(thing: unknown): thing is IUserDataProfile {
 	const candidate = thing as IUserDataProfile | undefined;
 
@@ -101,7 +99,7 @@ export function reviveProfile(profile: UriDto<IUserDataProfile>, scheme: string)
 
 export const EXTENSIONS_RESOURCE_NAME = 'extensions.json';
 
-export function toUserDataProfile(name: string, location: URI, useDefaultFlags?: UseDefaultProfileFlags): CustomUserDataProfile {
+export function toUserDataProfile(name: string, location: URI, useDefaultFlags?: UseDefaultProfileFlags): IUserDataProfile {
 	return {
 		id: hash(location.path).toString(16),
 		name: name,

--- a/src/vs/platform/userDataProfile/common/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/common/userDataProfile.ts
@@ -121,7 +121,8 @@ export class UserDataProfilesService extends Disposable implements IUserDataProf
 	readonly profilesHome: URI;
 
 	get defaultProfile(): IUserDataProfile { return this.profiles[0]; }
-	get profiles(): IUserDataProfile[] { return [this.createDefaultUserDataProfile(false)]; }
+	protected _profiles: IUserDataProfile[] = [this.createDefaultUserDataProfile(false)];
+	get profiles(): IUserDataProfile[] { return this._profiles; }
 
 	protected readonly _onDidChangeProfiles = this._register(new Emitter<DidChangeProfilesEvent>());
 	readonly onDidChangeProfiles = this._onDidChangeProfiles.event;

--- a/src/vs/platform/userDataProfile/common/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/common/userDataProfile.ts
@@ -79,7 +79,7 @@ export interface IUserDataProfilesService {
 	readonly profiles: IUserDataProfile[];
 
 	createProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, workspaceIdentifier?: WorkspaceIdentifier): Promise<IUserDataProfile>;
-	setProfileForWorkspace(profile: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): Promise<IUserDataProfile>;
+	setProfileForWorkspace(profile: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): Promise<void>;
 	getProfile(workspaceIdentifier: WorkspaceIdentifier): IUserDataProfile;
 	removeProfile(profile: IUserDataProfile): Promise<void>;
 }
@@ -143,7 +143,7 @@ export class UserDataProfilesService extends Disposable implements IUserDataProf
 	}
 
 	createProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, workspaceIdentifier?: WorkspaceIdentifier): Promise<IUserDataProfile> { throw new Error('Not implemented'); }
-	setProfileForWorkspace(profile: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): Promise<IUserDataProfile> { throw new Error('Not implemented'); }
+	setProfileForWorkspace(profile: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): Promise<void> { throw new Error('Not implemented'); }
 	getProfile(workspaceIdentifier: WorkspaceIdentifier): IUserDataProfile { throw new Error('Not implemented'); }
 	removeProfile(profile: IUserDataProfile): Promise<void> { throw new Error('Not implemented'); }
 }

--- a/src/vs/platform/userDataProfile/common/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/common/userDataProfile.ts
@@ -122,9 +122,8 @@ export class UserDataProfilesService extends Disposable implements IUserDataProf
 
 	readonly profilesHome: URI;
 
-	private readonly _defaultProfile = this.createDefaultUserDataProfile(false);
-	get defaultProfile(): IUserDataProfile { return this.profiles[0] ?? this._defaultProfile; }
-	get profiles(): IUserDataProfile[] { return []; }
+	get defaultProfile(): IUserDataProfile { return this.profiles[0]; }
+	get profiles(): IUserDataProfile[] { return [this.createDefaultUserDataProfile(false)]; }
 
 	protected readonly _onDidChangeProfiles = this._register(new Emitter<DidChangeProfilesEvent>());
 	readonly onDidChangeProfiles = this._onDidChangeProfiles.event;

--- a/src/vs/platform/userDataProfile/common/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/common/userDataProfile.ts
@@ -78,8 +78,7 @@ export interface IUserDataProfilesService {
 	readonly onDidChangeProfiles: Event<DidChangeProfilesEvent>;
 	readonly profiles: IUserDataProfile[];
 
-	newProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags): CustomUserDataProfile;
-	createProfile(profile: IUserDataProfile, workspaceIdentifier?: WorkspaceIdentifier): Promise<IUserDataProfile>;
+	createProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, workspaceIdentifier?: WorkspaceIdentifier): Promise<IUserDataProfile>;
 	setProfileForWorkspace(profile: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): Promise<IUserDataProfile>;
 	getProfile(workspaceIdentifier: WorkspaceIdentifier): IUserDataProfile;
 	removeProfile(profile: IUserDataProfile): Promise<void>;
@@ -139,16 +138,12 @@ export class UserDataProfilesService extends Disposable implements IUserDataProf
 		this.profilesHome = joinPath(this.environmentService.userRoamingDataHome, 'profiles');
 	}
 
-	newProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags): CustomUserDataProfile {
-		return toUserDataProfile(name, joinPath(this.profilesHome, hash(name).toString(16)), useDefaultFlags);
-	}
-
 	protected createDefaultUserDataProfile(extensions: boolean): IUserDataProfile {
 		const profile = toUserDataProfile(localize('defaultProfile', "Default"), this.environmentService.userRoamingDataHome);
 		return { ...profile, isDefault: true, extensionsResource: extensions ? profile.extensionsResource : undefined };
 	}
 
-	createProfile(profile: IUserDataProfile, workspaceIdentifier?: WorkspaceIdentifier): Promise<IUserDataProfile> { throw new Error('Not implemented'); }
+	createProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, workspaceIdentifier?: WorkspaceIdentifier): Promise<IUserDataProfile> { throw new Error('Not implemented'); }
 	setProfileForWorkspace(profile: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): Promise<IUserDataProfile> { throw new Error('Not implemented'); }
 	getProfile(workspaceIdentifier: WorkspaceIdentifier): IUserDataProfile { throw new Error('Not implemented'); }
 	removeProfile(profile: IUserDataProfile): Promise<void> { throw new Error('Not implemented'); }

--- a/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
@@ -82,7 +82,7 @@ export class UserDataProfilesMainService extends UserDataProfilesService impleme
 		return profile;
 	}
 
-	override async setProfileForWorkspace(profileToSet: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): Promise<IUserDataProfile> {
+	override async setProfileForWorkspace(profileToSet: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): Promise<void> {
 		if (!this.enabled) {
 			throw new Error(`Settings Profiles are disabled. Enable them via the '${PROFILES_ENABLEMENT_CONFIG}' setting.`);
 		}
@@ -93,7 +93,6 @@ export class UserDataProfilesMainService extends UserDataProfilesService impleme
 		}
 
 		this.updateWorkspaceAssociation(workspaceIdentifier, profile);
-		return profile;
 	}
 
 	async unsetWorkspace(workspaceIdentifier: WorkspaceIdentifier): Promise<void> {

--- a/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
@@ -42,9 +42,8 @@ export class UserDataProfilesNativeService extends UserDataProfilesService imple
 		return reviveProfile(result, this.profilesHome.scheme);
 	}
 
-	override async setProfileForWorkspace(profile: IUserDataProfile, workspaceIdentifier: ISingleFolderWorkspaceIdentifier | IWorkspaceIdentifier): Promise<IUserDataProfile> {
-		const result = await this.channel.call<UriDto<IUserDataProfile>>('setProfileForWorkspace', [profile, workspaceIdentifier]);
-		return reviveProfile(result, this.profilesHome.scheme);
+	override async setProfileForWorkspace(profile: IUserDataProfile, workspaceIdentifier: ISingleFolderWorkspaceIdentifier | IWorkspaceIdentifier): Promise<void> {
+		await this.channel.call<UriDto<IUserDataProfile>>('setProfileForWorkspace', [profile, workspaceIdentifier]);
 	}
 
 	override removeProfile(profile: IUserDataProfile): Promise<void> {

--- a/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
@@ -9,7 +9,7 @@ import { IEnvironmentService } from 'vs/platform/environment/common/environment'
 import { IFileService } from 'vs/platform/files/common/files';
 import { IMainProcessService } from 'vs/platform/ipc/electron-sandbox/services';
 import { ILogService } from 'vs/platform/log/common/log';
-import { DidChangeProfilesEvent, IUserDataProfile, IUserDataProfilesService, reviveProfile, UserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { DidChangeProfilesEvent, IUserDataProfile, IUserDataProfilesService, reviveProfile, UseDefaultProfileFlags, UserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { ISingleFolderWorkspaceIdentifier, IWorkspaceIdentifier } from 'vs/platform/workspace/common/workspace';
 
 export class UserDataProfilesNativeService extends UserDataProfilesService implements IUserDataProfilesService {
@@ -37,8 +37,8 @@ export class UserDataProfilesNativeService extends UserDataProfilesService imple
 		}));
 	}
 
-	override async createProfile(profile: IUserDataProfile, workspaceIdentifier?: ISingleFolderWorkspaceIdentifier | IWorkspaceIdentifier): Promise<IUserDataProfile> {
-		const result = await this.channel.call<UriDto<IUserDataProfile>>('createProfile', [profile, workspaceIdentifier]);
+	override async createProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, workspaceIdentifier?: ISingleFolderWorkspaceIdentifier | IWorkspaceIdentifier): Promise<IUserDataProfile> {
+		const result = await this.channel.call<UriDto<IUserDataProfile>>('createProfile', [name, useDefaultFlags, workspaceIdentifier]);
 		return reviveProfile(result, this.profilesHome.scheme);
 	}
 

--- a/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
@@ -16,7 +16,6 @@ export class UserDataProfilesNativeService extends UserDataProfilesService imple
 
 	private readonly channel: IChannel;
 
-	private _profiles: IUserDataProfile[] = [];
 	override get profiles(): IUserDataProfile[] { return this._profiles; }
 
 	constructor(

--- a/src/vs/platform/userDataProfile/node/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/node/userDataProfile.ts
@@ -57,15 +57,11 @@ export class UserDataProfilesService extends BaseUserDataProfilesService impleme
 
 	protected _profilesObject: UserDataProfilesObject | undefined;
 	protected get profilesObject(): UserDataProfilesObject {
-		if (!this.enabled) {
-			return { profiles: [], workspaces: new ResourceMap() };
-		}
 		if (!this._profilesObject) {
-			const profiles = this.getStoredProfiles().map<IUserDataProfile>(storedProfile => toUserDataProfile(storedProfile.name, storedProfile.location, storedProfile.useDefaultFlags));
+			const profiles = this.enabled ? this.getStoredProfiles().map<IUserDataProfile>(storedProfile => toUserDataProfile(storedProfile.name, storedProfile.location, storedProfile.useDefaultFlags)) : [];
 			let emptyWindow: IUserDataProfile | undefined;
 			const workspaces = new ResourceMap<IUserDataProfile>();
 			if (profiles.length) {
-				profiles.unshift(this.createDefaultUserDataProfile(true));
 				const profileAssicaitions = this.getStoredProfileAssociations();
 				if (profileAssicaitions.workspaces) {
 					for (const [workspacePath, profilePath] of Object.entries(profileAssicaitions.workspaces)) {
@@ -82,6 +78,7 @@ export class UserDataProfilesService extends BaseUserDataProfilesService impleme
 					emptyWindow = profiles.find(p => this.uriIdentityService.extUri.isEqual(p.location, emptyWindowProfileLocation));
 				}
 			}
+			profiles.unshift(this.createDefaultUserDataProfile(profiles.length > 0));
 			this._profilesObject = { profiles, workspaces, emptyWindow };
 		}
 		return this._profilesObject;

--- a/src/vs/platform/userDataProfile/test/common/userDataProfileService.test.ts
+++ b/src/vs/platform/userDataProfile/test/common/userDataProfileService.test.ts
@@ -54,8 +54,10 @@ suite('UserDataProfileService (Common)', () => {
 		assert.strictEqual(testObject.defaultProfile.extensionsResource, undefined);
 	});
 
-	test('profiles are empty', () => {
-		assert.deepStrictEqual(testObject.profiles, []);
+	test('profiles always include default profile', () => {
+		assert.deepStrictEqual(testObject.profiles.length, 1);
+		assert.deepStrictEqual(testObject.profiles[0].isDefault, true);
+		assert.deepStrictEqual(testObject.profiles[0].extensionsResource, undefined);
 	});
 
 

--- a/src/vs/platform/userDataProfile/test/electron-main/userDataProfileMainService.test.ts
+++ b/src/vs/platform/userDataProfile/test/electron-main/userDataProfileMainService.test.ts
@@ -54,8 +54,10 @@ suite('UserDataProfileMainService', () => {
 		assert.strictEqual(testObject.defaultProfile.extensionsResource, undefined);
 	});
 
-	test('profiles are empty', () => {
-		assert.deepStrictEqual(testObject.profiles, []);
+	test('profiles always include default profile', () => {
+		assert.deepStrictEqual(testObject.profiles.length, 1);
+		assert.deepStrictEqual(testObject.profiles[0].isDefault, true);
+		assert.deepStrictEqual(testObject.profiles[0].extensionsResource, undefined);
 	});
 
 	test('default profile when there are profiles', async () => {

--- a/src/vs/platform/userDataProfile/test/electron-main/userDataProfileMainService.test.ts
+++ b/src/vs/platform/userDataProfile/test/electron-main/userDataProfileMainService.test.ts
@@ -59,13 +59,13 @@ suite('UserDataProfileMainService', () => {
 	});
 
 	test('default profile when there are profiles', async () => {
-		await testObject.createProfile(testObject.newProfile('test'));
+		await testObject.createProfile('test');
 		assert.strictEqual(testObject.defaultProfile.isDefault, true);
 		assert.strictEqual(testObject.defaultProfile.extensionsResource?.toString(), joinPath(environmentService.userRoamingDataHome, 'extensions.json').toString());
 	});
 
 	test('default profile when profiles are removed', async () => {
-		const profile = await testObject.createProfile(testObject.newProfile('test'));
+		const profile = await testObject.createProfile('test');
 		await testObject.removeProfile(profile);
 		assert.strictEqual(testObject.defaultProfile.isDefault, true);
 		assert.strictEqual(testObject.defaultProfile.extensionsResource, undefined);

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -263,7 +263,7 @@ export class BrowserMain extends Disposable {
 		const userDataProfilesService = new UserDataProfilesService(environmentService, fileService, logService);
 		serviceCollection.set(IUserDataProfilesService, userDataProfilesService);
 
-		const userDataProfileService = new UserDataProfileService(userDataProfilesService.defaultProfile);
+		const userDataProfileService = new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService);
 		serviceCollection.set(IUserDataProfileService, userDataProfileService);
 
 		// URI Identity

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
@@ -133,7 +133,7 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 
 	private profileStatusAccessor: IStatusbarEntryAccessor | undefined;
 	private updateStatus(): void {
-		if (this.userDataProfilesService.profiles.length) {
+		if (this.userDataProfilesService.profiles.length > 1) {
 			const statusBarEntry: IStatusbarEntry = {
 				name: PROFILES_CATEGORY,
 				command: 'workbench.profiles.actions.switchProfile',

--- a/src/vs/workbench/contrib/userDataProfile/common/userDataProfileActions.ts
+++ b/src/vs/workbench/contrib/userDataProfile/common/userDataProfileActions.ts
@@ -117,12 +117,17 @@ registerAction2(class RemoveProfileAction extends Action2 {
 		const userDataProfileService = accessor.get(IUserDataProfileService);
 		const userDataProfilesService = accessor.get(IUserDataProfilesService);
 		const userDataProfileManagementService = accessor.get(IUserDataProfileManagementService);
+		const notificationService = accessor.get(INotificationService);
 
 		const profiles = userDataProfilesService.profiles.filter(p => p.id !== userDataProfileService.currentProfile.id && !p.isDefault);
 		if (profiles.length) {
 			const pick = await quickInputService.pick(profiles.map(profile => ({ label: profile.name, profile })), { placeHolder: localize('pick profile', "Select Settings Profile") });
 			if (pick) {
-				await userDataProfileManagementService.removeProfile(pick.profile);
+				try {
+					await userDataProfileManagementService.removeProfile(pick.profile);
+				} catch (error) {
+					notificationService.error(error);
+				}
 			}
 		}
 	}

--- a/src/vs/workbench/electron-sandbox/desktop.main.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.main.ts
@@ -237,7 +237,7 @@ export class DesktopMain extends Disposable {
 		// User Data Profiles
 		const userDataProfilesService = new UserDataProfilesNativeService(this.configuration.profiles.all, mainProcessService, environmentService, fileService, logService);
 		serviceCollection.set(IUserDataProfilesService, userDataProfilesService);
-		const userDataProfileService = new UserDataProfileService(reviveProfile(this.configuration.profiles.current, userDataProfilesService.profilesHome.scheme));
+		const userDataProfileService = new UserDataProfileService(reviveProfile(this.configuration.profiles.current, userDataProfilesService.profilesHome.scheme), userDataProfilesService);
 		serviceCollection.set(IUserDataProfileService, userDataProfileService);
 
 		// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/vs/workbench/services/configuration/test/browser/configurationEditingService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationEditingService.test.ts
@@ -111,7 +111,7 @@ suite('ConfigurationEditingService', () => {
 		environmentService.policyFile = joinPath(workspaceFolder, 'policies.json');
 		instantiationService.stub(IEnvironmentService, environmentService);
 		const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, logService));
-		userDataProfileService = new UserDataProfileService(userDataProfilesService.defaultProfile);
+		userDataProfileService = new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService);
 		const remoteAgentService = disposables.add(instantiationService.createInstance(RemoteAgentService, null));
 		disposables.add(fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, logService))));
 		instantiationService.stub(IFileService, fileService);

--- a/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts
@@ -86,7 +86,7 @@ suite('WorkspaceContextService - Folder', () => {
 		const environmentService = TestEnvironmentService;
 		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
 		const userDataProfilesService = new UserDataProfilesService(environmentService, fileService, logService);
-		testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, new UserDataProfileService(userDataProfilesService.defaultProfile), userDataProfilesService, fileService, new RemoteAgentService(null, environmentService, TestProductService, new RemoteAuthorityResolverService(TestProductService, undefined, undefined), new SignService(undefined), new NullLogService()), new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
+		testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService), userDataProfilesService, fileService, new RemoteAgentService(null, environmentService, TestProductService, new RemoteAuthorityResolverService(TestProductService, undefined, undefined), new SignService(undefined), new NullLogService()), new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
 		await (<WorkspaceService>testObject).initialize(convertToWorkspacePayload(folder));
 	});
 
@@ -127,7 +127,7 @@ suite('WorkspaceContextService - Folder', () => {
 		const environmentService = TestEnvironmentService;
 		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
 		const userDataProfilesService = new UserDataProfilesService(environmentService, fileService, logService);
-		const testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, new UserDataProfileService(userDataProfilesService.defaultProfile), userDataProfilesService, fileService, new RemoteAgentService(null, environmentService, TestProductService, new RemoteAuthorityResolverService(TestProductService, undefined, undefined), new SignService(undefined), new NullLogService()), new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
+		const testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService), userDataProfilesService, fileService, new RemoteAgentService(null, environmentService, TestProductService, new RemoteAuthorityResolverService(TestProductService, undefined, undefined), new SignService(undefined), new NullLogService()), new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
 		await (<WorkspaceService>testObject).initialize(convertToWorkspacePayload(folder));
 
 		const actual = testObject.getWorkspaceFolder(joinPath(folder, 'a'));
@@ -148,7 +148,7 @@ suite('WorkspaceContextService - Folder', () => {
 		const environmentService = TestEnvironmentService;
 		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
 		const userDataProfilesService = new UserDataProfilesService(environmentService, fileService, logService);
-		const testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, new UserDataProfileService(userDataProfilesService.defaultProfile), userDataProfilesService, fileService, new RemoteAgentService(null, environmentService, TestProductService, new RemoteAuthorityResolverService(TestProductService, undefined, undefined), new SignService(undefined), new NullLogService()), new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
+		const testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService), userDataProfilesService, fileService, new RemoteAgentService(null, environmentService, TestProductService, new RemoteAuthorityResolverService(TestProductService, undefined, undefined), new SignService(undefined), new NullLogService()), new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
 		await (<WorkspaceService>testObject).initialize(convertToWorkspacePayload(folder));
 
 
@@ -196,7 +196,7 @@ suite('WorkspaceContextService - Workspace', () => {
 		instantiationService.stub(IRemoteAgentService, remoteAgentService);
 		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
 		const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, logService));
-		testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, new UserDataProfileService(userDataProfilesService.defaultProfile), userDataProfilesService, fileService, remoteAgentService, new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
+		testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService), userDataProfilesService, fileService, remoteAgentService, new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
 
 		instantiationService.stub(IWorkspaceContextService, testObject);
 		instantiationService.stub(IConfigurationService, testObject);
@@ -255,7 +255,7 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 		instantiationService.stub(IRemoteAgentService, remoteAgentService);
 		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
 		const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, logService));
-		testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, new UserDataProfileService(userDataProfilesService.defaultProfile), userDataProfilesService, fileService, remoteAgentService, new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
+		testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService), userDataProfilesService, fileService, remoteAgentService, new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
 
 		instantiationService.stub(IFileService, fileService);
 		instantiationService.stub(IWorkspaceContextService, testObject);
@@ -499,7 +499,7 @@ suite('WorkspaceService - Initialization', () => {
 		instantiationService.stub(IRemoteAgentService, remoteAgentService);
 		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
 		const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, logService));
-		userDataProfileService = instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile));
+		userDataProfileService = instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService));
 		testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
 		instantiationService.stub(IFileService, fileService);
 		instantiationService.stub(IWorkspaceContextService, testObject);
@@ -759,7 +759,7 @@ suite('WorkspaceConfigurationService - Folder', () => {
 		instantiationService.stub(IRemoteAgentService, remoteAgentService);
 		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
 		const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, logService));
-		userDataProfileService = instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile));
+		userDataProfileService = instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService));
 		workspaceService = testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, new UriIdentityService(fileService), new NullLogService(), new FilePolicyService(environmentService.policyFile, fileService, logService)));
 		instantiationService.stub(IFileService, fileService);
 		instantiationService.stub(IWorkspaceContextService, testObject);
@@ -1425,7 +1425,7 @@ suite('WorkspaceConfigurationService - Profiles', () => {
 		instantiationService.stub(IRemoteAgentService, remoteAgentService);
 		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
 		const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, logService));
-		userDataProfileService = instantiationService.stub(IUserDataProfileService, new UserDataProfileService(toUserDataProfile('custom', joinPath(environmentService.userRoamingDataHome, 'profiles', 'temp'))));
+		userDataProfileService = instantiationService.stub(IUserDataProfileService, new UserDataProfileService(toUserDataProfile('custom', joinPath(environmentService.userRoamingDataHome, 'profiles', 'temp')), userDataProfilesService));
 		workspaceService = testObject = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, new UriIdentityService(fileService), new NullLogService(), new FilePolicyService(environmentService.policyFile, fileService, logService)));
 		instantiationService.stub(IFileService, fileService);
 		instantiationService.stub(IWorkspaceContextService, testObject);
@@ -1613,7 +1613,7 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 		instantiationService.stub(IRemoteAgentService, remoteAgentService);
 		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
 		const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, logService));
-		userDataProfileService = instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile));
+		userDataProfileService = instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService));
 		const workspaceService = disposables.add(new WorkspaceService({ configurationCache: new ConfigurationCache() }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
 
 		instantiationService.stub(IFileService, fileService);
@@ -2276,7 +2276,7 @@ suite('WorkspaceConfigurationService - Remote Folder', () => {
 		fileService.registerProvider(Schemas.vscodeUserData, disposables.add(new FileUserDataProvider(ROOT.scheme, fileSystemProvider, Schemas.vscodeUserData, new NullLogService())));
 		const configurationCache: IConfigurationCache = { read: () => Promise.resolve(''), write: () => Promise.resolve(), remove: () => Promise.resolve(), needsCaching: () => false };
 		const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, logService));
-		userDataProfileService = instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile));
+		userDataProfileService = instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService));
 		testObject = disposables.add(new WorkspaceService({ configurationCache, remoteAuthority }, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, new UriIdentityService(fileService), new NullLogService(), new NullPolicyService()));
 		instantiationService.stub(IWorkspaceContextService, testObject);
 		instantiationService.stub(IConfigurationService, testObject);

--- a/src/vs/workbench/services/extensionManagement/electron-sandbox/nativeExtensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-sandbox/nativeExtensionManagementService.ts
@@ -68,7 +68,7 @@ export class NativeExtensionManagementService extends ExtensionManagementChannel
 	private async whenProfileChanged(e: DidChangeUserDataProfileEvent): Promise<void> {
 		const previousExtensionsResource = e.previous.extensionsResource ?? joinPath(e.previous.location, EXTENSIONS_RESOURCE_NAME);
 		if (e.preserveData) {
-			await this.fileService.copy(previousExtensionsResource, e.profile.extensionsResource!);
+			await this.fileService.copy(previousExtensionsResource, previousExtensionsResource);
 		} else {
 			const oldExtensions = await super.getInstalled(ExtensionType.User, previousExtensionsResource);
 			const newExtensions = await this.getInstalled(ExtensionType.User);

--- a/src/vs/workbench/services/extensions/test/browser/extensionStorageMigration.test.ts
+++ b/src/vs/workbench/services/extensions/test/browser/extensionStorageMigration.test.ts
@@ -39,7 +39,7 @@ suite('ExtensionStorageMigration', () => {
 		instantiationService.stub(IFileService, fileService);
 		const environmentService = instantiationService.stub(IEnvironmentService, <Partial<IEnvironmentService>>{ userRoamingDataHome: ROOT, workspaceStorageHome });
 		const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, new NullLogService()));
-		instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile));
+		instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService));
 
 		instantiationService.stub(IExtensionStorageService, instantiationService.createInstance(ExtensionStorageService));
 	});

--- a/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
+++ b/src/vs/workbench/services/keybinding/test/browser/keybindingEditing.test.ts
@@ -66,7 +66,8 @@ suite('KeybindingsEditing', () => {
 		const configService = new TestConfigurationService();
 		configService.setUserConfiguration('files', { 'eol': '\n' });
 
-		userDataProfileService = new UserDataProfileService(new UserDataProfilesService(environmentService, fileService, logService).defaultProfile);
+		const userDataProfilesService = new UserDataProfilesService(environmentService, fileService, logService);
+		userDataProfileService = new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService);
 
 		instantiationService = workbenchInstantiationService({
 			fileService: () => fileService,

--- a/src/vs/workbench/services/storage/test/browser/storageService.test.ts
+++ b/src/vs/workbench/services/storage/test/browser/storageService.test.ts
@@ -16,9 +16,10 @@ import { InMemoryFileSystemProvider } from 'vs/platform/files/common/inMemoryFil
 import { NullLogService } from 'vs/platform/log/common/log';
 import { StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { createSuite } from 'vs/platform/storage/test/common/storageService.test';
-import { IUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { IUserDataProfile, UserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { BrowserStorageService, IndexedDBStorageDatabase } from 'vs/workbench/services/storage/browser/storageService';
 import { UserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfileService';
+import { TestEnvironmentService } from 'vs/workbench/test/browser/workbenchTestServices';
 
 async function createStorageService(): Promise<[DisposableStore, BrowserStorageService]> {
 	const disposables = new DisposableStore();
@@ -45,7 +46,7 @@ async function createStorageService(): Promise<[DisposableStore, BrowserStorageS
 		extensionsResource: joinPath(inMemoryExtraProfileRoot, 'extensionsResource')
 	};
 
-	const storageService = disposables.add(new BrowserStorageService({ id: 'workspace-storage-test' }, new UserDataProfileService(inMemoryExtraProfile), logService));
+	const storageService = disposables.add(new BrowserStorageService({ id: 'workspace-storage-test' }, new UserDataProfileService(inMemoryExtraProfile, new UserDataProfilesService(TestEnvironmentService, fileService, logService)), logService));
 
 	await storageService.initialize();
 

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
@@ -38,11 +38,9 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 	}
 
 	async createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean): Promise<IUserDataProfile> {
-		const workspaceIdentifier = this.getWorkspaceIdentifier();
-		const newProfile = this.userDataProfilesService.newProfile(name, useDefaultFlags);
-		const createdProfile = await this.userDataProfilesService.createProfile(newProfile, workspaceIdentifier);
-		await this.enterProfile(createdProfile, !!fromExisting);
-		return createdProfile;
+		const profile = await this.userDataProfilesService.createProfile(name, useDefaultFlags, this.getWorkspaceIdentifier());
+		await this.enterProfile(profile, !!fromExisting);
+		return profile;
 	}
 
 	async removeProfile(profile: IUserDataProfile): Promise<void> {

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
@@ -4,19 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from 'vs/base/common/lifecycle';
-import { joinPath } from 'vs/base/common/resources';
-import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { ILocalExtension, Metadata } from 'vs/platform/extensionManagement/common/extensionManagement';
-import { IExtensionsProfileScannerService } from 'vs/platform/extensionManagement/common/extensionsProfileScannerService';
-import { ExtensionType } from 'vs/platform/extensions/common/extensions';
-import { IFileService } from 'vs/platform/files/common/files';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { DidChangeProfilesEvent, EXTENSIONS_RESOURCE_NAME, IUserDataProfile, IUserDataProfilesService, UseDefaultProfileFlags, WorkspaceIdentifier } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { DidChangeProfilesEvent, IUserDataProfile, IUserDataProfilesService, UseDefaultProfileFlags, WorkspaceIdentifier } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
-import { IExtensionManagementServerService, IWorkbenchExtensionManagementService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IUserDataProfileManagementService, IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
@@ -27,10 +20,6 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 	constructor(
 		@IUserDataProfilesService private readonly userDataProfilesService: IUserDataProfilesService,
 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
-		@IFileService private readonly fileService: IFileService,
-		@IExtensionManagementServerService private readonly extensionManagementServerService: IExtensionManagementServerService,
-		@IWorkbenchExtensionManagementService private readonly extensionManagementService: IWorkbenchExtensionManagementService,
-		@IExtensionsProfileScannerService private readonly extensionsProfileScannerService: IExtensionsProfileScannerService,
 		@IHostService private readonly hostService: IHostService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
@@ -51,11 +40,6 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 	async createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean): Promise<IUserDataProfile> {
 		const workspaceIdentifier = this.getWorkspaceIdentifier();
 		const newProfile = this.userDataProfilesService.newProfile(name, useDefaultFlags);
-		await this.fileService.createFolder(newProfile.location);
-		if (!this.userDataProfilesService.defaultProfile.extensionsResource) {
-			// Extensions profile is not yet created for default profile, create it now
-			await this.createDefaultExtensionsProfile(joinPath(this.userDataProfilesService.defaultProfile.location, EXTENSIONS_RESOURCE_NAME));
-		}
 		const createdProfile = await this.userDataProfilesService.createProfile(newProfile, workspaceIdentifier);
 		await this.enterProfile(createdProfile, !!fromExisting);
 		return createdProfile;
@@ -71,11 +55,7 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 		if (profile.id === this.userDataProfileService.currentProfile.id) {
 			throw new Error(localize('cannotDeleteCurrentProfile', "Cannot delete the current profile"));
 		}
-		const defaultExtensionsResourceToDelete = this.userDataProfilesService.profiles.length === 2 ? this.userDataProfilesService.defaultProfile.extensionsResource : undefined;
 		await this.userDataProfilesService.removeProfile(profile);
-		if (defaultExtensionsResourceToDelete) {
-			try { await this.fileService.del(defaultExtensionsResourceToDelete); } catch (error) { /* ignore */ }
-		}
 	}
 
 	async switchProfile(profile: IUserDataProfile): Promise<void> {
@@ -117,15 +97,6 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 		this.extensionService.stopExtensionHosts();
 		await this.userDataProfileService.updateCurrentProfile(profile, preserveData);
 		await this.extensionService.startExtensionHosts();
-	}
-
-	private async createDefaultExtensionsProfile(extensionsProfileResource: URI): Promise<URI> {
-		try { await this.fileService.del(extensionsProfileResource); } catch (error) { /* ignore */ }
-		const extensionManagementService = this.extensionManagementServerService.localExtensionManagementServer?.extensionManagementService ?? this.extensionManagementService;
-		const userExtensions = await extensionManagementService.getInstalled(ExtensionType.User);
-		const extensions: [ILocalExtension, Metadata | undefined][] = await Promise.all(userExtensions.map(async e => ([e, await this.extensionManagementService.getMetadata(e)])));
-		await this.extensionsProfileScannerService.addExtensionsToProfile(extensions, extensionsProfileResource);
-		return extensionsProfileResource;
 	}
 }
 

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
@@ -46,10 +46,6 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 			this.enterProfile(this.userDataProfilesService.defaultProfile, false, localize('reload message when removed', "The current profile has been removed. Please reload to switch back to default profile"));
 			return;
 		}
-		if (this.userDataProfileService.currentProfile.isDefault) {
-			this.userDataProfileService.updateCurrentProfile(this.userDataProfilesService.defaultProfile, false);
-			return;
-		}
 	}
 
 	async createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean): Promise<IUserDataProfile> {

--- a/src/vs/workbench/services/userDataProfile/common/userDataProfileService.ts
+++ b/src/vs/workbench/services/userDataProfile/common/userDataProfileService.ts
@@ -6,7 +6,7 @@
 import { Promises } from 'vs/base/common/async';
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { IUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { IUserDataProfile, IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { DidChangeUserDataProfileEvent, IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 
 export class UserDataProfileService extends Disposable implements IUserDataProfileService {
@@ -19,17 +19,26 @@ export class UserDataProfileService extends Disposable implements IUserDataProfi
 	private _currentProfile: IUserDataProfile;
 	get currentProfile(): IUserDataProfile { return this._currentProfile; }
 
-	constructor(currentProfile: IUserDataProfile) {
+	constructor(currentProfile: IUserDataProfile, userDataProfilesService: IUserDataProfilesService) {
 		super();
 		this._currentProfile = currentProfile;
+		this._register(userDataProfilesService.onDidChangeProfiles(() => {
+			/**
+			 * If the current profile is default profile, then reset it because,
+			 * In Desktop the extensions resource will be set/unset in the default profile when profiles are changed.
+			 */
+			if (this._currentProfile.isDefault) {
+				this._currentProfile = userDataProfilesService.defaultProfile;
+			}
+		}));
 	}
 
 	async updateCurrentProfile(userDataProfile: IUserDataProfile, preserveData: boolean): Promise<void> {
-		const previous = this._currentProfile;
-		this._currentProfile = userDataProfile;
-		if (this._currentProfile.id === previous.id) {
+		if (this._currentProfile.id === userDataProfile.id) {
 			return;
 		}
+		const previous = this._currentProfile;
+		this._currentProfile = userDataProfile;
 		const joiners: Promise<void>[] = [];
 		this._onDidChangeCurrentProfile.fire({
 			preserveData,

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -286,7 +286,7 @@ export function workbenchInstantiationService(
 	const fileService = overrides?.fileService ? overrides.fileService(instantiationService) : new TestFileService();
 	instantiationService.stub(IFileService, fileService);
 	const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(environmentService, fileService, new NullLogService()));
-	instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile));
+	instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService));
 	instantiationService.stub(IUriIdentityService, new UriIdentityService(fileService));
 	instantiationService.stub(IWorkingCopyBackupService, new TestWorkingCopyBackupService());
 	instantiationService.stub(ITelemetryService, NullTelemetryService);

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -290,7 +290,7 @@ export function workbenchInstantiationService(disposables = new DisposableStore(
 	instantiationService.stub(IWorkbenchEnvironmentService, TestEnvironmentService);
 	instantiationService.stub(INativeWorkbenchEnvironmentService, TestEnvironmentService);
 	const userDataProfilesService = instantiationService.stub(IUserDataProfilesService, new UserDataProfilesService(TestEnvironmentService, new FileService(new NullLogService()), new NullLogService()));
-	instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile));
+	instantiationService.stub(IUserDataProfileService, new UserDataProfileService(userDataProfilesService.defaultProfile, userDataProfilesService));
 
 	return instantiationService;
 }


### PR DESCRIPTION
- always include default profile in profiles
- extract default extensions profile init and uninit
    invoke it from main
- move reset default profile to UserDataProfilesService
- merge newProfile with createProfile
- remove migration

Ref: https://github.com/microsoft/vscode/issues/153716