### PR TITLE
Fix error when evaluating lazy expression that doesn't exist in the variables view

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -171,7 +171,7 @@ export class VariablesView extends ViewPane {
 			}
 		}));
 		this._register(this.debugService.getViewModel().onDidEvaluateLazyExpression(async e => {
-			if (e instanceof Variable) {
+			if (e instanceof Variable && this.tree.hasNode(e)) {
 				await this.tree.updateChildren(e, false, true);
 				await this.tree.expand(e);
 			}


### PR DESCRIPTION
Fixes #154753