### PR TITLE
Another approach to stop language detection from stomping over changes

### DIFF
--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -849,9 +849,11 @@ export interface ITextModel {
 
 	/**
 	 * Set the current language mode associated with the model.
+	 * @param languageId The new language.
+	 * @param source The source of the call that set the language.
 	 * @internal
 	 */
-	setMode(languageId: string, reason?: string): void;
+	setMode(languageId: string, source?: string): void;
 
 	/**
 	 * Returns the real (inner-most) language mode at a given position.

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -851,7 +851,7 @@ export interface ITextModel {
 	 * Set the current language mode associated with the model.
 	 * @internal
 	 */
-	setMode(languageId: string): void;
+	setMode(languageId: string, reason?: string): void;
 
 	/**
 	 * Returns the real (inner-most) language mode at a given position.

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -1907,8 +1907,8 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 		return this.tokenization.getLanguageId();
 	}
 
-	public setMode(languageId: string, reason?: string): void {
-		this.tokenization.setLanguageId(languageId, reason);
+	public setMode(languageId: string, source?: string): void {
+		this.tokenization.setLanguageId(languageId, source);
 	}
 
 	public getLanguageIdAtPosition(lineNumber: number, column: number): string {

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -1907,8 +1907,8 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 		return this.tokenization.getLanguageId();
 	}
 
-	public setMode(languageId: string): void {
-		this.tokenization.setLanguageId(languageId);
+	public setMode(languageId: string, reason?: string): void {
+		this.tokenization.setLanguageId(languageId, reason);
 	}
 
 	public getLanguageIdAtPosition(lineNumber: number, column: number): string {

--- a/src/vs/editor/common/model/tokenizationTextModelPart.ts
+++ b/src/vs/editor/common/model/tokenizationTextModelPart.ts
@@ -485,7 +485,7 @@ export class TokenizationTextModelPart extends TextModelPart implements ITokeniz
 		return lineTokens.getLanguageId(lineTokens.findTokenIndexAtOffset(position.column - 1));
 	}
 
-	public setLanguageId(languageId: string): void {
+	public setLanguageId(languageId: string, reason: string = 'unknown'): void {
 		if (this._languageId === languageId) {
 			// There's nothing to do
 			return;
@@ -493,7 +493,8 @@ export class TokenizationTextModelPart extends TextModelPart implements ITokeniz
 
 		const e: IModelLanguageChangedEvent = {
 			oldLanguage: this._languageId,
-			newLanguage: languageId
+			newLanguage: languageId,
+			reason
 		};
 
 		this._languageId = languageId;

--- a/src/vs/editor/common/model/tokenizationTextModelPart.ts
+++ b/src/vs/editor/common/model/tokenizationTextModelPart.ts
@@ -485,7 +485,7 @@ export class TokenizationTextModelPart extends TextModelPart implements ITokeniz
 		return lineTokens.getLanguageId(lineTokens.findTokenIndexAtOffset(position.column - 1));
 	}
 
-	public setLanguageId(languageId: string, reason: string = 'unknown'): void {
+	public setLanguageId(languageId: string, source: string = 'api'): void {
 		if (this._languageId === languageId) {
 			// There's nothing to do
 			return;
@@ -494,7 +494,7 @@ export class TokenizationTextModelPart extends TextModelPart implements ITokeniz
 		const e: IModelLanguageChangedEvent = {
 			oldLanguage: this._languageId,
 			newLanguage: languageId,
-			reason
+			source
 		};
 
 		this._languageId = languageId;

--- a/src/vs/editor/common/services/model.ts
+++ b/src/vs/editor/common/services/model.ts
@@ -22,7 +22,7 @@ export interface IModelService {
 
 	updateModel(model: ITextModel, value: string | ITextBufferFactory): void;
 
-	setMode(model: ITextModel, languageSelection: ILanguageSelection): void;
+	setMode(model: ITextModel, languageSelection: ILanguageSelection, reason?: string): void;
 
 	destroyModel(resource: URI): void;
 

--- a/src/vs/editor/common/services/model.ts
+++ b/src/vs/editor/common/services/model.ts
@@ -22,7 +22,7 @@ export interface IModelService {
 
 	updateModel(model: ITextModel, value: string | ITextBufferFactory): void;
 
-	setMode(model: ITextModel, languageSelection: ILanguageSelection, reason?: string): void;
+	setMode(model: ITextModel, languageSelection: ILanguageSelection, source?: string): void;
 
 	destroyModel(resource: URI): void;
 

--- a/src/vs/editor/common/services/modelService.ts
+++ b/src/vs/editor/common/services/modelService.ts
@@ -91,11 +91,11 @@ class ModelData implements IDisposable {
 		this._disposeLanguageSelection();
 	}
 
-	public setLanguage(languageSelection: ILanguageSelection, reason?: string): void {
+	public setLanguage(languageSelection: ILanguageSelection, source?: string): void {
 		this._disposeLanguageSelection();
 		this._languageSelection = languageSelection;
-		this._languageSelectionListener = this._languageSelection.onDidChange(() => this.model.setMode(languageSelection.languageId, reason));
-		this.model.setMode(languageSelection.languageId, reason);
+		this._languageSelectionListener = this._languageSelection.onDidChange(() => this.model.setMode(languageSelection.languageId, source));
+		this.model.setMode(languageSelection.languageId, source);
 	}
 }
 
@@ -516,7 +516,7 @@ export class ModelService extends Disposable implements IModelService {
 		return modelData.model;
 	}
 
-	public setMode(model: ITextModel, languageSelection: ILanguageSelection, reason?: string): void {
+	public setMode(model: ITextModel, languageSelection: ILanguageSelection, source?: string): void {
 		if (!languageSelection) {
 			return;
 		}
@@ -524,7 +524,7 @@ export class ModelService extends Disposable implements IModelService {
 		if (!modelData) {
 			return;
 		}
-		modelData.setLanguage(languageSelection, reason);
+		modelData.setLanguage(languageSelection, source);
 	}
 
 	public destroyModel(resource: URI): void {

--- a/src/vs/editor/common/services/modelService.ts
+++ b/src/vs/editor/common/services/modelService.ts
@@ -91,11 +91,11 @@ class ModelData implements IDisposable {
 		this._disposeLanguageSelection();
 	}
 
-	public setLanguage(languageSelection: ILanguageSelection): void {
+	public setLanguage(languageSelection: ILanguageSelection, reason?: string): void {
 		this._disposeLanguageSelection();
 		this._languageSelection = languageSelection;
-		this._languageSelectionListener = this._languageSelection.onDidChange(() => this.model.setMode(languageSelection.languageId));
-		this.model.setMode(languageSelection.languageId);
+		this._languageSelectionListener = this._languageSelection.onDidChange(() => this.model.setMode(languageSelection.languageId, reason));
+		this.model.setMode(languageSelection.languageId, reason);
 	}
 }
 
@@ -516,7 +516,7 @@ export class ModelService extends Disposable implements IModelService {
 		return modelData.model;
 	}
 
-	public setMode(model: ITextModel, languageSelection: ILanguageSelection): void {
+	public setMode(model: ITextModel, languageSelection: ILanguageSelection, reason?: string): void {
 		if (!languageSelection) {
 			return;
 		}
@@ -524,7 +524,7 @@ export class ModelService extends Disposable implements IModelService {
 		if (!modelData) {
 			return;
 		}
-		modelData.setLanguage(languageSelection);
+		modelData.setLanguage(languageSelection, reason);
 	}
 
 	public destroyModel(resource: URI): void {

--- a/src/vs/editor/common/textModelEvents.ts
+++ b/src/vs/editor/common/textModelEvents.ts
@@ -21,9 +21,9 @@ export interface IModelLanguageChangedEvent {
 	readonly newLanguage: string;
 
 	/**
-	 * The reason that caused the change
+	 * Source of the call that caused the event.
 	 */
-	readonly reason: string;
+	readonly source: string;
 }
 
 /**

--- a/src/vs/editor/common/textModelEvents.ts
+++ b/src/vs/editor/common/textModelEvents.ts
@@ -19,6 +19,11 @@ export interface IModelLanguageChangedEvent {
 	 * New language
 	 */
 	readonly newLanguage: string;
