### PR TITLE
Accept merge with conflicts dialog (fix #162296)

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/commands/commands.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from 'vs/base/common/codicons';
+import { basename } from 'vs/base/common/resources';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { ILocalizedString } from 'vs/platform/action/common/action';
@@ -632,8 +633,9 @@ export class AcceptMerge extends MergeEditorAction2 {
 		if (viewModel.model.unhandledConflictsCount.get() > 0) {
 			const confirmResult = await dialogService.confirm({
 				type: 'info',
-				message: localize('mergeEditor.acceptMerge.unhandledConflicts', "There are still unhandled conflicts. Are you sure you want to accept the merge?"),
-				primaryButton: localize('mergeEditor.acceptMerge.unhandledConflicts.accept', "Complete merge with unhandled conflicts"),
+				message: localize('mergeEditor.acceptMerge.unhandledConflicts.message', "Do you want to complete the merge of {0}?", basename(inputModel.resultUri)),
+				detail: localize('mergeEditor.acceptMerge.unhandledConflicts.detail', "The file contains unhandled conflicts."),
+				primaryButton: localize('mergeEditor.acceptMerge.unhandledConflicts.accept', "Complete with Conflicts"),
 				secondaryButton: localize('mergeEditor.acceptMerge.unhandledConflicts.cancel', "Cancel"),
 			});
 


### PR DESCRIPTION
@hediet trying to align all of the dialogs we have:

<img width="309" alt="Screenshot 2022-09-30 at 07 59 34" src="https://user-images.githubusercontent.com/900690/193203051-5f7f9d7f-9525-4a21-9a93-4e35fc3f7c63.png">

<img width="332" alt="Screenshot 2022-09-30 at 07 59 27" src="https://user-images.githubusercontent.com/900690/193203070-3c02817f-3368-4855-b2d1-7384a1323074.png">

And with my changes now:

<img width="290" alt="image" src="https://user-images.githubusercontent.com/900690/193203103-8fe93ee0-66ec-4f9f-bdab-91ca32bad5dc.png">


