### PR TITLE
Add setting to not focus the panel when running selected text in terminal

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -79,6 +79,7 @@ export const enum TerminalSettingId {
 	Cwd = 'terminal.integrated.cwd',
 	ConfirmOnExit = 'terminal.integrated.confirmOnExit',
 	ConfirmOnKill = 'terminal.integrated.confirmOnKill',
+	ShowPanelOnRunSelectedText = 'terminal.integrated.showPanelOnRunSelectedText',
 	EnableBell = 'terminal.integrated.enableBell',
 	CommandsToSkipShell = 'terminal.integrated.commandsToSkipShell',
 	AllowChords = 'terminal.integrated.allowChords',

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -560,7 +560,9 @@ export function registerTerminalActions() {
 				text = editor.getModel().getValueInRange(selection, endOfLinePreference);
 			}
 			instance.sendText(text, true);
-			return terminalGroupService.showPanel();
+			if (terminalService.configHelper.config.showPanelOnRunSelectedText) {
+				return terminalGroupService.showPanel();
+			}
 		}
 	});
 	registerAction2(class extends Action2 {

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -263,6 +263,7 @@ export interface ITerminalConfiguration {
 	cwd: string;
 	confirmOnExit: ConfirmOnExit;
 	confirmOnKill: ConfirmOnKill;
+	showPanelOnRunSelectedText: boolean;
 	enableBell: boolean;
 	env: {
 		linux: { [key: string]: string };

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -355,6 +355,11 @@ const terminalConfiguration: IConfigurationNode = {
 			],
 			default: 'editor'
 		},
+		[TerminalSettingId.ShowPanelOnRunSelectedText]: {
+			description: localize('terminal.integrated.showPanelOnRunSelectedText', "Controls whether to focus the panel when the user sends selected text to the terminal."),
+			type: 'boolean',
+			default: true
+		},
 		[TerminalSettingId.EnableBell]: {
 			description: localize('terminal.integrated.enableBell', "Controls whether the terminal bell is enabled, this shows up as a visual bell next to the terminal's name."),
 			type: 'boolean',


### PR DESCRIPTION
Fixes #156434

This change adds a new settings option: `terminal.integrated.showPanelOnRunSelectedText` (boolean) which allows users to suppress automatically focusing the panel when sending selected text to the integrated terminal. The default value is true, corresponding to the existing behaviour.

This allows tmux users (etc.) to send selected to external terminals or terminals in the editor area without opening a duplicate terminal in the panel (see linked issue #156434).

These changes can be tested by:
- starting an integrated terminal in the panel
- closing the panel
- selecting some text and running `> Run Selected Text In Active Terminal`
- noticing that the panel opens (the default and existing behaviour)
- setting `"terminal.integrated.showPanelOnRunSelectedText": false` in settings
- closing the panel again
- selecting some text and running `> Run Selected Text In Active Terminal`
- noticing that the panel now does not automatically open

Thanks!