### PR TITLE
Unify Stop/Interrupt in core and jupyter

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
@@ -90,6 +90,10 @@ abstract class MainThreadKernel implements INotebookKernel {
 			this.implementsExecutionOrder = data.supportsExecutionOrder;
 			event.hasExecutionOrder = true;
 		}
+		if (data.supportsInterrupt !== undefined) {
+			this.implementsInterrupt = data.supportsInterrupt;
+			event.hasInterruptHandler = true;
+		}
 		this._onDidChange.fire(event);
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
@@ -503,7 +503,10 @@ registerAction2(class CancelAllNotebook extends CancelNotebook {
 	constructor() {
 		super({
 			id: CANCEL_NOTEBOOK_COMMAND_ID,
-			title: localize('notebookActions.cancelNotebook', "Stop Execution"),
+			title: {
+				value: localize('notebookActions.cancelNotebook', "Stop Execution"),
+				original: 'Stop Execution'
+			},
 			icon: icons.stopIcon,
 			menu: [
 				{
@@ -536,7 +539,10 @@ registerAction2(class InterruptNotebook extends CancelNotebook {
 	constructor() {
 		super({
 			id: INTERRUPT_NOTEBOOK_COMMAND_ID,
-			title: localize('notebookActions.interruptNotebook', "Interrupt"),
+			title: {
+				value: localize('notebookActions.interruptNotebook', "Interrupt"),
+				original: 'Interrupt'
+			},
 			icon: icons.stopIcon,
 			menu: [
 				{

--- a/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
@@ -5,7 +5,7 @@
 
 import { Iterable } from 'vs/base/common/iterator';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
-import { URI, UriComponents } from 'vs/base/common/uri';
+import { UriComponents } from 'vs/base/common/uri';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { localize } from 'vs/nls';
 import { MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
@@ -27,6 +27,7 @@ import { Schemas } from 'vs/base/common/network';
 
 const EXECUTE_NOTEBOOK_COMMAND_ID = 'notebook.execute';
 const CANCEL_NOTEBOOK_COMMAND_ID = 'notebook.cancelExecution';
+const INTERRUPT_NOTEBOOK_COMMAND_ID = 'notebook.interruptExecution';
 const CANCEL_CELL_COMMAND_ID = 'notebook.cell.cancelExecution';
 const EXECUTE_CELL_FOCUS_CONTAINER_COMMAND_ID = 'notebook.cell.executeAndFocusContainer';
 const EXECUTE_CELL_SELECT_BELOW = 'notebook.cell.executeAndSelectBelow';
@@ -488,22 +489,55 @@ registerAction2(class ExecuteCellInsertBelow extends NotebookCellAction {
 	}
 });
 
-registerAction2(class CancelNotebook extends NotebookAction {
+class CancelNotebook extends NotebookAction {
+	override getEditorContextFromArgsOrActive(accessor: ServicesAccessor, context?: UriComponents): INotebookActionContext | undefined {
+		return getContextFromUri(accessor, context) ?? getContextFromActiveEditor(accessor.get(IEditorService));
+	}
+
+	async runWithContext(accessor: ServicesAccessor, context: INotebookActionContext): Promise<void> {
+		return context.notebookEditor.cancelNotebookCells();
+	}
+}
+
+registerAction2(class CancelAllNotebook extends CancelNotebook {
 	constructor() {
 		super({
 			id: CANCEL_NOTEBOOK_COMMAND_ID,
 			title: localize('notebookActions.cancelNotebook', "Stop Execution"),
 			icon: icons.stopIcon,
-			description: {
-				description: localize('notebookActions.cancelNotebook', "Stop Execution"),
-				args: [
-					{
-						name: 'uri',
-						description: 'The document uri',
-						constraint: URI
-					}
-				]
-			},
+			menu: [
+				{
+					id: MenuId.EditorTitle,
+					order: -1,
+					group: 'navigation',
+					when: ContextKeyExpr.and(
+						NOTEBOOK_IS_ACTIVE_EDITOR,
+						NOTEBOOK_HAS_RUNNING_CELL,
+						NOTEBOOK_INTERRUPTIBLE_KERNEL.toNegated(),
+						ContextKeyExpr.notEquals('config.notebook.globalToolbar', true)
+					)
+				},
+				{
+					id: MenuId.NotebookToolbar,
+					order: -1,
+					group: 'navigation/execute',
+					when: ContextKeyExpr.and(
+						NOTEBOOK_HAS_RUNNING_CELL,
+						NOTEBOOK_INTERRUPTIBLE_KERNEL.toNegated(),
+						ContextKeyExpr.equals('config.notebook.globalToolbar', true)
+					)
+				}
+			]
+		});
+	}
+});
+
+registerAction2(class InterruptNotebook extends CancelNotebook {
+	constructor() {
+		super({
+			id: INTERRUPT_NOTEBOOK_COMMAND_ID,
+			title: localize('notebookActions.interruptNotebook', "Interrupt"),
+			icon: icons.stopIcon,
 			menu: [
 				{
 					id: MenuId.EditorTitle,
@@ -528,14 +562,6 @@ registerAction2(class CancelNotebook extends NotebookAction {
 				}
 			]
 		});
-	}
-
-	override getEditorContextFromArgsOrActive(accessor: ServicesAccessor, context?: UriComponents): INotebookActionContext | undefined {
-		return getContextFromUri(accessor, context) ?? getContextFromActiveEditor(accessor.get(IEditorService));
-	}
-
-	async runWithContext(accessor: ServicesAccessor, context: INotebookActionContext): Promise<void> {
-		return context.notebookEditor.cancelNotebookCells();
 	}
 });
 

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorWidgetContextKeys.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorWidgetContextKeys.ts
@@ -30,6 +30,7 @@ export class NotebookEditorContextKeys {
 	private readonly _disposables = new DisposableStore();
 	private readonly _viewModelDisposables = new DisposableStore();
 	private readonly _cellOutputsListeners: IDisposable[] = [];
+	private readonly _selectedKernelDisposables = new DisposableStore();
 
 	constructor(
 		private readonly _editor: INotebookEditorDelegate,
@@ -174,6 +175,13 @@ export class NotebookEditorContextKeys {
 		this._interruptibleKernel.set(selected?.implementsInterrupt ?? false);
 		this._notebookKernelSelected.set(Boolean(selected));
 		this._notebookKernel.set(selected?.id ?? '');
+
+		this._selectedKernelDisposables.clear();
+		if (selected) {
+			this._selectedKernelDisposables.add(selected.onDidChange(() => {
+				this._interruptibleKernel.set(selected?.implementsInterrupt ?? false);
+			}));
+		}
 	}
 
 	private _updateForNotebookOptions(): void {

--- a/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
@@ -30,6 +30,7 @@ export interface INotebookKernelChangeEvent {
 	kind?: true;
 	supportedLanguages?: true;
 	hasExecutionOrder?: true;
+	hasInterruptHandler?: true;
 }
 
 export interface INotebookKernel {


### PR DESCRIPTION
Fix #128245. The core now contributes an Interrupt button when the selected notebook controller has interrupt handler.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
