### PR TITLE
Add support for trigger points

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -395,6 +395,15 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 				true,
 				() => this.debugService.enableOrDisableBreakpoints(!breakpoints[0].enabled, breakpoints[0])
 			));
+
+			actions.push(new Action(
+				`workbench.debug.viewlet.action.toggleTriggerpoint`,
+				breakpoints[0].triggerpoint ? nls.localize('disableTriggerpoint', "Disable Triggerpoint") : nls.localize('enableTriggerpoint', "Enable Triggerpoint"),
+				undefined,
+				true,
+				() => this.debugService.enableOrDisableTriggerpoint(!breakpoints[0].triggerpoint, breakpoints[0])
+			));
+
 		} else if (breakpoints.length > 1) {
 			const sorted = breakpoints.slice().sort((first, second) => (first.column && second.column) ? first.column - second.column : 1);
 			actions.push(new SubmenuAction('debug.removeBreakpoints', nls.localize('removeBreakpoints', "Remove Breakpoints"), sorted.map(bp => new Action(

--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -1063,7 +1063,7 @@ export function getBreakpointMessageAndIcon(state: State, breakpointsActivated: 
 
 	const breakpointIcon = breakpoint instanceof DataBreakpoint ? icons.dataBreakpoint : breakpoint instanceof FunctionBreakpoint ? icons.functionBreakpoint : breakpoint.logMessage ? icons.logBreakpoint : icons.breakpoint;
 
-	if (!breakpoint.enabled || !breakpointsActivated) {
+	if (!breakpoint.enabled || !breakpointsActivated || breakpoint.softDisabled) {
 		return {
 			icon: breakpointIcon.disabled,
 			message: breakpoint.logMessage ? localize('disabledLogpoint', "Disabled Logpoint") : localize('disabledBreakpoint', "Disabled Breakpoint"),

--- a/src/vs/workbench/contrib/debug/common/debugStorage.ts
+++ b/src/vs/workbench/contrib/debug/common/debugStorage.ts
@@ -37,7 +37,7 @@ export class DebugStorage {
 		let result: Breakpoint[] | undefined;
 		try {
 			result = JSON.parse(this.storageService.get(DEBUG_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((breakpoint: any) => {
-				return new Breakpoint(URI.parse(breakpoint.uri.external || breakpoint.source.uri.external), breakpoint.lineNumber, breakpoint.column, breakpoint.enabled, breakpoint.condition, breakpoint.hitCondition, breakpoint.logMessage, breakpoint.adapterData, this.textFileService, this.uriIdentityService);
+				return new Breakpoint(URI.parse(breakpoint.uri.external || breakpoint.source.uri.external), breakpoint.lineNumber, breakpoint.column, breakpoint.enabled, breakpoint.condition, breakpoint.hitCondition, breakpoint.logMessage, breakpoint.adapterData, this.textFileService, this.uriIdentityService, breakpoint.id, breakpoint.triggerpoint);
 			});
 		} catch (e) { }
 

--- a/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
@@ -377,4 +377,16 @@ suite('Debug - Breakpoints', () => {
 
 		textModel.dispose();
 	});
+
+	test('soft disabled breakpoints', () => {
+		const modelUri = uri.file('/myfolder/myfile.js');
+
+		addBreakpointsAndCheckEvents(model, modelUri, [{ lineNumber: 5, enabled: true }, { lineNumber: 10, enabled: false }]);
+		assert.strictEqual(model.getBreakpoints().length, 2);
+
+		model.setSoftDisabled(model.getBreakpoints()[0], true);
+
+		assert.strictEqual(model.getBreakpoints({ enabledOnly: true }).length, 0);
+	});
+
 });

--- a/src/vs/workbench/contrib/debug/test/browser/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/mockDebug.ts
@@ -165,6 +165,10 @@ export class MockDebugService implements IDebugService {
 	runTo(uri: uri, lineNumber: number, column?: number): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
+
+	async enableOrDisableTriggerpoint(enable: boolean, breakpoint: IBreakpoint) {
+		throw new Error('Method not implemented.');
+	}
 }
 
 export class MockSession implements IDebugSession {


### PR DESCRIPTION
A trigger breakpoint is a kind of breakpoint which act as a trigger for
other breakpoints to be enabled for the debugger. A trigger point is used
when one wants to avoid hitting certain breakpoints until a specific path
is executed where the trigger point is placed in the the specific path.

The current implementation softly disable all none trigger breakpoints
until one of the trigger breakpoints is hit. When that happen all none
trigger breakpoints are enabled and the trigger points will be softly
disabled.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
