### PR TITLE
SCM - Add an authority to the URI of the SCM input's text document

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1789,7 +1789,8 @@ class SCMInputWidget {
 
 		const uri = URI.from({
 			scheme: Schemas.vscode,
-			path: `scm/${input.repository.provider.contextValue}/${input.repository.provider.id}/input`,
+			authority: 'scm',
+			path: `/${input.repository.provider.contextValue}/${input.repository.provider.id}/input`,
 			query
 		});
 


### PR DESCRIPTION
In order to enable handling problem markers emitted for the SCM input's text document, we want to move the `scm` segment from the path to the authority. @alexr00, could you please confirm that this change will not break the GHPR extension? Thanks!  