### PR TITLE
Use optional chaining for more method calls

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1149,9 +1149,7 @@ export function removeTabIndexAndUpdateFocus(node: HTMLElement): void {
 	// in the hierarchy of the parent DOM nodes.
 	if (document.activeElement === node) {
 		const parentFocusable = findParentWithAttribute(node.parentElement, 'tabIndex');
-		if (parentFocusable) {
-			parentFocusable.focus();
-		}
+		parentFocusable?.focus();
 	}
 
 	node.removeAttribute('tabindex');

--- a/src/vs/base/browser/indexedDB.ts
+++ b/src/vs/base/browser/indexedDB.ts
@@ -106,9 +106,7 @@ export class IndexedDB {
 		if (this.pendingTransactions.length) {
 			this.pendingTransactions.splice(0, this.pendingTransactions.length).forEach(transaction => transaction.abort());
 		}
-		if (this.database) {
-			this.database.close();
-		}
+		this.database?.close();
 		this.database = null;
 	}
 

--- a/src/vs/base/browser/mouseEvent.ts
+++ b/src/vs/base/browser/mouseEvent.ts
@@ -211,14 +211,10 @@ export class StandardWheelEvent {
 	}
 
 	public preventDefault(): void {
-		if (this.browserEvent) {
-			this.browserEvent.preventDefault();
-		}
+		this.browserEvent?.preventDefault();
 	}
 
 	public stopPropagation(): void {
-		if (this.browserEvent) {
-			this.browserEvent.stopPropagation();
-		}
+		this.browserEvent?.stopPropagation();
 	}
 }

