### PR TITLE
Recognise windows-controls-overlay display mode in isStandalone() check

### DIFF
--- a/src/vs/base/browser/browser.ts
+++ b/src/vs/base/browser/browser.ts
@@ -194,7 +194,7 @@ export const isAndroid = (userAgent.indexOf('Android') >= 0);
 
 let standalone = false;
 if (window.matchMedia) {
-	const standaloneMatchMedia = window.matchMedia('(display-mode: standalone)');
+	const standaloneMatchMedia = window.matchMedia('(display-mode: standalone) or (display-mode: window-controls-overlay)');
 	const fullScreenMatchMedia = window.matchMedia('(display-mode: fullscreen)');
 	standalone = standaloneMatchMedia.matches;
 	addMatchMediaChangeListener(standaloneMatchMedia, ({ matches }) => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This fixes #160695

Recently Chrome has started reporting the display-mode of a PWA as `window-controls-overlay` instead of `standalone` if window controls overlay is specified in this manifest file.

This causes issues with the open in new window logic (and anything that relies on `isStandalone()`.

I think we can fix this with a slight adjustment to the matchMedia query.

![image](https://user-images.githubusercontent.com/150152/189650784-3e878840-5457-4979-87a3-b364387874ff.png)
