### PR TITLE
Fix drop indicator showing up even if you have disabled dropIntoEditor

### DIFF
--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -400,8 +400,6 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 				if (target?.position) {
 					this._onDropIntoEditor.fire({ position: target.position, event: e });
 				}
-
-
 			},
 			onDragLeave: () => {
 				this.removeDropIndicator();

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -368,10 +368,15 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 			this._actions[internalAction.id] = internalAction;
 		});
 
+		const isDropIntoEnabled = () => {
+			return !this._configuration.options.get(EditorOption.readOnly)
+				&& this._configuration.options.get(EditorOption.dropIntoEditor).enabled;
+		};
+
 		this._register(new dom.DragAndDropObserver(this._domElement, {
 			onDragEnter: () => undefined,
 			onDragOver: e => {
-				if (!this._configuration.options.get(EditorOption.dropIntoEditor).enabled) {
+				if (!isDropIntoEnabled()) {
 					return;
 				}
 
@@ -381,7 +386,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 				}
 			},
 			onDrop: async e => {
-				if (!this._configuration.options.get(EditorOption.dropIntoEditor).enabled) {
+				if (!isDropIntoEnabled()) {
 					return;
 				}
 
@@ -395,6 +400,8 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 				if (target?.position) {
 					this._onDropIntoEditor.fire({ position: target.position, event: e });
 				}
+
+
 			},
 			onDragLeave: () => {
 				this.removeDropIndicator();

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -240,7 +240,6 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 		return {
 			...super.getConfigurationOverrides(),
 			readOnly,
-			dropIntoEditor: { enabled: !readOnly },
 			originalEditable: this.input instanceof DiffEditorInput && !this.input.original.hasCapability(EditorInputCapabilities.Readonly),
 			lineDecorationsWidth: '2ch'
 		};
@@ -248,10 +247,10 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 
 	protected override updateReadonly(input: EditorInput): void {
 		if (input instanceof DiffEditorInput) {
+			const readonly = input.hasCapability(EditorInputCapabilities.Readonly);
 			this.diffEditorControl?.updateOptions({
-				readOnly: input.hasCapability(EditorInputCapabilities.Readonly),
+				readOnly: readonly,
 				originalEditable: !input.original.hasCapability(EditorInputCapabilities.Readonly),
-				dropIntoEditor: { enabled: !input.hasCapability(EditorInputCapabilities.Readonly) }
 			});
 		} else {
 			super.updateReadonly(input);

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -247,9 +247,8 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 
 	protected override updateReadonly(input: EditorInput): void {
 		if (input instanceof DiffEditorInput) {
-			const readonly = input.hasCapability(EditorInputCapabilities.Readonly);
 			this.diffEditorControl?.updateOptions({
-				readOnly: readonly,
+				readOnly: input.hasCapability(EditorInputCapabilities.Readonly),
 				originalEditable: !input.original.hasCapability(EditorInputCapabilities.Readonly),
 			});
 		} else {

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -135,11 +135,7 @@ export abstract class AbstractTextEditor<T extends IEditorViewState> extends Abs
 
 	protected updateReadonly(input: EditorInput): void {
 		const readOnly = input.hasCapability(EditorInputCapabilities.Readonly);
-
-		this.updateEditorControlOptions({
-			readOnly,
-			dropIntoEditor: { enabled: !readOnly },
-		});
+		this.updateEditorControlOptions({ readOnly });
 	}
 
 	protected getConfigurationOverrides(): ICodeEditorOptions {
@@ -150,7 +146,6 @@ export abstract class AbstractTextEditor<T extends IEditorViewState> extends Abs
 			lineNumbersMinChars: 3,
 			fixedOverflowWidgets: true,
 			readOnly,
-			dropIntoEditor: { enabled: !readOnly },
 			renderValidationDecorations: 'on' // render problems even in readonly editors (https://github.com/microsoft/vscode/issues/89057)
 		};
 	}

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/markdownCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/markdownCell.ts
@@ -329,7 +329,6 @@ export class StatefulMarkdownCell extends Disposable {
 					width: width,
 					height: editorHeight
 				},
-				dropIntoEditor: { enabled: true },
 				// overflowWidgetsDomNode: this.notebookEditor.getOverflowContainerDomNode()
 			}, {
 				contributions: this.notebookEditor.creationOptions.cellEditorContributions

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
@@ -275,7 +275,6 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 				width: 0,
 				height: 0
 			},
-			dropIntoEditor: { enabled: true },
 		}, {
 			contributions: this.notebookEditor.creationOptions.cellEditorContributions
 		});


### PR DESCRIPTION
This fixes a number of places where we were adding `dropIntoEditor` to the config override, which also overrides the user's configation. Instead we can check if the editor is readonly in `codeEditorWidget`
