### PR TITLE
Better telemetry adblock check

### DIFF
--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -103,9 +103,9 @@ import { ExtensionsProfileScannerService, IExtensionsProfileScannerService } fro
 import { PolicyChannelClient } from 'vs/platform/policy/common/policyIpc';
 import { IPolicyService, NullPolicyService } from 'vs/platform/policy/common/policy';
 import { UserDataProfilesNativeService } from 'vs/platform/userDataProfile/electron-sandbox/userDataProfile';
-import { OneDataSystemWebAppender } from 'vs/platform/telemetry/browser/1dsAppender';
 import { DefaultExtensionsProfileInitService } from 'vs/platform/extensionManagement/electron-sandbox/defaultExtensionsProfileInit';
 import { SharedProcessRequestService } from 'vs/platform/request/electron-browser/sharedProcessRequestService';
+import { OneDataSystemAppender } from 'vs/platform/telemetry/node/1dsAppender';
 
 class SharedProcessMain extends Disposable {
 
@@ -283,7 +283,7 @@ class SharedProcessMain extends Disposable {
 			appenders.push(logAppender);
 			const { installSourcePath } = environmentService;
 			if (productService.aiConfig?.ariaKey) {
-				const collectorAppender = new OneDataSystemWebAppender(internalTelemetry, 'monacoworkbench', null, productService.aiConfig.ariaKey);
+				const collectorAppender = new OneDataSystemAppender(internalTelemetry, 'monacoworkbench', null, productService.aiConfig.ariaKey);
 				this._register(toDisposable(() => collectorAppender.flush())); // Ensure the 1DS appender is disposed so that it flushes remaining data
 				appenders.push(collectorAppender);
 			}

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -12,7 +12,7 @@ import { IProductService } from 'vs/platform/product/common/productService';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { OneDataSystemWebAppender } from 'vs/platform/telemetry/browser/1dsAppender';
 import { ClassifiedEvent, IGDPRProperty, OmitMetadata, StrictPropertyCheck } from 'vs/platform/telemetry/common/gdprTypings';
-import { ITelemetryData, ITelemetryInfo, ITelemetryService, TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
+import { ITelemetryData, ITelemetryInfo, ITelemetryService, TelemetryLevel, TELEMETRY_SETTING_ID } from 'vs/platform/telemetry/common/telemetry';
 import { TelemetryLogAppender } from 'vs/platform/telemetry/common/telemetryLogAppender';
 import { ITelemetryServiceConfig, TelemetryService as BaseTelemetryService } from 'vs/platform/telemetry/common/telemetryService';
 import { isInternalTelemetry, ITelemetryAppender, NullTelemetryService, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
@@ -38,6 +38,34 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 		super();
 
 		if (supportsTelemetry(productService, environmentService) && productService.aiConfig?.ariaKey) {
+			this.impl = this.initializeService(environmentService, loggerService, configurationService, storageService, productService, remoteAgentService);
+		} else {
+			this.impl = NullTelemetryService;
+		}
+
+		// When the level changes it could change from off to on and we want to make sure telemetry is properly intialized
+		this._register(configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(TELEMETRY_SETTING_ID)) {
+				this.impl = this.initializeService(environmentService, loggerService, configurationService, storageService, productService, remoteAgentService);
+			}
+		}));
+	}
+
+	/**
+	 * Initializes the telemetry service to be a full fledged service.
+	 * This is only done once and only when telemetry is enabled as this will also ping the endpoint to
+	 * ensure its not adblocked and we can send telemetry
+	 */
+	private initializeService(
+		environmentService: IBrowserWorkbenchEnvironmentService,
+		loggerService: ILoggerService,
+		configurationService: IConfigurationService,
+		storageService: IStorageService,
+		productService: IProductService,
+		remoteAgentService: IRemoteAgentService
+	) {
+		const telemetrySupported = supportsTelemetry(productService, environmentService) && productService.aiConfig?.ariaKey;
+		if (telemetrySupported && this.impl === NullTelemetryService && this.telemetryLevel.value !== TelemetryLevel.NONE) {
 			// If remote server is present send telemetry through that, else use the client side appender
 			const appenders = [];
 			const isInternal = isInternalTelemetry(productService, configurationService);
@@ -50,10 +78,9 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 				sendErrorTelemetry: this.sendErrorTelemetry,
 			};
 
-			this.impl = this._register(new BaseTelemetryService(config, configurationService, productService));
-		} else {
-			this.impl = NullTelemetryService;
+			return this._register(new BaseTelemetryService(config, configurationService, productService));
 		}
+		return NullTelemetryService;
 	}
 
 	setExperimentProperty(name: string, value: string): void {


### PR DESCRIPTION
1. Moves SharedProcess to the node appender. This prevents desktop from doing the adblock check as it is unnecessary.
2. Have the browser telemetry service listening to the telemetry level and only initialize when the level is on which then triggers the adblock check.

@sbatten is there a better way to do this? I'm not sure that I love this solution but the experience of vscode.dev with adblock on without this check is very noisy.

TODO: Add some caching to the appenders as initializing can take a bit and therefore events can be lost.

More robust fix of #157228