### PR TITLE
Enable user-select for monaco editor on macOS

### DIFF
--- a/src/vs/editor/browser/config/editorConfiguration.ts
+++ b/src/vs/editor/browser/config/editorConfiguration.ts
@@ -206,7 +206,7 @@ function digitCount(n: number): number {
 
 function getExtraEditorClassName(): string {
 	let extra = '';
-	if (!browser.isSafari && !browser.isWebkitWebView) {
+	if (!browser.isSafari && !browser.isWebkitWebView && !platform.isMacintosh) {
 		// Use user-select: none in all browsers except Safari and native macOS WebView
 		extra += 'no-user-select ';
 	}
@@ -217,6 +217,11 @@ function getExtraEditorClassName(): string {
 	}
 	if (platform.isMacintosh) {
 		extra += 'mac ';
+		// Use user-select: initial for lookup feature on macOS
+		// https://github.com/microsoft/vscode/issues/85632
+		if (!extra.includes('enable-user-select')) {
+			extra += 'enable-user-select ';
+		}
 	}
 	return extra;
 }

--- a/src/vs/editor/browser/config/editorConfiguration.ts
+++ b/src/vs/editor/browser/config/editorConfiguration.ts
@@ -206,7 +206,7 @@ function digitCount(n: number): number {
 
 function getExtraEditorClassName(): string {
 	let extra = '';
-	if (!browser.isSafari && !browser.isWebkitWebView && !platform.isMacintosh) {
+	if (!browser.isSafari && !browser.isWebkitWebView) {
 		// Use user-select: none in all browsers except Safari and native macOS WebView
 		extra += 'no-user-select ';
 	}
@@ -217,11 +217,6 @@ function getExtraEditorClassName(): string {
 	}
 	if (platform.isMacintosh) {
 		extra += 'mac ';
-		// Use user-select: initial for lookup feature on macOS
-		// https://github.com/microsoft/vscode/issues/85632
-		if (!extra.includes('enable-user-select')) {
-			extra += 'enable-user-select ';
-		}
 	}
 	return extra;
 }

--- a/src/vs/editor/browser/viewParts/lines/viewLines.css
+++ b/src/vs/editor/browser/viewParts/lines/viewLines.css
@@ -26,6 +26,15 @@
 	-webkit-user-select: none;
 	-ms-user-select: none;
 }
+/* Use user-select: text for lookup feature on macOS */
+/* https://github.com/microsoft/vscode/issues/85632 */
+.monaco-editor.mac .lines-content:hover,
+.monaco-editor.mac .view-line:hover,
+.monaco-editor.mac .view-lines:hover {
+	user-select: text;
+	-webkit-user-select: text;
+	-ms-user-select: text;
+}
 
 .monaco-editor.enable-user-select {
 	user-select: initial;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/85632

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

macOS lookup won't work for text setting or inherited `user-select: none` stylesheet.

The related code was changed many years ago:
- [_getExtraEditorClassName()](https://github.com/microsoft/vscode/blame/b504cc6daa4b814faf423ea6082f545eefdf112e/src/vs/editor/browser/config/configuration.ts#L202)
- [viewLines.css](https://github.com/microsoft/vscode/blame/344f4fa361e098b49aeace9602e89275fbbd17bf/src/vs/editor/browser/viewParts/lines/viewLines.css#L24)

I tested https://github.com/microsoft/vscode/issues/44517 is not reoccurring.

![2022-07-31 22 49 33](https://user-images.githubusercontent.com/5123601/182032025-994abc13-744d-44f4-b00d-fe63893879a1.gif)

