### PR TITLE
Introduce transient profiles

### DIFF
--- a/src/vs/code/electron-browser/sharedProcess/contrib/userDataProfilesCleaner.ts
+++ b/src/vs/code/electron-browser/sharedProcess/contrib/userDataProfilesCleaner.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
+
+export class UserDataProfilesCleaner extends Disposable {
+
+	constructor(
+		@IUserDataProfilesService userDataProfilesService: IUserDataProfilesService
+	) {
+		super();
+		userDataProfilesService.cleanUp();
+	}
+
+}

--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -105,6 +105,7 @@ import { IPolicyService, NullPolicyService } from 'vs/platform/policy/common/pol
 import { UserDataProfilesNativeService } from 'vs/platform/userDataProfile/electron-sandbox/userDataProfile';
 import { SharedProcessRequestService } from 'vs/platform/request/electron-browser/sharedProcessRequestService';
 import { OneDataSystemAppender } from 'vs/platform/telemetry/node/1dsAppender';
+import { UserDataProfilesCleaner } from 'vs/code/electron-browser/sharedProcess/contrib/userDataProfilesCleaner';
 
 class SharedProcessMain extends Disposable {
 
@@ -169,7 +170,8 @@ class SharedProcessMain extends Disposable {
 			instantiationService.createInstance(StorageDataCleaner, this.configuration.backupWorkspacesPath),
 			instantiationService.createInstance(LogsDataCleaner),
 			instantiationService.createInstance(LocalizationsUpdater),
-			instantiationService.createInstance(ExtensionsCleaner)
+			instantiationService.createInstance(ExtensionsCleaner),
+			instantiationService.createInstance(UserDataProfilesCleaner)
 		));
 	}
 

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -108,6 +108,7 @@ import { IRequestService } from 'vs/platform/request/common/request';
 import { ExtensionsProfileScannerService, IExtensionsProfileScannerService } from 'vs/platform/extensionManagement/common/extensionsProfileScannerService';
 import { IExtensionsScannerService } from 'vs/platform/extensionManagement/common/extensionsScannerService';
 import { ExtensionsScannerService } from 'vs/platform/extensionManagement/node/extensionsScannerService';
