### PR TITLE
Fix KaTeX equation numbering in notebook preview

### DIFF
--- a/extensions/markdown-math/notebook/katex.ts
+++ b/extensions/markdown-math/notebook/katex.ts
@@ -33,6 +33,9 @@ export async function activate(ctx: RendererContext<void>) {
 		.katex-error {
 			color: var(--vscode-editorError-foreground);
 		}
+		.katex-block {
+			counter-reset: katexEqnNo mmlEqnNo;
+		}
 	`;
 
 	// Put Everything into a template


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/155888

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

### Explanation

the KaTex has a stylesheet

https://github.com/KaTeX/KaTeX/blob/9164a15ef817161aa8f33beb0688e660fff87dd2/src/katex.less#L677

```css
body {
	counter-reset: katexEqnNo mmlEqnNo;
}
```

which will compile into `vscode/extensions/markdown-math/notebook-out/katex.min.css` 

However, the `body` style is not effective inside shadow-root element and will cause #155888.

![CleanShot 2022-07-26 at 18 45 19](https://user-images.githubusercontent.com/5123601/180988405-cf98b04c-404f-407c-863f-0b6aa70c4b2f.png)

Adding this styles to shadow root explicitly will fix the issue.


Before:
![CleanShot 2022-07-26 at 17 53 02](https://user-images.githubusercontent.com/5123601/180982389-abde51c2-3179-4b2e-89b9-b41c5815fd23.png)

After:
![CleanShot 2022-07-26 at 17 58 35](https://user-images.githubusercontent.com/5123601/180982405-cf9cdf19-8581-4b34-bfdd-561a2a244de1.png)
