### PR TITLE
Provide UX affordances for turning on Edit Sessions

### DIFF
--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -59,8 +59,7 @@ registerSingleton(IEditSessionsStorageService, EditSessionsWorkbenchService, fal
 
 const continueEditSessionCommand: IAction2Options = {
 	id: '_workbench.experimental.editSessions.actions.continueEditSession',
-	title: { value: localize('continue edit session', "Continue Edit Session..."), original: 'Continue Edit Session...' },
-	category: EDIT_SESSION_SYNC_CATEGORY,
+	title: { value: localize('continue working on', "Continue Working On..."), original: 'Continue Working On...' },
 	precondition: WorkspaceFolderCountContext.notEqualsTo('0'),
 	f1: true
 };

--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -29,7 +29,7 @@ import { IProductService } from 'vs/platform/product/common/productService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuration';
-import { Extensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
 import { ContextKeyExpr, ContextKeyExpression, IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -57,7 +57,7 @@ import * as Constants from 'vs/workbench/contrib/logs/common/logConstants';
 registerSingleton(IEditSessionsLogService, EditSessionsLogService, false);
 registerSingleton(IEditSessionsStorageService, EditSessionsWorkbenchService, false);
 
-const continueEditSessionCommand: IAction2Options = {
+const continueWorkingOnCommand: IAction2Options = {
 	id: '_workbench.experimental.editSessions.actions.continueEditSession',
 	title: { value: localize('continue working on', "Continue Working On..."), original: 'Continue Working On...' },
 	precondition: WorkspaceFolderCountContext.notEqualsTo('0'),
@@ -82,6 +82,7 @@ const resumingProgressOptions = {
 const queryParamName = 'editSessionId';
 const experimentalSettingName = 'workbench.experimental.editSessions.enabled';
 
+const useEditSessionsWithContinueOn = 'workbench.experimental.editSessions.continueOn';
 export class EditSessionsContribution extends Disposable implements IWorkbenchContribution {
 
 	private registered = false;
@@ -241,7 +242,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 		const that = this;
 		this._register(registerAction2(class ContinueEditSessionAction extends Action2 {
 			constructor() {
-				super(continueEditSessionCommand);
+				super(continueWorkingOnCommand);
 			}
 
 			async run(accessor: ServicesAccessor, workspaceUri: URI | undefined): Promise<void> {
@@ -251,11 +252,16 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 				};
 				that.telemetryService.publicLog2<ContinueEditSessionEvent, ContinueEditSessionClassification>('editSessions.continue.store');
 
+				const shouldStoreEditSession = await that.shouldContinueOnWithEditSession();
+
 				let uri = workspaceUri ?? await that.pickContinueEditSessionDestination();
 				if (uri === undefined) { return; }
 
 				// Run the store action to get back a ref
-				const ref = await that.storeEditSession(false);
+				let ref: string | undefined;
+				if (shouldStoreEditSession) {
+					ref = await that.storeEditSession(false);
+				}
 
 				// Append the ref to the URI
 				if (ref !== undefined && uri !== 'noDestinationUri') {
@@ -267,8 +273,12 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 					// Open the URI
 					that.logService.info(`Opening ${uri.toString()}`);
 					await that.openerService.open(uri, { openExternal: true });
-				} else if (ref === undefined) {
-					that.logService.warn(`Failed to store edit session when invoking ${continueEditSessionCommand.id}.`);
+				} else if (!shouldStoreEditSession && uri !== 'noDestinationUri') {
+					// Open the URI without an edit session ref
+					that.logService.info(`Opening ${uri.toString()}`);
+					await that.openerService.open(uri, { openExternal: true });
+				} else if (ref === undefined && shouldStoreEditSession) {
+					that.logService.warn(`Failed to store edit session when invoking ${continueWorkingOnCommand.id}.`);
 				}
 			}
 		}));
@@ -528,6 +538,34 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 		return [...trackedUris];
 	}
 
+	private hasEditSession() {
+		for (const repository of this.scmService.repositories) {
+			if (this.getChangedResources(repository).length > 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private async shouldContinueOnWithEditSession(): Promise<boolean> {
+		// If the user is already signed in, we should store edit session
+		if (this.editSessionsStorageService.isSignedIn) {
+			return true;
+		}
+
+		// If the user has been asked before and said no, don't use edit sessions
+		if (this.configurationService.getValue(useEditSessionsWithContinueOn) === 'off') {
+			return false;
+		}
+
+		// Prompt the user to use edit sessions if they currently could benefit from using it
+		if (this.hasEditSession()) {
+			return this.editSessionsStorageService.initialize(true);
+		}
+
+		return false;
+	}
+
 	//#region Continue Edit Session extension contribution point
 
 	private registerContributedEditSessionOptions() {
@@ -689,7 +727,7 @@ const continueEditSessionExtPoint = ExtensionsRegistry.registerExtensionPoint<IC
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 workbenchRegistry.registerWorkbenchContribution(EditSessionsContribution, 'EditSessionsContribution', LifecyclePhase.Restored);
 
-Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	...workbenchConfigurationNodeBase,
 	'properties': {
 		'workbench.experimental.editSessions.autoStore': {
@@ -720,5 +758,16 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			'default': 'onReload',
 			'markdownDescription': localize('autoResume', "Controls whether to automatically resume an available edit session for the current workspace."),
 		},
+		'workbench.experimental.editSessions.continueOn': {
+			enum: ['prompt', 'off'],
+			enumDescriptions: [
+				localize('continueOn.promptForAuth', 'Prompt the user to sign in to store edit sessions with Continue Working On.'),
+				localize('continueOn.off', 'Do not use edit sessions with Continue Working On unless the user has already turned on edit sessions.')
+			],
+			type: 'string',
+			tags: ['experimental', 'usesOnlineServices'],
+			default: 'prompt',
+			markdownDescription: localize('continueOn', 'Controls whether to prompt the user to store edit sessions when using Continue Working On.')
+		}
 	}
 });

--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -296,7 +296,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 				});
 			}
 
-			async run(accessor: ServicesAccessor, editSessionId?: string): Promise<void> {
+			async run(accessor: ServicesAccessor, editSessionId?: string, silent?: boolean): Promise<void> {
 				await that.progressService.withProgress(resumingProgressOptions, async () => {
 					type ResumeEvent = {};
 					type ResumeClassification = {
@@ -304,7 +304,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 					};
 					that.telemetryService.publicLog2<ResumeEvent, ResumeClassification>('editSessions.resume');
 
-					await that.resumeEditSession(editSessionId);
+					await that.resumeEditSession(editSessionId, silent);
 				});
 			}
 		}));

--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
@@ -416,7 +416,7 @@ export class EditSessionsWorkbenchService extends Disposable implements IEditSes
 			constructor() {
 				super({
 					id: 'workbench.editSessions.actions.resetAuth',
-					title: localize('reset auth.v2', 'Sign Out of Edit Sessions'),
+					title: localize('reset auth.v3', 'Turn off Edit Sessions...'),
 					category: EDIT_SESSION_SYNC_CATEGORY,
 					precondition: ContextKeyExpr.equals(EDIT_SESSIONS_SIGNED_IN_KEY, true),
 					menu: [{
@@ -433,8 +433,8 @@ export class EditSessionsWorkbenchService extends Disposable implements IEditSes
 			async run() {
 				const result = await that.dialogService.confirm({
 					type: 'info',
-					message: localize('sign out of edit sessions clear data prompt', 'Do you want to sign out of edit sessions?'),
-					checkbox: { label: localize('delete all edit sessions', 'Delete all stored edit sessions from the cloud.') },
+					message: localize('sign out of edit sessions clear data prompt.v2', 'Do you want to turn off Edit Sessions?'),
+					checkbox: { label: localize('delete all edit sessions.v2', 'Delete all stored data from the cloud.') },
 					primaryButton: localize('clear data confirm', 'Yes'),
 				});
 				if (result.confirmed) {

--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
@@ -384,11 +384,16 @@ export class EditSessionsWorkbenchService extends Disposable implements IEditSes
 			constructor() {
 				super({
 					id: 'workbench.editSessions.actions.signIn',
-					title: localize('sign in', 'Sign In'),
+					title: localize('sign in', 'Turn on Edit Sessions...'),
 					category: EDIT_SESSION_SYNC_CATEGORY,
 					precondition: ContextKeyExpr.equals(EDIT_SESSIONS_SIGNED_IN_KEY, false),
 					menu: [{
 						id: MenuId.CommandPalette,
+					},
+					{
+						id: MenuId.AccountsContext,
+						group: '2_editSessions',
+						when: ContextKeyExpr.equals(EDIT_SESSIONS_SIGNED_IN_KEY, false),
 					}]
 				});
 			}

--- a/src/vs/workbench/contrib/editSessions/common/editSessions.ts
+++ b/src/vs/workbench/contrib/editSessions/common/editSessions.ts
@@ -24,6 +24,7 @@ export interface IEditSessionsStorageService {
 
 	readonly isSignedIn: boolean;
 
+	initialize(fromContinueOn: boolean): Promise<boolean>;
 	read(ref: string | undefined): Promise<{ ref: string; editSession: EditSession } | undefined>;
 	write(editSession: EditSession): Promise<string>;
 	delete(ref: string | null): Promise<void>;


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode/issues/159078

- When the user invokes Continue On, prompt to turn on Edit Sessions but offer an option to skip turning on Edit Sessions in the quickpick and a quickpick item button to configure always skipping Edit Sessions
- Rename Continue Edit Session to Continue Working On
- If the user doesn't have Edit Sessions turned on and they are going from web to desktop without having used Edit Sessions on desktop before, their current edit session will fail to resume when using Continue On. To mitigate this, increment the global activity badge when the user hasn't turned on Edit Sessions. https://github.com/microsoft/vscode/pull/158781/ should allow users to disable this badge if desired