### PR TITLE
smoke(electron): wait for page navigation to commit before using driver

### DIFF
--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -115,6 +115,7 @@ export class Application {
 	}
 
 	private async checkWindowReady(code: Code): Promise<void> {
+		await measureAndLog(code.didFinishLoad(), 'Application#checkWindowReady: wait for navigation to be committed', this.logger);
 
 		// We need a rendered workbench
 		await measureAndLog(code.waitForElement('.monaco-workbench'), 'Application#checkWindowReady: wait for .monaco-workbench element', this.logger);

--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -115,9 +115,9 @@ export class Application {
 	}
 
 	private async checkWindowReady(code: Code): Promise<void> {
-		await measureAndLog(code.didFinishLoad(), 'Application#checkWindowReady: wait for navigation to be committed', this.logger);
 
 		// We need a rendered workbench
+		await measureAndLog(code.didFinishLoad(), 'Application#checkWindowReady: wait for navigation to be committed', this.logger);
 		await measureAndLog(code.waitForElement('.monaco-workbench'), 'Application#checkWindowReady: wait for .monaco-workbench element', this.logger);
 
 		// Remote but not web: wait for a remote connection state change

--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -115,7 +115,9 @@ export class Application {
 	}
 
 	private async checkWindowReady(code: Code): Promise<void> {
-		await measureAndLog(code.didFinishLoad(), 'Application#checkWindowReady: wait for navigation to be committed', this.logger);
+		if (!this.web) {
+			await measureAndLog(code.didFinishLoad(), 'Application#checkWindowReady: wait for navigation to be committed', this.logger);
+		}
 
 		// We need a rendered workbench
 		await measureAndLog(code.waitForElement('.monaco-workbench'), 'Application#checkWindowReady: wait for .monaco-workbench element', this.logger);

--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -115,9 +115,7 @@ export class Application {
 	}
 
 	private async checkWindowReady(code: Code): Promise<void> {
-		if (!this.web) {
-			await measureAndLog(code.didFinishLoad(), 'Application#checkWindowReady: wait for navigation to be committed', this.logger);
-		}
+		await measureAndLog(code.didFinishLoad(), 'Application#checkWindowReady: wait for navigation to be committed', this.logger);
 
 		// We need a rendered workbench
 		await measureAndLog(code.waitForElement('.monaco-workbench'), 'Application#checkWindowReady: wait for .monaco-workbench element', this.logger);

--- a/test/automation/src/code.ts
+++ b/test/automation/src/code.ts
@@ -135,6 +135,10 @@ export class Code {
 		await this.driver.dispatchKeybinding(keybinding);
 	}
 
+	async didFinishLoad(): Promise<void> {
+		return await this.driver.didFinishLoad();
+	}
+
 	async exit(): Promise<void> {
 		return measureAndLog(new Promise<void>((resolve, reject) => {
 			const pid = this.mainProcess.pid!;

--- a/test/automation/src/code.ts
+++ b/test/automation/src/code.ts
@@ -136,7 +136,7 @@ export class Code {
 	}
 
 	async didFinishLoad(): Promise<void> {
-		return await this.driver.didFinishLoad();
+		return this.driver.didFinishLoad();
 	}
 
 	async exit(): Promise<void> {

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -77,6 +77,16 @@ export class PlaywrightDriver {
 		}
 	}
 
+	async didFinishLoad(): Promise<void> {
+		const p = new Promise<void>((f) => {
+			// https://playwright.dev/docs/api/class-electronapplication#electron-application-event-window
+			(this.application as playwright.ElectronApplication).on('window', () => {
+				f();
+			});
+		});
+		await p;
+	}
+
 	private async takeScreenshot(name: string): Promise<void> {
 		try {
 			const persistPath = join(this.options.logsPath, `playwright-screenshot-${PlaywrightDriver.screenShotCounter++}-${name.replace(/\s+/g, '-')}.png`);

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -78,17 +78,17 @@ export class PlaywrightDriver {
 	}
 
 	async didFinishLoad(): Promise<void> {
+
+		// Web: via `load` state
 		if (this.options.web) {
-			await this.page.waitForLoadState('load');
-		} else {
-			const p = new Promise<void>((f) => {
-				// https://playwright.dev/docs/api/class-electronapplication#electron-application-event-window
-				(this.application as playwright.ElectronApplication).on('window', () => {
-					f();
-				});
-			});
-			await p;
+			return this.page.waitForLoadState('load');
 		}
+
+		// Desktop: via `window` event
+		return new Promise<void>(resolve => {
+			// https://playwright.dev/docs/api/class-electronapplication#electron-application-event-window
+			(this.application as playwright.ElectronApplication).on('window', () => resolve());
+		});
 	}
 
 	private async takeScreenshot(name: string): Promise<void> {

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -78,13 +78,17 @@ export class PlaywrightDriver {
 	}
 
 	async didFinishLoad(): Promise<void> {
-		const p = new Promise<void>((f) => {
-			// https://playwright.dev/docs/api/class-electronapplication#electron-application-event-window
-			(this.application as playwright.ElectronApplication).on('window', () => {
-				f();
+		if (this.options.web) {
+			await this.page.waitForLoadState('load');
+		} else {
+			const p = new Promise<void>((f) => {
+				// https://playwright.dev/docs/api/class-electronapplication#electron-application-event-window
+				(this.application as playwright.ElectronApplication).on('window', () => {
+					f();
+				});
 			});
-		});
-		await p;
+			await p;
+		}
 	}
 
 	private async takeScreenshot(name: string): Promise<void> {


### PR DESCRIPTION
Addresses the following error

```
[2022-08-04T00:58:03.481Z] getDriverHandle
[2022-08-04T00:58:03.768Z] Playwright (Electron): window.on('console') [[uncaught exception]: TypeError: Cannot read properties of undefined (reading 'getElements')]
[2022-08-04T00:58:03.768Z] Playwright (Electron): window.on('console') [TypeError: Cannot read properties of undefined (reading 'getElements')
    at eval (eval at evaluate (:192:30), <anonymous>:1:43)
    at UtilityScript.evaluate (<anonymous>:194:17)
    at UtilityScript.<anonymous> (<anonymous>:1:44)]
```

Example run https://dev.azure.com/vscode/VSCode/_build/results?buildId=70300&view=results

We currently rely on polling to identify if our custom driver is setup in the renderer, this broke with Electron 19 update very likely that playwright calls are made before the window has finished loading.

PR relies on https://playwright.dev/docs/api/class-electronapplication#electron-application-event-window to ensure window has finished navigation before the driver can be accessed.