### PR TITLE
`server-main.js` should respect the `--port` argument

### DIFF
--- a/src/server-main.js
+++ b/src/server-main.js
@@ -188,14 +188,10 @@ function sanitizeStringArg(val) {
  * @throws
  */
 async function parsePort(host, strPort) {
-	let specificPort;
 	if (strPort) {
 		let range;
 		if (strPort.match(/^\d+$/)) {
-			specificPort = parseInt(strPort, 10);
-			if (specificPort === 0) {
-				return specificPort;
-			}
+			return parseInt(strPort, 10);
 		} else if (range = parseRange(strPort)) {
 			const port = await findFreePort(host, range.start, range.end);
 			if (port !== undefined) {


### PR DESCRIPTION
After https://github.com/microsoft/vscode/pull/160094 merged, `server-main.js` ignores the `--port` argument.
This patch fixes the problem.

Please, see the issue https://github.com/microsoft/vscode/issues/161138 and the comment https://github.com/microsoft/vscode/pull/160094#issuecomment-1251221832

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
