### PR TITLE
🔨 Normalize CWD history entries (2nd approach)

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -325,6 +325,7 @@ export interface IPtyService extends IPtyHostController {
 	getProfiles?(workspaceId: string, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getEnvironment(): Promise<IProcessEnvironment>;
 	getWslPath(original: string, reverse?: boolean): Promise<string>;
+	getCygPath(original: string, reverse?: boolean): Promise<string>;
 	getRevivedPtyNewId(id: number): Promise<number | undefined>;
 	setTerminalLayoutInfo(args: ISetTerminalLayoutInfoArgs): Promise<void>;
 	getTerminalLayoutInfo(args: IGetTerminalLayoutInfoArgs): Promise<ITerminalsLayoutInfo | undefined>;

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -324,7 +324,7 @@ export interface IPtyService extends IPtyHostController {
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string>;
 	getProfiles?(workspaceId: string, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getEnvironment(): Promise<IProcessEnvironment>;
-	getWslPath(original: string): Promise<string>;
+	getWslPath(original: string, reverse?: boolean): Promise<string>;
 	getRevivedPtyNewId(id: number): Promise<number | undefined>;
 	setTerminalLayoutInfo(args: ISetTerminalLayoutInfoArgs): Promise<void>;
 	getTerminalLayoutInfo(args: IGetTerminalLayoutInfoArgs): Promise<ITerminalsLayoutInfo | undefined>;

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -295,6 +295,9 @@ export class PtyHostService extends Disposable implements IPtyService {
 	getWslPath(original: string, reverse?: boolean): Promise<string> {
 		return this._proxy.getWslPath(original, reverse);
 	}
+	getCygPath(original: string, reverse?: boolean): Promise<string> {
+		return this._proxy.getCygPath(original, reverse);
+	}
 
 	getRevivedPtyNewId(id: number): Promise<number | undefined> {
 		return this._proxy.getRevivedPtyNewId(id);

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -292,8 +292,8 @@ export class PtyHostService extends Disposable implements IPtyService {
 	getEnvironment(): Promise<IProcessEnvironment> {
 		return this._proxy.getEnvironment();
 	}
-	getWslPath(original: string): Promise<string> {
-		return this._proxy.getWslPath(original);
+	getWslPath(original: string, reverse?: boolean): Promise<string> {
+		return this._proxy.getWslPath(original, reverse);
 	}
 
 	getRevivedPtyNewId(id: number): Promise<number | undefined> {

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -27,6 +27,7 @@ import { TerminalAutoResponder } from 'vs/platform/terminal/common/terminalAutoR
 import { ErrorNoTelemetry } from 'vs/base/common/errors';
 import { ShellIntegrationAddon } from 'vs/platform/terminal/common/xterm/shellIntegrationAddon';
 import { formatMessageForTerminal } from 'vs/platform/terminal/common/terminalStrings';
+import * as path from 'vs/base/common/path';
 
 type WorkspaceId = string;
 
@@ -341,6 +342,29 @@ export class PtyService extends Disposable implements IPtyService {
 		else {
 			return new Promise<string>(c => {
 				const proc = execFile('bash.exe', ['-c', `wslpath -w ${escapeNonWindowsPath(original)}`], {}, (error, stdout, stderr) => {
+					c(stdout.trim());
+				});
+				proc.stdin!.end();
+			});
+		}
+	}
+
+	async getCygPath(original: string, reverse?: boolean): Promise<string> {
+		if (!isWindows) {
+			return original;
+		}
+
+		if (!reverse) {
+			return new Promise<string>(c => {
+				const proc = execFile('git-bash.exe', ['-c', `cygpath -u ${escapeNonWindowsPath(original)}`], {}, (error, stdout, stderr) => {
+					c(escapeNonWindowsPath(stdout.trim()));
+				});
+				proc.stdin!.end();
+			});
+		}
+		else {
+			return new Promise<string>(c => {
+				const proc = execFile('git-bash.exe', ['-c', `cygpath -w ${escapeNonWindowsPath(original)}`], {}, (error, stdout, stderr) => {
 					c(stdout.trim());
 				});
 				proc.stdin!.end();

--- a/src/vs/server/node/remoteTerminalChannel.ts
+++ b/src/vs/server/node/remoteTerminalChannel.ts
@@ -134,6 +134,7 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 			case '$getProfiles': return this._getProfiles.apply(this, args);
 			case '$getEnvironment': return this._getEnvironment();
 			case '$getWslPath': return this._getWslPath(args[0], args[1]);
+			case '$getCygPath': return this._getCygPath(args[0], args[1]);
 			case '$getTerminalLayoutInfo': return this._ptyService.getTerminalLayoutInfo(<IGetTerminalLayoutInfoArgs>args);
 			case '$setTerminalLayoutInfo': return this._ptyService.setTerminalLayoutInfo(<ISetTerminalLayoutInfoArgs>args);
 			case '$serializeTerminalState': return this._ptyService.serializeTerminalState.apply(this._ptyService, args);
@@ -320,6 +321,9 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 		return this._ptyService.getWslPath(original, reverse);
 	}
 
+	private _getCygPath(original: string, reverse?: boolean): Promise<string> {
+		return this._ptyService.getCygPath(original, reverse);
+	}
 
 	private _reduceConnectionGraceTime(): Promise<void> {
 		return this._ptyService.reduceConnectionGraceTime();

--- a/src/vs/server/node/remoteTerminalChannel.ts
+++ b/src/vs/server/node/remoteTerminalChannel.ts
@@ -133,7 +133,7 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 			case '$getDefaultSystemShell': return this._getDefaultSystemShell.apply(this, args);
 			case '$getProfiles': return this._getProfiles.apply(this, args);
 			case '$getEnvironment': return this._getEnvironment();
-			case '$getWslPath': return this._getWslPath(args[0]);
+			case '$getWslPath': return this._getWslPath(args[0], args[1]);
 			case '$getTerminalLayoutInfo': return this._ptyService.getTerminalLayoutInfo(<IGetTerminalLayoutInfoArgs>args);
 			case '$setTerminalLayoutInfo': return this._ptyService.setTerminalLayoutInfo(<ISetTerminalLayoutInfoArgs>args);
 			case '$serializeTerminalState': return this._ptyService.serializeTerminalState.apply(this._ptyService, args);
@@ -316,8 +316,8 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 		return { ...process.env };
 	}
 
-	private _getWslPath(original: string): Promise<string> {
-		return this._ptyService.getWslPath(original);
+	private _getWslPath(original: string, reverse?: boolean): Promise<string> {
+		return this._ptyService.getWslPath(original, reverse);
 	}
 
 

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -313,6 +313,14 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 		return this._remoteTerminalChannel?.getWslPath(original, reverse) || original;
 	}
 
+	async getCygPath(original: string, reverse?: boolean): Promise<string> {
+		const env = await this._remoteAgentService.getEnvironment();
+		if (env?.os !== OperatingSystem.Windows) {
+			return original;
+		}
+		return this._remoteTerminalChannel?.getCygPath(original, reverse) || original;
+	}
+
 	async setTerminalLayoutInfo(layout?: ITerminalsLayoutInfoById): Promise<void> {
 		if (!this._remoteTerminalChannel) {
 			throw new Error(`Cannot call setActiveInstanceId when there is no remote`);

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -305,12 +305,12 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 		return resolverResult.options?.extensionHostEnv as any;
 	}
 
-	async getWslPath(original: string): Promise<string> {
+	async getWslPath(original: string, reverse?: boolean): Promise<string> {
 		const env = await this._remoteAgentService.getEnvironment();
 		if (env?.os !== OperatingSystem.Windows) {
 			return original;
 		}
-		return this._remoteTerminalChannel?.getWslPath(original) || original;
+		return this._remoteTerminalChannel?.getWslPath(original, reverse) || original;
 	}
 
 	async setTerminalLayoutInfo(layout?: ITerminalsLayoutInfoById): Promise<void> {

--- a/src/vs/workbench/contrib/terminal/common/history.ts
+++ b/src/vs/workbench/contrib/terminal/common/history.ts
@@ -60,10 +60,10 @@ export function getCommandHistory(accessor: ServicesAccessor): ITerminalPersiste
 	return commandHistory;
 }
 
-let directoryHistory: ITerminalPersistedHistory<{ remoteAuthority?: string }> | undefined = undefined;
-export function getDirectoryHistory(accessor: ServicesAccessor): ITerminalPersistedHistory<{ remoteAuthority?: string }> {
+let directoryHistory: ITerminalPersistedHistory<{ remoteAuthority?: string; shellType?: TerminalShellType; platformNativePath?: string }> | undefined = undefined;
+export function getDirectoryHistory(accessor: ServicesAccessor): ITerminalPersistedHistory<{ remoteAuthority?: string; shellType?: TerminalShellType; platformNativePath?: string }> {
 	if (!directoryHistory) {
-		directoryHistory = accessor.get(IInstantiationService).createInstance(TerminalPersistedHistory, 'dirs') as TerminalPersistedHistory<{ remoteAuthority?: string }>;
+		directoryHistory = accessor.get(IInstantiationService).createInstance(TerminalPersistedHistory, 'dirs') as TerminalPersistedHistory<{ remoteAuthority?: string; shellType?: TerminalShellType; platformNativePath?: string }>;
 	}
 	return directoryHistory;
 }

--- a/src/vs/workbench/contrib/terminal/common/remoteTerminalChannel.ts
+++ b/src/vs/workbench/contrib/terminal/common/remoteTerminalChannel.ts
@@ -262,6 +262,10 @@ export class RemoteTerminalChannelClient implements IPtyHostController {
 		return this._channel.call('$getWslPath', [original, reverse]);
 	}
 
+	getCygPath(original: string, reverse?: boolean): Promise<string> {
+		return this._channel.call('$getCygPath', [original, reverse]);
+	}
+
 	setTerminalLayoutInfo(layout?: ITerminalsLayoutInfoById): Promise<void> {
 		const workspace = this._workspaceContextService.getWorkspace();
 		const args: ISetTerminalLayoutInfoArgs = {

--- a/src/vs/workbench/contrib/terminal/common/remoteTerminalChannel.ts
+++ b/src/vs/workbench/contrib/terminal/common/remoteTerminalChannel.ts
@@ -258,8 +258,8 @@ export class RemoteTerminalChannelClient implements IPtyHostController {
 		return this._channel.call('$getEnvironment');
 	}
 
-	getWslPath(original: string): Promise<string> {
-		return this._channel.call('$getWslPath', [original]);
+	getWslPath(original: string, reverse?: boolean): Promise<string> {
+		return this._channel.call('$getWslPath', [original, reverse]);
 	}
 
 	setTerminalLayoutInfo(layout?: ITerminalsLayoutInfoById): Promise<void> {

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -123,6 +123,7 @@ export interface ITerminalBackend {
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string>;
 	getProfiles(profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getWslPath(original: string, reverse?: boolean): Promise<string>;
+	getCygPath(original: string, reverse?: boolean): Promise<string>;
 	getEnvironment(): Promise<IProcessEnvironment>;
 	getShellEnvironment(): Promise<IProcessEnvironment | undefined>;
 	setTerminalLayoutInfo(layoutInfo?: ITerminalsLayoutInfoById): Promise<void>;

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -122,7 +122,7 @@ export interface ITerminalBackend {
 	listProcesses(): Promise<IProcessDetails[]>;
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string>;
 	getProfiles(profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
-	getWslPath(original: string): Promise<string>;
+	getWslPath(original: string, reverse?: boolean): Promise<string>;
 	getEnvironment(): Promise<IProcessEnvironment>;
 	getShellEnvironment(): Promise<IProcessEnvironment | undefined>;
 	setTerminalLayoutInfo(layoutInfo?: ITerminalsLayoutInfoById): Promise<void>;

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -202,8 +202,8 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 		return this._shellEnvironmentService.getShellEnv();
 	}
 
-	async getWslPath(original: string): Promise<string> {
-		return this._localPtyService.getWslPath(original);
+	async getWslPath(original: string, reverse?: boolean): Promise<string> {
+		return this._localPtyService.getWslPath(original, reverse);
 	}
 
 	async setTerminalLayoutInfo(layoutInfo?: ITerminalsLayoutInfoById): Promise<void> {

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -206,6 +206,10 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 		return this._localPtyService.getWslPath(original, reverse);
 	}
 
+	async getCygPath(original: string, reverse?: boolean): Promise<string> {
+		return this._localPtyService.getCygPath(original, reverse);
+	}
+
 	async setTerminalLayoutInfo(layoutInfo?: ITerminalsLayoutInfoById): Promise<void> {
 		const args: ISetTerminalLayoutInfoArgs = {
 			workspaceId: this._getWorkspaceId(),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #157932

:warning: *Since I couldn't manually test Windows-related behaviors, I wouldn't call this PR ready to review. Nor it's a draft PR, for I wouldn't contribute to it anymore. So, may this be a little groundwork for anyone who wants to use it.*

Changes made in this PR:

- A new parameter, `reverse:? boolean`, was added to `getWslPath` to let it act in the reverse order. That is, to receive WSL paths which are in POSIX format (like `/mnt/c/windows`) and return their Windows-native equivalent (e.g., `c:\windows`).
- A new method, `getCygPath`, was added to terminal backends to help with paths of Git-Bash in Windows. This acts just like the `getWslPath`, with the same signature.
- CWD history entries now include two optional fields: `shellType` and `platformNativePath`, which are supposed to be present when the actual CWD path is different than its platform-native representation. For example, in WSL, the working directory could be `/mnt/c/windows` and so is different than `c:\windows` which is its platform-native representation. The same thing happens on Git-Bash too. So, in such cases, we store the `shellType` and `platformNativePath` in the CWD history storage to later use them to properly eliminate duplicate items from the `Go To Recent Directory...` picker. For non-Windows environments, we do not store these two extra fields and things are the same as before.
