### PR TITLE
Remove redundant styles for underlined links

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/editorplaceholder.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorplaceholder.css
@@ -37,6 +37,5 @@
 .monaco-editor-pane-placeholder .monaco-link:hover {
 	font-size: 14px;
 	cursor: pointer;
-	text-decoration: underline;
 	margin-left: 5px;
 }


### PR DESCRIPTION
Fixes #155891

https://user-images.githubusercontent.com/35271042/180313440-4469c849-55ab-470b-bc6e-fd71c0a5b974.mp4


