### PR TITLE
Git - Use GIT_EDITOR environment variable to suppress the git commit editor during rebase

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1472,10 +1472,10 @@ export class Repository {
 	}
 
 	async rebaseContinue(): Promise<void> {
-		const args = ['-c', 'core.editor=true', 'rebase', '--continue'];
+		const args = ['rebase', '--continue'];
 
 		try {
-			await this.exec(args);
+			await this.exec(args, { env: { GIT_EDITOR: 'true' } });
 		} catch (commitErr) {
 			await this.handleCommitError(commitErr);
 		}


### PR DESCRIPTION
Related #114461