### PR TITLE
Make sure we always reset the code action widget context when the widget is hidden

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionWidget.ts
@@ -419,7 +419,6 @@ export class CodeActionWidget extends Disposable {
 	}
 
 	public hide() {
-		this._ctxMenuWidgetVisible.reset();
 		this.codeActionList.clear();
 		this._contextViewService.hideContextView();
 	}
@@ -530,6 +529,7 @@ export class CodeActionWidget extends Disposable {
 		});
 
 		this.currentShowingContext = undefined;
+		this._ctxMenuWidgetVisible.reset();
 		delegate.onHide(cancelled);
 	}
 


### PR DESCRIPTION
We've seen a handful of reports of keybindings not working. I'm not able to repo this, but the root cause may be that code action widget's context keys are not being cleared properly

This fixes it to make sure we always reset the context when the widget is closed

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
