### PR TITLE
Drag and Drop images into notebook markdown cells

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -38,6 +38,15 @@
             "tags": [
               "experimental"
             ]
+          },
+          "ipynb.experimental.dropImages.enabled":{
+            "type": "boolean",
+            "scope": "resource",
+            "markdownDescription": "%ipynb.experimental.dropImages.enabled%",
+            "default": false,
+            "tags": [
+              "experimental"
+            ]
           }
         }
       }

--- a/extensions/ipynb/package.nls.json
+++ b/extensions/ipynb/package.nls.json
@@ -1,5 +1,6 @@
 {
 	"displayName": ".ipynb support",
 	"description": "Provides basic support for opening and reading Jupyter's .ipynb notebook files",
-	"ipynb.experimental.pasteImages.enabled":"Enable/Disable pasting images into markdown cells within ipynb files. Requires enabling `#editor.experimental.pasteActions.enabled#`."
+	"ipynb.experimental.pasteImages.enabled":"Enable/Disable pasting images into markdown cells within ipynb files. Requires enabling `#editor.experimental.pasteActions.enabled#`.",
+	"ipynb.experimental.dropImages.enabled":"Enable/Disable dropping images into markdown cells within ipynb files."
 }

--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { ensureAllNewCellsHaveCellIds } from './cellIdService';
 import { NotebookSerializer } from './notebookSerializer';
-import * as NotebookImagePaste from './notebookImagePaste';
+import { imagePasteSetup, imageDropSetup } from './notebookImagePaste';
 
 // From {nbformat.INotebookMetadata} in @jupyterlab/coreutils
 type NotebookMetadata = {
@@ -78,7 +78,8 @@ export function activate(context: vscode.ExtensionContext) {
 		await vscode.window.showNotebookDocument(document);
 	}));
 
-	context.subscriptions.push(NotebookImagePaste.imagePasteSetup());
+	context.subscriptions.push(imagePasteSetup());
+	context.subscriptions.push(imageDropSetup());
 
 	// Update new file contribution
 	vscode.extensions.onDidChange(() => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Create and register DocumentDropEdit Provider, storing images as encoded base64 attachments. 

Currently the provider isn't being used at all, with the following settings being used:
```
    "ipynb.experimental.pasteImages.enabled": true,
    "editor.experimental.pasteActions.enabled": true,
    "editor.dropIntoEditor.enabled": true
```
cc @mattbierner, is there a missing bit of setup? Was looking at the drop example inside microsoft/vscode-extension-samples and couldn't find anything that I was missing on a first pass through.