### PR TITLE
Add a specialized unhandled conflicts close handler

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
@@ -19,9 +19,8 @@ import { AbstractTextResourceEditorInput } from 'vs/workbench/common/editor/text
 import { EditorWorkerServiceDiffComputer } from 'vs/workbench/contrib/mergeEditor/browser/model/diffComputer';
 import { MergeEditorModel } from 'vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { AutoSaveMode, IFilesConfigurationService } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
 import { ILanguageSupport, ITextFileEditorModel, ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
-import { assertType } from 'vs/base/common/types';
+import { autorun } from 'vs/base/common/observable';
 
 export class MergeEditorInputData {
 	constructor(
@@ -32,13 +31,14 @@ export class MergeEditorInputData {
 	) { }
 }
 
-export class MergeEditorInput extends AbstractTextResourceEditorInput implements ILanguageSupport, IEditorCloseHandler {
+export class MergeEditorInput extends AbstractTextResourceEditorInput implements ILanguageSupport {
 
 	static readonly ID = 'mergeEditor.Input';
 
 	private _model?: MergeEditorModel;
 	private _outTextModel?: ITextFileEditorModel;
-	private _ignoreUnhandledConflictsForDirtyState?: true;
+
+	override closeHandler: MergeEditorCloseHandler | undefined;
 
 	constructor(
 		public readonly base: URI,
@@ -47,8 +47,6 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 		public readonly result: URI,
 		@IInstantiationService private readonly _instaService: IInstantiationService,
 		@ITextModelService private readonly _textModelService: ITextModelService,
-		@IDialogService private readonly _dialogService: IDialogService,
-		@IFilesConfigurationService private readonly _filesConfigurationService: IFilesConfigurationService,
 		@IEditorService editorService: IEditorService,
 		@ITextFileService textFileService: ITextFileService,
 		@ILabelService labelService: ILabelService,
@@ -117,6 +115,13 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 				},
 			);
 
+			// set/unset the closeHandler whenever unhandled conflicts are detected
+			const closeHandler = this._instaService.createInstance(MergeEditorCloseHandler, this._model);
+			this._store.add(autorun('closeHandler', reader => {
+				const value = this._model!.hasUnhandledConflicts.read(reader);
+				this.closeHandler = value ? closeHandler : undefined;
+			}));
+
 			await this._model.onInitialized;
 
 			this._store.add(this._model);
@@ -126,7 +131,6 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 			this._store.add(result);
 		}
 
-		this._ignoreUnhandledConflictsForDirtyState = undefined;
 		return this._model;
 	}
 
@@ -146,66 +150,53 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 		return Boolean(this._outTextModel?.isDirty());
 	}
 
