### PR TITLE
improve fish shell integration in vi mode

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
@@ -86,11 +86,33 @@ function __vsc_fish_cmd_start
 	__vsc_esc B
 end
 
-# Preserve the user's existing prompt, and wrap it in our escape sequences.
+function __vsc_fish_has_mode_prompt -d "Returns true if fish_mode_prompt is defined and not empty"
+	functions fish_mode_prompt | string match -rvq '^ *(#|function |end$|$)'
+end
+
+# Preserve the user's existing prompt, to wrap in our escape sequences.
 functions --copy fish_prompt __vsc_fish_prompt
 
-function fish_prompt
-	__vsc_fish_prompt_start
-	__vsc_fish_prompt
-	__vsc_fish_cmd_start
+# Preserve and wrap fish_mode_prompt (which appears to the left of the regular
+# prompt), but only if it's not defined as an empty function (which is the
+# officially documented way to disable that feature).
+if __vsc_fish_has_mode_prompt
+	functions --copy fish_mode_prompt __vsc_fish_mode_prompt
+
+	function fish_mode_prompt
+		__vsc_fish_prompt_start
+		__vsc_fish_mode_prompt
+	end
+
+	function fish_prompt
+		__vsc_fish_prompt
+		__vsc_fish_cmd_start
+	end
+else
+	# No fish_mode_prompt, so put everything in fish_prompt.
+	function fish_prompt
+		__vsc_fish_prompt_start
+		__vsc_fish_prompt
+		__vsc_fish_cmd_start
+	end
 end


### PR DESCRIPTION
Part of #139400. Follow-up to #157291.

fish has an additional left-side prompt, which is used in ["vi mode"](https://fishshell.com/docs/current/interactive.html#vi-mode-commands) to indicate editor status: if `fish_mode_prompt` is a defined function that produces any output, that output is printed before `fish_prompt`.

This PR is based on [iTerm2's fish integration](https://github.com/gnachman/iTerm2/blob/master/Resources/shell_integration/iterm2_shell_integration.fish#L76-L109), and moves the start-of-prompt escape sequence to prefix `fish_mode_prompt`, if that function is defined and not empty. (The [officially documented](https://fishshell.com/docs/current/cmds/fish_mode_prompt.html) way to disable the editor status display is to define `function fish_mode_prompt; end` in your own config.) Otherwise it only modifies `fish_prompt` as before.