### PR TITLE
Re #134853. Support html headers in notebook outline

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
@@ -442,6 +442,17 @@ export class NotebookCellOutline extends Disposable implements IOutline<OutlineE
 					}
 				}
 				if (!hasHeader) {
+					// no markdown syntax headers, try to find html tags
+					const match = fullContent.match(/<h([1-6]).*>(.*)<\/h\1>/i);
+					if (match) {
+						hasHeader = true;
+						const level = parseInt(match[1]);
+						const text = match[2].trim();
+						entries.push(new OutlineEntry(entries.length, level, cell, text, false, false));
+					}
+				}
+
+				if (!hasHeader) {
 					content = renderMarkdownAsPlaintext({ value: content });
 				}
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Start with a simple regex parsing for html headers (h1 to h6). It works fine then we don't need to request full markdown rendering, which is async and can be slow.
