### PR TITLE
Add codespaces extension command

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -431,6 +431,20 @@
 	},
 	{
 		"type": "comment",
+		"name": "extCodespaces",
+		"allowUsers": [
+			"cleidigh",
+			"usernamehw",
+			"gjsjohnmurray",
+			"IllusionMH"
+		],
+		"action": "close",
+		"reason": "not_planned",
+		"addLabel": "*caused-by-extension",
+		"comment": "It looks like this is caused by the Codespaces extension. Please file the issue in the [Codespaces Discussion Forum](http://aka.ms/ghcs-feedback). Make sure to check their issue reporting template and provide them relevant information such as the extension version you're using. See also our [issue reporting guidelines](https://aka.ms/vscodeissuereporting) for more information.\n\nHappy Coding!"
+	},
+	{
+		"type": "comment",
 		"name": "gifPlease",
 		"allowUsers": [
 			"cleidigh",


### PR DESCRIPTION
Adds `/extCodespaces` to help triage codespaces issues.

FYI @usernamehw @gjsjohnmurray @IllusionMH @cleidigh

Feel free to provide feedback on other commands that might be helpful