### PR TITLE
testing: fix breakage if item has same ID as test controller

### DIFF
--- a/src/vs/workbench/api/common/extHostTestItem.ts
+++ b/src/vs/workbench/api/common/extHostTestItem.ts
@@ -175,6 +175,8 @@ export class TestItemImpl implements vscode.TestItem {
 }
 
 export class TestItemRootImpl extends TestItemImpl {
+	public readonly _isRoot = true;
+
 	constructor(controllerId: string, label: string) {
 		super(controllerId, controllerId, label, undefined);
 	}

--- a/src/vs/workbench/api/test/browser/extHostTesting.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTesting.test.ts
@@ -141,6 +141,19 @@ suite('ExtHost Testing', () => {
 			assert.strictEqual(ab.parent, a);
 		});
 
+		test('can add an item with same ID as root', () => {
+			single.collectDiff();
+
+			const child = new TestItemImpl('ctrlId', 'ctrlId', 'c', undefined);
+			single.root.children.add(child);
+			assert.deepStrictEqual(single.collectDiff(), [
+				{
+					op: TestDiffOpType.Add,
+					item: { controllerId: 'ctrlId', parent: new TestId(['ctrlId']).toString(), expand: TestItemExpandState.NotExpandable, item: convert.TestItem.from(child) },
+				}
+			]);
+		});
+
 		test('no-ops if items not changed', () => {
 			single.collectDiff();
 			assert.deepStrictEqual(single.collectDiff(), []);

--- a/src/vs/workbench/contrib/testing/common/testId.ts
+++ b/src/vs/workbench/contrib/testing/common/testId.ts
@@ -23,7 +23,7 @@ export const enum TestPosition {
 	IsParent,
 }
 
-type TestItemLike = { id: string; parent?: TestItemLike };
+type TestItemLike = { id: string; parent?: TestItemLike; _isRoot?: boolean };
 
 /**
  * The test ID is a stringifiable client that
@@ -35,7 +35,7 @@ export class TestId {
 	 * Creates a test ID from an ext host test item.
 	 */
 	public static fromExtHostTestItem(item: TestItemLike, rootId: string, parent = item.parent) {
-		if (item.id === rootId) {
+		if (item._isRoot) {
 			return new TestId([rootId]);
 		}
 
@@ -56,7 +56,7 @@ export class TestId {
 	}
 
 	/**
-	 * Cheaply ets whether the ID refers to the root .
+	 * Cheaply gets whether the ID refers to the root .
 	 */
 	public static root(idString: string) {
 		const idx = idString.indexOf(TestIdPathParts.Delimiter);

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -333,7 +333,7 @@ export const enum TestItemExpandState {
 }
 
 /**
- * TestItem-like shape, butm with an ID and children as strings.
+ * TestItem-like shape, but with an ID and children as strings.
  */
 export interface InternalTestItem {
 	/** Controller ID from whence this test came */


### PR DESCRIPTION
Fixes #160671

The equality check in `testId.ts` caused the ID to be malformed if it matched the root ID. Instead, use a special marker for the root item (which is only set on the internal "hidden" root item).