### PR TITLE
Bump distro + update labels

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -197,10 +197,10 @@
 	},
 	{
 		"type": "label",
-		"name": "~needs version info",
+		"name": "~version-info-needed",
 		"action": "updateLabels",
 		"addLabel": "info-needed",
-		"removeLabel": "~needs version info",
+		"removeLabel": "~version-info-needed",
 		"comment": "Thanks for creating this issue! We figured it's missing some basic information, such as a version number, or in some other way doesn't follow our [issue reporting guidelines](https://aka.ms/vscodeissuereporting). Please take the time to review these and update the issue.\n\nHappy Coding!"
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.70.0",
-  "distro": "25c5a766dec5d762c3205176fec650c6964c7763",
+  "distro": "81cca34eb9bc1d2c0a7d0124ce64b62c994ca9b7",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
Bumps distro commit and updates label `needs version info` to `version-info-needed`