### PR TITLE
Code Action Widget to fit color themes (#155907 and #155892)

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -222,6 +222,8 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		);
 
 		renderDisposables.add(this.codeActionList.value.onDidChangeSelection(e => this._onListSelection(e)));
+		renderDisposables.add(this._editor.onDidLayoutChange(e => this.hideCodeActionWidget()));
+
 
 		// Populating the list widget and tracking enabled options.
 		inputArray.forEach((item, index) => {
@@ -256,7 +258,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		// resize observer - can be used in the future since list widget supports dynamic height but not width
 		const maxWidth = Math.max(...arr);
 
-		// 40 is the additional padding for the list widget (26px left, 26px right)
+		// 40 is the additional padding for the list widget (20 left, 20 right)
 		renderMenu.style.width = maxWidth + 52 + 'px';
 		this.codeActionList.value?.layout(height, maxWidth);
 

--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -90,7 +90,7 @@ export interface ICodeActionMenuTemplateData {
 }
 
 const TEMPLATE_ID = 'codeActionWidget';
-const codeActionLineHeight = 27;
+const codeActionLineHeight = 26;
 
 class CodeMenuRenderer implements IListRenderer<ICodeActionMenuItem, ICodeActionMenuTemplateData> {
 	get templateId(): string { return TEMPLATE_ID; }
@@ -256,8 +256,8 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		// resize observer - can be used in the future since list widget supports dynamic height but not width
 		const maxWidth = Math.max(...arr);
 
-		// 40 is the additional padding for the list widget (20 left, 20 right)
-		renderMenu.style.width = maxWidth + 40 + 'px';
+		// 40 is the additional padding for the list widget (26px left, 26px right)
+		renderMenu.style.width = maxWidth + 52 + 'px';
 		this.codeActionList.value?.layout(height, maxWidth);
 
 		// List selection

--- a/src/vs/editor/contrib/codeAction/browser/media/action.css
+++ b/src/vs/editor/contrib/codeAction/browser/media/action.css
@@ -17,7 +17,8 @@
 	border-style: solid;
 	border-width: 1px;
 	border-color: var(--vscode-editorSuggestWidget-border);
-	background-color: var(--vscode-editorSuggestWidget-background);
+	background-color: var(--vscode-menu-background);
+	color: var(--vscode-menu-foreground);
 }
 
 .codeActionMenuWidget .monaco-list:not(.element-focused):focus:before {
@@ -41,7 +42,6 @@
 	-ms-user-select: none;
 	border: none !important;
 	border-width: 0px !important;
-	color: var(red) !important;
 }
 
 /* .codeActionMenuWidget .monaco-list:not(.element-focus) {
@@ -74,6 +74,7 @@
 
 .codeActionMenuWidget .monaco-list .monaco-list-row:hover:not(.option-disabled),
 .codeActionMenuWidget .monaco-list .moncao-list-row.focused:not(.option-disabled) {
+	color: var(--vscode-menu-selectionForeground) !important;
 	background-color: var(--vscode-menu-selectionBackground) !important;
 }
 
@@ -86,7 +87,7 @@
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
-	color: var(--vscode-list-inactiveSelectionBackground) !important;
+	color: var(--vscode-disabledForeground) !important;
 }
 
 .codeActionMenuWidget .monaco-list .separator {

--- a/src/vs/editor/contrib/codeAction/browser/media/action.css
+++ b/src/vs/editor/contrib/codeAction/browser/media/action.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .codeActionMenuWidget {
-	padding: 10px 0px 10px 0px;
+	padding: 8px 0px 8px 0px;
 	overflow: auto;
 	font-size: 13px;
 	border-radius: 5px;
@@ -14,9 +14,8 @@
 	/* flex-direction: column;
 	flex: 0 1 auto; */
 	width: 100%;
-	border-style: solid;
-	border-width: 1px;
-	border-color: var(--vscode-editorSuggestWidget-border);
+	border-width: 0px;
+	border-color: none;
 	background-color: var(--vscode-menu-background);
 	color: var(--vscode-menu-foreground);
 }
@@ -62,7 +61,7 @@
 	display: flex;
 	-mox-box-sizing: border-box;
 	box-sizing: border-box;
-	padding: 0px 20px 0px 20px;
+	padding: 0px 26px 0px 26px;
 	background-repeat: no-repeat;
 	background-position: 2px 2px;
 	white-space: nowrap;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes the issue where the color theme was not applied properly to the widget, and the sizing of the widget was not the same as the old context menu #155907

Also fixes the issue where the menu would not stay at the anchor when resized. Now matches the context menu where resizing or clicking off immediately closes the menu #155892
