### PR TITLE
actionViewItem - make sure to also set the aira-label on the label element

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionViewItems.ts
+++ b/src/vs/base/browser/ui/actionbar/actionViewItems.ts
@@ -388,6 +388,14 @@ export class ActionViewItem extends BaseActionViewItem {
 		}
 	}
 
+	override updateTooltip(): void {
+		super.updateTooltip();
+		if (this.label) {
+			const title = this.getTooltip() ?? '';
+			this.label.setAttribute('aria-label', title);
+		}
+	}
+
 	override updateChecked(): void {
 		if (this.label) {
 			if (this.action.checked) {


### PR DESCRIPTION
There is a regression that the html focus is set on the inner element of the action view item. I am not sure what change made this happen, but overall I think it makes sense. What is missing is the aria-label, so this commit sets the aria-label on that inner element.
I have verified that this indeed fixes the regression

fixes #155880
