### PR TITLE
The 3wm editor is not dirty by default anymore and therefore we can tweak the close handler

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DisposableStore } from 'vs/base/common/lifecycle';
-import { isEqual } from 'vs/base/common/resources';
+import { basename, isEqual } from 'vs/base/common/resources';
 import Severity from 'vs/base/common/severity';
 import { URI } from 'vs/base/common/uri';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
@@ -234,50 +234,79 @@ class MergeEditorCloseHandler implements IEditorCloseHandler {
 			return ConfirmResult.SAVE;
 		}
 
-		const actions: string[] = [
-			someAreDirty ? localize('unhandledConflicts.saveAndIgnore', "Save & Continue with Conflicts") : localize('unhandledConflicts.ignore', "Continue with Conflicts"),
-			localize('unhandledConflicts.discard', "Discard Merge Changes"),
-			localize('unhandledConflicts.cancel', "Cancel"),
-		];
+		const result = someAreDirty
+			? await this._confirmDirty(handler)
+			: await this._confirmNoneDirty(handler);
+
+		if (result !== ConfirmResult.CANCEL) {
+			// save or ignore: in both cases we tell the inputs to ignore unhandled conflicts
+			// for the dirty state computation.
+			for (const input of handler) {
+				input._ignoreUnhandledConflicts = true;
+			}
+		}
+
+		return result;
+	}
+
+	private async _confirmDirty(handler: MergeEditorCloseHandler[]): Promise<ConfirmResult> {
+		const isMany = handler.length > 1;
+
+		const message = isMany
+			? localize('messageN', 'Do you want to save the changes you made to {0} files?', handler.length)
+			: localize('message1', 'Do you want to save the changes you made to {0}?', basename(handler[0]._model.resultTextModel.uri));
+
 		const options = {
 			cancelId: 2,
-			detail: handler.length > 1
-				? localize('unhandledConflicts.detailN', 'Merge conflicts in {0} editors will remain unhandled.', handler.length)
-				: localize('unhandledConflicts.detail1', 'Merge conflicts in this editor will remain unhandled.')
+			detail: isMany
+				? localize('detailN', "The files contain unhandled conflicts. Your changes will be lost if you don't save them.")
+				: localize('detail1', "The file contains unhandled conflicts. Your changes will be lost if you don't save them.")
 		};
 
-		const { choice } = await this._dialogService.show(
-			Severity.Info,
-			localize('unhandledConflicts.msg', 'Do you want to continue with unhandled conflicts?'), // 1
-			actions,
-			options
-		);
+		const actions: string[] = [
+			localize('saveWithConflict', "Save with Conflicts"),
+			localize('discard', "Don't save"),
+			localize('cancel', "Cancel"),
+		];
+
+		const { choice } = await this._dialogService.show(Severity.Info, message, actions, options);
 
 		if (choice === options.cancelId) {
 			// cancel: stay in editor
 			return ConfirmResult.CANCEL;
-		}
-
-		// save or revert: in both cases we tell the inputs to ignore unhandled conflicts
-		// for the dirty state computation.
-		for (const input of handler) {
-			input._ignoreUnhandledConflicts = true;
-		}
-
-		if (choice === 0) {
-			// conflicts: continue with remaining conflicts
+		} else if (choice === 0) {
+			// save with conflicts
 			return ConfirmResult.SAVE;
-
-		} else if (choice === 1) {
-			// discard: undo all changes and save original (pre-merge) state
-			for (const input of handler) {
-				input._model.discardMergeChanges();
-			}
-			return ConfirmResult.SAVE;
-
 		} else {
-			// don't save
+			// discard changes
 			return ConfirmResult.DONT_SAVE;
+		}
+	}
+
+	private async _confirmNoneDirty(handler: MergeEditorCloseHandler[]): Promise<ConfirmResult> {
+		const isMany = handler.length > 1;
+
+		const message = isMany
+			? localize('conflictN', 'Do you want to close with conflicts in {0} files?', handler.length)
+			: localize('conflict1', 'Do you want to close with conflicts in {0}?', basename(handler[0]._model.resultTextModel.uri));
+
+		const options = {
+			cancelId: 1,
+			detail: isMany
+				? localize('detailNotDirtyN', "The files contain unhandled conflicts.")
+				: localize('detailNotDirty1', "The file contains unhandled conflicts.")
+		};
+
+		const actions = [
+			localize('closeWithConflicts', "Close with Conflicts"),
+			localize('cancel', "Cancel"),
+		];
+
+		const { choice } = await this._dialogService.show(Severity.Info, message, actions, options);
+		if (choice === options.cancelId) {
+			return ConfirmResult.CANCEL;
+		} else {
+			return ConfirmResult.SAVE;
 		}
 	}
 }

--- a/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
@@ -128,10 +128,6 @@ export class MergeEditorModel extends EditorModel {
 		return chunks.join();
 	}
 
-	public discardMergeChanges(): void {
-		this.resultTextModel.setValue(this.resultSnapshot);
-	}
-
 	constructor(
 		readonly base: ITextModel,
 		readonly input1: InputData,


### PR DESCRIPTION
Use default handling when there are no conflicts. Show a message when closing with unhandled conflicts, tweak depending on dirty state

fixes https://github.com/microsoft/vscode/issues/158405
