### PR TITLE
Inline CurrentDragAndDropData

### DIFF
--- a/src/vs/base/browser/dnd.ts
+++ b/src/vs/base/browser/dnd.ts
@@ -92,24 +92,3 @@ export interface IDragAndDropData {
 	update(dataTransfer: DataTransfer): void;
 	getData(): unknown;
 }
-
-export class DragAndDropData<T> implements IDragAndDropData {
-
-	constructor(private data: T) { }
-
-	update(): void {
-		// noop
-	}
-
-	getData(): T {
-		return this.data;
-	}
-}
-
-export interface IStaticDND {
-	CurrentDragAndDropData: IDragAndDropData | undefined;
-}
-
-export const StaticDND: IStaticDND = {
-	CurrentDragAndDropData: undefined
-};

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isFirefox } from 'vs/base/browser/browser';
-import { DataTransfers, IDragAndDropData, StaticDND } from 'vs/base/browser/dnd';
+import { DataTransfers, IDragAndDropData } from 'vs/base/browser/dnd';
 import { $, addDisposableListener, animate, getContentHeight, getContentWidth, getTopLeftOffset, scheduleAtNextAnimationFrame } from 'vs/base/browser/dom';
 import { DomEmitter } from 'vs/base/browser/event';
 import { IMouseWheelEvent } from 'vs/base/browser/mouseEvent';
@@ -37,6 +37,10 @@ interface IItem<T> {
 	dragStartDisposable: IDisposable;
 	checkedDisposable: IDisposable;
 }
+
+const StaticDND = {
+	CurrentDragAndDropData: undefined as IDragAndDropData | undefined
+};
 
 export interface IListViewDragAndDrop<T> extends IListDragAndDrop<T> {
 	getDragElements(element: T): T[];


### PR DESCRIPTION
This type is only used by the list. IMO makes sense to move it into the list class instead of having it as a generic concept. We can always move it back if needed

/cc @joaomoreno 