### PR TITLE
chore: use plugin executable for utility process on macOS

### DIFF
--- a/build/azure-pipelines/darwin/helper-plugin-entitlements.plist
+++ b/build/azure-pipelines/darwin/helper-plugin-entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/build/darwin/sign.js
+++ b/build/darwin/sign.js
@@ -26,6 +26,7 @@ async function main() {
     const helperAppBaseName = product.nameShort;
     const gpuHelperAppName = helperAppBaseName + ' Helper (GPU).app';
     const rendererHelperAppName = helperAppBaseName + ' Helper (Renderer).app';
+    const pluginHelperAppName = helperAppBaseName + ' Helper (Plugin).app';
     const infoPlistPath = path.resolve(appRoot, appName, 'Contents', 'Info.plist');
     const defaultOpts = {
         app: path.join(appRoot, appName),
@@ -45,7 +46,8 @@ async function main() {
         // TODO(deepak1556): Incorrectly declared type in electron-osx-sign
         ignore: (filePath) => {
             return filePath.includes(gpuHelperAppName) ||
-                filePath.includes(rendererHelperAppName);
+                filePath.includes(rendererHelperAppName) ||
+                filePath.includes(pluginHelperAppName);
         }
     };
     const gpuHelperOpts = {
@@ -59,6 +61,12 @@ async function main() {
         app: path.join(appFrameworkPath, rendererHelperAppName),
         entitlements: path.join(baseDir, 'azure-pipelines', 'darwin', 'helper-renderer-entitlements.plist'),
         'entitlements-inherit': path.join(baseDir, 'azure-pipelines', 'darwin', 'helper-renderer-entitlements.plist'),
+    };
+    const pluginHelperOpts = {
+        ...defaultOpts,
+        app: path.join(appFrameworkPath, pluginHelperAppName),
+        entitlements: path.join(baseDir, 'azure-pipelines', 'darwin', 'helper-plugin-entitlements.plist'),
+        'entitlements-inherit': path.join(baseDir, 'azure-pipelines', 'darwin', 'helper-plugin-entitlements.plist'),
     };
     // Only overwrite plist entries for x64 and arm64 builds,
     // universal will get its copy from the x64 build.
@@ -87,6 +95,7 @@ async function main() {
     }
     await codesign.signAsync(gpuHelperOpts);
     await codesign.signAsync(rendererHelperOpts);
+    await codesign.signAsync(pluginHelperOpts);
     await codesign.signAsync(appOpts);
 }
 if (require.main === module) {

--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -29,6 +29,7 @@ async function main(): Promise<void> {
 	const helperAppBaseName = product.nameShort;
 	const gpuHelperAppName = helperAppBaseName + ' Helper (GPU).app';
 	const rendererHelperAppName = helperAppBaseName + ' Helper (Renderer).app';
+	const pluginHelperAppName = helperAppBaseName + ' Helper (Plugin).app';
 	const infoPlistPath = path.resolve(appRoot, appName, 'Contents', 'Info.plist');
 
 	const defaultOpts: codesign.SignOptions = {
@@ -50,7 +51,8 @@ async function main(): Promise<void> {
 		// TODO(deepak1556): Incorrectly declared type in electron-osx-sign
 		ignore: (filePath: string) => {
 			return filePath.includes(gpuHelperAppName) ||
-				filePath.includes(rendererHelperAppName);
+				filePath.includes(rendererHelperAppName) ||
+				filePath.includes(pluginHelperAppName);
 		}
 	};
 
@@ -66,6 +68,13 @@ async function main(): Promise<void> {
 		app: path.join(appFrameworkPath, rendererHelperAppName),
 		entitlements: path.join(baseDir, 'azure-pipelines', 'darwin', 'helper-renderer-entitlements.plist'),
 		'entitlements-inherit': path.join(baseDir, 'azure-pipelines', 'darwin', 'helper-renderer-entitlements.plist'),
+	};
+
+	const pluginHelperOpts: codesign.SignOptions = {
+		...defaultOpts,
+		app: path.join(appFrameworkPath, pluginHelperAppName),
+		entitlements: path.join(baseDir, 'azure-pipelines', 'darwin', 'helper-plugin-entitlements.plist'),
+		'entitlements-inherit': path.join(baseDir, 'azure-pipelines', 'darwin', 'helper-plugin-entitlements.plist'),
 	};
 
 	// Only overwrite plist entries for x64 and arm64 builds,
@@ -96,6 +105,7 @@ async function main(): Promise<void> {
 
 	await codesign.signAsync(gpuHelperOpts);
 	await codesign.signAsync(rendererHelperOpts);
+	await codesign.signAsync(pluginHelperOpts);
 	await codesign.signAsync(appOpts as any);
 }
 

--- a/src/vs/platform/extensions/electron-main/extensionHostStarter.ts
+++ b/src/vs/platform/extensions/electron-main/extensionHostStarter.ts
@@ -424,6 +424,7 @@ class UtilityExtensionHostProcess extends Disposable {
 		const args: string[] = ['--type=extensionHost', '--skipWorkspaceStorageLock'];
 		const execArgv: string[] = opts.execArgv || [];
 		const env: { [key: string]: any } = { ...opts.env };
+		const allowLoadingUnsignedLibraries: boolean = true;
 
 		// Make sure all values are strings, otherwise the process will not start
 		for (const key of Object.keys(env)) {
@@ -432,7 +433,7 @@ class UtilityExtensionHostProcess extends Disposable {
 
 		this._logService.info(`UtilityProcess<${this.id}>: Creating new...`);
 
-		this._process = new UtilityProcess(modulePath, args, { serviceName, env, execArgv });
+		this._process = new UtilityProcess(modulePath, args, { serviceName, env, execArgv, allowLoadingUnsignedLibraries });
 
 		const stdoutDecoder = new StringDecoder('utf-8');
 		this._process.stdout?.on('data', (chunk) => {


### PR DESCRIPTION
This PR switches the executable used on macOS to spawn the extension host process from `Code Helper.app` to `Code Helper (Plugin).app` using the `allowLoadingUnsignedLibraries` capability of the utility process. 

This allows us to remove some privileged entitlements from the main application bundle which will protect the main process from loading any unsigned libraries or from dyld linker processing the `DYLD_` variables that can be used to inject code into the process.