### PR TITLE
Treat removing keybindings with `when = true` as if they wouldn't have a when clause

### DIFF
--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -70,7 +70,10 @@ export class KeybindingResolver {
 		if (keypressChordPart && defaultKb.keypressParts[1] !== keypressChordPart) {
 			return false;
 		}
-		if (when) {
+
+		// `true` means always, as does `undefined`
+		// so we will treat `true` === `undefined`
+		if (when && when.type !== ContextKeyExprType.True) {
 			if (!defaultKb.when) {
 				return false;
 			}

--- a/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
+++ b/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
@@ -235,12 +235,23 @@ suite('KeybindingResolver', () => {
 		]);
 	});
 
-	test('issue #157751: Keyboard Shortcuts: Change When Expression might actually remove keybinding in Insiders', () => {
+	test('issue #157751: Auto-quoting of context keys prevents removal of keybindings via UI', () => {
 		const defaults = [
 			kbItem(KeyCode.KeyA, 'command1', null, ContextKeyExpr.deserialize(`editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId in julia.supportedLanguageIds`), true),
 		];
 		const overrides = [
 			kbItem(KeyCode.KeyA, '-command1', null, ContextKeyExpr.deserialize(`editorTextFocus && activeEditor != 'workbench.editor.notebook' && editorLangId in 'julia.supportedLanguageIds'`), false),
+		];
+		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+		assert.deepStrictEqual(actual, []);
+	});
+
+	test('issue #160604: Remove keybindings with when clause does not work', () => {
+		const defaults = [
+			kbItem(KeyCode.KeyA, 'command1', null, undefined, true),
+		];
+		const overrides = [
+			kbItem(KeyCode.KeyA, '-command1', null, ContextKeyExpr.true(), false),
 		];
 		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
 		assert.deepStrictEqual(actual, []);


### PR DESCRIPTION
Fixes #160604