### PR TITLE
joh/fast pigeon

### DIFF
--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -792,7 +792,7 @@ export class Emitter<T> {
 		if (!this._listeners) {
 			return false;
 		}
-		return (!this._listeners.isEmpty());
+		return !this._listeners.isEmpty();
 	}
 }
 
@@ -994,6 +994,11 @@ export class MicrotaskEmitter<T> extends Emitter<T> {
 		this._mergeFn = options?.merge;
 	}
 	override fire(event: T): void {
+
+		if (!this.hasListeners()) {
+			return;
+		}
+
 		this._queuedEvents.push(event);
 		if (this._queuedEvents.length === 1) {
 			queueMicrotask(() => {

--- a/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts
@@ -297,7 +297,7 @@ export class GotoDefinitionAtPositionEditorContribution implements IEditorContri
 		this.editor.setPosition(position);
 		return this.editor.invokeWithinContext((accessor) => {
 			const canPeek = !openToSide && this.editor.getOption(EditorOption.definitionLinkOpensInPeek) && !this.isInPeekEditor(accessor);
-			const action = new DefinitionAction({ openToSide, openInPeek: canPeek, muteMessage: true }, { alias: '', label: '', id: '', precondition: undefined });
+			const action = new DefinitionAction({ openToSide, openInPeek: canPeek, muteMessage: true }, { title: '', id: '', precondition: undefined });
 			return action.run(accessor, this.editor);
 		});
 	}

--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsLocations.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsLocations.ts
@@ -105,7 +105,7 @@ export async function goToDefinitionWithLocation(accessor: ServicesAccessor, eve
 		const isInPeek = PeekContext.inPeekEditor.getValue(contextKeyService);
 		const canPeek = !openToSide && editor.getOption(EditorOption.definitionLinkOpensInPeek) && !isInPeek;
 
-		const action = new DefinitionAction({ openToSide, openInPeek: canPeek, muteMessage: true }, { alias: '', label: '', id: '', precondition: undefined });
+		const action = new DefinitionAction({ openToSide, openInPeek: canPeek, muteMessage: true }, { title: '', id: '', precondition: undefined });
 		return action.run(accessor, editor, { model: ref.object.textEditorModel, position: Range.getStartPosition(location.range) }, Range.lift(location.range));
 	});
 


### PR DESCRIPTION
- use `MicrotaskEmitter` to (drastically) reduce the number of MenuRegistry-change events
- debt - don't use appendMenuItems for goto commands anymore, also migrate to use `EditorAction2`
