### PR TITLE
joh/crooked tahr

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -29,20 +29,40 @@ export function isInDOM(node: Node | null): boolean {
 	return node?.isConnected ?? false;
 }
 
-export function addDisposableListener<K extends keyof GlobalEventHandlersEventMap>(node: EventTarget, type: K, handler: (event: GlobalEventHandlersEventMap[K]) => void, useCaptureOrOptions?: boolean | AddEventListenerOptions): IDisposable;
-export function addDisposableListener(node: EventTarget, type: string, handler: (event: any) => void, useCaptureOrOptions?: boolean | AddEventListenerOptions): IDisposable;
+class DomListener implements IDisposable {
+
+	private _handler: (e: any) => void;
+	private _node: EventTarget;
+	private readonly _type: string;
+	private readonly _options: boolean | AddEventListenerOptions;
+
+	constructor(node: EventTarget, type: string, handler: (e: any) => void, options?: boolean | AddEventListenerOptions) {
+		this._node = node;
+		this._type = type;
+		this._handler = handler;
+		this._options = (options || false);
+		this._node.addEventListener(this._type, this._handler, this._options);
+	}
+
+	public dispose(): void {
+		if (!this._handler) {
+			// Already disposed
+			return;
+		}
+
+		this._node.removeEventListener(this._type, this._handler, this._options);
+
+		// Prevent leakers from holding on to the dom or handler func
+		this._node = null!;
+		this._handler = null!;
+	}
+}
+
+export function addDisposableListener<K extends keyof GlobalEventHandlersEventMap>(node: EventTarget, type: K, handler: (event: GlobalEventHandlersEventMap[K]) => void, useCapture?: boolean): IDisposable;
+export function addDisposableListener(node: EventTarget, type: string, handler: (event: any) => void, useCapture?: boolean): IDisposable;
+export function addDisposableListener(node: EventTarget, type: string, handler: (event: any) => void, options: AddEventListenerOptions): IDisposable;
 export function addDisposableListener(node: EventTarget, type: string, handler: (event: any) => void, useCaptureOrOptions?: boolean | AddEventListenerOptions): IDisposable {
-	let controller: AbortController | undefined = new AbortController();
-
-	const opts: AddEventListenerOptions = typeof useCaptureOrOptions === 'boolean'
-		? { capture: useCaptureOrOptions, signal: controller.signal }
-		: { signal: controller.signal, ...(useCaptureOrOptions ?? {}) };
-
-	node.addEventListener(type, handler, opts);
-	return toDisposable(() => {
-		controller?.abort();
-		controller = undefined;
-	});
+	return new DomListener(node, type, handler, useCaptureOrOptions);
 }
 
 export interface IAddStandardDisposableListenerSignature {

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -19,7 +19,9 @@ import { withNullAsUndefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 
 export function clearNode(node: HTMLElement): void {
-	node.replaceChildren();
+	while (node.firstChild) {
+		node.firstChild.remove();
+	}
 }
 
 /**


### PR DESCRIPTION
This is for https://github.com/microsoft/vscode/issues/156864#issuecomment-1223906798 and attempts to pull back some time. jsben.ch show that these changes aren't perf-improvements (despite being clearer/cleaner code)


- Revert "Try using AbortController for disposable dom listeners"
- Revert "clearNode should use `replaceChildren` (#157169)"
