### PR TITLE
Activate RemoteEmptyWorkbenchPresentation on LifecyclePhase.Ready. For  #159675

### DIFF
--- a/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
@@ -135,7 +135,7 @@ const workbenchContributionsRegistry = Registry.as<IWorkbenchContributionsRegist
 workbenchContributionsRegistry.registerWorkbenchContribution(RemoteAgentDiagnosticListener, 'RemoteAgentDiagnosticListener', LifecyclePhase.Eventually);
 workbenchContributionsRegistry.registerWorkbenchContribution(RemoteExtensionHostEnvironmentUpdater, 'RemoteExtensionHostEnvironmentUpdater', LifecyclePhase.Eventually);
 workbenchContributionsRegistry.registerWorkbenchContribution(RemoteTelemetryEnablementUpdater, 'RemoteTelemetryEnablementUpdater', LifecyclePhase.Ready);
-workbenchContributionsRegistry.registerWorkbenchContribution(RemoteEmptyWorkbenchPresentation, 'RemoteEmptyWorkbenchPresentation', LifecyclePhase.Starting);
+workbenchContributionsRegistry.registerWorkbenchContribution(RemoteEmptyWorkbenchPresentation, 'RemoteEmptyWorkbenchPresentation', LifecyclePhase.Ready);
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 	.registerConfiguration({


### PR DESCRIPTION
I tested that chaning to ready works.

To verify:
- set `"workbench.startupEditor": "newUntitledFile"`
- open a remote window from the command line

e.g. `/scripts/code.sh -remote=test+test -n`

The file explorer should open