### PR TITLE
Small cleanup of dispose

### DIFF
--- a/src/vs/base/common/iterator.ts
+++ b/src/vs/base/common/iterator.ts
@@ -5,7 +5,7 @@
 
 export namespace Iterable {
 
-	export function is<T = any>(thing: any): thing is IterableIterator<T> {
+	export function is<T = any>(thing: any): thing is Iterable<T> {
 		return thing && typeof thing === 'object' && typeof thing[Symbol.iterator] === 'function';
 	}
 

--- a/src/vs/base/common/lifecycle.ts
+++ b/src/vs/base/common/lifecycle.ts
@@ -177,7 +177,7 @@ export class DisposableStore implements IDisposable {
 
 	static DISABLE_DISPOSED_WARNING = false;
 
-	private _toDispose = new Set<IDisposable>();
+	private readonly _toDispose = new Set<IDisposable>();
 	private _isDisposed = false;
 
 	constructor() {
@@ -210,6 +210,10 @@ export class DisposableStore implements IDisposable {
 	 * Dispose of all registered disposables but do not mark this object as disposed.
 	 */
 	public clear(): void {
+		if (this._toDispose.size === 0) {
+			return;
+		}
+
 		try {
 			dispose(this._toDispose.values());
 		} finally {

--- a/src/vs/base/common/lifecycle.ts
+++ b/src/vs/base/common/lifecycle.ts
@@ -118,10 +118,10 @@ export function isDisposable<E extends object>(thing: E): thing is E & IDisposab
 
 export function dispose<T extends IDisposable>(disposable: T): T;
 export function dispose<T extends IDisposable>(disposable: T | undefined): T | undefined;
-export function dispose<T extends IDisposable, A extends IterableIterator<T> = IterableIterator<T>>(disposables: IterableIterator<T>): A;
+export function dispose<T extends IDisposable, A extends Iterable<T> = Iterable<T>>(disposables: A): A;
 export function dispose<T extends IDisposable>(disposables: Array<T>): Array<T>;
 export function dispose<T extends IDisposable>(disposables: ReadonlyArray<T>): ReadonlyArray<T>;
-export function dispose<T extends IDisposable>(arg: T | IterableIterator<T> | undefined): any {
+export function dispose<T extends IDisposable>(arg: T | Iterable<T> | undefined): any {
 	if (Iterable.is(arg)) {
 		const errors: any[] = [];
 
@@ -215,7 +215,7 @@ export class DisposableStore implements IDisposable {
 		}
 
 		try {
-			dispose(this._toDispose.values());
+			dispose(this._toDispose);
 		} finally {
 			this._toDispose.clear();
 		}


### PR DESCRIPTION
- Optimize `DisposableStore.clear`  to quickly exit if the store is empty
- Let `dispose()` take an `Iterable` instead of an `IterableIterator`
- Fix `Iterator.is` to only assert that the type is an `Iterable` (and not an `IterableIterator`)