### PR TITLE
GitHub - Disable command & view in codespaces

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -2731,7 +2731,7 @@
       {
         "view": "scm",
         "contents": "%view.workbench.scm.folder%",
-        "when": "config.git.enabled && !git.missing && workbenchState == folder",
+        "when": "config.git.enabled && !git.missing && workbenchState == folder && remoteName != 'codespaces'",
         "enablement": "git.state == initialized",
         "group": "5_scm@1"
       },

--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -59,7 +59,7 @@
       "commandPalette": [
         {
           "command": "github.publish",
-          "when": "git-base.gitEnabled"
+          "when": "git-base.gitEnabled && remoteName != 'codespaces'"
         },
         {
           "command": "github.copyVscodeDevLink",


### PR DESCRIPTION
- Don't show "Initialize Repository" welcome view in Codespaces
- Don't show "Publish to GitHub" command in the command pallette