### PR TITLE
Pick up newest markdown language service

### DIFF
--- a/extensions/markdown-language-features/server/README.md
+++ b/extensions/markdown-language-features/server/README.md
@@ -23,12 +23,20 @@ This server uses the [Markdown Language Service](https://github.com/microsoft/vs
 
 - [Find all references](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_references) to headers and links across all Markdown files in the workspace.
 
-- [Rename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename) of headers and links across all Markdown files in the workspace.
-
 - [Go to definition](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_definition) from links to headers or link definitions.
 
-- (experimental) [Pull diagnostics (validation)](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics) for links.
+- [Rename](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename) of headers and links across all Markdown files in the workspace.
 
+- Find all references to a file. Uses a custom `markdown/getReferencesToFileInWorkspace` message.
+
+- [Code Actions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeAction)
+
+	- Organize link definitions source action.
+	- Extract link to definition refactoring.
+
+- (experimental) Updating links when a file is moved / renamed. Uses a custom `markdown/getEditForFileRenames` message.
+
+- (experimental) [Pull diagnostics (validation)](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics) for links.
 
 
 ## Client requirements

--- a/extensions/markdown-language-features/server/package.json
+++ b/extensions/markdown-language-features/server/package.json
@@ -13,7 +13,8 @@
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.5",
     "vscode-languageserver-types": "^3.17.1",
-    "vscode-markdown-languageservice": "^0.0.1",
+    "vscode-markdown-languageservice": "^0.1.0-alpha.1",
+    "vscode-nls": "^5.0.1",
     "vscode-uri": "^3.0.3"
   },
   "devDependencies": {

--- a/extensions/markdown-language-features/server/yarn.lock
+++ b/extensions/markdown-language-features/server/yarn.lock
@@ -42,10 +42,10 @@ vscode-languageserver@^8.0.2:
   dependencies:
     vscode-languageserver-protocol "3.17.2"
 
-vscode-markdown-languageservice@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.0.1.tgz#40398c7cb2d169359e690bc76bd6618dc377e58a"
-  integrity sha512-zQuAJXLY3Wmu7LknHaes8dDZt0TWwgJQlLocbHgBtnMp6Tdv7zgNToIkW4k4OReqpiOLt0llIamM29e6ober0Q==
+vscode-markdown-languageservice@^0.1.0-alpha.1:
+  version "0.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.1.0-alpha.1.tgz#60a9b445240eb2f90b5f2cfe203f9cdf1773d674"
+  integrity sha512-2detAtQRLGdc6MgdQI/8/+Bypa3enw6SA/ia4PCBctwO422kvYjBlyICnqP12ju6DVUNxfLQg5aNqa90xO1H2A==
   dependencies:
     picomatch "^2.3.1"
     vscode-languageserver-textdocument "^1.0.5"


### PR DESCRIPTION
This brings support for code actions and source actions, along with some bug fixes

Also fixes `getAllMarkdownDocuments` to prefer open documents instead of those on disk
