### PR TITLE
Fix Continue On when target URI already has a query param

### DIFF
--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -267,7 +267,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 				if (ref !== undefined && uri !== 'noDestinationUri') {
 					const encodedRef = encodeURIComponent(ref);
 					uri = uri.with({
-						query: uri.query.length > 0 ? (uri + `&${queryParamName}=${encodedRef}`) : `${queryParamName}=${encodedRef}`
+						query: uri.query.length > 0 ? (uri.query + `&${queryParamName}=${encodedRef}`) : `${queryParamName}=${encodedRef}`
 					});
 
 					// Open the URI


### PR DESCRIPTION
If the target URI contained a query parameter (which following some refactoring now happens for Continue On destinations that rely on an extension-provided protocol URL invocation, i.e. Reopen on Desktop and Clone Repository), we would append a URI to its own query parameters, which causes protocol URL handling to fail.