### PR TITLE
UX - Remove !important for the opacity of the focused elements

### DIFF
--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -185,7 +185,7 @@ body.web {
 	outline-width: 1px;
 	outline-style: solid;
 	outline-offset: -1px;
-	opacity: 1 !important;
+	opacity: 1;
 }
 
 .monaco-workbench input[type="checkbox"]:focus {


### PR DESCRIPTION
Related #156443

This pull request removes the `!important` property for the opacity of the focused elements. 
This enables widgets (ex: button) to have control over their opacity when for example the widget is disabled. 