### PR TITLE
Git - Add the ability to commit and not execute a post-commit command

### DIFF
--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -139,7 +139,13 @@ export interface CommitOptions {
 	requireUserConfig?: boolean;
 	useEditor?: boolean;
 	verbose?: boolean;
-	postCommitCommand?: string;
+	/**
+	 * string    - execute the specified command after the commit operation
+	 * undefined - execute the command specified in git.postCommitCommand
+	 *             after the commit operation
+	 * null      - do not execute any command after the commit operation
+	 */
+	postCommitCommand?: string | null;
 }
 
 export interface FetchOptions {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1277,7 +1277,9 @@ export class Repository implements Disposable {
 			});
 
 			// Execute post-commit command
-			await this.commitCommandCenter.executePostCommitCommand(opts.postCommitCommand);
+			if (opts.postCommitCommand !== null) {
+				await this.commitCommandCenter.executePostCommitCommand(opts.postCommitCommand);
+			}
 		}
 	}
 

--- a/extensions/github/src/publish.ts
+++ b/extensions/github/src/publish.ts
@@ -199,7 +199,7 @@ export async function publishRepository(gitAPI: GitAPI, repository?: Repository)
 					return;
 				}
 
-				await repository.commit('first commit', { all: true });
+				await repository.commit('first commit', { all: true, postCommitCommand: null });
 			}
 
 			progress.report({ message: localize('publishing_uploading', "Uploading files"), increment: 25 });

--- a/extensions/github/src/typings/git.d.ts
+++ b/extensions/github/src/typings/git.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri, Event, Disposable, ProviderResult } from 'vscode';
+import { Uri, Event, Disposable, ProviderResult, Command } from 'vscode';
 export { ProviderResult } from 'vscode';
 
 export interface Git {
@@ -12,6 +12,11 @@ export interface Git {
 
 export interface InputBox {
 	value: string;
+}
+
+export const enum ForcePushMode {
+	Force,
+	ForceWithLease
 }
 
 export const enum RefType {
@@ -131,6 +136,24 @@ export interface CommitOptions {
 	signCommit?: boolean;
 	empty?: boolean;
 	noVerify?: boolean;
+	requireUserConfig?: boolean;
+	useEditor?: boolean;
+	verbose?: boolean;
+	/**
+	 * string    - execute the specified command after the commit operation
+	 * undefined - execute the command specified in git.postCommitCommand
+	 *             after the commit operation
+	 * null      - do not execute any command after the commit operation
+	 */
+	postCommitCommand?: string | null;
+}
+
+export interface FetchOptions {
+	remote?: string;
+	ref?: string;
+	all?: boolean;
+	prune?: boolean;
+	depth?: number;
 }
 
 export interface BranchQuery {
@@ -158,6 +181,8 @@ export interface Repository {
 	show(ref: string, path: string): Promise<string>;
 	getCommit(ref: string): Promise<Commit>;
 
+	add(paths: string[]): Promise<void>;
+	revert(paths: string[]): Promise<void>;
 	clean(paths: string[]): Promise<void>;
 
 	apply(patch: string, reverse?: boolean): Promise<void>;
@@ -184,6 +209,9 @@ export interface Repository {
 
 	getMergeBase(ref1: string, ref2: string): Promise<string>;
 
+	tag(name: string, upstream: string): Promise<void>;
+	deleteTag(name: string): Promise<void>;
+
 	status(): Promise<void>;
 	checkout(treeish: string): Promise<void>;
 
@@ -191,9 +219,10 @@ export interface Repository {
 	removeRemote(name: string): Promise<void>;
 	renameRemote(name: string, newName: string): Promise<void>;
 
+	fetch(options?: FetchOptions): Promise<void>;
 	fetch(remote?: string, ref?: string, depth?: number): Promise<void>;
 	pull(unshallow?: boolean): Promise<void>;
-	push(remoteName?: string, branchName?: string, setUpstream?: boolean): Promise<void>;
+	push(remoteName?: string, branchName?: string, setUpstream?: boolean, force?: ForcePushMode): Promise<void>;
 
 	blame(path: string): Promise<string>;
 	log(options?: LogOptions): Promise<Commit[]>;
@@ -231,15 +260,27 @@ export interface CredentialsProvider {
 	getCredentials(host: Uri): ProviderResult<Credentials>;
 }
 
+export type CommitCommand = Command & { description?: string };
+
+export interface PostCommitCommandsProvider {
+	getCommands(repository: Repository): CommitCommand[];
+}
+
 export interface PushErrorHandler {
 	handlePushError(repository: Repository, remote: Remote, refspec: string, error: Error & { gitErrorCode: GitErrorCodes }): Promise<boolean>;
 }
 
 export type APIState = 'uninitialized' | 'initialized';
 
+export interface PublishEvent {
+	repository: Repository;
+	branch?: string;
+}
+
 export interface API {
 	readonly state: APIState;
 	readonly onDidChangeState: Event<APIState>;
+	readonly onDidPublish: Event<PublishEvent>;
 	readonly git: Git;
 	readonly repositories: Repository[];
 	readonly onDidOpenRepository: Event<Repository>;
@@ -248,10 +289,12 @@ export interface API {
 	toGitUri(uri: Uri, ref: string): Uri;
 	getRepository(uri: Uri): Repository | null;
 	init(root: Uri): Promise<Repository | null>;
+	openRepository(root: Uri): Promise<Repository | null>
 
 	registerRemoteSourcePublisher(publisher: RemoteSourcePublisher): Disposable;
 	registerRemoteSourceProvider(provider: RemoteSourceProvider): Disposable;
 	registerCredentialsProvider(provider: CredentialsProvider): Disposable;
+	registerPostCommitCommandsProvider(provider: PostCommitCommandsProvider): Disposable;
 	registerPushErrorHandler(handler: PushErrorHandler): Disposable;
 }
 
@@ -263,7 +306,7 @@ export interface GitExtension {
 	/**
 	 * Returns a specific API version.
 	 *
-	 * Throws error if git extension is disabled. You can listed to the
+	 * Throws error if git extension is disabled. You can listen to the
 	 * [GitExtension.onDidChangeEnablement](#GitExtension.onDidChangeEnablement) event
 	 * to know when the extension becomes enabled/disabled.
 	 *
@@ -309,4 +352,5 @@ export const enum GitErrorCodes {
 	PatchDoesNotApply = 'PatchDoesNotApply',
 	NoPathFound = 'NoPathFound',
 	UnknownPath = 'UnknownPath',
+	EmptyCommitMessage = 'EmptyCommitMessage'
 }


### PR DESCRIPTION
- Refresh git.d.ts in the github extension
- Add the ability to commit withouth executing a post commit command (used while publishing)