### PR TITLE
- Add `_isFakeAction` as a workaround to noop-actions that are contributed to menus but that don't do anything

### DIFF
--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -40,6 +40,8 @@ export interface ICommandAction {
 	source?: string;
 	precondition?: ContextKeyExpression;
 	toggled?: ContextKeyExpression | { condition: ContextKeyExpression; icon?: Icon; tooltip?: string; title?: string | ILocalizedString };
+	/** @deprecated see https://github.com/microsoft/vscode/issues/162004 */
+	_isFakeAction?: true;
 }
 
 export type ISerializableCommandAction = UriDto<ICommandAction>;

--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -151,8 +151,14 @@ export class WorkbenchToolBar extends ToolBar {
 
 				// add "hide foo" actions
 				let hideAction: IAction;
-				if ((action instanceof MenuItemAction || action instanceof SubmenuItemAction) && action.hideActions) {
+				if (action instanceof MenuItemAction || action instanceof SubmenuItemAction) {
+					if (!action.hideActions) {
+						// no context menu for MenuItemAction instances that support no hiding
+						// those are fake actions and need to be cleaned up
+						return;
+					}
 					hideAction = action.hideActions.hide;
+
 				} else {
 					hideAction = toAction({
 						id: 'label',

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -554,6 +554,13 @@ export interface IAction2Options extends ICommandAction {
 	 * showing keybindings that have no other UX.
 	 */
 	description?: ICommandHandlerDescription;
+
+	/**
+	 * @deprecated workaround added for https://github.com/microsoft/vscode/issues/162004
+	 * This action doesn't do anything is just a workaround for rendering "something"
+	 * inside a specific toolbar
+	 */
+	_isFakeAction?: true;
 }
 
 export abstract class Action2 {

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -229,7 +229,8 @@ class MenuInfo {
 					const menuHide = createMenuHide(this._id, isMenuItem ? item.command : item, this._hiddenStates);
 					if (isMenuItem) {
 						// MenuItemAction
-						activeActions.push(new MenuItemAction(item.command, item.alt, options, menuHide, this._contextKeyService, this._commandService));
+						const actualMenuHide = item.command._isFakeAction ? undefined : menuHide;
+						activeActions.push(new MenuItemAction(item.command, item.alt, options, actualMenuHide, this._contextKeyService, this._commandService));
 
 					} else {
 						// SubmenuItemAction

--- a/src/vs/workbench/contrib/comments/browser/commentsViewActions.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsViewActions.ts
@@ -412,6 +412,7 @@ registerAction2(class extends ViewAction<ICommentsView> {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
+			_isFakeAction: true,
 			id: `workbench.actions.treeView.${COMMENTS_VIEW_ID}.filter`,
 			title: localize('filter', "Filter"),
 			menu: {

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -879,6 +879,7 @@ function getReplView(viewsService: IViewsService): Repl | undefined {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
+			_isFakeAction: true,
 			id: FILTER_ACTION_ID,
 			title: localize('filter', "Filter"),
 			f1: false,
@@ -887,7 +888,7 @@ registerAction2(class extends Action2 {
 				group: 'navigation',
 				when: ContextKeyExpr.equals('view', REPL_VIEW_ID),
 				order: 10
-			}
+			},
 		});
 	}
 

--- a/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
+++ b/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
@@ -409,6 +409,7 @@ registerAction2(class extends ViewAction<IMarkersView> {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
+			_isFakeAction: true,
 			id: `workbench.actions.treeView.${Markers.MARKERS_VIEW_ID}.filter`,
 			title: localize('filter', "Filter"),
 			menu: {

--- a/src/vs/workbench/contrib/output/browser/output.contribution.ts
+++ b/src/vs/workbench/contrib/output/browser/output.contribution.ts
@@ -107,6 +107,7 @@ Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).regi
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
+			_isFakeAction: true,
 			id: `workbench.output.action.switchBetweenOutputs`,
 			title: nls.localize('switchToOutput.label', "Switch to Output"),
 			menu: {

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts
@@ -246,6 +246,7 @@ class FiltersDropdownMenuActionViewItem extends DropdownMenuActionViewItem {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
+			_isFakeAction: true,
 			id: TestCommandId.FilterAction,
 			title: { value: localize('filter', "Filter"), original: 'Filter' },
 		});


### PR DESCRIPTION
- Mark esp filtering/switching actions as fake actions

https://github.com/microsoft/vscode/issues/162004
