### PR TITLE
fix in paste filename logic

### DIFF
--- a/extensions/ipynb/src/notebookImagePaste.ts
+++ b/extensions/ipynb/src/notebookImagePaste.ts
@@ -135,7 +135,9 @@ function buildAttachment(b64: string, cell: vscode.NotebookCell, filename: strin
 			const objEntries = Object.entries(startingAttachments[tempFilename]);
 			if (objEntries.length) { // check that mime:b64 are present
 				const [, attachmentb64] = objEntries[0];
-				if (attachmentb64 !== b64) {	// append a "-#" here. same name, diff data. this matches jupyter behavior
+				if (attachmentb64 === b64) { // checking if filename can be reused, based on camparison of image data
+					break;
+				} else {
 					tempFilename = filename.concat(`-${appendValue}`) + filetype;
 				}
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

needs a break if the base64 data is the same, letting the filename be re-used. Weird loop behavior otherwise