### PR TITLE
Enforce yarn version

### DIFF
--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -30,13 +30,11 @@ if (
 	majorYarnVersion < 1 ||
 	majorYarnVersion === 1 && (
 		minorYarnVersion < 10 || (minorYarnVersion === 10 && patchYarnVersion < 1)
-	)
+	) ||
+	majorYarnVersion >= 2
 ) {
 	console.error('\033[1;31m*** Please use yarn >=1.10.1 and <2.\033[0;0m');
 	err = true;
-}
-if (majorYarnVersion >= 2) {
-	console.warn('\033[1;31m*** Warning: Versions of yarn >= 2 have not been tested.\033[0;0m')
 }
 
 if (!/yarn[\w-.]*\.c?js$|yarnpkg$/.test(process.env['npm_execpath'])) {

--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -21,13 +21,22 @@ const path = require('path');
 const fs = require('fs');
 const cp = require('child_process');
 const yarnVersion = cp.execSync('yarn -v', { encoding: 'utf8' }).trim();
-const parsedYarnVersion = /^(\d+)\.(\d+)\./.exec(yarnVersion);
+const parsedYarnVersion = /^(\d+)\.(\d+)\.(\d+)/.exec(yarnVersion);
 const majorYarnVersion = parseInt(parsedYarnVersion[1]);
 const minorYarnVersion = parseInt(parsedYarnVersion[2]);
+const patchYarnVersion = parseInt(parsedYarnVersion[3]);
 
-if (majorYarnVersion < 1 || minorYarnVersion < 10) {
-	console.error('\033[1;31m*** Please use yarn >=1.10.1.\033[0;0m');
+if (
+	majorYarnVersion < 1 ||
+	majorYarnVersion === 1 && (
+		minorYarnVersion < 10 || (minorYarnVersion === 10 && patchYarnVersion < 1)
+	)
+) {
+	console.error('\033[1;31m*** Please use yarn >=1.10.1 and <2.\033[0;0m');
 	err = true;
+}
+if (majorYarnVersion >= 2) {
+	console.warn('\033[1;31m*** Warning: Versions of yarn >= 2 have not been tested.\033[0;0m')
 }
 
 if (!/yarn[\w-.]*\.c?js$|yarnpkg$/.test(process.env['npm_execpath'])) {


### PR DESCRIPTION
Closes #162609.

Actually requires >=1.10.1 and <2, but was only enforcing >= 1 **or** >= x.10. Granted, there is no yarn v3.10 yet, but there may be someday. And if it actually requires >=1.10.1 (and not just >=1.10.0) as the error states, it should enforce that as well.

I initially mimicked the [node.js version checking code](https://github.com/microsoft/vscode/blob/2a07191/build/npm/preinstall.js#L12-L18), which only gives a warning if node.js >= 17, but now I'm not sure that makes sense, as yarn >= 2 will always fail without changes to support it. For example, [build/lib/dependencies.ts](https://github.com/microsoft/vscode/blob/2a07191/build/lib/dependencies.ts#L58-L59) relies on `yarn list`, which is not in yarn >=2, it would need to detect this and support the usage of [`yarn info` as a substitute](https://github.com/yarnpkg/berry/pull/4931). (I'm sure there are many more changes that would be needed, that's just an example, I didn't dig too deep)

I pushed a 2nd commit to instead error on yarn >= 2.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
