### PR TITLE
send uris for `git.mergeChanges` context as objects

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2081,7 +2081,7 @@ export class Repository implements Disposable {
 		this.setCountBadge();
 
 		// set mergeChanges context
-		commands.executeCommand('setContext', 'git.mergeChanges', merge.map(item => item.resourceUri.toString()));
+		commands.executeCommand('setContext', 'git.mergeChanges', merge.map(item => item.resourceUri));
 
 		this._onDidChangeStatus.fire();
 


### PR DESCRIPTION
That way they undergo uri transformation and the setContext-command will stringify them so that everything works, fixes https://github.com/microsoft/vscode/issues/159837
