### PR TITLE
Make returned editor contributions an iterable instead of an array

### DIFF
--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -24,6 +24,7 @@ import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { ILogService } from 'vs/platform/log/common/log';
+import { Iterable } from 'vs/base/common/iterator';
 
 
 export type ServicesAccessor = InstantiationServicesAccessor;
@@ -490,15 +491,15 @@ export namespace EditorExtensionsRegistry {
 		return EditorContributionRegistry.INSTANCE.getEditorActions();
 	}
 
-	export function getEditorContributions(): IEditorContributionDescription[] {
+	export function getEditorContributions(): Iterable<IEditorContributionDescription> {
 		return EditorContributionRegistry.INSTANCE.getEditorContributions();
 	}
 
-	export function getSomeEditorContributions(ids: string[]): IEditorContributionDescription[] {
-		return EditorContributionRegistry.INSTANCE.getEditorContributions().filter(c => ids.indexOf(c.id) >= 0);
+	export function getSomeEditorContributions(ids: string[]): Iterable<IEditorContributionDescription> {
+		return Iterable.filter(EditorContributionRegistry.INSTANCE.getEditorContributions(), c => ids.indexOf(c.id) >= 0);
 	}
 
-	export function getDiffEditorContributions(): IDiffEditorContributionDescription[] {
+	export function getDiffEditorContributions(): Iterable<IDiffEditorContributionDescription> {
 		return EditorContributionRegistry.INSTANCE.getDiffEditorContributions();
 	}
 }
@@ -528,16 +529,16 @@ class EditorContributionRegistry {
 		this.editorContributions.push({ id, ctor: ctor as IEditorContributionCtor });
 	}
 
-	public getEditorContributions(): IEditorContributionDescription[] {
-		return this.editorContributions.slice(0);
+	public getEditorContributions(): Iterable<IEditorContributionDescription> {
+		return this.editorContributions;
 	}
 
 	public registerDiffEditorContribution<Services extends BrandedService[]>(id: string, ctor: { new(editor: IDiffEditor, ...services: Services): IEditorContribution }): void {
 		this.diffEditorContributions.push({ id, ctor: ctor as IDiffEditorContributionCtor });
 	}
 
-	public getDiffEditorContributions(): IDiffEditorContributionDescription[] {
-		return this.diffEditorContributions.slice(0);
+	public getDiffEditorContributions(): Iterable<IDiffEditorContributionDescription> {
+		return this.diffEditorContributions;
 	}
 
 	public registerEditorAction(action: EditorAction) {

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -74,7 +74,7 @@ export interface ICodeEditorWidgetOptions {
 	 * Contributions to instantiate.
 	 * Defaults to EditorExtensionsRegistry.getEditorContributions().
 	 */
-	contributions?: IEditorContributionDescription[];
+	contributions?: Iterable<IEditorContributionDescription>;
 
 	/**
 	 * Telemetry data associated with this CodeEditorWidget.
@@ -329,12 +329,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		this._contentWidgets = {};
 		this._overlayWidgets = {};
 
-		let contributions: IEditorContributionDescription[];
-		if (Array.isArray(codeEditorWidgetOptions.contributions)) {
-			contributions = codeEditorWidgetOptions.contributions;
-		} else {
-			contributions = EditorExtensionsRegistry.getEditorContributions();
-		}
+		const contributions = codeEditorWidgetOptions.contributions ?? EditorExtensionsRegistry.getEditorContributions();
 		for (const desc of contributions) {
 			if (this._contributions[desc.id]) {
 				onUnexpectedError(new Error(`Cannot have two contributions with the same id ${desc.id}`));

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -42,7 +42,7 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { IDiffLinesChange, InlineDiffMargin } from 'vs/editor/browser/widget/inlineDiffMargin';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { Constants } from 'vs/base/common/uint';
-import { EditorExtensionsRegistry, IDiffEditorContributionDescription } from 'vs/editor/browser/editorExtensions';
+import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { IEditorProgressService, IProgressRunner } from 'vs/platform/progress/common/progress';
 import { ElementSizeObserver } from 'vs/editor/browser/config/elementSizeObserver';
@@ -366,7 +366,7 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 			this._containerDomElement.className = DiffEditorWidget._getClassName(this._themeService.getColorTheme(), this._options.renderSideBySide);
 		}));
 
-		const contributions: IDiffEditorContributionDescription[] = EditorExtensionsRegistry.getDiffEditorContributions();
+		const contributions = EditorExtensionsRegistry.getDiffEditorContributions();
 		for (const desc of contributions) {
 			try {
 				this._register(instantiationService.createInstance(desc.ctor, this));

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView.ts
@@ -6,6 +6,7 @@
 import { reset } from 'vs/base/browser/dom';
 import { renderLabelWithIcons } from 'vs/base/browser/ui/iconLabel/iconLabels';
 import { BugIndicatingError } from 'vs/base/common/errors';
+import { Iterable } from 'vs/base/common/iterator';
 import { autorun, autorunWithStore, derived, IObservable } from 'vs/base/common/observable';
 import { EditorExtensionsRegistry, IEditorContributionDescription } from 'vs/editor/browser/editorExtensions';
 import { IModelDeltaDecoration, MinimapPosition, OverviewRulerLane } from 'vs/editor/common/model';
@@ -115,7 +116,7 @@ export class BaseCodeEditorView extends CodeEditorView {
 		return result;
 	});
 
-	protected override getEditorContributions(): IEditorContributionDescription[] | undefined {
-		return EditorExtensionsRegistry.getEditorContributions().filter(c => c.id !== CodeLensContribution.ID);
+	protected override getEditorContributions(): Iterable<IEditorContributionDescription> | undefined {
+		return Iterable.filter(EditorExtensionsRegistry.getEditorContributions(), c => c.id !== CodeLensContribution.ID);
 	}
 }

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/codeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/codeEditorView.ts
@@ -103,7 +103,7 @@ export abstract class CodeEditorView extends Disposable {
 
 	}
 
-	protected getEditorContributions(): IEditorContributionDescription[] | undefined {
+	protected getEditorContributions(): Iterable<IEditorContributionDescription> | undefined {
 		return undefined;
 	}
 }

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView.ts
@@ -8,6 +8,7 @@ import { renderLabelWithIcons } from 'vs/base/browser/ui/iconLabel/iconLabels';
 import { Toggle } from 'vs/base/browser/ui/toggle/toggle';
 import { Action, IAction, Separator } from 'vs/base/common/actions';
 import { Codicon } from 'vs/base/common/codicons';
+import { Iterable } from 'vs/base/common/iterator';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { clamp } from 'vs/base/common/numbers';
 import { autorun, autorunWithStore, derived, IObservable, ISettableObservable, ITransaction, observableValue, transaction } from 'vs/base/common/observable';
@@ -204,8 +205,8 @@ export class InputCodeEditorView extends CodeEditorView {
 		return result;
 	});
 
-	protected override getEditorContributions(): IEditorContributionDescription[] | undefined {
-		return EditorExtensionsRegistry.getEditorContributions().filter(c => c.id !== CodeLensContribution.ID);
+	protected override getEditorContributions(): Iterable<IEditorContributionDescription> | undefined {
+		return Iterable.filter(EditorExtensionsRegistry.getEditorContributions(), c => c.id !== CodeLensContribution.ID);
 	}
 }
 

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView.ts
@@ -206,6 +206,6 @@ export class ResultCodeEditorView extends CodeEditorView {
 	});
 
 	protected override getEditorContributions(): IEditorContributionDescription[] | undefined {
-		return EditorExtensionsRegistry.getEditorContributions().filter(c => c.id !== CodeLensContribution.ID);
+		return Array.from(EditorExtensionsRegistry.getEditorContributions()).filter(c => c.id !== CodeLensContribution.ID);
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -323,8 +323,8 @@ export interface INotebookEditorContributionDescription {
 export interface INotebookEditorCreationOptions {
 	readonly isEmbedded?: boolean;
 	readonly isReadOnly?: boolean;
-	readonly contributions?: INotebookEditorContributionDescription[];
-	readonly cellEditorContributions?: IEditorContributionDescription[];
+	readonly contributions?: Iterable<INotebookEditorContributionDescription>;
+	readonly cellEditorContributions?: Iterable<IEditorContributionDescription>;
 	readonly menuIds: {
 		notebookToolbar: MenuId;
 		cellTitleToolbar: MenuId;

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -46,7 +46,7 @@ import { contrastBorder, diffInserted, diffRemoved, editorBackground, errorForeg
 import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { EDITOR_PANE_BACKGROUND, PANEL_BORDER, SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { debugIconStartForeground } from 'vs/workbench/contrib/debug/browser/debugColors';
-import { CellEditState, CellFindMatchWithIndex, CellFocusMode, CellLayoutContext, CellRevealType, IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellOutputViewModel, ICellViewModel, ICommonCellInfo, IDisplayOutputLayoutUpdateRequest, IFocusNotebookCellOptions, IInsetRenderOutput, IModelDecorationsChangeAccessor, INotebookDeltaDecoration, INotebookEditor, INotebookEditorContribution, INotebookEditorContributionDescription, INotebookEditorCreationOptions, INotebookEditorDelegate, INotebookEditorMouseEvent, INotebookEditorOptions, INotebookEditorViewState, INotebookViewCellsUpdateEvent, INotebookWebviewMessage, RenderOutputType } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { CellEditState, CellFindMatchWithIndex, CellFocusMode, CellLayoutContext, CellRevealType, IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellOutputViewModel, ICellViewModel, ICommonCellInfo, IDisplayOutputLayoutUpdateRequest, IFocusNotebookCellOptions, IInsetRenderOutput, IModelDecorationsChangeAccessor, INotebookDeltaDecoration, INotebookEditor, INotebookEditorContribution, INotebookEditorCreationOptions, INotebookEditorDelegate, INotebookEditorMouseEvent, INotebookEditorOptions, INotebookEditorViewState, INotebookViewCellsUpdateEvent, INotebookWebviewMessage, RenderOutputType } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NotebookEditorExtensionsRegistry } from 'vs/workbench/contrib/notebook/browser/notebookEditorExtensions';
 import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
 import { notebookDebug } from 'vs/workbench/contrib/notebook/browser/notebookLogger';
@@ -85,13 +85,14 @@ import { NotebookPerfMarks } from 'vs/workbench/contrib/notebook/common/notebook
 import { BaseCellEditorOptions } from 'vs/workbench/contrib/notebook/browser/viewModel/cellEditorOptions';
 import { ILogService } from 'vs/platform/log/common/log';
 import { FloatingClickMenu } from 'vs/workbench/browser/codeeditor';
+import { Iterable } from 'vs/base/common/iterator';
 
 const $ = DOM.$;
 
 export function getDefaultNotebookCreationOptions(): INotebookEditorCreationOptions {
 	// We inlined the id to avoid loading comment contrib in tests
 	const skipContributions = ['editor.contrib.review', FloatingClickMenu.ID];
-	const contributions = EditorExtensionsRegistry.getEditorContributions().filter(c => skipContributions.indexOf(c.id) === -1);
+	const contributions = Iterable.filter(EditorExtensionsRegistry.getEditorContributions(), c => skipContributions.indexOf(c.id) === -1);
 
 	return {
 		menuIds: {
@@ -349,12 +350,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 		this._editorEditable.set(!creationOptions.isReadOnly);
 
-		let contributions: INotebookEditorContributionDescription[];
-		if (Array.isArray(this.creationOptions.contributions)) {
-			contributions = this.creationOptions.contributions;
-		} else {
-			contributions = NotebookEditorExtensionsRegistry.getEditorContributions();
-		}
+		const contributions = this.creationOptions.contributions ?? NotebookEditorExtensionsRegistry.getEditorContributions();
 		for (const desc of contributions) {
 			let contribution: INotebookEditorContribution | undefined;
 			try {

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
@@ -61,6 +61,7 @@ import { renderSearchMessage } from 'vs/workbench/contrib/search/browser/searchM
 import { EditorExtensionsRegistry, IEditorContributionDescription } from 'vs/editor/browser/editorExtensions';
 import { UnusualLineTerminatorsDetector } from 'vs/editor/contrib/unusualLineTerminators/browser/unusualLineTerminators';
 import { isHighContrast } from 'vs/platform/theme/common/theme';
+import { Iterable } from 'vs/base/common/iterator';
 
 const RESULT_LINE_REGEX = /^(\s+)(\d+)(: |  )(\s*)(.*)$/;
 const FILE_LINE_REGEX = /^(\S.*):$/;
@@ -225,9 +226,9 @@ export class SearchEditor extends AbstractTextCodeEditor<SearchEditorViewState> 
 		}
 	}
 
-	private _getContributions(): IEditorContributionDescription[] {
+	private _getContributions(): Iterable<IEditorContributionDescription> {
 		const skipContributions = [UnusualLineTerminatorsDetector.ID];
-		return EditorExtensionsRegistry.getEditorContributions().filter(c => skipContributions.indexOf(c.id) === -1);
+		return Iterable.filter(EditorExtensionsRegistry.getEditorContributions(), c => skipContributions.indexOf(c.id) === -1);
 	}
 
 	protected override getCodeEditorWidgetOptions(): ICodeEditorWidgetOptions {


### PR DESCRIPTION
This lets us avoid having to call `.slice(0)` when we return the list of editor contributions. It also allows callers to pass in contributions from different sources, such as a `Set` of the values in a `map`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
