### PR TITLE
Fix #157689. Trigger outputs to re-render outputs when missing renderers are installed.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -100,6 +100,8 @@ export interface ICellOutputViewModel extends IDisposable {
 	resolveMimeTypes(textModel: NotebookTextModel, kernelProvides: readonly string[] | undefined): [readonly IOrderedMimeType[], number];
 	pickedMimeType: IOrderedMimeType | undefined;
 	hasMultiMimeType(): boolean;
+	readonly onDidResetRenderer: Event<void>;
+	resetRenderer(): void;
 	toRawJSON(): any;
 }
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookServiceImpl.ts
@@ -416,6 +416,8 @@ export class NotebookService extends Disposable implements INotebookService {
 		return this._notebookProviderInfoStore;
 	}
 	private readonly _notebookRenderersInfoStore = this._instantiationService.createInstance(NotebookOutputRendererInfoStore);
+	private readonly _onDidChangeOutputRenderers = this._register(new Emitter<void>());
+	readonly onDidChangeOutputRenderers = this._onDidChangeOutputRenderers.event;
 	private readonly _models = new ResourceMap<ModelData>();
 
 	private readonly _onWillAddNotebookDocument = this._register(new Emitter<NotebookTextModel>());
@@ -480,6 +482,8 @@ export class NotebookService extends Disposable implements INotebookService {
 					}));
 				}
 			}
+
+			this._onDidChangeOutputRenderers.fire();
 		});
 
 		const updateOrder = () => {

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -87,7 +87,11 @@ export class CellOutputElement extends Disposable {
 		this.contextKeyService = parentContextKeyService;
 
 		this._register(this.output.model.onDidChangeData(() => {
-			this.updateOutputData();
+			this.rerender();
+		}));
+
+		this._register(this.output.onDidResetRenderer(() => {
+			this.rerender();
 		}));
 	}
 
@@ -120,7 +124,7 @@ export class CellOutputElement extends Disposable {
 		}
 	}
 
