### PR TITLE
Polish walkthrough star icon styles

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -333,7 +333,7 @@
 .monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured .featured-icon {
 	top: -30px;
 	left: 4px;
-	font-size: 12pt;
+	font-size: 14px;
 }
 
 .monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .codicon.hide-category-button {


### PR DESCRIPTION
Fix #162974 by adjusting the icon font size.

## Before

<img width="161" alt="CleanShot 2022-10-07 at 10 36 50@2x" src="https://user-images.githubusercontent.com/25163139/194617396-663a6606-6dd3-4cad-b492-5e91fdaf5a30.png">

## After

<img width="224" alt="CleanShot 2022-10-07 at 10 36 22@2x" src="https://user-images.githubusercontent.com/25163139/194617415-cdce537d-ccea-4e63-9547-e1eab7ea7d90.png">
