### PR TITLE
Pick up new version of markdown-language-server

### DIFF
--- a/extensions/markdown-language-features/server/package.json
+++ b/extensions/markdown-language-features/server/package.json
@@ -13,7 +13,7 @@
     "vscode-languageserver": "^8.0.2-next.5`",
     "vscode-languageserver-textdocument": "^1.0.5",
     "vscode-languageserver-types": "^3.17.1",
-    "vscode-markdown-languageservice": "^0.0.0-alpha.11",
+    "vscode-markdown-languageservice": "^0.0.0-alpha.12",
     "vscode-uri": "^3.0.3"
   },
   "devDependencies": {

--- a/extensions/markdown-language-features/server/yarn.lock
+++ b/extensions/markdown-language-features/server/yarn.lock
@@ -47,10 +47,10 @@ vscode-languageserver@^8.0.2-next.5`:
   dependencies:
     vscode-languageserver-protocol "3.17.2-next.6"
 
-vscode-markdown-languageservice@^0.0.0-alpha.11:
-  version "0.0.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.0.0-alpha.11.tgz#9dcdfc23f9dcaeaca3b2a2c76fc504619eaeb284"
-  integrity sha512-syFamf99xx+Q9DkA66+8fbSz2A2LJkyOV+nSziGgAzdDPv4jkb7eWF6l+nUteHTGbRLQ+q0tfkj0A7OovueCSQ==
+vscode-markdown-languageservice@^0.0.0-alpha.12:
+  version "0.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.0.0-alpha.12.tgz#5a3c7559969c3cb455d508d48129c8e221589630"
+  integrity sha512-9dJ/GL6A9UUOcB1TpvgsbcwqsYjnxHx4jxDaqeZZEMWFSUySfp0PAn1ge2S2Qj00zypvsu0eCTGUNd56G1/BNQ==
   dependencies:
     picomatch "^2.3.1"
     vscode-languageserver-textdocument "^1.0.5"


### PR DESCRIPTION
This fixes md diagnostics and links for multiroot workspaces
