### PR TITLE
Use hideFind() and showFind() when retainContextWhenHidden enabled

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -42,6 +42,8 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 	private readonly _scopedContextKeyService = this._register(new MutableDisposable<IContextKeyService>());
 	private _findWidgetVisible: IContextKey<boolean> | undefined;
 	private _findWidgetEnabled: IContextKey<boolean> | undefined;
+	// This isn't associated with an editor action so doesn't need to be a context key
+	private _findActiveWhenHidden: boolean | undefined = false;
 
 	public readonly id: string;
 	public readonly providedViewType?: string;
@@ -348,13 +350,17 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 	redo(): void { this._webview.value?.redo(); }
 
 	showFind() {
-		if (this._webview.value) {
+		const shouldShowFind: boolean | undefined = (
+			(this.options.retainContextWhenHidden && this._findActiveWhenHidden) || !this.options.retainContextWhenHidden
+		);
+		if (this._webview.value && shouldShowFind) {
 			this._webview.value.showFind();
 			this._findWidgetVisible?.set(true);
 		}
 	}
 
 	hideFind() {
+		this._findActiveWhenHidden = this._findWidgetVisible?.get();
 		this._findWidgetVisible?.reset();
 		this._webview.value?.hideFind();
 	}

--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -147,7 +147,11 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 		if (this._container) {
 			this._container.style.visibility = 'hidden';
 		}
-		if (!this._options.retainContextWhenHidden) {
+		if (this._options.retainContextWhenHidden) {
+			// https://github.com/microsoft/vscode/issues/157424
+			// We don't want to clear webview when retaining context, instead we'll just hide find so we can show it again later
+			this._webview.value?.hideFind();
+		} else {
 			this._webview.clear();
 			this._webviewEvents.clear();
 		}
@@ -205,6 +209,13 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 
 			if (this._scopedContextKeyService.value) {
 				this._webview.value.setContextKeyService(this._scopedContextKeyService.value);
+			}
+
+			// Need to show the find widget again if we're supposed to retain context
+			// We previously hid find when we did this.release()
+			// https://github.com/microsoft/vscode/issues/157424
+			if (this._options.retainContextWhenHidden) {
+				this._webview.value.showFind();
 			}
 
 			if (this._html) {

--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -152,7 +152,7 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 		if (this._options.retainContextWhenHidden) {
 			// https://github.com/microsoft/vscode/issues/157424
 			// We need to record the current state when retaining context so we can try to showFind() when showing webview again
-			this._webview.value?.hideFind();
+			this.hideFind();
 		} else {
 			this._webview.clear();
 			this._webviewEvents.clear();

--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -360,10 +360,7 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 	}
 
 	showFind() {
-		const shouldShowFind: boolean | undefined = (
-			(this.options.retainContextWhenHidden && this._findActiveWhenHidden) || !this.options.retainContextWhenHidden
-		);
-		if (this._webview.value && shouldShowFind) {
+		if (this._webview.value) {
 			this._webview.value.showFind();
 			this._findWidgetVisible?.set(true);
 		}


### PR DESCRIPTION
I suspect this PR will fix the issue noted with #157424.  However, I was unable to test because Code - OSS Dev wouldn't activate the extension I was trying to test with.  I am attaching a short (but feels long) video showing the result I'm getting while trying to test.

But, to summarize the video, I startup Code - OSS from vscode with the code changes applied, I install a dummy extension with code to create web view panel using vsce and Install by VSIX, I show that the Runtime Status remains as "Not yet activated", then I attempt to run the extension command which creates the web view panel.  I am shown an error message (FYI -- It takes rougly 20 seconds to show the error after I run the command) saying that the command is not available (presumably just because the extension isn't getting loaded).  

I'm guessing some kind of disconnect between what the command pallet sees and what the app sees when the ext would get activated 🤷.  I know it's not ideal to submit a PR without having been able to successfully test the change, but I was unable to find any useful information about running custom extensions from Code - OSS.  (Besides what I saw at #23831)  With that in mind, I am open to trying things if anyone has any ideas.

https://user-images.githubusercontent.com/13624065/190867920-b187be4b-047d-401d-990e-a969f18f3d46.mp4

