### PR TITLE
Fix #161917. Bind pointer event listener on overview container

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffOverviewRuler.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffOverviewRuler.ts
@@ -66,7 +66,7 @@ export class NotebookDiffOverviewRuler extends Themable {
 			this._renderOverviewViewport();
 		}));
 
-		this._register(DOM.addStandardDisposableListener(this._overviewViewportDomElement.domNode, DOM.EventType.POINTER_DOWN, (e) => {
+		this._register(DOM.addStandardDisposableListener(container, DOM.EventType.POINTER_DOWN, (e) => {
 			this.notebookEditor.delegateVerticalScrollbarPointerDown(e);
 		}));
 	}


### PR DESCRIPTION
So clicking on the canvas or viewport DOM both work.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
