### PR TITLE
Fix menu shortcuts not working after a webview is shown

### DIFF
--- a/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
@@ -90,6 +90,13 @@ export class ElectronWebviewElement extends WebviewElement {
 		}
 	}
 
+	override dispose(): void {
+		// Make sure keyboard handler knows it closed (#71800)
+		this._webviewKeyboardHandler.didBlur();
+
+		super.dispose();
+	}
+
 	protected override webviewContentEndpoint(iframeId: string): string {
 		return `${Schemas.vscodeWebview}://${iframeId}`;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR is for #71800

Release notes, markdown preview, etc. use a web view. The web view uses `WindowIgnoreMenuShortcutsManager`/`allowMenuShortcuts` to disable menu shortcuts.
However, `WindowIgnoreMenuShortcutsManager.didBlur` isn't being called when the editor is closed, so the menu shortcuts stay disabled.

This seems to be a side effect of the fix for #82670.

This does not solve using Cmd+M or Cmd+H while focused on a web view.  I looked into detecting those keys and enabling menu shortcuts, but it seems like MacOS still won't detect them if you enable menu shortcuts after the key stroke is pressed but before the event is finished processing.

## Testing
- On a Mac, open a markdown preview or release notes, then close the editor.
- Use Cmd+M or Cmd+H.  it should work to minimize or hide the window.