### PR TITLE
adding brace completion for snippet inline completion item

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
@@ -734,8 +734,26 @@ export async function provideInlineCompletions(
 
 				snippetInfo = undefined;
 			} else if ('snippet' in item.insertText) {
+				const preBracketCompletionLength = item.insertText.snippet.length;
+
+				if (languageConfigurationService && item.completeBracketPairs) {
+					item.insertText.snippet = closeBrackets(
+						item.insertText.snippet,
+						range.getStartPosition(),
+						model,
+						languageConfigurationService
+					);
+
+					// Modify range depending on if brackets are added or removed
+					const diff = item.insertText.snippet.length - preBracketCompletionLength;
+					if (diff !== 0) {
+						range = new Range(range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn + diff);
+					}
+				}
+
 				const snippet = new SnippetParser().parse(item.insertText.snippet);
 				insertText = snippet.toString();
+
 				snippetInfo = {
 					snippet: item.insertText.snippet,
 					range: range


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Taking a stab at resolving this issue - https://github.com/microsoft/vscode/issues/160555 

I'm making an assumption that the brackets which denote tabstops/placeholders in the SnippetString will always be completed braces so any incomplete braces aside from there should then be completed by the brace completion. 