### PR TITLE
`MainThreadHostTreeView: [createInstance] First service dependency of CustomTreeView at position 4 conflicts with 2 static arguments`

### DIFF
--- a/src/vs/workbench/api/test/browser/mainThreadTreeViews.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadTreeViews.test.ts
@@ -57,7 +57,7 @@ suite('MainThreadHostTreeView', function () {
 			id: testTreeViewId,
 			ctorDescriptor: null!,
 			name: 'Test View 1',
-			treeView: instantiationService.createInstance(CustomTreeView, 'testTree', 'Test Title'),
+			treeView: instantiationService.createInstance(CustomTreeView, 'testTree', 'Test Title', 'extension.id'),
 		};
 		ViewsRegistry.registerViews([viewDescriptor], container);
 


### PR DESCRIPTION
Fixes #155155