--- a/src/vs/base/browser/ui/actionbar/actionViewItems.ts
+++ b/src/vs/base/browser/ui/actionbar/actionViewItems.ts
@@ -439,15 +439,11 @@ export class SelectActionViewItem extends BaseActionViewItem {
 	}
 
 	override focus(): void {
-		if (this.selectBox) {
-			this.selectBox.focus();
-		}
+		this.selectBox?.focus();
 	}
 
 	override blur(): void {
-		if (this.selectBox) {
-			this.selectBox.blur();
-		}
+		this.selectBox?.blur();
 	}
 
 	override render(container: HTMLElement): void {

--- a/src/vs/base/browser/ui/centered/centeredViewLayout.ts
+++ b/src/vs/base/browser/ui/centered/centeredViewLayout.ts
@@ -159,9 +159,7 @@ export class CenteredViewLayout implements IDisposable {
 				this.container.removeChild(this.splitView.el);
 			}
 			this.splitViewDisposables.clear();
-			if (this.splitView) {
-				this.splitView.dispose();
-			}
+			this.splitView?.dispose();
 			this.splitView = undefined;
 			this.emptyViews = undefined;
 			this.container.appendChild(this.view.element);

--- a/src/vs/base/browser/ui/dropdown/dropdown.ts
+++ b/src/vs/base/browser/ui/dropdown/dropdown.ts
@@ -192,9 +192,7 @@ export class Dropdown extends BaseDropdown {
 	override hide(): void {
 		super.hide();
 
-		if (this.contextViewProvider) {
-			this.contextViewProvider.hideContextView();
-		}
+		this.contextViewProvider?.hideContextView();
 	}
 
 	protected renderContents(container: HTMLElement): IDisposable | null {

--- a/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
+++ b/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
@@ -155,9 +155,7 @@ export class DropdownMenuActionViewItem extends BaseActionViewItem {
 	}
 
 	show(): void {
-		if (this.dropdownMenu) {
-			this.dropdownMenu.show();
-		}
+		this.dropdownMenu?.show();
 	}
 
 	protected override updateEnabled(): void {

--- a/src/vs/base/browser/ui/findinput/replaceInput.ts
+++ b/src/vs/base/browser/ui/findinput/replaceInput.ts
@@ -353,9 +353,7 @@ export class ReplaceInput extends Widget {
 	}
 
 	public validate(): void {
-		if (this.inputBox) {
-			this.inputBox.validate();
-		}
+		this.inputBox?.validate();
 	}
 
 	public showMessage(message: InputBoxMessage): void {
@@ -363,15 +361,11 @@ export class ReplaceInput extends Widget {
 	}
 
 	public clearMessage(): void {
-		if (this.inputBox) {
-			this.inputBox.hideMessage();
-		}
+		this.inputBox?.hideMessage();
 	}
 
 	private clearValidation(): void {
-		if (this.inputBox) {
-			this.inputBox.hideMessage();
-		}
+		this.inputBox?.hideMessage();
 	}
 
 	public set width(newWidth: number) {

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -621,9 +621,7 @@ export class InputBox extends Widget {
 
 		this.message = null;
 
-		if (this.actionbar) {
-			this.actionbar.dispose();
-		}
+		this.actionbar?.dispose();
 
 		super.dispose();
 	}

--- a/src/vs/base/browser/ui/list/listPaging.ts
+++ b/src/vs/base/browser/ui/list/listPaging.ts
@@ -38,9 +38,7 @@ class PagedRenderer<TElement, TTemplateData> implements IListRenderer<number, IT
 	}
 
 	renderElement(index: number, _: number, data: ITemplateData<TTemplateData>, height: number | undefined): void {
-		if (data.disposable) {
-			data.disposable.dispose();
-		}
+		data.disposable?.dispose();
 
 		if (!data.data) {
 			return;

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1528,9 +1528,7 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 	}
 
 	triggerTypeNavigation(): void {
-		if (this.typeNavigationController) {
-			this.typeNavigationController.trigger();
-		}
+		this.typeNavigationController?.trigger();
 	}
 
 	setSelection(indexes: number[], browserEvent?: UIEvent): void {

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -552,9 +552,7 @@ class BaseMenuActionViewItem extends BaseActionViewItem {
 	override focus(): void {
 		super.focus();
 
-		if (this.item) {
-			this.item.focus();
-		}
+		this.item?.focus();
 
 		this.applyStyle();
 	}

--- a/src/vs/base/browser/ui/menu/menubar.ts
+++ b/src/vs/base/browser/ui/menu/menubar.ts
@@ -985,9 +985,7 @@ export class MenuBar extends Disposable {
 				this.focusedMenu.holder.remove();
 			}
 
-			if (this.focusedMenu.widget) {
-				this.focusedMenu.widget.dispose();
-			}
+			this.focusedMenu.widget?.dispose();
 
 			this.focusedMenu = { index: this.focusedMenu.index };
 		}

--- a/src/vs/base/common/cancellation.ts
+++ b/src/vs/base/common/cancellation.ts
@@ -129,9 +129,7 @@ export class CancellationTokenSource {
 		if (cancel) {
 			this.cancel();
 		}
-		if (this._parentListener) {
-			this._parentListener.dispose();
-		}
+		this._parentListener?.dispose();
 		if (!this._token) {
 			// ensure to initialize with an empty token if we had none
 			this._token = CancellationToken.None;

--- a/src/vs/base/node/zip.ts
+++ b/src/vs/base/node/zip.ts
@@ -81,9 +81,7 @@ function extractEntry(stream: Readable, fileName: string, mode: number, targetPa
 	let istream: WriteStream;
 
 	token.onCancellationRequested(() => {
-		if (istream) {
-			istream.destroy();
-		}
+		istream?.destroy();
 	});
 
 	return Promise.resolve(Promises.mkdir(targetDirName, { recursive: true })).then(() => new Promise<void>((c, e) => {

--- a/src/vs/base/parts/ipc/electron-main/ipc.electron.ts
+++ b/src/vs/base/parts/ipc/electron-main/ipc.electron.ts
@@ -37,9 +37,7 @@ export class Server extends IPCServer {
 			const id = webContents.id;
 			const client = Server.Clients.get(id);
 
-			if (client) {
-				client.dispose();
-			}
+			client?.dispose();
 
 			const onDidClientReconnect = new Emitter<void>();
 			Server.Clients.set(id, toDisposable(() => onDidClientReconnect.fire()));

--- a/src/vs/base/parts/ipc/node/ipc.cp.ts
+++ b/src/vs/base/parts/ipc/node/ipc.cp.ts
@@ -241,9 +241,7 @@ export class Client implements IChannelClient, IDisposable {
 					console.warn('IPC "' + this.options.serverName + '" crashed with exit code ' + code + ' and signal ' + signal);
 				}
 
-				if (this.disposeDelayer) {
-					this.disposeDelayer.cancel();
-				}
+				this.disposeDelayer?.cancel();
 				this.disposeClient();
 				this._onDidProcessExit.fire({ code, signal });
 			});

--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1610,9 +1610,7 @@ export class QuickInputController extends Disposable {
 		this.onShowEmitter.fire();
 		const oldController = this.controller;
 		this.controller = controller;
-		if (oldController) {
-			oldController.didHide();
-		}
+		oldController?.didHide();
 
 		this.setEnabled(true);
 		ui.leftActionBar.clear();

--- a/src/vs/base/test/browser/indexedDB.test.ts
+++ b/src/vs/base/test/browser/indexedDB.test.ts
@@ -16,9 +16,7 @@ flakySuite('IndexedDB', () => {
 	});
 
 	teardown(() => {
-		if (indexedDB) {
-			indexedDB.close();
-		}
+		indexedDB?.close();
 	});
 
 	test('runInTransaction', async () => {

--- a/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
@@ -151,14 +151,10 @@ export class IssueReporter extends Disposable {
 		const { fileOnExtension } = this.issueReporterModel.getData();
 		if (fileOnExtension) {
 			const issueTitle = document.getElementById('issue-title');
-			if (issueTitle) {
-				issueTitle.focus();
-			}
+			issueTitle?.focus();
 		} else {
 			const issueType = document.getElementById('issue-type');
-			if (issueType) {
-				issueType.focus();
-			}
+			issueType?.focus();
 		}
 	}
 

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -1324,9 +1324,7 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 	}
 
 	private _setStrategy(newStrategy: DiffEditorWidgetStyle): void {
-		if (this._strategy) {
-			this._strategy.dispose();
-		}
+		this._strategy?.dispose();
 
 		this._strategy = newStrategy;
 		newStrategy.applyColors(this._themeService.getColorTheme());

--- a/src/vs/editor/browser/widget/diffReview.ts
+++ b/src/vs/editor/browser/widget/diffReview.ts
@@ -846,9 +846,7 @@ class DiffReviewNext extends EditorAction {
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
 		const diffEditor = findFocusedDiffEditor(accessor);
-		if (diffEditor) {
-			diffEditor.diffReviewNext();
-		}
+		diffEditor?.diffReviewNext();
 	}
 }
 
@@ -869,9 +867,7 @@ class DiffReviewPrev extends EditorAction {
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
 		const diffEditor = findFocusedDiffEditor(accessor);
-		if (diffEditor) {
-			diffEditor.diffReviewPrev();
-		}
+		diffEditor?.diffReviewPrev();
 	}
 }
 

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -761,13 +761,9 @@ export class ViewModel extends Disposable implements IViewModel {
 		const decorations = this.model.getOverviewRulerDecorations();
 		for (const decoration of decorations) {
 			const opts1 = <ModelDecorationOverviewRulerOptions>decoration.options.overviewRuler;
-			if (opts1) {
-				opts1.invalidateCachedColor();
-			}
+			opts1?.invalidateCachedColor();
 			const opts2 = <ModelDecorationMinimapOptions>decoration.options.minimap;
-			if (opts2) {
-				opts2.invalidateCachedColor();
-			}
+			opts2?.invalidateCachedColor();
 		}
 	}
 

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -245,17 +245,13 @@ export class FoldingController extends Disposable implements IEditorContribution
 					this.foldingRegionPromise.cancel();
 					this.foldingRegionPromise = null;
 				}
-				if (this.updateScheduler) {
-					this.updateScheduler.cancel();
-				}
+				this.updateScheduler?.cancel();
 				this.updateScheduler = null;
 				this.foldingModel = null;
 				this.foldingModelPromise = null;
 				this.hiddenRangeModel = null;
 				this.cursorChangedScheduler = null;
-				if (this.rangeProvider) {
-					this.rangeProvider.dispose();
-				}
+				this.rangeProvider?.dispose();
 				this.rangeProvider = null;
 			}
 		});
@@ -263,9 +259,7 @@ export class FoldingController extends Disposable implements IEditorContribution
 	}
 
 	private onFoldingStrategyChanged() {
-		if (this.rangeProvider) {
-			this.rangeProvider.dispose();
-		}
+		this.rangeProvider?.dispose();
 		this.rangeProvider = null;
 		this.triggerFoldingModelChanged();
 	}

--- a/src/vs/editor/contrib/gotoSymbol/browser/peek/referencesController.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/peek/referencesController.ts
@@ -238,9 +238,7 @@ export abstract class ReferencesController implements IEditorContribution {
 	}
 
 	private _gotoReference(ref: Location): Promise<any> {
-		if (this._widget) {
-			this._widget.hide();
-		}
+		this._widget?.hide();
 
 		this._ignoreModelChangeEvent = true;
 		const range = Range.lift(ref.range).collapseToStart();

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -428,9 +428,7 @@ export class ContentHoverWidget extends Disposable implements IContentWidget {
 		if (visibleData.stoleFocus) {
 			this._hover.containerDomNode.focus();
 		}
-		if (visibleData.colorPicker) {
-			visibleData.colorPicker.layout();
-		}
+		visibleData.colorPicker?.layout();
 	}
 
 	public hide(): void {

--- a/src/vs/editor/contrib/inPlaceReplace/browser/inPlaceReplace.ts
+++ b/src/vs/editor/contrib/inPlaceReplace/browser/inPlaceReplace.ts
@@ -56,9 +56,7 @@ class InPlaceReplaceController implements IEditorContribution {
 	public run(source: string, up: boolean): Promise<void> | undefined {
 
 		// cancel any pending request
-		if (this.currentRequest) {
-			this.currentRequest.cancel();
-		}
+		this.currentRequest?.cancel();
 
 		const editorSelection = this.editor.getSelection();
 		const model = this.editor.getModel();
@@ -121,9 +119,7 @@ class InPlaceReplaceController implements IEditorContribution {
 			}]);
 
 			// remove decoration after delay
-			if (this.decorationRemover) {
-				this.decorationRemover.cancel();
-			}
+			this.decorationRemover?.cancel();
 			this.decorationRemover = timeout(350);
 			this.decorationRemover.then(() => this.decorations.clear()).catch(onUnexpectedError);
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/ghostTextController.ts
@@ -247,8 +247,6 @@ export class TriggerInlineSuggestionAction extends EditorAction {
 
 	public async run(accessor: ServicesAccessor | undefined, editor: ICodeEditor): Promise<void> {
 		const controller = GhostTextController.get(editor);
-		if (controller) {
-			controller.trigger();
-		}
+		controller?.trigger();
 	}
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/suggestWidgetInlineCompletionProvider.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/suggestWidgetInlineCompletionProvider.ts
@@ -182,16 +182,12 @@ export class SuggestWidgetInlineCompletionProvider extends Disposable {
 
 	public stopForceRenderingAbove(): void {
 		const suggestController = SuggestController.get(this.editor);
-		if (suggestController) {
-			suggestController.stopForceRenderingAbove();
-		}
+		suggestController?.stopForceRenderingAbove();
 	}
 
 	public forceRenderingAbove(): void {
 		const suggestController = SuggestController.get(this.editor);
-		if (suggestController) {
-			suggestController.forceRenderingAbove();
-		}
+		suggestController?.forceRenderingAbove();
 	}
 }
 

--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -280,16 +280,12 @@ export class SnippetController2 implements IEditorContribution {
 	}
 
 	prev(): void {
-		if (this._session) {
-			this._session.prev();
-		}
+		this._session?.prev();
 		this._updateState();
 	}
 
 	next(): void {
-		if (this._session) {
-			this._session.next();
-		}
+		this._session?.next();
 		this._updateState();
 	}
 

--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -550,15 +550,11 @@ class WordHighlighterContribution extends Disposable implements IEditorContribut
 	}
 
 	public moveNext() {
-		if (this.wordHighlighter) {
-			this.wordHighlighter.moveNext();
-		}
+		this.wordHighlighter?.moveNext();
 	}
 
 	public moveBack() {
-		if (this.wordHighlighter) {
-			this.wordHighlighter.moveBack();
-		}
+		this.wordHighlighter?.moveBack();
 	}
 
 	public restoreViewState(state: boolean | undefined): void {

--- a/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
+++ b/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
@@ -287,9 +287,7 @@ export abstract class ZoneWidget implements IHorizontalSashLayoutProvider {
 			this._doLayout(containerHeight, this._getWidth(layoutInfo));
 		}
 
-		if (this._resizeSash) {
-			this._resizeSash.layout();
-		}
+		this._resizeSash?.layout();
 	}
 
 	get position(): Position | undefined {
@@ -323,9 +321,7 @@ export abstract class ZoneWidget implements IHorizontalSashLayoutProvider {
 			this.editor.removeOverlayWidget(this._overlayWidget);
 			this._overlayWidget = null;
 		}
-		if (this._arrow) {
-			this._arrow.hide();
-		}
+		this._arrow?.hide();
 	}
 
 	private _decoratingElementsHeight(): number {

--- a/src/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.ts
+++ b/src/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.ts
@@ -340,9 +340,7 @@ class ShowAccessibilityHelpAction extends EditorAction {
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
 		const controller = AccessibilityHelpController.get(editor);
-		if (controller) {
-			controller.show();
-		}
+		controller?.show();
 	}
 }
 

--- a/src/vs/editor/standalone/browser/inspectTokens/inspectTokens.ts
+++ b/src/vs/editor/standalone/browser/inspectTokens/inspectTokens.ts
@@ -89,9 +89,7 @@ class InspectTokens extends EditorAction {
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
 		const controller = InspectTokensController.get(editor);
-		if (controller) {
-			controller.launch();
-		}
+		controller?.launch();
 	}
 }
 

--- a/src/vs/platform/contextview/browser/contextMenuHandler.ts
+++ b/src/vs/platform/contextview/browser/contextMenuHandler.ts
@@ -134,9 +134,7 @@ export class ContextMenuHandler {
 					this.block = null;
 				}
 
-				if (this.focusToReturn) {
-					this.focusToReturn.focus();
-				}
+				this.focusToReturn?.focus();
 			}
 		}, shadowRootElement, !!shadowRootElement);
 	}
@@ -147,9 +145,7 @@ export class ContextMenuHandler {
 		this.contextViewService.hideContextView(false);
 
 		// Restore focus here
-		if (this.focusToReturn) {
-			this.focusToReturn.focus();
-		}
+		this.focusToReturn?.focus();
 	}
 
 	private onDidActionRun(e: IRunEvent): void {

--- a/src/vs/platform/history/browser/contextScopedHistoryWidget.ts
+++ b/src/vs/platform/history/browser/contextScopedHistoryWidget.ts
@@ -118,9 +118,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	primary: KeyCode.UpArrow,
 	secondary: [KeyMod.Alt | KeyCode.UpArrow],
 	handler: (accessor) => {
-		if (lastFocusedWidget) {
-			lastFocusedWidget.showPreviousValue();
-		}
+		lastFocusedWidget?.showPreviousValue();
 	}
 });
 
@@ -135,8 +133,6 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	primary: KeyCode.DownArrow,
 	secondary: [KeyMod.Alt | KeyCode.DownArrow],
 	handler: (accessor) => {
-		if (lastFocusedWidget) {
-			lastFocusedWidget.showNextValue();
-		}
+		lastFocusedWidget?.showNextValue();
 	}
 });

--- a/src/vs/platform/issue/electron-main/issueMainService.ts
+++ b/src/vs/platform/issue/electron-main/issueMainService.ts
@@ -176,15 +176,11 @@ export class IssueMainService implements ICommonIssueService {
 		});
 
 		validatedIpcMain.on('vscode:closeIssueReporter', event => {
-			if (this.issueReporterWindow) {
-				this.issueReporterWindow.close();
-			}
+			this.issueReporterWindow?.close();
 		});
 
 		validatedIpcMain.on('vscode:closeProcessExplorer', event => {
-			if (this.processExplorerWindow) {
-				this.processExplorerWindow.close();
-			}
+			this.processExplorerWindow?.close();
 		});
 
 		validatedIpcMain.on('vscode:windowsInfoRequest', async event => {

--- a/src/vs/platform/log/common/bufferLog.ts
+++ b/src/vs/platform/log/common/bufferLog.ts
@@ -81,14 +81,10 @@ export class BufferLogService extends AbstractLogger implements ILogService {
 	}
 
 	override dispose(): void {
-		if (this._logger) {
-			this._logger.dispose();
-		}
+		this._logger?.dispose();
 	}
 
 	flush(): void {
-		if (this._logger) {
-			this._logger.flush();
-		}
+		this._logger?.flush();
 	}
 }

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -173,16 +173,12 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 
 	async toggleFullScreen(windowId: number | undefined): Promise<void> {
 		const window = this.windowById(windowId);
-		if (window) {
-			window.toggleFullScreen();
-		}
+		window?.toggleFullScreen();
 	}
 
 	async handleTitleDoubleClick(windowId: number | undefined): Promise<void> {
 		const window = this.windowById(windowId);
-		if (window) {
-			window.handleTitleDoubleClick();
-		}
+		window?.handleTitleDoubleClick();
 	}
 
 	async isMaximized(windowId: number | undefined): Promise<boolean> {
@@ -665,9 +661,7 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 
 	async notifyReady(windowId: number | undefined): Promise<void> {
 		const window = this.windowById(windowId);
-		if (window) {
-			window.setReady();
-		}
+		window?.setReady();
 	}
 
 	async relaunch(windowId: number | undefined, options?: { addArgs?: string[]; removeArgs?: string[] }): Promise<void> {

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -333,9 +333,7 @@ async function connectToRemoteExtensionHostAgentAndReadOneMessage<T>(options: IS
 			}
 			result.reject(error);
 		} else {
-			if (options.reconnectionProtocol) {
-				options.reconnectionProtocol.endAcceptReconnection();
-			}
+			options.reconnectionProtocol?.endAcceptReconnection();
 			options.logService.trace(`${logPrefix} 6/6. handshake finished, connection is up and running after ${logElapsed(startTime)}!`);
 			result.resolve({ protocol, firstMessage: msg });
 		}

--- a/src/vs/platform/sharedProcess/electron-browser/sharedProcessWorkerMain.ts
+++ b/src/vs/platform/sharedProcess/electron-browser/sharedProcessWorkerMain.ts
@@ -102,9 +102,7 @@ class SharedProcessWorkerMain {
 
 	private terminate(configuration: ISharedProcessWorkerConfiguration): void {
 		const processDisposable = this.processes.get(hash(configuration));
-		if (processDisposable) {
-			processDisposable.dispose();
-		}
+		processDisposable?.dispose();
 	}
 }
 

--- a/src/vs/platform/terminal/common/terminalDataBuffering.ts
+++ b/src/vs/platform/terminal/common/terminalDataBuffering.ts
@@ -51,9 +51,7 @@ export class TerminalDataBufferer implements IDisposable {
 
 	stopBuffering(id: number) {
 		const buffer = this._terminalBufferMap.get(id);
-		if (buffer) {
-			buffer.dispose();
-		}
+		buffer?.dispose();
 	}
 
 	flushBuffer(id: number): void {

--- a/src/vs/platform/tunnel/node/tunnelService.ts
+++ b/src/vs/platform/tunnel/node/tunnelService.ts
@@ -20,9 +20,7 @@ import { ISignService } from 'vs/platform/sign/common/sign';
 async function createRemoteTunnel(options: IConnectionOptions, defaultTunnelHost: string, tunnelRemoteHost: string, tunnelRemotePort: number, tunnelLocalPort?: number): Promise<RemoteTunnel> {
 	let readyTunnel: NodeRemoteTunnel | undefined;
 	for (let attempts = 3; attempts; attempts--) {
-		if (readyTunnel) {
-			readyTunnel.dispose();
-		}
+		readyTunnel?.dispose();
 		const tunnel = new NodeRemoteTunnel(options, defaultTunnelHost, tunnelRemoteHost, tunnelRemotePort, tunnelLocalPort);
 		readyTunnel = await tunnel.waitForReady();
 		if ((tunnelLocalPort && BROWSER_RESTRICTED_PORTS[tunnelLocalPort]) || !BROWSER_RESTRICTED_PORTS[readyTunnel.tunnelLocalPort]) {

--- a/src/vs/platform/userDataSync/common/userDataAutoSyncService.ts
+++ b/src/vs/platform/userDataSync/common/userDataAutoSyncService.ts
@@ -408,9 +408,7 @@ class AutoSync extends Disposable {
 				this.logService.info('Auto sync: Cancelled sync that is in progress');
 				this.syncPromise = undefined;
 			}
-			if (this.syncTask) {
-				this.syncTask.stop();
-			}
+			this.syncTask?.stop();
 			this.logService.info('Auto Sync: Stopped');
 		}));
 		this.logService.info('Auto Sync: Started');

--- a/src/vs/platform/userDataSync/common/userDataSyncService.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncService.ts
@@ -118,9 +118,7 @@ export class UserDataSyncService extends Disposable implements IUserDataSyncServ
 				return cancellablePromise.finally(() => cancellablePromise = undefined);
 			},
 			async stop(): Promise<void> {
-				if (cancellablePromise) {
-					cancellablePromise.cancel();
-				}
+				cancellablePromise?.cancel();
 				if (that.status !== SyncStatus.Idle) {
 					return that.stop(synchronizers);
 				}

--- a/src/vs/platform/windows/electron-main/window.ts
+++ b/src/vs/platform/windows/electron-main/window.ts
@@ -1408,9 +1408,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 	}
 
 	close(): void {
-		if (this._win) {
-			this._win.close();
-		}
+		this._win?.close();
 	}
 
 	sendWhenReady(channel: string, token: CancellationToken, ...args: any[]): void {

--- a/src/vs/workbench/api/browser/mainThreadDocumentContentProviders.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentContentProviders.ts
@@ -71,9 +71,7 @@ export class MainThreadDocumentContentProviders implements MainThreadDocumentCon
 
 		// cancel and dispose an existing update
 		const pending = this._pendingUpdate.get(model.id);
-		if (pending) {
-			pending.cancel();
-		}
+		pending?.cancel();
 
 		// create and keep update token
 		const myToken = new CancellationTokenSource();

--- a/src/vs/workbench/api/browser/mainThreadOutputService.ts
+++ b/src/vs/workbench/api/browser/mainThreadOutputService.ts
@@ -80,9 +80,7 @@ export class MainThreadOutputService extends Disposable implements MainThreadOut
 
 	public async $dispose(channelId: string): Promise<void> {
 		const channel = this._getChannel(channelId);
-		if (channel) {
-			channel.dispose();
-		}
+		channel?.dispose();
 	}
 
 	private _getChannel(channelId: string): IOutputChannel | undefined {

--- a/src/vs/workbench/api/common/extHostComments.ts
+++ b/src/vs/workbench/api/common/extHostComments.ts
@@ -620,9 +620,7 @@ export function createExtHostComments(mainContext: IMainContext, commands: ExtHo
 		$deleteCommentThread(threadHandle: number): void {
 			const thread = this._threads.get(threadHandle);
 
-			if (thread) {
-				thread.dispose();
-			}
+			thread?.dispose();
 
 			this._threads.delete(threadHandle);
 		}

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1130,9 +1130,7 @@ class InlineCompletionAdapter extends InlineCompletionAdapterBase {
 		let disposableStore: DisposableStore | undefined = undefined;
 		const pid = this._references.createReferenceId({
 			dispose() {
-				if (disposableStore) {
-					disposableStore.dispose();
-				}
+				disposableStore?.dispose();
 			},
 			items: normalizedResult
 		});
@@ -1236,9 +1234,7 @@ class InlineCompletionAdapterNew extends InlineCompletionAdapterBase {
 		let disposableStore: DisposableStore | undefined = undefined;
 		const pid = this._references.createReferenceId({
 			dispose() {
-				if (disposableStore) {
-					disposableStore.dispose();
-				}
+				disposableStore?.dispose();
 			},
 			items: normalizedResult
 		});

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -215,9 +215,7 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 		return new extHostTypes.Disposable(() => {
 			this._notebookStatusBarItemProviders.delete(handle);
 			this._notebookProxy.$unregisterNotebookCellStatusBarItemProvider(handle, eventHandle);
-			if (subscription) {
-				subscription.dispose();
-			}
+			subscription?.dispose();
 		});
 	}
 

--- a/src/vs/workbench/api/common/extHostProgress.ts
+++ b/src/vs/workbench/api/common/extHostProgress.ts
@@ -42,9 +42,7 @@ export class ExtHostProgress implements ExtHostProgressShape {
 		const progressEnd = (handle: number): void => {
 			this._proxy.$progressEnd(handle);
 			this._mapHandleToCancellationSource.delete(handle);
-			if (source) {
-				source.dispose();
-			}
+			source?.dispose();
 		};
 
 		let p: Thenable<R>;

--- a/src/vs/workbench/api/common/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/common/extHostQuickOpen.ts
@@ -223,9 +223,7 @@ export function createExtHostQuickOpen(mainContext: IMainContext, workspace: IEx
 
 		$onDidAccept(sessionId: number): void {
 			const session = this._sessions.get(sessionId);
-			if (session) {
-				session._fireDidAccept();
-			}
+			session?._fireDidAccept();
 		}
 
 		$onDidChangeActive(sessionId: number, handles: number[]): void {
@@ -256,9 +254,7 @@ export function createExtHostQuickOpen(mainContext: IMainContext, workspace: IEx
 
 		$onDidHide(sessionId: number): void {
 			const session = this._sessions.get(sessionId);
-			if (session) {
-				session._fireDidHide();
-			}
+			session?._fireDidHide();
 		}
 	}
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -902,16 +902,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				break;
 			case Parts.PANEL_PART: {
 				const activePanel = this.paneCompositeService.getActivePaneComposite(ViewContainerLocation.Panel);
-				if (activePanel) {
-					activePanel.focus();
-				}
+				activePanel?.focus();
 				break;
 			}
 			case Parts.SIDEBAR_PART: {
 				const activeViewlet = this.paneCompositeService.getActivePaneComposite(ViewContainerLocation.Sidebar);
-				if (activeViewlet) {
-					activeViewlet.focus();
-				}
+				activeViewlet?.focus();
 				break;
 			}
 			case Parts.ACTIVITYBAR_PART:
@@ -922,9 +918,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			default: {
 				// Title Bar & Banner simply pass focus to container
 				const container = this.getContainer(part);
-				if (container) {
-					container.focus();
-				}
+				container?.focus();
 			}
 		}
 	}

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -483,9 +483,7 @@ export class ActivitybarPart extends Part implements IPaneCompositeSelectorPart 
 			this.keyboardNavigationDisposables.add(addDisposableListener(this.menuBarContainer, EventType.KEY_DOWN, e => {
 				const kbEvent = new StandardKeyboardEvent(e);
 				if (kbEvent.equals(KeyCode.DownArrow) || kbEvent.equals(KeyCode.RightArrow)) {
-					if (this.compositeBar) {
-						this.compositeBar.focus();
-					}
+					this.compositeBar?.focus();
 				}
 			}));
 		}
@@ -497,9 +495,7 @@ export class ActivitybarPart extends Part implements IPaneCompositeSelectorPart 
 				if (kbEvent.equals(KeyCode.DownArrow) || kbEvent.equals(KeyCode.RightArrow)) {
 					this.globalActivityActionBar?.focus(true);
 				} else if (kbEvent.equals(KeyCode.UpArrow) || kbEvent.equals(KeyCode.LeftArrow)) {
-					if (this.menuBar) {
-						this.menuBar.toggleFocus();
-					}
+					this.menuBar?.toggleFocus();
 				}
 			}));
 		}
@@ -628,9 +624,7 @@ export class ActivitybarPart extends Part implements IPaneCompositeSelectorPart 
 
 	private onDidDeregisterViewContainer(viewContainer: ViewContainer): void {
 		const disposable = this.viewContainerDisposables.get(viewContainer.id);
-		if (disposable) {
-			disposable.dispose();
-		}
+		disposable?.dispose();
 
 		this.viewContainerDisposables.delete(viewContainer.id);
 		this.removeComposite(viewContainer.id);

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -63,9 +63,7 @@ class FocusAuxiliaryBarAction extends Action {
 
 		// Focus into active composite
 		const composite = this.paneCompositeService.getActivePaneComposite(ViewContainerLocation.AuxiliaryBar);
-		if (composite) {
-			composite.focus();
-		}
+		composite?.focus();
 	}
 }
 

--- a/src/vs/workbench/browser/parts/compositeBar.ts
+++ b/src/vs/workbench/browser/parts/compositeBar.ts
@@ -557,9 +557,7 @@ export class CompositeBar extends Widget implements ICompositeBar {
 			this.compositeOverflowAction.dispose();
 			this.compositeOverflowAction = undefined;
 
-			if (this.compositeOverflowActionViewItem) {
-				this.compositeOverflowActionViewItem.dispose();
-			}
+			this.compositeOverflowActionViewItem?.dispose();
 			this.compositeOverflowActionViewItem = undefined;
 		}
 
@@ -596,9 +594,7 @@ export class CompositeBar extends Widget implements ICompositeBar {
 		// Add overflow action as needed
 		if (totalComposites > compositesToShow.length && !this.compositeOverflowAction) {
 			this.compositeOverflowAction = this.instantiationService.createInstance(CompositeOverflowActivityAction, () => {
-				if (this.compositeOverflowActionViewItem) {
-					this.compositeOverflowActionViewItem.showMenu();
-				}
+				this.compositeOverflowActionViewItem?.showMenu();
 			});
 			this.compositeOverflowActionViewItem = this.instantiationService.createInstance(
 				CompositeOverflowActivityActionViewItem,

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -711,9 +711,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		}
 		widget.setFocused(undefined);
 		widget.setSelection(undefined);
-		if (groups.activeGroup.activeEditorPane) {
-			groups.activeGroup.activeEditorPane.focus();
-		}
+		groups.activeGroup.activeEditorPane?.focus();
 	}
 });
 KeybindingsRegistry.registerCommandAndKeybindingRule({

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -278,9 +278,7 @@ abstract class AbstractFocusGroupAction extends Action {
 
 	override async run(): Promise<void> {
 		const group = this.editorGroupService.findGroup(this.scope, this.editorGroupService.activeGroup, true);
-		if (group) {
-			group.focus();
-		}
+		group?.focus();
 	}
 }
 

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -1035,9 +1035,7 @@ function registerFocusEditorGroupWihoutWrapCommands(): void {
 			const editorGroupService = accessor.get(IEditorGroupsService);
 
 			const group = editorGroupService.findGroup({ direction: command.direction }, editorGroupService.activeGroup, false);
-			if (group) {
-				group.focus();
-			}
+			group?.focus();
 		});
 	}
 }

--- a/src/vs/workbench/browser/parts/notifications/notificationsCommands.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsCommands.ts
@@ -133,9 +133,7 @@ export function registerNotificationCommands(center: INotificationsCenterControl
 		primary: KeyCode.RightArrow,
 		handler: (accessor, args?) => {
 			const notification = getNotificationFromContext(accessor.get(IListService), args);
-			if (notification) {
-				notification.expand();
-			}
+			notification?.expand();
 		}
 	});
 
@@ -147,9 +145,7 @@ export function registerNotificationCommands(center: INotificationsCenterControl
 		primary: KeyCode.LeftArrow,
 		handler: (accessor, args?) => {
 			const notification = getNotificationFromContext(accessor.get(IListService), args);
-			if (notification) {
-				notification.collapse();
-			}
+			notification?.collapse();
 		}
 	});
 
