### PR TITLE
iterate through all providers before returning

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalBaseContextualActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalBaseContextualActions.ts
@@ -14,9 +14,9 @@ export const GitCommandLineRegex = /git/;
 export const GitPushCommandLineRegex = /git\s+push/;
 export const AnyCommandLineRegex = /.{4,}/;
 export const GitSimilarOutputRegex = /most similar command is\s+([^\s]{3,})/;
-export const FreePortOutputRegex = /address already in use \d\.\d\.\d\.\d:(\d\d\d\d)\s+|Unable to bind [^ ]*:(\d+)|can't listen on port (\d+)|listen EADDRINUSE [^ ]*:(\d+)/;
-export const GitPushOutputRegex = /git push --set-upstream origin ([^\s]+)\s+/;
-export const GitCreatePrOutputRegex = /Create a pull request for \'([^\s]+)\' on GitHub by visiting:\s+remote:\s+(https:.+pull.+)\s+/;
+export const FreePortOutputRegex = /address already in use \d\.\d\.\d\.\d:(\d\d\d\d)|Unable to bind [^ ]*:(\d+)|can't listen on port (\d+)|listen EADDRINUSE [^ ]*:(\d+)/;
+export const GitPushOutputRegex = /git push --set-upstream origin ([^\s]+)/;
+export const GitCreatePrOutputRegex = /Create a pull request for \'([^\s]+)\' on GitHub by visiting:\s+remote:\s+(https:.+pull.+)/;
 
 export function gitSimilarCommand(): ITerminalContextualActionOptions {
 	return {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/contextualActionAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/contextualActionAddon.ts
@@ -143,23 +143,22 @@ export function getMatchActions(command: ITerminalCommand, actionOptions: Map<st
 				outputMatch = command.getOutputMatch(outputMatcher);
 			}
 			const actions = actionOption.getActions({ commandLineMatch, outputMatch }, command);
-			if (!actions) {
-				return matchActions.length === 0 ? undefined : matchActions;
-			}
-			for (const a of actions) {
-				matchActions.push({
-					id: a.id,
-					label: a.label,
-					class: a.class,
-					enabled: a.enabled,
-					run: async () => {
-						await a.run();
-						if (a.commandToRunInTerminal) {
-							onDidRequestRerunCommand?.fire({ command: a.commandToRunInTerminal, addNewLine: a.addNewLine });
-						}
-					},
-					tooltip: a.tooltip
-				});
+			if (actions) {
+				for (const a of actions) {
+					matchActions.push({
+						id: a.id,
+						label: a.label,
+						class: a.class,
+						enabled: a.enabled,
+						run: async () => {
+							await a.run();
+							if (a.commandToRunInTerminal) {
+								onDidRequestRerunCommand?.fire({ command: a.commandToRunInTerminal, addNewLine: a.addNewLine });
+							}
+						},
+						tooltip: a.tooltip
+					});
+				}
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/terminal/test/browser/contextualActionAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/contextualActionAddon.test.ts
@@ -18,7 +18,7 @@ import { freePort, FreePortOutputRegex, gitCreatePr, GitCreatePrOutputRegex, Git
 import { ContextualActionAddon, getMatchActions } from 'vs/workbench/contrib/terminal/browser/xterm/contextualActionAddon';
 import { Terminal } from 'xterm';
 
-suite('ContextualActionAddon', () => {
+suite.only('ContextualActionAddon', () => {
 	let contextualActionAddon: ContextualActionAddon;
 	let terminalInstance: Pick<ITerminalInstance, 'freePortKillProcess'>;
 	let commandDetection: CommandDetectionCapability;
@@ -117,7 +117,7 @@ suite('ContextualActionAddon', () => {
 					strictEqual(getMatchActions(createCommand(portCommand, `invalid output`, FreePortOutputRegex), expected), undefined);
 				});
 			});
-			test.skip('returns actions', () => {
+			test('returns actions', () => {
 				assertMatchOptions(getMatchActions(createCommand(portCommand, output, FreePortOutputRegex), expected), actionOptions);
 			});
 		});
@@ -151,7 +151,7 @@ suite('ContextualActionAddon', () => {
 					strictEqual(getMatchActions(createCommand(`git status`, output, GitPushOutputRegex, exitCode), expectedMap), undefined);
 				});
 			});
-			suite('returns undefined when', () => {
+			suite('returns actions when', () => {
 				test('expected unix exit code', () => {
 					assertMatchOptions(getMatchActions(createCommand(command, output, GitPushOutputRegex, exitCode), expectedMap), actions);
 				});
@@ -201,6 +201,47 @@ suite('ContextualActionAddon', () => {
 				test('expected unix exit code', () => {
 					assertMatchOptions(getMatchActions(createCommand(command, output, GitCreatePrOutputRegex, exitCode), expectedMap), actions);
 				});
+			});
+		});
+	});
+	suite('gitPush - multiple providers', () => {
+		const expectedMap = new Map();
+		const command = `git push`;
+		const output = `fatal: The current branch test22 has no upstream branch.
+		To push the current branch and set the remote as upstream, use
+
+			git push --set-upstream origin test22 `;
+		const exitCode = 128;
+		const actions = [
+			{
+				id: 'terminal.gitPush',
+				label: 'Git push test22',
+				run: true,
+				tooltip: 'Git push test22',
+				enabled: true
+			}
+		];
+		setup(() => {
+			const pushCommand = gitPushSetUpstream();
+			const prCommand = gitCreatePr(openerService);
+			contextualActionAddon.registerCommandFinishedListener(pushCommand);
+			contextualActionAddon.registerCommandFinishedListener(prCommand);
+			expectedMap.set(pushCommand.commandLineMatcher.toString(), [pushCommand, prCommand]);
+		});
+		suite('returns undefined when', () => {
+			test('output does not match', () => {
+				strictEqual(getMatchActions(createCommand(command, `invalid output`, GitPushOutputRegex, exitCode), expectedMap), undefined);
+			});
+			test('command does not match', () => {
+				strictEqual(getMatchActions(createCommand(`git status`, output, GitPushOutputRegex, exitCode), expectedMap), undefined);
+			});
+		});
+		suite('returns actions when', () => {
+			test('expected unix exit code', () => {
+				assertMatchOptions(getMatchActions(createCommand(command, output, GitPushOutputRegex, exitCode), expectedMap), actions);
+			});
+			test('matching exit status', () => {
+				assertMatchOptions(getMatchActions(createCommand(command, output, GitPushOutputRegex, 2), expectedMap), actions);
 			});
 		});
 	});

--- a/src/vs/workbench/contrib/terminal/test/browser/contextualActionAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/contextualActionAddon.test.ts
@@ -127,7 +127,7 @@ suite('ContextualActionAddon', () => {
 			const output = `fatal: The current branch test22 has no upstream branch.
 			To push the current branch and set the remote as upstream, use
 
-				git push --set-upstream origin test22 `;
+				git push --set-upstream origin test22`;
 			const exitCode = 128;
 			const actions = [
 				{
@@ -210,7 +210,7 @@ suite('ContextualActionAddon', () => {
 		const output = `fatal: The current branch test22 has no upstream branch.
 		To push the current branch and set the remote as upstream, use
 
-			git push --set-upstream origin test22 `;
+			git push --set-upstream origin test22`;
 		const exitCode = 128;
 		const actions = [
 			{

--- a/src/vs/workbench/contrib/terminal/test/browser/contextualActionAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/contextualActionAddon.test.ts
@@ -18,7 +18,7 @@ import { freePort, FreePortOutputRegex, gitCreatePr, GitCreatePrOutputRegex, Git
 import { ContextualActionAddon, getMatchActions } from 'vs/workbench/contrib/terminal/browser/xterm/contextualActionAddon';
 import { Terminal } from 'xterm';
 
-suite.only('ContextualActionAddon', () => {
+suite('ContextualActionAddon', () => {
 	let contextualActionAddon: ContextualActionAddon;
 	let terminalInstance: Pick<ITerminalInstance, 'freePortKillProcess'>;
 	let commandDetection: CommandDetectionCapability;


### PR DESCRIPTION
tests weren't failing bc the test output strings had spaces at the end of them, which was a requirement in the regex. occasionally they do have spaces in the actual output, which is why it was flaky. 

secondly, was returning too early in get match actions so sometimes the right output regex wasn't tested against by then

fix #161628
fix #161648