### PR TITLE
Fix: make git commands work with keyboard

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1717,7 +1717,11 @@ export class CommandCenter {
 
 	@command('git.commitMessageAccept')
 	async commitMessageAccept(arg?: Uri): Promise<void> {
-		if (!arg) { return; }
+		if (!arg) {
+			const activeEditor = window.activeTextEditor;
+			if (!activeEditor) { return; }
+			arg = activeEditor.document.uri;
+		}
 
 		// Close the tab
 		this._closeEditorTab(arg);
@@ -1725,11 +1729,15 @@ export class CommandCenter {
 
 	@command('git.commitMessageDiscard')
 	async commitMessageDiscard(arg?: Uri): Promise<void> {
-		if (!arg) { return; }
+		if (!arg) {
+			const activeEditor = window.activeTextEditor;
+			if (!activeEditor) { return; }
+			arg = activeEditor.document.uri;
+		}
 
 		// Clear the contents of the editor
 		const editors = window.visibleTextEditors
-			.filter(e => e.document.languageId === 'git-commit' && e.document.uri.toString() === arg.toString());
+			.filter(e => e.document.languageId === 'git-commit' && e.document.uri.toString() === arg!.toString());
 
 		if (editors.length !== 1) { return; }
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1717,11 +1717,8 @@ export class CommandCenter {
 
 	@command('git.commitMessageAccept')
 	async commitMessageAccept(arg?: Uri): Promise<void> {
-		if (!arg) {
-			const activeEditor = window.activeTextEditor;
-			if (!activeEditor) { return; }
-			arg = activeEditor.document.uri;
-		}
+		if (!arg && !window.activeTextEditor) { return; }
+		arg ??= window.activeTextEditor!.document.uri;
 
 		// Close the tab
 		this._closeEditorTab(arg);
@@ -1729,11 +1726,8 @@ export class CommandCenter {
 
 	@command('git.commitMessageDiscard')
 	async commitMessageDiscard(arg?: Uri): Promise<void> {
-		if (!arg) {
-			const activeEditor = window.activeTextEditor;
-			if (!activeEditor) { return; }
-			arg = activeEditor.document.uri;
-		}
+		if (!arg && !window.activeTextEditor) { return; }
+		arg ??= window.activeTextEditor!.document.uri;
 
 		// Clear the contents of the editor
 		const editors = window.visibleTextEditors


### PR DESCRIPTION
When executing commands from this PR using keyboard shortcut, there is no document uri provided, which makes them literally unusable. This PR resolves this **accessibility** issue