### PR TITLE
Remove string replace that didn't do anything

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/history.ts
+++ b/src/vs/workbench/contrib/terminal/common/history.ts
@@ -433,8 +433,7 @@ export function sanitizeFishHistoryCmd(cmd: string): string {
 	 * But since not all browsers support look aheads we opted to a simple
 	 * pattern and repeatedly calling replace method.
 	 */
-	return repeatedReplace(/(^|[^\\])((?:\\\\)*)(\\n)/g, cmd, '$1$2\n')
-		.replace(/\\/g, '\\');
+	return repeatedReplace(/(^|[^\\])((?:\\\\)*)(\\n)/g, cmd, '$1$2\n');
 }
 
 function repeatedReplace(pattern: RegExp, value: string, replaceValue: string): string {


### PR DESCRIPTION
This replace did nothing. Tested that `\` gets deserialized properly. FYI @babakks 