### PR TITLE
show remote indicator in web with websocket factory

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -281,7 +281,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 		}
 
 		// Show for remote windows on the desktop, but not when in code server web
-		if (this.remoteAuthority && !isWeb) {
+		if (this.remoteAuthority && (!isWeb || this.environmentService.options?.webSocketFactory)) {
 			const hostLabel = this.labelService.getHostLabel(Schemas.vscodeRemote, this.remoteAuthority) || this.remoteAuthority;
 			switch (this.connectionState) {
 				case 'initializing':


### PR DESCRIPTION
In the web, we currently don't show the remote indicator by default as typically it reflects the address in the browser URI.

If the web connects to a remote, then we want the remote indicator. 
This PR uses the presence of the `webSocketFactory` to determine that.

Note: web embedder can always define their own window indicator. that's what Codespaces-web does: that means: This change does not affect Codespaces