### PR TITLE
# Provide correct response to applyEdit()

### DIFF
--- a/src/vs/editor/browser/services/bulkEditService.ts
+++ b/src/vs/editor/browser/services/bulkEditService.ts
@@ -108,6 +108,7 @@ export interface IBulkEditOptions {
 
 export interface IBulkEditResult {
 	ariaSummary: string;
+	isApplied: boolean;
 }
 
 export type IBulkEditPreviewHandler = (edits: ResourceEdit[], options?: IBulkEditOptions) => Promise<ResourceEdit[]>;

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -817,7 +817,8 @@ class StandaloneBulkEditService implements IBulkEditService {
 		}
 
 		return {
-			ariaSummary: strings.format(StandaloneServicesNLS.bulkEditServiceSummary, totalEdits, totalFiles)
+			ariaSummary: strings.format(StandaloneServicesNLS.bulkEditServiceSummary, totalEdits, totalFiles),
+			isApplied: totalEdits > 0
 		};
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadBulkEdits.ts
+++ b/src/vs/workbench/api/browser/mainThreadBulkEdits.ts
@@ -27,7 +27,7 @@ export class MainThreadBulkEdits implements MainThreadBulkEditsShape {
 
 	$tryApplyWorkspaceEdit(dto: IWorkspaceEditDto, undoRedoGroupId?: number, isRefactoring?: boolean): Promise<boolean> {
 		const edits = reviveWorkspaceEditDto(dto, this._uriIdentService);
-		return this._bulkEditService.apply(edits, { undoRedoGroupId, respectAutoSaveConfig: isRefactoring }).then(() => true, err => {
+		return this._bulkEditService.apply(edits, { undoRedoGroupId, respectAutoSaveConfig: isRefactoring }).then((res) => res.isApplied, err => {
 			this._logService.warn(`IGNORING workspace edit: ${err}`);
 			return false;
 		});

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
@@ -88,6 +88,10 @@ class BulkEdit {
 		}
 	}
 
+	isApplied(): boolean {
+		return this._edits.length > 0;
+	}
+
 	async perform(): Promise<readonly URI[]> {
 
 		if (this._edits.length === 0) {
@@ -184,7 +188,7 @@ export class BulkEditService implements IBulkEditService {
 		let edits = liftEdits(Array.isArray(editsIn) ? editsIn : editsIn.edits);
 
 		if (edits.length === 0) {
-			return { ariaSummary: localize('nothing', "Made no edits") };
+			return { ariaSummary: localize('nothing', "Made no edits"), isApplied: false };
 		}
 
 		if (this._previewHandler && (options?.showPreview || edits.some(value => value.metadata?.needsConfirmation))) {
@@ -248,7 +252,7 @@ export class BulkEditService implements IBulkEditService {
 				await this._saveAll(resources);
 			}
 
-			return { ariaSummary: bulkEdit.ariaMessage() };
+			return { ariaSummary: bulkEdit.ariaMessage(), isApplied: bulkEdit.isApplied() };
 		} catch (err) {
 			// console.log('apply FAILED');
 			// console.log(err);

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
@@ -88,10 +88,6 @@ class BulkEdit {
 		}
 	}
 
-	isApplied(): boolean {
-		return this._edits.length > 0;
-	}
-
 	async perform(): Promise<readonly URI[]> {
 
 		if (this._edits.length === 0) {
@@ -252,7 +248,7 @@ export class BulkEditService implements IBulkEditService {
 				await this._saveAll(resources);
 			}
 
-			return { ariaSummary: bulkEdit.ariaMessage(), isApplied: bulkEdit.isApplied() };
+			return { ariaSummary: bulkEdit.ariaMessage(), isApplied: edits.length > 0 };
 		} catch (err) {
 			// console.log('apply FAILED');
 			// console.log(err);


### PR DESCRIPTION
At the moment `vscode.workspace.applyEdit()` returns always `true`, regardless whether the WorkspaceEdit was applied/discarded.

To provide a better feedback to the extensions relying on this signal, add a boolean property `isApplied` which would be `true` if at least one ResourceEdit has been applied. If none has been applied, no edit has been provided or discard has been pressed then `false` would be returned back.

This change should not impact existing functionality as only `src/vs/workbench/contrib/notebook/browser/diff/notebookDiffActions.ts` return back the result from `bulkEditService.applyEdit()` directly to callers of `notebook.diff.cell.revertInput` so the calling extensions (as its not called in VScode) should be able to continue functioning without any problems (as they would either rely on the result being undefined, or extracting the `ariaSummary`).

fixes https://github.com/microsoft/vscode/issues/161133