### PR TITLE
Show quick pick when redirect fails to complete redirect to be more robust

### DIFF
--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -11,7 +11,7 @@ import * as nls from 'vscode-nls';
 import { v4 as uuid } from 'uuid';
 import fetch, { Response } from 'node-fetch';
 import Logger from './logger';
-import { toBase64UrlEncoding } from './utils';
+import { isSupportedEnvironment, toBase64UrlEncoding } from './utils';
 import { sha256 } from './env/node/sha256';
 import { BetterTokenStorage, IDidChangeInOtherWindowEvent } from './betterSecretStorage';
 import { LoopbackAuthServer } from './authServer';
@@ -319,13 +319,7 @@ export class AzureActiveDirectoryService {
 			}, 5000);
 		}
 
-		const token = await this.exchangeCodeForToken(codeToExchange, codeVerifier, scopeData);
-		if (token.expiresIn) {
-			this.setSessionTimeout(token.sessionId, token.refreshToken, scopeData, token.expiresIn * AzureActiveDirectoryService.REFRESH_TIMEOUT_MODIFIER);
-		}
-		await this.setToken(token, scopeData);
-		Logger.info(`Login successful for scopes: ${scopeData.scopeStr}`);
-		const session = await this.convertToSession(token);
+		const session = await this.exchangeCodeForSession(codeToExchange, codeVerifier, scopeData);
 		return session;
 	}
 
@@ -355,9 +349,11 @@ export class AzureActiveDirectoryService {
 		const uri = vscode.Uri.parse(`${signInUrl}?${oauthStartQuery.toString()}`);
 		vscode.env.openExternal(uri);
 
+		let inputBox: vscode.InputBox | undefined;
 		const timeoutPromise = new Promise((_: (value: vscode.AuthenticationSession) => void, reject) => {
 			const wait = setTimeout(() => {
 				clearTimeout(wait);
+				inputBox?.dispose();
 				reject('Login timed out.');
 			}, 1000 * 60 * 5);
 		});
@@ -369,7 +365,12 @@ export class AzureActiveDirectoryService {
 		// before completing it.
 		let existingPromise = this._codeExchangePromises.get(scopeData.scopeStr);
 		if (!existingPromise) {
-			existingPromise = this.handleCodeResponse(scopeData);
+			if (isSupportedEnvironment(callbackUri)) {
+				existingPromise = this.handleCodeResponse(scopeData);
+			} else {
+				inputBox = vscode.window.createInputBox();
+				existingPromise = Promise.race([this.handleCodeInputBox(inputBox, codeVerifier, scopeData), this.handleCodeResponse(scopeData)]);
+			}
 			this._codeExchangePromises.set(scopeData.scopeStr, existingPromise);
 		}
 
@@ -659,13 +660,7 @@ export class AzureActiveDirectoryService {
 						throw new Error('No available code verifier');
 					}
 
-					const token = await this.exchangeCodeForToken(code, verifier, scopeData);
-					if (token.expiresIn) {
-						this.setSessionTimeout(token.sessionId, token.refreshToken, scopeData, token.expiresIn * AzureActiveDirectoryService.REFRESH_TIMEOUT_MODIFIER);
-					}
-					await this.setToken(token, scopeData);
-
-					const session = await this.convertToSession(token);
+					const session = await this.exchangeCodeForSession(code, verifier, scopeData);
 					resolve(session);
 				} catch (err) {
 					reject(err);
@@ -680,8 +675,32 @@ export class AzureActiveDirectoryService {
 		});
 	}
 
