### PR TITLE
Fix wrong matches in multiline file search

### DIFF
--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -301,11 +301,15 @@ export class RipgrepParser extends EventEmitter {
 			}
 
 			const matchText = bytesOrTextToString(match.match);
-			const inBetweenChars = fullTextBytes.slice(prevMatchEnd, match.start).toString().length;
-			const startCol = prevMatchEndCol + inBetweenChars;
+
+			const inBetweenText = fullTextBytes.slice(prevMatchEnd, match.start).toString();
+			const inBetweenStats = getNumLinesAndLastNewlineLength(inBetweenText);
+			const startCol = inBetweenStats.numLines > 0 ?
+				inBetweenStats.lastLineLength :
+				inBetweenStats.lastLineLength + prevMatchEndCol;
 
 			const stats = getNumLinesAndLastNewlineLength(matchText);
-			const startLineNumber = prevMatchEndLine;
+			const startLineNumber = inBetweenStats.numLines + prevMatchEndLine;
 			const endLineNumber = stats.numLines + startLineNumber;
 			const endCol = stats.numLines > 0 ?
 				stats.lastLineLength :

--- a/src/vs/workbench/services/search/test/node/ripgrepTextSearchEngineUtils.test.ts
+++ b/src/vs/workbench/services/search/test/node/ripgrepTextSearchEngineUtils.test.ts
@@ -261,5 +261,39 @@ suite('RipgrepTextSearchEngine', () => {
 					}
 				]);
 		});
+
+		test('multiple submatches without newline in between (#131507)', () => {
+			testParser(
+				[
+					makeRgMatch('file1.js', 'foobarbazquux', 4, [{ start: 0, end: 4 }, { start: 6, end: 10 }]),
+				],
+				[
+					{
+						preview: {
+							text: 'foobarbazquux',
+							matches: [new Range(0, 0, 0, 4), new Range(0, 6, 0, 10)]
+						},
+						uri: joinPath(TEST_FOLDER, 'file1.js'),
+						ranges: [new Range(3, 0, 3, 4), new Range(3, 6, 3, 10)]
+					}
+				]);
+		});
+
+		test('multiple submatches with newline in between (#131507)', () => {
+			testParser(
+				[
+					makeRgMatch('file1.js', 'foo\nbar\nbaz\nquux', 4, [{ start: 0, end: 5 }, { start: 8, end: 13 }]),
+				],
+				[
+					{
+						preview: {
+							text: 'foo\nbar\nbaz\nquux',
+							matches: [new Range(0, 0, 1, 1), new Range(2, 0, 3, 1)]
+						},
+						uri: joinPath(TEST_FOLDER, 'file1.js'),
+						ranges: [new Range(3, 0, 4, 1), new Range(5, 0, 6, 1)]
+					}
+				]);
+		});
 	});
 });


### PR DESCRIPTION
When multiple consecutive lines match a regular expression, RipGrep will return them  as one match with multiple submatches. The parser that converts the absolute positions of the submatches to (line number, column number) pairs was not taking into account that `inBetweenChars` may contain newlines, leading to wrong matches, and search/replace actions that gave unexpected results.

Fixes #131507

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
