### PR TITLE
Remove bracketed paste mode from sendText

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1487,12 +1487,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	}
 
 	async sendText(text: string, addNewLine: boolean): Promise<void> {
-		// Apply bracketed paste sequences if the terminal has the mode enabled, this will prevent
-		// the text from triggering keybindings https://github.com/microsoft/vscode/issues/153592
-		if (this.xterm?.raw.modes.bracketedPasteMode) {
-			text = `\x1b[200~${text}\x1b[201~`;
-		}
-
 		// Normalize line endings to 'enter' press.
 		text = text.replace(/\r?\n/g, '\r');
 		if (addNewLine && text[text.length - 1] !== '\r') {


### PR DESCRIPTION
This has to be optionally applied to fix #153592 properly, probably with new API
and command args.

Fixes #154863
