### PR TITLE
up timeout to 5min

### DIFF
--- a/extensions/github-authentication/src/githubServer.ts
+++ b/extensions/github-authentication/src/githubServer.ts
@@ -243,7 +243,7 @@ export class GitHubServer implements IGitHubServer {
 			try {
 				return await Promise.race([
 					codeExchangePromise.promise,
-					new Promise<string>((_, reject) => setTimeout(() => reject('Cancelled'), 60000)),
+					new Promise<string>((_, reject) => setTimeout(() => reject('Timed out'), 300_000)), // 5min timeout
 					promiseFromEvent<any, any>(token.onCancellationRequested, (_, __, reject) => { reject('User Cancelled'); }).promise
 				]);
 			} finally {
@@ -276,7 +276,7 @@ export class GitHubServer implements IGitHubServer {
 				vscode.env.openExternal(vscode.Uri.parse(`http://127.0.0.1:${port}/signin?nonce=${encodeURIComponent(server.nonce)}`));
 				const { code } = await Promise.race([
 					server.waitForOAuthResponse(),
-					new Promise<any>((_, reject) => setTimeout(() => reject('Cancelled'), 60000)),
+					new Promise<any>((_, reject) => setTimeout(() => reject('Timed out'), 300_000)), // 5min timeout
 					promiseFromEvent<any, any>(token.onCancellationRequested, (_, __, reject) => { reject('User Cancelled'); }).promise
 				]);
 				codeToExchange = code;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

1min isn't long enough. For me to access the Microsoft/vscode repo fresh with GitHub Repositories extension, I have to do:

1. Login to password manager
2. fill username in password into GitHub login page
3. 2FA using Yubikey
4. Start SAML flow for Microsoft org
5. fill username and password of Corp Microsoft account
6. Phone authenticator for Corp Microsoft account
7. redirect back to GitHub on success
8. continue on SAML page
9. redirect to vscode.dev to finally complete the login

If I forget my Yubikey downstairs, forget it. So 5min should be a bit friendlier.