### PR TITLE
Update diff color changes

### DIFF
--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -401,14 +401,14 @@ export const editorLightBulbAutoFixForeground = registerColor('editorLightBulbAu
 /**
  * Diff Editor Colors
  */
-export const defaultInsertColor = new Color(new RGBA(53, 175, 34, 0.24));
-export const defaultRemoveColor = new Color(new RGBA(255, 0, 0, 0.2));
+export const defaultInsertColor = new Color(new RGBA(155, 185, 85, .2));
+export const defaultRemoveColor = new Color(new RGBA(255, 0, 0, .2));
 
-export const diffInserted = registerColor('diffEditor.insertedTextBackground', { dark: defaultInsertColor, light: defaultInsertColor, hcDark: null, hcLight: null }, nls.localize('diffEditorInserted', 'Background color for text that got inserted. The color must not be opaque so as not to hide underlying decorations.'), true);
-export const diffRemoved = registerColor('diffEditor.removedTextBackground', { dark: defaultRemoveColor, light: defaultRemoveColor, hcDark: null, hcLight: null }, nls.localize('diffEditorRemoved', 'Background color for text that got removed. The color must not be opaque so as not to hide underlying decorations.'), true);
+export const diffInserted = registerColor('diffEditor.insertedTextBackground', { dark: '#9ccc2c33', light: '#9ccc2c66', hcDark: null, hcLight: null }, nls.localize('diffEditorInserted', 'Background color for text that got inserted. The color must not be opaque so as not to hide underlying decorations.'), true);
+export const diffRemoved = registerColor('diffEditor.removedTextBackground', { dark: '#ff000066', light: '#ff00004d', hcDark: null, hcLight: null }, nls.localize('diffEditorRemoved', 'Background color for text that got removed. The color must not be opaque so as not to hide underlying decorations.'), true);
 
-export const diffInsertedLine = registerColor('diffEditor.insertedLineBackground', { dark: null, light: null, hcDark: null, hcLight: null }, nls.localize('diffEditorInsertedLines', 'Background color for lines that got inserted. The color must not be opaque so as not to hide underlying decorations.'), true);
-export const diffRemovedLine = registerColor('diffEditor.removedLineBackground', { dark: null, light: null, hcDark: null, hcLight: null }, nls.localize('diffEditorRemovedLines', 'Background color for lines that got removed. The color must not be opaque so as not to hide underlying decorations.'), true);
+export const diffInsertedLine = registerColor('diffEditor.insertedLineBackground', { dark: defaultInsertColor, light: defaultInsertColor, hcDark: null, hcLight: null }, nls.localize('diffEditorInsertedLines', 'Background color for lines that got inserted. The color must not be opaque so as not to hide underlying decorations.'), true);
+export const diffRemovedLine = registerColor('diffEditor.removedLineBackground', { dark: defaultRemoveColor, light: defaultRemoveColor, hcDark: null, hcLight: null }, nls.localize('diffEditorRemovedLines', 'Background color for lines that got removed. The color must not be opaque so as not to hide underlying decorations.'), true);
 
 export const diffInsertedLineGutter = registerColor('diffEditorGutter.insertedLineBackground', { dark: null, light: null, hcDark: null, hcLight: null }, nls.localize('diffEditorInsertedLineGutter', 'Background color for the margin where lines got inserted.'));
 export const diffRemovedLineGutter = registerColor('diffEditorGutter.removedLineBackground', { dark: null, light: null, hcDark: null, hcLight: null }, nls.localize('diffEditorRemovedLineGutter', 'Background color for the margin where lines got removed.'));


### PR DESCRIPTION
Refs #153563

In https://github.com/microsoft/vscode/pull/154969 I simply updated the color token `diffEditor.insertedTextBackground` which is used in both the line and word diff. There was some feedback that this was too strong of a change and maybe we should update the word diff color instead. This PR attempts to update the word diff color token instead.

There is one downsides to this approach: by default `diffEditor.insertedLineBackground` is set to `null` but it uses the same color as `diffEditor.insertedTextBackground`. In order to achieve what we want, I had to swap the values and add in the new color for `diffEditor.insertedTextBackground`. Below is a comparison of original (left) and proposed (right):

<img width="1376" alt="CleanShot 2022-07-15 at 13 23 26@2x" src="https://user-images.githubusercontent.com/35271042/179305223-5f660146-b780-4779-884b-e371d1381b0a.png">

<img width="1375" alt="CleanShot 2022-07-15 at 13 23 45@2x" src="https://user-images.githubusercontent.com/35271042/179305255-8792bdaa-94d0-48d8-afb7-cb0b8c5e9a28.png">

All seems fine but when looking at themes, not every theme defines these two color tokens, so this change does mean some authors need to define this token:

<img width="1348" alt="CleanShot 2022-07-15 at 13 25 34@2x" src="https://user-images.githubusercontent.com/35271042/179305471-38d0be8c-8b33-4fd4-b8f3-0d522ea80e1f.png">

<img width="1366" alt="CleanShot 2022-07-15 at 13 26 21@2x" src="https://user-images.githubusercontent.com/35271042/179305586-75372947-fd32-4d26-9771-8b234564d924.png">

<img width="1370" alt="CleanShot 2022-07-15 at 13 27 46@2x" src="https://user-images.githubusercontent.com/35271042/179305752-2b6980b5-a8ae-4173-95e7-e05440fb45d6.png">

If this looks good then we can make the change and mention this in the release notes for theme authors.

cc @bpasero @joaomoreno 