### PR TITLE
Add button separator color token

### DIFF
--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -28,6 +28,7 @@ export interface IButtonStyles {
 	buttonBackground?: Color;
 	buttonHoverBackground?: Color;
 	buttonForeground?: Color;
+	buttonSeparator?: Color;
 	buttonSecondaryBackground?: Color;
 	buttonSecondaryHoverBackground?: Color;
 	buttonSecondaryForeground?: Color;
@@ -37,6 +38,7 @@ export interface IButtonStyles {
 const defaultOptions: IButtonStyles = {
 	buttonBackground: Color.fromHex('#0E639C'),
 	buttonHoverBackground: Color.fromHex('#006BB3'),
+	buttonSeparator: Color.white,
 	buttonForeground: Color.white
 };
 
@@ -63,6 +65,7 @@ export class Button extends Disposable implements IButton {
 	private buttonBackground: Color | undefined;
 	private buttonHoverBackground: Color | undefined;
 	private buttonForeground: Color | undefined;
+	private buttonSeparator: Color | undefined;
 	private buttonSecondaryBackground: Color | undefined;
 	private buttonSecondaryHoverBackground: Color | undefined;
 	private buttonSecondaryForeground: Color | undefined;
@@ -80,6 +83,7 @@ export class Button extends Disposable implements IButton {
 		mixin(this.options, defaultOptions, false);
 
 		this.buttonForeground = this.options.buttonForeground;
+		this.buttonSeparator = this.options.buttonSeparator;
 		this.buttonBackground = this.options.buttonBackground;
 		this.buttonHoverBackground = this.options.buttonHoverBackground;
 
@@ -157,6 +161,7 @@ export class Button extends Disposable implements IButton {
 
 	style(styles: IButtonStyles): void {
 		this.buttonForeground = styles.buttonForeground;
+		this.buttonSeparator = styles.buttonSeparator;
 		this.buttonBackground = styles.buttonBackground;
 		this.buttonHoverBackground = styles.buttonHoverBackground;
 		this.buttonSecondaryForeground = styles.buttonSecondaryForeground;
@@ -169,12 +174,13 @@ export class Button extends Disposable implements IButton {
 
 	private applyStyles(): void {
 		if (this._element) {
-			let background, foreground;
+			let background, foreground, separator;
 			if (this.options.secondary) {
 				foreground = this.buttonSecondaryForeground ? this.buttonSecondaryForeground.toString() : '';
 				background = this.buttonSecondaryBackground ? this.buttonSecondaryBackground.toString() : '';
 			} else {
 				foreground = this.buttonForeground ? this.buttonForeground.toString() : '';
+				separator = this.buttonSeparator ? this.buttonSeparator.toString() : '';
 				background = this.buttonBackground ? this.buttonBackground.toString() : '';
 			}
 
@@ -315,7 +321,7 @@ export class ButtonWithDropdown extends Disposable implements IButton {
 
 		// Separator
 		this.separatorContainer.style.backgroundColor = styles.buttonBackground?.toString() ?? '';
-		this.separator.style.backgroundColor = styles.buttonForeground?.toString() ?? '';
+		this.separator.style.backgroundColor = styles.buttonSeparator?.toString() ?? '';
 	}
 
 	focus(): void {

--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -65,7 +65,6 @@ export class Button extends Disposable implements IButton {
 	private buttonBackground: Color | undefined;
 	private buttonHoverBackground: Color | undefined;
 	private buttonForeground: Color | undefined;
-	private buttonSeparator: Color | undefined;
 	private buttonSecondaryBackground: Color | undefined;
 	private buttonSecondaryHoverBackground: Color | undefined;
 	private buttonSecondaryForeground: Color | undefined;
@@ -83,7 +82,6 @@ export class Button extends Disposable implements IButton {
 		mixin(this.options, defaultOptions, false);
 
 		this.buttonForeground = this.options.buttonForeground;
-		this.buttonSeparator = this.options.buttonSeparator;
 		this.buttonBackground = this.options.buttonBackground;
 		this.buttonHoverBackground = this.options.buttonHoverBackground;
 
@@ -161,7 +159,6 @@ export class Button extends Disposable implements IButton {
 
 	style(styles: IButtonStyles): void {
 		this.buttonForeground = styles.buttonForeground;
-		this.buttonSeparator = styles.buttonSeparator;
 		this.buttonBackground = styles.buttonBackground;
 		this.buttonHoverBackground = styles.buttonHoverBackground;
 		this.buttonSecondaryForeground = styles.buttonSecondaryForeground;
@@ -174,13 +171,12 @@ export class Button extends Disposable implements IButton {
 
 	private applyStyles(): void {
 		if (this._element) {
-			let background, foreground, separator;
+			let background, foreground;
 			if (this.options.secondary) {
 				foreground = this.buttonSecondaryForeground ? this.buttonSecondaryForeground.toString() : '';
 				background = this.buttonSecondaryBackground ? this.buttonSecondaryBackground.toString() : '';
 			} else {
 				foreground = this.buttonForeground ? this.buttonForeground.toString() : '';
-				separator = this.buttonSeparator ? this.buttonSeparator.toString() : '';
 				background = this.buttonBackground ? this.buttonBackground.toString() : '';
 			}
 

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -266,6 +266,7 @@ export const checkboxForeground = registerColor('checkbox.foreground', { dark: s
 export const checkboxBorder = registerColor('checkbox.border', { dark: selectBorder, light: selectBorder, hcDark: selectBorder, hcLight: selectBorder }, nls.localize('checkbox.border', "Border color of checkbox widget."));
 
 export const buttonForeground = registerColor('button.foreground', { dark: Color.white, light: Color.white, hcDark: Color.white, hcLight: Color.white }, nls.localize('buttonForeground', "Button foreground color."));
+export const buttonSeparator = registerColor('button.separator', { dark: transparent(buttonForeground, .4), light: transparent(buttonForeground, .4), hcDark: transparent(buttonForeground, .4), hcLight: transparent(buttonForeground, .4) }, nls.localize('buttonSeparator', "Button separator color."));
 export const buttonBackground = registerColor('button.background', { dark: '#0E639C', light: '#007ACC', hcDark: null, hcLight: '#0F4A85' }, nls.localize('buttonBackground', "Button background color."));
 export const buttonHoverBackground = registerColor('button.hoverBackground', { dark: lighten(buttonBackground, 0.2), light: darken(buttonBackground, 0.2), hcDark: null, hcLight: null }, nls.localize('buttonHoverBackground', "Button background color when hovering."));
 export const buttonBorder = registerColor('button.border', { dark: contrastBorder, light: contrastBorder, hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('buttonBorder', "Button border color."));

--- a/src/vs/platform/theme/common/styler.ts
+++ b/src/vs/platform/theme/common/styler.ts
@@ -6,7 +6,7 @@
 import { Color } from 'vs/base/common/color';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { IThemable, styleFn } from 'vs/base/common/styler';
-import { activeContrastBorder, badgeBackground, badgeForeground, breadcrumbsActiveSelectionForeground, breadcrumbsBackground, breadcrumbsFocusForeground, breadcrumbsForeground, buttonBackground, buttonBorder, buttonForeground, buttonHoverBackground, buttonSecondaryBackground, buttonSecondaryForeground, buttonSecondaryHoverBackground, ColorIdentifier, ColorTransform, ColorValue, contrastBorder, editorWidgetBackground, editorWidgetBorder, editorWidgetForeground, focusBorder, inputActiveOptionBackground, inputActiveOptionBorder, inputActiveOptionForeground, inputBackground, inputBorder, inputForeground, inputValidationErrorBackground, inputValidationErrorBorder, inputValidationErrorForeground, inputValidationInfoBackground, inputValidationInfoBorder, inputValidationInfoForeground, inputValidationWarningBackground, inputValidationWarningBorder, inputValidationWarningForeground, keybindingLabelBackground, keybindingLabelBorder, keybindingLabelBottomBorder, keybindingLabelForeground, listActiveSelectionBackground, listActiveSelectionForeground, listActiveSelectionIconForeground, listDropBackground, listFilterWidgetBackground, listFilterWidgetNoMatchesOutline, listFilterWidgetOutline, listFocusBackground, listFocusForeground, listFocusOutline, listHoverBackground, listHoverForeground, listInactiveFocusBackground, listInactiveFocusOutline, listInactiveSelectionBackground, listInactiveSelectionForeground, listInactiveSelectionIconForeground, menuBackground, menuBorder, menuForeground, menuSelectionBackground, menuSelectionBorder, menuSelectionForeground, menuSeparatorBackground, pickerGroupForeground, problemsErrorIconForeground, problemsInfoIconForeground, problemsWarningIconForeground, progressBarBackground, quickInputListFocusBackground, quickInputListFocusForeground, quickInputListFocusIconForeground, resolveColorValue, scrollbarShadow, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground, selectBackground, selectBorder, selectForeground, selectListBackground, checkboxBackground, checkboxBorder, checkboxForeground, tableColumnsBorder, tableOddRowsBackgroundColor, textLinkForeground, treeIndentGuidesStroke, widgetShadow, listFocusAndSelectionOutline } from 'vs/platform/theme/common/colorRegistry';
+import { activeContrastBorder, badgeBackground, badgeForeground, breadcrumbsActiveSelectionForeground, breadcrumbsBackground, breadcrumbsFocusForeground, breadcrumbsForeground, buttonBackground, buttonBorder, buttonForeground, buttonHoverBackground, buttonSecondaryBackground, buttonSecondaryForeground, buttonSecondaryHoverBackground, ColorIdentifier, ColorTransform, ColorValue, contrastBorder, editorWidgetBackground, editorWidgetBorder, editorWidgetForeground, focusBorder, inputActiveOptionBackground, inputActiveOptionBorder, inputActiveOptionForeground, inputBackground, inputBorder, inputForeground, inputValidationErrorBackground, inputValidationErrorBorder, inputValidationErrorForeground, inputValidationInfoBackground, inputValidationInfoBorder, inputValidationInfoForeground, inputValidationWarningBackground, inputValidationWarningBorder, inputValidationWarningForeground, keybindingLabelBackground, keybindingLabelBorder, keybindingLabelBottomBorder, keybindingLabelForeground, listActiveSelectionBackground, listActiveSelectionForeground, listActiveSelectionIconForeground, listDropBackground, listFilterWidgetBackground, listFilterWidgetNoMatchesOutline, listFilterWidgetOutline, listFocusBackground, listFocusForeground, listFocusOutline, listHoverBackground, listHoverForeground, listInactiveFocusBackground, listInactiveFocusOutline, listInactiveSelectionBackground, listInactiveSelectionForeground, listInactiveSelectionIconForeground, menuBackground, menuBorder, menuForeground, menuSelectionBackground, menuSelectionBorder, menuSelectionForeground, menuSeparatorBackground, pickerGroupForeground, problemsErrorIconForeground, problemsInfoIconForeground, problemsWarningIconForeground, progressBarBackground, quickInputListFocusBackground, quickInputListFocusForeground, quickInputListFocusIconForeground, resolveColorValue, scrollbarShadow, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground, selectBackground, selectBorder, selectForeground, selectListBackground, checkboxBackground, checkboxBorder, checkboxForeground, tableColumnsBorder, tableOddRowsBackgroundColor, textLinkForeground, treeIndentGuidesStroke, widgetShadow, listFocusAndSelectionOutline, buttonSeparator } from 'vs/platform/theme/common/colorRegistry';
 import { isHighContrast } from 'vs/platform/theme/common/theme';
 import { IColorTheme, IThemeService } from 'vs/platform/theme/common/themeService';
 
@@ -225,6 +225,7 @@ export const defaultListStyles: IColorMapping = {
 
 export interface IButtonStyleOverrides extends IStyleOverrides {
 	buttonForeground?: ColorIdentifier;
+	buttonSeparator?: ColorIdentifier;
 	buttonBackground?: ColorIdentifier;
 	buttonHoverBackground?: ColorIdentifier;
 	buttonSecondaryForeground?: ColorIdentifier;
@@ -236,6 +237,7 @@ export interface IButtonStyleOverrides extends IStyleOverrides {
 export function attachButtonStyler(widget: IThemable, themeService: IThemeService, style?: IButtonStyleOverrides): IDisposable {
 	return attachStyler(themeService, {
 		buttonForeground: style?.buttonForeground || buttonForeground,
+		buttonSeparator: style?.buttonSeparator || buttonSeparator,
 		buttonBackground: style?.buttonBackground || buttonBackground,
 		buttonHoverBackground: style?.buttonHoverBackground || buttonHoverBackground,
 		buttonSecondaryForeground: style?.buttonSecondaryForeground || buttonSecondaryForeground,
@@ -349,6 +351,7 @@ export const defaultDialogStyles = <IDialogStyleOverrides>{
 	dialogShadow: widgetShadow,
 	dialogBorder: contrastBorder,
 	buttonForeground: buttonForeground,
+	buttonSeparator: buttonSeparator,
 	buttonBackground: buttonBackground,
 	buttonSecondaryBackground: buttonSecondaryBackground,
 	buttonSecondaryForeground: buttonSecondaryForeground,


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode/issues/152758

This makes the button separator a color token, which is inherited from `button.foreground` to preserve theming, and adds a bit of transparency to reduce the contrast. Themes can override this by setting `button.separator`.

## Before
<img width="293" src="https://user-images.githubusercontent.com/35271042/178817623-c5fd945a-5acf-40dd-80e0-a21d385c3f1f.png">


## After
<img width="303" src="https://user-images.githubusercontent.com/35271042/178817633-e995e4cf-976c-41cc-8de6-5c7bc24000a5.png">
