### PR TITLE
Re-enable terminal profiles tests

### DIFF
--- a/test/smoke/src/areas/terminal/terminal-profiles.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-profiles.test.ts
@@ -10,7 +10,7 @@ const CONTRIBUTED_PROFILE_NAME = `JavaScript Debug Terminal`;
 const ANY_PROFILE_NAME = '^((?!JavaScript Debug Terminal).)*$';
 
 export function setup() {
-	describe.skip('Terminal Profiles', () => {
+	describe('Terminal Profiles', () => {
 		// Acquire automation API
 		let terminal: Terminal;
 		let settingsEditor: SettingsEditor;


### PR DESCRIPTION
It passed a loop of 50x tests so it looks like the flakiness is gone

Fixes #156961

---

Test runs:

- https://monacotools.visualstudio.com/DefaultCollection/Monaco/_build/results?buildId=184158&view=results
- https://dev.azure.com/monacotools/Monaco/_build/results?buildId=184197&view=results