-	updateOutputData() {
+	rerender() {
 		if (
 			this.notebookEditor.hasModel() &&
 			this.innerContainer &&

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -34,7 +34,7 @@ import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/w
 import { asWebviewUri, webviewGenericCspSource } from 'vs/workbench/common/webview';
 import { CellEditState, ICellOutputViewModel, ICellViewModel, ICommonCellInfo, IDisplayOutputLayoutUpdateRequest, IDisplayOutputViewModel, IFocusNotebookCellOptions, IGenericCellViewModel, IInsetRenderOutput, INotebookEditorCreationOptions, INotebookWebviewMessage, RenderOutputType } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NOTEBOOK_WEBVIEW_BOUNDARY } from 'vs/workbench/contrib/notebook/browser/view/notebookCellList';
-import { preloadsScriptStr, RendererMetadata } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads';
+import { preloadsScriptStr } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads';
 import { transformWebviewThemeVars } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewThemeMapping';
 import { MarkupCellViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/markupCellViewModel';
 import { CellUri, INotebookRendererInfo, NotebookSetting, RendererMessagingSpec } from 'vs/workbench/contrib/notebook/common/notebookCommon';
@@ -45,7 +45,7 @@ import { IWebviewElement, IWebviewService, WebviewContentPurpose } from 'vs/work
 import { WebviewWindowDragMonitor } from 'vs/workbench/contrib/webview/browser/webviewWindowDragMonitor';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
-import { FromWebviewMessage, IAckOutputHeight, IClickedDataUrlMessage, ICodeBlockHighlightRequest, IContentWidgetTopRequest, IControllerPreload, ICreationContent, ICreationRequestMessage, IFindMatch, IMarkupCellInitialization, ToWebviewMessage } from './webviewMessages';
+import { FromWebviewMessage, IAckOutputHeight, IClickedDataUrlMessage, ICodeBlockHighlightRequest, IContentWidgetTopRequest, IControllerPreload, ICreationContent, ICreationRequestMessage, IFindMatch, IMarkupCellInitialization, RendererMetadata, ToWebviewMessage } from './webviewMessages';
 
 export interface ICachedInset<K extends ICommonCellInfo> {
 	outputId: string;
@@ -900,16 +900,7 @@ var requirejs = (function() {
 	}
 
 	private _createInset(webviewService: IWebviewService, content: string) {
-		const workspaceFolders = this.contextService.getWorkspace().folders.map(x => x.uri);
-		const notebookDir = this.getNotebookBaseUri();
-
-		this.localResourceRootsCache = [
-			...this.notebookService.getNotebookProviderResourceRoots(),
-			...this.notebookService.getRenderers().map(x => dirname(x.entrypoint)),
-			...workspaceFolders,
-			notebookDir,
-			...this.getBuiltinLocalResourceRoots(),
-		];
+		this.localResourceRootsCache = this._getResourceRootsCache();
 		const webview = webviewService.createWebviewElement({
 			id: this.id,
 			options: {
@@ -927,6 +918,18 @@ var requirejs = (function() {
 
 		webview.html = content;
 		return webview;
+	}
+
+	private _getResourceRootsCache() {
+		const workspaceFolders = this.contextService.getWorkspace().folders.map(x => x.uri);
+		const notebookDir = this.getNotebookBaseUri();
+		return [
+			...this.notebookService.getNotebookProviderResourceRoots(),
+			...this.notebookService.getRenderers().map(x => dirname(x.entrypoint)),
+			...workspaceFolders,
+			notebookDir,
+			...this.getBuiltinLocalResourceRoots()
+		];
 	}
 
 	private initializeWebViewState() {
@@ -1168,25 +1171,37 @@ var requirejs = (function() {
 		await p;
 	}
 
+	/**
+	 * Validate if cached inset is out of date and require a rerender
+	 * Note that it doesn't account for output content change.
+	 */
+	private _cachedInsetEqual(cachedInset: ICachedInset<T>, content: IInsetRenderOutput) {
+		if (content.type === RenderOutputType.Extension) {
+			// Use a new renderer
+			return cachedInset.renderer?.id === content.renderer.id;
+		} else {
+			// The new renderer is the default HTML renderer
+			return cachedInset.cachedCreation.type === 'html';
+		}
+	}
+
 	async createOutput(cellInfo: T, content: IInsetRenderOutput, cellTop: number, offset: number) {
 		if (this._disposed) {
 			return;
 		}
 
-		if (this.insetMapping.has(content.source)) {
-			const outputCache = this.insetMapping.get(content.source);
+		const cachedInset = this.insetMapping.get(content.source);
 
-			if (outputCache) {
-				this.hiddenInsetMapping.delete(content.source);
-				this._sendMessageToWebview({
-					type: 'showOutput',
-					cellId: outputCache.cellInfo.cellId,
-					outputId: outputCache.outputId,
-					cellTop: cellTop,
-					outputOffset: offset
-				});
-				return;
-			}
+		if (cachedInset && this._cachedInsetEqual(cachedInset, content)) {
+			this.hiddenInsetMapping.delete(content.source);
+			this._sendMessageToWebview({
+				type: 'showOutput',
+				cellId: cachedInset.cellInfo.cellId,
+				outputId: cachedInset.outputId,
+				cellTop: cellTop,
+				outputOffset: offset
+			});
+			return;
 		}
 
 		const messageBase = {
@@ -1405,6 +1420,25 @@ var requirejs = (function() {
 			removedClassNames: removed
 		});
 
+	}
+
+	updateOutputRenderers() {
+		if (!this.webview) {
+			return;
+		}
+
+		const renderersData = this.getRendererData();
+		this.localResourceRootsCache = this._getResourceRootsCache();
+		const mixedResourceRoots = [
+			...(this.localResourceRootsCache || []),
+			...(this._currentKernel ? [this._currentKernel.localResourceRoot] : []),
+		];
+
+		this.webview.localResourcesRoot = mixedResourceRoots;
+		this._sendMessageToWebview({
+			type: 'updateRenderers',
+			rendererData: renderersData
+		});
 	}
 
 	async updateKernelPreloads(kernel: INotebookKernel | undefined) {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -272,6 +272,20 @@ export interface IUpdateControllerPreloadsMessage {
 	readonly resources: readonly IControllerPreload[];
 }
 
+export interface RendererMetadata {
+	readonly id: string;
+	readonly entrypoint: string;
+	readonly mimeTypes: readonly string[];
+	readonly extends: string | undefined;
+	readonly messaging: boolean;
+	readonly isBuiltin: boolean;
+}
+
+export interface IUpdateRenderersMessage {
+	readonly type: 'updateRenderers';
+	readonly rendererData: readonly RendererMetadata[];
+}
+
 export interface IUpdateDecorationsMessage {
 	readonly type: 'decorations';
 	readonly cellId: string;
@@ -450,6 +464,7 @@ export type ToWebviewMessage = IClearMessage |
 	IHideOutputMessage |
 	IShowOutputMessage |
 	IUpdateControllerPreloadsMessage |
+	IUpdateRenderersMessage |
 	IUpdateDecorationsMessage |
 	ICustomKernelMessage |
 	ICustomRendererMessage |

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -6,7 +6,7 @@
 import type { Event } from 'vs/base/common/event';
 import type { IDisposable } from 'vs/base/common/lifecycle';
 import type * as webviewMessages from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
-import { NotebookCellMetadata } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import type { NotebookCellMetadata } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import type * as rendererApi from 'vscode-notebook-renderer';
 
 // !! IMPORTANT !! ----------------------------------------------------------------------------------
@@ -68,7 +68,7 @@ interface PreloadContext {
 	readonly nonce: string;
 	readonly style: PreloadStyles;
 	readonly options: PreloadOptions;
-	readonly rendererData: readonly RendererMetadata[];
+	readonly rendererData: readonly webviewMessages.RendererMetadata[];
 	readonly isWorkspaceTrusted: boolean;
 	readonly lineLimit: number;
 }
@@ -1154,6 +1154,11 @@ async function webviewPreloads(ctx: PreloadContext) {
 				}
 				break;
 			}
+			case 'updateRenderers': {
+				const { rendererData } = event.data;
+				renderers.updateRendererData(rendererData);
+				break;
+			}
 			case 'focus-output':
 				focusFirstFocusableInCell(event.data.cellId);
 				break;
@@ -1236,7 +1241,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 
 	class Renderer {
 		constructor(
-			public readonly data: RendererMetadata,
+			public readonly data: webviewMessages.RendererMetadata,
 			private readonly loadExtension: (id: string) => Promise<void>,
 		) { }
 
@@ -1395,6 +1400,50 @@ async function webviewPreloads(ctx: PreloadContext) {
 
 		public getRenderer(id: string) {
 			return this._renderers.get(id);
+		}
+
+		private rendererEqual(a: webviewMessages.RendererMetadata, b: webviewMessages.RendererMetadata) {
+			if (a.entrypoint !== b.entrypoint || a.id !== b.id || a.extends !== b.extends || a.messaging !== b.messaging) {
+				return false;
+			}
+
+			if (a.mimeTypes.length !== b.mimeTypes.length) {
+				return false;
+			}
+
+			for (let i = 0; i < a.mimeTypes.length; i++) {
+				if (a.mimeTypes[i] !== b.mimeTypes[i]) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		public updateRendererData(rendererData: readonly webviewMessages.RendererMetadata[]) {
+			const oldKeys = new Set(this._renderers.keys());
+			const newKeys = new Set(rendererData.map(d => d.id));
+
+			for (const renderer of rendererData) {
+				const existing = this._renderers.get(renderer.id);
+				if (existing && this.rendererEqual(existing.data, renderer)) {
+					continue;
+				}
+
+				this._renderers.set(renderer.id, new Renderer(renderer, async (extensionId) => {
+					const ext = this._renderers.get(extensionId);
+					if (!ext) {
+						throw new Error(`Could not find extending renderer: ${extensionId}`);
+					}
+					await ext.load();
+				}));
+			}
+
+			for (const key of oldKeys) {
+				if (!newKeys.has(key)) {
+					this._renderers.delete(key);
+				}
+			}
 		}
 
 		public async load(id: string) {
@@ -2199,16 +2248,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 	}();
 }
 
-export interface RendererMetadata {
-	readonly id: string;
-	readonly entrypoint: string;
-	readonly mimeTypes: readonly string[];
-	readonly extends: string | undefined;
-	readonly messaging: boolean;
-	readonly isBuiltin: boolean;
-}
-
-export function preloadsScriptStr(styleValues: PreloadStyles, options: PreloadOptions, renderers: readonly RendererMetadata[], isWorkspaceTrusted: boolean, lineLimit: number, nonce: string) {
+export function preloadsScriptStr(styleValues: PreloadStyles, options: PreloadOptions, renderers: readonly webviewMessages.RendererMetadata[], isWorkspaceTrusted: boolean, lineLimit: number, nonce: string) {
 	const ctx: PreloadContext = {
 		style: styleValues,
 		options,

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/cellOutputViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/cellOutputViewModel.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ICellOutputViewModel, IGenericCellViewModel } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
@@ -11,6 +12,8 @@ import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookS
 
 let handle = 0;
 export class CellOutputViewModel extends Disposable implements ICellOutputViewModel {
+	private _onDidResetRendererEmitter = this._register(new Emitter<void>());
+	readonly onDidResetRenderer = this._onDidResetRendererEmitter.event;
 	outputHandle = handle++;
 	get model(): ICellOutput {
 		return this._outputRawData;
@@ -55,6 +58,12 @@ export class CellOutputViewModel extends Disposable implements ICellOutputViewMo
 		}
 
 		return [mimeTypes, Math.max(index, 0)];
+	}
+
+	resetRenderer() {
+		// reset the output renderer
+		this._pickedMimeType = undefined;
+		this._onDidResetRendererEmitter.fire();
 	}
 
 	toRawJSON() {

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -59,7 +59,7 @@ export interface INotebookService {
 	canResolve(viewType: string): Promise<boolean>;
 
 	readonly onWillRemoveViewType: Event<string>;
-
+	readonly onDidChangeOutputRenderers: Event<void>;
 	readonly onWillAddNotebookDocument: Event<NotebookTextModel>;
 	readonly onDidAddNotebookDocument: Event<NotebookTextModel>;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

* Listen to notebook output renderer registration
* Update the notebook webview to load new output renderers
* If an output can't be renderer because of missing renderer, trigger it to rerender