### PR TITLE
Making the vertical sash visible by changing the CSS parameters (Fixes #160271)

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
@@ -29,7 +29,7 @@
 
 .monaco-editor .sticky-widget {
 	width : 100%;
-	box-shadow : var(--vscode-scrollbar-shadow) 0 2px 6px -2px;
+	box-shadow : var(--vscode-scrollbar-shadow) 0 3px 2px -2px;
 	z-index : 2;
 	background-color : var(--vscode-editorStickyScroll-background);
 }

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -275,7 +275,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 				const mouseOverEvent = new StandardMouseEvent(e);
 				const text = mouseOverEvent.target.innerText;
 				this._hoverOnLine = line;
-				// TODO: workaround to find the column index, perhaps need more solid solution
+				// TODO: workaround to find the column index, perhaps need a more solid solution
 				this._hoverOnColumn = this._editor.getModel().getLineContent(line).indexOf(text) + 1 || -1;
 			}
 		}));
@@ -296,8 +296,9 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		const minimapSide = this._editor.getOption(EditorOption.minimap).side;
 		if (minimapSide === 'left') {
 			this._rootDomNode.style.marginLeft = this._editor.getLayoutInfo().minimap.minimapCanvasOuterWidth + 'px';
-		} else if (minimapSide === 'right') {
-			this._rootDomNode.style.marginLeft = '0px';
+		}
+		else if (minimapSide === 'right') {
+			this._rootDomNode.style.marginLeft = '1px';
 		}
 		this._rootDomNode.style.zIndex = '11';
 	}


### PR DESCRIPTION
Tweaking the CSS parameters in order to make the vertical sash once again visible. Added an offset of 1px when the minimap is set to be on the right side.

Fixes https://github.com/microsoft/vscode/issues/160271.

![image](https://user-images.githubusercontent.com/61460952/192777231-ae7e8cc4-9b56-4a8c-896a-a5bd130e317e.png)