+
+	/**
+	 * The reason that caused the change
+	 */
+	readonly reason: string;
 }
 
 /**

--- a/src/vs/editor/common/tokenizationTextModelPart.ts
+++ b/src/vs/editor/common/tokenizationTextModelPart.ts
@@ -95,7 +95,7 @@ export interface ITokenizationTextModelPart {
 	getLanguageId(): string;
 	getLanguageIdAtPosition(lineNumber: number, column: number): string;
 
-	setLanguageId(languageId: string, reason?: string): void;
+	setLanguageId(languageId: string, source?: string): void;
 
 	readonly backgroundTokenizationState: BackgroundTokenizationState;
 	readonly onBackgroundTokenizationStateChanged: Event<void>;

--- a/src/vs/editor/common/tokenizationTextModelPart.ts
+++ b/src/vs/editor/common/tokenizationTextModelPart.ts
@@ -95,7 +95,7 @@ export interface ITokenizationTextModelPart {
 	getLanguageId(): string;
 	getLanguageIdAtPosition(lineNumber: number, column: number): string;
 
-	setLanguageId(languageId: string): void;
+	setLanguageId(languageId: string, reason?: string): void;
 
 	readonly backgroundTokenizationState: BackgroundTokenizationState;
 	readonly onBackgroundTokenizationStateChanged: Event<void>;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2635,9 +2635,9 @@ declare namespace monaco.editor {
 		 */
 		readonly newLanguage: string;
 		/**
-		 * The reason that caused the change
+		 * Source of the call that caused the event.
 		 */
