### PR TITLE
Adopt DisposableMap in more places

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -10,7 +10,7 @@ import { IHoverDelegate } from 'vs/base/browser/ui/iconLabel/iconHoverDelegate';
 import { ActionRunner, IAction, IActionRunner, IRunEvent, Separator } from 'vs/base/common/actions';
 import { Emitter } from 'vs/base/common/event';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
-import { Disposable, DisposableStore, dispose, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableMap, DisposableStore, dispose, IDisposable } from 'vs/base/common/lifecycle';
 import * as types from 'vs/base/common/types';
 import 'vs/css!./actionbar';
 
@@ -72,7 +72,7 @@ export class ActionBar extends Disposable implements IActionRunner {
 
 	// View Items
 	viewItems: IActionViewItem[];
-	private viewItemDisposables: Map<IActionViewItem, IDisposable>;
+	private readonly viewItemDisposables = this._register(new DisposableMap<IActionViewItem>());
 	private previouslyFocusedItem?: number;
 	protected focusedItem?: number;
 	private focusTracker: DOM.IFocusTracker;
@@ -121,7 +121,6 @@ export class ActionBar extends Disposable implements IActionRunner {
 		this._actionRunnerDisposables.add(this._actionRunner.onWillRun(e => this._onWillRun.fire(e)));
 
 		this.viewItems = [];
-		this.viewItemDisposables = new Map<IActionViewItem, IDisposable>();
 		this.focusedItem = undefined;
 
 		this.domNode = document.createElement('div');
@@ -413,8 +412,7 @@ export class ActionBar extends Disposable implements IActionRunner {
 	pull(index: number): void {
 		if (index >= 0 && index < this.viewItems.length) {
 			this.actionsList.removeChild(this.actionsList.childNodes[index]);
-			this.viewItemDisposables.get(this.viewItems[index])?.dispose();
-			this.viewItemDisposables.delete(this.viewItems[index]);
+			this.viewItemDisposables.deleteAndDispose(this.viewItems[index]);
 			dispose(this.viewItems.splice(index, 1));
 			this.refreshRole();
 		}
@@ -422,9 +420,8 @@ export class ActionBar extends Disposable implements IActionRunner {
 
 	clear(): void {
 		dispose(this.viewItems);
-		dispose(this.viewItemDisposables.values());
-		this.viewItemDisposables.clear();
 		this.viewItems = [];
+		this.viewItemDisposables.clearAndDisposeAll();
 		DOM.clearNode(this.actionsList);
 		this.refreshRole();
 	}

--- a/src/vs/base/common/lifecycle.ts
+++ b/src/vs/base/common/lifecycle.ts
@@ -452,9 +452,14 @@ export class DisposableMap<K, V extends IDisposable = IDisposable> implements ID
 	private readonly _store = new Map<K, V>();
 	private _isDisposed = false;
 
+	constructor() {
+		trackDisposable(this);
+	}
+
 	dispose() {
-		this.clearAndDisposeAll();
+		markAsDisposed(this);
 		this._isDisposed = true;
+		this.clearAndDisposeAll();
 	}
 
 	clearAndDisposeAll() {

--- a/src/vs/editor/contrib/gotoSymbol/browser/symbolNavigation.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/symbolNavigation.ts
@@ -5,7 +5,7 @@
 
 import { Emitter, Event } from 'vs/base/common/event';
 import { KeyCode } from 'vs/base/common/keyCodes';
-import { combinedDisposable, DisposableStore, dispose, IDisposable } from 'vs/base/common/lifecycle';
+import { combinedDisposable, DisposableMap, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { isEqual } from 'vs/base/common/resources';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorCommand, registerEditorCommand } from 'vs/editor/browser/editorExtensions';
@@ -183,7 +183,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 
 class EditorState {
 
-	private readonly _listener = new Map<ICodeEditor, IDisposable>();
+	private readonly _listener = new DisposableMap<ICodeEditor>();
 	private readonly _disposables = new DisposableStore();
 
 	private readonly _onDidChange = new Emitter<{ editor: ICodeEditor }>();
@@ -198,7 +198,7 @@ class EditorState {
 	dispose(): void {
 		this._disposables.dispose();
 		this._onDidChange.dispose();
-		dispose(this._listener.values());
+		this._listener.dispose();
 	}
 
 	private _onDidAddEditor(editor: ICodeEditor): void {
@@ -209,7 +209,6 @@ class EditorState {
 	}
 
 	private _onDidRemoveEditor(editor: ICodeEditor): void {
-		this._listener.get(editor)?.dispose();
-		this._listener.delete(editor);
+		this._listener.deleteAndDispose(editor);
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadWindow.ts
+++ b/src/vs/workbench/api/browser/mainThreadWindow.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from 'vs/base/common/event';
-import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
@@ -16,7 +16,6 @@ export class MainThreadWindow implements MainThreadWindowShape {
 
 	private readonly proxy: ExtHostWindowShape;
 	private readonly disposables = new DisposableStore();
-	private readonly resolved = new Map<number, IDisposable>();
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -31,11 +30,6 @@ export class MainThreadWindow implements MainThreadWindowShape {
 
 	dispose(): void {
 		this.disposables.dispose();
-
-		for (const value of this.resolved.values()) {
-			value.dispose();
-		}
-		this.resolved.clear();
 	}
 
 	$getWindowVisibility(): Promise<boolean> {

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -12,7 +12,7 @@ import { GlobalActivityActionViewItem, ViewContainerActivityAction, PlaceHolderT
 import { IBadge, NumberBadge } from 'vs/workbench/services/activity/common/activity';
 import { IWorkbenchLayoutService, Parts, Position } from 'vs/workbench/services/layout/browser/layoutService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IDisposable, toDisposable, DisposableStore, Disposable } from 'vs/base/common/lifecycle';
+import { IDisposable, toDisposable, DisposableStore, Disposable, DisposableMap } from 'vs/base/common/lifecycle';
 import { Event } from 'vs/base/common/event';
 import { ToggleActivityBarVisibilityAction, ToggleSidebarPositionAction } from 'vs/workbench/browser/actions/layoutActions';
 import { IThemeService, IColorTheme, ThemeIcon } from 'vs/platform/theme/common/themeService';
@@ -115,7 +115,7 @@ export class ActivitybarPart extends Part implements IPaneCompositeSelectorPart 
 	private readonly accountsActivity: ICompositeActivity[] = [];
 
 	private readonly compositeActions = new Map<string, { activityAction: ViewContainerActivityAction; pinnedAction: ToggleCompositePinnedAction }>();
-	private readonly viewContainerDisposables = new Map<string, IDisposable>();
+	private readonly viewContainerDisposables = this._register(new DisposableMap<string>());
 
 	private readonly keyboardNavigationDisposables = this._register(new DisposableStore());
 
@@ -684,10 +684,7 @@ export class ActivitybarPart extends Part implements IPaneCompositeSelectorPart 
 	}
 
 	private onDidDeregisterViewContainer(viewContainer: ViewContainer): void {
-		const disposable = this.viewContainerDisposables.get(viewContainer.id);
-		disposable?.dispose();
-
-		this.viewContainerDisposables.delete(viewContainer.id);
+		this.viewContainerDisposables.deleteAndDispose(viewContainer.id);
 		this.removeComposite(viewContainer.id);
 	}
 

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -27,7 +27,7 @@ import { IActivityHoverOptions, ToggleCompositePinnedAction } from 'vs/workbench
 import { IBadge } from 'vs/workbench/services/activity/common/activity';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { Dimension, trackFocus, EventHelper, $, asCSSUrl, createCSSRule } from 'vs/base/browser/dom';
-import { IDisposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { IDisposable, DisposableStore, DisposableMap } from 'vs/base/common/lifecycle';
 import { IContextKey, IContextKeyService, ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { isUndefinedOrNull, assertIsDefined } from 'vs/base/common/types';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
@@ -114,7 +114,7 @@ export abstract class BasePanelPart extends CompositePart<PaneComposite> impleme
 	private globalToolBar: ToolBar | undefined;
 	private globalActions: CompositeMenuActions;
 
-	private readonly panelDisposables: Map<string, IDisposable> = new Map<string, IDisposable>();
+	private readonly panelDisposables = new DisposableMap<string>();
 
 	private blockOpeningPanel = false;
 	protected contentDimension: Dimension | undefined;
@@ -292,9 +292,7 @@ export abstract class BasePanelPart extends CompositePart<PaneComposite> impleme
 	}
 
 	private async onDidDeregisterPanel(panelId: string): Promise<void> {
-		const disposable = this.panelDisposables.get(panelId);
-		disposable?.dispose();
-		this.panelDisposables.delete(panelId);
+		this.panelDisposables.deleteAndDispose(panelId);
 
 		const activeContainers = this.viewDescriptorService.getViewContainersByLocation(this.viewContainerLocation)
 			.filter(container => this.viewDescriptorService.getViewContainerModel(container).activeViewDescriptors.length > 0);

--- a/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
@@ -5,7 +5,7 @@
 
 import * as dom from 'vs/base/browser/dom';
 import * as nls from 'vs/nls';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableMap } from 'vs/base/common/lifecycle';
 import * as languages from 'vs/editor/common/languages';
 import { Emitter } from 'vs/base/common/event';
 import { ICommentService } from 'vs/workbench/contrib/comments/browser/commentService';
@@ -29,7 +29,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 	private _onDidResize = new Emitter<dom.Dimension>();
 	onDidResize = this._onDidResize.event;
 
-	private _commentDisposable = new Map<CommentNode<T>, IDisposable>();
+	private _commentDisposable = this._register(new DisposableMap<CommentNode<T>>());
 	private _markdownRenderer: MarkdownRenderer;
 
 	get length() {
@@ -39,7 +39,6 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 	get activeComment() {
 		return this._commentElements.filter(node => node.isEditing)[0];
 	}
-
 
 	constructor(
 		readonly owner: string,
@@ -160,8 +159,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 		// del removed elements
 		for (let i = commentElementsToDel.length - 1; i >= 0; i--) {
 			const commentToDelete = commentElementsToDel[i];
-			this._commentDisposable.get(commentToDelete)?.dispose();
-			this._commentDisposable.delete(commentToDelete);
+			this._commentDisposable.deleteAndDispose(commentToDelete);
 
 			this._commentElements.splice(commentElementsToDelIndex[i], 1);
 			this._commentsElement.removeChild(commentToDelete.domNode);
@@ -256,7 +254,5 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 			this._resizeObserver.disconnect();
 			this._resizeObserver = null;
 		}
-
-		this._commentDisposable.forEach(v => v.dispose());
 	}
 }

--- a/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
@@ -5,7 +5,7 @@
 
 import { IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IAction } from 'vs/base/common/actions';
-import { DisposableStore, dispose, IDisposable } from 'vs/base/common/lifecycle';
+import { DisposableMap, DisposableStore } from 'vs/base/common/lifecycle';
 import 'vs/css!./media/debugViewlet';
 import * as nls from 'vs/nls';
 import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
@@ -38,7 +38,7 @@ export class DebugViewPaneContainer extends ViewPaneContainer {
 	private startDebugActionViewItem: StartDebugActionViewItem | undefined;
 	private progressResolve: (() => void) | undefined;
 	private breakpointView: ViewPane | undefined;
-	private paneListeners = new Map<string, IDisposable>();
+	private readonly paneListeners = this._register(new DisposableMap<string>());
 
 	private readonly stopActionViewItemDisposables = this._register(new DisposableStore());
 
@@ -149,8 +149,7 @@ export class DebugViewPaneContainer extends ViewPaneContainer {
 	override removePanes(panes: ViewPane[]): void {
 		super.removePanes(panes);
 		for (const pane of panes) {
-			dispose(this.paneListeners.get(pane.id));
-			this.paneListeners.delete(pane.id);
+			this.paneListeners.deleteAndDispose(pane.id);
 		}
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/executionStatusBarItemController.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/executionStatusBarItemController.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { disposableTimeout, RunOnceScheduler } from 'vs/base/common/async';
-import { Disposable, DisposableMap, dispose, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableMap, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import { localize } from 'vs/nls';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { themeColorFromId, ThemeIcon } from 'vs/platform/theme/common/themeService';


### PR DESCRIPTION
This adopts the `DisposableMap` type added in #163006 in more places where it was a simple, drop-in replacement

