### PR TITLE
testing: remove redundant parent in InternalTestItem

### DIFF
--- a/src/vs/workbench/api/common/extHostTesting.ts
+++ b/src/vs/workbench/api/common/extHostTesting.ts
@@ -751,7 +751,8 @@ class MirroredChangeCollector extends IncrementalChangeCollector<MirroredCollect
 
 		this.updated.delete(node);
 
-		if (node.parent && this.alreadyRemoved.has(node.parent)) {
+		const parentId = TestId.parentId(node.item.extId);
+		if (parentId && this.alreadyRemoved.has(parentId.toString())) {
 			this.alreadyRemoved.add(node.item.extId);
 			return;
 		}

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1846,7 +1846,8 @@ export namespace TestResults {
 		const byInternalId = new Map<string, TestResultItem.Serialized>();
 		for (const item of serialized.items) {
 			byInternalId.set(item.item.extId, item);
-			if (serialized.request.targets.some(t => t.controllerId === item.controllerId && t.testIds.includes(item.item.extId))) {
+			const controllerId = TestId.root(item.item.extId);
+			if (serialized.request.targets.some(t => t.controllerId === controllerId && t.testIds.includes(item.item.extId))) {
 				roots.push(item);
 			}
 		}

--- a/src/vs/workbench/api/test/browser/extHostTesting.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTesting.test.ts
@@ -102,19 +102,19 @@ suite('ExtHost Testing', () => {
 			assert.deepStrictEqual(single.collectDiff(), [
 				{
 					op: TestDiffOpType.Add,
-					item: { controllerId: 'ctrlId', parent: null, expand: TestItemExpandState.BusyExpanding, item: { ...convert.TestItem.from(single.root) } }
+					item: { controllerId: 'ctrlId', expand: TestItemExpandState.BusyExpanding, item: { ...convert.TestItem.from(single.root) } }
 				},
 				{
 					op: TestDiffOpType.Add,
-					item: { controllerId: 'ctrlId', parent: single.root.id, expand: TestItemExpandState.BusyExpanding, item: { ...convert.TestItem.from(a) } }
+					item: { controllerId: 'ctrlId', expand: TestItemExpandState.BusyExpanding, item: { ...convert.TestItem.from(a) } }
 				},
 				{
 					op: TestDiffOpType.Add,
-					item: { controllerId: 'ctrlId', parent: new TestId(['ctrlId', 'id-a']).toString(), expand: TestItemExpandState.NotExpandable, item: convert.TestItem.from(a.children.get('id-aa') as TestItemImpl) }
+					item: { controllerId: 'ctrlId', expand: TestItemExpandState.NotExpandable, item: convert.TestItem.from(a.children.get('id-aa') as TestItemImpl) }
 				},
 				{
 					op: TestDiffOpType.Add,
-					item: { controllerId: 'ctrlId', parent: new TestId(['ctrlId', 'id-a']).toString(), expand: TestItemExpandState.NotExpandable, item: convert.TestItem.from(a.children.get('id-ab') as TestItemImpl) }
+					item: { controllerId: 'ctrlId', expand: TestItemExpandState.NotExpandable, item: convert.TestItem.from(a.children.get('id-ab') as TestItemImpl) }
 				},
 				{
 					op: TestDiffOpType.Update,
@@ -122,7 +122,7 @@ suite('ExtHost Testing', () => {
 				},
 				{
 					op: TestDiffOpType.Add,
-					item: { controllerId: 'ctrlId', parent: single.root.id, expand: TestItemExpandState.NotExpandable, item: convert.TestItem.from(b) }
+					item: { controllerId: 'ctrlId', expand: TestItemExpandState.NotExpandable, item: convert.TestItem.from(b) }
 				},
 				{
 					op: TestDiffOpType.Update,
@@ -184,7 +184,6 @@ suite('ExtHost Testing', () => {
 				{
 					op: TestDiffOpType.Add, item: {
 						controllerId: 'ctrlId',
-						parent: new TestId(['ctrlId', 'id-a']).toString(),
 						expand: TestItemExpandState.NotExpandable,
 						item: convert.TestItem.from(child),
 					}
@@ -213,7 +212,6 @@ suite('ExtHost Testing', () => {
 				{
 					op: TestDiffOpType.Add, item: {
 						controllerId: 'ctrlId',
-						parent: new TestId(['ctrlId', 'id-a']).toString(),
 						expand: TestItemExpandState.NotExpandable,
 						item: convert.TestItem.from(child),
 					}
@@ -326,7 +324,7 @@ suite('ExtHost Testing', () => {
 				},
 				{
 					op: TestDiffOpType.Add,
-					item: { controllerId: 'ctrlId', parent: new TestId(['ctrlId', 'id-a']).toString(), expand: TestItemExpandState.NotExpandable, item: convert.TestItem.from(b) }
+					item: { controllerId: 'ctrlId', expand: TestItemExpandState.NotExpandable, item: convert.TestItem.from(b) }
 				},
 			]);
 

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByLocation.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByLocation.ts
@@ -18,6 +18,7 @@ import { InternalTestItem, TestDiffOpType, TestItemExpandState, TestResultState,
 import { TestResultItemChangeReason } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
 import { ITestService } from 'vs/workbench/contrib/testing/common/testService';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 
 const computedStateAccessor: IComputedStateAndDurationAccessor<IActionableTestTreeElement> = {
 	getOwnState: i => i instanceof TestItemTreeElement ? i.ownState : TestResultState.Unset,
@@ -212,7 +213,8 @@ export class HierarchicalByLocationProjection extends Disposable implements ITes
 	}
 
 	protected createItem(item: InternalTestItem): ByLocationTestItemElement {
-		const parent = item.parent ? this.items.get(item.parent)! : null;
+		const parentId = TestId.parentId(item.item.extId);
+		const parent = parentId ? this.items.get(parentId)! : null;
 		return new ByLocationTestItemElement(item, parent, n => this.changes.addedOrRemoved(n));
 	}
 

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByName.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByName.ts
@@ -12,6 +12,7 @@ import { NodeRenderDirective } from 'vs/workbench/contrib/testing/browser/explor
 import { InternalTestItem } from 'vs/workbench/contrib/testing/common/testTypes';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
 import { ITestService } from 'vs/workbench/contrib/testing/common/testService';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 
 /**
  * Type of test element in the list.
@@ -97,7 +98,8 @@ export class HierarchicalByNameProjection extends HierarchicalByLocationProjecti
 	 * @override
 	 */
 	protected override createItem(item: InternalTestItem): ByLocationTestItemElement {
-		const actualParent = item.parent ? this.items.get(item.parent) as ByNameTestItemElement : undefined;
+		const parentId = TestId.parentId(item.item.extId);
+		const actualParent = parentId ? this.items.get(parentId.toString()) as ByNameTestItemElement : undefined;
 		if (!actualParent) {
 			return new ByNameTestItemElement(item, null, r => this.changes.addedOrRemoved(r));
 		}

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -49,6 +49,7 @@ import { LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
 import { getContextForTestItem, ITestService, testsInFile } from 'vs/workbench/contrib/testing/common/testService';
 import { stripIcons } from 'vs/base/common/iconLabels';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 
 const MAX_INLINE_MESSAGE_LENGTH = 128;
 
@@ -840,7 +841,7 @@ class MultiRunTestDecoration extends RunTestDecoration implements ITestDecoratio
 		const testItems = this.tests.map(testItem => ({
 			currentLabel: testItem.test.item.label,
 			testItem,
-			parent: testItem.test.parent,
+			parent: TestId.fromString(testItem.test.item.extId).parentId,
 		}));
 
 		const getLabelConflicts = (tests: typeof testItems) => {
@@ -856,9 +857,9 @@ class MultiRunTestDecoration extends RunTestDecoration implements ITestDecoratio
 		while ((conflicts = getLabelConflicts(testItems)).length && hasParent) {
 			for (const conflict of conflicts) {
 				if (conflict.parent) {
-					const parent = this.testService.collection.getNodeById(conflict.parent);
+					const parent = this.testService.collection.getNodeById(conflict.parent.toString());
 					conflict.currentLabel = parent?.item.label + ' > ' + conflict.currentLabel;
-					conflict.parent = parent?.parent ? parent.parent : null;
+					conflict.parent = conflict.parent.parentId;
 				} else {
 					hasParent = false;
 				}

--- a/src/vs/workbench/contrib/testing/common/mainThreadTestCollection.ts
+++ b/src/vs/workbench/contrib/testing/common/mainThreadTestCollection.ts
@@ -89,11 +89,11 @@ export class MainThreadTestCollection extends AbstractIncrementalTestCollection<
 			for (const child of queue.pop()!) {
 				const item = this.items.get(child)!;
 				ops.push({
-					op: TestDiffOpType.Add, item: {
+					op: TestDiffOpType.Add,
+					item: {
 						controllerId: item.controllerId,
 						expand: item.expand,
 						item: item.item,
-						parent: item.parent,
 					}
 				});
 				queue.push(item.children);

--- a/src/vs/workbench/contrib/testing/common/testId.ts
+++ b/src/vs/workbench/contrib/testing/common/testId.ts
@@ -85,6 +85,14 @@ export class TestId {
 	}
 
 	/**
+	 * Cheaply gets the parent ID of a test identified with the string.
+	 */
+	public static parentId(idString: string) {
+		const idx = idString.lastIndexOf(TestIdPathParts.Delimiter);
+		return idx === -1 ? undefined : idString.slice(0, idx);
+	}
+
+	/**
 	 * Compares the position of the two ID strings.
 	 */
 	public static compare(a: string, b: string) {
@@ -115,8 +123,8 @@ export class TestId {
 	/**
 	 * Gets the ID of the parent test.
 	 */
-	public get parentId(): TestId {
-		return this.viewEnd > 1 ? new TestId(this.path, this.viewEnd - 1) : this;
+	public get parentId(): TestId | undefined {
+		return this.viewEnd > 1 ? new TestId(this.path, this.viewEnd - 1) : undefined;
 	}
 
 	/**
@@ -146,6 +154,16 @@ export class TestId {
 	 */
 	public *idsFromRoot() {
 		for (let i = 1; i <= this.viewEnd; i++) {
+			yield new TestId(this.path, i);
+		}
+	}
+
+	/**
+	 * Returns an iterable that yields IDs of the current item up to the root
+	 * item.
+	 */
+	public *idsToRoot() {
+		for (let i = this.viewEnd; i > 0; i--) {
 			yield new TestId(this.path, i);
 		}
 	}

--- a/src/vs/workbench/contrib/testing/common/testItemCollection.ts
+++ b/src/vs/workbench/contrib/testing/common/testItemCollection.ts
@@ -16,7 +16,6 @@ import { URI } from 'vs/base/common/uri';
  */
 interface CollectionItem<T> {
 	readonly fullId: TestId;
-	readonly parent: TestId | null;
 	actual: T;
 	expand: TestItemExpandState;
 	/**
@@ -351,7 +350,6 @@ export class TestItemCollection<T extends ITestItemLike> extends Disposable {
 			internal = {
 				fullId,
 				actual,
-				parent: parent ? fullId.parentId : null,
 				expandLevels: parent?.expandLevels /* intentionally undefined or 0 */ ? parent.expandLevels - 1 : undefined,
 				expand: TestItemExpandState.NotExpandable, // updated by `connectItemAndChildren`
 			};
@@ -362,7 +360,6 @@ export class TestItemCollection<T extends ITestItemLike> extends Disposable {
 			this.pushDiff({
 				op: TestDiffOpType.Add,
 				item: {
-					parent: internal.parent && internal.parent.toString(),
 					controllerId: this.options.controllerId,
 					expand: internal.expand,
 					item: this.options.toITestItem(actual),

--- a/src/vs/workbench/contrib/testing/common/testService.ts
+++ b/src/vs/workbench/contrib/testing/common/testService.ts
@@ -77,10 +77,8 @@ export interface IMainThreadTestCollection extends AbstractIncrementalTestCollec
  * Iterates through the item and its parents to the root.
  */
 export const getCollectionItemParents = function* (collection: IMainThreadTestCollection, item: InternalTestItem) {
-	let i: InternalTestItem | undefined = item;
-	while (i) {
-		yield i;
-		i = i.parent ? collection.getNodeById(i.parent) : undefined;
+	for (const id of TestId.fromString(item.item.extId).idsToRoot()) {
+		yield collection.getNodeById(id.toString())!;
 	}
 };
 

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -8,6 +8,7 @@ import { MarshalledId } from 'vs/base/common/marshallingIds';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { IPosition } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 
 export const enum TestResultState {
 	Unset = 0,
@@ -340,31 +341,27 @@ export interface InternalTestItem {
 	controllerId: string;
 	/** Expandability state */
 	expand: TestItemExpandState;
-	/** Parent ID, if any */
-	parent: string | null;
 	/** Raw test item properties */
 	item: ITestItem;
 }
 
 export namespace InternalTestItem {
 	export interface Serialized {
-		controllerId: string;
 		expand: TestItemExpandState;
-		parent: string | null;
 		item: ITestItem.Serialized;
 	}
 
 	export const serialize = (item: InternalTestItem): Serialized => ({
-		controllerId: item.controllerId,
 		expand: item.expand,
-		parent: item.parent,
 		item: ITestItem.serialize(item.item)
 	});
 
 	export const deserialize = (serialized: Serialized): InternalTestItem => ({
-		controllerId: serialized.controllerId,
+		// the `controllerId` is derived from the test.item.extId. It's redundant
+		// in the non-serialized InternalTestItem too, but there just because it's
+		// checked against in many hot paths.
+		controllerId: TestId.root(serialized.item.extId),
 		expand: serialized.expand,
-		parent: serialized.parent,
 		item: ITestItem.deserialize(serialized.item)
 	});
 }
@@ -468,6 +465,14 @@ export namespace TestResultItem {
 		computedState: original.computedState,
 		tasks: original.tasks.map(ITestTaskState.serialize),
 		retired: original.retired,
+	});
+
+	export const deserialize = (serialized: Serialized): TestResultItem => ({
+		...InternalTestItem.deserialize(serialized),
+		ownComputedState: serialized.ownComputedState,
+		computedState: serialized.computedState,
+		tasks: serialized.tasks.map(ITestTaskState.deserialize),
+		retired: true,
 	});
 }
 
@@ -684,13 +689,14 @@ export abstract class AbstractIncrementalTestCollection<T extends IncrementalTes
 			switch (op.op) {
 				case TestDiffOpType.Add: {
 					const internalTest = InternalTestItem.deserialize(op.item);
-					if (!internalTest.parent) {
+					const parentId = TestId.parentId(internalTest.item.extId)?.toString();
+					if (!parentId) {
 						const created = this.createItem(internalTest);
 						this.roots.add(created);
 						this.items.set(internalTest.item.extId, created);
 						changes.add(created);
-					} else if (this.items.has(internalTest.parent)) {
-						const parent = this.items.get(internalTest.parent)!;
+					} else if (this.items.has(parentId)) {
+						const parent = this.items.get(parentId)!;
 						parent.children.add(internalTest.item.extId);
 						const created = this.createItem(internalTest, parent);
 						this.items.set(internalTest.item.extId, created);
@@ -730,8 +736,9 @@ export abstract class AbstractIncrementalTestCollection<T extends IncrementalTes
 						break;
 					}
 
-					if (toRemove.parent) {
-						const parent = this.items.get(toRemove.parent)!;
+					const parentId = TestId.parentId(toRemove.item.extId)?.toString();
+					if (parentId) {
+						const parent = this.items.get(parentId)!;
 						parent.children.delete(toRemove.item.extId);
 					} else {
 						this.roots.delete(toRemove);

--- a/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByLocation.test.ts
+++ b/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByLocation.test.ts
@@ -55,10 +55,10 @@ suite('Workbench - Testing Explorer Hierarchal by Location Projection', () => {
 		harness.flush();
 		harness.pushDiff({
 			op: TestDiffOpType.Add,
-			item: { controllerId: 'ctrl2', parent: null, expand: TestItemExpandState.Expanded, item: new TestTestItem('ctrl2', 'c', 'c').toTestItem() },
+			item: { controllerId: 'ctrl2', expand: TestItemExpandState.Expanded, item: new TestTestItem(new TestId(['ctrlId2']), 'c').toTestItem() },
 		}, {
 			op: TestDiffOpType.Add,
-			item: { controllerId: 'ctrl2', parent: new TestId(['ctrl2', 'c']).toString(), expand: TestItemExpandState.NotExpandable, item: new TestTestItem('ctrl2', 'c-a', 'ca').toTestItem() },
+			item: { controllerId: 'ctrl2', expand: TestItemExpandState.NotExpandable, item: new TestTestItem(new TestId(['ctrlId2', 'id-c']), 'ca').toTestItem() },
 		});
 
 		assert.deepStrictEqual(harness.flush(), [
@@ -76,7 +76,7 @@ suite('Workbench - Testing Explorer Hierarchal by Location Projection', () => {
 			{ e: 'b' }
 		]);
 
-		harness.c.root.children.get('id-a')!.children.add(new TestTestItem('ctrlId', 'ac', 'ac'));
+		harness.c.root.children.get('id-a')!.children.add(new TestTestItem(new TestId(['ctrlId', 'id-a', 'id-ac']), 'ac'));
 
 		assert.deepStrictEqual(harness.flush(), [
 			{ e: 'a', children: [{ e: 'aa' }, { e: 'ab' }, { e: 'ac' }] },
@@ -117,7 +117,6 @@ suite('Workbench - Testing Explorer Hierarchal by Location Projection', () => {
 				tags: [],
 				uri: undefined,
 			},
-			parent: 'id-root',
 			tasks: [],
 			ownComputedState: state,
 			computedState: state,

--- a/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByName.test.ts
+++ b/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByName.test.ts
@@ -8,10 +8,10 @@ import { AbstractTreeViewState } from 'vs/base/browser/ui/tree/abstractTree';
 import { Emitter } from 'vs/base/common/event';
 import { HierarchicalByNameProjection } from 'vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByName';
 import { TestDiffOpType, TestItemExpandState } from 'vs/workbench/contrib/testing/common/testTypes';
-import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { TestResultItemChange } from 'vs/workbench/contrib/testing/common/testResult';
 import { TestTreeTestHarness } from 'vs/workbench/contrib/testing/test/browser/testObjectTree';
 import { TestTestItem } from 'vs/workbench/contrib/testing/test/common/testStubs';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 
 suite('Workbench - Testing Explorer Hierarchal by Name Projection', () => {
 	let harness: TestTreeTestHarness<HierarchicalByNameProjection>;
@@ -44,10 +44,10 @@ suite('Workbench - Testing Explorer Hierarchal by Name Projection', () => {
 		harness.flush();
 		harness.pushDiff({
 			op: TestDiffOpType.Add,
-			item: { controllerId: 'ctrl2', parent: null, expand: TestItemExpandState.Expanded, item: new TestTestItem('ctrl2', 'c', 'root2').toTestItem() },
+			item: { controllerId: 'ctrl2', expand: TestItemExpandState.Expanded, item: new TestTestItem(new TestId(['ctrl2']), 'root2').toTestItem() },
 		}, {
 			op: TestDiffOpType.Add,
-			item: { controllerId: 'ctrl2', parent: new TestId(['ctrl2', 'c']).toString(), expand: TestItemExpandState.NotExpandable, item: new TestTestItem('ctrl2', 'c-a', 'c', undefined).toTestItem() },
+			item: { controllerId: 'ctrl2', expand: TestItemExpandState.NotExpandable, item: new TestTestItem(new TestId(['ctrl2', 'id-c']), 'c', undefined).toTestItem() },
 		});
 
 		assert.deepStrictEqual(harness.flush(), [
@@ -59,7 +59,7 @@ suite('Workbench - Testing Explorer Hierarchal by Name Projection', () => {
 	test('updates nodes if they add children', async () => {
 		harness.flush();
 
-		harness.c.root.children.get('id-a')!.children.add(new TestTestItem('ctrl2', 'ac', 'ac'));
+		harness.c.root.children.get('id-a')!.children.add(new TestTestItem(new TestId(['ctrlId', 'id-a', 'id-ac']), 'ac'));
 
 		assert.deepStrictEqual(harness.flush(), [
 			{ e: 'aa' },
@@ -81,7 +81,7 @@ suite('Workbench - Testing Explorer Hierarchal by Name Projection', () => {
 
 	test('swaps when node is no longer leaf', async () => {
 		harness.flush();
-		harness.c.root.children.get('id-b')!.children.add(new TestTestItem('ctrl2', 'ba', 'ba'));
+		harness.c.root.children.get('id-b')!.children.add(new TestTestItem(new TestId(['ctrlId', 'id-b', 'id-ba']), 'ba'));
 
 		assert.deepStrictEqual(harness.flush(), [
 			{ e: 'aa' },

--- a/src/vs/workbench/contrib/testing/test/common/testStubs.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testStubs.ts
@@ -35,18 +35,21 @@ export class TestTestItem implements ITestItemLike {
 		return this.api.parent;
 	}
 
-	public api: ITestItemApi<TestTestItem> = { controllerId: this.controllerId };
+	public get id() {
+		return this._extId.localId;
+	}
+
+	public api: ITestItemApi<TestTestItem> = { controllerId: this._extId.controllerId };
 
 	public children = createTestItemChildren(this.api, i => i.api, TestTestItem);
 
 	constructor(
-		public readonly controllerId: string,
-		public readonly id: string,
+		private readonly _extId: TestId,
 		label: string,
 		uri?: URI,
 	) {
 		this.props = {
-			extId: '',
+			extId: _extId.toString(),
 			busy: false,
 			description: null,
 			error: null,
@@ -69,20 +72,23 @@ export class TestTestItem implements ITestItemLike {
 
 	public toTestItem(): ITestItem {
 		const props = { ...this.props };
-		props.extId = TestId.fromExtHostTestItem(this, this.controllerId).toString();
+		props.extId = this._extId.toString();
 		return props;
 	}
 }
 
 export class TestTestCollection extends TestItemCollection<TestTestItem> {
 	constructor(controllerId = 'ctrlId') {
+		const root = new TestTestItem(new TestId([controllerId]), 'root');
+		(root as any)._isRoot = true;
+
 		super({
 			controllerId,
 			getApiFor: t => t.api,
 			toITestItem: t => t.toTestItem(),
 			getChildren: t => t.children,
 			getDocumentVersion: () => undefined,
-			root: new TestTestItem(controllerId, controllerId, 'root'),
+			root,
 		});
 	}
 
@@ -111,14 +117,14 @@ export const testStubs = {
 		const collection = new TestTestCollection();
 		collection.resolveHandler = item => {
 			if (item === undefined) {
-				const a = new TestTestItem('ctrlId', idPrefix + 'a', 'a', URI.file('/'));
+				const a = new TestTestItem(new TestId(['ctrlId', 'id-a']), 'a', URI.file('/'));
 				a.canResolveChildren = true;
-				const b = new TestTestItem('ctrlId', idPrefix + 'b', 'b', URI.file('/'));
+				const b = new TestTestItem(new TestId(['ctrlId', 'id-b']), 'b', URI.file('/'));
 				collection.root.children.add(a);
 				collection.root.children.add(b);
 			} else if (item.id === idPrefix + 'a') {
-				item.children.add(new TestTestItem('ctrlId', idPrefix + 'aa', 'aa', URI.file('/')));
-				item.children.add(new TestTestItem('ctrlId', idPrefix + 'ab', 'ab', URI.file('/')));
+				item.children.add(new TestTestItem(new TestId(['ctrlId', 'id-a', 'id-aa']), 'aa', URI.file('/')));
+				item.children.add(new TestTestItem(new TestId(['ctrlId', 'id-a', 'id-ab']), 'ab', URI.file('/')));
 			}
 		};
 


### PR DESCRIPTION
Initially, test IDs were just the strings given by the extension, but a while ago we changed to the "extId", which is a concatenation of the ID the extension provided, with all the parent IDs and the test controller ID, so that we can uniquely identify any given test.

```
someController\0parent1\0parent2\0my test case
```

Because of this, we can derive the parent extId from any test's extId, but we never got rid of this duplicate information. In this PR, we do.
