### PR TITLE
Search Tree Performance - FolderMatches and FileMatches

### DIFF
--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -607,23 +607,9 @@ export class FolderMatch extends Disposable {
 		return [...this.fileMatchesIterator(), ...this.folderMatchesIterator()];
 	}
 
-	// /**
-	//  * for testing only; try to use fileMatchesIterator for performance reasons
-	//  */
-	// fileMatchesArray(): FileMatch[] {
-	// 	return [...this.fileMatchesIterator()];
-	// }
-
 	fileMatchesIterator(): IterableIterator<FileMatch> {
 		return this._fileMatches.values();
 	}
-
-	// /**
-	//  * for testing only; try to use folderMatchesIterator for performance reasons
-	//  */
-	// folderMatchesArray(): FolderMatchWithResource[] {
-	// 	return [...this.folderMatchesIterator()];
-	// }
 
 	folderMatchesIterator(): IterableIterator<FolderMatchWithResource> {
 		return this._folderMatches.values();

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -607,19 +607,23 @@ export class FolderMatch extends Disposable {
 		return [...this.fileMatchesIterator(), ...this.folderMatchesIterator()];
 	}
 
-	fileMatchesArray(): FileMatch[] {
-		// for testing only; try to use fileMatchesIterator for performance reasons
-		return [...this.fileMatchesIterator()];
-	}
+	// /**
+	//  * for testing only; try to use fileMatchesIterator for performance reasons
+	//  */
+	// fileMatchesArray(): FileMatch[] {
+	// 	return [...this.fileMatchesIterator()];
+	// }
 
 	fileMatchesIterator(): IterableIterator<FileMatch> {
 		return this._fileMatches.values();
 	}
 
-	folderMatchesArray(): FolderMatchWithResource[] {
-		// for testing only; try to use folderMatchesIterator for performance reasons
-		return [...this.folderMatchesIterator()];
-	}
+	// /**
+	//  * for testing only; try to use folderMatchesIterator for performance reasons
+	//  */
+	// folderMatchesArray(): FolderMatchWithResource[] {
+	// 	return [...this.folderMatchesIterator()];
+	// }
 
 	folderMatchesIterator(): IterableIterator<FolderMatchWithResource> {
 		return this._folderMatches.values();
@@ -735,10 +739,6 @@ export class FolderMatch extends Disposable {
 		return folderMatch;
 	}
 
-	public getFileMatch(resource: URI): FileMatch | undefined {
-		return this._fileMatches.get(resource);
-	}
-
 	doAddFolder(folderMatch: FolderMatchWithResource) {
 		if (this instanceof FolderMatchWithResource && !this.uriHasParent(this.resource, folderMatch.resource)) {
 			throw Error(`${folderMatch.resource} does not belong as a child of ${this.resource}`);
@@ -792,7 +792,7 @@ export class FolderMatch extends Disposable {
 
 		const removed = [];
 		for (const match of fileMatches as FileMatch[]) {
-			if (this.getFileMatch(match.resource)) {
+			if (this._fileMatches.get(match.resource)) {
 				this._fileMatches.delete(match.resource);
 				if (dispose) {
 					match.dispose();

--- a/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
-import { Match, FileMatch, SearchResult, SearchModel } from 'vs/workbench/contrib/search/common/searchModel';
+import { Match, FileMatch, SearchResult, SearchModel, FolderMatch } from 'vs/workbench/contrib/search/common/searchModel';
 import { URI } from 'vs/base/common/uri';
 import { IFileMatch, TextSearchMatch, OneLineRange, ITextSearchMatch, QueryType } from 'vs/workbench/services/search/common/search';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
@@ -402,47 +402,55 @@ suite('SearchResult', () => {
 		const root3 = testObject.folderMatches()[3];
 
 		const root0DownstreamFiles = root0.downstreamFileMatches();
-		assert.deepStrictEqual(root0DownstreamFiles, root0.fileMatchesArray().concat(root0.folderMatchesArray()[0].fileMatchesArray()));
-		assert.deepStrictEqual(root0.folderMatchesArray()[0].downstreamFileMatches(), root0.folderMatchesArray()[0].fileMatchesArray());
-		assert.deepStrictEqual(root0.folderMatchesArray()[0].fileMatchesArray()[0].parent(), root0.folderMatchesArray()[0]);
-		assert.deepStrictEqual(root0.folderMatchesArray()[0].parent(), root0);
-		assert.deepStrictEqual(root0.folderMatchesArray()[0].closestRoot, root0);
+		assert.deepStrictEqual(root0DownstreamFiles, [...root0.fileMatchesIterator(), ...getFolderMatchAtIndex(root0, 0).fileMatchesIterator()]);
+		assert.deepStrictEqual(getFolderMatchAtIndex(root0, 0).downstreamFileMatches(), Array.from(getFolderMatchAtIndex(root0, 0).fileMatchesIterator()));
+		assert.deepStrictEqual(getFileMatchAtIndex(getFolderMatchAtIndex(root0, 0), 0).parent(), getFolderMatchAtIndex(root0, 0));
+		assert.deepStrictEqual(getFolderMatchAtIndex(root0, 0).parent(), root0);
+		assert.deepStrictEqual(getFolderMatchAtIndex(root0, 0).closestRoot, root0);
 		root0DownstreamFiles.forEach((e) => {
 			assert.deepStrictEqual(e.closestRoot, root0);
 		});
 
 		const root1DownstreamFiles = root1.downstreamFileMatches();
-		assert.deepStrictEqual(root1.downstreamFileMatches(), root1.fileMatchesArray().concat(root1.folderMatchesArray()[0].fileMatchesArray())); // excludes the matches from nested root
-		assert.deepStrictEqual(root1.folderMatchesArray()[0].fileMatchesArray()[0].parent(), root1.folderMatchesArray()[0]);
+		assert.deepStrictEqual(root1.downstreamFileMatches(), [...root1.fileMatchesIterator(), ...getFolderMatchAtIndex(root1, 0).fileMatchesIterator()]); // excludes the matches from nested root
+		assert.deepStrictEqual(getFileMatchAtIndex(getFolderMatchAtIndex(root1, 0), 0).parent(), getFolderMatchAtIndex(root1, 0));
 		root1DownstreamFiles.forEach((e) => {
 			assert.deepStrictEqual(e.closestRoot, root1);
 		});
 
 		const root2DownstreamFiles = root2.downstreamFileMatches();
-		assert.deepStrictEqual(root2DownstreamFiles, root2.fileMatchesArray());
-		assert.deepStrictEqual(root2.fileMatchesArray()[0].parent(), root2);
-		assert.deepStrictEqual(root2.fileMatchesArray()[0].closestRoot, root2);
+		assert.deepStrictEqual(root2DownstreamFiles, Array.from(root2.fileMatchesIterator()));
+		assert.deepStrictEqual(getFileMatchAtIndex(root2, 0).parent(), root2);
+		assert.deepStrictEqual(getFileMatchAtIndex(root2, 0).closestRoot, root2);
 
 
 		const root3DownstreamFiles = root3.downstreamFileMatches();
-		const root3Level3Folder = root3.folderMatchesArray()[0].folderMatchesArray()[0];
-		assert.deepStrictEqual(root3DownstreamFiles, [root3.fileMatchesArray(), ...root3Level3Folder.folderMatchesArray()[0].fileMatchesArray(), ...root3Level3Folder.folderMatchesArray()[1].fileMatchesArray()].flat());
-		assert.deepStrictEqual(root3Level3Folder.downstreamFileMatches(), root3.folderMatchesArray()[0].downstreamFileMatches());
+		const root3Level3Folder = getFolderMatchAtIndex(getFolderMatchAtIndex(root3, 0), 0);
+		assert.deepStrictEqual(root3DownstreamFiles, [...root3.fileMatchesIterator(), ...getFolderMatchAtIndex(root3Level3Folder, 0).fileMatchesIterator(), ...getFolderMatchAtIndex(root3Level3Folder, 1).fileMatchesIterator()].flat());
+		assert.deepStrictEqual(root3Level3Folder.downstreamFileMatches(), getFolderMatchAtIndex(root3, 0).downstreamFileMatches());
 
-		assert.deepStrictEqual(root3Level3Folder.folderMatchesArray()[1].fileMatchesArray()[0].parent(), root3Level3Folder.folderMatchesArray()[1]);
-		assert.deepStrictEqual(root3Level3Folder.folderMatchesArray()[1].parent(), root3Level3Folder);
-		assert.deepStrictEqual(root3Level3Folder.parent(), root3.folderMatchesArray()[0]);
+		assert.deepStrictEqual(getFileMatchAtIndex(getFolderMatchAtIndex(root3Level3Folder, 1), 0).parent(), getFolderMatchAtIndex(root3Level3Folder, 1));
+		assert.deepStrictEqual(getFolderMatchAtIndex(root3Level3Folder, 1).parent(), root3Level3Folder);
+		assert.deepStrictEqual(root3Level3Folder.parent(), getFolderMatchAtIndex(root3, 0));
 
 		root3DownstreamFiles.forEach((e) => {
 			assert.deepStrictEqual(e.closestRoot, root3);
 		});
 	});
 
+	function getFolderMatchAtIndex(parent: FolderMatch, index: number) {
+		return Array.from(parent.folderMatchesIterator())[index];
+	}
+
+	function getFileMatchAtIndex(parent: FolderMatch, index: number) {
+		return Array.from(parent.fileMatchesIterator())[index];
+	}
+
 	test('Removing an intermediate folder should call OnChange() on all downstream file matches', function () {
 		const target = sinon.spy();
 		const testObject = getPopulatedSearchResultForTreeTesting();
 
-		const folderMatch = testObject.folderMatches()[3].folderMatchesArray()[0].folderMatchesArray()[0].folderMatchesArray()[0];
+		const folderMatch = getFolderMatchAtIndex(getFolderMatchAtIndex(getFolderMatchAtIndex(testObject.folderMatches()[3], 0), 0), 0);
 
 		const expectedArrayResult = folderMatch.downstreamFileMatches();
 
@@ -456,7 +464,7 @@ suite('SearchResult', () => {
 		const target = sinon.spy();
 		const testObject = getPopulatedSearchResultForTreeTesting();
 
-		const folderMatch = testObject.folderMatches()[3].folderMatchesArray()[0];
+		const folderMatch = getFolderMatchAtIndex(testObject.folderMatches()[3], 0);
 
 		const expectedArrayResult = folderMatch.downstreamFileMatches();
 

--- a/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
@@ -438,14 +438,6 @@ suite('SearchResult', () => {
 		});
 	});
 
-	function getFolderMatchAtIndex(parent: FolderMatch, index: number) {
-		return Array.from(parent.folderMatchesIterator())[index];
-	}
-
-	function getFileMatchAtIndex(parent: FolderMatch, index: number) {
-		return Array.from(parent.fileMatchesIterator())[index];
-	}
-
 	test('Removing an intermediate folder should call OnChange() on all downstream file matches', function () {
 		const target = sinon.spy();
 		const testObject = getPopulatedSearchResultForTreeTesting();
@@ -607,5 +599,13 @@ suite('SearchResult', () => {
 				new TextSearchMatch('preview 6', lineOneRange), new TextSearchMatch('preview 7', lineOneRange))
 		]);
 		return testObject;
+	}
+
+	function getFolderMatchAtIndex(parent: FolderMatch, index: number) {
+		return Array.from(parent.folderMatchesIterator())[index];
+	}
+
+	function getFileMatchAtIndex(parent: FolderMatch, index: number) {
+		return Array.from(parent.fileMatchesIterator())[index];
 	}
 });

--- a/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
@@ -402,36 +402,36 @@ suite('SearchResult', () => {
 		const root3 = testObject.folderMatches()[3];
 
 		const root0DownstreamFiles = root0.downstreamFileMatches();
-		assert.deepStrictEqual(root0DownstreamFiles, root0.fileMatches().concat(root0.folderMatches()[0].fileMatches()));
-		assert.deepStrictEqual(root0.folderMatches()[0].downstreamFileMatches(), root0.folderMatches()[0].fileMatches());
-		assert.deepStrictEqual(root0.folderMatches()[0].fileMatches()[0].parent(), root0.folderMatches()[0]);
-		assert.deepStrictEqual(root0.folderMatches()[0].parent(), root0);
-		assert.deepStrictEqual(root0.folderMatches()[0].closestRoot, root0);
+		assert.deepStrictEqual(root0DownstreamFiles, root0.fileMatchesArray().concat(root0.folderMatchesArray()[0].fileMatchesArray()));
+		assert.deepStrictEqual(root0.folderMatchesArray()[0].downstreamFileMatches(), root0.folderMatchesArray()[0].fileMatchesArray());
+		assert.deepStrictEqual(root0.folderMatchesArray()[0].fileMatchesArray()[0].parent(), root0.folderMatchesArray()[0]);
+		assert.deepStrictEqual(root0.folderMatchesArray()[0].parent(), root0);
+		assert.deepStrictEqual(root0.folderMatchesArray()[0].closestRoot, root0);
 		root0DownstreamFiles.forEach((e) => {
 			assert.deepStrictEqual(e.closestRoot, root0);
 		});
 
 		const root1DownstreamFiles = root1.downstreamFileMatches();
-		assert.deepStrictEqual(root1.downstreamFileMatches(), root1.fileMatches().concat(root1.folderMatches()[0].fileMatches())); // excludes the matches from nested root
-		assert.deepStrictEqual(root1.folderMatches()[0].fileMatches()[0].parent(), root1.folderMatches()[0]);
+		assert.deepStrictEqual(root1.downstreamFileMatches(), root1.fileMatchesArray().concat(root1.folderMatchesArray()[0].fileMatchesArray())); // excludes the matches from nested root
+		assert.deepStrictEqual(root1.folderMatchesArray()[0].fileMatchesArray()[0].parent(), root1.folderMatchesArray()[0]);
 		root1DownstreamFiles.forEach((e) => {
 			assert.deepStrictEqual(e.closestRoot, root1);
 		});
 
 		const root2DownstreamFiles = root2.downstreamFileMatches();
-		assert.deepStrictEqual(root2DownstreamFiles, root2.fileMatches());
-		assert.deepStrictEqual(root2.fileMatches()[0].parent(), root2);
-		assert.deepStrictEqual(root2.fileMatches()[0].closestRoot, root2);
+		assert.deepStrictEqual(root2DownstreamFiles, root2.fileMatchesArray());
+		assert.deepStrictEqual(root2.fileMatchesArray()[0].parent(), root2);
+		assert.deepStrictEqual(root2.fileMatchesArray()[0].closestRoot, root2);
 
 
 		const root3DownstreamFiles = root3.downstreamFileMatches();
-		const root3Level3Folder = root3.folderMatches()[0].folderMatches()[0];
-		assert.deepStrictEqual(root3DownstreamFiles, [root3.fileMatches(), ...root3Level3Folder.folderMatches()[0].fileMatches(), ...root3Level3Folder.folderMatches()[1].fileMatches()].flat());
-		assert.deepStrictEqual(root3Level3Folder.downstreamFileMatches(), root3.folderMatches()[0].downstreamFileMatches());
+		const root3Level3Folder = root3.folderMatchesArray()[0].folderMatchesArray()[0];
+		assert.deepStrictEqual(root3DownstreamFiles, [root3.fileMatchesArray(), ...root3Level3Folder.folderMatchesArray()[0].fileMatchesArray(), ...root3Level3Folder.folderMatchesArray()[1].fileMatchesArray()].flat());
+		assert.deepStrictEqual(root3Level3Folder.downstreamFileMatches(), root3.folderMatchesArray()[0].downstreamFileMatches());
 
-		assert.deepStrictEqual(root3Level3Folder.folderMatches()[1].fileMatches()[0].parent(), root3Level3Folder.folderMatches()[1]);
-		assert.deepStrictEqual(root3Level3Folder.folderMatches()[1].parent(), root3Level3Folder);
-		assert.deepStrictEqual(root3Level3Folder.parent(), root3.folderMatches()[0]);
+		assert.deepStrictEqual(root3Level3Folder.folderMatchesArray()[1].fileMatchesArray()[0].parent(), root3Level3Folder.folderMatchesArray()[1]);
+		assert.deepStrictEqual(root3Level3Folder.folderMatchesArray()[1].parent(), root3Level3Folder);
+		assert.deepStrictEqual(root3Level3Folder.parent(), root3.folderMatchesArray()[0]);
 
 		root3DownstreamFiles.forEach((e) => {
 			assert.deepStrictEqual(e.closestRoot, root3);
@@ -442,7 +442,7 @@ suite('SearchResult', () => {
 		const target = sinon.spy();
 		const testObject = getPopulatedSearchResultForTreeTesting();
 
-		const folderMatch = testObject.folderMatches()[3].folderMatches()[0].folderMatches()[0].folderMatches()[0];
+		const folderMatch = testObject.folderMatches()[3].folderMatchesArray()[0].folderMatchesArray()[0].folderMatchesArray()[0];
 
 		const expectedArrayResult = folderMatch.downstreamFileMatches();
 
@@ -456,7 +456,7 @@ suite('SearchResult', () => {
 		const target = sinon.spy();
 		const testObject = getPopulatedSearchResultForTreeTesting();
 
-		const folderMatch = testObject.folderMatches()[3].folderMatches()[0];
+		const folderMatch = testObject.folderMatches()[3].folderMatchesArray()[0];
 
 		const expectedArrayResult = folderMatch.downstreamFileMatches();
 


### PR DESCRIPTION
Fixes #162246

Changing the calls to `folderMatches()` and `fileMatches()` to return an iterator to reduce performance overhead of search tree changes.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
