### PR TITLE
Apply editor-font-family to all `code` in notebooks

### DIFF
--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -259,11 +259,10 @@ export const activate: ActivationFunction<void> = (ctx) => {
 
 		code {
 			font-size: 1em;
+			font-family: var(--vscode-editor-font-family);
 		}
 
 		pre code {
-			font-family: var(--vscode-editor-font-family);
-
 			line-height: 1.357em;
 			white-space: pre-wrap;
 		}


### PR DESCRIPTION
Fixes #146696

This matches what we do in the markdown preview
