### PR TITLE
Throw when invalid parameter hint label is passed in

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1134,6 +1134,10 @@ export namespace CompletionItem {
 
 export namespace ParameterInformation {
 	export function from(info: types.ParameterInformation): languages.ParameterInformation {
+		if (typeof info.label !== 'string' && !Array.isArray(info.label)) {
+			throw new TypeError('Invalid label');
+		}
+
 		return {
 			label: info.label,
 			documentation: MarkdownString.fromStrict(info.documentation)


### PR DESCRIPTION
Fixes #161055

I'm fairly sure that our code is correct if everything has the expected types. However extensions may be passing us invalid data so that the types are runtime don't match what we expect

