### PR TITLE
Escape query, fixes #153583

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -554,7 +554,7 @@ export class SettingMatches {
 		// Trim excess ending characters off the query.
 		singleWordQuery = singleWordQuery.toLowerCase().replace(/[\s-\._]+$/, '');
 		lineToSearch = lineToSearch.toLowerCase();
-		const singleWordRegex = new RegExp(`\\b${singleWordQuery}\\b`);
+		const singleWordRegex = new RegExp(`\\b${strings.escapeRegExpCharacters(singleWordQuery)}\\b`);
 		if (singleWordRegex.test(lineToSearch)) {
 			this.matchType |= SettingMatchType.WholeWordMatch;
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #153583

The PR escapes the Settings editor search query so that the regex parser doesn't try to parse the query string as regex.
