### PR TITLE
Don't fill in tasks type/labels

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -394,13 +394,11 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 								properties: {
 									type: {
 										type: 'string',
-										description: nls.localize('runTask.type', "The contributed task type"),
-										enum: Array.from(this._providerTypes.values()).map(provider => provider)
+										description: nls.localize('runTask.type', "The contributed task type")
 									},
 									taskName: {
 										type: 'string',
-										description: nls.localize('runTask.taskName', "The task's label or a term to filter by"),
-										enum: await this.tasks().then((tasks) => tasks.map(t => t._label))
+										description: nls.localize('runTask.taskName', "The task's label or a term to filter by")
 									}
 								}
 							}


### PR DESCRIPTION
These change throughout the lifecycle of the window, require workspace trust and
are expensive to fetch. Just having help with autocompleting type/taskName is
good enough here.

Fixes #155087

![image](https://user-images.githubusercontent.com/2193314/179759084-0ecc8408-3196-46e2-8176-694f572f67e7.png)
