### PR TITLE
Stop adding notebook-triage labels.

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -86,21 +86,6 @@
 	},
 	{
 		"type": "label",
-		"name": "notebook",
-		"regex": "notebook.*",
-		"assign": [
-			"rebornix"
-		]
-	},
-	{
-		"type": "label",
-		"name": "notebook-triage",
-		"regex": "notebook.*",
-		"action": "updateLabels",
-		"addLabel": "notebook-triage"
-	},
-	{
-		"type": "label",
 		"name": "L10N",
 		"assign": [
 			"csigs",


### PR DESCRIPTION
We now have code ownership so we don't need an auto-assigned label for triage.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
