### PR TITLE
Revert testplan validator until bugs can be worked out

### DIFF
--- a/.github/workflows/on-open.yml
+++ b/.github/workflows/on-open.yml
@@ -62,12 +62,12 @@ jobs:
           needsMoreInfoLabel: "info-needed"
           translatorRequestedLabelPrefix: "translation-required-"
           translatorRequestedLabelColor: "c29cff"
-            # source of truth in ./test-plan-item-validator.yml
-      - name: Run Test Plan Item Validator
-        uses: ./actions/test-plan-item-validator
-        with:
-          refLabel: on-testplan
-          label: testplan-item
-          invalidLabel: invalid-testplan-item
-          comment: Invalid test plan item. See errors below and the [test plan item spec](https://github.com/microsoft/vscode/wiki/Writing-Test-Plan-Items) for more information. This comment will go away when the issues are resolved.
+      # source of truth in ./test-plan-item-validator.yml
+      # - name: Run Test Plan Item Validator
+      #   uses: ./actions/test-plan-item-validator
+      #   with:
+      #     refLabel: on-testplan
+      #     label: testplan-item
+      #     invalidLabel: invalid-testplan-item
+      #     comment: Invalid test plan item. See errors below and the [test plan item spec](https://github.com/microsoft/vscode/wiki/Writing-Test-Plan-Items) for more information. This comment will go away when the issues are resolved.
 


### PR DESCRIPTION
Seems like I was overzealous with the testplan validator and it needs to be more restrictive. Disabling while bugs worked out