### PR TITLE
Don't show unbound breakpoint indicator for disabled breakpoints

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -287,7 +287,7 @@ export class BreakpointsView extends ViewPane {
 		const dbg = currentType ? this.debugService.getAdapterManager().getDebugger(currentType) : undefined;
 		const message = dbg?.uiMessages && dbg.uiMessages[DebuggerUiMessage.UnverifiedBreakpoints];
 		const debuggerHasUnverifiedBps = message && this.debugService.getModel().getBreakpoints().filter(bp => {
-			if (bp.verified) {
+			if (bp.verified || !bp.enabled) {
 				return false;
 			}
 


### PR DESCRIPTION
Fixes #157317

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
