### PR TITLE
Update close reason

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -193,7 +193,7 @@
 			"IllusionMH"
 		],
 		"action": "close",
-		"reason": "complete",
+		"reason": "completed",
 		"addLabel": "unreleased"
 	},
 	{


### PR DESCRIPTION
GitHub blog specifies 'complete' but the string is actually 'completed'

https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/