### PR TITLE
Use 1px borders for merge editor conflicts

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/view/media/mergeEditor.css
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/media/mergeEditor.css
@@ -59,20 +59,20 @@
 }
 
 .merge-editor-block {
-	border: 2px solid var(--vscode-mergeEditor-conflict-unhandledUnfocused-border);
+	border: 1px solid var(--vscode-mergeEditor-conflict-unhandledUnfocused-border);
 }
 
 .merge-editor-block.focused {
-	border: 2px solid var(--vscode-mergeEditor-conflict-unhandledFocused-border);
+	border: 1px solid var(--vscode-mergeEditor-conflict-unhandledFocused-border);
 }
 
 .merge-editor-block.handled {
-	border: 2px solid var(--vscode-mergeEditor-conflict-handledUnfocused-border);
+	border: 1px solid var(--vscode-mergeEditor-conflict-handledUnfocused-border);
 
 }
 
 .merge-editor-block.handled.focused {
-	border: 2px solid var(--vscode-mergeEditor-conflict-handledFocused-border);
+	border: 1px solid var(--vscode-mergeEditor-conflict-handledFocused-border);
 }
 
 .gutter.monaco-editor > div {
@@ -159,7 +159,7 @@
 }
 
 .conflict-zone-root {
-	border: 2px solid var(--vscode-mergeEditor-conflict-unhandledUnfocused-border);
+	border: 1px solid var(--vscode-mergeEditor-conflict-unhandledUnfocused-border);
 	background-color: var(--vscode-mergeEditor-change-background);
 
 	height: 90%;
@@ -190,7 +190,7 @@
 
 
 .focused.conflict-zone .conflict-zone-root {
-	border: 2px solid var(--vscode-mergeEditor-conflict-unhandledFocused-border);
+	border: 1px solid var(--vscode-mergeEditor-conflict-unhandledFocused-border);
 }
 
 


### PR DESCRIPTION
Moves from 2px to 1px borders to reduce perceived weight.

## Before

![CleanShot 2022-08-22 at 10 52 03@2x](https://user-images.githubusercontent.com/25163139/185986800-d1afa13e-b9be-42e0-8873-afd402809f5d.png)

## After

![CleanShot 2022-08-22 at 10 53 01@2x](https://user-images.githubusercontent.com/25163139/185986966-a8be24c1-e47c-420a-be49-e2d99b14518b.png)

