### PR TITLE
Enforce all properties on output matchers

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -935,11 +935,27 @@ export interface ICommandAction extends IAction {
 	addNewLine?: boolean;
 }
 
+/**
+ * A matcher that runs on a sub-section of a terminal command's output
+ */
 export interface ITerminalOutputMatcher {
+	/**
+	 * A string or regex to match against the unwrapped line.
+	 */
 	lineMatcher: string | RegExp;
-	anchor?: 'top' | 'bottom';
-	offset?: number;
-	length?: number;
+	/**
+	 * Which side of the output to anchor the {@link offset} and {@link length} against.
+	 */
+	anchor: 'top' | 'bottom';
+	/**
+	 * How far from either the top or the bottom of the butter to start matching against.
+	 */
+	offset: number;
+	/**
+	 * The number of rows to match against, this should be as small as possible for performance
+	 * reasons.
+	 */
+	length: number;
 }
 
 export interface IXtermTerminal {

--- a/src/vs/workbench/contrib/terminal/browser/terminalBaseContextualActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalBaseContextualActions.ts
@@ -21,7 +21,12 @@ export const GitCreatePrOutputRegex = /Create a pull request for \'([^\s]+)\' on
 export function gitSimilarCommand(): ITerminalContextualActionOptions {
 	return {
 		commandLineMatcher: GitCommandLineRegex,
-		outputMatcher: { lineMatcher: GitSimilarOutputRegex, anchor: 'bottom' },
+		outputMatcher: {
+			lineMatcher: GitSimilarOutputRegex,
+			anchor: 'bottom',
+			offset: 0,
+			length: 3
+		},
 		actionName: (matchResult: ContextualMatchResult) => matchResult.outputMatch ? `Run git ${matchResult.outputMatch[1]}` : ``,
 		exitStatus: false,
 		getActions: (matchResult: ContextualMatchResult, command: ITerminalCommand) => {
@@ -45,7 +50,14 @@ export function freePort(terminalInstance?: Partial<ITerminalInstance>): ITermin
 	return {
 		actionName: (matchResult: ContextualMatchResult) => matchResult.outputMatch ? `Free port ${matchResult.outputMatch[1]}` : '',
 		commandLineMatcher: AnyCommandLineRegex,
-		outputMatcher: !isWindows ? { lineMatcher: FreePortOutputRegex, anchor: 'bottom' } : undefined,
+		// TODO: Support free port on Windows https://github.com/microsoft/vscode/issues/161775
+		outputMatcher: isWindows ? undefined : {
+			lineMatcher: FreePortOutputRegex,
+			anchor: 'bottom',
+			offset: 0,
+			length: 20
+		},
+		exitStatus: false,
 		getActions: (matchResult: ContextualMatchResult, command: ITerminalCommand) => {
 			const port = matchResult?.outputMatch?.[1];
 			if (!port) {
@@ -69,7 +81,12 @@ export function gitPushSetUpstream(): ITerminalContextualActionOptions {
 	return {
 		actionName: (matchResult: ContextualMatchResult) => matchResult.outputMatch ? `Git push ${matchResult.outputMatch[1]}` : '',
 		commandLineMatcher: GitPushCommandLineRegex,
-		outputMatcher: { lineMatcher: GitPushOutputRegex, anchor: 'bottom' },
+		outputMatcher: {
+			lineMatcher: GitPushOutputRegex,
+			anchor: 'bottom',
+			offset: 0,
+			length: 5
+		},
 		exitStatus: false,
 		getActions: (matchResult: ContextualMatchResult, command: ITerminalCommand) => {
 			const branch = matchResult?.outputMatch?.[1];
@@ -94,7 +111,12 @@ export function gitCreatePr(openerService: IOpenerService): ITerminalContextualA
 	return {
 		actionName: (matchResult: ContextualMatchResult) => matchResult.outputMatch ? `Create PR for ${matchResult.outputMatch[1]}` : '',
 		commandLineMatcher: GitPushCommandLineRegex,
-		outputMatcher: { lineMatcher: GitCreatePrOutputRegex, anchor: 'bottom' },
+		outputMatcher: {
+			lineMatcher: GitCreatePrOutputRegex,
+			anchor: 'bottom',
+			offset: 0,
+			length: 5
+		},
 		exitStatus: true,
 		getActions: (matchResult: ContextualMatchResult, command?: ITerminalCommand) => {
 			if (!command) {


### PR DESCRIPTION
This enforces output matchers will always have an anchor, offset and length as otherwise the matcher will search every line which could be thousands of lines. This also runs the free port issue only on a failed command, we can amend the xterm.js script to exit with error if needed to support this as it should do that anyway.

Fixes #161758
