### PR TITLE
Add env for terminalProcess getCwd Unicode path on macOS

### DIFF
--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -583,7 +583,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 					return;
 				}
 				this._logService.trace('IPty#pid');
-				exec('lsof -OPln -p ' + this._ptyProcess.pid + ' | grep cwd', (error, stdout, stderr) => {
+				exec('lsof -OPln -p ' + this._ptyProcess.pid + ' | grep cwd', { env: { ...process.env, LANG: 'en_US.UTF-8' } }, (error, stdout, stderr) => {
 					if (!error && stdout !== '') {
 						resolve(stdout.substring(stdout.indexOf('/'), stdout.length - 1));
 					} else {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/83496, should also close https://github.com/microsoft/vscode/issues/145364, and close https://github.com/microsoft/vscode/issues/150136 since the root cause is the same. 

#### Explanation

`lsof` won't support Unicode output unless provided LANG in environment variables, which causing cwd issues above.

Reference:
https://opensource.apple.com/source/lsof/lsof-68/lsof/lsof.man.auto.html

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
