### PR TITLE
enable task reconnection by default and fix for windows

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -351,6 +351,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	private async _reconnectTasks(): Promise<void> {
 		const tasks = await this.getSavedTasks('persistent');
 		if (!tasks.length) {
+			this._tasksReconnected = true;
 			return;
 		}
 		for (const task of tasks) {
@@ -1067,7 +1068,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	}
 
 	private async _setPersistentTask(task: Task): Promise<void> {
-		if (!task.configurationProperties.isBackground || !this._tasksReconnected) {
+		if (!task.configurationProperties.problemMatchers || !this._tasksReconnected) {
 			return;
 		}
 		let key = task.getRecentlyUsedKey();

--- a/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
@@ -515,9 +515,8 @@ configurationRegistry.registerConfiguration({
 		},
 		[TaskSettingId.Reconnection]: {
 			type: 'boolean',
-			description: nls.localize('task.experimental.reconnection', "On window reload, reconnect to running watch/background tasks. Note that this is experimental, so you could encounter issues."),
-			default: false,
-			tags: ['experimental']
+			description: nls.localize('task.reconnection', "On window reload, reconnect to tasks that have problem matchers."),
+			default: true
 		},
 		[TaskSettingId.SaveBeforeRun]: {
 			markdownDescription: nls.localize(


### PR DESCRIPTION
fixes #156899

The problem was:
1. Watch tasks on windows have `isBackground` false, so now check if `problemMatchers` are defined instead. 
@alexr00 should I also ensure that the length of the `problemMatchers` is greater than 0?
2. I was returning and not setting `tasksReconnected` to true when there were initially 0. 