### PR TITLE
Fix notebook links with empty hashes

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -110,8 +110,14 @@ async function webviewPreloads(ctx: PreloadContext) {
 					handleBlobUrlClick(node.href, node.download);
 				} else if (node.href.startsWith('data:')) {
 					handleDataUrl(node.href, node.download);
-				} else if (node.hash && node.getAttribute('href') === node.hash) {
+				} else if (node.getAttribute('href')?.trim().startsWith('#')) {
 					// Scrolling to location within current doc
+
+					if (!node.hash) {
+						postNotebookMessage<webviewMessages.IScrollToRevealMessage>('scroll-to-reveal', { scrollTop: 0 });
+						return;
+					}
+
 					const targetId = node.hash.substring(1);
 
 					// Check outer document first


### PR DESCRIPTION
Fixes #153032

This fixes our handling of `href="#"` on links in notebooks
