### PR TITLE
Add "Open Side Bar View" action

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -426,7 +426,7 @@ registerAction2(
 			viewsService.openView(viewId, true);
 		}
 	}
-);;
+);
 registerThemingParticipant((theme, collector) => {
 	const activityBarForegroundColor = theme.getColor(ACTIVITY_BAR_FOREGROUND);
 	if (activityBarForegroundColor) {

--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -36,10 +36,9 @@ import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storag
 import { IHoverService } from 'vs/workbench/services/hover/browser/hover';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
-import { ViewContainerLocation } from 'vs/workbench/common/views';
+import { ViewContainerLocation, IViewsService } from 'vs/workbench/common/views';
 import { IPaneCompositePart } from 'vs/workbench/browser/parts/paneCompositePart';
 import { ICredentialsService } from 'vs/platform/credentials/common/credentials';
-import { IViewsService } from 'vs/workbench/common/views';
 
 export class ViewContainerActivityAction extends ActivityAction {
 

--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -426,7 +426,7 @@ registerAction2(
 			viewsService.openView(viewId, true);
 		}
 	}
-);
+);;
 registerThemingParticipant((theme, collector) => {
 	const activityBarForegroundColor = theme.getColor(ACTIVITY_BAR_FOREGROUND);
 	if (activityBarForegroundColor) {

--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -39,6 +39,7 @@ import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/b
 import { ViewContainerLocation } from 'vs/workbench/common/views';
 import { IPaneCompositePart } from 'vs/workbench/browser/parts/paneCompositePart';
 import { ICredentialsService } from 'vs/platform/credentials/common/credentials';
+import { IViewsService } from 'vs/workbench/common/views';
 
 export class ViewContainerActivityAction extends ActivityAction {
 
@@ -410,7 +411,23 @@ registerAction2(
 			layoutService.focusPart(Parts.ACTIVITYBAR_PART);
 		}
 	});
+registerAction2(
+	class OpenSideBarViewAction extends Action2 {
+		constructor() {
+			super({
+				id: 'workbench.action.openSideBarView',
+				title: { value: localize('openSideBarView', "Open Side Bar View"), original: 'Open Side Bar View' },
+				category: CATEGORIES.View,
+				f1: true
+			});
+		}
 
+		async run(accessor: ServicesAccessor, viewId: string): Promise<void> {
+			const viewsService = accessor.get(IViewsService);
+			viewsService.openView(viewId, true);
+		}
+	}
+);
 registerThemingParticipant((theme, collector) => {
 	const activityBarForegroundColor = theme.getColor(ACTIVITY_BAR_FOREGROUND);
 	if (activityBarForegroundColor) {


### PR DESCRIPTION


Motivation: with increasing versatility of Action Bar being filled with items contributed by extensions it is desirable to navigate quickly among them using this command.

Therefore, I am working on an extension with a similar function, which also requires users to quickly display the extended view through commands, which can help users quickly use the extended view we provide, especially if there are too many views installed in the sidebar when.

This PR fixes #155454
