### PR TITLE
Fixed wrong SignatureInformation.activeParameter comment

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -4037,7 +4037,7 @@ declare module 'vscode' {
 		/**
 		 * The index of the active parameter.
 		 *
-		 * If provided, this is used in place of {@linkcode SignatureHelp.activeSignature}.
+		 * If provided, this is used in place of {@linkcode SignatureHelp.activeParameter}.
 		 */
 		activeParameter?: number;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes the comment of SignatureInformation.activeParameter.

Spotted this in the docs.

Current:
If provided, this is used in place of [SignatureHelp.activeSignature](https://code.visualstudio.com/api/references/vscode-api#SignatureHelp.activeSignature).

Expected:
If provided, this is used in place of [SignatureHelp.activeParameter](https://code.visualstudio.com/api/references/vscode-api#SignatureHelp.activeParameter).
