### PR TITLE
remove terminal data when terminal is disposed of for reconnected terminals

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -168,7 +168,7 @@ export interface IPtyHostAttachTarget {
 	fixedDimensions: IFixedTerminalDimensions | undefined;
 	environmentVariableCollections: ISerializableEnvironmentVariableCollections | undefined;
 	reconnectionOwner?: string;
-	task?: { label: string; id: string; lastTask?: string; group?: string };
+	task?: { label: string; id: string; lastTask: string; group?: string };
 }
 
 export enum TitleEventSource {
@@ -469,7 +469,7 @@ export interface IShellLaunchConfig {
 	/**
 	 * This is a terminal that attaches to an already running terminal.
 	 */
-	attachPersistentProcess?: { id: number; findRevivedId?: boolean; pid: number; title: string; titleSource: TitleEventSource; cwd: string; icon?: TerminalIcon; color?: string; hasChildProcesses?: boolean; fixedDimensions?: IFixedTerminalDimensions; environmentVariableCollections?: ISerializableEnvironmentVariableCollections; reconnectionOwner?: string; task?: { label: string; id: string; lastTask?: string; group?: string } };
+	attachPersistentProcess?: { id: number; findRevivedId?: boolean; pid: number; title: string; titleSource: TitleEventSource; cwd: string; icon?: TerminalIcon; color?: string; hasChildProcesses?: boolean; fixedDimensions?: IFixedTerminalDimensions; environmentVariableCollections?: ISerializableEnvironmentVariableCollections; reconnectionOwner?: string; task?: { label: string; id: string; lastTask: string; group?: string } };
 
 	/**
 	 * Whether the terminal process environment should be exactly as provided in

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -544,7 +544,7 @@ export interface IShellLaunchConfig {
 	/**
 	 * The task associated with this terminal
 	 */
-	task?: { lastTask?: string; group?: string; label: string; id: string };
+	task?: { lastTask: string; group?: string; label: string; id: string };
 }
 
 export interface ICreateContributedTerminalProfileOptions {

--- a/src/vs/platform/terminal/common/terminalProcess.ts
+++ b/src/vs/platform/terminal/common/terminalProcess.ts
@@ -61,7 +61,7 @@ export interface IProcessDetails {
 	fixedDimensions: IFixedTerminalDimensions | undefined;
 	environmentVariableCollections: ISerializableEnvironmentVariableCollections | undefined;
 	reconnectionOwner?: string;
-	task?: { label: string; id: string; lastTask?: string; group?: string };
+	task?: { label: string; id: string; lastTask: string; group?: string };
 }
 
 export type ITerminalTabLayoutInfoDto = IRawTerminalTabLayoutInfo<IProcessDetails>;

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -345,7 +345,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 
 	private async _reconnectTasks(): Promise<void> {
 		const recentlyUsedTasks = await this.readRecentTasks();
-		if (!recentlyUsedTasks) {
+		if (!recentlyUsedTasks.length) {
 			return;
 		}
 		for (const task of recentlyUsedTasks) {

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -290,6 +290,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			this._setTaskLRUCacheLimit();
 			return this._updateWorkspaceTasks(TaskRunSource.ConfigurationChange);
 		}));
+		this._register(this.onDidChangeTaskSystemInfo(async () => await this._restartTasks()));
 		this._taskRunningState = TASK_RUNNING_STATE.bindTo(_contextKeyService);
 		this._onDidStateChange = this._register(new Emitter());
 		this._registerCommands();
@@ -618,7 +619,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		return infosCount > 0;
 	}
 
-	public async registerTaskSystem(key: string, info: ITaskSystemInfo): Promise<void> {
+	public registerTaskSystem(key: string, info: ITaskSystemInfo): void {
 		// Ideally the Web caller of registerRegisterTaskSystem would use the correct key.
 		// However, the caller doesn't know about the workspace folders at the time of the call, even though we know about them here.
 		if (info.platform === Platform.Platform.Web) {
@@ -638,7 +639,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 
 		if (this.hasTaskSystemInfo) {
 			this._onDidChangeTaskSystemInfo.fire();
-			await this._restartTasks();
 		}
 	}
 

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -249,6 +249,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 
 	private _reconnectToTerminals(terminals: ITerminalInstance[]): void {
 		for (const terminal of terminals) {
+			console.log('reconnecting to terminals');
 			const taskForTerminal = terminal.shellLaunchConfig.attachPersistentProcess?.task;
 			if (taskForTerminal?.id && taskForTerminal?.lastTask) {
 				this._tasksToReconnect.push(taskForTerminal.id);
@@ -257,6 +258,8 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 				this._logService.trace(`Could not reconnect to terminal ${terminal.instanceId} with process details ${terminal.shellLaunchConfig.attachPersistentProcess}`);
 			}
 		}
+		console.log('reconnected', terminals.length);
+		this._hasReconnected = true;
 	}
 
 	public get onDidStateChange(): Event<ITaskEvent> {
@@ -275,7 +278,6 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 		const terminals = this._terminalService.getReconnectedTerminals(ReconnectionType);
 		if (!this._hasReconnected && terminals && terminals.length > 0) {
 			this._reconnectToTerminals(terminals);
-			this._hasReconnected = true;
 		}
 		if (this._tasksToReconnect.includes(task._id)) {
 			this._lastTask = new VerifiedTask(task, resolver, trigger);
@@ -1296,6 +1298,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			if (!terminals?.length) {
 				return;
 			}
+			console.log('reviving terminals', terminals.map(t => t.shellLaunchConfig?.attachPersistentProcess?.task));
 			for (const terminal of terminals) {
 				if (terminal.shellLaunchConfig.attachPersistentProcess?.task?.lastTask) {
 					this._terminals[terminal.instanceId] = { lastTask: terminal.shellLaunchConfig.attachPersistentProcess.task.lastTask, group: terminal.shellLaunchConfig.attachPersistentProcess.task.group, terminal };

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -249,7 +249,6 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 
 	private _reconnectToTerminals(terminals: ITerminalInstance[]): void {
 		for (const terminal of terminals) {
-			console.log('reconnecting to terminals');
 			const taskForTerminal = terminal.shellLaunchConfig.attachPersistentProcess?.task;
 			if (taskForTerminal?.id && taskForTerminal?.lastTask) {
 				this._tasksToReconnect.push(taskForTerminal.id);
@@ -258,7 +257,6 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 				this._logService.trace(`Could not reconnect to terminal ${terminal.instanceId} with process details ${terminal.shellLaunchConfig.attachPersistentProcess}`);
 			}
 		}
-		console.log('reconnected', terminals.length);
 		this._hasReconnected = true;
 	}
 
@@ -276,6 +274,9 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 
 	public reconnect(task: Task, resolver: ITaskResolver, trigger: string = Triggers.command): ITaskExecuteResult | undefined {
 		const terminals = this._terminalService.getReconnectedTerminals(ReconnectionType);
+		if (!terminals || terminals?.length === 0) {
+			return;
+		}
 		if (!this._hasReconnected && terminals && terminals.length > 0) {
 			this._reviveTerminals();
 			this._reconnectToTerminals(terminals);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes part of #155163 - the error about splitting a terminal without a group no longer happens. The cause was it wasn't getting removed from `activeTasks` on dispose
