### PR TITLE
Increase contrast for diff inserted bg

### DIFF
--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -400,7 +400,7 @@ export const editorLightBulbAutoFixForeground = registerColor('editorLightBulbAu
 /**
  * Diff Editor Colors
  */
-export const defaultInsertColor = new Color(new RGBA(155, 185, 85, 0.2));
+export const defaultInsertColor = new Color(new RGBA(53, 175, 34, 0.24));
 export const defaultRemoveColor = new Color(new RGBA(255, 0, 0, 0.2));
 
 export const diffInserted = registerColor('diffEditor.insertedTextBackground', { dark: defaultInsertColor, light: defaultInsertColor, hcDark: null, hcLight: null }, nls.localize('diffEditorInserted', 'Background color for text that got inserted. The color must not be opaque so as not to hide underlying decorations.'), true);


### PR DESCRIPTION
This PR fixes #153563 and increases the contrast for `diffEditor.insertedTextBackground`, which uses the same color token for both dark and light themes.

## Before
<img width="356" alt="CleanShot 2022-07-12 at 11 16 56@2x" src="https://user-images.githubusercontent.com/35271042/178565670-7b888a2b-4fed-41c8-a5c6-d33eaee0e688.png">

<img width="352" alt="CleanShot 2022-07-13 at 07 26 41@2x" src="https://user-images.githubusercontent.com/35271042/178758045-a3ab8194-8168-45c7-841b-52aedac03451.png">


## After
<img width="327" alt="CleanShot 2022-07-12 at 11 17 24@2x" src="https://user-images.githubusercontent.com/35271042/178565776-9cdd96b5-ffbe-4746-a6b3-0b434f1e9a76.png">

<img width="330" alt="CleanShot 2022-07-13 at 07 25 39@2x" src="https://user-images.githubusercontent.com/35271042/178757848-0b3f316a-2489-434b-97d7-7b130a8f766b.png">

fyi @alexdima @aeschli 