### PR TITLE
refactor handling profiles from CLI

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1008,7 +1008,7 @@ export class CodeApplication extends Disposable {
 					waitMarkerFileURI,
 					initialStartup: true,
 					remoteAuthority,
-					profile,
+					profile
 				});
 			}
 

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -110,6 +110,7 @@ import { IExtensionsScannerService } from 'vs/platform/extensionManagement/commo
 import { ExtensionsScannerService } from 'vs/platform/extensionManagement/node/extensionsScannerService';
 import { UserDataTransientProfilesHandler } from 'vs/platform/userDataProfile/electron-main/userDataTransientProfilesHandler';
 import { RunOnceScheduler, runWhenIdle } from 'vs/base/common/async';
+import { IUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
 
 /**
  * The main VS Code application. There will only ever be one instance,
@@ -539,15 +540,13 @@ export class CodeApplication extends Disposable {
 
 		// Ensure profile exists when passed in from CLI
 		const profilePromise = this.userDataProfilesMainService.checkAndCreateProfileFromCli(this.environmentMainService.args);
-		if (profilePromise) {
-			await profilePromise;
-		}
+		const profile = profilePromise ? await profilePromise : undefined;
 
 		// Init Channels
 		appInstantiationService.invokeFunction(accessor => this.initChannels(accessor, mainProcessElectronServer, sharedProcessClient));
 
 		// Open Windows
-		const windows = appInstantiationService.invokeFunction(accessor => this.openFirstWindow(accessor, mainProcessElectronServer));
+		const windows = appInstantiationService.invokeFunction(accessor => this.openFirstWindow(accessor, profile, mainProcessElectronServer));
 
 		// Post Open Windows Tasks
 		appInstantiationService.invokeFunction(accessor => this.afterWindowOpen(accessor, sharedProcess));
@@ -835,7 +834,7 @@ export class CodeApplication extends Disposable {
 		mainProcessElectronServer.registerChannel(ipcExtensionHostStarterChannelName, extensionHostStarterChannel);
 	}
 
-	private openFirstWindow(accessor: ServicesAccessor, mainProcessElectronServer: ElectronIPCServer): ICodeWindow[] {
+	private openFirstWindow(accessor: ServicesAccessor, profile: IUserDataProfile | undefined, mainProcessElectronServer: ElectronIPCServer): ICodeWindow[] {
 		const windowsMainService = this.windowsMainService = accessor.get(IWindowsMainService);
 		const urlService = accessor.get(IURLService);
 		const nativeHostMainService = accessor.get(INativeHostMainService);
@@ -995,31 +994,36 @@ export class CodeApplication extends Disposable {
 			});
 		}
 
-		// new window if "-n"
-		if (args['new-window'] && !hasCliArgs && !hasFolderURIs && !hasFileURIs) {
-			return windowsMainService.open({
-				context,
-				cli: args,
-				forceNewWindow: true,
-				forceEmpty: true,
-				noRecentEntry,
-				waitMarkerFileURI,
-				initialStartup: true,
-				remoteAuthority
-			});
-		}
+		// Start without file/folder arguments
+		if (!hasCliArgs && !hasFolderURIs && !hasFileURIs) {
 
-		// mac: open-file event received on startup
-		if (macOpenFiles.length && !hasCliArgs && !hasFolderURIs && !hasFileURIs) {
-			return windowsMainService.open({
-				context: OpenContext.DOCK,
-				cli: args,
-				urisToOpen: macOpenFiles.map(file => this.getWindowOpenableFromPathSync(file)),
-				noRecentEntry,
-				waitMarkerFileURI,
-				initialStartup: true,
-				// remoteAuthority: will be determined based on macOpenFiles
-			});
+			// Force new window
+			if (args['new-window'] || profile) {
+				return windowsMainService.open({
+					context,
+					cli: args,
+					forceNewWindow: true,
+					forceEmpty: true,
+					noRecentEntry,
+					waitMarkerFileURI,
+					initialStartup: true,
+					remoteAuthority,
+					profile,
+				});
+			}
+
+			// mac: open-file event received on startup
+			if (macOpenFiles.length) {
+				return windowsMainService.open({
+					context: OpenContext.DOCK,
+					cli: args,
+					urisToOpen: macOpenFiles.map(file => this.getWindowOpenableFromPathSync(file)),
+					noRecentEntry,
+					waitMarkerFileURI,
+					initialStartup: true,
+					// remoteAuthority: will be determined based on macOpenFiles
+				});
+			}
 		}
 
 		// default: read paths from cli
@@ -1033,7 +1037,8 @@ export class CodeApplication extends Disposable {
 			waitMarkerFileURI,
 			gotoLineMode: args.goto,
 			initialStartup: true,
-			remoteAuthority
+			remoteAuthority,
+			profile
 		});
 	}
 

--- a/src/vs/platform/debug/electron-main/extensionHostDebugIpc.ts
+++ b/src/vs/platform/debug/electron-main/extensionHostDebugIpc.ts
@@ -38,13 +38,12 @@ export class ElectronExtensionHostDebugBroadcastChannel<TContext> extends Extens
 
 		// Ensure profile exists when passed in from args
 		const profilePromise = this.userDataProfilesMainService.checkAndCreateProfileFromCli(pargs);
-		if (profilePromise) {
-			await profilePromise;
-		}
+		const profile = profilePromise ? await profilePromise : undefined;
 
 		const [codeWindow] = this.windowsMainService.openExtensionDevelopmentHostWindow(extDevPaths, {
 			context: OpenContext.API,
 			cli: pargs,
+			profile
 		});
 
 		if (!debugRenderer) {

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -117,16 +117,15 @@ export class LaunchMainService implements ILaunchMainService {
 
 		// Ensure profile exists when passed in from CLI
 		const profilePromise = this.userDataProfilesMainService.checkAndCreateProfileFromCli(args);
-		if (profilePromise) {
-			await profilePromise;
-		}
+		const profile = profilePromise ? await profilePromise : undefined;
 
 		const baseConfig: IOpenConfiguration = {
 			context,
 			cli: args,
 			userEnv,
 			waitMarkerFileURI,
-			remoteAuthority
+			remoteAuthority,
+			profile
 		};
 
 		// Special case extension development
@@ -139,7 +138,7 @@ export class LaunchMainService implements ILaunchMainService {
 			let openNewWindow = false;
 
 			// Force new window
-			if (args['new-window'] || args['unity-launch']) {
+			if (args['new-window'] || args['unity-launch'] || profile) {
 				openNewWindow = true;
 			}
 

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -11,6 +11,7 @@ import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { ICodeWindow } from 'vs/platform/window/electron-main/window';
 import { IOpenEmptyWindowOptions, IWindowOpenable } from 'vs/platform/window/common/window';
+import { IUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile';
 
 export const IWindowsMainService = createDecorator<IWindowsMainService>('windowsMainService');
 
@@ -96,6 +97,7 @@ export interface IOpenConfiguration extends IBaseOpenConfiguration {
 	 * - a workspace that is neither `file://` nor `vscode-remote://`
 	 */
 	readonly remoteAuthority?: string;
+	readonly profile?: IUserDataProfile;
 }
 
 export interface IOpenEmptyConfiguration extends IBaseOpenConfiguration { }

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -76,6 +76,7 @@ interface IOpenBrowserWindowOptions {
 	readonly windowToUse?: ICodeWindow;
 
 	readonly emptyWindowBackupInfo?: IEmptyWindowBackupInfo;
+	readonly profile?: IUserDataProfile;
 }
 
 interface IPathResolveOptions {
@@ -152,11 +153,6 @@ interface IPathToOpen<T = IEditorOptions> extends IPath<T> {
 	 * Optional label for the recent history
 	 */
 	label?: string;
-
-	/**
-	 * profile to use
-	 */
-	profile?: IUserDataProfile;
 }
 
 interface IWorkspacePathToOpen extends IPathToOpen {
@@ -297,8 +293,6 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 					// When run with --add, take the folders that are to be opened as
 					// folders that should be added to the currently active window.
 					foldersToAdd.push(path);
-					// Unset the profile so that it is not associated to the folder
-					path.profile = undefined;
 				} else {
 					foldersToOpen.push(path);
 				}
@@ -313,10 +307,6 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 				emptyWindowsWithBackupsToRestore.push({ backupFolder: basename(path.backupPath), remoteAuthority: path.remoteAuthority });
 			} else {
 				emptyToOpen++;
-			}
-			if (path.profile) {
-				// Set the profile to use for the folder/workspace/empty window to open
-				this.userDataProfilesMainService.setProfileForWorkspaceSync(path.workspace ?? 'empty-window', path.profile);
 			}
 		}
 
