### PR TITLE
Add a view and actions for managing edit sessions

### DIFF
--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -564,7 +564,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		'workbench.experimental.editSessions.enabled': {
 			'type': 'boolean',
 			'tags': ['experimental', 'usesOnlineServices'],
-			'default': false,
+			'default': true,
 			'markdownDescription': localize('editSessionsEnabled', "Controls whether to display cloud-enabled actions to store and resume uncommitted changes when switching between web, desktop, or devices."),
 		},
 	}

--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -10,7 +10,7 @@ import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle
 import { Action2, IAction2Options, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { localize } from 'vs/nls';
-import { IEditSessionsWorkbenchService, Change, ChangeType, Folder, EditSession, FileType, EDIT_SESSION_SYNC_CATEGORY, EDIT_SESSIONS_CONTAINER_ID, EditSessionSchemaVersion, IEditSessionsLogService, EDIT_SESSIONS_VIEW_ICON } from 'vs/workbench/contrib/editSessions/common/editSessions';
+import { IEditSessionsWorkbenchService, Change, ChangeType, Folder, EditSession, FileType, EDIT_SESSION_SYNC_CATEGORY, EDIT_SESSIONS_CONTAINER_ID, EditSessionSchemaVersion, IEditSessionsLogService, EDIT_SESSIONS_VIEW_ICON, EDIT_SESSIONS_TITLE } from 'vs/workbench/contrib/editSessions/common/editSessions';
 import { ISCMRepository, ISCMService } from 'vs/workbench/contrib/scm/common/scm';
 import { IFileService } from 'vs/platform/files/common/files';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
@@ -141,7 +141,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 		const container = Registry.as<IViewContainersRegistry>(ViewExtensions.ViewContainersRegistry).registerViewContainer(
 			{
 				id: EDIT_SESSIONS_CONTAINER_ID,
-				title: localize('edit sessions', 'Edit Sessions'),
+				title: EDIT_SESSIONS_TITLE,
 				ctorDescriptor: new SyncDescriptor(
 					ViewPaneContainer,
 					[EDIT_SESSIONS_CONTAINER_ID, { mergeViewWithContainerWhenSingleView: true }]
@@ -218,7 +218,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 				});
 			}
 
-			async run(accessor: ServicesAccessor): Promise<void> {
+			async run(accessor: ServicesAccessor, editSessionId?: string): Promise<void> {
 				await that.progressService.withProgress({
 					location: ProgressLocation.Notification,
 					title: localize('resuming edit session', 'Resuming edit session...')
@@ -229,7 +229,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 					};
 					that.telemetryService.publicLog2<ResumeEvent, ResumeClassification>('editSessions.resume');
 
-					await that.resumeEditSession();
+					await that.resumeEditSession(editSessionId);
 				});
 			}
 		}));

--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -10,7 +10,7 @@ import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle
 import { Action2, IAction2Options, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { localize } from 'vs/nls';
-import { IEditSessionsWorkbenchService, Change, ChangeType, Folder, EditSession, FileType, EDIT_SESSION_SYNC_CATEGORY, EDIT_SESSIONS_CONTAINER_ID, EditSessionSchemaVersion, IEditSessionsLogService, EDIT_SESSIONS_VIEW_ICON, EDIT_SESSIONS_TITLE } from 'vs/workbench/contrib/editSessions/common/editSessions';
+import { IEditSessionsWorkbenchService, Change, ChangeType, Folder, EditSession, FileType, EDIT_SESSION_SYNC_CATEGORY, EDIT_SESSIONS_CONTAINER_ID, EditSessionSchemaVersion, IEditSessionsLogService, EDIT_SESSIONS_VIEW_ICON, EDIT_SESSIONS_TITLE, EDIT_SESSIONS_SCHEME } from 'vs/workbench/contrib/editSessions/common/editSessions';
 import { ISCMRepository, ISCMService } from 'vs/workbench/contrib/scm/common/scm';
 import { IFileService } from 'vs/platform/files/common/files';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
@@ -44,6 +44,8 @@ import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { EditSessionsDataViews } from 'vs/workbench/contrib/editSessions/browser/editSessionsViews';
+import { ITextModelService } from 'vs/editor/common/services/resolverService';
+import { EditSessionsContentProvider } from 'vs/workbench/contrib/editSessions/browser/editSessionsContentProvider';
 
 registerSingleton(IEditSessionsLogService, EditSessionsLogService);
 registerSingleton(IEditSessionsWorkbenchService, EditSessionsWorkbenchService);
@@ -83,6 +85,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 		@IProductService private readonly productService: IProductService,
 		@IConfigurationService private configurationService: IConfigurationService,
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
+		@ITextModelService textModelResolverService: ITextModelService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@ICommandService private commandService: ICommandService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
@@ -135,6 +138,8 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 			}
 			this.continueEditSessionOptions = continueEditSessionOptions;
 		});