@@ -162,9 +158,7 @@ export function registerNotificationCommands(center: INotificationsCenterControl
 		secondary: [KeyCode.Enter],
 		handler: accessor => {
 			const notification = getNotificationFromContext(accessor.get(IListService));
-			if (notification) {
-				notification.toggle();
-			}
+			notification?.toggle();
 		}
 	});
 

--- a/src/vs/workbench/browser/parts/notifications/notificationsStatus.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsStatus.ts
@@ -217,9 +217,7 @@ export class NotificationsStatus extends Disposable {
 					clearTimeout(hideHandle);
 				}
 
-				if (statusMessageEntry) {
-					statusMessageEntry.dispose();
-				}
+				statusMessageEntry?.dispose();
 			}
 		};
 

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -70,9 +70,7 @@ class FocusPanelAction extends Action {
 
 		// Focus into active panel
 		const panel = this.paneCompositeService.getActivePaneComposite(ViewContainerLocation.Panel);
-		if (panel) {
-			panel.focus();
-		}
+		panel?.focus();
 	}
 }
 

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -292,9 +292,7 @@ export abstract class BasePanelPart extends CompositePart<PaneComposite> impleme
 
 	private async onDidDeregisterPanel(panelId: string): Promise<void> {
 		const disposable = this.panelDisposables.get(panelId);
-		if (disposable) {
-			disposable.dispose();
-		}
+		disposable?.dispose();
 		this.panelDisposables.delete(panelId);
 
 		const activeContainers = this.viewDescriptorService.getViewContainersByLocation(this.viewContainerLocation)

--- a/src/vs/workbench/browser/parts/sidebar/sidebarActions.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarActions.ts
@@ -42,9 +42,7 @@ export class FocusSideBarAction extends Action2 {
 
 		// Focus into active viewlet
 		const viewlet = paneCompositeService.getActivePaneComposite(ViewContainerLocation.Sidebar);
-		if (viewlet) {
-			viewlet.focus();
-		}
+		viewlet?.focus();
 	}
 }
 

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -535,9 +535,7 @@ export class CustomMenubarControl extends MenubarControl {
 				}
 
 				async run(): Promise<void> {
-					if (that.menubar) {
-						that.menubar.toggleFocus();
-					}
+					that.menubar?.toggleFocus();
 				}
 			}));
 		}
