### PR TITLE
Send ctrl+c before running a command unless there is no input

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -146,6 +146,11 @@ export interface ICommandDetectionCapability {
 	readonly executingCommandObject: ITerminalCommand | undefined;
 	/** The current cwd at the cursor's position. */
 	readonly cwd: string | undefined;
+	/**
+	 * Whether a command is currently being input. If the a command is current not being input or
+	 * the state cannot reliably be detected the fallback of undefined will be used.
+	 */
+	readonly hasInput: boolean | undefined;
 	readonly onCommandStarted: Event<ITerminalCommand>;
 	readonly onCommandFinished: Event<ITerminalCommand>;
 	readonly onCommandInvalidated: Event<ITerminalCommand[]>;

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -72,6 +72,23 @@ export class CommandDetectionCapability implements ICommandDetectionCapability {
 		return undefined;
 	}
 	get cwd(): string | undefined { return this._cwd; }
+	private get _isInputting(): boolean {
+		return !!(this._currentCommand.commandStartMarker && !this._currentCommand.commandExecutedMarker);
+	}
+
+	get hasInput(): boolean | undefined {
+		if (!this._isInputting || !this._currentCommand?.commandStartMarker) {
+			return undefined;
+		}
+		if (this._terminal.buffer.active.cursorY === this._currentCommand.commandStartMarker?.line) {
+			const line = this._terminal.buffer.active.getLine(this._terminal.buffer.active.cursorY)?.translateToString(true, this._currentCommand.commandStartX);
+			if (!line) {
+				return undefined;
+			}
+			return line.length > 0;
+		}
+		return true;
+	}
 
 	private readonly _onCommandStarted = new Emitter<ITerminalCommand>();
 	readonly onCommandStarted = this._onCommandStarted.event;
@@ -316,6 +333,16 @@ export class CommandDetectionCapability implements ICommandDetectionCapability {
 		}
 		this._currentCommand.commandStartX = this._terminal.buffer.active.cursorX;
 		this._currentCommand.commandStartMarker = options?.marker || this._terminal.registerMarker(0);
+
+		// Clear executed as it much happen after command start
+		this._currentCommand.commandExecutedMarker?.dispose();
+		this._currentCommand.commandExecutedMarker = undefined;
+		this._currentCommand.commandExecutedX = undefined;
+		for (const m of this._commandMarkers) {
+			m.dispose();
+		}
+		this._commandMarkers.length = 0;
+
 		this._onCommandStarted.fire({ marker: options?.marker || this._currentCommand.commandStartMarker, markProperties: options?.markProperties } as ITerminalCommand);
 		this._logService.debug('CommandDetectionCapability#handleCommandStart', this._currentCommand.commandStartX, this._currentCommand.commandStartMarker?.line);
 	}

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -334,7 +334,7 @@ export class CommandDetectionCapability implements ICommandDetectionCapability {
 		this._currentCommand.commandStartX = this._terminal.buffer.active.cursorX;
 		this._currentCommand.commandStartMarker = options?.marker || this._terminal.registerMarker(0);
 
-		// Clear executed as it much happen after command start
+		// Clear executed as it must happen after command start
 		this._currentCommand.commandExecutedMarker?.dispose();
 		this._currentCommand.commandExecutedMarker = undefined;
 		this._currentCommand.commandExecutedX = undefined;

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -80,9 +80,9 @@ export class CommandDetectionCapability implements ICommandDetectionCapability {
 		if (!this._isInputting || !this._currentCommand?.commandStartMarker) {
 			return undefined;
 		}
-		if (this._terminal.buffer.active.cursorY === this._currentCommand.commandStartMarker?.line) {
+		if (this._terminal.buffer.active.baseY + this._terminal.buffer.active.cursorY === this._currentCommand.commandStartMarker?.line) {
 			const line = this._terminal.buffer.active.getLine(this._terminal.buffer.active.cursorY)?.translateToString(true, this._currentCommand.commandStartX);
-			if (!line) {
+			if (line === undefined) {
 				return undefined;
 			}
 			return line.length > 0;

--- a/src/vs/workbench/contrib/terminal/browser/terminalRunRecentQuickPick.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalRunRecentQuickPick.ts
@@ -264,8 +264,8 @@ export async function showRunRecentQuickPick(
 		} else { // command
 			text = result.rawLabel;
 		}
-		instance.sendText(text, !quickPick.keyMods.alt, true);
 		quickPick.hide();
+		runCommand(instance, text, !quickPick.keyMods.alt);
 		if (quickPick.keyMods.alt) {
 			instance.focus();
 		}
@@ -281,6 +281,16 @@ export async function showRunRecentQuickPick(
 			r();
 		});
 	});
+}
+
+async function runCommand(instance: ITerminalInstance, commandLine: string, addNewLine: boolean): Promise<void> {
+	// Determine whether to send ETX (ctrl+c) before running the command. This should always
+	// happen unless command detection can reliably say that a command is being entered and
+	// there is no content in the prompt
+	if (instance.capabilities.get(TerminalCapability.CommandDetection)?.hasInput !== false) {
+		await instance.sendText('\x03', false);
+	}
+	await instance.sendText(commandLine, addNewLine, true);
 }
 
 class TerminalOutputProvider implements ITextModelContentProvider {


### PR DESCRIPTION
Fixes #144279

- [x] Test on Windows (^C is sent for everything basically, as designed due to flaky markers)
- [x] Test on mac (should only clear when needed)