### PR TITLE
Merge Editor: use dashed borders for unhandled changes

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/view/media/mergeEditor.css
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/media/mergeEditor.css
@@ -59,11 +59,11 @@
 }
 
 .merge-editor-block {
-	border: 1px solid var(--vscode-mergeEditor-conflict-unhandledUnfocused-border);
+	border: 1px dashed var(--vscode-mergeEditor-conflict-unhandledUnfocused-border);
 }
 
 .merge-editor-block.focused {
-	border: 1px solid var(--vscode-mergeEditor-conflict-unhandledFocused-border);
+	border: 1px dashed var(--vscode-mergeEditor-conflict-unhandledFocused-border);
 }
 
 .merge-editor-block.handled {
@@ -93,12 +93,12 @@
 
 
 .merge-accept-gutter-marker.multi-line.focused .background {
-	border: 1px solid var(--vscode-mergeEditor-conflict-unhandledFocused-border);
+	border: 1px dashed var(--vscode-mergeEditor-conflict-unhandledFocused-border);
 	border-right: 0;
 }
 
 .merge-accept-gutter-marker.multi-line .background {
-	border: 1px solid var(--vscode-mergeEditor-conflict-unhandledUnfocused-border);
+	border: 1px dashed var(--vscode-mergeEditor-conflict-unhandledUnfocused-border);
 	border-right: 0;
 }
 
@@ -159,7 +159,7 @@
 }
 
 .conflict-zone-root {
-	border: 1px solid var(--vscode-mergeEditor-conflict-unhandledUnfocused-border);
+	border: 1px dashed var(--vscode-mergeEditor-conflict-unhandledUnfocused-border);
 	background-color: var(--vscode-mergeEditor-change-background);
 
 	height: 90%;
@@ -190,7 +190,7 @@
 
 
 .focused.conflict-zone .conflict-zone-root {
-	border: 1px solid var(--vscode-mergeEditor-conflict-unhandledFocused-border);
+	border: 1px dashed var(--vscode-mergeEditor-conflict-unhandledFocused-border);
 }
 
 


### PR DESCRIPTION
Accessibility and usability-driven change to use something other than color to differentiate between handled and unhandled changed

## Before

![CleanShot 2022-08-22 at 12 54 13@2x](https://user-images.githubusercontent.com/25163139/186007192-a59fedbb-55b2-4d8b-8b33-118aa4d94afc.png)

## After
![CleanShot 2022-08-22 at 12 53 47@2x](https://user-images.githubusercontent.com/25163139/186007147-aab48b58-1f2c-4b7a-852f-38aa812bcc87.png)

