### PR TITLE
Filter away settings that don't belong in the User tab

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -753,7 +753,7 @@ export class SettingsEditor2 extends EditorPane {
 
 		this.noResultsMessage = DOM.append(this.bodyContainer, $('.no-results-message'));
 
-		this.noResultsMessage.innerText = localize('noResults', "No Settings Found");
+		this.noResultsMessage.innerText = localize('noResultsWithDetails', "No Settings Found. Settings might be available under a different tab.");
 
 		this.clearFilterLinkContainer = $('span.clear-search-filters');
 
@@ -1616,6 +1616,10 @@ export class SettingsEditor2 extends EditorPane {
 			this.searchResultLabel = resultString;
 			this.updateInputAriaLabel();
 			this.countElement.innerText = resultString;
+
+			if (count === 0) {
+				resultString = localize('noResultsWithDetails', "No Settings Found. Settings might be available under a different tab.");
+			}
 			aria.status(resultString);
 
 			if (this.countElement.style.display !== 'block') {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -2073,8 +2073,8 @@ export class SettingsTreeFilter implements ITreeFilter<SettingsTreeElement> {
 			}
 		}
 
-		// Non-user scope selected
-		if (element instanceof SettingsTreeSettingElement && this.viewState.settingsTarget !== ConfigurationTarget.USER_LOCAL) {
+		// Filter out settings that don't belong in the selected scope
+		if (element instanceof SettingsTreeSettingElement) {
 			const isRemote = !!this.environmentService.remoteAuthority;
 			if (!element.matchesScope(this.viewState.settingsTarget, isRemote)) {
 				return false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #145079

Keeping settings in the User tab can still lead to confusing UX at times.
For example, when on a remote workspace, the user is unable to successfully adjust the `azure.authenticationLibrary` setting in the User tab (see https://github.com/microsoft/vscode/issues/145079#issue-1168956904 for details). Also, the user currently cannot search for the `azure.authenticationLibrary` setting in the User tab on a remote workspace anyway&mdash;they have to scroll down to it or reveal it by clicking on the correct subsection of the ToC.

This PR removes those settings from the User tab, and changes the "No settings found" message (and aria status message) to explain that the setting might be available under a different tab.

Another solution would be to still propagate the value to the JSON file and add a warning to the setting in the UI that the value cannot be applied in the current scope. However, even in this case, the user would have to switch tabs to properly adjust the setting.

