### PR TITLE
Problemts view - add opener to handle markers for SCM input text document

### DIFF
--- a/src/vs/workbench/contrib/markers/browser/markersView.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersView.ts
@@ -273,26 +273,28 @@ export class MarkersView extends ViewPane implements IMarkersView {
 			element instanceof RelatedInformation ? { resource: element.raw.resource, selection: element.raw } :
 				'marker' in element ? { resource: element.marker.resource, selection: element.marker.range } :
 					{ resource: null, selection: null };
-		if (resource && resource instanceof URI && selection) {
-			if (resource.scheme === Schemas.file) {
-				this.editorService.openEditor({
-					resource,
-					options: {
-						selection,
-						preserveFocus,
-						pinned,
-						revealIfVisible: true
-					},
-				}, sideByside ? SIDE_GROUP : ACTIVE_GROUP).then(editor => {
-					if (editor && preserveFocus) {
-						this.rangeHighlightDecorations.highlightRange({ resource, range: selection }, <ICodeEditor>editor.getControl());
-					} else {
-						this.rangeHighlightDecorations.removeHighlightRange();
-					}
-				});
-			} else {
-				this.openerService.open(resource);
-			}
+
+		if (resource && resource instanceof URI && resource.scheme === Schemas.vscode) {
+			this.openerService.open(resource);
+			return true;
+		}
+
+		if (resource && selection) {
+			this.editorService.openEditor({
+				resource,
+				options: {
+					selection,
+					preserveFocus,
+					pinned,
+					revealIfVisible: true
+				},
+			}, sideByside ? SIDE_GROUP : ACTIVE_GROUP).then(editor => {
+				if (editor && preserveFocus) {
+					this.rangeHighlightDecorations.highlightRange({ resource, range: selection }, <ICodeEditor>editor.getControl());
+				} else {
+					this.rangeHighlightDecorations.removeHighlightRange();
+				}
+			});
 			return true;
 		} else {
 			this.rangeHighlightDecorations.removeHighlightRange();

--- a/src/vs/workbench/contrib/scm/browser/activity.ts
+++ b/src/vs/workbench/contrib/scm/browser/activity.ts
@@ -296,11 +296,7 @@ class SCMInputTextDocumentLabelFormatter {
 
 	readonly label = (resource: URI) => {
 		const repositoryId = getRepositoryId(resource.path);
-		if (repositoryId === undefined) {
-			return resource.toString();
-		}
-
-		const repository = this.scmService.getRepository(repositoryId);
+		const repository = this.scmService.getRepository(repositoryId ?? '');
 		if (repository === undefined || repository.provider.rootUri === undefined) {
 			return resource.toString();
 		}
@@ -335,11 +331,7 @@ class SCMInputTextDocumentOpener implements IOpener {
 		}
 
 		const repositoryId = getRepositoryId(resource.path);
-		if (repositoryId === undefined) {
-			return false;
-		}
-
-		const repository = this.scmService.getRepository(repositoryId);
+		const repository = this.scmService.getRepository(repositoryId ?? '');
 		if (repository === undefined) {
 			return false;
 		}


### PR DESCRIPTION
Related #155282

This pull requests created an opener that would handle problem markers that are associated with the text document behind the SCM input. The opener toggles the visibility of the repository if needed, and focuses the input field.