### PR TITLE
labels: fix caching of unintended formatters

### DIFF
--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -145,7 +145,7 @@ export class LabelService extends Disposable implements ILabelService {
 
 		const memento = this.storedFormattersMemento = new Memento('cachedResourceLabelFormatters', storageService);
 		this.storedFormatters = memento.getMemento(StorageScope.PROFILE, StorageTarget.MACHINE);
-		this.formatters = this.storedFormatters?.formatters || [];
+		this.formatters = this.storedFormatters?.formatters?.slice() || [];
 
 		// Remote environment is potentially long running
 		this.resolveRemoteEnvironment();

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -143,7 +143,7 @@ export class LabelService extends Disposable implements ILabelService {
 		this.os = OS;
 		this.userHome = pathService.defaultUriScheme === Schemas.file ? this.pathService.userHome({ preferLocal: true }) : undefined;
 
-		const memento = this.storedFormattersMemento = new Memento('cachedResourceLabelFormatters', storageService);
+		const memento = this.storedFormattersMemento = new Memento('cachedResourceLabelFormatters2', storageService);
 		this.storedFormatters = memento.getMemento(StorageScope.PROFILE, StorageTarget.MACHINE);
 		this.formatters = this.storedFormatters?.formatters?.slice() || [];
 

--- a/src/vs/workbench/services/label/test/browser/label.test.ts
+++ b/src/vs/workbench/services/label/test/browser/label.test.ts
@@ -166,7 +166,7 @@ suite('URI Label', () => {
 
 
 	test('label caching', () => {
-		const m = new Memento('cachedResourceLabelFormatters', storageService).getMemento(StorageScope.PROFILE, StorageTarget.MACHINE);
+		const m = new Memento('cachedResourceLabelFormatters2', storageService).getMemento(StorageScope.PROFILE, StorageTarget.MACHINE);
 		const makeFormatter = (scheme: string): ResourceLabelFormatter => ({ formatting: { label: `\${path} (${scheme})`, separator: '/' }, scheme });
 		assert.deepStrictEqual(m, {});
 


### PR DESCRIPTION
`this.formatters` was the same list instance stored in the memo, so we
could cache things we didn't want to. I believe this caused #156135,
since things we _intend_ to cache from the extension host are parsed
from JSON and cannot be circular.

Fixes #156135
Fixes #155844