### PR TITLE
Fix NotebookEditorModel#isResolved. Fix #161049.

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
@@ -473,7 +473,7 @@ export class SimpleNotebookEditorModel extends EditorModel implements INotebookE
 	}
 
 	override isResolved(): this is IResolvedNotebookEditorModel {
-		return Boolean(this._workingCopy);
+		return Boolean(this._workingCopy?.model?.notebookModel);
 	}
 
 	isDirty(): boolean {


### PR DESCRIPTION
#161049 throws an exception but that's because we are assuming the model is already resolved, however the validation of model resolution is wrong. Note that this doesn't fix the underling issue but can give us better exceptions thrown at the right place.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
