### PR TITLE
Revert "Bracket support for #if and #endif in cpp"

### DIFF
--- a/extensions/cpp/language-configuration.json
+++ b/extensions/cpp/language-configuration.json
@@ -6,8 +6,7 @@
 	"brackets": [
 		["{", "}"],
 		["[", "]"],
-		["(", ")"],
-		["#if","#endif"],
+		["(", ")"]
 	],
 	"autoClosingPairs": [
 		{ "open": "[", "close": "]" },


### PR DESCRIPTION
Reverts microsoft/vscode#159997, reopens #159586.

`#if` / `#endif` bracket pairs cause lots of new problems, e.g. this one:

![](https://user-images.githubusercontent.com/19859882/190555400-e904a35f-7b33-4c8c-a534-cd5c9a7a6cc2.png)