### PR TITLE
track usage of snippets to support snippet LRU

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -102,6 +102,7 @@ class InsertSnippetAction extends EditorAction {
 					snippet,
 					'',
 					SnippetSource.User,
+					`random/${Math.random()}`
 				));
 			}
 
@@ -143,6 +144,7 @@ class InsertSnippetAction extends EditorAction {
 			clipboardText = await clipboardService.readText();
 		}
 		SnippetController2.get(editor)?.insert(snippet.codeSnippet, { clipboardText });
+		snippetService.updateUsageTimestamp(snippet);
 	}
 }
 

--- a/src/vs/workbench/contrib/snippets/browser/snippetCompletionProvider.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetCompletionProvider.ts
@@ -8,7 +8,7 @@ import { compare, compareSubstring } from 'vs/base/common/strings';
 import { Position } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { ITextModel } from 'vs/editor/common/model';
-import { CompletionItem, CompletionItemKind, CompletionItemProvider, CompletionList, CompletionItemInsertTextRule, CompletionContext, CompletionTriggerKind, CompletionItemLabel } from 'vs/editor/common/languages';
+import { CompletionItem, CompletionItemKind, CompletionItemProvider, CompletionList, CompletionItemInsertTextRule, CompletionContext, CompletionTriggerKind, CompletionItemLabel, Command } from 'vs/editor/common/languages';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { SnippetParser } from 'vs/editor/contrib/snippet/browser/snippetParser';
 import { localize } from 'vs/nls';
@@ -19,6 +19,18 @@ import { StopWatch } from 'vs/base/common/stopwatch';
 import { ILanguageConfigurationService } from 'vs/editor/common/languages/languageConfigurationRegistry';
 import { getWordAtText } from 'vs/editor/common/core/wordHelper';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
