### PR TITLE
Fix telemetry SDK intialization warnings

### DIFF
--- a/src/vs/platform/telemetry/browser/1dsAppender.ts
+++ b/src/vs/platform/telemetry/browser/1dsAppender.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { AppInsightsCore } from '@microsoft/1ds-core-js';
-import { AbstractOneDataSystemAppender } from 'vs/platform/telemetry/common/1dsAppender';
+import { AbstractOneDataSystemAppender, IAppInsightsCore } from 'vs/platform/telemetry/common/1dsAppender';
 
 
 export class OneDataSystemWebAppender extends AbstractOneDataSystemAppender {
@@ -12,7 +11,7 @@ export class OneDataSystemWebAppender extends AbstractOneDataSystemAppender {
 		isInternalTelemetry: boolean,
 		eventPrefix: string,
 		defaultData: { [key: string]: any } | null,
-		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
+		iKeyOrClientFactory: string | (() => IAppInsightsCore), // allow factory function for testing
 	) {
 		super(isInternalTelemetry, eventPrefix, defaultData, iKeyOrClientFactory);
 

--- a/src/vs/platform/telemetry/node/1dsAppender.ts
+++ b/src/vs/platform/telemetry/node/1dsAppender.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { AppInsightsCore } from '@microsoft/1ds-core-js';
 import type { IPayloadData, IXHROverride } from '@microsoft/1ds-post-js';
 import * as https from 'https';
-import { AbstractOneDataSystemAppender } from 'vs/platform/telemetry/common/1dsAppender';
+import { AbstractOneDataSystemAppender, IAppInsightsCore } from 'vs/platform/telemetry/common/1dsAppender';
 
 
 export class OneDataSystemAppender extends AbstractOneDataSystemAppender {
@@ -15,7 +14,7 @@ export class OneDataSystemAppender extends AbstractOneDataSystemAppender {
 		isInternalTelemetry: boolean,
 		eventPrefix: string,
 		defaultData: { [key: string]: any } | null,
-		iKeyOrClientFactory: string | (() => AppInsightsCore), // allow factory function for testing
+		iKeyOrClientFactory: string | (() => IAppInsightsCore), // allow factory function for testing
 	) {
 		// Override the way events get sent since node doesn't have XHTMLRequest
 		const customHttpXHROverride: IXHROverride = {

--- a/src/vs/platform/telemetry/test/browser/1dsAppender.test.ts
+++ b/src/vs/platform/telemetry/test/browser/1dsAppender.test.ts
@@ -2,26 +2,23 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { AppInsightsCore } from '@microsoft/1ds-core-js';
+import { ITelemetryItem, ITelemetryUnloadState } from '@microsoft/1ds-core-js';
 import * as assert from 'assert';
 import { OneDataSystemWebAppender } from 'vs/platform/telemetry/browser/1dsAppender';
+import { IAppInsightsCore } from 'vs/platform/telemetry/common/1dsAppender';
 
-class AppInsightsCoreMock extends AppInsightsCore {
-	public override config: any;
+class AppInsightsCoreMock implements IAppInsightsCore {
+	pluginVersionString: string = 'Test Runner';
 	public events: any[] = [];
 	public IsTrackingPageView: boolean = false;
 	public exceptions: any[] = [];
 
-	constructor() {
-		super();
-	}
-
-	public override track(event: any) {
+	public track(event: ITelemetryItem) {
 		this.events.push(event.baseData);
 	}
 
-	public override flush(options: any): void {
-		// called on dispose
+	public unload(isAsync: boolean, unloadComplete: (unloadState: ITelemetryUnloadState) => void): void {
+		// No-op
 	}
 }
 


### PR DESCRIPTION
Fixes #157207 

We cannot extend the real type because then some initialization occurs in the constructor of the base class. Here I just pulled out the properties I need into our own interface.