### PR TITLE
Address minor strictNullChecks issues.

### DIFF
--- a/src/vs/editor/test/common/services/editorSimpleWorker.test.ts
+++ b/src/vs/editor/test/common/services/editorSimpleWorker.test.ts
@@ -166,9 +166,9 @@ suite('EditorSimpleWorker', () => {
 			if (!result) {
 				assert.ok(false);
 			}
-			assert.strictEqual(result.words.length, 1);
-			assert.strictEqual(typeof result.duration, 'number');
-			assert.strictEqual(result.words[0], 'foobar');
+			assert.strictEqual(result!.words.length, 1);
+			assert.strictEqual(typeof result!.duration, 'number');
+			assert.strictEqual(result!.words[0], 'foobar');
 		});
 	});
 

--- a/src/vs/workbench/services/workingCopy/test/browser/storedFileWorkingCopy.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/storedFileWorkingCopy.test.ts
@@ -286,7 +286,7 @@ suite('StoredFileWorkingCopy', function () {
 		assert.strictEqual(workingCopy.isReadonly(), false);
 		assert.strictEqual(workingCopy.model?.contents, 'hello backup');
 
-		workingCopy.model.updateContents('hello updated');
+		workingCopy.model?.updateContents('hello updated');
 		await workingCopy.save();
 
 		// subsequent resolve ignores any backups
@@ -858,7 +858,7 @@ suite('StoredFileWorkingCopy', function () {
 		});
 
 		let disposedModelEvent = false;
-		workingCopy.model.onWillDispose(() => {
+		workingCopy.model?.onWillDispose(() => {
 			disposedModelEvent = true;
 		});
 

--- a/src/vs/workbench/services/workingCopy/test/browser/untitledFileWorkingCopy.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/untitledFileWorkingCopy.test.ts
@@ -270,7 +270,7 @@ suite('UntitledFileWorkingCopy', () => {
 		assert.strictEqual(workingCopy.model?.contents, 'Hello Initial');
 		assert.strictEqual(contentChangeCounter, 1);
 
-		workingCopy.model.updateContents('Changed contents');
+		workingCopy.model?.updateContents('Changed contents');
 
 		await workingCopy.resolve(); // second resolve should be ignored
 		assert.strictEqual(workingCopy.model?.contents, 'Changed contents');


### PR DESCRIPTION
In our codebase, following files fail to build when we enable strictNullChecks in TS compiler.
The following commit addresses these problems.
