### PR TITLE
Add perf marks for auto resuming edit sessions

### DIFF
--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -96,6 +96,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 		super();
 
 		if (this.environmentService.editSessionId !== undefined) {
+			performance.mark('code/willResumeEditSessionFromIdentifier');
 			type ResumeEvent = {};
 			type ResumeClassification = {
 				owner: 'joyceerhl'; comment: 'Reporting when an action is resumed from an edit session identifier.';
@@ -103,6 +104,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 			this.telemetryService.publicLog2<ResumeEvent, ResumeClassification>('editSessions.continue.resume');
 
 			void this.resumeEditSession(this.environmentService.editSessionId).finally(() => this.environmentService.editSessionId = undefined);
+			performance.mark('code/didResumeEditSessionFromIdentifier');
 		}
 
 		this.configurationService.onDidChangeConfiguration((e) => {


### PR DESCRIPTION
Re: https://github.com/microsoft/vscode/issues/141293

Adding performance marks so we know how long it takes to auto-resume an edit session.