### PR TITLE
Add support for a border below section headers in Sidebar and Panel

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -33,6 +33,7 @@ export interface IPaneStyles {
 	headerForeground?: Color;
 	headerBackground?: Color;
 	headerBorder?: Color;
+	headerBorderBottom?: Color;
 	leftBorder?: Color;
 }
 
@@ -281,6 +282,7 @@ export abstract class Pane extends Disposable implements IView {
 		this.header.style.color = this.styles.headerForeground ? this.styles.headerForeground.toString() : '';
 		this.header.style.backgroundColor = this.styles.headerBackground ? this.styles.headerBackground.toString() : '';
 		this.header.style.borderTop = this.styles.headerBorder && this.orientation === Orientation.VERTICAL ? `1px solid ${this.styles.headerBorder}` : '';
+		this.header.style.borderBottom = this.styles.headerBorderBottom ? `1px solid ${this.styles.headerBorderBottom}` : '';
 		this._dropBackground = this.styles.dropBackground;
 		this.element.style.borderLeft = this.styles.leftBorder && this.orientation === Orientation.HORIZONTAL ? `1px solid ${this.styles.leftBorder}` : '';
 	}

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -35,7 +35,7 @@ import { CompositeDragAndDropObserver, toggleDropEffect } from 'vs/workbench/bro
 import { ViewPane } from 'vs/workbench/browser/parts/views/viewPane';
 import { IViewletViewOptions } from 'vs/workbench/browser/parts/views/viewsViewlet';
 import { Component } from 'vs/workbench/common/component';
-import { PANEL_SECTION_BORDER, PANEL_SECTION_DRAG_AND_DROP_BACKGROUND, PANEL_SECTION_HEADER_BACKGROUND, PANEL_SECTION_HEADER_BORDER, PANEL_SECTION_HEADER_FOREGROUND, SIDE_BAR_DRAG_AND_DROP_BACKGROUND, SIDE_BAR_SECTION_HEADER_BACKGROUND, SIDE_BAR_SECTION_HEADER_BORDER, SIDE_BAR_SECTION_HEADER_FOREGROUND } from 'vs/workbench/common/theme';
+import { PANEL_SECTION_BORDER, PANEL_SECTION_DRAG_AND_DROP_BACKGROUND, PANEL_SECTION_HEADER_BACKGROUND, PANEL_SECTION_HEADER_BORDER, PANEL_SECTION_HEADER_BORDER_BOTTOM, PANEL_SECTION_HEADER_FOREGROUND, SIDE_BAR_DRAG_AND_DROP_BACKGROUND, SIDE_BAR_SECTION_HEADER_BACKGROUND, SIDE_BAR_SECTION_HEADER_BORDER, SIDE_BAR_SECTION_HEADER_BORDER_BOTTOM, SIDE_BAR_SECTION_HEADER_FOREGROUND } from 'vs/workbench/common/theme';
 import { IAddedViewDescriptorRef, ICustomViewDescriptor, IView, IViewContainerModel, IViewDescriptor, IViewDescriptorRef, IViewDescriptorService, IViewPaneContainer, IViewsService, ViewContainer, ViewContainerLocation, ViewContainerLocationToString, ViewVisibilityState } from 'vs/workbench/common/views';
 import { FocusedViewContext } from 'vs/workbench/common/contextkeys';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
@@ -54,6 +54,7 @@ export interface IPaneColors extends IColorMapping {
 	headerForeground?: ColorIdentifier;
 	headerBackground?: ColorIdentifier;
 	headerBorder?: ColorIdentifier;
+	headerBorderBottom?: ColorIdentifier;
 	leftBorder?: ColorIdentifier;
 }
 
@@ -848,6 +849,7 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 			headerForeground: isPanel ? PANEL_SECTION_HEADER_FOREGROUND : SIDE_BAR_SECTION_HEADER_FOREGROUND,
 			headerBackground: isPanel ? PANEL_SECTION_HEADER_BACKGROUND : SIDE_BAR_SECTION_HEADER_BACKGROUND,
 			headerBorder: isPanel ? PANEL_SECTION_HEADER_BORDER : SIDE_BAR_SECTION_HEADER_BORDER,
+			headerBorderBottom: isPanel ? PANEL_SECTION_HEADER_BORDER_BOTTOM : SIDE_BAR_SECTION_HEADER_BORDER_BOTTOM,
 			dropBackground: isPanel ? PANEL_SECTION_DRAG_AND_DROP_BACKGROUND : SIDE_BAR_DRAG_AND_DROP_BACKGROUND,
 			leftBorder: isPanel ? PANEL_SECTION_BORDER : undefined
 		}, pane);

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -394,6 +394,13 @@ export const PANEL_SECTION_HEADER_BORDER = registerColor('panelSectionHeader.bor
 	hcLight: contrastBorder
 }, localize('panelSectionHeaderBorder', "Panel section header border color used when multiple views are stacked vertically in the panel. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels."));
 
+export const PANEL_SECTION_HEADER_BORDER_BOTTOM = registerColor('panelSectionHeader.borderBottom', {
+	dark: null,
+	light: null,
+	hcDark: null,
+	hcLight: null
+}, localize('panelSectionHeaderBorderBottom', "Panel section header bottom border color. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels."));
+
 export const PANEL_SECTION_BORDER = registerColor('panelSection.border', {
 	dark: PANEL_BORDER,
 	light: PANEL_BORDER,
@@ -714,6 +721,13 @@ export const SIDE_BAR_SECTION_HEADER_BORDER = registerColor('sideBarSectionHeade
 	hcDark: contrastBorder,
 	hcLight: contrastBorder
 }, localize('sideBarSectionHeaderBorder', "Side bar section header border color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar."));
+
+export const SIDE_BAR_SECTION_HEADER_BORDER_BOTTOM = registerColor('sideBarSectionHeader.borderBottom', {
+	dark: null,
+	light: null,
+	hcDark: null,
+	hcLight: null
+}, localize('sideBarSectionHeaderBorderBottom', "Side bar section header bottom border color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar."));
 
 
 // < --- Title Bar --- >


### PR DESCRIPTION
This fixes #157343

Eg:  
![image](https://user-images.githubusercontent.com/150152/183220268-e08f3081-72a1-433d-8be8-cc3eb04f86f1.png)

![image](https://user-images.githubusercontent.com/150152/183220558-5aa9b1bd-3ce6-4263-8469-06ab38d117d1.png)

It allows for a border to be places below section headers. 

In the screenshots above, I have added the border manually in settings.json. This is default to null for all themes since I wasn't sure how it would look with the high contrast themes when I was creating it, but looking at the screenshot above, I think you could make a case for enabling it.