### PR TITLE
fix: dynamic debug of node.js terminal types failing

### DIFF
--- a/product.json
+++ b/product.json
@@ -46,7 +46,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.71.0",
+			"version": "1.71.1",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
This contains the following changes: https://github.com/microsoft/vscode-js-debug/compare/v1.71.0...v1.71.1

This fixes #159881
