### PR TITLE
Change explorer filter icon to listFilter

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -663,7 +663,7 @@ export interface ICaseSensitiveToggleOpts {
 export class ModeToggle extends Toggle {
 	constructor(opts?: ICaseSensitiveToggleOpts) {
 		super({
-			icon: Codicon.filter,
+			icon: Codicon.listFilter,
 			title: localize('filter', "Filter"),
 			isChecked: opts?.isChecked ?? false,
 			inputActiveOptionBorder: opts?.inputActiveOptionBorder,


### PR DESCRIPTION
This makes it distinct from the common filter icon that we're moving to always be a dropdown.

Part of #156179

![image](https://user-images.githubusercontent.com/2193314/185659100-2cdbd32e-a548-44cd-a71b-db4118bd107a.png)
