### PR TITLE
Not add '[' to ipv6 host when '[' exists.

### DIFF
--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -150,7 +150,7 @@ class RemoteAuthoritiesImpl {
 		}
 		const authority = uri.authority;
 		let host = this._hosts[authority];
-		if (host && host.indexOf(':') !== -1) {
+		if (host && host.indexOf(':') !== -1 && host.indexOf('[') === -1) {
 			host = `[${host}]`;
 		}
 		const port = this._ports[authority];

--- a/src/vs/platform/remote/browser/browserSocketFactory.ts
+++ b/src/vs/platform/remote/browser/browserSocketFactory.ts
@@ -274,7 +274,7 @@ export class BrowserSocketFactory implements ISocketFactory {
 
 	connect(host: string, port: number, path: string, query: string, debugLabel: string, callback: IConnectCallback): void {
 		const webSocketSchema = (/^https:/.test(window.location.href) ? 'wss' : 'ws');
-		const socket = this._webSocketFactory.create(`${webSocketSchema}://${/:/.test(host) ? `[${host}]` : host}:${port}${path}?${query}&skipWebSocketFrames=false`, debugLabel);
+		const socket = this._webSocketFactory.create(`${webSocketSchema}://${(/:/.test(host) && !/\[/.test(host)) ? `[${host}]` : host}:${port}${path}?${query}&skipWebSocketFrames=false`, debugLabel);
 		const errorListener = socket.onError((err) => callback(err, undefined));
 		socket.onOpen(() => {
 			errorListener.dispose();


### PR DESCRIPTION
Start code server and bound to ipv6.

```sh
code-server serve-local --host :: --without-connection-token
```

The websocket address is started with two '['.

![image](https://user-images.githubusercontent.com/15117147/182635657-98f7c1bc-09b6-4e0c-9574-6aae92c55756.png)
