### PR TITLE
Allow msftInternal to be setting toggled

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -75,7 +75,7 @@ import { resolveCommonProperties } from 'vs/platform/telemetry/common/commonProp
 import { ITelemetryService, machineIdKey, TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
 import { TelemetryAppenderClient } from 'vs/platform/telemetry/common/telemetryIpc';
 import { ITelemetryServiceConfig, TelemetryService } from 'vs/platform/telemetry/common/telemetryService';
-import { getPiiPathsFromEnvironment, getTelemetryLevel, NullTelemetryService, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
+import { getPiiPathsFromEnvironment, getTelemetryLevel, isInternalTelemetry, NullTelemetryService, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 import { IUpdateService } from 'vs/platform/update/common/update';
 import { UpdateChannel } from 'vs/platform/update/common/updateIpc';
 import { DarwinUpdateService } from 'vs/platform/update/electron-main/updateService.darwin';
@@ -680,9 +680,10 @@ export class CodeApplication extends Disposable {
 
 		// Telemetry
 		if (supportsTelemetry(this.productService, this.environmentMainService)) {
+			const isInternal = isInternalTelemetry(this.productService, this.configurationService);
 			const channel = getDelayedChannel(sharedProcessReady.then(client => client.getChannel('telemetryAppender')));
 			const appender = new TelemetryAppenderClient(channel);
-			const commonProperties = resolveCommonProperties(this.fileService, release(), hostname(), process.arch, this.productService.commit, this.productService.version, machineId, this.productService.msftInternalDomains, this.environmentMainService.installSourcePath);
+			const commonProperties = resolveCommonProperties(this.fileService, release(), hostname(), process.arch, this.productService.commit, this.productService.version, machineId, isInternal, this.environmentMainService.installSourcePath);
 			const piiPaths = getPiiPathsFromEnvironment(this.environmentMainService);
 			const config: ITelemetryServiceConfig = { appenders: [appender], commonProperties, piiPaths, sendErrorTelemetry: true };
 

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -52,7 +52,7 @@ import { StateService } from 'vs/platform/state/node/stateService';
 import { resolveCommonProperties } from 'vs/platform/telemetry/common/commonProperties';
 import { ITelemetryService, machineIdKey } from 'vs/platform/telemetry/common/telemetry';
 import { ITelemetryServiceConfig, TelemetryService } from 'vs/platform/telemetry/common/telemetryService';
-import { supportsTelemetry, NullTelemetryService, getPiiPathsFromEnvironment } from 'vs/platform/telemetry/common/telemetryUtils';
+import { supportsTelemetry, NullTelemetryService, getPiiPathsFromEnvironment, isInternalTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 import { OneDataSystemAppender } from 'vs/platform/telemetry/node/1dsAppender';
 import { buildTelemetryMessage } from 'vs/platform/telemetry/node/telemetry';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
@@ -187,9 +187,10 @@ class CliMain extends Disposable {
 
 		// Telemetry
 		const appenders: OneDataSystemAppender[] = [];
+		const isInternal = isInternalTelemetry(productService, configurationService);
 		if (supportsTelemetry(productService, environmentService)) {
 			if (productService.aiConfig && productService.aiConfig.ariaKey) {
-				appenders.push(new OneDataSystemAppender(configurationService, 'monacoworkbench', null, productService.aiConfig.ariaKey));
+				appenders.push(new OneDataSystemAppender(isInternal, 'monacoworkbench', null, productService.aiConfig.ariaKey));
 			}
 
 			const { installSourcePath } = environmentService;
@@ -208,7 +209,7 @@ class CliMain extends Disposable {
 						}
 					}
 
-					return resolveCommonProperties(fileService, release(), hostname(), process.arch, productService.commit, productService.version, machineId, productService.msftInternalDomains, installSourcePath);
+					return resolveCommonProperties(fileService, release(), hostname(), process.arch, productService.commit, productService.version, machineId, isInternal, installSourcePath);
 				})(),
 				piiPaths: getPiiPathsFromEnvironment(environmentService)
 			};

--- a/src/vs/platform/telemetry/browser/1dsAppender.ts
+++ b/src/vs/platform/telemetry/browser/1dsAppender.ts
@@ -4,18 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { AppInsightsCore } from '@microsoft/1ds-core-js';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { AbstractOneDataSystemAppender } from 'vs/platform/telemetry/common/1dsAppender';
 
 
 export class OneDataSystemWebAppender extends AbstractOneDataSystemAppender {
 	constructor(
-		configurationService: IConfigurationService | undefined,
+		isInternalTelemetry: boolean,
 		eventPrefix: string,
 		defaultData: { [key: string]: any } | null,
 		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
 	) {
-		super(configurationService, eventPrefix, defaultData, iKeyOrClientFactory);
+		super(isInternalTelemetry, eventPrefix, defaultData, iKeyOrClientFactory);
 
 		// If we cannot fetch the endpoint it means it is down and we should not send any telemetry.
 		// This is most likely due to ad blockers

--- a/src/vs/platform/telemetry/common/1dsAppender.ts
+++ b/src/vs/platform/telemetry/common/1dsAppender.ts
@@ -7,7 +7,6 @@ import type { AppInsightsCore, IExtendedConfiguration } from '@microsoft/1ds-cor
 import type { IChannelConfiguration, IXHROverride, PostChannel } from '@microsoft/1ds-post-js';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { mixin } from 'vs/base/common/objects';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ITelemetryAppender, validateTelemetryData } from 'vs/platform/telemetry/common/telemetryUtils';
 
 const endpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0';
@@ -63,7 +62,7 @@ export abstract class AbstractOneDataSystemAppender implements ITelemetryAppende
 	protected readonly endPointUrl = endpointUrl;
 
 	constructor(
-		private readonly _configurationService: IConfigurationService | undefined,
+		private readonly _isInternalTelemetry: boolean,
 		private _eventPrefix: string,
 		private _defaultData: { [key: string]: any } | null,
 		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
@@ -92,8 +91,7 @@ export abstract class AbstractOneDataSystemAppender implements ITelemetryAppende
 		}
 
 		if (!this._asyncAiCore) {
-			const isInternal = this._configurationService?.getValue<boolean>('telemetry.internalTesting');
-			this._asyncAiCore = getClient(this._aiCoreOrKey, isInternal, this._xhrOverride);
+			this._asyncAiCore = getClient(this._aiCoreOrKey, this._isInternalTelemetry, this._xhrOverride);
 		}
 
 		this._asyncAiCore.then(

--- a/src/vs/platform/telemetry/common/commonProperties.ts
+++ b/src/vs/platform/telemetry/common/commonProperties.ts
@@ -25,7 +25,7 @@ export async function resolveCommonProperties(
 	commit: string | undefined,
 	version: string | undefined,
 	machineId: string | undefined,
-	msftInternalDomains: string[] | undefined,
+	isInternalTelemetry: boolean,
 	installSourcePath: string,
 	product?: string
 ): Promise<{ [name: string]: string | boolean | undefined }> {
@@ -50,10 +50,9 @@ export async function resolveCommonProperties(
 	// __GDPR__COMMON__ "common.product" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
 	result['common.product'] = product || 'desktop';
 
-	const msftInternal = verifyMicrosoftInternalDomain(msftInternalDomains || []);
-	if (msftInternal) {
+	if (isInternalTelemetry) {
 		// __GDPR__COMMON__ "common.msftInternal" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true }
-		result['common.msftInternal'] = msftInternal;
+		result['common.msftInternal'] = isInternalTelemetry;
 	}
 
 	// dynamic properties which value differs on each call

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -11,6 +11,7 @@ import { URI } from 'vs/base/common/uri';
 import { ConfigurationTarget, ConfigurationTargetToString, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IProductService } from 'vs/platform/product/common/productService';
+import { verifyMicrosoftInternalDomain } from 'vs/platform/telemetry/common/commonProperties';
 import { ClassifiedEvent, GDPRClassification, StrictPropertyCheck } from 'vs/platform/telemetry/common/gdprTypings';
 import { ICustomEndpointTelemetryService, ITelemetryData, ITelemetryEndpoint, ITelemetryInfo, ITelemetryService, TelemetryConfiguration, TelemetryLevel, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from 'vs/platform/telemetry/common/telemetry';
 
@@ -250,6 +251,18 @@ function flatKeys(result: string[], prefix: string, value: { [key: string]: any 
 	} else {
 		result.push(prefix);
 	}
+}
+
+/**
+ * Whether or not this is an internal user
+ * @param productService The product service
+ * @param configService The config servivce
+ * @returns true if internal, false otherwise
+ */
+export function isInternalTelemetry(productService: IProductService, configService: IConfigurationService) {
+	const msftInternalDomains = productService.msftInternalDomains || [];
+	const internalTesting = configService.getValue<boolean>('telemetry.internalTesting');
+	return verifyMicrosoftInternalDomain(msftInternalDomains) || internalTesting;
 }
 
 interface IPathEnvironment {

--- a/src/vs/platform/telemetry/node/1dsAppender.ts
+++ b/src/vs/platform/telemetry/node/1dsAppender.ts
@@ -6,14 +6,13 @@
 import type { AppInsightsCore } from '@microsoft/1ds-core-js';
 import type { IPayloadData, IXHROverride } from '@microsoft/1ds-post-js';
 import * as https from 'https';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { AbstractOneDataSystemAppender } from 'vs/platform/telemetry/common/1dsAppender';
 
 
 export class OneDataSystemAppender extends AbstractOneDataSystemAppender {
 
 	constructor(
-		configurationService: IConfigurationService | undefined,
+		isInternalTelemetry: boolean,
 		eventPrefix: string,
 		defaultData: { [key: string]: any } | null,
 		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
@@ -48,6 +47,6 @@ export class OneDataSystemAppender extends AbstractOneDataSystemAppender {
 			}
 		};
 
-		super(configurationService, eventPrefix, defaultData, iKeyOrClientFactory, customHttpXHROverride);
+		super(isInternalTelemetry, eventPrefix, defaultData, iKeyOrClientFactory, customHttpXHROverride);
 	}
 }

--- a/src/vs/platform/telemetry/test/browser/1dsAppender.test.ts
+++ b/src/vs/platform/telemetry/test/browser/1dsAppender.test.ts
@@ -33,7 +33,7 @@ suite('AIAdapter', () => {
 
 	setup(() => {
 		appInsightsMock = new AppInsightsCoreMock();
-		adapter = new OneDataSystemWebAppender(undefined, prefix, undefined!, () => appInsightsMock);
+		adapter = new OneDataSystemWebAppender(false, prefix, undefined!, () => appInsightsMock);
 	});
 
 	teardown(() => {
@@ -48,7 +48,7 @@ suite('AIAdapter', () => {
 	});
 
 	test('addional data', () => {
-		adapter = new OneDataSystemWebAppender(undefined, prefix, { first: '1st', second: 2, third: true }, () => appInsightsMock);
+		adapter = new OneDataSystemWebAppender(false, prefix, { first: '1st', second: 2, third: true }, () => appInsightsMock);
 		adapter.log('testEvent');
 
 		assert.strictEqual(appInsightsMock.events.length, 1);

--- a/src/vs/workbench/contrib/debug/node/telemetryApp.ts
+++ b/src/vs/workbench/contrib/debug/node/telemetryApp.ts
@@ -7,7 +7,7 @@ import { Server } from 'vs/base/parts/ipc/node/ipc.cp';
 import { TelemetryAppenderChannel } from 'vs/platform/telemetry/common/telemetryIpc';
 import { OneDataSystemAppender } from 'vs/platform/telemetry/node/1dsAppender';
 
-const appender = new OneDataSystemAppender(undefined, process.argv[2], JSON.parse(process.argv[3]), process.argv[4]);
+const appender = new OneDataSystemAppender(false, process.argv[2], JSON.parse(process.argv[3]), process.argv[4]);
 process.once('exit', () => appender.flush());
 
 const channel = new TelemetryAppenderChannel([appender]);

--- a/src/vs/workbench/services/telemetry/browser/workbenchCommonProperties.ts
+++ b/src/vs/workbench/services/telemetry/browser/workbenchCommonProperties.ts
@@ -24,12 +24,13 @@ export async function resolveWorkbenchCommonProperties(
 	storageService: IStorageService,
 	commit: string | undefined,
 	version: string | undefined,
+	isInternalTelemetry: boolean,
 	remoteAuthority?: string,
 	productIdentifier?: string,
 	removeMachineId?: boolean,
 	resolveAdditionalProperties?: () => { [key: string]: any }
-): Promise<{ [name: string]: string | undefined }> {
-	const result: { [name: string]: string | undefined } = Object.create(null);
+): Promise<{ [name: string]: string | boolean | undefined }> {
+	const result: { [name: string]: string | boolean | undefined } = Object.create(null);
 	const firstSessionDate = storageService.get(firstSessionDateStorageKey, StorageScope.APPLICATION)!;
 	const lastSessionDate = storageService.get(lastSessionDateStorageKey, StorageScope.APPLICATION)!;
 
@@ -74,6 +75,11 @@ export async function resolveWorkbenchCommonProperties(
 	result['common.userAgent'] = Platform.userAgent ? cleanUserAgent(Platform.userAgent) : undefined;
 	// __GDPR__COMMON__ "common.isTouchDevice" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	result['common.isTouchDevice'] = String(Gesture.isTouchDevice());
+
+	if (isInternalTelemetry) {
+		// __GDPR__COMMON__ "common.msftInternal" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true }
+		result['common.msftInternal'] = isInternalTelemetry;
+	}
 
 	// dynamic properties which value differs on each call
 	let seq = 0;

--- a/src/vs/workbench/services/telemetry/electron-sandbox/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/electron-sandbox/telemetryService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ITelemetryService, ITelemetryInfo, ITelemetryData, TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
-import { supportsTelemetry, NullTelemetryService, getPiiPathsFromEnvironment } from 'vs/platform/telemetry/common/telemetryUtils';
+import { supportsTelemetry, NullTelemetryService, getPiiPathsFromEnvironment, isInternalTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/environment/electron-sandbox/environmentService';
@@ -37,10 +37,11 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 		super();
 
 		if (supportsTelemetry(productService, environmentService)) {
+			const isInternal = isInternalTelemetry(productService, configurationService);
 			const channel = sharedProcessService.getChannel('telemetryAppender');
 			const config: ITelemetryServiceConfig = {
 				appenders: [new TelemetryAppenderClient(channel)],
-				commonProperties: resolveWorkbenchCommonProperties(storageService, fileService, environmentService.os.release, environmentService.os.hostname, productService.commit, productService.version, environmentService.machineId, productService.msftInternalDomains, environmentService.installSourcePath, environmentService.remoteAuthority),
+				commonProperties: resolveWorkbenchCommonProperties(storageService, fileService, environmentService.os.release, environmentService.os.hostname, productService.commit, productService.version, environmentService.machineId, isInternal, environmentService.installSourcePath, environmentService.remoteAuthority),
 				piiPaths: getPiiPathsFromEnvironment(environmentService),
 				sendErrorTelemetry: true
 			};

--- a/src/vs/workbench/services/telemetry/electron-sandbox/workbenchCommonProperties.ts
+++ b/src/vs/workbench/services/telemetry/electron-sandbox/workbenchCommonProperties.ts
@@ -18,11 +18,11 @@ export async function resolveWorkbenchCommonProperties(
 	commit: string | undefined,
 	version: string | undefined,
 	machineId: string,
-	msftInternalDomains: string[] | undefined,
+	isInternalTelemetry: boolean,
 	installSourcePath: string,
 	remoteAuthority?: string
 ): Promise<{ [name: string]: string | boolean | undefined }> {
-	const result = await resolveCommonProperties(fileService, release, hostname, process.arch, commit, version, machineId, msftInternalDomains, installSourcePath);
+	const result = await resolveCommonProperties(fileService, release, hostname, process.arch, commit, version, machineId, isInternalTelemetry, installSourcePath);
 	const firstSessionDate = storageService.get(firstSessionDateStorageKey, StorageScope.APPLICATION)!;
 	const lastSessionDate = storageService.get(lastSessionDateStorageKey, StorageScope.APPLICATION)!;
 

--- a/src/vs/workbench/services/telemetry/test/browser/commonProperties.test.ts
+++ b/src/vs/workbench/services/telemetry/test/browser/commonProperties.test.ts
@@ -23,7 +23,7 @@ suite('Browser Telemetry - common properties', function () {
 			};
 		};
 
-		const props = await resolveWorkbenchCommonProperties(testStorageService, commit, version, undefined, undefined, false, resolveCommonTelemetryProperties);
+		const props = await resolveWorkbenchCommonProperties(testStorageService, commit, version, false, undefined, undefined, false, resolveCommonTelemetryProperties);
 
 		assert.ok('commitHash' in props);
 		assert.ok('sessionID' in props);
@@ -53,10 +53,10 @@ suite('Browser Telemetry - common properties', function () {
 			});
 		};
 
-		const props = await resolveWorkbenchCommonProperties(testStorageService, commit, version, undefined, undefined, false, resolveCommonTelemetryProperties);
+		const props = await resolveWorkbenchCommonProperties(testStorageService, commit, version, false, undefined, undefined, false, resolveCommonTelemetryProperties);
 		assert.strictEqual(props['userId'], 1);
 
-		const props2 = await resolveWorkbenchCommonProperties(testStorageService, commit, version, undefined, undefined, false, resolveCommonTelemetryProperties);
+		const props2 = await resolveWorkbenchCommonProperties(testStorageService, commit, version, false, undefined, undefined, false, resolveCommonTelemetryProperties);
 		assert.strictEqual(props2['userId'], 2);
 	});
 });

--- a/src/vs/workbench/services/telemetry/test/electron-browser/commonProperties.test.ts
+++ b/src/vs/workbench/services/telemetry/test/electron-browser/commonProperties.test.ts
@@ -46,7 +46,7 @@ suite('Telemetry - common properties', function () {
 	test('default', async function () {
 		await Promises.mkdir(parentDir, { recursive: true });
 		fs.writeFileSync(installSource, 'my.install.source');
-		const props = await resolveWorkbenchCommonProperties(testStorageService, testFileService, release(), hostname(), commit, version, 'someMachineId', undefined, installSource);
+		const props = await resolveWorkbenchCommonProperties(testStorageService, testFileService, release(), hostname(), commit, version, 'someMachineId', false, installSource);
 		assert.ok('commitHash' in props);
 		assert.ok('sessionID' in props);
 		assert.ok('timestamp' in props);
@@ -66,7 +66,7 @@ suite('Telemetry - common properties', function () {
 		// machine id et al
 		assert.ok('common.machineId' in props, 'machineId');
 		fs.unlinkSync(installSource);
-		const props_1 = await resolveWorkbenchCommonProperties(testStorageService, testFileService, release(), hostname(), commit, version, 'someMachineId', undefined, installSource);
+		const props_1 = await resolveWorkbenchCommonProperties(testStorageService, testFileService, release(), hostname(), commit, version, 'someMachineId', false, installSource);
 		assert.ok(!('common.source' in props_1));
 	});
 
@@ -74,14 +74,14 @@ suite('Telemetry - common properties', function () {
 
 		testStorageService.store('telemetry.lastSessionDate', new Date().toUTCString(), StorageScope.APPLICATION, StorageTarget.MACHINE);
 
-		const props = await resolveWorkbenchCommonProperties(testStorageService, testFileService, release(), hostname(), commit, version, 'someMachineId', undefined, installSource);
+		const props = await resolveWorkbenchCommonProperties(testStorageService, testFileService, release(), hostname(), commit, version, 'someMachineId', false, installSource);
 		assert.ok('common.lastSessionDate' in props); // conditional, see below
 		assert.ok('common.isNewSession' in props);
 		assert.strictEqual(props['common.isNewSession'], '0');
 	});
 
 	test('values chance on ask', async function () {
-		const props = await resolveWorkbenchCommonProperties(testStorageService, testFileService, release(), hostname(), commit, version, 'someMachineId', undefined, installSource);
+		const props = await resolveWorkbenchCommonProperties(testStorageService, testFileService, release(), hostname(), commit, version, 'someMachineId', false, installSource);
 		let value1 = props['common.sequence'];
 		let value2 = props['common.sequence'];
 		assert.ok(value1 !== value2, 'seq');


### PR DESCRIPTION
This aligns `telemetry.internalTesting` and `msftInternal` to better get an idea of our internal usage