### PR TITLE
Add subtle border radius to inputs and dropdowns to match buttons

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.css
+++ b/src/vs/base/browser/ui/inputbox/inputBox.css
@@ -8,6 +8,7 @@
 	display: block;
 	padding: 0;
 	box-sizing:	border-box;
+	border-radius: 2px;
 
 	/* Customizable */
 	font-size: inherit;

--- a/src/vs/base/browser/ui/inputbox/inputBox.css
+++ b/src/vs/base/browser/ui/inputbox/inputBox.css
@@ -22,7 +22,7 @@
 .monaco-inputbox > .ibwrapper > .mirror {
 
 	/* Customizable */
-	padding: 4px;
+	padding: 4px 6px;
 }
 
 .monaco-inputbox > .ibwrapper {

--- a/src/vs/base/browser/ui/selectBox/selectBox.css
+++ b/src/vs/base/browser/ui/selectBox/selectBox.css
@@ -6,6 +6,7 @@
 .monaco-select-box {
 	width: 100%;
 	cursor: pointer;
+	border-radius: 2px;
 }
 
 .monaco-select-box-dropdown-container {

--- a/src/vs/editor/contrib/rename/browser/renameInputField.css
+++ b/src/vs/editor/contrib/rename/browser/renameInputField.css
@@ -15,6 +15,7 @@
 .monaco-editor .rename-box .rename-input {
 	padding: 3px;
 	width: calc(100% - 6px);
+	border-radius: 2px;
 }
 
 .monaco-editor .rename-box .rename-label {

--- a/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.css
+++ b/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .suggest-input-container {
-	padding: 2px 4px;
+	padding: 2px 6px;
 	border-radius: 2px;
 }
 

--- a/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.css
+++ b/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.css
@@ -5,6 +5,7 @@
 
 .suggest-input-container {
 	padding: 2px 4px;
+	border-radius: 2px;
 }
 
 .suggest-input-container .monaco-editor-background,

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -561,7 +561,7 @@
 	width: initial;
 	font: inherit;
 	height: 26px;
-	padding: 2px 8px;
+	padding: 2px 6px;
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item-new-extensions {

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -285,6 +285,7 @@
 	box-sizing: border-box;
 	padding: 1px;
 	outline-offset: -1px;
+	border-radius: 2px;
 }
 
 .scm-editor-validation-container {

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -194,6 +194,19 @@
 .scm-view .scm-input {
 	height: 100%;
 	padding-left: 11px;
+	border-radius: 2px;
+}
+
+.scm-view .scm-input .margin {
+	width: 6px !important;
+}
+
+.scm-input .monaco-scrollable-element {
+	left: 6px !important;
+}
+
+.scm-view .scm-editor-container .monaco-editor {
+	border-radius: 2px !important;
 }
 
 .scm-view .scm-editor {
@@ -325,7 +338,7 @@
 	position: absolute;
 	pointer-events: none;
 	z-index: 1;
-	padding: 2px 4px 3px 4px;
+	padding: 2px 6px 3px 6px;
 	box-sizing: border-box;
 	width: 100%;
 	overflow: hidden;


### PR DESCRIPTION
Fixes #147121 by matching our common inputs to the new 2px button border radius. Also slightly tweaks L/R input padding to match what is used in dropdowns.

## Examples

<img width="659" alt="CleanShot 2022-10-05 at 16 18 47@2x" src="https://user-images.githubusercontent.com/25163139/194181182-7153260e-8c8b-451f-b19a-824321bc008e.png">

<img width="369" alt="CleanShot 2022-10-05 at 16 18 31@2x" src="https://user-images.githubusercontent.com/25163139/194181190-20b6c174-481e-4bb6-abb5-aa6b6ecbf13e.png">

<img width="416" alt="CleanShot 2022-10-05 at 16 18 35@2x" src="https://user-images.githubusercontent.com/25163139/194181206-fdafaccb-68db-4b40-887e-6500c46c31c7.png">


<img width="522" alt="CleanShot 2022-10-05 at 16 18 40@2x" src="https://user-images.githubusercontent.com/25163139/194181196-34c574dc-9cf9-4c0a-9fee-bffe9562eefe.png">

<img width="323" alt="CleanShot 2022-10-05 at 17 01 29@2x" src="https://user-images.githubusercontent.com/25163139/194185004-2cae23aa-fde3-40f5-82fc-154d08147d07.png">
