### PR TITLE
Include directory of notebook in local resources roots

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -884,11 +884,13 @@ var requirejs = (function() {
 
 	private _createInset(webviewService: IWebviewService, content: string) {
 		const workspaceFolders = this.contextService.getWorkspace().folders.map(x => x.uri);
+		const notebookDir = dirname(this.documentUri);
 
 		this.localResourceRootsCache = [
 			...this.notebookService.getNotebookProviderResourceRoots(),
 			...this.notebookService.getRenderers().map(x => dirname(x.entrypoint)),
 			...workspaceFolders,
+			notebookDir,
 			...this.getBuiltinLocalResourceRoots(),
 		];
 		const webview = webviewService.createWebviewElement({


### PR DESCRIPTION
Fixes #156815

This is also how the markdown preview operates: https://github.com/microsoft/vscode/blob/3b549009fe133f5b98f1fd9c8d3116dbd033dbe9/extensions/markdown-language-features/src/preview/preview.ts#L442

