### PR TITLE
Automatically add `testplan-item` label to valid TPIs

### DIFF
--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -71,7 +71,7 @@ jobs:
         if: contains(github.event.issue.labels.*.name, 'testplan-item') || contains(github.event.issue.labels.*.name, 'invalid-testplan-item')
         uses: ./actions/test-plan-item-validator
         with:
-          appInsightsKey: ${{secrets.TRIAGE_ACTIONS_APP_INSIGHTS}}
+          refLabel: on-testplan
           label: testplan-item
           invalidLabel: invalid-testplan-item
           comment: Invalid test plan item. See errors below and the [test plan item spec](https://github.com/microsoft/vscode/wiki/Writing-Test-Plan-Items) for more information. This comment will go away when the issues are resolved.

--- a/.github/workflows/on-open.yml
+++ b/.github/workflows/on-open.yml
@@ -62,3 +62,12 @@ jobs:
           needsMoreInfoLabel: "info-needed"
           translatorRequestedLabelPrefix: "translation-required-"
           translatorRequestedLabelColor: "c29cff"
+            # source of truth in ./test-plan-item-validator.yml
+      - name: Run Test Plan Item Validator
+        uses: ./actions/test-plan-item-validator
+        with:
+          refLabel: on-testplan
+          label: testplan-item
+          invalidLabel: invalid-testplan-item
+          comment: Invalid test plan item. See errors below and the [test plan item spec](https://github.com/microsoft/vscode/wiki/Writing-Test-Plan-Items) for more information. This comment will go away when the issues are resolved.
+

--- a/.github/workflows/test-plan-item-validator.yml
+++ b/.github/workflows/test-plan-item-validator.yml
@@ -3,7 +3,7 @@ on:
   issues:
     types: [edited]
 
-# also edit in ./on-label.yml
+# also edit in ./on-label.yml and ./on-open.yml
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
         if: contains(github.event.issue.labels.*.name, 'testplan-item') || contains(github.event.issue.labels.*.name, 'invalid-testplan-item')
         uses: ./actions/test-plan-item-validator
         with:
+          refLabel: on-testplan
           label: testplan-item
-          appInsightsKey: ${{secrets.TRIAGE_ACTIONS_APP_INSIGHTS}}
           invalidLabel: invalid-testplan-item
           comment: Invalid test plan item. See errors below and the [test plan item spec](https://github.com/microsoft/vscode/wiki/Writing-Test-Plan-Items) for more information. This comment will go away when the issues are resolved.


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-github-triage-actions/issues/84