### PR TITLE
Fix tab position when wrapping tabs

### DIFF
--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -1154,9 +1154,9 @@ export class TabsTitleControl extends TitleControl {
 			tabContainer.classList.toggle(`sticky-${option}`, isTabSticky && options.pinnedTabSizing === option);
 		}
 
-		// Sticky compact/shrink tabs need a position to remain at their location
+		// If not wrapping tabs, sticky compact/shrink tabs need a position to remain at their location
 		// when scrolling to stay in view (requirement for position: sticky)
-		if (isTabSticky && options.pinnedTabSizing !== 'normal') {
+		if (!options.wrapTabs && isTabSticky && options.pinnedTabSizing !== 'normal') {
 			let stickyTabWidth = 0;
 			switch (options.pinnedTabSizing) {
 				case 'compact':


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/154432

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

### Explanation

Sticky tabs need a `style.left` with a `px` to remain at their location. 
If setting `workbench.editor.wrapTabs: true`, it is not needed any more.
Setting a `style.left` with wrong `px` will cause the issue in #154432.

Before:

https://user-images.githubusercontent.com/5123601/180719442-d3c9ce83-fd39-4c09-a4ed-2bd2122dcb92.mp4

After:

https://user-images.githubusercontent.com/5123601/180719470-359ed15b-3859-454c-abd7-038fa59a8ff2.mp4


