### PR TITLE
create the profile on main side

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -128,7 +128,8 @@ export class CodeApplication extends Disposable {
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IStateMainService private readonly stateMainService: IStateMainService,
 		@IFileService private readonly fileService: IFileService,
-		@IProductService private readonly productService: IProductService
+		@IProductService private readonly productService: IProductService,
+		@IUserDataProfilesMainService private readonly userDataProfilesMainService: IUserDataProfilesMainService,
 	) {
 		super();
 
@@ -533,6 +534,8 @@ export class CodeApplication extends Disposable {
 
 		// Setup Handlers
 		this.setUpHandlers(appInstantiationService);
+
+		await this.userDataProfilesMainService.checkAndCreateProfileFromEnv(this.environmentMainService.args);
 
 		// Init Channels
 		appInstantiationService.invokeFunction(accessor => this.initChannels(accessor, mainProcessElectronServer, sharedProcessClient));

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -535,7 +535,11 @@ export class CodeApplication extends Disposable {
 		// Setup Handlers
 		this.setUpHandlers(appInstantiationService);
 
-		await this.userDataProfilesMainService.checkAndCreateProfileFromEnv(this.environmentMainService.args);
+		// Ensure profile exists when passed in from CLI
+		const profilePromise = this.userDataProfilesMainService.checkAndCreateProfileFromCli(this.environmentMainService.args);
+		if (profilePromise) {
+			await profilePromise;
+		}
 
 		// Init Channels
 		appInstantiationService.invokeFunction(accessor => this.initChannels(accessor, mainProcessElectronServer, sharedProcessClient));

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -21,6 +21,7 @@ import { IWindowSettings } from 'vs/platform/window/common/window';
 import { IOpenConfiguration, IWindowsMainService, OpenContext } from 'vs/platform/windows/electron-main/windows';
 import { isSingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspace/common/workspace';
 import { IWorkspacesManagementMainService } from 'vs/platform/workspaces/electron-main/workspacesManagementMainService';
+import { IUserDataProfilesMainService } from 'vs/platform/userDataProfile/electron-main/userDataProfile';
 
 export const ID = 'launchMainService';
 export const ILaunchMainService = createDecorator<ILaunchMainService>(ID);
@@ -46,7 +47,8 @@ export class LaunchMainService implements ILaunchMainService {
 		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
 		@IURLService private readonly urlService: IURLService,
 		@IWorkspacesManagementMainService private readonly workspacesManagementMainService: IWorkspacesManagementMainService,
-		@IConfigurationService private readonly configurationService: IConfigurationService
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IUserDataProfilesMainService private readonly userDataProfilesMainService: IUserDataProfilesMainService,
 	) { }
 
 	async start(args: NativeParsedArgs, userEnv: IProcessEnvironment): Promise<void> {
@@ -113,6 +115,8 @@ export class LaunchMainService implements ILaunchMainService {
 
 		const waitMarkerFileURI = args.wait && args.waitMarkerFilePath ? URI.file(args.waitMarkerFilePath) : undefined;
 		const remoteAuthority = args.remote || undefined;
+
+		await this.userDataProfilesMainService.checkAndCreateProfileFromEnv(args);
 
 		const baseConfig: IOpenConfiguration = {
 			context,

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -116,7 +116,11 @@ export class LaunchMainService implements ILaunchMainService {
 		const waitMarkerFileURI = args.wait && args.waitMarkerFilePath ? URI.file(args.waitMarkerFilePath) : undefined;
 		const remoteAuthority = args.remote || undefined;
 
-		await this.userDataProfilesMainService.checkAndCreateProfileFromEnv(args);
+		// Ensure profile exists when passed in from CLI
+		const profilePromise = this.userDataProfilesMainService.checkAndCreateProfileFromCli(args);
+		if (profilePromise) {
+			await profilePromise;
+		}
 
 		const baseConfig: IOpenConfiguration = {
 			context,

--- a/src/vs/platform/userDataProfile/common/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/common/userDataProfile.ts
@@ -226,11 +226,6 @@ export class UserDataProfilesService extends Disposable implements IUserDataProf
 		return this._profilesObject;
 	}
 
-	async reload(): Promise<IUserDataProfile[]> {
-		this._profilesObject = undefined;
-		return this.profiles;
-	}
-
 	getProfile(workspaceIdentifier: WorkspaceIdentifier, profileToUseIfNotSet: IUserDataProfile): IUserDataProfile {
 		if (!this.enabled) {
 			return this.defaultProfile;
@@ -323,6 +318,10 @@ export class UserDataProfilesService extends Disposable implements IUserDataProf
 	}
 
 	async setProfileForWorkspace(profileToSet: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): Promise<void> {
+		this.setProfileForWorkspaceSync(profileToSet, workspaceIdentifier);
+	}
+
+	setProfileForWorkspaceSync(profileToSet: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): void {
 		if (!this.enabled) {
 			throw new Error(`Settings Profiles are disabled. Enable them via the '${PROFILES_ENABLEMENT_CONFIG}' setting.`);
 		}

--- a/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
@@ -14,12 +14,14 @@ import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity'
 import { IUserDataProfilesService, WorkspaceIdentifier, StoredUserDataProfile, StoredProfileAssociations, WillCreateProfileEvent, WillRemoveProfileEvent, IUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { UserDataProfilesService } from 'vs/platform/userDataProfile/node/userDataProfile';
 import { IStringDictionary } from 'vs/base/common/collections';
+import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
 
 export const IUserDataProfilesMainService = refineServiceDecorator<IUserDataProfilesService, IUserDataProfilesMainService>(IUserDataProfilesService);
 export interface IUserDataProfilesMainService extends IUserDataProfilesService {
 	isEnabled(): boolean;
 	unsetWorkspace(workspaceIdentifier: WorkspaceIdentifier): Promise<void>;
-	reload(): Promise<IUserDataProfile[]>;
+	setProfileForWorkspaceSync(profileToSet: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): void;
+	checkAndCreateProfileFromEnv(args: NativeParsedArgs): Promise<void>;
 	readonly onWillCreateProfile: Event<WillCreateProfileEvent>;
 	readonly onWillRemoveProfile: Event<WillRemoveProfileEvent>;
 }
@@ -38,6 +40,23 @@ export class UserDataProfilesMainService extends UserDataProfilesService impleme
 
 	isEnabled(): boolean {
 		return this.enabled;
+	}
+
+	async checkAndCreateProfileFromEnv(args: NativeParsedArgs): Promise<void> {
+		if (!this.isEnabled()) {
+			return;
+		}
+		if (!args.profile) {
+			return;
+		}
+		// Do not create the profile if folder/file arguments are not provided
+		if (!args._.length && !args['folder-uri'] && !args['file-uri']) {
+			return;
+		}
+		if (this.profiles.some(p => p.name === args.profile)) {
+			return;
+		}
+		await this.createProfile(args.profile);
 	}
 
 	protected override saveStoredProfiles(storedProfiles: StoredUserDataProfile[]): void {

--- a/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
@@ -21,7 +21,7 @@ export interface IUserDataProfilesMainService extends IUserDataProfilesService {
 	isEnabled(): boolean;
 	unsetWorkspace(workspaceIdentifier: WorkspaceIdentifier): Promise<void>;
 	setProfileForWorkspaceSync(profileToSet: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): void;
-	checkAndCreateProfileFromEnv(args: NativeParsedArgs): Promise<void>;
+	checkAndCreateProfileFromCli(args: NativeParsedArgs): Promise<IUserDataProfile> | undefined;
 	readonly onWillCreateProfile: Event<WillCreateProfileEvent>;
 	readonly onWillRemoveProfile: Event<WillRemoveProfileEvent>;
 }
@@ -42,21 +42,21 @@ export class UserDataProfilesMainService extends UserDataProfilesService impleme
 		return this.enabled;
 	}
 
-	async checkAndCreateProfileFromEnv(args: NativeParsedArgs): Promise<void> {
+	checkAndCreateProfileFromCli(args: NativeParsedArgs): Promise<IUserDataProfile> | undefined {
 		if (!this.isEnabled()) {
-			return;
+			return undefined;
 		}
 		if (!args.profile) {
-			return;
+			return undefined;
 		}
 		// Do not create the profile if folder/file arguments are not provided
 		if (!args._.length && !args['folder-uri'] && !args['file-uri']) {
-			return;
+			return undefined;
 		}
 		if (this.profiles.some(p => p.name === args.profile)) {
-			return;
+			return undefined;
 		}
-		await this.createProfile(args.profile);
+		return this.createProfile(args.profile);
 	}
 
 	protected override saveStoredProfiles(storedProfiles: StoredUserDataProfile[]): void {

--- a/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
@@ -71,11 +71,6 @@ export class UserDataProfilesNativeService extends Disposable implements IUserDa
 		return this.channel.call('resetWorkspaces');
 	}
 
-	async reload(): Promise<void> {
-		const all = await this.channel.call<UriDto<IUserDataProfile>[]>('reload');
-		this._profiles = all.map(profile => reviveProfile(profile, this.profilesHome.scheme));
-	}
-
 	getProfile(workspaceIdentifier: WorkspaceIdentifier, profileToUseIfNotSet: IUserDataProfile): IUserDataProfile { throw new Error('Not implemented'); }
 }
 

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -273,18 +273,6 @@ export interface IOSConfiguration {
 	readonly hostname: string;
 }
 
-export interface IUserDataProfileInfo {
-	readonly name?: string;
-}
-
-export function isUserDataProfileInfo(thing: unknown): thing is IUserDataProfileInfo {
-	const candidate = thing as IUserDataProfileInfo | undefined;
-
-	return !!(candidate && typeof candidate === 'object'
-		&& typeof candidate.name === 'string'
-	);
-}
-
 export interface INativeWindowConfiguration extends IWindowConfiguration, NativeParsedArgs, ISandboxConfiguration {
 	mainPid: number;
 
@@ -295,7 +283,7 @@ export interface INativeWindowConfiguration extends IWindowConfiguration, Native
 
 	profiles: {
 		all: readonly UriDto<IUserDataProfile>[];
-		workspace: UriDto<IUserDataProfile> | IUserDataProfileInfo;
+		profile: UriDto<IUserDataProfile>;
 	};
 
 	homeDir: string;

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -41,7 +41,6 @@ import { IWindowState, ICodeWindow, ILoadEvent, WindowMode, WindowError, LoadRea
 import { Color } from 'vs/base/common/color';
 import { IPolicyService } from 'vs/platform/policy/common/policy';
 import { IUserDataProfile, IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
-import { revive } from 'vs/base/common/marshalling';
 import { IStateMainService } from 'vs/platform/state/electron-main/state';
 import product from 'vs/platform/product/common/product';
 
@@ -121,7 +120,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
 	get openedWorkspace(): IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | undefined { return this._config?.workspace; }
 
-	get profile(): IUserDataProfile | undefined { return this.config ? this.userDataProfilesService.getProfile(this.config.workspace ?? 'empty-window', revive(this.config.profiles.workspace)) : undefined; }
+	get profile(): IUserDataProfile | undefined { return this.config ? this.userDataProfilesService.getProfile(this.config.workspace ?? 'empty-window', this.userDataProfilesService.profiles.find(p => p.id === this.config!.profiles.profile.id) ?? this.userDataProfilesService.defaultProfile) : undefined; }
 
 	get remoteAuthority(): string | undefined { return this._config?.remoteAuthority; }
 
@@ -972,7 +971,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 		configuration.policiesData = this.policyService.serialize(); // set policies data again
 		configuration.profiles = {
 			all: this.userDataProfilesService.profiles,
-			workspace: this.profile || this.userDataProfilesService.defaultProfile
+			profile: this.profile || this.userDataProfilesService.defaultProfile
 		};
 
 		// Load config

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -120,7 +120,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
 	get openedWorkspace(): IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | undefined { return this._config?.workspace; }
 
-	get profile(): IUserDataProfile | undefined { return this.config ? this.userDataProfilesService.getProfile(this.config.workspace ?? 'empty-window', this.userDataProfilesService.profiles.find(p => p.id === this.config!.profiles.profile.id) ?? this.userDataProfilesService.defaultProfile) : undefined; }
+	get profile(): IUserDataProfile | undefined { return this.config ? this.userDataProfilesService.getProfile(this.config.workspace ?? 'empty-window', this.userDataProfilesService.profiles.find(profile => profile.id === this.config?.profiles.profile.id) ?? this.userDataProfilesService.defaultProfile) : undefined; }
 
 	get remoteAuthority(): string | undefined { return this._config?.remoteAuthority; }
 

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1323,17 +1323,6 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 	private openInBrowserWindow(options: IOpenBrowserWindowOptions): ICodeWindow {
 		const windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
 
-		let profile: IUserDataProfile | undefined;
-		if (options.userDataProfileInfo) {
-			profile = this.userDataProfilesMainService.profiles.find(p => p.name === options.userDataProfileInfo!.name);
-			if (profile) {
-				this.userDataProfilesMainService.setProfileForWorkspaceSync(profile, options.workspace ?? 'empty-window');
-			}
-		}
-		if (!profile) {
-			profile = this.userDataProfilesMainService.getProfile(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesMainService.defaultProfile);
-		}
-
 		// Build up the window configuration from provided options, config and environment
 		const configuration: INativeWindowConfiguration = {
 
@@ -1359,7 +1348,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 
 			profiles: {
 				all: this.userDataProfilesMainService.profiles,
-				profile
+				profile: this.resolveProfileForBrowserWindow(options)
 			},
 
 			homeDir: this.environmentMainService.userHome.fsPath,
@@ -1479,6 +1468,25 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		}
 
 		return window;
+	}
+
+	private resolveProfileForBrowserWindow(options: IOpenBrowserWindowOptions) {
+
+		// Resolve profile by name if provided
+		let profile: IUserDataProfile | undefined;
+		if (options.userDataProfileInfo) {
+			profile = this.userDataProfilesMainService.profiles.find(profile => profile.name === options.userDataProfileInfo!.name);
+			if (profile) {
+				this.userDataProfilesMainService.setProfileForWorkspaceSync(profile, options.workspace ?? 'empty-window');
+			}
+		}
+
+		// Otherwise use associated profile
+		if (!profile) {
+			profile = this.userDataProfilesMainService.getProfile(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesMainService.defaultProfile);
+		}
+
+		return profile;
 	}
 
 	private doOpenInBrowserWindow(window: ICodeWindow, configuration: INativeWindowConfiguration, options: IOpenBrowserWindowOptions): void {

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -38,7 +38,7 @@ import { IProductService } from 'vs/platform/product/common/productService';
 import { IProtocolMainService } from 'vs/platform/protocol/electron-main/protocol';
 import { getRemoteAuthority } from 'vs/platform/remote/common/remoteHosts';
 import { IStateMainService } from 'vs/platform/state/electron-main/state';
-import { IAddFoldersRequest, INativeOpenFileRequest, INativeWindowConfiguration, IOpenEmptyWindowOptions, IPath, IPathsToWaitFor, isFileToOpen, isFolderToOpen, isWorkspaceToOpen, IWindowOpenable, IWindowSettings, IUserDataProfileInfo } from 'vs/platform/window/common/window';
+import { IAddFoldersRequest, INativeOpenFileRequest, INativeWindowConfiguration, IOpenEmptyWindowOptions, IPath, IPathsToWaitFor, isFileToOpen, isFolderToOpen, isWorkspaceToOpen, IWindowOpenable, IWindowSettings } from 'vs/platform/window/common/window';
 import { CodeWindow } from 'vs/platform/windows/electron-main/windowImpl';
 import { IOpenConfiguration, IOpenEmptyConfiguration, IWindowsCountChangedEvent, IWindowsMainService, OpenContext } from 'vs/platform/windows/electron-main/windows';
 import { findWindowOnExtensionDevelopmentPath, findWindowOnFile, findWindowOnWorkspaceOrFolder } from 'vs/platform/windows/electron-main/windowsFinder';
@@ -51,8 +51,9 @@ import { IWorkspacesManagementMainService } from 'vs/platform/workspaces/electro
 import { ICodeWindow, UnloadReason } from 'vs/platform/window/electron-main/window';
 import { IThemeMainService } from 'vs/platform/theme/electron-main/themeMainService';
 import { IEditorOptions, ITextEditorOptions } from 'vs/platform/editor/common/editor';
-import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { IUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { IPolicyService } from 'vs/platform/policy/common/policy';
+import { IUserDataProfilesMainService } from 'vs/platform/userDataProfile/electron-main/userDataProfile';
 
 //#region Helper Interfaces
 
@@ -77,6 +78,10 @@ interface IOpenBrowserWindowOptions {
 	readonly emptyWindowBackupInfo?: IEmptyWindowBackupInfo;
 
 	readonly userDataProfileInfo?: IUserDataProfileInfo;
+}
+
+interface IUserDataProfileInfo {
+	readonly name?: string;
 }
 
 interface IPathResolveOptions {
@@ -208,7 +213,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		@IStateMainService private readonly stateMainService: IStateMainService,
 		@IPolicyService private readonly policyService: IPolicyService,
 		@IEnvironmentMainService private readonly environmentMainService: IEnvironmentMainService,
-		@IUserDataProfilesService private readonly userDataProfilesService: IUserDataProfilesService,
+		@IUserDataProfilesMainService private readonly userDataProfilesMainService: IUserDataProfilesMainService,
 		@ILifecycleMainService private readonly lifecycleMainService: ILifecycleMainService,
 		@IBackupMainService private readonly backupMainService: IBackupMainService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -1318,6 +1323,17 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 	private openInBrowserWindow(options: IOpenBrowserWindowOptions): ICodeWindow {
 		const windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
 
+		let profile: IUserDataProfile | undefined;
+		if (options.userDataProfileInfo) {
+			profile = this.userDataProfilesMainService.profiles.find(p => p.name === options.userDataProfileInfo!.name);
+			if (profile) {
+				this.userDataProfilesMainService.setProfileForWorkspaceSync(profile, options.workspace ?? 'empty-window');
+			}
+		}
+		if (!profile) {
+			profile = this.userDataProfilesMainService.getProfile(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesMainService.defaultProfile);
+		}
+
 		// Build up the window configuration from provided options, config and environment
 		const configuration: INativeWindowConfiguration = {
 
@@ -1342,8 +1358,8 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			backupPath: options.emptyWindowBackupInfo ? join(this.environmentMainService.backupHome, options.emptyWindowBackupInfo.backupFolder) : undefined,
 
 			profiles: {
-				all: this.userDataProfilesService.profiles,
-				workspace: options.userDataProfileInfo ?? this.userDataProfilesService.getProfile(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesService.defaultProfile),
+				all: this.userDataProfilesMainService.profiles,
+				profile
 			},
 
 			homeDir: this.environmentMainService.userHome.fsPath,

--- a/src/vs/workbench/services/userDataProfile/common/userDataProfileService.ts
+++ b/src/vs/workbench/services/userDataProfile/common/userDataProfileService.ts
@@ -6,8 +6,7 @@
 import { Promises } from 'vs/base/common/async';
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { IUserDataProfile, IUserDataProfilesService, WorkspaceIdentifier } from 'vs/platform/userDataProfile/common/userDataProfile';
-import { IAnyWorkspaceIdentifier, isSingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspace/common/workspace';
+import { IUserDataProfile, IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { DidChangeUserDataProfileEvent, IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 
 export class UserDataProfileService extends Disposable implements IUserDataProfileService {
@@ -25,7 +24,7 @@ export class UserDataProfileService extends Disposable implements IUserDataProfi
 
 	constructor(
 		currentProfile: IUserDataProfile,
-		@IUserDataProfilesService private readonly userDataProfilesService: IUserDataProfilesService
+		@IUserDataProfilesService userDataProfilesService: IUserDataProfilesService
 	) {
 		super();
 		this._currentProfile = currentProfile;
@@ -63,24 +62,6 @@ export class UserDataProfileService extends Disposable implements IUserDataProfi
 			}
 		});
 		await Promises.settled(joiners);
-	}
-
-	async initProfileWithName(profileName: string, anyWorkspaceIdentifier: IAnyWorkspaceIdentifier): Promise<void> {
-		if (this.currentProfile.name === profileName) {
-			return;
-		}
-		const workspaceIdentifier = this.getWorkspaceIdentifier(anyWorkspaceIdentifier);
-		let profile = this.userDataProfilesService.profiles.find(p => p.name === profileName);
-		if (profile) {
-			await this.userDataProfilesService.setProfileForWorkspace(profile, workspaceIdentifier);
-		} else {
-			profile = await this.userDataProfilesService.createProfile(profileName, undefined, workspaceIdentifier);
-		}
-		await this.updateCurrentProfile(profile, false);
-	}
-
-	private getWorkspaceIdentifier(anyWorkspaceIdentifier: IAnyWorkspaceIdentifier): WorkspaceIdentifier {
-		return isSingleFolderWorkspaceIdentifier(anyWorkspaceIdentifier) || isWorkspaceIdentifier(anyWorkspaceIdentifier) ? anyWorkspaceIdentifier : 'empty-window';
 	}
 
 }

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -87,7 +87,7 @@ export const TestNativeWindowConfiguration: INativeWindowConfiguration = {
 	homeDir: homeDir,
 	tmpDir: tmpdir(),
 	userDataDir: getUserDataPath(args),
-	profiles: { workspace: NULL_PROFILE, all: [NULL_PROFILE] },
+	profiles: { profile: NULL_PROFILE, all: [NULL_PROFILE] },
 	...args
 };
 


### PR DESCRIPTION
@bpasero After thinking a bit, I felt creating the profile (passed in CLI) on the main side is the right thing to do.

Moved creating the profile requested from CLI on the main side. It was done on the renderer before because it is easy for the renderer to create the profile from the template if template is passed or initialize the profile from another profile. But this caused complex window configuration to be passed from main to the window. 

By moving profile creation to the main side the window configuration has become simple and main always sends what profile to use to the window. Later, we can introduce profile init info API to the window configuration so that the window/renderer will initialize the profile as requested (from tempalte or from another profile).