### PR TITLE
build: use swiftshader on macOS CI

### DIFF
--- a/test/automation/src/electron.ts
+++ b/test/automation/src/electron.ts
@@ -49,6 +49,15 @@ export async function resolveElectronConfiguration(options: LaunchOptions): Prom
 		args.push('--disable-dev-shm-usage');
 	}
 
+	if (process.platform === 'darwin') {
+		// On macOS force software based rendering since we are seeing GPU process
+		// hangs when initializing GL context. This is very likely possible
+		// that there are new displays available in the CI hardware and
+		// the relevant drivers couldn't be loaded via the GPU sandbox.
+		// TODO(deepak1556): remove this switch with Electron update.
+		args.push('--use-gl=swiftshader');
+	}
+
 	if (remote) {
 		// Replace workspace path with URI
 		args[0] = `--${workspacePath.endsWith('.code-workspace') ? 'file' : 'folder'}-uri=vscode-remote://test+test/${URI.file(workspacePath).path}`;


### PR DESCRIPTION
Addressing recent hangs seen in CI https://dev.azure.com/monacotools/Monaco/_build/results?buildId=187271&view=results

```
OpenGL!CGLChoosePixelFormat + 0xd97
OpenGL!CGLChoosePixelFormat + 0x55
libGLESv2.dylib!rx::DisplayCGL::initialize(egl::Display*) [FunctionsCGL.h : 22 + 0xc]
libGLESv2.dylib!egl::Display::initialize() [Display.cpp : 973 + 0xc]
libGLESv2.dylib!egl::Initialize(egl::Thread*, egl::Display*, int*, int*) [egl_stubs.cpp : 448 + 0x16]
libGLESv2.dylib!EGL_Initialize [entry_points_egl_autogen.cpp : 330 + 0x13]
Electron Framework!gl::GLSurfaceEGL::InitializeDisplay(gl::EGLDisplayPlatform, unsigned long long) [gl_surface_egl.cc : 1486 + 0x17]
Electron Framework!gl::GLSurfaceEGL::InitializeOneOff(gl::EGLDisplayPlatform, unsigned long long) [gl_surface_egl.cc : 1030 + 0xf]
Electron Framework!gl::init::InitializeGLOneOffPlatform(unsigned long long) [gl_initializer_mac.cc : 186 + 0xf]
Electron Framework!gl::init::InitializeGLOneOffPlatformImplementation(bool, bool, bool, unsigned long long) [gl_factory.cc : 216 + 0x8]
Electron Framework!gl::init::(anonymous namespace)::InitializeGLOneOffPlatformHelper(bool, unsigned long long) [gl_factory.cc : 143 + 0x13]
Electron Framework!gl::init::InitializeGLNoExtensionsOneOff(bool, unsigned long long) [gl_factory.cc : 172 + 0xa]
Electron Framework!gpu::GpuInit::InitializeAndStartSandbox(base::CommandLine*, gpu::GpuPreferences const&) [gpu_init.cc : 439 + 0xb]
Electron Framework!content::GpuMain(content::MainFunctionParams) [gpu_main.cc : 329 + 0xb]
```
