### PR TITLE
Code action widget accessibility for screen reader

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -384,6 +384,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 				} else if (optionKind === CodeActionMenu.documentationID) {
 					documentationGroup.push(item);
 				} else {
+					// Pushes all the other actions to the "Other" group
 					otherGroup.push(item);
 				}
 
@@ -418,6 +419,9 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 
 				} else if (firstAction === CodeActionMenu.documentationID) {
 					totalActionEntries.push(...entry);
+				} else {
+					// Takes and flattens all the `other` actions
+					menuEntriesToPush(localize('codeAction.widget.id.more', 'More Actions...'), entry);
 				}
 			} else {
 				// case for separator - not a code action action

--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -332,10 +332,10 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 				accessibilityProvider: {
 					getAriaLabel: element => {
 						if (element.action instanceof CodeActionAction) {
-							let label = element.action.label;
+							const label = element.action.label;
 							if (!element.action.enabled) {
 								if (element.action instanceof CodeActionAction) {
-									label += `Disabled Reason: ${element.action.action.disabled}`;
+									localize({ key: 'customCodeActionWidget.labels', comment: ['Code action labels for accessibility.'] }, "{0}, Disabled Reason: {1}", label, element.action.action.disabled);
 								}
 							}
 							return label;

--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -329,7 +329,23 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		}, [this.listRenderer],
 			{
 				keyboardSupport: false,
-
+				accessibilityProvider: {
+					getAriaLabel: element => {
+						if (element.action instanceof CodeActionAction) {
+							let label = element.action.label;
+							if (!element.action.enabled) {
+								if (element.action instanceof CodeActionAction) {
+									label += `Disabled Reason: ${element.action.action.disabled}`;
+								}
+							}
+							return label;
+						}
+						return null;
+					},
+					getWidgetAriaLabel: () => localize({ key: 'customCodeActionWidget', comment: ['A Code Action Option'] }, "Code Action Widget"),
+					getRole: () => 'option',
+					getWidgetRole: () => 'code-action-widget'
+				}
 			}
 		);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/157402

Added accessibility provider to list widget which will read the label + the disabled reason OR how to apply/refactor preview
