### PR TITLE
Engineering - unify all Code OSS pipeline jobs

### DIFF
--- a/build/azure-pipelines/product-build-pr.yml
+++ b/build/azure-pipelines/product-build-pr.yml
@@ -87,8 +87,8 @@ jobs:
             VSCODE_RUN_SMOKE_TESTS: true
 
   - ${{ if eq(variables['VSCODE_CIBUILD'], true) }}:
-    - job: MaintainNodeModulesCache
-      displayName: Maintain node_modules cache
+    - job: Linuxx64MaintainNodeModulesCache
+      displayName: Linux (Maintain node_modules cache)
       pool: vscode-1es-vscode-linux-20.04
       timeoutInMinutes: 30
       variables:

--- a/build/azure-pipelines/product-build-pr.yml
+++ b/build/azure-pipelines/product-build-pr.yml
@@ -22,176 +22,168 @@ variables:
   - name: VSCODE_STEP_ON_IT
     value: false
 
-stages:
-  - ${{ if eq(variables['VSCODE_CIBUILD'], true) }}:
-    - stage: MaintainNodeModulesCache
-      displayName: Maintain node_modules cache
-      jobs:
-        - job: MaintainNodeModulesCache
-          displayName: Maintain node_modules cache
-          pool: vscode-1es-vscode-linux-20.04
-          variables:
-            VSCODE_ARCH: x64
-          steps:
-            - template: product-build-pr-cache.yml
-
+jobs:
   - ${{ if ne(variables['VSCODE_CIBUILD'], true) }}:
-    - stage: Compile
+    - job: Compile
       displayName: Compile & Hygiene
-      jobs:
-        - job: Compile
-          displayName: Compile & Hygiene
-          pool: vscode-1es-vscode-linux-20.04
-          variables:
-            VSCODE_ARCH: x64
-          steps:
-            - template: product-compile.yml
-              parameters:
-                VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+      pool: vscode-1es-vscode-linux-20.04
+      timeoutInMinutes: 30
+      variables:
+        VSCODE_ARCH: x64
+      steps:
+        - template: product-compile.yml
+          parameters:
+            VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
 
-    - stage: Test
-      dependsOn: []
-      jobs:
-        - job: Linuxx64UnitTest
-          displayName: Linux (Unit Tests)
-          pool: vscode-1es-vscode-linux-20.04
-          # container: vscode-bionic-x64
-          timeoutInMinutes: 60
-          variables:
-            VSCODE_ARCH: x64
-            NPM_ARCH: x64
-            DISPLAY: ":10"
-          steps:
-            - template: linux/product-build-linux-client.yml
-              parameters:
-                VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
-                VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-                VSCODE_RUN_UNIT_TESTS: true
-                VSCODE_RUN_INTEGRATION_TESTS: false
-                VSCODE_RUN_SMOKE_TESTS: false
-        - job: Linuxx64IntegrationTest
-          displayName: Linux (Integration Tests)
-          pool: vscode-1es-vscode-linux-20.04
-          # container: vscode-bionic-x64
-          timeoutInMinutes: 60
-          variables:
-            VSCODE_ARCH: x64
-            NPM_ARCH: x64
-            DISPLAY: ":10"
-          steps:
-            - template: linux/product-build-linux-client.yml
-              parameters:
-                VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
-                VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-                VSCODE_RUN_UNIT_TESTS: false
-                VSCODE_RUN_INTEGRATION_TESTS: true
-                VSCODE_RUN_SMOKE_TESTS: false
-        - job: Linuxx64SmokeTest
-          displayName: Linux (Smoke Tests)
-          pool: vscode-1es-vscode-linux-20.04
-          # container: vscode-bionic-x64
-          timeoutInMinutes: 60
-          variables:
-            VSCODE_ARCH: x64
-            NPM_ARCH: x64
-            DISPLAY: ":10"
-          steps:
-            - template: linux/product-build-linux-client.yml
-              parameters:
-                VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
-                VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-                VSCODE_RUN_UNIT_TESTS: false
-                VSCODE_RUN_INTEGRATION_TESTS: false
-                VSCODE_RUN_SMOKE_TESTS: true
+    - job: Linuxx64UnitTest
+      displayName: Linux (Unit Tests)
+      pool: vscode-1es-vscode-linux-20.04
+      timeoutInMinutes: 30
+      variables:
+        VSCODE_ARCH: x64
+        NPM_ARCH: x64
+        DISPLAY: ":10"
+      steps:
+        - template: linux/product-build-linux-client.yml
+          parameters:
+            VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
+            VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+            VSCODE_RUN_UNIT_TESTS: true
+            VSCODE_RUN_INTEGRATION_TESTS: false
+            VSCODE_RUN_SMOKE_TESTS: false
 
