### PR TITLE
Enable high contrast outlines on all activity bar items

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -473,7 +473,7 @@ registerThemingParticipant((theme, collector) => {
 				left: 8px;
 				height: 32px;
 				width: 32px;
-				z-index: 1;
+				z-index: 200;
 			}
 
 			.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.active:before,

--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -473,7 +473,7 @@ registerThemingParticipant((theme, collector) => {
 				left: 8px;
 				height: 32px;
 				width: 32px;
-				z-index: 200;
+				z-index: 1;
 			}
 
 			.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.active:before,

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -8,6 +8,58 @@
 	position: relative;
 }
 
+.monaco-workbench .activitybar > .content .composite-bar > .monaco-action-bar .action-item::before,
+.monaco-workbench .activitybar > .content .composite-bar > .monaco-action-bar .action-item::after {
+	position: absolute;
+	content: '';
+	width: 48px;
+	height: 2px;
+	background-color: transparent;
+	transition-property: background-color;
+	transition-duration: 0ms;
+	transition-delay: 100ms;
+}
+
+.monaco-workbench .activitybar > .content.dragged-over .composite-bar > .monaco-action-bar .action-item::before,
+.monaco-workbench .activitybar > .content.dragged-over .composite-bar > .monaco-action-bar .action-item::after {
+	display: block;
+}
+
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item::before {
+	top: 1px;
+	margin-top: -2px;
+}
+
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item::after {
+	bottom: 1px;
+	margin-bottom: -2px;
+}
+
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item:first-of-type::before {
+	top: 2px;
+	margin-top: -2px;
+}
+
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
+	bottom: 2px;
+	margin-bottom: -2px;
+}
+
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.top::before,
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.top::after,
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.bottom::before,
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.bottom::after {
+	transition-delay: 0s;
+}
+
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.bottom + .action-item::before,
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.top::before,
+.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item:last-of-type.bottom::after,
+.monaco-workbench .activitybar > .content.dragged-over-head > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
+.monaco-workbench .activitybar > .content.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
+	background-color: var(--insert-border-color);
+}
+
 .monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-label {
 	position: relative;
 	z-index: 1;

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -17,7 +17,6 @@
 	height: 48px;
 	margin-right: 0;
 	box-sizing: border-box;
-
 }
 
 .monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-label:not(.codicon) {

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -8,59 +8,6 @@
 	position: relative;
 }
 
-.monaco-workbench .activitybar > .content .composite-bar > .monaco-action-bar .action-item::before,
-.monaco-workbench .activitybar > .content .composite-bar > .monaco-action-bar .action-item::after {
-	position: absolute;
-	content: '';
-	width: 48px;
-	height: 2px;
-	display: none;
-	background-color: transparent;
-	transition-property: background-color;
-	transition-duration: 0ms;
-	transition-delay: 100ms;
-}
-
-.monaco-workbench .activitybar > .content.dragged-over .composite-bar > .monaco-action-bar .action-item::before,
-.monaco-workbench .activitybar > .content.dragged-over .composite-bar > .monaco-action-bar .action-item::after {
-	display: block;
-}
-
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item::before {
-	top: 1px;
-	margin-top: -2px;
-}
-
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item::after {
-	bottom: 1px;
-	margin-bottom: -2px;
-}
-
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item:first-of-type::before {
-	top: 2px;
-	margin-top: -2px;
-}
-
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
-	bottom: 2px;
-	margin-bottom: -2px;
-}
-
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.top::before,
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.top::after,
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.bottom::before,
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.bottom::after {
-	transition-delay: 0s;
-}
-
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.bottom + .action-item::before,
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item.top::before,
-.monaco-workbench .activitybar > .content > .composite-bar > .monaco-action-bar .action-item:last-of-type.bottom::after,
-.monaco-workbench .activitybar > .content.dragged-over-head > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
-.monaco-workbench .activitybar > .content.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
-	background-color: var(--insert-border-color);
-}
-
 .monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-label {
 	position: relative;
 	z-index: 1;


### PR DESCRIPTION
Fixes #143533 by...
- Showing solid outline on currently active view container
- Showing dashed outline on hover on top items—previously only the bottom accounts/settings items showed the outlines.

## Before
![before](https://user-images.githubusercontent.com/25163139/182928441-06b93669-9843-4142-8b86-f838b7d910ab.gif)

## After
![after](https://user-images.githubusercontent.com/25163139/182928520-0a45fa2b-f8be-4c99-9bd8-bf690543fda0.gif)

