### PR TITLE
ipc - support for `Uint8Array`

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -195,9 +195,9 @@ enum DataType {
 	String = 1,
 	Buffer = 2,
 	VSBuffer = 3,
-	Uint8Array = 4,
-	Array = 5,
-	Object = 6,
+	Array = 4,
+	Object = 5,
+	Uint8Array = 6
 }
 
 function createSizeBuffer(size: number): VSBuffer {

--- a/src/vs/base/parts/sandbox/electron-browser/preload.js
+++ b/src/vs/base/parts/sandbox/electron-browser/preload.js
@@ -145,7 +145,7 @@
 			/**
 			 * @param {string} channel
 			 * @param {any[]} args
-			 * @returns {Promise<any> | undefined}
+			 * @returns {Promise<any> | never}
 			 */
 			invoke(channel, ...args) {
 				if (validateIPC(channel)) {
@@ -156,7 +156,7 @@
 			/**
 			 * @param {string} channel
 			 * @param {(event: IpcRendererEvent, ...args: any[]) => void} listener
-			 * @returns {IpcRenderer}
+			 * @returns {IpcRenderer | never}
 			 */
 			on(channel, listener) {
 				if (validateIPC(channel)) {
@@ -169,7 +169,7 @@
 			/**
 			 * @param {string} channel
 			 * @param {(event: IpcRendererEvent, ...args: any[]) => void} listener
-			 * @returns {IpcRenderer}
+			 * @returns {IpcRenderer | never}
 			 */
 			once(channel, listener) {
 				if (validateIPC(channel)) {
@@ -182,7 +182,7 @@
 			/**
 			 * @param {string} channel
 			 * @param {(event: IpcRendererEvent, ...args: any[]) => void} listener
-			 * @returns {IpcRenderer}
+			 * @returns {IpcRenderer | never}
 			 */
 			removeListener(channel, listener) {
 				if (validateIPC(channel)) {

--- a/src/vs/workbench/services/clipboard/electron-sandbox/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/electron-sandbox/clipboardService.ts
@@ -65,13 +65,13 @@ export class NativeClipboardService implements IClipboardService {
 			return [];
 		}
 
-		const bufferValue = buffer.toString();
+		const bufferValue = VSBuffer.wrap(buffer).toString();
 		if (!bufferValue) {
 			return [];
 		}
 
 		try {
-			return bufferValue.split('\n').map(f => URI.parse(f));
+			return bufferValue.split('\n').map(line => URI.parse(line));
 		} catch (error) {
 			return []; // do not trust clipboard data
 		}


### PR DESCRIPTION
cc @alexdima this enables `Uint8Array` support for IPC. We need this because when `sandbox: true` all `VSBuffer.buffer` will be `Uint8Array` and not `Buffer` anymore.

This PR fixes https://github.com/microsoft/vscode/issues/154820