### PR TITLE
Align "Show welcome page on startup" checkbox elements

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -751,6 +751,8 @@
 	text-align: center;
 	display: flex;
 	justify-content: center;
+	align-items: center;
+	gap: 4px;
 }
 
 .monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox {

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -752,7 +752,7 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	gap: 4px;
+	gap: 8px;
 }
 
 .monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox {


### PR DESCRIPTION
## Before

<img width="247" alt="CleanShot 2022-10-06 at 13 52 54@2x" src="https://user-images.githubusercontent.com/25163139/194417139-d6fa3b2a-1074-40b4-ac0e-10e1e259d272.png">

## After

<img width="271" alt="CleanShot 2022-10-06 at 13 57 44@2x" src="https://user-images.githubusercontent.com/25163139/194417208-d5126cb5-9e20-44f1-a13e-dd2f58b94c73.png">
