### PR TITLE
Clear passwords that don't decrypt

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadSecretState.ts
+++ b/src/vs/workbench/api/browser/mainThreadSecretState.ts
@@ -65,9 +65,17 @@ export class MainThreadSecretState extends Disposable implements MainThreadSecre
 				if (value.extensionId === extensionId) {
 					return value.content;
 				}
-			} catch (e) {
-				this.logService.error(e);
-				throw new Error('Cannot get password');
+			} catch (parseError) {
+				this.logService.error(parseError);
+
+				// If we can't parse the decrypted value, then it's not a valid secret so we should try to delete it
+				try {
+					await this.credentialsService.deletePassword(fullKey, key);
+				} catch (e) {
+					this.logService.error(e);
+				}
+
+				throw new Error('Unable to parse decrypted password');
 			}
 		}
 


### PR DESCRIPTION
If a password is not decrypted properly, then it should be removed from the secret storage because it's essentially dead.

Fixes #151654

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
