### PR TITLE
Fix 'join all editor groups' for notebooks Fixes #134158

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookEditorServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookEditorServiceImpl.ts
@@ -58,12 +58,12 @@ export class NotebookEditorWidgetService implements INotebookEditorService {
 			}));
 			listeners.push(group.onWillMoveEditor(e => {
 				if (e.editor instanceof NotebookEditorInput) {
-					this._freeWidget(e.editor, e.groupId, e.target);
+					this._allowWidgetMove(e.editor, e.groupId, e.target);
 				}
 
 				if (isCompositeNotebookEditorInput(e.editor)) {
 					e.editor.editorInputs.forEach(input => {
-						this._freeWidget(input, e.groupId, e.target);
+						this._allowWidgetMove(input, e.groupId, e.target);
 					});
 				}
 			}));
@@ -105,7 +105,7 @@ export class NotebookEditorWidgetService implements INotebookEditorService {
 		domNode.remove();
 	}
 
-	private _freeWidget(input: NotebookEditorInput, sourceID: GroupIdentifier, targetID: GroupIdentifier): void {
+	private _allowWidgetMove(input: NotebookEditorInput, sourceID: GroupIdentifier, targetID: GroupIdentifier): void {
 		const targetWidget = this._borrowableEditors.get(targetID)?.get(input.resource);
 		if (targetWidget) {
 			// not needed
@@ -116,9 +116,10 @@ export class NotebookEditorWidgetService implements INotebookEditorService {
 		if (!widget) {
 			throw new Error('no widget at source group');
 		}
+		// don't allow the widget to be retrieved at its previous location any more
 		this._borrowableEditors.get(sourceID)?.delete(input.resource);
-		widget.token = undefined;
 
+		// allow the widget to be retrieved at its new location
 		let targetMap = this._borrowableEditors.get(targetID);
 		if (!targetMap) {
 			targetMap = new ResourceMap();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
See https://github.com/microsoft/vscode/issues/134158

To reproduce the issue: (Jupyter extension needed)

1. Close all editors
2. Open a split view with the text editor on the left and an interactive window or notebook on the right
3. With focus on the left editor, run the command "View: Join All Editor Groups" in the command palette
4. Expected behaviour: interactive/notebook disappears
5. Actual behaviour: the tab (top bit) is moved and the text editor grows to fill the space but some UI from the notebook or interactive is floating in front of it. See screenshot in issue.

The intended flow-

See call stack

![image](https://user-images.githubusercontent.com/1485998/194707451-86071050-4314-4aca-bce9-1960d28d32fa.png)

In `NotebookEditor.clearInput`, the intention is to call `NotebookEditorWidget.onWillHide` to set `elem.style.visibility = 'hidden'` which hides the notebook.

When the bug happens, then this call is not possible because `NotebookEditor` no longer "owns" its `_widget`.

https://github.com/microsoft/vscode/blob/eebdf8174b087979ae6af103f6f2e2f6f9062056/src/vs/workbench/contrib/notebook/browser/services/notebookEditorServiceImpl.ts#L160

The ownership was removed too early by the `_freeWidget` function.

https://github.com/microsoft/vscode/blob/eebdf8174b087979ae6af103f6f2e2f6f9062056/src/vs/workbench/contrib/notebook/browser/services/notebookEditorServiceImpl.ts#L120