### PR TITLE
Fix isStandalone when PWA entering fullscreen

### DIFF
--- a/src/vs/base/browser/browser.ts
+++ b/src/vs/base/browser/browser.ts
@@ -194,9 +194,16 @@ export const isAndroid = (userAgent.indexOf('Android') >= 0);
 
 let standalone = false;
 if (window.matchMedia) {
-	const matchMedia = window.matchMedia('(display-mode: standalone)');
-	standalone = matchMedia.matches;
-	addMatchMediaChangeListener(matchMedia, ({ matches }) => {
+	const standaloneMatchMedia = window.matchMedia('(display-mode: standalone)');
+	const fullScreenMatchMedia = window.matchMedia('(display-mode: fullscreen)');
+	standalone = standaloneMatchMedia.matches;
+	addMatchMediaChangeListener(standaloneMatchMedia, ({ matches }) => {
+		// entering fullscreen would change standaloneMatchMedia.matches to false
+		// if standalone is true (running as PWA) and entering fullscreen, skip this change
+		if (standalone && fullScreenMatchMedia.matches) {
+			return;
+		}
+		// otherwise update standalone (browser to PWA or PWA to browser)
 		standalone = matches;
 	});
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/156347

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

### Context
`standalone` is dynamic and updated whenever `display-mode` changed. This is useful when user switching from browser to PWA mode (or PWA mode to browser). See https://github.com/microsoft/vscode/pull/143287 

The problem is when PWA entering full-screen mode. It will also change `display-mode` resulting `standalone = false`. 

### Solution
Check `display-mode: fullscreen` state and skip these updates.
