### PR TITLE
mark keybinding service as Eager because it reads extension points and because it installs "the" keyboard listener,

### DIFF
--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -32,7 +32,7 @@ import { IKeyboardMapper } from 'vs/platform/keyboardLayout/common/keyboardMappe
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { MenuRegistry } from 'vs/platform/actions/common/actions';
-import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { commandsExtensionPoint } from 'vs/workbench/services/actions/common/menusExtensionPoint';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { RunOnceScheduler } from 'vs/base/common/async';
@@ -922,4 +922,4 @@ const keyboardConfiguration: IConfigurationNode = {
 
 configurationRegistry.registerConfiguration(keyboardConfiguration);
 
-registerSingleton(IKeybindingService, WorkbenchKeybindingService, false);
+registerSingleton(IKeybindingService, WorkbenchKeybindingService, InstantiationType.Eager);


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/159178
