### PR TITLE
send telemetry about git-exec duration

### DIFF
--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -89,7 +89,7 @@ async function createModel(context: ExtensionContext, outputChannelLogger: Outpu
 		userAgent: `git/${info.version} (${(os as any).version?.() ?? os.type()} ${os.release()}; ${os.platform()} ${os.arch()}) vscode/${vscodeVersion} (${env.appName})`,
 		version: info.version,
 		env: environment,
-	});
+	}, telemetryReporter);
 	const model = new Model(git, askpass, context.globalState, outputChannelLogger, telemetryReporter);
 	disposables.push(model);
 


### PR DESCRIPTION
Our git extension keeps showing up as one of the top extensions causing extension host freezes. The suspicion is that this is due to spawning processes. Let's get true numbers about this