### PR TITLE
Use ids instead of indexes for resolving data transfer files

### DIFF
--- a/src/vs/base/common/dataTransfer.ts
+++ b/src/vs/base/common/dataTransfer.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from 'vs/base/common/uri';
+import { generateUuid } from 'vs/base/common/uuid';
 
 export interface IDataTransferFile {
 	readonly name: string;
@@ -12,6 +13,7 @@ export interface IDataTransferFile {
 }
 
 export interface IDataTransferItem {
+	readonly id: string;
 	asString(): Thenable<string>;
 	asFile(): IDataTransferFile | undefined;
 	value: any;
@@ -19,6 +21,7 @@ export interface IDataTransferItem {
 
 export function createStringDataTransferItem(stringOrPromise: string | Promise<string>): IDataTransferItem {
 	return {
+		id: generateUuid(),
 		asString: async () => stringOrPromise,
 		asFile: () => undefined,
 		value: typeof stringOrPromise === 'string' ? stringOrPromise : undefined,
@@ -27,6 +30,7 @@ export function createStringDataTransferItem(stringOrPromise: string | Promise<s
 
 export function createFileDataTransferItem(fileName: string, uri: URI | undefined, data: () => Promise<Uint8Array>): IDataTransferItem {
 	return {
+		id: generateUuid(),
 		asString: async () => '',
 		asFile: () => ({ name: fileName, uri, data }),
 		value: undefined,

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -380,12 +380,12 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 		));
 	}
 
-	$resolvePasteFileData(handle: number, requestId: number, dataIndex: number): Promise<VSBuffer> {
+	$resolvePasteFileData(handle: number, requestId: number, dataId: string): Promise<VSBuffer> {
 		const provider = this._pasteEditProviders.get(handle);
 		if (!provider) {
 			throw new Error('Could not find provider');
 		}
-		return provider.resolveFileData(requestId, dataIndex);
+		return provider.resolveFileData(requestId, dataId);
 	}
 
 	// --- formatting
@@ -896,12 +896,12 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 		));
 	}
 
-	async $resolveDocumentOnDropFileData(handle: number, requestId: number, dataIndex: number): Promise<VSBuffer> {
+	async $resolveDocumentOnDropFileData(handle: number, requestId: number, dataId: string): Promise<VSBuffer> {
 		const provider = this._documentOnDropEditProviders.get(handle);
 		if (!provider) {
 			throw new Error('Could not find provider');
 		}
-		return provider.resolveDocumentOnDropFileData(requestId, dataIndex);
+		return provider.resolveDocumentOnDropFileData(requestId, dataId);
 	}
 }
 
@@ -961,8 +961,8 @@ class MainThreadPasteEditProvider implements languages.DocumentPasteEditProvider
 		}
 	}
 
-	resolveFileData(requestId: number, dataIndex: number): Promise<VSBuffer> {
-		return this.dataTransfers.resolveDropFileData(requestId, dataIndex);
+	resolveFileData(requestId: number, dataId: string): Promise<VSBuffer> {
+		return this.dataTransfers.resolveDropFileData(requestId, dataId);
 	}
 }
 
@@ -993,8 +993,8 @@ class MainThreadDocumentOnDropEditProvider implements languages.DocumentOnDropEd
 		}
 	}
 
-	public resolveDocumentOnDropFileData(requestId: number, dataIndex: number): Promise<VSBuffer> {
-		return this.dataTransfers.resolveDropFileData(requestId, dataIndex);
+	public resolveDocumentOnDropFileData(requestId: number, dataId: string): Promise<VSBuffer> {
+		return this.dataTransfers.resolveDropFileData(requestId, dataId);
 	}
 }
 

--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -117,12 +117,12 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 		}
 	}
 
