### PR TITLE
Fix markdown open preview opening duplicate preview

### DIFF
--- a/extensions/markdown-language-features/src/preview/previewManager.ts
+++ b/extensions/markdown-language-features/src/preview/previewManager.ts
@@ -42,8 +42,9 @@ class PreviewStore<T extends IManagedMarkdownPreview> extends Disposable {
 	}
 
 	public get(resource: vscode.Uri, previewSettings: DynamicPreviewSettings): T | undefined {
+		const previewColumn = this.resolvePreviewColumn(previewSettings);
 		for (const preview of this._previews) {
-			if (preview.matchesResource(resource, previewSettings.previewColumn, previewSettings.locked)) {
+			if (preview.matchesResource(resource, previewColumn, previewSettings.locked)) {
 				return preview;
 			}
 		}
@@ -56,6 +57,18 @@ class PreviewStore<T extends IManagedMarkdownPreview> extends Disposable {
 
 	public delete(preview: T) {
 		this._previews.delete(preview);
+	}
+
+	private resolvePreviewColumn(previewSettings: DynamicPreviewSettings): vscode.ViewColumn | undefined {
+		if (previewSettings.previewColumn === vscode.ViewColumn.Active) {
+			return vscode.window.tabGroups.activeTabGroup.viewColumn;
+		}
+
+		if (previewSettings.previewColumn === vscode.ViewColumn.Beside) {
+			return vscode.window.tabGroups.activeTabGroup.viewColumn + 1;
+		}
+
+		return previewSettings.previewColumn;
 	}
 }
 


### PR DESCRIPTION
This fixes the markdown 'open preview' command when used with `vscode.ViewColumn.Active` or `vscode.ViewColumn.Beside`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
