### PR TITLE
Make dialog confirmation customizable for 3 actions (#156418)

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -1524,23 +1524,27 @@ export class ClearRecentFilesAction extends Action {
 		label: string,
 		@IWorkspacesService private readonly workspacesService: IWorkspacesService,
 		@IHistoryService private readonly historyService: IHistoryService,
-		@IDialogService private readonly dialogService: IDialogService
+		@IDialogService private readonly dialogService: IDialogService,
+		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super(id, label);
 	}
 
 	override async run(): Promise<void> {
+		const shouldConfirm = this.configurationService.getValue<boolean>('workbench.confirmClearRecentFiles');
 
-		// Ask for confirmation
-		const { confirmed } = await this.dialogService.confirm({
-			message: localize('confirmClearRecentsMessage', "Do you want to clear all recently opened files and workspaces?"),
-			detail: localize('confirmClearDetail', "This action is irreversible!"),
-			primaryButton: localize({ key: 'clearButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Clear"),
-			type: 'warning'
-		});
+		if (shouldConfirm) {
+			// Ask for confirmation
+			const { confirmed } = await this.dialogService.confirm({
+				message: localize('confirmClearRecentsMessage', "Do you want to clear all recently opened files and workspaces?"),
+				detail: localize('confirmClearDetail', "This action is irreversible!"),
+				primaryButton: localize({ key: 'clearButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Clear"),
+				type: 'warning'
+			});
 
-		if (!confirmed) {
-			return;
+			if (!confirmed) {
+				return;
+			}
 		}
 
 		// Clear global recently opened
@@ -1800,23 +1804,27 @@ export class ClearEditorHistoryAction extends Action {
 		id: string,
 		label: string,
 		@IHistoryService private readonly historyService: IHistoryService,
-		@IDialogService private readonly dialogService: IDialogService
+		@IDialogService private readonly dialogService: IDialogService,
+		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super(id, label);
 	}
 
 	override async run(): Promise<void> {
+		const shouldConfirm = this.configurationService.getValue<boolean>('workbench.confirmClearEditorHistory');
 
-		// Ask for confirmation
-		const { confirmed } = await this.dialogService.confirm({
-			message: localize('confirmClearEditorHistoryMessage', "Do you want to clear the history of recently opened editors?"),
-			detail: localize('confirmClearDetail', "This action is irreversible!"),
-			primaryButton: localize({ key: 'clearButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Clear"),
-			type: 'warning'
-		});
+		if (shouldConfirm) {
+			// Ask for confirmation
+			const { confirmed } = await this.dialogService.confirm({
+				message: localize('confirmClearEditorHistoryMessage', "Do you want to clear the history of recently opened editors?"),
+				detail: localize('confirmClearDetail', "This action is irreversible!"),
+				primaryButton: localize({ key: 'clearButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Clear"),
+				type: 'warning'
+			});
 
-		if (!confirmed) {
-			return;
+			if (!confirmed) {
+				return;
+			}
 		}
 
 		// Clear editor history

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -290,6 +290,16 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'default': false,
 				'description': localize('perEditorGroup', "Controls if the limit of maximum opened editors should apply per editor group or across all editor groups.")
 			},
+			'workbench.confirmClearEditorHistory': {
+				'type': 'boolean',
+				'default': true,
+				'description': localize('confirmClearEditorHistory', "Controls whether to ask for confirmation when executing the clear editor history action (workbench.action.clearEditorHistory).")
+			},
+			'workbench.confirmClearRecentFiles': {
+				'type': 'boolean',
+				'default': true,
+				'description': localize('confirmClearRecentFiles', "Controls whether to ask for confirmation when executing the File: clear recently opened action (workbench.action.clearRecentFiles).")
+			},
 			'workbench.localHistory.enabled': {
 				'type': 'boolean',
 				'default': true,
@@ -327,6 +337,11 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('commandHistory', "Controls the number of recently used commands to keep in history for the command palette. Set to 0 to disable command history."),
 				'default': 50,
 				'minimum': 0
+			},
+			'workbench.commandPalette.confirmClearCommandHistory': {
+				'type': 'boolean',
+				'default': true,
+				'description': localize('confirmClearCommandHistory', "Controls whether to ask for confirmation when executing the clear command history action (workbench.action.clearRecentFiles).")
 			},
 			'workbench.commandPalette.preserveInput': {
 				'type': 'boolean',

--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -193,16 +193,20 @@ export class ClearCommandHistoryAction extends Action2 {
 		const commandHistoryLength = CommandsHistory.getConfiguredCommandHistoryLength(configurationService);
 		if (commandHistoryLength > 0) {
 
-			// Ask for confirmation
-			const { confirmed } = await dialogService.confirm({
-				message: localize('confirmClearMessage', "Do you want to clear the history of recently used commands?"),
-				detail: localize('confirmClearDetail', "This action is irreversible!"),
-				primaryButton: localize({ key: 'clearButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Clear"),
-				type: 'warning'
-			});
+			const shouldConfirm = configurationService.getValue<boolean>('workbench.commandPalette.confirmClearCommandHistory');
 
-			if (!confirmed) {
-				return;
+			if (shouldConfirm) {
+				// Ask for confirmation
+				const { confirmed } = await dialogService.confirm({
+					message: localize('confirmClearMessage', "Do you want to clear the history of recently used commands?"),
+					detail: localize('confirmClearDetail', "This action is irreversible!"),
+					primaryButton: localize({ key: 'clearButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Clear"),
+					type: 'warning'
+				});
+
+				if (!confirmed) {
+					return;
+				}
 			}
 
 			CommandsHistory.clearHistory(configurationService, storageService);


### PR DESCRIPTION
Issue: https://github.com/microsoft/vscode/issues/156418

Contribute settings to customize whether should prompt confirmation or not for the following actions:

-  `workbench.action.clearRecentFiles` =setting=> `workbench.confirmClearRecentFiles`

-  `workbench.action.clearEditorHistory` =setting=> `workbench.confirmClearEditorHistory`

- `workbench.action.clearCommandHistory` =setting=> `workbench.commandPalette.confirmClearCommandHistory`

    The default is to show the confirmation dialog.

Update actions to read the settings. And check if should prompt dialog or not.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
