### PR TITLE
restore user's `ZDOTDIR` for non-login shells w shell integration

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -126,3 +126,7 @@ __vsc_preexec() {
 }
 add-zsh-hook precmd __vsc_precmd
 add-zsh-hook preexec __vsc_preexec
+
+if [[ $options[login] = off ]]; then
+	ZDOTDIR=$USER_ZDOTDIR
+fi


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/157128
