### PR TITLE
Disable test for ContextualActionAddon

### DIFF
--- a/src/vs/workbench/contrib/terminal/test/browser/contextualActionAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/contextualActionAddon.test.ts
@@ -115,7 +115,7 @@ suite('ContextualActionAddon', () => {
 					strictEqual(getMatchActions(createCommand(portCommand, `invalid output`, FreePortOutputRegex), expected), undefined);
 				});
 			});
-			test('returns actions', () => {
+			test.skip('returns actions', () => {
 				assertMatchOptions(getMatchActions(createCommand(portCommand, output, FreePortOutputRegex), expected), actionOptions);
 			});
 		});


### PR DESCRIPTION
The test was added along with https://github.com/microsoft/vscode/commit/de450f991c2daa1f3207dfff4a4d7a3ffb2fd699, since this is new, we disable the test temporily instead of reverting all changes.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
