### PR TITLE
testing: add support for jumping to test messages in terminal output

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingOutputTerminalService.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputTerminalService.ts
@@ -17,15 +17,17 @@ import { TERMINAL_VIEW_ID } from 'vs/workbench/contrib/terminal/common/terminal'
 import { testingViewIcon } from 'vs/workbench/contrib/testing/browser/icons';
 import { ITestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
+import { getMarkId } from 'vs/workbench/contrib/testing/common/testTypes';
 
 
 export interface ITestingOutputTerminalService {
 	_serviceBrand: undefined;
 
 	/**
-	 * Opens a terminal for the given test's output.
+	 * Opens a terminal for the given test's output. Optionally, scrolls to and
+	 * selects the given marker in the test results.
 	 */
-	open(result: ITestResult): Promise<void>;
+	open(result: ITestResult, marker?: number): Promise<void>;
 }
 
 const friendlyDate = (date: number) => {
@@ -78,7 +80,7 @@ export class TestingOutputTerminalService implements ITestingOutputTerminalServi
 	/**
 	 * @inheritdoc
 	 */
-	public async open(result: ITestResult | undefined): Promise<void> {
+	public async open(result: ITestResult | undefined, marker?: number): Promise<void> {
 		const testOutputPtys = this.terminalService.instances
 			.map(t => {
 				const output = this.outputTerminals.get(t);
@@ -95,6 +97,8 @@ export class TestingOutputTerminalService implements ITestingOutputTerminalServi
 			} else {
 				this.terminalGroupService.showPanel();
 			}
+
+			this.revealMarker(existing[0], marker);
 			return;
 		}
 
@@ -114,10 +118,10 @@ export class TestingOutputTerminalService implements ITestingOutputTerminalServi
 				customPtyImplementation: () => output,
 				name: getTitle(result),
 			},
-		}), output, result);
+		}), output, result, marker);
 	}
 
-	private async showResultsInTerminal(terminal: ITerminalInstance, output: TestOutputProcess, result: ITestResult | undefined) {
+	private async showResultsInTerminal(terminal: ITerminalInstance, output: TestOutputProcess, result: ITestResult | undefined, thenSelectMarker?: number) {
 		this.outputTerminals.set(terminal, output);
 		output.resetFor(result?.id, getTitle(result));
 		this.terminalService.setActiveInstance(terminal);
@@ -151,8 +155,15 @@ export class TestingOutputTerminalService implements ITestingOutputTerminalServi
 				const text = localize('runFinished', 'Test run finished at {0}', completedAt.toLocaleString());
 				output.pushData(`\r\n\r\n\x1b[1m> ${text} <\x1b[0m\r\n\r\n`);
 				output.ended = true;
+				this.revealMarker(terminal, thenSelectMarker);
 			},
 		});
+	}
+
+	private revealMarker(terminal: ITerminalInstance, marker?: number) {
+		if (marker !== undefined) {
+			terminal.scrollToMark(getMarkId(marker, true), getMarkId(marker, false), true);
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -163,8 +163,15 @@ export interface ITestOutputMessage {
 	type: TestMessageType.Output;
 	offset: number;
 	length: number;
+	marker?: number;
 	location: IRichLocation | undefined;
 }
+
+/**
+ * Gets the TTY marker ID for either starting or ending
+ * an ITestOutputMessage.marker of the given ID.
+ */
+export const getMarkId = (marker: number, start: boolean) => `${start ? 's' : 'e'}${marker}`;
 
 export namespace ITestOutputMessage {
 	export interface Serialized {


### PR DESCRIPTION
Written in order to test https://github.com/microsoft/vscode/issues/157026. Adds a "go to output" button on individual test messages that allows jumping to them in the terminal. I will probably also add this for tests themselves (to jump to the first logged message, if any)

I will not merge this until after endgame.