### PR TITLE
Allow video attributes on rendered markdown

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -358,6 +358,26 @@ function sanitizeRenderedMarkdown(
 	}
 }
 
+export const allowedMarkdownAttr = [
+	'align',
+	'alt',
+	'class',
+	'controls',
+	'data-code',
+	'data-href',
+	'height',
+	'href',
+	'loop',
+	'muted',
+	'playsinline',
+	'poster',
+	'src',
+	'style',
+	'target',
+	'title',
+	'width',
+];
+
 function getSanitizerOptions(options: { readonly isTrusted?: boolean }): { config: dompurify.Config; allowedSchemes: string[] } {
 	const allowedSchemes = [
 		Schemas.http,
@@ -381,7 +401,7 @@ function getSanitizerOptions(options: { readonly isTrusted?: boolean }): { confi
 			// HTML tags that can result from markdown are from reading https://spec.commonmark.org/0.29/
 			// HTML table tags that can result from markdown are from https://github.github.com/gfm/#tables-extension-
 			ALLOWED_TAGS: [...DOM.basicMarkupHtmlTags],
-			ALLOWED_ATTR: ['href', 'data-href', 'target', 'title', 'src', 'alt', 'class', 'style', 'data-code', 'width', 'height', 'align'],
+			ALLOWED_ATTR: allowedMarkdownAttr,
 			ALLOW_UNKNOWN_PROTOCOLS: true,
 		},
 		allowedSchemes

--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -5,6 +5,7 @@
 
 import { hookDomPurifyHrefAndSrcSanitizer, basicMarkupHtmlTags } from 'vs/base/browser/dom';
 import * as dompurify from 'vs/base/browser/dompurify/dompurify';
+import { allowedMarkdownAttr } from 'vs/base/browser/markdownRenderer';
 import { marked } from 'vs/base/common/marked/marked';
 import { Schemas } from 'vs/base/common/network';
 import { ILanguageService } from 'vs/editor/common/languages/language';
@@ -164,8 +165,9 @@ function sanitize(documentContent: string, allowUnknownProtocols: boolean): stri
 					'checklist',
 				],
 				ALLOWED_ATTR: [
-					'href', 'data-href', 'data-command', 'target', 'title', 'name', 'src', 'alt', 'class', 'id', 'role', 'tabindex', 'style', 'data-code',
-					'width', 'height', 'align', 'x-dispatch',
+					...allowedMarkdownAttr,
+					'data-command', 'name', 'id', 'role', 'tabindex',
+					'x-dispatch',
 					'required', 'checked', 'placeholder', 'when-checked', 'checked-on',
 				],
 			},


### PR DESCRIPTION
This adds:

- `loop`
- `muted`
- `poster`
- `playsinline`
- `controls`

To the list of allowed attributes 
