### PR TITLE
Polish up restart dialogs and switch to using Language instead of language

### DIFF
--- a/src/vs/workbench/contrib/localization/browser/localeService.ts
+++ b/src/vs/workbench/contrib/localization/browser/localeService.ts
@@ -3,31 +3,62 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { language } from 'vs/base/common/platform';
+import { localize } from 'vs/nls';
+import { Language } from 'vs/base/common/platform';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { ILanguagePackItem } from 'vs/platform/languagePacks/common/languagePacks';
 import { ILocaleService } from 'vs/workbench/contrib/localization/common/locale';
+import { IHostService } from 'vs/workbench/services/host/browser/host';
+import { IProductService } from 'vs/platform/product/common/productService';
 
 export class WebLocaleService implements ILocaleService {
 	declare readonly _serviceBrand: undefined;
 
-	async setLocale(languagePackItem: ILanguagePackItem): Promise<boolean> {
+	constructor(
+		@IDialogService private readonly dialogService: IDialogService,
+		@IHostService private readonly hostService: IHostService,
+		@IProductService private readonly productService: IProductService
+	) { }
+
+	async setLocale(languagePackItem: ILanguagePackItem): Promise<void> {
 		const locale = languagePackItem.id;
-		if (locale === language || (!locale && language === navigator.language)) {
-			return false;
+		if (locale === Language.value() || (!locale && Language.value() === navigator.language)) {
+			return;
 		}
 		if (locale) {
 			window.localStorage.setItem('vscode.nls.locale', locale);
 		} else {
 			window.localStorage.removeItem('vscode.nls.locale');
 		}
-		return true;
+
+		const restartDialog = await this.dialogService.confirm({
+			type: 'info',
+			message: localize('relaunchDisplayLanguageMessage', "{0} needs to reload to change the display language", this.productService.nameLong),
+			detail: localize('relaunchDisplayLanguageDetail', "Press the reload button to refresh the page and set the display language to {0}.", languagePackItem.label),
+			primaryButton: localize({ key: 'reload', comment: ['&& denotes a mnemonic character'] }, "&&Reload"),
+		});
+
+		if (restartDialog.confirmed) {
+			this.hostService.restart();
+		}
 	}
 
-	async clearLocalePreference(): Promise<boolean> {
-		if (language === navigator.language) {
-			return false;
-		}
+	async clearLocalePreference(): Promise<void> {
 		window.localStorage.removeItem('vscode.nls.locale');
-		return true;
+
+		if (Language.value() === navigator.language) {
+			return;
+		}
+
+		const restartDialog = await this.dialogService.confirm({
+			type: 'info',
+			message: localize('clearDisplayLanguageMessage', "{0} needs to reload to change the display language", this.productService.nameLong),
+			detail: localize('clearDisplayLanguageDetail', "Press the reload button to refresh the page and use your browser's language."),
+			primaryButton: localize({ key: 'reload', comment: ['&& denotes a mnemonic character'] }, "&&Reload"),
+		});
+
+		if (restartDialog.confirmed) {
+			this.hostService.restart();
+		}
 	}
 }

--- a/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
@@ -5,17 +5,12 @@
 
 import { localize } from 'vs/nls';
 import { IQuickInputService, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
-import { IHostService } from 'vs/workbench/services/host/browser/host';
-import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { IProductService } from 'vs/platform/product/common/productService';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { Action2, MenuId } from 'vs/platform/actions/common/actions';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { ILanguagePackItem, ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
 import { ILocaleService } from 'vs/workbench/contrib/localization/common/locale';
-
-const restart = localize('restart', "&&Restart");
 
 export class ConfigureDisplayLanguageAction extends Action2 {
 	public static readonly ID = 'workbench.action.configureLocale';
@@ -34,9 +29,6 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 	public async run(accessor: ServicesAccessor): Promise<void> {
 		const languagePackService: ILanguagePackService = accessor.get(ILanguagePackService);
 		const quickInputService: IQuickInputService = accessor.get(IQuickInputService);
-		const hostService: IHostService = accessor.get(IHostService);
-		const dialogService: IDialogService = accessor.get(IDialogService);
-		const productService: IProductService = accessor.get(IProductService);
 		const localeService: ILocaleService = accessor.get(ILocaleService);
 
 		const installedLanguages = await languagePackService.getInstalledLanguages();
@@ -72,19 +64,7 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 		disposables.add(qp.onDidAccept(async () => {
 			const selectedLanguage = qp.activeItems[0];
 			qp.hide();
-
-			if (await localeService.setLocale(selectedLanguage)) {
-				const restartDialog = await dialogService.confirm({
-					type: 'info',
-					message: localize('relaunchDisplayLanguageMessage', "A restart is required for the change in display language to take effect."),
-					detail: localize('relaunchDisplayLanguageDetail', "Press the restart button to restart {0} and change the display language.", productService.nameLong),
-					primaryButton: restart
-				});
-
-				if (restartDialog.confirmed) {
-					hostService.restart();
-				}
-			}
+			await localeService.setLocale(selectedLanguage);
 		}));
 
 		qp.show();
@@ -108,21 +88,6 @@ export class ClearDisplayLanguageAction extends Action2 {
 
 	public async run(accessor: ServicesAccessor): Promise<void> {
 		const localeService: ILocaleService = accessor.get(ILocaleService);
-		const dialogService: IDialogService = accessor.get(IDialogService);
-		const productService: IProductService = accessor.get(IProductService);
-		const hostService: IHostService = accessor.get(IHostService);
-
-		if (await localeService.clearLocalePreference()) {
-			const restartDialog = await dialogService.confirm({
-				type: 'info',
-				message: localize('relaunchAfterClearDisplayLanguageMessage', "A restart is required for the change in display language to take effect."),
-				detail: localize('relaunchAfterClearDisplayLanguageDetail', "Press the restart button to restart {0} and change the display language.", productService.nameLong),
-				primaryButton: restart
-			});
-
-			if (restartDialog.confirmed) {
-				hostService.restart();
-			}
-		}
+		await localeService.clearLocalePreference();
 	}
 }

--- a/src/vs/workbench/contrib/localization/common/locale.ts
+++ b/src/vs/workbench/contrib/localization/common/locale.ts
@@ -10,6 +10,6 @@ export const ILocaleService = createDecorator<ILocaleService>('localizationServi
 
 export interface ILocaleService {
 	readonly _serviceBrand: undefined;
-	setLocale(languagePackItem: ILanguagePackItem): Promise<boolean>;
-	clearLocalePreference(): Promise<boolean>;
+	setLocale(languagePackItem: ILanguagePackItem): Promise<void>;
+	clearLocalePreference(): Promise<void>;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #154370

#### Before (everywhere)

![image](https://user-images.githubusercontent.com/2644648/177860873-2b9c6b7c-ae88-4f17-8aaa-b234219e407a.png)

#### After

`Configure Display Language` web
![image](https://user-images.githubusercontent.com/2644648/177860607-0f09c9c2-ee80-411f-b574-18531c569af0.png)
`Clear Display Language Preference` web
![image](https://user-images.githubusercontent.com/2644648/177860615-0e1b50af-9410-4274-9547-15f59bb5b72d.png)
`Configure Display Language` desktop
![image](https://user-images.githubusercontent.com/2644648/177860625-c9fb3a73-fe71-4971-a3ca-f6c0a1fe94ca.png)
`Clear Display Language Preference` desktop is the same as 3 but it says “English”
