### PR TITLE
fix setting description for notebook image paste

### DIFF
--- a/extensions/ipynb/package.nls.json
+++ b/extensions/ipynb/package.nls.json
@@ -1,5 +1,5 @@
 {
 	"displayName": ".ipynb support",
 	"description": "Provides basic support for opening and reading Jupyter's .ipynb notebook files",
-	"ipynb.experimental.pasteImages.enabled":"Enable/Disable pasting images into markdown cells within ipynb files. Requires enabling `#ipynb.experimental.pasteImages.enabled#`."
+	"ipynb.experimental.pasteImages.enabled":"Enable/Disable pasting images into markdown cells within ipynb files. Requires enabling `#editor.experimental.pasteActions.enabled#`."
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #159091

setting for enabling image pasting into notebook cells referenced itself, rather than markdown editor setting.
