### PR TITLE
IntelliSense in JSON keyboard shortcut editor doesn't work for non-default profiles

### DIFF
--- a/extensions/configuration-editing/package.json
+++ b/extensions/configuration-editing/package.json
@@ -72,6 +72,10 @@
         "url": "vscode://schemas/keybindings"
       },
       {
+        "fileMatch": "%APP_SETTINGS_HOME%/profiles/*/keybindings.json",
+        "url": "vscode://schemas/keybindings"
+      },
+      {
         "fileMatch": "vscode://defaultsettings/*.json",
         "url": "vscode://schemas/settings/default"
       },
@@ -117,6 +121,10 @@
       },
       {
         "fileMatch": "%APP_SETTINGS_HOME%/snippets/*.json",
+        "url": "vscode://schemas/snippets"
+      },
+      {
+        "fileMatch": "%APP_SETTINGS_HOME%/profiles/*/snippets/.json",
         "url": "vscode://schemas/snippets"
       },
       {


### PR DESCRIPTION
Fixes #162332