### PR TITLE
Fix open and delete of nested files

### DIFF
--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -154,10 +154,16 @@ export class ExplorerService implements IExplorerService {
 
 		const items = new Set<ExplorerItem>(this.view.getContext(respectMultiSelection));
 		items.forEach(item => {
-			if (respectMultiSelection && this.view?.isItemCollapsed(item) && item.nestedChildren) {
-				for (const child of item.nestedChildren) {
-					items.add(child);
+			try {
+				if (respectMultiSelection && this.view?.isItemCollapsed(item) && item.nestedChildren) {
+					for (const child of item.nestedChildren) {
+						items.add(child);
+					}
 				}
+			} catch {
+				// We will error out trying to resolve collapsed nodes that have not yet been resolved.
+				// So we catch and ignore them in the multiSelect context
+				return;
 			}
 		});
 


### PR DESCRIPTION
Fixes #157829
Fixes #154744


This is one of the cases where I'm not 100% sure why this fix works but it does 🤷 . It seems like we try to resolve the nodes twice and the first set resolves correctly then the second set errors out as not existing on the tree. Catching these errors and ignoring them allows us to properly get the nested file context.