-		readonly reason: string;
+		readonly source: string;
 	}
 
 	/**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2634,6 +2634,10 @@ declare namespace monaco.editor {
 		 * New language
 		 */
 		readonly newLanguage: string;
+		/**
+		 * The reason that caused the change. Defaults to unknown.
+		 */
+		readonly reason: string;
 	}
 
 	/**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2635,7 +2635,7 @@ declare namespace monaco.editor {
 		 */
 		readonly newLanguage: string;
 		/**
-		 * The reason that caused the change. Defaults to unknown.
+		 * The reason that caused the change
 		 */
 		readonly reason: string;
 	}

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -71,8 +71,8 @@ class SideBySideEditorLanguageSupport implements ILanguageSupport {
 
 	constructor(private primary: ILanguageSupport, private secondary: ILanguageSupport) { }
 
-	setLanguageId(languageId: string): void {
-		[this.primary, this.secondary].forEach(editor => editor.setLanguageId(languageId));
+	setLanguageId(languageId: string, source?: string): void {
+		[this.primary, this.secondary].forEach(editor => editor.setLanguageId(languageId, source));
 	}
 }
 
@@ -1237,7 +1237,7 @@ export class ChangeLanguageAction extends Action {
 
 				// Change language
 				if (typeof languageSelection !== 'undefined') {
-					languageSupport.setLanguageId(languageSelection.languageId);
+					languageSupport.setLanguageId(languageSelection.languageId, ChangeLanguageAction.ID);
 
 					if (resource?.scheme === Schemas.untitled) {
 						type SetUntitledDocumentLanguageEvent = { to: string; from: string; modelPreference: string };

--- a/src/vs/workbench/common/editor/textEditorModel.ts
+++ b/src/vs/workbench/common/editor/textEditorModel.ts
@@ -99,11 +99,13 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 	}
 
 	protected installModelListeners(model: ITextModel): void {
+
 		// Setup listener for lower level language changes
 		const disposable = model.onDidChangeLanguage((e) => {
 			if (e.reason === LanguageDetectionLanguageEventReason) {
 				return;
 			}
+
 			this._hasLanguageSetExplicitly = true;
 			disposable.dispose();
 		});

--- a/src/vs/workbench/common/editor/textEditorModel.ts
+++ b/src/vs/workbench/common/editor/textEditorModel.ts
@@ -13,7 +13,7 @@ import { IModelService } from 'vs/editor/common/services/model';
 import { MutableDisposable } from 'vs/base/common/lifecycle';
 import { PLAINTEXT_LANGUAGE_ID } from 'vs/editor/common/languages/modesRegistry';
 import { withUndefinedAsNull } from 'vs/base/common/types';
-import { ILanguageDetectionService, LanguageDetectionLanguageEventReason } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
+import { ILanguageDetectionService, LanguageDetectionLanguageEventSource } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
 import { ThrottledDelayer } from 'vs/base/common/async';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { localize } from 'vs/nls';
@@ -78,15 +78,15 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 	private _hasLanguageSetExplicitly: boolean = false;
 	get hasLanguageSetExplicitly(): boolean { return this._hasLanguageSetExplicitly; }
 
-	setLanguageId(languageId: string): void {
+	setLanguageId(languageId: string, source?: string): void {
 
 		// Remember that an explicit language was set
 		this._hasLanguageSetExplicitly = true;
 
-		this.setLanguageIdInternal(languageId);
+		this.setLanguageIdInternal(languageId, source);
 	}
 
-	private setLanguageIdInternal(languageId: string, reason?: string): void {
+	private setLanguageIdInternal(languageId: string, source?: string): void {
 		if (!this.isResolved()) {
 			return;
 		}
@@ -95,14 +95,14 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 			return;
 		}
 
-		this.modelService.setMode(this.textEditorModel, this.languageService.createById(languageId), reason);
+		this.modelService.setMode(this.textEditorModel, this.languageService.createById(languageId), source);
 	}
 
 	protected installModelListeners(model: ITextModel): void {
 
 		// Setup listener for lower level language changes
 		const disposable = this._register(model.onDidChangeLanguage((e) => {
-			if (e.reason === LanguageDetectionLanguageEventReason) {
+			if (e.source === LanguageDetectionLanguageEventSource) {
 				return;
 			}
 
@@ -130,7 +130,7 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 
 		const lang = await this.languageDetectionService.detectLanguage(this.textEditorModelHandle);
 		if (lang && !this.isDisposed()) {
-			this.setLanguageIdInternal(lang, LanguageDetectionLanguageEventReason);
+			this.setLanguageIdInternal(lang, LanguageDetectionLanguageEventSource);
 
 			const languageName = this.languageService.getLanguageName(lang);
 			if (languageName) {

--- a/src/vs/workbench/common/editor/textEditorModel.ts
+++ b/src/vs/workbench/common/editor/textEditorModel.ts
@@ -101,14 +101,14 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 	protected installModelListeners(model: ITextModel): void {
 
 		// Setup listener for lower level language changes
-		const disposable = model.onDidChangeLanguage((e) => {
+		const disposable = this._register(model.onDidChangeLanguage((e) => {
 			if (e.reason === LanguageDetectionLanguageEventReason) {
 				return;
 			}
 
 			this._hasLanguageSetExplicitly = true;
 			disposable.dispose();
-		});
+		}));
 	}
 
 	getLanguageId(): string | undefined {

--- a/src/vs/workbench/common/editor/textEditorModel.ts
+++ b/src/vs/workbench/common/editor/textEditorModel.ts
@@ -12,7 +12,7 @@ import { ILanguageService, ILanguageSelection } from 'vs/editor/common/languages
 import { IModelService } from 'vs/editor/common/services/model';
 import { MutableDisposable } from 'vs/base/common/lifecycle';
 import { PLAINTEXT_LANGUAGE_ID } from 'vs/editor/common/languages/modesRegistry';
-import { assertIsDefined, withUndefinedAsNull } from 'vs/base/common/types';
+import { withUndefinedAsNull } from 'vs/base/common/types';
 import { ILanguageDetectionService, LanguageDetectionLanguageEventReason } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
 import { ThrottledDelayer } from 'vs/base/common/async';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
@@ -98,16 +98,15 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 		this.modelService.setMode(this.textEditorModel, this.languageService.createById(languageId), reason);
 	}
 
-	override resolve(): Promise<void> {
-		const textEditorModel = assertIsDefined(this.textEditorModel);
-		const disposable = textEditorModel.onDidChangeLanguage((e) => {
+	protected installModelListeners(model: ITextModel): void {
+		// Setup listener for lower level language changes
+		const disposable = model.onDidChangeLanguage((e) => {
 			if (e.reason === LanguageDetectionLanguageEventReason) {
 				return;
 			}
 			this._hasLanguageSetExplicitly = true;
 			disposable.dispose();
 		});
-		return super.resolve();
 	}
 
 	getLanguageId(): string | undefined {

--- a/src/vs/workbench/common/editor/textResourceEditorInput.ts
+++ b/src/vs/workbench/common/editor/textResourceEditorInput.ts
@@ -130,10 +130,10 @@ export class TextResourceEditorInput extends AbstractTextResourceEditorInput imp
 		}
 	}
 
-	setLanguageId(languageId: string): void {
+	setLanguageId(languageId: string, source?: string): void {
 		this.setPreferredLanguageId(languageId);
 
-		this.cachedModel?.setLanguageId(languageId);
+		this.cachedModel?.setLanguageId(languageId, source);
 	}
 
 	setPreferredLanguageId(languageId: string): void {

--- a/src/vs/workbench/contrib/files/browser/editors/fileEditorInput.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/fileEditorInput.ts
@@ -246,10 +246,10 @@ export class FileEditorInput extends AbstractTextResourceEditorInput implements 
 		return this.preferredLanguageId;
 	}
 
-	setLanguageId(languageId: string): void {
+	setLanguageId(languageId: string, source?: string): void {
 		this.setPreferredLanguageId(languageId);
 
-		this.model?.setLanguageId(languageId);
+		this.model?.setLanguageId(languageId, source);
 	}
 
 	setPreferredLanguageId(languageId: string): void {

--- a/src/vs/workbench/contrib/languageDetection/browser/languageDetection.contribution.ts
+++ b/src/vs/workbench/contrib/languageDetection/browser/languageDetection.contribution.ts
@@ -11,7 +11,7 @@ import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWo
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
-import { ILanguageDetectionService, LanguageDetectionHintConfig, LanguageDetectionLanguageEventReason } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
+import { ILanguageDetectionService, LanguageDetectionHintConfig, LanguageDetectionLanguageEventSource } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
 import { ThrottledDelayer } from 'vs/base/common/async';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
@@ -139,7 +139,7 @@ registerAction2(class extends Action2 {
 		if (editorUri) {
 			const lang = await languageDetectionService.detectLanguage(editorUri);
 			if (lang) {
-				editor.getModel()?.setMode(lang, LanguageDetectionLanguageEventReason);
+				editor.getModel()?.setMode(lang, LanguageDetectionLanguageEventSource);
 			} else {
 				notificationService.warn(localize('noDetection', "Unable to detect editor language"));
 			}

--- a/src/vs/workbench/contrib/languageDetection/browser/languageDetection.contribution.ts
+++ b/src/vs/workbench/contrib/languageDetection/browser/languageDetection.contribution.ts
@@ -11,7 +11,7 @@ import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWo
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
-import { ILanguageDetectionService, LanguageDetectionHintConfig } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
+import { ILanguageDetectionService, LanguageDetectionHintConfig, LanguageDetectionLanguageEventReason } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService';
 import { ThrottledDelayer } from 'vs/base/common/async';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
@@ -139,7 +139,7 @@ registerAction2(class extends Action2 {
 		if (editorUri) {
 			const lang = await languageDetectionService.detectLanguage(editorUri);
 			if (lang) {
-				editor.getModel()?.setMode(lang);
+				editor.getModel()?.setMode(lang, LanguageDetectionLanguageEventReason);
 			} else {
 				notificationService.warn(localize('noDetection', "Unable to detect editor language"));
 			}

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInput.ts
@@ -194,8 +194,8 @@ export class MergeEditorInput extends AbstractTextResourceEditorInput implements
 		return Boolean(this._outTextModel?.isDirty());
 	}
 
-	setLanguageId(languageId: string, _setExplicitly?: boolean): void {
-		this._model?.setLanguageId(languageId);
+	setLanguageId(languageId: string, source?: string): void {
+		this._model?.setLanguageId(languageId, source);
 	}
 
 	// implement get/set languageId

--- a/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
@@ -400,12 +400,12 @@ export class MergeEditorModel extends EditorModel {
 
 	public readonly hasUnhandledConflicts = this.unhandledConflictsCount.map(value => /** @description hasUnhandledConflicts */ value > 0);
 
-	public setLanguageId(languageId: string): void {
+	public setLanguageId(languageId: string, source?: string): void {
 		const language = this.languageService.createById(languageId);
-		this.modelService.setMode(this.base, language);
-		this.modelService.setMode(this.input1.textModel, language);
-		this.modelService.setMode(this.input2.textModel, language);
-		this.modelService.setMode(this.resultTextModel, language);
+		this.modelService.setMode(this.base, language, source);
+		this.modelService.setMode(this.input1.textModel, language, source);
+		this.modelService.setMode(this.input2.textModel, language, source);
+		this.modelService.setMode(this.resultTextModel, language, source);
 	}
 
 	public getInitialResultValue(): string {

--- a/src/vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets.ts
+++ b/src/vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets.ts
@@ -62,7 +62,7 @@ export class ApplyFileSnippetAction extends SnippetsAction {
 			}]);
 
 			// set language if possible
-			modelService.setMode(editor.getModel(), langService.createById(selection.langId));
+			modelService.setMode(editor.getModel(), langService.createById(selection.langId), ApplyFileSnippetAction.Id);
 		}
 	}
 

--- a/src/vs/workbench/services/languageDetection/common/languageDetectionWorkerService.ts
+++ b/src/vs/workbench/services/languageDetection/common/languageDetectionWorkerService.ts
@@ -8,6 +8,8 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 
 export const ILanguageDetectionService = createDecorator<ILanguageDetectionService>('ILanguageDetectionService');
 
+export const LanguageDetectionLanguageEventReason = 'languageDetection';
+
 export interface ILanguageDetectionService {
 	readonly _serviceBrand: undefined;
 

--- a/src/vs/workbench/services/languageDetection/common/languageDetectionWorkerService.ts
+++ b/src/vs/workbench/services/languageDetection/common/languageDetectionWorkerService.ts
@@ -8,7 +8,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 
 export const ILanguageDetectionService = createDecorator<ILanguageDetectionService>('ILanguageDetectionService');
 
-export const LanguageDetectionLanguageEventReason = 'languageDetection';
+export const LanguageDetectionLanguageEventSource = 'languageDetection';
 
 export interface ILanguageDetectionService {
 	readonly _serviceBrand: undefined;

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -556,15 +556,15 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		}
 	}
 
-	override installModelListeners(model: ITextModel): void {
+	protected override installModelListeners(model: ITextModel): void {
 
 		// See https://github.com/microsoft/vscode/issues/30189
 		// This code has been extracted to a different method because it caused a memory leak
 		// where `value` was captured in the content change listener closure scope.
 
-		// Listen to text model events
 		this._register(model.onDidChangeContent(e => this.onModelContentChanged(model, e.isUndoing || e.isRedoing)));
 		this._register(model.onDidChangeLanguage(() => this.onMaybeShouldChangeEncoding())); // detect possible encoding change via language specific settings
+
 		super.installModelListeners(model);
 	}
 

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -556,7 +556,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		}
 	}
 
-	private installModelListeners(model: ITextModel): void {
+	override installModelListeners(model: ITextModel): void {
 
 		// See https://github.com/microsoft/vscode/issues/30189
 		// This code has been extracted to a different method because it caused a memory leak
@@ -565,6 +565,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		// Listen to text model events
 		this._register(model.onDidChangeContent(e => this.onModelContentChanged(model, e.isUndoing || e.isRedoing)));
 		this._register(model.onDidChangeLanguage(() => this.onMaybeShouldChangeEncoding())); // detect possible encoding change via language specific settings
+		super.installModelListeners(model);
 	}
 
 	private onModelContentChanged(model: ITextModel, isUndoingOrRedoing: boolean): void {

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -197,8 +197,8 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		this.modelService.setMode(this.textEditorModel, languageSelection);
 	}
 
-	override setLanguageId(languageId: string): void {
-		super.setLanguageId(languageId);
+	override setLanguageId(languageId: string, source?: string): void {
+		super.setLanguageId(languageId, source);
 
 		this.preferredLanguageId = languageId;
 	}

--- a/src/vs/workbench/services/textfile/common/textfiles.ts
+++ b/src/vs/workbench/services/textfile/common/textfiles.ts
@@ -468,7 +468,7 @@ export interface ILanguageSupport {
 	/**
 	 * Sets the language id of the object.
 	 */
-	setLanguageId(languageId: string, setExplicitly?: boolean): void;
+	setLanguageId(languageId: string, source?: string): void;
 }
 
 export interface ITextFileEditorModelSaveEvent extends IWorkingCopySaveEvent {

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorInput.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorInput.ts
@@ -108,8 +108,8 @@ export class UntitledTextEditorInput extends AbstractTextResourceEditorInput imp
 		return this.model.setEncoding(encoding);
 	}
 
-	setLanguageId(languageId: string): void {
-		this.model.setLanguageId(languageId);
+	setLanguageId(languageId: string, source?: string): void {
+		this.model.setLanguageId(languageId, source);
 	}
 
 	getLanguageId(): string | undefined {

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -357,9 +357,10 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 		return super.resolve();
 	}
 
-	override installModelListeners(model: ITextModel): void {
+	protected override installModelListeners(model: ITextModel): void {
 		this._register(model.onDidChangeContent(e => this.onModelContentChanged(model, e)));
 		this._register(model.onDidChangeLanguage(() => this.onConfigurationChange(true))); // language change can have impact on config
+
 		super.installModelListeners(model);
 	}
 

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -333,8 +333,7 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 
 		// Listen to text model events
 		const textEditorModel = assertIsDefined(this.textEditorModel);
-		this._register(textEditorModel.onDidChangeContent(e => this.onModelContentChanged(textEditorModel, e)));
-		this._register(textEditorModel.onDidChangeLanguage(() => this.onConfigurationChange(true))); // language change can have impact on config
+		this.installModelListeners(textEditorModel);
 
 		// Only adjust name and dirty state etc. if we
 		// actually created the untitled model
@@ -356,6 +355,12 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 		}
 
 		return super.resolve();
+	}
+
+	override installModelListeners(model: ITextModel): void {
+		this._register(model.onDidChangeContent(e => this.onModelContentChanged(model, e)));
+		this._register(model.onDidChangeLanguage(() => this.onConfigurationChange(true))); // language change can have impact on config
+		super.installModelListeners(model);
 	}
 
 	private onModelContentChanged(textEditorModel: ITextModel, e: IModelContentChangedEvent): void {

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -190,14 +190,14 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 
 	//#region Language
 
-	override setLanguageId(languageId: string): void {
+	override setLanguageId(languageId: string, source?: string): void {
 		const actualLanguage: string | undefined = languageId === UntitledTextEditorModel.ACTIVE_EDITOR_LANGUAGE_ID
 			? this.editorService.activeTextEditorLanguageId
 			: languageId;
 		this.preferredLanguageId = actualLanguage;
 
 		if (actualLanguage) {
-			super.setLanguageId(actualLanguage);
+			super.setLanguageId(actualLanguage, source);
 		}
 	}
 

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1608,7 +1608,7 @@ export class TestFileEditorInput extends EditorInput implements IFileEditorInput
 	setPreferredDescription(description: string): void { }
 	setPreferredEncoding(encoding: string) { }
 	setPreferredContents(contents: string): void { }
-	setLanguageId(languageId: string) { }
+	setLanguageId(languageId: string, source?: string) { }
 	setPreferredLanguageId(languageId: string) { }
 	setForceOpenAsBinary(): void { }
 	setFailToOpen(): void {


### PR DESCRIPTION
This change does two important things:

1. Has the higher level `EditorModel` listen for when the lower level model changes languages (this is important because many things change the language at that level instead of this higher level)
2. adds a `reason` to this event so that the language detection can ignore language changes events that it caused.

This is an alternate approach to: https://github.com/microsoft/vscode/pull/159482

Fixes #159202
Fixes #152776

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
