### PR TITLE
Use %s to format % chars instead of sed to sanitize

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -59,8 +59,7 @@ __vsc_update_cwd() {
 
 __vsc_command_output_start() {
 	builtin printf "\033]633;C\007"
-	# Send command line, escaping printf format chars %
-	builtin printf "\033]633;E;$(echo $__vsc_current_command | sed s/%/%%/g)\007"
+	builtin printf "\033]633;E;%s\007" "$__vsc_current_command"
 }
 
 __vsc_continuation_start() {

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -51,7 +51,7 @@ __vsc_update_cwd() {
 __vsc_command_output_start() {
 	builtin printf "\033]633;C\007"
 	# Send command line, escaping printf format chars %
-	builtin printf "\033]633;E;$(echo $__vsc_current_command | sed s/%/%%/g)\007"
+	builtin printf "\033]633;E;%s\007" "$__vsc_current_command"
 }
 
 __vsc_continuation_start() {


### PR DESCRIPTION
Fixes #157524
