### PR TITLE
Create terminal find widget lazily, add LazyValue helper

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Orientation } from 'vs/base/browser/ui/splitview/splitview';
+import { LazyValue } from 'vs/base/common/async';
 import { Event } from 'vs/base/common/event';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { OperatingSystem } from 'vs/base/common/platform';
@@ -456,7 +457,7 @@ export interface ITerminalInstance {
 
 	readonly statusList: ITerminalStatusList;
 
-	readonly findWidget: TerminalFindWidget;
+	readonly findWidget: LazyValue<TerminalFindWidget>;
 
 	/**
 	 * The process ID of the shell process, this is undefined when there is no process associated
@@ -578,6 +579,8 @@ export interface ITerminalInstance {
 	onExit: Event<number | ITerminalLaunchError | undefined>;
 
 	onDidChangeFindResults: Event<{ resultIndex: number; resultCount: number } | undefined>;
+
+	onDidFocusFindWidget: Event<void>;
 
 	readonly exitCode: number | undefined;
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -1071,7 +1071,7 @@ export function registerTerminalActions() {
 			});
 		}
 		run(accessor: ServicesAccessor) {
-			accessor.get(ITerminalService).activeInstance?.findWidget.reveal();
+			accessor.get(ITerminalService).activeInstance?.findWidget.value.reveal();
 		}
 	});
 	registerAction2(class extends Action2 {
@@ -1091,7 +1091,7 @@ export function registerTerminalActions() {
 			});
 		}
 		run(accessor: ServicesAccessor) {
-			accessor.get(ITerminalService).activeInstance?.findWidget.hide();
+			accessor.get(ITerminalService).activeInstance?.findWidget.value.hide();
 		}
 	});
 
@@ -1444,7 +1444,7 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			const terminalService = accessor.get(ITerminalService);
-			const state = terminalService.activeInstance?.findWidget.findState;
+			const state = terminalService.activeInstance?.findWidget.value.findState;
 			state?.change({ isRegex: !state.isRegex }, false);
 		}
 	});
@@ -1466,7 +1466,7 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			const terminalService = accessor.get(ITerminalService);
-			const state = terminalService.activeInstance?.findWidget.findState;
+			const state = terminalService.activeInstance?.findWidget.value.findState;
 			state?.change({ wholeWord: !state.wholeWord }, false);
 		}
 	});
@@ -1488,7 +1488,7 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			const terminalService = accessor.get(ITerminalService);
-			const state = terminalService.activeInstance?.findWidget.findState;
+			const state = terminalService.activeInstance?.findWidget.value.findState;
 			state?.change({ matchCase: !state.matchCase }, false);
 		}
 	});
@@ -1517,8 +1517,8 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			const terminalService = accessor.get(ITerminalService);
-			terminalService.activeInstance?.findWidget.show();
-			terminalService.activeInstance?.findWidget.find(false);
+			terminalService.activeInstance?.findWidget.value.show();
+			terminalService.activeInstance?.findWidget.value.find(false);
 		}
 	});
 	registerAction2(class extends Action2 {
@@ -1546,8 +1546,8 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			const terminalService = accessor.get(ITerminalService);
-			terminalService.activeInstance?.findWidget.show();
-			terminalService.activeInstance?.findWidget.find(true);
+			terminalService.activeInstance?.findWidget.value.show();
+			terminalService.activeInstance?.findWidget.value.find(true);
 		}
 	});
 	registerAction2(class extends Action2 {

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditor.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditor.ts
@@ -79,7 +79,7 @@ export class TerminalEditor extends EditorPane {
 			// panel and the editors, this is needed so that the active instance gets set
 			// when focus changes between them.
 			this._register(this._editorInput.terminalInstance.onDidFocus(() => this._setActiveInstance()));
-			this._register(this._editorInput.terminalInstance.findWidget.focusTracker.onDidFocus(() => this._setActiveInstance()));
+			this._register(this._editorInput.terminalInstance.onDidFocusFindWidget(() => this._setActiveInstance()));
 			this._editorInput.setCopyLaunchConfig(this._editorInput.terminalInstance.shellLaunchConfig);
 		}
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
@@ -369,7 +369,7 @@ export class TerminalGroup extends Disposable implements ITerminalGroup {
 				this._setActiveInstance(instance);
 				this._onDidFocusInstance.fire(instance);
 			}),
-			instance.findWidget.focusTracker.onDidFocus(() => this._setActiveInstance(instance)),
+			instance.onDidFocusFindWidget(() => this._setActiveInstance(instance)),
 			instance.capabilities.onDidAddCapability(() => this._onDidChangeInstanceCapability.fire(instance)),
 			instance.capabilities.onDidRemoveCapability(() => this._onDidChangeInstanceCapability.fire(instance)),
 		]);


### PR DESCRIPTION
@jrieken a review here would be appreciated as you wrote `IdleValue`. The idea here is similar to `IdleValue` but it won't initialize the value at all until requested. For this specific use case, I don't want to create find widgets for every terminal as it will often be a waste of cpu/battery/memory. I wouldn't be surprised if something like this already existed, but I couldn't find it if so.