### PR TITLE
cli: point docs to the new RA extension ns

### DIFF
--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Setup
 
 0. Clone, and then run `git submodule update --init --recursive`
-1. Get the extensions: [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer) and [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)
+1. Get the extensions: [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) and [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)
 2. Ensure your workspace is set to the `launcher` folder being the root.
 
 ## Building the CLI on Windows


### PR DESCRIPTION
This is mostly cosmetic, but there was a lot of confusion between RLS/RA and we should probably point to the new extension "home" here.