### PR TITLE
Revert "Re-Enables bracket pair matching/colorization for monarch"

### DIFF
--- a/src/vs/editor/common/languages/supports/tokenization.ts
+++ b/src/vs/editor/common/languages/supports/tokenization.ts
@@ -230,12 +230,10 @@ export class TokenTheme {
 		if (typeof result === 'undefined') {
 			const rule = this._match(token);
 			const standardToken = toStandardTokenType(token);
-
 			result = (
 				rule.metadata
 				| (standardToken << MetadataConsts.TOKEN_TYPE_OFFSET)
 			) >>> 0;
-			result |= MetadataConsts.BALANCED_BRACKETS_MASK;
 			this._cache.set(token, result);
 		}
 


### PR DESCRIPTION
Reverts microsoft/vscode#156450

This sets the bit also for textmate, not just for monarch. A stupid oversight.