### PR TITLE
Add scripts links to package.json

### DIFF
--- a/extensions/npm/src/features/jsonContributions.ts
+++ b/extensions/npm/src/features/jsonContributions.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Location, getLocation, createScanner, SyntaxKind, ScanError, JSONScanner, Node } from 'jsonc-parser';
+import { Location, getLocation, createScanner, SyntaxKind, ScanError, JSONScanner, Node, parseTree } from 'jsonc-parser';
 import { BowerJSONContribution } from './bowerJSONContribution';
 import { PackageJSONContribution } from './packageJSONContribution';
 import { XHRRequest } from 'request-light';
@@ -50,8 +50,8 @@ export class JSONLinksProvider implements DocumentLinkProvider {
 
 	}
 	provideDocumentLinks(document: TextDocument, _token: CancellationToken): ProviderResult<DocumentLink[]> {
-
-		// return this.jsonContribution.collectDocumentLinks!(document, )
+		const rootNode = parseTree(document.getText())!
+		return this.jsonContribution.collectDocumentLinks!(document, rootNode,)
 	}
 }
 

--- a/extensions/npm/src/features/jsonContributions.ts
+++ b/extensions/npm/src/features/jsonContributions.ts
@@ -26,8 +26,8 @@ export interface IJSONContribution {
 	collectPropertySuggestions(resourceUri: Uri, location: Location, currentWord: string, addValue: boolean, isLast: boolean, result: ISuggestionsCollector): Thenable<any> | null;
 	collectValueSuggestions(resourceUri: Uri, location: Location, result: ISuggestionsCollector): Thenable<any> | null;
 	collectDefaultSuggestions(resourceUri: Uri, result: ISuggestionsCollector): Thenable<any>;
-	collectDocumentLinks?(document: TextDocument, rootNode: Node): Thenable<DocumentLink[]> | null;
 	resolveSuggestion?(resourceUri: Uri | undefined, item: CompletionItem): Thenable<CompletionItem | null> | null;
+	collectDocumentLinks?(document: TextDocument, rootNode: Node): Thenable<DocumentLink[] | null>;
 }
 
 export function addJSONProviders(xhr: XHRRequest, npmCommandPath: string | undefined): Disposable {
@@ -37,8 +37,8 @@ export function addJSONProviders(xhr: XHRRequest, npmCommandPath: string | undef
 		const selector = contribution.getDocumentSelector();
 		subscriptions.push(languages.registerCompletionItemProvider(selector, new JSONCompletionItemProvider(contribution), '"', ':'));
 		subscriptions.push(languages.registerHoverProvider(selector, new JSONHoverProvider(contribution)));
-		if (contribution.collectDocumentLinks) {
-			subscriptions.push(languages.registerHoverProvider(selector, new JSONHoverProvider(contribution)));
+		if ('collectDocumentLinks' in contribution) {
+			subscriptions.push(languages.registerDocumentLinkProvider(selector, new JSONLinksProvider(contribution)));
 		}
 	});
 	return Disposable.from(...subscriptions);
@@ -50,8 +50,8 @@ export class JSONLinksProvider implements DocumentLinkProvider {
 
 	}
 	provideDocumentLinks(document: TextDocument, _token: CancellationToken): ProviderResult<DocumentLink[]> {
-		const rootNode = parseTree(document.getText())!
-		return this.jsonContribution.collectDocumentLinks!(document, rootNode,)
+		const rootNode = parseTree(document.getText())!;
+		return this.jsonContribution.collectDocumentLinks!(document, rootNode,);
 	}
 }
 

--- a/extensions/npm/src/features/jsonContributions.ts
+++ b/extensions/npm/src/features/jsonContributions.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Location, getLocation, createScanner, SyntaxKind, ScanError, JSONScanner } from 'jsonc-parser';
+import { Location, getLocation, createScanner, SyntaxKind, ScanError, JSONScanner, Node } from 'jsonc-parser';
 import { BowerJSONContribution } from './bowerJSONContribution';
 import { PackageJSONContribution } from './packageJSONContribution';
 import { XHRRequest } from 'request-light';
 
 import {
 	CompletionItem, CompletionItemProvider, CompletionList, TextDocument, Position, Hover, HoverProvider,
-	CancellationToken, Range, DocumentSelector, languages, Disposable, Uri, MarkdownString
+	CancellationToken, Range, DocumentSelector, languages, Disposable, Uri, MarkdownString, DocumentLink, DocumentLinkProvider, ProviderResult
 } from 'vscode';
 
 export interface ISuggestionsCollector {
@@ -26,6 +26,7 @@ export interface IJSONContribution {
 	collectPropertySuggestions(resourceUri: Uri, location: Location, currentWord: string, addValue: boolean, isLast: boolean, result: ISuggestionsCollector): Thenable<any> | null;
 	collectValueSuggestions(resourceUri: Uri, location: Location, result: ISuggestionsCollector): Thenable<any> | null;
 	collectDefaultSuggestions(resourceUri: Uri, result: ISuggestionsCollector): Thenable<any>;
+	collectDocumentLinks?(document: TextDocument, rootNode: Node): Thenable<DocumentLink[]> | null;
 	resolveSuggestion?(resourceUri: Uri | undefined, item: CompletionItem): Thenable<CompletionItem | null> | null;
 }
 
@@ -36,8 +37,22 @@ export function addJSONProviders(xhr: XHRRequest, npmCommandPath: string | undef
 		const selector = contribution.getDocumentSelector();
 		subscriptions.push(languages.registerCompletionItemProvider(selector, new JSONCompletionItemProvider(contribution), '"', ':'));
 		subscriptions.push(languages.registerHoverProvider(selector, new JSONHoverProvider(contribution)));
+		if (contribution.collectDocumentLinks) {
+			subscriptions.push(languages.registerHoverProvider(selector, new JSONHoverProvider(contribution)));
+		}
 	});
 	return Disposable.from(...subscriptions);