-        # - job: macOSUnitTest
-        #   displayName: macOS (Unit Tests)
-        #   pool:
-        #     vmImage: macOS-latest
-        #   timeoutInMinutes: 60
-        #   variables:
-        #     BUILDSECMON_OPT_IN: true
-        #     VSCODE_ARCH: x64
-        #   steps:
-        #     - template: darwin/product-build-darwin.yml
-        #       parameters:
-        #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
-        #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-        #         VSCODE_RUN_UNIT_TESTS: true
-        #         VSCODE_RUN_INTEGRATION_TESTS: false
-        #         VSCODE_RUN_SMOKE_TESTS: false
-        # - job: macOSIntegrationTest
-        #   displayName: macOS (Integration Tests)
-        #   pool:
-        #     vmImage: macOS-latest
-        #   timeoutInMinutes: 60
-        #   variables:
-        #     BUILDSECMON_OPT_IN: true
-        #     VSCODE_ARCH: x64
-        #   steps:
-        #     - template: darwin/product-build-darwin.yml
-        #       parameters:
-        #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
-        #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-        #         VSCODE_RUN_UNIT_TESTS: false
-        #         VSCODE_RUN_INTEGRATION_TESTS: true
-        #         VSCODE_RUN_SMOKE_TESTS: false
-        # - job: macOSSmokeTest
-        #   displayName: macOS (Smoke Tests)
-        #   pool:
-        #     vmImage: macOS-latest
-        #   timeoutInMinutes: 60
-        #   variables:
-        #     BUILDSECMON_OPT_IN: true
-        #     VSCODE_ARCH: x64
-        #   steps:
-        #     - template: darwin/product-build-darwin.yml
-        #       parameters:
-        #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
-        #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-        #         VSCODE_RUN_UNIT_TESTS: false
-        #         VSCODE_RUN_INTEGRATION_TESTS: false
-        #         VSCODE_RUN_SMOKE_TESTS: true
+    - job: Linuxx64IntegrationTest
+      displayName: Linux (Integration Tests)
+      pool: vscode-1es-vscode-linux-20.04
+      timeoutInMinutes: 30
+      variables:
+        VSCODE_ARCH: x64
+        NPM_ARCH: x64
+        DISPLAY: ":10"
+      steps:
+        - template: linux/product-build-linux-client.yml
+          parameters:
+            VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
+            VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+            VSCODE_RUN_UNIT_TESTS: false
+            VSCODE_RUN_INTEGRATION_TESTS: true
+            VSCODE_RUN_SMOKE_TESTS: false
 
