### PR TITLE
Fixes Merge editor saves files using the wrong newlines

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel.ts
@@ -181,7 +181,7 @@ export class MergeEditorModel extends EditorModel {
 
 		appendLinesToResult(baseLines, LineRange.fromLineNumbers(baseStartLineNumber, baseLines.length + 1));
 
-		return resultLines.join('\n');
+		return resultLines.join(this.resultTextModel.getEOL());
 	}
 
 	public hasBaseRange(baseRange: ModifiedBaseRange): boolean {


### PR DESCRIPTION
Unfortunately, in the 1.72 release, the merge editor always overwrites the result file with LF style line endings.
This is because `textModel.setValue` only normalizes inconsistent line endings, but does not keep the EOL style from the previous value. However, `textModel.pushEditOperations` normalizes text to the current EOL of the document, this is why this was not problematic before.

This PR fixes that behavior by keeping the EOL style of the result file.
