### PR TITLE
We only need to wait on the input box for un-supported environments

### DIFF
--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -369,7 +369,7 @@ export class AzureActiveDirectoryService {
 				existingPromise = this.handleCodeResponse(scopeData);
 			} else {
 				inputBox = vscode.window.createInputBox();
-				existingPromise = Promise.race([this.handleCodeInputBox(inputBox, codeVerifier, scopeData), this.handleCodeResponse(scopeData)]);
+				existingPromise = this.handleCodeInputBox(inputBox, codeVerifier, scopeData);
 			}
 			this._codeExchangePromises.set(scopeData.scopeStr, existingPromise);
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This code use to be in there for backcompat reasons but now we don't need it since we won't redirect back to vscode.dev on unsupported environements (like if Server Distro is running on a url we don't own)