+
+		textModelResolverService.registerTextModelContentProvider(EDIT_SESSIONS_SCHEME, instantiationService.createInstance(EditSessionsContentProvider));
 	}
 
 	private registerViews() {

--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsContentProvider.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsContentProvider.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from 'vs/base/common/uri';
+import { ITextModel } from 'vs/editor/common/model';
+import { IModelService } from 'vs/editor/common/services/model';
+import { ITextModelContentProvider } from 'vs/editor/common/services/resolverService';
+import { EDIT_SESSIONS_SCHEME, IEditSessionsWorkbenchService } from 'vs/workbench/contrib/editSessions/common/editSessions';
+
+export class EditSessionsContentProvider implements ITextModelContentProvider {
+
+	constructor(
+		@IEditSessionsWorkbenchService private editSessionsWorkbenchService: IEditSessionsWorkbenchService,
+		@IModelService private readonly modelService: IModelService,
+	) { }
+
+	async provideTextContent(uri: URI): Promise<ITextModel | null> {
+		let model: ITextModel | null = null;
+		if (uri.scheme === EDIT_SESSIONS_SCHEME) {
+			const match = /(?<ref>[^/]+)\/(?<folderName>[^/]+)\/(?<filePath>.*)/.exec(uri.path.substring(1));
+			if (match?.groups) {
+				const { ref, folderName, filePath } = match.groups;
+				const data = await this.editSessionsWorkbenchService.read(ref);
+				const content = data?.editSession.folders.find((f) => f.name === folderName)?.workingChanges.find((change) => change.relativeFilePath === filePath)?.contents;
+				if (content) {
+					model = this.modelService.createModel(content, null, uri);
+				}
+			}
+		}
+		return model;
+	}
+}

--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsViews.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsViews.ts
@@ -10,11 +10,11 @@ import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiati
 import { Registry } from 'vs/platform/registry/common/platform';
 import { TreeView, TreeViewPane } from 'vs/workbench/browser/parts/views/treeView';
 import { Extensions, ITreeItem, ITreeViewDataProvider, ITreeViewDescriptor, IViewsRegistry, TreeItemCollapsibleState, TreeViewItemHandleArg, ViewContainer } from 'vs/workbench/common/views';
-import { EDIT_SESSIONS_TITLE, IEditSessionsWorkbenchService } from 'vs/workbench/contrib/editSessions/common/editSessions';
+import { EDIT_SESSIONS_SCHEME, EDIT_SESSIONS_TITLE, IEditSessionsWorkbenchService } from 'vs/workbench/contrib/editSessions/common/editSessions';
 import { URI } from 'vs/base/common/uri';
 import { fromNow } from 'vs/base/common/date';
 import { Codicon } from 'vs/base/common/codicons';
-import { API_OPEN_DIFF_EDITOR_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
+import { API_OPEN_EDITOR_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
 import { registerAction2, Action2, MenuId } from 'vs/platform/actions/common/actions';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { ICommandService } from 'vs/platform/commands/common/commands';
@@ -131,7 +131,7 @@ class EditSessionDataViewDataProvider implements ITreeViewDataProvider {
 	private async getAllEditSessions(): Promise<ITreeItem[]> {
 		const allEditSessions = await this.editSessionsWorkbenchService.list();
 		return allEditSessions.map((session) => {
-			const resource = URI.from({ scheme: 'vscode-edit-sessions', authority: 'remote-session-content', path: `/${session.ref}` });
+			const resource = URI.from({ scheme: EDIT_SESSIONS_SCHEME, authority: 'remote-session-content', path: `/${session.ref}` });
 			return {
 				handle: resource.toString(),
 				collapsibleState: TreeItemCollapsibleState.Collapsed,
@@ -151,7 +151,7 @@ class EditSessionDataViewDataProvider implements ITreeViewDataProvider {
 		}
 
 		return data.editSession.folders.map((folder) => {
-			const resource = URI.from({ scheme: 'vscode-edit-sessions', authority: 'remote-session-content', path: `/${data.ref}/${folder.name}` });
+			const resource = URI.from({ scheme: EDIT_SESSIONS_SCHEME, authority: 'remote-session-content', path: `/${data.ref}/${folder.name}` });
 			return {
 				handle: resource.toString(),
 				collapsibleState: TreeItemCollapsibleState.Collapsed,
@@ -169,7 +169,7 @@ class EditSessionDataViewDataProvider implements ITreeViewDataProvider {
 		}
 
 		return (data.editSession.folders.find((folder) => folder.name === folderName)?.workingChanges ?? []).map((change) => {
-			const resource = URI.from({ scheme: 'vscode-edit-sessions', authority: 'remote-session-content', path: `/${data.ref}/${folderName}/${change.relativeFilePath}` });
+			const resource = URI.from({ scheme: EDIT_SESSIONS_SCHEME, authority: 'remote-session-content', path: `/${data.ref}/${folderName}/${change.relativeFilePath}` });
 			return {
 				handle: resource.toString(),
 				resourceUri: resource,
@@ -177,7 +177,7 @@ class EditSessionDataViewDataProvider implements ITreeViewDataProvider {
 				label: { label: change.relativeFilePath },
 				themeIcon: Codicon.file,
 				command: {
-					id: API_OPEN_DIFF_EDITOR_COMMAND_ID,
+					id: API_OPEN_EDITOR_COMMAND_ID,
 					title: localize('open file', 'Open File'),
 					arguments: [resource, undefined, undefined]
 				}

--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsViews.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsViews.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+import { localize } from 'vs/nls';
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { TreeView, TreeViewPane } from 'vs/workbench/browser/parts/views/treeView';
+import { Extensions, ITreeItem, ITreeViewDataProvider, ITreeViewDescriptor, IViewsRegistry, TreeItemCollapsibleState, ViewContainer } from 'vs/workbench/common/views';
+import { IEditSessionsWorkbenchService } from 'vs/workbench/contrib/editSessions/common/editSessions';
+import { URI } from 'vs/base/common/uri';
+import { fromNow } from 'vs/base/common/date';
+import { Codicon } from 'vs/base/common/codicons';
+import { API_OPEN_DIFF_EDITOR_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
+
+export class EditSessionsDataViews extends Disposable {
+	constructor(
+		container: ViewContainer,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) {
+		super();
+		this.registerViews(container);
+	}
+
+	private registerViews(container: ViewContainer): void {
+		const id = 'workbench.views.editSessions.data';
+		const name = localize('edit sessions data', 'All Sessions');
+		const treeView = this.instantiationService.createInstance(TreeView, id, name);
+		treeView.showCollapseAllAction = true;
+		treeView.showRefreshAction = true;
+		const disposable = treeView.onDidChangeVisibility(visible => {
+			if (visible && !treeView.dataProvider) {
+				disposable.dispose();
+				treeView.dataProvider = this.instantiationService.createInstance(EditSessionDataViewDataProvider);
+			}
+		});
+		Registry.as<IViewsRegistry>(Extensions.ViewsRegistry).registerViews([<ITreeViewDescriptor>{
+			id,
+			name,
+			ctorDescriptor: new SyncDescriptor(TreeViewPane),
+			canToggleVisibility: true,
+			canMoveView: false,
+			treeView,
+			collapsed: false,
+			order: 100,
+			hideByDefault: true,
+		}], container);
+	}
+}
+
+class EditSessionDataViewDataProvider implements ITreeViewDataProvider {
+	constructor(
+		@IEditSessionsWorkbenchService private readonly editSessionsWorkbenchService: IEditSessionsWorkbenchService
+	) { }
+
+	async getChildren(element?: ITreeItem): Promise<ITreeItem[]> {
+		if (!element) {
+			return this.getAllEditSessions();
+		}
+
+		const [ref, folderName, filePath] = URI.parse(element.handle).path.substring(1).split('/');
+
+		if (ref && !folderName) {
+			return this.getEditSession(ref);
+		} else if (ref && folderName && !filePath) {
+			return this.getEditSessionFolderContents(ref, folderName);
+		}
+
+		return [];
+	}
+
+	private async getAllEditSessions(): Promise<ITreeItem[]> {
+		const allEditSessions = await this.editSessionsWorkbenchService.list();
+		return allEditSessions.map((session) => {
+			const resource = URI.from({ scheme: 'vscode-edit-sessions', authority: 'remote-session-content', path: `/${session.ref}` });
+			return {
+				handle: resource.toString(),
+				collapsibleState: TreeItemCollapsibleState.Collapsed,
+				label: { label: session.ref },
+				description: fromNow(session.created, true),
+				themeIcon: Codicon.repo
+			};
+		});
+	}
+
+	private async getEditSession(ref: string): Promise<ITreeItem[]> {
+		const data = await this.editSessionsWorkbenchService.read(ref);
+
+		if (!data) {
+			return [];
+		}
+
+		return data.editSession.folders.map((folder) => {
+			const resource = URI.from({ scheme: 'vscode-edit-sessions', authority: 'remote-session-content', path: `/${data.ref}/${folder.name}` });
+			return {
+				handle: resource.toString(),
+				collapsibleState: TreeItemCollapsibleState.Collapsed,
+				label: { label: folder.name },
+				themeIcon: Codicon.folder
+			};
+		});
+	}
+
+	private async getEditSessionFolderContents(ref: string, folderName: string): Promise<ITreeItem[]> {
+		const data = await this.editSessionsWorkbenchService.read(ref);
+
+		if (!data) {
+			return [];
+		}
+
+		return (data.editSession.folders.find((folder) => folder.name === folderName)?.workingChanges ?? []).map((change) => {
+			const resource = URI.from({ scheme: 'vscode-edit-sessions', authority: 'remote-session-content', path: `/${data.ref}/${folderName}/${change.relativeFilePath}` });
+			return {
+				handle: resource.toString(),
+				resourceUri: resource,
+				collapsibleState: TreeItemCollapsibleState.None,
+				label: { label: change.relativeFilePath },
+				themeIcon: Codicon.file,
+				command: {
+					id: API_OPEN_DIFF_EDITOR_COMMAND_ID,
+					title: localize('open file', 'Open File'),
+					arguments: [resource, undefined, undefined]
+				}
+			};
+		});
+	}
+}

--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsWorkbenchService.ts
@@ -14,7 +14,7 @@ import { IProductService } from 'vs/platform/product/common/productService';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
 import { IRequestService } from 'vs/platform/request/common/request';
 import { IStorageService, IStorageValueChangeEvent, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
-import { createSyncHeaders, IAuthenticationProvider } from 'vs/platform/userDataSync/common/userDataSync';
+import { createSyncHeaders, IAuthenticationProvider, IResourceRefHandle } from 'vs/platform/userDataSync/common/userDataSync';
 import { UserDataSyncStoreClient } from 'vs/platform/userDataSync/common/userDataSyncStoreService';
 import { AuthenticationSession, AuthenticationSessionsChangeEvent, IAuthenticationService } from 'vs/workbench/services/authentication/common/authentication';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
@@ -120,6 +120,21 @@ export class EditSessionsWorkbenchService extends Disposable implements IEditSes
 		} catch (ex) {
 			this.logService.error(ex);
 		}
+	}
+
+	async list(): Promise<IResourceRefHandle[]> {
+		await this.initialize();
+		if (!this.initialized) {
+			throw new Error(`Unable to list edit sessions.`);
+		}
+
+		try {
+			return this.storeClient?.getAllRefs('editSessions') ?? [];
+		} catch (ex) {
+			this.logService.error(ex);
+		}
+
+		return [];
 	}
 
 	private async initialize() {

--- a/src/vs/workbench/contrib/editSessions/common/editSessions.ts
+++ b/src/vs/workbench/contrib/editSessions/common/editSessions.ts
@@ -74,3 +74,5 @@ export const EDIT_SESSIONS_CONTAINER_ID = 'workbench.view.editSessions';
 export const EDIT_SESSIONS_TITLE = localize('edit sessions', 'Edit Sessions');
 
 export const EDIT_SESSIONS_VIEW_ICON = registerIcon('edit-sessions-view-icon', Codicon.cloudDownload, localize('editSessionViewIcon', 'View icon of the edit sessions view.'));
+
+export const EDIT_SESSIONS_SCHEME = 'vscode-edit-sessions';

--- a/src/vs/workbench/contrib/editSessions/common/editSessions.ts
+++ b/src/vs/workbench/contrib/editSessions/common/editSessions.ts
@@ -71,5 +71,6 @@ export const EDIT_SESSIONS_SIGNED_IN_KEY = 'editSessionsSignedIn';
 export const EDIT_SESSIONS_SIGNED_IN = new RawContextKey<boolean>(EDIT_SESSIONS_SIGNED_IN_KEY, false);
 
 export const EDIT_SESSIONS_CONTAINER_ID = 'workbench.view.editSessions';
+export const EDIT_SESSIONS_TITLE = localize('edit sessions', 'Edit Sessions');
 
 export const EDIT_SESSIONS_VIEW_ICON = registerIcon('edit-sessions-view-icon', Codicon.cloudDownload, localize('editSessionViewIcon', 'View icon of the edit sessions view.'));

--- a/src/vs/workbench/contrib/editSessions/common/editSessions.ts
+++ b/src/vs/workbench/contrib/editSessions/common/editSessions.ts
@@ -3,11 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Codicon } from 'vs/base/common/codicons';
 import { localize } from 'vs/nls';
 import { ILocalizedString } from 'vs/platform/action/common/action';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { ILogService } from 'vs/platform/log/common/log';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
+import { IResourceRefHandle } from 'vs/platform/userDataSync/common/userDataSync';
 
 export const EDIT_SESSION_SYNC_CATEGORY: ILocalizedString = {
 	original: 'Edit Sessions',
@@ -21,6 +24,7 @@ export interface IEditSessionsWorkbenchService {
 	read(ref: string | undefined): Promise<{ ref: string; editSession: EditSession } | undefined>;
 	write(editSession: EditSession): Promise<string>;
 	delete(ref: string): Promise<void>;
+	list(): Promise<IResourceRefHandle[]>;
 }
 
 export const IEditSessionsLogService = createDecorator<IEditSessionsLogService>('IEditSessionsLogService');
@@ -65,3 +69,7 @@ export interface EditSession {
 
 export const EDIT_SESSIONS_SIGNED_IN_KEY = 'editSessionsSignedIn';
 export const EDIT_SESSIONS_SIGNED_IN = new RawContextKey<boolean>(EDIT_SESSIONS_SIGNED_IN_KEY, false);
+
+export const EDIT_SESSIONS_CONTAINER_ID = 'workbench.view.editSessions';
+
+export const EDIT_SESSIONS_VIEW_ICON = registerIcon('edit-sessions-view-icon', Codicon.cloudDownload, localize('editSessionViewIcon', 'View icon of the edit sessions view.'));

--- a/src/vs/workbench/contrib/editSessions/test/browser/editSessions.test.ts
+++ b/src/vs/workbench/contrib/editSessions/test/browser/editSessions.test.ts
@@ -28,6 +28,12 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 import { TestEnvironmentService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { Event } from 'vs/base/common/event';
+import { IViewDescriptorService } from 'vs/workbench/common/views';
+import { ITextModelService } from 'vs/editor/common/services/resolverService';
 
 const folderName = 'test-folder';
 const folderUri = URI.file(`/${folderName}`);
@@ -76,6 +82,17 @@ suite('Edit session sync', () => {
 
 		// Stub repositories
 		instantiationService.stub(ISCMService, '_repositories', new Map());
+		instantiationService.stub(IContextKeyService, new MockContextKeyService());
+		instantiationService.stub(IThemeService, new class extends mock<IThemeService>() {
+			override onDidColorThemeChange = Event.None;
+			override onDidFileIconThemeChange = Event.None;
+		});
+		instantiationService.stub(IViewDescriptorService, {
+			onDidChangeLocation: Event.None
+		});
+		instantiationService.stub(ITextModelService, new class extends mock<ITextModelService>() {
+			override registerTextModelContentProvider = () => ({ dispose: () => { } });
+		});
 
 		editSessionsContribution = instantiationService.createInstance(EditSessionsContribution);
 	});


### PR DESCRIPTION
Re: https://github.com/microsoft/vscode/issues/141293

This PR adds a new edit sessions view for easily viewing and managing all known edit sessions, as well as actions for:
- Viewing the working contents of a specific file in an edit session
- Resuming a specific edit session
- Deleting a specific edit session
