### PR TITLE
Expose inputBoxUri and make IW Tab ctor private

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditorTabs.ts
@@ -166,7 +166,8 @@ export class MainThreadEditorTabs implements MainThreadEditorTabsShape {
 		if (editor instanceof InteractiveEditorInput) {
 			return {
 				kind: TabInputKind.InteractiveEditorInput,
-				uri: editor.resource
+				uri: editor.resource,
+				inputBoxUri: editor.inputResource
 			};
 		}
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -677,6 +677,7 @@ export interface WebviewInputDto {
 export interface InteractiveEditorInputDto {
 	kind: TabInputKind.InteractiveEditorInput;
 	uri: UriComponents;
+	inputBoxUri: UriComponents;
 }
 
 export interface TabInputDto {

--- a/src/vs/workbench/api/common/extHostEditorTabs.ts
+++ b/src/vs/workbench/api/common/extHostEditorTabs.ts
@@ -95,7 +95,7 @@ class ExtHostEditorTab {
 			case TabInputKind.TerminalEditorInput:
 				return new TerminalEditorTabInput();
 			case TabInputKind.InteractiveEditorInput:
-				return new InteractiveWindowInput(URI.revive(this._dto.input.uri));
+				return new InteractiveWindowInput(URI.revive(this._dto.input.uri), URI.revive(this._dto.input.inputBoxUri));
 			default:
 				return undefined;
 		}

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3729,6 +3729,6 @@ export class TerminalEditorTabInput {
 	constructor() { }
 }
 export class InteractiveWindowInput {
-	constructor(readonly uri: URI) { }
+	constructor(readonly uri: URI, readonly inputBoxUri: URI) { }
 }
 //#endregion

--- a/src/vscode-dts/vscode.proposed.interactiveWindow.d.ts
+++ b/src/vscode-dts/vscode.proposed.interactiveWindow.d.ts
@@ -12,7 +12,11 @@ declare module 'vscode' {
 		 * The uri of the history notebook in the interactive window.
 		 */
 		readonly uri: Uri;
-		constructor(uri: Uri);
+		/**
+		 * The uri of the input box in the interactive window.
+		 */
+		readonly inputBoxUri: Uri;
+		private constructor(uri: Uri, inputBoxUri: Uri);
 	}
 
 	export interface Tab {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

As we discussed offline, we are exposing the `TabInputInteractiveWindow.inputBoxUri` but making the ctor private as we don't support extension create IW yet through Tab API.