### PR TITLE
Better handle moves of multiple markdown links

### DIFF
--- a/extensions/markdown-language-features/server/package.json
+++ b/extensions/markdown-language-features/server/package.json
@@ -13,7 +13,7 @@
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.5",
     "vscode-languageserver-types": "^3.17.1",
-    "vscode-markdown-languageservice": "^0.1.0-alpha.6",
+    "vscode-markdown-languageservice": "^0.1.0-alpha.8",
     "vscode-nls": "^5.0.1",
     "vscode-uri": "^3.0.3"
   },

--- a/extensions/markdown-language-features/server/src/protocol.ts
+++ b/extensions/markdown-language-features/server/src/protocol.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RequestType } from 'vscode-languageserver';
+import { FileRename, RequestType } from 'vscode-languageserver';
 import type * as lsp from 'vscode-languageserver-types';
 import type * as md from 'vscode-markdown-languageservice';
 
@@ -22,7 +22,7 @@ export const findMarkdownFilesInWorkspace = new RequestType<{}, string[], any>('
 
 //#region To server
 export const getReferencesToFileInWorkspace = new RequestType<{ uri: string }, lsp.Location[], any>('markdown/getReferencesToFileInWorkspace');
-export const getEditForFileRenames = new RequestType<Array<{ oldUri: string; newUri: string }>, lsp.WorkspaceEdit, any>('markdown/getEditForFileRenames');
+export const getEditForFileRenames = new RequestType<FileRename[], { participatingRenames: readonly FileRename[]; edit: lsp.WorkspaceEdit }, any>('markdown/getEditForFileRenames');
 
 export const fs_watcher_onChange = new RequestType<{ id: number; uri: string; kind: 'create' | 'change' | 'delete' }, void, any>('markdown/fs/watcher/onChange');
 

--- a/extensions/markdown-language-features/server/src/server.ts
+++ b/extensions/markdown-language-features/server/src/server.ts
@@ -228,7 +228,15 @@ export async function startServer(connection: Connection, serverConfig: {
 	}));
 
 	connection.onRequest(protocol.getEditForFileRenames, (async (params, token: CancellationToken) => {
-		return mdLs!.getRenameFilesInWorkspaceEdit(params.map(x => ({ oldUri: URI.parse(x.oldUri), newUri: URI.parse(x.newUri) })), token);
+		const result = await mdLs!.getRenameFilesInWorkspaceEdit(params.map(x => ({ oldUri: URI.parse(x.oldUri), newUri: URI.parse(x.newUri) })), token);
+		if (!result) {
+			return result;
+		}
+
+		return {
+			edit: result.edit,
+			participatingRenames: result.participatingRenames.map(rename => ({ oldUri: rename.oldUri.toString(), newUri: rename.newUri.toString() }))
+		};
 	}));
 
 	connection.onRequest(protocol.resolveLinkTarget, (async (params, token: CancellationToken) => {

--- a/extensions/markdown-language-features/server/yarn.lock
+++ b/extensions/markdown-language-features/server/yarn.lock
@@ -42,10 +42,10 @@ vscode-languageserver@^8.0.2:
   dependencies:
     vscode-languageserver-protocol "3.17.2"
 
-vscode-markdown-languageservice@^0.1.0-alpha.6:
-  version "0.1.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.1.0-alpha.6.tgz#cc82c608d816b7b73459e648bf29ed49946d5425"
-  integrity sha512-EhWN8Y3HJTgI2XR39F0sHSRLMbTTKiMbQedf/d4SJupA1ks0kPQyQz/Ystp1Aua44Z/nNcYo4UNNFOOM0sxRPw==
+vscode-markdown-languageservice@^0.1.0-alpha.8:
+  version "0.1.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.1.0-alpha.8.tgz#c9a3a8366f1f18776e74e2a2df65351c52328301"
+  integrity sha512-rgjO3ZIO1ZH3DFGMQ6v7jXPz+LaV8SYo1Cuy9iIOanD9md4/jXRX16e62bgBdTFP+SAcCk6oKc5AqDqEMybAug==
   dependencies:
     picomatch "^2.3.1"
     vscode-languageserver-textdocument "^1.0.5"

--- a/extensions/markdown-language-features/src/client/protocol.ts
+++ b/extensions/markdown-language-features/src/client/protocol.ts
@@ -5,7 +5,7 @@
 
 import type Token = require('markdown-it/lib/token');
 import * as vscode from 'vscode';
-import { RequestType } from 'vscode-languageclient';
+import { FileRename, RequestType } from 'vscode-languageclient';
 import type * as lsp from 'vscode-languageserver-types';
 import type * as md from 'vscode-markdown-languageservice';
 
@@ -30,7 +30,7 @@ export const findMarkdownFilesInWorkspace = new RequestType<{}, string[], any>('
 
 //#region To server
 export const getReferencesToFileInWorkspace = new RequestType<{ uri: string }, lsp.Location[], any>('markdown/getReferencesToFileInWorkspace');
-export const getEditForFileRenames = new RequestType<Array<{ oldUri: string; newUri: string }>, lsp.WorkspaceEdit, any>('markdown/getEditForFileRenames');
+export const getEditForFileRenames = new RequestType<Array<FileRename>, { participatingRenames: readonly FileRename[]; edit: lsp.WorkspaceEdit }, any>('markdown/getEditForFileRenames');
 
 export const fs_watcher_onChange = new RequestType<{ id: number; uri: string; kind: 'create' | 'change' | 'delete' }, void, any>('markdown/fs/watcher/onChange');
 

--- a/extensions/markdown-language-features/src/languageFeatures/linkUpdater.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/linkUpdater.ts
@@ -69,18 +69,11 @@ class UpdateLinksOnFileRenameHandler extends Disposable {
 		const renames = Array.from(this._pendingRenames);
 		this._pendingRenames.clear();
 
-		const edit = new vscode.WorkspaceEdit();
-		const resourcesBeingRenamed: vscode.Uri[] = [];
+		const result = await this.getEditsForFileRename(renames, noopToken);
 
-		for (const { oldUri, newUri } of renames) {
-			if (await this.withEditsForFileRename(edit, oldUri, newUri, noopToken)) {
-				resourcesBeingRenamed.push(newUri);
-			}
-		}
-
-		if (edit.size) {
-			if (await this.confirmActionWithUser(resourcesBeingRenamed)) {
-				await vscode.workspace.applyEdit(edit);
+		if (result && result.edit.size) {
+			if (await this.confirmActionWithUser(result.resourcesBeingRenamed)) {
+				await vscode.workspace.applyEdit(result.edit);
 			}
 		}
 	}
@@ -194,25 +187,25 @@ class UpdateLinksOnFileRenameHandler extends Disposable {
 		return false;
 	}
 
-	private async withEditsForFileRename(
-		workspaceEdit: vscode.WorkspaceEdit,
-		oldUri: vscode.Uri,
-		newUri: vscode.Uri,
-		token: vscode.CancellationToken,
-	): Promise<boolean> {
-		const edit = await this.client.getEditForFileRenames([{ oldUri: oldUri.toString(), newUri: newUri.toString() }], token);
-		if (!edit.documentChanges?.length) {
-			return false;
+	private async getEditsForFileRename(renames: readonly RenameAction[], token: vscode.CancellationToken): Promise<{ edit: vscode.WorkspaceEdit; resourcesBeingRenamed: vscode.Uri[] } | undefined> {
+		const result = await this.client.getEditForFileRenames(renames.map(rename => ({ oldUri: rename.oldUri.toString(), newUri: rename.newUri.toString() })), token);
+		if (!result?.edit.documentChanges?.length) {
+			return undefined;
 		}
 
-		for (const change of edit.documentChanges as TextDocumentEdit[]) {
+		const workspaceEdit = new vscode.WorkspaceEdit();
+
+		for (const change of result.edit.documentChanges as TextDocumentEdit[]) {
 			const uri = vscode.Uri.parse(change.textDocument.uri);
 			for (const edit of change.edits) {
 				workspaceEdit.replace(uri, convertRange(edit.range), edit.newText);
 			}
 		}
 
-		return true;
+		return {
+			edit: workspaceEdit,
+			resourcesBeingRenamed: result.participatingRenames.map(x => vscode.Uri.parse(x.newUri)),
+		};
 	}
 
 	private getConfirmMessage(start: string, resourcesToConfirm: readonly vscode.Uri[]): string {


### PR DESCRIPTION
This makes the markdown language service handle moving/renaming multiple files instead of making multiple calls into the language service

