### PR TITLE
Limit cell execution update events. Shouldn't be needed for output updates.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookExecutionStateServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookExecutionStateServiceImpl.ts
@@ -416,7 +416,9 @@ class CellExecution extends Disposable implements INotebookCellExecution {
 			this._applyExecutionEdits(edits);
 		}
 
-		this._onDidUpdate.fire();
+		if (updates.some(u => u.editType === CellExecutionUpdateType.ExecutionState)) {
+			this._onDidUpdate.fire();
+		}
 	}
 
 	complete(completionData: ICellExecutionComplete): void {


### PR DESCRIPTION
Helps with #146768 but not a fix
