### PR TITLE
Allow CommentNode to change body text and enter edit mode at the same time

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -528,15 +528,17 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 			this.updateCommentBody(newComment.body);
 		}
 
-		if (newComment.mode !== undefined && newComment.mode !== this.comment.mode) {
+		const isChangingMode: boolean = newComment.mode !== undefined && newComment.mode !== this.comment.mode;
+
+		this.comment = newComment;
+
+		if (isChangingMode) {
 			if (newComment.mode === languages.CommentMode.Editing) {
 				this.switchToEditMode();
 			} else {
 				this.removeCommentEditor();
 			}
 		}
-
-		this.comment = newComment;
 
 		if (newComment.label) {
 			this._isPendingLabel.innerText = newComment.label;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses #155764

If an extension attempts to change a comment's body and change to edit mode at once, the previous value for the comment body is shown in the edit box.