### PR TITLE
Transform URIs of hover results

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -250,7 +250,8 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 			} else {
 				let resolvedHref = _href(href, false);
 				if (markdown.baseUri) {
-					resolvedHref = resolveWithBaseUri(URI.from(markdown.baseUri), href);
+					// resolvedHref might have different URI parts in the case of being transformed during collecting
+					resolvedHref = resolveWithBaseUri(URI.from(markdown.baseUri), resolvedHref);
 				}
 				a.dataset.href = resolvedHref;
 			}

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -219,6 +219,24 @@ suite('MarkdownRenderer', () => {
 		assert.ok(data.documentUri.toString().startsWith('file:///c%3A/'));
 	});
 
+	test('render collected transformed uri', () => {
+		// MarkdownString.uris maps hrefs into uris, which may have different scheme and authority
+		// should render the transformed uri to data-href
+		const md: IMarkdownString = JSON.parse('{"value":"[link](file:///foo/bar)","supportThemeIcons":false,"supportHtml":false,"uris":{"file:///foo/bar":{"$mid":1,"external":"vscode-remote://host/foo/bar","path":"/foo/bar","scheme":"vscode-remote","authority":"host"}}}');
+		const element = renderMarkdown(md).element;
+
+		const anchor = element.querySelector('a')!;
+		assert.ok(anchor);
+		assert.ok(anchor.dataset['href']);
+
+		const uri = URI.parse(anchor.dataset['href']!);
+
+		assert.ok(uri);
+		assert.strictEqual(uri.scheme, 'vscode-remote');
+		assert.strictEqual(uri.authority, 'host');
+		assert.strictEqual(uri.fsPath, '/foo/bar');
+	});
+
 	test('Should not render command links by default', () => {
 		const md = new MarkdownString(`[command1](command:doFoo) <a href="command:doFoo">command2</a>`, {
 			supportHtml: true

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -246,6 +246,7 @@ class HoverAdapter {
 	constructor(
 		private readonly _documents: ExtHostDocuments,
 		private readonly _provider: vscode.HoverProvider,
+		private readonly _uriTransformer: IURITransformer,
 	) { }
 
 	async provideHover(resource: URI, position: IPosition, token: CancellationToken): Promise<languages.Hover | undefined> {

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -263,7 +263,7 @@ class HoverAdapter {
 		if (!value.range) {
 			value.range = new Range(pos, pos);
 		}
-		return typeConvert.Hover.from(value);
+		return typeConvert.Hover.from(value, this._uriTransformer);
 	}
 }
 
@@ -2009,7 +2009,7 @@ export class ExtHostLanguageFeatures implements extHostProtocol.ExtHostLanguageF
 	// --- extra info
 
 	registerHoverProvider(extension: IExtensionDescription, selector: vscode.DocumentSelector, provider: vscode.HoverProvider, extensionId?: ExtensionIdentifier): vscode.Disposable {
-		const handle = this._addNewAdapter(new HoverAdapter(this._documents, provider), extension);
+		const handle = this._addNewAdapter(new HoverAdapter(this._documents, provider, this._uriTransformer), extension);
 		this._proxy.$registerHoverProvider(handle, this._transformDocumentSelector(selector));
 		return this._createDisposable(handle);
 	}

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -344,7 +344,6 @@ export namespace MarkdownString {
 				uri = uriTransformer ? uriTransformer.transformOutgoingURI(uri) : uri;
 				uri = uri.with({ query: _uriMassage(uri.query, resUris) });
 				resUris[href] = uri;
-				console.log('uri', uri);
 			} catch (e) {
 				// ignore
 			}

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -340,7 +340,8 @@ export namespace MarkdownString {
 
 		const collectUri = (href: string): string => {
 			try {
-				let uri = uriTransformer ? uriTransformer.transformOutgoingURI(URI.parse(href, true)) : URI.parse(href, true);
+				let uri = URI.parse(href, true);
+				uri = uriTransformer ? uriTransformer.transformOutgoingURI(uri) : uri;
 				uri = uri.with({ query: _uriMassage(uri.query, resUris) });
 				resUris[href] = uri;
 				console.log('uri', uri);

--- a/src/vs/workbench/api/common/uriTransformer.ts
+++ b/src/vs/workbench/api/common/uriTransformer.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { UriParts, IRawURITransformer } from 'vs/base/common/uriIpc';
+
+/**
+ * ```
+ * --------------------------------
+ * |    UI SIDE    |  AGENT SIDE  |
+ * |---------------|--------------|
+ * | vscode-remote | file         |
+ * | file          | vscode-local |
+ * --------------------------------
+ * ```
+ */
+export function createRemoteRawURITransformer(remoteAuthority: string): IRawURITransformer {
+	return {
+		transformIncoming: (uri: UriParts): UriParts => {
+			if (uri.scheme === 'vscode-remote') {
+				return { scheme: 'file', path: uri.path, query: uri.query, fragment: uri.fragment };
+			}
+			if (uri.scheme === 'file') {
+				return { scheme: 'vscode-local', path: uri.path, query: uri.query, fragment: uri.fragment };
+			}
+			return uri;
+		},
+		transformOutgoing: (uri: UriParts): UriParts => {
+			if (uri.scheme === 'file') {
+				return { scheme: 'vscode-remote', authority: remoteAuthority, path: uri.path, query: uri.query, fragment: uri.fragment };
+			}
+			if (uri.scheme === 'vscode-local') {
+				return { scheme: 'file', path: uri.path, query: uri.query, fragment: uri.fragment };
+			}
+			return uri;
+		},
+		transformOutgoingScheme: (scheme: string): string => {
+			if (scheme === 'file') {
+				return 'vscode-remote';
+			} else if (scheme === 'vscode-local') {
+				return 'file';
+			}
+			return scheme;
+		}
+	};
+}

--- a/src/vs/workbench/api/node/uriTransformer.ts
+++ b/src/vs/workbench/api/node/uriTransformer.ts
@@ -3,49 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { UriParts, IRawURITransformer, URITransformer, IURITransformer } from 'vs/base/common/uriIpc';
+import { URITransformer, IURITransformer } from 'vs/base/common/uriIpc';
+import { createRemoteRawURITransformer } from 'vs/workbench/api/common/uriTransformer';
 
-/**
- * ```
- * --------------------------------
- * |    UI SIDE    |  AGENT SIDE  |
- * |---------------|--------------|
- * | vscode-remote | file         |
- * | file          | vscode-local |
- * --------------------------------
- * ```
- */
-function createRawURITransformer(remoteAuthority: string): IRawURITransformer {
-	return {
-		transformIncoming: (uri: UriParts): UriParts => {
-			if (uri.scheme === 'vscode-remote') {
-				return { scheme: 'file', path: uri.path, query: uri.query, fragment: uri.fragment };
-			}
-			if (uri.scheme === 'file') {
-				return { scheme: 'vscode-local', path: uri.path, query: uri.query, fragment: uri.fragment };
-			}
-			return uri;
-		},
-		transformOutgoing: (uri: UriParts): UriParts => {
-			if (uri.scheme === 'file') {
-				return { scheme: 'vscode-remote', authority: remoteAuthority, path: uri.path, query: uri.query, fragment: uri.fragment };
-			}
-			if (uri.scheme === 'vscode-local') {
-				return { scheme: 'file', path: uri.path, query: uri.query, fragment: uri.fragment };
-			}
-			return uri;
-		},
-		transformOutgoingScheme: (scheme: string): string => {
-			if (scheme === 'file') {
-				return 'vscode-remote';
-			} else if (scheme === 'vscode-local') {
-				return 'file';
-			}
-			return scheme;
-		}
-	};
-}
 
 export function createURITransformer(remoteAuthority: string): IURITransformer {
-	return new URITransformer(createRawURITransformer(remoteAuthority));
+	return new URITransformer(createRemoteRawURITransformer(remoteAuthority));
 }

--- a/src/vs/workbench/api/test/browser/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostLanguageFeatures.test.ts
@@ -497,13 +497,11 @@ suite('ExtHostLanguageFeatures', function () {
 		}));
 
 		await rpcProtocol.sync();
-		await getHoverPromise(languageFeaturesService.hoverProvider, model, new EditorPosition(1, 1), CancellationToken.None).then(value => {
-			console.error(JSON.stringify(value[0].contents[0]));
-
-			value[0].contents.forEach((md, index) => assert.deepEqual(
-				Object.values((md.uris || {})).map(uri => URI.revive(uri).toString()), fixtures[index][1])
-			);
-		});
+		const hovers = await getHoverPromise(languageFeaturesService.hoverProvider, model, new EditorPosition(1, 1), CancellationToken.None);
+		assert.strictEqual(hovers.length, 1);
+		hovers[0].contents.forEach((md, index) => assert.deepEqual(
+			Object.values((md.uris || {})).map(uri => URI.revive(uri).toString()), fixtures[index][1])
+		);
 	});
 
 	// --- occurrences


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
trying to (partially) fix https://github.com/microsoft/vscode/issues/157124 with unit tests

`file://` and `vscode-local://` URIs provided by `HoverProvider`s are now transformed and `MarkdownRenderer` will render the transformed URI