### PR TITLE
Git - Do not use the last argument as the path to the commit message file

### DIFF
--- a/extensions/git/src/git-editor-main.ts
+++ b/extensions/git/src/git-editor-main.ts
@@ -11,7 +11,7 @@ function fatal(err: any): void {
 
 function main(argv: string[]): void {
 	const ipcClient = new IPCClient('git-editor');
-	const commitMessagePath = argv[argv.length - 1];
+	const commitMessagePath = argv[2] !== '--ms-enable-electron-run-as-node' ? argv[2] : argv[3];
 
 	ipcClient.call({ commitMessagePath }).then(() => {
 		setTimeout(() => process.exit(0), 0);


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode/issues/154449.

As of right now, `git-editor-main` assumes that the last argument that is passed to it is the path of the `COMMIT_EDITMSG` file. It looks like there are some cases in which that is not the case. In these cases we would throw while trying to open the editor tab resulting in the failure described in the linkes issue.