### PR TITLE
Escape bolding in name error message

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -658,8 +658,10 @@ export function validateFileName(pathService: IPathService, item: ExplorerItem, 
 
 	// Check for invalid file name.
 	if (names.some(folderName => !pathService.hasValidBasename(item.resource, os, folderName))) {
+		// Escape * characters
+		const escapedName = name.replace(/\*/g, '\\*');
 		return {
-			content: nls.localize('invalidFileNameError', "The name **{0}** is not valid as a file or folder name. Please choose a different name.", trimLongName(name)),
+			content: nls.localize('invalidFileNameError', "The name **{0}** is not valid as a file or folder name. Please choose a different name.", trimLongName(escapedName)),
 			severity: Severity.Error
 		};
 	}


### PR DESCRIPTION
Fixes #150856

Escapes file names that are `**` that can cause wierd bolding in the markdown