### PR TITLE
Allow CodeActionMenu to be reused outside of editor

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -15,17 +15,14 @@ import { Codicon } from 'vs/base/common/codicons';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import { OS } from 'vs/base/common/platform';
 import 'vs/css!./media/action';
-import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { Command } from 'vs/editor/common/languages';
-import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { CodeActionItem, CodeActionSet } from 'vs/editor/contrib/codeAction/browser/codeAction';
 import { CodeActionKind, CodeActionTrigger, CodeActionTriggerSource } from 'vs/editor/contrib/codeAction/browser/types';
 import 'vs/editor/contrib/symbolIcons/browser/symbolIcons'; // The codicon symbol colors are defined here and must be loaded to get colors
 import { localize } from 'vs/nls';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { CodeActionKeybindingResolver } from './codeActionKeybindingResolver';
@@ -38,12 +35,14 @@ export const acceptSelectedCodeActionCommand = 'acceptSelectedCodeAction';
 export const previewSelectedCodeActionCommand = 'previewSelectedCodeAction';
 
 interface CodeActionWidgetDelegate {
-	onSelectCodeAction: (action: CodeActionItem, trigger: CodeActionTrigger, options: { readonly preview: boolean }) => Promise<any>;
+	onSelectCodeAction(action: CodeActionItem, trigger: CodeActionTrigger, options: { readonly preview: boolean }): Promise<any>;
+	onHide(cancelled: boolean): void;
 }
 
 export interface CodeActionShowOptions {
 	readonly includeDisabledActions: boolean;
 	readonly fromLightbulb?: boolean;
+	readonly showHeaders?: boolean;
 }
 
 enum CodeActionListItemKind {
@@ -350,26 +349,35 @@ let showDisabled = false;
 
 export class CodeActionMenu extends Disposable {
 
+	private static _instance?: CodeActionMenu;
+
+	public static get INSTANCE(): CodeActionMenu | undefined { return this._instance; }
+
+	public static getOrCreateInstance(instantiationService: IInstantiationService): CodeActionMenu {
+		if (!this._instance) {
+			this._instance = instantiationService.createInstance(CodeActionMenu);
+		}
+		return this._instance;
+	}
+
 	private readonly codeActionList = this._register(new MutableDisposable<CodeActionList>());
 
 	private currentShowingContext?: {
 		readonly options: CodeActionShowOptions;
 		readonly trigger: CodeActionTrigger;
 		readonly anchor: IAnchor;
+		readonly container: HTMLElement | undefined;
 		readonly codeActions: CodeActionSet;
+		readonly delegate: CodeActionWidgetDelegate;
 	};
 
 	private readonly _ctxMenuWidgetVisible: IContextKey<boolean>;
 
 	constructor(
-		private readonly _editor: ICodeEditor,
-		private readonly _delegate: CodeActionWidgetDelegate,
 		@ICommandService private readonly _commandService: ICommandService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IContextViewService private readonly _contextViewService: IContextViewService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
-		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
@@ -381,38 +389,27 @@ export class CodeActionMenu extends Disposable {
 		return !!this.currentShowingContext;
 	}
 
-	public async show(trigger: CodeActionTrigger, codeActions: CodeActionSet, anchor: IAnchor, options: CodeActionShowOptions): Promise<void> {
+	public async show(trigger: CodeActionTrigger, codeActions: CodeActionSet, anchor: IAnchor, container: HTMLElement | undefined, options: CodeActionShowOptions, delegate: CodeActionWidgetDelegate): Promise<void> {
 		this.currentShowingContext = undefined;
-
-		const editorDom = this._editor.getDomNode();
-		if (!editorDom) {
-			return;
-		}
 
 		const actionsToShow = options.includeDisabledActions && (showDisabled || codeActions.validActions.length === 0) ? codeActions.allActions : codeActions.validActions;
 		if (!actionsToShow.length) {
 			return;
 		}
 
-		this.currentShowingContext = { trigger, codeActions, anchor, options };
+		this.currentShowingContext = { trigger, codeActions, anchor, container, delegate, options };
 
 		this._contextViewService.showContextView({
 			getAnchor: () => anchor,
-			render: (container: HTMLElement) => this.renderWidget(container, trigger, codeActions, options, actionsToShow),
-			onHide: (didCancel: boolean) => this.onWidgetClosed(trigger, options, codeActions, didCancel),
-		}, editorDom, false);
+			render: (container: HTMLElement) => this.renderWidget(container, trigger, codeActions, options, actionsToShow, delegate),
+			onHide: (didCancel: boolean) => this.onWidgetClosed(trigger, options, codeActions, didCancel, delegate),
+		}, container, false);
 	}
 
-	/**
-	 * Focuses on the previous item in the list using the list widget.
-	 */
 	public focusPrevious() {
 		this.codeActionList.value?.focusPrevious();
 	}
 
-	/**
-	 * Focuses on the next item in the list using the list widget.
-	 */
 	public focusNext() {
 		this.codeActionList.value?.focusNext();
 	}
@@ -427,12 +424,7 @@ export class CodeActionMenu extends Disposable {
 		this._contextViewService.hideContextView();
 	}
 
-	private shouldShowHeaders(): boolean {
-		const model = this._editor.getModel();
-		return this._configurationService.getValue('editor.codeActionWidget.showHeaders', { resource: model?.uri });
-	}
-
-	private renderWidget(element: HTMLElement, trigger: CodeActionTrigger, codeActions: CodeActionSet, options: CodeActionShowOptions, showingCodeActions: readonly CodeActionItem[]): IDisposable {
+	private renderWidget(element: HTMLElement, trigger: CodeActionTrigger, codeActions: CodeActionSet, options: CodeActionShowOptions, showingCodeActions: readonly CodeActionItem[], delegate: CodeActionWidgetDelegate): IDisposable {
 		const renderDisposables = new DisposableStore();
 
 		const widget = document.createElement('div');
@@ -441,10 +433,10 @@ export class CodeActionMenu extends Disposable {
 
 		this.codeActionList.value = new CodeActionList(
 			showingCodeActions,
-			this.shouldShowHeaders(),
+			options.showHeaders ?? true,
 			(action, options) => {
 				this.hide();
-				this._delegate.onSelectCodeAction(action, trigger, options);
+				delegate.onSelectCodeAction(action, trigger, options);
 			},
 			this._keybindingService);
 
@@ -482,7 +474,7 @@ export class CodeActionMenu extends Disposable {
 		// Action bar
 		let actionBarWidth = 0;
 		if (!options.fromLightbulb) {
-			const actionBar = this.createActionBar(trigger, showingCodeActions, codeActions, options);
+			const actionBar = this.createActionBar(codeActions, options);
 			if (actionBar) {
 				widget.appendChild(actionBar.getContainer().parentElement!);
 				renderDisposables.add(actionBar);
@@ -492,8 +484,6 @@ export class CodeActionMenu extends Disposable {
 
 		const width = this.codeActionList.value.layout(actionBarWidth);
 		widget.style.width = `${width}px`;
-
-		renderDisposables.add(this._editor.onDidLayoutChange(() => this.hide()));
 
 		const focusTracker = renderDisposables.add(dom.trackFocus(element));
 		renderDisposables.add(focusTracker.onDidBlur(() => this.hide()));
@@ -507,18 +497,18 @@ export class CodeActionMenu extends Disposable {
 	 * Toggles whether the disabled actions in the code action widget are visible or not.
 	 */
 	private toggleShowDisabled(newShowDisabled: boolean): void {
-		const previouslyShowingActions = this.currentShowingContext;
+		const previousCtx = this.currentShowingContext;
 
 		this.hide();
 
 		showDisabled = newShowDisabled;
 
-		if (previouslyShowingActions) {
-			this.show(previouslyShowingActions.trigger, previouslyShowingActions.codeActions, previouslyShowingActions.anchor, previouslyShowingActions.options);
+		if (previousCtx) {
+			this.show(previousCtx.trigger, previousCtx.codeActions, previousCtx.anchor, previousCtx.container, previousCtx.options, previousCtx.delegate);
 		}
 	}
 
-	private onWidgetClosed(trigger: CodeActionTrigger, options: CodeActionShowOptions, codeActions: CodeActionSet, didCancel: boolean): void {
+	private onWidgetClosed(trigger: CodeActionTrigger, options: CodeActionShowOptions, codeActions: CodeActionSet, cancelled: boolean, delegate: CodeActionWidgetDelegate): void {
 		type ApplyCodeActionEvent = {
 			codeActionFrom: CodeActionTriggerSource;
 			validCodeActions: number;
@@ -536,15 +526,15 @@ export class CodeActionMenu extends Disposable {
 		this._telemetryService.publicLog2<ApplyCodeActionEvent, ApplyCodeEventClassification>('codeAction.applyCodeAction', {
 			codeActionFrom: options.fromLightbulb ? CodeActionTriggerSource.Lightbulb : trigger.triggerAction,
 			validCodeActions: codeActions.validActions.length,
-			cancelled: didCancel,
+			cancelled: cancelled,
 		});
 
 		this.currentShowingContext = undefined;
-		this._editor.focus();
+		delegate.onHide(cancelled);
 	}
 
-	private createActionBar(trigger: CodeActionTrigger, inputCodeActions: readonly CodeActionItem[], codeActions: CodeActionSet, options: CodeActionShowOptions): ActionBar | undefined {
-		const actions = this.getActionBarActions(trigger, inputCodeActions, codeActions, options);
+	private createActionBar(codeActions: CodeActionSet, options: CodeActionShowOptions): ActionBar | undefined {
+		const actions = this.getActionBarActions(codeActions, options);
 		if (!actions.length) {
 			return undefined;
 		}
@@ -555,8 +545,15 @@ export class CodeActionMenu extends Disposable {
 		return actionBar;
 	}
 
-	private getActionBarActions(trigger: CodeActionTrigger, inputCodeActions: readonly CodeActionItem[], codeActions: CodeActionSet, options: CodeActionShowOptions): IAction[] {
-		const actions = this.getDocumentationActions(trigger, inputCodeActions, codeActions.documentation);
+	private getActionBarActions(codeActions: CodeActionSet, options: CodeActionShowOptions): IAction[] {
+		const actions = codeActions.documentation.map((command): IAction => ({
+			id: command.id,
+			label: command.title,
+			tooltip: command.tooltip ?? '',
+			class: undefined,
+			enabled: true,
+			run: () => this._commandService.executeCommand(command.id, ...(command.arguments ?? [])),
+		}));
 
 		if (options.includeDisabledActions && codeActions.validActions.length > 0 && codeActions.allActions.length !== codeActions.validActions.length) {
 			actions.push(showDisabled ? {
@@ -575,32 +572,7 @@ export class CodeActionMenu extends Disposable {
 				run: () => this.toggleShowDisabled(true)
 			});
 		}
+
 		return actions;
-	}
-
-	private getDocumentationActions(
-		trigger: CodeActionTrigger,
-		actionsToShow: readonly CodeActionItem[],
-		documentation: readonly Command[],
-	): IAction[] {
-		const allDocumentation: Command[] = [...documentation];
-
-		const model = this._editor.getModel();
-		if (model && actionsToShow.length) {
-			for (const provider of this._languageFeaturesService.codeActionProvider.all(model)) {
-				if (provider._getAdditionalMenuItems) {
-					allDocumentation.push(...provider._getAdditionalMenuItems({ trigger: trigger.type, only: trigger.filter?.include?.value }, actionsToShow.map(item => item.action)));
-				}
-			}
-		}
-
-		return allDocumentation.map((command): IAction => ({
-			id: command.id,
-			label: command.title,
-			tooltip: command.tooltip ?? '',
-			class: undefined,
-			enabled: true,
-			run: () => this._commandService.executeCommand(command.id, ...(command.arguments ?? [])),
-		}));
 	}
 }

--- a/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
@@ -14,6 +14,7 @@ import { ScrollType } from 'vs/editor/common/editorCommon';
 import { CodeActionTriggerType } from 'vs/editor/common/languages';
 import { CodeActionItem, CodeActionSet } from 'vs/editor/contrib/codeAction/browser/codeAction';
 import { MessageController } from 'vs/editor/contrib/message/browser/messageController';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { CodeActionMenu, CodeActionShowOptions } from './codeActionMenu';
 import { CodeActionsState } from './codeActionModel';
@@ -21,8 +22,6 @@ import { LightBulbWidget } from './lightBulbWidget';
 import { CodeActionAutoApply, CodeActionTrigger } from './types';
 
 export class CodeActionUi extends Disposable {
-
-	private readonly _codeActionWidget: Lazy<CodeActionMenu>;
 	private readonly _lightBulbWidget: Lazy<LightBulbWidget>;
 	private readonly _activeCodeActions = this._register(new MutableDisposable<CodeActionSet>());
 
@@ -35,44 +34,24 @@ export class CodeActionUi extends Disposable {
 		private readonly delegate: {
 			applyCodeAction: (action: CodeActionItem, regtriggerAfterApply: boolean, preview: boolean) => Promise<void>;
 		},
-		@IInstantiationService instantiationService: IInstantiationService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 
-		this._codeActionWidget = new Lazy(() => {
-			return this._register(instantiationService.createInstance(CodeActionMenu, this._editor, {
-				onSelectCodeAction: async (action, trigger, options) => {
-					this.delegate.applyCodeAction(action, /* retrigger */ true, Boolean(options.preview || trigger.preview));
-				}
-			}));
-		});
 
 		this._lightBulbWidget = new Lazy(() => {
-			const widget = this._register(instantiationService.createInstance(LightBulbWidget, this._editor, quickFixActionId, preferredFixActionId));
-			this._register(widget.onClick(e => this.showCodeActionList(e.trigger, e.actions, e, { includeDisabledActions: false, fromLightbulb: true })));
+			const widget = this._register(_instantiationService.createInstance(LightBulbWidget, this._editor, quickFixActionId, preferredFixActionId));
+			this._register(widget.onClick(e => this.showCodeActionList(e.trigger, e.actions, e, { includeDisabledActions: false, fromLightbulb: true, showHeaders: this.shouldShowHeaders() })));
 			return widget;
 		});
+
+		this._register(this._editor.onDidLayoutChange(() => CodeActionMenu.INSTANCE?.hide()));
 	}
 
 	override dispose() {
 		this.#disposed = true;
 		super.dispose();
-	}
-
-	public hideCodeActionWidget() {
-		this._codeActionWidget.rawValue?.hide();
-	}
-
-	public acceptSelected(options?: { readonly preview?: boolean }) {
-		this._codeActionWidget.rawValue?.acceptSelected(options);
-	}
-
-	public focusNext() {
-		this._codeActionWidget.rawValue?.focusNext();
-	}
-
-	public focusPrevious() {
-		this._codeActionWidget.rawValue?.focusPrevious();
 	}
 
 	public async update(newState: CodeActionsState.State): Promise<void> {
@@ -132,10 +111,10 @@ export class CodeActionUi extends Disposable {
 			}
 
 			this._activeCodeActions.value = actions;
-			this._codeActionWidget.getValue().show(newState.trigger, actions, this.toCoords(newState.position), { includeDisabledActions, fromLightbulb: false });
+			this.showCodeActionList(newState.trigger, actions, this.toCoords(newState.position), { includeDisabledActions, fromLightbulb: false, showHeaders: this.shouldShowHeaders() });
 		} else {
 			// auto magically triggered
-			if (this._codeActionWidget.getValue().isVisible) {
+			if (CodeActionMenu.INSTANCE?.isVisible) {
 				// TODO: Figure out if we should update the showing menu?
 				actions.dispose();
 			} else {
@@ -173,8 +152,21 @@ export class CodeActionUi extends Disposable {
 	}
 
 	public async showCodeActionList(trigger: CodeActionTrigger, actions: CodeActionSet, at: IAnchor | IPosition, options: CodeActionShowOptions): Promise<void> {
+		const editorDom = this._editor.getDomNode();
+		if (!editorDom) {
+			return;
+		}
+
 		const anchor = Position.isIPosition(at) ? this.toCoords(at) : at;
-		this._codeActionWidget.getValue().show(trigger, actions, anchor, options);
+
+		CodeActionMenu.getOrCreateInstance(this._instantiationService).show(trigger, actions, anchor, editorDom, { ...options, showHeaders: this.shouldShowHeaders() }, {
+			onSelectCodeAction: async (action, trigger, options) => {
+				this.delegate.applyCodeAction(action, /* retrigger */ true, Boolean(options.preview || trigger.preview));
+			},
+			onHide: () => {
+				this._editor?.focus();
+			},
+		});
 	}
 
 	private toCoords(position: IPosition): IAnchor {
@@ -192,5 +184,10 @@ export class CodeActionUi extends Disposable {
 		const y = editorCoords.top + cursorCoords.top + cursorCoords.height;
 
 		return { x, y };
+	}
+
+	private shouldShowHeaders(): boolean {
+		const model = this._editor?.getModel();
+		return this._configurationService.getValue('editor.codeActionWidget.showHeaders', { resource: model?.uri });
 	}
 }


### PR DESCRIPTION
This updates the new code action menu so it can be reused in non-editor contexts, such as in the markers view

