### PR TITLE
Fix branch checkout after git clone

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -520,7 +520,7 @@ export class CommandCenter {
 			);
 
 			if (options.ref !== undefined) {
-				const repository = this.model.getRepository(Uri.file(repositoryPath));
+				const repository = await this.model.openRepository(repositoryPath).then(() => this.model.getRepository(repositoryPath));
 				await repository?.checkout(options.ref);
 			}
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -526,7 +526,8 @@ export class CommandCenter {
 						location: ProgressLocation.Notification,
 						title: localize('checking out ref', "Checking out ref '{0}'...", options.ref)
 					}, async () => {
-						const repository = await this.model.openRepository(repositoryPath).then(() => this.model.getRepository(repositoryPath));
+						await this.model.openRepository(repositoryPath);
+						const repository = this.model.getRepository(repositoryPath);
 						await repository?.checkout(refToCheckoutAfterClone);
 					});
 			}

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -519,9 +519,16 @@ export class CommandCenter {
 				(progress, token) => this.git.clone(url!, { parentPath: parentPath!, progress, recursive: options.recursive }, token)
 			);
 
-			if (options.ref !== undefined) {
-				const repository = await this.model.openRepository(repositoryPath).then(() => this.model.getRepository(repositoryPath));
-				await repository?.checkout(options.ref);
+			const refToCheckoutAfterClone = options.ref;
+			if (refToCheckoutAfterClone !== undefined) {
+				await window.withProgress(
+					{
+						location: ProgressLocation.Notification,
+						title: localize('checking out ref', "Checking out ref '{0}'...", options.ref)
+					}, async () => {
+						const repository = await this.model.openRepository(repositoryPath).then(() => this.model.getRepository(repositoryPath));
+						await repository?.checkout(refToCheckoutAfterClone);
+					});
 			}
 
 			const config = workspace.getConfiguration('git');


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/vscode/issues/158386

The previous implementation would always fail to discover the repository we were interested in, because `getRepository` only looks at repositories that are already known to the git extension, and the newly cloned git repo needs to be explicitly opened with `openRepository` first.