### PR TITLE
Tell users about enabled TS plugins on crash

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -584,6 +584,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 			this.numberRestarts++;
 			let startService = true;
 
+			const pluginExtensionList = this.pluginManager.plugins.map(plugin => plugin.extension.id).join(', ');
 			const reportIssueItem: vscode.MessageItem = {
 				title: localize('serverDiedReportIssue', 'Report Issue'),
 			};
@@ -596,7 +597,9 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 					startService = false;
 					this.hasServerFatallyCrashedTooManyTimes = true;
 					prompt = vscode.window.showErrorMessage(
-						localize('serverDiedAfterStart', 'The TypeScript language service died 5 times right after it got started. The service will not be restarted.'),
+						this.pluginManager.plugins.length
+							? localize('serverDiedImmediatelyWithPlugins', "The JS/TS language service immediately crashed 5 times. The service will not be restarted.\nThis may be caused by a plugin contributed by one of these extensions: {0}", pluginExtensionList)
+							: localize('serverDiedImmediately', "The JS/TS language service immediately crashed 5 times. The service will not be restarted."),
 						reportIssueItem);
 
 					/* __GDPR__
@@ -610,19 +613,28 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 					this.logTelemetry('serviceExited');
 				} else if (diff < 60 * 1000 * 5 /* 5 Minutes */) {
 					this.lastStart = Date.now();
-					prompt = vscode.window.showWarningMessage(
-						localize('serverDied', 'The TypeScript language service died unexpectedly 5 times in the last 5 Minutes.'),
-						reportIssueItem);
+					if (!this._isPromptingAfterCrash) {
+						prompt = vscode.window.showWarningMessage(
+							this.pluginManager.plugins.length
+								? localize('serverDiedFiveTimesWithPlugins', "The JS/TS language service crashed 5 times in the last 5 Minutes.\nThis may be caused by a plugin contributed by one of these extensions: {0}", pluginExtensionList)
+								: localize('serverDiedFiveTimes', "The JS/TS language service crashed 5 times in the last 5 Minutes."),
+							reportIssueItem);
+					}
 				}
 			} else if (['vscode-insiders', 'code-oss'].includes(vscode.env.uriScheme)) {
 				// Prompt after a single restart
-				if (!this._isPromptingAfterCrash && previousState.type === ServerState.Type.Errored && previousState.error instanceof TypeScriptServerError) {
-					this.numberRestarts = 0;
-					this._isPromptingAfterCrash = true;
+				this.numberRestarts = 0;
+				if (!this._isPromptingAfterCrash) {
 					prompt = vscode.window.showWarningMessage(
-						localize('serverDiedOnce', 'The TypeScript language service died unexpectedly.'),
+						this.pluginManager.plugins.length
+							? localize('serverDiedOnceWithPlugins', "The JS/TS language service crashed.\nThis may be caused by a plugin contributed by one of these extensions: {0}", pluginExtensionList)
+							: localize('serverDiedOnce', "The JS/TS language service crashed."),
 						reportIssueItem);
 				}
+			}
+
+			if (prompt) {
+				this._isPromptingAfterCrash = true;
 			}
 
 			prompt?.then(item => {

--- a/extensions/typescript-language-features/src/utils/plugins.ts
+++ b/extensions/typescript-language-features/src/utils/plugins.ts
@@ -8,6 +8,7 @@ import * as arrays from './arrays';
 import { Disposable } from './dispose';
 
 export interface TypeScriptServerPlugin {
+	readonly extension: vscode.Extension<unknown>;
 	readonly uri: vscode.Uri;
 	readonly name: string;
 	readonly enableForWorkspaceTypeScriptVersions: boolean;
@@ -74,6 +75,7 @@ export class PluginManager extends Disposable {
 				const plugins: TypeScriptServerPlugin[] = [];
 				for (const plugin of pack.contributes.typescriptServerPlugins) {
 					plugins.push({
+						extension,
 						name: plugin.name,
 						enableForWorkspaceTypeScriptVersions: !!plugin.enableForWorkspaceTypeScriptVersions,
 						uri: extension.extensionUri,


### PR DESCRIPTION
We've been seeing a fair number of reported issues about TS Server crashes that are caused by plugins contributed by extension. This change adds info to the error message about enabled global plugins so users can try disabling them

See #155365 for example

Other changes:

- Use `JS/TS` instead of Typescript since the server is used for javascript too (the word `typescript` is a somewhat common source of confusion for newer js users)
- Fix some missing checks to `_isPromptingAfterCrash` and some extra guards that were causing some crashes to not show this message
- Use `crashed` instead of `died unexpectedly`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