-	private async exchangeCodeForToken(code: string, codeVerifier: string, scopeData: IScopeData): Promise<IToken> {
+	private async handleCodeInputBox(inputBox: vscode.InputBox, verifier: string, scopeData: IScopeData): Promise<vscode.AuthenticationSession> {
+		inputBox.ignoreFocusOut = true;
+		inputBox.title = localize('pasteCodeTitle', 'Microsoft Authentication');
+		inputBox.prompt = localize('pasteCodePrompt', 'Provide the authorization code to complete the sign in flow.');
+		inputBox.placeholder = localize('pasteCodePlaceholder', 'Paste authorization code here...');
+		return new Promise((resolve: (value: vscode.AuthenticationSession) => void, reject) => {
+			inputBox.show();
+			inputBox.onDidAccept(async () => {
+				const code = inputBox.value;
+				if (code) {
+					const session = await this.exchangeCodeForSession(code, verifier, scopeData);
+					resolve(session);
+				}
+			});
+			inputBox.onDidHide(() => {
+				if (!inputBox.value) {
+					inputBox.dispose();
+					reject('Cancelled');
+				}
+			});
+		});
+	}
+
+	private async exchangeCodeForSession(code: string, codeVerifier: string, scopeData: IScopeData): Promise<vscode.AuthenticationSession> {
 		Logger.info(`Exchanging login code for token for scopes: ${scopeData.scopeStr}`);
+		let token: IToken | undefined;
 		try {
 			const postData = querystring.stringify({
 				grant_type: 'authorization_code',
@@ -698,11 +717,18 @@ export class AzureActiveDirectoryService {
 
 			const json = await this.fetchTokenResponse(endpoint, postData, scopeData);
 			Logger.info(`Exchanging login code for token (for scopes: ${scopeData.scopeStr}) succeeded!`);
-			return this.convertToTokenSync(json, scopeData);
+			token = this.convertToTokenSync(json, scopeData);
 		} catch (e) {
 			Logger.error(`Error exchanging code for token (for scopes ${scopeData.scopeStr}): ${e}`);
 			throw e;
 		}
+
+		if (token.expiresIn) {
+			this.setSessionTimeout(token.sessionId, token.refreshToken, scopeData, token.expiresIn * AzureActiveDirectoryService.REFRESH_TIMEOUT_MODIFIER);
+		}
+		await this.setToken(token, scopeData);
+		Logger.info(`Login successful for scopes: ${scopeData.scopeStr}`);
+		return await this.convertToSession(token);
 	}
 
 	private async fetchTokenResponse(endpoint: string, postData: string, scopeData: IScopeData): Promise<ITokenResponse> {

--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -685,6 +685,7 @@ export class AzureActiveDirectoryService {
 			inputBox.onDidAccept(async () => {
 				const code = inputBox.value;
 				if (code) {
+					inputBox.dispose();
 					const session = await this.exchangeCodeForSession(code, verifier, scopeData);
 					resolve(session);
 				}

--- a/extensions/microsoft-authentication/src/utils.ts
+++ b/extensions/microsoft-authentication/src/utils.ts
@@ -2,7 +2,31 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { env, UIKind, Uri } from 'vscode';
 
 export function toBase64UrlEncoding(base64string: string) {
 	return base64string.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_'); // Need to use base64url encoding
+}
+
+export function isSupportedEnvironment(uri: Uri): boolean {
+	if (env.uiKind === UIKind.Desktop) {
+		return true;
+	}
+	// local development (localhost:* or 127.0.0.1:*)
+	if (/^https?$/i.test(uri.scheme) && /^(localhost|127\.0\.0\.1):\d+$/i.test(uri.authority)) {
+		return true;
+	}
+	// At this point we should only ever see https
+	if (uri.scheme !== 'https') {
+		return false;
+	}
+
+	return (
+		// vscode.dev & insiders.vscode.dev
+		/(?:^|\.)vscode\.dev$/.test(uri.authority) ||
+		// github.dev & codespaces
+		/(?:^|\.)github\.dev$/.test(uri.authority) ||
+		// github.dev/codespaces local setup (github.localhost)
+		/(?:^|\.)github\.localhost$/.test(uri.authority)
+	);
 }

--- a/extensions/microsoft-authentication/src/utils.ts
+++ b/extensions/microsoft-authentication/src/utils.ts
@@ -8,12 +8,21 @@ export function toBase64UrlEncoding(base64string: string) {
 	return base64string.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_'); // Need to use base64url encoding
 }
 
+const LOCALHOST_ADDRESSES = ['localhost', '127.0.0.1', '0:0:0:0:0:0:0:1', '::1'];
+function isLocalhost(uri: Uri): boolean {
+	if (!/^https?$/i.test(uri.scheme)) {
+		return false;
+	}
+	const host = uri.authority.split(':')[0];
+	return LOCALHOST_ADDRESSES.indexOf(host) >= 0;
+}
+
 export function isSupportedEnvironment(uri: Uri): boolean {
 	if (env.uiKind === UIKind.Desktop) {
 		return true;
 	}
 	// local development (localhost:* or 127.0.0.1:*)
-	if (/^https?$/i.test(uri.scheme) && /^(localhost|127\.0\.0\.1):\d+$/i.test(uri.authority)) {
+	if (isLocalhost(uri)) {
 		return true;
 	}
 	// At this point we should only ever see https


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
We were seeing some folks who are running code-server on a different url (like an ip address of an Azure VM) were struggling to complete the auth flow.

To assist, this shows an input box now where the user can paste in their authorization code to complete the auth flow.

![image](https://user-images.githubusercontent.com/2644648/181392478-c69f6c05-569a-4d07-96ed-bffd1a4d24ed.png)
