### PR TITLE
stop shipping build-only dependencies

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -1,9 +1,13 @@
 # cleanup rules for node modules, .gitignore style
 
-# native node modules
-
 nan/**
-*/node_modules/nan/**
+**/node_modules/nan/**
+node-gyp/**
+**/node_modules/node-gyp/**
+node-gyp-build/**
+**/node_modules/node-gyp-build/**
+node-addon-api/**
+**/node_modules/node-addon-api/**
 
 fsevents/binding.gyp
 fsevents/fsevents.cc


### PR DESCRIPTION
While investigating our build output, I noticed we're shipping these modules which aren't used at all at runtime. This shaves 2MB off our ASAR package:

![image](https://user-images.githubusercontent.com/22350/192786624-18a5fe5f-4372-4c1d-b9b1-4c85f432262e.png)

![image](https://user-images.githubusercontent.com/22350/192786686-a60cc627-0c40-4a7c-b820-3182acf628ce.png)

