### PR TITLE
rename l10nBundleLocation to l10n

### DIFF
--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -268,7 +268,9 @@ export interface IRelaxedExtensionManifest {
 	description?: string;
 	main?: string;
 	browser?: string;
-	l10nBundleLocation?: string;
+	// For now this only supports pointing to l10n bundle files
+	// but it will be used for package.l10n.json files in the future
+	l10n?: string;
 	icon?: string;
 	categories?: string[];
 	keywords?: string[];

--- a/src/vs/workbench/api/common/extHostLocalizationService.ts
+++ b/src/vs/workbench/api/common/extHostLocalizationService.ts
@@ -54,7 +54,7 @@ export class ExtHostLocalizationService implements ExtHostLocalizationShape {
 	async initializeLocalizedMessages(extension: IExtensionDescription): Promise<void> {
 		if (Language.isDefault()
 			// TODO: support builtin extensions
-			|| !extension.l10nBundleLocation
+			|| !extension.l10n
 		) {
 			return;
 		}
@@ -93,10 +93,9 @@ export class ExtHostLocalizationService implements ExtHostLocalizationShape {
 		// 	return URI.joinPath(this.initData.nlsBaseUrl, extension.identifier.value, 'main');
 		// }
 
-		if (extension.l10nBundleLocation) {
-			return URI.joinPath(extension.extensionLocation, extension.l10nBundleLocation);
-		}
-		return undefined;
+		return extension.l10n
+			? URI.joinPath(extension.extensionLocation, extension.l10n)
+			: undefined;
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Renaming this to l10n. The plan is that this would also be honored to pick of package.l10n.json files when we support those... so we don't want to lock ourselves in to the previous name.