### PR TITLE
enabled core cell delete for IW and undo operations

### DIFF
--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkCellEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkCellEdits.ts
@@ -72,7 +72,8 @@ export class BulkCellEdits {
 
 			// apply edits
 			const edits = group.map(entry => entry.cellEdit);
-			ref.object.notebook.applyEdits(edits, true, undefined, () => undefined, this._undoRedoGroup, true);
+			const computeUndo = !ref.object.isReadonly;
+			ref.object.notebook.applyEdits(edits, true, undefined, () => undefined, this._undoRedoGroup, computeUndo);
 			ref.dispose();
 
 			this._progress.report(undefined);

--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOperations.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOperations.ts
@@ -123,6 +123,7 @@ export function runDeleteAction(editor: IActiveNotebookEditor, cell: ICellViewMo
 	const targetCellIndex = editor.getCellIndex(cell);
 	const containingSelection = selections.find(selection => selection.start <= targetCellIndex && targetCellIndex < selection.end);
 
+	const computeUndoRedo = !editor.isReadOnly || textModel.viewType === 'interactive';
 	if (containingSelection) {
 		const edits: ICellReplaceEdit[] = selections.reverse().map(selection => ({
 			editType: CellEditType.Replace, index: selection.start, count: selection.end - selection.start, cells: []
@@ -143,7 +144,7 @@ export function runDeleteAction(editor: IActiveNotebookEditor, cell: ICellViewMo
 					return { kind: SelectionStateType.Index, focus: { start: 0, end: 0 }, selections: [{ start: 0, end: 0 }] };
 				}
 			}
-		}, undefined, true);
+		}, undefined, computeUndoRedo);
 	} else {
 		const focus = editor.getFocus();
 		const edits: ICellReplaceEdit[] = [{
@@ -169,14 +170,14 @@ export function runDeleteAction(editor: IActiveNotebookEditor, cell: ICellViewMo
 
 			textModel.applyEdits(edits, true, { kind: SelectionStateType.Index, focus: editor.getFocus(), selections: editor.getSelections() }, () => ({
 				kind: SelectionStateType.Index, focus: newFocus, selections: finalSelections
-			}), undefined, true);
+			}), undefined, computeUndoRedo);
 		} else {
 			// users decide to delete a cell out of current focus/selection
 			const newFocus = focus.start > targetCellIndex ? { start: focus.start - 1, end: focus.end - 1 } : focus;
 
 			textModel.applyEdits(edits, true, { kind: SelectionStateType.Index, focus: editor.getFocus(), selections: editor.getSelections() }, () => ({
 				kind: SelectionStateType.Index, focus: newFocus, selections: finalSelections
-			}), undefined, true);
+			}), undefined, computeUndoRedo);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOperations.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOperations.ts
@@ -649,6 +649,6 @@ export function insertCellAtIndex(viewModel: NotebookViewModel, index: number, s
 				}
 			]
 		}
-	], synchronous, { kind: SelectionStateType.Index, focus: viewModel.getFocus(), selections: viewModel.getSelections() }, () => endSelections, undefined, pushUndoStop);
+	], synchronous, { kind: SelectionStateType.Index, focus: viewModel.getFocus(), selections: viewModel.getSelections() }, () => endSelections, undefined, pushUndoStop && !viewModel.options.isReadOnly);
 	return viewModel.cellAt(index)!;
 }

--- a/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
@@ -201,7 +201,8 @@ registerAction2(class ClearCellOutputsAction extends NotebookCellAction {
 			return;
 		}
 
-		editor.textModel.applyEdits([{ editType: CellEditType.Output, index, outputs: [] }], true, undefined, () => undefined, undefined, true);
+		const computeUndoRedo = !editor.isReadOnly;
+		editor.textModel.applyEdits([{ editType: CellEditType.Output, index, outputs: [] }], true, undefined, () => undefined, undefined, computeUndoRedo);
 
 		const runState = notebookExecutionStateService.getCellExecution(context.cell.uri)?.state;
 		if (runState !== NotebookCellExecutionState.Executing) {
@@ -213,7 +214,7 @@ registerAction2(class ClearCellOutputsAction extends NotebookCellAction {
 					executionOrder: null,
 					lastRunSuccess: null
 				}
-			}], true, undefined, () => undefined, undefined, true);
+			}], true, undefined, () => undefined, undefined, computeUndoRedo);
 		}
 	}
 });
