### PR TITLE
Don't fire empty updates when a pausable emitter is resumed

### DIFF
--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -938,9 +938,11 @@ export class PauseableEmitter<T> extends Emitter<T> {
 			if (this._mergeFn) {
 				// use the merge function to create a single composite
 				// event. make a copy in case firing pauses this emitter
-				const events = Array.from(this._eventQueue);
-				this._eventQueue.clear();
-				super.fire(this._mergeFn(events));
+				if (this._eventQueue.size > 0) {
+					const events = Array.from(this._eventQueue);
+					this._eventQueue.clear();
+					super.fire(this._mergeFn(events));
+				}
 
 			} else {
 				// no merging, fire each event individually and test

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -623,6 +623,17 @@ suite('PausableEmitter', function () {
 		assert.deepStrictEqual(data, [1, 1, 2, 2, 3, 3]);
 
 	});
+
+	test('empty pause with merge', function () {
+		const data: number[] = [];
+		const emitter = new PauseableEmitter<number>({ merge: a => a[0] });
+		emitter.event(e => data.push(1));
+
+		emitter.pause();
+		emitter.resume();
+		assert.deepStrictEqual(data, []);
+	});
+
 });
 
 suite('Event utils - ensureNoDisposablesAreLeakedInTestSuite', function () {


### PR DESCRIPTION
Noticed this because this code buffers context key change events, but sometimes none actually changed:

https://github.com/9at8/vscode/blob/0884315fc01e6a46927c36c662c41b19d1dbe0be/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellContextKeys.ts#L123-L141

The alternative would be to duplicate all of those same checks outside of the `bufferChangeEvents` call, which might lead to duplication but I can live with, but it doesn't seem like there is ever a reason to fire an empty update like this.