### PR TITLE
Fix `View: Toggle Editor Group Sizes`

### DIFF
--- a/src/vs/base/browser/ui/grid/grid.ts
+++ b/src/vs/base/browser/ui/grid/grid.ts
@@ -528,6 +528,16 @@ export class Grid<T extends IView = IView> extends Disposable {
 	}
 
 	/**
+	 * Returns whether all other {@link IView views} are at their minimum size.
+	 *
+	 * @param view The reference {@link IView view}.
+	 */
+	isViewSizeMaximized(view: T): boolean {
+		const location = this.getViewLocation(view);
+		return this.gridview.isViewSizeMaximized(location);
+	}
+
+	/**
 	 * Get the size of a {@link IView view}.
 	 *
 	 * @param view The {@link IView view}. Provide `undefined` to get the size

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -592,6 +592,10 @@ class BranchNode implements ISplitView<ILayoutContext>, IDisposable {
 		this.splitview.resizeView(index, size);
 	}
 
+	isChildSizeMaximized(index: number): boolean {
+		return this.splitview.isViewSizeMaximized(index);
+	}
+
 	distributeViewSizes(recursive = false): void {
 		this.splitview.distributeViewSizes();
 
@@ -1429,6 +1433,27 @@ export class GridView implements IDisposable {
 		for (let i = 0; i < ancestors.length; i++) {
 			ancestors[i].resizeChild(location[i], Number.POSITIVE_INFINITY);
 		}
+	}
+
+	/**
+	 * Returns whether all other {@link IView views} are at their minimum size.
+	 *
+	 * @param location The {@link GridLocation location} of the view.
+	 */
+	isViewSizeMaximized(location: GridLocation): boolean {
+		const [ancestors, node] = this.getNode(location);
+
+		if (!(node instanceof LeafNode)) {
+			throw new Error('Invalid location');
+		}
+
+		for (let i = 0; i < ancestors.length; i++) {
+			if (!ancestors[i].isChildSizeMaximized(location[i])) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -932,6 +932,23 @@ export class SplitView<TLayoutContext = undefined> extends Disposable {
 	}
 
 	/**
+	 * Returns whether all other {@link IView views} are at their minimum size.
+	 */
+	isViewSizeMaximized(index: number): boolean {
+		if (index < 0 || index >= this.viewItems.length) {
+			return false;
+		}
+
+		for (const item of this.viewItems) {
+			if (item !== this.viewItems[index] && item.size > item.minimumSize) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Distribute the entire {@link SplitView} size among all {@link IView views}.
 	 */
 	distributeViewSizes(): void {

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -135,8 +135,6 @@ export interface IEditorGroupView extends IDisposable, ISerializableView, IEdito
 
 	readonly titleHeight: IEditorGroupTitleHeight;
 
-	readonly isMinimized: boolean;
-
 	readonly disposed: boolean;
 
 	setActive(isActive: boolean): void;

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -1016,7 +1016,7 @@ export class MinimizeOtherGroupsAction extends Action {
 	}
 
 	override async run(): Promise<void> {
-		this.editorGroupService.arrangeGroups(GroupsArrangement.MINIMIZE_OTHERS);
+		this.editorGroupService.arrangeGroups(GroupsArrangement.MAXIMIZE);
 	}
 }
 
@@ -1067,7 +1067,7 @@ export class MaximizeGroupAction extends Action {
 		if (this.editorService.activeEditor) {
 			this.layoutService.setPartHidden(true, Parts.SIDEBAR_PART);
 			this.layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
-			this.editorGroupService.arrangeGroups(GroupsArrangement.MINIMIZE_OTHERS);
+			this.editorGroupService.arrangeGroups(GroupsArrangement.MAXIMIZE);
 		}
 	}
 }

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -781,14 +781,6 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		return this.titleAreaControl.getHeight();
 	}
 
-	get isMinimized(): boolean {
-		if (!this.dimension) {
-			return false;
-		}
-
-		return this.dimension.width === this.minimumWidth || this.dimension.height === this.minimumHeight;
-	}
-
 	notifyIndexChanged(newIndex: number): void {
 		if (this._index !== newIndex) {
 			this._index = newIndex;

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -362,32 +362,22 @@ export class EditorPart extends Part implements IEditorGroupsService, IEditorGro
 			case GroupsArrangement.EVEN:
 				this.gridWidget.distributeViewSizes();
 				break;
-			case GroupsArrangement.MINIMIZE_OTHERS:
+			case GroupsArrangement.MAXIMIZE:
 				this.gridWidget.maximizeViewSize(target);
 				break;
 			case GroupsArrangement.TOGGLE:
 				if (this.isGroupMaximized(target)) {
 					this.arrangeGroups(GroupsArrangement.EVEN);
 				} else {
-					this.arrangeGroups(GroupsArrangement.MINIMIZE_OTHERS);
+					this.arrangeGroups(GroupsArrangement.MAXIMIZE);
 				}
 
 				break;
 		}
 	}
 
-	private isGroupMaximized(targetGroup: IEditorGroupView): boolean {
-		for (const group of this.groups) {
-			if (group === targetGroup) {
-				continue; // ignore target group
-			}
-
-			if (!group.isMinimized) {
-				return false; // target cannot be maximized if one group is not minimized
-			}
-		}
-
-		return true;
+	isGroupMaximized(targetGroup: IEditorGroupView): boolean {
+		return this.gridWidget.isViewSizeMaximized(targetGroup);
 	}
 
 	setGroupOrientation(orientation: GroupOrientation): void {
@@ -609,7 +599,7 @@ export class EditorPart extends Part implements IEditorGroupsService, IEditorGro
 		if (this.gridWidget) {
 			const viewSize = this.gridWidget.getViewSize(group);
 			if (viewSize.width === group.minimumWidth || viewSize.height === group.minimumHeight) {
-				this.arrangeGroups(GroupsArrangement.MINIMIZE_OTHERS, group);
+				this.arrangeGroups(GroupsArrangement.MAXIMIZE, group);
 			}
 		}
 	}

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -47,7 +47,7 @@ export const enum GroupsArrangement {
 	 * Make the current active group consume the maximum
 	 * amount of space possible.
 	 */
-	MINIMIZE_OTHERS,
+	MAXIMIZE,
 
 	/**
 	 * Size all groups evenly.

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -1661,7 +1661,7 @@ suite('EditorService', () => {
 		editor = await service.openEditor(input2, { pinned: true, activation: EditorActivation.ACTIVATE }, sideGroup);
 		assert.strictEqual(part.activeGroup, sideGroup);
 
-		part.arrangeGroups(GroupsArrangement.MINIMIZE_OTHERS);
+		part.arrangeGroups(GroupsArrangement.MAXIMIZE);
 		editor = await service.openEditor(input1, { pinned: true, preserveFocus: true, activation: EditorActivation.RESTORE }, rootGroup);
 		assert.strictEqual(part.activeGroup, sideGroup);
 	});
@@ -1681,13 +1681,13 @@ suite('EditorService', () => {
 		assert.strictEqual(part.activeGroup, sideGroup);
 		assert.notStrictEqual(rootGroup, sideGroup);
 
-		part.arrangeGroups(GroupsArrangement.MINIMIZE_OTHERS, part.activeGroup);
+		part.arrangeGroups(GroupsArrangement.MAXIMIZE, part.activeGroup);
 
 		await rootGroup.closeEditor(input2);
 		assert.strictEqual(part.activeGroup, sideGroup);
 
-		assert.strictEqual(rootGroup.isMinimized, true);
-		assert.strictEqual(part.activeGroup.isMinimized, false);
+		assert(!part.isGroupMaximized(rootGroup));
+		assert(part.isGroupMaximized(part.activeGroup));
 	});
 
 	test('active editor change / visible editor change events', async function () {

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -853,7 +853,6 @@ export class TestEditorGroupView implements IEditorGroupView {
 	titleHeight!: IEditorGroupTitleHeight;
 
 	isEmpty = true;
-	isMinimized = false;
 
 	onWillDispose: Event<void> = Event.None;
 	onDidModelChange: Event<IGroupModelChangeEvent> = Event.None;


### PR DESCRIPTION
Figuring out whether a view was maximized was faulty, since it doesn't
necessarily mean that all other views are minimized. Pushed the
logic down to grid/gridview/splitview so it's now just simple widget
API.

Fixes: #154068