@@ -256,10 +257,11 @@ registerAction2(class ClearAllCellOutputsAction extends NotebookAction {
 			return;
 		}
 
+		const computeUndoRedo = !editor.isReadOnly;
 		editor.textModel.applyEdits(
 			editor.textModel.cells.map((cell, index) => ({
 				editType: CellEditType.Output, index, outputs: []
-			})), true, undefined, () => undefined, undefined, true);
+			})), true, undefined, () => undefined, undefined, computeUndoRedo);
 
 		const clearExecutionMetadataEdits = editor.textModel.cells.map((cell, index) => {
 			const runState = notebookExecutionStateService.getCellExecution(cell.uri)?.state;
@@ -278,7 +280,7 @@ registerAction2(class ClearAllCellOutputsAction extends NotebookAction {
 			}
 		}).filter(edit => !!edit) as ICellEditOperation[];
 		if (clearExecutionMetadataEdits.length) {
-			context.notebookEditor.textModel.applyEdits(clearExecutionMetadataEdits, true, undefined, () => undefined, undefined, true);
+			context.notebookEditor.textModel.applyEdits(clearExecutionMetadataEdits, true, undefined, () => undefined, undefined, computeUndoRedo);
 		}
 	}
 });
@@ -498,7 +500,7 @@ async function setCellToLanguage(languageId: string, context: IChangeCellContext
 		const index = context.notebookEditor.textModel.cells.indexOf(context.cell.model);
 		context.notebookEditor.textModel.applyEdits(
 			[{ editType: CellEditType.CellLanguage, index, language: languageId }],
-			true, undefined, () => undefined, undefined, true
+			true, undefined, () => undefined, undefined, !context.notebookEditor.isReadOnly
 		);
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
@@ -134,7 +134,7 @@ registerAction2(class DeleteCellAction extends NotebookCellAction {
 					mac: {
 						primary: KeyMod.CtrlCmd | KeyCode.Backspace
 					},
-					when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_EDITOR_EDITABLE, ContextKeyExpr.not(InputFocusedContextKey)),
+					when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED, ContextKeyExpr.not(InputFocusedContextKey)),
 					weight: KeybindingWeight.WorkbenchContrib
 				},
 				menu: [
@@ -145,7 +145,6 @@ registerAction2(class DeleteCellAction extends NotebookCellAction {
 					},
 					{
 						id: MenuId.InteractiveCellDelete,
-						when: NOTEBOOK_EDITOR_EDITABLE,
 						group: CELL_TITLE_CELL_GROUP_ID
 					}
 				],
@@ -154,7 +153,7 @@ registerAction2(class DeleteCellAction extends NotebookCellAction {
 	}
 
 	async runWithContext(accessor: ServicesAccessor, context: INotebookCellActionContext) {
-		if (!context.notebookEditor.hasModel() || context.notebookEditor.isReadOnly) {
+		if (!context.notebookEditor.hasModel()) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
@@ -954,9 +954,6 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 	}
 
 	async undo() {
-		if (this._options.isReadOnly) {
-			return null;
-		}
 
 		const editStack = this._undoService.getElements(this.uri);
 		const element = editStack.past.length ? editStack.past[editStack.past.length - 1] : undefined;
@@ -974,9 +971,6 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 	}
 
 	async redo() {
-		if (this._options.isReadOnly) {
-			return null;
-		}
 
 		const editStack = this._undoService.getElements(this.uri);
 		const element = editStack.future[0];

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -402,7 +402,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 			true,
 			undefined, () => undefined,
 			undefined,
-			true
+			false
 		);
 	}
 


### PR DESCRIPTION
https://github.com/microsoft/vscode-jupyter/issues/7756

- Check if an operation should be placed on the undo stack, rather than checking if undo is available at all
  - The interactive window is a partially read-only notebook, and `delete cell` is an exception since it can be performed by the user. We want to enable undo for that operation
- deleting a cell while having focus elsewhere requires first focusing on the history, but doesn't always work depending on which component was actually given focus ([out of scope issue](https://github.com/microsoft/vscode/issues/160463))
- Also stopped some maintenance code from being placed on the undo stack (`reset`)
