### PR TITLE
feat: baseConfigurationResolverService: pass args to command

### DIFF
--- a/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
@@ -204,7 +204,7 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 
 		for (const variable of variables) {
 
-			const [type, name] = variable.split(':', 2);
+			const [type, name, args] = variable.split(':', 3);
 
 			let result: string | undefined;
 
@@ -217,7 +217,7 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 				case 'command': {
 					// use the name as a command ID #12735
 					const commandId = (variableToCommandMap ? variableToCommandMap[name] : undefined) || name;
-					result = await this.commandService.executeCommand(commandId, configuration);
+					result = await this.commandService.executeCommand(commandId, configuration, args);
 					if (typeof result !== 'string' && !Types.isUndefinedOrNull(result)) {
 						throw new Error(nls.localize('commandVariable.noStringType', "Cannot substitute command variable '{0}' because command did not return a result of type string.", commandId));
 					}


### PR DESCRIPTION
From the tasks.json parse the "${command:command.name:args}"
to be able to use arguments in a command used in tasks.

This change does not impact what we already have, `args` will be
returned as `undefined` if not placed.

Signed-off-by: Matheus Castello <matheus.castello@toradex.com>

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
