### PR TITLE
Show connection state and remote icon in embedder API connections

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -276,7 +276,19 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 		// Remote Indicator: show if provided via options, e.g. by the web embedder API
 		const remoteIndicator = this.environmentService.options?.windowIndicator;
 		if (remoteIndicator) {
-			this.renderRemoteStatusIndicator(truncate(remoteIndicator.label, RemoteStatusIndicator.REMOTE_STATUS_LABEL_MAX_LENGTH), remoteIndicator.tooltip, remoteIndicator.command);
+			switch (this.connectionState) {
+				case 'initializing':
+					this.renderRemoteStatusIndicator(nls.localize('host.open', "Opening Remote..."), nls.localize('host.open', "Opening Remote..."), undefined, true /* progress */);
+					break;
+				case 'reconnecting':
+					this.renderRemoteStatusIndicator(`${nls.localize('host.reconnecting', "Reconnecting to {0}...", truncate(remoteIndicator.label, RemoteStatusIndicator.REMOTE_STATUS_LABEL_MAX_LENGTH))}`, undefined, undefined, true);
+					break;
+				case 'disconnected':
+					this.renderRemoteStatusIndicator(`$(alert) ${nls.localize('disconnectedFrom', "Disconnected from {0}", truncate(remoteIndicator.label, RemoteStatusIndicator.REMOTE_STATUS_LABEL_MAX_LENGTH))}`);
+					break;
+				default:
+					this.renderRemoteStatusIndicator(`$(remote) ${truncate(remoteIndicator.label, RemoteStatusIndicator.REMOTE_STATUS_LABEL_MAX_LENGTH)}`, remoteIndicator.tooltip, remoteIndicator.command);
+			}
 			return;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cli/issues/431

Shows same connection icon logic and labels in the Remote Indicator for remote connections made through the Embedder API. 

![Recording 2022-07-19 at 09 54 10](https://user-images.githubusercontent.com/12758612/179806926-02845ca9-ac0e-451c-8721-2cacfdb3b364.gif)

