### PR TITLE
allow generic marker only decorations while terminal decorations are disabled

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -147,13 +147,17 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 	}
 
 	private _updateGutterDecorationVisibility(): void {
-		const commandDecorationElements = document.querySelectorAll(DecorationSelector.CommandDecoration);
+		const commandDecorationElements = document.querySelectorAll(`.${DecorationSelector.CommandDecoration}:not(.${DecorationSelector.GenericMarkerIcon})`);
 		for (const commandDecorationElement of commandDecorationElements) {
 			this._updateCommandDecorationVisibility(commandDecorationElement);
 		}
 	}
 
 	private _updateCommandDecorationVisibility(commandDecorationElement: Element): void {
+		if (commandDecorationElement.classList.contains(DecorationSelector.GenericMarkerIcon)) {
+			// we always show gutter decorations for generic markers ATM
+			return;
+		}
 		if (this._showGutterDecorations) {
 			commandDecorationElement.classList.remove(DecorationSelector.Hide);
 		} else {
@@ -279,7 +283,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 		}
 		const decoration = this._terminal.registerDecoration({
 			marker: command.marker,
-			overviewRulerOptions: this._showOverviewRulerDecorations ? (beforeCommandExecution
+			overviewRulerOptions: this._showOverviewRulerDecorations || this._showGenericDecorations && command.genericMarkProperties ? (beforeCommandExecution
 				? { color, position: 'left' }
 				: { color, position: command.exitCode ? 'right' : 'left' }) : undefined
 		});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #156728

While this fixes the issue, some things we need to think about:
- should the setting for this be generic instead of task specific or will we allow configuring this for each generic marker contributor?
- should we support `gutter` | `overviewRuler` | `both` | `never` for `tasks.showDecorations` or is that overkill?
