### PR TITLE
Emmet: Add back trigger character arguments

### DIFF
--- a/extensions/emmet/src/emmetCommon.ts
+++ b/extensions/emmet/src/emmetCommon.ts
@@ -204,7 +204,7 @@ function refreshCompletionProviders(_: vscode.ExtensionContext) {
 			completionProviderDisposables.push(inlineCompletionsProvider);
 		}
 
-		const explicitProvider = vscode.languages.registerCompletionItemProvider({ language, scheme: '*' }, completionProvider);
+		const explicitProvider = vscode.languages.registerCompletionItemProvider({ language, scheme: '*' }, completionProvider, ...LANGUAGE_MODES[includedLanguages[language]]);
 		completionProviderDisposables.push(explicitProvider);
 
 		languageMappingForCompletionProviders.set(language, includedLanguages[language]);
@@ -217,7 +217,7 @@ function refreshCompletionProviders(_: vscode.ExtensionContext) {
 				completionProviderDisposables.push(inlineCompletionsProvider);
 			}
 
-			const explicitProvider = vscode.languages.registerCompletionItemProvider({ language, scheme: '*' }, completionProvider);
+			const explicitProvider = vscode.languages.registerCompletionItemProvider({ language, scheme: '*' }, completionProvider, ...LANGUAGE_MODES[language]);
 			completionProviderDisposables.push(explicitProvider);
 
 			languageMappingForCompletionProviders.set(language, language);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #154375

I forgot to carry over the trigger character args when refactoring Emmet to use both inline and explicit completion providers.
