### PR TITLE
Fix Continue On when there is currently no edit session and the user has turned on edit sessions

### DIFF
--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -550,7 +550,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 	private async shouldContinueOnWithEditSession(): Promise<boolean> {
 		// If the user is already signed in, we should store edit session
 		if (this.editSessionsStorageService.isSignedIn) {
-			return true;
+			return this.hasEditSession();
 		}
 
 		// If the user has been asked before and said no, don't use edit sessions


### PR DESCRIPTION
Followup to https://github.com/microsoft/vscode/pull/160364