### PR TITLE
Don't poll for parent process existance in the sandboxed case

### DIFF
--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -286,37 +286,39 @@ function connectToRenderer(protocol: IMessagePassingProtocol): Promise<IRenderer
 				}
 			}
 
-			// Kill oneself if one's parent dies. Much drama.
-			let epermErrors = 0;
-			setInterval(function () {
-				try {
-					process.kill(initData.parentPid, 0); // throws an exception if the main process doesn't exist anymore.
-					epermErrors = 0;
-				} catch (e) {
-					if (e && e.code === 'EPERM') {
-						// Even if the parent process is still alive,
-						// some antivirus software can lead to an EPERM error to be thrown here.
-						// Let's terminate only if we get 3 consecutive EPERM errors.
-						epermErrors++;
-						if (epermErrors >= 3) {
-							onTerminate(`parent process ${initData.parentPid} does not exist anymore (3 x EPERM): ${e.message} (code: ${e.code}) (errno: ${e.errno})`);
+			if (initData.parentPid) {
+				// Kill oneself if one's parent dies. Much drama.
+				let epermErrors = 0;
+				setInterval(function () {
+					try {
+						process.kill(initData.parentPid, 0); // throws an exception if the main process doesn't exist anymore.
+						epermErrors = 0;
+					} catch (e) {
+						if (e && e.code === 'EPERM') {
+							// Even if the parent process is still alive,
+							// some antivirus software can lead to an EPERM error to be thrown here.
+							// Let's terminate only if we get 3 consecutive EPERM errors.
+							epermErrors++;
+							if (epermErrors >= 3) {
+								onTerminate(`parent process ${initData.parentPid} does not exist anymore (3 x EPERM): ${e.message} (code: ${e.code}) (errno: ${e.errno})`);
+							}
+						} else {
+							onTerminate(`parent process ${initData.parentPid} does not exist anymore: ${e.message} (code: ${e.code}) (errno: ${e.errno})`);
 						}
-					} else {
-						onTerminate(`parent process ${initData.parentPid} does not exist anymore: ${e.message} (code: ${e.code}) (errno: ${e.errno})`);
 					}
-				}
-			}, 1000);
+				}, 1000);
 
-			// In certain cases, the event loop can become busy and never yield
-			// e.g. while-true or process.nextTick endless loops
-			// So also use the native node module to do it from a separate thread
-			let watchdog: typeof nativeWatchdog;
-			try {
-				watchdog = require.__$__nodeRequire('native-watchdog');
-				watchdog.start(initData.parentPid);
-			} catch (err) {
-				// no problem...
-				onUnexpectedError(err);
+				// In certain cases, the event loop can become busy and never yield
+				// e.g. while-true or process.nextTick endless loops
+				// So also use the native node module to do it from a separate thread
+				let watchdog: typeof nativeWatchdog;
+				try {
+					watchdog = require.__$__nodeRequire('native-watchdog');
+					watchdog.start(initData.parentPid);
+				} catch (err) {
+					// no problem...
+					onUnexpectedError(err);
+				}
 			}
 
 			// Tell the outside that we are initialized

--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -281,7 +281,7 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 		return {
 			commit: this._productService.commit,
 			version: this._productService.version,
-			parentPid: -1,
+			parentPid: 0,
 			environment: {
 				isExtensionDevelopmentDebug: this._environmentService.debugRenderer,
 				appName: this._productService.nameLong,

--- a/src/vs/workbench/services/extensions/common/extensionHostProtocol.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostProtocol.ts
@@ -20,7 +20,10 @@ export interface IExtensionDescriptionDelta {
 export interface IExtensionHostInitData {
 	version: string;
 	commit?: string;
-	parentPid: number;
+	/**
+	 * When set to `0`, no polling for the parent process still running will happen.
+	 */
+	parentPid: number | 0;
 	environment: IEnvironment;
 	workspace?: IStaticWorkspaceData | null;
 	allExtensions: IExtensionDescription[];

--- a/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
@@ -437,7 +437,7 @@ export class SandboxLocalProcessExtensionHost implements IExtensionHost {
 		return {
 			commit: this._productService.commit,
 			version: this._productService.version,
-			parentPid: process.pid,
+			parentPid: process.sandboxed ? 0 : process.pid,
 			environment: {
 				isExtensionDevelopmentDebug: this._isExtensionDevDebug,
 				appRoot: this._environmentService.appRoot ? URI.file(this._environmentService.appRoot) : undefined,


### PR DESCRIPTION
`process.pid` is always `1` on a sandboxed renderer, so avoid polling for the renderer process still running from the extension host, since the extension host is a `UtilityProcess` anyways, with a lifecycle managed by Electron.

Fixes #154235