### PR TITLE
Fix nb diff overview ruler scaling.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffOverviewRuler.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffOverviewRuler.ts
@@ -124,6 +124,7 @@ export class NotebookDiffOverviewRuler extends Themable {
 	private _layoutNow() {
 		const layoutInfo = this.notebookEditor.getLayoutInfo();
 		const height = layoutInfo.height;
+		const scrollHeight = layoutInfo.scrollHeight;
 		const ratio = browser.PixelRatio.value;
 		this._domNode.setWidth(this.width);
 		this._domNode.setHeight(height);
@@ -131,7 +132,7 @@ export class NotebookDiffOverviewRuler extends Themable {
 		this._domNode.domNode.height = height * ratio;
 		const ctx = this._domNode.domNode.getContext('2d')!;
 		ctx.clearRect(0, 0, this.width * ratio, height * ratio);
-		this._renderCanvas(ctx, this.width * ratio, ratio);
+		this._renderCanvas(ctx, this.width * ratio, height * ratio, scrollHeight * ratio, ratio);
 		this._renderOverviewViewport();
 	}
 
@@ -168,7 +169,7 @@ export class NotebookDiffOverviewRuler extends Themable {
 		};
 	}
 
-	private _renderCanvas(ctx: CanvasRenderingContext2D, width: number, ratio: number) {
+	private _renderCanvas(ctx: CanvasRenderingContext2D, width: number, height: number, scrollHeight: number, ratio: number) {
 		if (!this._insertColorHex || !this._removeColorHex) {
 			// no op when colors are not yet known
 			return;
@@ -179,7 +180,8 @@ export class NotebookDiffOverviewRuler extends Themable {
 		for (let i = 0; i < this._diffElementViewModels.length; i++) {
 			const element = this._diffElementViewModels[i];
 
-			const cellHeight = element.layoutInfo.totalHeight * ratio;
+			const cellHeight = (element.layoutInfo.totalHeight / scrollHeight) * ratio * height;
+
 			switch (element.type) {
 				case 'insert':
 					ctx.fillStyle = this._insertColorHex;


### PR DESCRIPTION
The cell decoration height in the overview ruler should scale per diff editor scroll height.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
