### PR TITLE
Fixes #159034

### DIFF
--- a/src/vs/editor/contrib/find/browser/findOptionsWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findOptionsWidget.ts
@@ -41,6 +41,7 @@ export class FindOptionsWidget extends Widget implements IOverlayWidget {
 
 		this._domNode = document.createElement('div');
 		this._domNode.className = 'findOptionsWidget';
+		this._domNode.style.zIndex = '11';
 		this._domNode.style.display = 'none';
 		this._domNode.style.top = '10px';
 		this._domNode.setAttribute('role', 'presentation');


### PR DESCRIPTION
Sticky Scroll slides below the find options widget. 
Fixes  #159034.

![sticky-scroll-issue](https://user-images.githubusercontent.com/61460952/187621944-0fc7cf79-bdf5-4b44-9a4d-2287f9bc996b.gif)
