### PR TITLE
Minimal document edits for file content change

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
@@ -125,13 +125,22 @@ export class CodeCellViewModel extends BaseCellViewModel implements ICellViewMod
 
 		this._register(this.model.onDidChangeOutputs((splice) => {
 			const removedOutputs: ICellOutputViewModel[] = [];
+			let outputLayoutChange = false;
+			for (let i = splice.start; i < splice.start + splice.deleteCount; i++) {
+				if (this._outputCollection[i] !== undefined && this._outputCollection[i] !== 0) {
+					outputLayoutChange = true;
+				}
+			}
+
 			this._outputCollection.splice(splice.start, splice.deleteCount, ...splice.newOutputs.map(() => 0));
 			removedOutputs.push(...this._outputViewModels.splice(splice.start, splice.deleteCount, ...splice.newOutputs.map(output => new CellOutputViewModel(this, output, this._notebookService))));
 
 			this._outputsTop = null;
 			this._onDidChangeOutputs.fire(splice);
 			this._onDidRemoveOutputs.fire(removedOutputs);
-			this.layoutChange({ outputHeight: true }, 'CodeCellViewModel#model.onDidChangeOutputs');
+			if (outputLayoutChange) {
+				this.layoutChange({ outputHeight: true }, 'CodeCellViewModel#model.onDidChangeOutputs');
+			}
 			dispose(removedOutputs);
 		}));
 

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorWidgetContextKeys.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorWidgetContextKeys.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as DOM from 'vs/base/browser/dom';
 import { DisposableStore, dispose, IDisposable } from 'vs/base/common/lifecycle';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ICellViewModel, INotebookEditorDelegate, KERNEL_EXTENSIONS } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
@@ -102,9 +103,15 @@ export class NotebookEditorContextKeys {
 			this._hasOutputs.set(hasOutputs);
 		};
 
+		const layoutDisposable = this._viewModelDisposables.add(new DisposableStore());
+
 		const addCellOutputsListener = (c: ICellViewModel) => {
 			return c.model.onDidChangeOutputs(() => {
-				recomputeOutputsExistence();
+				layoutDisposable.clear();
+
+				layoutDisposable.add(DOM.scheduleAtNextAnimationFrame(() => {
+					recomputeOutputsExistence();
+				}));
 			});
 		};
 

