### PR TITLE
Differenciate suggested kernels and fallbacks

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -549,7 +549,9 @@ export class InteractiveEditor extends EditorPane {
 
 		if (notebook && textModel) {
 			const info = this.#notebookKernelService.getMatchingKernel(notebook);
-			const selectedOrSuggested = info.selected ?? info.suggestions[0];
+			const selectedOrSuggested = info.selected
+				?? (info.suggestions.length === 1 ? info.suggestions[0] : undefined)
+				?? (info.all.length === 1 ? info.all[0] : undefined);
 
 			if (selectedOrSuggested) {
 				const language = selectedOrSuggested.supportedLanguages[0];

--- a/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
@@ -463,7 +463,8 @@ export class KernelStatus extends Disposable implements IWorkbenchContribution {
 		this._kernelInfoElement.clear();
 
 		const { selected, suggestions, all } = this._notebookKernelService.getMatchingKernel(notebook);
-		const suggested = (suggestions.length === 1 && all.length === 1) ? suggestions[0] : undefined;
+		const suggested = (suggestions.length === 1 ? suggestions[0] : undefined)
+			?? (all.length === 1) ? all[0] : undefined;
 		let isSuggested = false;
 
 		if (all.length === 0) {

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
@@ -248,9 +248,6 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 		const selected = selectedId ? this._kernels.get(selectedId)?.kernel : undefined;
 		const suggestions = kernels.filter(item => item.instanceAffinity > 1 && item.kernel !== selected).map(item => item.kernel);
 		const hidden = kernels.filter(item => item.instanceAffinity < 0).map(item => item.kernel);
-		if (!suggestions.length && all.length) {
-			suggestions.push(all[0]);
-		}
 		return { all, selected, suggestions, hidden };
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelActionViewItem.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelActionViewItem.ts
@@ -99,7 +99,9 @@ export class NotebooKernelActionViewItem extends ActionViewItem {
 	private _updateActionFromKernelInfo(info: INotebookKernelMatchResult): void {
 		this._action.enabled = true;
 		this._action.class = ThemeIcon.asClassName(selectKernelIcon);
-		const selectedOrSuggested = info.selected ?? (info.suggestions.length === 1 ? info.suggestions[0] : undefined);
+		const selectedOrSuggested = info.selected
+			?? (info.suggestions.length === 1 ? info.suggestions[0] : undefined)
+			?? (info.all.length === 1 ? info.all[0] : undefined);
 		if (selectedOrSuggested) {
 			// selected or suggested kernel
 			this._action.label = this._generateKenrelLabel(selectedOrSuggested);


### PR DESCRIPTION
When extensions contribute multiple controllers but don't update their affinity, we should not auto suggest the first controller, instead we should show the "Select Kernel" command.


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
