### PR TITLE
add wslFeatureInstalled context key

### DIFF
--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -121,6 +121,8 @@ export interface ICommonNativeHostService {
 
 	getOSColorScheme(): Promise<IColorScheme>;
 
+	hasWSLFeatureInstalled(): Promise<boolean>;
+
 	// Process
 	killProcess(pid: number, code: string): Promise<void>;
 

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -40,6 +40,7 @@ import { IWindowsMainService, OpenContext } from 'vs/platform/windows/electron-m
 import { isWorkspaceIdentifier, toWorkspaceIdentifier } from 'vs/platform/workspace/common/workspace';
 import { IWorkspacesManagementMainService } from 'vs/platform/workspaces/electron-main/workspacesManagementMainService';
 import { VSBuffer } from 'vs/base/common/buffer';
+import { hasWSLFeatureInstalled } from 'vs/platform/remote/node/wsl';
 
 export interface INativeHostMainService extends AddFirstParameterToFunctions<ICommonNativeHostService, Promise<unknown> /* only methods, not events */, number | undefined /* window ID */> { }
 
@@ -565,6 +566,12 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 
 	public async getOSColorScheme(): Promise<IColorScheme> {
 		return this.themeMainService.getColorScheme();
+	}
+
+
+	// WSL
+	public async hasWSLFeatureInstalled(): Promise<boolean> {
+		return isWindows && hasWSLFeatureInstalled();
 	}
 
 

--- a/src/vs/platform/remote/node/wsl.ts
+++ b/src/vs/platform/remote/node/wsl.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as os from 'os';
+import * as cp from 'child_process';
+import { promises as fs } from 'fs';
+import path = require('path');
+
+let hasWSLFeaturePromise: Promise<boolean> | undefined;
+
+export async function hasWSLFeatureInstalled(refresh = false): Promise<boolean> {
+	if (hasWSLFeaturePromise === undefined || refresh) {
+		hasWSLFeaturePromise = testWSLFeatureInstalled();
+	}
+	return hasWSLFeaturePromise;
+}
+
+async function testWSLFeatureInstalled(): Promise<boolean> {
+	const windowsBuildNumber = getWindowsBuildNumber();
+	if (windowsBuildNumber === undefined) {
+		return false;
+	}
+	if (windowsBuildNumber >= 22000) {
+		const wslExePath = getWSLExecutablePath();
+		if (wslExePath) {
+			return new Promise<boolean>(s => {
+				cp.execFile(wslExePath, ['--status'], err => s(!err));
+			});
+		}
+	} else {
+		const dllPath = getLxssManagerDllPath();
+		if (dllPath) {
+			try {
+				if ((await fs.stat(dllPath)).isFile()) {
+					return true;
+				}
+			} catch (e) {
+			}
+		}
+	}
+	return false;
+}
+
+function getWindowsBuildNumber(): number | undefined {
+	const osVersion = (/(\d+)\.(\d+)\.(\d+)/g).exec(os.release());
+	if (osVersion) {
+		return parseInt(osVersion[3]);
+	}
+	return undefined;
+}
+
+function getSystem32Path(subPath: string): string | undefined {
+	const systemRoot = process.env['SystemRoot'];
+	if (systemRoot) {
+		const is32ProcessOn64Windows = process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
+		return path.join(systemRoot, is32ProcessOn64Windows ? 'Sysnative' : 'System32', subPath);
+	}
+	return undefined;
+}
+
+function getWSLExecutablePath(): string | undefined {
+	return getSystem32Path('wsl.exe');
+}
+
+/**
+ * In builds < 22000 this dll inidcates that WSL is installed
+ */
+function getLxssManagerDllPath(): string | undefined {
+	return getSystem32Path('lxss\\LxssManager.dll');
+}

--- a/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { isMacintosh } from 'vs/base/common/platform';
+import { isMacintosh, isWindows } from 'vs/base/common/platform';
 import { KeyMod, KeyChord, KeyCode } from 'vs/base/common/keyCodes';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions as WorkbenchContributionsExtensions } from 'vs/workbench/common/contributions';
@@ -169,7 +169,9 @@ workbenchContributionsRegistry.registerWorkbenchContribution(RemoteAgentDiagnost
 workbenchContributionsRegistry.registerWorkbenchContribution(RemoteExtensionHostEnvironmentUpdater, 'RemoteExtensionHostEnvironmentUpdater', LifecyclePhase.Eventually);
 workbenchContributionsRegistry.registerWorkbenchContribution(RemoteTelemetryEnablementUpdater, 'RemoteTelemetryEnablementUpdater', LifecyclePhase.Ready);
 workbenchContributionsRegistry.registerWorkbenchContribution(RemoteEmptyWorkbenchPresentation, 'RemoteEmptyWorkbenchPresentation', LifecyclePhase.Ready);
-workbenchContributionsRegistry.registerWorkbenchContribution(WSLContextKeyInitializer, 'WSLContextKeyInitializer', LifecyclePhase.Ready);
+if (isWindows) {
+	workbenchContributionsRegistry.registerWorkbenchContribution(WSLContextKeyInitializer, 'WSLContextKeyInitializer', LifecyclePhase.Ready);
+}
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 	.registerConfiguration({

--- a/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
@@ -134,7 +134,9 @@ class RemoteEmptyWorkbenchPresentation extends Disposable implements IWorkbenchC
 	}
 }
 
-
+/**
+ * Sets the 'wslFeatureInstalled' context key if the WSL feature is or was installed on this machine.
+ */
 class WSLContextKeyInitializer extends Disposable implements IWorkbenchContribution {
 
 	constructor(

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -240,6 +240,7 @@ export class TestNativeHostService implements INativeHostService {
 	async getOSStatistics(): Promise<IOSStatistics> { return Object.create(null); }
 	async getOSVirtualMachineHint(): Promise<number> { return 0; }
 	async getOSColorScheme(): Promise<IColorScheme> { return { dark: true, highContrast: false }; }
+	async hasWSLFeatureInstalled(): Promise<boolean> { return false; }
 	async killProcess(): Promise<void> { }
 	async setDocumentEdited(edited: boolean): Promise<void> { }
 	async openExternal(url: string): Promise<boolean> { return false; }


### PR DESCRIPTION
adds a context variable 'wslFeatureInstalled' that is set when the WSL feature is installed.

Once detected, this is remembered in the storage, so the test is no longer made.