@@ -538,7 +528,8 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 					filesToOpen,
 					forceNewWindow: true,
 					remoteAuthority: filesToOpen.remoteAuthority,
-					forceNewTabbedWindow: openConfig.forceNewTabbedWindow
+					forceNewTabbedWindow: openConfig.forceNewTabbedWindow,
+					profile: openConfig.profile
 				}), true);
 			}
 		}
@@ -684,7 +675,8 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			forceNewTabbedWindow: openConfig.forceNewTabbedWindow,
 			filesToOpen,
 			windowToUse,
-			emptyWindowBackupInfo
+			emptyWindowBackupInfo,
+			profile: openConfig.profile
 		});
 	}
 
@@ -704,7 +696,8 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			forceNewWindow,
 			forceNewTabbedWindow: openConfig.forceNewTabbedWindow,
 			filesToOpen,
-			windowToUse
+			windowToUse,
+			profile: openConfig.profile
 		});
 	}
 
@@ -731,20 +724,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 				pathsToOpen.push(Object.create(null)); // add an empty window if we did not have windows to open from command line
 			}
 
-			// Apply profile if any
-			const profileToUse = openConfig.cli.profile ? this.userDataProfilesMainService.profiles.find(p => p.name === openConfig.cli.profile) : undefined;
-			if (profileToUse) {
-				for (const pathToOpen of pathsToOpen) {
-					pathToOpen.profile = profileToUse;
-				}
-			}
-
 			isCommandLineOrAPICall = true;
