### PR TITLE
Enable conflict marker decorators even if merge editor is enabled.

### DIFF
--- a/extensions/merge-conflict/src/services.ts
+++ b/extensions/merge-conflict/src/services.ts
@@ -48,19 +48,6 @@ export default class ServiceWrapper implements vscode.Disposable {
 	}
 
 	createExtensionConfiguration(): interfaces.IExtensionConfiguration {
-
-		// PRAGMATIC way to avoid conflicting with the new merge editor: when git opts into
-		// using the merge editor we disable this extension - for the merge editor but also
-		// for "other" editors
-		const gitConfig = vscode.workspace.getConfiguration('git');
-		if (gitConfig.get<boolean>('mergeEditor')) {
-			return {
-				enableCodeLens: false,
-				enableDecorations: false,
-				enableEditorOverview: false
-			};
-		}
-
 		const workspaceConfiguration = vscode.workspace.getConfiguration(ConfigurationSectionName);
 		const codeLensEnabled: boolean = workspaceConfiguration.get('codeLens.enabled', true);
 		const decoratorsEnabled: boolean = workspaceConfiguration.get('decorators.enabled', true);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