-        # - job: WindowsUnitTests
-        #   displayName: Windows (Unit Tests)
-        #   pool: vscode-1es-vscode-windows-2019
-        #   timeoutInMinutes: 60
-        #   variables:
-        #     VSCODE_ARCH: x64
-        #   steps:
-        #     - template: win32/product-build-win32.yml
-        #       parameters:
-        #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
-        #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-        #         VSCODE_RUN_UNIT_TESTS: true
-        #         VSCODE_RUN_INTEGRATION_TESTS: false
-        #         VSCODE_RUN_SMOKE_TESTS: false
-        # - job: WindowsIntegrationTests
-        #   displayName: Windows (Integration Tests)
-        #   pool: vscode-1es-vscode-windows-2019
-        #   timeoutInMinutes: 60
-        #   variables:
-        #     VSCODE_ARCH: x64
-        #   steps:
-        #     - template: win32/product-build-win32.yml
-        #       parameters:
-        #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
-        #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-        #         VSCODE_RUN_UNIT_TESTS: false
-        #         VSCODE_RUN_INTEGRATION_TESTS: true
-        #         VSCODE_RUN_SMOKE_TESTS: false
-        # - job: WindowsSmokeTests
-        #   displayName: Windows (Smoke Tests)
-        #   pool: vscode-1es-vscode-windows-2019
-        #   timeoutInMinutes: 60
-        #   variables:
-        #     VSCODE_ARCH: x64
-        #   steps:
-        #     - template: win32/product-build-win32.yml
-        #       parameters:
-        #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
-        #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
-        #         VSCODE_RUN_UNIT_TESTS: false
-        #         VSCODE_RUN_INTEGRATION_TESTS: false
-        #         VSCODE_RUN_SMOKE_TESTS: true
+    - job: Linuxx64SmokeTest
+      displayName: Linux (Smoke Tests)
+      pool: vscode-1es-vscode-linux-20.04
+      timeoutInMinutes: 30
+      variables:
+        VSCODE_ARCH: x64
+        NPM_ARCH: x64
+        DISPLAY: ":10"
+      steps:
+        - template: linux/product-build-linux-client.yml
+          parameters:
+            VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
+            VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+            VSCODE_RUN_UNIT_TESTS: false
+            VSCODE_RUN_INTEGRATION_TESTS: false
+            VSCODE_RUN_SMOKE_TESTS: true
+
+  - ${{ if eq(variables['VSCODE_CIBUILD'], true) }}:
+    - job: MaintainNodeModulesCache
+      displayName: Maintain node_modules cache
+      pool: vscode-1es-vscode-linux-20.04
+      timeoutInMinutes: 30
+      variables:
+        VSCODE_ARCH: x64
+      steps:
+        - template: product-build-pr-cache.yml
+
+  # - job: macOSUnitTest
+  #   displayName: macOS (Unit Tests)
+  #   pool:
+  #     vmImage: macOS-latest
+  #   timeoutInMinutes: 60
+  #   variables:
+  #     BUILDSECMON_OPT_IN: true
+  #     VSCODE_ARCH: x64
+  #   steps:
+  #     - template: darwin/product-build-darwin.yml
+  #       parameters:
+  #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
+  #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+  #         VSCODE_RUN_UNIT_TESTS: true
+  #         VSCODE_RUN_INTEGRATION_TESTS: false
+  #         VSCODE_RUN_SMOKE_TESTS: false
+  # - job: macOSIntegrationTest
+  #   displayName: macOS (Integration Tests)
+  #   pool:
+  #     vmImage: macOS-latest
+  #   timeoutInMinutes: 60
+  #   variables:
+  #     BUILDSECMON_OPT_IN: true
+  #     VSCODE_ARCH: x64
+  #   steps:
+  #     - template: darwin/product-build-darwin.yml
+  #       parameters:
+  #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
+  #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+  #         VSCODE_RUN_UNIT_TESTS: false
+  #         VSCODE_RUN_INTEGRATION_TESTS: true
+  #         VSCODE_RUN_SMOKE_TESTS: false
+  # - job: macOSSmokeTest
+  #   displayName: macOS (Smoke Tests)
+  #   pool:
+  #     vmImage: macOS-latest
+  #   timeoutInMinutes: 60
+  #   variables:
+  #     BUILDSECMON_OPT_IN: true
+  #     VSCODE_ARCH: x64
+  #   steps:
+  #     - template: darwin/product-build-darwin.yml
+  #       parameters:
+  #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
+  #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+  #         VSCODE_RUN_UNIT_TESTS: false
+  #         VSCODE_RUN_INTEGRATION_TESTS: false
+  #         VSCODE_RUN_SMOKE_TESTS: true
+
+  # - job: WindowsUnitTests
+  #   displayName: Windows (Unit Tests)
+  #   pool: vscode-1es-vscode-windows-2019
+  #   timeoutInMinutes: 60
+  #   variables:
+  #     VSCODE_ARCH: x64
+  #   steps:
+  #     - template: win32/product-build-win32.yml
+  #       parameters:
+  #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
+  #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+  #         VSCODE_RUN_UNIT_TESTS: true
+  #         VSCODE_RUN_INTEGRATION_TESTS: false
+  #         VSCODE_RUN_SMOKE_TESTS: false
+  # - job: WindowsIntegrationTests
+  #   displayName: Windows (Integration Tests)
+  #   pool: vscode-1es-vscode-windows-2019
+  #   timeoutInMinutes: 60
+  #   variables:
+  #     VSCODE_ARCH: x64
+  #   steps:
+  #     - template: win32/product-build-win32.yml
+  #       parameters:
+  #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
+  #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+  #         VSCODE_RUN_UNIT_TESTS: false
+  #         VSCODE_RUN_INTEGRATION_TESTS: true
+  #         VSCODE_RUN_SMOKE_TESTS: false
+  # - job: WindowsSmokeTests
+  #   displayName: Windows (Smoke Tests)
+  #   pool: vscode-1es-vscode-windows-2019
+  #   timeoutInMinutes: 60
+  #   variables:
+  #     VSCODE_ARCH: x64
+  #   steps:
+  #     - template: win32/product-build-win32.yml
+  #       parameters:
+  #         VSCODE_PUBLISH: ${{ variables.VSCODE_PUBLISH }}
+  #         VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+  #         VSCODE_RUN_UNIT_TESTS: false
+  #         VSCODE_RUN_INTEGRATION_TESTS: false
+  #         VSCODE_RUN_SMOKE_TESTS: true


### PR DESCRIPTION
Code OSS - move all jobs in one stage so that we can reuse the node_modules cache