### PR TITLE
testing: greatly improve decoration syncing

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -115,14 +115,13 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 		// is up to date. This prevents issues, as in #138632, #138835, #138922.
 		this._register(this.testService.onWillProcessDiff(diff => {
 			for (const entry of diff) {
-				if (entry.op !== TestDiffOpType.Update || entry.item.docv === undefined || entry.item.item?.range === undefined) {
+				if (entry.op !== TestDiffOpType.DocumentSynced) {
 					continue;
 				}
 
-				const uri = this.testService.collection.getNodeById(entry.item.extId)?.item.uri;
-				const rec = uri && this.decorationCache.get(uri);
+				const rec = this.decorationCache.get(entry.uri);
 				if (rec) {
-					rec.rangeUpdateVersionId = entry.item.docv;
+					rec.rangeUpdateVersionId = entry.docv;
 				}
 			}
 
@@ -193,7 +192,7 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 		const uriStr = model.uri.toString();
 		const cached = this.decorationCache.get(model.uri);
 		const testRangesUpdated = cached?.rangeUpdateVersionId === model.getVersionId();
-		const lastDecorations = cached?.value ?? new TestDecorations();
+		const lastDecorations = cached?.value ?? new TestDecorations<ITestDecoration>();
 		const newDecorations = new TestDecorations<ITestDecoration>();
 
 		model.changeDecorations(accessor => {
@@ -210,7 +209,7 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 
 			for (const [line, tests] of runDecorations.lines()) {
 				const multi = tests.length > 1;
-				let existing = lastDecorations.findOnLine(line, d => multi ? d instanceof MultiRunTestDecoration : d instanceof RunSingleTestDecoration) as RunTestDecoration | undefined;
+				let existing = lastDecorations.value.find(d => d instanceof RunTestDecoration && d.exactlyContainsTests(tests)) as RunTestDecoration | undefined;
 
 				// see comment in the constructor for what's going on here
 				if (existing && testRangesUpdated && model.getDecorationRange(existing.id)?.startLineNumber !== line) {
@@ -647,6 +646,27 @@ abstract class RunTestDecoration {
 			default:
 				this.defaultRun();
 				break;
+		}
+
+		return true;
+	}
+
+	public exactlyContainsTests(tests: readonly { test: IncrementalTestCollectionItem }[]): boolean {
+		if (tests.length !== this.tests.length) {
+			return false;
+		}
+		if (tests.length === 1) {
+			return tests[0].test.item.extId === this.tests[0].test.item.extId;
+		}
+
+		const ownTests = new Set();
+		for (const t of this.tests) {
+			ownTests.add(t.test.item.extId);
+		}
+		for (const t of tests) {
+			if (!ownTests.delete(t.test.item.extId)) {
+				return false;
+			}
 		}
 
 		return true;

--- a/src/vs/workbench/contrib/testing/common/testItemCollection.ts
+++ b/src/vs/workbench/contrib/testing/common/testItemCollection.ts
@@ -33,6 +33,7 @@ export const enum TestItemEventOp {
 	RemoveChild,
 	SetProp,
 	Bulk,
+	DocumentSynced,
 }
 
 export interface ITestItemUpsertChild {
@@ -65,13 +66,18 @@ export interface ITestItemBulkReplace {
 	ops: (ITestItemUpsertChild | ITestItemRemoveChild)[];
 }
 
+export interface ITestItemDocumentSynced {
+	op: TestItemEventOp.DocumentSynced;
+}
+
 export type ExtHostTestItemEvent =
 	| ITestItemSetTags
 	| ITestItemUpsertChild
 	| ITestItemRemoveChild
 	| ITestItemUpdateCanResolveChildren
 	| ITestItemSetProp
-	| ITestItemBulkReplace;
+	| ITestItemBulkReplace
+	| ITestItemDocumentSynced;
 
 export interface ITestItemApi<T> {
 	controllerId: string;
@@ -201,17 +207,28 @@ export class TestItemCollection<T extends ITestItemLike> extends Disposable {
 	 * Pushes a new diff entry onto the collected diff list.
 	 */
 	public pushDiff(diff: TestsDiffOp) {
-		// Try to merge updates, since they're invoked per-property
-		const last = this.diff[this.diff.length - 1];
-		if (last && diff.op === TestDiffOpType.Update) {
-			if (last.op === TestDiffOpType.Update && last.item.extId === diff.item.extId) {
-				applyTestItemUpdate(last.item, diff.item);
-				return;
+		switch (diff.op) {
+			case TestDiffOpType.DocumentSynced: {
+				if (this.diff.some(d => d.op === TestDiffOpType.DocumentSynced && d.uri === diff.uri)) {
+					return;
+				}
+				break;
 			}
+			case TestDiffOpType.Update: {
+				// Try to merge updates, since they're invoked per-property
+				const last = this.diff[this.diff.length - 1];
+				if (last) {
+					if (last.op === TestDiffOpType.Update && last.item.extId === diff.item.extId) {
+						applyTestItemUpdate(last.item, diff.item);
+						return;
+					}
 
-			if (last.op === TestDiffOpType.Add && last.item.item.extId === diff.item.extId) {
-				applyTestItemUpdate(last.item, diff.item);
-				return;
+					if (last.op === TestDiffOpType.Add && last.item.item.extId === diff.item.extId) {
+						applyTestItemUpdate(last.item, diff.item);
+						return;
+					}
+				}
+				break;
 			}
 		}
 
@@ -291,12 +308,26 @@ export class TestItemCollection<T extends ITestItemLike> extends Disposable {
 					item: {
 						extId: internal.fullId.toString(),
 						item: evt.update,
-						docv: this.options.getDocumentVersion(internal.actual.uri),
 					}
 				});
 				break;
+
+			case TestItemEventOp.DocumentSynced:
+				this.documentSynced(internal.actual.uri);
+				break;
+
 			default:
 				assertNever(evt);
+		}
+	}
+
+	private documentSynced(uri: URI | undefined) {
+		if (uri) {
+			this.pushDiff({
+				op: TestDiffOpType.DocumentSynced,
+				uri,
+				docv: this.options.getDocumentVersion(uri)
+			});
 		}
 	}
 
@@ -370,6 +401,9 @@ export class TestItemCollection<T extends ITestItemLike> extends Disposable {
 				this.removeItem(TestId.joinToString(fullId, child.id));
 			}
 		}
+
+		// Mark ranges in the document as synced (#161320)
+		this.documentSynced(internal.actual.uri);
 	}
 
 	private diffTagRefs(newTags: readonly ITestTag[], oldTags: readonly ITestTag[], extId: string) {

--- a/src/vs/workbench/contrib/testing/common/testItemCollection.ts
+++ b/src/vs/workbench/contrib/testing/common/testItemCollection.ts
@@ -209,9 +209,13 @@ export class TestItemCollection<T extends ITestItemLike> extends Disposable {
 	public pushDiff(diff: TestsDiffOp) {
 		switch (diff.op) {
 			case TestDiffOpType.DocumentSynced: {
-				if (this.diff.some(d => d.op === TestDiffOpType.DocumentSynced && d.uri === diff.uri)) {
-					return;
+				for (const existing of this.diff) {
+					if (existing.op === TestDiffOpType.DocumentSynced && existing.uri === diff.uri) {
+						existing.docv = diff.docv;
+						return;
+					}
 				}
+
 				break;
 			}
 			case TestDiffOpType.Update: {


### PR DESCRIPTION
- Mark a decoration as synced to a range on _any_ assignment to its range. Fixes https://github.com/microsoft/vscode/issues/161320
- Improve re-usage of testing decorations. Better performance and less unnecessary flickering.

Together these drastically improve decoration behavior:


https://user-images.githubusercontent.com/2230985/191628564-f4402f02-5b8a-4480-87e6-142c73efc8e2.mp4



This should make @hediet much happier too 🙂 
