### PR TITLE
restore `separator` class for Separator item

### DIFF
--- a/src/vs/base/common/actions.ts
+++ b/src/vs/base/common/actions.ts
@@ -219,7 +219,7 @@ export class Separator implements IAction {
 
 	readonly label: string = '';
 	readonly tooltip: string = '';
-	readonly class: string = '';
+	readonly class: string = 'separator';
 	readonly enabled: boolean = false;
 	readonly checked: boolean = false;
 	async run() { }


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/161643
