### PR TITLE
Remove notebook content provider save and backup functionality

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
@@ -115,18 +115,6 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		};
 		return dto;
 	},
-	saveNotebook: async (_document: vscode.NotebookDocument, _cancellation: vscode.CancellationToken) => {
-		return;
-	},
-	saveNotebookAs: async (_targetResource: vscode.Uri, _document: vscode.NotebookDocument, _cancellation: vscode.CancellationToken) => {
-		return;
-	},
-	backupNotebook: async (_document: vscode.NotebookDocument, _context: vscode.NotebookDocumentBackupContext, _cancellation: vscode.CancellationToken) => {
-		return {
-			id: '1',
-			delete: () => { }
-		};
-	}
 };
 
 (vscode.env.uiKind === vscode.UIKind.Web ? suite.skip : suite)('Notebook API tests', function () {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
@@ -232,7 +232,8 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 		await closeAllEditors();
 	});
 
-	test('#115855 onDidSaveNotebookDocument', async function () {
+	// TODO: Skipped due to notebook content provider removal
+	test.skip('#115855 onDidSaveNotebookDocument', async function () {
 		const resource = await createRandomNotebookFile();
 		const notebook = await vscode.workspace.openNotebookDocument(resource);
 

--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.document.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.document.test.ts
@@ -320,40 +320,6 @@ suite('Notebook Document', function () {
 		assert.ok(document.metadata.custom.extraNotebookMetadata, `Test metadata not found`);
 	});
 
-	test('document save API', async function () {
-		const uri = await utils.createRandomFile(undefined, undefined, '.nbdtest');
-		const notebook = await vscode.workspace.openNotebookDocument(uri);
-
-		assert.strictEqual(notebook.uri.toString(), uri.toString());
-		assert.strictEqual(notebook.isDirty, false);
-		assert.strictEqual(notebook.isUntitled, false);
-		assert.strictEqual(notebook.cellCount, 1);
-		assert.strictEqual(notebook.notebookType, 'notebook.nbdtest');
-
-		const edit = new vscode.WorkspaceEdit();
-		edit.set(notebook.uri, [vscode.NotebookEdit.replaceCells(new vscode.NotebookRange(0, 0), [{
-			kind: vscode.NotebookCellKind.Markup,
-			languageId: 'markdown',
-			metadata: undefined,
-			outputs: [],
-			value: 'new_markdown'
-		}, {
-			kind: vscode.NotebookCellKind.Code,
-			languageId: 'fooLang',
-			metadata: undefined,
-			outputs: [],
-			value: 'new_code'
-		}])]);
-
-		const success = await vscode.workspace.applyEdit(edit);
-		assert.strictEqual(success, true);
-		assert.strictEqual(notebook.isDirty, true);
-
-		await notebook.save();
-		assert.strictEqual(notebook.isDirty, false);
-	});
-
-
 	test('setTextDocumentLanguage for notebook cells', async function () {
 
 		const uri = await utils.createRandomFile(undefined, undefined, '.nbdtest');
@@ -384,21 +350,6 @@ suite('Notebook Document', function () {
 		let cellDoc = await vscode.workspace.openTextDocument(firstCelUri);
 		cellDoc = await vscode.languages.setTextDocumentLanguage(cellDoc, 'css');
 		assert.strictEqual(cellDoc.languageId, 'css');
-	});
-
-	test('dirty state - complex', async function () {
-		const resource = await utils.createRandomFile(undefined, undefined, '.nbdtest');
-		const document = await vscode.workspace.openNotebookDocument(resource);
-		assert.strictEqual(document.isDirty, false);
-
-		const edit = new vscode.WorkspaceEdit();
-		edit.set(document.uri, [vscode.NotebookEdit.replaceCells(new vscode.NotebookRange(0, document.cellCount), [])]);
-		assert.ok(await vscode.workspace.applyEdit(edit));
-
-		assert.strictEqual(document.isDirty, true);
-
-		await document.save();
-		assert.strictEqual(document.isDirty, false);
 	});
 
 	test('dirty state - serializer', async function () {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.document.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.document.test.ts
@@ -26,15 +26,6 @@ suite('Notebook Document', function () {
 				[new vscode.NotebookCellData(vscode.NotebookCellKind.Code, uri.toString(), 'javascript')],
 			);
 		}
-		async saveNotebook(_document: vscode.NotebookDocument, _cancellation: vscode.CancellationToken) {
-			//
-		}
-		async saveNotebookAs(_targetResource: vscode.Uri, _document: vscode.NotebookDocument, _cancellation: vscode.CancellationToken) {
-			//
-		}
-		async backupNotebook(_document: vscode.NotebookDocument, _context: vscode.NotebookDocumentBackupContext, _cancellation: vscode.CancellationToken) {
-			return { id: '', delete() { } };
-		}
 	};
 
 	const disposables: vscode.Disposable[] = [];

--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.kernel.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.kernel.test.ts
@@ -124,18 +124,6 @@ const apiTestContentProvider: vscode.NotebookContentProvider = {
 			]
 		};
 		return dto;
-	},
-	saveNotebook: async (_document: vscode.NotebookDocument, _cancellation: vscode.CancellationToken) => {
-		return;
-	},
-	saveNotebookAs: async (_targetResource: vscode.Uri, _document: vscode.NotebookDocument, _cancellation: vscode.CancellationToken) => {
-		return;
-	},
-	backupNotebook: async (_document: vscode.NotebookDocument, _context: vscode.NotebookDocumentBackupContext, _cancellation: vscode.CancellationToken) => {
-		return {
-			id: '1',
-			delete: () => { }
-		};
 	}
 };
 

--- a/extensions/vscode-notebook-tests/src/extension.ts
+++ b/extensions/vscode-notebook-tests/src/extension.ts
@@ -43,18 +43,6 @@ export function activate(context: vscode.ExtensionContext): any {
 			};
 
 			return dto;
-		},
-		saveNotebook: async (_document: vscode.NotebookDocument, _cancellation: vscode.CancellationToken) => {
-			return;
-		},
-		saveNotebookAs: async (_targetResource: vscode.Uri, _document: vscode.NotebookDocument, _cancellation: vscode.CancellationToken) => {
-			return;
-		},
-		backupNotebook: async (_document: vscode.NotebookDocument, _context: vscode.NotebookDocumentBackupContext, _cancellation: vscode.CancellationToken) => {
-			return {
-				id: '1',
-				delete: () => { }
-			};
 		}
 	}));
 

