### PR TITLE
fix #159755

### DIFF
--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -6,7 +6,7 @@
 import 'vs/css!./media/compositepart';
 import { localize } from 'vs/nls';
 import { defaultGenerator } from 'vs/base/common/idGenerator';
-import { IDisposable, dispose, DisposableStore, MutableDisposable } from 'vs/base/common/lifecycle';
+import { IDisposable, dispose, DisposableStore, MutableDisposable, } from 'vs/base/common/lifecycle';
 import { Emitter } from 'vs/base/common/event';
 import { isCancellationError } from 'vs/base/common/errors';
 import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
@@ -16,7 +16,6 @@ import { IAction, WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassific
 import { Part, IPartOptions } from 'vs/workbench/browser/part';
 import { Composite, CompositeRegistry } from 'vs/workbench/browser/composite';
 import { IComposite } from 'vs/workbench/common/composite';
-import { CompositeProgressIndicator } from 'vs/workbench/services/progress/browser/progressIndicator';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
@@ -32,6 +31,7 @@ import { Dimension, append, $, hide, show } from 'vs/base/browser/dom';
 import { AnchorAlignment } from 'vs/base/browser/ui/contextview/contextview';
 import { assertIsDefined, withNullAsUndefined } from 'vs/base/common/types';
 import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { AbstractProgressScope, ScopedProgressIndicator } from 'vs/workbench/services/progress/browser/progressIndicator';
 
 export interface ICompositeTitleLabel {
 
@@ -172,7 +172,14 @@ export abstract class CompositePart<T extends Composite> extends Part {
 		// Instantiate composite from registry otherwise
 		const compositeDescriptor = this.registry.getComposite(id);
 		if (compositeDescriptor) {
-			const compositeProgressIndicator = this.instantiationService.createInstance(CompositeProgressIndicator, assertIsDefined(this.progressBar), compositeDescriptor.id, !!isActive);
+			const that = this;
+			const compositeProgressIndicator = new ScopedProgressIndicator(assertIsDefined(this.progressBar), new class extends AbstractProgressScope {
+				constructor() {
+					super(compositeDescriptor!.id, !!isActive);
+					this._register(that.onDidCompositeOpen.event(e => this.onScopeOpened(e.composite.getId())));
+					this._register(that.onDidCompositeClose.event(e => this.onScopeClosed(e.getId())));
+				}
+			}());
 			const compositeInstantiationService = this.instantiationService.createChild(new ServiceCollection(
 				[IEditorProgressService, compositeProgressIndicator] // provide the editor progress service for any editors instantiated within the composite
 			));

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -159,4 +159,4 @@ export class PaneCompositeParts extends Disposable implements IPaneCompositePart
 	}
 }
 
-registerSingleton(IPaneCompositePartService, PaneCompositeParts, false);
+registerSingleton(IPaneCompositePartService, PaneCompositeParts, true);

--- a/src/vs/workbench/browser/parts/views/viewsService.ts
+++ b/src/vs/workbench/browser/parts/views/viewsService.ts
@@ -648,5 +648,4 @@ export function getPartByLocation(viewContainerLocation: ViewContainerLocation):
 	}
 }
 
-registerSingleton(IViewsService, ViewsService, false /* Eager because of the cyclic dependency when registering PaneComposites (Panel that is active) in its constructor:
-ViewsService is registering a panel that is active -> PaneCompositeParts -> PanelPart (CompositePart) is opening the registered panel that is active -> CompositeProgressIndicator -> ViewsService */);
+registerSingleton(IViewsService, ViewsService, false /* Eager because it registers viewlets and panels in the constructor which are required during workbench layout */);

