### PR TITLE
Change scrolling behaviour of 'Next Problem' Fixes #156782

### DIFF
--- a/src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts
+++ b/src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts
@@ -350,6 +350,7 @@ export class MarkerNavigationWidget extends PeekViewWidget {
 		const range = Range.lift(marker);
 		const editorPosition = this.editor.getPosition();
 		const position = editorPosition && range.containsPosition(editorPosition) ? editorPosition : range.getStartPosition();
+		this.editor.revealPositionInCenterIfOutsideViewport(position, ScrollType.Smooth);
 		super.show(position, this.computeRequiredHeight());
 
 		const model = this.editor.getModel();
@@ -361,7 +362,6 @@ export class MarkerNavigationWidget extends PeekViewWidget {
 		}
 		this._icon.className = `codicon ${SeverityIcon.className(MarkerSeverity.toSeverity(this._severity))}`;
 
-		this.editor.revealPositionNearTop(position, ScrollType.Smooth);
 		this.editor.focus();
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

See issue  #156782

I made the F8 key (next problem) behave as similar as I could manage to Alt+F3 (next change in file) (although I couldn't get the code to match)

To test I just made some one-line changes which introduced problems. Like this ([ vscode-extension-samples repo ](https://github.com/microsoft/vscode-extension-samples) )

```diff
diff --git a/test-provider-sample/src/extension.ts b/test-provider-sample/src/extension.ts
index f505c3e..555088f 100644
--- a/test-provider-sample/src/extension.ts
+++ b/test-provider-sample/src/extension.ts
@@ -6 +6 @@ export async function activate(context: vscode.ExtensionContext) {
-       ctrl = vscode.tests.createTestController('mathTestController', 'Markdown Math');
+       ctrl = vscode.tests.createTestController('mathTestController', 'Markdown Math') + 2;
@@ -37 +37 @@ export async function activate(context: vscode.ExtensionContext) {
-                                                       test.uri.toString(),
+                                                       test.uri.toString() / 5,
@@ -77 +77 @@ export async function activate(context: vscode.ExtensionContext) {
-                                                       vscode.Uri.parse(uri),
+                                                       vscode.Uri.parse(uri) + 1,
@@ -104 +104 @@ export async function activate(context: vscode.ExtensionContext) {
-                       await data.updateFromDisk(ctrl, item);
+                       await data.updateFromDisk(ctrl, item) + 3;
@@ -109 +109 @@ export async function activate(context: vscode.ExtensionContext) {
-               if (e.uri.scheme !== 'file') {
+               if (e.uri.scheme !== 'file' / 5) {
@@ -113 +113 @@ export async function activate(context: vscode.ExtensionContext) {
-               if (!e.uri.path.endsWith('.md')) {
+               if (!e.uri.path.endsWith('.md') / 7)  {
@@ -133 +133 @@ export async function activate(context: vscode.ExtensionContext) {
-                       console.log("banana", setTag);
+                       console.log("banana", setTag) + 8;
```