### PR TITLE
Fix JSON Settings editor commands wrt Setting profiles

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -236,7 +236,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					category,
 					menu: {
 						id: MenuId.CommandPalette,
-						when: ContextKeyExpr.equals(CONTEXT_CURRENT_PROFILE.key, that.userDataProfilesService.defaultProfile.id)
+						when: ContextKeyExpr.notEquals(CONTEXT_CURRENT_PROFILE.key, that.userDataProfilesService.defaultProfile.id)
 					}
 				});
 			}

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
@@ -23,7 +23,7 @@ import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
 import { IUserDataProfileManagementService, IUserDataProfileService, ManageProfilesSubMenu, PROFILES_CATEGORY, PROFILES_ENABLEMENT_CONTEXT, PROFILES_TTILE } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 
-const CONTEXT_CURRENT_PROFILE = new RawContextKey<string>('currentUserDataProfile', '');
+export const CONTEXT_CURRENT_PROFILE = new RawContextKey<string>('currentUserDataProfile', '');
 
 export const userDataProfilesIcon = registerIcon('settingsProfiles-icon', Codicon.settings, localize('settingsProfilesIcon', 'Icon for Settings Profiles.'));
 
@@ -46,7 +46,7 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 
 		this.currentProfileContext = CONTEXT_CURRENT_PROFILE.bindTo(contextKeyService);
 		this.currentProfileContext.set(this.userDataProfileService.currentProfile.id);
-		this._register(this.userDataProfileService.onDidChangeCurrentProfile(e => this.currentProfileContext.set(this.userDataProfileService.currentProfile.id)));
+		this._register(this.userDataProfileService.onDidChangeCurrentProfile(() => this.currentProfileContext.set(this.userDataProfileService.currentProfile.id)));
 
 		this.updateStatus();
 		this._register(Event.any(this.workspaceContextService.onDidChangeWorkbenchState, this.userDataProfileService.onDidChangeCurrentProfile, this.userDataProfilesService.onDidChangeProfiles)(() => this.updateStatus()));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Ref https://github.com/microsoft/vscode/issues/152888

This PR fixes some JSON Setting editor commands.

In a non-default profile with a workspace open, we now have at least the following commands:

- Open User Settings (JSON)
- Open Current Profile Settings (JSON)
- Open Workspace Settings (JSON)

In the default profile with a workspace open, we have at least the following commands:

- Open User Settings (JSON)
- Open Workspace Settings (JSON)

The two separate cases arise from the fact that for backwards compatibility, the default profile's user setting file stores both application-scoped and non-application-scoped settings, whereas for non-default profiles, the profile settings file stores only non-application-scoped settings, whereas the user settings file is actually the default profile user setting file (and thus contains application-scoped settings). 