### PR TITLE
Add swift to supported darwin document types

### DIFF
--- a/build/lib/electron.js
+++ b/build/lib/electron.js
@@ -152,6 +152,7 @@ exports.config = {
             'F# script': ['fsx', 'fsscript'],
             'SVG document': ['svg', 'svgz'],
             'TOML document': 'toml',
+            'Swift source code': 'swift',
         }, 'default'),
         // Default icon with default name
         darwinBundleDocumentType([

--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -167,6 +167,7 @@ export const config = {
 			'F# script': ['fsx', 'fsscript'],
 			'SVG document': ['svg', 'svgz'],
 			'TOML document': 'toml',
+			'Swift source code': 'swift',
 		}, 'default'),
 		// Default icon with default name
 		darwinBundleDocumentType([


### PR DESCRIPTION
This allows swift files to be opened by vscode, including using the "Open With" context menu.