### PR TITLE
Problems view - do not show markers for SCM input

### DIFF
--- a/src/vs/platform/markers/common/markerService.ts
+++ b/src/vs/platform/markers/common/markerService.ts
@@ -103,7 +103,7 @@ class MarkerStats implements MarkerStatistics {
 		const result: MarkerStatistics = { errors: 0, warnings: 0, infos: 0, unknowns: 0 };
 
 		// TODO this is a hack
-		if (resource.scheme === Schemas.inMemory || resource.scheme === Schemas.walkThrough || resource.scheme === Schemas.walkThroughSnippet) {
+		if (resource.scheme === Schemas.inMemory || resource.scheme === Schemas.walkThrough || resource.scheme === Schemas.walkThroughSnippet || resource.scheme === Schemas.vscodeSourceControl) {
 			return result;
 		}
 

--- a/src/vs/workbench/contrib/markers/browser/markersTable.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTable.ts
@@ -411,7 +411,7 @@ export class MarkersTable extends Disposable implements IProblemsWidget {
 		const items: MarkerTableItem[] = [];
 		for (const resourceMarker of this.resourceMarkers) {
 			for (const marker of resourceMarker.markers) {
-				if (marker.resource.scheme === network.Schemas.walkThrough || marker.resource.scheme === network.Schemas.walkThroughSnippet) {
+				if (marker.resource.scheme === network.Schemas.walkThrough || marker.resource.scheme === network.Schemas.walkThroughSnippet || marker.resource.scheme === network.Schemas.vscodeSourceControl) {
 					continue;
 				}
 

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -456,7 +456,7 @@ export class Filter implements ITreeFilter<MarkerElement, FilterData> {
 	}
 
 	private filterResourceMarkers(resourceMarkers: ResourceMarkers): TreeFilterResult<FilterData> {
-		if (resourceMarkers.resource.scheme === network.Schemas.walkThrough || resourceMarkers.resource.scheme === network.Schemas.walkThroughSnippet) {
+		if (resourceMarkers.resource.scheme === network.Schemas.walkThrough || resourceMarkers.resource.scheme === network.Schemas.walkThroughSnippet || resourceMarkers.resource.scheme === network.Schemas.vscodeSourceControl) {
 			return false;
 		}
 


### PR DESCRIPTION
With this change, all problem markers that are emitted for the `vscode-scm` schema will not be shown in the problems view. 