### PR TITLE
Add rounded corners to buttons

### DIFF
--- a/src/vs/base/browser/ui/button/button.css
+++ b/src/vs/base/browser/ui/button/button.css
@@ -8,6 +8,7 @@
 	display: flex;
 	width: 100%;
 	padding: 4px;
+	border-radius: 2px;
 	text-align: center;
 	cursor: pointer;
 	justify-content: center;

--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -257,3 +257,16 @@
 .extension-list-item .monaco-action-bar > .actions-container > .action-item.action-dropdown-item > .monaco-dropdown .extension-action.label {
 	border-left-width: 0;
 }
+
+/* single install */
+.extension-list-item .monaco-action-bar > .actions-container > .action-item.action-dropdown-item.empty > .extension-action {
+	border-radius: 2px;
+}
+
+/* split install */
+.extension-list-item .monaco-action-bar > .actions-container > .action-item.action-dropdown-item:not(.empty) > .extension-action.label:not(.dropdown) {
+	border-radius: 2px 0 0 2px;
+}
+.extension-list-item .monaco-action-bar > .actions-container > .action-item.action-dropdown-item > .monaco-dropdown .extension-action {
+	border-radius: 0 2px 2px 0;
+}

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -257,8 +257,19 @@
 	display: none;
 }
 
+/* single install */
+.extension-editor > .header > .details > .actions-status-container > .monaco-action-bar > .actions-container > .action-item > .extension-action.label {
+	border-radius: 2px;
+}
+
+/* split install */
+.extension-editor > .header > .details > .actions-status-container > .monaco-action-bar > .actions-container > .action-item.action-dropdown-item > .extension-action.label {
+	border-radius: 2px 0 0 2px;
+}
+
 .extension-editor > .header > .details > .actions-status-container > .monaco-action-bar > .actions-container > .action-item.action-dropdown-item > .monaco-dropdown .extension-action.label {
 	border-left-width: 0;
+	border-radius: 0 3px 3px 0;
 }
 
 .extension-editor > .header > .details > .actions-status-container > .monaco-action-bar > .actions-container > .action-item > .action-label.extension-status {

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -269,7 +269,7 @@
 
 .extension-editor > .header > .details > .actions-status-container > .monaco-action-bar > .actions-container > .action-item.action-dropdown-item > .monaco-dropdown .extension-action.label {
 	border-left-width: 0;
-	border-radius: 0 3px 3px 0;
+	border-radius: 0 2px 2px 0;
 }
 
 .extension-editor > .header > .details > .actions-status-container > .monaco-action-bar > .actions-container > .action-item > .action-label.extension-status {

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -254,6 +254,15 @@
 	padding: 0 4px;
 }
 
+/* split commit button */
+.scm-view .button-container > .monaco-button-dropdown > .monaco-dropdown-button.codicon-drop-down-button {
+	border-radius: 0 2px 2px 0;
+}
+
+.scm-view .button-container > .monaco-button-dropdown > .monaco-button.monaco-text-button {
+	border-radius: 2px 0 0 2px;
+}
+
 .scm-view .scm-editor.hidden {
 	display: none;
 }


### PR DESCRIPTION
Partially fixes https://github.com/microsoft/vscode/issues/147121 and adds a 2px border-radius on all of our buttons, including split buttons to better align with our other rounded corners.

https://user-images.githubusercontent.com/35271042/184974942-2f2d1b76-bc70-4e5c-98c9-7d5bbce294ff.mp4

And a few other variants

<img width="296" alt="CleanShot 2022-08-16 at 13 08 07@2x" src="https://user-images.githubusercontent.com/35271042/184975116-1f387af2-f147-4d74-96cd-227ab1b99c7e.png">

<img width="321" alt="CleanShot 2022-08-16 at 13 08 37@2x" src="https://user-images.githubusercontent.com/35271042/184975312-28ec1d41-99fe-42ed-8340-9e3fb7670b3d.png">

<img width="533" alt="CleanShot 2022-08-16 at 13 10 42@2x" src="https://user-images.githubusercontent.com/35271042/184976018-724ce438-a2c8-4894-971a-78f48c4dcbba.png">

cc @lszomoru 