### PR TITLE
set to udf after

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -882,6 +882,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			watchingProblemMatcher.aboutToStart();
 			let delayer: Async.Delayer<any> | undefined = undefined;
 			[terminal, error] = this._terminalForTask ? [this._terminalForTask, undefined] : await this._createTerminal(task, resolver, workspaceFolder);
+			this._terminalForTask = undefined;
 
 			if (error) {
 				return Promise.reject(new Error((<TaskError>error).message));
@@ -964,6 +965,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			});
 		} else {
 			[terminal, error] = this._terminalForTask ? [this._terminalForTask, undefined] : await this._createTerminal(task, resolver, workspaceFolder);
+			this._terminalForTask = undefined;
 
 			if (error) {
 				return Promise.reject(new Error((<TaskError>error).message));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

follow up to https://github.com/microsoft/vscode/pull/155254

The terminal for task should be set to udf after it's used so a bad state is prevented in which it gets used again
one such bad state: 
fixes #155307