### PR TITLE
Don't re-render markdown cells on `initializeWebViewState`

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -913,13 +913,6 @@ var requirejs = (function() {
 	}
 
 	private initializeWebViewState() {
-		const renderers = new Set<INotebookRendererInfo>();
-		for (const inset of this.insetMapping.values()) {
-			if (inset.renderer) {
-				renderers.add(inset.renderer);
-			}
-		}
-
 		this._preloadsCache.clear();
 		if (this._currentKernel) {
 			this._updatePreloadsFromKernel(this._currentKernel);
@@ -929,9 +922,6 @@ var requirejs = (function() {
 			this._sendMessageToWebview({ ...inset.cachedCreation, initiallyHidden: this.hiddenInsetMapping.has(output) });
 		}
 
-		const mdCells = [...this.markupPreviewMapping.values()];
-		this.markupPreviewMapping.clear();
-		this.initializeMarkup(mdCells);
 		this._updateStyles();
 		this._updateOptions();
 	}


### PR DESCRIPTION
Fixes #156914

I don't really understand what `initializeWebViewState` is doing here but there are two things:

- I've removed a list of renderers it creates and then never uses
- I've removed the part where it calls back into `initializeMarkup`. This should have already been called during `_warmupViewport`
