### PR TITLE
joh/hide menuItems

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -95,8 +95,8 @@ export class ActionBar extends Disposable implements IActionRunner {
 	private _onDidRun = this._register(new Emitter<IRunEvent>());
 	readonly onDidRun = this._onDidRun.event;
 
-	private _onBeforeRun = this._register(new Emitter<IRunEvent>());
-	readonly onBeforeRun = this._onBeforeRun.event;
+	private _onWillRun = this._register(new Emitter<IRunEvent>());
+	readonly onWillRun = this._onWillRun.event;
 
 	constructor(container: HTMLElement, options: IActionBarOptions = {}) {
 		super();
@@ -117,7 +117,7 @@ export class ActionBar extends Disposable implements IActionRunner {
 		}
 
 		this._register(this._actionRunner.onDidRun(e => this._onDidRun.fire(e)));
-		this._register(this._actionRunner.onBeforeRun(e => this._onBeforeRun.fire(e)));
+		this._register(this._actionRunner.onWillRun(e => this._onWillRun.fire(e)));
 
 		this.viewItems = [];
 		this.viewItemDisposables = new Map<IActionViewItem, IDisposable>();

--- a/src/vs/base/browser/ui/menu/menubar.ts
+++ b/src/vs/base/browser/ui/menu/menubar.ts
@@ -109,7 +109,7 @@ export class MenuBar extends Disposable {
 		this.menuUpdater = this._register(new RunOnceScheduler(() => this.update(), 200));
 
 		this.actionRunner = this.options.actionRunner ?? this._register(new ActionRunner());
-		this._register(this.actionRunner.onBeforeRun(() => {
+		this._register(this.actionRunner.onWillRun(() => {
 			this.setUnfocusedState();
 		}));
 

--- a/src/vs/base/browser/ui/toolbar/toolbar.ts
+++ b/src/vs/base/browser/ui/toolbar/toolbar.ts
@@ -148,8 +148,8 @@ export class ToolBar extends Disposable {
 		return itemsWidth;
 	}
 
-	getItemAction(index: number) {
-		return this.actionBar.getAction(index);
+	getItemAction(indexOrElement: number | HTMLElement) {
+		return this.actionBar.getAction(indexOrElement);
 	}
 
 	getItemWidth(index: number): number {

--- a/src/vs/base/browser/ui/toolbar/toolbar.ts
+++ b/src/vs/base/browser/ui/toolbar/toolbar.ts
@@ -36,13 +36,13 @@ export interface IToolBarOptions {
  */
 export class ToolBar extends Disposable {
 	private options: IToolBarOptions;
-	private actionBar: ActionBar;
+	protected readonly actionBar: ActionBar;
 	private toggleMenuAction: ToggleMenuAction;
 	private toggleMenuActionViewItem: DropdownMenuActionViewItem | undefined;
 	private submenuActionViewItems: DropdownMenuActionViewItem[] = [];
 	private hasSecondaryActions: boolean = false;
-	private lookupKeybindings: boolean;
-	private element: HTMLElement;
+	private readonly lookupKeybindings: boolean;
+	private readonly element: HTMLElement;
 
 	private _onDidChangeDropdownVisibility = this._register(new EventMultiplexer<boolean>());
 	readonly onDidChangeDropdownVisibility = this._onDidChangeDropdownVisibility.event;

--- a/src/vs/base/common/actions.ts
+++ b/src/vs/base/common/actions.ts
@@ -37,7 +37,7 @@ export interface IAction {
 
 export interface IActionRunner extends IDisposable {
 	readonly onDidRun: Event<IRunEvent>;
-	readonly onBeforeRun: Event<IRunEvent>;
+	readonly onWillRun: Event<IRunEvent>;
 
 	run(action: IAction, context?: unknown): unknown;
 }
@@ -165,10 +165,10 @@ export interface IRunEvent {
 
 export class ActionRunner extends Disposable implements IActionRunner {
 
-	private _onBeforeRun = this._register(new Emitter<IRunEvent>());
-	readonly onBeforeRun = this._onBeforeRun.event;
+	private readonly _onWillRun = this._register(new Emitter<IRunEvent>());
+	readonly onWillRun = this._onWillRun.event;
 
-	private _onDidRun = this._register(new Emitter<IRunEvent>());
+	private readonly _onDidRun = this._register(new Emitter<IRunEvent>());
 	readonly onDidRun = this._onDidRun.event;
 
 	async run(action: IAction, context?: unknown): Promise<void> {
@@ -176,7 +176,7 @@ export class ActionRunner extends Disposable implements IActionRunner {
 			return;
 		}
 
-		this._onBeforeRun.fire({ action });
+		this._onWillRun.fire({ action });
 
 		let error: Error | undefined = undefined;
 		try {

--- a/src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts
+++ b/src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts
@@ -305,7 +305,7 @@ export class MarkerNavigationWidget extends PeekViewWidget {
 	protected override _fillHead(container: HTMLElement): void {
 		super._fillHead(container);
 
-		this._disposables.add(this._actionbarWidget!.actionRunner.onBeforeRun(e => this.editor.focus()));
+		this._disposables.add(this._actionbarWidget!.actionRunner.onWillRun(e => this.editor.focus()));
 
 		const actions: IAction[] = [];
 		const menu = this._menuService.createMenu(MarkerNavigationWidget.TitleMenu, this._contextKeyService);

--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -198,7 +198,7 @@ export class WorkbenchToolBar extends ToolBar {
 	}
 
 	/**
-	 * @deprecated The WorkbenchToolBar does not support this method because it wrorks with menus.
+	 * @deprecated The WorkbenchToolBar does not support this method because it works with menus.
 	 */
 	override setActions(): void {
 		throw new BugIndicatingError('This toolbar is populated from a menu.');

--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -1,0 +1,147 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { addDisposableListener } from 'vs/base/browser/dom';
+import { IToolBarOptions, ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
+import { IAction, Separator, SubmenuAction } from 'vs/base/common/actions';
+import { coalesceInPlace } from 'vs/base/common/arrays';
+import { BugIndicatingError } from 'vs/base/common/errors';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { createAndFillInActionBarActions, createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { IMenuActionOptions, IMenuService, MenuId, MenuItemAction } from 'vs/platform/actions/common/actions';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+
+export const enum HiddenItemStrategy {
+	Hide = 0,
+	RenderInSecondaryGroup = 1
+}
+
+export interface IToolBarRenderOptions {
+	primaryGroup?: string | ((actionGroup: string) => boolean);
+	primaryMaxCount?: number;
+	shouldInlineSubmenu?: (action: SubmenuAction, group: string, groupSize: number) => boolean;
+	useSeparatorsInPrimaryActions?: boolean;
+	hiddenItemStrategy?: HiddenItemStrategy;
+}
+
+export type IWorkbenchToolBarOptions = Exclude<IToolBarOptions, { allowContextMenu: boolean }> & {
+	contextMenu?: MenuId;
+	toolbarOptions?: IToolBarRenderOptions;
+	menuOptions?: IMenuActionOptions;
+};
+
+export class WorkbenchToolBar extends ToolBar {
+
+	private static readonly _mandatoryOptions: IWorkbenchToolBarOptions = { allowContextMenu: true };
+
+	constructor(
+		container: HTMLElement,
+		menuId: MenuId,
+		options: IWorkbenchToolBarOptions | undefined,
+		@IMenuService menuService: IMenuService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+	) {
+		options = { ...options, ...WorkbenchToolBar._mandatoryOptions };
+		super(container, contextMenuService, options);
+
+		const sessionDisposable = new DisposableStore();
+		const menu = this._store.add(menuService.createMenu(menuId, contextKeyService));
+
+		const updateToolbar = () => {
+
+			sessionDisposable.clear();
+
+			const toggleActions: IAction[] = [];
+			const primary: IAction[] = [];
+			const secondary: IAction[] = [];
+
+			createAndFillInActionBarActions(
+				menu,
+				options?.menuOptions,
+				{ primary, secondary },
+				options?.toolbarOptions?.primaryGroup, options?.toolbarOptions?.primaryMaxCount, options?.toolbarOptions?.shouldInlineSubmenu, options?.toolbarOptions?.useSeparatorsInPrimaryActions
+			);
+
+			let shouldPrependSeparator = secondary.length > 0;
+
+			// move all hidden items to secondary group
+			for (let i = 0; i < primary.length; i++) {
+				const action = primary[i];
+				if (!(action instanceof MenuItemAction)) {
+					continue;
+				}
+				if (!action.hideActions) {
+					continue;
+				}
+
+				// collect all toggle actions
+				toggleActions.push(action.hideActions.toggle);
+
+				// hidden items move into overflow or ignore
+				if (action.hideActions.isHidden) {
+					primary[i] = undefined!;
+					if (options?.toolbarOptions?.hiddenItemStrategy !== HiddenItemStrategy.Hide) {
+						if (shouldPrependSeparator) {
+							shouldPrependSeparator = false;
+							secondary.unshift(new Separator());
+						}
+						secondary.unshift(action);
+					}
+				}
+			}
+			coalesceInPlace(primary);
+			super.setActions(primary, secondary);
+
+			// add context menu for toggle actions
+			if (toggleActions.length > 0) {
+				sessionDisposable.add(addDisposableListener(this.getElement(), 'contextmenu', e => {
+
+					const action = this.getItemAction(<HTMLElement>e.target);
+					if (!(action)) {
+						return;
+					}
+					e.preventDefault();
+					e.stopPropagation();
+
+					let actions = toggleActions;
+
+					// add "hide foo" actions
+					if (action instanceof MenuItemAction && action.hideActions) {
+						actions = [action.hideActions.hide, new Separator(), ...toggleActions];
+					}
+
+					// add context menu actions (iff appicable)
+					if (options?.contextMenu) {
+						const menu = menuService.createMenu(options.contextMenu, contextKeyService);
+						const contextMenuActions: IAction[] = [];
+						createAndFillInContextMenuActions(menu, options?.menuOptions, contextMenuActions);
+						menu.dispose();
+
+						if (contextMenuActions.length > 0) {
+							actions = [...actions, new Separator(), ...contextMenuActions];
+						}
+					}
+
+					contextMenuService.showContextMenu({
+						getAnchor: () => e,
+						getActions: () => actions,
+					});
+				}));
+			}
+		};
+
+		this._store.add(menu.onDidChange(updateToolbar));
+		updateToolbar();
+	}
+
+	/**
+	 * @deprecated The WorkbenchToolBar does not support this method because it wrorks with menus.
+	 */
+	override setActions(): void {
+		throw new BugIndicatingError('This toolbar is populated from a menu.');
+	}
+}

--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -193,7 +193,10 @@ export class WorkbenchToolBar extends ToolBar {
 
 		// telemetry logic
 		if (options?.telemetrySource) {
-			this.actionRunner.onDidRun(e => telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: e.action.id, from: options!.telemetrySource! }));
+			this._store.add(this.actionBar.onDidRun(e => telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>(
+				'workbenchActionExecuted',
+				{ id: e.action.id, from: options!.telemetrySource! })
+			));
 		}
 	}
 

--- a/src/vs/platform/actions/common/actions.contribution.ts
+++ b/src/vs/platform/actions/common/actions.contribution.ts
@@ -6,9 +6,8 @@
 import { IMenuService, registerAction2 } from 'vs/platform/actions/common/actions';
 import { MenuHiddenStatesReset } from 'vs/platform/actions/common/menuResetAction';
 import { MenuService } from 'vs/platform/actions/common/menuService';
-import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
-
-registerSingleton(IMenuService, MenuService, true);
+registerSingleton(IMenuService, MenuService, InstantiationType.Delayed);
 
 registerAction2(MenuHiddenStatesReset);

--- a/src/vs/platform/contextview/browser/contextMenuHandler.ts
+++ b/src/vs/platform/contextview/browser/contextMenuHandler.ts
@@ -81,7 +81,7 @@ export class ContextMenuHandler {
 				const menuDisposables = new DisposableStore();
 
 				const actionRunner = delegate.actionRunner || new ActionRunner();
-				actionRunner.onBeforeRun(this.onActionRun, this, menuDisposables);
+				actionRunner.onWillRun(this.onActionRun, this, menuDisposables);
 				actionRunner.onDidRun(this.onDidActionRun, this, menuDisposables);
 				menu = new Menu(container, actions, {
 					actionViewItemProvider: delegate.getActionViewItem,

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -664,7 +664,7 @@ export class TabsTitleControl extends TitleControl {
 		const tabActionRunner = new EditorCommandsContextActionRunner({ groupId: this.group.id, editorIndex: index });
 
 		const tabActionBar = new ActionBar(tabActionsContainer, { ariaLabel: localize('ariaLabelTabActions', "Tab actions"), actionRunner: tabActionRunner });
-		tabActionBar.onBeforeRun(e => {
+		tabActionBar.onWillRun(e => {
 			if (e.action.id === this.closeEditorAction.id) {
 				this.blockRevealActiveTabOnce();
 			}

--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -6,7 +6,6 @@
 import { reset } from 'vs/base/browser/dom';
 import { IHoverDelegate } from 'vs/base/browser/ui/iconLabel/iconHoverDelegate';
 import { renderIcon } from 'vs/base/browser/ui/iconLabel/iconLabels';
-import { WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
 import { Codicon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
 import { DisposableStore } from 'vs/base/common/lifecycle';
@@ -18,7 +17,6 @@ import { Action2, MenuId, MenuItemAction, registerAction2 } from 'vs/platform/ac
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import * as colors from 'vs/platform/theme/common/colorRegistry';
 import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
 import { MENUBAR_SELECTION_BACKGROUND, MENUBAR_SELECTION_FOREGROUND, PANEL_BORDER, TITLE_BAR_ACTIVE_FOREGROUND } from 'vs/workbench/common/theme';
@@ -37,8 +35,7 @@ export class CommandCenterControl {
 		hoverDelegate: IHoverDelegate,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IQuickInputService quickInputService: IQuickInputService,
-		@IKeybindingService keybindingService: IKeybindingService,
-		@ITelemetryService telemetryService: ITelemetryService,
+		@IKeybindingService keybindingService: IKeybindingService
 	) {
 		this.element.classList.add('command-center');
 
@@ -48,6 +45,7 @@ export class CommandCenterControl {
 				primaryGroup: () => true,
 				hiddenItemStrategy: HiddenItemStrategy.Hide
 			},
+			telemetrySource: 'commandCenter',
 			actionViewItemProvider: (action) => {
 
 				if (action instanceof MenuItemAction && action.id === 'workbench.action.quickOpen') {
@@ -119,10 +117,7 @@ export class CommandCenterControl {
 
 		this._disposables.add(quickInputService.onShow(this._setVisibility.bind(this, false)));
 		this._disposables.add(quickInputService.onHide(this._setVisibility.bind(this, true)));
-
-		titleToolbar.actionRunner.onDidRun(e => {
-			telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: e.action.id, from: 'commandCenter' });
-		});
+		this._disposables.add(titleToolbar);
 	}
 
 	private _setVisibility(show: boolean): void {

--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -6,17 +6,15 @@
 import { reset } from 'vs/base/browser/dom';
 import { IHoverDelegate } from 'vs/base/browser/ui/iconLabel/iconHoverDelegate';
 import { renderIcon } from 'vs/base/browser/ui/iconLabel/iconLabels';
-import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
-import { IAction, WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
+import { WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
 import { Codicon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { assertType } from 'vs/base/common/types';
 import { localize } from 'vs/nls';
-import { createActionViewItem, createAndFillInContextMenuActions, MenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
-import { Action2, IMenuService, MenuId, MenuItemAction, registerAction2 } from 'vs/platform/actions/common/actions';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { createActionViewItem, MenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { HiddenItemStrategy, WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+import { Action2, MenuId, MenuItemAction, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
@@ -37,17 +35,19 @@ export class CommandCenterControl {
 	constructor(
 		windowTitle: WindowTitle,
 		hoverDelegate: IHoverDelegate,
-		@IContextMenuService contextMenuService: IContextMenuService,
-		@IContextKeyService contextKeyService: IContextKeyService,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IMenuService menuService: IMenuService,
 		@IQuickInputService quickInputService: IQuickInputService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@ITelemetryService telemetryService: ITelemetryService,
 	) {
 		this.element.classList.add('command-center');
 
-		const titleToolbar = new ToolBar(this.element, contextMenuService, {
+		const titleToolbar = instantiationService.createInstance(WorkbenchToolBar, this.element, MenuId.CommandCenter, {
+			contextMenu: MenuId.TitleBarContext,
+			toolbarOptions: {
+				primaryGroup: () => true,
+				hiddenItemStrategy: HiddenItemStrategy.Hide
+			},
 			actionViewItemProvider: (action) => {
 
 				if (action instanceof MenuItemAction && action.id === 'workbench.action.quickOpen') {
@@ -114,20 +114,9 @@ export class CommandCenterControl {
 				} else {
 					return createActionViewItem(instantiationService, action, { hoverDelegate });
 				}
-			},
-			allowContextMenu: true
+			}
 		});
-		const menu = this._disposables.add(menuService.createMenu(MenuId.CommandCenter, contextKeyService));
-		const menuUpdater = () => {
-			const actions: IAction[] = [];
-			createAndFillInContextMenuActions(menu, undefined, actions);
-			titleToolbar.setActions(actions);
-		};
-		menuUpdater();
-		this._disposables.add(menu.onDidChange(menuUpdater));
-		this._disposables.add(keybindingService.onDidUpdateKeybindings(() => {
-			menuUpdater();
-		}));
+
 		this._disposables.add(quickInputService.onShow(this._setVisibility.bind(this, false)));
 		this._disposables.add(quickInputService.onHide(this._setVisibility.bind(this, true)));
 

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -31,12 +31,12 @@ import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/commo
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { Codicon } from 'vs/base/common/codicons';
 import { getIconRegistry } from 'vs/platform/theme/common/iconRegistry';
-import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
 import { CommandCenterControl } from 'vs/workbench/browser/parts/titlebar/commandCenterControl';
 import { IHoverDelegate } from 'vs/base/browser/ui/iconLabel/iconHoverDelegate';
 import { IHoverService } from 'vs/workbench/services/hover/browser/hover';
 import { CATEGORIES } from 'vs/workbench/common/actions';
+import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
 
 export class TitlebarPart extends Part implements ITitleService {
 
@@ -72,7 +72,7 @@ export class TitlebarPart extends Part implements ITitleService {
 	private appIconBadge: HTMLElement | undefined;
 	protected menubar?: HTMLElement;
 	protected layoutControls: HTMLElement | undefined;
-	private layoutToolbar: ToolBar | undefined;
+	private layoutToolbar: WorkbenchToolBar | undefined;
 	protected lastLayoutDimensions: Dimension | undefined;
 
 	private hoverDelegate: IHoverDelegate;
@@ -269,27 +269,13 @@ export class TitlebarPart extends Part implements ITitleService {
 			this.layoutControls = append(this.rootContainer, $('div.layout-controls-container'));
 			this.layoutControls.classList.toggle('show-layout-control', this.layoutControlEnabled);
 
-			this.layoutToolbar = new ToolBar(this.layoutControls, this.contextMenuService, {
+			this.layoutToolbar = this.instantiationService.createInstance(WorkbenchToolBar, this.layoutControls, MenuId.LayoutControlMenu, {
+				contextMenu: MenuId.TitleBarContext,
+				toolbarOptions: { primaryGroup: () => true },
 				actionViewItemProvider: action => {
 					return createActionViewItem(this.instantiationService, action, { hoverDelegate: this.hoverDelegate });
-				},
-				allowContextMenu: true
-			});
-
-			const menu = this._register(this.menuService.createMenu(MenuId.LayoutControlMenu, this.contextKeyService));
-			const updateLayoutMenu = () => {
-				if (!this.layoutToolbar) {
-					return;
 				}
-
-				const actions: IAction[] = [];
-				createAndFillInContextMenuActions(menu, undefined, { primary: [], secondary: actions });
-
-				this.layoutToolbar.setActions(actions);
-			};
-
-			menu.onDidChange(updateLayoutMenu);
-			updateLayoutMenu();
+			});
 		}
 
 		this.windowControls = append(this.element, $('div.window-controls-container'));

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/codeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/codeEditorView.ts
@@ -5,8 +5,6 @@
 
 import { h } from 'vs/base/browser/dom';
 import { IView, IViewSize } from 'vs/base/browser/ui/grid/grid';
-import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
-import { IAction } from 'vs/base/common/actions';
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import { autorun, derived, IObservable, observableFromEvent } from 'vs/base/common/observable';
@@ -15,10 +13,8 @@ import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
-import { createAndFillInActionBarActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
-import { IMenuService, MenuId } from 'vs/platform/actions/common/actions';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+import { MenuId } from 'vs/platform/actions/common/actions';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { DEFAULT_EDITOR_MAX_DIMENSIONS, DEFAULT_EDITOR_MIN_DIMENSIONS } from 'vs/workbench/browser/parts/editor/editor';
 import { setStyle } from 'vs/workbench/contrib/mergeEditor/browser/utils';
@@ -134,22 +130,14 @@ export class TitleMenu extends Disposable {
 	constructor(
 		menuId: MenuId,
 		targetHtmlElement: HTMLElement,
-		@IContextMenuService contextMenuService: IContextMenuService,
-		@IMenuService menuService: IMenuService,
-		@IContextKeyService contextKeyService: IContextKeyService,
+		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
 
-		const titleMenu = menuService.createMenu(menuId, contextKeyService);
-		const toolBar = new ToolBar(targetHtmlElement, contextMenuService);
-		const toolBarUpdate = () => {
-			const secondary: IAction[] = [];
-			createAndFillInActionBarActions(titleMenu, { renderShortTitle: true }, secondary);
-			toolBar.setActions([], secondary);
-		};
-		this._store.add(toolBar);
-		this._store.add(titleMenu);
-		this._store.add(titleMenu.onDidChange(toolBarUpdate));
-		toolBarUpdate();
+		const toolbar = instantiationService.createInstance(WorkbenchToolBar, targetHtmlElement, menuId, {
+			menuOptions: { renderShortTitle: true },
+			toolbarOptions: { primaryGroup: () => false }
+		});
+		this._store.add(toolbar);
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
@@ -540,12 +540,14 @@ export class NotebookEditorToolbar extends Disposable {
 
 		for (let i = 0; i < toolbar.getItemsLength(); i++) {
 			const action = toolbar.getItemAction(i);
-			actions.push({
-				action: action,
-				size: toolbar.getItemWidth(i),
-				visible: true,
-				renderLabel: true
-			});
+			if (action) {
+				actions.push({
+					action: action,
+					size: toolbar.getItemWidth(i),
+					visible: true,
+					renderLabel: true
+				});
+			}
 		}
 
 		this._primaryActions = actions;

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookTopCellToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookTopCellToolbar.ts
@@ -5,7 +5,7 @@
 
 import * as DOM from 'vs/base/browser/dom';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+import { HiddenItemStrategy, WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
 import { IMenuService, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
@@ -44,8 +44,9 @@ export class ListTopCellToolbar extends Disposable {
 				shouldForwardArgs: true
 			},
 			toolbarOptions: {
-				primaryGroup: g => /^inline/.test(g)
-			}
+				primaryGroup: g => /^inline/.test(g),
+				hiddenItemStrategy: HiddenItemStrategy.Hide,
+			},
 		}));
 
 		this.toolbar.context = <INotebookActionContext>{

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookTopCellToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookTopCellToolbar.ts
@@ -4,11 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as DOM from 'vs/base/browser/dom';
-import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
-import { IAction } from 'vs/base/common/actions';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-import { createAndFillInActionBarActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
-import { IMenu, IMenuService, MenuItemAction } from 'vs/platform/actions/common/actions';
+import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+import { IMenuService, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -18,8 +16,7 @@ import { CodiconActionViewItem } from 'vs/workbench/contrib/notebook/browser/vie
 
 export class ListTopCellToolbar extends Disposable {
 	private topCellToolbar: HTMLElement;
-	private menu: IMenu;
-	private toolbar: ToolBar;
+	private toolbar: WorkbenchToolBar;
 	private readonly _modelDisposables = this._register(new DisposableStore());
 	constructor(
 		protected readonly notebookEditor: INotebookEditorDelegate,
@@ -34,7 +31,7 @@ export class ListTopCellToolbar extends Disposable {
 
 		this.topCellToolbar = DOM.append(insertionIndicatorContainer, DOM.$('.cell-list-top-cell-toolbar-container'));
 
-		this.toolbar = this._register(new ToolBar(this.topCellToolbar, this.contextMenuService, {
+		this.toolbar = this._register(instantiationService.createInstance(WorkbenchToolBar, this.topCellToolbar, this.notebookEditor.creationOptions.menuIds.cellTopInsertToolbar, {
 			actionViewItemProvider: action => {
 				if (action instanceof MenuItemAction) {
 					const item = this.instantiationService.createInstance(CodiconActionViewItem, action, undefined);
@@ -42,17 +39,18 @@ export class ListTopCellToolbar extends Disposable {
 				}
 
 				return undefined;
+			},
+			menuOptions: {
+				shouldForwardArgs: true
+			},
+			toolbarOptions: {
+				primaryGroup: g => /^inline/.test(g)
 			}
 		}));
+
 		this.toolbar.context = <INotebookActionContext>{
 			notebookEditor
 		};
-
-		this.menu = this._register(this.menuService.createMenu(this.notebookEditor.creationOptions.menuIds.cellTopInsertToolbar, contextKeyService));
-		this._register(this.menu.onDidChange(() => {
-			this.updateActions();
-		}));
-		this.updateActions();
 
 		// update toolbar container css based on cell list length
 		this._register(this.notebookEditor.onDidChangeModel(() => {
@@ -70,28 +68,11 @@ export class ListTopCellToolbar extends Disposable {
 		this.updateClass();
 	}
 
-	private updateActions() {
-		const actions = this.getCellToolbarActions(this.menu, false);
-		this.toolbar.setActions(actions.primary, actions.secondary);
-	}
-
 	private updateClass() {
 		if (this.notebookEditor.hasModel() && this.notebookEditor.getLength() === 0) {
 			this.topCellToolbar.classList.add('emptyNotebook');
 		} else {
 			this.topCellToolbar.classList.remove('emptyNotebook');
 		}
-	}
-
-	private getCellToolbarActions(menu: IMenu, alwaysFillSecondaryActions: boolean): { primary: IAction[]; secondary: IAction[] } {
-		type NewType = IAction;
-
-		const primary: NewType[] = [];
-		const secondary: IAction[] = [];
-		const result = { primary, secondary };
-
-		createAndFillInActionBarActions(menu, { shouldForwardArgs: true }, result, g => /^inline/.test(g));
-
-		return result;
 	}
 }

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -2287,7 +2287,7 @@ export class SCMViewPane extends ViewPane {
 
 		const actionRunner = new RepositoryPaneActionRunner(() => this.getSelectedResources());
 		this._register(actionRunner);
-		this._register(actionRunner.onBeforeRun(() => this.tree.domFocus()));
+		this._register(actionRunner.onWillRun(() => this.tree.domFocus()));
 
 		const renderers: ICompressibleTreeRenderer<any, any, any>[] = [
 			this.instantiationService.createInstance(RepositoryRenderer, getActionViewItemProvider(this.instantiationService)),
@@ -2502,7 +2502,7 @@ export class SCMViewPane extends ViewPane {
 		}
 
 		const actionRunner = new RepositoryPaneActionRunner(() => this.getSelectedResources());
-		actionRunner.onBeforeRun(() => this.tree.domFocus());
+		actionRunner.onWillRun(() => this.tree.domFocus());
 
 		this.contextMenuService.showContextMenu({
 			getAnchor: () => e.anchor,


### PR DESCRIPTION
This is for https://github.com/microsoft/vscode/issues/154804

- allow action- and toolbar to return action from HTMLElement
- add `WorkbenchToolBar` which works with a `MenuId` and not with `setActions`
- make it easy to send the `workbenchActionExecuted` telemetry event
- always do keybindings, document options
- use `WorkbenchToolBar` in codeEditorView (3wm)
- adopt `WorkbenchToolbar` for notebookTopCellToolbar
- truely hide item from top cell toolbar
- :lipstick: rename to `onWillRun` and add readonly to emitters
- when setting an IActionRunner on the actionbar it needs to re-wire its events and disconnect from the old events
- properly listen/subscribe to run events, use more readonly in `ToolBar`
