### PR TITLE
Add editor.openFolderDefaultPath (Proof-of-concept)

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -276,6 +276,7 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 			renderOverviewRuler: true,
 			diffWordWrap: 'inherit',
 			diffAlgorithm: 'smart',
+			openFolderDefaultPath: ''
 		});
 
 		if (typeof options.isInEmbeddedEditor !== 'undefined') {
@@ -2711,6 +2712,7 @@ function validateDiffEditorOptions(options: Readonly<IDiffEditorOptions>, defaul
 		renderOverviewRuler: validateBooleanOption(options.renderOverviewRuler, defaults.renderOverviewRuler),
 		diffWordWrap: validateDiffWordWrap(options.diffWordWrap, defaults.diffWordWrap),
 		diffAlgorithm: validateStringSetOption(options.diffAlgorithm, defaults.diffAlgorithm, ['smart', 'experimental']),
+		openFolderDefaultPath: options.openFolderDefaultPath || '',
 	};
 }
 
@@ -2728,6 +2730,7 @@ function changedDiffEditorOptions(a: ValidDiffEditorBaseOptions, b: ValidDiffEdi
 		renderOverviewRuler: (a.renderOverviewRuler !== b.renderOverviewRuler),
 		diffWordWrap: (a.diffWordWrap !== b.diffWordWrap),
 		diffAlgorithm: (a.diffAlgorithm !== b.diffAlgorithm),
+		openFolderDefaultPath: (a.openFolderDefaultPath !== b.openFolderDefaultPath),
 	};
 }
 

--- a/src/vs/editor/common/config/editorConfigurationSchema.ts
+++ b/src/vs/editor/common/config/editorConfigurationSchema.ts
@@ -131,6 +131,11 @@ const editorConfiguration: IConfigurationNode = {
 				]
 			}
 		},
+		'editor.openFolderDefaultPath': {
+			type: 'string',
+			default: '',
+			markdownDescription: nls.localize('openFolderDefaultPath', "The default path used when opening a folder in the context menu.")
+		},
 		'diffEditor.maxComputationTime': {
 			type: 'number',
 			default: 5000,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -715,6 +715,11 @@ export interface IDiffEditorBaseOptions {
 	 */
 	renderMarginRevertIcon?: boolean;
 	/**
+	 * The default path used when opening a folder in the context menu.
+	 * Defaults to user's home directory.
+	 */
+	openFolderDefaultPath?: string;
+	/**
 	 * Original model should be editable?
 	 * Defaults to false.
 	 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3491,6 +3491,11 @@ declare namespace monaco.editor {
 		 */
 		renderMarginRevertIcon?: boolean;
 		/**
+		 * The default path used when opening a folder in the context menu.
+		 * Defaults to user's home directory.
+		 */
+		openFolderDefaultPath?: string;
+		/**
 		 * Original model should be editable?
 		 * Defaults to false.
 		 */

--- a/src/vs/workbench/browser/actions/workspaceActions.ts
+++ b/src/vs/workbench/browser/actions/workspaceActions.ts
@@ -22,6 +22,8 @@ import { IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IsMacNativeContext } from 'vs/platform/contextkey/common/contextkeys';
 import { ILocalizedString } from 'vs/platform/action/common/action';
+import { URI } from 'vs/base/common/uri';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 const workspacesCategory: ILocalizedString = { value: localize('workspaces', "Workspaces"), original: 'Workspaces' };
 const fileCategory = { value: localize('filesCategory', "File"), original: 'File' };
@@ -77,8 +79,13 @@ export class OpenFolderAction extends Action2 {
 
 	override async run(accessor: ServicesAccessor, data?: ITelemetryData): Promise<void> {
 		const fileDialogService = accessor.get(IFileDialogService);
+		const configurationService = accessor.get(IConfigurationService);
+		const openFolderDefaultPath = configurationService.getValue<string>('editor.openFolderDefaultPath');
 
-		return fileDialogService.pickFolderAndOpen({ forceNewWindow: false, telemetryExtraData: data });
+
+		const uri = URI.parse(`file:///${openFolderDefaultPath}`);
+
+		return fileDialogService.pickFolderAndOpen({ forceNewWindow: false, telemetryExtraData: data, defaultUri: uri });
 	}
 }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/115730

How to test
1. Define `editor.openFolderDefaultPath` setting
2. `Ctrl+K+O`. You should see file dialog starting with your custom location

please feel free to leave feedback since I really don't know how to name things here, etc