### PR TITLE
Move telemetry test from electron-browser to browser

### DIFF
--- a/src/vs/platform/telemetry/browser/1dsAppender.ts
+++ b/src/vs/platform/telemetry/browser/1dsAppender.ts
@@ -10,7 +10,7 @@ import { AbstractOneDataSystemAppender } from 'vs/platform/telemetry/common/1dsA
 
 export class OneDataSystemWebAppender extends AbstractOneDataSystemAppender {
 	constructor(
-		configurationService: IConfigurationService,
+		configurationService: IConfigurationService | undefined,
 		eventPrefix: string,
 		defaultData: { [key: string]: any } | null,
 		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing

--- a/src/vs/platform/telemetry/common/1dsAppender.ts
+++ b/src/vs/platform/telemetry/common/1dsAppender.ts
@@ -115,6 +115,10 @@ export abstract class AbstractOneDataSystemAppender implements ITelemetryAppende
 		data = validateTelemetryData(data);
 		const name = this._eventPrefix + '/' + eventName;
 
+		if (data?.properties?.version) {
+			data.properties.pluginVersionString = data.properties.version;
+		}
+
 		try {
 			this._withAIClient((aiClient) => aiClient.track({
 				name,

--- a/src/vs/platform/telemetry/test/browser/1dsAppender.test.ts
+++ b/src/vs/platform/telemetry/test/browser/1dsAppender.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { AppInsightsCore } from '@microsoft/1ds-core-js';
 import * as assert from 'assert';
-import { OneDataSystemAppender } from 'vs/platform/telemetry/node/1dsAppender';
+import { OneDataSystemWebAppender } from 'vs/platform/telemetry/browser/1dsAppender';
 
 class AppInsightsCoreMock extends AppInsightsCore {
 	public override config: any;
@@ -27,13 +27,13 @@ class AppInsightsCoreMock extends AppInsightsCore {
 
 suite('AIAdapter', () => {
 	let appInsightsMock: AppInsightsCoreMock;
-	let adapter: OneDataSystemAppender;
+	let adapter: OneDataSystemWebAppender;
 	const prefix = 'prefix';
 
 
 	setup(() => {
 		appInsightsMock = new AppInsightsCoreMock();
-		adapter = new OneDataSystemAppender(undefined, prefix, undefined!, () => appInsightsMock);
+		adapter = new OneDataSystemWebAppender(undefined, prefix, undefined!, () => appInsightsMock);
 	});
 
 	teardown(() => {
@@ -48,7 +48,7 @@ suite('AIAdapter', () => {
 	});
 
 	test('addional data', () => {
-		adapter = new OneDataSystemAppender(undefined, prefix, { first: '1st', second: 2, third: true }, () => appInsightsMock);
+		adapter = new OneDataSystemWebAppender(undefined, prefix, { first: '1st', second: 2, third: true }, () => appInsightsMock);
 		adapter.log('testEvent');
 
 		assert.strictEqual(appInsightsMock.events.length, 1);


### PR DESCRIPTION
1. Moves away from using the electron-browser layer for telemetry testing as requested by @bpasero.
2. Tries a workaround for incorrect version information