### PR TITLE
Fix panel tab outline offset (Fix #146856)

### DIFF
--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -1082,7 +1082,7 @@ registerThemingParticipant((theme, collector) => {
 					outline-width: 1px;
 					outline-style: solid;
 					border-bottom: none;
-					outline-offset: -2px;
+					outline-offset: -1px;
 				}
 
 				.monaco-workbench .part.basepanel > .title > .panel-switcher-container > .monaco-action-bar .action-item:not(.checked):hover .action-label {


### PR DESCRIPTION
Fix #146856

## Before
<img width="150" alt="CleanShot 2022-08-04 at 12 04 03@2x" src="https://user-images.githubusercontent.com/25163139/182932754-a22d6486-31a3-41ed-a6a4-e32f85a95fed.png">

## After
<img width="150" alt="CleanShot 2022-08-04 at 12 03 45@2x" src="https://user-images.githubusercontent.com/25163139/182932773-191468ce-dddd-46d9-a277-c9bf39031c21.png">