--- a/src/vs/workbench/api/browser/mainThreadNotebook.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebook.ts
@@ -11,7 +11,7 @@ import { URI } from 'vs/base/common/uri';
 import { NotebookDto } from 'vs/workbench/api/browser/mainThreadNotebookDto';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
 import { INotebookCellStatusBarService } from 'vs/workbench/contrib/notebook/common/notebookCellStatusBarService';
-import { INotebookCellStatusBarItemProvider, INotebookContributionData, NotebookData as NotebookData, NotebookExtensionDescription, TransientCellMetadata, TransientDocumentMetadata, TransientOptions } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { INotebookCellStatusBarItemProvider, INotebookContributionData, NotebookData as NotebookData, NotebookExtensionDescription, TransientOptions } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookContentProvider, INotebookService, SimpleNotebookProviderInfo } from 'vs/workbench/contrib/notebook/common/notebookService';
 import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { ExtHostContext, ExtHostNotebookShape, MainContext, MainThreadNotebookShape } from '../common/extHost.protocol';
@@ -67,15 +67,7 @@ export class MainThreadNotebooks implements MainThreadNotebookShape {
 					transientOptions: contentOptions
 				};
 			},
-			save: async (uri: URI, token: CancellationToken) => {
-				return this._proxy.$saveNotebook(viewType, uri, token);
-			},
-			saveAs: async (uri: URI, target: URI, token: CancellationToken) => {
-				return this._proxy.$saveNotebookAs(viewType, uri, target, token);
-			},
-			backup: async (uri: URI, token: CancellationToken) => {
-				return this._proxy.$backupNotebook(viewType, uri, token);
-			}
+			backup: async (uri: URI, token: CancellationToken) => ''
 		};
 
 		const disposable = new DisposableStore();
