### PR TITLE
Added hover on menu and preview key from menu, fix on #149415 and #156323

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -151,6 +151,10 @@ export class QuickFixController extends Disposable implements IEditorContributio
 		}
 	}
 
+	public selectedOptionWithPreview() {
+		this._ui.getValue().onPreviewEnter();
+	}
+
 	public showCodeActions(trigger: CodeActionTrigger, actions: CodeActionSet, at: IAnchor | IPosition) {
 		return this._ui.getValue().showCodeActionList(trigger, actions, at, { includeDisabledActions: false, fromLightbulb: false });
 	}
@@ -563,6 +567,18 @@ registerEditorCommand(new CodeActionContribution({
 		weight: weight + 100000,
 		primary: KeyCode.Enter,
 		secondary: [KeyMod.Shift | KeyCode.Tab],
+	}
+}));
+
+registerEditorCommand(new CodeActionContribution({
+	id: 'onEnterSelectCodeActionWithPreview',
+	precondition: Context.Visible,
+	handler(x) {
+		x.selectedOptionWithPreview();
+	},
+	kbOpts: {
+		weight: weight + 100000,
+		primary: KeyMod.CtrlCmd | KeyCode.Enter,
 	}
 }));
 

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -152,7 +152,10 @@ export class QuickFixController extends Disposable implements IEditorContributio
 	}
 
 	public selectedOptionWithPreview() {
-		this._ui.getValue().onPreviewEnter();
+		if (this._ui.hasValue()) {
+			this._ui.getValue().onPreviewEnter();
+		}
+
 	}
 
 	public showCodeActions(trigger: CodeActionTrigger, actions: CodeActionSet, at: IAnchor | IPosition) {

--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -165,6 +165,8 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 	private hasSeperator: boolean = false;
 	private block?: HTMLElement;
 
+	public static readonly documentationID: string = '_documentation';
+
 	public static readonly ID: string = 'editor.contrib.codeActionMenu';
 
 	public static get(editor: ICodeEditor): CodeActionMenu | null {
@@ -277,7 +279,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			const currIsSeparator = item.class === 'separator';
 			let isDocumentation = false;
 			if (item instanceof CodeActionAction) {
-				isDocumentation = item.action.kind === '_documentation';
+				isDocumentation = item.action.kind === CodeActionMenu.documentationID;
 			}
 
 			if (currIsSeparator) {
@@ -511,7 +513,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			result.push(new Separator(), ...allDocumentation.map(command => toCodeActionAction(new CodeActionItem({
 				title: command.title,
 				command: command,
-				kind: '_documentation'
+				kind: CodeActionMenu.documentationID
 			}, undefined))));
 		}
 

--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -5,7 +5,7 @@
 
 import * as dom from 'vs/base/browser/dom';
 import { IAnchor } from 'vs/base/browser/ui/contextview/contextview';
-import { IListEvent, IListRenderer } from 'vs/base/browser/ui/list/list';
+import { IListEvent, IListMouseEvent, IListRenderer } from 'vs/base/browser/ui/list/list';
 import { List } from 'vs/base/browser/ui/list/listWidget';
 import { Action, IAction, Separator } from 'vs/base/common/actions';
 import { canceled } from 'vs/base/common/errors';
@@ -69,6 +69,7 @@ export interface ICodeActionMenuItem {
 	decoratorRight?: string;
 	isSeparator?: boolean;
 	isEnabled: boolean;
+	isDocumentation: boolean;
 	index: number;
 	disposables?: IDisposable[];
 }
@@ -93,6 +94,13 @@ const TEMPLATE_ID = 'codeActionWidget';
 const codeActionLineHeight = 26;
 
 class CodeMenuRenderer implements IListRenderer<ICodeActionMenuItem, ICodeActionMenuTemplateData> {
+
+	constructor(
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
+	) {
+
+	}
+
 	get templateId(): string { return TEMPLATE_ID; }
 
 	renderTemplate(container: HTMLElement): ICodeActionMenuTemplateData {
@@ -114,6 +122,7 @@ class CodeMenuRenderer implements IListRenderer<ICodeActionMenuItem, ICodeAction
 
 		const isEnabled = element.isEnabled;
 		const isSeparator = element.isSeparator;
+		const isDocumentation = element.isDocumentation;
 
 		data.text.textContent = text;
 		// data.detail.textContent = detail;
@@ -128,6 +137,14 @@ class CodeMenuRenderer implements IListRenderer<ICodeActionMenuItem, ICodeAction
 		if (isSeparator) {
 			data.root.classList.add('separator');
 			data.root.style.height = '10px';
+		}
+
+		if (!isDocumentation) {
+			const updateLabel = () => {
+				const [accept, preview] = [`onEnterSelectCodeAction`, `onEnterSelectCodeActionWithPreview`];
+				data.root.title = this.keybindingService.lookupKeybinding(accept)?.getLabel() + ' to Refactor, ' + this.keybindingService.lookupKeybinding(preview)?.getLabel() + ' to Preview';
+			};
+			updateLabel();
 		}
 
 	}
@@ -155,7 +172,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 	}
 
 	private readonly _keybindingResolver: CodeActionKeybindingResolver;
-	private listRenderer: CodeMenuRenderer = new CodeMenuRenderer();
+	private listRenderer: CodeMenuRenderer;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -176,6 +193,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		});
 
 		this._ctxMenuWidgetVisible = Context.Visible.bindTo(this._contextKeyService);
