### PR TITLE
move terminal decorator icon ids to terminalIcons

### DIFF
--- a/src/vs/base/common/codicons.ts
+++ b/src/vs/base/common/codicons.ts
@@ -96,7 +96,6 @@ export class Codicon implements CSSIcon {
 	public static readonly circleFilled = new Codicon('circle-filled', { fontCharacter: '\\ea71' });
 	public static readonly primitiveDot = new Codicon('primitive-dot', Codicon.circleFilled.definition);
 	public static readonly closeDirty = new Codicon('close-dirty', Codicon.circleFilled.definition);
-	public static readonly terminalDecorationSuccess = new Codicon('terminal-decoration-success', Codicon.circleFilled.definition);
 	public static readonly debugBreakpoint = new Codicon('debug-breakpoint', Codicon.circleFilled.definition);
 	public static readonly debugBreakpointDisabled = new Codicon('debug-breakpoint-disabled', Codicon.circleFilled.definition);
 	public static readonly debugHint = new Codicon('debug-hint', Codicon.circleFilled.definition);
@@ -221,7 +220,6 @@ export class Codicon implements CSSIcon {
 	public static readonly chromeRestore = new Codicon('chrome-restore', { fontCharacter: '\\eabb' });
 	public static readonly circle = new Codicon('circle', { fontCharacter: '\\eabc' });
 	public static readonly circleOutline = new Codicon('circle-outline', Codicon.circle.definition);
-	public static readonly terminalDecorationIncomplete = new Codicon('terminal-decoration-incomplete', Codicon.circle.definition);
 	public static readonly debugBreakpointUnverified = new Codicon('debug-breakpoint-unverified', Codicon.circle.definition);
 	public static readonly circleSlash = new Codicon('circle-slash', { fontCharacter: '\\eabd' });
 	public static readonly circuitBoard = new Codicon('circuit-board', { fontCharacter: '\\eabe' });
@@ -433,7 +431,6 @@ export class Codicon implements CSSIcon {
 	public static readonly debugStackframeActive = new Codicon('debug-stackframe-active', { fontCharacter: '\\eb89' });
 	public static readonly circleSmallFilled = new Codicon('circle-small-filled', { fontCharacter: '\\eb8a' });
 	public static readonly debugStackframeDot = new Codicon('debug-stackframe-dot', Codicon.circleSmallFilled.definition);
-	public static readonly terminalDecorationMark = new Codicon('terminal-decoration-mark', Codicon.circleSmallFilled.definition);
 	public static readonly debugStackframe = new Codicon('debug-stackframe', { fontCharacter: '\\eb8b' });
 	public static readonly debugStackframeFocused = new Codicon('debug-stackframe-focused', { fontCharacter: '\\eb8b' });
 	public static readonly debugBreakpointUnsupported = new Codicon('debug-breakpoint-unsupported', { fontCharacter: '\\eb8c' });
@@ -554,7 +551,6 @@ export class Codicon implements CSSIcon {
 	public static readonly indent = new Codicon('indent', { fontCharacter: '\\ebf9' });
 	public static readonly recordSmall = new Codicon('record-small', { fontCharacter: '\\ebfa' });
 	public static readonly errorSmall = new Codicon('error-small', { fontCharacter: '\\ebfb' });
-	public static readonly terminalDecorationError = new Codicon('terminal-decoration-error', Codicon.errorSmall.definition);
 	public static readonly arrowCircleDown = new Codicon('arrow-circle-down', { fontCharacter: '\\ebfc' });
 	public static readonly arrowCircleLeft = new Codicon('arrow-circle-left', { fontCharacter: '\\ebfd' });
 	public static readonly arrowCircleRight = new Codicon('arrow-circle-right', { fontCharacter: '\\ebfe' });

--- a/src/vs/workbench/contrib/terminal/browser/terminalIcons.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalIcons.ts
@@ -14,3 +14,8 @@ export const killTerminalIcon = registerIcon('terminal-kill', Codicon.trash, loc
 export const newTerminalIcon = registerIcon('terminal-new', Codicon.add, localize('newTerminalIcon', 'Icon for creating a new terminal instance.'));
 
 export const configureTerminalProfileIcon = registerIcon('terminal-configure-profile', Codicon.gear, localize('configureTerminalProfileIcon', 'Icon for creating a new terminal profile.'));
+
+export const terminalDecorationMark = registerIcon('terminal-decoration-mark', Codicon.circleSmallFilled, localize('terminalDecorationMark', 'Icon for a terminal decoration mark.'));
+export const terminalDecorationIncomplete = registerIcon('terminal-decoration-incomplete', Codicon.circle, localize('terminalDecorationIncomplete', 'Icon for a terminal decoration of a command that was incomplete.'));
+export const terminalDecorationError = registerIcon('terminal-decoration-error', Codicon.errorSmall, localize('terminalDecorationError', 'Icon for a terminal decoration of a command that errored.'));
+export const terminalDecorationSuccess = registerIcon('terminal-decoration-success', Codicon.circleFilled, localize('terminalDecorationSuccess', 'Icon for a terminal decoration of a command that was successful.'));

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -26,7 +26,6 @@ import { Color } from 'vs/base/common/color';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IGenericMarkProperties } from 'vs/platform/terminal/common/terminalProcess';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
-import { Codicon } from 'vs/base/common/codicons';
 import { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { terminalDecorationError, terminalDecorationIncomplete, terminalDecorationMark, terminalDecorationSuccess } from 'vs/workbench/contrib/terminal/browser/terminalIcons';
 
@@ -455,30 +454,11 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 		quickPick.onDidAccept(async e => {
 			quickPick.hide();
 			const result = quickPick.activeItems[0];
-			let iconSetting: string | undefined;
 			switch (result.id) {
 				case 'a': this._showToggleVisibilityQuickPick(); break;
 			}
-			if (iconSetting) {
-				this._showChangeIconQuickPick(iconSetting);
-			}
 		});
 		quickPick.show();
-	}
-
-	private async _showChangeIconQuickPick(iconSetting: string) {
-		type Item = IQuickPickItem & { icon: Codicon };
-		const items: Item[] = [];
-		for (const icon of Codicon.getAll()) {
-			items.push({ label: `$(${icon.id})`, description: `${icon.id}`, icon });
-		}
-		const result = await this._quickInputService.pick(items, {
-			matchOnDescription: true
-		});
-		if (result) {
-			this._configurationService.updateValue(iconSetting, result.icon.id);
-			this._showConfigureCommandDecorationsQuickPick();
-		}
 	}
 
 	private _showToggleVisibilityQuickPick() {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -9,7 +9,7 @@ import { IDecoration, ITerminalAddon, Terminal } from 'xterm';
 import * as dom from 'vs/base/browser/dom';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { CommandInvalidationReason, ITerminalCapabilityStore, TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
-import { IColorTheme, ICssStyleCollector, IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
+import { IColorTheme, ICssStyleCollector, IThemeService, registerThemingParticipant, ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IHoverService } from 'vs/workbench/services/hover/browser/hover';
 import { IAction, Separator } from 'vs/base/common/actions';
@@ -28,6 +28,7 @@ import { IGenericMarkProperties } from 'vs/platform/terminal/common/terminalProc
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { Codicon } from 'vs/base/common/codicons';
 import { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import { terminalDecorationError, terminalDecorationIncomplete, terminalDecorationMark, terminalDecorationSuccess } from 'vs/workbench/contrib/terminal/browser/terminalIcons';
 
 const enum DecorationSelector {
 	CommandDecoration = 'terminal-command-decoration',
@@ -333,7 +334,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 		element.classList.add(DecorationSelector.CommandDecoration, DecorationSelector.Codicon, DecorationSelector.XtermDecoration);
 
 		if (genericMarkProperties) {
-			element.classList.add(DecorationSelector.DefaultColor, ...Codicon.terminalDecorationMark.classNamesArray);
+			element.classList.add(DecorationSelector.DefaultColor, ...ThemeIcon.asClassNameArray(terminalDecorationMark));
 			if (!genericMarkProperties.hoverMessage) {
 				//disable the mouse pointer
 				element.classList.add(DecorationSelector.Default);
@@ -343,12 +344,12 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 			this._updateCommandDecorationVisibility(element);
 			if (exitCode === undefined) {
 				element.classList.add(DecorationSelector.DefaultColor, DecorationSelector.Default);
-				element.classList.add(...Codicon.terminalDecorationIncomplete.classNamesArray);
+				element.classList.add(...ThemeIcon.asClassNameArray(terminalDecorationIncomplete));
 			} else if (exitCode) {
 				element.classList.add(DecorationSelector.ErrorColor);
-				element.classList.add(...Codicon.terminalDecorationError.classNamesArray);
+				element.classList.add(...ThemeIcon.asClassNameArray(terminalDecorationError));
 			} else {
-				element.classList.add(...Codicon.terminalDecorationSuccess.classNamesArray);
+				element.classList.add(...ThemeIcon.asClassNameArray(terminalDecorationSuccess));
 			}
 		}
 	}


### PR DESCRIPTION
Define the terminal decoration icons in terminalIcons, not Codicon.

see https://github.com/microsoft/vscode/issues/156503#issuecomment-1225779890