### PR TITLE
Update Groovy extension language contribution

### DIFF
--- a/extensions/groovy/package.json
+++ b/extensions/groovy/package.json
@@ -30,7 +30,7 @@
           "Jenkinsfile"
         ],
         "filenamePatterns": [
-          "Jenkinsfile.*"
+          "Jenkinsfile*"
         ],
         "firstLine": "^#!.*\\bgroovy\\b",
         "configuration": "./language-configuration.json"


### PR DESCRIPTION
Change `filenamePatterns` to `Jenkinsfile.*` to `Jenkinsfile*` to capture files starting with Jenkinsfile, not necessarily having a period as a delimiter.