@@ -849,9 +847,7 @@ export class CustomMenubarControl extends MenubarControl {
 				this.container.classList.remove('inactive');
 			} else {
 				this.container.classList.add('inactive');
-				if (this.menubar) {
-					this.menubar.blur();
-				}
+				this.menubar?.blur();
 			}
 		}
 	}
@@ -928,8 +924,6 @@ export class CustomMenubarControl extends MenubarControl {
 	}
 
 	toggleFocus() {
-		if (this.menubar) {
-			this.menubar.toggleFocus();
-		}
+		this.menubar?.toggleFocus();
 	}
 }

--- a/src/vs/workbench/common/editor/diffEditorInput.ts
+++ b/src/vs/workbench/common/editor/diffEditorInput.ts
@@ -171,9 +171,7 @@ export class DiffEditorInput extends SideBySideEditorInput implements IDiffEdito
 		// inputs that need to be loaded again and thus we always recreate the model and dispose
 		// the previous one - if any.
 		const resolvedModel = await this.createModel();
-		if (this.cachedModel) {
-			this.cachedModel.dispose();
-		}
+		this.cachedModel?.dispose();
 
 		this.cachedModel = resolvedModel;
 

--- a/src/vs/workbench/common/notifications.ts
+++ b/src/vs/workbench/common/notifications.ts
@@ -195,9 +195,7 @@ export class NotificationsModel extends Disposable implements INotificationsMode
 
 		// Deduplicate
 		const duplicate = this.findNotification(item);
