### PR TITLE
Replace deprecated method subtr in driver.ts

### DIFF
--- a/src/vs/platform/driver/browser/driver.ts
+++ b/src/vs/platform/driver/browser/driver.ts
@@ -112,9 +112,8 @@ export class BrowserWindowDriver implements IWindowDriver {
 		const start = textarea.selectionStart;
 		const newStart = start + text.length;
 		const value = textarea.value;
-		const newValue = value.substr(0, start) + text + value.substr(start);
 
-		textarea.value = newValue;
+		textarea.value = value.substring(0, start) + text + value.substring(start);
 		textarea.setSelectionRange(newStart, newStart);
 
 		const event = new Event('input', { 'bubbles': true, 'cancelable': true });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

According to MDN [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) of substr, developers should not use substr because it is not in main part of ECMAscript specification. So, I replace it with substring method. Their functionality is equal. Only code quality improvement.
