### PR TITLE
tweak message when closing dirty and conflicting merge editor

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -1555,7 +1555,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 			// Let editor handle confirmation if implemented
 			if (typeof editor.closeHandler?.confirm === 'function') {
-				confirmation = await editor.closeHandler.confirm();
+				confirmation = await editor.closeHandler.confirm([{ editor, groupId: this.id }]);
 			}
 
 			// Show a file specific confirmation

--- a/src/vs/workbench/common/editor/editorInput.ts
+++ b/src/vs/workbench/common/editor/editorInput.ts
@@ -30,10 +30,10 @@ export interface IEditorCloseHandler {
 	 * should be used besides dirty state, this method should be
 	 * implemented to show a different dialog.
 	 *
-	 * @param editors if more than one editor is closed, will pass in
-	 * each editor of the same kind to be able to show a combined dialog.
+	 * @param editors All editors of the same kind that are being closed. Should be used
+	 * to show a combined dialog.
 	 */
-	confirm(editors?: ReadonlyArray<IEditorIdentifier>): Promise<ConfirmResult>;
+	confirm(editors: ReadonlyArray<IEditorIdentifier>): Promise<ConfirmResult>;
 }
 
 /**

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
@@ -100,7 +100,7 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 		return false;
 	}
 
-	async confirm(terminals?: ReadonlyArray<IEditorIdentifier>): Promise<ConfirmResult> {
+	async confirm(terminals: ReadonlyArray<IEditorIdentifier>): Promise<ConfirmResult> {
 		const { choice } = await this._dialogService.show(
 			Severity.Warning,
 			localize('confirmDirtyTerminal.message', "Do you want to terminate running processes?"),
@@ -110,7 +110,7 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 			],
 			{
 				cancelId: 1,
-				detail: terminals && terminals.length > 1 ?
+				detail: terminals.length > 1 ?
 					terminals.map(terminal => terminal.editor.getName()).join('\n') + '\n\n' + localize('confirmDirtyTerminals.detail', "Closing will terminate the running processes in the terminals.") :
 					localize('confirmDirtyTerminal.detail', "Closing will terminate the running processes in this terminal.")
 			}


### PR DESCRIPTION
fyi @bpasero this ensures the close handler is always called with `IEditorIdentifier[]`

re https://github.com/microsoft/vscode/issues/152841