-		}
-
-		// Add empty window with passed profile when no files/folders are passed
-		else if (openConfig.cli.profile) {
-			pathsToOpen = [{ profile: this.userDataProfilesMainService.profiles.find(p => p.name === openConfig.cli.profile) }];
 		}
 
 		// Extract paths: from previous session
@@ -1307,16 +1287,19 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		openConfig.cli['folder-uri'] = folderUris;
 		openConfig.cli['file-uri'] = fileUris;
 
+		const noFilesOrFolders = !cliArgs.length && !folderUris.length && !fileUris.length;
+
 		// Open it
 		const openArgs: IOpenConfiguration = {
 			context: openConfig.context,
 			cli: openConfig.cli,
 			forceNewWindow: true,
-			forceEmpty: !cliArgs.length && !folderUris.length && !fileUris.length && !openConfig.cli.profile,
+			forceEmpty: noFilesOrFolders,
 			userEnv: openConfig.userEnv,
 			noRecentEntry: true,
 			waitMarkerFileURI: openConfig.waitMarkerFileURI,
-			remoteAuthority
+			remoteAuthority,
+			profile: openConfig.profile
 		};
 
 		return this.open(openArgs);
@@ -1350,7 +1333,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 
 			profiles: {
 				all: this.userDataProfilesMainService.profiles,
-				profile: this.userDataProfilesMainService.getOrSetProfileForWorkspace(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesMainService.defaultProfile)
+				profile: this.resolveProfileForBrowserWindow(options)
 			},
 
 			homeDir: this.environmentMainService.userHome.fsPath,
@@ -1488,6 +1471,22 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 
 		// Load it
 		window.load(configuration);
+	}
+
+	private resolveProfileForBrowserWindow(options: IOpenBrowserWindowOptions) {
+
+		// Use the provided profile if any
+		let profile = options.profile;
+		if (profile) {
+			this.userDataProfilesMainService.setProfileForWorkspaceSync(options.workspace ?? 'empty-window', profile);
+		}
+
+		// Otherwise use associated profile
+		if (!profile) {
+			profile = this.userDataProfilesMainService.getOrSetProfileForWorkspace(options.workspace ?? 'empty-window', (options.windowToUse ?? this.getLastActiveWindow())?.profile ?? this.userDataProfilesMainService.defaultProfile);
+		}
+
+		return profile;
 	}
 
 	private onWindowClosed(window: ICodeWindow): void {

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1287,14 +1287,12 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		openConfig.cli['folder-uri'] = folderUris;
 		openConfig.cli['file-uri'] = fileUris;
 
-		const noFilesOrFolders = !cliArgs.length && !folderUris.length && !fileUris.length;
-
 		// Open it
 		const openArgs: IOpenConfiguration = {
 			context: openConfig.context,
 			cli: openConfig.cli,
 			forceNewWindow: true,
-			forceEmpty: noFilesOrFolders,
+			forceEmpty: !cliArgs.length && !folderUris.length && !fileUris.length,
 			userEnv: openConfig.userEnv,
 			noRecentEntry: true,
 			waitMarkerFileURI: openConfig.waitMarkerFileURI,
@@ -1473,7 +1471,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		window.load(configuration);
 	}
 
-	private resolveProfileForBrowserWindow(options: IOpenBrowserWindowOptions) {
+	private resolveProfileForBrowserWindow(options: IOpenBrowserWindowOptions): IUserDataProfile {
 
 		// Use the provided profile if any
 		let profile = options.profile;


### PR DESCRIPTION
Better implementation of handling profiles from CLI

- Added `profile` property in `IOpenConfiguration` - profile to use while opening windows with this configuration
- Consumers (CLI / Ext host Debug) parse CLI args and set the profile to use while opening the windows

Please note that most of the changes in `windowMainService` are to undo and go back to the state before https://github.com/microsoft/vscode/pull/160163