### PR TITLE
Prevent unicode11 addon from loading in unit tests

### DIFF
--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
@@ -80,7 +80,7 @@ const defaultTerminalConfig: Partial<ITerminalConfiguration> = {
 	scrollback: 1000,
 	fastScrollSensitivity: 2,
 	mouseWheelScrollSensitivity: 1,
-	unicodeVersion: '11'
+	unicodeVersion: '6'
 };
 
 suite('XtermTerminal', () => {


### PR DESCRIPTION
It's not clear what caused the flake in #153757 but this should fix the suspicious
unicode warning. We can reinvestigate if it happens again after this fix.

Fixes #153757
