### PR TITLE
change default value of `editor.suggest.matchOnWordStartOnly`

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4162,7 +4162,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 				},
 				'editor.suggest.matchOnWordStartOnly': {
 					type: 'boolean',
-					default: false,
+					default: true,
 					markdownDescription: nls.localize('editor.suggest.matchOnWordStartOnly', "When enabled IntelliSense filtering requires that the first character matches on a word start, e.g `c` on `Console` or `WebContext` but _not_ on `description`. When disabled IntelliSense will show more results but still sorts them by match quality.")
 				},
 				'editor.suggest.showFields': {


### PR DESCRIPTION
fixes (again) https://github.com/microsoft/vscode/issues/53715#issuecomment-1226021304
