### PR TITLE
Added settings to disable headers in code action widget

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionWidgetContribution.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionWidgetContribution.ts
@@ -20,3 +20,16 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		},
 	}
 });
+
+Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
+	...editorConfigurationBaseNode,
+	properties: {
+		'editor.experimental.useCustomCodeActionMenu.toggleHeaders': {
+			type: 'boolean',
+			tags: ['experimental'],
+			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
+			description: nls.localize('codeActionWidget.toggle', "Disables headers in the code action widget."),
+			default: false,
+		},
+	}
+});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Registers a new setting where if enabled, will disable the headers separators in the custom code action widget.
Fixes https://github.com/microsoft/vscode/issues/158311