+import { UserDataTransientProfilesHandler } from 'vs/platform/userDataProfile/electron-main/userDataTransientProfilesHandler';
 
 /**
  * The main VS Code application. There will only ever be one instance,
@@ -562,6 +563,9 @@ export class CodeApplication extends Disposable {
 
 		// Default Extensions Profile Init Handler
 		this._register(instantiationService.createInstance(DefaultExtensionsProfileInitHandler));
+
+		// Transient profiles handler
+		this._register(instantiationService.createInstance(UserDataTransientProfilesHandler));
 	}
 
 	private async resolveMachineId(): Promise<string> {

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -92,7 +92,7 @@ export interface NativeParsedArgs {
 	editSessionId?: string;
 	'locate-shell-integration-path'?: string;
 	'profile'?: string;
-	'transient'?: boolean;
+	'profile-transient'?: boolean;
 
 	// chromium command line args: https://electronjs.org/docs/all#supported-chrome-command-line-switches
 	'no-proxy-server'?: boolean;

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -92,6 +92,7 @@ export interface NativeParsedArgs {
 	editSessionId?: string;
 	'locate-shell-integration-path'?: string;
 	'profile'?: string;
+	'transient'?: boolean;
 
 	// chromium command line args: https://electronjs.org/docs/all#supported-chrome-command-line-switches
 	'no-proxy-server'?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -50,7 +50,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'waitMarkerFilePath': { type: 'string' },
 	'locale': { type: 'string', cat: 'o', args: 'locale', description: localize('locale', "The locale to use (e.g. en-US or zh-TW).") },
 	'user-data-dir': { type: 'string', cat: 'o', args: 'dir', description: localize('userDataDir', "Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code.") },
-	'profile': { type: 'string', 'cat': 'o', args: 'settingsProfileName', description: localize('settingsProfileName', "Opens the provided folder or workspace with the given profile. If the profile does not exist, a new empty one is created.") },
+	'profile': { type: 'string', 'cat': 'o', args: 'settingsProfileName', description: localize('settingsProfileName', "Opens the provided folder or workspace with the given profile. If the profile does not exist, a new empty one is created. Use '--transient' argument to not to persist the profile.") },
 	'help': { type: 'boolean', cat: 'o', alias: 'h', description: localize('help', "Print usage.") },
 
 	'extensions-dir': { type: 'string', deprecates: ['extensionHomePath'], cat: 'e', args: 'dir', description: localize('extensionHomePath', "Set the root path for extensions.") },
@@ -130,6 +130,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'__enable-file-policy': { type: 'boolean' },
 	'editSessionId': { type: 'string' },
 	'locate-shell-integration-path': { type: 'string', args: ['bash', 'pwsh', 'zsh', 'fish'] },
+	'transient': { type: 'boolean' },
 
 	// chromium flags
 	'no-proxy-server': { type: 'boolean' },

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -50,7 +50,8 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'waitMarkerFilePath': { type: 'string' },
 	'locale': { type: 'string', cat: 'o', args: 'locale', description: localize('locale', "The locale to use (e.g. en-US or zh-TW).") },
 	'user-data-dir': { type: 'string', cat: 'o', args: 'dir', description: localize('userDataDir', "Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code.") },
-	'profile': { type: 'string', 'cat': 'o', args: 'settingsProfileName', description: localize('settingsProfileName', "Opens the provided folder or workspace with the given profile. If the profile does not exist, a new empty one is created. Use '--transient' argument to not to persist the profile.") },
+	'profile': { type: 'string', 'cat': 'o', args: 'settingsProfileName', description: localize('settingsProfileName', "Opens the provided folder or workspace with the given profile. If the profile does not exist, a new empty one is created.") },
+	'profile-transient': { type: 'boolean', 'cat': 'o', description: localize('transientProfile', "Creates an empty transient profile and opens the provided folder or workspace with this profile.") },
 	'help': { type: 'boolean', cat: 'o', alias: 'h', description: localize('help', "Print usage.") },
 
 	'extensions-dir': { type: 'string', deprecates: ['extensionHomePath'], cat: 'e', args: 'dir', description: localize('extensionHomePath', "Set the root path for extensions.") },
@@ -130,7 +131,6 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'__enable-file-policy': { type: 'boolean' },
 	'editSessionId': { type: 'string' },
 	'locate-shell-integration-path': { type: 'string', args: ['bash', 'pwsh', 'zsh', 'fish'] },
-	'transient': { type: 'boolean' },
 
 	// chromium flags
 	'no-proxy-server': { type: 'boolean' },

--- a/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
@@ -19,9 +19,10 @@ import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
 export const IUserDataProfilesMainService = refineServiceDecorator<IUserDataProfilesService, IUserDataProfilesMainService>(IUserDataProfilesService);
 export interface IUserDataProfilesMainService extends IUserDataProfilesService {
 	isEnabled(): boolean;
-	unsetWorkspace(workspaceIdentifier: WorkspaceIdentifier): Promise<void>;
-	setProfileForWorkspaceSync(profileToSet: IUserDataProfile, workspaceIdentifier: WorkspaceIdentifier): void;
+	getOrSetProfileForWorkspace(workspaceIdentifier: WorkspaceIdentifier, profileToSet?: IUserDataProfile): IUserDataProfile;
+	setProfileForWorkspaceSync(workspaceIdentifier: WorkspaceIdentifier, profileToSet: IUserDataProfile, transient?: boolean): void;
 	checkAndCreateProfileFromCli(args: NativeParsedArgs): Promise<IUserDataProfile> | undefined;
+	unsetWorkspace(workspaceIdentifier: WorkspaceIdentifier, transient?: boolean): void;
 	readonly onWillCreateProfile: Event<WillCreateProfileEvent>;
 	readonly onWillRemoveProfile: Event<WillRemoveProfileEvent>;
 }
@@ -56,7 +57,7 @@ export class UserDataProfilesMainService extends UserDataProfilesService impleme
 		if (this.profiles.some(p => p.name === args.profile)) {
 			return undefined;
 		}
-		return this.createProfile(args.profile);
+		return this.createProfile(args.profile, undefined, undefined, args.transient);
 	}
 
 	protected override saveStoredProfiles(storedProfiles: StoredUserDataProfile[]): void {

--- a/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
@@ -20,7 +20,7 @@ export const IUserDataProfilesMainService = refineServiceDecorator<IUserDataProf
 export interface IUserDataProfilesMainService extends IUserDataProfilesService {
 	isEnabled(): boolean;
 	getOrSetProfileForWorkspace(workspaceIdentifier: WorkspaceIdentifier, profileToSet?: IUserDataProfile): IUserDataProfile;
-	setProfileForWorkspaceSync(workspaceIdentifier: WorkspaceIdentifier, profileToSet: IUserDataProfile, transient?: boolean): void;
+	setProfileForWorkspaceSync(workspaceIdentifier: WorkspaceIdentifier, profileToSet: IUserDataProfile): void;
 	checkAndCreateProfileFromCli(args: NativeParsedArgs): Promise<IUserDataProfile> | undefined;
 	unsetWorkspace(workspaceIdentifier: WorkspaceIdentifier, transient?: boolean): void;
 	readonly onWillCreateProfile: Event<WillCreateProfileEvent>;
@@ -47,17 +47,25 @@ export class UserDataProfilesMainService extends UserDataProfilesService impleme
 		if (!this.isEnabled()) {
 			return undefined;
 		}
-		if (!args.profile) {
-			return undefined;
-		}
 		// Do not create the profile if folder/file arguments are not provided
 		if (!args._.length && !args['folder-uri'] && !args['file-uri']) {
 			return undefined;
 		}
-		if (this.profiles.some(p => p.name === args.profile)) {
-			return undefined;
+		if (args.profile) {
+			if (this.profiles.some(p => p.name === args.profile)) {
+				return undefined;
+			}
+			return this.createProfile(args.profile);
 		}
-		return this.createProfile(args.profile, undefined, undefined, args.transient);
+		if (args['profile-transient']) {
+			return this.createTransientProfile()
+				.then(profile => {
+					// Set the profile name to use
+					args.profile = profile.name;
+					return profile;
+				});
+		}
+		return undefined;
 	}
 
 	protected override saveStoredProfiles(storedProfiles: StoredUserDataProfile[]): void {

--- a/src/vs/platform/userDataProfile/electron-main/userDataTransientProfilesHandler.ts
+++ b/src/vs/platform/userDataProfile/electron-main/userDataTransientProfilesHandler.ts
@@ -28,7 +28,7 @@ export class UserDataTransientProfilesHandler extends Disposable {
 		const profile = this.userDataProfilesService.getOrSetProfileForWorkspace(workspace);
 		if (profile.isTransient) {
 			this.userDataProfilesService.unsetWorkspace(workspace, true);
-			await this.userDataProfilesService.removeProfile(profile, true);
+			await this.userDataProfilesService.cleanUpTransientProfiles();
 		}
 	}
 

--- a/src/vs/platform/userDataProfile/electron-main/userDataTransientProfilesHandler.ts
+++ b/src/vs/platform/userDataProfile/electron-main/userDataTransientProfilesHandler.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WorkspaceIdentifier } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { ILifecycleMainService, } from 'vs/platform/lifecycle/electron-main/lifecycleMainService';
+import { LoadReason } from 'vs/platform/window/electron-main/window';
+import { IUserDataProfilesMainService } from 'vs/platform/userDataProfile/electron-main/userDataProfile';
+
+export class UserDataTransientProfilesHandler extends Disposable {
+
+	constructor(
+		@ILifecycleMainService lifecycleMainService: ILifecycleMainService,
+		@IUserDataProfilesMainService private readonly userDataProfilesService: IUserDataProfilesMainService,
+	) {
+		super();
+		this._register(lifecycleMainService.onWillLoadWindow(e => {
+			if (e.reason === LoadReason.LOAD) {
+				this.unsetTransientProfileForWorkspace(e.window.previousWorkspace ?? 'empty-window');
+			}
+		}));
+		this._register(lifecycleMainService.onBeforeCloseWindow(window => this.unsetTransientProfileForWorkspace(window.openedWorkspace ?? 'empty-window')));
+	}
+
+	private async unsetTransientProfileForWorkspace(workspace: WorkspaceIdentifier): Promise<void> {
+		const profile = this.userDataProfilesService.getOrSetProfileForWorkspace(workspace);
+		if (profile.isTransient) {
+			this.userDataProfilesService.unsetWorkspace(workspace, true);
+			await this.userDataProfilesService.removeProfile(profile, true);
+		}
+	}
+
+}

--- a/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
@@ -48,8 +48,13 @@ export class UserDataProfilesNativeService extends Disposable implements IUserDa
 		this.onDidResetWorkspaces = this.channel.listen<void>('onDidResetWorkspaces');
 	}
 
-	async createProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, workspaceIdentifier?: WorkspaceIdentifier, transient?: boolean): Promise<IUserDataProfile> {
-		const result = await this.channel.call<UriDto<IUserDataProfile>>('createProfile', [name, useDefaultFlags, workspaceIdentifier, transient]);
+	async createProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, workspaceIdentifier?: WorkspaceIdentifier): Promise<IUserDataProfile> {
+		const result = await this.channel.call<UriDto<IUserDataProfile>>('createProfile', [name, useDefaultFlags, workspaceIdentifier]);
+		return reviveProfile(result, this.profilesHome.scheme);
+	}
+
+	async createTransientProfile(workspaceIdentifier?: WorkspaceIdentifier): Promise<IUserDataProfile> {
+		const result = await this.channel.call<UriDto<IUserDataProfile>>('createTransientProfile', [workspaceIdentifier]);
 		return reviveProfile(result, this.profilesHome.scheme);
 	}
 
@@ -57,8 +62,8 @@ export class UserDataProfilesNativeService extends Disposable implements IUserDa
 		await this.channel.call<UriDto<IUserDataProfile>>('setProfileForWorkspace', [workspaceIdentifier, profile]);
 	}
 
-	removeProfile(profile: IUserDataProfile, donotRemoveIfAssociated?: boolean): Promise<void> {
-		return this.channel.call('removeProfile', [profile, donotRemoveIfAssociated]);
+	removeProfile(profile: IUserDataProfile): Promise<void> {
+		return this.channel.call('removeProfile', [profile]);
 	}
 
 	async updateProfile(profile: IUserDataProfile, name: string, useDefaultFlags?: UseDefaultProfileFlags): Promise<IUserDataProfile> {
@@ -72,6 +77,10 @@ export class UserDataProfilesNativeService extends Disposable implements IUserDa
 
 	cleanUp(): Promise<void> {
 		return this.channel.call('cleanUp');
+	}
+
+	cleanUpTransientProfiles(): Promise<void> {
+		return this.channel.call('cleanUpTransientProfiles');
 	}
 
 }

--- a/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-sandbox/userDataProfile.ts
@@ -11,7 +11,6 @@ import { IChannel } from 'vs/base/parts/ipc/common/ipc';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IMainProcessService } from 'vs/platform/ipc/electron-sandbox/services';
 import { DidChangeProfilesEvent, IUserDataProfile, IUserDataProfilesService, reviveProfile, UseDefaultProfileFlags, WorkspaceIdentifier } from 'vs/platform/userDataProfile/common/userDataProfile';
-import { ISingleFolderWorkspaceIdentifier, IWorkspaceIdentifier } from 'vs/platform/workspace/common/workspace';
 
 export class UserDataProfilesNativeService extends Disposable implements IUserDataProfilesService {
 
@@ -49,17 +48,17 @@ export class UserDataProfilesNativeService extends Disposable implements IUserDa
 		this.onDidResetWorkspaces = this.channel.listen<void>('onDidResetWorkspaces');
 	}
 
-	async createProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, workspaceIdentifier?: ISingleFolderWorkspaceIdentifier | IWorkspaceIdentifier): Promise<IUserDataProfile> {
-		const result = await this.channel.call<UriDto<IUserDataProfile>>('createProfile', [name, useDefaultFlags, workspaceIdentifier]);
+	async createProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, workspaceIdentifier?: WorkspaceIdentifier, transient?: boolean): Promise<IUserDataProfile> {
+		const result = await this.channel.call<UriDto<IUserDataProfile>>('createProfile', [name, useDefaultFlags, workspaceIdentifier, transient]);
 		return reviveProfile(result, this.profilesHome.scheme);
 	}
 
-	async setProfileForWorkspace(profile: IUserDataProfile, workspaceIdentifier: ISingleFolderWorkspaceIdentifier | IWorkspaceIdentifier): Promise<void> {
-		await this.channel.call<UriDto<IUserDataProfile>>('setProfileForWorkspace', [profile, workspaceIdentifier]);
+	async setProfileForWorkspace(workspaceIdentifier: WorkspaceIdentifier, profile: IUserDataProfile): Promise<void> {
+		await this.channel.call<UriDto<IUserDataProfile>>('setProfileForWorkspace', [workspaceIdentifier, profile]);
 	}
 
-	removeProfile(profile: IUserDataProfile): Promise<void> {
-		return this.channel.call('removeProfile', [profile]);
+	removeProfile(profile: IUserDataProfile, donotRemoveIfAssociated?: boolean): Promise<void> {
+		return this.channel.call('removeProfile', [profile, donotRemoveIfAssociated]);
 	}
 
 	async updateProfile(profile: IUserDataProfile, name: string, useDefaultFlags?: UseDefaultProfileFlags): Promise<IUserDataProfile> {
@@ -71,6 +70,9 @@ export class UserDataProfilesNativeService extends Disposable implements IUserDa
 		return this.channel.call('resetWorkspaces');
 	}
 
-	getProfile(workspaceIdentifier: WorkspaceIdentifier, profileToUseIfNotSet: IUserDataProfile): IUserDataProfile { throw new Error('Not implemented'); }
+	cleanUp(): Promise<void> {
+		return this.channel.call('cleanUp');
+	}
+
 }
 

--- a/src/vs/platform/userDataProfile/test/common/userDataProfileService.test.ts
+++ b/src/vs/platform/userDataProfile/test/common/userDataProfileService.test.ts
@@ -74,17 +74,33 @@ suite('UserDataProfileService (Common)', () => {
 		assert.deepStrictEqual(testObject.profiles[0].extensionsResource, undefined);
 	});
 
-	test('create transient profile', async () => {
-		const profile = await testObject.createProfile('transient', undefined, undefined, true);
+	test('create transient profiles', async () => {
+		const profile1 = await testObject.createTransientProfile();
+		const profile2 = await testObject.createTransientProfile();
+		const profile3 = await testObject.createTransientProfile();
 
-		assert.deepStrictEqual(profile.name, 'transient');
-		assert.deepStrictEqual(profile.isTransient, true);
-		assert.deepStrictEqual(testObject.profiles.length, 2);
-		assert.deepStrictEqual(testObject.profiles[1].id, profile.id);
+		assert.deepStrictEqual(testObject.profiles.length, 4);
+		assert.deepStrictEqual(profile1.name, 'Temp 1');
+		assert.deepStrictEqual(profile1.isTransient, true);
+		assert.deepStrictEqual(testObject.profiles[1].id, profile1.id);
+		assert.deepStrictEqual(profile2.name, 'Temp 2');
+		assert.deepStrictEqual(profile2.isTransient, true);
+		assert.deepStrictEqual(testObject.profiles[2].id, profile2.id);
+		assert.deepStrictEqual(profile3.name, 'Temp 3');
+		assert.deepStrictEqual(profile3.isTransient, true);
+		assert.deepStrictEqual(testObject.profiles[3].id, profile3.id);
+	});
+
+	test('create transient profile when a normal profile with Temp is already created', async () => {
+		await testObject.createProfile('Temp 1');
+		const profile1 = await testObject.createTransientProfile();
+
+		assert.deepStrictEqual(profile1.name, 'Temp 2');
+		assert.deepStrictEqual(profile1.isTransient, true);
 	});
 
 	test('profiles include default profile with extension resource defined when transiet prrofile is created', async () => {
-		await testObject.createProfile('transient', undefined, undefined, true);
+		await testObject.createTransientProfile();
 
 		assert.deepStrictEqual(testObject.profiles.length, 2);
 		assert.deepStrictEqual(testObject.profiles[0].isDefault, true);
@@ -92,13 +108,12 @@ suite('UserDataProfileService (Common)', () => {
 	});
 
 	test('profiles include default profile with extension resource undefined when transiet prrofile is removed', async () => {
-		const profile = await testObject.createProfile('transient', undefined, undefined, true);
+		const profile = await testObject.createTransientProfile();
 		await testObject.removeProfile(profile);
 
 		assert.deepStrictEqual(testObject.profiles.length, 1);
 		assert.deepStrictEqual(testObject.profiles[0].isDefault, true);
 		assert.deepStrictEqual(testObject.profiles[0].extensionsResource, undefined);
 	});
-
 
 });

--- a/src/vs/platform/userDataProfile/test/common/userDataProfileService.test.ts
+++ b/src/vs/platform/userDataProfile/test/common/userDataProfileService.test.ts
@@ -74,6 +74,15 @@ suite('UserDataProfileService (Common)', () => {
 		assert.deepStrictEqual(testObject.profiles[0].extensionsResource, undefined);
 	});
 
+	test('create transient profile', async () => {
+		const profile = await testObject.createProfile('transient', undefined, undefined, true);
+
+		assert.deepStrictEqual(profile.name, 'transient');
+		assert.deepStrictEqual(profile.isTransient, true);
+		assert.deepStrictEqual(testObject.profiles.length, 2);
+		assert.deepStrictEqual(testObject.profiles[1].id, profile.id);
+	});
+
 	test('profiles include default profile with extension resource defined when transiet prrofile is created', async () => {
 		await testObject.createProfile('transient', undefined, undefined, true);
 

--- a/src/vs/platform/userDataProfile/test/common/userDataProfileService.test.ts
+++ b/src/vs/platform/userDataProfile/test/common/userDataProfileService.test.ts
@@ -13,7 +13,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { InMemoryFileSystemProvider } from 'vs/platform/files/common/inMemoryFilesystemProvider';
 import { AbstractNativeEnvironmentService } from 'vs/platform/environment/common/environmentService';
 import product from 'vs/platform/product/common/product';
-import { UserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { StoredProfileAssociations, StoredUserDataProfile, UserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService';
 
 const ROOT = URI.file('tests').with({ scheme: 'vscode-tests' });
@@ -23,6 +23,17 @@ class TestEnvironmentService extends AbstractNativeEnvironmentService {
 		super(Object.create(null), Object.create(null), { _serviceBrand: undefined, ...product });
 	}
 	override get userRoamingDataHome() { return this._appSettingsHome.with({ scheme: Schemas.vscodeUserData }); }
+}
+
+class TestUserDataProfilesService extends UserDataProfilesService {
+
+	private storedProfiles: StoredUserDataProfile[] = [];
+	protected override getStoredProfiles(): StoredUserDataProfile[] { return this.storedProfiles; }
+	protected override saveStoredProfiles(storedProfiles: StoredUserDataProfile[]): void { this.storedProfiles = storedProfiles; }
+
+	private storedProfileAssociations: StoredProfileAssociations = {};
+	protected override getStoredProfileAssociations(): StoredProfileAssociations { return this.storedProfileAssociations; }
+	protected override saveStoredProfileAssociations(storedProfileAssociations: StoredProfileAssociations): void { this.storedProfileAssociations = storedProfileAssociations; }
 }
 
 suite('UserDataProfileService (Common)', () => {
@@ -36,9 +47,11 @@ suite('UserDataProfileService (Common)', () => {
 		const fileService = disposables.add(new FileService(logService));
 		const fileSystemProvider = disposables.add(new InMemoryFileSystemProvider());
 		disposables.add(fileService.registerProvider(ROOT.scheme, fileSystemProvider));
+		disposables.add(fileService.registerProvider(Schemas.vscodeUserData, fileSystemProvider));
 
 		environmentService = new TestEnvironmentService(joinPath(ROOT, 'User'));
-		testObject = new UserDataProfilesService(environmentService, fileService, new UriIdentityService(fileService), logService);
+		testObject = new TestUserDataProfilesService(environmentService, fileService, new UriIdentityService(fileService), logService);
+		testObject.setEnablement(true);
 	});
 
 	teardown(() => disposables.clear());
@@ -56,6 +69,23 @@ suite('UserDataProfileService (Common)', () => {
 	});
 
 	test('profiles always include default profile', () => {
+		assert.deepStrictEqual(testObject.profiles.length, 1);
+		assert.deepStrictEqual(testObject.profiles[0].isDefault, true);
+		assert.deepStrictEqual(testObject.profiles[0].extensionsResource, undefined);
+	});
+
+	test('profiles include default profile with extension resource defined when transiet prrofile is created', async () => {
+		await testObject.createProfile('transient', undefined, undefined, true);
+
+		assert.deepStrictEqual(testObject.profiles.length, 2);
+		assert.deepStrictEqual(testObject.profiles[0].isDefault, true);
+		assert.deepStrictEqual(testObject.profiles[0].extensionsResource?.toString(), joinPath(environmentService.userRoamingDataHome, 'extensions.json').toString());
+	});
+
+	test('profiles include default profile with extension resource undefined when transiet prrofile is removed', async () => {
+		const profile = await testObject.createProfile('transient', undefined, undefined, true);
+		await testObject.removeProfile(profile);
+
 		assert.deepStrictEqual(testObject.profiles.length, 1);
 		assert.deepStrictEqual(testObject.profiles[0].isDefault, true);
 		assert.deepStrictEqual(testObject.profiles[0].extensionsResource, undefined);

--- a/src/vs/platform/window/electron-main/window.ts
+++ b/src/vs/platform/window/electron-main/window.ts
@@ -27,6 +27,7 @@ export interface ICodeWindow extends IDisposable {
 	readonly win: BrowserWindow | null; /* `null` after being disposed */
 	readonly config: INativeWindowConfiguration | undefined;
 
