### PR TITLE
Fix profile indicator rendering when sidebar is at right side

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -179,8 +179,8 @@
 .monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-label.profile-activity-item {
 	height: 20px;
 	width: 32px;
-	margin: 14px 8px;
-	padding: 0px;
+	margin: 14px 8px !important;
+	padding: 0px !important;
 	justify-content: center;
 	align-items: center;
 	font-size: 11px;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #162333

After:

![image](https://user-images.githubusercontent.com/1330321/193784224-72d44738-fdea-4d29-86ff-d5a221d88228.png)
