### PR TITLE
Issue reporter fails to report when `sandbox` is enabled

### DIFF
--- a/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
@@ -73,6 +73,7 @@ export class IssueReporter extends Disposable {
 
 		const targetExtension = configuration.data.extensionId ? configuration.data.enabledExtensions.find(extension => extension.id === configuration.data.extensionId) : undefined;
 		this.issueReporterModel = new IssueReporterModel({
+			...configuration.data,
 			issueType: configuration.data.issueType || IssueType.Bug,
 			versionInfo: {
 				vscodeVersion: `${configuration.product.nameShort} ${!!configuration.product.darwinUniversalAssetId ? `${configuration.product.version} (Universal)` : configuration.product.version} (${configuration.product.commit || 'Commit unknown'}, ${configuration.product.date || 'Date unknown'})`,
@@ -80,7 +81,7 @@ export class IssueReporter extends Disposable {
 			},
 			extensionsDisabled: !!configuration.disableExtensions,
 			fileOnExtension: configuration.data.extensionId ? !targetExtension?.isBuiltin : undefined,
-			selectedExtension: targetExtension,
+			selectedExtension: targetExtension
 		});
 
 		const issueReporterElement = this.getElementById('issue-reporter');


### PR DESCRIPTION
I do not really understand how the issue reporter was working so far, but it looks like all of the `IssueReporterData` is not stored into the `IssueReporterModel` so I would assume many of the properties in an issue are actually wrong, for example restricted mode, etc.

I only noticed this because my new property `isSandboxed` was not working.

@TylerLeonhardt maybe you have an idea or overview why the issue reporter is broken like this?