### PR TITLE
use window.openedWorkspace

### DIFF
--- a/src/vs/platform/userDataProfile/electron-main/userDataTransientProfilesHandler.ts
+++ b/src/vs/platform/userDataProfile/electron-main/userDataTransientProfilesHandler.ts
@@ -18,7 +18,7 @@ export class UserDataTransientProfilesHandler extends Disposable {
 		super();
 		this._register(lifecycleMainService.onWillLoadWindow(e => {
 			if (e.reason === LoadReason.LOAD) {
-				this.unsetTransientProfileForWorkspace(e.window.previousWorkspace ?? 'empty-window');
+				this.unsetTransientProfileForWorkspace(e.window.openedWorkspace ?? 'empty-window');
 			}
 		}));
 		this._register(lifecycleMainService.onBeforeCloseWindow(window => this.unsetTransientProfileForWorkspace(window.openedWorkspace ?? 'empty-window')));

--- a/src/vs/platform/window/electron-main/window.ts
+++ b/src/vs/platform/window/electron-main/window.ts
@@ -27,7 +27,6 @@ export interface ICodeWindow extends IDisposable {
 	readonly win: BrowserWindow | null; /* `null` after being disposed */
 	readonly config: INativeWindowConfiguration | undefined;
 
-	readonly previousWorkspace?: IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier;
 	readonly openedWorkspace?: IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier;
 
 	readonly profile?: IUserDataProfile;

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -119,8 +119,6 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
 	get backupPath(): string | undefined { return this._config?.backupPath; }
 
-	private _previousWorkspace: IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | undefined;
-	get previousWorkspace(): IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | undefined { return this._previousWorkspace; }
 	get openedWorkspace(): IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | undefined { return this._config?.workspace; }
 
 	get profile(): IUserDataProfile | undefined { return this.config ? this.userDataProfilesService.getOrSetProfileForWorkspace(this.config.workspace ?? 'empty-window', this.userDataProfilesService.profiles.find(profile => profile.id === this.config?.profiles.profile.id) ?? this.userDataProfilesService.defaultProfile) : undefined; }
@@ -853,8 +851,6 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 
 			this._win.setTitle(this.productService.nameLong);
 		}
-
-		this._previousWorkspace = this.openedWorkspace;
 
 		// Update configuration values based on our window context
 		// and set it into the config object URL for usage.


### PR DESCRIPTION
Fixes #159189

It seems `window.openedWorkspace` contains previous workspace when a new workspace is being loaded into same window. So use this property and remove `window.previousWorkspace` 