### PR TITLE
focused element and selected elements as arguments for title commands

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -168,6 +168,7 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 		this._register(treeView.onDidExpandItem(item => this._proxy.$setExpanded(treeViewId, item.handle, true)));
 		this._register(treeView.onDidCollapseItem(item => this._proxy.$setExpanded(treeViewId, item.handle, false)));
 		this._register(treeView.onDidChangeSelection(items => this._proxy.$setSelection(treeViewId, items.map(({ handle }) => handle))));
+		this._register(treeView.onDidChangeFocus(item => this._proxy.$setFocus(treeViewId, item.handle)));
 		this._register(treeView.onDidChangeVisibility(isVisible => this._proxy.$setVisible(treeViewId, isVisible)));
 	}
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1404,6 +1404,7 @@ export interface ExtHostTreeViewsShape {
 	$handleDrag(sourceViewId: string, sourceTreeItemHandles: string[], operationUuid: string, token: CancellationToken): Promise<DataTransferDTO | undefined>;
 	$setExpanded(treeViewId: string, treeItemHandle: string, expanded: boolean): void;
 	$setSelection(treeViewId: string, treeItemHandles: string[]): void;
+	$setFocus(treeViewId: string, treeItemHandle: string): void;
 	$setVisible(treeViewId: string, visible: boolean): void;
 	$hasResolve(treeViewId: string): Promise<boolean>;
 	$resolve(treeViewId: string, treeItemHandle: string, token: CancellationToken): Promise<ITreeItem | undefined>;

--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -34,14 +34,6 @@ interface CommandHandler {
 	extension?: IExtensionDescription;
 }
 
-export interface UnrollableArgument {
-	unrollArguments: any[];
-}
-
-function isUnrollableArgument(arg: any): arg is UnrollableArgument {
-	return arg !== undefined && Object.prototype.hasOwnProperty.call(arg, 'unrollArguments');
-}
-
 export interface ArgumentProcessor {
 	processArgument(arg: any): any;
 }
@@ -293,12 +285,6 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 
 	$executeContributedCommand(id: string, ...args: any[]): Promise<unknown> {
 		this._logService.trace('ExtHostCommands#$executeContributedCommand', id);
-
-		for (let i = args.length - 1; i >= 0; i--) {
-			if (isUnrollableArgument(args[i])) {
-				args.splice(i, 1, ...(args[i] as UnrollableArgument).unrollArguments);
-			}
-		}
 
 		if (!this._commands.has(id)) {
 			return Promise.reject(new Error(`Contributed command '${id}' does not exist.`));

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -59,7 +59,7 @@ export class ExtHostTreeViews implements ExtHostTreeViewsShape {
 	) {
 
 		function isTreeViewConvertableItem(arg: any): boolean {
-			return arg && arg.$treeViewId && (arg.$treeItemHandle || arg.$selectedTreeItems);
+			return arg && arg.$treeViewId && (arg.$treeItemHandle || arg.$selectedTreeItems || arg.$focusedTreeItem);
 		}
 		commands.registerArgumentProcessor({
 			processArgument: arg => {
@@ -221,6 +221,14 @@ export class ExtHostTreeViews implements ExtHostTreeViewsShape {
 		treeView.setSelection(treeItemHandles);
 	}
 
+	$setFocus(treeViewId: string, treeItemHandles: string) {
+		const treeView = this.treeViews.get(treeViewId);
+		if (!treeView) {
+			throw new Error(localize('treeView.notRegistered', 'No tree view with id \'{0}\' registered.', treeViewId));
+		}
+		treeView.setFocus(treeItemHandles);
+	}
+
 	$setVisible(treeViewId: string, isVisible: boolean): void {
 		const treeView = this.treeViews.get(treeViewId);
 		if (!treeView) {
@@ -241,7 +249,10 @@ export class ExtHostTreeViews implements ExtHostTreeViewsShape {
 			return treeView.getExtensionElement(arg.$treeItemHandle);
 		}
 		if (treeView && '$selectedTreeItems' in arg && arg.$selectedTreeItems) {
-			return { selectedTreeItems: treeView.selectedElements };
+			return treeView.selectedElements.length ? treeView.selectedElements : undefined;
+		}
+		if (treeView && '$focusedTreeItem' in arg && arg.$focusedTreeItem) {
+			return treeView.focusedElement;
 		}
 		return null;
 	}
@@ -275,6 +286,9 @@ class ExtHostTreeView<T> extends Disposable {
 
 	private _selectedHandles: TreeItemHandle[] = [];
 	get selectedElements(): T[] { return <T[]>this._selectedHandles.map(handle => this.getExtensionElement(handle)).filter(element => !isUndefinedOrNull(element)); }
+
+	private _focusedHandle: TreeItemHandle | undefined = undefined;
+	get focusedElement(): T | undefined { return <T | undefined>(this._focusedHandle ? this.getExtensionElement(this._focusedHandle) : undefined); }
 
 	private _onDidExpandElement: Emitter<vscode.TreeViewExpansionEvent<T>> = this._register(new Emitter<vscode.TreeViewExpansionEvent<T>>());
 	readonly onDidExpandElement: Event<vscode.TreeViewExpansionEvent<T>> = this._onDidExpandElement.event;
@@ -453,6 +467,10 @@ class ExtHostTreeView<T> extends Disposable {
 			this._selectedHandles = treeItemHandles;
 			this._onDidChangeSelection.fire(Object.freeze({ selection: this.selectedElements }));
 		}
+	}
+
+	setFocus(treeItemHandle: TreeItemHandle) {
+		this._focusedHandle = treeItemHandle;
 	}
 
 	setVisible(visible: boolean): void {

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -248,9 +248,6 @@ export class ExtHostTreeViews implements ExtHostTreeViewsShape {
 		if (treeView && '$treeItemHandle' in arg) {
 			return treeView.getExtensionElement(arg.$treeItemHandle);
 		}
-		if (treeView && '$selectedTreeItems' in arg && arg.$selectedTreeItems) {
-			return treeView.selectedElements.length ? treeView.selectedElements : undefined;
-		}
 		if (treeView && '$focusedTreeItem' in arg && arg.$focusedTreeItem) {
 			return treeView.focusedElement;
 		}

--- a/src/vs/workbench/browser/parts/views/viewPane.ts
+++ b/src/vs/workbench/browser/parts/views/viewPane.ts
@@ -11,7 +11,7 @@ import { attachButtonStyler, attachProgressBarStyler } from 'vs/platform/theme/c
 import { PANEL_BACKGROUND, SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { after, append, $, trackFocus, EventType, addDisposableListener, createCSSRule, asCSSUrl } from 'vs/base/browser/dom';
 import { IDisposable, Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-import { IAction } from 'vs/base/common/actions';
+import { IAction, IActionRunner } from 'vs/base/common/actions';
 import { ActionsOrientation, IActionViewItem, prepareActions } from 'vs/base/browser/ui/actionbar/actionbar';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
@@ -298,7 +298,8 @@ export abstract class ViewPane extends Pane implements IView {
 			actionViewItemProvider: action => this.getActionViewItem(action),
 			ariaLabel: nls.localize('viewToolbarAriaLabel', "{0} actions", this.title),
 			getKeyBinding: action => this.keybindingService.lookupKeybinding(action.id),
-			renderDropdownAsChildElement: true
+			renderDropdownAsChildElement: true,
+			actionRunner: this.getActionRunner()
 		});
 
 		this._register(this.toolbar);
@@ -516,6 +517,10 @@ export abstract class ViewPane extends Pane implements IView {
 	}
 
 	getActionsContext(): unknown {
+		return undefined;
+	}
+
+	getActionRunner(): IActionRunner | undefined {
 		return undefined;
 	}
 

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -663,6 +663,8 @@ export interface ITreeView extends IDisposable {
 
 	readonly onDidChangeSelection: Event<ITreeItem[]>;
 
+	readonly onDidChangeFocus: Event<ITreeItem>;
+
 	readonly onDidChangeVisibility: Event<boolean>;
 
 	readonly onDidChangeActions: Event<void>;
@@ -712,7 +714,8 @@ export interface ITreeViewDescriptor extends IViewDescriptor {
 
 export type TreeViewPaneHandleArg = {
 	$treeViewId: string;
-	$selectedTreeItems: boolean;
+	$selectedTreeItems?: boolean;
+	$focusedTreeItem?: boolean;
 };
 
 export type TreeViewItemHandleArg = {

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -693,6 +693,8 @@ export interface ITreeView extends IDisposable {
 
 	setSelection(items: ITreeItem[]): void;
 
+	getSelection(): ITreeItem[];
+
 	setFocus(item: ITreeItem): void;
 
 	show(container: any): void;

--- a/src/vs/workbench/contrib/userDataSync/browser/userDataSyncMergesView.ts
+++ b/src/vs/workbench/contrib/userDataSync/browser/userDataSyncMergesView.ts
@@ -36,7 +36,7 @@ import { IEditorContribution } from 'vs/editor/common/editorCommon';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { FloatingClickWidget } from 'vs/workbench/browser/codeeditor';
 import { registerEditorContribution } from 'vs/editor/browser/editorExtensions';
-import { Severity } from 'vs/platform/notification/common/notification';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { EditorResolution } from 'vs/platform/editor/common/editor';
 
@@ -66,8 +66,9 @@ export class UserDataSyncMergesViewPane extends TreeViewPane {
 		@IOpenerService openerService: IOpenerService,
 		@IThemeService themeService: IThemeService,
 		@ITelemetryService telemetryService: ITelemetryService,
+		@INotificationService notificationService: INotificationService
 	) {
-		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
+		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService, notificationService);
 		this.userDataSyncPreview = userDataSyncWorkbenchService.userDataSyncPreview;
 
 		this._register(this.userDataSyncPreview.onDidChangeResources(() => this.updateSyncButtonEnablement()));


### PR DESCRIPTION
Creates the arguments (focusedItem: T | undefined, selectedItems: T[] | undefined) for title commands. As we want to create 2 arguments from the result of `getActionContext()` we have to create an argument which can be unrolled into multiple arguments later.