### PR TITLE
Visual fixes-context menu and breakpoint editor widget

### DIFF
--- a/src/vs/editor/contrib/find/browser/findOptionsWidget.css
+++ b/src/vs/editor/contrib/find/browser/findOptionsWidget.css
@@ -2,16 +2,8 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-.monaco-editor .zone-widget {
-	position: absolute;
-	z-index: 35;
-}
 
-
-.monaco-editor .zone-widget .zone-widget-container {
-	border-top-style: solid;
-	border-bottom-style: solid;
-	border-top-width: 0;
-	border-bottom-width: 0;
-	position: relative;
+/* Find options widget */
+.monaco-editor .findOptionsWidget {
+	z-index: 38; /* must be higher than sticky-widget */
 }

--- a/src/vs/editor/contrib/find/browser/findOptionsWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findOptionsWidget.ts
@@ -9,6 +9,7 @@ import { Widget } from 'vs/base/browser/ui/widget';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { ICodeEditor, IOverlayWidget, IOverlayWidgetPosition, OverlayWidgetPositionPreference } from 'vs/editor/browser/editorBrowser';
 import { FIND_IDS } from 'vs/editor/contrib/find/browser/findModel';
+import 'vs/css!./findOptionsWidget';
 import { FindReplaceState } from 'vs/editor/contrib/find/browser/findState';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { contrastBorder, editorWidgetBackground, editorWidgetForeground, inputActiveOptionBackground, inputActiveOptionBorder, inputActiveOptionForeground, widgetShadow } from 'vs/platform/theme/common/colorRegistry';
@@ -43,7 +44,6 @@ export class FindOptionsWidget extends Widget implements IOverlayWidget {
 		this._domNode.className = 'findOptionsWidget';
 		this._domNode.style.display = 'none';
 		this._domNode.style.top = '10px';
-		this._domNode.style.zIndex = '12';
 		this._domNode.setAttribute('role', 'presentation');
 		this._domNode.setAttribute('aria-hidden', 'true');
 

--- a/src/vs/editor/contrib/find/browser/findWidget.css
+++ b/src/vs/editor/contrib/find/browser/findWidget.css
@@ -6,7 +6,7 @@
 /* Find widget */
 .monaco-editor .find-widget {
 	position: absolute;
-	z-index: 35;
+	z-index: 37; /* must be higher than zone-widget and sticky-widget */
 	height: 33px;
 	overflow: hidden;
 	line-height: 19px;

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
@@ -30,6 +30,6 @@
 .monaco-editor .sticky-widget {
 	width : 100%;
 	box-shadow : var(--vscode-scrollbar-shadow) 0 3px 2px -2px;
-	z-index : 2;
+	z-index : 36; /* must be higher than zone-widget */
 	background-color : var(--vscode-editorStickyScroll-background);
 }

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -300,7 +300,6 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		else if (minimapSide === 'right') {
 			this._rootDomNode.style.marginLeft = '1px';
 		}
-		this._rootDomNode.style.zIndex = '11';
 	}
 
 	public getId(): string {

--- a/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
@@ -185,6 +185,7 @@ export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWi
 
 	protected _fillContainer(container: HTMLElement): void {
 		this.setCssClass('breakpoint-widget');
+		this.setCssClass('monaco-editor-background');
 		const selectBox = new SelectBox(<ISelectOptionItem[]>[{ text: nls.localize('expression', "Expression") }, { text: nls.localize('hitCount', "Hit Count") }, { text: nls.localize('logMessage', "Log Message") }], this.context, this.contextViewService, undefined, { ariaLabel: nls.localize('breakpointType', 'Breakpoint Type') });
 		this.toDispose.push(attachSelectBoxStyler(selectBox, this.themeService));
 		this.selectContainer = $('.breakpoint-select-container');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #146638

When in a peek, the context menu is in the `.zone-widget` stacking context.

I have increased its `z-index`.

![Screenshot 2022-09-10 203623](https://user-images.githubusercontent.com/1485998/189499162-7f1d8f19-e3f7-48f2-aca8-62e7fd70287d.png)

I also fixed the interaction between the horizontal editor scrollbar and the breakpoint condition widget.

![image](https://user-images.githubusercontent.com/1485998/189499177-8e08daa3-d6a8-4f57-9f7a-0f79cee347b4.png)

Screenshot from VS Code 1.71.0:

![image](https://user-images.githubusercontent.com/1485998/189499404-d1b7faf9-015f-45ba-b3a0-b715df6e32af.png)

Screenshot with the find widget:

![image](https://user-images.githubusercontent.com/1485998/189499362-93354666-0088-4038-9e1f-9ec07e4cd886.png)
