### PR TITLE
delayed service shouldn't be created by early listeners

### DIFF
--- a/src/vs/platform/instantiation/common/instantiationService.ts
+++ b/src/vs/platform/instantiation/common/instantiationService.ts
@@ -4,11 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IdleValue } from 'vs/base/common/async';
+import { Event } from 'vs/base/common/event';
 import { illegalState } from 'vs/base/common/errors';
+import { toDisposable } from 'vs/base/common/lifecycle';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { Graph } from 'vs/platform/instantiation/common/graph';
 import { IInstantiationService, ServiceIdentifier, ServicesAccessor, _util } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { LinkedList } from 'vs/base/common/linkedList';
 
 // TRACING
 const _enableAllTracing = false
@@ -246,15 +249,52 @@ export class InstantiationService implements IInstantiationService {
 			// Return a proxy object that's backed by an idle value. That
 			// strategy is to instantiate services in our idle time or when actually
 			// needed but not when injected into a consumer
+
+			// return "empty events" when the service isn't instantiated yet
+			const earlyListeners = new Map<string, LinkedList<Parameters<Event<any>>>>();
+
 			const idle = new IdleValue<any>(() => {
 				const result = child._createInstance<T>(ctor, args, _trace);
+
+				// early listeners that we kept are now being subscribed to
+				// the real service
+				for (const [key, values] of earlyListeners) {
+					const candidate = <Event<any>>(<any>result)[key];
+					if (typeof candidate === 'function') {
+						for (const listener of values) {
+							candidate.apply(result, listener);
+						}
+					}
+				}
+				earlyListeners.clear();
+
 				return result;
 			});
 			return <T>new Proxy(Object.create(null), {
 				get(target: any, key: PropertyKey): any {
+
+					if (!idle.isInitialized) {
+						// looks like an event
+						if (typeof key === 'string' && (key.startsWith('onDid') || key.startsWith('onWill'))) {
+							let list = earlyListeners.get(key);
+							if (!list) {
+								list = new LinkedList();
+								earlyListeners.set(key, list);
+							}
+							const event: Event<any> = (callback, thisArg, disposables) => {
+								const rm = list!.push([callback, thisArg, disposables]);
+								return toDisposable(rm);
+							};
+							return event;
+						}
+					}
+
+					// value already exists
 					if (key in target) {
 						return target[key];
 					}
+
+					// create value
 					const obj = idle.value;
 					let prop = obj[key];
 					if (typeof prop !== 'function') {

--- a/src/vs/platform/instantiation/test/common/instantiationService.test.ts
+++ b/src/vs/platform/instantiation/test/common/instantiationService.test.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { Emitter, Event } from 'vs/base/common/event';
+import { dispose } from 'vs/base/common/lifecycle';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { createDecorator, IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
@@ -458,5 +460,68 @@ suite('Instantiation Service', () => {
 			const cycle = insta2._globalGraph?.findCycleSlow();
 			assert.strictEqual(cycle, 'A -> B -> A');
 		}
+	});
+
+	test('Delayed and events', function () {
+		const A = createDecorator<A>('A');
+		interface A {
+			_serviceBrand: undefined;
+			onDidDoIt: Event<any>;
+			doIt(): void;
+		}
+
+		let created = false;
+		class AImpl implements A {
+			_serviceBrand: undefined;
+			_doIt = 0;
+
+			_onDidDoIt = new Emitter<this>();
+			onDidDoIt: Event<this> = this._onDidDoIt.event;
+
+			constructor() {
+				created = true;
+			}
+
+			doIt(): void {
+				this._doIt += 1;
+				this._onDidDoIt.fire(this);
+			}
+		}
+
+		const insta = new InstantiationService(new ServiceCollection(
+			[A, new SyncDescriptor(AImpl, undefined, true)],
+		), true, undefined, true);
+
+		class Consumer {
+			constructor(@A readonly a: A) {
+				// eager subscribe -> NO service instance
+			}
+		}
+
+		const c: Consumer = insta.createInstance(Consumer);
+		let eventCount = 0;
+
+		// subscribing to event doesn't trigger instantiation
+		const listener = (e: any) => {
+			assert.ok(e instanceof AImpl);
+			eventCount++;
+		};
+		const d1 = c.a.onDidDoIt(listener);
+		const d2 = c.a.onDidDoIt(listener);
+		assert.strictEqual(created, false);
+		assert.strictEqual(eventCount, 0);
+		d2.dispose();
+
+		// instantiation happens on first call
+		c.a.doIt();
+		assert.strictEqual(created, true);
+		assert.strictEqual(eventCount, 1);
+
+
+		const d3 = c.a.onDidDoIt(listener);
+		c.a.doIt();
+		assert.strictEqual(eventCount, 3);
+
+		dispose([d1, d3]);
 	});
 });


### PR DESCRIPTION
Injected service proxies can be created via event listeners. We can be smart about that because these proxies won't ever fire aways
