### PR TITLE
Switch first and second result in quickOpen if first result is the current editor

### DIFF
--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -175,6 +175,10 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 					}
 				}
 
+				if (items.length > 1) {
+					items = this.reorderPicks(items);
+				}
+
 				picker.items = items;
 				if (activeItem) {
 					picker.activeItems = [activeItem];
@@ -363,6 +367,17 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 		}));
 
 		return disposables;
+	}
+
+	/**
+	 * If needed, returns the array of picks reordered.
+	 *
+	 * @param picks the original list of picks and separators
+	 * @returns the picks, possibly in a new array in a better order
+	 */
+	protected reorderPicks(picks: readonly Pick<T>[]): readonly Pick<T>[] {
+		// by default picks don't need reordering
+		return picks;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -5,7 +5,7 @@
 
 import 'vs/css!./media/anythingQuickAccess';
 import { IQuickInputButton, IKeyMods, quickPickItemScorerAccessor, QuickPickItemScorerAccessor, IQuickPick, IQuickPickItemWithResource, QuickInputHideReason, IQuickInputService, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
-import { IPickerQuickAccessItem, PickerQuickAccessProvider, TriggerAction, FastAndSlowPicks, Picks, PicksWithActive } from 'vs/platform/quickinput/browser/pickerQuickAccess';
+import { IPickerQuickAccessItem, PickerQuickAccessProvider, TriggerAction, FastAndSlowPicks, Picks, Pick, PicksWithActive } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { prepareQuery, IPreparedQuery, compareItemsByFuzzyScore, scoreItemFuzzy, FuzzyScorerCache } from 'vs/base/common/fuzzyScorer';
 import { IFileQueryBuilderOptions, QueryBuilder } from 'vs/workbench/services/search/common/queryBuilder';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -296,6 +296,68 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		// including the `@` character to open it (e.g. /some/file@path)
 		// refs: https://github.com/microsoft/vscode/issues/93845
 		return this.doGetPicks(filter, { enableEditorSymbolSearch: lastWasFiltering, includeHelp: runOptions?.includeHelp, from: runOptions?.from }, disposables, token);
+	}
+
+	// if the first pick is the active editor, it's not a useful first hit, so swap it with the second pick
+	override reorderPicks(picks: readonly Pick<IAnythingQuickPickItem>[]): readonly Pick<IAnythingQuickPickItem>[] {
+		const findNonSeparatorItemIndex = (start: number) => {
+			for (let i = start; i < picks.length; i += 1) {
+				if (picks[i].type !== 'separator') {
+					return i;
+				}
+			}
+			return -1;
+		};
+
+		const firstIndex = findNonSeparatorItemIndex(0);
+		if (firstIndex < 0) {
+			return picks;
+		}
+
+		const firstPick = picks[firstIndex];
+		if (!('resource' in firstPick) || !firstPick.resource || firstPick.resource?.fsPath !== this.editorService.activeEditor?.resource?.fsPath) {
+			// first pick is not the active editor
+			return picks;
+		}
+
+		// the first pick is the current editor so it's not a useful first hit
+		const secondIndex = findNonSeparatorItemIndex(firstIndex + 1);
+		if (secondIndex < 0) {
+			return picks; // nothing to switch with
+		}
+
+		const secondPick = picks[secondIndex];
+		if (secondIndex === firstIndex + 1) {
+			// the second item does not have its own separator, so we can simply swap the first and second
+			const retval = Array.from(picks);
+			retval[firstIndex] = secondPick;
+			retval[secondIndex] = firstPick;
+			return retval;
+		} else {
+			// there is a separator before the second item, we need to move the second item together with its seaparator
+			//   maybe something like firstWithSeparator (array)
+			const secondSeparator = picks[secondIndex - 1];
+
+			if (firstIndex === 0) {
+				// first pick isn't preceded by a separator
+				return [
+					secondPick,
+					firstPick,
+					secondSeparator,
+					...picks.slice(secondIndex + 1),
+				];
+			} else {
+				const firstSeparator = picks[firstIndex - 1];
+				return [
+					secondSeparator,
+					secondPick,
+					firstSeparator,
+					firstPick,
+					secondSeparator, // repeated as it applies to the following picks
+					...picks.slice(secondIndex + 1),
+				];
+			}
+		}
 	}
 
 	private doGetPicks(

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -315,7 +315,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		}
 
 		const firstPick = picks[firstIndex];
-		if (!('resource' in firstPick) || !firstPick.resource || firstPick.resource?.fsPath !== this.editorService.activeEditor?.resource?.fsPath) {
+		if (!('resource' in firstPick) || !firstPick.resource || firstPick.resource.fsPath !== this.editorService.activeEditor?.resource?.fsPath) {
 			// first pick is not the active editor
 			return picks;
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #159299 

This code intercepts quick-open pick lists and if the first pick is the same file as the current editor, it switches the first two results.

It's my first attempt to contribute to VSCode therefore it's more of an RFC, I guess. 8-) 

To test this, go to quick open (ctrl-p or cmd-p), type something to find a file, open that file, then go to quick open, type the same something as before, and the same file shouldn't be the first pick this time.
