### PR TITLE
Expose snippet support registration

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -24,6 +24,7 @@ import { IMarkerData, IMarkerService } from 'vs/platform/markers/common/markers'
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { LanguageSelector } from 'vs/editor/common/languageSelector';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { setSnippetSuggestSupport } from 'vs/editor/contrib/suggest/browser/suggest';
 
 /**
  * Register information about a new language.
@@ -579,6 +580,13 @@ export function registerCompletionItemProvider(languageSelector: LanguageSelecto
 }
 
 /**
+ * Set the snippet completion item provider.
+ */
+export function setSnippetCompletionItemProvider(provider: languages.CompletionItemProvider): void {
+	setSnippetSuggestSupport(provider);
+}
+
+/**
  * Register a document color provider (used by Color Picker, Color Decorator).
  */
 export function registerColorProvider(languageSelector: LanguageSelector, provider: languages.DocumentColorProvider): IDisposable {
@@ -726,6 +734,7 @@ export function createMonacoLanguagesAPI(): typeof monaco.languages {
 		registerReferenceProvider: <any>registerReferenceProvider,
 		registerRenameProvider: <any>registerRenameProvider,
 		registerCompletionItemProvider: <any>registerCompletionItemProvider,
+		setSnippetCompletionItemProvider: <any>setSnippetCompletionItemProvider,
 		registerSignatureHelpProvider: <any>registerSignatureHelpProvider,
 		registerHoverProvider: <any>registerHoverProvider,
 		registerDocumentSymbolProvider: <any>registerDocumentSymbolProvider,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6087,6 +6087,11 @@ declare namespace monaco.languages {
 	export function registerCompletionItemProvider(languageSelector: LanguageSelector, provider: CompletionItemProvider): IDisposable;
 
 	/**
+	 * Set the snippet completion item provider.
+	 */
+	export function setSnippetCompletionItemProvider(provider: CompletionItemProvider): void;
+
+	/**
 	 * Register a document color provider (used by Color Picker, Color Decorator).
 	 */
 	export function registerColorProvider(languageSelector: LanguageSelector, provider: DocumentColorProvider): IDisposable;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Expose the `setSnippetSuggestSupport`. It allows to register a completion item provider to all existing trigger characters.

All the code is already there is monaco-editor, only the `setSnippetSuggestSupport` function is tree-shaked out.
