### PR TITLE
Update merge editor diff and word diff colors

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/view/colors.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/colors.ts
@@ -14,7 +14,7 @@ export const diff = registerColor(
 
 export const diffWord = registerColor(
 	'mergeEditor.change.word.background',
-	{ dark: '#9ccc2c33', light: '#9ccc2c66', hcDark: '#9ccc2c66', hcLight: '#9ccc2c66', },
+	{ dark: '#9ccc2c33', light: '#9ccc2c66', hcDark: '#9ccc2c33', hcLight: '#9ccc2c66', },
 	localize('mergeEditor.change.word.background', 'The background color for word changes.')
 );
 

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/colors.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/colors.ts
@@ -14,7 +14,7 @@ export const diff = registerColor(
 
 export const diffWord = registerColor(
 	'mergeEditor.change.word.background',
-	{ dark: '#9bb9551e', light: '#9bb9551e', hcDark: '#9bb9551e', hcLight: '#9bb9551e', },
+	{ dark: '#9ccc2c33', light: '#9ccc2c66', hcDark: '#9ccc2c66', hcLight: '#9ccc2c66', },
 	localize('mergeEditor.change.word.background', 'The background color for word changes.')
 );
 


### PR DESCRIPTION
Uses `defaultInsertColor` and `diffInserted` for diffs and word diffs in the merge editor. Fixes #158797.