### PR TITLE
Remove .el7 from release name

### DIFF
--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -1,6 +1,6 @@
 Name:     @@NAME@@
 Version:  @@VERSION@@
-Release:  @@RELEASE@@.el7
+Release:  @@RELEASE@@
 Summary:  Code editing. Redefined.
 Group:    Development/Tools
 Vendor:   Microsoft Corporation


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #144969

Packages are compatible with RHEL 7,8,9 not just 7. It is pointless to keep .el7 in the naming system, removing it will match other Microsoft RPM-packaged products such as the Edge browser