### PR TITLE
The `openMergeEditor` command should check the active tab when it is called without an URI

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -445,6 +445,12 @@ export class CommandCenter {
 
 	@command('git.openMergeEditor')
 	async openMergeEditor(uri: unknown) {
+		if (uri === undefined) {
+			// fallback to active editor...
+			if (window.tabGroups.activeTabGroup.activeTab?.input instanceof TabInputText) {
+				uri = window.tabGroups.activeTabGroup.activeTab.input.uri;
+			}
+		}
 		if (!(uri instanceof Uri)) {
 			return;
 		}


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/160924
