### PR TITLE
macOS - detect fullscreen transitions

### DIFF
--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { app, BrowserWindow, BrowserWindowConstructorOptions, Display, Event, nativeImage, NativeImage, Rectangle, screen, SegmentedControlSegment, systemPreferences, TouchBar, TouchBarSegmentedControl } from 'electron';
-import { RunOnceScheduler } from 'vs/base/common/async';
+import { app, BrowserWindow, BrowserWindowConstructorOptions, Display, Event as ElectronEvent, nativeImage, NativeImage, Rectangle, screen, SegmentedControlSegment, systemPreferences, TouchBar, TouchBarSegmentedControl } from 'electron';
+import { DeferredPromise, RunOnceScheduler, timeout } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
 import { Emitter } from 'vs/base/common/event';
@@ -136,9 +136,14 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
 	//#endregion
 
-
 	private readonly windowState: IWindowState;
 	private currentMenuBarVisibility: MenuBarVisibility | undefined;
+
+	// TODO@electron workaround for https://github.com/electron/electron/issues/35360
+	// where on macOS the window will report a wrong state for `isFullScreen()` while
+	// transitioning into and out of native full screen.
+	private transientIsNativeFullScreen: boolean | undefined = undefined;
+	private joinNativeFullScreenTransition: DeferredPromise<void> | undefined = undefined;
 
 	private representedFilename: string | undefined;
 	private documentEdited: boolean | undefined;
@@ -550,7 +555,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 		});
 
 		// Window (Un)Maximize
-		this._win.on('maximize', (e: Event) => {
+		this._win.on('maximize', (e: ElectronEvent) => {
 			if (this._config) {
 				this._config.maximized = true;
 			}
@@ -558,7 +563,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 			app.emit('browser-window-maximize', e, this._win);
 		});
 
-		this._win.on('unmaximize', (e: Event) => {
+		this._win.on('unmaximize', (e: ElectronEvent) => {
 			if (this._config) {
 				this._config.maximized = false;
 			}
@@ -569,10 +574,16 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 		// Window Fullscreen
 		this._win.on('enter-full-screen', () => {
 			this.sendWhenReady('vscode:enterFullScreen', CancellationToken.None);
+
+			this.joinNativeFullScreenTransition?.complete();
+			this.joinNativeFullScreenTransition = undefined;
 		});
 
 		this._win.on('leave-full-screen', () => {
 			this.sendWhenReady('vscode:leaveFullScreen', CancellationToken.None);
+
+			this.joinNativeFullScreenTransition?.complete();
+			this.joinNativeFullScreenTransition = undefined;
 		});
 
 		// Handle configuration changes
@@ -1280,11 +1291,30 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 		}
 	}
 
-	get isFullScreen(): boolean { return this._win.isFullScreen() || this._win.isSimpleFullScreen(); }
+	get isFullScreen(): boolean {
+		if (isMacintosh && typeof this.transientIsNativeFullScreen === 'boolean') {
+			return this.transientIsNativeFullScreen;
+		}
+
+		return this._win.isFullScreen() || this._win.isSimpleFullScreen();
+	}
 
 	private setNativeFullScreen(fullscreen: boolean): void {
 		if (this._win.isSimpleFullScreen()) {
 			this._win.setSimpleFullScreen(false);
+		}
+
+		this.doSetNativeFullScreen(fullscreen);
+	}
+
+	private doSetNativeFullScreen(fullscreen: boolean): void {
+		if (isMacintosh) {
+			this.transientIsNativeFullScreen = fullscreen;
+			this.joinNativeFullScreenTransition = new DeferredPromise<void>();
+			Promise.race([
+				this.joinNativeFullScreenTransition.p,
+				timeout(1000) // still timeout after some time in case we miss the event
+			]).finally(() => this.transientIsNativeFullScreen = undefined);
 		}
 
 		this._win.setFullScreen(fullscreen);
@@ -1292,7 +1322,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
 	private setSimpleFullScreen(fullscreen: boolean): void {
 		if (this._win.isFullScreen()) {
-			this._win.setFullScreen(false);
+			this.doSetNativeFullScreen(false);
 		}
 
 		this._win.setSimpleFullScreen(fullscreen);

--- a/src/vs/platform/windows/electron-main/windowsStateHandler.ts
+++ b/src/vs/platform/windows/electron-main/windowsStateHandler.ts
@@ -181,7 +181,7 @@ export class WindowsStateHandler extends Disposable {
 			if (currentWindowsState.lastPluginDevelopmentHostWindow.uiState.mode === WindowMode.Fullscreen) {
 				if (displaysWithFullScreenWindow.has(currentWindowsState.lastPluginDevelopmentHostWindow.uiState.display)) {
 					if (isMacintosh && !extensionHostWindow.win?.isSimpleFullScreen()) {
-						currentWindowsState.lastPluginDevelopmentHostWindow.uiState.mode = WindowMode.Normal;
+						currentWindowsState.lastPluginDevelopmentHostWindow.uiState.mode = WindowMode.Maximized;
 					}
 				} else {
 					displaysWithFullScreenWindow.add(currentWindowsState.lastPluginDevelopmentHostWindow.uiState.display);
@@ -201,7 +201,7 @@ export class WindowsStateHandler extends Disposable {
 				if (windowState.uiState.mode === WindowMode.Fullscreen) {
 					if (displaysWithFullScreenWindow.has(windowState.uiState.display)) {
 						if (isMacintosh && windowState.windowId !== currentWindowsState.lastActiveWindow?.windowId && !window.win?.isSimpleFullScreen()) {
-							windowState.uiState.mode = WindowMode.Normal;
+							windowState.uiState.mode = WindowMode.Maximized;
 						}
 					} else {
 						displaysWithFullScreenWindow.add(windowState.uiState.display);
@@ -284,7 +284,7 @@ export class WindowsStateHandler extends Disposable {
 			}
 
 			if (!allowFullscreen) {
-				state.mode = WindowMode.Normal;
+				state.mode = WindowMode.Maximized;
 			}
 		}
 


### PR DESCRIPTION
fyi @sbatten this will properly set `fullscreen` property on macOS into configuration, resulting in less flicker for hiding the custom title bar:

https://github.com/microsoft/vscode/blob/0dddb856fd89d55b1dadc97ab49aca800f3eb8ff/src/vs/platform/windows/electron-main/windowImpl.ts#L923