### PR TITLE
Add npmignore to markdown server

### DIFF
--- a/extensions/markdown-language-features/server/.npmignore
+++ b/extensions/markdown-language-features/server/.npmignore
@@ -1,0 +1,12 @@
+.vscode/
+.github/
+out/test/
+src/
+.eslintrc.js
+.gitignore
+tsconfig*.json
+*.tsbuildinfo
+*.map
+example.cjs
+CODE_OF_CONDUCT.md
+SECURITY.md

--- a/extensions/markdown-language-features/server/package.json
+++ b/extensions/markdown-language-features/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageserver",
   "description": "Markdown language server",
-  "version": "1.0.0",
+  "version": "0.0.0-alpha-1",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Needed so we can publish this as a package 