@@ -86,19 +78,6 @@ export class MainThreadNotebooks implements MainThreadNotebookShape {
 		this._notebookProviders.set(viewType, { controller, disposable });
 	}
 
-	async $updateNotebookProviderOptions(viewType: string, options?: { transientOutputs: boolean; transientCellMetadata: TransientCellMetadata; transientDocumentMetadata: TransientDocumentMetadata }): Promise<void> {
-		const provider = this._notebookProviders.get(viewType);
-
-		if (provider && options) {
-			provider.controller.options = options;
-			this._notebookService.listNotebookDocuments().forEach(document => {
-				if (document.viewType === viewType) {
-					document.transientOptions = provider.controller.options;
-				}
-			});
-		}
-	}
-
 	async $unregisterNotebookProvider(viewType: string): Promise<void> {
 		const entry = this._notebookProviders.get(viewType);
 		if (entry) {
@@ -106,7 +85,6 @@ export class MainThreadNotebooks implements MainThreadNotebookShape {
 			this._notebookProviders.delete(viewType);
 		}
 	}
-
 
 	$registerNotebookSerializer(handle: number, extension: NotebookExtensionDescription, viewType: string, options: TransientOptions, data: INotebookContributionData | undefined): void {
 		const registration = this._notebookService.registerNotebookSerializer(viewType, extension, {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -157,7 +157,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostDocuments = rpcProtocol.set(ExtHostContext.ExtHostDocuments, new ExtHostDocuments(rpcProtocol, extHostDocumentsAndEditors));
 	const extHostDocumentContentProviders = rpcProtocol.set(ExtHostContext.ExtHostDocumentContentProviders, new ExtHostDocumentContentProvider(rpcProtocol, extHostDocumentsAndEditors, extHostLogService));
 	const extHostDocumentSaveParticipant = rpcProtocol.set(ExtHostContext.ExtHostDocumentSaveParticipant, new ExtHostDocumentSaveParticipant(extHostLogService, extHostDocuments, rpcProtocol.getProxy(MainContext.MainThreadBulkEdits)));
-	const extHostNotebook = rpcProtocol.set(ExtHostContext.ExtHostNotebook, new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments, extensionStoragePaths));
+	const extHostNotebook = rpcProtocol.set(ExtHostContext.ExtHostNotebook, new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments));
 	const extHostNotebookDocuments = rpcProtocol.set(ExtHostContext.ExtHostNotebookDocuments, new ExtHostNotebookDocuments(extHostNotebook));
 	const extHostNotebookEditors = rpcProtocol.set(ExtHostContext.ExtHostNotebookEditors, new ExtHostNotebookEditors(extHostLogService, extHostNotebook));
 	const extHostNotebookKernels = rpcProtocol.set(ExtHostContext.ExtHostNotebookKernels, new ExtHostNotebookKernels(rpcProtocol, initData, extHostNotebook, extHostCommands, extHostLogService));

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -962,7 +962,6 @@ export interface INotebookCellStatusBarListDto {
 
 export interface MainThreadNotebookShape extends IDisposable {
 	$registerNotebookProvider(extension: notebookCommon.NotebookExtensionDescription, viewType: string, options: notebookCommon.TransientOptions, registration: notebookCommon.INotebookContributionData | undefined): Promise<void>;
-	$updateNotebookProviderOptions(viewType: string, options?: { transientOutputs: boolean; transientCellMetadata: notebookCommon.TransientCellMetadata; transientDocumentMetadata: notebookCommon.TransientDocumentMetadata }): Promise<void>;
 	$unregisterNotebookProvider(viewType: string): Promise<void>;
 
 	$registerNotebookSerializer(handle: number, extension: notebookCommon.NotebookExtensionDescription, viewType: string, options: notebookCommon.TransientOptions, registration: notebookCommon.INotebookContributionData | undefined): void;
@@ -2056,9 +2055,6 @@ export interface ExtHostNotebookShape extends ExtHostNotebookDocumentsAndEditors
 	$releaseNotebookCellStatusBarItems(id: number): void;
 
 	$openNotebook(viewType: string, uri: UriComponents, backupId: string | undefined, untitledDocumentData: VSBuffer | undefined, token: CancellationToken): Promise<SerializableObjectWithBuffers<NotebookDataDto>>;
-	$saveNotebook(viewType: string, uri: UriComponents, token: CancellationToken): Promise<boolean>;
-	$saveNotebookAs(viewType: string, uri: UriComponents, target: UriComponents, token: CancellationToken): Promise<boolean>;
-	$backupNotebook(viewType: string, uri: UriComponents, cancellation: CancellationToken): Promise<string>;
 
 	$dataToNotebook(handle: number, data: VSBuffer, token: CancellationToken): Promise<SerializableObjectWithBuffers<NotebookDataDto>>;
 	$notebookToData(handle: number, data: SerializableObjectWithBuffers<NotebookDataDto>, token: CancellationToken): Promise<VSBuffer>;

--- a/src/vs/workbench/api/common/extHostNotebookDocument.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocument.ts
@@ -141,7 +141,6 @@ export class ExtHostNotebookDocument {
 	private _metadata: Record<string, any>;
 	private _versionId: number = 0;
 	private _isDirty: boolean = false;
-	private _backup?: vscode.NotebookDocumentBackup;
 	private _disposed: boolean = false;
 
 	constructor(
@@ -188,16 +187,6 @@ export class ExtHostNotebookDocument {
 			this._notebook = Object.freeze(apiObject);
 		}
 		return this._notebook;
-	}
-
-	updateBackup(backup: vscode.NotebookDocumentBackup): void {
-		this._backup?.delete();
-		this._backup = backup;
-	}
-
-	disposeBackup(): void {
-		this._backup?.delete();
-		this._backup = undefined;
 	}
 
 	acceptDocumentPropertiesChanged(data: extHostProtocol.INotebookDocumentPropertiesChangeData) {

--- a/src/vs/workbench/api/test/browser/extHostNotebook.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostNotebook.test.ts
@@ -19,8 +19,6 @@ import { ExtHostDocuments } from 'vs/workbench/api/common/extHostDocuments';
 import { ExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
 import { nullExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
 import { isEqual } from 'vs/base/common/resources';
-import { IExtensionStoragePaths } from 'vs/workbench/api/common/extHostStoragePaths';
-import { generateUuid } from 'vs/base/common/uuid';
 import { Event } from 'vs/base/common/event';
 import { ExtHostNotebookDocuments } from 'vs/workbench/api/common/extHostNotebookDocuments';
 import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
@@ -54,12 +52,7 @@ suite('NotebookCell#Document', function () {
 		});
 		extHostDocumentsAndEditors = new ExtHostDocumentsAndEditors(rpcProtocol, new NullLogService());
 		extHostDocuments = new ExtHostDocuments(rpcProtocol, extHostDocumentsAndEditors);
-		const extHostStoragePaths = new class extends mock<IExtensionStoragePaths>() {
-			override workspaceValue() {
-				return URI.from({ scheme: 'test', path: generateUuid() });
-			}
-		};
-		extHostNotebooks = new ExtHostNotebookController(rpcProtocol, new ExtHostCommands(rpcProtocol, new NullLogService()), extHostDocumentsAndEditors, extHostDocuments, extHostStoragePaths);
+		extHostNotebooks = new ExtHostNotebookController(rpcProtocol, new ExtHostCommands(rpcProtocol, new NullLogService()), extHostDocumentsAndEditors, extHostDocuments);
 		extHostNotebookDocuments = new ExtHostNotebookDocuments(extHostNotebooks);
 
 		const reg = extHostNotebooks.registerNotebookContentProvider(nullExtensionDescription, 'test', new class extends mock<vscode.NotebookContentProvider>() {

--- a/src/vs/workbench/api/test/browser/extHostNotebookKernel.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostNotebookKernel.test.ts
@@ -7,7 +7,6 @@ import * as assert from 'assert';
 import { Barrier } from 'vs/base/common/async';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { URI, UriComponents } from 'vs/base/common/uri';
-import { generateUuid } from 'vs/base/common/uuid';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { ICellExecuteUpdateDto, ICellExecutionCompleteDto, INotebookKernelDto2, MainContext, MainThreadCommandsShape, MainThreadNotebookDocumentsShape, MainThreadNotebookKernelsShape, MainThreadNotebookShape } from 'vs/workbench/api/common/extHost.protocol';
@@ -19,7 +18,6 @@ import { ExtHostNotebookController } from 'vs/workbench/api/common/extHostNotebo
 import { ExtHostNotebookDocument } from 'vs/workbench/api/common/extHostNotebookDocument';
 import { ExtHostNotebookDocuments } from 'vs/workbench/api/common/extHostNotebookDocuments';
 import { ExtHostNotebookKernels } from 'vs/workbench/api/common/extHostNotebookKernels';
-import { IExtensionStoragePaths } from 'vs/workbench/api/common/extHostStoragePaths';
 import { NotebookCellOutput, NotebookCellOutputItem } from 'vs/workbench/api/common/extHostTypes';
 import { CellKind, CellUri, NotebookCellsChangeType } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { CellExecutionUpdateType } from 'vs/workbench/contrib/notebook/common/notebookExecutionService';
@@ -90,13 +88,8 @@ suite('NotebookKernel', function () {
 		});
 		extHostDocumentsAndEditors = new ExtHostDocumentsAndEditors(rpcProtocol, new NullLogService());
 		extHostDocuments = new ExtHostDocuments(rpcProtocol, extHostDocumentsAndEditors);
-		const extHostStoragePaths = new class extends mock<IExtensionStoragePaths>() {
-			override workspaceValue() {
-				return URI.from({ scheme: 'test', path: generateUuid() });
-			}
-		};
 		extHostCommands = new ExtHostCommands(rpcProtocol, new NullLogService());
-		extHostNotebooks = new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments, extHostStoragePaths);
+		extHostNotebooks = new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments);
 
 		extHostNotebookDocuments = new ExtHostNotebookDocuments(extHostNotebooks);
 

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -136,14 +136,6 @@ export class InteractiveDocumentContribution extends Disposable implements IWork
 					transientOptions: contentOptions
 				};
 			},
-			save: async (uri: URI) => {
-				// trigger backup always
-				return false;
-			},
-			saveAs: async (uri: URI, target: URI, token: CancellationToken) => {
-				// return this._proxy.$saveNotebookAs(viewType, uri, target, token);
-				return false;
-			},
 			backup: async (uri: URI, token: CancellationToken) => {
 				const doc = notebookService.listNotebookDocuments().find(document => document.uri.toString() === uri.toString());
 				if (doc) {

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
@@ -377,7 +377,7 @@ export class ComplexNotebookEditorModel extends EditorModel implements INotebook
 			if (!this.isResolved()) {
 				return;
 			}
-			const success = await this._contentProvider.save(this.notebook.uri, CancellationToken.None);
+			const success = false;
 			this._logService.debug(`[notebook editor model] save(${versionId}) - document saved saved, start updating file stats`, this.resource.toString(true), success);
 			this._lastResolvedFileStat = await this._resolveStats(this.resource);
 			if (success) {
@@ -407,7 +407,7 @@ export class ComplexNotebookEditorModel extends EditorModel implements INotebook
 			return undefined;
 		}
 
-		const success = await this._contentProvider.saveAs(this.notebook.uri, targetResource, CancellationToken.None);
+		const success = false;
 		this._logService.debug(`[notebook editor model] saveAs - document saved, start updating file stats`, this.resource.toString(true), success);
 		this._lastResolvedFileStat = await this._resolveStats(this.resource);
 		if (!success) {

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -22,8 +22,6 @@ export interface INotebookContentProvider {
 	options: TransientOptions;
 
 	open(uri: URI, backupId: string | VSBuffer | undefined, untitledDocumentData: VSBuffer | undefined, token: CancellationToken): Promise<{ data: NotebookData; transientOptions: TransientOptions }>;
-	save(uri: URI, token: CancellationToken): Promise<boolean>;
-	saveAs(uri: URI, target: URI, token: CancellationToken): Promise<boolean>;
 	backup(uri: URI, token: CancellationToken): Promise<string | VSBuffer>;
 }
 

--- a/src/vscode-dts/vscode.proposed.notebookContentProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookContentProvider.d.ts
@@ -8,29 +8,6 @@ declare module 'vscode' {
 	// https://github.com/microsoft/vscode/issues/147248
 
 	/** @deprecated */
-	interface NotebookDocumentBackup {
-		/**
-		 * Unique identifier for the backup.
-		 *
-		 * This id is passed back to your extension in `openNotebook` when opening a notebook editor from a backup.
-		 */
-		readonly id: string;
-
-		/**
-		 * Delete the current backup.
-		 *
-		 * This is called by the editor when it is clear the current backup is no longer needed, such as when a new backup
-		 * is made or when the file is saved.
-		 */
-		delete(): void;
-	}
-
-	/** @deprecated */
-	interface NotebookDocumentBackupContext {
-		readonly destination: Uri;
-	}
-
-	/** @deprecated */
 	interface NotebookDocumentOpenContext {
 		readonly backupId?: string;
 		readonly untitledDocumentData?: Uint8Array;
@@ -39,26 +16,13 @@ declare module 'vscode' {
 	// todo@API use openNotebookDOCUMENT to align with openCustomDocument etc?
 	// todo@API rename to NotebookDocumentContentProvider
 	/** @deprecated */
-
 	export interface NotebookContentProvider {
-
-		readonly options?: NotebookDocumentContentOptions;
-		readonly onDidChangeNotebookContentOptions?: Event<NotebookDocumentContentOptions>;
 
 		/**
 		 * Content providers should always use {@link FileSystemProvider file system providers} to
 		 * resolve the raw content for `uri` as the resource is not necessarily a file on disk.
 		 */
 		openNotebook(uri: Uri, openContext: NotebookDocumentOpenContext, token: CancellationToken): NotebookData | Thenable<NotebookData>;
-
-		// todo@API use NotebookData instead
-		saveNotebook(document: NotebookDocument, token: CancellationToken): Thenable<void>;
-
-		// todo@API use NotebookData instead
-		saveNotebookAs(targetResource: Uri, document: NotebookDocument, token: CancellationToken): Thenable<void>;
-
-		// todo@API use NotebookData instead
-		backupNotebook(document: NotebookDocument, context: NotebookDocumentBackupContext, token: CancellationToken): Thenable<NotebookDocumentBackup>;
 	}
 
 	export namespace workspace {

--- a/src/vscode-dts/vscode.proposed.notebookLiveShare.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookLiveShare.d.ts
@@ -14,8 +14,12 @@ declare module 'vscode' {
 	}
 
 	export namespace workspace {
-		// SPECIAL overload with NotebookRegistrationData
+		/**
+		 * SPECIAL overload with NotebookRegistrationData
+		 * @deprecated
+		 */
 		export function registerNotebookContentProvider(notebookType: string, provider: NotebookContentProvider, options?: NotebookDocumentContentOptions, registrationData?: NotebookRegistrationData): Disposable;
+
 		// SPECIAL overload with NotebookRegistrationData
 		export function registerNotebookSerializer(notebookType: string, serializer: NotebookSerializer, options?: NotebookDocumentContentOptions, registration?: NotebookRegistrationData): Disposable;
 	}


### PR DESCRIPTION
For #147248

When stepping through the liveshare code, we figured out they do not appear to be using `save`, `saveAs`, or `backup` (they return empty results for these)

This PR removes this part of the proposal so we can track just the parts of the api that they are using

