### PR TITLE
There is no need to pass in `nodeMain` when passing in `baseUrl`

### DIFF
--- a/src/bootstrap-amd.js
+++ b/src/bootstrap-amd.js
@@ -18,7 +18,6 @@ loader.config({
 	baseUrl: bootstrap.fileUriFromPath(__dirname, { isWindows: process.platform === 'win32' }),
 	catchError: true,
 	nodeRequire: require,
-	nodeMain: __filename,
 	'vs/nls': nlsConfig,
 	amdModulesPattern: /^vs\//,
 	recordStats: true

--- a/test/unit/electron/renderer.js
+++ b/test/unit/electron/renderer.js
@@ -84,7 +84,6 @@ function initLoader(opts) {
 	loader = require(`${_out}/vs/loader`);
 	const loaderConfig = {
 		nodeRequire: require,
-		nodeMain: __filename,
 		catchError: true,
 		baseUrl: bootstrap.fileUriFromPath(path.join(__dirname, '../../../src'), { isWindows: process.platform === 'win32' }),
 		paths: {

--- a/test/unit/node/index.js
+++ b/test/unit/node/index.js
@@ -94,7 +94,6 @@ function main() {
 
 	const loaderConfig = {
 		nodeRequire: require,
-		nodeMain: __filename,
 		baseUrl: fileUriFromPath(src, { isWindows: process.platform === 'win32' }),
 		catchError: true
 	};


### PR DESCRIPTION
cc @bpasero