### PR TITLE
Expose enum item labels, fixes #117696

### DIFF
--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -78,6 +78,13 @@ const configurationEntrySchema: IJSONSchema = {
 								},
 								description: nls.localize('scope.markdownEnumDescriptions', 'Descriptions for enum values in the markdown format.')
 							},
+							enumItemLabels: {
+								type: 'array',
+								items: {
+									type: 'string'
+								},
+								description: nls.localize('scope.enumItemLabels', 'Labels for enum values. When specified, the {0} values still show after the labels, but less prominently.', '`enum`')
+							},
 							markdownDescription: {
 								type: 'string',
 								description: nls.localize('scope.markdownDescription', 'The description in the markdown format.')

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -83,7 +83,7 @@ const configurationEntrySchema: IJSONSchema = {
 								items: {
 									type: 'string'
 								},
-								description: nls.localize('scope.enumItemLabels', 'Labels for enum values to be displayed in the Settings editor. When specified, the {0} values still show after the labels, but less prominently.', '`enum`')
+								markdownDescription: nls.localize('scope.enumItemLabels', 'Labels for enum values to be displayed in the Settings editor. When specified, the {0} values still show after the labels, but less prominently.', '`enum`')
 							},
 							markdownDescription: {
 								type: 'string',

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -83,7 +83,7 @@ const configurationEntrySchema: IJSONSchema = {
 								items: {
 									type: 'string'
 								},
-								description: nls.localize('scope.enumItemLabels', 'Labels for enum values. When specified, the {0} values still show after the labels, but less prominently.', '`enum`')
+								description: nls.localize('scope.enumItemLabels', 'Labels for enum values to be displayed in the Settings editor. When specified, the {0} values still show after the labels, but less prominently.', '`enum`')
 							},
 							markdownDescription: {
 								type: 'string',


### PR DESCRIPTION
Fixes #117696

It turns out we had `enumItemLabels` all along, but there just wasn't a completion for it.

![Screenshot showing enumItemLabels in a setting configuration JSON](https://user-images.githubusercontent.com/7199958/186021646-464a3969-f219-4edd-977e-99b49436eabc.png)