### PR TITLE
Some explorer commands should ignore nested children

### DIFF
--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -147,7 +147,7 @@ export class ExplorerService implements IExplorerService {
 		this.view = contextProvider;
 	}
 
-	getContext(respectMultiSelection: boolean): ExplorerItem[] {
+	getContext(respectMultiSelection: boolean, ignoreNestedChildren: boolean = false): ExplorerItem[] {
 		if (!this.view) {
 			return [];
 		}
@@ -155,7 +155,7 @@ export class ExplorerService implements IExplorerService {
 		const items = new Set<ExplorerItem>(this.view.getContext(respectMultiSelection));
 		items.forEach(item => {
 			try {
-				if (respectMultiSelection && this.view?.isItemCollapsed(item) && item.nestedChildren) {
+				if (respectMultiSelection && !ignoreNestedChildren && this.view?.isItemCollapsed(item) && item.nestedChildren) {
 					for (const child of item.nestedChildren) {
 						items.add(child);
 					}

--- a/src/vs/workbench/contrib/files/browser/files.ts
+++ b/src/vs/workbench/contrib/files/browser/files.ts
@@ -23,7 +23,7 @@ export interface IExplorerService {
 	readonly roots: ExplorerItem[];
 	readonly sortOrderConfiguration: ISortOrderConfiguration;
 
-	getContext(respectMultiSelection: boolean): ExplorerItem[];
+	getContext(respectMultiSelection: boolean, ignoreNestedChildren?: boolean): ExplorerItem[];
 	hasViewFocus(): boolean;
 	setEditable(stat: ExplorerItem, data: IEditableData | null): Promise<void>;
 	getEditable(): { stat: ExplorerItem; data: IEditableData } | undefined;
@@ -105,7 +105,7 @@ export function getMultiSelectedResources(resource: URI | object | undefined, li
 		// Explorer
 		if (list instanceof AsyncDataTree && list.getFocus().every(item => item instanceof ExplorerItem)) {
 			// Explorer
-			const context = explorerService.getContext(true);
+			const context = explorerService.getContext(true, true);
 			if (context.length) {
 				return context.map(c => c.resource);
 			}


### PR DESCRIPTION
Fixes #155766
Fixes #159228

Some explorer commands such as `delete` we want to act on the whole file stack with nested files. Others such as `copy path` we want to ingore the files nested beneath.