### PR TITLE
[release/1.71] Disables the canvas renderer on Safari

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -286,7 +286,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 	}
 
 	private _shouldLoadCanvas(): boolean {
-		return (this._configHelper.config.gpuAcceleration === 'auto' && (XtermTerminal._suggestedRendererType === undefined || XtermTerminal._suggestedRendererType === 'canvas')) || this._configHelper.config.gpuAcceleration === 'canvas';
+		return !isSafari && (this._configHelper.config.gpuAcceleration === 'auto' && (XtermTerminal._suggestedRendererType === undefined || XtermTerminal._suggestedRendererType === 'canvas')) || this._configHelper.config.gpuAcceleration === 'canvas';
 	}
 
 	forceRedraw() {


### PR DESCRIPTION
Fixes #160070

---

A runtime crash can occur in the canvas renderer in Safari which causes rendering glitches. This is a quick fix that just disables the renderer in the release branch, the real fix is in xterm.js which isn't ideal for recovery releases.