### PR TITLE
Add jsonc registration for TypeDoc config

### DIFF
--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -61,7 +61,8 @@
         "filenames": [
           "babel.config.json",
           ".babelrc.json",
-          ".ember-cli"
+          ".ember-cli",
+          "typedoc.json"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
This is supported as of TypeDoc 0.23. Since it is more commonly used than ember-cli, seems reasonable to add it here.

Closes #157363