### PR TITLE
Issue Reporter: add link to guidance on wiki (#73512)

### DIFF
--- a/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
@@ -730,7 +730,7 @@ export class IssueReporter extends Disposable {
 			} else if (!fileOnMarketplace) {
 				show(extensionsBlock);
 			}
-			reset(descriptionTitle, localize('stepsToReproduce', "Steps to Reproduce"), $('span.required-input', undefined, '*'));
+			reset(descriptionTitle, localize('stepsToReproduce', "Steps to Reproduce") + ' ', $('span.required-input', undefined, '*'));
 			reset(descriptionSubtitle, localize('bugDescription', "Share the steps needed to reliably reproduce the problem. Please include actual and expected results. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub."));
 		} else if (issueType === IssueType.PerformanceIssue) {
 			show(problemSource);
@@ -749,10 +749,10 @@ export class IssueReporter extends Disposable {
 				show(extensionsBlock);
 			}
 
-			reset(descriptionTitle, localize('stepsToReproduce', "Steps to Reproduce"), $('span.required-input', undefined, '*'));
+			reset(descriptionTitle, localize('stepsToReproduce', "Steps to Reproduce") + ' ', $('span.required-input', undefined, '*'));
 			reset(descriptionSubtitle, localize('performanceIssueDesciption', "When did this performance issue happen? Does it occur on startup or after a specific series of actions? We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub."));
 		} else if (issueType === IssueType.FeatureRequest) {
-			reset(descriptionTitle, localize('description', "Description"), $('span.required-input', undefined, '*'));
+			reset(descriptionTitle, localize('description', "Description") + ' ', $('span.required-input', undefined, '*'));
 			reset(descriptionSubtitle, localize('featureRequestDescription', "Please describe the feature you would like to see. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub."));
 			show(problemSource);
 

--- a/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
@@ -16,10 +16,9 @@ export default (): string => `
 <div id="issue-reporter">
 	<div id="english" class="input-group hidden">${escape(localize('completeInEnglish', "Please complete the form in English."))}</div>
 
-	<div class="input-group">
-		<a href='https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions' target='_blank'>
-			${escape(localize('reviewGuidance', "Before you report an issue here please review the guidance we provide."))}
-		</a>
+	<div id="review-guidance-help-text" class="input-group">
+		${escape(localize('reviewGuidanceLabelText', "Before you report an issue here please {0}."))
+		.replace('{0}', `<a href="https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions" target="_blank">${escape(localize('reviewGuidanceLinkText', "review the guidance we provide"))}</a>`)}
 	</div>
 
 	<div class="section">

--- a/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
@@ -17,8 +17,9 @@ export default (): string => `
 	<div id="english" class="input-group hidden">${escape(localize('completeInEnglish', "Please complete the form in English."))}</div>
 
 	<div class="input-group">
-		${escape(localize('reviewGuidance', "Before you report an issue here please review the guidance we provide:"))}
-		${localize('reviewGuidanceLink', " <a href='{0}' target='_blank'>{1}</a>", 'https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions', 'Guidance')}
+		<a href='https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions' target='_blank'>
+			${escape(localize('reviewGuidance', "Before you report an issue here please review the guidance we provide."))}
+		</a>
 	</div>
 
 	<div class="section">

--- a/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
@@ -11,15 +11,22 @@ const sendProcessInfoLabel = escape(localize('sendProcessInfo', "Include my curr
 const sendWorkspaceInfoLabel = escape(localize('sendWorkspaceInfo', "Include my workspace metadata"));
 const sendExtensionsLabel = escape(localize('sendExtensions', "Include my enabled extensions"));
 const sendExperimentsLabel = escape(localize('sendExperiments', "Include A/B experiment info"));
+const reviewGuidanceLabel = localize( // intentionally not escaped because of its embedded tags
+	{
+		key: 'reviewGuidanceLabel',
+		comment: [
+			'{Locked="<a href=\"https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions\" target=\"_blank\">"}',
+			'{Locked="</a>"}'
+		]
+	},
+	'Before you report an issue here please <a href="https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions" target="_blank">review the guidance we provide</a>.'
+);
 
 export default (): string => `
 <div id="issue-reporter">
 	<div id="english" class="input-group hidden">${escape(localize('completeInEnglish', "Please complete the form in English."))}</div>
 
-	<div id="review-guidance-help-text" class="input-group">
-		${escape(localize('reviewGuidanceLabelText', "Before you report an issue here please {0}."))
-		.replace('{0}', `<a href="https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions" target="_blank">${escape(localize('reviewGuidanceLinkText', "review the guidance we provide"))}</a>`)}
-	</div>
+	<div id="review-guidance-help-text" class="input-group">${reviewGuidanceLabel}</div>
 
 	<div class="section">
 		<div class="input-group">

--- a/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
@@ -16,6 +16,11 @@ export default (): string => `
 <div id="issue-reporter">
 	<div id="english" class="input-group hidden">${escape(localize('completeInEnglish', "Please complete the form in English."))}</div>
 
+	<div class="input-group">
+		${escape(localize('reviewGuidance', "Before you report an issue here please review the guidance we provide:"))}
+		${localize('reviewGuidanceLink', " <a href='{0}' target='_blank'>{1}</a>", 'https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions', 'Guidance')}
+	</div>
+
 	<div class="section">
 		<div class="input-group">
 			<label class="inline-label" for="issue-type">${escape(localize('issueTypeLabel', "This is a"))}</label>

--- a/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
@@ -30,7 +30,7 @@ export default (): string => `
 		</div>
 
 		<div class="input-group" id="problem-source">
-			<label class="inline-label" for="issue-source">${escape(localize('issueSourceLabel', "File on"))}<span class="required-input">*</span></label>
+			<label class="inline-label" for="issue-source">${escape(localize('issueSourceLabel', "File on"))} <span class="required-input">*</span></label>
 			<select id="issue-source" class="inline-form-control" required>
 				<!-- To be dynamically filled -->
 			</select>


### PR DESCRIPTION
This PR fixes #73512

However until #130497 is fixed this change makes it more likely that users will lose the Issue Reporter window because clicking the new link will launch a new browser window/tab and focus it, hiding ours.

![image](https://user-images.githubusercontent.com/6726799/180765940-ccb06cd9-15a7-4ef5-b88e-5b1f9c8273ff.png)

