### PR TITLE
Add Command for focusing extension output channel `View: Show Output...`

### DIFF
--- a/src/vs/workbench/contrib/output/browser/output.contribution.ts
+++ b/src/vs/workbench/contrib/output/browser/output.contribution.ts
@@ -273,6 +273,42 @@ registerAction2(class extends Action2 {
 	}
 });
 
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: `workbench.action.showOutput`,
+			title: { value: nls.localize('showOutput', "Show Output..."), original: 'Show Output...' },
+			category: CATEGORIES.View,
+			menu: {
+				id: MenuId.CommandPalette,
+			},
+			description: {
+				description: '',
+				args: [{
+					name: 'preserveFocus',
+					schema: {
+						type: 'boolean'
+					}
+				}]
+			}
+		});
+	}
+	async run(accessor: ServicesAccessor, preserveFocus = false): Promise<void> {
+		const outputService = accessor.get(IOutputService);
+		const quickInputService = accessor.get(IQuickInputService);
+
+		const entries: IOutputChannelQuickPickItem[] = outputService.getChannelDescriptors()
+			// filter out log outputs as we have commands for them
+			.filter(c => !(c.file && c.log))
+			.map(channel => (<IOutputChannelQuickPickItem>{ id: channel.id, label: channel.label, channel }));
+
+		const entry = await quickInputService.pick(entries, { placeHolder: nls.localize('selectOutputChannel', "Select Output Channel") });
+		if (entry) {
+			return outputService.showChannel(entry.channel.id, preserveFocus);
+		}
+	}
+});
+
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	id: 'output',
 	order: 30,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

### Motivation

It is possible for now to open only log output via quick pick. This new command makes it possible to also open other types of output (these are above the `---` in dropdown menu).

Workaround with extensions API isn't possible as it is possible to focus output by id since output Ids are predictable, but not get list of outputs.

![image](https://user-images.githubusercontent.com/46503702/188852118-a8e8a7af-9f9d-4be6-87a6-d16f438a7723.png)

I added `preserveFocus` arg as it was important to keep focus on the primary editor in my case. (or should I make it object? Can also remove.) Feel free to negotiate. 🙌