### PR TITLE
manually set editor focus after returning from snippet-picker

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/commands/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/commands/insertSnippet.ts
@@ -147,6 +147,7 @@ export class InsertSnippetAction extends SnippetEditorAction {
 		if (snippet.needsClipboard) {
 			clipboardText = await clipboardService.readText();
 		}
+		editor.focus();
 		SnippetController2.get(editor)?.insert(snippet.codeSnippet, { clipboardText });
 		snippetService.updateUsageTimestamp(snippet);
 	}

--- a/src/vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet.ts
@@ -72,6 +72,7 @@ export class SurroundWithSnippetEditorAction extends SnippetEditorAction {
 			clipboardText = await clipboardService.readText();
 		}
 
+		editor.focus();
 		SnippetController2.get(editor)?.insert(snippet.codeSnippet, { clipboardText });
 		snippetsService.updateUsageTimestamp(snippet);
 	}


### PR DESCRIPTION
workaround and likely not fix for https://github.com/microsoft/vscode/issues/162729
