### PR TITLE
Update formatting writing extension package.json

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
@@ -254,7 +254,7 @@ export abstract class AbstractExtensionsScannerService extends Disposable implem
 		metaData.installedTimestamp = metaData.installedTimestamp || undefined;
 		manifest.__metadata = { ...manifest.__metadata, ...metaData };
 
-		await this.fileService.writeFile(joinPath(extensionLocation, 'package.json'), VSBuffer.fromString(JSON.stringify(manifest, null, '\t')));
+		await this.fileService.writeFile(joinPath(extensionLocation, 'package.json'), VSBuffer.fromString(JSON.stringify(manifest, null, 2) + '\n'));
 	}
 
 	private async applyScanOptions(extensions: IRelaxedScannedExtension[], type: ExtensionType | 'development', scanOptions: ScanOptions, pickLatest: boolean): Promise<IRelaxedScannedExtension[]> {


### PR DESCRIPTION
Using two spaces and a final newline is consistent with npm, and probably most projects.

This is relevant, because `__metadata` is written when running VSCode extension tests.

Refs #148975
