### PR TITLE
Don't do telemetry health check when telemetry is off

### DIFF
--- a/src/vs/platform/telemetry/browser/1dsAppender.ts
+++ b/src/vs/platform/telemetry/browser/1dsAppender.ts
@@ -15,11 +15,5 @@ export class OneDataSystemWebAppender extends AbstractOneDataSystemAppender {
 		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
 	) {
 		super(isInternalTelemetry, eventPrefix, defaultData, iKeyOrClientFactory);
-
-		// If we cannot fetch the endpoint it means it is down and we should not send any telemetry.
-		// This is most likely due to ad blockers
-		fetch(this.endPointUrl, { method: 'POST' }).catch(err => {
-			this._aiCoreOrKey = undefined;
-		});
 	}
 }

--- a/src/vs/platform/telemetry/common/1dsAppender.ts
+++ b/src/vs/platform/telemetry/common/1dsAppender.ts
@@ -9,7 +9,7 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 import { mixin } from 'vs/base/common/objects';
 import { ITelemetryAppender, validateTelemetryData } from 'vs/platform/telemetry/common/telemetryUtils';
 
-const endpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0';
+export const telemetryEndpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0';
 
 async function getClient(instrumentationKey: string, addInternalFlag?: boolean, xhrOverride?: IXHROverride): Promise<AppInsightsCore> {
 	const oneDs = await import('@microsoft/1ds-core-js');
@@ -19,7 +19,7 @@ async function getClient(instrumentationKey: string, addInternalFlag?: boolean, 
 	// Configure the app insights core to send to collector++ and disable logging of debug info
 	const coreConfig: IExtendedConfiguration = {
 		instrumentationKey,
-		endpointUrl,
+		endpointUrl: telemetryEndpointUrl,
 		loggingLevelTelemetry: 0,
 		loggingLevelConsole: 0,
 		disableCookiesUsage: true,
@@ -59,7 +59,7 @@ export abstract class AbstractOneDataSystemAppender implements ITelemetryAppende
 
 	protected _aiCoreOrKey: AppInsightsCore | string | undefined;
 	private _asyncAiCore: Promise<AppInsightsCore> | null;
-	protected readonly endPointUrl = endpointUrl;
+	protected readonly endPointUrl = telemetryEndpointUrl;
 
 	constructor(
 		private readonly _isInternalTelemetry: boolean,


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode/issues/157228


We were doing the ad-block endpoint check even with telemetry off. This did not send any data and was merely a blank request to the URL but it is not expected that any telemetry related network requests would be created when telemetry is off. This fix patches that for the recovery release. A larger fix with more changes will come for the main branch to handle this more gracefully.