### PR TITLE
Ensure exact match links are only checked on paths containing separators 

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkOpeners.ts
@@ -218,12 +218,13 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 
 	private async _tryOpenExactLink(text: string, link: ITerminalSimpleLink): Promise<boolean> {
 		const sanitizedLink = text.replace(/:\d+(:\d+)?$/, '');
-		// For only file links disallow exact link matching, for example searching for `foo.txt`
-		// when no cwd information is available should search when only the initial cwd is available
-		// as it's ambiguous if there are multiple matches.
+		// For links made up of only a file name (no folder), disallow exact link matching. For
+		// example searching for `foo.txt` when there is no cwd information available (ie. only the
+		// initial cwd) should NOT search  as it's ambiguous if there are multiple matches.
 		//
-		// However, for `src/foo.txt`, if there's an exact match for `src/foo.txt` in any folder we
-		// want to take it, even if there are partial matches like `src2/foo.txt` available.
+		// However, for a link like `src/foo.txt`, if there's an exact match for `src/foo.txt` in
+		// any folder we want to take it, even if there are partial matches like `src2/foo.txt`
+		// available.
 		if (!sanitizedLink.match(/[\\/]/)) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkOpeners.ts
@@ -218,6 +218,9 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 
 	private async _tryOpenExactLink(text: string, link: ITerminalSimpleLink): Promise<boolean> {
 		const sanitizedLink = text.replace(/:\d+(:\d+)?$/, '');
+		if (!osPathModule(this._os).isAbsolute(sanitizedLink)) {
+			return false;
+		}
 		try {
 			const result = await this._getExactMatch(sanitizedLink);
 			if (result) {

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkOpeners.ts
@@ -218,7 +218,13 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 
 	private async _tryOpenExactLink(text: string, link: ITerminalSimpleLink): Promise<boolean> {
 		const sanitizedLink = text.replace(/:\d+(:\d+)?$/, '');
-		if (!osPathModule(this._os).isAbsolute(sanitizedLink)) {
+		// For only file links disallow exact link matching, for example searching for `foo.txt`
+		// when no cwd information is available should search when only the initial cwd is available
+		// as it's ambiguous if there are multiple matches.
+		//
+		// However, for `src/foo.txt`, if there's an exact match for `src/foo.txt` in any folder we
+		// want to take it, even if there are partial matches like `src2/foo.txt` available.
+		if (!sanitizedLink.match(/[\\/]/)) {
 			return false;
 		}
 		try {

--- a/src/vs/workbench/contrib/terminal/test/browser/links/terminalLinkOpeners.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/links/terminalLinkOpeners.test.ts
@@ -97,7 +97,37 @@ suite('Workbench - TerminalLinkOpeners', () => {
 			capabilities.add(TerminalCapability.CommandDetection, commandDetection);
 		});
 
-		test('should open single exact match against cwd when searching if it exists', async () => {
+		test('should open single exact match against cwd when searching if it exists when command detection cwd is available', async () => {
+			localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener, OperatingSystem.Linux);
+			const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+			opener = instantiationService.createInstance(TerminalSearchLinkOpener, capabilities, Promise.resolve('/initial/cwd'), localFileOpener, localFolderOpener, OperatingSystem.Linux);
+			// Set a fake detected command starting as line 0 to establish the cwd
+			commandDetection.setCommands([{
+				command: '',
+				cwd: '/initial/cwd',
+				timestamp: 0,
+				getOutput() { return undefined; },
+				marker: {
+					line: 0
+				} as Partial<IXtermMarker> as any,
+				hasOutput: true
+			}]);
+			fileService.setFiles([
+				URI.from({ scheme: Schemas.file, path: '/initial/cwd/foo/bar.txt' }),
+				URI.from({ scheme: Schemas.file, path: '/initial/cwd/foo2/bar.txt' })
+			]);
+			await opener.open({
+				text: 'foo/bar.txt',
+				bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+				type: TerminalBuiltinLinkType.Search
+			});
+			deepStrictEqual(activationResult, {
+				link: 'file:///initial/cwd/foo/bar.txt',
+				source: 'editor'
+			});
+		});
+
+		test('should open single exact match against cwd for paths containing a separator when searching if it exists, even when command detection isn\'t available', async () => {
 			localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener, OperatingSystem.Linux);
 			const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
 			opener = instantiationService.createInstance(TerminalSearchLinkOpener, capabilities, Promise.resolve('/initial/cwd'), localFileOpener, localFolderOpener, OperatingSystem.Linux);
@@ -113,6 +143,25 @@ suite('Workbench - TerminalLinkOpeners', () => {
 			deepStrictEqual(activationResult, {
 				link: 'file:///initial/cwd/foo/bar.txt',
 				source: 'editor'
+			});
+		});
+
+		test('should not open single exact match for paths not containing a when command detection isn\'t available', async () => {
+			localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener, OperatingSystem.Linux);
+			const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+			opener = instantiationService.createInstance(TerminalSearchLinkOpener, capabilities, Promise.resolve('/initial/cwd'), localFileOpener, localFolderOpener, OperatingSystem.Linux);
+			fileService.setFiles([
+				URI.from({ scheme: Schemas.file, path: '/initial/cwd/foo/bar.txt' }),
+				URI.from({ scheme: Schemas.file, path: '/initial/cwd/foo2/bar.txt' })
+			]);
+			await opener.open({
+				text: 'bar.txt',
+				bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+				type: TerminalBuiltinLinkType.Search
+			});
+			deepStrictEqual(activationResult, {
+				link: 'bar.txt',
+				source: 'search'
 			});
 		});
 


### PR DESCRIPTION
Fixes #153832
