### PR TITLE
Add Settings indicator for application-scoped settings

### DIFF
--- a/src/vs/platform/configuration/common/configuration.ts
+++ b/src/vs/platform/configuration/common/configuration.ts
@@ -34,7 +34,8 @@ export function isConfigurationUpdateOverrides(thing: any): thing is IConfigurat
 export type IConfigurationUpdateOverrides = Omit<IConfigurationOverrides, 'overrideIdentifier'> & { overrideIdentifiers?: string[] | null };
 
 export const enum ConfigurationTarget {
-	USER = 1,
+	APPLICATION = 1,
+	USER,
 	USER_LOCAL,
 	USER_REMOTE,
 	WORKSPACE,
@@ -44,6 +45,7 @@ export const enum ConfigurationTarget {
 }
 export function ConfigurationTargetToString(configurationTarget: ConfigurationTarget) {
 	switch (configurationTarget) {
+		case ConfigurationTarget.APPLICATION: return 'APPLICATION';
 		case ConfigurationTarget.USER: return 'USER';
 		case ConfigurationTarget.USER_LOCAL: return 'USER_LOCAL';
 		case ConfigurationTarget.USER_REMOTE: return 'USER_REMOTE';

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -295,7 +295,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					constructor() {
 						super({
 							id: SETTINGS_EDITOR_COMMAND_SWITCH_TO_APPLICATION_JSON,
-							title: { value: nls.localize('openApplicationSettings', "Open Default Profile Settings (JSON)"), original: 'Open Default Profile Settings (JSON)' },
+							title: { value: nls.localize('openApplicationSettings', "Open User Settings (JSON)"), original: 'Open User Settings (JSON)' },
 							f1: true,
 							menu: [{ id: submenuId }]
 						});

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -295,7 +295,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					constructor() {
 						super({
 							id: SETTINGS_EDITOR_COMMAND_SWITCH_TO_APPLICATION_JSON,
-							title: { value: nls.localize('openApplicationSettings', "Open Non-Profile Specific Settings (JSON)"), original: 'Open Non-Profile Specific Settings (JSON)' },
+							title: { value: nls.localize('openApplicationSettings', "Open Default Profile Settings (JSON)"), original: 'Open Default Profile Settings (JSON)' },
 							f1: true,
 							menu: [{ id: submenuId }]
 						});

--- a/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
@@ -40,6 +40,9 @@ import { IPreferencesEditorModel, IPreferencesService, ISetting, ISettingsEditor
 import { DefaultSettingsEditorModel, SettingsEditorModel, WorkspaceConfigurationEditorModel } from 'vs/workbench/services/preferences/common/preferencesModels';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
+import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
+import { isEqual } from 'vs/base/common/resources';
+import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 
 export interface IPreferencesRenderer extends IDisposable {
 	render(): void;
@@ -481,6 +484,8 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 		@IWorkspaceTrustManagementService private readonly workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
+		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
+		@IUserDataProfilesService private readonly userDataProfilesService: IUserDataProfilesService,
 	) {
 		super();
 		this._register(this.editor.getModel()!.onDidChangeContent(() => this.delayedRender()));
@@ -577,6 +582,22 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 	}
 
 	private handleLocalUserConfiguration(setting: ISetting, configuration: IConfigurationPropertySchema, markerData: IMarkerData[]): void {
+		if (!this.userDataProfileService.currentProfile.isDefault) {
+			if (isEqual(this.userDataProfilesService.defaultProfile.settingsResource, this.settingsEditorModel.uri) && configuration.scope !== ConfigurationScope.APPLICATION) {
+				// If we're in the default profile setting file, and the setting is not
+				// application-scoped, fade it out.
+				markerData.push({
+					severity: MarkerSeverity.Hint,
+					tags: [MarkerTag.Unnecessary],
+					...setting.range,
+					message: nls.localize('defaultProfileSettingWhileNonDefaultActive', "This setting cannot be applied while a non-default profile is active. It will be applied when the default profile is active.")
+				});
+			} else if (isEqual(this.userDataProfileService.currentProfile.settingsResource, this.settingsEditorModel.uri) && configuration.scope === ConfigurationScope.APPLICATION) {
+				// If we're in a profile setting file, and the setting is
+				// application-scoped, fade it out.
+				markerData.push(this.generateUnsupportedApplicationSettingMarker(setting));
+			}
+		}
 		if (this.environmentService.remoteAuthority && (configuration.scope === ConfigurationScope.MACHINE || configuration.scope === ConfigurationScope.MACHINE_OVERRIDABLE)) {
 			markerData.push({
 				severity: MarkerSeverity.Hint,
@@ -641,7 +662,7 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 			severity: MarkerSeverity.Hint,
 			tags: [MarkerTag.Unnecessary],
 			...setting.range,
-			message: nls.localize('unsupportedApplicationSetting', "This setting can be applied only in application user settings")
+			message: nls.localize('unsupportedApplicationSetting', "This setting has an application scope and can be set only in the default profile user settings file.")
 		};
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
@@ -662,7 +662,7 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 			severity: MarkerSeverity.Hint,
 			tags: [MarkerTag.Unnecessary],
 			...setting.range,
-			message: nls.localize('unsupportedApplicationSetting', "This setting has an application scope and can be set only in the default profile user settings file.")
+			message: nls.localize('unsupportedApplicationSetting', "This setting has an application scope and can be set only in the user settings file.")
 		};
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -38,7 +38,6 @@ import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 
-
 export class FolderSettingsActionViewItem extends BaseActionViewItem {
 
 	private _folder: IWorkspaceFolder | null;

--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -37,6 +37,7 @@ import { settingsEditIcon, settingsScopeDropDownIcon } from 'vs/workbench/contri
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 import { ILanguageService } from 'vs/editor/common/languages/language';
+import { CONTEXT_SETTINGS_EDITOR_IN_USER_TAB } from 'vs/workbench/contrib/preferences/common/preferences';
 
 export class FolderSettingsActionViewItem extends BaseActionViewItem {
 
@@ -220,6 +221,7 @@ export class SettingsTargetsWidget extends Widget {
 	private folderSettingsAction!: Action;
 	private folderSettings!: FolderSettingsActionViewItem;
 	private options: ISettingsTargetsWidgetOptions;
+	private inUserTab: IContextKey<boolean>;
 
 	private _settingsTarget: SettingsTarget | null = null;
 
@@ -234,13 +236,15 @@ export class SettingsTargetsWidget extends Widget {
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@ILabelService private readonly labelService: ILabelService,
 		@IPreferencesService private readonly preferencesService: IPreferencesService,
-		@ILanguageService private readonly languageService: ILanguageService
+		@ILanguageService private readonly languageService: ILanguageService,
+		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
 		super();
 		this.options = options ?? {};
 		this.create(parent);
 		this._register(this.contextService.onDidChangeWorkbenchState(() => this.onWorkbenchStateChanged()));
 		this._register(this.contextService.onDidChangeWorkspaceFolders(() => this.update()));
+		this.inUserTab = CONTEXT_SETTINGS_EDITOR_IN_USER_TAB.bindTo(contextKeyService);
 	}
 
 	private resetLabels() {
@@ -301,6 +305,7 @@ export class SettingsTargetsWidget extends Widget {
 		} else {
 			this.folderSettings.getAction().checked = false;
 		}
+		this.inUserTab.set(this.userLocalSettings.checked);
 	}
 
 	setResultCount(settingsTarget: SettingsTarget, count: number): void {

--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -37,7 +37,7 @@ import { settingsEditIcon, settingsScopeDropDownIcon } from 'vs/workbench/contri
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 import { ILanguageService } from 'vs/editor/common/languages/language';
-import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
+
 
 export class FolderSettingsActionViewItem extends BaseActionViewItem {
 
@@ -235,22 +235,13 @@ export class SettingsTargetsWidget extends Widget {
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@ILabelService private readonly labelService: ILabelService,
 		@IPreferencesService private readonly preferencesService: IPreferencesService,
-		@ILanguageService private readonly languageService: ILanguageService,
-		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService
+		@ILanguageService private readonly languageService: ILanguageService
 	) {
 		super();
 		this.options = options ?? {};
 		this.create(parent);
 		this._register(this.contextService.onDidChangeWorkbenchState(() => this.onWorkbenchStateChanged()));
 		this._register(this.contextService.onDidChangeWorkspaceFolders(() => this.update()));
-		this._register(this.userDataProfileService.onDidChangeCurrentProfile((e) => {
-			if (!e.profile.isDefault) {
-				this.userLocalSettings.label = localize('profileSettings', "Profile") + ` [${e.profile.name}]`;
-			} else {
-				this.userLocalSettings.label = localize('userSettings', "User");
-			}
-			this.update();
-		}));
 	}
 
 	private resetLabels() {

--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -215,7 +215,6 @@ export interface ISettingsTargetsWidgetOptions {
 export class SettingsTargetsWidget extends Widget {
 
 	private settingsSwitcherBar!: ActionBar;
-	private applicationSettings!: Action;
 	private userLocalSettings!: Action;
 	private userRemoteSettings!: Action;
 	private workspaceSettings!: Action;
@@ -257,7 +256,6 @@ export class SettingsTargetsWidget extends Widget {
 	private resetLabels() {
 		const remoteAuthority = this.environmentService.remoteAuthority;
 		const hostLabel = remoteAuthority && this.labelService.getHostLabel(Schemas.vscodeRemote, remoteAuthority);
-		this.applicationSettings.label = localize('applicationSettings', "Application");
 		this.userLocalSettings.label = localize('userSettings', "User");
 		this.userRemoteSettings.label = localize('userSettingsRemote', "Remote") + (hostLabel ? ` [${hostLabel}]` : '');
 		this.workspaceSettings.label = localize('workspaceSettings', "Workspace");
@@ -273,11 +271,6 @@ export class SettingsTargetsWidget extends Widget {
 			animated: false,
 			actionViewItemProvider: (action: IAction) => action.id === 'folderSettings' ? this.folderSettings : undefined
 		}));
-
-		this.applicationSettings = new Action('applicationSettings', '', '.settings-tab', false, () => this.updateTarget(ConfigurationTarget.APPLICATION));
-		this.preferencesService.getEditableSettingsURI(ConfigurationTarget.APPLICATION).then(uri => {
-			this.applicationSettings.tooltip = uri?.fsPath ?? '';
-		});
 
 		this.userLocalSettings = new Action('userSettings', '', '.settings-tab', true, () => this.updateTarget(ConfigurationTarget.USER_LOCAL));
 		this.preferencesService.getEditableSettingsURI(ConfigurationTarget.USER_LOCAL).then(uri => {
@@ -300,7 +293,7 @@ export class SettingsTargetsWidget extends Widget {
 		this.resetLabels();
 		this.update();
 
-		this.settingsSwitcherBar.push([this.applicationSettings, this.userLocalSettings, this.userRemoteSettings, this.workspaceSettings, this.folderSettingsAction]);
+		this.settingsSwitcherBar.push([this.userLocalSettings, this.userRemoteSettings, this.workspaceSettings, this.folderSettingsAction]);
 	}
 
 	get settingsTarget(): SettingsTarget | null {
@@ -309,7 +302,6 @@ export class SettingsTargetsWidget extends Widget {
 
 	set settingsTarget(settingsTarget: SettingsTarget | null) {
 		this._settingsTarget = settingsTarget;
-		this.applicationSettings.checked = ConfigurationTarget.APPLICATION === this.settingsTarget;
 		this.userLocalSettings.checked = ConfigurationTarget.USER_LOCAL === this.settingsTarget;
 		this.userRemoteSettings.checked = ConfigurationTarget.USER_REMOTE === this.settingsTarget;
 		this.workspaceSettings.checked = ConfigurationTarget.WORKSPACE === this.settingsTarget;
@@ -347,7 +339,6 @@ export class SettingsTargetsWidget extends Widget {
 			const languageToUse = this.languageService.getLanguageName(filter);
 			if (languageToUse) {
 				const languageSuffix = ` [${languageToUse}]`;
-				this.applicationSettings.label += languageSuffix;
 				this.userLocalSettings.label += languageSuffix;
 				this.userRemoteSettings.label += languageSuffix;
 				this.workspaceSettings.label += languageSuffix;
@@ -380,7 +371,6 @@ export class SettingsTargetsWidget extends Widget {
 
 	private async update(): Promise<void> {
 		this.settingsSwitcherBar.domNode.classList.toggle('empty-workbench', this.contextService.getWorkbenchState() === WorkbenchState.EMPTY);
-		this.applicationSettings.enabled = !this.userDataProfileService.currentProfile.isDefault;
 		this.userRemoteSettings.enabled = !!(this.options.enableRemoteSettings && this.environmentService.remoteAuthority);
 		this.workspaceSettings.enabled = this.contextService.getWorkbenchState() !== WorkbenchState.EMPTY;
 		this.folderSettings.getAction().enabled = this.contextService.getWorkbenchState() === WorkbenchState.WORKSPACE && this.contextService.getWorkspace().folders.length > 0;

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -688,12 +688,17 @@ export class SettingsEditor2 extends EditorPane {
 		}
 	}
 
+	switchToApplicationSettingsFile(): Promise<IEditorPane | undefined> {
+		const query = parseQuery(this.searchWidget.getValue()).query;
+		return this.openSettingsFile({ query }, true);
+	}
+
 	switchToSettingsFile(): Promise<IEditorPane | undefined> {
 		const query = parseQuery(this.searchWidget.getValue()).query;
 		return this.openSettingsFile({ query });
 	}
 
-	private async openSettingsFile(options?: ISettingsEditorOptions): Promise<IEditorPane | undefined> {
+	private async openSettingsFile(options?: ISettingsEditorOptions, forceOpenApplicationSettings?: boolean): Promise<IEditorPane | undefined> {
 		const currentSettingsTarget = this.settingsTargetsWidget.settingsTarget;
 
 		const openOptions: IOpenSettingsOptions = { jsonEditor: true, ...options };
@@ -704,6 +709,9 @@ export class SettingsEditor2 extends EditorPane {
 				if (configurationScope === ConfigurationScope.APPLICATION) {
 					return this.preferencesService.openApplicationSettings(openOptions);
 				}
+			}
+			if (forceOpenApplicationSettings) {
+				return this.preferencesService.openApplicationSettings(openOptions);
 			}
 			return this.preferencesService.openUserSettings(openOptions);
 		} else if (currentSettingsTarget === ConfigurationTarget.USER_REMOTE) {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -61,6 +61,7 @@ import { ILanguageService } from 'vs/editor/common/languages/language';
 import { SettingsSearchFilterDropdownMenuActionViewItem } from 'vs/workbench/contrib/preferences/browser/settingsSearchMenu';
 import { IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ISettingOverrideClickEvent } from 'vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators';
+import { ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
 
 export const enum SettingsFocusContext {
 	Search,
@@ -852,7 +853,7 @@ export class SettingsEditor2 extends EditorPane {
 
 	private createSettingsTree(container: HTMLElement): void {
 		this.settingRenderers = this.instantiationService.createInstance(SettingTreeRenderers);
-		this._register(this.settingRenderers.onDidChangeSetting(e => this.onDidChangeSetting(e.key, e.value, e.type, e.manualReset)));
+		this._register(this.settingRenderers.onDidChangeSetting(e => this.onDidChangeSetting(e.key, e.value, e.type, e.manualReset, e.scope)));
 		this._register(this.settingRenderers.onDidOpenSettings(settingKey => {
 			this.openSettingsFile({ revealSetting: { key: settingKey, edit: true } });
 		}));
@@ -939,18 +940,18 @@ export class SettingsEditor2 extends EditorPane {
 		}));
 	}
 
-	private onDidChangeSetting(key: string, value: any, type: SettingValueType | SettingValueType[], manualReset: boolean): void {
+	private onDidChangeSetting(key: string, value: any, type: SettingValueType | SettingValueType[], manualReset: boolean, scope: ConfigurationScope | undefined): void {
 		const parsedQuery = parseQuery(this.searchWidget.getValue());
 		const languageFilter = parsedQuery.languageFilter;
 		if (this.pendingSettingUpdate && this.pendingSettingUpdate.key !== key) {
-			this.updateChangedSetting(key, value, manualReset, languageFilter);
+			this.updateChangedSetting(key, value, manualReset, languageFilter, scope);
 		}
 
 		this.pendingSettingUpdate = { key, value, languageFilter };
 		if (SettingsEditor2.shouldSettingUpdateFast(type)) {
-			this.settingFastUpdateDelayer.trigger(() => this.updateChangedSetting(key, value, manualReset, languageFilter));
+			this.settingFastUpdateDelayer.trigger(() => this.updateChangedSetting(key, value, manualReset, languageFilter, scope));
 		} else {
-			this.settingSlowUpdateDelayer.trigger(() => this.updateChangedSetting(key, value, manualReset, languageFilter));
+			this.settingSlowUpdateDelayer.trigger(() => this.updateChangedSetting(key, value, manualReset, languageFilter, scope));
 		}
 	}
 
@@ -1020,12 +1021,15 @@ export class SettingsEditor2 extends EditorPane {
 		return ancestors.reverse();
 	}
 
-	private updateChangedSetting(key: string, value: any, manualReset: boolean, languageFilter: string | undefined): Promise<void> {
+	private updateChangedSetting(key: string, value: any, manualReset: boolean, languageFilter: string | undefined, scope: ConfigurationScope | undefined): Promise<void> {
 		// ConfigurationService displays the error if this fails.
-		// Force a render afterwards because onDidConfigurationUpdate doesn't fire if the update doesn't result in an effective setting value change
-		const settingsTarget = this.settingsTargetsWidget.settingsTarget;
+		// Force a render afterwards because onDidConfigurationUpdate doesn't fire if the update doesn't result in an effective setting value change.
+
+		// Application-scoped settings could appear alongside profile settings even though they are saved in separate files, so check specifically if the setting
+		// is an application-scoped setting, otherwise default to the original behaviour.
+		const settingsTarget = scope === ConfigurationScope.APPLICATION ? ConfigurationTarget.APPLICATION : this.settingsTargetsWidget.settingsTarget;
 		const resource = URI.isUri(settingsTarget) ? settingsTarget : undefined;
-		const configurationTarget = <ConfigurationTarget>(resource ? ConfigurationTarget.WORKSPACE_FOLDER : settingsTarget);
+		const configurationTarget = <ConfigurationTarget | null>(resource ? ConfigurationTarget.WORKSPACE_FOLDER : settingsTarget) ?? ConfigurationTarget.USER_LOCAL;
 		const overrides: IConfigurationUpdateOverrides = { resource, overrideIdentifiers: languageFilter ? [languageFilter] : undefined };
 
 		const configurationTargetIsWorkspace = configurationTarget === ConfigurationTarget.WORKSPACE || configurationTarget === ConfigurationTarget.WORKSPACE_FOLDER;

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -140,7 +140,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 			this.scopeOverridesElement.style.display = 'inline';
 			this.scopeOverridesElement.classList.add('with-custom-hover');
 
-			const applicationSettingText = localize('applicationSetting', "Not profile-specific");
+			const applicationSettingText = localize('applicationSetting', "Applies to all profiles");
 			this.scopeOverridesLabel.text = applicationSettingText;
 
 			const content = localize('applicationSettingDescription', "The setting is not specific to the current profile, and will retain its value when switching profiles.");

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -12,7 +12,7 @@ import { Emitter } from 'vs/base/common/event';
 import { IDisposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { localize } from 'vs/nls';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { getIgnoredSettings } from 'vs/platform/userDataSync/common/settingsMerge';
 import { getDefaultIgnoredSettings, IUserDataSyncEnablementService } from 'vs/platform/userDataSync/common/userDataSync';
 import { SettingsTreeSettingElement } from 'vs/workbench/contrib/preferences/browser/settingsTreeModels';
@@ -133,7 +133,19 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 	updateScopeOverrides(element: SettingsTreeSettingElement, elementDisposables: DisposableStore, onDidClickOverrideElement: Emitter<ISettingOverrideClickEvent>) {
 		this.scopeOverridesElement.innerText = '';
 		this.scopeOverridesElement.style.display = 'none';
-		if (element.overriddenScopeList.length || element.overriddenDefaultsLanguageList.length) {
+		if (element.matchesScope(ConfigurationTarget.APPLICATION, false)) {
+			// If the setting is an application-scoped setting, there are no overrides so we can use this
+			// indicator to display that information instead.
+			this.scopeOverridesElement.style.display = 'inline';
+			this.scopeOverridesElement.classList.add('with-custom-hover');
+
+			const applicationSettingText = localize('applicationSetting', "Applies to all profiles");
+			this.scopeOverridesLabel.text = applicationSettingText;
+
+			const content = localize('applicationSettingDescription', "Setting applies to all profiles.");
+			this.hover?.dispose();
+			this.hover = setupCustomHover(this.hoverDelegate, this.scopeOverridesElement, content);
+		} else if (element.overriddenScopeList.length || element.overriddenDefaultsLanguageList.length) {
 			if ((MODIFIED_INDICATOR_USE_INLINE_ONLY && element.overriddenScopeList.length) ||
 				(element.overriddenScopeList.length === 1 && !element.overriddenDefaultsLanguageList.length)) {
 				// Render inline if we have the flag and there are scope overrides to render,

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -44,7 +44,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 
 	constructor(
 		container: HTMLElement,
-		@IConfigurationService configurationService: IConfigurationService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IHoverService hoverService: IHoverService,
 		@IUserDataSyncEnablementService private readonly userDataSyncEnablementService: IUserDataSyncEnablementService,
 		@ILanguageService private readonly languageService: ILanguageService) {
@@ -133,16 +133,17 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 	updateScopeOverrides(element: SettingsTreeSettingElement, elementDisposables: DisposableStore, onDidClickOverrideElement: Emitter<ISettingOverrideClickEvent>) {
 		this.scopeOverridesElement.innerText = '';
 		this.scopeOverridesElement.style.display = 'none';
-		if (element.matchesScope(ConfigurationTarget.APPLICATION, false)) {
+		const profileFeatureEnabled = this.configurationService.getValue<boolean>('workbench.experimental.settingsProfiles.enabled');
+		if (profileFeatureEnabled && element.matchesScope(ConfigurationTarget.APPLICATION, false)) {
 			// If the setting is an application-scoped setting, there are no overrides so we can use this
 			// indicator to display that information instead.
 			this.scopeOverridesElement.style.display = 'inline';
 			this.scopeOverridesElement.classList.add('with-custom-hover');
 
-			const applicationSettingText = localize('applicationSetting', "Applies to all profiles");
+			const applicationSettingText = localize('applicationSetting', "Not profile-specific");
 			this.scopeOverridesLabel.text = applicationSettingText;
 
-			const content = localize('applicationSettingDescription', "Setting applies to all profiles.");
+			const content = localize('applicationSettingDescription', "The setting is not specific to the current profile, and will retain its value after switching profiles.");
 			this.hover?.dispose();
 			this.hover = setupCustomHover(this.hoverDelegate, this.scopeOverridesElement, content);
 		} else if (element.overriddenScopeList.length || element.overriddenDefaultsLanguageList.length) {
@@ -293,8 +294,9 @@ function getAccessibleScopeDisplayMidSentenceText(completeScope: string, languag
 export function getIndicatorsLabelAriaLabel(element: SettingsTreeSettingElement, configurationService: IConfigurationService, languageService: ILanguageService): string {
 	const ariaLabelSections: string[] = [];
 
-	if (element.matchesScope(ConfigurationTarget.APPLICATION, false)) {
-		ariaLabelSections.push(localize('applicationSettingDescription', "Setting applies to all profiles."));
+	const profileFeatureEnabled = configurationService.getValue<boolean>('workbench.experimental.settingsProfiles.enabled');
+	if (profileFeatureEnabled && element.matchesScope(ConfigurationTarget.APPLICATION, false)) {
+		ariaLabelSections.push(localize('applicationSettingDescriptionAccessible', "Setting value retained while switching profiles"));
 	}
 
 	// Add other overrides text

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -143,7 +143,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 			const applicationSettingText = localize('applicationSetting', "Not profile-specific");
 			this.scopeOverridesLabel.text = applicationSettingText;
 
-			const content = localize('applicationSettingDescription', "The setting is not specific to the current profile, and will retain its value after switching profiles.");
+			const content = localize('applicationSettingDescription', "The setting is not specific to the current profile, and will retain its value when switching profiles.");
 			this.hover?.dispose();
 			this.hover = setupCustomHover(this.hoverDelegate, this.scopeOverridesElement, content);
 		} else if (element.overriddenScopeList.length || element.overriddenDefaultsLanguageList.length) {
@@ -296,7 +296,7 @@ export function getIndicatorsLabelAriaLabel(element: SettingsTreeSettingElement,
 
 	const profileFeatureEnabled = configurationService.getValue<boolean>('workbench.experimental.settingsProfiles.enabled');
 	if (profileFeatureEnabled && element.matchesScope(ConfigurationTarget.APPLICATION, false)) {
-		ariaLabelSections.push(localize('applicationSettingDescriptionAccessible', "Setting value retained while switching profiles"));
+		ariaLabelSections.push(localize('applicationSettingDescriptionAccessible', "Setting value retained when switching profiles"));
 	}
 
 	// Add other overrides text

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -293,6 +293,10 @@ function getAccessibleScopeDisplayMidSentenceText(completeScope: string, languag
 export function getIndicatorsLabelAriaLabel(element: SettingsTreeSettingElement, configurationService: IConfigurationService, languageService: ILanguageService): string {
 	const ariaLabelSections: string[] = [];
 
+	if (element.matchesScope(ConfigurationTarget.APPLICATION, false)) {
+		ariaLabelSections.push(localize('applicationSettingDescription', "Setting applies to all profiles."));
+	}
+
 	// Add other overrides text
 	const otherOverridesStart = element.isConfigured ?
 		localize('alsoConfiguredIn', "Also modified in") :

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -64,6 +64,7 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { focusedRowBackground, focusedRowBorder, rowHoverBackground, settingsHeaderForeground, settingsNumberInputBackground, settingsNumberInputBorder, settingsNumberInputForeground, settingsSelectBackground, settingsSelectBorder, settingsSelectForeground, settingsSelectListBorder, settingsTextInputBackground, settingsTextInputBorder, settingsTextInputForeground } from 'vs/workbench/contrib/preferences/common/settingsEditorColorRegistry';
 import { getIndicatorsLabelAriaLabel, ISettingOverrideClickEvent, SettingsTreeIndicatorsLabel } from 'vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators';
 import { ILanguageService } from 'vs/editor/common/languages/language';
+import { ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
 
 const $ = DOM.$;
 
@@ -667,6 +668,7 @@ export interface ISettingChangeEvent {
 	value: any; // undefined => reset/unconfigure
 	type: SettingValueType | SettingValueType[];
 	manualReset: boolean;
+	scope: ConfigurationScope | undefined;
 }
 
 export interface ISettingLinkClickEvent {
@@ -922,7 +924,13 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 
 		template.indicatorsLabel.updateScopeOverrides(element, template.elementDisposables, this._onDidClickOverrideElement);
 
-		const onChange = (value: any) => this._onDidChangeSetting.fire({ key: element.setting.key, value, type: template.context!.valueType, manualReset: false });
+		const onChange = (value: any) => this._onDidChangeSetting.fire({
+			key: element.setting.key,
+			value,
+			type: template.context!.valueType,
+			manualReset: false,
+			scope: element.setting.scope
+		});
 		const deprecationText = element.setting.deprecationMessage || '';
 		if (deprecationText && element.setting.deprecationMessageIsMarkdown) {
 			const disposables = new DisposableStore();
@@ -1506,7 +1514,8 @@ export class SettingExcludeRenderer extends AbstractSettingRenderer implements I
 				key: template.context.setting.key,
 				value: Object.keys(newValue).length === 0 ? undefined : sortKeys(newValue),
 				type: template.context.valueType,
-				manualReset: false
+				manualReset: false,
+				scope: template.context.setting.scope
 			});
 		}
 	}
@@ -1971,7 +1980,13 @@ export class SettingTreeRenderers {
 			new Action('settings.resetSetting', localize('resetSettingLabel', "Reset Setting"), undefined, undefined, async context => {
 				if (context instanceof SettingsTreeSettingElement) {
 					if (!context.isUntrusted) {
-						this._onDidChangeSetting.fire({ key: context.setting.key, value: undefined, type: context.setting.type as SettingValueType, manualReset: true });
+						this._onDidChangeSetting.fire({
+							key: context.setting.key,
+							value: undefined,
+							type: context.setting.type as SettingValueType,
+							manualReset: true,
+							scope: context.setting.scope
+						});
 					}
 				}
 			}),

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -472,7 +472,7 @@ export class SettingsTreeModel {
 		private _isWorkspaceTrusted: boolean,
 		@IWorkbenchConfigurationService private readonly _configurationService: IWorkbenchConfigurationService,
 		@ILanguageService private readonly _languageService: ILanguageService,
-		@IUserDataProfileService private readonly _userDataProfileService: IUserDataProfileService
+		@IUserDataProfileService private readonly _userDataProfileService: IUserDataProfileService,
 	) {
 	}
 
@@ -614,7 +614,7 @@ export function inspectSetting(key: string, target: SettingsTarget, languageFilt
 	if (!isConfigured) {
 		if (target === ConfigurationTarget.APPLICATION) {
 			isConfigured = !!configurationService.restrictedSettings.application?.includes(key);
-		} if (target === ConfigurationTarget.USER_LOCAL) {
+		} else if (target === ConfigurationTarget.USER_LOCAL) {
 			isConfigured = !!configurationService.restrictedSettings.userLocal?.includes(key);
 		} else if (target === ConfigurationTarget.USER_REMOTE) {
 			isConfigured = !!configurationService.restrictedSettings.userRemote?.includes(key);
@@ -828,7 +828,7 @@ export class SearchResultModel extends SettingsTreeModel {
 		@IWorkbenchConfigurationService configurationService: IWorkbenchConfigurationService,
 		@IWorkbenchEnvironmentService private environmentService: IWorkbenchEnvironmentService,
 		@ILanguageService languageService: ILanguageService,
-		@IUserDataProfileService userDataProfileService: IUserDataProfileService
+		@IUserDataProfileService userDataProfileService: IUserDataProfileService,
 	) {
 		super(viewState, isWorkspaceTrusted, configurationService, languageService, userDataProfileService);
 		this.update({ id: 'searchResultModel', label: '' });

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -13,7 +13,7 @@ import { ITOCEntry, knownAcronyms, knownTermMappings, tocData } from 'vs/workben
 import { ENABLE_LANGUAGE_FILTER, MODIFIED_SETTING_TAG, POLICY_SETTING_TAG, REQUIRE_TRUSTED_WORKSPACE_SETTING_TAG } from 'vs/workbench/contrib/preferences/common/preferences';
 import { IExtensionSetting, ISearchResult, ISetting, SettingValueType } from 'vs/workbench/services/preferences/common/preferences';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
-import { FOLDER_SCOPES, WORKSPACE_SCOPES, REMOTE_MACHINE_SCOPES, LOCAL_MACHINE_SCOPES, IWorkbenchConfigurationService, LOCAL_MACHINE_PROFILE_SCOPES } from 'vs/workbench/services/configuration/common/configuration';
+import { FOLDER_SCOPES, WORKSPACE_SCOPES, REMOTE_MACHINE_SCOPES, LOCAL_MACHINE_SCOPES, IWorkbenchConfigurationService, LOCAL_MACHINE_PROFILE_SCOPES, APPLICATION_SCOPES } from 'vs/workbench/services/configuration/common/configuration';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Emitter } from 'vs/base/common/event';
@@ -366,24 +366,28 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 			return true;
 		}
 
+		if (configTarget === ConfigurationTarget.APPLICATION) {
+			return APPLICATION_SCOPES.includes(this.setting.scope);
+		}
+
 		if (configTarget === ConfigurationTarget.WORKSPACE_FOLDER) {
-			return FOLDER_SCOPES.indexOf(this.setting.scope) !== -1;
+			return FOLDER_SCOPES.includes(this.setting.scope);
 		}
 
 		if (configTarget === ConfigurationTarget.WORKSPACE) {
-			return WORKSPACE_SCOPES.indexOf(this.setting.scope) !== -1;
+			return WORKSPACE_SCOPES.includes(this.setting.scope);
 		}
 
 		if (configTarget === ConfigurationTarget.USER_REMOTE) {
-			return REMOTE_MACHINE_SCOPES.indexOf(this.setting.scope) !== -1;
+			return REMOTE_MACHINE_SCOPES.includes(this.setting.scope);
 		}
 
 		if (configTarget === ConfigurationTarget.USER_LOCAL) {
 			if (!this.userDataProfileService.currentProfile.isDefault) {
-				return LOCAL_MACHINE_PROFILE_SCOPES.indexOf(this.setting.scope) !== -1;
+				return LOCAL_MACHINE_PROFILE_SCOPES.includes(this.setting.scope);
 			}
 			if (isRemote) {
-				return LOCAL_MACHINE_SCOPES.indexOf(this.setting.scope) !== -1;
+				return LOCAL_MACHINE_SCOPES.includes(this.setting.scope);
 			}
 		}
 

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -53,6 +53,7 @@ export const CONTEXT_KEYBINDINGS_EDITOR = new RawContextKey<boolean>('inKeybindi
 export const CONTEXT_KEYBINDINGS_SEARCH_FOCUS = new RawContextKey<boolean>('inKeybindingsSearch', false);
 export const CONTEXT_KEYBINDING_FOCUS = new RawContextKey<boolean>('keybindingFocus', false);
 export const CONTEXT_WHEN_FOCUS = new RawContextKey<boolean>('whenFocus', false);
+export const CONTEXT_SETTINGS_EDITOR_IN_USER_TAB = new RawContextKey<boolean>('inSettingsEditorUserTab', false);
 
 export const KEYBINDINGS_EDITOR_COMMAND_SEARCH = 'keybindings.editor.searchKeybindings';
 export const KEYBINDINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS = 'keybindings.editor.clearSearchResults';

--- a/src/vs/workbench/services/configuration/common/configuration.ts
+++ b/src/vs/workbench/services/configuration/common/configuration.ts
@@ -64,7 +64,7 @@ export type RestrictedSettings = {
 export const IWorkbenchConfigurationService = refineServiceDecorator<IConfigurationService, IWorkbenchConfigurationService>(IConfigurationService);
 export interface IWorkbenchConfigurationService extends IConfigurationService {
 	/**
-	 * Restricted settings defined in each configuraiton target
+	 * Restricted settings defined in each configuration target
 	 */
 	readonly restrictedSettings: RestrictedSettings;
 

--- a/src/vs/workbench/services/configuration/common/configuration.ts
+++ b/src/vs/workbench/services/configuration/common/configuration.ts
@@ -24,6 +24,7 @@ export const folderSettingsSchemaId = 'vscode://schemas/settings/folder';
 export const launchSchemaId = 'vscode://schemas/launch';
 export const tasksSchemaId = 'vscode://schemas/tasks';
 
+export const APPLICATION_SCOPES = [ConfigurationScope.APPLICATION];
 export const PROFILE_SCOPES = [ConfigurationScope.MACHINE, ConfigurationScope.WINDOW, ConfigurationScope.RESOURCE, ConfigurationScope.LANGUAGE_OVERRIDABLE];
 export const LOCAL_MACHINE_PROFILE_SCOPES = [ConfigurationScope.WINDOW, ConfigurationScope.RESOURCE, ConfigurationScope.LANGUAGE_OVERRIDABLE];
 export const LOCAL_MACHINE_SCOPES = [ConfigurationScope.APPLICATION, ...LOCAL_MACHINE_PROFILE_SCOPES];

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -168,7 +168,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 			return this.createDefaultSettingsEditorModel(uri);
 		}
 
-		if (this.userSettingsResource.toString() === uri.toString()) {
+		if (this.userSettingsResource.toString() === uri.toString() || this.userDataProfilesService.defaultProfile.settingsResource.toString() === uri.toString()) {
 			return this.createEditableSettingsEditorModel(ConfigurationTarget.USER_LOCAL, uri);
 		}
 

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -250,6 +250,14 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return this.editorGroupService.activeGroup.activeEditorPane!;
 	}
 
+	openApplicationSettings(options: IOpenSettingsOptions = {}): Promise<IEditorPane | undefined> {
+		options = {
+			...options,
+			target: ConfigurationTarget.USER_LOCAL,
+		};
+		return this.open(this.userDataProfilesService.defaultProfile.settingsResource, options);
+	}
+
 	openUserSettings(options: IOpenSettingsOptions = {}): Promise<IEditorPane | undefined> {
 		options = {
 			...options,

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -45,6 +45,7 @@ import { ITextFileService } from 'vs/workbench/services/textfile/common/textfile
 import { isArray, isObject } from 'vs/base/common/types';
 import { SuggestController } from 'vs/editor/contrib/suggest/browser/suggestController';
 import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
+import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 
 const emptyEditableSettingsContent = '{\n}';
 
@@ -67,6 +68,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
+		@IUserDataProfilesService private readonly userDataProfilesService: IUserDataProfilesService,
 		@ITextModelService private readonly textModelResolverService: ITextModelService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IModelService private readonly modelService: IModelService,
@@ -451,7 +453,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 	public async getEditableSettingsURI(configurationTarget: ConfigurationTarget, resource?: URI): Promise<URI | null> {
 		switch (configurationTarget) {
 			case ConfigurationTarget.APPLICATION:
-				return this.userSettingsResource;
+				return this.userDataProfilesService.defaultProfile.settingsResource;
 			case ConfigurationTarget.USER:
 			case ConfigurationTarget.USER_LOCAL:
 				return this.userSettingsResource;

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -450,6 +450,8 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 
 	public async getEditableSettingsURI(configurationTarget: ConfigurationTarget, resource?: URI): Promise<URI | null> {
 		switch (configurationTarget) {
+			case ConfigurationTarget.APPLICATION:
+				return this.userSettingsResource;
 			case ConfigurationTarget.USER:
 			case ConfigurationTarget.USER_LOCAL:
 				return this.userSettingsResource;

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -233,6 +233,7 @@ export interface IPreferencesService {
 
 	openRawDefaultSettings(): Promise<IEditorPane | undefined>;
 	openSettings(options?: IOpenSettingsOptions): Promise<IEditorPane | undefined>;
+	openApplicationSettings(options?: IOpenSettingsOptions): Promise<IEditorPane | undefined>;
 	openUserSettings(options?: IOpenSettingsOptions): Promise<IEditorPane | undefined>;
 	openRemoteSettings(options?: IOpenSettingsOptions): Promise<IEditorPane | undefined>;
 	openWorkspaceSettings(options?: IOpenSettingsOptions): Promise<IEditorPane | undefined>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #152888

## Changes in this PR

- Adds indicators to application-scoped settings with custom hovers. These indicators currently always show up, even for the default profile.
- Adds aria text for those indicators.
- Changes the link for "Edit in settings.json" to go to the right file when a non-default profile is active.
- Changes the action button to have a dropdown when in a non-default profile.
- Fades out profile-specific settings when editing the default profile settings JSON file.
- Fades out application-scoped settings when editing the profile settings JSON file.

## Screenshots

![Example showing a faded out profile setting in the default profile JSON file while the user has a non-default profile active](https://user-images.githubusercontent.com/7199958/179271737-03d82d23-8eae-4c7d-a9eb-fa8cb4d81195.PNG)
![The new dropdown that displays when switching to the JSON file from the User tab in the GUI Settings editor, showing the options "Open Default Profile Settings (JSON)" and "Open Profile Settings (JSON)"](https://user-images.githubusercontent.com/7199958/179271742-ee128494-e530-484c-9a07-8b1842fcd51c.PNG)
![Example showing a faded out application-scoped setting in the profile JSON file and a message saying that they must set the setting in the default profile JSON file](https://user-images.githubusercontent.com/7199958/179271744-1335d8df-116a-47f6-a28b-0e492409202c.PNG)
![The new "Applies to all profiles" indicator on the telemetry.telemetryLevel setting in the GUI Settings editor](https://user-images.githubusercontent.com/7199958/179271747-2365935d-2581-486d-8941-8bb159017eb9.PNG)
