### PR TITLE
Markdown tests: suite.only use (fix #162159)

### DIFF
--- a/extensions/markdown-language-features/src/test/engine.test.ts
+++ b/extensions/markdown-language-features/src/test/engine.test.ts
@@ -30,7 +30,7 @@ suite('markdown.engine', () => {
 		});
 	});
 
-	suite.only('image-caching', () => {
+	suite('image-caching', () => {
 		const input = '![](img.png) [](no-img.png) ![](http://example.org/img.png) ![](img.png) ![](./img2.png)';
 
 		test('Extracts all images', async () => {


### PR DESCRIPTION
Running a full build to get the markdown integration tests run on all platforms: https://monacotools.visualstudio.com/DefaultCollection/Monaco/_build/results?buildId=186964&view=results