### PR TITLE
Address comments from API sync

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -314,15 +314,15 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				return extHostTelemetry.getTelemetryConfiguration();
 			},
 			get onDidChangeTelemetryEnabled(): Event<boolean> {
-				return extHostTelemetry.onDidChangeTelemetryEnabled;
+				if (isProposedApiEnabled(extension, 'telemetry')) {
+					return extHostTelemetry.onDidChangeTelemetryConfiguration;
+				} else {
+					return extHostTelemetry.onDidChangeTelemetryEnabled;
+				}
 			},
 			get telemetryConfiguration(): vscode.TelemetryConfiguration {
 				checkProposedApiEnabled(extension, 'telemetry');
 				return extHostTelemetry.getTelemetryDetails();
-			},
-			get onDidChangeTelemetryConfiguration(): Event<vscode.TelemetryConfiguration> {
-				checkProposedApiEnabled(extension, 'telemetry');
-				return extHostTelemetry.onDidChangeTelemetryConfiguration;
 			},
 			get isNewAppInstall() {
 				const installAge = Date.now() - new Date(initData.telemetryInfo.firstSessionDate).getTime();

--- a/src/vs/workbench/api/common/extHostTelemetry.ts
+++ b/src/vs/workbench/api/common/extHostTelemetry.ts
@@ -13,8 +13,9 @@ export class ExtHostTelemetry implements ExtHostTelemetryShape {
 	private readonly _onDidChangeTelemetryEnabled = new Emitter<boolean>();
 	readonly onDidChangeTelemetryEnabled: Event<boolean> = this._onDidChangeTelemetryEnabled.event;
 
-	private readonly _onDidChangeTelemetryConfiguration = new Emitter<TelemetryConfiguration>();
-	readonly onDidChangeTelemetryConfiguration: Event<TelemetryConfiguration> = this._onDidChangeTelemetryConfiguration.event;
+	// TODO @lramos15 remove this one API is finalized as it's the same as `onDidChangeTelemetryEnabled` just fires more
+	private readonly _onDidChangeTelemetryConfiguration = new Emitter<boolean>();
+	readonly onDidChangeTelemetryConfiguration: Event<boolean> = this._onDidChangeTelemetryConfiguration.event;
 
 	private _productConfig: { usage: boolean; error: boolean } = { usage: true, error: true };
 	private _level: TelemetryLevel = TelemetryLevel.NONE;
@@ -43,7 +44,7 @@ export class ExtHostTelemetry implements ExtHostTelemetryShape {
 		if (this._oldTelemetryEnablement !== this.getTelemetryConfiguration()) {
 			this._onDidChangeTelemetryEnabled.fire(this.getTelemetryConfiguration());
 		}
-		this._onDidChangeTelemetryConfiguration.fire(this.getTelemetryDetails());
+		this._onDidChangeTelemetryConfiguration.fire(this.getTelemetryConfiguration());
 	}
 }
 

--- a/src/vscode-dts/vscode.proposed.telemetry.d.ts
+++ b/src/vscode-dts/vscode.proposed.telemetry.d.ts
@@ -26,11 +26,5 @@ declare module 'vscode' {
 		 * Can be observed to determine what telemetry the extension is allowed to send
 		 */
 		export const telemetryConfiguration: TelemetryConfiguration;
-
-		/**
-		 * An {@link Event} which fires when the collectable state of telemetry changes
-		 * Returns a {@link TelemetryConfiguration} object
-		 */
-		export const onDidChangeTelemetryConfiguration: Event<TelemetryConfiguration | undefined>;
 	}
 }


### PR DESCRIPTION
This removes the new `onDidChangeTelemetryConfiguration` event and just makes the old one fire more. I think we still need to update the comment to reflex this in the `.d.ts` but I didn't want to do that until it's ok to finalize just so nobody gets confused