### PR TITLE
Support latest md ls

### DIFF
--- a/extensions/markdown-language-features/src/client.ts
+++ b/extensions/markdown-language-features/src/client.ts
@@ -40,7 +40,6 @@ export async function startClient(factory: LanguageClientConstructor, workspace:
 				return looksLikeMarkdownPath(resource);
 			},
 		},
-
 	};
 
 	const client = factory('markdown', localize('markdownServer.name', 'Markdown Language Server'), clientOptions);
@@ -114,6 +113,10 @@ export async function startClient(factory: LanguageClientConstructor, workspace:
 
 	client.onRequest(proto.fs_watcher_delete, async (params): Promise<void> => {
 		watchers.delete(params.id);
+	});
+
+	vscode.commands.registerCommand('vscodeMarkdownLanguageservice.open', (uri, args) => {
+		return vscode.commands.executeCommand('vscode.open', uri, args);
 	});
 
 	await client.start();


### PR DESCRIPTION
- Update `looksLikeMarkdownPath` to look at open documents and notebooks, not just the uri
- Register custom command  for document links