-		if (duplicate) {
-			duplicate.close();
-		}
+		duplicate?.close();
 
 		// Add to list as first entry
 		this._notifications.splice(0, 0, item);

--- a/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution.ts
@@ -189,9 +189,7 @@ registerAction2(class ApplyAction extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<any> {
 		const viewsService = accessor.get(IViewsService);
 		const view = await getBulkEditPane(viewsService);
-		if (view) {
-			view.accept();
-		}
+		view?.accept();
 	}
 });
 
@@ -215,9 +213,7 @@ registerAction2(class DiscardAction extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const viewsService = accessor.get(IViewsService);
 		const view = await getBulkEditPane(viewsService);
-		if (view) {
-			view.discard();
-		}
+		view?.discard();
 	}
 });
 
@@ -246,9 +242,7 @@ registerAction2(class ToggleAction extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const viewsService = accessor.get(IViewsService);
 		const view = await getBulkEditPane(viewsService);
-		if (view) {
-			view.toggleChecked();
-		}
+		view?.toggleChecked();
 	}
 });
 
@@ -275,9 +269,7 @@ registerAction2(class GroupByFile extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const viewsService = accessor.get(IViewsService);
 		const view = await getBulkEditPane(viewsService);
-		if (view) {
-			view.groupByFile();
-		}
+		view?.groupByFile();
 	}
 });
 
@@ -302,9 +294,7 @@ registerAction2(class GroupByType extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const viewsService = accessor.get(IViewsService);
 		const view = await getBulkEditPane(viewsService);
-		if (view) {
-			view.groupByType();
-		}
+		view?.groupByType();
 	}
 });
 
@@ -328,9 +318,7 @@ registerAction2(class ToggleGrouping extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const viewsService = accessor.get(IViewsService);
 		const view = await getBulkEditPane(viewsService);
-		if (view) {
-			view.toggleGrouping();
-		}
+		view?.toggleGrouping();
 	}
 });
 

--- a/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.ts
@@ -307,9 +307,7 @@ class ShowAccessibilityHelpAction extends Action2 {
 
 		if (activeEditor) {
 			const controller = AccessibilityHelpController.get(activeEditor);
-			if (controller) {
-				controller.show();
-			}
+			controller?.show();
 		}
 	}
 }

--- a/src/vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens.ts
@@ -126,9 +126,7 @@ class InspectEditorTokens extends EditorAction {
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
 		const controller = InspectEditorTokensController.get(editor);
-		if (controller) {
-			controller.toggle();
-		}
+		controller?.toggle();
 	}
 }
 

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -281,9 +281,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 
 	private createReactionPicker(reactionGroup: languages.CommentReaction[]): ToggleReactionsAction {
 		const toggleReactionAction = this._register(new ToggleReactionsAction(() => {
-			if (toggleReactionActionViewItem) {
-				toggleReactionActionViewItem.show();
-			}
+			toggleReactionActionViewItem?.show();
 		}, nls.localize('commentToggleReaction', "Toggle Reaction")));
 
 		let reactionMenuActions: Action[] = [];
@@ -438,9 +436,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 		}
 		this._body.classList.remove('hidden');
 
-		if (this._commentEditorModel) {
-			this._commentEditorModel.dispose();
-		}
+		this._commentEditorModel?.dispose();
 
 		this._commentEditorDisposables.forEach(dispose => dispose.dispose());
 		this._commentEditorDisposables = [];
@@ -547,13 +543,9 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 		}
 
 		// update comment reactions
-		if (this._reactionActionsContainer) {
-			this._reactionActionsContainer.remove();
-		}
+		this._reactionActionsContainer?.remove();
 
