### PR TITLE
Pass display language as a locale to Electron

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -201,10 +201,6 @@ function configureCommandlineSwitchesSync(cliArgs) {
 					// If the locale is `qps-ploc`, the Microsoft
 					// Pseudo Language Language Pack is being used.
 					// In that case, use `en` as the Electron locale.
-					// The if statement can be removed when Electron officially
-					// adopts the getSystemLocale API.
-					// Ref https://github.com/microsoft/vscode/issues/159813
-					// and https://github.com/electron/electron/pull/35697
 					const localeToUse = (!argvValue || argvValue === 'qps-ploc') ?
 						'en' : argvValue;
 					app.commandLine.appendSwitch('lang', localeToUse);
@@ -574,14 +570,16 @@ async function resolveNlsConfiguration() {
 		// code is here.
 
 		// The ternary and ts-ignore can both be removed once Electron
-		// officially adopts the getSystemLocale API.
-		// Ref https://github.com/electron/electron/pull/35697
+		// officially adopts the getSystemPreferredLanguages API.
+		// Ref https://github.com/microsoft/vscode/issues/159813
+		// and https://github.com/electron/electron/pull/36035
 		/**
 		 * @type string
 		 */
-		let appLocale = (product.quality === 'insider' || product.quality === 'exploration') ?
+		// @ts-ignore API not yet available in the official Electron
+		let appLocale = ((product.quality === 'insider' || product.quality === 'exploration') && app?.getSystemPreferredLanguages()?.length) ?
 			// @ts-ignore API not yet available in the official Electron
-			app.getSystemLocale() : app.getLocale();
+			app.getSystemPreferredLanguages()[0] : app.getLocale();
 		if (!appLocale) {
 			nlsConfiguration = { locale: 'en', availableLanguages: {} };
 		} else {

--- a/src/main.js
+++ b/src/main.js
@@ -196,8 +196,11 @@ function configureCommandlineSwitchesSync(cliArgs) {
 			// Locale
 			else if (argvKey === 'locale') {
 				if (product.quality === 'insider' || product.quality === 'exploration') {
-					// Pass in the locale to Electron so that the Windows Control Overlay
-					// is rendered correctly.
+					// Pass in the locale to Electron so that the
+					// Windows Control Overlay is rendered correctly.
+					// If the locale is `qps-ploc`, the Microsoft
+					// Pseudo Language Language Pack is being used.
+					// In that case, use `en` as the Electron locale.
 					// The if statement can be removed when Electron officially
 					// adopts the getSystemLocale API.
 					// Ref https://github.com/microsoft/vscode/issues/159813
@@ -586,8 +589,8 @@ async function resolveNlsConfiguration() {
 			appLocale = appLocale.toLowerCase();
 
 			if (!appLocale.startsWith('pt') && !appLocale.startsWith('zh')) {
-				// Trim off the country code to help with the recommender.
-				// If - isn't in the string, the following code leaves appLocale unchanged.
+				// Trim off the country code to help with the language pack recommender.
+				// If '-' isn't in the string, the following code leaves appLocale unchanged.
 				appLocale = appLocale.split('-')[0];
 			}
 

--- a/src/main.js
+++ b/src/main.js
@@ -588,12 +588,6 @@ async function resolveNlsConfiguration() {
 			// See above the comment about the loader and case sensitiveness
 			appLocale = appLocale.toLowerCase();
 
-			if (!appLocale.startsWith('pt') && !appLocale.startsWith('zh')) {
-				// Trim off the country code to help with the language pack recommender.
-				// If '-' isn't in the string, the following code leaves appLocale unchanged.
-				appLocale = appLocale.split('-')[0];
-			}
-
 			const { getNLSConfiguration } = require('./vs/base/node/languagePacks');
 			nlsConfiguration = await getNLSConfiguration(product.commit, userDataPath, metaDataFile, appLocale);
 			if (!nlsConfiguration) {

--- a/src/main.js
+++ b/src/main.js
@@ -573,15 +573,23 @@ async function resolveNlsConfiguration() {
 		// The ternary and ts-ignore can both be removed once Electron
 		// officially adopts the getSystemLocale API.
 		// Ref https://github.com/electron/electron/pull/35697
+		/**
+		 * @type string
+		 */
 		let appLocale = (product.quality === 'insider' || product.quality === 'exploration') ?
 			// @ts-ignore API not yet available in the official Electron
 			app.getSystemLocale() : app.getLocale();
 		if (!appLocale) {
 			nlsConfiguration = { locale: 'en', availableLanguages: {} };
 		} else {
-
 			// See above the comment about the loader and case sensitiveness
 			appLocale = appLocale.toLowerCase();
+
+			if (!appLocale.startsWith('pt') && !appLocale.startsWith('zh')) {
+				// Trim off the country code to help with the recommender.
+				// If - isn't in the string, the following code leaves appLocale unchanged.
+				appLocale = appLocale.split('-')[0];
+			}
 
 			const { getNLSConfiguration } = require('./vs/base/node/languagePacks');
 			nlsConfiguration = await getNLSConfiguration(product.commit, userDataPath, metaDataFile, appLocale);

--- a/src/main.js
+++ b/src/main.js
@@ -570,16 +570,16 @@ async function resolveNlsConfiguration() {
 		// code is here.
 
 		// The ternary and ts-ignore can both be removed once Electron
-		// officially adopts the getSystemPreferredLanguages API.
+		// officially adopts the getPreferredSystemLanguages API.
 		// Ref https://github.com/microsoft/vscode/issues/159813
 		// and https://github.com/electron/electron/pull/36035
 		/**
 		 * @type string
 		 */
 		// @ts-ignore API not yet available in the official Electron
-		let appLocale = ((product.quality === 'insider' || product.quality === 'exploration') && app?.getSystemPreferredLanguages()?.length) ?
+		let appLocale = ((product.quality === 'insider' || product.quality === 'exploration') && app?.getPreferredSystemLanguages()?.length) ?
 			// @ts-ignore API not yet available in the official Electron
-			app.getSystemPreferredLanguages()[0] : app.getLocale();
+			app.getPreferredSystemLanguages()[0] : app.getLocale();
 		if (!appLocale) {
 			nlsConfiguration = { locale: 'en', availableLanguages: {} };
 		} else {

--- a/src/main.js
+++ b/src/main.js
@@ -100,6 +100,7 @@ if (locale) {
 }
 
 if (product.quality === 'insider' || product.quality === 'exploration') {
+
 	// Pass in the locale to Electron so that the
 	// Windows Control Overlay is rendered correctly on Windows,
 	// and so that the traffic lights are rendered properly
@@ -107,6 +108,7 @@ if (product.quality === 'insider' || product.quality === 'exploration') {
 	// If the locale is `qps-ploc`, the Microsoft
 	// Pseudo Language Language Pack is being used.
 	// In that case, use `en` as the Electron locale.
+
 	const electronLocale = (!locale || locale === 'qps-ploc') ? 'en' : locale;
 	app.commandLine.appendSwitch('lang', electronLocale);
 }
@@ -168,7 +170,7 @@ function configureCommandlineSwitchesSync(cliArgs) {
 		'disable-hardware-acceleration',
 
 		// override for the color profile to use
-		'force-color-profile',
+		'force-color-profile'
 	];
 
 	if (process.platform === 'linux') {
@@ -578,6 +580,7 @@ async function resolveNlsConfiguration() {
 		if (!appLocale) {
 			nlsConfiguration = { locale: 'en', availableLanguages: {} };
 		} else {
+
 			// See above the comment about the loader and case sensitiveness
 			appLocale = appLocale.toLowerCase();
 

--- a/src/main.js
+++ b/src/main.js
@@ -180,6 +180,8 @@ function configureCommandlineSwitchesSync(cliArgs) {
 	// Read argv config
 	const argvConfig = readArgvConfigSync();
 
+	let hasLocaleSwitch = false;
+	const isInsiderOrExploration = product.quality === 'insider' || product.quality === 'exploration';
 	Object.keys(argvConfig).forEach(argvKey => {
 		const argvValue = argvConfig[argvKey];
 
@@ -195,7 +197,7 @@ function configureCommandlineSwitchesSync(cliArgs) {
 
 			// Locale
 			else if (argvKey === 'locale') {
-				if (product.quality === 'insider' || product.quality === 'exploration') {
+				if (isInsiderOrExploration) {
 					// Pass in the locale to Electron so that the
 					// Windows Control Overlay is rendered correctly.
 					// If the locale is `qps-ploc`, the Microsoft
@@ -204,6 +206,7 @@ function configureCommandlineSwitchesSync(cliArgs) {
 					const localeToUse = (!argvValue || argvValue === 'qps-ploc') ?
 						'en' : argvValue;
 					app.commandLine.appendSwitch('lang', localeToUse);
+					hasLocaleSwitch = true;
 				}
 			}
 
@@ -236,6 +239,11 @@ function configureCommandlineSwitchesSync(cliArgs) {
 			}
 		}
 	});
+
+	if (!hasLocaleSwitch && isInsiderOrExploration) {
+		// Default Electron's locale to English
+		app.commandLine.appendSwitch('lang', 'en');
+	}
 
 	/* Following features are disabled from the runtime.
 	 * `CalculateNativeWinOcclusion` - Disable native window occlusion tracker,

--- a/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
@@ -87,7 +87,12 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 
 	private checkAndInstall(): void {
 		const language = platform.language;
-		const locale = platform.locale; // might contain trailing country code
+		let locale = platform.locale ?? '';
+		if (locale.startsWith('zh-hans')) {
+			locale = 'zh-cn';
+		} else if (locale.startsWith('zh-hant')) {
+			locale = 'zh-tw';
+		}
 		const languagePackSuggestionIgnoreList = <string[]>JSON.parse(this.storageService.get(LANGUAGEPACK_SUGGESTION_IGNORE_STORAGE_KEY, StorageScope.APPLICATION, '[]'));
 
 		if (!this.galleryService.isEnabled()) {

--- a/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
@@ -87,7 +87,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 
 	private checkAndInstall(): void {
 		const language = platform.language;
-		const locale = platform.locale;
+		const locale = platform.locale; // might contain trailing country code
 		const languagePackSuggestionIgnoreList = <string[]>JSON.parse(this.storageService.get(LANGUAGEPACK_SUGGESTION_IGNORE_STORAGE_KEY, StorageScope.APPLICATION, '[]'));
 
 		if (!this.galleryService.isEnabled()) {
@@ -96,118 +96,121 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 		if (!language || !locale || locale === 'en' || locale.indexOf('en-') === 0) {
 			return;
 		}
-		if (language === locale || languagePackSuggestionIgnoreList.includes(locale)) {
+		if (locale.startsWith(language) || languagePackSuggestionIgnoreList.includes(locale)) {
 			return;
 		}
 
-		this.isLanguageInstalled(locale)
-			.then(installed => {
+		this.isLocaleInstalled(locale)
+			.then(async (installed) => {
 				if (installed) {
 					return;
 				}
 
-				this.galleryService.query({ text: `tag:lp-${locale}` }, CancellationToken.None).then(tagResult => {
+				let searchLocale = locale;
+				let tagResult = await this.galleryService.query({ text: `tag:lp-${searchLocale}` }, CancellationToken.None);
+				if (tagResult.total === 0) {
+					// Trim the locale and try again.
+					searchLocale = locale.split('-')[0];
+					tagResult = await this.galleryService.query({ text: `tag:lp-${searchLocale}` }, CancellationToken.None);
 					if (tagResult.total === 0) {
 						return;
 					}
+				}
 
-					const extensionToInstall = tagResult.total === 1 ? tagResult.firstPage[0] : tagResult.firstPage.find(e => e.publisher === 'MS-CEINTL' && e.name.startsWith('vscode-language-pack'));
-					const extensionToFetchTranslationsFrom = extensionToInstall ?? tagResult.firstPage[0];
+				const extensionToInstall = tagResult.total === 1 ? tagResult.firstPage[0] : tagResult.firstPage.find(e => e.publisher === 'MS-CEINTL' && e.name.startsWith('vscode-language-pack'));
+				const extensionToFetchTranslationsFrom = extensionToInstall ?? tagResult.firstPage[0];
 
-					if (!extensionToFetchTranslationsFrom.assets.manifest) {
-						return;
-					}
+				if (!extensionToFetchTranslationsFrom.assets.manifest) {
+					return;
+				}
 
-					Promise.all([this.galleryService.getManifest(extensionToFetchTranslationsFrom, CancellationToken.None), this.galleryService.getCoreTranslation(extensionToFetchTranslationsFrom, locale)])
-						.then(([manifest, translation]) => {
-							const loc = manifest && manifest.contributes && manifest.contributes.localizations && manifest.contributes.localizations.find(x => x.languageId.toLowerCase() === locale);
-							const languageName = loc ? (loc.languageName || locale) : locale;
-							const languageDisplayName = loc ? (loc.localizedLanguageName || loc.languageName || locale) : locale;
-							const translationsFromPack: { [key: string]: string } = translation?.contents?.['vs/workbench/contrib/localization/electron-sandbox/minimalTranslations'] ?? {};
-							const promptMessageKey = extensionToInstall ? 'installAndRestartMessage' : 'showLanguagePackExtensions';
-							const useEnglish = !translationsFromPack[promptMessageKey];
+				Promise.all([this.galleryService.getManifest(extensionToFetchTranslationsFrom, CancellationToken.None), this.galleryService.getCoreTranslation(extensionToFetchTranslationsFrom, searchLocale)])
+					.then(([manifest, translation]) => {
+						const loc = manifest && manifest.contributes && manifest.contributes.localizations && manifest.contributes.localizations.find(x => locale.startsWith(x.languageId.toLowerCase()));
+						const languageName = loc ? (loc.languageName || locale) : locale;
+						const languageDisplayName = loc ? (loc.localizedLanguageName || loc.languageName || locale) : locale;
+						const translationsFromPack: { [key: string]: string } = translation?.contents?.['vs/workbench/contrib/localization/electron-sandbox/minimalTranslations'] ?? {};
+						const promptMessageKey = extensionToInstall ? 'installAndRestartMessage' : 'showLanguagePackExtensions';
+						const useEnglish = !translationsFromPack[promptMessageKey];
 
-							const translations: { [key: string]: string } = {};
-							Object.keys(minimumTranslatedStrings).forEach(key => {
-								if (!translationsFromPack[key] || useEnglish) {
-									translations[key] = minimumTranslatedStrings[key].replace('{0}', languageName);
-								} else {
-									translations[key] = `${translationsFromPack[key].replace('{0}', languageDisplayName)} (${minimumTranslatedStrings[key].replace('{0}', languageName)})`;
-								}
-							});
-
-							const logUserReaction = (userReaction: string) => {
-								/* __GDPR__
-									"languagePackSuggestion:popup" : {
-										"owner": "TylerLeonhardt",
-										"userReaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-										"language": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-									}
-								*/
-								this.telemetryService.publicLog('languagePackSuggestion:popup', { userReaction, language: locale });
-							};
-
-							const searchAction = {
-								label: translations['searchMarketplace'],
-								run: () => {
-									logUserReaction('search');
-									this.paneCompositeService.openPaneComposite(EXTENSIONS_VIEWLET_ID, ViewContainerLocation.Sidebar, true)
-										.then(viewlet => viewlet?.getViewPaneContainer() as IExtensionsViewPaneContainer)
-										.then(viewlet => {
-											viewlet.search(`tag:lp-${locale}`);
-											viewlet.focus();
-										});
-								}
-							};
-
-							const installAndRestartAction = {
-								label: translations['installAndRestart'],
-								run: () => {
-									logUserReaction('installAndRestart');
-									this.installExtension(extensionToInstall!).then(() => this.hostService.restart());
-								}
-							};
-
-							const promptMessage = translations[promptMessageKey];
-
-							this.notificationService.prompt(
-								Severity.Info,
-								promptMessage,
-								[extensionToInstall ? installAndRestartAction : searchAction,
-								{
-									label: localize('neverAgain', "Don't Show Again"),
-									isSecondary: true,
-									run: () => {
-										languagePackSuggestionIgnoreList.push(locale);
-										this.storageService.store(
-											LANGUAGEPACK_SUGGESTION_IGNORE_STORAGE_KEY,
-											JSON.stringify(languagePackSuggestionIgnoreList),
-											StorageScope.APPLICATION,
-											StorageTarget.USER
-										);
-										logUserReaction('neverShowAgain');
-									}
-								}],
-								{
-									onCancel: () => {
-										logUserReaction('cancelled');
-									}
-								}
-							);
-
+						const translations: { [key: string]: string } = {};
+						Object.keys(minimumTranslatedStrings).forEach(key => {
+							if (!translationsFromPack[key] || useEnglish) {
+								translations[key] = minimumTranslatedStrings[key].replace('{0}', languageName);
+							} else {
+								translations[key] = `${translationsFromPack[key].replace('{0}', languageDisplayName)} (${minimumTranslatedStrings[key].replace('{0}', languageName)})`;
+							}
 						});
-				});
-			});
 
+						const logUserReaction = (userReaction: string) => {
+							/* __GDPR__
+								"languagePackSuggestion:popup" : {
+									"owner": "TylerLeonhardt",
+									"userReaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+									"language": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+								}
+							*/
+							this.telemetryService.publicLog('languagePackSuggestion:popup', { userReaction, language: locale });
+						};
+
+						const searchAction = {
+							label: translations['searchMarketplace'],
+							run: () => {
+								logUserReaction('search');
+								this.paneCompositeService.openPaneComposite(EXTENSIONS_VIEWLET_ID, ViewContainerLocation.Sidebar, true)
+									.then(viewlet => viewlet?.getViewPaneContainer() as IExtensionsViewPaneContainer)
+									.then(viewlet => {
+										viewlet.search(`tag:lp-${searchLocale}`);
+										viewlet.focus();
+									});
+							}
+						};
+
+						const installAndRestartAction = {
+							label: translations['installAndRestart'],
+							run: () => {
+								logUserReaction('installAndRestart');
+								this.installExtension(extensionToInstall!).then(() => this.hostService.restart());
+							}
+						};
+
+						const promptMessage = translations[promptMessageKey];
+
+						this.notificationService.prompt(
+							Severity.Info,
+							promptMessage,
+							[extensionToInstall ? installAndRestartAction : searchAction,
+							{
+								label: localize('neverAgain', "Don't Show Again"),
+								isSecondary: true,
+								run: () => {
+									languagePackSuggestionIgnoreList.push(locale);
+									this.storageService.store(
+										LANGUAGEPACK_SUGGESTION_IGNORE_STORAGE_KEY,
+										JSON.stringify(languagePackSuggestionIgnoreList),
+										StorageScope.APPLICATION,
+										StorageTarget.USER
+									);
+									logUserReaction('neverShowAgain');
+								}
+							}],
+							{
+								onCancel: () => {
+									logUserReaction('cancelled');
+								}
+							}
+						);
+					});
+			});
 	}
 
-	private async isLanguageInstalled(language: string | undefined): Promise<boolean> {
+	private async isLocaleInstalled(locale: string): Promise<boolean> {
 		const installed = await this.extensionManagementService.getInstalled();
 		return installed.some(i => !!(i.manifest
 			&& i.manifest.contributes
 			&& i.manifest.contributes.localizations
 			&& i.manifest.contributes.localizations.length
-			&& i.manifest.contributes.localizations.some(l => l.languageId.toLowerCase() === language)));
+			&& i.manifest.contributes.localizations.some(l => locale.startsWith(l.languageId.toLowerCase()))));
 	}
 
 	private installExtension(extension: IGalleryExtension): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Ref #159813
Passing the locale to Electron fixes how the WCO is rendered, otherwise, Electron decides the locale based on the system language. The WCO should be rendered based on the display language, not the system language.

Ref https://github.com/microsoft/vscode/issues/161218
Fixes https://github.com/microsoft/vscode/issues/163458

TODO:
- [x] Determine what other regressions this change could cause.
- [x] Do we want to limit this change to just Windows?

The screenshot below shows that the WCO has been moved out of the way with the fix.
![Screenshot](https://user-images.githubusercontent.com/7199958/188233704-3376fffe-ae1e-4489-875a-6ee50d8b8927.PNG)
