### PR TITLE
Remove reliance on history and always send command line

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -65,13 +65,7 @@ __vsc_update_cwd() {
 
 __vsc_command_output_start() {
 	builtin printf "\033]633;C\007"
-	if [[ ! "$BASH_COMMAND" =~ ^__vsc_prompt* ]]; then
-		__vsc_current_command=$BASH_COMMAND
-		builtin printf "\033]633;E;$BASH_COMMAND\007"
-	else
-		__vsc_current_command=""
-		builtin printf "\033]633;E\007"
-	fi
+	builtin printf "\033]633;E;$__vsc_current_command\007"
 }
 
 __vsc_continuation_start() {
@@ -111,6 +105,7 @@ __vsc_update_prompt() {
 
 __vsc_precmd() {
 	__vsc_command_complete "$__vsc_status"
+	__vsc_current_command=""
 	__vsc_update_prompt
 }
 
@@ -118,6 +113,11 @@ __vsc_preexec() {
 	if [ "$__vsc_in_command_execution" = "0" ]; then
 		__vsc_initialized=1
 		__vsc_in_command_execution="1"
+		if [[ ! "$BASH_COMMAND" =~ ^__vsc_prompt* ]]; then
+			__vsc_current_command=$BASH_COMMAND
+		else
+			__vsc_current_command=""
+		fi
 		__vsc_command_output_start
 	fi
 }

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -39,13 +39,6 @@ if [[ "$PROMPT_COMMAND" =~ .*(' '.*\;)|(\;.*' ').* ]]; then
 	builtin return
 fi
 
-# Disable shell integration if HISTCONTROL is set to erase duplicate entries as the exit code
-# reporting relies on the duplicates existing
-if [[ "$HISTCONTROL" =~ .*erasedups.* ]]; then
-	builtin unset VSCODE_SHELL_INTEGRATION
-	builtin return
-fi
-
 if [ -z "$VSCODE_SHELL_INTEGRATION" ]; then
 	builtin return
 fi
@@ -56,7 +49,7 @@ __vsc_original_PS2="$PS2"
 __vsc_custom_PS1=""
 __vsc_custom_PS2=""
 __vsc_in_command_execution="1"
-__vsc_last_history_id=$(history 1 | awk '{print $1;}')
+__vsc_current_command=""
 
 __vsc_prompt_start() {
 	builtin printf "\033]633;A\007"
@@ -72,6 +65,13 @@ __vsc_update_cwd() {
 
 __vsc_command_output_start() {
 	builtin printf "\033]633;C\007"
+	if [[ ! "$BASH_COMMAND" =~ ^__vsc_prompt* ]]; then
+		__vsc_current_command=$BASH_COMMAND
+		builtin printf "\033]633;E;$BASH_COMMAND\007"
+	else
+		__vsc_current_command=""
+		builtin printf "\033]633;E\007"
+	fi
 }
 
 __vsc_continuation_start() {
@@ -83,12 +83,10 @@ __vsc_continuation_end() {
 }
 
 __vsc_command_complete() {
-	local __vsc_history_id=$(builtin history 1 | awk '{print $1;}')
-	if [[ "$__vsc_history_id" == "$__vsc_last_history_id" ]]; then
+	if [ "$__vsc_current_command" = "" ]; then
 		builtin printf "\033]633;D\007"
 	else
 		builtin printf "\033]633;D;%s\007" "$__vsc_status"
-		__vsc_last_history_id=$__vsc_history_id
 	fi
 	__vsc_update_cwd
 }

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -33,9 +33,8 @@ if [ -z "$VSCODE_SHELL_INTEGRATION" ]; then
 	builtin return
 fi
 
-__vsc_initialized="0"
 __vsc_in_command_execution="1"
-__vsc_last_history_id=0
+__vsc_current_command=""
 
 __vsc_prompt_start() {
 	builtin printf "\033]633;A\007"
@@ -51,6 +50,7 @@ __vsc_update_cwd() {
 
 __vsc_command_output_start() {
 	builtin printf "\033]633;C\007"
+	builtin printf "\033]633;E;$__vsc_current_command\007"
 }
 
 __vsc_continuation_start() {
@@ -70,17 +70,10 @@ __vsc_right_prompt_end() {
 }
 
 __vsc_command_complete() {
-	builtin local __vsc_history_id=$(builtin history | tail -n1 | awk '{print $1;}')
-	# Don't write the command complete sequence for the first prompt without an associated command
-	if [[ "$__vsc_initialized" == "1" ]]; then
-		if [[ "$__vsc_history_id" == "$__vsc_last_history_id" ]]; then
-			builtin printf "\033]633;D\007"
-		else
-			builtin printf "\033]633;D;%s\007" "$__vsc_status"
-			__vsc_last_history_id=$__vsc_history_id
-		fi
-	else
+	if [[ "$__vsc_current_command" == "" ]]; then
 		builtin printf "\033]633;D\007"
+	else
+		builtin printf "\033]633;D;%s\007" "$__vsc_status"
 	fi
 	__vsc_update_cwd
 }
@@ -112,6 +105,7 @@ __vsc_precmd() {
 	fi
 
 	__vsc_command_complete "$__vsc_status"
+	__vsc_current_command=""
 
 	# in command execution
 	if [ -n "$__vsc_in_command_execution" ]; then
@@ -125,8 +119,8 @@ __vsc_preexec() {
 	if [ -n "$RPROMPT" ]; then
 		RPROMPT="$__vsc_prior_rprompt"
 	fi
-	__vsc_initialized="1"
 	__vsc_in_command_execution="1"
+	__vsc_current_command=$1
 	__vsc_command_output_start
 }
 add-zsh-hook precmd __vsc_precmd


### PR DESCRIPTION
Fixes #143766

---

Summary of changes:

- History is no longer used to detect "empty commands"
- `$BASH_COMMAND` is used for bash and `$1` is used for zsh to detect the full command line which is always sent over like in pwsh to improve the command accuracy vscode receives

@meganrogge testing on your setup would be good here, seems to work on my machine