+import { CommandsRegistry } from 'vs/platform/commands/common/commands';
+
+
+const markSnippetAsUsed = '_snippet.markAsUsed';
+
+CommandsRegistry.registerCommand(markSnippetAsUsed, (accessor, ...args) => {
+	const snippetsService = accessor.get(ISnippetsService);
+	const [first] = args;
+	if (first instanceof Snippet) {
+		snippetsService.updateUsageTimestamp(first);
+	}
+});
 
 export class SnippetCompletion implements CompletionItem {
 
@@ -31,10 +43,11 @@ export class SnippetCompletion implements CompletionItem {
 	kind: CompletionItemKind;
 	insertTextRules: CompletionItemInsertTextRule;
 	extensionId?: ExtensionIdentifier;
+	command?: Command;
 
 	constructor(
 		readonly snippet: Snippet,
-		range: IRange | { insert: IRange; replace: IRange }
+		range: IRange | { insert: IRange; replace: IRange },
 	) {
 		this.label = { label: snippet.prefix, description: snippet.name };
 		this.detail = localize('detail.snippet', "{0} ({1})", snippet.description || snippet.name, snippet.source);
@@ -44,6 +57,7 @@ export class SnippetCompletion implements CompletionItem {
 		this.sortText = `${snippet.snippetSource === SnippetSource.Extension ? 'z' : 'a'}-${snippet.prefix}`;
 		this.kind = CompletionItemKind.Snippet;
 		this.insertTextRules = CompletionItemInsertTextRule.InsertAsSnippet;
+		this.command = { id: markSnippetAsUsed, title: '', arguments: [snippet] };
 	}
 
 	resolve(): this {

--- a/src/vs/workbench/contrib/snippets/browser/snippetPicker.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetPicker.ts
@@ -27,7 +27,7 @@ export async function pickSnippet(accessor: ServicesAccessor, languageIdOrSnippe
 		snippets = (await snippetService.getSnippets(languageIdOrSnippets, { includeDisabledSnippets: true, includeNoPrefixSnippets: true }));
 	}
 
-	snippets.sort(Snippet.compare);
+	snippets.sort((a, b) => a.snippetSource - b.snippetSource);
 
 	const makeSnippetPicks = () => {
 		const result: QuickPickInput<ISnippetPick>[] = [];

--- a/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
@@ -15,6 +15,7 @@ export const ISnippetsService = createDecorator<ISnippetsService>('snippetServic
 export interface ISnippetGetOptions {
 	includeDisabledSnippets?: boolean;
 	includeNoPrefixSnippets?: boolean;
+	noRecencySort?: boolean;
 }
 
 export interface ISnippetsService {
@@ -26,6 +27,8 @@ export interface ISnippetsService {
 	isEnabled(snippet: Snippet): boolean;
 
 	updateEnablement(snippet: Snippet, enabled: boolean): void;
+
+	updateUsageTimestamp(snippet: Snippet): void;
 
 	getSnippets(languageId: string, opt?: ISnippetGetOptions): Promise<Snippet[]>;
 

--- a/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsFile.ts
@@ -113,7 +113,7 @@ export class Snippet {
 		readonly body: string,
 		readonly source: string,
 		readonly snippetSource: SnippetSource,
-		readonly snippetIdentifier?: string,
+		readonly snippetIdentifier: string,
 		readonly extensionId?: ExtensionIdentifier,
 	) {
 		this.prefixLow = prefix.toLowerCase();
@@ -138,24 +138,6 @@ export class Snippet {
 
 	get usesSelection(): boolean {
 		return this._bodyInsights.value.usesSelectionVariable;
-	}
-
-	static compare(a: Snippet, b: Snippet): number {
-		if (a.snippetSource < b.snippetSource) {
-			return -1;
-		} else if (a.snippetSource > b.snippetSource) {
-			return 1;
-		} else if (a.source < b.source) {
-			return -1;
-		} else if (a.source > b.source) {
-			return 1;
-		} else if (a.name > b.name) {
-			return 1;
-		} else if (a.name < b.name) {
-			return -1;
-		} else {
-			return 0;
-		}
 	}
 }
 
@@ -195,7 +177,7 @@ export class SnippetFile {
 		public defaultScopes: string[] | undefined,
 		private readonly _extension: IExtensionDescription | undefined,
 		private readonly _fileService: IFileService,
-		private readonly _extensionResourceLoaderService: IExtensionResourceLoaderService
+		private readonly _extensionResourceLoaderService: IExtensionResourceLoaderService,
 	) {
 		this.isGlobalSnippets = extname(location.path) === '.code-snippets';
 		this.isUserSnippets = !this._extension;
@@ -330,7 +312,7 @@ export class SnippetFile {
 				body,
 				source,
 				this.source,
-				this._extension && `${relativePath(this._extension.extensionLocation, this.location)}/${name}`,
+				this._extension ? `${relativePath(this._extension.extensionLocation, this.location)}/${name}` : `${basename(this.location.path)}/${name}`,
 				this._extension?.identifier,
 			));
 		}

--- a/src/vs/workbench/contrib/snippets/browser/snippetsService.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsService.ts
@@ -167,6 +167,42 @@ class SnippetEnablement {
 	}
 }
 
+class SnippetUsageTimestamps {
+
+	private static _key = 'snippets.usageTimestamps';
+
+	private readonly _usages: Map<string, number>;
+
+	constructor(
+		@IStorageService private readonly _storageService: IStorageService,
+	) {
+
+		const raw = _storageService.get(SnippetUsageTimestamps._key, StorageScope.PROFILE, '');
+		let data: [string, number][] | undefined;
+		try {
+			data = JSON.parse(raw);
+		} catch {
+			data = [];
+		}
+
+		this._usages = Array.isArray(data) ? new Map(data) : new Map();
+	}
+
+	getUsageTimestamp(id: string): number | undefined {
+		return this._usages.get(id);
+	}
+
+	updateUsageTimestamp(id: string): void {
+		// map uses insertion order, we want most recent at the end
+		this._usages.delete(id);
+		this._usages.set(id, Date.now());
+
+		// persist last 100 item
+		const all = [...this._usages].slice(-100);
+		this._storageService.store(SnippetUsageTimestamps._key, JSON.stringify(all), StorageScope.PROFILE, StorageTarget.USER);
+	}
+}
+
 class SnippetsService implements ISnippetsService {
 
 	declare readonly _serviceBrand: undefined;
@@ -175,6 +211,7 @@ class SnippetsService implements ISnippetsService {
 	private readonly _pendingWork: Promise<any>[] = [];
 	private readonly _files = new ResourceMap<SnippetFile>();
 	private readonly _enablement: SnippetEnablement;
+	private readonly _usageTimestamps: SnippetUsageTimestamps;
 
 	constructor(
 		@IEnvironmentService private readonly _environmentService: IEnvironmentService,
@@ -198,6 +235,7 @@ class SnippetsService implements ISnippetsService {
 		setSnippetSuggestSupport(new SnippetCompletionProvider(this._languageService, this, languageConfigurationService));
 
 		this._enablement = instantiationService.createInstance(SnippetEnablement);
+		this._usageTimestamps = instantiationService.createInstance(SnippetUsageTimestamps);
 	}
 
 	dispose(): void {
@@ -205,13 +243,15 @@ class SnippetsService implements ISnippetsService {
 	}
 
 	isEnabled(snippet: Snippet): boolean {
-		return !snippet.snippetIdentifier || !this._enablement.isIgnored(snippet.snippetIdentifier);
+		return !this._enablement.isIgnored(snippet.snippetIdentifier);
 	}
 
 	updateEnablement(snippet: Snippet, enabled: boolean): void {
-		if (snippet.snippetIdentifier) {
-			this._enablement.updateIgnored(snippet.snippetIdentifier, !enabled);
-		}
+		this._enablement.updateIgnored(snippet.snippetIdentifier, !enabled);
+	}
+
+	updateUsageTimestamp(snippet: Snippet): void {
+		this._usageTimestamps.updateUsageTimestamp(snippet.snippetIdentifier);
 	}
 
 	private _joinSnippets(): Promise<any> {
@@ -240,7 +280,7 @@ class SnippetsService implements ISnippetsService {
 			}
 		}
 		await Promise.all(promises);
-		return this._filterSnippets(result, opts);
+		return this._filterAndSortSnippets(result, opts);
 	}
 
 	getSnippetsSync(languageId: string, opts?: ISnippetGetOptions): Snippet[] {
@@ -253,14 +293,45 @@ class SnippetsService implements ISnippetsService {
 				file.select(languageId, result);
 			}
 		}
-		return this._filterSnippets(result, opts);
+		return this._filterAndSortSnippets(result, opts);
 	}
 
-	private _filterSnippets(snippets: Snippet[], opts?: ISnippetGetOptions): Snippet[] {
-		return snippets.filter(snippet => {
+	private _filterAndSortSnippets(snippets: Snippet[], opts?: ISnippetGetOptions): Snippet[] {
+		const result = snippets.filter(snippet => {
 			return (snippet.prefix || opts?.includeNoPrefixSnippets) // prefix or no-prefix wanted
 				&& (this.isEnabled(snippet) || opts?.includeDisabledSnippets); // enabled or disabled wanted
 		});
+
+		return result.sort((a, b) => {
+			let result = 0;
+			if (!opts?.noRecencySort) {
+				const val1 = this._usageTimestamps.getUsageTimestamp(a.snippetIdentifier) ?? -1;
+				const val2 = this._usageTimestamps.getUsageTimestamp(b.snippetIdentifier) ?? -1;
+				result = val2 - val1;
+			}
+			if (result === 0) {
+				result = this._compareSnippet(a, b);
+			}
+			return result;
+		});
+	}
+
+	private _compareSnippet(a: Snippet, b: Snippet): number {
+		if (a.snippetSource < b.snippetSource) {
+			return -1;
+		} else if (a.snippetSource > b.snippetSource) {
+			return 1;
+		} else if (a.source < b.source) {
+			return -1;
+		} else if (a.source > b.source) {
+			return 1;
+		} else if (a.name > b.name) {
+			return 1;
+		} else if (a.name < b.name) {
+			return -1;
+		} else {
+			return 0;
+		}
 	}
 
 	// --- loading, watching

--- a/src/vs/workbench/contrib/snippets/browser/surroundWithSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/surroundWithSnippet.ts
@@ -56,5 +56,6 @@ registerAction2(class SurroundWithAction extends EditorAction2 {
 		}
 
 		SnippetController2.get(editor)?.insert(snippet.codeSnippet, { clipboardText });
+		snippetService.updateUsageTimestamp(snippet);
 	}
 });

--- a/src/vs/workbench/contrib/snippets/test/browser/snippetFile.test.ts
+++ b/src/vs/workbench/contrib/snippets/test/browser/snippetFile.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert';
 import { SnippetFile, Snippet, SnippetSource } from 'vs/workbench/contrib/snippets/browser/snippetsFile';
 import { URI } from 'vs/base/common/uri';
 import { SnippetParser } from 'vs/editor/contrib/snippet/browser/snippetParser';
+import { generateUuid } from 'vs/base/common/uuid';
 
 suite('Snippets', function () {
 
@@ -24,12 +25,12 @@ suite('Snippets', function () {
 		assert.strictEqual(bucket.length, 0);
 
 		file = new TestSnippetFile(URI.file('somepath/foo.code-snippets'), [
-			new Snippet(['foo'], 'FooSnippet1', 'foo', '', 'snippet', 'test', SnippetSource.User),
-			new Snippet(['foo'], 'FooSnippet2', 'foo', '', 'snippet', 'test', SnippetSource.User),
-			new Snippet(['bar'], 'BarSnippet1', 'foo', '', 'snippet', 'test', SnippetSource.User),
-			new Snippet(['bar.comment'], 'BarSnippet2', 'foo', '', 'snippet', 'test', SnippetSource.User),
-			new Snippet(['bar.strings'], 'BarSnippet2', 'foo', '', 'snippet', 'test', SnippetSource.User),
-			new Snippet(['bazz', 'bazz'], 'BazzSnippet1', 'foo', '', 'snippet', 'test', SnippetSource.User),
+			new Snippet(['foo'], 'FooSnippet1', 'foo', '', 'snippet', 'test', SnippetSource.User, generateUuid()),
+			new Snippet(['foo'], 'FooSnippet2', 'foo', '', 'snippet', 'test', SnippetSource.User, generateUuid()),
+			new Snippet(['bar'], 'BarSnippet1', 'foo', '', 'snippet', 'test', SnippetSource.User, generateUuid()),
+			new Snippet(['bar.comment'], 'BarSnippet2', 'foo', '', 'snippet', 'test', SnippetSource.User, generateUuid()),
+			new Snippet(['bar.strings'], 'BarSnippet2', 'foo', '', 'snippet', 'test', SnippetSource.User, generateUuid()),
+			new Snippet(['bazz', 'bazz'], 'BazzSnippet1', 'foo', '', 'snippet', 'test', SnippetSource.User, generateUuid()),
 		]);
 
 		bucket = [];
@@ -56,8 +57,8 @@ suite('Snippets', function () {
 	test('SnippetFile#select - any scope', function () {
 
 		const file = new TestSnippetFile(URI.file('somepath/foo.code-snippets'), [
-			new Snippet([], 'AnySnippet1', 'foo', '', 'snippet', 'test', SnippetSource.User),
-			new Snippet(['foo'], 'FooSnippet1', 'foo', '', 'snippet', 'test', SnippetSource.User),
+			new Snippet([], 'AnySnippet1', 'foo', '', 'snippet', 'test', SnippetSource.User, generateUuid()),
+			new Snippet(['foo'], 'FooSnippet1', 'foo', '', 'snippet', 'test', SnippetSource.User, generateUuid()),
 		]);
 
 		const bucket: Snippet[] = [];
@@ -69,7 +70,7 @@ suite('Snippets', function () {
 	test('Snippet#needsClipboard', function () {
 
 		function assertNeedsClipboard(body: string, expected: boolean): void {
-			const snippet = new Snippet(['foo'], 'FooSnippet1', 'foo', '', body, 'test', SnippetSource.User);
+			const snippet = new Snippet(['foo'], 'FooSnippet1', 'foo', '', body, 'test', SnippetSource.User, generateUuid());
 			assert.strictEqual(snippet.needsClipboard, expected);
 
 			assert.strictEqual(SnippetParser.guessNeedsClipboard(body), expected);
@@ -86,7 +87,7 @@ suite('Snippets', function () {
 	test('Snippet#isTrivial', function () {
 
 		function assertIsTrivial(body: string, expected: boolean): void {
-			const snippet = new Snippet(['foo'], 'FooSnippet1', 'foo', '', body, 'test', SnippetSource.User);
+			const snippet = new Snippet(['foo'], 'FooSnippet1', 'foo', '', body, 'test', SnippetSource.User, generateUuid());
 			assert.strictEqual(snippet.isTrivial, expected);
 		}
 

--- a/src/vs/workbench/contrib/snippets/test/browser/snippetsRewrite.test.ts
+++ b/src/vs/workbench/contrib/snippets/test/browser/snippetsRewrite.test.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { generateUuid } from 'vs/base/common/uuid';
 import { Snippet, SnippetSource } from 'vs/workbench/contrib/snippets/browser/snippetsFile';
 
 suite('SnippetRewrite', function () {
 
 	function assertRewrite(input: string, expected: string | boolean): void {
-		const actual = new Snippet(['foo'], 'foo', 'foo', 'foo', input, 'foo', SnippetSource.User);
+		const actual = new Snippet(['foo'], 'foo', 'foo', 'foo', input, 'foo', SnippetSource.User, generateUuid());
 		if (typeof expected === 'boolean') {
 			assert.strictEqual(actual.codeSnippet, input);
 		} else {
@@ -47,7 +48,7 @@ suite('SnippetRewrite', function () {
 	});
 
 	test('lazy bogous variable rewrite', function () {
-		const snippet = new Snippet(['fooLang'], 'foo', 'prefix', 'desc', 'This is ${bogous} because it is a ${var}', 'source', SnippetSource.Extension);
+		const snippet = new Snippet(['fooLang'], 'foo', 'prefix', 'desc', 'This is ${bogous} because it is a ${var}', 'source', SnippetSource.Extension, generateUuid());
 		assert.strictEqual(snippet.body, 'This is ${bogous} because it is a ${var}');
 		assert.strictEqual(snippet.codeSnippet, 'This is ${1:bogous} because it is a ${2:var}');
 		assert.strictEqual(snippet.isBogous, true);

--- a/src/vs/workbench/contrib/snippets/test/browser/snippetsService.test.ts
+++ b/src/vs/workbench/contrib/snippets/test/browser/snippetsService.test.ts
@@ -15,6 +15,7 @@ import { TestLanguageConfigurationService } from 'vs/editor/test/common/modes/te
 import { EditOperation } from 'vs/editor/common/core/editOperation';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { ILanguageService } from 'vs/editor/common/languages/language';
+import { generateUuid } from 'vs/base/common/uuid';
 
 class SimpleSnippetService implements ISnippetsService {
 	declare readonly _serviceBrand: undefined;
@@ -32,6 +33,9 @@ class SimpleSnippetService implements ISnippetsService {
 		throw new Error();
 	}
 	updateEnablement(): void {
+		throw new Error();
+	}
+	updateUsageTimestamp(snippet: Snippet): void {
 		throw new Error();
 	}
 }
@@ -59,7 +63,8 @@ suite('SnippetsService', function () {
 			'',
 			'barCodeSnippet',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		), new Snippet(
 			['fooLang'],
 			'bazzTest',
@@ -67,7 +72,8 @@ suite('SnippetsService', function () {
 			'',
 			'bazzCodeSnippet',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 	});
 
@@ -128,7 +134,8 @@ suite('SnippetsService', function () {
 			'',
 			's1',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		), new Snippet(
 			['fooLang'],
 			'name',
@@ -136,7 +143,8 @@ suite('SnippetsService', function () {
 			'',
 			's2',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -206,7 +214,8 @@ suite('SnippetsService', function () {
 			'',
 			'insert me',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -241,7 +250,8 @@ suite('SnippetsService', function () {
 			'',
 			'<foo>$0</foo>',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -263,7 +273,8 @@ suite('SnippetsService', function () {
 			'',
 			'second',
 			'',
-			SnippetSource.Extension
+			SnippetSource.Extension,
+			generateUuid()
 		), new Snippet(
 			['fooLang'],
 			'first',
@@ -271,7 +282,8 @@ suite('SnippetsService', function () {
 			'',
 			'first',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -299,7 +311,8 @@ suite('SnippetsService', function () {
 			'',
 			'second',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
 
@@ -323,7 +336,8 @@ suite('SnippetsService', function () {
 			'',
 			'second',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -342,7 +356,8 @@ suite('SnippetsService', function () {
 			'',
 			'second',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -361,7 +376,8 @@ suite('SnippetsService', function () {
 			'',
 			'second',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -384,7 +400,8 @@ suite('SnippetsService', function () {
 			'',
 			'second',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -408,7 +425,8 @@ suite('SnippetsService', function () {
 			'',
 			'second',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, languageConfigurationService);
@@ -427,7 +445,8 @@ suite('SnippetsService', function () {
 			'',
 			'second',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -446,7 +465,8 @@ suite('SnippetsService', function () {
 			'',
 			'<= #dly"',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		), new Snippet(
 			['fooLang'],
 			'noblockwdelay',
@@ -454,7 +474,8 @@ suite('SnippetsService', function () {
 			'',
 			'eleven',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -484,7 +505,8 @@ suite('SnippetsService', function () {
 			'',
 			'not word snippet',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -526,7 +548,8 @@ suite('SnippetsService', function () {
 			'',
 			'<span></span>',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -558,7 +581,8 @@ suite('SnippetsService', function () {
 			'',
 			'[PSCustomObject] @{ Key = Value }',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, languageConfigurationService);
@@ -583,7 +607,8 @@ suite('SnippetsService', function () {
 			'',
 			'~\\cite{$CLIPBOARD}',
 			'',
-			SnippetSource.User
+			SnippetSource.User,
+			generateUuid()
 		)]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -602,9 +627,9 @@ suite('SnippetsService', function () {
 	test('still show suggestions in string when disable string suggestion #136611', async function () {
 
 		snippetService = new SimpleSnippetService([
-			new Snippet(['fooLang'], 'aaa', 'aaa', '', 'value', '', SnippetSource.User),
-			new Snippet(['fooLang'], 'bbb', 'bbb', '', 'value', '', SnippetSource.User),
-			// new Snippet(['fooLang'], '\'ccc', '\'ccc', '', 'value', '', SnippetSource.User)
+			new Snippet(['fooLang'], 'aaa', 'aaa', '', 'value', '', SnippetSource.User, generateUuid()),
+			new Snippet(['fooLang'], 'bbb', 'bbb', '', 'value', '', SnippetSource.User, generateUuid()),
+			// new Snippet(['fooLang'], '\'ccc', '\'ccc', '', 'value', '', SnippetSource.User, generateUuid())
 		]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -624,9 +649,9 @@ suite('SnippetsService', function () {
 	test('still show suggestions in string when disable string suggestion #136611', async function () {
 
 		snippetService = new SimpleSnippetService([
-			new Snippet(['fooLang'], 'aaa', 'aaa', '', 'value', '', SnippetSource.User),
-			new Snippet(['fooLang'], 'bbb', 'bbb', '', 'value', '', SnippetSource.User),
-			new Snippet(['fooLang'], '\'ccc', '\'ccc', '', 'value', '', SnippetSource.User)
+			new Snippet(['fooLang'], 'aaa', 'aaa', '', 'value', '', SnippetSource.User, generateUuid()),
+			new Snippet(['fooLang'], 'bbb', 'bbb', '', 'value', '', SnippetSource.User, generateUuid()),
+			new Snippet(['fooLang'], '\'ccc', '\'ccc', '', 'value', '', SnippetSource.User, generateUuid())
 		]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -645,9 +670,9 @@ suite('SnippetsService', function () {
 
 	test('Snippet suggestions are too eager #138707 (word)', async function () {
 		snippetService = new SimpleSnippetService([
-			new Snippet(['fooLang'], 'tys', 'tys', '', 'value', '', SnippetSource.User),
-			new Snippet(['fooLang'], 'hell_or_tell', 'hell_or_tell', '', 'value', '', SnippetSource.User),
-			new Snippet(['fooLang'], '^y', '^y', '', 'value', '', SnippetSource.User),
+			new Snippet(['fooLang'], 'tys', 'tys', '', 'value', '', SnippetSource.User, generateUuid()),
+			new Snippet(['fooLang'], 'hell_or_tell', 'hell_or_tell', '', 'value', '', SnippetSource.User, generateUuid()),
+			new Snippet(['fooLang'], '^y', '^y', '', 'value', '', SnippetSource.User, generateUuid()),
 		]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -666,9 +691,9 @@ suite('SnippetsService', function () {
 
 	test('Snippet suggestions are too eager #138707 (no word)', async function () {
 		snippetService = new SimpleSnippetService([
-			new Snippet(['fooLang'], 'tys', 'tys', '', 'value', '', SnippetSource.User),
-			new Snippet(['fooLang'], 't', 't', '', 'value', '', SnippetSource.User),
-			new Snippet(['fooLang'], '^y', '^y', '', 'value', '', SnippetSource.User),
+			new Snippet(['fooLang'], 'tys', 'tys', '', 'value', '', SnippetSource.User, generateUuid()),
+			new Snippet(['fooLang'], 't', 't', '', 'value', '', SnippetSource.User, generateUuid()),
+			new Snippet(['fooLang'], '^y', '^y', '', 'value', '', SnippetSource.User, generateUuid()),
 		]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -687,8 +712,8 @@ suite('SnippetsService', function () {
 
 	test('Snippet suggestions are too eager #138707 (word/word)', async function () {
 		snippetService = new SimpleSnippetService([
-			new Snippet(['fooLang'], 'async arrow function', 'async arrow function', '', 'value', '', SnippetSource.User),
-			new Snippet(['fooLang'], 'foobarrrrrr', 'foobarrrrrr', '', 'value', '', SnippetSource.User),
+			new Snippet(['fooLang'], 'async arrow function', 'async arrow function', '', 'value', '', SnippetSource.User, generateUuid()),
+			new Snippet(['fooLang'], 'foobarrrrrr', 'foobarrrrrr', '', 'value', '', SnippetSource.User, generateUuid()),
 		]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());
@@ -707,7 +732,7 @@ suite('SnippetsService', function () {
 
 	test('Strange and useless autosuggestion #region/#endregion PHP #140039', async function () {
 		snippetService = new SimpleSnippetService([
-			new Snippet(['fooLang'], 'reg', '#region', '', 'value', '', SnippetSource.User),
+			new Snippet(['fooLang'], 'reg', '#region', '', 'value', '', SnippetSource.User, generateUuid()),
 		]);
 
 
@@ -725,9 +750,9 @@ suite('SnippetsService', function () {
 
 	test.skip('Snippets disappear with . key #145960', async function () {
 		snippetService = new SimpleSnippetService([
-			new Snippet(['fooLang'], 'div', 'div', '', 'div', '', SnippetSource.User),
-			new Snippet(['fooLang'], 'div.', 'div.', '', 'div.', '', SnippetSource.User),
-			new Snippet(['fooLang'], 'div#', 'div#', '', 'div#', '', SnippetSource.User),
+			new Snippet(['fooLang'], 'div', 'div', '', 'div', '', SnippetSource.User, generateUuid()),
+			new Snippet(['fooLang'], 'div.', 'div.', '', 'div.', '', SnippetSource.User, generateUuid()),
+			new Snippet(['fooLang'], 'div#', 'div#', '', 'div#', '', SnippetSource.User, generateUuid()),
 		]);
 
 		const provider = new SnippetCompletionProvider(languageService, snippetService, new TestLanguageConfigurationService());


### PR DESCRIPTION
enforce that all snippets have an identifier, mark a snippet as used after completing with it or after inserting one, store the last 100 snippet usages per (user, profile)
