### PR TITLE
debug: potential fix for unit test flake

### DIFF
--- a/src/vs/workbench/contrib/debug/test/node/streamDebugAdapter.test.ts
+++ b/src/vs/workbench/contrib/debug/test/node/streamDebugAdapter.test.ts
@@ -49,7 +49,13 @@ suite('Debug - StreamDebugAdapter', () => {
 
 		const pipeName = crypto.randomBytes(10).toString('hex');
 		const pipePath = platform.isWindows ? join('\\\\.\\pipe\\', pipeName) : join(tmpdir(), pipeName);
-		const server = net.createServer(serverConnection).listen(pipePath);
+		const server = await new Promise<net.Server>((resolve, reject) => {
+			const server = net.createServer(serverConnection);
+			server.once('listening', () => resolve(server));
+			server.once('error', reject);
+			server.listen(pipePath);
+		});
+
 		const debugAdapter = new NamedPipeDebugAdapter({
 			type: 'pipeServer',
 			path: pipePath


### PR DESCRIPTION
Fixes #155801

If the server wasn't there, this should generally have failed with an ENOENT immediately... but instead verbosely wait for the server to come up and handle any errors in the listening process correctly. Maybe a silent failure happened.