### PR TITLE
show "Accept Merge" only for files currently under conflict.

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -601,7 +601,7 @@
         "command": "git.acceptMerge",
         "title": "%command.git.acceptMerge%",
         "category": "Git",
-        "enablement": "isMergeEditor"
+        "enablement": "isMergeEditor && mergeEditorResultUri in git.mergeChanges"
       }
     ],
     "keybindings": [
@@ -1549,7 +1549,7 @@
       "merge/toolbar": [
         {
           "command": "git.acceptMerge",
-          "when": "isMergeEditor && baseResourceScheme =~ /^git$|^file$/"
+          "when": "isMergeEditor && mergeEditorBaseUri =~ /^(git|file):/ && mergeEditorResultUri in git.mergeChanges"
         }
       ],
       "scm/change/title": [

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2028,6 +2028,9 @@ export class Repository implements Disposable {
 		// set count badge
 		this.setCountBadge();
 
+		// set mergeChanges context
+		commands.executeCommand('setContext', 'git.mergeChanges', merge.map(item => item.resourceUri.toString()));
+
 		this._onDidChangeStatus.fire();
 
 		this._sourceControl.commitTemplate = await this.getInputTemplate();

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/mergeEditor.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/mergeEditor.ts
@@ -11,7 +11,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { Color } from 'vs/base/common/color';
 import { BugIndicatingError } from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
-import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
 import { autorunWithStore, IObservable } from 'vs/base/common/observable';
 import { basename, isEqual } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
@@ -44,7 +44,7 @@ import { DocumentMapping, getOppositeDirection, MappingDirection } from 'vs/work
 import { MergeEditorModel } from 'vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel';
 import { deepMerge, ReentrancyBarrier, thenIfNotDisposed } from 'vs/workbench/contrib/mergeEditor/browser/utils';
 import { MergeEditorViewModel } from 'vs/workbench/contrib/mergeEditor/browser/view/viewModel';
-import { ctxBaseResourceScheme, ctxIsMergeEditor, ctxMergeEditorLayout, MergeEditorLayoutTypes } from 'vs/workbench/contrib/mergeEditor/common/mergeEditor';
+import { ctxMergeBaseUri, ctxIsMergeEditor, ctxMergeEditorLayout, ctxMergeResultUri, MergeEditorLayoutTypes } from 'vs/workbench/contrib/mergeEditor/common/mergeEditor';
 import { settingsSashBorder } from 'vs/workbench/contrib/preferences/common/settingsEditorColorRegistry';
 import { IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { EditorInputFactoryFunction, IEditorResolverService, MergeEditorInputFactoryFunction, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
@@ -94,7 +94,8 @@ export class MergeEditor extends AbstractTextEditor<IMergeEditorViewState> {
 	private readonly _layoutMode: MergeEditorLayout;
 	private readonly _ctxIsMergeEditor: IContextKey<boolean>;
 	private readonly _ctxUsesColumnLayout: IContextKey<string>;
-	private readonly _ctxBaseResourceScheme: IContextKey<string>;
+	private readonly _ctxResultUri: IContextKey<string>;
+	private readonly _ctxBaseUri: IContextKey<string>;
 
 	private _model: MergeEditorModel | undefined;
 	public get model(): MergeEditorModel | undefined { return this._model; }
@@ -121,7 +122,8 @@ export class MergeEditor extends AbstractTextEditor<IMergeEditorViewState> {
 
 		this._ctxIsMergeEditor = ctxIsMergeEditor.bindTo(_contextKeyService);
 		this._ctxUsesColumnLayout = ctxMergeEditorLayout.bindTo(_contextKeyService);
-		this._ctxBaseResourceScheme = ctxBaseResourceScheme.bindTo(_contextKeyService);
+		this._ctxBaseUri = ctxMergeBaseUri.bindTo(_contextKeyService);
+		this._ctxResultUri = ctxMergeResultUri.bindTo(_contextKeyService);
 
 		this._layoutMode = instantiation.createInstance(MergeEditorLayout);
 		this._ctxUsesColumnLayout.set(this._layoutMode.value);
@@ -205,6 +207,7 @@ export class MergeEditor extends AbstractTextEditor<IMergeEditorViewState> {
 	override dispose(): void {
 		this._sessionDisposables.dispose();
 		this._ctxIsMergeEditor.reset();
+		this._ctxUsesColumnLayout.reset();
 		super.dispose();
 	}
 
@@ -305,7 +308,14 @@ export class MergeEditor extends AbstractTextEditor<IMergeEditorViewState> {
 		this.input1View.setModel(viewModel, model.input1, model.input1Title || localize('input1', 'Input 1'), model.input1Detail, model.input1Description);
 		this.input2View.setModel(viewModel, model.input2, model.input2Title || localize('input2', 'Input 2',), model.input2Detail, model.input2Description);
 		this.inputResultView.setModel(viewModel, model.result, localize('result', 'Result',), this._labelService.getUriLabel(model.result.uri, { relative: true }), undefined);
-		this._ctxBaseResourceScheme.set(model.base.uri.scheme);
+
+		// Set/unset context keys based on input
+		this._ctxResultUri.set(model.result.uri.toString());
+		this._ctxBaseUri.set(model.base.uri.toString());
+		this._sessionDisposables.add(toDisposable(() => {
+			this._ctxBaseUri.reset();
+			this._ctxResultUri.reset();
+		}));
 
 		const viewState = this.loadEditorViewState(input, context);
 		if (viewState) {

--- a/src/vs/workbench/contrib/mergeEditor/common/mergeEditor.ts
+++ b/src/vs/workbench/contrib/mergeEditor/common/mergeEditor.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { localize } from 'vs/nls';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 
 export type MergeEditorLayoutTypes = 'mixed' | 'columns';
 
-export const ctxIsMergeEditor = new RawContextKey<boolean>('isMergeEditor', false);
-export const ctxMergeEditorLayout = new RawContextKey<MergeEditorLayoutTypes>('mergeEditorLayout', 'mixed');
-export const ctxBaseResourceScheme = new RawContextKey<string>('baseResourceScheme', '');
+export const ctxIsMergeEditor = new RawContextKey<boolean>('isMergeEditor', false, { type: 'boolean', description: localize('is', 'The editor is a merge editor') });
+export const ctxMergeEditorLayout = new RawContextKey<MergeEditorLayoutTypes>('mergeEditorLayout', 'mixed', { type: 'string', description: localize('editorLayout', 'The layout mode of a merge editor') });
+export const ctxMergeBaseUri = new RawContextKey<string>('mergeEditorBaseUri', '', { type: 'string', description: localize('baseUri', 'The uri of the baser of a merge editor') });
+export const ctxMergeResultUri = new RawContextKey<string>('mergeEditorResultUri', '', { type: 'string', description: localize('resultUri', 'The uri of the result of a merge editor') });

--- a/src/vs/workbench/contrib/userDataSync/browser/userDataSync.ts
+++ b/src/vs/workbench/contrib/userDataSync/browser/userDataSync.ts
@@ -18,7 +18,7 @@ import { localize } from 'vs/nls';
 import { MenuId, MenuRegistry, registerAction2, Action2 } from 'vs/platform/actions/common/actions';
 import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ContextKeyEqualsExpr, ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
@@ -59,7 +59,7 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { MergeEditorInput } from 'vs/workbench/contrib/mergeEditor/browser/mergeEditorInput';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
-import { ctxIsMergeEditor } from 'vs/workbench/contrib/mergeEditor/common/mergeEditor';
+import { ctxIsMergeEditor, ctxMergeBaseUri } from 'vs/workbench/contrib/mergeEditor/common/mergeEditor';
 import { EditorResolution } from 'vs/platform/editor/common/editor';
 
 const CONTEXT_CONFLICTS_SOURCES = new RawContextKey<string>('conflictsSources', '');
@@ -1292,7 +1292,7 @@ export class UserDataSyncWorkbenchContribution extends Disposable implements IWo
 					title: localize('accept merges title', "Accept Merge"),
 					menu: [{
 						id: MenuId.MergeToolbar,
-						when: ContextKeyExpr.and(ctxIsMergeEditor, ContextKeyEqualsExpr.create('baseResourceScheme', USER_DATA_SYNC_SCHEME)),
+						when: ContextKeyExpr.and(ctxIsMergeEditor, ContextKeyExpr.regex(ctxMergeBaseUri.key, new RegExp(`^${USER_DATA_SYNC_SCHEME}:`))),
 					}],
 				});
 			}


### PR DESCRIPTION
While the merge editor shows users can handle merge conflicts outside of it, e.g on the console via `git add <FILE>`. The merge editor should have this graceful and step one is to hide the "Accept Merge" command when the file isn't conflicting anymore

* Adds a git-context key that contains all resource-uri-strings under conflict
* Enable/placement of the Accept Merge command is driven by that
* some merge editor context key sugar
