### PR TITLE
Lightly modernize quick pick styles

### DIFF
--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -57,7 +57,7 @@
 
 .quick-input-header {
 	display: flex;
-	padding: 8px 8px 0px 8px;
+	padding: 8px 6px 0px 6px;
 	margin-bottom: -2px;
 }
 
@@ -163,6 +163,10 @@
 	max-height: calc(20 * 22px);
 }
 
+.quick-input-list .monaco-scrollable-element {
+	padding: 0px 6px;
+}
+
 .quick-input-list .quick-input-list-entry {
 	box-sizing: border-box;
 	overflow: hidden;
@@ -174,6 +178,10 @@
 .quick-input-list .quick-input-list-entry.quick-input-list-separator-border {
 	border-top-width: 1px;
 	border-top-style: solid;
+}
+
+.quick-input-list .monaco-list-row {
+	border-radius: 3px;
 }
 
 .quick-input-list .monaco-list-row[data-index="0"] .quick-input-list-entry.quick-input-list-separator-border {
@@ -247,7 +255,7 @@
 }
 
 .quick-input-list .quick-input-list-entry .quick-input-list-separator {
-	margin-right: 8px; /* separate from keybindings or actions */
+	margin-right: 4px; /* separate from keybindings or actions */
 }
 
 .quick-input-list .quick-input-list-entry-action-bar {

--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -150,12 +150,13 @@
 
 .quick-input-list {
 	line-height: 22px;
-	margin-top: 8px;
-	padding: 0px 1px 1px 1px;
+	margin-top: 6px;
+	padding: 1px;
 }
 
 .quick-input-widget.hidden-input .quick-input-list {
-	margin-top: 0; /* reduce margins when input box hidden */
+	margin-top: 4px; /* reduce margins when input box hidden */
+	padding-bottom: 4px;
 }
 
 .quick-input-list .monaco-list {
@@ -164,7 +165,7 @@
 }
 
 .quick-input-list .monaco-scrollable-element {
-	padding: 0px 6px;
+	padding: 0px 5px;
 }
 
 .quick-input-list .quick-input-list-entry {


### PR DESCRIPTION
Adds minor padding to the quick input list and border radius to the items:

## Examples

<img width="626" alt="CleanShot 2022-10-07 at 15 26 15@2x" src="https://user-images.githubusercontent.com/25163139/194670893-4bf027d2-d183-485f-b9b2-6506d3e36fa9.png">

## Demo

https://user-images.githubusercontent.com/25163139/194669327-d551ad4c-1cc7-454d-ba55-33ce4ccf0242.mp4

## Prior Art

<img width="746" alt="CleanShot 2022-10-07 at 15 24 56@2x" src="https://user-images.githubusercontent.com/25163139/194670810-332c003d-e9bf-4877-87c5-626804b0badb.png">

<img width="285" alt="CleanShot 2022-10-07 at 15 08 38@2x" src="https://user-images.githubusercontent.com/25163139/194669558-95d6d0ce-8829-4142-b3bd-ff6d01ba5899.png">

<img width="849" alt="CleanShot 2022-10-07 at 15 08 59@2x" src="https://user-images.githubusercontent.com/25163139/194669563-2da8abcb-2eab-4d70-9b99-3d44fd6b59d3.png">

![win11-context-menu](https://user-images.githubusercontent.com/25163139/194669547-59e4cdd5-ed07-4eeb-8d02-2dfe91e45a19.jpeg)