--- a/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
@@ -16,7 +16,7 @@ import { TextModel } from 'vs/editor/common/model/textModel';
 import { PLAINTEXT_LANGUAGE_ID } from 'vs/editor/common/languages/modesRegistry';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { NotebookCellOutputTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellOutputTextModel';
-import { CellInternalMetadataChangedEvent, CellKind, ICell, ICellOutput, IOutputDto, IOutputItemDto, NotebookCellCollapseState, NotebookCellInternalMetadata, NotebookCellMetadata, NotebookCellOutputsSplice, TransientOptions } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { CellInternalMetadataChangedEvent, CellKind, ICell, ICellDto2, ICellOutput, IOutputDto, IOutputItemDto, NotebookCellCollapseState, NotebookCellInternalMetadata, NotebookCellMetadata, NotebookCellOutputsSplice, TransientOptions } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 
 export class NotebookCellTextModel extends Disposable implements ICell {
 	private readonly _onDidChangeOutputs = this._register(new Emitter<NotebookCellOutputsSplice>());
@@ -347,6 +347,42 @@ export class NotebookCellTextModel extends Disposable implements ICell {
 		}
 
 		return this.getHashValue() === b.getHashValue();
+	}
+
+	/**
+	 * Only compares
+	 * - language
+	 * - mime
+	 * - cellKind
+	 * - internal metadata
+	 * - source
+	 */
+	fastEqual(b: ICellDto2): boolean {
+		if (this.language !== b.language) {
+			return false;
+		}
+
+		if (this.mime !== b.mime) {
+			return false;
+		}
+
+		if (this.cellKind !== b.cellKind) {
+			return false;
+		}
+
+		if (this.internalMetadata?.executionOrder !== b.internalMetadata?.executionOrder
+			|| this.internalMetadata?.lastRunSuccess !== b.internalMetadata?.lastRunSuccess
+			|| this.internalMetadata?.runStartTime !== b.internalMetadata?.runStartTime
+			|| this.internalMetadata?.runStartTimeAdjustment !== b.internalMetadata?.runStartTimeAdjustment
+			|| this.internalMetadata?.runEndTime !== b.internalMetadata?.runEndTime) {
+			return false;
+		}
+
+		if (this._source !== b.source) {
+			return false;
+		}
+
+		return true;
 	}
 
 	override dispose() {

--- a/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from 'vs/base/common/event';
-import { hash } from 'vs/base/common/hash';
+import { hash, StringSHA1 } from 'vs/base/common/hash';
 import { Disposable, DisposableStore, dispose } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import * as UUID from 'vs/base/common/uuid';
@@ -143,6 +143,7 @@ export class NotebookCellTextModel extends Disposable implements ICell {
 		return this._textBuffer;
 	}
 
+	private _textBufferHash: string | null = null;
 	private _hash: number | null = null;
 
 	private _versionId: number = 1;
@@ -224,12 +225,27 @@ export class NotebookCellTextModel extends Disposable implements ICell {
 		}
 	}
 
+	getTextBufferHash() {
+		if (this._textBufferHash !== null) {
+			return this._textBufferHash;
+		}
+
+		const shaComputer = new StringSHA1();
+		const snapshot = this.textBuffer.createSnapshot(false);
+		let text: string | null;
+		while ((text = snapshot.read())) {
+			shaComputer.update(text);
+		}
+		this._textBufferHash = shaComputer.digest();
+		return this._textBufferHash;
+	}
+
 	getHashValue(): number {
 		if (this._hash !== null) {
 			return this._hash;
 		}
 
-		this._hash = hash([hash(this.language), hash(this.getValue()), this._getPersisentMetadata(), this.transientOptions.transientOutputs ? [] : this._outputs.map(op => ({
+		this._hash = hash([hash(this.language), this.getTextBufferHash(), this._getPersisentMetadata(), this.transientOptions.transientOutputs ? [] : this._outputs.map(op => ({
 			outputs: op.outputs.map(output => ({
 				mime: output.mime,
 				data: Array.from(output.data.buffer)

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -392,9 +392,11 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 	reset(cells: ICellDto2[], metadata: NotebookDocumentMetadata, transientOptions: TransientOptions): void {
 		this.transientOptions = transientOptions;
 		this._cellhandlePool = 0;
+		const edits = NotebookTextModel.computeEdits(this, cells);
+
 		this.applyEdits(
 			[
-				{ editType: CellEditType.Replace, index: 0, count: this.cells.length, cells },
+				...edits,
 				{ editType: CellEditType.DocumentMetadata, metadata }
 			],
 			true,
@@ -402,6 +404,84 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 			undefined,
 			true
 		);
+	}
+
+	static computeEdits(model: NotebookTextModel, cells: ICellDto2[]) {
+		const edits: ICellEditOperation[] = [];
+
+		const commonPrefix = this._commonPrefix(model.cells, model.cells.length, 0, cells, cells.length, 0);
+
+		if (commonPrefix > 0) {
+			for (let i = 0; i < commonPrefix; i++) {
+				edits.push(
+					{
+						editType: CellEditType.Metadata,
+						index: i,
+						metadata: cells[i].metadata ?? {}
+					},
+					{
+						editType: CellEditType.Output,
+						index: i,
+						outputs: cells[i].outputs,
+						append: false
+					}
+				);
+			}
+		}
+
+		if (model.cells.length === cells.length && commonPrefix === model.cells.length) {
+			return edits;
+		}
+
+		const commonSuffix = this._commonSuffix(model.cells, model.cells.length - commonPrefix, commonPrefix, cells, cells.length - commonPrefix, commonPrefix);
+
+		if (commonSuffix > 0) {
+			edits.push({ editType: CellEditType.Replace, index: commonPrefix, count: model.cells.length - commonPrefix - commonSuffix, cells: cells.slice(commonPrefix, cells.length - commonSuffix) });
+		} else if (commonPrefix > 0) {
+			edits.push({ editType: CellEditType.Replace, index: commonPrefix, count: model.cells.length - commonPrefix, cells: cells.slice(commonPrefix) });
+		} else {
+			edits.push({ editType: CellEditType.Replace, index: 0, count: model.cells.length, cells });
+		}
+
+		if (commonSuffix > 0) {
+			// has same suffix
+			for (let i = commonSuffix; i > 0; i--) {
+				edits.push(
+					{
+						editType: CellEditType.Metadata,
+						index: model.cells.length - i,
+						metadata: cells[cells.length - i].metadata ?? {}
+					},
+					{
+						editType: CellEditType.Output,
+						index: model.cells.length - i,
+						outputs: cells[cells.length - i].outputs,
+						append: false
+					}
+				);
+			}
+		}
+
+		return edits;
+	}
+
+	private static _commonPrefix(a: readonly NotebookCellTextModel[], aLen: number, aDelta: number, b: ICellDto2[], bLen: number, bDelta: number): number {
+		const maxResult = Math.min(aLen, bLen);
+		let result = 0;
+		for (let i = 0; i < maxResult && a[aDelta + i].fastEqual(b[bDelta + i]); i++) {
+			result++;
+		}
+
+		return result;
+	}
+
+	private static _commonSuffix(a: readonly NotebookCellTextModel[], aLen: number, aDelta: number, b: ICellDto2[], bLen: number, bDelta: number): number {
+		const maxResult = Math.min(aLen, bLen);
+		let result = 0;
+		for (let i = 0; i < maxResult && a[aDelta + aLen - i - 1].fastEqual(b[bDelta + bLen - i - 1]); i++) {
+			result++;
+		}
+		return result;
 	}
 
 	applyEdits(rawEdits: ICellEditOperation[], synchronous: boolean, beginSelectionState: ISelectionState | undefined, endSelectionsComputer: () => ISelectionState | undefined, undoRedoGroup: UndoRedoGroup | undefined, computeUndoRedo: boolean): boolean {

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -391,7 +391,6 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 
 	reset(cells: ICellDto2[], metadata: NotebookDocumentMetadata, transientOptions: TransientOptions): void {
 		this.transientOptions = transientOptions;
-		this._cellhandlePool = 0;
 		const edits = NotebookTextModel.computeEdits(this, cells);
 
 		this.applyEdits(

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookTextModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookTextModel.test.ts
@@ -10,6 +10,7 @@ import { Mimes } from 'vs/base/common/mime';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
+import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { CellEditType, CellKind, ICellEditOperation, NotebookTextModelChangedEvent, NotebookTextModelWillAddRemoveEvent, SelectionStateType } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { setupInstantiationService, TestCell, valueBytesFromString, withTestNotebook } from 'vs/workbench/contrib/notebook/test/browser/testNotebookEditor';
 
@@ -758,6 +759,231 @@ suite('NotebookTextModel', () => {
 			assert.strictEqual(model.cells[0].outputs[1].outputId, 'out5');
 			assert.strictEqual(model.cells[0].outputs[2].outputId, 'out3');
 			assert.strictEqual(model.cells[0].outputs[3].outputId, 'out6');
+		});
+	});
+
+	test('computeEdits no insert', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}]
+		], (editor) => {
+			const model = editor.textModel;
+			const edits = NotebookTextModel.computeEdits(model, [
+				{ source: 'var a = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined }
+			]);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Metadata, index: 0, metadata: {} },
+				{ editType: CellEditType.Output, index: 0, outputs: [], append: false }
+			]);
+		});
+	});
+
+	test('computeEdits cell content changed', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}]
+		], (editor) => {
+			const model = editor.textModel;
+			const cells = [
+				{ source: 'var a = 2;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined }
+			];
+			const edits = NotebookTextModel.computeEdits(model, cells);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Replace, index: 0, count: 1, cells },
+			]);
+		});
+	});
+
+	test('computeEdits last cell content changed', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}],
+			['var b = 1;', 'javascript', CellKind.Code, [], {}]
+		], (editor) => {
+			const model = editor.textModel;
+			const cells = [
+				{ source: 'var a = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined },
+				{ source: 'var b = 2;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined }
+			];
+			const edits = NotebookTextModel.computeEdits(model, cells);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Metadata, index: 0, metadata: {} },
+				{ editType: CellEditType.Output, index: 0, outputs: [], append: false },
+				{ editType: CellEditType.Replace, index: 1, count: 1, cells: cells.slice(1) },
+			]);
+		});
+	});
+	test('computeEdits first cell content changed', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}],
+			['var b = 1;', 'javascript', CellKind.Code, [], {}]
+		], (editor) => {
+			const model = editor.textModel;
+			const cells = [
+				{ source: 'var a = 2;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined },
+				{ source: 'var b = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined }
+			];
+			const edits = NotebookTextModel.computeEdits(model, cells);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Replace, index: 0, count: 1, cells: cells.slice(0, 1) },
+				{ editType: CellEditType.Metadata, index: 1, metadata: {} },
+				{ editType: CellEditType.Output, index: 1, outputs: [], append: false },
+			]);
+		});
+	});
+
+	test('computeEdits middle cell content changed', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}],
+			['var b = 1;', 'javascript', CellKind.Code, [], {}],
+			['var c = 1;', 'javascript', CellKind.Code, [], {}],
+		], (editor) => {
+			const model = editor.textModel;
+			const cells = [
+				{ source: 'var a = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined },
+				{ source: 'var b = 2;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined },
+				{ source: 'var c = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined }
+			];
+			const edits = NotebookTextModel.computeEdits(model, cells);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Metadata, index: 0, metadata: {} },
+				{ editType: CellEditType.Output, index: 0, outputs: [], append: false },
+				{ editType: CellEditType.Replace, index: 1, count: 1, cells: cells.slice(1, 2) },
+				{ editType: CellEditType.Metadata, index: 2, metadata: {} },
+				{ editType: CellEditType.Output, index: 2, outputs: [], append: false },
+			]);
+		});
+	});
+
+	test('computeEdits cell metadata changed', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}],
+			['var b = 1;', 'javascript', CellKind.Code, [], {}]
+		], (editor) => {
+			const model = editor.textModel;
+			const cells = [
+				{ source: 'var a = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: { name: 'foo' } },
+				{ source: 'var b = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined }
+			];
+			const edits = NotebookTextModel.computeEdits(model, cells);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Metadata, index: 0, metadata: { name: 'foo' } },
+				{ editType: CellEditType.Output, index: 0, outputs: [], append: false },
+				{ editType: CellEditType.Metadata, index: 1, metadata: {} },
+				{ editType: CellEditType.Output, index: 1, outputs: [], append: false },
+			]);
+		});
+	});
+
+	test('computeEdits cell language changed', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}],
+			['var b = 1;', 'javascript', CellKind.Code, [], {}]
+		], (editor) => {
+			const model = editor.textModel;
+			const cells = [
+				{ source: 'var a = 1;', language: 'typescript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined },
+				{ source: 'var b = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined }
+			];
+			const edits = NotebookTextModel.computeEdits(model, cells);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Replace, index: 0, count: 1, cells: cells.slice(0, 1) },
+				{ editType: CellEditType.Metadata, index: 1, metadata: {} },
+				{ editType: CellEditType.Output, index: 1, outputs: [], append: false },
+			]);
+		});
+	});
+
+	test('computeEdits cell kind changed', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}],
+			['var b = 1;', 'javascript', CellKind.Code, [], {}]
+		], (editor) => {
+			const model = editor.textModel;
+			const cells = [
+				{ source: 'var a = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined },
+				{ source: 'var b = 1;', language: 'javascript', cellKind: CellKind.Markup, mime: undefined, outputs: [], metadata: undefined }
+			];
+			const edits = NotebookTextModel.computeEdits(model, cells);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Metadata, index: 0, metadata: {} },
+				{ editType: CellEditType.Output, index: 0, outputs: [], append: false },
+				{ editType: CellEditType.Replace, index: 1, count: 1, cells: cells.slice(1) },
+			]);
+		});
+	});
+
+	test('computeEdits cell metadata & content changed', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}],
+			['var b = 1;', 'javascript', CellKind.Code, [], {}]
+		], (editor) => {
+			const model = editor.textModel;
+			const cells = [
+				{ source: 'var a = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: { name: 'foo' } },
+				{ source: 'var b = 2;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: { name: 'bar' } }
+			];
+			const edits = NotebookTextModel.computeEdits(model, cells);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Metadata, index: 0, metadata: { name: 'foo' } },
+				{ editType: CellEditType.Output, index: 0, outputs: [], append: false },
+				{ editType: CellEditType.Replace, index: 1, count: 1, cells: cells.slice(1) }
+			]);
+		});
+	});
+
+	test('computeEdits cell internal metadata changed', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}],
+			['var b = 1;', 'javascript', CellKind.Code, [], {}]
+		], (editor) => {
+			const model = editor.textModel;
+			const cells = [
+				{ source: 'var a = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined, internalMetadata: { executionOrder: 1 } },
+				{ source: 'var b = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined }
+			];
+			const edits = NotebookTextModel.computeEdits(model, cells);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Replace, index: 0, count: 1, cells: cells.slice(0, 1) },
+				{ editType: CellEditType.Metadata, index: 1, metadata: {} },
+				{ editType: CellEditType.Output, index: 1, outputs: [], append: false },
+			]);
+		});
+	});
+
+	test('computeEdits cell insertion', async function () {
+		await withTestNotebook([
+			['var a = 1;', 'javascript', CellKind.Code, [], {}],
+			['var b = 1;', 'javascript', CellKind.Code, [], {}]
+		], (editor) => {
+			const model = editor.textModel;
+			const cells = [
+				{ source: 'var a = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined, },
+				{ source: 'var c = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: undefined, },
+				{ source: 'var b = 1;', language: 'javascript', cellKind: CellKind.Code, mime: undefined, outputs: [], metadata: { foo: 'bar' } }
+			];
+			const edits = NotebookTextModel.computeEdits(model, cells);
+
+			assert.deepStrictEqual(edits, [
+				{ editType: CellEditType.Metadata, index: 0, metadata: {} },
+				{ editType: CellEditType.Output, index: 0, outputs: [], append: false },
+				{ editType: CellEditType.Replace, index: 1, count: 0, cells: cells.slice(1, 2) },
+				{ editType: CellEditType.Metadata, index: 1, metadata: { foo: 'bar' } },
+				{ editType: CellEditType.Output, index: 1, outputs: [], append: false },
+			]);
+
+			model.applyEdits(edits, true, undefined, () => undefined, undefined, true);
+			assert.equal(model.cells.length, 3);
+			assert.equal(model.cells[1].getValue(), 'var c = 1;');
+			assert.equal(model.cells[2].getValue(), 'var b = 1;');
+			assert.deepStrictEqual(model.cells[2].metadata, { foo: 'bar' });
 		});
 	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Re https://github.com/microsoft/vscode/issues/157695. Previously, we would replace the whole notebook with the new content whenever there is file change event, even if there is no real change in the file event.

In this PR, we attempt to compute minimal edits required for updating the `NotebookTextModel` to latest. The content change is translated to

* If cells at the same position have the same language, content, cellKind, internal metadata, and mime, then we treat them as _unchanged_, we will not do a replacement
  * Instead, we update its metadata (object) and outputs (buffers) accordingly. To ensure it's performant, we don't compare metadata (as it can be big and nested) or outputs (comparing buffers can take long time)
* Otherwise, we do a simple replacement, which means the cell is removed and then inserted with new ones, this will lose the cell view states.