### PR TITLE
editors - add capability to control centered layout (fix #154738)

### DIFF
--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -733,6 +733,12 @@ export const enum EditorInputCapabilities {
 	 * editor by holding shift.
 	 */
 	CanDropIntoEditor = 1 << 7,
+
+	/**
+	 * Signals that the editor is composed of multiple editors
+	 * within.
+	 */
+	MultipleEditors = 1 << 8
 }
 
 export type IUntypedEditorInput = IResourceEditorInput | ITextResourceEditorInput | IUntitledTextResourceEditorInput | IResourceDiffEditorInput | IResourceSideBySideEditorInput | IResourceMergeEditorInput;

--- a/src/vs/workbench/common/editor/sideBySideEditorInput.ts
+++ b/src/vs/workbench/common/editor/sideBySideEditorInput.ts
@@ -42,6 +42,9 @@ export class SideBySideEditorInput extends EditorInput implements ISideBySideEdi
 			capabilities |= EditorInputCapabilities.Singleton;
 		}
 
+		// Indicate we show more than one editor
+		capabilities |= EditorInputCapabilities.MultipleEditors;
+
 		return capabilities;
 	}
 

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
@@ -13,7 +13,7 @@ import { ConfirmResult, IDialogService } from 'vs/platform/dialogs/common/dialog
 import { IFileService } from 'vs/platform/files/common/files';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILabelService } from 'vs/platform/label/common/label';
-import { IEditorIdentifier, IResourceMergeEditorInput, isResourceMergeEditorInput, IUntypedEditorInput } from 'vs/workbench/common/editor';
+import { EditorInputCapabilities, IEditorIdentifier, IResourceMergeEditorInput, isResourceMergeEditorInput, IUntypedEditorInput } from 'vs/workbench/common/editor';
 import { EditorInput, IEditorCloseHandler } from 'vs/workbench/common/editor/editorInput';
 import { AbstractTextResourceEditorInput } from 'vs/workbench/common/editor/textResourceEditorInput';
 import { EditorWorkerServiceDiffComputer } from 'vs/workbench/contrib/mergeEditor/browser/model/diffComputer';
@@ -82,6 +82,10 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 
 	get typeId(): string {
 		return MergeEditorInput.ID;
+	}
+
+	override get capabilities(): EditorInputCapabilities {
+		return super.capabilities | EditorInputCapabilities.MultipleEditors;
 	}
 
 	override getName(): string {

--- a/src/vs/workbench/test/browser/parts/editor/editor.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editor.test.ts
@@ -120,7 +120,7 @@ suite('Workbench editor utils', () => {
 		testInput2.capabilities = EditorInputCapabilities.None;
 
 		const sideBySideInput = instantiationService.createInstance(SideBySideEditorInput, 'name', undefined, testInput1, testInput2);
-		assert.strictEqual(sideBySideInput.hasCapability(EditorInputCapabilities.None), true);
+		assert.strictEqual(sideBySideInput.hasCapability(EditorInputCapabilities.MultipleEditors), true);
 		assert.strictEqual(sideBySideInput.hasCapability(EditorInputCapabilities.Readonly), false);
 		assert.strictEqual(sideBySideInput.hasCapability(EditorInputCapabilities.Untitled), false);
 		assert.strictEqual(sideBySideInput.hasCapability(EditorInputCapabilities.RequiresTrust), false);


### PR DESCRIPTION
By adding a new capability `MultipleEditors`. I am open for a better name, I am trying to express that the editor is composed of multiple editors within.