### PR TITLE
Toggle word wrap state (if defined) also on the other side when opening a diff editor

### DIFF
--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -1122,6 +1122,12 @@ export interface IDiffEditor extends editorCommon.IEditor {
 	readonly onDidUpdateDiff: Event<void>;
 
 	/**
+	 * An event emitted when the diff model is changed (i.e. the diff editor shows new content).
+	 * @event
+	 */
+	readonly onDidChangeModel: Event<void>;
+
+	/**
 	 * Saves current view state of the editor in a serializable object.
 	 */
 	saveViewState(): editorCommon.IDiffEditorViewState | null;

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -181,6 +181,9 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 	private readonly _onDidDispose: Emitter<void> = this._register(new Emitter<void>());
 	public readonly onDidDispose: Event<void> = this._onDidDispose.event;
 
+	protected readonly _onDidChangeModel: Emitter<void> = this._register(new Emitter<void>());
+	public readonly onDidChangeModel: Event<void> = this._onDidChangeModel.event;
+
 	private readonly _onDidUpdateDiff: Emitter<void> = this._register(new Emitter<void>());
 	public readonly onDidUpdateDiff: Event<void> = this._onDidUpdateDiff.event;
 
@@ -830,6 +833,8 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		}
 
 		this._layoutOverviewViewport();
+
+		this._onDidChangeModel.fire();
 	}
 
 	public getContainerDomNode(): HTMLElement {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5510,6 +5510,11 @@ declare namespace monaco.editor {
 		 */
 		readonly onDidUpdateDiff: IEvent<void>;
 		/**
+		 * An event emitted when the diff model is changed (i.e. the diff editor shows new content).
+		 * @event
+		 */
+		readonly onDidChangeModel: IEvent<void>;
+		/**
 		 * Saves current view state of the editor in a serializable object.
 		 */
 		saveViewState(): IDiffEditorViewState | null;

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleWordWrap.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleWordWrap.ts
@@ -6,11 +6,11 @@
 import * as nls from 'vs/nls';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-import { IActiveCodeEditor, ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { EditorAction, ServicesAccessor, registerEditorAction, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
+import { IActiveCodeEditor, ICodeEditor, IDiffEditor } from 'vs/editor/browser/editorBrowser';
+import { EditorAction, ServicesAccessor, registerEditorAction, registerEditorContribution, registerDiffEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
-import { IEditorContribution } from 'vs/editor/common/editorCommon';
+import { IDiffEditorContribution, IEditorContribution } from 'vs/editor/common/editorCommon';
 import { ITextModel } from 'vs/editor/common/model';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
@@ -93,28 +93,35 @@ class ToggleWordWrapAction extends EditorAction {
 		writeTransientState(model, newState, codeEditorService);
 
 		// if we are in a diff editor, update the other editor (if possible)
-		if (editor.getOption(EditorOption.inDiffEditor)) {
-			// this editor belongs to a diff editor
-			for (const diffEditor of codeEditorService.listDiffEditors()) {
-				const originalEditor = diffEditor.getOriginalEditor();
-				const modifiedEditor = diffEditor.getModifiedEditor();
-				if (originalEditor === editor) {
-					if (canToggleWordWrap(codeEditorService, modifiedEditor)) {
-						writeTransientState(modifiedEditor.getModel(), newState, codeEditorService);
-						diffEditor.updateOptions({});
-					}
-					break;
-				}
-				if (modifiedEditor === editor) {
-					if (canToggleWordWrap(codeEditorService, originalEditor)) {
-						writeTransientState(originalEditor.getModel(), newState, codeEditorService);
-						diffEditor.updateOptions({});
-					}
-					break;
-				}
+		const diffEditor = findDiffEditorContainingCodeEditor(editor, codeEditorService);
+		if (diffEditor) {
+			const originalEditor = diffEditor.getOriginalEditor();
+			const modifiedEditor = diffEditor.getModifiedEditor();
+			const otherEditor = (originalEditor === editor ? modifiedEditor : originalEditor);
+			if (canToggleWordWrap(codeEditorService, otherEditor)) {
+				writeTransientState(otherEditor.getModel(), newState, codeEditorService);
+				diffEditor.updateOptions({});
 			}
 		}
 	}
+}
+
+/**
+ * If `editor` is the original or modified editor of a diff editor, it returns it.
+ * It returns null otherwise.
+ */
+function findDiffEditorContainingCodeEditor(editor: ICodeEditor, codeEditorService: ICodeEditorService): IDiffEditor | null {
+	if (!editor.getOption(EditorOption.inDiffEditor)) {
+		return null;
+	}
+	for (const diffEditor of codeEditorService.listDiffEditors()) {
+		const originalEditor = diffEditor.getOriginalEditor();
+		const modifiedEditor = diffEditor.getModifiedEditor();
+		if (originalEditor === editor || modifiedEditor === editor) {
+			return diffEditor;
+		}
+	}
+	return null;
 }
 
 class ToggleWordWrapController extends Disposable implements IEditorContribution {
@@ -178,6 +185,45 @@ class ToggleWordWrapController extends Disposable implements IEditorContribution
 		this._editor.updateOptions({
 			wordWrapOverride2: wordWrapOverride2
 		});
+	}
+}
+
+class DiffToggleWordWrapController extends Disposable implements IDiffEditorContribution {
+
+	public static readonly ID = 'diffeditor.contrib.toggleWordWrapController';
+
+	constructor(
+		private readonly _diffEditor: IDiffEditor,
+		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService
+	) {
+		super();
+
+		this._register(this._diffEditor.onDidChangeModel(() => {
+			this._ensureSyncedWordWrapToggle();
+		}));
+	}
+
+	private _ensureSyncedWordWrapToggle(): void {
+		const originalEditor = this._diffEditor.getOriginalEditor();
+		const modifiedEditor = this._diffEditor.getModifiedEditor();
+
+		if (!originalEditor.hasModel() || !modifiedEditor.hasModel()) {
+			return;
+		}
+
+		const originalTransientState = readTransientState(originalEditor.getModel(), this._codeEditorService);
+		const modifiedTransientState = readTransientState(modifiedEditor.getModel(), this._codeEditorService);
+
+		console.log(originalTransientState, modifiedTransientState);
+
+		if (originalTransientState && !modifiedTransientState && canToggleWordWrap(this._codeEditorService, originalEditor)) {
+			writeTransientState(modifiedEditor.getModel(), originalTransientState, this._codeEditorService);
+			this._diffEditor.updateOptions({});
+		}
+		if (!originalTransientState && modifiedTransientState && canToggleWordWrap(this._codeEditorService, modifiedEditor)) {
+			writeTransientState(originalEditor.getModel(), modifiedTransientState, this._codeEditorService);
+			this._diffEditor.updateOptions({});
+		}
 	}
 }
 
@@ -272,7 +318,7 @@ const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(Extension
 workbenchRegistry.registerWorkbenchContribution(EditorWordWrapContextKeyTracker, LifecyclePhase.Ready);
 
 registerEditorContribution(ToggleWordWrapController.ID, ToggleWordWrapController);
-
+registerDiffEditorContribution(DiffToggleWordWrapController.ID, DiffToggleWordWrapController);
 registerEditorAction(ToggleWordWrapAction);
 
 MenuRegistry.appendMenuItem(MenuId.EditorTitle, {


### PR DESCRIPTION
Fixes #161412