### PR TITLE
Add allow list of valid notebook command uris

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -557,24 +557,8 @@ var requirejs = (function() {
 				return;
 			}
 
-			if (matchesScheme(link, Schemas.command)) {
-				const ret = /command\:workbench\.action\.openLargeOutput\?(.*)/.exec(link);
-				if (ret && ret.length === 2) {
-					const outputId = ret[1];
-					this.openerService.open(CellUri.generateCellOutputUri(this.documentUri, outputId));
-					return;
-				}
-				console.warn('Command links are deprecated and will be removed, use message passing instead: https://github.com/microsoft/vscode/issues/123601');
-			}
-
-			if (matchesScheme(link, Schemas.command)) {
-				if (this.workspaceTrustManagementService.isWorkspaceTrusted()) {
-					this.openerService.open(link, { fromUserGesture: true, allowContributedOpeners: true, allowCommands: true });
-				} else {
-					console.warn('Command links are disabled in untrusted workspaces');
-				}
-			} else if (matchesSomeScheme(link, Schemas.vscodeNotebookCell, Schemas.http, Schemas.https, Schemas.mailto)) {
-				this.openerService.open(link, { fromUserGesture: true, allowContributedOpeners: true, allowCommands: true });
+			if (matchesSomeScheme(link, Schemas.vscodeNotebookCell, Schemas.http, Schemas.https, Schemas.mailto)) {
+				this.openerService.open(link, { fromUserGesture: true, allowContributedOpeners: true, allowCommands: false });
 			}
 		}));
 
@@ -693,23 +677,35 @@ var requirejs = (function() {
 				}
 				case 'clicked-link': {
 					let linkToOpen: URI | string | undefined;
+
 					if (matchesScheme(data.href, Schemas.command)) {
-						const ret = /command\:workbench\.action\.openLargeOutput\?(.*)/.exec(data.href);
-						if (ret && ret.length === 2) {
-							const outputId = ret[1];
-							const group = this.editorGroupService.activeGroup;
-
-							if (group) {
-								if (group.activeEditor) {
-									group.pinEditor(group.activeEditor);
+						// We allow a very limited set of commands
+						const uri = URI.parse(data.href);
+						switch (uri.path) {
+							case 'workbench.action.openLargeOutput': {
+								const outputId = uri.query;
+								const group = this.editorGroupService.activeGroup;
+								if (group) {
+									if (group.activeEditor) {
+										group.pinEditor(group.activeEditor);
+									}
 								}
-							}
 
-							this.openerService.open(CellUri.generateCellOutputUri(this.documentUri, outputId));
-							return;
+								this.openerService.open(CellUri.generateCellOutputUri(this.documentUri, outputId));
+								return;
+							}
+							case 'github-issues.authNow':
+							case 'workbench.extensions.search':
+							case 'workbench.action.openSettings': {
+								this.openerService.open(data.href, { fromUserGesture: true, allowCommands: true, fromWorkspace: true });
+								return;
+							}
 						}
+
+						return;
 					}
-					if (matchesSomeScheme(data.href, Schemas.http, Schemas.https, Schemas.mailto, Schemas.command, Schemas.vscodeNotebookCell, Schemas.vscodeNotebook)) {
+
+					if (matchesSomeScheme(data.href, Schemas.http, Schemas.https, Schemas.mailto, Schemas.vscodeNotebookCell, Schemas.vscodeNotebook)) {
 						linkToOpen = data.href;
 					} else if (!/^[\w\-]+:/.test(data.href)) {
 						const fragmentStartIndex = data.href.lastIndexOf('#');
@@ -740,7 +736,7 @@ var requirejs = (function() {
 					}
 
 					if (linkToOpen) {
-						this.openerService.open(linkToOpen, { fromUserGesture: true, allowCommands: true, fromWorkspace: true });
+						this.openerService.open(linkToOpen, { fromUserGesture: true, allowCommands: false, fromWorkspace: true });
 					}
 					break;
 				}


### PR DESCRIPTION
This restricts notebooks to run three command uris. These 3 commands should all be safe to run, even with untrusted inputs
Fixes #163321