### PR TITLE
Add schema for typedoc.json to default jsonValidation

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -137,6 +137,10 @@
       {
         "fileMatch": "jsconfig.*.json",
         "url": "./schemas/jsconfig.schema.json"
+      },
+      {
+        "fileMatch": "typedoc.json",
+        "url": "https://typedoc.org/schema.json"
       }
     ],
     "configuration": {


### PR DESCRIPTION
It is not clear to me if this is the correct place for this, if it even belongs in the repo, but there are other non-ts-related schemas in this file (babel, bower), so adding one more didn't seem too bad.

This should probably only be accepted if #157362 is accepted.