-	override readonly closeHandler = this;
-
-	showConfirm(): boolean {
-		if (this.isDirty()) {
-			// text model dirty -> 3wm is dirty
-			return true;
-		}
-		if (!this._ignoreUnhandledConflictsForDirtyState) {
-			// unhandled conflicts -> 3wm asks to confirm UNLESS we explicitly set this input
-			// to ignore unhandled conflicts. This happens only after confirming to ignore unhandled changes
-			return Boolean(this._model && this._model.hasUnhandledConflicts.get());
-		}
-		return false;
+	setLanguageId(languageId: string, _setExplicitly?: boolean): void {
+		this._model?.setLanguageId(languageId);
 	}
 
-	async confirm(editors?: ReadonlyArray<IEditorIdentifier>): Promise<ConfirmResult> {
+	// implement get/set languageId
+	// implement get/set encoding
+}
 
-		const inputs: MergeEditorInput[] = [this];
-		if (editors) {
-			for (const { editor } of editors) {
-				if (editor instanceof MergeEditorInput) {
-					inputs.push(editor);
-				}
-			}
-		}
+class MergeEditorCloseHandler implements IEditorCloseHandler {
 
-		const inputsWithUnhandledConflicts = inputs
+	private _ignoreUnhandledConflicts: boolean = false;
+
+	constructor(
+		private readonly _model: MergeEditorModel,
+		@IDialogService private readonly _dialogService: IDialogService,
+	) { }
+
+	showConfirm(): boolean {
+		// unhandled conflicts -> 3wm asks to confirm UNLESS we explicitly set this input
+		// to ignore unhandled conflicts. This happens only after confirming to ignore unhandled changes
+		return !this._ignoreUnhandledConflicts && this._model.hasUnhandledConflicts.get();
+	}
+
+	async confirm(editors?: readonly IEditorIdentifier[] | undefined): Promise<ConfirmResult> {
+
+		const handler: MergeEditorCloseHandler[] = [this];
+		editors?.forEach(candidate => candidate.editor.closeHandler instanceof MergeEditorCloseHandler && handler.push(candidate.editor.closeHandler));
+
+		const inputsWithUnhandledConflicts = handler
 			.filter(input => input._model && input._model.hasUnhandledConflicts.get());
 
 		if (inputsWithUnhandledConflicts.length === 0) {
+			// shouldn't happen
 			return ConfirmResult.SAVE;
 		}
 
-		const actions: string[] = [];
+		const actions: string[] = [
+			localize('unhandledConflicts.ignore', "Continue with Conflicts"),
+			localize('unhandledConflicts.discard', "Discard Merge Changes"),
+			localize('unhandledConflicts.cancel', "Cancel"),
+		];
 		const options = {
-			cancelId: 0,
-			detail: inputs.length > 1
-				? localize('unhandledConflicts.detailN', 'Merge conflicts in {0} editors will remain unhandled.', inputs.length)
+			cancelId: 2,
+			detail: handler.length > 1
+				? localize('unhandledConflicts.detailN', 'Merge conflicts in {0} editors will remain unhandled.', handler.length)
 				: localize('unhandledConflicts.detail1', 'Merge conflicts in this editor will remain unhandled.')
 		};
-
-		const isAnyAutoSave = this._filesConfigurationService.getAutoSaveMode() !== AutoSaveMode.OFF;
-		if (!isAnyAutoSave) {
-			// manual-save: FYI and discard
-			actions.push(
-				localize('unhandledConflicts.manualSaveIgnore', "Save and Continue with Conflicts"), // 0
-				localize('unhandledConflicts.discard', "Discard Merge Changes"), // 1
-				localize('unhandledConflicts.manualSaveNoSave', "Don't Save"), // 2
-			);
-
-		} else {
-			// auto-save: only FYI
-			actions.push(
-				localize('unhandledConflicts.ignore', "Continue with Conflicts"), // 0
-				localize('unhandledConflicts.discard', "Discard Merge Changes"), // 1
-			);
-		}
-
-		actions.push(localize('unhandledConflicts.cancel', "Cancel"));
-		options.cancelId = actions.length - 1;
 
 		const { choice } = await this._dialogService.show(
 			Severity.Info,
@@ -221,8 +212,8 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 
 		// save or revert: in both cases we tell the inputs to ignore unhandled conflicts
 		// for the dirty state computation.
-		for (const input of inputs) {
-			input._ignoreUnhandledConflictsForDirtyState = true;
+		for (const input of handler) {
+			input._ignoreUnhandledConflicts = true;
 		}
 
 		if (choice === 0) {
@@ -231,7 +222,7 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 
 		} else if (choice === 1) {
 			// discard: undo all changes and save original (pre-merge) state
-			for (const input of inputs) {
+			for (const input of handler) {
 				input._discardMergeChanges();
 			}
 			return ConfirmResult.SAVE;
@@ -243,8 +234,6 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 	}
 
 	private _discardMergeChanges(): void {
-		assertType(this._model !== undefined);
-
 		const chunks: string[] = [];
 		while (true) {
 			const chunk = this._model.resultSnapshot.read();
@@ -255,11 +244,4 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 		}
 		this._model.result.setValue(chunks.join());
 	}
-
-	setLanguageId(languageId: string, _setExplicitly?: boolean): void {
-		this._model?.setLanguageId(languageId);
-	}
-
-	// implement get/set languageId
-	// implement get/set encoding
 }


### PR DESCRIPTION
This is set dynamically whenever unhandled conflicts are detected. It unsets itself when merging is done so that the normal save-close-handler comes to play

https://github.com/microsoft/vscode/issues/152841
