### PR TITLE
Add auto open on Refactor Preview focus/init

### DIFF
--- a/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane.ts
@@ -39,6 +39,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ResourceEdit } from 'vs/editor/browser/services/bulkEditService';
 import { ButtonBar } from 'vs/base/browser/ui/button/button';
+import { IEditorPane } from 'google3/third_party/vscode/src/vs/workbench/common/editor';
 
 const enum State {
 	Data = 'data',
@@ -69,6 +70,7 @@ export class BulkEditPane extends ViewPane {
 	private _currentResolve?: (edit?: ResourceEdit[]) => void;
 	private _currentInput?: BulkFileOperations;
 	private _currentProvider?: BulkEditPreviewProvider;
+	private _activeEditor?: IEditorPane;
 
 
 	constructor(
@@ -99,6 +101,20 @@ export class BulkEditPane extends ViewPane {
 		this._ctxHasCategories = BulkEditPane.ctxHasCategories.bindTo(_contextKeyService);
 		this._ctxGroupByFile = BulkEditPane.ctxGroupByFile.bindTo(_contextKeyService);
 		this._ctxHasCheckedChanges = BulkEditPane.ctxHasCheckedChanges.bindTo(_contextKeyService);
+
+		this.onDidFocus(e => {
+			if (
+				!this._activeEditor
+				|| this._activeEditor.isVisible()
+				|| !this._activeEditor?.group?.previewEditor
+			) {
+				return;
+			}
+
+			this._activeEditor.group.openEditor(
+				this._activeEditor.group.previewEditor
+			);
+		});
 	}
 
 	override dispose(): void {
@@ -212,6 +228,7 @@ export class BulkEditPane extends ViewPane {
 			this._currentResolve = resolve;
 			this._setTreeInput(input);
 
+			this._openEditorOnFirstApplicableEdit(input);
 			// refresh when check state changes
 			this._sessionDisposables.add(input.checked.onDidChange(() => {
 				this._tree.updateChildren();
@@ -246,6 +263,47 @@ export class BulkEditPane extends ViewPane {
 				expand.push(...this._tree.getNode(element).children);
 			}
 		}
+	}
+
+	private async _openEditorOnFirstApplicableEdit(input: BulkFileOperations) {
+		const elements = await this._treeDataSource.getChildren(input);
+		// if no item is selected, first FileElement is returned
+		const hasNoCheckedEdit = !input.checked.checkedCount;
+		const element = await this._getFirstApplicableElement(elements, hasNoCheckedEdit);
+		if (!element) return;
+
+		await this._openElementAsEditor({
+			editorOptions: {
+				pinned: false,
+				preserveFocus: true,
+				revealIfOpened: true
+			},
+			sideBySide: false,
+			element,
+		});
+	}
+
+	private async _getFirstApplicableElement(elements: BulkEditElement[], hasNoCheckedEdit: boolean):
+		Promise<FileElement | TextEditElement | undefined> {
+		let applicableElement: FileElement | TextEditElement | undefined;
+		for (const element of elements) {
+			if (element instanceof FileElement) {
+				if (hasNoCheckedEdit) { return element; }
+				applicableElement = await this._getTextEditElement(element);
+			} else if (element instanceof CategoryElement) {
+				applicableElement = await this._getFirstApplicableElement(
+					await this._treeDataSource.getChildren(element),
+					hasNoCheckedEdit);
+			}
+			if (applicableElement) return applicableElement;
+		}
+		return applicableElement;
+	}
+
+	private async _getTextEditElement(element: FileElement):
+		Promise<TextEditElement | undefined> {
+		const textEditElements = await this._treeDataSource.getChildren(element) as TextEditElement[];
+		return textEditElements.find(element => element.isChecked());
 	}
 
 	accept(): void {
@@ -339,11 +397,11 @@ export class BulkEditPane extends ViewPane {
 
 		if (fileElement.edit.type & BulkFileOperationType.Delete) {
 			// delete -> show single editor
-			this._editorService.openEditor({
+			this._activeEditor = await this._editorService.openEditor({
 				label: localize('edt.title.del', "{0} (delete, refactor preview)", basename(fileElement.edit.uri)),
 				resource: previewUri,
 				options
-			});
+			}, e.sideBySide ? SIDE_GROUP : ACTIVE_GROUP);
 
 		} else {
 			// rename, create, edits -> show diff editr
@@ -369,7 +427,7 @@ export class BulkEditPane extends ViewPane {
 				label = localize('edt.title.1', "{0} (refactor preview)", basename(fileElement.edit.uri));
 			}
 
-			this._editorService.openEditor({
+			this._activeEditor = await this._editorService.openEditor({
 				original: { resource: leftResource },
 				modified: { resource: previewUri },
 				label,


### PR DESCRIPTION
Auto opens the Diff Editor when Refactor Preview panel is displayed.
The opening is initiated when the BulkEditPane is created -> when Tree with Edits are populated, by passing the current input into the `this._openEditorOnFirstApplicableEdit`. This function retrieves either the first checked edit (TextEditElement), if there is any, or the first FileElement if there is none checked.

Assuming that the refactor preview opens only if there is `needsConfirmation` flag set on at least one `WorkspaceEdit`, but the edits that require confirmation are not checked by default, so they would not be visible in the opened Diff Editor, it makes more sense to try to open the edit that is checked/visible.
Only if all edits would require confirmation, then the first file would be opened.

The Diff editor should automatically reopen on subsequent reopening of the **Refactor Preview** panel, if it is not already in view. `onDidFocus` makes sure that if the `_activeEditor` exists, and is not visible would be reopened.
To allow this functionality to work for both Editors that can open from BulkEdits, group has been added as well to the deletion editor.
Both `_editorService.openEditor()` in `_openElementAsEditor()` have been `awaited`, so their reference can be used to reopen the DiffEditor.