### PR TITLE
fix sticky scroll start line number

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollProvider.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollProvider.ts
@@ -147,7 +147,7 @@ class StickyOutlineElement {
 		});
 		let range: StickyRange | undefined;
 		if (outlineModel instanceof OutlineElement) {
-			range = new StickyRange(outlineModel.symbol.range.startLineNumber, outlineModel.symbol.range.endLineNumber);
+			range = new StickyRange(outlineModel.symbol.selectionRange.startLineNumber, outlineModel.symbol.range.endLineNumber);
 		} else {
 			range = undefined;
 		}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/157680
Fixes https://github.com/microsoft/vscode/issues/157180
Fixes https://github.com/microsoft/vscode/issues/157293
Fixes https://github.com/microsoft/vscode/issues/157380
Fixes https://github.com/microsoft/vscode/issues/157375

---

fix https://github.com/microsoft/vscode/issues/157375

when class or method have decorator(TypeScript) or attribute(C#), 
range.startLineNumber is begin of decorator, but selectionRange.startLineNumber is start of method.


![image](https://user-images.githubusercontent.com/6461899/183333021-3d1ab4f1-8cfe-4b7d-97c6-d4201f362738.png)