### PR TITLE
Commit dropdown button uses text-overflow

### DIFF
--- a/extensions/git/src/actionButton.ts
+++ b/extensions/git/src/actionButton.ts
@@ -5,7 +5,7 @@
 
 import * as nls from 'vscode-nls';
 import { Command, Disposable, Event, EventEmitter, SourceControlActionButton, Uri, workspace } from 'vscode';
-import { Branch, CommitCommand, Status } from './api/git';
+import { Branch, Status } from './api/git';
 import { CommitCommandsCenter } from './postCommitCommands';
 import { Repository, Operation } from './repository';
 import { dispose } from './util';
@@ -97,12 +97,11 @@ export class ActionButtonCommand {
 		return {
 			command: primaryCommand,
 			secondaryCommands: this.getCommitActionButtonSecondaryCommands(),
-			description: primaryCommand.description ?? primaryCommand.title,
 			enabled: (this.state.repositoryHasChangesToCommit || this.state.isRebaseInProgress) && !this.state.isCommitInProgress && !this.state.isMergeInProgress
 		};
 	}
 
-	private getCommitActionButtonPrimaryCommand(): CommitCommand {
+	private getCommitActionButtonPrimaryCommand(): Command {
 		// Rebase Continue
 		if (this.state.isRebaseInProgress) {
 			return {
@@ -127,8 +126,7 @@ export class ActionButtonCommand {
 		const commandGroups: Command[][] = [];
 		for (const commands of this.postCommitCommandCenter.getSecondaryCommands()) {
 			commandGroups.push(commands.map(c => {
-				// Use the description as title if present
-				return { command: 'git.commit', title: c.description ?? c.title, tooltip: c.tooltip, arguments: c.arguments };
+				return { command: 'git.commit', title: c.title, tooltip: c.tooltip, arguments: c.arguments };
 			}));
 		}
 

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -260,10 +260,8 @@ export interface CredentialsProvider {
 	getCredentials(host: Uri): ProviderResult<Credentials>;
 }
 
-export type CommitCommand = Command & { description?: string };
-
 export interface PostCommitCommandsProvider {
-	getCommands(repository: Repository): CommitCommand[];
+	getCommands(repository: Repository): Command[];
 }
 
 export interface PushErrorHandler {

--- a/extensions/github/src/typings/git.d.ts
+++ b/extensions/github/src/typings/git.d.ts
@@ -260,10 +260,8 @@ export interface CredentialsProvider {
 	getCredentials(host: Uri): ProviderResult<Credentials>;
 }
 
-export type CommitCommand = Command & { description?: string };
-
 export interface PostCommitCommandsProvider {
-	getCommands(repository: Repository): CommitCommand[];
+	getCommands(repository: Repository): Command[];
 }
 
 export interface PushErrorHandler {

--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -198,7 +198,23 @@ export class Button extends Disposable implements IButton {
 	set label(value: string) {
 		this._element.classList.add('monaco-text-button');
 		if (this.options.supportIcons) {
-			reset(this._element, ...renderLabelWithIcons(value));
+			// Remove empty segments
+			const segments = renderLabelWithIcons(value)
+				.filter(segment => {
+					return (typeof (segment) === 'string' && segment.trim() === '') ? false : true;
+				});
+
+			// Convert string segments to <span> nodes
+			const content = segments.map(segment => {
+				if (typeof (segment) === 'string') {
+					const node = document.createElement('span');
+					node.textContent = segment.trim();
+					return node;
+				}
+				return segment;
+			});
+
+			reset(this._element, ...content);
 		} else {
 			this._element.textContent = value;
 		}
@@ -263,7 +279,7 @@ export class ButtonWithDropdown extends Disposable implements IButton {
 		this.element.classList.add('monaco-button-dropdown');
 		container.appendChild(this.element);
 
-		this.button = this._register(new ButtonWithDescription(this.element, options));
+		this.button = this._register(new Button(this.element, options));
 		this._register(this.button.onDidClick(e => this._onDidClick.fire(e)));
 		this.action = this._register(new Action('primaryAction', this.button.label, undefined, true, async () => this._onDidClick.fire(undefined)));
 
@@ -298,10 +314,6 @@ export class ButtonWithDropdown extends Disposable implements IButton {
 
 	set icon(icon: CSSIcon) {
 		this.button.icon = icon;
-	}
-
-	set description(value: string) {
-		(this.button as ButtonWithDescription).description = value;
 	}
 
 	set enabled(enabled: boolean) {

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -267,6 +267,13 @@
 
 .scm-view .button-container > .monaco-button-dropdown > .monaco-button.monaco-text-button {
 	border-radius: 2px 0 0 2px;
+	min-width: 0;
+}
+
+.scm-view .button-container > .monaco-button-dropdown > .monaco-button.monaco-text-button > span:not(.codicon) {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .scm-view .scm-editor.hidden {

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -2675,9 +2675,6 @@ export class SCMActionButton implements IDisposable {
 				title: button.command.tooltip,
 				supportIcons: true
 			});
-			if (button.description) {
-				(this.button as ButtonWithDropdown).description = button.description;
-			}
 		} else if (button.description) {
 			// ButtonWithDescription
 			this.button = new ButtonWithDescription(this.container, { supportIcons: true, title: button.command.tooltip });


### PR DESCRIPTION
Related #159243

Commit action button is now using text overflow instead of label/description.

<img width="193" alt="image" src="https://user-images.githubusercontent.com/3372902/189983669-c86c5b71-e012-42d5-bb85-3bc66b248b9a.png">
