### PR TITLE
🔨 Fix un-updated scroll position by propagating `onDidFocus` into views

### DIFF
--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -112,6 +112,8 @@ export interface IView {
 	 */
 	readonly onDidChange: Event<IViewSize | undefined>;
 
+	readonly onDidFocus?: Event<void>;
+
 	/**
 	 * This will be called by the {@link GridView} during layout. A view meant to
 	 * pass along the layout information down to its descendants.
@@ -778,6 +780,7 @@ class LeafNode implements ISplitView<ILayoutContext>, IDisposable {
 	private readonly _onDidSetLinkedNode = new Emitter<number | undefined>();
 	private _onDidViewChange: Event<number | undefined>;
 	readonly onDidChange: Event<number | undefined>;
+	readonly onDidFocus?: Event<void>;
 
 	private disposables = new DisposableStore();
 
@@ -794,6 +797,9 @@ class LeafNode implements ISplitView<ILayoutContext>, IDisposable {
 		const onDidChange = createLatchedOnDidChangeViewEvent(view);
 		this._onDidViewChange = Event.map(onDidChange, e => e && (this.orientation === Orientation.VERTICAL ? e.width : e.height), this.disposables);
 		this.onDidChange = Event.any(this._onDidViewChange, this._onDidSetLinkedNode.event, this._onDidLinkedWidthNodeChange.event, this._onDidLinkedHeightNodeChange.event);
+		if (view.onDidFocus) {
+			this.onDidFocus = Event.any(view.onDidFocus);
+		}
 	}
 
 	get width(): number {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #157737

This is done by propagating `onDidFocus` as an optional event into view types of GridView and SplitView:

![Recording 2022-09-05 at 18 57 33](https://user-images.githubusercontent.com/36728931/188472354-158bb403-2d7a-46ff-aef4-63e6272abc6b.gif)