+		this.listRenderer = new CodeMenuRenderer(keybindingService);
 	}
 
 	get isVisible(): boolean {
@@ -199,6 +217,18 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		}
 	}
 
+
+	private _onListHover(e: IListMouseEvent<ICodeActionMenuItem>): void {
+		if (!e.element) {
+			this.codeActionList.value?.setFocus([]);
+		} else {
+			if (e.element?.isEnabled) {
+				this.codeActionList.value?.setFocus([e.element.index]);
+				this.focusedEnabledItem = this.viewItems.indexOf(e.element);
+				this.currSelectedItem = e.element.index;
+			}
+		}
+	}
 
 	private renderCodeActionMenuList(element: HTMLElement, inputArray: IAction[]): IDisposable {
 		const renderDisposables = new DisposableStore();
@@ -236,6 +266,8 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		}, [this.listRenderer], { keyboardSupport: false }
 		);
 
+		renderDisposables.add(this.codeActionList.value.onMouseOver(e => this._onListHover(e)));
+		renderDisposables.add(this.codeActionList.value.onDidChangeFocus(e => this.codeActionList.value?.domFocus()));
 		renderDisposables.add(this.codeActionList.value.onDidChangeSelection(e => this._onListSelection(e)));
 		renderDisposables.add(this._editor.onDidLayoutChange(e => this.hideCodeActionWidget()));
 
