### PR TITLE
build support for ipynb markdown renderer

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -399,6 +399,7 @@ const esbuildMediaScripts = [
     'markdown-language-features/esbuild-preview.js',
     'markdown-math/esbuild.js',
     'notebook-renderers/esbuild.js',
+    'ipynb/esbuild.js',
     'simple-browser/esbuild-preview.js',
 ];
 async function webpackExtensions(taskName, isWatch, webpackConfigLocations) {

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -486,6 +486,7 @@ const esbuildMediaScripts = [
 	'markdown-language-features/esbuild-preview.js',
 	'markdown-math/esbuild.js',
 	'notebook-renderers/esbuild.js',
+	'ipynb/esbuild.js',
 	'simple-browser/esbuild-preview.js',
 ];
 


### PR DESCRIPTION
added `'ipynb/esbuild.js'` to the esbuild media scripts when building extensions