### PR TITLE
TypeError: Cannot read properties of null (reading 'value')

### DIFF
--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -701,8 +701,7 @@ class ExtHostTreeView<T> extends Disposable {
 
 	private validateTreeItem(extensionTreeItem: vscode.TreeItem) {
 		if (!TreeItem.isTreeItem(extensionTreeItem)) {
-			// TODO: #154757 we should consider throwing, but let's wait and see if there are tons of reports of this first.
-			console.log(`Extension ${this.extension.identifier.value} has provided an invalid tree item.`);
+			throw new Error(`Extension ${this.extension.identifier.value} has provided an invalid tree item.`);
 		}
 	}
 


### PR DESCRIPTION
Start throwing when we get a bad tree item.
Fixes #154757