### PR TITLE
#157310 Fix typo (minimum -> maximum) in splitview.ts comment

### DIFF
--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -52,7 +52,7 @@ export interface IView<TLayoutContext = undefined> {
 	readonly minimumSize: number;
 
 	/**
-	 * A minimum size for this view.
+	 * A maximum size for this view.
 	 *
 	 * @remarks If none, set it to `Number.POSITIVE_INFINITY`.
 	 */


### PR DESCRIPTION
This PR fixes the issue filed in https://github.com/microsoft/vscode/issues/157310