### PR TITLE
Support toggleable selection during rename

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -483,6 +483,7 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 		const styler = attachInputBoxStyler(inputBox, this.themeService);
 
 		const lastDot = value.lastIndexOf('.');
+		let currentSelectionState = 'prefix';
 
 		inputBox.value = value;
 		inputBox.focus();
@@ -520,7 +521,22 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 				label.setFile(joinPath(parent, value || ' '), labelOptions); // update label icon while typing!
 			}),
 			DOM.addStandardDisposableListener(inputBox.inputElement, DOM.EventType.KEY_DOWN, (e: IKeyboardEvent) => {
-				if (e.equals(KeyCode.Enter)) {
+				if (e.equals(KeyCode.F2)) {
+					const dotIndex = inputBox.value.lastIndexOf('.');
+					if (stat.isDirectory || dotIndex === -1) {
+						return;
+					}
+					if (currentSelectionState === 'prefix') {
+						currentSelectionState = 'all';
+						inputBox.select({ start: 0, end: inputBox.value.length });
+					} else if (currentSelectionState === 'all') {
+						currentSelectionState = 'suffix';
+						inputBox.select({ start: dotIndex, end: inputBox.value.length });
+					} else {
+						currentSelectionState = 'prefix';
+						inputBox.select({ start: 0, end: dotIndex });
+					}
+				} else if (e.equals(KeyCode.Enter)) {
 					if (!inputBox.validate()) {
 						done(true, true);
 					}

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -531,7 +531,7 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 						inputBox.select({ start: 0, end: inputBox.value.length });
 					} else if (currentSelectionState === 'all') {
 						currentSelectionState = 'suffix';
-						inputBox.select({ start: dotIndex, end: inputBox.value.length });
+						inputBox.select({ start: dotIndex + 1, end: inputBox.value.length });
 					} else {
 						currentSelectionState = 'prefix';
 						inputBox.select({ start: 0, end: dotIndex });


### PR DESCRIPTION
Fixes #158080.

Would be better if this also mapped to the same keybinding as whatever you have rename to, but for now F2 will work. F2 is also better on Mac than enter as enter completes the rename
![Recording 2022-08-15 at 12 01 20](https://user-images.githubusercontent.com/4544166/184689455-17b82d00-0606-4349-8abf-2054b0be5e34.gif)

