### PR TITLE
use common extension manifest string replacer for web and desktop

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionNls.ts
+++ b/src/vs/platform/extensionManagement/common/extensionNls.ts
@@ -42,11 +42,17 @@ function replaceNLStrings(extensionManifest: IExtensionManifest, messages: ITran
 				const message: string | undefined = typeof translated === 'string' ? translated : translated.message;
 				if (message !== undefined) {
 					// This branch returns ILocalizedString's instead of Strings so that the Command Palette can contain both the localized and the original value.
-					if (command && originalMessages && (key === 'title' || key === 'category')) {
-						const originalMessage = originalMessages[messageKey];
+					const original = originalMessages?.[messageKey];
+					const originalMessage: string | undefined = typeof original === 'string' ? original : original?.message;
+					if (
+						// if we are translating the title or category of a command
+						command && (key === 'title' || key === 'category') &&
+						// and the original value is not the same as the translated value
+						originalMessage && originalMessage !== message
+					) {
 						const localizedString: ILocalizedString = {
 							value: message,
-							original: typeof originalMessage === 'string' ? originalMessage : originalMessage?.message
+							original: originalMessage
 						};
 						obj[key] = localizedString;
 					} else {

--- a/src/vs/platform/extensionManagement/common/extensionNls.ts
+++ b/src/vs/platform/extensionManagement/common/extensionNls.ts
@@ -3,30 +3,75 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { cloneAndChange } from 'vs/base/common/objects';
+import { isObject, isString } from 'vs/base/common/types';
+import { ILocalizedString } from 'vs/platform/action/common/action';
 import { IExtensionManifest } from 'vs/platform/extensions/common/extensions';
-
-const nlsRegex = /^%([\w\d.-]+)%$/i;
+import { localize } from 'vs/nls';
 
 export interface ITranslations {
 	[key: string]: string | { message: string; comment: string[] };
 }
 
-export function localizeManifest(manifest: IExtensionManifest, translations: ITranslations, fallbackTranslations?: ITranslations): IExtensionManifest {
-	const patcher = (value: string): string | undefined => {
-		if (typeof value !== 'string') {
-			return undefined;
+export function localizeManifest(extensionManifest: IExtensionManifest, translations: ITranslations, fallbackTranslations?: ITranslations): IExtensionManifest {
+	try {
+		replaceNLStrings(extensionManifest, translations, fallbackTranslations);
+	} catch (error) {
+		/*Ignore Error*/
+	}
+	return extensionManifest;
+}
+
+/**
+ * This routine makes the following assumptions:
+ * The root element is an object literal
+ */
+function replaceNLStrings(extensionManifest: IExtensionManifest, messages: ITranslations, originalMessages?: ITranslations): void {
+	const processEntry = (obj: any, key: string | number, command?: boolean) => {
+		const value = obj[key];
+		if (isString(value)) {
+			const str = <string>value;
+			const length = str.length;
+			if (length > 1 && str[0] === '%' && str[length - 1] === '%') {
+				const messageKey = str.substr(1, length - 2);
+				let translated = messages[messageKey];
+				// If the messages come from a language pack they might miss some keys
+				// Fill them from the original messages.
+				if (translated === undefined && originalMessages) {
+					translated = originalMessages[messageKey];
+				}
+				const message: string | undefined = typeof translated === 'string' ? translated : translated.message;
+				if (message !== undefined) {
+					// This branch returns ILocalizedString's instead of Strings so that the Command Palette can contain both the localized and the original value.
+					if (command && originalMessages && (key === 'title' || key === 'category')) {
+						const originalMessage = originalMessages[messageKey];
+						const localizedString: ILocalizedString = {
+							value: message,
+							original: typeof originalMessage === 'string' ? originalMessage : originalMessage?.message
+						};
+						obj[key] = localizedString;
+					} else {
+						obj[key] = message;
+					}
+				} else {
+					console.warn(`[${extensionManifest.name}]: ${localize('missingNLSKey', "Couldn't find message for key {0}.", messageKey)}`);
+				}
+			}
+		} else if (isObject(value)) {
+			for (const k in value) {
+				if (value.hasOwnProperty(k)) {
+					k === 'commands' ? processEntry(value, k, true) : processEntry(value, k, command);
+				}
+			}
+		} else if (Array.isArray(value)) {
+			for (let i = 0; i < value.length; i++) {
+				processEntry(value, i, command);
+			}
 		}
-
-		const match = nlsRegex.exec(value);
-
-		if (!match) {
-			return undefined;
-		}
-
-		const translation = translations?.[match[1]] ?? fallbackTranslations?.[match[1]] ?? value;
-		return typeof translation === 'string' ? translation : (typeof translation.message === 'string' ? translation.message : value);
 	};
 
-	return cloneAndChange(manifest, patcher);
+	for (const key in extensionManifest) {
+		if (extensionManifest.hasOwnProperty(key)) {
+			processEntry(extensionManifest, key);
+		}
+	}
 }

--- a/src/vs/platform/extensionManagement/test/common/extensionNls.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/extensionNls.test.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { deepClone } from 'vs/base/common/objects';
+import { ILocalizedString } from 'vs/platform/action/common/action';
+import { localizeManifest } from 'vs/platform/extensionManagement/common/extensionNls';
+import { IExtensionManifest, IConfiguration } from 'vs/platform/extensions/common/extensions';
+
+const manifest: IExtensionManifest = {
+	name: 'test',
+	publisher: 'test',
+	version: '1.0.0',
+	engines: {
+		vscode: '*'
+	},
+	contributes: {
+		commands: [
+			{
+				command: 'test.command',
+				title: '%test.command.title%',
+				category: '%test.command.category%'
+			},
+		],
+		authentication: [
+			{
+				id: 'test.authentication',
+				label: '%test.authentication.label%',
+			}
+		],
+		configuration: {
+			// to ensure we test another "title" property
+			title: '%test.configuration.title%',
+			properties: {
+				'test.configuration': {
+					type: 'string',
+					description: 'not important',
+				}
+			}
+		}
+	}
+};
+
+suite('Localize Manifest', () => {
+	test('replaces template strings', function () {
+		const localizedManifest = localizeManifest(
+			deepClone(manifest),
+			{
+				'test.command.title': 'Test Command',
+				'test.command.category': 'Test Category',
+				'test.authentication.label': 'Test Authentication',
+				'test.configuration.title': 'Test Configuration',
+			}
+		);
+
+		assert.strictEqual(localizedManifest.contributes?.commands?.[0].title, 'Test Command');
+		assert.strictEqual(localizedManifest.contributes?.commands?.[0].category, 'Test Category');
+		assert.strictEqual(localizedManifest.contributes?.authentication?.[0].label, 'Test Authentication');
+		assert.strictEqual((localizedManifest.contributes?.configuration as IConfiguration).title, 'Test Configuration');
+	});
+
+	test('replaces template strings with fallback if not found in translations', function () {
+		const localizedManifest = localizeManifest(
+			deepClone(manifest),
+			{},
+			{
+				'test.command.title': 'Test Command',
+				'test.command.category': 'Test Category',
+				'test.authentication.label': 'Test Authentication',
+				'test.configuration.title': 'Test Configuration',
+			}
+		);
+
+		assert.strictEqual(localizedManifest.contributes?.commands?.[0].title, 'Test Command');
+		assert.strictEqual(localizedManifest.contributes?.commands?.[0].category, 'Test Category');
+		assert.strictEqual(localizedManifest.contributes?.authentication?.[0].label, 'Test Authentication');
+		assert.strictEqual((localizedManifest.contributes?.configuration as IConfiguration).title, 'Test Configuration');
+	});
+
+	test('replaces template strings - command title & categories become ILocalizedString', function () {
+		const localizedManifest = localizeManifest(
+			deepClone(manifest),
+			{
+				'test.command.title': 'Befehl test',
+				'test.command.category': 'Testkategorie',
+				'test.authentication.label': 'Testauthentifizierung',
+				'test.configuration.title': 'Testkonfiguration',
+			},
+			{
+				'test.command.title': 'Test Command',
+				'test.command.category': 'Test Category',
+				'test.authentication.label': 'Test Authentication',
+				'test.configuration.title': 'Test Configuration',
+			}
+		);
+
+		const title = localizedManifest.contributes?.commands?.[0].title as ILocalizedString;
+		const category = localizedManifest.contributes?.commands?.[0].category as ILocalizedString;
+		assert.strictEqual(title.value, 'Befehl test');
+		assert.strictEqual(title.original, 'Test Command');
+		assert.strictEqual(category.value, 'Testkategorie');
+		assert.strictEqual(category.original, 'Test Category');
+
+		// Everything else stays as a string.
+		assert.strictEqual(localizedManifest.contributes?.authentication?.[0].label, 'Testauthentifizierung');
+		assert.strictEqual((localizedManifest.contributes?.configuration as IConfiguration).title, 'Testkonfiguration');
+	});
+});

--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -6,6 +6,7 @@
 import Severity from 'vs/base/common/severity';
 import * as strings from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
+import { ILocalizedString } from 'vs/platform/action/common/action';
 import { ExtensionKind } from 'vs/platform/environment/common/environment';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { getRemoteName } from 'vs/platform/remote/common/remoteHosts';
@@ -17,8 +18,8 @@ export const UNDEFINED_PUBLISHER = 'undefined_publisher';
 
 export interface ICommand {
 	command: string;
-	title: string;
-	category?: string;
+	title: string | ILocalizedString;
+	category?: string | ILocalizedString;
 }
 
 export interface IConfigurationProperty {

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -1545,7 +1545,7 @@ export class ExtensionEditor extends EditorPane {
 				),
 				...commands.map(c => $('tr', undefined,
 					$('td', undefined, $('code', undefined, c.id)),
-					$('td', undefined, c.title),
+					$('td', undefined, typeof c.title === 'string' ? c.title : c.title.value),
 					$('td', undefined, ...c.keybindings.map(keybinding => renderKeybinding(keybinding))),
 					$('td', undefined, ...c.menus.map(context => $('code', undefined, context)))
 				))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
So commands in web also show up like this:
![image](https://user-images.githubusercontent.com/2644648/186038496-f0e74488-9aba-4f7e-9c99-7249b381c610.png)

Fixes https://github.com/microsoft/vscode/issues/153538