### PR TITLE
fix #159577

### DIFF
--- a/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
@@ -56,10 +56,6 @@ export class UserDataProfilesMainService extends UserDataProfilesService impleme
 		if (!this.isEnabled()) {
 			return undefined;
 		}
-		// Do not create the profile if folder/file arguments are not provided
-		if (!args._.length && !args['folder-uri'] && !args['file-uri']) {
-			return undefined;
-		}
 		if (args.profile) {
 			if (this.profiles.some(p => p.name === args.profile)) {
 				return undefined;

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -76,12 +76,6 @@ interface IOpenBrowserWindowOptions {
 	readonly windowToUse?: ICodeWindow;
 
 	readonly emptyWindowBackupInfo?: IEmptyWindowBackupInfo;
-
-	readonly userDataProfileInfo?: IUserDataProfileInfo;
-}
-
-interface IUserDataProfileInfo {
-	readonly name?: string;
 }
 
 interface IPathResolveOptions {
@@ -160,9 +154,9 @@ interface IPathToOpen<T = IEditorOptions> extends IPath<T> {
 	label?: string;
 
 	/**
-	 * Info of the profile to use
+	 * profile to use
 	 */
-	userDataProfileInfo?: IUserDataProfileInfo;
+	profile?: IUserDataProfile;
 }
 
 interface IWorkspacePathToOpen extends IPathToOpen {
@@ -317,6 +311,10 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 				emptyWindowsWithBackupsToRestore.push({ backupFolder: basename(path.backupPath), remoteAuthority: path.remoteAuthority });
 			} else {
 				emptyToOpen++;
+			}
+			if (path.profile) {
+				// Set the profile to use for the folder/workspace/empty window to open
+				this.userDataProfilesMainService.setProfileForWorkspaceSync(path.workspace ?? 'empty-window', path.profile);
 			}
 		}
 
@@ -704,8 +702,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			forceNewWindow,
 			forceNewTabbedWindow: openConfig.forceNewTabbedWindow,
 			filesToOpen,
-			windowToUse,
-			userDataProfileInfo: folderOrWorkspace.userDataProfileInfo
+			windowToUse
 		});
 	}
 
@@ -732,7 +729,20 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 				pathsToOpen.push(Object.create(null)); // add an empty window if we did not have windows to open from command line
 			}
 
+			// Apply profile if any
+			const profileToUse = openConfig.cli.profile ? this.userDataProfilesMainService.profiles.find(p => p.name === openConfig.cli.profile) : undefined;
+			if (profileToUse) {
+				for (const pathToOpen of pathsToOpen) {
+					pathToOpen.profile = profileToUse;
+				}
+			}
+
 			isCommandLineOrAPICall = true;
+		}
+
+		// Add empty window with passed profile when no files/folders are passed
+		else if (openConfig.cli.profile) {
+			pathsToOpen = [{ profile: this.userDataProfilesMainService.profiles.find(p => p.name === openConfig.cli.profile) }];
 		}
 
 		// Extract paths: from previous session
@@ -858,13 +868,6 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			const path = pathResolveOptions.remoteAuthority ? this.doResolvePathRemote(cliPath, pathResolveOptions) : this.doResolveFilePath(cliPath, pathResolveOptions);
 			if (path) {
 				pathsToOpen.push(path);
-			}
-		}
-
-		// Apply profile if any
-		if (cli.profile) {
-			for (const path of pathsToOpen) {
-				path.userDataProfileInfo = { name: cli.profile };
 			}
 		}
 
@@ -1302,14 +1305,12 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		openConfig.cli['folder-uri'] = folderUris;
 		openConfig.cli['file-uri'] = fileUris;
 
-		const noFilesOrFolders = !cliArgs.length && !folderUris.length && !fileUris.length;
-
 		// Open it
 		const openArgs: IOpenConfiguration = {
 			context: openConfig.context,
 			cli: openConfig.cli,
 			forceNewWindow: true,
-			forceEmpty: noFilesOrFolders,
+			forceEmpty: !cliArgs.length && !folderUris.length && !fileUris.length && !openConfig.cli.profile,
 			userEnv: openConfig.userEnv,
 			noRecentEntry: true,
 			waitMarkerFileURI: openConfig.waitMarkerFileURI,
@@ -1347,7 +1348,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 
 			profiles: {
 				all: this.userDataProfilesMainService.profiles,
-				profile: this.resolveProfileForBrowserWindow(options)
+				profile: this.userDataProfilesMainService.getOrSetProfileForWorkspace(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesMainService.defaultProfile)
 			},
 
 			homeDir: this.environmentMainService.userHome.fsPath,
@@ -1467,25 +1468,6 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		}
 
 		return window;
-	}
-
-	private resolveProfileForBrowserWindow(options: IOpenBrowserWindowOptions) {
-
-		// Resolve profile by name if provided
-		let profile: IUserDataProfile | undefined;
-		if (options.userDataProfileInfo) {
-			profile = this.userDataProfilesMainService.profiles.find(profile => profile.name === options.userDataProfileInfo!.name);
-			if (profile) {
-				this.userDataProfilesMainService.setProfileForWorkspaceSync(options.workspace ?? 'empty-window', profile);
-			}
-		}
-
-		// Otherwise use associated profile
-		if (!profile) {
-			profile = this.userDataProfilesMainService.getOrSetProfileForWorkspace(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesMainService.defaultProfile);
-		}
-
-		return profile;
 	}
 
 	private doOpenInBrowserWindow(window: ICodeWindow, configuration: INativeWindowConfiguration, options: IOpenBrowserWindowOptions): void {

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -297,6 +297,8 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 					// When run with --add, take the folders that are to be opened as
 					// folders that should be added to the currently active window.
 					foldersToAdd.push(path);
+					// Unset the profile so that it is not associated to the folder
+					path.profile = undefined;
 				} else {
 					foldersToOpen.push(path);
 				}


### PR DESCRIPTION
Support profiles from CLI when no folder/workspace is passed in which case an empty window with passed profile is opened Eg:

`code --profile test` opens an empty window with test profile