### PR TITLE
Update Get Started `h2` font weight

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -66,7 +66,7 @@
 }
 
 .monaco-workbench .part.editor>.content .gettingStartedContainer h2 {
-	font-weight: 200;
+	font-weight: 400;
 	margin-top: 0;
 	margin-bottom: 5px;
 	font-size: 1.5em;


### PR DESCRIPTION
Continuing to update instances where we're using the old school `thin` / 200 font weight. Note the change to `Start | Walkthroughs | Recent`.

## Before

<img width="1048" alt="CleanShot 2022-10-06 at 13 14 26@2x" src="https://user-images.githubusercontent.com/25163139/194410074-d271757b-4939-4f8f-a538-3eeb4d2dd047.png">

## After

<img width="1062" alt="CleanShot 2022-10-06 at 13 14 59@2x" src="https://user-images.githubusercontent.com/25163139/194410088-04b6313a-0959-4b8c-807c-b56b1a818088.png">

