### PR TITLE
switch default - use browser request by default

### DIFF
--- a/src/vs/platform/request/electron-browser/sharedProcessRequestService.ts
+++ b/src/vs/platform/request/electron-browser/sharedProcessRequestService.ts
@@ -37,11 +37,11 @@ export class SharedProcessRequestService implements IRequestService {
 	}
 
 	private getRequestService(): IRequestService {
-		if (this.configurationService.getValue('developer.sharedProcess.useBrowserRequestService') === true) {
-			this.logService.trace('Using browser request service');
-			return this.browserRequestService;
+		if (this.configurationService.getValue('developer.sharedProcess.redirectRequestsToMain') === true) {
+			this.logService.trace('Using main request service');
+			return this.mainRequestService;
 		}
-		this.logService.trace('Using main request service');
-		return this.mainRequestService;
+		this.logService.trace('Using browser request service');
+		return this.browserRequestService;
 	}
 }


### PR DESCRIPTION
switch default - use browser request by default

@bpasero Reverting to use browser request service in shared process because of the bug #155204