### PR TITLE
Allow kernel source command to throw

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
@@ -71,7 +71,11 @@ class SourceAction extends Disposable implements ISourceAction {
 	}
 
 	private async _runAction(): Promise<void> {
-		await this.action.run();
+		try {
+			await this.action.run();
+		} catch (error) {
+			console.warn(`Kernel source command failed: ${error}`);
+		}
 	}
 }
 


### PR DESCRIPTION
The kernel source command state is not cleared properly when the kernel source command throws

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
