### PR TITLE
Fix notebook execution test failures

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.kernel.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.kernel.test.ts
@@ -56,7 +56,6 @@ export class Kernel {
 	}
 
 	protected async _execute(cells: vscode.NotebookCell[]): Promise<void> {
-		console.log(`Executing ${cells.length} cells`);
 		for (const cell of cells) {
 			await this._runCell(cell);
 		}

--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.kernel.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.kernel.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import 'mocha';
 import { TextDecoder } from 'util';
 import * as vscode from 'vscode';
-import { asPromise, assertNoRpc, closeAllEditors, createRandomFile, disposeAll, revertAllDirty, saveAllEditors } from '../utils';
+import { asPromise, assertNoRpc, closeAllEditors, createRandomFile, DeferredPromise, disposeAll, revertAllDirty, saveAllEditors } from '../utils';
 
 async function createRandomNotebookFile() {
 	return createRandomFile('', undefined, '.vsctestnb');
@@ -56,6 +56,7 @@ export class Kernel {
 	}
 
 	protected async _execute(cells: vscode.NotebookCell[]): Promise<void> {
+		console.log(`Executing ${cells.length} cells`);
 		for (const cell of cells) {
 			await this._runCell(cell);
 		}
@@ -181,7 +182,7 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const editor = vscode.window.activeNotebookEditor!;
 		const cell = editor.notebook.cellAt(0);
 
-		await withEvent(vscode.workspace.onDidChangeNotebookDocument, async (event) => {
+		await withEvent(vscode.workspace.onDidChangeNotebookDocument, async event => {
 			await vscode.commands.executeCommand('notebook.execute');
 			await event;
 			assert.strictEqual(cell.outputs.length, 1, 'should execute'); // runnable, it worked
@@ -196,7 +197,7 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const secondResource = await createRandomNotebookFile();
 		await vscode.commands.executeCommand('vscode.openWith', secondResource, 'notebookCoreTest');
 
-		await withEvent<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument, async (event) => {
+		await withEvent<vscode.NotebookDocumentChangeEvent>(vscode.workspace.onDidChangeNotebookDocument, async event => {
 			await vscode.commands.executeCommand('notebook.cell.execute', { start: 0, end: 1 }, notebook.uri);
 			await event;
 			assert.strictEqual(cell.outputs.length, 1, 'should execute'); // runnable, it worked
@@ -204,35 +205,33 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		});
 	});
 
-	// #126371
-	test('cell execute command takes arguments', async () => {
+	test('cell execute command takes arguments 2', async () => {
 		const notebook = await openRandomNotebookDocument();
 		await vscode.window.showNotebookDocument(notebook);
 
 		let firstCellExecuted = false;
 		let secondCellExecuted = false;
-		let resolve: () => void;
-		const p = new Promise<void>(r => resolve = r);
-		const listener = vscode.workspace.onDidChangeNotebookDocument(e => {
+
+		const def = new DeferredPromise<void>();
+		testDisposables.push(vscode.workspace.onDidChangeNotebookDocument(e => {
 			e.cellChanges.forEach(change => {
-				if (change.cell.index === 0) {
+				if (change.cell.index === 0 && change.executionSummary) {
 					firstCellExecuted = true;
 				}
 
-				if (change.cell.index === 1) {
+				if (change.cell.index === 1 && change.executionSummary) {
 					secondCellExecuted = true;
 				}
 			});
 
 			if (firstCellExecuted && secondCellExecuted) {
-				resolve();
+				def.complete();
 			}
-		});
+		}));
 
 		vscode.commands.executeCommand('notebook.cell.execute', { document: notebook.uri, ranges: [{ start: 0, end: 1 }, { start: 1, end: 2 }] });
 
-		await p;
-		listener.dispose();
+		await def.p;
 		await saveAllFilesAndCloseAll();
 	});
 
@@ -301,27 +300,30 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		const cell = editor.notebook.cellAt(0);
 
 		let eventCount = 0;
-		let resolve: () => void;
-		const p = new Promise<void>(r => resolve = r);
-		const listener = vscode.notebooks.onDidChangeNotebookCellExecutionState(e => {
-			if (eventCount === 0) {
-				assert.strictEqual(e.state, vscode.NotebookCellExecutionState.Pending, 'should be set to Pending');
-			} else if (eventCount === 1) {
-				assert.strictEqual(e.state, vscode.NotebookCellExecutionState.Executing, 'should be set to Executing');
-				assert.strictEqual(cell.outputs.length, 0, 'no outputs yet: ' + JSON.stringify(cell.outputs[0]));
-			} else if (eventCount === 2) {
-				assert.strictEqual(e.state, vscode.NotebookCellExecutionState.Idle, 'should be set to Idle');
-				assert.strictEqual(cell.outputs.length, 1, 'should have an output');
-				resolve();
-			}
+		const def = new DeferredPromise<void>();
+		testDisposables.push(vscode.notebooks.onDidChangeNotebookCellExecutionState(e => {
+			try {
+				assert.strictEqual(e.cell.document.uri.toString(), cell.document.uri.toString(), 'event should be fired for the executing cell');
 
-			eventCount++;
-		});
+				if (eventCount === 0) {
+					assert.strictEqual(e.state, vscode.NotebookCellExecutionState.Pending, 'should be set to Pending');
+				} else if (eventCount === 1) {
+					assert.strictEqual(e.state, vscode.NotebookCellExecutionState.Executing, 'should be set to Executing');
+					assert.strictEqual(cell.outputs.length, 0, 'no outputs yet: ' + JSON.stringify(cell.outputs[0]));
+				} else if (e.state === vscode.NotebookCellExecutionState.Idle) {
+					assert.strictEqual(cell.outputs.length, 1, 'should have an output');
+					def.complete();
+				}
+
+				eventCount++;
+			} catch (err) {
+				def.error(err);
+			}
+		}));
 
 		vscode.commands.executeCommand('notebook.cell.execute', { document: notebook.uri, ranges: [{ start: 0, end: 1 }] });
 
-		await p;
-		listener.dispose();
+		await def.p;
 	});
 
 	test('Output changes are applied once the promise resolves', async function () {

--- a/extensions/vscode-api-tests/src/utils.ts
+++ b/extensions/vscode-api-tests/src/utils.ts
@@ -184,3 +184,61 @@ export async function poll<T>(
 		trial++;
 	}
 }
+
+export type ValueCallback<T = unknown> = (value: T | Promise<T>) => void;
+
+/**
+ * Creates a promise whose resolution or rejection can be controlled imperatively.
+ */
+export class DeferredPromise<T> {
+
+	private completeCallback!: ValueCallback<T>;
+	private errorCallback!: (err: unknown) => void;
+	private rejected = false;
+	private resolved = false;
+
+	public get isRejected() {
+		return this.rejected;
+	}
+
+	public get isResolved() {
+		return this.resolved;
+	}
+
+	public get isSettled() {
+		return this.rejected || this.resolved;
+	}
+
+	public readonly p: Promise<T>;
+
+	constructor() {
+		this.p = new Promise<T>((c, e) => {
+			this.completeCallback = c;
+			this.errorCallback = e;
+		});
+	}
+
+	public complete(value: T) {
+		return new Promise<void>(resolve => {
+			this.completeCallback(value);
+			this.resolved = true;
+			resolve();
+		});
+	}
+
+	public error(err: unknown) {
+		return new Promise<void>(resolve => {
+			this.errorCallback(err);
+			this.rejected = true;
+			resolve();
+		});
+	}
+
+	public cancel() {
+		new Promise<void>(resolve => {
+			this.errorCallback(new Error('Canceled'));
+			this.rejected = true;
+			resolve();
+		});
+	}
+}

--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -1389,7 +1389,7 @@ export class DeferredPromise<T> {
 		return this.rejected || this.resolved;
 	}
 
-	public p: Promise<T>;
+	public readonly p: Promise<T>;
 
 	constructor() {
 		this.p = new Promise<T>((c, e) => {

--- a/src/vs/workbench/api/common/extHostNotebookKernels.ts
+++ b/src/vs/workbench/api/common/extHostNotebookKernels.ts
@@ -348,10 +348,13 @@ export class ExtHostNotebookKernels implements ExtHostNotebookKernelsShape {
 		const document = this._extHostNotebook.getNotebookDocument(URI.revive(uri));
 		const cell = document.getCell(cellHandle);
 		if (cell) {
-			this._onDidChangeCellExecutionState.fire({
-				cell: cell.apiCell,
-				state: state ? extHostTypeConverters.NotebookCellExecutionState.to(state) : ExtHostNotebookCellExecutionState.Idle
-			});
+			const newState = state ? extHostTypeConverters.NotebookCellExecutionState.to(state) : ExtHostNotebookCellExecutionState.Idle;
+			if (newState !== undefined) {
+				this._onDidChangeCellExecutionState.fire({
+					cell: cell.apiCell,
+					state: newState
+				});
+			}
 		}
 	}
 

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1538,13 +1538,14 @@ export namespace NotebookCellExecutionSummary {
 }
 
 export namespace NotebookCellExecutionState {
-	export function to(state: notebooks.NotebookCellExecutionState): vscode.NotebookCellExecutionState {
-		if (state === notebooks.NotebookCellExecutionState.Executing) {
-			return types.NotebookCellExecutionState.Executing;
+	export function to(state: notebooks.NotebookCellExecutionState): vscode.NotebookCellExecutionState | undefined {
+		if (state === notebooks.NotebookCellExecutionState.Unconfirmed) {
+			return types.NotebookCellExecutionState.Pending;
 		} else if (state === notebooks.NotebookCellExecutionState.Pending) {
-			return types.NotebookCellExecutionState.Pending;
-		} else if (state === notebooks.NotebookCellExecutionState.Unconfirmed) {
-			return types.NotebookCellExecutionState.Pending;
+			// Since the (proposed) extension API doesn't have the distinction between Unconfirmed and Pending, we don't want to fire an update for Pending twice
+			return undefined;
+		} else if (state === notebooks.NotebookCellExecutionState.Executing) {
+			return types.NotebookCellExecutionState.Executing;
 		} else {
 			throw new Error(`Unknown state: ${state}`);
 		}


### PR DESCRIPTION
An error thrown in an event handler did not cause the test to fail, using DeferredPromise. Adjusting the api event to account for Unconfirmed vs Pending states. And accounting for onDidChangeNotebookDocument being fired multiple times during a test, causing the test to complete early while execution was still happening.
Fixes #157067

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
