### PR TITLE
devcontainer schema: handle deprecated properties

### DIFF
--- a/extensions/configuration-editing/schemas/devContainer.codespaces.schema.json
+++ b/extensions/configuration-editing/schemas/devContainer.codespaces.schema.json
@@ -177,6 +177,13 @@
 					}
 				}
 			}
+		},
+		"codespaces": {
+			"type": "object",
+			"additionalProperties": true,
+			"description": "Codespaces-specific configuration.",
+			"deprecated": true,
+			"deprecationMessage": "Use 'customizations/codespaces' instead"
 		}
 	}
 }

--- a/extensions/configuration-editing/schemas/devContainer.vscode.schema.json
+++ b/extensions/configuration-editing/schemas/devContainer.vscode.schema.json
@@ -28,6 +28,29 @@
 					}
 				}
 			}
+		},
+		"extensions": {
+			"type": "array",
+			"description": "An array of extensions that should be installed into the container.",
+			"items": {
+				"type": "string",
+				"pattern": "^([a-z0-9A-Z][a-z0-9A-Z-]*)\\.([a-z0-9A-Z][a-z0-9A-Z-]*)((@(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)|@prerelease)?$",
+				"errorMessage": "Expected format: '${publisher}.${name}' or '${publisher}.${name}@${version}'. Example: 'ms-dotnettools.csharp'."
+			},
+			"deprecated": true,
+			"deprecationMessage": "Use 'customizations/vscode/extensions' instead"
+		},
+		"settings": {
+			"$ref": "vscode://schemas/settings/machine",
+			"description": "Machine specific settings that should be copied into the container. These are only copied when connecting to the container for the first time, rebuilding the container then triggers it again.",
+			"deprecated": true,
+			"deprecationMessage": "Use 'customizations/vscode/settings' instead"
+		},
+		"devPort": {
+			"type": "integer",
+			"description": "The port VS Code can use to connect to its backend.",
+			"deprecated": true,
+			"deprecationMessage": "Use 'customizations/vscode/devPort' instead"
 		}
 	}
 }


### PR DESCRIPTION
Implementing review comments from https://github.com/devcontainers/spec/pull/65.

Moves out the deprecated vscode/codespace specific parts from base to the vscode/codespaces schemas and marks them as deprecated there.