### PR TITLE
Fix Simplify bash PROMPT_COMMAND handling commit

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -168,7 +168,7 @@ __vsc_prompt_cmd_original() {
 			eval "${cmd:-}"
 		done
 	else
-		__vsc_restor_exit_code "${__vsc_status}"
+		__vsc_restore_exit_code "${__vsc_status}"
 		eval "${__vsc_original_prompt_command:-}"
 	fi
 	__vsc_precmd

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -154,7 +154,7 @@ fi
 
 __vsc_update_prompt
 
-__vsc_restor_exit_code() {
+__vsc_restore_exit_code() {
 	return $1
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -154,6 +154,10 @@ fi
 
 __vsc_update_prompt
 
+__vsc_restor_exit_code() {
+	return $1
+}
+
 __vsc_prompt_cmd_original() {
 	__vsc_status="$?"
 	# Evaluate the original PROMPT_COMMAND similarly to how bash would normally
@@ -164,6 +168,7 @@ __vsc_prompt_cmd_original() {
 			eval "${cmd:-}"
 		done
 	else
+		__vsc_restor_exit_code "${__vsc_status}"
 		eval "${__vsc_original_prompt_command:-}"
 	fi
 	__vsc_precmd


### PR DESCRIPTION
Fix @Tyriar commit dfc99af92ae923841caa055260deac9b61570725 `Simplify bash PROMPT_COMMAND handling`.

What's happend ?

I use a modified PS1 for bash prompt:
```
function _update_ps1() {
    PS1="$(/usr/local/bin/powerline-go -error $? -jobs $(jobs -p | /usr/bin/wc -l) -modules "user,host,cwd,perms,git,hg,jobs,exit,root")"
}

if [ "$TERM" != "linux" ] && [ -f "/usr/local/bin/powerline-go" ]; then
    PROMPT_COMMAND="_update_ps1; $PROMPT_COMMAND"
fi
```
It works fine without VSCode terminal integration. `$?` return last exit code of command.

But, since VSCode 1.7.0, `$?` return value of `[[ ${#__vsc_original_prompt_command[@]} -gt 1 ]]` line (line [161](https://github.com/microsoft/vscode/blame/main/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh#L161)).

In my case, `$?` return always error.

Debug trace:
```
+ builtin unset VSCODE_INJECTION
...
++ __vsc_status=0
++ [[ 1 -gt 1 ]]
++ eval '_update_ps1; '
+++ _update_ps1
+++++ /usr/bin/wc -l
+++++ jobs -p
++++ /usr/local/bin/powerline-go -error 1 -jobs 0 -modules user,host,cwd,perms,git,hg,jobs,exit,root
+++ PS1='\[\e[38;5;250m\]\[\e[48;5;240m\] vagrant \[\e[48;5;238m\]\[\e[38;5;240m\]\[\e[0m\]\[\e[38;5;250m\]\[\e[48;5;238m\] mv-ulm \[\e[48;5;31m\]\[\e[38;5;238m\]\[\e[0m\]\[\e[38;5;15m\]\[\e[48;5;31m\] ~ \[\e[48;5;161m\]\[\e[38;5;31m\]\[\e[0m\]\[\e[38;5;15m\]\[\e[48;5;161m\] ERROR \[\e[48;5;161m\]\[\e[38;5;161m\]\[\e[0m\]\[\e[38;5;15m\]\[\e[48;5;161m\] \$ \[\e[0m\]\[\e[38;5;161m\]\[\e[0m\] '
```

In my case, `$?` return value of `[[ 1 -gt 1 ]]`.

fixes https://github.com/microsoft/vscode/issues/157206