### PR TITLE
Add Refactor.move and Refactor.inline to code action widget

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -86,10 +86,12 @@ const uncategorizedCodeActionGroup = Object.freeze<CodeActionGroup>({ kind: Code
 
 const codeActionGroups = Object.freeze<CodeActionGroup[]>([
 	{ kind: CodeActionKind.QuickFix, title: localize('codeAction.widget.id.quickfix', 'Quick Fix...') },
-	{ kind: CodeActionKind.Extract, title: localize('codeAction.widget.id.extract', 'Extract...'), icon: { codicon: Codicon.wrench } },
-	{ kind: CodeActionKind.Convert, title: localize('codeAction.widget.id.convert', 'Convert...'), icon: { codicon: Codicon.zap, color: 'var(--vscode-editorLightBulbAutoFix-foreground)' } },
-	{ kind: CodeActionKind.SurroundWith, title: localize('codeAction.widget.id.surround', 'Surround With...'), icon: { codicon: Codicon.symbolArray } },
-	{ kind: CodeActionKind.Source, title: localize('codeAction.widget.id.source', 'Source Action...'), icon: { codicon: Codicon.lightBulb, color: 'var(--vscode-editorLightBulb-foreground)' } },
+	{ kind: CodeActionKind.RefactorExtract, title: localize('codeAction.widget.id.extract', 'Extract...'), icon: { codicon: Codicon.wrench } },
+	{ kind: CodeActionKind.RefactorInline, title: localize('codeAction.widget.id.inline', 'Inline...'), icon: { codicon: Codicon.wrench } },
+	{ kind: CodeActionKind.RefactorRewrite, title: localize('codeAction.widget.id.convert', 'Rewrite...'), icon: { codicon: Codicon.wrench } },
+	{ kind: CodeActionKind.RefactorMove, title: localize('codeAction.widget.id.move', 'Move...'), icon: { codicon: Codicon.wrench } },
+	{ kind: CodeActionKind.SurroundWith, title: localize('codeAction.widget.id.surround', 'Surround With...'), icon: { codicon: Codicon.symbolSnippet } },
+	{ kind: CodeActionKind.Source, title: localize('codeAction.widget.id.source', 'Source Action...'), icon: { codicon: Codicon.symbolFile } },
 	uncategorizedCodeActionGroup,
 ]);
 

--- a/src/vs/editor/contrib/codeAction/browser/types.ts
+++ b/src/vs/editor/contrib/codeAction/browser/types.ts
@@ -13,8 +13,10 @@ export class CodeActionKind {
 	public static readonly Empty = new CodeActionKind('');
 	public static readonly QuickFix = new CodeActionKind('quickfix');
 	public static readonly Refactor = new CodeActionKind('refactor');
-	public static readonly Extract = CodeActionKind.Refactor.append('extract');
-	public static readonly Convert = CodeActionKind.Refactor.append('rewrite');
+	public static readonly RefactorExtract = CodeActionKind.Refactor.append('extract');
+	public static readonly RefactorInline = CodeActionKind.Refactor.append('inline');
+	public static readonly RefactorMove = CodeActionKind.Refactor.append('move');
+	public static readonly RefactorRewrite = CodeActionKind.Refactor.append('rewrite');
 	public static readonly Source = new CodeActionKind('source');
 	public static readonly SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');
 	public static readonly SourceFixAll = CodeActionKind.Source.append('fixAll');


### PR DESCRIPTION
Fixes #158515

Also aligns the icon to be more consistent with how they are used:

- Surround with snippets use snippet icon
- All refactorings use the wrench icon
- Remove custom color which was added to some refactorings but not others
