### PR TITLE
testing: clean up and compact test result storage

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTesting.ts
+++ b/src/vs/workbench/api/browser/mainThreadTesting.ts
@@ -41,17 +41,6 @@ export class MainThreadTesting extends Disposable implements MainThreadTestingSh
 		super();
 		this.proxy = extHostContext.getProxy(ExtHostContext.ExtHostTesting);
 
-		const prevResults = resultService.results.map(r => r.toJSON()).filter(isDefined);
-		if (prevResults.length) {
-			try {
-				this.proxy.$publishTestResults(prevResults);
-			} catch (err) {
-				// See https://github.com/microsoft/vscode/issues/151147
-				// Trying to send more than 1GB of data can cause the method to throw.
-				onUnexpectedError(err);
-			}
-		}
-
 		this._register(this.testService.onDidCancelTestRun(({ runId }) => {
 			this.proxy.$cancelExtensionTestRun(runId);
 		}));

--- a/src/vs/workbench/api/browser/mainThreadTesting.ts
+++ b/src/vs/workbench/api/browser/mainThreadTesting.ts
@@ -7,7 +7,6 @@ import { VSBuffer } from 'vs/base/common/buffer';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { revive } from 'vs/base/common/marshalling';
-import { isDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { Range } from 'vs/editor/common/core/range';
 import { MutableObservableValue } from 'vs/workbench/contrib/testing/common/observableValue';
@@ -19,7 +18,6 @@ import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResu
 import { IMainThreadTestController, ITestRootProvider, ITestService } from 'vs/workbench/contrib/testing/common/testService';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
 import { ExtHostContext, ExtHostTestingShape, ILocationDto, ITestControllerPatch, MainContext, MainThreadTestingShape } from '../common/extHost.protocol';
-import { onUnexpectedError } from 'vs/base/common/errors';
 
 @extHostNamedCustomer(MainContext.MainThreadTesting)
 export class MainThreadTesting extends Disposable implements MainThreadTestingShape, ITestRootProvider {

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByLocation.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByLocation.ts
@@ -105,6 +105,7 @@ export class HierarchicalByLocationProjection extends Disposable implements ITes
 			// children and should trust whatever the result service gives us.
 			const explicitComputed = item.children.size ? undefined : result.computedState;
 
+			item.retired = !!result.retired;
 			item.ownState = result.ownComputedState;
 			item.ownDuration = result.ownDuration;
 
@@ -270,6 +271,7 @@ export class HierarchicalByLocationProjection extends Disposable implements ITes
 
 		const prevState = this.results.getStateById(treeElement.test.item.extId)?.[1];
 		if (prevState) {
+			treeElement.retired = !!prevState.retired;
 			treeElement.ownState = prevState.computedState;
 			treeElement.ownDuration = prevState.ownDuration;
 

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
@@ -120,6 +120,11 @@ export class TestItemTreeElement implements IActionableTestTreeElement {
 	}
 
 	/**
+	 * Whether the node's test result is 'retired' -- from an outdated test run.
+	 */
+	public retired = false;
+
+	/**
 	 * @inheritdoc
 	 */
 	public state = TestResultState.Unset;

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -76,6 +76,11 @@
 	margin-right: 0.25em;
 }
 
+.test-explorer .computed-state.retired,
+.testing-run-glyph.retired {
+	opacity: 0.7  !important;
+}
+
 .test-explorer .test-is-hidden {
 	opacity: 0.8;
 }
@@ -158,7 +163,7 @@
 }
 
 /** -- filter  */
-.testing-filter-action-bar {
+.monaco-action-bar.testing-filter-action-bar {
 	flex-shrink: 0;
 	margin: 4px 12px;
 	height: auto;

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -12,7 +12,6 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { IMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
 import { Disposable, DisposableStore, IReference, MutableDisposable } from 'vs/base/common/lifecycle';
 import { ResourceMap } from 'vs/base/common/map';
-import { removeAnsiEscapeCodes } from 'vs/base/common/strings';
 import { Constants } from 'vs/base/common/uint';
 import { URI } from 'vs/base/common/uri';
 import { generateUuid } from 'vs/base/common/uuid';
@@ -440,6 +439,7 @@ const createRunTestDecoration = (tests: readonly IncrementalTestCollectionItem[]
 	let computedState = TestResultState.Unset;
 	const hoverMessageParts: string[] = [];
 	let testIdWithMessages: string | undefined;
+	let retired = false;
 	for (let i = 0; i < tests.length; i++) {
 		const test = tests[i];
 		const resultItem = states[i];
@@ -448,6 +448,7 @@ const createRunTestDecoration = (tests: readonly IncrementalTestCollectionItem[]
 			hoverMessageParts.push(labelForTestInState(test.item.label, state));
 		}
 		computedState = maxPriority(computedState, state);
+		retired = retired || !!resultItem?.retired;
 		if (!testIdWithMessages && resultItem?.tasks.some(t => t.messages.length)) {
 			testIdWithMessages = test.item.extId;
 		}
@@ -460,7 +461,10 @@ const createRunTestDecoration = (tests: readonly IncrementalTestCollectionItem[]
 
 	let hoverMessage: IMarkdownString | undefined;
 
-	const glyphMarginClassName = ThemeIcon.asClassName(icon) + ' testing-run-glyph';
+	let glyphMarginClassName = ThemeIcon.asClassName(icon) + ' testing-run-glyph';
+	if (retired) {
+		glyphMarginClassName += ' retired';
+	}
 
 	return {
 		range: firstLineRange(range),
@@ -901,7 +905,7 @@ class TestMessageDecoration implements ITestDecoration {
 		this.location = testMessage.location!;
 		this.line = this.location.range.startLineNumber;
 		const severity = testMessage.type;
-		const message = typeof testMessage.message === 'string' ? removeAnsiEscapeCodes(testMessage.message) : testMessage.message;
+		const message = testMessage.message;
 
 		const options = editorService.resolveDecorationOptions(TestMessageDecoration.decorationId, true);
 		options.hoverMessage = typeof message === 'string' ? new MarkdownString().appendText(message) : message;

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -1015,6 +1015,13 @@ const getLabelForTestTreeElement = (element: TestItemTreeElement) => {
 				comment: ['{0} is the original label in testing.treeElementLabel, {1} is a duration'],
 			}, '{0}, in {1}', label, formatDuration(element.duration));
 		}
+
+		if (element.retired) {
+			label = localize({
+				key: 'testing.treeElementLabelOutdated',
+				comment: ['{0} is the original label in testing.treeElementLabel'],
+			}, '{0}, outdated result', label);
+		}
 	}
 
 	return label;
@@ -1201,6 +1208,9 @@ class TestItemRenderer extends ActionableItemTemplateData<TestItemTreeElement> {
 				: node.element.state);
 
 		data.icon.className = 'computed-state ' + (icon ? ThemeIcon.asClassName(icon) : '');
+		if (node.element.retired) {
+			data.icon.className += ' retired';
+		}
 
 		data.label.title = getLabelForTestTreeElement(node.element);
 		dom.reset(data.label, ...renderLabelWithIcons(node.element.label));

--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -27,7 +27,7 @@ import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Lazy } from 'vs/base/common/lazy';
 import { Disposable, DisposableStore, IDisposable, IReference, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { clamp } from 'vs/base/common/numbers';
-import { count, removeAnsiEscapeCodes } from 'vs/base/common/strings';
+import { count } from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
 import { ICodeEditor, IDiffEditorConstructionOptions, isCodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorAction2 } from 'vs/editor/browser/editorExtensions';
@@ -1165,7 +1165,7 @@ class TestMessageElement implements ITreeElement {
 		public readonly taskIndex: number,
 		public readonly messageIndex: number,
 	) {
-		const { type, message, location } = test.tasks[taskIndex].messages[messageIndex];
+		const { message, location } = test.tasks[taskIndex].messages[messageIndex];
 
 		this.location = location;
 		this.uri = this.context = buildTestUri({
@@ -1178,9 +1178,7 @@ class TestMessageElement implements ITreeElement {
 
 		this.id = this.uri.toString();
 
-		const asPlaintext = type === TestMessageType.Output
-			? removeAnsiEscapeCodes(message)
-			: renderStringAsPlaintext(message);
+		const asPlaintext = renderStringAsPlaintext(message);
 		const lines = count(asPlaintext.trimRight(), '\n');
 		this.label = firstLine(asPlaintext);
 		if (lines > 0) {

--- a/src/vs/workbench/contrib/testing/browser/testingOutputTerminalService.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputTerminalService.ts
@@ -113,7 +113,7 @@ export class TestingOutputTerminalService implements ITestingOutputTerminalServi
 				icon: testingViewIcon,
 				customPtyImplementation: () => output,
 				name: getTitle(result),
-			}
+			},
 		}), output, result);
 	}
 

--- a/src/vs/workbench/contrib/testing/test/common/testResultStorage.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultStorage.test.ts
@@ -6,7 +6,6 @@
 import * as assert from 'assert';
 import { range } from 'vs/base/common/arrays';
 import { NullLogService } from 'vs/platform/log/common/log';
-import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { ITestResult, LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { InMemoryResultStorage, RETAIN_MAX_RESULTS } from 'vs/workbench/contrib/testing/common/testResultStorage';
 import { emptyOutputController } from 'vs/workbench/contrib/testing/test/common/testResultService.test';
@@ -16,7 +15,7 @@ import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServic
 suite('Workbench - Test Result Storage', () => {
 	let storage: InMemoryResultStorage;
 
-	const makeResult = (addMessage?: string) => {
+	const makeResult = (taskName = 't') => {
 		const t = new LiveTestResult(
 			'',
 			emptyOutputController(),
@@ -24,7 +23,7 @@ suite('Workbench - Test Result Storage', () => {
 			{ targets: [] }
 		);
 
-		t.addTask({ id: 't', name: undefined, running: true });
+		t.addTask({ id: taskName, name: undefined, running: true });
 		const tests = testStubs.nested();
 		tests.expand(tests.root.id, Infinity);
 		t.addTestChainToRun('ctrlId', [
@@ -33,15 +32,6 @@ suite('Workbench - Test Result Storage', () => {
 			tests.root.children.get('id-a')!.children.get('id-aa')!.toTestItem(),
 		]);
 
-		if (addMessage) {
-			t.appendMessage(new TestId(['ctrlId', 'id-a']).toString(), 't', {
-				message: addMessage,
-				actual: undefined,
-				expected: undefined,
-				location: undefined,
-				type: 0,
-			});
-		}
 		t.markComplete();
 		return t;
 	};


### PR DESCRIPTION
This PR does several chore things around test results:

- Removes the persistence of test messages, which should reduce the
  size of stored results significantly (we only keep the state). This
  is the same as what IntelliJ does with some cursory testing, and I
  think it makes sense.
- Brings back some of the notion of 'outdated' tests, so previously
  executed tests are shown in a more muted color. This is useful since
  they no longer are "full" results, and are instead just messages.
- Previous results are no longer 'restored' to the extension host on
  boot, which directly fixes #151147
- Compacts the storage of terminal output: we'll now only keep the first
  100 bytes of any terminal output associated with the test, and read
  from the disk on-demand when the full message is viewed.

Later I want to make terminal messages fancier (see the #terminal channel).

Fixes https://github.com/microsoft/vscode/issues/154204 as well