### PR TITLE
Taking into account the sticky scroll widget when revealing a range

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2523,21 +2523,21 @@ export interface IEditorExperimentalOptions {
 		 * Enable the sticky scroll
 		 */
 		enabled?: boolean;
-		numberLines?: number;
+		maxLineCount?: number;
 	};
 }
 
 export interface EditorExperimentalOptions {
 	stickyScroll: {
 		enabled: boolean;
-		numberLines: number;
+		maxLineCount: number;
 	};
 }
 
 class EditorExperimental extends BaseEditorOption<EditorOption.experimental, IEditorExperimentalOptions, EditorExperimentalOptions> {
 
 	constructor() {
-		const defaults: EditorExperimentalOptions = { stickyScroll: { enabled: false, numberLines: 5 } };
+		const defaults: EditorExperimentalOptions = { stickyScroll: { enabled: false, maxLineCount: 5 } };
 		super(
 			EditorOption.experimental, 'experimental', defaults,
 			{
@@ -2546,16 +2546,12 @@ class EditorExperimental extends BaseEditorOption<EditorOption.experimental, IEd
 					default: defaults.stickyScroll.enabled,
 					description: nls.localize('editor.experimental.stickyScroll', "Shows the nested current scopes during the scroll at the top of the editor.")
 				},
-				'editor.experimental.stickyScroll.numberLines': {
+				'editor.experimental.stickyScroll.maxLineCount': {
 					type: 'number',
-					default: defaults.stickyScroll.numberLines,
-					enum: [1, 5, 10],
-					enumDescriptions: [
-						nls.localize('minimap.size.1', "Render maximum 1 line in the sticky scroll widget"),
-						nls.localize('minimap.size.5', "Render maximum 5 lines in the sticky scroll widget"),
-						nls.localize('minimap.size.10', "Render maximum 10 lines in the sticky scroll widget"),
-					],
-					description: nls.localize('editor.experimental.stickyScroll.', "Defines the number of sticky lines to show.")
+					default: defaults.stickyScroll.maxLineCount,
+					minimum: 1,
+					maximum: 10,
+					description: nls.localize('editor.experimental.stickyScroll.', "Defines the maximum number of sticky lines to show.")
 				},
 			}
 		);
@@ -2569,7 +2565,7 @@ class EditorExperimental extends BaseEditorOption<EditorOption.experimental, IEd
 		return {
 			stickyScroll: {
 				enabled: boolean(input.stickyScroll?.enabled, this.defaultValue.stickyScroll.enabled),
-				numberLines: EditorIntOption.clampedInt(input.stickyScroll?.numberLines, this.defaultValue.stickyScroll.numberLines, 1, 10),
+				maxLineCount: EditorIntOption.clampedInt(input.stickyScroll?.maxLineCount, this.defaultValue.stickyScroll.maxLineCount, 1, 10),
 			}
 		};
 	}

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2537,7 +2537,7 @@ export interface EditorExperimentalOptions {
 class EditorExperimental extends BaseEditorOption<EditorOption.experimental, IEditorExperimentalOptions, EditorExperimentalOptions> {
 
 	constructor() {
-		const defaults: EditorExperimentalOptions = { stickyScroll: { enabled: false, numberLines: 10 } };
+		const defaults: EditorExperimentalOptions = { stickyScroll: { enabled: false, numberLines: 5 } };
 		super(
 			EditorOption.experimental, 'experimental', defaults,
 			{
@@ -2549,12 +2549,11 @@ class EditorExperimental extends BaseEditorOption<EditorOption.experimental, IEd
 				'editor.experimental.stickyScroll.numberLines': {
 					type: 'number',
 					default: defaults.stickyScroll.numberLines,
-					enum: [1, 5, 10, 15],
+					enum: [1, 5, 10],
 					enumDescriptions: [
 						nls.localize('minimap.size.1', "Render maximum 1 line in the sticky scroll widget"),
 						nls.localize('minimap.size.5', "Render maximum 5 lines in the sticky scroll widget"),
 						nls.localize('minimap.size.10', "Render maximum 10 lines in the sticky scroll widget"),
-						nls.localize('minimap.size.15', "Render maximum 15 lines in the sticky scroll widget"),
 					],
 					description: nls.localize('editor.experimental.stickyScroll.', "Defines the number of sticky lines to show.")
 				},
@@ -2570,7 +2569,7 @@ class EditorExperimental extends BaseEditorOption<EditorOption.experimental, IEd
 		return {
 			stickyScroll: {
 				enabled: boolean(input.stickyScroll?.enabled, this.defaultValue.stickyScroll.enabled),
-				numberLines: EditorIntOption.clampedInt(input.stickyScroll?.numberLines, this.defaultValue.stickyScroll.numberLines, 1, 15),
+				numberLines: EditorIntOption.clampedInt(input.stickyScroll?.numberLines, this.defaultValue.stickyScroll.numberLines, 1, 10),
 			}
 		};
 	}

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2523,19 +2523,21 @@ export interface IEditorExperimentalOptions {
 		 * Enable the sticky scroll
 		 */
 		enabled?: boolean;
+		numberLines?: number;
 	};
 }
 
 export interface EditorExperimentalOptions {
 	stickyScroll: {
 		enabled: boolean;
+		numberLines: number;
 	};
 }
 
 class EditorExperimental extends BaseEditorOption<EditorOption.experimental, IEditorExperimentalOptions, EditorExperimentalOptions> {
 
 	constructor() {
-		const defaults: EditorExperimentalOptions = { stickyScroll: { enabled: false } };
+		const defaults: EditorExperimentalOptions = { stickyScroll: { enabled: false, numberLines: 10 } };
 		super(
 			EditorOption.experimental, 'experimental', defaults,
 			{
@@ -2543,6 +2545,18 @@ class EditorExperimental extends BaseEditorOption<EditorOption.experimental, IEd
 					type: 'boolean',
 					default: defaults.stickyScroll.enabled,
 					description: nls.localize('editor.experimental.stickyScroll', "Shows the nested current scopes during the scroll at the top of the editor.")
+				},
+				'editor.experimental.stickyScroll.numberLines': {
+					type: 'number',
+					default: defaults.stickyScroll.numberLines,
+					enum: [1, 5, 10, 15],
+					enumDescriptions: [
+						nls.localize('minimap.size.1', "Render maximum 1 line in the sticky scroll widget"),
+						nls.localize('minimap.size.5', "Render maximum 5 lines in the sticky scroll widget"),
+						nls.localize('minimap.size.10', "Render maximum 10 lines in the sticky scroll widget"),
+						nls.localize('minimap.size.15', "Render maximum 15 lines in the sticky scroll widget"),
+					],
+					description: nls.localize('editor.experimental.stickyScroll.', "Defines the number of sticky lines to show.")
 				},
 			}
 		);
@@ -2555,7 +2569,8 @@ class EditorExperimental extends BaseEditorOption<EditorOption.experimental, IEd
 		const input = _input as IEditorExperimentalOptions;
 		return {
 			stickyScroll: {
-				enabled: boolean(input.stickyScroll?.enabled, this.defaultValue.stickyScroll.enabled)
+				enabled: boolean(input.stickyScroll?.enabled, this.defaultValue.stickyScroll.enabled),
+				numberLines: EditorIntOption.clampedInt(input.stickyScroll?.numberLines, this.defaultValue.stickyScroll.numberLines, 1, 15),
 			}
 		};
 	}

--- a/src/vs/editor/common/viewModel.ts
+++ b/src/vs/editor/common/viewModel.ts
@@ -28,8 +28,6 @@ export interface IViewModel extends ICursorSimpleModel {
 
 	readonly cursorConfig: CursorConfiguration;
 
-	stickyWidgetHeight?: number;
-
 	addViewEventHandler(eventHandler: ViewEventHandler): void;
 	removeViewEventHandler(eventHandler: ViewEventHandler): void;
 

--- a/src/vs/editor/common/viewModel.ts
+++ b/src/vs/editor/common/viewModel.ts
@@ -28,6 +28,8 @@ export interface IViewModel extends ICursorSimpleModel {
 
 	readonly cursorConfig: CursorConfiguration;
 
+	stickyWidgetHeight?: number;
+
 	addViewEventHandler(eventHandler: ViewEventHandler): void;
 	removeViewEventHandler(eventHandler: ViewEventHandler): void;
 

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.ts
@@ -89,22 +89,8 @@ class StickyScrollController extends Disposable implements IEditorContribution {
 			// Old _ranges not updated yet
 			return;
 		}
-		const widgetState = this.getScrollWidgetState();
-		this.stickyScrollWidget.setState(widgetState);
-		this.editor._getViewModel().stickyWidgetHeight = this.updateWidgetMeasures(widgetState);
+		this.stickyScrollWidget.setState(this.getScrollWidgetState());
 	}
-
-	public updateWidgetMeasures(state: StickyScrollWidgetState): number {
-		const lineHeight: number = this.editor.getOption(EditorOption.lineHeight);
-		let widgetHeight;
-		if (state.lineNumbers.length > 0) {
-			widgetHeight = lineHeight * (state.lineNumbers.length - 1) + lineHeight + state.lastLineRelativePosition;
-		} else {
-			widgetHeight = 0;
-		}
-		return widgetHeight;
-	}
-
 
 	private getScrollWidgetState(): StickyScrollWidgetState {
 		const lineHeight: number = this.editor.getOption(EditorOption.lineHeight);

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.ts
@@ -94,7 +94,7 @@ class StickyScrollController extends Disposable implements IEditorContribution {
 
 	private getScrollWidgetState(): StickyScrollWidgetState {
 		const lineHeight: number = this.editor.getOption(EditorOption.lineHeight);
-		const maxNumberStickyLines = this.editor.getOption(EditorOption.experimental).stickyScroll.numberLines;
+		const maxNumberStickyLines = this.editor.getOption(EditorOption.experimental).stickyScroll.maxLineCount;
 		const scrollTop: number = this.editor.getScrollTop();
 		let lastLineRelativePosition: number = 0;
 		const lineNumbers: number[] = [];

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.ts
@@ -105,6 +105,7 @@ class StickyScrollController extends Disposable implements IEditorContribution {
 		return widgetHeight;
 	}
 
+
 	private getScrollWidgetState(): StickyScrollWidgetState {
 		const lineHeight: number = this.editor.getOption(EditorOption.lineHeight);
 		const maxNumberStickyLines = this.editor.getOption(EditorOption.experimental).stickyScroll.numberLines;

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.ts
@@ -89,11 +89,25 @@ class StickyScrollController extends Disposable implements IEditorContribution {
 			// Old _ranges not updated yet
 			return;
 		}
-		this.stickyScrollWidget.setState(this.getScrollWidgetState());
+		const widgetState = this.getScrollWidgetState();
+		this.stickyScrollWidget.setState(widgetState);
+		this.editor._getViewModel().stickyWidgetHeight = this.updateWidgetMeasures(widgetState);
+	}
+
+	public updateWidgetMeasures(state: StickyScrollWidgetState): number {
+		const lineHeight: number = this.editor.getOption(EditorOption.lineHeight);
+		let widgetHeight;
+		if (state.lineNumbers.length > 0) {
+			widgetHeight = lineHeight * (state.lineNumbers.length - 1) + lineHeight + state.lastLineRelativePosition;
+		} else {
+			widgetHeight = 0;
+		}
+		return widgetHeight;
 	}
 
 	private getScrollWidgetState(): StickyScrollWidgetState {
 		const lineHeight: number = this.editor.getOption(EditorOption.lineHeight);
+		const maxNumberStickyLines = this.editor.getOption(EditorOption.experimental).stickyScroll.numberLines;
 		const scrollTop: number = this.editor.getScrollTop();
 		let lastLineRelativePosition: number = 0;
 		const lineNumbers: number[] = [];
@@ -120,6 +134,9 @@ class StickyScrollController extends Disposable implements IEditorContribution {
 					}
 					else if (bottomOfElementAtDepth > bottomOfBeginningLine && bottomOfElementAtDepth <= bottomOfEndLine) {
 						lineNumbers.push(start);
+					}
+					if (lineNumbers.length === maxNumberStickyLines) {
+						break;
 					}
 				}
 			}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3829,14 +3829,14 @@ declare namespace monaco.editor {
 			 * Enable the sticky scroll
 			 */
 			enabled?: boolean;
-			numberLines?: number;
+			maxLineCount?: number;
 		};
 	}
 
 	export interface EditorExperimentalOptions {
 		stickyScroll: {
 			enabled: boolean;
-			numberLines: number;
+			maxLineCount: number;
 		};
 	}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3829,12 +3829,14 @@ declare namespace monaco.editor {
 			 * Enable the sticky scroll
 			 */
 			enabled?: boolean;
+			numberLines?: number;
 		};
 	}
 
 	export interface EditorExperimentalOptions {
 		stickyScroll: {
 			enabled: boolean;
+			numberLines: number;
 		};
 	}
 


### PR DESCRIPTION
Fixes #157175

The new solution does not use the sticky widget height to reveal ranges. Three cases are tested and shown in the gif:

1. Moving the cursor up by one using the arrow pointing up on the keyboard
2. Undoing and revealing the line where the last operation was performed
3. Continuing to write on a line outside of the visible view port and revealing that line 

![sticky-scroll-ts](https://user-images.githubusercontent.com/61460952/184341687-6d031a2f-5fa2-421d-bf2e-7649049ab0b0.gif)

