### PR TITLE
Provide simpler route for activating shell integration

### DIFF
--- a/scripts/code-cli.bat
+++ b/scripts/code-cli.bat
@@ -6,7 +6,7 @@ title VSCode Dev
 pushd %~dp0..
 
 :: Get electron, compile, built-in extensions
-@REM if "%VSCODE_SKIP_PRELAUNCH%"=="" node build/lib/preLaunch.js
+if "%VSCODE_SKIP_PRELAUNCH%"=="" node build/lib/preLaunch.js
 
 for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"nameShort\":.*" product.json') do set NAMESHORT=%%~a
 set NAMESHORT=%NAMESHORT: "=%
@@ -24,7 +24,7 @@ set ELECTRON_ENABLE_LOGGING=1
 set ELECTRON_ENABLE_STACK_DUMPING=1
 
 :: Launch Code
-%CODE% out\cli.js --ms-enable-electron-run-as-node %~dp0.. %*
+%CODE% --inspect=5874 out\cli.js --ms-enable-electron-run-as-node %~dp0.. %*
 goto end
 
 :builtin

--- a/scripts/code-cli.bat
+++ b/scripts/code-cli.bat
@@ -6,7 +6,7 @@ title VSCode Dev
 pushd %~dp0..
 
 :: Get electron, compile, built-in extensions
-if "%VSCODE_SKIP_PRELAUNCH%"=="" node build/lib/preLaunch.js
+@REM if "%VSCODE_SKIP_PRELAUNCH%"=="" node build/lib/preLaunch.js
 
 for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"nameShort\":.*" product.json') do set NAMESHORT=%%~a
 set NAMESHORT=%NAMESHORT: "=%
@@ -24,7 +24,7 @@ set ELECTRON_ENABLE_LOGGING=1
 set ELECTRON_ENABLE_STACK_DUMPING=1
 
 :: Launch Code
-%CODE% --inspect=5874 out\cli.js --ms-enable-electron-run-as-node %~dp0.. %*
+%CODE% out\cli.js --ms-enable-electron-run-as-node %~dp0.. %*
 goto end
 
 :builtin

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -24,6 +24,8 @@ import product from 'vs/platform/product/common/product';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { randomPath } from 'vs/base/common/extpath';
 import { Utils } from 'vs/platform/profiling/common/profiling';
