### PR TITLE
When VScode restart, the window which is fullscreen before should restore normal (fix #159229)

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsStateHandler.ts
+++ b/src/vs/platform/windows/electron-main/windowsStateHandler.ts
@@ -181,7 +181,7 @@ export class WindowsStateHandler extends Disposable {
 			if (currentWindowsState.lastPluginDevelopmentHostWindow.uiState.mode === WindowMode.Fullscreen) {
 				if (displaysWithFullScreenWindow.has(currentWindowsState.lastPluginDevelopmentHostWindow.uiState.display)) {
 					if (isMacintosh && !extensionHostWindow.win?.isSimpleFullScreen()) {
-						currentWindowsState.lastPluginDevelopmentHostWindow.uiState.mode = WindowMode.Maximized;
+						currentWindowsState.lastPluginDevelopmentHostWindow.uiState.mode = WindowMode.Normal;
 					}
 				} else {
 					displaysWithFullScreenWindow.add(currentWindowsState.lastPluginDevelopmentHostWindow.uiState.display);
@@ -201,7 +201,7 @@ export class WindowsStateHandler extends Disposable {
 				if (windowState.uiState.mode === WindowMode.Fullscreen) {
 					if (displaysWithFullScreenWindow.has(windowState.uiState.display)) {
 						if (isMacintosh && windowState.windowId !== currentWindowsState.lastActiveWindow?.windowId && !window.win?.isSimpleFullScreen()) {
-							windowState.uiState.mode = WindowMode.Maximized;
+							windowState.uiState.mode = WindowMode.Normal;
 						}
 					} else {
 						displaysWithFullScreenWindow.add(windowState.uiState.display);
@@ -284,7 +284,7 @@ export class WindowsStateHandler extends Disposable {
 			}
 
 			if (!allowFullscreen) {
-				state.mode = WindowMode.Maximized;
+				state.mode = WindowMode.Normal;
 			}
 		}
 


### PR DESCRIPTION
Partially reverts changes from https://github.com/microsoft/vscode/commit/a9ee44e80d47b01f34ccc3318e0386d61410afe5 to restore how it was before.