### PR TITLE
Use triage bot PAT for TPI validator so comments come from bot

### DIFF
--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -71,6 +71,7 @@ jobs:
         if: contains(github.event.issue.labels.*.name, 'testplan-item') || contains(github.event.issue.labels.*.name, 'invalid-testplan-item')
         uses: ./actions/test-plan-item-validator
         with:
+          token: ${{secrets.VSCODE_ISSUE_TRIAGE_BOT_PAT}}
           refLabel: on-testplan
           label: testplan-item
           invalidLabel: invalid-testplan-item

--- a/.github/workflows/on-open.yml
+++ b/.github/workflows/on-open.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Run Test Plan Item Validator
         uses: ./actions/test-plan-item-validator
         with:
+          token: ${{secrets.VSCODE_ISSUE_TRIAGE_BOT_PAT}}
           refLabel: on-testplan
           label: testplan-item
           invalidLabel: invalid-testplan-item

--- a/.github/workflows/test-plan-item-validator.yml
+++ b/.github/workflows/test-plan-item-validator.yml
@@ -22,6 +22,7 @@ jobs:
         if: contains(github.event.issue.labels.*.name, 'testplan-item') || contains(github.event.issue.labels.*.name, 'invalid-testplan-item')
         uses: ./actions/test-plan-item-validator
         with:
+          token: ${{secrets.VSCODE_ISSUE_TRIAGE_BOT_PAT}}
           refLabel: on-testplan
           label: testplan-item
           invalidLabel: invalid-testplan-item


### PR DESCRIPTION
The TPI validator was posting comments as GitHub action. We try to use the triage bot in public facing experiences. This updates the token to use the triage bot
