### PR TITLE
Delay PreferencesActionsContribution

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -1243,7 +1243,9 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 }
 
 const workbenchContributionsRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
-workbenchContributionsRegistry.registerWorkbenchContribution(PreferencesActionsContribution, 'PreferencesActionsContribution', LifecyclePhase.Starting);
+// PreferencesActionsContribution is heavy because it runs through various details to determine which actions to render.
+// We don't need it to start so early.
+workbenchContributionsRegistry.registerWorkbenchContribution(PreferencesActionsContribution, 'PreferencesActionsContribution', LifecyclePhase.Restored);
 workbenchContributionsRegistry.registerWorkbenchContribution(PreferencesContribution, 'PreferencesContribution', LifecyclePhase.Starting);
 
 registerEditorContribution(SettingsEditorContribution.ID, SettingsEditorContribution);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Ref https://github.com/microsoft/vscode/issues/159675

PreferencesActionsContribution is a heavy contribution that uses various factors to determine which actions to add in for the Settings editor. I don't think it needs to load so early, nor do I expect many users to even notice that those actions load in later.