### PR TITLE
Temporarily remove explorer expand all

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -989,7 +989,7 @@ registerAction2(class extends Action2 {
 			menu: {
 				id: MenuId.ViewTitle,
 				group: 'navigation',
-				when: ContextKeyExpr.and(ContextKeyExpr.equals('view', VIEW_ID), ViewHasSomeCollapsibleRootItemContext),
+				when: ContextKeyExpr.equals('view', VIEW_ID),
 				order: 40
 			}
 		});
@@ -999,28 +999,5 @@ registerAction2(class extends Action2 {
 		const viewsService = accessor.get(IViewsService);
 		const explorerView = viewsService.getViewWithId(VIEW_ID) as ExplorerView;
 		explorerView.collapseAll();
-	}
-});
-
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: 'workbench.files.action.expandExplorerFolders',
-			title: { value: nls.localize('expandExplorerFolders', "Expand Folders in Explorer"), original: 'Expand Folders in Explorer' },
-			f1: true,
-			icon: Codicon.expandAll,
-			menu: {
-				id: MenuId.ViewTitle,
-				group: 'navigation',
-				when: ContextKeyExpr.and(ContextKeyExpr.equals('view', VIEW_ID), ViewHasSomeCollapsibleRootItemContext.toNegated()),
-				order: 40
-			}
-		});
-	}
-
-	run(accessor: ServicesAccessor) {
-		const viewsService = accessor.get(IViewsService);
-		const explorerView = viewsService.getViewWithId(VIEW_ID) as ExplorerView;
-		explorerView.expandAll();
 	}
 });


### PR DESCRIPTION
Explorer expand all has some difficult UX questions that still need answering so removing it for now due to the upcoming release