### PR TITLE
Initialize Offline contribution on Restored phase

### DIFF
--- a/src/vs/workbench/contrib/offline/browser/offline.contribution.ts
+++ b/src/vs/workbench/contrib/offline/browser/offline.contribution.ts
@@ -94,4 +94,4 @@ export class OfflineStatusBarController implements IWorkbenchContribution {
 }
 
 Registry.as<IWorkbenchContributionsRegistry>(Extensions.Workbench)
-	.registerWorkbenchContribution(OfflineStatusBarController, LifecyclePhase.Starting);
+	.registerWorkbenchContribution(OfflineStatusBarController, LifecyclePhase.Restored);


### PR DESCRIPTION
In a rare case of the slow network, Chrome can signal that the network is offline during the VSCode initialization - while the workbench parts still were not created, but the Offline contribution was already registered (since Starting is an initial lifecycle stage).
Then as assertion is thrown from the Offline contribution, and it only updates the color of the status bar, but does not place the 'Offline' status bar item - I think this may be confusing for users; also the status bar color will never change back if the attempt to change a status bar will happen during the Offline contribtion *construction* - there will be no code to change it back.

Solution: initialize the Offline contribution later; this should not make a big difference.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
