### PR TITLE
Mark that notebook metadata is `readonly`

### DIFF
--- a/extensions/ipynb/src/notebookImagePaste.ts
+++ b/extensions/ipynb/src/notebookImagePaste.ts
@@ -122,7 +122,7 @@ function encodeBase64(buffer: Uint8Array, padded = true, urlSafe = false) {
 }
 
 function buildMetadata(b64: string, cell: vscode.NotebookCell, filename: string, filetype: string, startingAttachments: any): { [key: string]: any } {
-	const outputMetadata: { [key: string]: any } = cell.metadata;
+	const outputMetadata = { ...cell.metadata };
 	const customField = cell.metadata.custom;
 	if (!customField) {
 		return { 'custom': { 'attachments': { [filename]: { 'image/png': b64 } } } };

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -13025,7 +13025,7 @@ declare module 'vscode' {
 		/**
 		 * The metadata of this cell. Can be anything but must be JSON-stringifyable.
 		 */
-		readonly metadata: { [key: string]: any };
+		readonly metadata: { readonly [key: string]: any };
 
 		/**
 		 * The outputs of this cell.


### PR DESCRIPTION
Fixes #158955

We freeze the object here https://github.com/microsoft/vscode/blob/0656d21d11910e1b241d7d6c52761d89c0ba23a4/src/vs/workbench/api/common/extHostNotebookDocument.ts#L70 so you can't assign new properties to it

/cc @rebornix 
