### PR TITLE
do not report builtin extensions

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -786,7 +786,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 	}
 	private _reportTelemetry() {
 		const extensionIds = this.installed.filter(extension =>
-			extension.type === ExtensionType.User &&
+			!extension.isBuiltin &&
 			(extension.enablementState === EnablementState.EnabledWorkspace ||
 				extension.enablementState === EnablementState.EnabledGlobally))
 			.map(extension => ExtensionIdentifier.toKey(extension.identifier.id));


### PR DESCRIPTION
It can happen that some extensions are builtin extensions but not system extensions. Eg: `GitHub.remotehub` extension in vscode.dev. We shall not include such extensions in the event.