### PR TITLE
Move some more menu registration into registerAction2

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -359,12 +359,29 @@ class ToggleSidebarVisibilityAction extends Action2 {
 		super({
 			id: ToggleSidebarVisibilityAction.ID,
 			title: { value: localize('toggleSidebar', "Toggle Primary Side Bar Visibility"), original: 'Toggle Primary Side Bar Visibility' },
+			toggled: {
+				condition: SideBarVisibleContext,
+				title: localize('primary sidebar', "Primary Side Bar"),
+				mnemonicTitle: localize('primary sidebar mnemonic', "&&Primary Side Bar"),
+			},
 			category: Categories.View,
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.KeyB
-			}
+			},
+			menu: [
+				{
+					id: MenuId.LayoutControlMenuSubmenu,
+					group: '0_workbench_layout',
+					order: 0
+				},
+				{
+					id: MenuId.MenubarAppearanceMenu,
+					group: '2_workbench_layout',
+					order: 1
+				}
+			]
 		});
 	}
 
@@ -399,28 +416,6 @@ MenuRegistry.appendMenuItems([
 			},
 			when: ContextKeyExpr.and(SideBarVisibleContext, ContextKeyExpr.equals('viewLocation', ViewContainerLocationToString(ViewContainerLocation.Sidebar))),
 			order: 2
-		}
-	}, {
-		id: MenuId.MenubarAppearanceMenu,
-		item: {
-			group: '2_workbench_layout',
-			command: {
-				id: ToggleSidebarVisibilityAction.ID,
-				title: localize({ key: 'miShowSidebar', comment: ['&& denotes a mnemonic'] }, "&&Primary Side Bar"),
-				toggled: SideBarVisibleContext
-			},
-			order: 1
-		}
-	}, {
-		id: MenuId.LayoutControlMenuSubmenu,
-		item: {
-			group: '0_workbench_layout',
-			command: {
-				id: ToggleSidebarVisibilityAction.ID,
-				title: localize('miSidebarNoMnnemonic', "Primary Side Bar"),
-				toggled: SideBarVisibleContext
-			},
-			order: 0
 		}
 	}, {
 		id: MenuId.LayoutControlMenu,

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -30,8 +30,26 @@ export class ToggleAuxiliaryBarAction extends Action2 {
 		super({
 			id: ToggleAuxiliaryBarAction.ID,
 			title: { value: ToggleAuxiliaryBarAction.LABEL, original: 'Toggle Secondary Side Bar Visibility' },
+			toggled: {
+				condition: AuxiliaryBarVisibleContext,
+				title: localize('secondary sidebar', "Secondary Side Bar"),
+				mnemonicTitle: localize('secondary sidebar mnemonic', "Secondary Si&&de Bar"),
+			},
+
 			category: Categories.View,
 			f1: true,
+			menu: [
+				{
+					id: MenuId.LayoutControlMenuSubmenu,
+					group: '0_workbench_layout',
+					order: 1
+				},
+				{
+					id: MenuId.MenubarAppearanceMenu,
+					group: '2_workbench_layout',
+					order: 2
+				}
+			]
 		});
 	}
 
@@ -75,18 +93,6 @@ registerAction2(class FocusAuxiliaryBarAction extends Action2 {
 
 MenuRegistry.appendMenuItems([
 	{
-		id: MenuId.LayoutControlMenuSubmenu,
-		item: {
-			group: '0_workbench_layout',
-			command: {
-				id: ToggleAuxiliaryBarAction.ID,
-				title: localize('miAuxiliaryBarNoMnemonic', "Secondary Side Bar"),
-				toggled: AuxiliaryBarVisibleContext
-			},
-			order: 2
-		}
-	},
-	{
 		id: MenuId.LayoutControlMenu,
 		item: {
 			group: '0_workbench_toggles',
@@ -99,8 +105,7 @@ MenuRegistry.appendMenuItems([
 			when: ContextKeyExpr.and(ContextKeyExpr.or(ContextKeyExpr.equals('config.workbench.layoutControl.type', 'toggles'), ContextKeyExpr.equals('config.workbench.layoutControl.type', 'both')), ContextKeyExpr.equals('config.workbench.sideBar.location', 'right')),
 			order: 0
 		}
-	},
-	{
+	}, {
 		id: MenuId.LayoutControlMenu,
 		item: {
 			group: '0_workbench_toggles',
@@ -111,18 +116,6 @@ MenuRegistry.appendMenuItems([
 				icon: auxiliaryBarRightOffIcon,
 			},
 			when: ContextKeyExpr.and(ContextKeyExpr.or(ContextKeyExpr.equals('config.workbench.layoutControl.type', 'toggles'), ContextKeyExpr.equals('config.workbench.layoutControl.type', 'both')), ContextKeyExpr.equals('config.workbench.sideBar.location', 'left')),
-			order: 2
-		}
-	},
-	{
-		id: MenuId.MenubarAppearanceMenu,
-		item: {
-			group: '2_workbench_layout',
-			command: {
-				id: ToggleAuxiliaryBarAction.ID,
-				title: localize({ key: 'miAuxiliaryBar', comment: ['&& denotes a mnemonic'] }, "Secondary Si&&de Bar"),
-				toggled: AuxiliaryBarVisibleContext
-			},
 			order: 2
 		}
 	}, {

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -38,9 +38,25 @@ export class TogglePanelAction extends Action2 {
 		super({
 			id: TogglePanelAction.ID,
 			title: { value: TogglePanelAction.LABEL, original: 'Toggle Panel Visibility' },
+			toggled: {
+				condition: PanelVisibleContext,
+				title: localize('toggle panel', "Panel"),
+				mnemonicTitle: localize('toggle panel mnemonic', "&&Panel"),
+			},
 			f1: true,
 			category: Categories.View,
 			keybinding: { primary: KeyMod.CtrlCmd | KeyCode.KeyJ, weight: KeybindingWeight.WorkbenchContrib },
+			menu: [
+				{
+					id: MenuId.MenubarAppearanceMenu,
+					group: '2_workbench_layout',
+					order: 5
+				}, {
+					id: MenuId.LayoutControlMenuSubmenu,
+					group: '0_workbench_layout',
+					order: 4
+				},
+			]
 		});
 	}
 
@@ -408,28 +424,6 @@ registerAction2(class extends Action2 {
 
 MenuRegistry.appendMenuItems([
 	{
-		id: MenuId.MenubarAppearanceMenu,
-		item: {
-			group: '2_workbench_layout',
-			command: {
-				id: TogglePanelAction.ID,
-				title: localize({ key: 'miPanel', comment: ['&& denotes a mnemonic'] }, "&&Panel"),
-				toggled: PanelVisibleContext
-			},
-			order: 5
-		}
-	}, {
-		id: MenuId.LayoutControlMenuSubmenu,
-		item: {
-			group: '0_workbench_layout',
-			command: {
-				id: TogglePanelAction.ID,
-				title: localize('miPanelNoMnemonic', "Panel"),
-				toggled: PanelVisibleContext
-			},
-			order: 4
-		}
-	}, {
 		id: MenuId.LayoutControlMenu,
 		item: {
 			group: '0_workbench_toggles',


### PR DESCRIPTION
Review of this PR does not depend on the text below refs #162713

---

cc @jrieken I have updated to use the toggle title as you mentioned. I've hit some limitations with it that could warrant some changes but there are some workarounds that may be what you prefer, but this PR is a good outline.

If you take a look at any Toggle X Visibility action for the panel/bars, you can see they are re-used in several menus. I moved some of the menu registrations to registerAction2 call, but still some remain in appendMenuItems for the time being. Take the layout control as an example. It has both an icon representation and a menu representation.

<img width="85" alt="image" src="https://user-images.githubusercontent.com/6561887/195163737-99b4ba6b-ec69-4100-989c-44ab5ac066f7.png">
<img width="123" alt="image" src="https://user-images.githubusercontent.com/6561887/195163842-1e969721-3d01-42f2-b643-f4a8b58a84e4.png">

I think I can get the text part working by using the tooltip property for the toggle icon case, but there is a unique problem here that the icon has conditions based on the position of the activity bar. This means I need 2 menu registrations with separate when conditions and complete sets of icons, titles, toggles etc.

The other menus we register this action to only use the toggle one way, so we always want to say hide/close. This is essentially a title override for the menu and I don't think we have any real way to express that here.