+import { dirname } from 'vs/base/common/resources';
+import { FileAccess } from 'vs/base/common/network';
 
 function shouldSpawnCliProcess(argv: NativeParsedArgs): boolean {
 	return !!argv['install-source']
@@ -57,6 +59,23 @@ export async function main(argv: string[]): Promise<any> {
 	// Version Info
 	else if (args.version) {
 		console.log(buildVersionMessage(product.version, product.commit));
+	}
+
+	// Shell integration
+	else if (args['shell-integration']) {
+		// Silently fail when the terminal is not VS Code's integrated terminal
+		if (process.env['TERM_PROGRAM'] !== 'vscode') {
+			return;
+		}
+		let p: string;
+		switch (args['shell-integration']) {
+			case 'bash': p = 'vs\\workbench\\contrib\\terminal\\browser\\media\\shellIntegration-bash.sh'; break;
+			// Usage: if ($s=$(code --shell-integration pwsh)) { . $s }
+			case 'pwsh': p = 'vs\\workbench\\contrib\\terminal\\browser\\media\\shellIntegration.ps1'; break;
+			case 'zsh': p = 'vs\\workbench\\contrib\\terminal\\browser\\media\\shellIntegration-rc.zsh'; break;
+			default: throw new Error('Error using --shell-integration: Invalid shell type');
+		}
+		console.log(`${dirname(FileAccess.asFileUri('', require)).fsPath}\\out\\${p}`);
 	}
 
 	// Extensions Management

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -26,6 +26,7 @@ import { randomPath } from 'vs/base/common/extpath';
 import { Utils } from 'vs/platform/profiling/common/profiling';
 import { dirname } from 'vs/base/common/resources';
 import { FileAccess } from 'vs/base/common/network';
+import { join } from 'path';
 
 function shouldSpawnCliProcess(argv: NativeParsedArgs): boolean {
 	return !!argv['install-source']
@@ -67,15 +68,17 @@ export async function main(argv: string[]): Promise<any> {
 		if (process.env['TERM_PROGRAM'] !== 'vscode') {
 			return;
 		}
-		let p: string;
+		let file: string;
 		switch (args['shell-integration']) {
-			case 'bash': p = 'vs\\workbench\\contrib\\terminal\\browser\\media\\shellIntegration-bash.sh'; break;
-			// Usage: if ($s=$(code --shell-integration pwsh)) { . $s }
-			case 'pwsh': p = 'vs\\workbench\\contrib\\terminal\\browser\\media\\shellIntegration.ps1'; break;
-			case 'zsh': p = 'vs\\workbench\\contrib\\terminal\\browser\\media\\shellIntegration-rc.zsh'; break;
+			// Usage: `. "$(code --shell-integration bash)"`
+			case 'bash': file = 'shellIntegration-bash.sh'; break;
+			// Usage: `if ($s=$(code --shell-integration pwsh)) { . $s }`
+			case 'pwsh': file = 'shellIntegration.ps1'; break;
+			// Usage: `. "$(code --shell-integration zsh)"`
+			case 'zsh': file = 'shellIntegration-rc.zsh'; break;
 			default: throw new Error('Error using --shell-integration: Invalid shell type');
 		}
-		console.log(`${dirname(FileAccess.asFileUri('', require)).fsPath}\\out\\${p}`);
+		console.log(join(dirname(FileAccess.asFileUri('', require)).fsPath, 'out', 'vs', 'workbench', 'contrib', 'terminal', 'browser', 'media', file));
 	}
 
 	// Extensions Management

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -69,11 +69,11 @@ export async function main(argv: string[]): Promise<any> {
 		}
 		let file: string;
 		switch (args['shell-integration']) {
-			// Usage: `. "$(code --shell-integration bash)"`
+			// Usage: `[[ "$TERM_PROGRAM" == "vscode" ]] && . "$(code --shell-integration bash)"`
 			case 'bash': file = 'shellIntegration-bash.sh'; break;
-			// Usage: `if ($s=$(code --shell-integration pwsh)) { . $s }`
+			// Usage: `if ($env:TERM_PROGRAM -eq "vscode") { . "$(code --shell-integration pwsh)" }`
 			case 'pwsh': file = 'shellIntegration.ps1'; break;
-			// Usage: `. "$(code --shell-integration zsh)"`
+			// Usage: `[[ "$TERM_PROGRAM" == "vscode" ]] && . "$(code --shell-integration zsh)"`
 			case 'zsh': file = 'shellIntegration-rc.zsh'; break;
 			default: throw new Error('Error using --shell-integration: Invalid shell type');
 		}

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -8,7 +8,7 @@ import { chmodSync, existsSync, readFileSync, statSync, truncateSync, unlinkSync
 import { homedir, release, tmpdir } from 'os';
 import type { ProfilingSession, Target } from 'v8-inspect-profiler';
 import { Event } from 'vs/base/common/event';
-import { isAbsolute, resolve } from 'vs/base/common/path';
+import { isAbsolute, resolve, join } from 'vs/base/common/path';
 import { IProcessEnvironment, isMacintosh, isWindows } from 'vs/base/common/platform';
 import { randomPort } from 'vs/base/common/ports';
 import { isString } from 'vs/base/common/types';
@@ -26,7 +26,6 @@ import { randomPath } from 'vs/base/common/extpath';
 import { Utils } from 'vs/platform/profiling/common/profiling';
 import { dirname } from 'vs/base/common/resources';
 import { FileAccess } from 'vs/base/common/network';
-import { join } from 'path';
 
 function shouldSpawnCliProcess(argv: NativeParsedArgs): boolean {
 	return !!argv['install-source']

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -89,6 +89,7 @@ export interface NativeParsedArgs {
 	'logsPath'?: string;
 	'__enable-file-policy'?: boolean;
 	editSessionId?: string;
+	'shell-integration'?: string;
 
 	// chromium command line args: https://electronjs.org/docs/all#supported-chrome-command-line-switches
 	'no-proxy-server'?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -127,7 +127,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'logsPath': { type: 'string' },
 	'__enable-file-policy': { type: 'boolean' },
 	'editSessionId': { type: 'string' },
-	'shell-integration': { type: 'boolean' },
+	'shell-integration': { type: 'string' },
 
 	// chromium flags
 	'no-proxy-server': { type: 'boolean' },

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -127,6 +127,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'logsPath': { type: 'string' },
 	'__enable-file-policy': { type: 'boolean' },
 	'editSessionId': { type: 'string' },
+	'shell-integration': { type: 'boolean' },
 
 	// chromium flags
 	'no-proxy-server': { type: 'boolean' },

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -49,6 +49,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'waitMarkerFilePath': { type: 'string' },
 	'locale': { type: 'string', cat: 'o', args: 'locale', description: localize('locale', "The locale to use (e.g. en-US or zh-TW).") },
 	'user-data-dir': { type: 'string', cat: 'o', args: 'dir', description: localize('userDataDir', "Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code.") },
+	'shell-integration': { type: 'string', cat: 'o', args: ['bash', 'pwsh', 'zsh'], description: localize('shellIntergation', "Print the shell integration script file path for the specified shell.") },
 	'help': { type: 'boolean', cat: 'o', alias: 'h', description: localize('help', "Print usage.") },
 
 	'extensions-dir': { type: 'string', deprecates: ['extensionHomePath'], cat: 'e', args: 'dir', description: localize('extensionHomePath', "Set the root path for extensions.") },
@@ -127,7 +128,6 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'logsPath': { type: 'string' },
 	'__enable-file-policy': { type: 'boolean' },
 	'editSessionId': { type: 'string' },
-	'shell-integration': { type: 'string' },
 
 	// chromium flags
 	'no-proxy-server': { type: 'boolean' },

--- a/src/vs/server/node/serverEnvironmentService.ts
+++ b/src/vs/server/node/serverEnvironmentService.ts
@@ -81,6 +81,7 @@ export const serverOptions: OptionDescriptions<ServerParsedArgs> = {
 
 	'help': OPTIONS['help'],
 	'version': OPTIONS['version'],
+	'shell-integration': OPTIONS['shell-integration'],
 
 	'compatibility': { type: 'string' },
 
@@ -193,6 +194,7 @@ export interface ServerParsedArgs {
 	/* ----- server cli ----- */
 	help: boolean;
 	version: boolean;
+	'shell-integration'?: string;
 
 	compatibility: string;
 


### PR DESCRIPTION
Fixes #153921

```pwsh
# pwsh
if ($env:TERM_PROGRAM -eq "vscode") { . "$(code --shell-integration pwsh)" }
```

```sh
# bash
[[ "$TERM_PROGRAM" == "vscode" ]] && . "$(code --shell-integration bash)"

# zsh
[[ "$TERM_PROGRAM" == "vscode" ]] && . "$(code --shell-integration zsh)"
```