### PR TITLE
joh/plastic fowl

### DIFF
--- a/src/vs/editor/browser/services/bulkEditService.ts
+++ b/src/vs/editor/browser/services/bulkEditService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { TextEdit, WorkspaceEdit, WorkspaceEditMetadata, WorkspaceFileEdit, WorkspaceFileEditOptions, WorkspaceTextEdit } from 'vs/editor/common/languages';
+import { TextEdit, WorkspaceEdit, WorkspaceEditMetadata, IWorkspaceFileEdit, WorkspaceFileEditOptions, IWorkspaceTextEdit } from 'vs/editor/common/languages';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IProgress, IProgressStep } from 'vs/platform/progress/common/progress';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -15,49 +15,77 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 
 export const IBulkEditService = createDecorator<IBulkEditService>('IWorkspaceEditService');
 
-function isWorkspaceFileEdit(thing: any): thing is WorkspaceFileEdit {
-	return isObject(thing) && (Boolean((<WorkspaceFileEdit>thing).newUri) || Boolean((<WorkspaceFileEdit>thing).oldUri));
-}
-
-function isWorkspaceTextEdit(thing: any): thing is WorkspaceTextEdit {
-	return isObject(thing) && URI.isUri((<WorkspaceTextEdit>thing).resource) && isObject((<WorkspaceTextEdit>thing).edit);
-}
-
 export class ResourceEdit {
 
 	protected constructor(readonly metadata?: WorkspaceEditMetadata) { }
 
 	static convert(edit: WorkspaceEdit): ResourceEdit[] {
 
-
 		return edit.edits.map(edit => {
-			if (isWorkspaceTextEdit(edit)) {
-				return new ResourceTextEdit(edit.resource, edit.edit, edit.modelVersionId, edit.metadata);
+			if (ResourceTextEdit.is(edit)) {
+				return ResourceTextEdit.lift(edit);
 			}
-			if (isWorkspaceFileEdit(edit)) {
-				return new ResourceFileEdit(edit.oldUri, edit.newUri, edit.options, edit.metadata);
+
+			if (ResourceFileEdit.is(edit)) {
+				return ResourceFileEdit.lift(edit);
 			}
 			throw new Error('Unsupported edit');
 		});
 	}
 }
 
-export class ResourceTextEdit extends ResourceEdit {
+export class ResourceTextEdit extends ResourceEdit implements IWorkspaceTextEdit {
+
+	static is(candidate: any): candidate is IWorkspaceTextEdit {
+		if (candidate instanceof ResourceTextEdit) {
+			return true;
+		}
+		return isObject(candidate)
+			&& URI.isUri((<IWorkspaceTextEdit>candidate).resource)
+			&& isObject((<IWorkspaceTextEdit>candidate).textEdit);
+	}
+
+	static lift(edit: IWorkspaceTextEdit): ResourceTextEdit {
+		if (edit instanceof ResourceTextEdit) {
+			return edit;
+		} else {
+			return new ResourceTextEdit(edit.resource, edit.textEdit, edit.versionId, edit.metadata);
+		}
+	}
+
 	constructor(
 		readonly resource: URI,
 		readonly textEdit: TextEdit & { insertAsSnippet?: boolean },
-		readonly versionId?: number,
+		readonly versionId: number | undefined = undefined,
 		metadata?: WorkspaceEditMetadata,
 	) {
 		super(metadata);
 	}
 }
 
-export class ResourceFileEdit extends ResourceEdit {
+export class ResourceFileEdit extends ResourceEdit implements IWorkspaceFileEdit {
+
+	static is(candidate: any): candidate is IWorkspaceFileEdit {
+		if (candidate instanceof ResourceFileEdit) {
+			return true;
+		} else {
+			return isObject(candidate)
+				&& (Boolean((<IWorkspaceFileEdit>candidate).newResource) || Boolean((<IWorkspaceFileEdit>candidate).oldResource));
+		}
+	}
+
+	static lift(edit: IWorkspaceFileEdit): ResourceFileEdit {
+		if (edit instanceof ResourceFileEdit) {
+			return edit;
+		} else {
+			return new ResourceFileEdit(edit.oldResource, edit.newResource, edit.options, edit.metadata);
+		}
+	}
+
 	constructor(
 		readonly oldResource: URI | undefined,
 		readonly newResource: URI | undefined,
-		readonly options?: WorkspaceFileEditOptions,
+		readonly options: WorkspaceFileEditOptions = {},
 		metadata?: WorkspaceEditMetadata
 	) {
 		super(metadata);

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1412,22 +1412,22 @@ export interface WorkspaceFileEditOptions {
 	maxSize?: number;
 }
 
-export interface WorkspaceFileEdit {
-	oldUri?: URI;
-	newUri?: URI;
+export interface IWorkspaceFileEdit {
+	oldResource?: URI;
+	newResource?: URI;
 	options?: WorkspaceFileEditOptions;
 	metadata?: WorkspaceEditMetadata;
 }
 
-export interface WorkspaceTextEdit {
+export interface IWorkspaceTextEdit {
 	resource: URI;
-	edit: TextEdit;
-	modelVersionId?: number;
+	textEdit: TextEdit & { insertAsSnippet?: boolean };
+	versionId: number | undefined;
 	metadata?: WorkspaceEditMetadata;
 }
 
 export interface WorkspaceEdit {
-	edits: Array<WorkspaceTextEdit | WorkspaceFileEdit>;
+	edits: Array<IWorkspaceTextEdit | IWorkspaceFileEdit>;
 }
 
 export interface Rejection {

--- a/src/vs/editor/contrib/codeAction/test/browser/codeAction.test.ts
+++ b/src/vs/editor/contrib/codeAction/test/browser/codeAction.test.ts
@@ -73,7 +73,7 @@ suite('CodeAction', () => {
 			bcd: {
 				diagnostics: <IMarkerData[]>[],
 				edit: new class implements languages.WorkspaceEdit {
-					edits!: languages.WorkspaceTextEdit[];
+					edits!: languages.IWorkspaceTextEdit[];
 				},
 				title: 'abc'
 			}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7015,22 +7015,24 @@ declare namespace monaco.languages {
 		maxSize?: number;
 	}
 
-	export interface WorkspaceFileEdit {
-		oldUri?: Uri;
-		newUri?: Uri;
+	export interface IWorkspaceFileEdit {
+		oldResource?: Uri;
+		newResource?: Uri;
 		options?: WorkspaceFileEditOptions;
 		metadata?: WorkspaceEditMetadata;
 	}
 
-	export interface WorkspaceTextEdit {
+	export interface IWorkspaceTextEdit {
 		resource: Uri;
-		edit: TextEdit;
-		modelVersionId?: number;
+		textEdit: TextEdit & {
+			insertAsSnippet?: boolean;
+		};
+		versionId: number | undefined;
 		metadata?: WorkspaceEditMetadata;
 	}
 
 	export interface WorkspaceEdit {
-		edits: Array<WorkspaceTextEdit | WorkspaceFileEdit>;
+		edits: Array<IWorkspaceTextEdit | IWorkspaceFileEdit>;
 	}
 
 	export interface Rejection {

--- a/src/vs/workbench/api/common/extHostDocumentSaveParticipant.ts
+++ b/src/vs/workbench/api/common/extHostDocumentSaveParticipant.ts
@@ -6,7 +6,7 @@
 import { Event } from 'vs/base/common/event';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { illegalState } from 'vs/base/common/errors';
-import { ExtHostDocumentSaveParticipantShape, IWorkspaceEditDto, WorkspaceEditType, MainThreadBulkEditsShape } from 'vs/workbench/api/common/extHost.protocol';
+import { ExtHostDocumentSaveParticipantShape, IWorkspaceEditDto, MainThreadBulkEditsShape } from 'vs/workbench/api/common/extHost.protocol';
 import { TextEdit } from 'vs/workbench/api/common/extHostTypes';
 import { Range, TextDocumentSaveReason, EndOfLine } from 'vs/workbench/api/common/extHostTypeConverters';
 import { ExtHostDocuments } from 'vs/workbench/api/common/extHostDocuments';
@@ -146,12 +146,12 @@ export class ExtHostDocumentSaveParticipant implements ExtHostDocumentSavePartic
 				if (Array.isArray(value) && (<vscode.TextEdit[]>value).every(e => e instanceof TextEdit)) {
 					for (const { newText, newEol, range } of value) {
 						dto.edits.push({
-							_type: WorkspaceEditType.Text,
 							resource: document.uri,
-							edit: {
+							versionId: undefined,
+							textEdit: {
 								range: range && Range.from(range),
 								text: newText,
-								eol: newEol && EndOfLine.from(newEol)
+								eol: newEol && EndOfLine.from(newEol),
 							}
 						});
 					}

--- a/src/vs/workbench/api/test/browser/extHostBulkEdits.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostBulkEdits.test.ts
@@ -4,13 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
 import * as extHostTypes from 'vs/workbench/api/common/extHostTypes';
-import { MainContext, IWorkspaceEditDto, WorkspaceEditType, MainThreadBulkEditsShape } from 'vs/workbench/api/common/extHost.protocol';
+import { MainContext, IWorkspaceEditDto, MainThreadBulkEditsShape, IWorkspaceTextEditDto } from 'vs/workbench/api/common/extHost.protocol';
 import { URI } from 'vs/base/common/uri';
 import { mock } from 'vs/base/test/common/mock';
 import { ExtHostDocumentsAndEditors } from 'vs/workbench/api/common/extHostDocumentsAndEditors';
 import { SingleProxyRPCProtocol, TestRPCProtocol } from 'vs/workbench/api/test/common/testRPCProtocol';
 import { NullLogService } from 'vs/platform/log/common/log';
-import { assertType } from 'vs/base/common/types';
 import { ExtHostBulkEdits } from 'vs/workbench/api/common/extHostBulkEdits';
 import { nullExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
 
@@ -50,8 +49,7 @@ suite('ExtHostBulkEdits.applyWorkspaceEdit', () => {
 		await bulkEdits.applyWorkspaceEdit(edit, nullExtensionDescription);
 		assert.strictEqual(workspaceResourceEdits.edits.length, 1);
 		const [first] = workspaceResourceEdits.edits;
-		assertType(first._type === WorkspaceEditType.Text);
-		assert.strictEqual(first.modelVersionId, 1337);
+		assert.strictEqual((<IWorkspaceTextEditDto>first).versionId, 1337);
 	});
 
 	test('does not use version id if document is not available', async () => {
@@ -60,8 +58,7 @@ suite('ExtHostBulkEdits.applyWorkspaceEdit', () => {
 		await bulkEdits.applyWorkspaceEdit(edit, nullExtensionDescription);
 		assert.strictEqual(workspaceResourceEdits.edits.length, 1);
 		const [first] = workspaceResourceEdits.edits;
-		assertType(first._type === WorkspaceEditType.Text);
-		assert.ok(typeof first.modelVersionId === 'undefined');
+		assert.ok(typeof (<IWorkspaceTextEditDto>first).versionId === 'undefined');
 	});
 
 });

--- a/src/vs/workbench/api/test/browser/extHostDocumentSaveParticipant.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostDocumentSaveParticipant.test.ts
@@ -266,8 +266,8 @@ suite('ExtHostDocumentSaveParticipant', () => {
 			sub.dispose();
 
 			assert.strictEqual(dto.edits.length, 2);
-			assert.ok((<IWorkspaceTextEditDto>dto.edits[0]).edit);
-			assert.ok((<IWorkspaceTextEditDto>dto.edits[1]).edit);
+			assert.ok((<IWorkspaceTextEditDto>dto.edits[0]).textEdit);
+			assert.ok((<IWorkspaceTextEditDto>dto.edits[1]).textEdit);
 		});
 	});
 
@@ -317,7 +317,7 @@ suite('ExtHostDocumentSaveParticipant', () => {
 				for (const edit of dto.edits) {
 
 					const uri = URI.revive((<IWorkspaceTextEditDto>edit).resource);
-					const { text, range } = (<IWorkspaceTextEditDto>edit).edit;
+					const { text, range } = (<IWorkspaceTextEditDto>edit).textEdit;
 					documents.$acceptModelChanged(uri, {
 						changes: [{
 							range,

--- a/src/vs/workbench/api/test/browser/mainThreadEditors.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadEditors.test.ts
@@ -9,7 +9,7 @@ import { TestConfigurationService } from 'vs/platform/configuration/test/common/
 import { ModelService } from 'vs/editor/common/services/modelService';
 import { TestCodeEditorService } from 'vs/editor/test/browser/editorTestServices';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
-import { IWorkspaceTextEditDto, WorkspaceEditType } from 'vs/workbench/api/common/extHost.protocol';
+import { IWorkspaceTextEditDto } from 'vs/workbench/api/common/extHost.protocol';
 import { mock } from 'vs/base/test/common/mock';
 import { Event } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
@@ -197,10 +197,9 @@ suite('MainThreadEditors', () => {
 		const model = modelService.createModel('something', null, resource);
 
 		const workspaceResourceEdit: IWorkspaceTextEditDto = {
-			_type: WorkspaceEditType.Text,
 			resource: resource,
-			modelVersionId: model.getVersionId(),
-			edit: {
+			versionId: model.getVersionId(),
+			textEdit: {
 				text: 'asdfg',
 				range: new Range(1, 1, 1, 1)
 			}
@@ -219,19 +218,17 @@ suite('MainThreadEditors', () => {
 		const model = modelService.createModel('something', null, resource);
 
 		const workspaceResourceEdit1: IWorkspaceTextEditDto = {
-			_type: WorkspaceEditType.Text,
 			resource: resource,
-			modelVersionId: model.getVersionId(),
-			edit: {
+			versionId: model.getVersionId(),
+			textEdit: {
 				text: 'asdfg',
 				range: new Range(1, 1, 1, 1)
 			}
 		};
 		const workspaceResourceEdit2: IWorkspaceTextEditDto = {
-			_type: WorkspaceEditType.Text,
 			resource: resource,
-			modelVersionId: model.getVersionId(),
-			edit: {
+			versionId: model.getVersionId(),
+			textEdit: {
 				text: 'asdfg',
 				range: new Range(1, 1, 1, 1)
 			}
@@ -251,9 +248,9 @@ suite('MainThreadEditors', () => {
 	test(`applyWorkspaceEdit with only resource edit`, () => {
 		return bulkEdits.$tryApplyWorkspaceEdit({
 			edits: [
-				{ _type: WorkspaceEditType.File, oldUri: resource, newUri: resource, options: undefined },
-				{ _type: WorkspaceEditType.File, oldUri: undefined, newUri: resource, options: undefined },
-				{ _type: WorkspaceEditType.File, oldUri: resource, newUri: undefined, options: undefined }
+				{ oldResource: resource, newResource: resource, options: undefined },
+				{ oldResource: undefined, newResource: resource, options: undefined },
+				{ oldResource: resource, newResource: undefined, options: undefined }
 			]
 		}).then((result) => {
 			assert.strictEqual(result, true);

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkCellEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkCellEdits.ts
@@ -6,20 +6,36 @@
 import { groupBy } from 'vs/base/common/arrays';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { compare } from 'vs/base/common/strings';
+import { isObject } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { ResourceEdit } from 'vs/editor/browser/services/bulkEditService';
 import { WorkspaceEditMetadata } from 'vs/editor/common/languages';
 import { IProgress } from 'vs/platform/progress/common/progress';
 import { UndoRedoGroup, UndoRedoSource } from 'vs/platform/undoRedo/common/undoRedo';
-import { ICellEditOperation } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { ICellPartialMetadataEdit, ICellReplaceEdit, IDocumentMetadataEdit, IWorkspaceNotebookCellEdit } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookEditorModelResolverService } from 'vs/workbench/contrib/notebook/common/notebookEditorModelResolverService';
 
-export class ResourceNotebookCellEdit extends ResourceEdit {
+export class ResourceNotebookCellEdit extends ResourceEdit implements IWorkspaceNotebookCellEdit {
+
+	static is(candidate: any): candidate is IWorkspaceNotebookCellEdit {
+		if (candidate instanceof ResourceNotebookCellEdit) {
+			return true;
+		}
+		return URI.isUri((<IWorkspaceNotebookCellEdit>candidate).resource)
+			&& isObject((<IWorkspaceNotebookCellEdit>candidate).cellEdit);
+	}
+
+	static lift(edit: IWorkspaceNotebookCellEdit): ResourceNotebookCellEdit {
+		if (edit instanceof ResourceNotebookCellEdit) {
+			return edit;
+		}
+		return new ResourceNotebookCellEdit(edit.resource, edit.cellEdit, edit.notebookVersionId, edit.metadata);
+	}
 
 	constructor(
 		readonly resource: URI,
-		readonly cellEdit: ICellEditOperation,
-		readonly versionId?: number,
+		readonly cellEdit: ICellPartialMetadataEdit | IDocumentMetadataEdit | ICellReplaceEdit,
+		readonly notebookVersionId: number | undefined,
 		metadata?: WorkspaceEditMetadata
 	) {
 		super(metadata);
@@ -49,7 +65,7 @@ export class BulkCellEdits {
 			const ref = await this._notebookModelService.resolve(first.resource);
 
 			// check state
-			if (typeof first.versionId === 'number' && ref.object.notebook.versionId !== first.versionId) {
+			if (typeof first.notebookVersionId === 'number' && ref.object.notebook.versionId !== first.notebookVersionId) {
 				ref.dispose();
 				throw new Error(`Notebook '${first.resource}' has changed in the meantime`);
 			}

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkCellEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkCellEdits.ts
@@ -35,7 +35,7 @@ export class ResourceNotebookCellEdit extends ResourceEdit implements IWorkspace
 	constructor(
 		readonly resource: URI,
 		readonly cellEdit: ICellPartialMetadataEdit | IDocumentMetadataEdit | ICellReplaceEdit,
-		readonly notebookVersionId: number | undefined,
+		readonly notebookVersionId: number | undefined = undefined,
 		metadata?: WorkspaceEditMetadata
 	) {
 		super(metadata);

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
@@ -17,7 +17,7 @@ import { FindMatch, IModelDecorationOptions, IModelDeltaDecoration, TrackedRange
 import { MultiModelEditStackElement, SingleModelEditStackElement } from 'vs/editor/common/model/editStack';
 import { IntervalNode, IntervalTree } from 'vs/editor/common/model/intervalTree';
 import { ModelDecorationOptions } from 'vs/editor/common/model/textModel';
-import { WorkspaceTextEdit } from 'vs/editor/common/languages';
+import { IWorkspaceTextEdit } from 'vs/editor/common/languages';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { FoldingRegions } from 'vs/editor/contrib/folding/browser/foldingRanges';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -924,14 +924,15 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 			return;
 		}
 
-		const textEdits: WorkspaceTextEdit[] = [];
+		const textEdits: IWorkspaceTextEdit[] = [];
 		this._lastNotebookEditResource.push(matches[0].cell.uri);
 
 		matches.forEach(match => {
 			match.matches.forEach((singleMatch, index) => {
 				if ((singleMatch as OutputFindMatch).index === undefined) {
 					textEdits.push({
-						edit: { range: (singleMatch as FindMatch).range, text: texts[index] },
+						versionId: undefined,
+						textEdit: { range: (singleMatch as FindMatch).range, text: texts[index] },
 						resource: match.cell.uri
 					});
 				}

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -17,7 +17,7 @@ import { ISplice } from 'vs/base/common/sequence';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { ILineChange } from 'vs/editor/common/diff/diffComputer';
 import * as editorCommon from 'vs/editor/common/editorCommon';
-import { Command } from 'vs/editor/common/languages';
+import { Command, WorkspaceEditMetadata } from 'vs/editor/common/languages';
 import { IReadonlyTextBuffer } from 'vs/editor/common/model';
 import { IAccessibilityInformation } from 'vs/platform/accessibility/common/accessibility';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
@@ -496,6 +496,14 @@ export interface ICellMoveEdit {
 
 export type IImmediateCellEditOperation = ICellOutputEditByHandle | ICellPartialMetadataEditByHandle | ICellOutputItemEdit | ICellPartialInternalMetadataEdit | ICellPartialInternalMetadataEditByHandle | ICellPartialMetadataEdit;
 export type ICellEditOperation = IImmediateCellEditOperation | ICellReplaceEdit | ICellOutputEdit | ICellMetadataEdit | ICellPartialMetadataEdit | ICellPartialInternalMetadataEdit | IDocumentMetadataEdit | ICellMoveEdit | ICellOutputItemEdit | ICellLanguageEdit;
+
+
+export interface IWorkspaceNotebookCellEdit {
+	metadata?: WorkspaceEditMetadata;
+	resource: URI;
+	notebookVersionId: number | undefined;
+	cellEdit: ICellPartialMetadataEdit | IDocumentMetadataEdit | ICellReplaceEdit;
+}
 
 export interface NotebookData {
 	readonly cells: ICellDto2[];


### PR DESCRIPTION
- * derive workspace dto with util * be strict when defining reference version ids (must be set to a value or undefined)
- relax `ResourceNotebookCellEdit`