-	$resolveDropFileData(destinationViewId: string, requestId: number, dataItemIndex: number): Promise<VSBuffer> {
+	$resolveDropFileData(destinationViewId: string, requestId: number, dataItemId: string): Promise<VSBuffer> {
 		const controller = this._dndControllers.get(destinationViewId);
 		if (!controller) {
 			throw new Error('Unknown tree');
 		}
-		return controller.resolveDropFileData(requestId, dataItemIndex);
+		return controller.resolveDropFileData(requestId, dataItemId);
 	}
 
 	private async reveal(treeView: ITreeView, dataProvider: TreeViewDataProvider, itemIn: ITreeItem, parentChain: ITreeItem[], options: IRevealOptions): Promise<void> {
@@ -235,8 +235,8 @@ class TreeViewDragAndDropController implements ITreeViewDragAndDropController {
 		return additionalDataTransfer;
 	}
 
-	public resolveDropFileData(requestId: number, dataItemIndex: number): Promise<VSBuffer> {
-		return this.dataTransfersCache.resolveDropFileData(requestId, dataItemIndex);
+	public resolveDropFileData(requestId: number, dataItemId: string): Promise<VSBuffer> {
+		return this.dataTransfersCache.resolveDropFileData(requestId, dataItemId);
 	}
 }
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -264,7 +264,7 @@ export interface MainThreadTreeViewsShape extends IDisposable {
 	$setMessage(treeViewId: string, message: string): void;
 	$setTitle(treeViewId: string, title: string, description: string | undefined): void;
 	$setBadge(treeViewId: string, badge: IViewBadge | undefined): void;
-	$resolveDropFileData(destinationViewId: string, requestId: number, dataItemIndex: number): Promise<VSBuffer>;
+	$resolveDropFileData(destinationViewId: string, requestId: number, dataItemId: string): Promise<VSBuffer>;
 }
 
 export interface MainThreadDownloadServiceShape extends IDisposable {
@@ -394,8 +394,8 @@ export interface MainThreadLanguageFeaturesShape extends IDisposable {
 	$registerCallHierarchyProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerTypeHierarchyProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerDocumentOnDropEditProvider(handle: number, selector: IDocumentFilterDto[]): void;
-	$resolvePasteFileData(handle: number, requestId: number, dataIndex: number): Promise<VSBuffer>;
-	$resolveDocumentOnDropFileData(handle: number, requestId: number, dataIndex: number): Promise<VSBuffer>;
+	$resolvePasteFileData(handle: number, requestId: number, dataId: string): Promise<VSBuffer>;
+	$resolveDocumentOnDropFileData(handle: number, requestId: number, dataId: string): Promise<VSBuffer>;
 	$setLanguageConfiguration(handle: number, languageId: string, configuration: ILanguageConfigurationDto): void;
 }
 
@@ -1390,6 +1390,7 @@ export interface IDataTransferFileDTO {
 }
 
 export interface DataTransferItemDTO {
+	readonly id: string;
 	readonly asString: string;
 	readonly fileData: IDataTransferFileDTO | undefined;
 }

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -511,8 +511,8 @@ class DocumentPasteEditProvider {
 		const doc = this._documents.getDocument(resource);
 		const vscodeRanges = ranges.map(range => typeConvert.Range.to(range));
 
-		const dataTransfer = typeConvert.DataTransfer.toDataTransfer(dataTransferDto, async (index) => {
-			return (await this._proxy.$resolvePasteFileData(this._handle, requestId, index)).buffer;
+		const dataTransfer = typeConvert.DataTransfer.toDataTransfer(dataTransferDto, async (id) => {
+			return (await this._proxy.$resolvePasteFileData(this._handle, requestId, id)).buffer;
 		});
 
 		const edit = await this._provider.provideDocumentPasteEdits(doc, vscodeRanges, dataTransfer, token);
@@ -1794,8 +1794,8 @@ class DocumentOnDropEditAdapter {
 	async provideDocumentOnDropEdits(requestId: number, uri: URI, position: IPosition, dataTransferDto: extHostProtocol.DataTransferDTO, token: CancellationToken): Promise<extHostProtocol.IDocumentOnDropEditDto | undefined> {
 		const doc = this._documents.getDocument(uri);
 		const pos = typeConvert.Position.to(position);
-		const dataTransfer = typeConvert.DataTransfer.toDataTransfer(dataTransferDto, async (index) => {
-			return (await this._proxy.$resolveDocumentOnDropFileData(this._handle, requestId, index)).buffer;
+		const dataTransfer = typeConvert.DataTransfer.toDataTransfer(dataTransferDto, async (id) => {
+			return (await this._proxy.$resolveDocumentOnDropFileData(this._handle, requestId, id)).buffer;
 		});
 
 		const edit = await this._provider.provideDocumentDropEdits(doc, pos, dataTransfer, token);

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2562,7 +2562,14 @@ export class DataTransferItem {
 		return undefined;
 	}
 
-	constructor(public readonly value: any) { }
+	public readonly id: string;
+
+	constructor(
+		public readonly value: any,
+		id?: string,
+	) {
+		this.id = id ?? generateUuid();
+	}
 }
 
 @es5ClassCompat

--- a/src/vs/workbench/api/common/shared/dataTransferCache.ts
+++ b/src/vs/workbench/api/common/shared/dataTransferCache.ts
@@ -22,15 +22,20 @@ export class DataTransferCache {
 		};
 	}
 
-	async resolveDropFileData(requestId: number, dataItemIndex: number): Promise<VSBuffer> {
+	async resolveDropFileData(requestId: number, dataItemId: string): Promise<VSBuffer> {
 		const entry = this.dataTransfers.get(requestId);
 		if (!entry) {
 			throw new Error('No data transfer found');
 		}
 
-		const file = entry[dataItemIndex]?.asFile();
+		const item = entry.find(x => x.id === dataItemId);
+		if (!item) {
+			throw new Error('No item found in data transfer');
+		}
+
+		const file = item.asFile();
 		if (!file) {
-			throw new Error('No file item found in data transfer');
+			throw new Error('Found data transfer item is not a file');
 		}
 
 		return VSBuffer.wrap(await file.data());


### PR DESCRIPTION
When an extension needs to read a data transfer file, we were previously using the index of the item. This is unreliable as it means we have to ensure the array of data transfer items never changes order

With this PR, i've switched us to use a unique `id` instead

Fixes #160346