@@ -243,11 +275,16 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		// Populating the list widget and tracking enabled options.
 		inputArray.forEach((item, index) => {
 			const currIsSeparator = item.class === 'separator';
+			let isDocumentation = false;
+			if (item instanceof CodeActionAction) {
+				isDocumentation = item.action.kind === '_documentation';
+			}
+
 			if (currIsSeparator) {
 				// set to true forever
 				this.hasSeperator = true;
 			}
-			const menuItem = <ICodeActionMenuItem>{ title: item.label, detail: item.tooltip, action: inputArray[index], isEnabled: item.enabled, isSeparator: currIsSeparator, index };
+			const menuItem = <ICodeActionMenuItem>{ title: item.label, detail: item.tooltip, action: inputArray[index], isEnabled: item.enabled, isSeparator: currIsSeparator, index, isDocumentation };
 			if (item.enabled) {
 				this.viewItems.push(menuItem);
 			}
@@ -278,7 +315,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		this.codeActionList.value?.layout(height, maxWidth);
 
 		// List selection
-		if (this.viewItems.length < 1) {
+		if (this.viewItems.length < 1 || (this.viewItems.length === 1 && this.viewItems[0].isDocumentation)) {
 			this.currSelectedItem = 0;
 		} else {
 			this.focusedEnabledItem = 0;
@@ -303,7 +340,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 	protected focusPrevious() {
 		if (typeof this.focusedEnabledItem === 'undefined') {
 			this.focusedEnabledItem = this.viewItems[0].index;
-		} else if (this.viewItems.length < 1) {
+		} else if (this.viewItems.length < 1 || (this.viewItems.length === 1 && !this.viewItems[0].isDocumentation)) {
 			return false;
 		}
 
@@ -326,7 +363,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 	protected focusNext() {
 		if (typeof this.focusedEnabledItem === 'undefined') {
 			this.focusedEnabledItem = this.viewItems.length - 1;
-		} else if (this.viewItems.length < 1) {
+		} else if (this.viewItems.length < 1 || (this.viewItems.length === 1 && !this.viewItems[0].isDocumentation)) {
 			return false;
 		}
 
@@ -474,6 +511,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			result.push(new Separator(), ...allDocumentation.map(command => toCodeActionAction(new CodeActionItem({
 				title: command.title,
 				command: command,
+				kind: '_documentation'
 			}, undefined))));
 		}
 

--- a/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
@@ -23,6 +23,7 @@ export class CodeActionUi extends Disposable {
 	private readonly _codeActionWidget: Lazy<CodeActionMenu>;
 	private readonly _lightBulbWidget: Lazy<LightBulbWidget>;
 	private readonly _activeCodeActions = this._register(new MutableDisposable<CodeActionSet>());
+	private previewOn: boolean = false;
 
 	#disposed = false;
 
@@ -40,7 +41,12 @@ export class CodeActionUi extends Disposable {
 		this._codeActionWidget = new Lazy(() => {
 			return this._register(instantiationService.createInstance(CodeActionMenu, this._editor, {
 				onSelectCodeAction: async (action, trigger) => {
-					this.delegate.applyCodeAction(action, /* retrigger */ true, Boolean(trigger.preview));
+					if (this.previewOn) {
+						this.delegate.applyCodeAction(action, /* retrigger */ true, Boolean(this.previewOn));
+					} else {
+						this.delegate.applyCodeAction(action, /* retrigger */ true, Boolean(trigger.preview));
+					}
+					this.previewOn = false;
 				}
 			}));
 		});
@@ -68,6 +74,11 @@ export class CodeActionUi extends Disposable {
 		if (this._codeActionWidget.hasValue()) {
 			this._codeActionWidget.getValue().onEnterSet();
 		}
+	}
+
+	public onPreviewEnter() {
+		this.previewOn = true;
+		this.onEnter();
 	}
 
 	public navigateList(navUp: Boolean) {

--- a/src/vs/editor/contrib/codeAction/browser/media/action.css
+++ b/src/vs/editor/contrib/codeAction/browser/media/action.css
@@ -30,10 +30,10 @@
 	z-index: 5; /* make sure we are on top of the tree items */
 	content: "";
 	pointer-events: none; /* enable click through */
-	outline: 0px solid; /* we still need to handle the empty tree or no focus item case */
-	outline-width: 0px;
-	outline-style: none;
-	outline-offset: 0px;
+	outline: 0px solid !important; /* we still need to handle the empty tree or no focus item case */
+	outline-width: 0px !important;
+	outline-style: none !important;
+	outline-offset: 0px !important;
 }
 
 .codeActionMenuWidget .monaco-list {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

- Hovering over enabled items will now show `Enter to Refactor, Ctrl + Enter to Preview` (or your respective key bindings).
- Keybindings from this menu will enable refactorings with preview.\
- Fix where if `Learn more about JS/TS Refactorings` is the only enabled option, it won't be automatically selected or highlighted ( #149415)
- Fix where clicking on disabled items will highlight the entire widget. (#156323)