### PR TITLE
testing: fix error when updating test items without URIs

### DIFF
--- a/src/vs/workbench/api/common/extHostTestItem.ts
+++ b/src/vs/workbench/api/common/extHostTestItem.ts
@@ -167,7 +167,7 @@ export class ExtHostTestItemCollection extends TestItemCollection<TestItemImpl> 
 	constructor(controllerId: string, controllerLabel: string, editors: ExtHostDocumentsAndEditors) {
 		super({
 			controllerId,
-			getDocumentVersion: (uri: URI) => editors.getDocument(uri)?.version,
+			getDocumentVersion: uri => uri && editors.getDocument(uri)?.version,
 			getApiFor: getPrivateApiFor as (impl: TestItemImpl) => ITestItemApi<TestItemImpl>,
 			getChildren: (item) => item.children as ITestChildrenLike<TestItemImpl>,
 			root: new TestItemRootImpl(controllerId, controllerLabel),


### PR DESCRIPTION
TS allowed me to assign `(u: URI) => string` to `(u: URI | undefined) => string` which it seems like should not be valid 🤔

Fixes #160318
