### PR TITLE
Avoid tweaking command arguments when they are already provided by extensions

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellStatusPart.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellStatusPart.ts
@@ -313,7 +313,9 @@ class CellStatusBarItem extends Disposable {
 		const id = typeof command === 'string' ? command : command.id;
 		const args = typeof command === 'string' ? [] : command.arguments ?? [];
 
-		args.unshift(this._context);
+		if (typeof command === 'string' || !command.arguments || !Array.isArray(command.arguments) || command.arguments.length === 0) {
+			args.unshift(this._context);
+		}
 
 		this._telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id, from: 'cell status bar' });
 		try {


### PR DESCRIPTION
For `command: vscode.Command` contributions from extension host, extensions can customize the command arguments, when provided, the core should not tweak the argument list at all.

cc @roblourens 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
