### PR TITLE
no telemetry needed when task end event gets fired twice

### DIFF
--- a/src/vs/workbench/api/common/extHostTask.ts
+++ b/src/vs/workbench/api/common/extHostTask.ts
@@ -25,7 +25,7 @@ import * as Platform from 'vs/base/common/platform';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IExtHostApiDeprecationService } from 'vs/workbench/api/common/extHostApiDeprecationService';
 import { USER_TASKS_GROUP_KEY } from 'vs/workbench/contrib/tasks/common/tasks';
-import { NotSupportedError } from 'vs/base/common/errors';
+import { ErrorNoTelemetry, NotSupportedError } from 'vs/base/common/errors';
 
 export interface IExtHostTask extends ExtHostTaskShape {
 
@@ -631,7 +631,7 @@ export abstract class ExtHostTaskBase implements ExtHostTaskShape, IExtHostTask 
 		if (typeof execution === 'string') {
 			const taskExecution = this._taskExecutionPromises.get(execution);
 			if (!taskExecution) {
-				throw new Error('Unexpected: The specified task is missing an execution');
+				throw new ErrorNoTelemetry('Unexpected: The specified task is missing an execution');
 			}
 			return taskExecution;
 		}


### PR DESCRIPTION
the task execution gets set here before the task is executed

https://github.com/microsoft/vscode/blob/d7ce06ba60892228695e15dfb667f1259851dfaf/src/vs/workbench/api/common/extHostTask.ts#L745

but looks like this could occur if `TaskEventKind.End` fires more than once

https://github.com/microsoft/vscode/blob/d7ce06ba60892228695e15dfb667f1259851dfaf/src/vs/workbench/api/browser/mainThreadTask.ts#L448-L450

which leads to the task already having been deleted 

https://github.com/microsoft/vscode/blob/d7ce06ba60892228695e15dfb667f1259851dfaf/src/vs/workbench/api/common/extHostTask.ts#L510-L518
fix #160572