--- a/src/vs/workbench/services/progress/test/browser/progressIndicator.test.ts
+++ b/src/vs/workbench/services/progress/test/browser/progressIndicator.test.ts
@@ -4,30 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { IEditorControl } from 'vs/workbench/common/editor';
-import { CompositeProgressScope, CompositeProgressIndicator } from 'vs/workbench/services/progress/browser/progressIndicator';
-import { TestSideBarPart, TestViewsService, TestPaneCompositeService } from 'vs/workbench/test/browser/workbenchTestServices';
-import { Event } from 'vs/base/common/event';
-import { IView, IViewPaneContainer, ViewContainerLocation } from 'vs/workbench/common/views';
-import { IPaneComposite } from 'vs/workbench/common/panecomposite';
-
-class TestViewlet implements IPaneComposite {
-
-	constructor(private id: string) { }
-
-	readonly onDidBlur = Event.None;
-	readonly onDidFocus = Event.None;
-
-	hasFocus() { return false; }
-	getId(): string { return this.id; }
-	getTitle(): string { return this.id; }
-	getControl(): IEditorControl { return null!; }
-	focus(): void { }
-	getOptimalWidth(): number { return 10; }
-	openView<T extends IView>(id: string, focus?: boolean): T | undefined { return undefined; }
-	getViewPaneContainer(): IViewPaneContainer { return null!; }
-	saveState(): void { }
-}
+import { AbstractProgressScope, ScopedProgressIndicator } from 'vs/workbench/services/progress/browser/progressIndicator';
 
 class TestProgressBar {
 	fTotal: number = 0;
@@ -86,40 +63,23 @@ class TestProgressBar {
 
 suite('Progress Indicator', () => {
 
-	test('CompositeScope', () => {
-		const paneCompositeService = new TestPaneCompositeService();
-		const viewsService = new TestViewsService();
-		const service = new CompositeProgressScope(paneCompositeService, viewsService, 'test.scopeId', false);
-		const testViewlet = new TestViewlet('test.scopeId');
-
-		assert(!service.isActive);
-		(paneCompositeService.getPartByLocation(ViewContainerLocation.Sidebar) as TestSideBarPart).onDidViewletOpenEmitter.fire(testViewlet);
-		assert(service.isActive);
-
-		(paneCompositeService.getPartByLocation(ViewContainerLocation.Sidebar) as TestSideBarPart).onDidViewletCloseEmitter.fire(testViewlet);
-		assert(!service.isActive);
-
-		viewsService.onDidChangeViewVisibilityEmitter.fire({ id: 'test.scopeId', visible: true });
-		assert(service.isActive);
-
-		viewsService.onDidChangeViewVisibilityEmitter.fire({ id: 'test.scopeId', visible: false });
-		assert(!service.isActive);
-	});
-
-	test('CompositeProgressIndicator', async () => {
+	test('ScopedProgressIndicator', async () => {
 		const testProgressBar = new TestProgressBar();
-		const paneCompositeService = new TestPaneCompositeService();
-		const viewsService = new TestViewsService();
-		const service = new CompositeProgressIndicator((<any>testProgressBar), 'test.scopeId', true, paneCompositeService, viewsService);
+		const progressScope = new class extends AbstractProgressScope {
+			constructor() { super('test.scopeId', true); }
+			override onScopeOpened(scopeId: string) { super.onScopeOpened(scopeId); }
+			override onScopeClosed(scopeId: string): void { super.onScopeClosed(scopeId); }
+		}();
+		const testObject = new ScopedProgressIndicator((<any>testProgressBar), progressScope);
 
 		// Active: Show (Infinite)
-		let fn = service.show(true);
+		let fn = testObject.show(true);
 		assert.strictEqual(true, testProgressBar.fInfinite);
 		fn.done();
 		assert.strictEqual(true, testProgressBar.fDone);
 
 		// Active: Show (Total / Worked)
-		fn = service.show(100);
+		fn = testObject.show(100);
 		assert.strictEqual(false, !!testProgressBar.fInfinite);
 		assert.strictEqual(100, testProgressBar.fTotal);
 		fn.worked(20);
@@ -130,46 +90,31 @@ suite('Progress Indicator', () => {
 		assert.strictEqual(true, testProgressBar.fDone);
 
 		// Inactive: Show (Infinite)
-		const testViewlet = new TestViewlet('test.scopeId');
-		(paneCompositeService.getPartByLocation(ViewContainerLocation.Sidebar) as TestSideBarPart).onDidViewletCloseEmitter.fire(testViewlet);
-		service.show(true);
+		progressScope.onScopeClosed('test.scopeId');
+		testObject.show(true);
 		assert.strictEqual(false, !!testProgressBar.fInfinite);
-		(paneCompositeService.getPartByLocation(ViewContainerLocation.Sidebar) as TestSideBarPart).onDidViewletOpenEmitter.fire(testViewlet);
+		progressScope.onScopeOpened('test.scopeId');
 		assert.strictEqual(true, testProgressBar.fInfinite);
 
 		// Inactive: Show (Total / Worked)
-		(paneCompositeService.getPartByLocation(ViewContainerLocation.Sidebar) as TestSideBarPart).onDidViewletCloseEmitter.fire(testViewlet);
-		fn = service.show(100);
+		progressScope.onScopeClosed('test.scopeId');
+		fn = testObject.show(100);
 		fn.total(80);
 		fn.worked(20);
 		assert.strictEqual(false, !!testProgressBar.fTotal);
-		(paneCompositeService.getPartByLocation(ViewContainerLocation.Sidebar) as TestSideBarPart).onDidViewletOpenEmitter.fire(testViewlet);
+		progressScope.onScopeOpened('test.scopeId');
 		assert.strictEqual(20, testProgressBar.fWorked);
 		assert.strictEqual(80, testProgressBar.fTotal);
 
 		// Acive: Show While
 		let p = Promise.resolve(null);
-		await service.showWhile(p);
+		await testObject.showWhile(p);
 		assert.strictEqual(true, testProgressBar.fDone);
-		(paneCompositeService.getPartByLocation(ViewContainerLocation.Sidebar) as TestSideBarPart).onDidViewletCloseEmitter.fire(testViewlet);
+		progressScope.onScopeClosed('test.scopeId');
 		p = Promise.resolve(null);
-		await service.showWhile(p);
+		await testObject.showWhile(p);
 		assert.strictEqual(true, testProgressBar.fDone);
-		(paneCompositeService.getPartByLocation(ViewContainerLocation.Sidebar) as TestSideBarPart).onDidViewletOpenEmitter.fire(testViewlet);
+		progressScope.onScopeOpened('test.scopeId');
 		assert.strictEqual(true, testProgressBar.fDone);
-
-		// Visible view: Show (Infinite)
-		viewsService.onDidChangeViewVisibilityEmitter.fire({ id: 'test.scopeId', visible: true });
-		fn = service.show(true);
-		assert.strictEqual(true, testProgressBar.fInfinite);
-		fn.done();
-		assert.strictEqual(true, testProgressBar.fDone);
-
-		// Hidden view: Show (Infinite)
-		viewsService.onDidChangeViewVisibilityEmitter.fire({ id: 'test.scopeId', visible: false });
-		service.show(true);
-		assert.strictEqual(false, !!testProgressBar.fInfinite);
-		viewsService.onDidChangeViewVisibilityEmitter.fire({ id: 'test.scopeId', visible: true });
-		assert.strictEqual(true, testProgressBar.fInfinite);
 	});
 });


### PR DESCRIPTION
- Remove views service dependency in composite part
- Create ProgressScope for composites by depending on the visibility events from the composite
- Create ProgressScope for views by depending on the visibility of the views
- ViewService still has to be eager because it registers viewlets and panels in the constructor. 