### PR TITLE
Fix race when loading notebook webviews

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1517,7 +1517,7 @@ var requirejs = (function() {
 		});
 	}
 
-	private async _sendMessageToWebview(message: ToWebviewMessage) {
+	private _sendMessageToWebview(message: ToWebviewMessage) {
 		if (this._disposed) {
 			return;
 		}

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -116,9 +116,8 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Disposable {
 
 	private _initialized?: DeferredPromise<void>;
 	private _webviewPreloadInitialized?: DeferredPromise<void>;
-	private _pendingMessageQueue: ToWebviewMessage[] | undefined = [];
 	private firstInit = true;
-	private initializeMarkupPromise?: { readonly requestId: string; readonly p: DeferredPromise<void>; isFirstInit: boolean };
+	private initializeMarkupPromise?: { readonly requestId: string; readonly p: DeferredPromise<void>; readonly isFirstInit: boolean };
 
 	private readonly nonce = UUID.generateUuid();
 
@@ -507,11 +506,6 @@ var requirejs = (function() {
 		}
 
 		await this._initialized.p;
-
-		for (const msg of this._pendingMessageQueue ?? []) {
-			this.webview?.postMessage(msg);
-		}
-		this._pendingMessageQueue = undefined;
 	}
 
 	private getNotebookBaseUri() {
@@ -1528,11 +1522,7 @@ var requirejs = (function() {
 			return;
 		}
 
-		if (this._pendingMessageQueue) {
-			this._pendingMessageQueue.push(message);
-		} else {
-			this.webview?.postMessage(message);
-		}
+		this.webview?.postMessage(message);
 	}
 
 	override dispose() {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -138,6 +138,7 @@ export interface ICellDragEndMessage extends BaseToWebviewMessage {
 
 export interface IInitializedMarkupMessage extends BaseToWebviewMessage {
 	readonly type: 'initializedMarkup';
+	readonly requestId: string;
 }
 
 export interface ICodeBlockHighlightRequest {
@@ -351,6 +352,7 @@ export interface IMarkupCellInitialization {
 export interface IInitializeMarkupCells {
 	readonly type: 'initializeMarkup';
 	readonly cells: readonly IMarkupCellInitialization[];
+	readonly requestId: string;
 }
 
 export interface INotebookStylesMessage {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1048,7 +1048,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 					await Promise.all(event.data.cells.map(info => viewModel.ensureMarkupCell(info)));
 				} finally {
 					dimensionUpdater.updateImmediately();
-					postNotebookMessage('initializedMarkup', {});
+					postNotebookMessage('initializedMarkup', { requestId: event.data.requestId });
 				}
 				break;
 			}


### PR DESCRIPTION
This tries to fix #161520 by doing the following:

- Wait for basic initialization to finish before posting messages
- `initializedMarkup` should wait  for the correct response instead of the first response

This fixes the issue in my testing, but causes the layout to shift around during load. @rebornix  let's try to debug this next week 
