### PR TITLE
clearNode should use `replaceChildren`

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -19,9 +19,7 @@ import { withNullAsUndefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 
 export function clearNode(node: HTMLElement): void {
-	while (node.firstChild) {
-		node.firstChild.remove();
-	}
+	node.replaceChildren();
 }
 
 /**


### PR DESCRIPTION
The new-ish `replaceChildren` api lets us quickly remove all children of an html element without having to iterate through the children
