### PR TITLE
use the profile from current or last active window

### DIFF
--- a/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Emitter } from 'vs/base/common/event';
+import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { joinPath } from 'vs/base/common/resources';
 import { UriDto } from 'vs/base/common/types';
@@ -29,6 +29,8 @@ export class UserDataProfilesNativeService extends Disposable implements IUserDa
 	private readonly _onDidChangeProfiles = this._register(new Emitter<DidChangeProfilesEvent>());
 	readonly onDidChangeProfiles = this._onDidChangeProfiles.event;
 
+	readonly onDidResetWorkspaces: Event<void>;
+
 	constructor(
 		profiles: UriDto<IUserDataProfile>[],
 		@IMainProcessService mainProcessService: IMainProcessService,
@@ -45,6 +47,7 @@ export class UserDataProfilesNativeService extends Disposable implements IUserDa
 			this._profiles = e.all.map(profile => reviveProfile(profile, this.profilesHome.scheme));
 			this._onDidChangeProfiles.fire({ added, removed, updated, all: this.profiles });
 		}));
+		this.onDidResetWorkspaces = this.channel.listen<void>('onDidResetWorkspaces');
 	}
 
 	async createProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, workspaceIdentifier?: ISingleFolderWorkspaceIdentifier | IWorkspaceIdentifier): Promise<IUserDataProfile> {
@@ -65,6 +68,10 @@ export class UserDataProfilesNativeService extends Disposable implements IUserDa
 		return reviveProfile(result, this.profilesHome.scheme);
 	}
 
-	getProfile(workspaceIdentifier: WorkspaceIdentifier): IUserDataProfile { throw new Error('Not implemented'); }
+	resetWorkspaces(): Promise<void> {
+		return this.channel.call('resetWorkspaces');
+	}
+
+	getProfile(workspaceIdentifier: WorkspaceIdentifier, profileToUseIfNotSet: IUserDataProfile): IUserDataProfile { throw new Error('Not implemented'); }
 }
 

--- a/src/vs/platform/windows/electron-main/window.ts
+++ b/src/vs/platform/windows/electron-main/window.ts
@@ -117,8 +117,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
 	get openedWorkspace(): IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | undefined { return this._config?.workspace; }
 
-	private _profile: IUserDataProfile | undefined;
-	get profile(): IUserDataProfile | undefined { if (!this._profile) { this._profile = revive(this._config?.profiles.current); } return this._profile; }
+	get profile(): IUserDataProfile | undefined { return this.config ? this.userDataProfilesService.getProfile(this.config.workspace ?? 'empty-window', revive(this.config.profiles.current)) : undefined; }
 
 	get remoteAuthority(): string | undefined { return this._config?.remoteAuthority; }
 
@@ -948,7 +947,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 		configuration.editSessionId = this.environmentMainService.editSessionId; // set latest edit session id
 		configuration.profiles = {
 			all: this.userDataProfilesService.profiles,
-			current: this.userDataProfilesService.getProfile(configuration.workspace ?? 'empty-window'),
+			current: this.profile || this.userDataProfilesService.defaultProfile,
 		};
 
 		// Load config

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1326,7 +1326,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 
 			profiles: {
 				all: this.userDataProfilesService.profiles,
-				current: this.userDataProfilesService.getProfile(options.workspace ?? 'empty-window'),
+				current: this.userDataProfilesService.getProfile(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesService.defaultProfile),
 			},
 
 			homeDir: this.environmentMainService.userHome.fsPath,

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -269,7 +269,7 @@ export class BrowserMain extends Disposable {
 		// User Data Profiles
 		const userDataProfilesService = new BrowserUserDataProfilesService(environmentService, fileService, uriIdentityService, logService);
 		serviceCollection.set(IUserDataProfilesService, userDataProfilesService);
-		const userDataProfileService = new UserDataProfileService(userDataProfilesService.getProfile(isWorkspaceIdentifier(payload) || isSingleFolderWorkspaceIdentifier(payload) ? payload : 'empty-window'), userDataProfilesService);
+		const userDataProfileService = new UserDataProfileService(userDataProfilesService.getProfile(isWorkspaceIdentifier(payload) || isSingleFolderWorkspaceIdentifier(payload) ? payload : 'empty-window', userDataProfilesService.defaultProfile), userDataProfilesService);
 		serviceCollection.set(IUserDataProfileService, userDataProfileService);
 
 		// Long running services (workspace, config, storage)

--- a/src/vs/workbench/contrib/userDataProfile/common/userDataProfileActions.ts
+++ b/src/vs/workbench/contrib/userDataProfile/common/userDataProfileActions.ts
@@ -275,31 +275,6 @@ registerAction2(class SwitchProfileAction extends Action2 {
 	}
 });
 
