### PR TITLE
Fix undo redo stops when copy paste / drop creates a new file

### DIFF
--- a/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
+++ b/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
@@ -13,16 +13,14 @@ import { URI } from 'vs/base/common/uri';
 import { addExternalEditorsDropData, toVSDataTransfer, UriList } from 'vs/editor/browser/dnd';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { registerEditorContribution } from 'vs/editor/browser/editorExtensions';
-import { IBulkEditService } from 'vs/editor/browser/services/bulkEditService';
+import { IBulkEditService, ResourceTextEdit } from 'vs/editor/browser/services/bulkEditService';
 import { IPosition } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
-import { Selection, SelectionDirection } from 'vs/editor/common/core/selection';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
-import { DocumentOnDropEdit, DocumentOnDropEditProvider } from 'vs/editor/common/languages';
+import { DocumentOnDropEdit, DocumentOnDropEditProvider, WorkspaceEdit } from 'vs/editor/common/languages';
 import { ITextModel } from 'vs/editor/common/model';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { CodeEditorStateFlag, EditorStateCancellationTokenSource } from 'vs/editor/contrib/editorState/browser/editorState';
-import { performSnippetEdit } from 'vs/editor/contrib/snippet/browser/snippetController2';
 import { SnippetParser } from 'vs/editor/contrib/snippet/browser/snippetParser';
 import { localize } from 'vs/nls';
 import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
@@ -68,7 +66,7 @@ export class DropIntoEditorController extends Disposable implements IEditorContr
 		try {
 			const providers = this._languageFeaturesService.documentOnDropEditProvider.ordered(model);
 
-			const edit = await this._progressService.withProgress({
+			const providerEdit = await this._progressService.withProgress({
 				location: ProgressLocation.Notification,
 				delay: 750,
 				title: localize('dropProgressTitle', "Running drop handlers..."),
@@ -94,13 +92,19 @@ export class DropIntoEditorController extends Disposable implements IEditorContr
 				return;
 			}
 
-			if (edit) {
-				const range = new Range(position.lineNumber, position.column, position.lineNumber, position.column);
-				performSnippetEdit(editor, typeof edit.insertText === 'string' ? SnippetParser.escape(edit.insertText) : edit.insertText.snippet, [Selection.fromRange(range, SelectionDirection.LTR)]);
-
-				if (edit.additionalEdit) {
-					await this._bulkEditService.apply(edit.additionalEdit, { editor });
-				}
+			if (providerEdit) {
+				const snippet = typeof providerEdit.insertText === 'string' ? SnippetParser.escape(providerEdit.insertText) : providerEdit.insertText.snippet;
+				const combinedWorkspaceEdit: WorkspaceEdit = {
+					edits: [
+						new ResourceTextEdit(model.uri, {
+							range: new Range(position.lineNumber, position.column, position.lineNumber, position.column),
+							text: snippet,
+							insertAsSnippet: true,
+						}),
+						...(providerEdit.additionalEdit?.edits ?? [])
+					]
+				};
+				await this._bulkEditService.apply(combinedWorkspaceEdit, { editor });
 				return;
 			}
 		} finally {

--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -10,7 +10,6 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorCommand, registerEditorCommand, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
-import { ISelection, Selection } from 'vs/editor/common/core/selection';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { CompletionItem, CompletionItemKind, CompletionItemProvider } from 'vs/editor/common/languages';
@@ -348,21 +347,3 @@ registerEditorCommand(new CommandCtor({
 	// 	primary: KeyCode.Enter,
 	// }
 }));
-
-
-// ---
-
-export function performSnippetEdit(editor: ICodeEditor, snippet: string, selections: ISelection[]): boolean {
-	const controller = SnippetController2.get(editor);
-	if (!controller) {
-		return false;
-	}
-	editor.focus();
-	controller.apply(selections.map(selection => {
-		return {
-			range: Selection.liftSelection(selection),
-			template: snippet
-		};
-	}));
-	return controller.isInSnippet();
-}


### PR DESCRIPTION
@jrieken To get undo/redo working when pasting creates a new file, I had to combine the workspace edit so that we make a single call to the `BulkEditService`. This still results into two undo/redo stops being created: the top one for adding the text to the file, and the second one for creating the file. Is there a way to combine these two to a single undo/redo stop?