+	readonly previousWorkspace?: IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier;
 	readonly openedWorkspace?: IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier;
 
 	readonly profile?: IUserDataProfile;

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -40,9 +40,10 @@ import { IWorkspacesManagementMainService } from 'vs/platform/workspaces/electro
 import { IWindowState, ICodeWindow, ILoadEvent, WindowMode, WindowError, LoadReason, defaultWindowState } from 'vs/platform/window/electron-main/window';
 import { Color } from 'vs/base/common/color';
 import { IPolicyService } from 'vs/platform/policy/common/policy';
-import { IUserDataProfile, IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
+import { IUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { IStateMainService } from 'vs/platform/state/electron-main/state';
 import product from 'vs/platform/product/common/product';
+import { IUserDataProfilesMainService } from 'vs/platform/userDataProfile/electron-main/userDataProfile';
 
 export interface IWindowCreationOptions {
 	state: IWindowState;
@@ -118,9 +119,11 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
 	get backupPath(): string | undefined { return this._config?.backupPath; }
 
+	private _previousWorkspace: IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | undefined;
+	get previousWorkspace(): IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | undefined { return this._previousWorkspace; }
 	get openedWorkspace(): IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | undefined { return this._config?.workspace; }
 
-	get profile(): IUserDataProfile | undefined { return this.config ? this.userDataProfilesService.getProfile(this.config.workspace ?? 'empty-window', this.userDataProfilesService.profiles.find(profile => profile.id === this.config?.profiles.profile.id) ?? this.userDataProfilesService.defaultProfile) : undefined; }
+	get profile(): IUserDataProfile | undefined { return this.config ? this.userDataProfilesService.getOrSetProfileForWorkspace(this.config.workspace ?? 'empty-window', this.userDataProfilesService.profiles.find(profile => profile.id === this.config?.profiles.profile.id) ?? this.userDataProfilesService.defaultProfile) : undefined; }
 
 	get remoteAuthority(): string | undefined { return this._config?.remoteAuthority; }
 
@@ -165,7 +168,7 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 		@ILogService private readonly logService: ILogService,
 		@IEnvironmentMainService private readonly environmentMainService: IEnvironmentMainService,
 		@IPolicyService private readonly policyService: IPolicyService,
-		@IUserDataProfilesService private readonly userDataProfilesService: IUserDataProfilesService,
+		@IUserDataProfilesMainService private readonly userDataProfilesService: IUserDataProfilesMainService,
 		@IFileService private readonly fileService: IFileService,
 		@IApplicationStorageMainService private readonly applicationStorageMainService: IApplicationStorageMainService,
 		@IStorageMainService private readonly storageMainService: IStorageMainService,
@@ -850,6 +853,8 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
 			this._win.setTitle(this.productService.nameLong);
 		}
+
+		this._previousWorkspace = this.openedWorkspace;
 
 		// Update configuration values based on our window context
 		// and set it into the config object URL for usage.

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -862,10 +862,9 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		}
 
 		// Apply profile if any
-		const profileName = cli['profile'];
-		if (profileName) {
+		if (cli.profile) {
 			for (const path of pathsToOpen) {
-				path.userDataProfileInfo = { name: profileName };
+				path.userDataProfileInfo = { name: cli.profile };
 			}
 		}
 
@@ -1477,13 +1476,13 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		if (options.userDataProfileInfo) {
 			profile = this.userDataProfilesMainService.profiles.find(profile => profile.name === options.userDataProfileInfo!.name);
 			if (profile) {
-				this.userDataProfilesMainService.setProfileForWorkspaceSync(profile, options.workspace ?? 'empty-window');
+				this.userDataProfilesMainService.setProfileForWorkspaceSync(options.workspace ?? 'empty-window', profile, options.cli?.transient);
 			}
 		}
 
 		// Otherwise use associated profile
 		if (!profile) {
-			profile = this.userDataProfilesMainService.getProfile(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesMainService.defaultProfile);
+			profile = this.userDataProfilesMainService.getOrSetProfileForWorkspace(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesMainService.defaultProfile);
 		}
 
 		return profile;

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1476,7 +1476,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		if (options.userDataProfileInfo) {
 			profile = this.userDataProfilesMainService.profiles.find(profile => profile.name === options.userDataProfileInfo!.name);
 			if (profile) {
-				this.userDataProfilesMainService.setProfileForWorkspaceSync(options.workspace ?? 'empty-window', profile, options.cli?.transient);
+				this.userDataProfilesMainService.setProfileForWorkspaceSync(options.workspace ?? 'empty-window', profile);
 			}
 		}
 

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -278,7 +278,7 @@ export class BrowserMain extends Disposable {
 		const userDataProfilesService = new BrowserUserDataProfilesService(environmentService, fileService, uriIdentityService, logService);
 		serviceCollection.set(IUserDataProfilesService, userDataProfilesService);
 		const lastActiveProfile = environmentService.lastActiveProfile ? userDataProfilesService.profiles.find(p => p.id === environmentService.lastActiveProfile) : undefined;
-		const currentProfile = userDataProfilesService.getProfile(isWorkspaceIdentifier(payload) || isSingleFolderWorkspaceIdentifier(payload) ? payload : 'empty-window', lastActiveProfile ?? userDataProfilesService.defaultProfile);
+		const currentProfile = userDataProfilesService.getOrSetProfileForWorkspace(isWorkspaceIdentifier(payload) || isSingleFolderWorkspaceIdentifier(payload) ? payload : 'empty-window', lastActiveProfile ?? userDataProfilesService.defaultProfile);
 		const userDataProfileService = new UserDataProfileService(currentProfile, userDataProfilesService);
 		serviceCollection.set(IUserDataProfileService, userDataProfileService);
 

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
@@ -6,6 +6,7 @@
 import { Codicon } from 'vs/base/common/codicons';
 import { Event } from 'vs/base/common/event';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
+import { isWeb } from 'vs/base/common/platform';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { localize } from 'vs/nls';
 import { Action2, ISubmenuItem, MenuId, MenuRegistry, registerAction2 } from 'vs/platform/actions/common/actions';
@@ -21,6 +22,7 @@ import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace
 import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuration';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { MangeSettingsProfileAction } from 'vs/workbench/contrib/userDataProfile/browser/userDataProfileActions';
+import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
 import { CURRENT_PROFILE_CONTEXT, HAS_PROFILES_CONTEXT, IUserDataProfileManagementService, IUserDataProfileService, ManageProfilesSubMenu, PROFILES_CATEGORY, PROFILES_ENABLEMENT_CONTEXT, PROFILES_TTILE } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 
@@ -39,6 +41,7 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 		@IProductService private readonly productService: IProductService,
 		@IContextKeyService contextKeyService: IContextKeyService,
+		@ILifecycleService lifecycleService: ILifecycleService,
 	) {
 		super();
 
@@ -56,6 +59,10 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 		this._register(Event.any(this.workspaceContextService.onDidChangeWorkbenchState, this.userDataProfileService.onDidChangeCurrentProfile, this.userDataProfileService.onDidUpdateCurrentProfile, this.userDataProfilesService.onDidChangeProfiles)(() => this.updateStatus()));
 
 		this.registerActions();
+
+		if (isWeb) {
+			lifecycleService.when(LifecyclePhase.Eventually).then(() => userDataProfilesService.cleanUp());
+		}
 	}
 
 	private registerConfiguration(): void {

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfileActions.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfileActions.ts
@@ -18,7 +18,6 @@ import { IUserDataProfileTemplate, isUserDataProfileTemplate, IUserDataProfileMa
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IUserDataProfile, IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { CATEGORIES } from 'vs/workbench/common/actions';
-import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { compare } from 'vs/base/common/strings';
@@ -42,7 +41,7 @@ class CreateFromCurrentProfileAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor) {
+	async run(accessor: ServicesAccessor, transient?: boolean) {
 		const quickInputService = accessor.get(IQuickInputService);
 		const notificationService = accessor.get(INotificationService);
 		const userDataProfileManagementService = accessor.get(IUserDataProfileManagementService);
@@ -59,7 +58,7 @@ class CreateFromCurrentProfileAction extends Action2 {
 		});
 		if (name) {
 			try {
-				await userDataProfileManagementService.createAndEnterProfile(name, undefined, true);
+				await userDataProfileManagementService.createAndEnterProfile(name, undefined, true, transient);
 			} catch (error) {
 				notificationService.error(error);
 			}
@@ -84,7 +83,7 @@ class CreateEmptyProfileAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor) {
+	async run(accessor: ServicesAccessor, transient?: boolean) {
 		const quickInputService = accessor.get(IQuickInputService);
 		const userDataProfileManagementService = accessor.get(IUserDataProfileManagementService);
 		const notificationService = accessor.get(INotificationService);
@@ -101,7 +100,7 @@ class CreateEmptyProfileAction extends Action2 {
 		});
 		if (name) {
 			try {
-				await userDataProfileManagementService.createAndEnterProfile(name);
+				await userDataProfileManagementService.createAndEnterProfile(name, undefined, undefined, transient);
 			} catch (error) {
 				notificationService.error(error);
 			}
@@ -146,6 +145,25 @@ registerAction2(class CreateProfileAction extends Action2 {
 		if (pick) {
 			return commandService.executeCommand(pick.id);
 		}
+	}
+});
+
+registerAction2(class CreateTransientProfileAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.profiles.actions.createTransientProfile',
+			title: {
+				value: localize('create transient profile', "Create Transient Settings Profile..."),
+				original: 'Create Transient Settings Profile...'
+			},
+			category: PROFILES_CATEGORY,
+			f1: true,
+			precondition: PROFILES_ENABLEMENT_CONTEXT
+		});
+	}
+
+	async run(accessor: ServicesAccessor) {
+		return accessor.get(ICommandService).executeCommand(CreateEmptyProfileAction.ID, true);
 	}
 });
 
@@ -509,13 +527,7 @@ registerAction2(class CleanupProfilesAction extends Action2 {
 	}
 
 	async run(accessor: ServicesAccessor) {
-		const userDataProfilesService = accessor.get(IUserDataProfilesService);
-		const fileService = accessor.get(IFileService);
-		const uriIdentityService = accessor.get(IUriIdentityService);
-
-		const stat = await fileService.resolve(userDataProfilesService.profilesHome);
-		await Promise.all((stat.children || [])?.filter(child => child.isDirectory && userDataProfilesService.profiles.every(p => !uriIdentityService.extUri.isEqual(p.location, child.resource)))
-			.map(child => fileService.del(child.resource, { recursive: true })));
+		return accessor.get(IUserDataProfilesService).cleanUp();
 	}
 });
 

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfileActions.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfileActions.ts
@@ -41,7 +41,7 @@ class CreateFromCurrentProfileAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor, transient?: boolean) {
+	async run(accessor: ServicesAccessor) {
 		const quickInputService = accessor.get(IQuickInputService);
 		const notificationService = accessor.get(INotificationService);
 		const userDataProfileManagementService = accessor.get(IUserDataProfileManagementService);
@@ -58,7 +58,7 @@ class CreateFromCurrentProfileAction extends Action2 {
 		});
 		if (name) {
 			try {
-				await userDataProfileManagementService.createAndEnterProfile(name, undefined, true, transient);
+				await userDataProfileManagementService.createAndEnterProfile(name, undefined, true);
 			} catch (error) {
 				notificationService.error(error);
 			}
@@ -83,7 +83,7 @@ class CreateEmptyProfileAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor, transient?: boolean) {
+	async run(accessor: ServicesAccessor) {
 		const quickInputService = accessor.get(IQuickInputService);
 		const userDataProfileManagementService = accessor.get(IUserDataProfileManagementService);
 		const notificationService = accessor.get(INotificationService);
@@ -100,7 +100,7 @@ class CreateEmptyProfileAction extends Action2 {
 		});
 		if (name) {
 			try {
-				await userDataProfileManagementService.createAndEnterProfile(name, undefined, undefined, transient);
+				await userDataProfileManagementService.createAndEnterProfile(name, undefined, undefined);
 			} catch (error) {
 				notificationService.error(error);
 			}
@@ -153,8 +153,8 @@ registerAction2(class CreateTransientProfileAction extends Action2 {
 		super({
 			id: 'workbench.profiles.actions.createTransientProfile',
 			title: {
-				value: localize('create transient profile', "Create Transient Settings Profile..."),
-				original: 'Create Transient Settings Profile...'
+				value: localize('create transient profile', "Create Transient Settings Profile"),
+				original: 'Create Transient Settings Profile'
 			},
 			category: PROFILES_CATEGORY,
 			f1: true,
@@ -163,7 +163,7 @@ registerAction2(class CreateTransientProfileAction extends Action2 {
 	}
 
 	async run(accessor: ServicesAccessor) {
-		return accessor.get(ICommandService).executeCommand(CreateEmptyProfileAction.ID, true);
+		return accessor.get(IUserDataProfileManagementService).createAndEnterTransientProfile();
 	}
 });
 

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
@@ -48,13 +48,19 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 
 	private async onDidChangeCurrentProfile(e: DidChangeUserDataProfileEvent): Promise<void> {
 		if (e.previous.isTransient) {
-			await this.userDataProfilesService.removeProfile(e.previous, true);
+			await this.userDataProfilesService.cleanUpTransientProfiles();
 		}
 	}
 
-	async createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean, transient?: boolean): Promise<IUserDataProfile> {
-		const profile = await this.userDataProfilesService.createProfile(name, useDefaultFlags, this.getWorkspaceIdentifier(), transient);
+	async createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean): Promise<IUserDataProfile> {
+		const profile = await this.userDataProfilesService.createProfile(name, useDefaultFlags, this.getWorkspaceIdentifier());
 		await this.enterProfile(profile, !!fromExisting);
+		return profile;
+	}
+
+	async createAndEnterTransientProfile(): Promise<IUserDataProfile> {
+		const profile = await this.userDataProfilesService.createTransientProfile(this.getWorkspaceIdentifier());
+		await this.enterProfile(profile, false);
 		return profile;
 	}
 

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileManagement.ts
@@ -12,7 +12,7 @@ import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
-import { IUserDataProfileManagementService, IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
+import { DidChangeUserDataProfileEvent, IUserDataProfileManagementService, IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 
 export class UserDataProfileManagementService extends Disposable implements IUserDataProfileManagementService {
 	readonly _serviceBrand: undefined;
@@ -29,6 +29,7 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 		super();
 		this._register(userDataProfilesService.onDidChangeProfiles(e => this.onDidChangeProfiles(e)));
 		this._register(userDataProfilesService.onDidResetWorkspaces(() => this.onDidResetWorkspaces()));
+		this._register(userDataProfileService.onDidChangeCurrentProfile(e => this.onDidChangeCurrentProfile(e)));
 	}
 
 	private onDidChangeProfiles(e: DidChangeProfilesEvent): void {
@@ -45,8 +46,14 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 		}
 	}
 
-	async createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean): Promise<IUserDataProfile> {
-		const profile = await this.userDataProfilesService.createProfile(name, useDefaultFlags, this.getWorkspaceIdentifier());
+	private async onDidChangeCurrentProfile(e: DidChangeUserDataProfileEvent): Promise<void> {
+		if (e.previous.isTransient) {
+			await this.userDataProfilesService.removeProfile(e.previous, true);
+		}
+	}
+
+	async createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean, transient?: boolean): Promise<IUserDataProfile> {
+		const profile = await this.userDataProfilesService.createProfile(name, useDefaultFlags, this.getWorkspaceIdentifier(), transient);
 		await this.enterProfile(profile, !!fromExisting);
 		return profile;
 	}
@@ -79,7 +86,7 @@ export class UserDataProfileManagementService extends Disposable implements IUse
 		if (this.userDataProfileService.currentProfile.id === profile.id) {
 			return;
 		}
-		await this.userDataProfilesService.setProfileForWorkspace(profile, workspaceIdentifier);
+		await this.userDataProfilesService.setProfileForWorkspace(workspaceIdentifier, profile);
 		await this.enterProfile(profile, false);
 	}
 

--- a/src/vs/workbench/services/userDataProfile/common/userDataProfile.ts
+++ b/src/vs/workbench/services/userDataProfile/common/userDataProfile.ts
@@ -32,7 +32,8 @@ export const IUserDataProfileManagementService = createDecorator<IUserDataProfil
 export interface IUserDataProfileManagementService {
 	readonly _serviceBrand: undefined;
 
-	createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean, transient?: boolean): Promise<IUserDataProfile>;
+	createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean): Promise<IUserDataProfile>;
+	createAndEnterTransientProfile(): Promise<IUserDataProfile>;
 	removeProfile(profile: IUserDataProfile): Promise<void>;
 	renameProfile(profile: IUserDataProfile, name: string): Promise<void>;
 	switchProfile(profile: IUserDataProfile): Promise<void>;

--- a/src/vs/workbench/services/userDataProfile/common/userDataProfile.ts
+++ b/src/vs/workbench/services/userDataProfile/common/userDataProfile.ts
@@ -32,7 +32,7 @@ export const IUserDataProfileManagementService = createDecorator<IUserDataProfil
 export interface IUserDataProfileManagementService {
 	readonly _serviceBrand: undefined;
 
-	createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean): Promise<IUserDataProfile>;
+	createAndEnterProfile(name: string, useDefaultFlags?: UseDefaultProfileFlags, fromExisting?: boolean, transient?: boolean): Promise<IUserDataProfile>;
 	removeProfile(profile: IUserDataProfile): Promise<void>;
 	renameProfile(profile: IUserDataProfile, name: string): Promise<void>;
 	switchProfile(profile: IUserDataProfile): Promise<void>;

--- a/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
@@ -246,7 +246,7 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 		} else {
 			path = untitledWorkspace.configPath;
 			if (!this.userDataProfileService.currentProfile.isDefault) {
-				await this.userDataProfilesService.setProfileForWorkspace(this.userDataProfileService.currentProfile, untitledWorkspace);
+				await this.userDataProfilesService.setProfileForWorkspace(untitledWorkspace, this.userDataProfileService.currentProfile);
 			}
 		}
 
@@ -285,7 +285,7 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 		const isNotUntitledWorkspace = !isUntitledWorkspace(targetConfigPathURI, this.environmentService);
 		if (isNotUntitledWorkspace && !this.userDataProfileService.currentProfile.isDefault) {
 			const newWorkspace = await this.workspacesService.getWorkspaceIdentifier(targetConfigPathURI);
-			await this.userDataProfilesService.setProfileForWorkspace(this.userDataProfileService.currentProfile, newWorkspace);
+			await this.userDataProfilesService.setProfileForWorkspace(newWorkspace, this.userDataProfileService.currentProfile);
 		}
 
 		// Return early if target is same as source


### PR DESCRIPTION
Introduce transient profiles. These profiles are deleted automatically once the last window which uses it is closed.

You can create and associate a transient profile from

- CLI by passing `--profile-transient` flag. Eg: `code <folder-uri> --profile-transient`
- UI from Command Palette using command `Create Transient Settings Profile`

These will create a transient settings profile and associate it to the workspace. Once the workspace is closed (or uses different profile) this profile is deleted.

Fixes #154460

CC @bpasero 