### PR TITLE
"Create Manual Folding Ranges from Selection" is not in Command Palette when use Chinese (Simplified)

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -1066,7 +1066,7 @@ class FoldRangeFromSelectionAction extends FoldingAction<void> {
 		super({
 			id: 'editor.createFoldingRangeFromSelection',
 			label: nls.localize('createManualFoldRange.label', "Create Manual Folding Range from Selection"),
-			alias: 'Create Folding Range from Selection',
+			alias: 'Create Manual Folding Range from Selection',
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,


### PR DESCRIPTION
Fixes #160363