+}
+
+export class JSONLinksProvider implements DocumentLinkProvider {
+
+	constructor(private jsonContribution: IJSONContribution) {
+
+	}
+	provideDocumentLinks(document: TextDocument, _token: CancellationToken): ProviderResult<DocumentLink[]> {
+
+		// return this.jsonContribution.collectDocumentLinks!(document, )
+	}
 }
 
 export class JSONHoverProvider implements HoverProvider {

--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -17,7 +17,7 @@ const LIMIT = 40;
 
 const USER_AGENT = 'Visual Studio Code';
 
-const scriptLinksCommandRegex = /((?<START>(^|&&|")\s?((pnpm|yarn|npm) run) )(?<NAME>[A-z\d:-]+))|((?<START2>(^|&&|")\s?(pnpm|yarn) )(?<NAME2>[A-z\d:-]+))/g;
+const scriptLinksCommandRegex = /((?<START>(^|&&|")\s?((pnpm|yarn|npm) run) )(?<NAME>[\wA-Z\d:-]+))|((?<START2>(^|&&|")\s?(pnpm|yarn) )(?<NAME2>[\wA-Z\d:-]+))/g;
 
 export class PackageJSONContribution implements IJSONContribution {
 

--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -227,7 +227,7 @@ export class PackageJSONContribution implements IJSONContribution {
 		if (scriptsNodes) {
 			for (const scriptNode of this.convertObjectNodeToValues(scriptsNodes)) {
 				// ensure script's length matches real text length in JSON document
-				const script = (getNodeValue(scriptNode) as string).replaceAll("\\", "\\\\").replace(/[\n\r\t]/g, '\\$&').replaceAll('"', '\\"');
+				const script = (getNodeValue(scriptNode) as string).replaceAll('\\', '\\\\').replace(/[\n\r\t]/g, '\\$&').replaceAll('"', '\\"');
 				let match: RegExpExecArray | null;
 				while ((match = scriptLinksCommandRegex.exec(script))) {
 					const scriptRefName = match.groups!.NAME || match.groups!.NAME2!;

--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -227,7 +227,7 @@ export class PackageJSONContribution implements IJSONContribution {
 		if (scriptsNodes) {
 			for (const scriptNode of this.convertObjectNodeToValues(scriptsNodes)) {
 				// ensure script's length matches real text length in JSON document
-				const script = (getNodeValue(scriptNode) as string).replaceAll("\\", "\\\\").replace(/\t|\n|\r/g, '\\$&').replaceAll('"', '\\"');
+				const script = (getNodeValue(scriptNode) as string).replaceAll("\\", "\\\\").replace(/[\n\r\t]/g, '\\$&').replaceAll('"', '\\"');
 				let match: RegExpExecArray | null;
 				while ((match = scriptLinksCommandRegex.exec(script))) {
 					const scriptRefName = match.groups!.NAME || match.groups!.NAME2!;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Requ

https://user-images.githubusercontent.com/46503702/189620881-37add7e0-b1cc-440f-9e1a-3ab66a6f9637.mp4


https://user-images.githubusercontent.com/46503702/189620809-1df060fb-966d-405b-b8f4-82075047263f.mp4

est. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

### Motivation

Given this example:

```json
{
  "name": "test",
  "scripts": {
      "prepublishOnly": "npm run build --component-a && npm run build --component-c && ...",
      "build": "...",
      "start": "echo \"\\\n\r\t love npm run for sure!\" && concurrently \"npm run build\" \"yarn build-test:of-course\"",
      "build-test:desktop-web": ""
  }
}
```

Let's imagine your position is in `prepublishOnly` on the first `npm run build` and you want to quickly check/edit contents of the `build` script. Focusing next occurrence will not work here, as it won't focus the script definition. The same is also applies to copy-pasting script name to outline command, which can focus you into dependencies for example.

This is also what I was using to check that it works.


https://user-images.githubusercontent.com/46503702/189621505-7fd47ad9-6c58-47ac-8271-e05a943d6f96.mp4



Btw I understand that this regexp might be hard to read, for now I didn't figure out a way to make it easier to read. Let me know your what you think about this PR! 🙌