### PR TITLE
Always log tsserver exit code, even for kill processes

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -430,13 +430,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		});
 
 		handle.onExit((data: TypeScriptServerExitEvent) => {
-			if (this.token !== mytoken) {
-				// this is coming from an old process
-				return;
-			}
-
 			const { code, signal } = data;
-
 			if (code === null || typeof code === 'undefined') {
 				this.info(`TSServer exited. Signal: ${signal}`);
 			} else {
@@ -454,6 +448,11 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 					}
 				*/
 				this.logTelemetry('tsserver.exitWithCode', { code, signal: signal ?? undefined });
+			}
+
+			if (this.token !== mytoken) {
+				// this is coming from an old process
+				return;
 			}
 
 			if (handle.tsServerLogFile) {


### PR DESCRIPTION
We suspect that some exit code info is being dropped since 1.61. Changing this code to always log, even when the user manually restarts the server
