### PR TITLE
Changing the z-index of the find options widget (Fixes #160627)

### DIFF
--- a/src/vs/editor/contrib/find/browser/findOptionsWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findOptionsWidget.ts
@@ -43,6 +43,7 @@ export class FindOptionsWidget extends Widget implements IOverlayWidget {
 		this._domNode.className = 'findOptionsWidget';
 		this._domNode.style.display = 'none';
 		this._domNode.style.top = '10px';
+		this._domNode.style.zIndex = '12';
 		this._domNode.setAttribute('role', 'presentation');
 		this._domNode.setAttribute('aria-hidden', 'true');
 


### PR DESCRIPTION
Fixes #160627

Changing the z-index of the find options widget so that this widget appears above the sticky scroll widget.

