### PR TITLE
build: apply built-in ext cache to the rest of the pipeline

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin-sign.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-sign.yml
@@ -47,6 +47,12 @@ steps:
       cacheHitVar: NODE_MODULES_RESTORED
     displayName: Restore node_modules cache
 
+  - task: Cache@2
+    inputs:
+      key: '"$(Agent.OS)" | product.json'
+      path: .build/builtInExtensions
+    displayName: Restore built-in extensions
+
   - script: |
       set -e
       tar -xzf .build/node_modules_cache/cache.tgz
@@ -87,6 +93,13 @@ steps:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - script: |
+      set -e
+      node build/lib/builtInExtensions.js
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download missing built-in extensions
 
   - script: |
       set -e

--- a/build/azure-pipelines/darwin/product-build-darwin-universal.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-universal.yml
@@ -47,6 +47,12 @@ steps:
       cacheHitVar: NODE_MODULES_RESTORED
     displayName: Restore node_modules cache
 
+  - task: Cache@2
+    inputs:
+      key: '"$(Agent.OS)" | product.json'
+      path: .build/builtInExtensions
+    displayName: Restore built-in extensions
+
   - script: |
       set -e
       tar -xzf .build/node_modules_cache/cache.tgz
@@ -87,6 +93,13 @@ steps:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - script: |
+      set -e
+      node build/lib/builtInExtensions.js
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download missing built-in extensions
 
   - script: |
       set -e

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -81,6 +81,12 @@ steps:
       cacheHitVar: NODE_MODULES_RESTORED
     displayName: Restore node_modules cache
 
+  - task: Cache@2
+    inputs:
+      key: '"$(Agent.OS)" | product.json'
+      path: .build/builtInExtensions
+    displayName: Restore built-in extensions
+
   - script: |
       set -e
       tar -xzf .build/node_modules_cache/cache.tgz
@@ -114,6 +120,13 @@ steps:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - script: |
+      set -e
+      node build/lib/builtInExtensions.js
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download missing built-in extensions
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/product-build-alpine.yml
+++ b/build/azure-pipelines/linux/product-build-alpine.yml
@@ -67,6 +67,12 @@ steps:
       cacheHitVar: NODE_MODULES_RESTORED
     displayName: Restore node_modules cache
 
+  - task: Cache@2
+    inputs:
+      key: '"$(Agent.OS)" | product.json'
+      path: .build/builtInExtensions
+    displayName: Restore built-in extensions
+
   - script: |
       set -e
       tar -xzf .build/node_modules_cache/cache.tgz
@@ -97,6 +103,13 @@ steps:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - script: |
+      set -e
+      node build/lib/builtInExtensions.js
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download missing built-in extensions
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/product-build-linux-client.yml
+++ b/build/azure-pipelines/linux/product-build-linux-client.yml
@@ -109,6 +109,12 @@ steps:
         cacheHitVar: NODE_MODULES_RESTORED
       displayName: Restore node_modules cache
 
+  - task: Cache@2
+    inputs:
+      key: '"$(Agent.OS)" | product.json'
+      path: .build/builtInExtensions
+    displayName: Restore built-in extensions
+
   - script: |
       set -e
       tar -xzf .build/node_modules_cache/cache.tgz
@@ -186,6 +192,13 @@ steps:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - script: |
+      set -e
+      node build/lib/builtInExtensions.js
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download missing built-in extensions
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
     - script: |

--- a/build/azure-pipelines/product-build-pr-cache.yml
+++ b/build/azure-pipelines/product-build-pr-cache.yml
@@ -19,6 +19,12 @@ steps:
       cacheHitVar: NODE_MODULES_RESTORED
     displayName: Restore node_modules cache
 
+  - task: Cache@2
+    inputs:
+      key: '"$(Agent.OS)" | product.json'
+      path: .build/builtInExtensions
+    displayName: Restore built-in extensions
+
   - script: |
       set -e
       tar -xzf .build/node_modules_cache/cache.tgz
@@ -49,6 +55,13 @@ steps:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - script: |
+      set -e
+      node build/lib/builtInExtensions.js
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download missing built-in extensions
 
   - script: |
       set -e

--- a/build/azure-pipelines/product-compile.yml
+++ b/build/azure-pipelines/product-compile.yml
@@ -103,6 +103,13 @@ steps:
 
   - script: |
       set -e
+      node build/lib/builtInExtensions.js
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download missing built-in extensions
+
+  - script: |
+      set -e
       node build/azure-pipelines/common/listNodeModules.js .build/node_modules_list.txt
       mkdir -p .build/node_modules_cache
       tar -czf .build/node_modules_cache/cache.tgz --files-from .build/node_modules_list.txt
@@ -115,11 +122,6 @@ steps:
         set -e
         node build/azure-pipelines/mixin
       displayName: Mix in quality
-
-  - script: |
-      set -e
-      node build/lib/builtInExtensions.js
-    displayName: Download missing built-in extensions
 
   - script: |
       set -e

--- a/build/azure-pipelines/web/product-build-web.yml
+++ b/build/azure-pipelines/web/product-build-web.yml
@@ -58,6 +58,12 @@ steps:
       cacheHitVar: NODE_MODULES_RESTORED
     displayName: Restore node_modules cache
 
+  - task: Cache@2
+    inputs:
+      key: '"$(Agent.OS)" | product.json'
+      path: .build/builtInExtensions
+    displayName: Restore built-in extensions
+
   - script: |
       set -e
       tar -xzf .build/node_modules_cache/cache.tgz
@@ -88,6 +94,13 @@ steps:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - script: |
+      set -e
+      node build/lib/builtInExtensions.js
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download missing built-in extensions
 
   - script: |
       set -e

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -89,6 +89,12 @@ steps:
       cacheHitVar: NODE_MODULES_RESTORED
     displayName: Restore node_modules cache
 
+  - task: Cache@2
+    inputs:
+      key: '"$(Agent.OS)" | product.json'
+      path: .build/builtInExtensions
+    displayName: Restore built-in extensions
+
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
@@ -118,6 +124,14 @@ steps:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - powershell: |
+      . build/azure-pipelines/win32/exec.ps1
+      $ErrorActionPreference = "Stop"
+      exec { node build/lib/builtInExtensions.js }
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download missing built-in extensions
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1


### PR DESCRIPTION
Applies https://github.com/microsoft/vscode/pull/156918 to everywhere we cache node_modules. It may not be strictly necessary everywhere, but it doesn't hurt. Also includes the GITHUB_TOKEN to avoid rate limiting when we do actually need to download components.