### PR TITLE
Polish code actions widget styling

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionWidget.css
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionWidget.css
@@ -70,7 +70,7 @@
 
 .codeActionWidget .monaco-list-row.code-action {
 	display: flex;
-	gap: 10px;
+	gap: 6px;
 	align-items: center;
 }
 

--- a/src/vs/editor/contrib/codeAction/browser/codeActionWidget.css
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionWidget.css
@@ -95,7 +95,7 @@
 /* Action bar */
 
 .codeActionWidget .codeActionWidget-action-bar {
-	padding: 4px 0;
+	margin-top: 4px;
 	background-color: var(--vscode-editorHoverWidget-statusBarBackground);
 	border-top: 1px solid var(--vscode-editorHoverWidget-border);
 }
@@ -107,17 +107,19 @@
 }
 
 .codeActionWidget .codeActionWidget-action-bar .actions-container {
-	padding: 0 10px;
+	padding: 0 8px;
 }
 
 .codeActionWidget-action-bar .action-label {
 	color: var(--vscode-textLink-activeForeground);
 	font-size: 12px;
+	line-height: 22px;
+	padding: 0;
 	pointer-events: all;
 }
 
 .codeActionWidget-action-bar .action-item {
-	margin-right: 10px;
+	margin-right: 16px;
 	pointer-events: none;
 }
 

--- a/src/vs/editor/contrib/codeAction/browser/codeActionWidget.css
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionWidget.css
@@ -12,10 +12,8 @@
 	display: block;
 	width: 100%;
 	border: 1px solid var(--vscode-editorWidget-border) !important;
-	border-color: none;
 	background-color: var(--vscode-editorWidget-background);
 	color: var(--vscode-editorWidget-foreground);
-	box-shadow: var(--vscode-widget-shadow) 0 2px 8px;
 }
 
 .codeActionWidget .monaco-list {
@@ -42,7 +40,7 @@
 	width: 100%;
 }
 
-.codeActionWidget .monaco-list .monaco-list-row.code-action.focused:not(.option-disabled)  {
+.codeActionWidget .monaco-list .monaco-list-row.code-action.focused:not(.option-disabled) {
 	background-color: var(--vscode-quickInputList-focusBackground);
 	color: var(--vscode-quickInputList-focusForeground);
 	outline: 1px solid var(--vscode-menu-selectionBorder, transparent);
@@ -51,7 +49,7 @@
 
 .codeActionWidget .monaco-list-row.group-header {
 	color: var(--vscode-pickerGroup-foreground);
-	font-weight: bold;
+	font-weight: 600;
 }
 
 .codeActionWidget .monaco-list .group-header,
@@ -97,16 +95,15 @@
 /* Action bar */
 
 .codeActionWidget .codeActionWidget-action-bar {
-	margin-top: 4px;
-	margin-bottom: 4px;
+	padding: 4px 0;
+	background-color: var(--vscode-editorHoverWidget-statusBarBackground);
+	border-top: 1px solid var(--vscode-editorHoverWidget-border);
 }
 
 .codeActionWidget .codeActionWidget-action-bar::before {
 	display: block;
 	content: "";
 	width: 100%;
-	margin-bottom: 4px;
-	border-bottom: 1px solid var(--vscode-menu-separatorBackground);
 }
 
 .codeActionWidget .codeActionWidget-action-bar .actions-container {
@@ -115,6 +112,7 @@
 
 .codeActionWidget-action-bar .action-label {
 	color: var(--vscode-textLink-activeForeground);
+	font-size: 12px;
 	pointer-events: all;
 }
 


### PR DESCRIPTION
Fixes #162125

- Fixes action/status bar padding, background color and border color
- Fixes action label font size and item margin
- Reduces gap between icon and label
- Removes box-shadow
- Tweaks header font weight
- Refactors action/status bar CSS with proper padding vs. margin rules 

## Before

<img width="423" alt="CleanShot 2022-10-04 at 10 15 38@2x" src="https://user-images.githubusercontent.com/25163139/193883982-fc233658-15d8-45ee-b8cf-7db05c6385f3.png">

<img width="413" alt="CleanShot 2022-10-04 at 10 19 17@2x" src="https://user-images.githubusercontent.com/25163139/193884689-532c9a22-26b3-4979-83bc-0bdb088dbcc0.png">

## After

<img width="435" alt="CleanShot 2022-10-04 at 10 34 29@2x" src="https://user-images.githubusercontent.com/25163139/193887622-d42ffe48-dff8-4d1b-af8e-fea3050315a1.png">

<img width="403" alt="CleanShot 2022-10-04 at 10 34 19@2x" src="https://user-images.githubusercontent.com/25163139/193887638-f114ae0e-86c4-4806-b10d-aca91ac1d26b.png">

## Reference

<img width="658" alt="CleanShot 2022-10-04 at 10 19 53@2x" src="https://user-images.githubusercontent.com/25163139/193884770-503198e8-2b97-4e72-afd9-03d9712bdf97.png">

<img width="647" alt="CleanShot 2022-10-04 at 10 18 59@2x" src="https://user-images.githubusercontent.com/25163139/193884739-238127b6-aa80-4c92-92da-7b8472ab9f8c.png">

cc @mjbvz 