### PR TITLE
more checking for undefined objects, fixed bug causing renderer crash

### DIFF
--- a/extensions/ipynb/src/cellAttachmentRenderer.ts
+++ b/extensions/ipynb/src/cellAttachmentRenderer.ts
@@ -22,11 +22,19 @@ export async function activate(ctx: RendererContext<void>) {
 		md.renderer.rules.image = (tokens: MarkdownItToken[], idx: number, options, env, self) => {
 			const token = tokens[idx];
 			const src = token.attrGet('src');
-			const attachments: Record<string, Record<string, string>> = env.outputItem.metadata?.custom?.attachments;
+			const attachments: Record<string, Record<string, string>> = env.outputItem.metadata?.custom?.attachments; // this stores attachment entries for every image in the cell
 			if (attachments && src) {
-				const [attachmentKey, attachmentVal] = Object.entries(attachments[src.replace('attachment:', '')])[0];
-				const b64Markdown = 'data:' + attachmentKey + ';base64,' + attachmentVal;
-				token.attrSet('src', b64Markdown);
+				const imageAttachment = attachments[src.replace('attachment:', '')];
+				if (imageAttachment) {
+					// objEntries will always be length 1, with objEntries[0] holding [0]=mime,[1]=b64
+					// if length = 0, something is wrong with the attachment, mime/b64 weren't copied over
+					const objEntries = Object.entries(imageAttachment);
+					if (objEntries.length) {
+						const [attachmentKey, attachmentVal] = objEntries[0];
+						const b64Markdown = 'data:' + attachmentKey + ';base64,' + attachmentVal;
+						token.attrSet('src', b64Markdown);
+					}
+				}
 			}
 
 			if (original) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix: #156599
Relevant to testplan: #156380

Just added more type checking and undefined checks. Weird cases where markdown filename didn't match attachment file name or image entry was incomplete without mime or b64 data