### PR TITLE
fix api proposal generation EOL

### DIFF
--- a/build/lib/compilation.js
+++ b/build/lib/compilation.js
@@ -188,6 +188,15 @@ class MonacoGenerator {
     }
 }
 function generateApiProposalNames() {
+    let eol;
+    try {
+        const src = fs.readFileSync('src/vs/workbench/services/extensions/common/extensionsApiProposals.ts', 'utf-8');
+        const match = /\r?\n/m.exec(src);
+        eol = match ? match[0] : os.EOL;
+    }
+    catch {
+        eol = os.EOL;
+    }
     const pattern = /vscode\.proposed\.([a-zA-Z]+)\.d\.ts$/;
     const proposalNames = new Set();
     const input = es.through();
@@ -214,7 +223,7 @@ function generateApiProposalNames() {
             '});',
             'export type ApiProposalName = keyof typeof allApiProposals;',
             '',
-        ].join(os.EOL);
+        ].join(eol);
         this.emit('data', new File({
             path: 'vs/workbench/services/extensions/common/extensionsApiProposals.ts',
             contents: Buffer.from(contents)

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -226,6 +226,16 @@ class MonacoGenerator {
 }
 
 function generateApiProposalNames() {
+	let eol: string;
+
+	try {
+		const src = fs.readFileSync('src/vs/workbench/services/extensions/common/extensionsApiProposals.ts', 'utf-8');
+		const match = /\r?\n/m.exec(src);
+		eol = match ? match[0] : os.EOL;
+	} catch {
+		eol = os.EOL;
+	}
+
 	const pattern = /vscode\.proposed\.([a-zA-Z]+)\.d\.ts$/;
 	const proposalNames = new Set<string>();
 
@@ -254,7 +264,7 @@ function generateApiProposalNames() {
 				'});',
 				'export type ApiProposalName = keyof typeof allApiProposals;',
 				'',
-			].join(os.EOL);
+			].join(eol);
 
 			this.emit('data', new File({
 				path: 'vs/workbench/services/extensions/common/extensionsApiProposals.ts',


### PR DESCRIPTION
on Windows, my files are checked out with LF. the script which generates extensionApiProposals.ts always uses os.EOL, so it always is dirty on my repo every time I compile

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
