### PR TITLE
improve trust handling in tasks

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -58,7 +58,6 @@ import { TerminalTaskSystem } from './terminalTaskSystem';
 import { IQuickInputService, IQuickPick, IQuickPickItem, QuickPickInput } from 'vs/platform/quickinput/common/quickInput';
 
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { RunAutomaticTasks } from 'vs/workbench/contrib/tasks/browser/runAutomaticTasks';
 import { TaskDefinitionRegistry } from 'vs/workbench/contrib/tasks/common/taskDefinitionRegistry';
 
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
@@ -1219,10 +1218,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 				}
 			} else {
 				executeTaskResult = await this._executeTask(task, resolver, runSource);
-			}
-			if (runSource === TaskRunSource.User) {
-				const workspaceTasks = await this.getWorkspaceTasks();
-				RunAutomaticTasks.runWithPermission(this, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, workspaceTasks);
 			}
 			return executeTaskResult;
 		} catch (error) {

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2206,6 +2206,9 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	}
 
 	public async getWorkspaceTasks(runSource: TaskRunSource = TaskRunSource.User): Promise<Map<string, IWorkspaceFolderTaskResult>> {
+		if (!(await this._trust())) {
+			return new Map();
+		}
 		await this._waitForSupportedExecutions;
 		if (this._workspaceTasksPromise) {
 			return this._workspaceTasksPromise;

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2206,9 +2206,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	}
 
 	public async getWorkspaceTasks(runSource: TaskRunSource = TaskRunSource.User): Promise<Map<string, IWorkspaceFolderTaskResult>> {
-		if (!(await this._trust())) {
-			return new Map();
-		}
 		await this._waitForSupportedExecutions;
 		if (this._workspaceTasksPromise) {
 			return this._workspaceTasksPromise;

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -197,7 +197,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	private static _nextHandle: number = 0;
 
 	private _tasksReconnected: boolean = false;
-	private _automaticTasksHaveRun: boolean = false;
 	private _schemaVersion: JsonSchemaVersion | undefined;
 	private _executionEngine: ExecutionEngine | undefined;
 	private _workspaceFolders: IWorkspaceFolder[] | undefined;
@@ -365,12 +364,9 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	}
 
 	private async _runAutomaticTasks(): Promise<void> {
-		if (!this._automaticTasksHaveRun) {
-			this.getWorkspaceTasks().then(async (tasks) => {
-				RunAutomaticTasks.runWithPermission(this, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, tasks);
-			});
-			this._automaticTasksHaveRun = true;
-		}
+		this.getWorkspaceTasks().then(async (tasks) => {
+			RunAutomaticTasks.runWithPermission(this, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, tasks);
+		});
 	}
 
 	private _attemptTaskReconnection(): void {
@@ -379,9 +375,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			|| this._lifecycleService.startupKind !== StartupKind.ReloadedWindow) {
 			this._storageService.remove(AbstractTaskService.PersistentTasks_Key, StorageScope.WORKSPACE);
 			this._tasksReconnected = true;
-			this._runAutomaticTasks().then(() => {
-				return;
-			});
+			this._runAutomaticTasks().then(() => { return; });
 		}
 		this._getTaskSystem();
 		this._waitForSupportedExecutions.then(async () => {

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -197,6 +197,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	private static _nextHandle: number = 0;
 
 	private _tasksReconnected: boolean = false;
+	private _automaticTasksHaveRun: boolean = false;
 	private _schemaVersion: JsonSchemaVersion | undefined;
 	private _executionEngine: ExecutionEngine | undefined;
 	private _workspaceFolders: IWorkspaceFolder[] | undefined;
@@ -363,20 +364,29 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		this._onDidRegisterSupportedExecutions.fire();
 	}
 
-	private _attemptTaskReconnection(): void {
-		if (this._lifecycleService.startupKind !== StartupKind.ReloadedWindow) {
-			this._tasksReconnected = true;
-			this._storageService.remove(AbstractTaskService.PersistentTasks_Key, StorageScope.WORKSPACE);
+	private async _runAutomaticTasks(): Promise<void> {
+		if (!this._automaticTasksHaveRun) {
+			this.getWorkspaceTasks().then(async (tasks) => {
+				RunAutomaticTasks.runWithPermission(this, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, tasks);
+			});
+			this._automaticTasksHaveRun = true;
 		}
-		if (!this._configurationService.getValue(TaskSettingId.Reconnection) || this._tasksReconnected) {
+	}
+
+	private _attemptTaskReconnection(): void {
+		if (this._tasksReconnected
+			|| !this._configurationService.getValue(TaskSettingId.Reconnection)
+			|| this._lifecycleService.startupKind !== StartupKind.ReloadedWindow) {
+			this._storageService.remove(AbstractTaskService.PersistentTasks_Key, StorageScope.WORKSPACE);
 			this._tasksReconnected = true;
-			return;
+			this._runAutomaticTasks().then(() => {
+				return;
+			});
 		}
 		this._getTaskSystem();
-		this._waitForSupportedExecutions.then(() => {
-			this.getWorkspaceTasks().then(async () => {
-				this._tasksReconnected = await this._reconnectTasks();
-			});
+		this._waitForSupportedExecutions.then(async () => {
+			await this._runAutomaticTasks();
+			this._tasksReconnected = await this._reconnectTasks();
 		});
 	}
 
@@ -1219,10 +1229,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 				}
 			} else {
 				executeTaskResult = await this._executeTask(task, resolver, runSource);
-			}
-			if (runSource === TaskRunSource.User) {
-				const workspaceTasks = await this.getWorkspaceTasks();
-				RunAutomaticTasks.runWithPermission(this, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, workspaceTasks);
 			}
 			return executeTaskResult;
 		} catch (error) {

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -46,16 +46,16 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 	}
 
 	private async _tryRunTasks() {
+		if (this._hasRunTasks || this._configurationService.getValue(ALLOW_AUTOMATIC_TASKS) === 'off') {
+			return;
+		}
+		this._hasRunTasks = true;
 		this._logService.trace('RunAutomaticTasks: Trying to run tasks.');
 		// Wait until we have task system info (the extension host and workspace folders are available).
 		if (!this._taskService.hasTaskSystemInfo) {
 			this._logService.trace('RunAutomaticTasks: Awaiting task system info.');
 			await Event.toPromise(Event.once(this._taskService.onDidChangeTaskSystemInfo));
 		}
-		if (this._hasRunTasks || this._configurationService.getValue(ALLOW_AUTOMATIC_TASKS) === 'off') {
-			return;
-		}
-		this._hasRunTasks = true;
 		const workspaceTasks = await this._taskService.getWorkspaceTasks(TaskRunSource.FolderOpen);
 		this._logService.trace(`RunAutomaticTasks: Found ${workspaceTasks.size} automatic tasks`);
 		await this._runWithPermission(this._taskService, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, workspaceTasks);

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -47,8 +47,10 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		}
 
 		const workspaceTasks = await this._taskService.getWorkspaceTasks(TaskRunSource.FolderOpen);
-		this._logService.trace(`RunAutomaticTasks: Found ${workspaceTasks.size} automatic tasks`);
-		await RunAutomaticTasks.runWithPermission(this._taskService, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, workspaceTasks);
+		if (workspaceTasks.size) {
+			this._logService.trace(`RunAutomaticTasks: Found ${workspaceTasks.size} automatic tasks`);
+			await RunAutomaticTasks.runWithPermission(this._taskService, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, workspaceTasks);
+		}
 	}
 
 	private static _runTasks(taskService: ITaskService, tasks: Array<Task | Promise<Task | undefined>>) {

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -124,7 +124,7 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 
 	public static async runWithPermission(taskService: ITaskService, storageService: IStorageService, notificationService: INotificationService, workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		openerService: IOpenerService, configurationService: IConfigurationService, workspaceTaskResult: Map<string, IWorkspaceFolderTaskResult>) {
-		const isWorkspaceTrusted = workspaceTrustManagementService.isWorkspaceTrusted;
+		const isWorkspaceTrusted = workspaceTrustManagementService.isWorkspaceTrusted();
 		if (!isWorkspaceTrusted || configurationService.getValue(ALLOW_AUTOMATIC_TASKS) === 'off') {
 			return;
 		}

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -38,10 +38,7 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		this._tryRunTasks();
 		this._register(this._workspaceTrustManagementService.onDidChangeTrust(async trusted => {
 			if (trusted) {
-				const workspaceTaskResult = await _taskService.getWorkspaceTasks();
-				if (workspaceTaskResult) {
-					await RunAutomaticTasks.runWithPermission(_taskService, _storageService, _notificationService, _workspaceTrustManagementService, _openerService, _configurationService, workspaceTaskResult);
-				}
+				await this._tryRunTasks();
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -25,7 +25,6 @@ const HAS_PROMPTED_FOR_AUTOMATIC_TASKS = 'task.hasPromptedForAutomaticTasks';
 const ALLOW_AUTOMATIC_TASKS = 'task.allowAutomaticTasks';
 
 export class RunAutomaticTasks extends Disposable implements IWorkbenchContribution {
-	static _hasRunAutomaticTasks: boolean;
 	constructor(
 		@ITaskService private readonly _taskService: ITaskService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -130,11 +129,9 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		const hasShownPromptForAutomaticTasks = storageService.getBoolean(HAS_PROMPTED_FOR_AUTOMATIC_TASKS, StorageScope.WORKSPACE, false);
 		const { tasks, taskNames, locations } = RunAutomaticTasks._findAutoTasks(taskService, workspaceTaskResult);
 
-		if (taskNames.length === 0 || RunAutomaticTasks._hasRunAutomaticTasks) {
+		if (taskNames.length === 0) {
 			return;
 		}
-
-		RunAutomaticTasks._hasRunAutomaticTasks = true;
 
 		if (configurationService.getValue(ALLOW_AUTOMATIC_TASKS) === 'on') {
 			RunAutomaticTasks._runTasks(taskService, tasks);

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -56,6 +56,7 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		if (this._hasRunTasks || !isWorkspaceTrusted || this._configurationService.getValue(ALLOW_AUTOMATIC_TASKS) === 'off') {
 			return;
 		}
+		this._hasRunTasks = true;
 		const workspaceTasks = await this._taskService.getWorkspaceTasks(TaskRunSource.FolderOpen);
 		this._logService.trace(`RunAutomaticTasks: Found ${workspaceTasks.size} automatic tasks`);
 		await this._runWithPermission(this._taskService, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, workspaceTasks);
@@ -73,7 +74,6 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 				taskService.run(task);
 			}
 		});
-		this._hasRunTasks = true;
 	}
 
 	private _getTaskSource(source: TaskSource): URI | undefined {

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -25,6 +25,7 @@ const HAS_PROMPTED_FOR_AUTOMATIC_TASKS = 'task.hasPromptedForAutomaticTasks';
 const ALLOW_AUTOMATIC_TASKS = 'task.allowAutomaticTasks';
 
 export class RunAutomaticTasks extends Disposable implements IWorkbenchContribution {
+	static _hasRunAutomaticTasks: boolean;
 	constructor(
 		@ITaskService private readonly _taskService: ITaskService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -129,9 +130,11 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		const hasShownPromptForAutomaticTasks = storageService.getBoolean(HAS_PROMPTED_FOR_AUTOMATIC_TASKS, StorageScope.WORKSPACE, false);
 		const { tasks, taskNames, locations } = RunAutomaticTasks._findAutoTasks(taskService, workspaceTaskResult);
 
-		if (taskNames.length === 0) {
+		if (taskNames.length === 0 || RunAutomaticTasks._hasRunAutomaticTasks) {
 			return;
 		}
+
+		RunAutomaticTasks._hasRunAutomaticTasks = true;
 
 		if (configurationService.getValue(ALLOW_AUTOMATIC_TASKS) === 'on') {
 			RunAutomaticTasks._runTasks(taskService, tasks);

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -47,10 +47,8 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		}
 
 		const workspaceTasks = await this._taskService.getWorkspaceTasks(TaskRunSource.FolderOpen);
-		if (workspaceTasks.size) {
-			this._logService.trace(`RunAutomaticTasks: Found ${workspaceTasks.size} automatic tasks`);
-			await RunAutomaticTasks.runWithPermission(this._taskService, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, workspaceTasks);
-		}
+		this._logService.trace(`RunAutomaticTasks: Found ${workspaceTasks.size} automatic tasks`);
+		await RunAutomaticTasks.runWithPermission(this._taskService, this._storageService, this._notificationService, this._workspaceTrustManagementService, this._openerService, this._configurationService, workspaceTasks);
 	}
 
 	private static _runTasks(taskService: ITaskService, tasks: Array<Task | Promise<Task | undefined>>) {

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -35,7 +35,9 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@INotificationService private readonly _notificationService: INotificationService) {
 		super();
-		this._tryRunTasks();
+		if (this._workspaceTrustManagementService.isWorkspaceTrusted()) {
+			this._tryRunTasks();
+		}
 		this._register(this._workspaceTrustManagementService.onDidChangeTrust(async trusted => {
 			if (trusted) {
 				await this._tryRunTasks();

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -52,8 +52,7 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 			this._logService.trace('RunAutomaticTasks: Awaiting task system info.');
 			await Event.toPromise(Event.once(this._taskService.onDidChangeTaskSystemInfo));
 		}
-		const isWorkspaceTrusted = this._workspaceTrustManagementService.isWorkspaceTrusted();
-		if (this._hasRunTasks || !isWorkspaceTrusted || this._configurationService.getValue(ALLOW_AUTOMATIC_TASKS) === 'off') {
+		if (this._hasRunTasks || this._configurationService.getValue(ALLOW_AUTOMATIC_TASKS) === 'off') {
 			return;
 		}
 		this._hasRunTasks = true;


### PR DESCRIPTION
fix #160013
fix https://github.com/microsoft/vscode/issues/160368
fix https://github.com/microsoft/vscode/issues/156183

I had missed a place where trust gets requested within `runAutomaticTasks` `tryRunTasks` function that gets called in the constructor

https://github.com/microsoft/vscode/blob/872c9079b137119777a4afc2c6f047d4eee8d329/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts#L57

Now we will check if it's currently untrusted before that happens and, if so, return.

https://github.com/microsoft/vscode/blob/872c9079b137119777a4afc2c6f047d4eee8d329/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts#L53-L56

Another issue was automatic tasks were getting executed in `run` of the task service, so any time a task was run, that would happen. 

I believe this was as a result of an incorrect refactor I made to the structure of that function, but think the more appropriate condition for when to try again is when the workspace becomes trusted.

https://github.com/microsoft/vscode/blob/872c9079b137119777a4afc2c6f047d4eee8d329/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts#L39-L43