### PR TITLE
Fix accidental case fallthroughs in experimentation services.

### DIFF
--- a/extensions/github-authentication/src/experimentationService.ts
+++ b/extensions/github-authentication/src/experimentationService.ts
@@ -18,14 +18,19 @@ export class ExperimentationTelemetry implements IExperimentationTelemetry {
 		switch (vscode.env.uriScheme) {
 			case 'vscode':
 				targetPopulation = TargetPopulation.Public;
+				break;
 			case 'vscode-insiders':
 				targetPopulation = TargetPopulation.Insiders;
+				break;
 			case 'vscode-exploration':
 				targetPopulation = TargetPopulation.Internal;
+				break;
 			case 'code-oss':
 				targetPopulation = TargetPopulation.Team;
+				break;
 			default:
 				targetPopulation = TargetPopulation.Public;
+				break;
 		}
 
 		const id = this.context.extension.id;

--- a/extensions/typescript-language-features/src/experimentationService.ts
+++ b/extensions/typescript-language-features/src/experimentationService.ts
@@ -35,14 +35,19 @@ export class ExperimentationService implements vscode.Disposable {
 		switch (vscode.env.uriScheme) {
 			case 'vscode':
 				targetPopulation = tas.TargetPopulation.Public;
+				break;
 			case 'vscode-insiders':
 				targetPopulation = tas.TargetPopulation.Insiders;
+				break;
 			case 'vscode-exploration':
 				targetPopulation = tas.TargetPopulation.Internal;
+				break;
 			case 'code-oss':
 				targetPopulation = tas.TargetPopulation.Team;
+				break;
 			default:
 				targetPopulation = tas.TargetPopulation.Public;
+				break;
 		}
 
 		const id = this._extensionContext.extension.id;


### PR DESCRIPTION
These code paths always set the `targetPopulation` variables to `public`, which meant insiders experiments would never work.