### PR TITLE
joh/querulous beaver

### DIFF
--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -10,12 +10,14 @@ import { TernarySearchTree } from 'vs/base/common/map';
 import { MarshalledObject } from 'vs/base/common/marshalling';
 import { MarshalledId } from 'vs/base/common/marshallingIds';
 import { cloneAndChange, distinct } from 'vs/base/common/objects';
+import { StopWatch } from 'vs/base/common/stopwatch';
 import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ContextKeyExpression, ContextKeyInfo, ContextKeyValue, IContext, IContextKey, IContextKeyChangeEvent, IContextKeyService, IContextKeyServiceTarget, IReadableSet, RawContextKey, SET_CONTEXT_COMMAND_ID } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 const KEYBINDING_CONTEXT_ATTR = 'data-keybinding-context';
 
@@ -603,7 +605,27 @@ function findContextAttr(domNode: IContextKeyServiceTarget | null): number {
 }
 
 export function setContext(accessor: ServicesAccessor, contextKey: any, contextValue: any) {
-	accessor.get(IContextKeyService).createKey(String(contextKey), stringifyURIs(contextValue));
+	const contextKeyService = accessor.get(IContextKeyService);
+	const telemetryService = accessor.get(ITelemetryService);
+
+	const sw = new StopWatch(true);
+	contextKeyService.createKey(String(contextKey), stringifyURIs(contextValue));
+	const duration = sw.elapsed();
+
+	type TelemetryData = {
+		duration: number;
+		contextKey: string;
+	};
+	type TelemetryClassification = {
+		owner: 'jrieken';
+		comment: 'Performance numbers of the setContext-API command';
+		duration: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The time it took to set the context key' };
+		contextKey: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The context key that got set' };
+	};
+	telemetryService.publicLog2<TelemetryData, TelemetryClassification>('command.setContext', {
+		contextKey: String(contextKey),
+		duration
+	});
 }
 
 function stringifyURIs(contextValue: any): any {

--- a/src/vs/platform/contextkey/test/browser/contextkey.test.ts
+++ b/src/vs/platform/contextkey/test/browser/contextkey.test.ts
@@ -6,12 +6,14 @@ import * as assert from 'assert';
 import { DeferredPromise } from 'vs/base/common/async';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
+import { mock } from 'vs/base/test/common/mock';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { ContextKeyService, setContext } from 'vs/platform/contextkey/browser/contextKeyService';
 import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 suite('ContextKeyService', () => {
 	test('updateParent', () => {
@@ -64,7 +66,12 @@ suite('ContextKeyService', () => {
 		const contextKeyService: IContextKeyService = disposables.add(new ContextKeyService(configurationService));
 		const instantiationService = new TestInstantiationService(new ServiceCollection(
 			[IConfigurationService, configurationService],
-			[IContextKeyService, contextKeyService]
+			[IContextKeyService, contextKeyService],
+			[ITelemetryService, new class extends mock<ITelemetryService>() {
+				override async publicLog2() {
+					//
+				}
+			}]
 		));
 
 		const uri = URI.parse('test://abc');

--- a/src/vs/workbench/contrib/performance/electron-sandbox/rendererAutoProfiler.ts
+++ b/src/vs/workbench/contrib/performance/electron-sandbox/rendererAutoProfiler.ts
@@ -121,7 +121,7 @@ type TelemetryEventClassification = {
 	owner: 'jrieken';
 	comment: 'Insight about what happened before/while a long task was reported';
 	sessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Session identifier that allows to correlate CPU samples and events' };
-	timestamp: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Unix time at which the long task approximately happened' };
+	timestamp: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Unix time at which the long task approximately happened' };
 	recentCommands: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Events prior to the long task' };
 	views: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Visible views' };
 	editors: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Visible editor' };


### PR DESCRIPTION
- fix telemetry annotation for freeze event
- track duration of `setContext` API command invocation
