### PR TITLE
Show number of selected lines in status bar

### DIFF
--- a/src/vs/editor/common/standaloneStrings.ts
+++ b/src/vs/editor/common/standaloneStrings.ts
@@ -7,9 +7,9 @@ import * as nls from 'vs/nls';
 
 export namespace AccessibilityHelpNLS {
 	export const noSelection = nls.localize("noSelection", "No selection");
-	export const singleSelectionRange = nls.localize("singleSelectionRange", "Line {0}, Column {1} ({2} selected)");
+	export const singleSelectionRange = nls.localize("singleSelectionRange", "Line {0}, Column {1} ({2} lines, {3} characters selected)");
 	export const singleSelection = nls.localize("singleSelection", "Line {0}, Column {1}");
-	export const multiSelectionRange = nls.localize("multiSelectionRange", "{0} selections ({1} characters selected)");
+	export const multiSelectionRange = nls.localize("multiSelectionRange", "{0} selections ({1} lines, {2} characters selected)");
 	export const multiSelection = nls.localize("multiSelection", "{0} selections");
 	export const emergencyConfOn = nls.localize("emergencyConfOn", "Now changing the setting `accessibilitySupport` to 'on'.");
 	export const openingDocs = nls.localize("openingDocs", "Now opening the Editor Accessibility documentation page.");

--- a/src/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.ts
+++ b/src/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.ts
@@ -67,21 +67,21 @@ class AccessibilityHelpController extends Disposable
 }
 
 
-function getSelectionLabel(selections: Selection[] | null, charactersSelected: number): string {
+function getSelectionLabel(selections: Selection[] | null, charactersSelected: number, linesSelected: number): string {
 	if (!selections || selections.length === 0) {
 		return AccessibilityHelpNLS.noSelection;
 	}
 
 	if (selections.length === 1) {
 		if (charactersSelected) {
-			return strings.format(AccessibilityHelpNLS.singleSelectionRange, selections[0].positionLineNumber, selections[0].positionColumn, charactersSelected);
+			return strings.format(AccessibilityHelpNLS.singleSelectionRange, selections[0].positionLineNumber, selections[0].positionColumn, linesSelected, charactersSelected);
 		}
 
 		return strings.format(AccessibilityHelpNLS.singleSelection, selections[0].positionLineNumber, selections[0].positionColumn);
 	}
 
 	if (charactersSelected) {
-		return strings.format(AccessibilityHelpNLS.multiSelectionRange, selections.length, charactersSelected);
+		return strings.format(AccessibilityHelpNLS.multiSelectionRange, selections.length, linesSelected, charactersSelected);
 	}
 
 	if (selections.length > 0) {
@@ -220,18 +220,20 @@ class AccessibilityHelpWidget extends Widget implements IOverlayWidget {
 		const options = this._editor.getOptions();
 
 		const selections = this._editor.getSelections();
-		let charactersSelected = 0;
+
+		let charactersSelected = 0, linesSelected = 0;
 
 		if (selections) {
 			const model = this._editor.getModel();
 			if (model) {
 				selections.forEach((selection) => {
 					charactersSelected += model.getValueLengthInRange(selection);
+					linesSelected += (selection.endLineNumber - selection.startLineNumber + 1);
 				});
 			}
 		}
 
-		let text = getSelectionLabel(selections, charactersSelected);
+		let text = getSelectionLabel(selections, charactersSelected, linesSelected);
 
 		if (options.get(EditorOption.inDiffEditor)) {
 			if (options.get(EditorOption.readOnly)) {

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -135,6 +135,7 @@ function toEditorWithLanguageSupport(input: EditorInput): ILanguageSupport | nul
 interface IEditorSelectionStatus {
 	selections?: Selection[];
 	charactersSelected?: number;
+	linesSelected?: number;
 }
 
 class StateChange {
@@ -736,14 +737,15 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 
 			// Compute selection length
 			info.charactersSelected = 0;
+			info.linesSelected = 0;
 			const textModel = editorWidget.getModel();
 			if (textModel) {
 				for (const selection of info.selections) {
-					if (typeof info.charactersSelected !== 'number') {
-						info.charactersSelected = 0;
-					}
+					if (typeof info.charactersSelected !== 'number') { info.charactersSelected = 0; }
+					if (typeof info.linesSelected !== 'number') { info.linesSelected = 0; }
 
 					info.charactersSelected += textModel.getCharacterCountInRange(selection);
+					info.linesSelected += (selection.endLineNumber - selection.startLineNumber + 1);
 				}
 			}
 

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -276,9 +276,9 @@ class State {
 	}
 }
 
-const nlsSingleSelectionRange = localize('singleSelectionRange', "Ln {0}, Col {1} ({2} lines, {3} characters selected)");
+const nlsSingleSelectionRange = localize('singleSelectionRange', "Ln {0}, Col {1} ({2} lines, {3} chars)");
 const nlsSingleSelection = localize('singleSelection', "Ln {0}, Col {1}");
-const nlsMultiSelectionRange = localize('multiSelectionRange', "{0} selections ({1} lines, {2} characters selected)");
+const nlsMultiSelectionRange = localize('multiSelectionRange', "{0} selections ({1} lines, {2} chars)");
 const nlsMultiSelection = localize('multiSelection', "{0} selections");
 const nlsEOLLF = localize('endOfLineLineFeed', "LF");
 const nlsEOLCRLF = localize('endOfLineCarriageReturnLineFeed', "CRLF");

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -276,9 +276,9 @@ class State {
 	}
 }
 
-const nlsSingleSelectionRange = localize('singleSelectionRange', "Ln {0}, Col {1} ({2} selected)");
+const nlsSingleSelectionRange = localize('singleSelectionRange', "Ln {0}, Col {1} ({2} lines, {3} characters selected)");
 const nlsSingleSelection = localize('singleSelection', "Ln {0}, Col {1}");
-const nlsMultiSelectionRange = localize('multiSelectionRange', "{0} selections ({1} characters selected)");
+const nlsMultiSelectionRange = localize('multiSelectionRange', "{0} selections ({1} lines, {2} characters selected)");
 const nlsMultiSelection = localize('multiSelection', "{0} selections");
 const nlsEOLLF = localize('endOfLineLineFeed', "LF");
 const nlsEOLCRLF = localize('endOfLineCarriageReturnLineFeed', "CRLF");
@@ -552,14 +552,14 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 
 		if (info.selections.length === 1) {
 			if (info.charactersSelected) {
-				return format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected);
+				return format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.linesSelected, info.charactersSelected);
 			}
 
 			return format(nlsSingleSelection, info.selections[0].positionLineNumber, info.selections[0].positionColumn);
 		}
 
 		if (info.charactersSelected) {
-			return format(nlsMultiSelectionRange, info.selections.length, info.charactersSelected);
+			return format(nlsMultiSelectionRange, info.selections.length, info.linesSelected, info.charactersSelected);
 		}
 
 		if (info.selections.length > 0) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Display line count of current selection in status bar, e.g. `(2 lines, 5 chars)`.

Fix #154327

<img width="500" alt="image" src="https://user-images.githubusercontent.com/1430856/207485003-6e241116-04ed-4620-844c-f3dc322013e2.png">

<!--
<img src=https://user-images.githubusercontent.com/1430856/180638605-a0ccdeb1-00c1-4e66-84d1-744915b93374.png width=500>
-->
