### PR TITLE
Removed erroneous references to PREFIX environment variable

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -98,7 +98,7 @@ __vsc_update_prompt() {
 		# means the user re-exported the PS1 so we should re-wrap it
 		if [[ "$__vsc_custom_PS1" == "" || "$__vsc_custom_PS1" != "$PS1" ]]; then
 			__vsc_original_PS1=$PS1
-			__vsc_custom_PS1="\[$(__vsc_prompt_start)\]$PREFIX$__vsc_original_PS1\[$(__vsc_prompt_end)\]"
+			__vsc_custom_PS1="\[$(__vsc_prompt_start)\]$__vsc_original_PS1\[$(__vsc_prompt_end)\]"
 			PS1="$__vsc_custom_PS1"
 		fi
 		if [[ "$__vsc_custom_PS2" == "" || "$__vsc_custom_PS2" != "$PS2" ]]; then

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -84,14 +84,11 @@ if [[ -o NOUNSET ]]; then
 	if [ -z "${RPROMPT-}" ]; then
 		RPROMPT=""
 	fi
-	if [ -z "${PREFIX-}" ]; then
-		PREFIX=""
-	fi
 fi
 __vsc_update_prompt() {
 	__vsc_prior_prompt="$PS1"
 	__vsc_in_command_execution=""
-	PS1="%{$(__vsc_prompt_start)%}$PREFIX$PS1%{$(__vsc_prompt_end)%}"
+	PS1="%{$(__vsc_prompt_start)%}$PS1%{$(__vsc_prompt_end)%}"
 	PS2="%{$(__vsc_continuation_start)%}$PS2%{$(__vsc_continuation_end)%}"
 	if [ -n "$RPROMPT" ]; then
 		__vsc_prior_rprompt="$RPROMPT"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Closes #160748.

This patch removes references to the PREFIX environment variable in the Bash and Zsh integrated terminals.
Without this change, the PS1 prompt for both of these shells contained $PREFIX, which is a common environment variable users tend to set.

To test these changes:
1. Enable the integrated terminal for Bash or Zsh
2. In the terminal, assign a value to a variable called PREFIX
3. Nothing should happen to the prompt
