### PR TITLE
testing: ensure discovery happens before "run at cursor" executes

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTesting.ts
+++ b/src/vs/workbench/api/browser/mainThreadTesting.ts
@@ -171,6 +171,7 @@ export class MainThreadTesting extends Disposable implements MainThreadTestingSh
 			id: controllerId,
 			label,
 			canRefresh,
+			syncTests: () => this.proxy.$syncTests(),
 			refreshTests: token => this.proxy.$refreshTests(controllerId, token),
 			configureRunProfile: id => this.proxy.$configureRunProfile(controllerId, id),
 			runTests: (reqs, token) => this.proxy.$runControllerTests(reqs, token),

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2195,6 +2195,8 @@ export interface ExtHostTestingShape {
 	$configureRunProfile(controllerId: string, configId: number): void;
 	/** Asks the controller to refresh its tests */
 	$refreshTests(controllerId: string, token: CancellationToken): Promise<void>;
+	/** Ensures any pending test diffs are flushed */
+	$syncTests(): Promise<void>;
 }
 
 export interface ExtHostLocalizationShape {

--- a/src/vs/workbench/api/common/extHostTesting.ts
+++ b/src/vs/workbench/api/common/extHostTesting.ts
@@ -176,6 +176,17 @@ export class ExtHostTesting implements ExtHostTestingShape {
 	/**
 	 * @inheritdoc
 	 */
+	$syncTests(): Promise<void> {
+		for (const { collection } of this.controllers.values()) {
+			collection.flushDiff();
+		}
+
+		return Promise.resolve();
+	}
+
+	/**
+	 * @inheritdoc
+	 */
 	$provideFileCoverage(runId: string, taskId: string, token: CancellationToken): Promise<IFileCoverage[]> {
 		const coverage = mapFind(this.runTracker.trackers, t => t.id === runId ? t.getCoverage(taskId) : undefined);
 		return coverage?.provideFileCoverage(token) ?? Promise.resolve([]);

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -40,6 +40,8 @@ import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResu
 import { expandAndGetTestById, IMainThreadTestCollection, ITestService, testsInFile } from 'vs/workbench/contrib/testing/common/testService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
+import { getTestingConfiguration, TestingConfigKeys } from 'vs/workbench/contrib/testing/common/configuration';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 const category = Categories.Test;
 
@@ -679,9 +681,15 @@ abstract class ExecuteTestAtCursor extends Action2 {
 	 * @override
 	 */
 	public async run(accessor: ServicesAccessor) {
-		const control = accessor.get(IEditorService).activeTextEditorControl;
-		const position = control?.getPosition();
-		const model = control?.getModel();
+		const editorService = accessor.get(IEditorService);
+		const activeEditorPane = editorService.activeEditorPane;
+		const activeControl = editorService.activeTextEditorControl;
+		if (!activeEditorPane || !activeControl) {
+			return;
+		}
+
+		const position = activeControl?.getPosition();
+		const model = activeControl?.getModel();
 		if (!position || !model || !('uri' in model)) {
 			return;
 		}
@@ -689,12 +697,20 @@ abstract class ExecuteTestAtCursor extends Action2 {
 		const testService = accessor.get(ITestService);
 		const profileService = accessor.get(ITestProfileService);
 		const uriIdentityService = accessor.get(IUriIdentityService);
+		const progressService = accessor.get(IProgressService);
+		const configurationService = accessor.get(IConfigurationService);
 
 		let bestNodes: InternalTestItem[] = [];
 		let bestRange: Range | undefined;
 
 		let bestNodesBefore: InternalTestItem[] = [];
 		let bestRangeBefore: Range | undefined;
+
+		const saveBeforeTest = getTestingConfiguration(configurationService, TestingConfigKeys.SaveBeforeTest);
+		if (saveBeforeTest) {
+			await editorService.save({ editor: activeEditorPane.input, groupId: activeEditorPane.group.id });
+			await testService.syncTests();
+		}
 
 		// testsInFile will descend in the test tree. We assume that as we go
 		// deeper, ranges get more specific. We'll want to run all tests whose
@@ -703,8 +719,8 @@ abstract class ExecuteTestAtCursor extends Action2 {
 		// If we don't find any test whose range contains the position, we pick
 		// the closest one before the position. Again, if we find several tests
 		// whose range is equal to the closest one, we run them all.
-		await showDiscoveringWhile(accessor.get(IProgressService), (async () => {
-			for await (const test of testsInFile(testService.collection, uriIdentityService, model.uri)) {
+		await showDiscoveringWhile(progressService, (async () => {
+			for await (const test of testsInFile(testService, uriIdentityService, model.uri)) {
 				if (!test.item.range || !(profileService.capabilitiesForTest(test) & this.group)) {
 					continue;
 				}

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -414,7 +414,7 @@ export class TestingDecorations extends Disposable implements IEditorContributio
 		this.decorations.syncDecorations(uri);
 
 		(async () => {
-			for await (const _test of testsInFile(this.testService.collection, this.uriIdentityService, uri)) {
+			for await (const _test of testsInFile(this.testService, this.uriIdentityService, uri, false)) {
 				// consume the iterator so that all tests in the file get expanded. Or
 				// at least until the URI changes. If new items are requested, changes
 				// will be trigged in the `onDidProcessDiff` callback.

--- a/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
+++ b/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
@@ -241,6 +241,18 @@ export class TestService extends Disposable implements ITestService {
 	/**
 	 * @inheritdoc
 	 */
+	public async syncTests(): Promise<void> {
+		const cts = new CancellationTokenSource();
+		try {
+			await Promise.all([...this.testControllers.values()].map(c => c.syncTests(cts.token)));
+		} finally {
+			cts.dispose(true);
+		}
+	}
+
+	/**
+	 * @inheritdoc
+	 */
 	public async refreshTests(controllerId?: string): Promise<void> {
 		const cts = new CancellationTokenSource();
 		this.testRefreshCancellations.add(cts);
@@ -255,7 +267,7 @@ export class TestService extends Disposable implements ITestService {
 		} finally {
 			this.testRefreshCancellations.delete(cts);
 			this.isRefreshingTests.set(this.testRefreshCancellations.size > 0);
-			cts.dispose();
+			cts.dispose(true);
 		}
 	}
 
@@ -305,7 +317,7 @@ export class TestService extends Disposable implements ITestService {
 		if (req.isUiTriggered === false) {
 			return;
 		}
-		const saveBeforeTest: boolean = getTestingConfiguration(this.configurationService, TestingConfigKeys.SaveBeforeTest);
+		const saveBeforeTest = getTestingConfiguration(this.configurationService, TestingConfigKeys.SaveBeforeTest);
 		if (saveBeforeTest) {
 			await editorService.saveAll();
 		}


### PR DESCRIPTION
With this change, when "run at cursor" is executed, we'll:

1. Save the file
2. Forcefully sync tests from the ext host (normally they're on a 300ms throttle)
3. Wait for `busy = false` on all tests whose URIs are a parent or equal to the current file.

Fixes #157656