### PR TITLE
Refactor code action widget

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -9,7 +9,7 @@ import 'vs/base/browser/ui/codicons/codiconStyles'; // The codicon symbol styles
 import { IAnchor } from 'vs/base/browser/ui/contextview/contextview';
 import { IListEvent, IListMouseEvent, IListRenderer } from 'vs/base/browser/ui/list/list';
 import { List } from 'vs/base/browser/ui/list/listWidget';
-import { Action, IAction, Separator } from 'vs/base/common/actions';
+import { Action, IAction } from 'vs/base/common/actions';
 import { Codicon } from 'vs/base/common/codicons';
 import { canceled } from 'vs/base/common/errors';
 import { ResolvedKeybinding } from 'vs/base/common/keybindings';
@@ -26,6 +26,7 @@ import { codeActionCommandId, CodeActionItem, CodeActionSet, fixAllCommandId, or
 import { CodeActionAutoApply, CodeActionCommandArgs, CodeActionKind, CodeActionTrigger, CodeActionTriggerSource } from 'vs/editor/contrib/codeAction/browser/types';
 import 'vs/editor/contrib/symbolIcons/browser/symbolIcons'; // The codicon symbol colors are defined here and must be loaded to get colors
 import { localize } from 'vs/nls';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
@@ -68,49 +69,42 @@ export interface CodeActionShowOptions {
 	readonly includeDisabledActions: boolean;
 	readonly fromLightbulb?: boolean;
 }
-export interface ICodeActionMenuItem {
-	action: IAction;
-	isSeparator: boolean;
-	isEnabled: boolean;
-	isDocumentation: boolean;
-	isHeader: boolean;
-	headerTitle: string;
-	index: number;
-	disposables?: IDisposable[];
-	params: ICodeActionMenuParameters;
+
+enum CodeActionListItemKind {
+	CodeAction = 'action',
+	Header = 'header'
 }
+
+interface CodeActionListItemCodeAction {
+	readonly kind: CodeActionListItemKind.CodeAction;
+	readonly action: IAction;
+	readonly index: number;
+	readonly params: ICodeActionMenuParameters;
+}
+
+interface CodeActionListItemHeader {
+	readonly kind: CodeActionListItemKind.Header;
+	readonly headerTitle: string;
+	readonly index: number;
+}
+
+type ICodeActionMenuItem = CodeActionListItemCodeAction | CodeActionListItemHeader;
 
 export interface ICodeActionMenuParameters {
-	options: CodeActionShowOptions;
-	trigger: CodeActionTrigger;
-	anchor: { x: number; y: number };
-	menuActions: IAction[];
-	codeActions: CodeActionSet;
-	visible: boolean;
-	showDisabled: boolean;
-	menuObj: CodeActionMenu;
-
-}
-
-export interface ICodeMenuOptions {
-	useCustomDrawn?: boolean;
-	ariaLabel?: string;
-	ariaDescription?: string;
-	minBottomMargin?: number;
-	optionsAsChildren?: boolean;
+	readonly options: CodeActionShowOptions;
+	readonly trigger: CodeActionTrigger;
+	readonly anchor: { x: number; y: number };
+	readonly menuActions: IAction[];
+	readonly documentationActions: readonly Command[];
+	readonly codeActions: CodeActionSet;
+	readonly visible: boolean;
+	readonly showDisabled: boolean;
 }
 
 interface ICodeActionMenuTemplateData {
-	readonly root: HTMLElement;
+	readonly container: HTMLElement;
 	readonly text: HTMLElement;
-	readonly disposables: DisposableStore;
 	readonly icon: HTMLElement;
-}
-
-enum TemplateIds {
-	Header = 'header',
-	Separator = 'separator',
-	Base = 'base',
 }
 
 const codeActionLineHeight = 24;
@@ -119,13 +113,13 @@ const headerLineHeight = 26;
 // TODO: Take a look at user storage for this so it is preserved across windows and on reload.
 let showDisabled = false;
 
-class CodeActionItemRenderer implements IListRenderer<ICodeActionMenuItem, ICodeActionMenuTemplateData> {
+class CodeActionItemRenderer implements IListRenderer<CodeActionListItemCodeAction, ICodeActionMenuTemplateData> {
 	constructor(
 		private readonly acceptKeybindings: [string, string],
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 	) { }
 
-	get templateId(): string { return TemplateIds.Base; }
+	get templateId(): string { return CodeActionListItemKind.CodeAction; }
 
 	renderTemplate(container: HTMLElement): ICodeActionMenuTemplateData {
 		const iconContainer = document.createElement('div');
@@ -138,114 +132,68 @@ class CodeActionItemRenderer implements IListRenderer<ICodeActionMenuItem, ICode
 		const text = document.createElement('span');
 		container.append(text);
 
-		return {
-			root: container,
-			icon,
-			text,
-			disposables: new DisposableStore(),
-		};
+		return { container, icon, text };
 	}
 
-	renderElement(element: ICodeActionMenuItem, index: number, templateData: ICodeActionMenuTemplateData): void {
+	renderElement(element: CodeActionListItemCodeAction, _index: number, templateData: ICodeActionMenuTemplateData): void {
 		const data: ICodeActionMenuTemplateData = templateData;
 
 		const text = element.action.label;
-		element.isEnabled = element.action.enabled;
 
 		if (element.action instanceof CodeActionAction) {
-			const openedFromString = (element.params?.options.fromLightbulb) ? CodeActionTriggerSource.Lightbulb : element.params?.trigger.triggerAction;
+			data.text.textContent = text;
 
-			// Check documentation type
-			element.isDocumentation = element.action.action.kind === CodeActionMenu.documentationID;
-
-			if (element.isDocumentation) {
-				element.isEnabled = false;
-				data.root.classList.add('documentation');
-
-				const container = data.root;
-
-				const actionbarContainer = dom.append(container, dom.$('.codeActionWidget-action-bar'));
-
-				const reRenderAction = showDisabled ?
-					<IAction>{
-						id: 'hideMoreCodeActions',
-						label: localize('hideMoreCodeActions', 'Hide Disabled'),
-						enabled: true,
-						run: () => CodeActionMenu.toggleDisabledOptions(element.params)
-					} :
-					<IAction>{
-						id: 'showMoreCodeActions',
-						label: localize('showMoreCodeActions', 'Show Disabled'),
-						enabled: true,
-						run: () => CodeActionMenu.toggleDisabledOptions(element.params)
-					};
-
-				const actionbar = new ActionBar(actionbarContainer);
-				data.disposables.add(actionbar);
-
-				if (openedFromString === CodeActionTriggerSource.Refactor && (element.params.codeActions.validActions.length > 0 || element.params.codeActions.allActions.length === element.params.codeActions.validActions.length)) {
-					actionbar.push([element.action, reRenderAction], { icon: false, label: true });
-				} else {
-					actionbar.push([element.action], { icon: false, label: true });
-				}
+			// Icons and Label modification based on group
+			const kind = element.action.action.kind ? new CodeActionKind(element.action.action.kind) : CodeActionKind.None;
+			if (CodeActionKind.SurroundWith.contains(kind)) {
+				data.icon.className = Codicon.symbolArray.classNames;
+			} else if (CodeActionKind.Extract.contains(kind)) {
+				data.icon.className = Codicon.wrench.classNames;
+			} else if (CodeActionKind.Convert.contains(kind)) {
+				data.icon.className = Codicon.zap.classNames;
+				data.icon.style.color = `var(--vscode-editorLightBulbAutoFix-foreground)`;
+			} else if (CodeActionKind.QuickFix.contains(kind)) {
+				data.icon.className = Codicon.lightBulb.classNames;
+				data.icon.style.color = `var(--vscode-editorLightBulb-foreground)`;
 			} else {
-				data.text.textContent = text;
+				data.icon.className = Codicon.lightBulb.classNames;
+				data.icon.style.color = `var(--vscode-editorLightBulb-foreground)`;
+			}
 
-				// Icons and Label modifaction based on group
-				const group = element.action.action.kind;
-				if (CodeActionKind.SurroundWith.contains(new CodeActionKind(String(group)))) {
-					data.icon.className = Codicon.symbolArray.classNames;
-				} else if (CodeActionKind.Extract.contains(new CodeActionKind(String(group)))) {
-					data.icon.className = Codicon.wrench.classNames;
-				} else if (CodeActionKind.Convert.contains(new CodeActionKind(String(group)))) {
-					data.icon.className = Codicon.zap.classNames;
-					data.icon.style.color = `var(--vscode-editorLightBulbAutoFix-foreground)`;
-				} else if (CodeActionKind.QuickFix.contains(new CodeActionKind(String(group)))) {
-					data.icon.className = Codicon.lightBulb.classNames;
-					data.icon.style.color = `var(--vscode-editorLightBulb-foreground)`;
-				} else {
-					data.icon.className = Codicon.lightBulb.classNames;
-					data.icon.style.color = `var(--vscode-editorLightBulb-foreground)`;
-				}
-
-				// Check if action has disabled reason
-				if (element.action.action.disabled) {
-					data.root.title = element.action.action.disabled;
-				} else {
-					const updateLabel = () => {
-						const [accept, preview] = this.acceptKeybindings;
-
-						data.root.title = localize({ key: 'label', comment: ['placeholders are keybindings, e.g "F2 to Apply, Shift+F2 to Preview"'] }, "{0} to Apply, {1} to Preview", this.keybindingService.lookupKeybinding(accept)?.getLabel(), this.keybindingService.lookupKeybinding(preview)?.getLabel());
-
-					};
-					updateLabel();
-				}
+			// Check if action has disabled reason
+			if (element.action.action.disabled) {
+				data.container.title = element.action.action.disabled;
+			} else {
+				const updateLabel = () => {
+					const [accept, preview] = this.acceptKeybindings;
+					data.container.title = localize({ key: 'label', comment: ['placeholders are keybindings, e.g "F2 to Apply, Shift+F2 to Preview"'] }, "{0} to Apply, {1} to Preview", this.keybindingService.lookupKeybinding(accept)?.getLabel(), this.keybindingService.lookupKeybinding(preview)?.getLabel());
+				};
+				updateLabel();
 			}
 		}
 
-		if (!element.isEnabled) {
-			data.root.classList.add('option-disabled');
-			data.root.style.backgroundColor = 'transparent !important';
+		if (!element.action.enabled) {
+			data.container.classList.add('option-disabled');
+			data.container.style.backgroundColor = 'transparent !important';
 			data.icon.style.opacity = '0.4';
 		} else {
-			data.root.classList.remove('option-disabled');
+			data.container.classList.remove('option-disabled');
 		}
 	}
 
-	disposeTemplate(templateData: ICodeActionMenuTemplateData): void {
-		templateData.disposables.dispose();
+	disposeTemplate(_templateData: ICodeActionMenuTemplateData): void {
+		// noop
 	}
 }
 
-
 interface HeaderTemplateData {
-	readonly root: HTMLElement;
+	readonly container: HTMLElement;
 	readonly text: HTMLElement;
 }
 
-class HeaderRenderer implements IListRenderer<ICodeActionMenuItem, HeaderTemplateData> {
+class HeaderRenderer implements IListRenderer<CodeActionListItemHeader, HeaderTemplateData> {
 
-	get templateId(): string { return TemplateIds.Header; }
+	get templateId(): string { return CodeActionListItemKind.Header; }
 
 	renderTemplate(container: HTMLElement): HeaderTemplateData {
 		container.classList.add('group-header', 'option-disabled');
@@ -253,15 +201,11 @@ class HeaderRenderer implements IListRenderer<ICodeActionMenuItem, HeaderTemplat
 		const text = document.createElement('span');
 		container.append(text);
 
-		return {
-			root: container,
-			text,
-		};
+		return { container, text };
 	}
 
-	renderElement(element: ICodeActionMenuItem, _index: number, templateData: HeaderTemplateData): void {
+	renderElement(element: CodeActionListItemHeader, _index: number, templateData: HeaderTemplateData): void {
 		templateData.text.textContent = element.headerTitle;
-		element.isEnabled = false;
 	}
 
 	disposeTemplate(_templateData: HeaderTemplateData): void {
@@ -269,38 +213,17 @@ class HeaderRenderer implements IListRenderer<ICodeActionMenuItem, HeaderTemplat
 	}
 }
 
-class SeparatorRenderer implements IListRenderer<ICodeActionMenuItem, void> {
-
-	get templateId(): string { return TemplateIds.Separator; }
-
-	renderTemplate(container: HTMLElement): void {
-		container.classList.add('separator');
-		container.style.height = '10px';
-	}
-
-	renderElement(_element: ICodeActionMenuItem, _index: number, _templateData: void): void {
-		// noop
-	}
-
-	disposeTemplate(_templateData: void): void {
-		// noop
-	}
-}
 
 export class CodeActionMenu extends Disposable implements IEditorContribution {
+
 	private readonly _showingActions = this._register(new MutableDisposable<CodeActionSet>());
 	private codeActionList = this._register(new MutableDisposable<List<ICodeActionMenuItem>>());
-	private options: ICodeActionMenuItem[] = [];
+
 	private _visible: boolean = false;
 	private _ctxMenuWidgetVisible: IContextKey<boolean>;
-	private viewItems: ICodeActionMenuItem[] = [];
+	private viewItems: readonly CodeActionListItemCodeAction[] = [];
 	private focusedEnabledItem: number | undefined;
 	private currSelectedItem: number | undefined;
-	private hasSeparator: boolean = false;
-	private block?: HTMLElement;
-	private pointerBlock?: HTMLElement;
-
-	public static readonly documentationID: string = '_documentation';
 
 	public static readonly ID: string = 'editor.contrib.codeActionMenu';
 
@@ -311,6 +234,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 	constructor(
 		private readonly _editor: ICodeEditor,
 		private readonly _delegate: CodeActionWidgetDelegate,
+		@ICommandService private readonly commandService: ICommandService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
@@ -338,13 +262,16 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 	}
 
 	private _onListSelection(e: IListEvent<ICodeActionMenuItem>): void {
-		if (e.elements.length) {
-			e.elements.forEach(element => {
-				if (element.isEnabled) {
-					element.action.run();
-					this.hideCodeActionWidget();
-				}
-			});
+		let didSelect = false;
+		for (const element of e.elements) {
+			if (element.kind === CodeActionListItemKind.CodeAction) {
+				didSelect = true;
+				element.action.run();
+			}
+		}
+
+		if (didSelect) {
+			this.hideCodeActionWidget();
 		}
 	}
 
@@ -353,7 +280,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			this.currSelectedItem = undefined;
 			this.codeActionList.value?.setFocus([]);
 		} else {
-			if (e.element?.isEnabled) {
+			if (e.element.kind === CodeActionListItemKind.CodeAction && e.element.action.enabled) {
 				this.codeActionList.value?.setFocus([e.element.index]);
 				this.focusedEnabledItem = this.viewItems.indexOf(e.element);
 				this.currSelectedItem = e.element.index;
@@ -365,68 +292,57 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 	}
 
 	private _onListClick(e: IListMouseEvent<ICodeActionMenuItem>): void {
-		if (e.element) {
-			if (!e.element.isEnabled) {
-				this.currSelectedItem = undefined;
-				this.codeActionList.value?.setFocus([]);
-			}
+		if (e.element && e.element.kind === CodeActionListItemKind.CodeAction && !e.element.action.enabled) {
+			this.currSelectedItem = undefined;
+			this.codeActionList.value?.setFocus([]);
 		}
 	}
 
 	/**
 	 * Renders the code action widget given the provided actions.
 	 */
-	private renderCodeActionMenuList(element: HTMLElement, inputArray: IAction[], params: ICodeActionMenuParameters): IDisposable {
+	private renderCodeActionMenuList(element: HTMLElement, inputArray: readonly IAction[], inputDocumentation: readonly Command[], params: ICodeActionMenuParameters): IDisposable {
 		const renderDisposables = new DisposableStore();
-		const renderMenu = document.createElement('div');
+
+		const model = this._editor.getModel();
+		if (!model) {
+			return renderDisposables;
+		}
+
+		const widget = document.createElement('div');
+		widget.classList.add('codeActionWidget');
+		element.appendChild(widget);
 
 		// Render invisible div to block mouse interaction in the rest of the UI
 		const menuBlock = document.createElement('div');
-		this.block = element.appendChild(menuBlock);
-		this.block.classList.add('context-view-block');
-		this.block.style.position = 'fixed';
-		this.block.style.cursor = 'initial';
-		this.block.style.left = '0';
-		this.block.style.top = '0';
-		this.block.style.width = '100%';
-		this.block.style.height = '100%';
-		this.block.style.zIndex = '-1';
+		const block = element.appendChild(menuBlock);
+		block.classList.add('context-view-block');
+		block.style.position = 'fixed';
+		block.style.cursor = 'initial';
+		block.style.left = '0';
+		block.style.top = '0';
+		block.style.width = '100%';
+		block.style.height = '100%';
+		block.style.zIndex = '-1';
+		renderDisposables.add(dom.addDisposableListener(block, dom.EventType.MOUSE_DOWN, e => e.stopPropagation()));
 
-		renderDisposables.add(dom.addDisposableListener(this.block, dom.EventType.MOUSE_DOWN, e => e.stopPropagation()));
+		const codeActionList = document.createElement('div');
+		codeActionList.classList.add('codeActionList');
+		widget.appendChild(codeActionList);
 
-		renderMenu.id = 'codeActionMenuWidget';
-		renderMenu.classList.add('codeActionMenuWidget');
-
-		element.appendChild(renderMenu);
-
-		this.codeActionList.value = new List('codeActionWidget', renderMenu, {
+		this.codeActionList.value = new List('codeActionWidget', codeActionList, {
 			getHeight(element) {
-				if (element.isSeparator) {
-					return 10;
-				} else if (element.isHeader) {
-					return headerLineHeight;
-				} else {
-					return codeActionLineHeight;
-				}
+				return element.kind === CodeActionListItemKind.Header ? headerLineHeight : codeActionLineHeight;
 			},
-			getTemplateId(element) {
-				if (element.isHeader) {
-					return TemplateIds.Header;
-				} else if (element.isSeparator) {
-					return TemplateIds.Separator;
-				} else {
-					return TemplateIds.Base;
-				}
-			}
+			getTemplateId: element => element.kind,
 		}, [
 			new CodeActionItemRenderer([acceptSelectedCodeActionCommand, previewSelectedCodeActionCommand], this.keybindingService),
 			new HeaderRenderer(),
-			new SeparatorRenderer(),
 		], {
 			keyboardSupport: false,
 			accessibilityProvider: {
 				getAriaLabel: element => {
-					if (element.action instanceof CodeActionAction) {
+					if (element.kind === CodeActionListItemKind.CodeAction && element.action instanceof CodeActionAction) {
 						let label = element.action.label;
 						if (!element.action.enabled) {
 							if (element.action instanceof CodeActionAction) {
@@ -444,19 +360,19 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		});
 
 		const pointerBlockDiv = document.createElement('div');
-		this.pointerBlock = element.appendChild(pointerBlockDiv);
-		this.pointerBlock.classList.add('context-view-pointerBlock');
-		this.pointerBlock.style.position = 'fixed';
-		this.pointerBlock.style.cursor = 'initial';
-		this.pointerBlock.style.left = '0';
-		this.pointerBlock.style.top = '0';
-		this.pointerBlock.style.width = '100%';
-		this.pointerBlock.style.height = '100%';
-		this.pointerBlock.style.zIndex = '2';
+		const pointerBlock = element.appendChild(pointerBlockDiv);
+		pointerBlock.classList.add('context-view-pointerBlock');
+		pointerBlock.style.position = 'fixed';
+		pointerBlock.style.cursor = 'initial';
+		pointerBlock.style.left = '0';
+		pointerBlock.style.top = '0';
+		pointerBlock.style.width = '100%';
+		pointerBlock.style.height = '100%';
+		pointerBlock.style.zIndex = '2';
 
 		// Removes block on click INSIDE widget or ANY mouse movement
-		renderDisposables.add(dom.addDisposableListener(this.pointerBlock, dom.EventType.POINTER_MOVE, () => this.pointerBlock?.remove()));
-		renderDisposables.add(dom.addDisposableListener(this.pointerBlock, dom.EventType.MOUSE_DOWN, () => this.pointerBlock?.remove()));
+		renderDisposables.add(dom.addDisposableListener(pointerBlock, dom.EventType.POINTER_MOVE, () => pointerBlock.remove()));
+		renderDisposables.add(dom.addDisposableListener(pointerBlock, dom.EventType.MOUSE_DOWN, () => pointerBlock.remove()));
 
 		renderDisposables.add(this.codeActionList.value.onMouseClick(e => this._onListClick(e)));
 		renderDisposables.add(this.codeActionList.value.onMouseOver(e => this._onListHover(e)));
@@ -464,19 +380,12 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		renderDisposables.add(this.codeActionList.value.onDidChangeSelection(e => this._onListSelection(e)));
 		renderDisposables.add(this._editor.onDidLayoutChange(() => this.hideCodeActionWidget()));
 
-		const model = this._editor.getModel();
-
-		if (!model) {
-			return renderDisposables;
-		}
-
 		let numHeaders = 0;
 		const totalActionEntries: (IAction | string)[] = [];
 
 		// Checks if headers are disabled.
 		if (!this.isCodeActionWidgetHeadersShown(model)) {
 			totalActionEntries.push(...inputArray);
-
 		} else {
 			// Filters and groups code actions by their group
 			const menuEntries: IAction[][] = [];
@@ -487,37 +396,29 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			const convertGroup: IAction[] = [];
 			const surroundGroup: IAction[] = [];
 			const sourceGroup: IAction[] = [];
-			const separatorGroup: IAction[] = [];
-			const documentationGroup: IAction[] = [];
 			const otherGroup: IAction[] = [];
 
 			inputArray.forEach((item) => {
 				if (item instanceof CodeActionAction) {
-					const optionKind = item.action.kind;
-
-					if (CodeActionKind.SurroundWith.contains(new CodeActionKind(String(optionKind)))) {
+					const kind = item.action.kind ? new CodeActionKind(item.action.kind) : CodeActionKind.None;
+					if (CodeActionKind.SurroundWith.contains(kind)) {
 						surroundGroup.push(item);
-					} else if (CodeActionKind.QuickFix.contains(new CodeActionKind(String(optionKind)))) {
+					} else if (CodeActionKind.QuickFix.contains(kind)) {
 						quickfixGroup.push(item);
-					} else if (CodeActionKind.Extract.contains(new CodeActionKind(String(optionKind)))) {
+					} else if (CodeActionKind.Extract.contains(kind)) {
 						extractGroup.push(item);
-					} else if (CodeActionKind.Convert.contains(new CodeActionKind(String(optionKind)))) {
+					} else if (CodeActionKind.Convert.contains(kind)) {
 						convertGroup.push(item);
-					} else if (CodeActionKind.Source.contains(new CodeActionKind(String(optionKind)))) {
+					} else if (CodeActionKind.Source.contains(kind)) {
 						sourceGroup.push(item);
-					} else if (optionKind === CodeActionMenu.documentationID) {
-						documentationGroup.push(item);
 					} else {
 						// Pushes all the other actions to the "Other" group
 						otherGroup.push(item);
 					}
-
-				} else if (item.id === `vs.actions.separator`) {
-					separatorGroup.push(item);
 				}
 			});
 
-			menuEntries.push(quickfixGroup, extractGroup, convertGroup, surroundGroup, sourceGroup, otherGroup, separatorGroup, documentationGroup);
+			menuEntries.push(quickfixGroup, extractGroup, convertGroup, surroundGroup, sourceGroup, otherGroup);
 
 			const menuEntriesToPush = (menuID: string, entry: IAction[]) => {
 				totalActionEntries.push(menuID);
@@ -527,20 +428,17 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			// Creates flat list of all menu entries with headers as separators
 			menuEntries.forEach(entry => {
 				if (entry.length > 0 && entry[0] instanceof CodeActionAction) {
-					const firstAction = entry[0].action.kind;
-					if (CodeActionKind.SurroundWith.contains(new CodeActionKind(String(firstAction)))) {
+					const firstKind = entry[0].action.kind ? new CodeActionKind(entry[0].action.kind) : CodeActionKind.None;
+					if (CodeActionKind.SurroundWith.contains(firstKind)) {
 						menuEntriesToPush(localize('codeAction.widget.id.surround', 'Surround With...'), entry);
-					} else if (CodeActionKind.QuickFix.contains(new CodeActionKind(String(firstAction)))) {
+					} else if (CodeActionKind.QuickFix.contains(firstKind)) {
 						menuEntriesToPush(localize('codeAction.widget.id.quickfix', 'Quick Fix...'), entry);
-					} else if (CodeActionKind.Extract.contains(new CodeActionKind(String(firstAction)))) {
+					} else if (CodeActionKind.Extract.contains(firstKind)) {
 						menuEntriesToPush(localize('codeAction.widget.id.extract', 'Extract...'), entry);
-					} else if (CodeActionKind.Convert.contains(new CodeActionKind(String(firstAction)))) {
+					} else if (CodeActionKind.Convert.contains(firstKind)) {
 						menuEntriesToPush(localize('codeAction.widget.id.convert', 'Convert...'), entry);
-					} else if (CodeActionKind.Source.contains(new CodeActionKind(String(firstAction)))) {
+					} else if (CodeActionKind.Source.contains(firstKind)) {
 						menuEntriesToPush(localize('codeAction.widget.id.source', 'Source Action...'), entry);
-
-					} else if (firstAction === CodeActionMenu.documentationID) {
-						totalActionEntries.push(...entry);
 					} else {
 						// Takes and flattens all the `other` actions
 						menuEntriesToPush(localize('codeAction.widget.id.more', 'More Actions...'), entry);
@@ -549,64 +447,28 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 					// case for separator - separators are not codeActionAction typed
 					totalActionEntries.push(...entry);
 				}
-
 			});
-
 		}
 
 		// Populating the list widget and tracking enabled options.
-		totalActionEntries.forEach((item, index) => {
+		const allMenuItems = totalActionEntries.map((item, index): ICodeActionMenuItem => {
 			if (typeof item === `string`) {
-				const menuItem = <ICodeActionMenuItem>{ isEnabled: false, isSeparator: false, index, isHeader: true, headerTitle: item };
-				this.options.push(menuItem);
+				return { kind: CodeActionListItemKind.Header, index, headerTitle: item };
 			} else {
-				const currIsSeparator = item.class === 'separator';
-
-				if (currIsSeparator) {
-					// set to true forever because there is a separator
-					this.hasSeparator = true;
-				}
-
-				const menuItem = <ICodeActionMenuItem>{ action: item, isEnabled: item.enabled, isSeparator: currIsSeparator, index, params };
-				if (item.enabled) {
-					this.viewItems.push(menuItem);
-				}
-				this.options.push(menuItem);
+				return { kind: CodeActionListItemKind.CodeAction, action: item, index, params };
 			}
 		});
 
-		this.codeActionList.value.splice(0, this.codeActionList.value.length, this.options);
+		this.viewItems = allMenuItems.filter(item => item.kind === CodeActionListItemKind.CodeAction && item.action.enabled) as CodeActionListItemCodeAction[];
+		this.codeActionList.value.splice(0, this.codeActionList.value.length, allMenuItems);
 
 		// Updating list height, depending on how many separators and headers there are.
-		const height = this.hasSeparator ? (totalActionEntries.length - 1) * codeActionLineHeight + 10 : totalActionEntries.length * codeActionLineHeight;
+		const height = totalActionEntries.length * codeActionLineHeight;
 		const heightWithHeaders = height + numHeaders * headerLineHeight - numHeaders * codeActionLineHeight;
-		renderMenu.style.height = String(heightWithHeaders) + 'px';
 		this.codeActionList.value.layout(heightWithHeaders);
 
-		// For finding width dynamically (not using resize observer)
-		const arr: number[] = [];
-		this.options.forEach((item, index) => {
-			if (!this.codeActionList.value) {
-				return;
-			}
-			const element = document.getElementById(this.codeActionList.value?.getElementID(index))?.querySelector('span')?.offsetWidth;
-			arr.push(element ?? 0);
-		});
-
-		// resize observer - can be used in the future since list widget supports dynamic height but not width
-		let maxWidth = Math.max(...arr);
-
-		// If there are no actions, the minimum width is the width of the list widget's action bar.
-		if (params.trigger.triggerAction === CodeActionTriggerSource.Refactor && maxWidth < 230) {
-			maxWidth = 230;
-		}
-
-		// 52 is the additional padding for the list widget (26 left, 26 right)
-		renderMenu.style.width = maxWidth + 52 + 5 + 'px';
-		this.codeActionList.value?.layout(heightWithHeaders, maxWidth);
-
 		// List selection
-		if (this.viewItems.length < 1 || this.viewItems.every(item => item.isDocumentation)) {
+		if (this.viewItems.length < 1) {
 			this.currSelectedItem = undefined;
 		} else {
 			this.focusedEnabledItem = 0;
@@ -622,6 +484,66 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		});
 		renderDisposables.add(blurListener);
 		renderDisposables.add(focusTracker);
+
+		// Action bar
+		let actionBarWidth = 0;
+		if (!params?.options.fromLightbulb) {
+			const actions = inputDocumentation.map((doc): IAction => ({
+				id: doc.id,
+				label: doc.title,
+				tooltip: doc.tooltip ?? '',
+				class: undefined,
+				enabled: true,
+				run: () => this.commandService.executeCommand(doc.id, ...(doc.arguments ?? [])),
+			}));
+
+			if (params.options.includeDisabledActions && params.codeActions.validActions.length > 0 && params.codeActions.allActions.length !== params.codeActions.validActions.length) {
+				actions.push(showDisabled ? {
+					id: 'hideMoreCodeActions',
+					label: localize('hideMoreCodeActions', 'Hide Disabled'),
+					enabled: true,
+					tooltip: '',
+					class: undefined,
+					run: () => this.toggleDisabledOptions(params, false)
+				} : {
+					id: 'showMoreCodeActions',
+					label: localize('showMoreCodeActions', 'Show Disabled'),
+					enabled: true,
+					tooltip: '',
+					class: undefined,
+					run: () => this.toggleDisabledOptions(params, true)
+				});
+			}
+
+			if (actions.length) {
+				const actionbarContainer = dom.append(widget, dom.$('.codeActionWidget-action-bar'));
+				const actionbar = renderDisposables.add(new ActionBar(actionbarContainer));
+				actionbar.push(actions, { icon: false, label: true });
+				actionBarWidth = actionbarContainer.offsetWidth;
+			}
+		}
+
+		// For finding width dynamically (not using resize observer)
+		const itemWidths: number[] = allMenuItems.map((_, index): number => {
+			if (!this.codeActionList.value) {
+				return 0;
+			}
+			const element = document.getElementById(this.codeActionList.value?.getElementID(index));
+			if (element) {
+				const textPadding = 10;
+				const iconPadding = 10;
+				return [...element.children].reduce((p, c) => p + c.clientWidth, 0) + (textPadding * 2) + iconPadding;
+			}
+			return 0;
+		});
+
+		// resize observer - can be used in the future since list widget supports dynamic height but not width
+		const width = Math.max(...itemWidths, actionBarWidth);
+		widget.style.width = width + 'px';
+		this.codeActionList.value?.layout(heightWithHeaders, width);
+
+		codeActionList.style.height = `${heightWithHeaders}px`;
+
 		this._ctxMenuWidgetVisible.set(true);
 
 		return renderDisposables;
@@ -630,11 +552,11 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 	/**
 	 * Focuses on the previous item in the list using the list widget.
 	 */
-	protected focusPrevious() {
+	public focusPrevious() {
 		if (typeof this.focusedEnabledItem === 'undefined') {
 			this.focusedEnabledItem = this.viewItems[0].index;
 		} else if (this.viewItems.length < 1) {
-			return false;
+			return;
 		}
 
 		const startIndex = this.focusedEnabledItem;
@@ -648,19 +570,17 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			item = this.viewItems[this.focusedEnabledItem];
 			this.codeActionList.value?.setFocus([item.index]);
 			this.currSelectedItem = item.index;
-		} while (this.focusedEnabledItem !== startIndex && ((!item.isEnabled) || item.action.id === Separator.ID));
-
-		return true;
+		} while (this.focusedEnabledItem !== startIndex && !item.action.enabled);
 	}
 
 	/**
 	 * Focuses on the next item in the list using the list widget.
 	 */
-	protected focusNext() {
+	public focusNext() {
 		if (typeof this.focusedEnabledItem === 'undefined') {
 			this.focusedEnabledItem = this.viewItems.length - 1;
 		} else if (this.viewItems.length < 1) {
-			return false;
+			return;
 		}
 
 		const startIndex = this.focusedEnabledItem;
@@ -671,17 +591,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			item = this.viewItems[this.focusedEnabledItem];
 			this.codeActionList.value?.setFocus([item.index]);
 			this.currSelectedItem = item.index;
-		} while (this.focusedEnabledItem !== startIndex && ((!item.isEnabled) || item.action.id === Separator.ID));
-
-		return true;
-	}
-
-	public navigateListWithKeysUp() {
-		this.focusPrevious();
-	}
-
-	public navigateListWithKeysDown() {
-		this.focusNext();
+		} while (this.focusedEnabledItem !== startIndex && !item.action.enabled);
 	}
 
 	public onEnterSet() {
@@ -690,17 +600,11 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		}
 	}
 
-	override dispose() {
-		super.dispose();
-	}
-
 	hideCodeActionWidget() {
 		this._ctxMenuWidgetVisible.reset();
-		this.options = [];
 		this.viewItems = [];
 		this.focusedEnabledItem = 0;
 		this.currSelectedItem = undefined;
-		this.hasSeparator = false;
 		this._contextViewService.hideContextView();
 	}
 
@@ -723,17 +627,16 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			codeActionFrom: openedFromString,
 			validCodeActions: CodeActions.validActions.length,
 			cancelled: didCancel,
-
 		});
 	}
 
 	/**
 	 * Helper function to create a context view item using code action `params`.
 	 */
-	private showContextViewHelper(params: ICodeActionMenuParameters, menuActions: IAction[]) {
+	private showContextViewHelper(params: ICodeActionMenuParameters, menuActions: readonly IAction[], documentation: readonly Command[]) {
 		this._contextViewService.showContextView({
 			getAnchor: () => params.anchor,
-			render: (container: HTMLElement) => this.renderCodeActionMenuList(container, menuActions, params),
+			render: (container: HTMLElement) => this.renderCodeActionMenuList(container, menuActions, documentation, params),
 			onHide: (didCancel: boolean) => {
 				const openedFromString = (params.options.fromLightbulb) ? CodeActionTriggerSource.Lightbulb : params.trigger.triggerAction;
 				this.codeActionTelemetry(openedFromString, didCancel, params.codeActions);
@@ -743,22 +646,22 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		},
 			this._editor.getDomNode()!, false,
 		);
-
 	}
 
 	/**
 	 * Toggles whether the disabled actions in the code action widget are visible or not.
 	 */
-	public static toggleDisabledOptions(params: ICodeActionMenuParameters): void {
-		params.menuObj.hideCodeActionWidget();
+	public toggleDisabledOptions(params: ICodeActionMenuParameters, newShowDisabled: boolean): void {
+		this.hideCodeActionWidget();
 
-		showDisabled = !showDisabled;
+		showDisabled = newShowDisabled;
 
 		const actionsToShow = showDisabled ? params.codeActions.allActions : params.codeActions.validActions;
 
-		const menuActions = params.menuObj.getMenuActions(params.trigger, actionsToShow, params.codeActions.documentation);
+		const menuActions = this.getMenuActions(params.trigger, actionsToShow);
+		const documentationActions = this.getDocumentation(params.trigger, actionsToShow, params.codeActions.documentation);
 
-		params.menuObj.showContextViewHelper(params, menuActions);
+		this.showContextViewHelper(params, menuActions, documentationActions);
 	}
 
 	public async show(trigger: CodeActionTrigger, codeActions: CodeActionSet, at: IAnchor | IPosition, options: CodeActionShowOptions): Promise<void> {
@@ -767,13 +670,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			return;
 		}
 
-		let actionsToShow = options.includeDisabledActions ? codeActions.allActions : codeActions.validActions;
-
-		// If there are no refactorings, we should still show the menu and only displayed disabled actions without `enable` button.
-		if (trigger.triggerAction === CodeActionTriggerSource.Refactor && codeActions.validActions.length > 0) {
-			actionsToShow = showDisabled ? codeActions.allActions : codeActions.validActions;
-		}
-
+		const actionsToShow = options.includeDisabledActions ? codeActions.allActions : codeActions.validActions;
 		if (!actionsToShow.length) {
 			this._visible = false;
 			return;
@@ -788,27 +685,30 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		this._visible = true;
 		this._showingActions.value = codeActions;
 
-		const menuActions = this.getMenuActions(trigger, actionsToShow, codeActions.documentation);
+		const menuActions = this.getMenuActions(trigger, actionsToShow);
+		const documentationActions = this.getDocumentation(trigger, actionsToShow, codeActions.documentation);
+		const anchor = Position.isIPosition(at) ? this._toCoords(at) : at;
 
-		const anchor = Position.isIPosition(at) ? this._toCoords(at) : at || { x: 0, y: 0 };
-
-		const params = <ICodeActionMenuParameters>{ options, trigger, codeActions, anchor, menuActions, showDisabled: true, visible: this._visible, menuObj: this };
-		this.showContextViewHelper(params, menuActions);
+		const params: ICodeActionMenuParameters = { options, trigger, codeActions, anchor, menuActions, documentationActions, showDisabled, visible: this._visible };
+		this.showContextViewHelper(params, menuActions, documentationActions);
 	}
 
 	private getMenuActions(
 		trigger: CodeActionTrigger,
-		actionsToShow: readonly CodeActionItem[],
-		documentation: readonly Command[]
-	): IAction[] {
-		const toCodeActionAction = (item: CodeActionItem): CodeActionAction => new CodeActionAction(item.action, () => this._delegate.onSelectCodeAction(item, trigger));
-		const result: IAction[] = actionsToShow
-			.map(toCodeActionAction);
+		actionsToShow: readonly CodeActionItem[]
+	): CodeActionAction[] {
+		return actionsToShow.map(item => new CodeActionAction(item.action, () => this._delegate.onSelectCodeAction(item, trigger)));
+	}
 
+	private getDocumentation(
+		trigger: CodeActionTrigger,
+		actionsToShow: readonly CodeActionItem[],
+		documentation: readonly Command[],
+	): Command[] {
 		const allDocumentation: Command[] = [...documentation];
 
 		const model = this._editor.getModel();
-		if (model && result.length) {
+		if (model && actionsToShow.length) {
 			for (const provider of this._languageFeaturesService.codeActionProvider.all(model)) {
 				if (provider._getAdditionalMenuItems) {
 					allDocumentation.push(...provider._getAdditionalMenuItems({ trigger: trigger.type, only: trigger.filter?.include?.value }, actionsToShow.map(item => item.action)));
@@ -816,15 +716,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 			}
 		}
 
-		if (allDocumentation.length) {
-			result.push(new Separator(), ...allDocumentation.map(command => toCodeActionAction(new CodeActionItem({
-				title: command.title,
-				command: command,
-				kind: CodeActionMenu.documentationID
-			}, undefined))));
-		}
-
-		return result;
+		return allDocumentation;
 	}
 
 	private _toCoords(position: IPosition): { x: number; y: number } {

--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -600,7 +600,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		}
 	}
 
-	hideCodeActionWidget() {
+	public hideCodeActionWidget() {
 		this._ctxMenuWidgetVisible.reset();
 		this.viewItems = [];
 		this.focusedEnabledItem = 0;
@@ -608,7 +608,7 @@ export class CodeActionMenu extends Disposable implements IEditorContribution {
 		this._contextViewService.hideContextView();
 	}
 
-	codeActionTelemetry(openedFromString: CodeActionTriggerSource, didCancel: boolean, CodeActions: CodeActionSet) {
+	private codeActionTelemetry(openedFromString: CodeActionTriggerSource, didCancel: boolean, CodeActions: CodeActionSet) {
 		type ApplyCodeActionEvent = {
 			codeActionFrom: CodeActionTriggerSource;
 			validCodeActions: number;

--- a/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
@@ -65,15 +65,11 @@ export class CodeActionUi extends Disposable {
 	}
 
 	public hideCodeActionWidget() {
-		if (this._codeActionWidget.hasValue()) {
-			this._codeActionWidget.getValue().hideCodeActionWidget();
-		}
+		this._codeActionWidget.rawValue?.hideCodeActionWidget();
 	}
 
 	public onEnter() {
-		if (this._codeActionWidget.hasValue()) {
-			this._codeActionWidget.getValue().onEnterSet();
-		}
+		this._codeActionWidget.rawValue?.onEnterSet();
 	}
 
 	public onPreviewEnter() {
@@ -82,12 +78,10 @@ export class CodeActionUi extends Disposable {
 	}
 
 	public navigateList(navUp: Boolean) {
-		if (this._codeActionWidget.hasValue()) {
-			if (navUp) {
-				this._codeActionWidget.getValue().navigateListWithKeysUp();
-			} else {
-				this._codeActionWidget.getValue().navigateListWithKeysDown();
-			}
+		if (navUp) {
+			this._codeActionWidget.rawValue?.focusPrevious();
+		} else {
+			this._codeActionWidget.rawValue?.focusNext();
 		}
 	}
 

--- a/src/vs/editor/contrib/codeAction/browser/media/action.css
+++ b/src/vs/editor/contrib/codeAction/browser/media/action.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.codeActionMenuWidget .monaco-list:not(.element-focused):focus:before {
+.codeActionWidget .monaco-list:not(.element-focused):focus:before {
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -12,17 +12,16 @@
 	z-index: 5; /* make sure we are on top of the tree items */
 	content: "";
 	pointer-events: none; /* enable click through */
-	outline: 0px solid !important; /* we still need to handle the empty tree or no focus item case */
-	outline-width: 0px !important;
+	outline: 0 solid !important; /* we still need to handle the empty tree or no focus item case */
+	outline-width: 0 !important;
 	outline-style: none;
-	outline-offset: 0px;
+	outline-offset: 0;
 }
 
-.codeActionMenuWidget {
-	padding: 0px 0px 3px 0px;
+.codeActionWidget {
 	overflow: auto;
 	font-size: 13px;
-	border-radius: 0px;
+	border-radius: 0;
 	min-width: 160px;
 	z-index: 40;
 	display: block;
@@ -33,56 +32,52 @@
 	border-color: none;
 	background-color: var(--vscode-menu-background);
 	color: var(--vscode-menu-foreground);
-	box-shadow: rgb(0,0,0, 16%) 0px 2px 8px;
+	box-shadow: rgb(0,0,0, 16%) 0 2px 8px;
 }
 
 
-.codeActionMenuWidget .monaco-list {
+.codeActionWidget .monaco-list {
 	user-select: none;
 	-webkit-user-select: none;
 	-ms-user-select: none;
 	border: none !important;
-	border-width: 0px !important;
+	border-width: 0 !important;
 }
 
-.codeActionMenuWidget .monaco-list .monaco-scrollable-element .monaco-list-rows {
+.codeActionWidget .monaco-list .monaco-scrollable-element .monaco-list-rows {
 	height: 100% !important;
 }
 
-.codeActionMenuWidget .monaco-list .monaco-scrollable-element {
+.codeActionWidget .monaco-list .monaco-scrollable-element {
 	overflow: visible;
 }
-/** Styles for each row in the list element **/
 
-.codeActionMenuWidget .monaco-list .monaco-list-row:not(.separator) {
+/** Styles for each row in the list element **/
+.codeActionWidget .monaco-list .monaco-list-row:not(.separator) {
 	display: flex;
-	-mox-box-sizing: border-box;
 	box-sizing: border-box;
-	padding: 0px 26px 0px 10px;
-	background-repeat: no-repeat;
-	background-position: 2px 2px;
+	padding: 0 10px;
 	white-space: nowrap;
 	cursor: pointer;
 	touch-action: none;
 	width: 100%;
 }
 
-
-.codeActionMenuWidget .monaco-list .monaco-list-row:hover:not(.option-disabled),
-.codeActionMenuWidget .monaco-list .monaco-list-row.focused:not(.option-disabled) {
+.codeActionWidget .monaco-list .monaco-list-row:hover:not(.option-disabled),
+.codeActionWidget .monaco-list .monaco-list-row.focused:not(.option-disabled) {
 	background-color: var(--vscode-list-hoverBackground) !important;
 	color: var(--vscode-list-activeSelectionForeground) !important;
 }
 
-.codeActionMenuWidget .monaco-list .monaco-list-row.focused:not(.option-disabled)  {
-	outline: 0px solid !important;
+.codeActionWidget .monaco-list .monaco-list-row.focused:not(.option-disabled)  {
+	outline: 0 solid !important;
 	background-color: var(--vscode-menu-selectionBackground) !important;
 }
 
-.codeActionMenuWidget .monaco-list .option-disabled,
-.codeActionMenuWidget .monaco-list .option-disabled:before,
-.codeActionMenuWidget .monaco-list .option-disabled .focused,
-.codeActionMenuWidget .monaco-list .option-disabled .focused:before {
+.codeActionWidget .monaco-list .option-disabled,
+.codeActionWidget .monaco-list .option-disabled:before,
+.codeActionWidget .monaco-list .option-disabled .focused,
+.codeActionWidget .monaco-list .option-disabled .focused:before {
 	cursor: default !important;
 	-webkit-touch-callout: none;
 	-webkit-user-select: none;
@@ -92,51 +87,41 @@
 	user-select: none;
 	background-color: var(--vscode-menu-background) !important;
 	color: var(--vscode-disabledForeground) !important;
-	outline: 0px solid !important;
+	outline: 0 solid !important;
 }
 
-.codeActionMenuWidget .monaco-list .monaco-list-row.group-header {
-	padding: 3px 10px 0px 10px;
-}
-
-.codeActionMenuWidget .monaco-list .monaco-list-row.documentation {
-	padding: 0px 10px 0px 10px;
-}
-
-
-.codeActionMenuWidget .monaco-list .group-header.option-disabled {
+.codeActionWidget .monaco-list .group-header.option-disabled {
 	color: var(--vscode-textLink-activeForeground) !important;
 	font-weight: bold;
-
 }
 
-.codeActionMenuWidget .monaco-list .separator {
-	border-bottom: 1px solid var(--vscode-menu-separatorBackground);
-	padding-top: 0px !important;
-	/* padding: 30px; */
-	width: 100%;
-	height: 0px !important;
-	opacity: 1;
-	font-size: inherit;
-	margin: 5px 0 !important;
-	border-radius: 0;
-	display: flex;
-	-mox-box-sizing: border-box;
-	box-sizing: border-box;
-	background-repeat: no-repeat;
-	background-position: 2px 2px;
-	white-space: nowrap;
-	cursor: pointer;
-	touch-action: none;
-}
-
-.codeActionMenuWidget .monaco-list-row:not(.group-header):not(.documentation) .icon-container {
+.codeActionWidget .monaco-list-row:not(.group-header) .icon-container {
 	margin-top: 3px;
 	margin-right: 10px;
 	width: 13px;
 	height: 13px;
 	flex-shrink: 0;
 	color: var(--vscode-editorLightBulb-foreground);
+}
+
+
+/* Action bar */
+
+.codeActionWidget .codeActionWidget-action-bar {
+	margin-top: 4px;
+	margin-bottom: 4px;
+}
+
+.codeActionWidget .codeActionWidget-action-bar::before {
+	display: block;
+	content: "";
+	width: 100%;
+	margin-bottom: 4px;
+	border-bottom: 1px solid var(--vscode-menu-separatorBackground);
+}
+
+.codeActionWidget .codeActionWidget-action-bar .actions-container {
+	padding: 0 10px;
 }
 
 .codeActionWidget-action-bar .action-label {

--- a/src/vs/editor/contrib/codeAction/browser/media/action.css
+++ b/src/vs/editor/contrib/codeAction/browser/media/action.css
@@ -19,14 +19,11 @@
 }
 
 .codeActionWidget {
-	overflow: auto;
 	font-size: 13px;
 	border-radius: 0;
 	min-width: 160px;
 	z-index: 40;
 	display: block;
-	/* flex-direction: column;
-	flex: 0 1 auto; */
 	width: 100%;
 	border: 1px solid var(--vscode-menu-separatorBackground) !important;
 	border-color: none;
@@ -35,11 +32,9 @@
 	box-shadow: rgb(0,0,0, 16%) 0 2px 8px;
 }
 
-
 .codeActionWidget .monaco-list {
 	user-select: none;
 	-webkit-user-select: none;
-	-ms-user-select: none;
 	border: none !important;
 	border-width: 0 !important;
 }


### PR DESCRIPTION
Refactors the code action widget. The goal was to move the documentation items out of the main list widget

While doing this, I also tried to clean up the code to be safer (less state) and more readable

Fixes #158855
Fixes #158854

