### PR TITLE
Handle commands separated by && in shell integration

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -160,6 +160,8 @@ __vsc_prompt_cmd_original() {
 	fi
 	if [[ "$__vsc_original_prompt_command" =~ .+\;.+ ]]; then
 		IFS=';'
+	elif [[ "$__vsc_original_prompt_command" =~ .+&&.+ ]]; then
+		IFS='&&'
 	else
 		IFS=' '
 	fi
@@ -171,8 +173,10 @@ __vsc_prompt_cmd_original() {
 		unset IFS
 	fi
 	for ((i = 0; i < ${#ADDR[@]}; i++)); do
-		(exit ${__vsc_status})
-		builtin eval ${ADDR[i]}
+		if [[ "${ADDR[i]}" != "" ]]; then
+			(exit ${__vsc_status})
+			builtin eval ${ADDR[i]}
+		fi
 	done
 	__vsc_precmd
 }


### PR DESCRIPTION
This handles the reported case, we won't handle all cases yet such as `||` but how to fix this problem properly would be best fixed by a bash expert

Fixes #155221
