### PR TITLE
Add shell-integration to isSupportedForCmd

### DIFF
--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -44,6 +44,7 @@ const isSupportedForCmd = (optionId: keyof RemoteParsedArgs) => {
 		case 'enable-smoke-test-driver':
 		case 'extensions-download-dir':
 		case 'builtin-extensions-dir':
+		case 'shell-integration':
 		case 'telemetry':
 			return false;
 		default:


### PR DESCRIPTION
Fixes #153921

Missed this as part of the server shell integration manual install