### PR TITLE
Update aria label to match explorer

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -60,7 +60,7 @@ export abstract class Pane extends Disposable implements IView {
 	private _headerVisible = true;
 	private _minimumBodySize: number;
 	private _maximumBodySize: number;
-	private ariaHeaderLabel: string;
+	private _ariaHeaderLabel: string;
 	private styles: IPaneStyles = {};
 	private animationTimer: number | undefined = undefined;
 
@@ -69,6 +69,15 @@ export abstract class Pane extends Disposable implements IView {
 
 	private readonly _onDidChangeExpansionState = this._register(new Emitter<boolean>());
 	readonly onDidChangeExpansionState: Event<boolean> = this._onDidChangeExpansionState.event;
+
+	get ariaHeaderLabel(): string {
+		return this._ariaHeaderLabel;
+	}
+
+	set ariaHeaderLabel(newLabel: string) {
+		this._ariaHeaderLabel = newLabel;
+		this.header.setAttribute('aria-label', this.ariaHeaderLabel);
+	}
 
 	get draggableElement(): HTMLElement {
 		return this.header;
@@ -127,7 +136,7 @@ export abstract class Pane extends Disposable implements IView {
 		super();
 		this._expanded = typeof options.expanded === 'undefined' ? true : !!options.expanded;
 		this._orientation = typeof options.orientation === 'undefined' ? Orientation.VERTICAL : options.orientation;
-		this.ariaHeaderLabel = localize('viewSection', "{0} Section", options.title);
+		this._ariaHeaderLabel = localize('viewSection', "{0} Section", options.title);
 		this._minimumBodySize = typeof options.minimumBodySize === 'number' ? options.minimumBodySize : this._orientation === Orientation.HORIZONTAL ? 200 : 120;
 		this._maximumBodySize = typeof options.maximumBodySize === 'number' ? options.maximumBodySize : Number.POSITIVE_INFINITY;
 

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -262,7 +262,8 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 			const title = workspace.folders.map(folder => folder.name).join();
 			titleElement.textContent = this.name;
 			titleElement.title = title;
-			titleElement.setAttribute('aria-label', nls.localize('explorerSection', "Explorer Section: {0}", this.name));
+			this.ariaHeaderLabel = nls.localize('explorerSection', "Explorer Section: {0}", this.name);
+			titleElement.setAttribute('aria-label', this.ariaHeaderLabel);
 		};
 
 		this._register(this.contextService.onDidChangeWorkspaceName(setHeader));


### PR DESCRIPTION
Fixes #160788


Not sure if this is the best approach but it avoid a large re-render just to update the aria label and seems to work well.