### PR TITLE
revert and still use PAT

### DIFF
--- a/build/azure-pipelines/distro-build.yml
+++ b/build/azure-pipelines/distro-build.yml
@@ -7,15 +7,25 @@ trigger:
 pr: none
 
 steps:
-  - checkout: self
-    persistCredentials: true
-
   - task: NodeTool@0
     inputs:
       versionSpec: "16.x"
 
+  - task: AzureKeyVault@1
+    displayName: "Azure Key Vault: Get Secrets"
+    inputs:
+      azureSubscription: "vscode-builds-subscription"
+      KeyVaultName: vscode
+      SecretsFilter: "github-distro-mixin-password"
+
   - script: |
       set -e
+
+      cat << EOF > ~/.netrc
+      machine github.com
+      login vscode
+      password $(github-distro-mixin-password)
+      EOF
 
       git config user.email "vscode@microsoft.com"
       git config user.name "VSCode"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
From what I can tell… it looks like Azure Pipelines doesn’t ask for the workflow scope, so Azure Pipelines is unable to commit a GitHub Action file to a repo…wild.

This pipeline will have to continue using a PAT :disappointed: