### PR TITLE
joh/notebook toolbar

### DIFF
--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -5,10 +5,11 @@
 
 import { addDisposableListener } from 'vs/base/browser/dom';
 import { IToolBarOptions, ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
-import { IAction, Separator, SubmenuAction, WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
+import { IAction, Separator, SubmenuAction, toAction, WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
 import { coalesceInPlace } from 'vs/base/common/arrays';
 import { BugIndicatingError } from 'vs/base/common/errors';
 import { DisposableStore } from 'vs/base/common/lifecycle';
+import { localize } from 'vs/nls';
 import { createAndFillInActionBarActions, createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { IMenuActionOptions, IMenuService, MenuId, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -141,9 +142,18 @@ export class WorkbenchToolBar extends ToolBar {
 				let actions = toggleActions;
 
 				// add "hide foo" actions
+				let hideAction: IAction;
 				if (action instanceof MenuItemAction && action.hideActions) {
-					actions = [action.hideActions.hide, new Separator(), ...toggleActions];
+					hideAction = action.hideActions.hide;
+				} else {
+					hideAction = toAction({
+						id: 'label',
+						label: localize('hide', "Hide"),
+						enabled: false,
+						run() { }
+					});
 				}
+				actions = [hideAction, new Separator(), ...toggleActions];
 
 				// add context menu actions (iff appicable)
 				if (this._options?.contextMenu) {

--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -90,7 +90,7 @@ export class WorkbenchToolBar extends ToolBar {
 		}
 	}
 
-	override setActions(_primary: readonly IAction[], _secondary: readonly IAction[]): void {
+	override setActions(_primary: readonly IAction[], _secondary: readonly IAction[] = []): void {
 
 		this._sessionDisposables.clear();
 		const primary = _primary.slice();

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditorBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditorBrowser.ts
@@ -11,11 +11,11 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
 import { DiffEditorWidget } from 'vs/editor/browser/widget/diffEditorWidget';
-import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 import { IMouseWheelEvent } from 'vs/base/browser/mouseEvent';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { NotebookOptions } from 'vs/workbench/contrib/notebook/common/notebookOptions';
 import { NotebookLayoutInfo } from 'vs/workbench/contrib/notebook/browser/notebookViewEvents';
+import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
 
 export enum DiffSide {
 	Original = 0,
@@ -83,7 +83,7 @@ export interface CellDiffSideBySideRenderTemplate extends CellDiffCommonRenderTe
 	readonly sourceEditor: DiffEditorWidget;
 	readonly editorContainer: HTMLElement;
 	readonly inputToolbarContainer: HTMLElement;
-	readonly toolbar: ToolBar;
+	readonly toolbar: WorkbenchToolBar;
 	readonly metadataHeaderContainer: HTMLElement;
 	readonly metadataInfoContainer: HTMLElement;
 	readonly outputHeaderContainer: HTMLElement;

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffList.ts
@@ -20,7 +20,6 @@ import { isMacintosh } from 'vs/base/common/platform';
 import { DeletedElement, fixedDiffEditorOptions, fixedEditorOptions, getOptimizedNestedCodeEditorWidgetOptions, InsertElement, ModifiedElement } from 'vs/workbench/contrib/notebook/browser/diff/diffComponents';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
 import { DiffEditorWidget } from 'vs/editor/browser/widget/diffEditorWidget';
-import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 import { IMenuService, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -29,6 +28,7 @@ import { IMouseWheelEvent } from 'vs/base/browser/mouseEvent';
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { BareFontInfo } from 'vs/editor/common/config/fontInfo';
 import { PixelRatio } from 'vs/base/browser/browser';
+import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
 
 export class NotebookCellTextDiffListDelegate implements IListVirtualDelegate<DiffElementViewModelBase> {
 	private readonly lineHeight: number;
@@ -184,7 +184,7 @@ export class CellDiffSideBySideRenderer implements IListRenderer<SideBySideDiffE
 
 		const inputToolbarContainer = DOM.append(sourceContainer, DOM.$('.editor-input-toolbar-container'));
 		const cellToolbarContainer = DOM.append(inputToolbarContainer, DOM.$('div.property-toolbar'));
-		const toolbar = new ToolBar(cellToolbarContainer, this.contextMenuService, {
+		const toolbar = this.instantiationService.createInstance(WorkbenchToolBar, cellToolbarContainer, {
 			actionViewItemProvider: action => {
 				if (action instanceof MenuItemAction) {
 					const item = new CodiconActionViewItem(action, undefined, this.keybindingService, this.notificationService, this.contextKeyService, this.themeService, this.contextMenuService);

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -6,18 +6,16 @@
 import * as DOM from 'vs/base/browser/dom';
 import { FastDomNode } from 'vs/base/browser/fastDomNode';
 import { renderMarkdown } from 'vs/base/browser/markdownRenderer';
-import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 import { Action, IAction } from 'vs/base/common/actions';
 import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { MarshalledId } from 'vs/base/common/marshallingIds';
 import * as nls from 'vs/nls';
 import { createAndFillInActionBarActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
 import { IMenuService, MenuId } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
@@ -75,11 +73,10 @@ export class CellOutputElement extends Disposable {
 		readonly output: ICellOutputViewModel,
 		@INotebookService private readonly notebookService: INotebookService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
-		@IContextMenuService private readonly contextMenuService: IContextMenuService,
-		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IContextKeyService parentContextKeyService: IContextKeyService,
 		@IMenuService private readonly menuService: IMenuService,
-		@IPaneCompositePartService private readonly paneCompositeService: IPaneCompositePartService
+		@IPaneCompositePartService private readonly paneCompositeService: IPaneCompositePartService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
 
@@ -268,8 +265,7 @@ export class CellOutputElement extends Disposable {
 
 		outputItemDiv.appendChild(mimeTypePicker);
 
-		const toolbar = this._renderDisposableStore.add(new ToolBar(mimeTypePicker, this.contextMenuService, {
-			getKeyBinding: action => this.keybindingService.lookupKeybinding(action.id),
+		const toolbar = this._renderDisposableStore.add(this.instantiationService.createInstance(WorkbenchToolBar, mimeTypePicker, {
 			renderDropdownAsChildElement: false
 		}));
 		toolbar.context = <INotebookCellActionContext>{

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellToolbars.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellToolbars.ts
@@ -19,7 +19,7 @@ import { ICellViewModel, INotebookEditorDelegate } from 'vs/workbench/contrib/no
 import { CodiconActionViewItem } from 'vs/workbench/contrib/notebook/browser/view/cellParts/cellActionView';
 import { CellPart } from 'vs/workbench/contrib/notebook/browser/view/cellPart';
 import { registerStickyScroll } from 'vs/workbench/contrib/notebook/browser/view/cellParts/stickyScroll';
-import { MenuWorkbenchToolBar, WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+import { HiddenItemStrategy, MenuWorkbenchToolBar, WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
 
 export class BetweenCellToolbar extends CellPart {
 	private _betweenCellToolbar!: MenuWorkbenchToolBar;
@@ -104,7 +104,7 @@ export class CellTitleToolbarPart extends CellPart {
 		this._toolbar = instantiationService.invokeFunction(accessor => createToolbar(accessor, toolbarContainer));
 		this._titleMenu = this._register(menuService.createMenu(toolbarId, contextKeyService));
 
-		this._deleteToolbar = this._register(instantiationService.invokeFunction(accessor => createToolbar(accessor, toolbarContainer, 'cell-delete-toolbar')));
+		this._deleteToolbar = this._register(instantiationService.invokeFunction(accessor => createToolbar(accessor, toolbarContainer, 'cell-delete-toolbar', HiddenItemStrategy.Ignore)));
 		this._deleteMenu = this._register(menuService.createMenu(deleteToolbarId, contextKeyService));
 		if (!this._notebookEditor.creationOptions.isReadOnly) {
 			const deleteActions = getCellToolbarActions(this._deleteMenu);
@@ -190,14 +190,15 @@ function getCellToolbarActions(menu: IMenu): { primary: IAction[]; secondary: IA
 	return result;
 }
 
-function createToolbar(accessor: ServicesAccessor, container: HTMLElement, elementClass?: string): WorkbenchToolBar {
+function createToolbar(accessor: ServicesAccessor, container: HTMLElement, elementClass?: string, hiddenItemStrategy?: HiddenItemStrategy): WorkbenchToolBar {
 	const instantiationService = accessor.get(IInstantiationService);
 
 	const toolbar = instantiationService.createInstance(WorkbenchToolBar, container, {
 		actionViewItemProvider: action => {
 			return createActionViewItem(instantiationService, action);
 		},
-		renderDropdownAsChildElement: true
+		renderDropdownAsChildElement: true,
+		hiddenItemStrategy
 	});
 
 	if (elementClass) {

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCellRunToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCellRunToolbar.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 import { Action, IAction } from 'vs/base/common/actions';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { MarshalledId } from 'vs/base/common/marshallingIds';
@@ -11,6 +10,7 @@ import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { localize } from 'vs/nls';
 import { DropdownWithPrimaryActionViewItem } from 'vs/platform/actions/browser/dropdownWithPrimaryActionViewItem';
 import { createAndFillInActionBarActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
 import { IMenu, IMenuService, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { InputFocusedContext } from 'vs/platform/contextkey/common/contextkeys';
@@ -24,7 +24,7 @@ import { registerStickyScroll } from 'vs/workbench/contrib/notebook/browser/view
 import { NOTEBOOK_CELL_EXECUTION_STATE, NOTEBOOK_CELL_LIST_FOCUSED, NOTEBOOK_CELL_TYPE, NOTEBOOK_EDITOR_FOCUSED } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 
 export class RunToolbar extends CellPart {
-	private toolbar!: ToolBar;
+	private toolbar!: WorkbenchToolBar;
 
 	constructor(
 		readonly notebookEditor: INotebookEditorDelegate,
@@ -40,6 +40,7 @@ export class RunToolbar extends CellPart {
 
 		const menu = this._register(menuService.createMenu(this.notebookEditor.creationOptions.menuIds.cellExecutePrimary!, contextKeyService));
 		const secondaryMenu = this._register(menuService.createMenu(this.notebookEditor.creationOptions.menuIds.cellExecuteToolbar, contextKeyService));
+		// TODO@roblourens what does secondaryMenu actually do? where/when is it rendered?
 		this.createRunCellToolbar(runButtonContainer, cellContainer, contextKeyService);
 		const updateActions = () => {
 			const actions = this.getCellToolbarActions(menu);
@@ -79,7 +80,7 @@ export class RunToolbar extends CellPart {
 
 		const keybindingProvider = (action: IAction) => this.keybindingService.lookupKeybinding(action.id, executionContextKeyService);
 		const executionContextKeyService = this._register(getCodeCellExecutionContextKeyService(contextKeyService));
-		this.toolbar = this._register(new ToolBar(container, this.contextMenuService, {
+		this.toolbar = this._register(this.instantiationService.createInstance(WorkbenchToolBar, container, {
 			getKeyBinding: keybindingProvider,
 			actionViewItemProvider: _action => {
 				actionViewItemDisposables.clear();

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCellRunToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCellRunToolbar.ts
@@ -10,7 +10,7 @@ import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { localize } from 'vs/nls';
 import { DropdownWithPrimaryActionViewItem } from 'vs/platform/actions/browser/dropdownWithPrimaryActionViewItem';
 import { createAndFillInActionBarActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
-import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+import { HiddenItemStrategy, WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
 import { IMenu, IMenuService, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { InputFocusedContext } from 'vs/platform/contextkey/common/contextkeys';
@@ -81,6 +81,7 @@ export class RunToolbar extends CellPart {
 		const keybindingProvider = (action: IAction) => this.keybindingService.lookupKeybinding(action.id, executionContextKeyService);
 		const executionContextKeyService = this._register(getCodeCellExecutionContextKeyService(contextKeyService));
 		this.toolbar = this._register(this.instantiationService.createInstance(WorkbenchToolBar, container, {
+			hiddenItemStrategy: HiddenItemStrategy.Ignore,
 			getKeyBinding: keybindingProvider,
 			actionViewItemProvider: _action => {
 				actionViewItemDisposables.clear();

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
@@ -16,7 +16,6 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { toolbarActiveBackground } from 'vs/platform/theme/common/colorRegistry';
 import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { SELECT_KERNEL_ID } from 'vs/workbench/contrib/notebook/browser/controller/coreActions';
@@ -28,6 +27,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { IWorkbenchAssignmentService } from 'vs/workbench/services/assignment/common/assignmentService';
 import { NotebookOptions } from 'vs/workbench/contrib/notebook/common/notebookOptions';
 import { IActionViewItemProvider } from 'vs/base/browser/ui/actionbar/actionbar';
+import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
 
 interface IActionModel {
 	action: IAction;
@@ -264,7 +264,7 @@ export class NotebookEditorToolbar extends Disposable {
 	private _notebookTopLeftToolbarContainer!: HTMLElement;
 	private _notebookTopRightToolbarContainer!: HTMLElement;
 	private _notebookGlobalActionsMenu!: IMenu;
-	private _notebookLeftToolbar!: ToolBar;
+	private _notebookLeftToolbar!: WorkbenchToolBar;
 	private _primaryActions: IActionModel[];
 	get primaryActions(): IActionModel[] {
 		return this._primaryActions;
@@ -273,7 +273,7 @@ export class NotebookEditorToolbar extends Disposable {
 	get secondaryActions(): IAction[] {
 		return this._secondaryActions;
 	}
-	private _notebookRightToolbar!: ToolBar;
+	private _notebookRightToolbar!: WorkbenchToolBar;
 	private _useGlobalToolbar: boolean = false;
 	private _strategy!: IActionLayoutStrategy;
 	private _renderLabel: RenderLabel = RenderLabel.Always;
@@ -297,7 +297,6 @@ export class NotebookEditorToolbar extends Disposable {
 		@IContextMenuService readonly contextMenuService: IContextMenuService,
 		@IMenuService readonly menuService: IMenuService,
 		@IEditorService private readonly editorService: IEditorService,
-		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IWorkbenchAssignmentService private readonly experimentService: IWorkbenchAssignmentService
 	) {
 		super();
@@ -369,8 +368,7 @@ export class NotebookEditorToolbar extends Disposable {
 			}
 		};
 
-		this._notebookLeftToolbar = new ToolBar(this._notebookTopLeftToolbarContainer, this.contextMenuService, {
-			getKeyBinding: action => this.keybindingService.lookupKeybinding(action.id),
+		this._notebookLeftToolbar = this.instantiationService.createInstance(WorkbenchToolBar, this._notebookTopLeftToolbarContainer, {
 			actionViewItemProvider: (action) => {
 				return this._strategy.actionProvider(action);
 			},
@@ -379,8 +377,7 @@ export class NotebookEditorToolbar extends Disposable {
 		this._register(this._notebookLeftToolbar);
 		this._notebookLeftToolbar.context = context;
 
-		this._notebookRightToolbar = new ToolBar(this._notebookTopRightToolbarContainer, this.contextMenuService, {
-			getKeyBinding: action => this.keybindingService.lookupKeybinding(action.id),
+		this._notebookRightToolbar = this.instantiationService.createInstance(WorkbenchToolBar, this._notebookTopRightToolbarContainer, {
 			actionViewItemProvider: actionProvider,
 			renderDropdownAsChildElement: true
 		});
@@ -425,8 +422,7 @@ export class NotebookEditorToolbar extends Disposable {
 				const oldElement = this._notebookLeftToolbar.getElement();
 				oldElement.parentElement?.removeChild(oldElement);
 				this._notebookLeftToolbar.dispose();
-				this._notebookLeftToolbar = new ToolBar(this._notebookTopLeftToolbarContainer, this.contextMenuService, {
-					getKeyBinding: action => this.keybindingService.lookupKeybinding(action.id),
+				this._notebookLeftToolbar = this.instantiationService.createInstance(WorkbenchToolBar, this._notebookTopLeftToolbarContainer, {
 					actionViewItemProvider: actionProvider,
 					renderDropdownAsChildElement: true
 				});

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
@@ -16,6 +16,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { toolbarActiveBackground } from 'vs/platform/theme/common/colorRegistry';
 import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { SELECT_KERNEL_ID } from 'vs/workbench/contrib/notebook/browser/controller/coreActions';
@@ -27,7 +28,6 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { IWorkbenchAssignmentService } from 'vs/workbench/services/assignment/common/assignmentService';
 import { NotebookOptions } from 'vs/workbench/contrib/notebook/common/notebookOptions';
 import { IActionViewItemProvider } from 'vs/base/browser/ui/actionbar/actionbar';
-import { WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
 
 interface IActionModel {
 	action: IAction;
@@ -264,7 +264,7 @@ export class NotebookEditorToolbar extends Disposable {
 	private _notebookTopLeftToolbarContainer!: HTMLElement;
 	private _notebookTopRightToolbarContainer!: HTMLElement;
 	private _notebookGlobalActionsMenu!: IMenu;
-	private _notebookLeftToolbar!: WorkbenchToolBar;
+	private _notebookLeftToolbar!: ToolBar;
 	private _primaryActions: IActionModel[];
 	get primaryActions(): IActionModel[] {
 		return this._primaryActions;
@@ -273,7 +273,7 @@ export class NotebookEditorToolbar extends Disposable {
 	get secondaryActions(): IAction[] {
 		return this._secondaryActions;
 	}
-	private _notebookRightToolbar!: WorkbenchToolBar;
+	private _notebookRightToolbar!: ToolBar;
 	private _useGlobalToolbar: boolean = false;
 	private _strategy!: IActionLayoutStrategy;
 	private _renderLabel: RenderLabel = RenderLabel.Always;
@@ -297,6 +297,7 @@ export class NotebookEditorToolbar extends Disposable {
 		@IContextMenuService readonly contextMenuService: IContextMenuService,
 		@IMenuService readonly menuService: IMenuService,
 		@IEditorService private readonly editorService: IEditorService,
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IWorkbenchAssignmentService private readonly experimentService: IWorkbenchAssignmentService
 	) {
 		super();
@@ -368,7 +369,8 @@ export class NotebookEditorToolbar extends Disposable {
 			}
 		};
 
-		this._notebookLeftToolbar = this.instantiationService.createInstance(WorkbenchToolBar, this._notebookTopLeftToolbarContainer, {
+		this._notebookLeftToolbar = new ToolBar(this._notebookTopLeftToolbarContainer, this.contextMenuService, {
+			getKeyBinding: action => this.keybindingService.lookupKeybinding(action.id),
 			actionViewItemProvider: (action) => {
 				return this._strategy.actionProvider(action);
 			},
@@ -377,7 +379,8 @@ export class NotebookEditorToolbar extends Disposable {
 		this._register(this._notebookLeftToolbar);
 		this._notebookLeftToolbar.context = context;
 
-		this._notebookRightToolbar = this.instantiationService.createInstance(WorkbenchToolBar, this._notebookTopRightToolbarContainer, {
+		this._notebookRightToolbar = new ToolBar(this._notebookTopRightToolbarContainer, this.contextMenuService, {
+			getKeyBinding: action => this.keybindingService.lookupKeybinding(action.id),
 			actionViewItemProvider: actionProvider,
 			renderDropdownAsChildElement: true
 		});
@@ -422,7 +425,8 @@ export class NotebookEditorToolbar extends Disposable {
 				const oldElement = this._notebookLeftToolbar.getElement();
 				oldElement.parentElement?.removeChild(oldElement);
 				this._notebookLeftToolbar.dispose();
-				this._notebookLeftToolbar = this.instantiationService.createInstance(WorkbenchToolBar, this._notebookTopLeftToolbarContainer, {
+				this._notebookLeftToolbar = new ToolBar(this._notebookTopLeftToolbarContainer, this.contextMenuService, {
+					getKeyBinding: action => this.keybindingService.lookupKeybinding(action.id),
 					actionViewItemProvider: actionProvider,
 					renderDropdownAsChildElement: true
 				});


### PR DESCRIPTION
This is for https://github.com/microsoft/vscode/issues/154804

We now have [`WorkbenchToolBar`](https://github.com/microsoft/vscode/blob/7c5634e0aa6b7638abeef7b74010ef6dfdba091b/src/vs/platform/actions/browser/toolbar.ts#L63) and [`MenuWorkbenchToolBar`](https://github.com/microsoft/vscode/blob/7c5634e0aa6b7638abeef7b74010ef6dfdba091b/src/vs/platform/actions/browser/toolbar.ts#L219). The latter is better/simpler but a little harder to adopt. This PR is about adopting each in notebook land. This will brings the ability to right click an item and hide it. 

I couldn't get this to work with notebook title toolbar. There must be some extra filtering that I didn't understand... Some work is left but I leave it to @roblourens or @rebornix 


---

- Use `MenuWorkbenchToolBar` in interactive editor
- use `WorkbenchToolBar` in cellOutput but not `MenuWorkbenchToolBar` because some custom action things are going on
- use `MenuWorkbenchToolBar` in BetweenCellToolBar
- use `WorkbenchToolBar` in codeCellRunToolbar
- use `WorkbenchToolBar` in notebook editor toolbar
- use `WorkbenchToolBar` in notebook diff land
- Revert "use `WorkbenchToolBar` in notebook editor toolbar"
- show a disabled placeholder action when right clicking a none MenuItemAction, e.g the `...` button
- tweak delete cell toolbar
- tweak hiddenItemStrategy for run toolbar