-		if (this._reactionsActionBar) {
-			this._reactionsActionBar.clear();
-		}
+		this._reactionsActionBar?.clear();
 
 		if (this.comment.commentReactions && this.comment.commentReactions.some(reaction => !!reaction.count)) {
 			this.createReactionsContainer(this._commentDetailsContainer);

--- a/src/vs/workbench/contrib/comments/browser/commentReply.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentReply.ts
@@ -163,9 +163,7 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 	}
 
 	async submitComment(): Promise<void> {
-		if (this._commentFormActions) {
-			this._commentFormActions.triggerDefaultAction();
-		}
+		this._commentFormActions?.triggerDefaultAction();
 	}
 
 	setCommentEditorDecorations() {

--- a/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
@@ -595,9 +595,7 @@ export class CommentController implements IEditorContribution {
 		this._computeCommentingRangeScheduler = new Delayer<ICommentInfo[]>(200);
 		this.localToDispose.add({
 			dispose: () => {
-				if (this._computeCommentingRangeScheduler) {
-					this._computeCommentingRangeScheduler.cancel();
-				}
+				this._computeCommentingRangeScheduler?.cancel();
 				this._computeCommentingRangeScheduler = null;
 			}
 		});
@@ -974,9 +972,7 @@ export class NextCommentThreadAction extends EditorAction {
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
 		const controller = CommentController.get(editor);
-		if (controller) {
-			controller.nextCommentThread();
-		}
+		controller?.nextCommentThread();
 	}
 }
 
@@ -997,9 +993,7 @@ export class PreviousCommentThreadAction extends EditorAction {
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
 		const controller = CommentController.get(editor);
-		if (controller) {
-			controller.previousCommentThread();
-		}
+		controller?.previousCommentThread();
 	}
 }
 

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -510,9 +510,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 			activeCodeEditor.changeDecorations((changeAccessor) => {
 				const decorationIds = changeAccessor.deltaDecorations(this.breakpointDecorations.map(bpd => bpd.decorationId), desiredBreakpointDecorations);
 				this.breakpointDecorations.forEach(bpd => {
-					if (bpd.inlineWidget) {
-						bpd.inlineWidget.dispose();
-					}
+					bpd.inlineWidget?.dispose();
 				});
 				this.breakpointDecorations = decorationIds.map((decorationId, index) => {
 					let inlineWidget: InlineBreakpointWidget | undefined = undefined;
@@ -613,9 +611,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 
 	// breakpoint widget
 	showBreakpointWidget(lineNumber: number, column: number | undefined, context?: BreakpointWidgetContext): void {
-		if (this.breakpointWidget) {
-			this.breakpointWidget.dispose();
-		}
+		this.breakpointWidget?.dispose();
 
 		this.breakpointWidget = this.instantiationService.createInstance(BreakpointWidget, this.editor, lineNumber, column, context);
 		this.breakpointWidget.show({ lineNumber, column: 1 });
@@ -632,9 +628,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 	}
 
 	dispose(): void {
-		if (this.breakpointWidget) {
-			this.breakpointWidget.dispose();
-		}
+		this.breakpointWidget?.dispose();
 		this.editor.removeDecorations(this.breakpointDecorations.map(bpd => bpd.decorationId));
 		dispose(this.toDispose);
 	}

--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -221,9 +221,7 @@ export class BreakpointsView extends ViewPane {
 
 	override focus(): void {
 		super.focus();
-		if (this.list) {
-			this.list.domFocus();
-		}
+		this.list?.domFocus();
 	}
 
 	renderInputBox(data: InputBoxData | undefined): void {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -174,9 +174,7 @@ export class DebugService implements IDebugService {
 		}));
 		this.disposables.add(this.model.onDidChangeCallStack(() => {
 			const numberOfSessions = this.model.getSessions().filter(s => !s.parentSession).length;
-			if (this.activity) {
-				this.activity.dispose();
-			}
+			this.activity?.dispose();
 			if (numberOfSessions > 0) {
 				const viewContainer = this.viewDescriptorService.getViewContainerByViewId(CALLSTACK_VIEW_ID);
 				if (viewContainer) {

--- a/src/vs/workbench/contrib/debug/browser/debugStatus.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugStatus.ts
@@ -72,9 +72,7 @@ export class DebugStatusContribution implements IWorkbenchContribution {
 	}
 
 	dispose(): void {
-		if (this.entryAccessor) {
-			this.entryAccessor.dispose();
-		}
+		this.entryAccessor?.dispose();
 		dispose(this.toDispose);
 	}
 }

--- a/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
@@ -259,9 +259,7 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 	override dispose(): void {
 		super.dispose();
 
-		if (this.$el) {
-			this.$el.remove();
-		}
+		this.$el?.remove();
 		if (this.disposeOnUpdate) {
 			dispose(this.disposeOnUpdate);
 		}

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -709,9 +709,7 @@ export class RawDebugSession implements IDisposable {
 
 			let cancelationListener: IDisposable;
 			const requestId = this.debugAdapter.sendRequest(command, args, (response: DebugProtocol.Response) => {
-				if (cancelationListener) {
-					cancelationListener.dispose();
-				}
+				cancelationListener?.dispose();
 
 				if (response.success) {
 					completeDispatch(response);

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -226,9 +226,7 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 	private async onDidFocusSession(session: IDebugSession | undefined): Promise<void> {
 		if (session) {
 			sessionsToIgnore.delete(session);
-			if (this.completionItemProvider) {
-				this.completionItemProvider.dispose();
-			}
+			this.completionItemProvider?.dispose();
 			if (session.capabilities.supportsCompletionsRequest) {
 				this.completionItemProvider = this.languageFeaturesService.completionProvider.register({ scheme: DEBUG_SCHEME, pattern: '**/replinput', hasAccessToAllModels: true }, {
 					triggerCharacters: session.capabilities.completionTriggerCharacters || ['.'],
@@ -408,9 +406,7 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 			}
 		}
 		if (session) {
-			if (this.replElementsChangeListener) {
-				this.replElementsChangeListener.dispose();
-			}
+			this.replElementsChangeListener?.dispose();
 			this.replElementsChangeListener = session.onDidChangeReplElements(() => {
 				this.refreshReplElements(session!.getReplElements().length === 0);
 			});
@@ -748,9 +744,7 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 
 	override dispose(): void {
 		this.replInput.dispose();
-		if (this.replElementsChangeListener) {
-			this.replElementsChangeListener.dispose();
-		}
+		this.replElementsChangeListener?.dispose();
 		this.refreshScheduler.dispose();
 		this.modelChangeListener.dispose();
 		super.dispose();

--- a/src/vs/workbench/contrib/debug/browser/replFilter.ts
+++ b/src/vs/workbench/contrib/debug/browser/replFilter.ts
@@ -159,15 +159,11 @@ export class ReplFilterActionViewItem extends BaseActionViewItem {
 	}
 
 	override focus(): void {
-		if (this.filterInputBox) {
-			this.filterInputBox.focus();
-		}
+		this.filterInputBox?.focus();
 	}
 
 	override blur(): void {
-		if (this.filterInputBox) {
-			this.filterInputBox.blur();
-		}
+		this.filterInputBox?.blur();
 	}
 
 	override setFocusable(): void {

--- a/src/vs/workbench/contrib/debug/common/debugContentProvider.ts
+++ b/src/vs/workbench/contrib/debug/common/debugContentProvider.ts
@@ -110,9 +110,7 @@ export class DebugContentProvider implements IWorkbenchContribution, ITextModelC
 
 					// cancel and dispose an existing update
 					const cancellationSource = this.pendingUpdates.get(model.id);
-					if (cancellationSource) {
-						cancellationSource.cancel();
-					}
+					cancellationSource?.cancel();
 
 					// create and keep update token
 					const myToken = new CancellationTokenSource();

--- a/src/vs/workbench/contrib/experiments/test/electron-browser/experimentService.test.ts
+++ b/src/vs/workbench/contrib/experiments/test/electron-browser/experimentService.test.ts
@@ -106,9 +106,7 @@ suite('Experiment Service', () => {
 		});
 
 		teardown(() => {
-			if (testObject) {
-				testObject.dispose();
-			}
+			testObject?.dispose();
 		});
 	});
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -1737,9 +1737,7 @@ registerAction2(class ShowExtensionEditorFindAction extends Action2 {
 	}
 	run(accessor: ServicesAccessor): any {
 		const extensionEditor = getExtensionEditor(accessor);
-		if (extensionEditor) {
-			extensionEditor.showFind();
-		}
+		extensionEditor?.showFind();
 	}
 });
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -586,9 +586,7 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer implements IE
 	}
 
 	override focus(): void {
-		if (this.searchBox) {
-			this.searchBox.focus();
-		}
+		this.searchBox?.focus();
 	}
 
 	override layout(dimension: Dimension): void {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
@@ -388,9 +388,7 @@ export class ExtensionPackCountWidget extends ExtensionWidget {
 	}
 
 	private clear(): void {
-		if (this.element) {
-			this.element.remove();
-		}
+		this.element?.remove();
 	}
 
 	render(): void {

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionRecommendationsService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionRecommendationsService.test.ts
@@ -258,9 +258,7 @@ suite('ExtensionRecommendationsService Test', () => {
 	});
 
 	suiteTeardown(() => {
-		if (experimentService) {
-			experimentService.dispose();
-		}
+		experimentService?.dispose();
 	});
 
 	setup(() => {

--- a/src/vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler.ts
@@ -196,9 +196,7 @@ const pendingResolveSaveConflictMessages: INotificationHandle[] = [];
 function clearPendingResolveSaveConflictMessages(): void {
 	while (pendingResolveSaveConflictMessages.length > 0) {
 		const item = pendingResolveSaveConflictMessages.pop();
-		if (item) {
-			item.close();
-		}
+		item?.close();
 	}
 }
 

--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -121,9 +121,7 @@ export class ExplorerService implements IExplorerService {
 			}
 		}));
 		this.disposables.add(this.model.onDidChangeRoots(() => {
-			if (this.view) {
-				this.view.setTreeInput();
-			}
+			this.view?.setTreeInput();
 		}));
 
 		// Refresh explorer when window gets focus to compensate for missing file events #126817

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -889,9 +889,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 	}
 
 	override dispose(): void {
-		if (this.dragHandler) {
-			this.dragHandler.dispose();
-		}
+		this.dragHandler?.dispose();
 		super.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty.ts
+++ b/src/vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty.ts
@@ -185,9 +185,7 @@ registerAction2(class StartReadHints extends EditorAction2 {
 
 	runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor) {
 		const ctrl = InlayHintsAccessibility.get(editor);
-		if (ctrl) {
-			ctrl.startInlayHintsReading();
-		}
+		ctrl?.startInlayHintsReading();
 	}
 });
 
@@ -211,9 +209,7 @@ registerAction2(class StopReadHints extends EditorAction2 {
 
 	runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor) {
 		const ctrl = InlayHintsAccessibility.get(editor);
-		if (ctrl) {
-			ctrl.stopInlayHintsReading();
-		}
+		ctrl?.stopInlayHintsReading();
 	}
 });
 

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -316,13 +316,9 @@ export class InteractiveEditor extends EditorPane {
 
 		// there currently is a widget which we still own so
 		// we need to hide it before getting a new widget
-		if (this.#notebookWidget.value) {
-			this.#notebookWidget.value.onWillHide();
-		}
+		this.#notebookWidget.value?.onWillHide();
 
-		if (this.#codeEditorWidget) {
-			this.#codeEditorWidget.dispose();
-		}
+		this.#codeEditorWidget?.dispose();
 
 		this.#widgetDisposableStore.clear();
 
@@ -665,9 +661,7 @@ export class InteractiveEditor extends EditorPane {
 			this.#notebookWidget.value.onWillHide();
 		}
 
-		if (this.#codeEditorWidget) {
-			this.#codeEditorWidget.dispose();
-		}
+		this.#codeEditorWidget?.dispose();
 
 		this.#notebookWidget = { value: undefined };
 		this.#widgetDisposableStore.clear();

--- a/src/vs/workbench/contrib/markers/browser/markersView.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersView.ts
@@ -427,9 +427,7 @@ export class MarkersView extends ViewPane implements IMarkersView {
 			for (const element of elements) {
 				if (element instanceof Marker) {
 					const viewModel = this.markersViewModel.getViewModel(element);
-					if (viewModel) {
-						viewModel.showLightBulb();
-					}
+					viewModel?.showLightBulb();
 				}
 			}
 		}));

--- a/src/vs/workbench/contrib/markers/browser/markersViewActions.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersViewActions.ts
@@ -284,15 +284,11 @@ export class MarkersFilterActionViewItem extends BaseActionViewItem {
 	}
 
 	override focus(): void {
-		if (this.filterInputBox) {
-			this.filterInputBox.focus();
-		}
+		this.filterInputBox?.focus();
 	}
 
 	override blur(): void {
-		if (this.filterInputBox) {
-			this.filterInputBox.blur();
-		}
+		this.filterInputBox?.blur();
 	}
 
 	override setFocusable(): void {

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor.ts
@@ -430,9 +430,7 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 	}
 
 	private async _createModifiedWebview(id: string, resource: URI): Promise<void> {
-		if (this._modifiedWebview) {
-			this._modifiedWebview.dispose();
-		}
+		this._modifiedWebview?.dispose();
 
 		this._modifiedWebview = this.instantiationService.createInstance(BackLayerWebView, this, id, resource, {
 			...this._notebookOptions.computeDiffWebviewOptions(),
@@ -449,9 +447,7 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 	}
 
 	private async _createOriginalWebview(id: string, resource: URI): Promise<void> {
-		if (this._originalWebview) {
-			this._originalWebview.dispose();
-		}
+		this._originalWebview?.dispose();
 
 		this._originalWebview = this.instantiationService.createInstance(BackLayerWebView, this, id, resource, {
 			...this._notebookOptions.computeDiffWebviewOptions(),

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -182,9 +182,7 @@ export class NotebookEditor extends EditorPane implements IEditorPaneWithSelecti
 
 			// there currently is a widget which we still own so
 			// we need to hide it before getting a new widget
-			if (this._widget.value) {
-				this._widget.value.onWillHide();
-			}
+			this._widget.value?.onWillHide();
 
 			this._widget = <IBorrowValue<NotebookEditorWidget>>this._instantiationService.invokeFunction(this._notebookWidgetService.retrieveWidget, group, input);
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2530,9 +2530,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 	}
 
 	findStop() {
-		if (this._webview) {
-			this._webview.findStop();
-		}
+		this._webview?.findStop();
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/baseCellViewModel.ts
@@ -608,9 +608,7 @@ export abstract class BaseCellViewModel extends Disposable {
 			this._undoRedoService.removeElements(this.uri);
 		}
 
-		if (this._textModelRef) {
-			this._textModelRef.dispose();
-		}
+		this._textModelRef?.dispose();
 	}
 
 	toJSON(): object {

--- a/src/vs/workbench/contrib/output/browser/outputView.ts
+++ b/src/vs/workbench/contrib/output/browser/outputView.ts
@@ -149,9 +149,7 @@ export class OutputViewPane extends ViewPane {
 
 		const input = this.createInput(channel);
 		if (!this.editor.input || !input.matches(this.editor.input)) {
-			if (this.editorPromise) {
-				this.editorPromise.cancel();
-			}
+			this.editorPromise?.cancel();
 			this.editorPromise = createCancelablePromise(token => this.editor.setInput(this.createInput(channel), { preserveFocus: true }, Object.create(null), token)
 				.then(() => this.editor));
 		}

--- a/src/vs/workbench/contrib/output/common/outputChannelModel.ts
+++ b/src/vs/workbench/contrib/output/common/outputChannelModel.ts
@@ -278,9 +278,7 @@ export class FileOutputChannelModel extends Disposable implements IOutputChannel
 	}
 
 	protected cancelModelUpdate(): void {
-		if (this.modelUpdateCancellationSource.value) {
-			this.modelUpdateCancellationSource.value.cancel();
-		}
+		this.modelUpdateCancellationSource.value?.cancel();
 		this.modelUpdateCancellationSource.value = undefined;
 		this.appendThrottler.cancel();
 		this.replacePromise = undefined;

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -613,9 +613,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 
 		function settingsEditorFocusSearch(accessor: ServicesAccessor) {
 			const preferencesEditor = getPreferencesEditor(accessor);
-			if (preferencesEditor) {
-				preferencesEditor.focusSearch();
-			}
+			preferencesEditor?.focusSearch();
 		}
 
 		registerAction2(class extends Action2 {
@@ -655,9 +653,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 
 			run(accessor: ServicesAccessor) {
 				const preferencesEditor = getPreferencesEditor(accessor);
-				if (preferencesEditor) {
-					preferencesEditor.clearSearchResults();
-				}
+				preferencesEditor?.clearSearchResults();
 			}
 		});
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1208,9 +1208,7 @@ export class SettingsEditor2 extends EditorPane {
 			}
 		}
 
-		if (this.searchResultModel) {
-			this.searchResultModel.updateChildren();
-		}
+		this.searchResultModel?.updateChildren();
 
 		if (this.settingsTreeModel) {
 			this.settingsTreeModel.update(resolvedSettingsRoot);

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1006,9 +1006,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 	}
 
 	disposeElement(_element: ITreeNode<SettingsTreeElement>, _index: number, template: IDisposableTemplate, _height: number | undefined): void {
-		if ((template as ISettingItemTemplate).elementDisposables) {
-			(template as ISettingItemTemplate).elementDisposables.clear();
-		}
+		(template as ISettingItemTemplate).elementDisposables?.clear();
 	}
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -624,9 +624,7 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 		this.listDisposables.add(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_END, (ev) => {
 			counter = 0;
 			rowElement.classList.remove('drag-hover');
-			if (ev.dataTransfer) {
-				ev.dataTransfer.clearData();
-			}
+			ev.dataTransfer?.clearData();
 			if (this.dragDetails) {
 				this.dragDetails = undefined;
 			}

--- a/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
+++ b/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
@@ -185,9 +185,7 @@ export class WorkspaceChangeExtHostRelauncher extends Disposable implements IWor
 			});
 
 		this._register(toDisposable(() => {
-			if (this.onDidChangeWorkspaceFoldersUnbind) {
-				this.onDidChangeWorkspaceFoldersUnbind.dispose();
-			}
+			this.onDidChangeWorkspaceFoldersUnbind?.dispose();
 		}));
 	}
 

--- a/src/vs/workbench/contrib/remote/browser/remote.ts
+++ b/src/vs/workbench/contrib/remote/browser/remote.ts
@@ -766,9 +766,7 @@ export class RemoteAgentConnectionStatusListener extends Disposable implements I
 			const reconnectButton = {
 				label: nls.localize('reconnectNow', "Reconnect Now"),
 				callback: () => {
-					if (reconnectWaitEvent) {
-						reconnectWaitEvent.skipWait();
-					}
+					reconnectWaitEvent?.skipWait();
 				}
 			};
 
@@ -808,9 +806,7 @@ export class RemoteAgentConnectionStatusListener extends Disposable implements I
 			// ReconnectionRunning -> ConnectionGain, ReconnectionPermanentFailure
 
 			connection.onDidStateChange((e) => {
-				if (visibleProgress) {
-					visibleProgress.stopTimer();
-				}
+				visibleProgress?.stopTimer();
 
 				if (disposableListener) {
 					disposableListener.dispose();

--- a/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
@@ -112,9 +112,7 @@ export class ForwardedPortsView extends Disposable implements IWorkbenchContribu
 	}
 
 	private async updateActivityBadge() {
-		if (this._activityBadge) {
-			this._activityBadge.dispose();
-		}
+		this._activityBadge?.dispose();
 		if (this.remoteExplorerService.tunnelModel.forwarded.size > 0) {
 			this._activityBadge = this.activityService.showViewActivity(TUNNEL_VIEW_ID, {
 				badge: new NumberBadge(this.remoteExplorerService.tunnelModel.forwarded.size, n => n === 1 ? nls.localize('1forwardedPort', "1 forwarded port") : nls.localize('nForwardedPorts', "{0} forwarded ports", n))
@@ -334,9 +332,7 @@ class OnAutoForwardedAction extends Disposable {
 			return;
 		}
 
-		if (this.lastNotification) {
-			this.lastNotification.close();
-		}
+		this.lastNotification?.close();
 		let message = this.basicMessage(tunnel);
 		const choices = [this.openBrowserChoice(tunnel)];
 		if (!isWeb) {
@@ -391,9 +387,7 @@ class OnAutoForwardedAction extends Disposable {
 				if (!newTunnel) {
 					return;
 				}
-				if (this.lastNotification) {
-					this.lastNotification.close();
-				}
+				this.lastNotification?.close();
 				this.lastShownPort = newTunnel.tunnelRemotePort;
 				this.lastNotification = this.notificationService.prompt(Severity.Info,
 					this.basicMessage(newTunnel) + this.linkMessage(),
@@ -453,9 +447,7 @@ class OutputAutomaticPortForwarding extends Disposable {
 		if (!this.urlFinder && !this.remoteExplorerService.portsFeaturesEnabled) {
 			return;
 		}
-		if (this.portsFeatures) {
-			this.portsFeatures.dispose();
-		}
+		this.portsFeatures?.dispose();
 		this.urlFinder = this._register(new UrlFinder(this.terminalService, this.debugService));
 		this._register(this.urlFinder.onDidMatchLocalUrl(async (localUrl) => {
 			if (mapHasAddressLocalhostOrAllInterfaces(this.remoteExplorerService.tunnelModel.detected, localUrl.host, localUrl.port)) {
@@ -543,9 +535,7 @@ class ProcAutomaticPortForwarding extends Disposable {
 		if (this.candidateListener || !this.remoteExplorerService.portsFeaturesEnabled) {
 			return;
 		}
-		if (this.portsFeatures) {
-			this.portsFeatures.dispose();
-		}
+		this.portsFeatures?.dispose();
 
 		// Capture list of starting candidates so we don't auto forward them later.
 		await this.setInitialCandidates();

--- a/src/vs/workbench/contrib/search/browser/patternInputWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/patternInputWidget.ts
@@ -70,9 +70,7 @@ export class PatternInputWidget extends Widget implements IThemable {
 
 	override dispose(): void {
 		super.dispose();
-		if (this.inputFocusTracker) {
-			this.inputFocusTracker.dispose();
-		}
+		this.inputFocusTracker?.dispose();
 	}
 
 	setWidth(newWidth: number): void {

--- a/src/vs/workbench/contrib/search/browser/replaceService.ts
+++ b/src/vs/workbench/contrib/search/browser/replaceService.ts
@@ -128,9 +128,7 @@ export class ReplaceService implements IReplaceService {
 		});
 		const input = editor?.input;
 		const disposable = fileMatch.onDispose(() => {
-			if (input) {
-				input.dispose();
-			}
+			input?.dispose();
 			disposable.dispose();
 		});
 		await this.updateReplacePreview(fileMatch);

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -88,9 +88,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
 	handler: (accessor, args: any) => {
 		const searchView = getSearchView(accessor.get(IViewsService));
-		if (searchView) {
-			searchView.focusPreviousInputBox();
-		}
+		searchView?.focusPreviousInputBox();
 	}
 });
 
@@ -576,9 +574,7 @@ CommandsRegistry.registerCommand({
 
 		if (mode === 'view') {
 			const searchView = await openSearchView(accessor.get(IViewsService), true);
-			if (searchView) {
-				searchView.searchInFolders();
-			}
+			searchView?.searchInFolders();
 		}
 		else {
 			return accessor.get(ICommandService).executeCommand(SearchEditorConstants.OpenEditorCommandId, {

--- a/src/vs/workbench/contrib/search/browser/searchActions.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActions.ts
@@ -65,30 +65,22 @@ function doAppendKeyBindingLabel(label: string, keyBinding: ResolvedKeybinding |
 
 export const toggleCaseSensitiveCommand = (accessor: ServicesAccessor) => {
 	const searchView = getSearchView(accessor.get(IViewsService));
-	if (searchView) {
-		searchView.toggleCaseSensitive();
-	}
+	searchView?.toggleCaseSensitive();
 };
 
 export const toggleWholeWordCommand = (accessor: ServicesAccessor) => {
 	const searchView = getSearchView(accessor.get(IViewsService));
-	if (searchView) {
-		searchView.toggleWholeWords();
-	}
+	searchView?.toggleWholeWords();
 };
 
 export const toggleRegexCommand = (accessor: ServicesAccessor) => {
 	const searchView = getSearchView(accessor.get(IViewsService));
-	if (searchView) {
-		searchView.toggleRegex();
-	}
+	searchView?.toggleRegex();
 };
 
 export const togglePreserveCaseCommand = (accessor: ServicesAccessor) => {
 	const searchView = getSearchView(accessor.get(IViewsService));
-	if (searchView) {
-		searchView.togglePreserveCase();
-	}
+	searchView?.togglePreserveCase();
 };
 
 export class FocusNextInputAction extends Action {
@@ -110,9 +102,7 @@ export class FocusNextInputAction extends Action {
 		}
 
 		const searchView = getSearchView(this.viewsService);
-		if (searchView) {
-			searchView.focusNextInputBox();
-		}
+		searchView?.focusNextInputBox();
 	}
 }
 
@@ -135,9 +125,7 @@ export class FocusPreviousInputAction extends Action {
 		}
 
 		const searchView = getSearchView(this.viewsService);
-		if (searchView) {
-			searchView.focusPreviousInputBox();
-		}
+		searchView?.focusPreviousInputBox();
 	}
 }
 
@@ -275,17 +263,13 @@ export function expandAll(accessor: ServicesAccessor) {
 export function clearSearchResults(accessor: ServicesAccessor) {
 	const viewsService = accessor.get(IViewsService);
 	const searchView = getSearchView(viewsService);
-	if (searchView) {
-		searchView.clearSearchResults();
-	}
+	searchView?.clearSearchResults();
 }
 
 export function cancelSearch(accessor: ServicesAccessor) {
 	const viewsService = accessor.get(IViewsService);
 	const searchView = getSearchView(viewsService);
-	if (searchView) {
-		searchView.cancelSearch();
-	}
+	searchView?.cancelSearch();
 }
 
 export function refreshSearch(accessor: ServicesAccessor) {
@@ -352,9 +336,7 @@ export class FocusNextSearchResultAction extends Action {
 		}
 
 		return openSearchView(this.viewsService).then(searchView => {
-			if (searchView) {
-				searchView.selectNextMatch();
-			}
+			searchView?.selectNextMatch();
 		});
 	}
 }
@@ -378,9 +360,7 @@ export class FocusPreviousSearchResultAction extends Action {
 		}
 
 		return openSearchView(this.viewsService).then(searchView => {
-			if (searchView) {
-				searchView.selectPreviousMatch();
-			}
+			searchView?.selectPreviousMatch();
 		});
 	}
 }
@@ -819,9 +799,7 @@ export const clearHistoryCommand: ICommandHandler = accessor => {
 export const focusSearchListCommand: ICommandHandler = accessor => {
 	const viewsService = accessor.get(IViewsService);
 	openSearchView(viewsService).then(searchView => {
-		if (searchView) {
-			searchView.moveFocusToResults();
-		}
+		searchView?.moveFocusToResults();
 	});
 };
 

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -594,9 +594,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	}
 
 	protected _disposeTaskSystemListeners(): void {
-		if (this._taskSystemListener) {
-			this._taskSystemListener.dispose();
-		}
+		this._taskSystemListener?.dispose();
 	}
 
 	public registerTaskProvider(provider: ITaskProvider, type: string): IDisposable {
@@ -1394,9 +1392,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			const twoTabs = insertSpaces ? ' '.repeat(tabSize * 2) : '\t\t';
 			stringValue = twoTabs + stringified.slice(0, stringified.length - 1) + twoTabs + stringified.slice(stringified.length - 1);
 		} finally {
-			if (reference) {
-				reference.dispose();
-			}
+			reference?.dispose();
 		}
 		return stringValue;
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditor.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditor.ts
@@ -137,9 +137,7 @@ export class TerminalEditor extends EditorPane {
 				// Drop selection and focus terminal on Linux to enable middle button paste when click
 				// occurs on the selection itself.
 				const terminal = this._terminalEditorService.activeInstance;
-				if (terminal) {
-					terminal.focus();
-				}
+				terminal?.focus();
 			} else if (event.which === 3) {
 				const rightClickBehavior = this._terminalService.configHelper.config.rightClickBehavior;
 				if (rightClickBehavior === 'nothing') {

--- a/src/vs/workbench/contrib/terminal/browser/terminalFindWidget.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalFindWidget.ts
@@ -87,9 +87,7 @@ export class TerminalFindWidget extends SimpleFindWidget {
 		super.hide();
 		this._findWidgetVisible.reset();
 		const instance = this._terminalService.activeInstance;
-		if (instance) {
-			instance.focus();
-		}
+		instance?.focus();
 		// Terminals in a group currently share a find widget, so hide
 		// all decorations for terminals in this group
 		const activeGroup = this._terminalGroupService.activeGroup;

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -240,9 +240,7 @@ export class TerminalViewPane extends ViewPane {
 				return this._instantiationService.createInstance(SingleTerminalTabActionViewItem, action, actions);
 			}
 			case TerminalCommandId.CreateWithProfileButton: {
-				if (this._tabButtons) {
-					this._tabButtons.dispose();
-				}
+				this._tabButtons?.dispose();
 
 				const actions = getTerminalActionBarArgs(TerminalLocation.Panel, this._terminalProfileService.availableProfiles, this._getDefaultProfileName(), this._terminalProfileService.contributedProfiles, this._instantiationService, this._terminalService, this._contextKeyService, this._commandService, this._dropdownMenu);
 				this._tabButtons = new DropdownWithPrimaryActionViewItem(actions.primaryAction, actions.dropdownAction, actions.dropdownMenuActions, actions.className, this._contextMenuService, {}, this._keybindingService, this._notificationService, this._contextKeyService, this._themeService);

--- a/src/vs/workbench/contrib/welcomeOverlay/browser/welcomeOverlay.ts
+++ b/src/vs/workbench/contrib/welcomeOverlay/browser/welcomeOverlay.ts
@@ -144,9 +144,7 @@ export class HideWelcomeOverlayAction extends Action {
 	}
 
 	public override run(): Promise<void> {
-		if (welcomeOverlay) {
-			welcomeOverlay.hide();
-		}
+		welcomeOverlay?.hide();
 		return Promise.resolve();
 	}
 }

--- a/src/vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution.ts
+++ b/src/vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution.ts
@@ -27,9 +27,7 @@ export class ViewsWelcomeContribution extends Disposable implements IWorkbenchCo
 				for (const welcome of contribution.value) {
 					const disposable = this.viewWelcomeContents.get(welcome);
 
-					if (disposable) {
-						disposable.dispose();
-					}
+					disposable?.dispose();
 				}
 			}
 

--- a/src/vs/workbench/services/decorations/test/browser/decorationsService.test.ts
+++ b/src/vs/workbench/services/decorations/test/browser/decorationsService.test.ts
@@ -20,9 +20,7 @@ suite('DecorationsService', function () {
 	let service: DecorationsService;
 
 	setup(function () {
-		if (service) {
-			service.dispose();
-		}
+		service?.dispose();
 		service = new DecorationsService(
 			new class extends mock<IUriIdentityService>() {
 				override extUri = resources.extUri;

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -538,9 +538,7 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 			}
 		} finally {
 			this._inHandleDeltaExtensions = false;
-			if (lock) {
-				lock.dispose();
-			}
+			lock?.dispose();
 		}
 	}
 

--- a/src/vs/workbench/services/extensions/electron-sandbox/electronExtensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/electronExtensionService.ts
@@ -615,9 +615,7 @@ export abstract class ElectronExtensionService extends AbstractExtensionService 
 
 		// Dispose the management connection to avoid reconnecting after the extension host exits
 		const connection = this._remoteAgentService.getConnection();
-		if (connection) {
-			connection.dispose();
-		}
+		connection?.dispose();
 
 		if (this._isExtensionDevTestFromCli) {
 			// When CLI testing make sure to exit with proper exit code

--- a/src/vs/workbench/services/progress/browser/progressService.ts
+++ b/src/vs/workbench/services/progress/browser/progressService.ts
@@ -505,9 +505,7 @@ export class ProgressService extends Disposable implements IProgressService {
 
 			// Infinite
 			else {
-				if (discreteProgressRunner) {
-					discreteProgressRunner.done();
-				}
+				discreteProgressRunner?.done();
 				progressIndicator.showWhile(promise, options.delay);
 			}
 

--- a/src/vs/workbench/services/search/common/fileSearchManager.ts
+++ b/src/vs/workbench/services/search/common/fileSearchManager.ts
@@ -300,9 +300,7 @@ export class FileSearchManager {
 
 	clearCache(cacheKey: string): void {
 		const sessionTokenSource = this.getSessionTokenSource(cacheKey);
-		if (sessionTokenSource) {
-			sessionTokenSource.cancel();
-		}
+		sessionTokenSource?.cancel();
 	}
 
 	private getSessionTokenSource(cacheKey: string | undefined): CancellationTokenSource | undefined {

--- a/src/vs/workbench/services/search/node/fileSearch.ts
+++ b/src/vs/workbench/services/search/node/fileSearch.ts
@@ -315,9 +315,7 @@ export class FileWalker {
 			if (err || last) {
 				onData = () => { };
 
-				if (this.cmdSW) {
-					this.cmdSW.stop();
-				}
+				this.cmdSW?.stop();
 			}
 			cb(err, stdout, last);
 		};

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -66,13 +66,9 @@ export class RipgrepTextSearchEngine {
 			const cancel = () => {
 				isDone = true;
 
-				if (rgProc) {
-					rgProc.kill();
-				}
+				rgProc?.kill();
 
-				if (ripgrepParser) {
-					ripgrepParser.cancel();
-				}
+				ripgrepParser?.cancel();
 			};
 
 			let limitHit = false;

--- a/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
@@ -501,9 +501,7 @@ export class TextFileEditorModelManager extends Disposable implements ITextFileE
 
 		// dispose any previously stored dispose listener for this resource
 		const disposeListener = this.mapResourceToDisposeListener.get(resource);
-		if (disposeListener) {
-			disposeListener.dispose();
-		}
+		disposeListener?.dispose();
 
 		// store in cache but remove when model gets disposed
 		this.mapResourceToModel.set(resource, model);

--- a/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
+++ b/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
@@ -873,9 +873,7 @@ class WorkspaceTrustMemento {
 	set acceptsOutOfWorkspaceFiles(value: boolean) {
 		this._mementoObject[this._acceptsOutOfWorkspaceFilesKey] = value;
 
-		if (this._memento) {
-			this._memento.saveMemento();
-		}
+		this._memento?.saveMemento();
 	}
 
 	get isEmptyWorkspaceTrusted(): boolean | undefined {
@@ -885,9 +883,7 @@ class WorkspaceTrustMemento {
 	set isEmptyWorkspaceTrusted(value: boolean | undefined) {
 		this._mementoObject[this._isEmptyWorkspaceTrustedKey] = value;
 
-		if (this._memento) {
-			this._memento.saveMemento();
-		}
+		this._memento?.saveMemento();
 	}
 }
 


### PR DESCRIPTION
This rewrites code such as:

```ts
if (thing) {
    thing.method();
}
```

To the more concise:

```ts
thing?.method();
```

This was done using a simple find replace. I tried to keep the change pretty conservative so it only touches simple cases like above
