### PR TITLE
Pass progress type along in notification updates

### DIFF
--- a/src/vs/platform/progress/common/progress.ts
+++ b/src/vs/platform/progress/common/progress.ts
@@ -64,6 +64,7 @@ export interface IProgressNotificationOptions extends IProgressOptions {
 	readonly secondaryActions?: readonly IAction[];
 	readonly delay?: number;
 	readonly silent?: boolean;
+	readonly type?: 'syncing' | 'loading';
 }
 
 export interface IProgressDialogOptions extends IProgressOptions {

--- a/src/vs/workbench/browser/parts/statusbar/statusbarItem.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarItem.ts
@@ -248,7 +248,7 @@ class StatusBarCodiconLabel extends SimpleIconLabel {
 	private progressCodicon = renderIcon(syncing);
 
 	private currentText = '';
-	private currentShowProgress = false;
+	private currentShowProgress: boolean | 'syncing' | 'loading' = false;
 
 	constructor(
 		private readonly container: HTMLElement
@@ -258,7 +258,7 @@ class StatusBarCodiconLabel extends SimpleIconLabel {
 
 	set showProgress(showProgress: boolean | 'syncing' | 'loading') {
 		if (this.currentShowProgress !== showProgress) {
-			this.currentShowProgress = !!showProgress;
+			this.currentShowProgress = showProgress;
 			this.progressCodicon = renderIcon(showProgress === 'loading' ? spinningLoading : syncing);
 			this.text = this.currentText;
 		}

--- a/src/vs/workbench/services/progress/browser/progressService.ts
+++ b/src/vs/workbench/services/progress/browser/progressService.ts
@@ -71,15 +71,17 @@ export class ProgressService extends Disposable implements IProgressService {
 		switch (location) {
 			case ProgressLocation.Notification:
 				return this.withNotificationProgress({ ...options, location, silent: this.notificationService.doNotDisturbMode }, task, onDidCancel);
-			case ProgressLocation.Window:
+			case ProgressLocation.Window: {
+				const type = (options as IProgressWindowOptions).type;
 				if ((options as IProgressWindowOptions).command) {
 					// Window progress with command get's shown in the status bar
-					return this.withWindowProgress({ ...options, location }, task);
+					return this.withWindowProgress({ ...options, location, type }, task);
 				}
 				// Window progress without command can be shown as silent notification
 				// which will first appear in the status bar and can then be brought to
 				// the front when clicking.
-				return this.withNotificationProgress({ delay: 150 /* default for ProgressLocation.Window */, ...options, silent: true, location: ProgressLocation.Notification }, task, onDidCancel);
+				return this.withNotificationProgress({ delay: 150 /* default for ProgressLocation.Window */, ...options, silent: true, location: ProgressLocation.Notification, type }, task, onDidCancel);
+			}
 			case ProgressLocation.Explorer:
 				return this.withPaneCompositeProgress('workbench.view.explorer', ViewContainerLocation.Sidebar, task, { ...options, location });
 			case ProgressLocation.Scm:
@@ -235,7 +237,8 @@ export class ProgressService extends Disposable implements IProgressService {
 			this.withWindowProgress({
 				location: ProgressLocation.Window,
 				title: options.title ? parseLinkedText(options.title).toString() : undefined, // convert markdown links => string
-				command: 'notifications.showList'
+				command: 'notifications.showList',
+				type: options.type
 			}, progress => {
 
 				function reportProgress(step: IProgressStep) {


### PR DESCRIPTION
Fixes #155955

Demonstrating the icon updating with changes in the progress stack:

![Recording 2022-08-03 at 06 33 31](https://user-images.githubusercontent.com/2193314/182620902-c42ea48a-0959-475b-ab73-8013cc51fd1c.gif)