-registerAction2(class CleanupProfilesAction extends Action2 {
-	constructor() {
-		super({
-			id: 'workbench.profiles.actions.cleanupProfiles',
-			title: {
-				value: localize('cleanup profile', "Cleanup Settings Profiles"),
-				original: 'Cleanup Profiles'
-			},
-			category: CATEGORIES.Developer,
-			f1: true,
-			precondition: PROFILES_ENABLEMENT_CONTEXT,
-		});
-	}
-
-	async run(accessor: ServicesAccessor) {
-		const userDataProfilesService = accessor.get(IUserDataProfilesService);
-		const fileService = accessor.get(IFileService);
-		const uriIdentityService = accessor.get(IUriIdentityService);
-
-		const stat = await fileService.resolve(userDataProfilesService.profilesHome);
-		await Promise.all((stat.children || [])?.filter(child => child.isDirectory && userDataProfilesService.profiles.every(p => !uriIdentityService.extUri.isEqual(p.location, child.resource)))
-			.map(child => fileService.del(child.resource, { recursive: true })));
-	}
-});
-
 registerAction2(class ExportProfileAction extends Action2 {
 	constructor() {
 		super({
@@ -448,4 +423,51 @@ registerAction2(class ImportProfileAction extends Action2 {
 		}
 	}
 
+});
+
+// Developer Actions
+
+registerAction2(class CleanupProfilesAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.profiles.actions.cleanupProfiles',
+			title: {
+				value: localize('cleanup profile', "Cleanup Settings Profiles"),
+				original: 'Cleanup Profiles'
+			},
+			category: CATEGORIES.Developer,
+			f1: true,
+			precondition: PROFILES_ENABLEMENT_CONTEXT,
+		});
+	}
+
+	async run(accessor: ServicesAccessor) {
+		const userDataProfilesService = accessor.get(IUserDataProfilesService);
+		const fileService = accessor.get(IFileService);
+		const uriIdentityService = accessor.get(IUriIdentityService);
+
+		const stat = await fileService.resolve(userDataProfilesService.profilesHome);
+		await Promise.all((stat.children || [])?.filter(child => child.isDirectory && userDataProfilesService.profiles.every(p => !uriIdentityService.extUri.isEqual(p.location, child.resource)))
+			.map(child => fileService.del(child.resource, { recursive: true })));
+	}
+});
+
+registerAction2(class ResetWorkspacesAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.profiles.actions.resetWorkspaces',
+			title: {
+				value: localize('reset workspaces', "Reset Workspace Settings Profiles Associations"),
+				original: 'Reset Workspace Settings Profiles Associations'
+			},
+			category: CATEGORIES.Developer,
+			f1: true,
+			precondition: PROFILES_ENABLEMENT_CONTEXT,
+		});
+	}
+
+	async run(accessor: ServicesAccessor) {
+		const userDataProfilesService = accessor.get(IUserDataProfilesService);
+		return userDataProfilesService.resetWorkspaces();
+	}
 });

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
@@ -28,10 +28,18 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 	) {
 		super();
 		this._register(userDataProfilesService.onDidChangeProfiles(e => this.onDidChangeProfiles(e)));
+		this._register(userDataProfilesService.onDidResetWorkspaces(() => this.onDidResetWorkspaces()));
 	}
 
 	private onDidChangeProfiles(e: DidChangeProfilesEvent): void {
 		if (e.removed.some(profile => profile.id === this.userDataProfileService.currentProfile.id)) {
+			this.enterProfile(this.userDataProfilesService.defaultProfile, false, localize('reload message when removed', "The current settings profile has been removed. Please reload to switch back to default settings profile"));
+			return;
+		}
+	}
+
+	private onDidResetWorkspaces(): void {
+		if (!this.userDataProfileService.currentProfile.isDefault) {
 			this.enterProfile(this.userDataProfilesService.defaultProfile, false, localize('reload message when removed', "The current settings profile has been removed. Please reload to switch back to default settings profile"));
 			return;
 		}


### PR DESCRIPTION
When a workspace is opened for the first time, use the profile from the current window or last active window.

Fixes #153472