### PR TITLE
Darken red colour in light theme for better contrast

### DIFF
--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -104,7 +104,7 @@
 		{
 			"scope": "entity.other.attribute-name",
 			"settings": {
-				"foreground": "#ff0000"
+				"foreground": "#e50000"
 			}
 		},
 		{
@@ -329,7 +329,7 @@
 				"source.coffee.embedded"
 			],
 			"settings": {
-				"foreground": "#ff0000"
+				"foreground": "#e50000"
 			}
 		},
 		{

--- a/extensions/vscode-colorize-tests/test/colorize-results/12750_html.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/12750_html.json
@@ -40,9 +40,9 @@
 		"t": "text.html.derivative meta.embedded.block.html meta.tag.metadata.script.start.html meta.attribute.type.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/14119_less.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/14119_less.json
@@ -40,9 +40,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -52,9 +52,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/25920_html.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/25920_html.json
@@ -76,9 +76,9 @@
 		"t": "text.html.derivative meta.embedded.block.html meta.tag.metadata.script.start.html meta.attribute.type.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -196,9 +196,9 @@
 		"t": "text.html.derivative meta.embedded.block.html text.html.basic meta.tag.structure.div.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -388,9 +388,9 @@
 		"t": "text.html.derivative meta.embedded.block.html meta.tag.metadata.script.start.html meta.attribute.type.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -652,9 +652,9 @@
 		"t": "text.html.derivative meta.embedded.block.html meta.tag.metadata.script.start.html meta.attribute.type.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -772,9 +772,9 @@
 		"t": "text.html.derivative meta.embedded.block.html text.html.basic meta.tag.structure.div.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -964,9 +964,9 @@
 		"t": "text.html.derivative meta.tag.structure.body.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-4287_pug.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-4287_pug.json
@@ -4,9 +4,9 @@
 		"t": "text.pug entity.other.attribute-name.class.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-7115_xml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-7115_xml.json
@@ -28,9 +28,9 @@
 		"t": "text.xml meta.tag.preprocessor.xml entity.other.attribute-name.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -88,9 +88,9 @@
 		"t": "text.xml meta.tag.preprocessor.xml entity.other.attribute-name.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -148,9 +148,9 @@
 		"t": "text.xml meta.tag.preprocessor.xml entity.other.attribute-name.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -316,9 +316,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -388,9 +388,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-cssvariables_less.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-cssvariables_less.json
@@ -64,9 +64,9 @@
 		"t": "source.css.less meta.property-list.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -76,9 +76,9 @@
 		"t": "source.css.less meta.property-list.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -160,9 +160,9 @@
 		"t": "source.css.less meta.property-list.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -172,9 +172,9 @@
 		"t": "source.css.less meta.property-list.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -400,9 +400,9 @@
 		"t": "source.css.less meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-cssvariables_scss.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-cssvariables_scss.json
@@ -64,9 +64,9 @@
 		"t": "source.css.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -148,9 +148,9 @@
 		"t": "source.css.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -268,9 +268,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -376,9 +376,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -508,9 +508,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-embedding_html.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-embedding_html.json
@@ -268,9 +268,9 @@
 		"t": "text.html.derivative meta.embedded.block.html source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -424,9 +424,9 @@
 		"t": "text.html.derivative meta.tag.inline.a.start.html meta.attribute.event-handler.blur.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -508,9 +508,9 @@
 		"t": "text.html.derivative meta.tag.inline.a.start.html meta.attribute.event-handler.click.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -592,9 +592,9 @@
 		"t": "text.html.derivative meta.tag.inline.a.start.html meta.attribute.event-handler.drag.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -724,9 +724,9 @@
 		"t": "text.html.derivative meta.tag.structure.div.start.html meta.attribute.style.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -868,9 +868,9 @@
 		"t": "text.html.derivative meta.tag.structure.div.start.html meta.attribute.style.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1012,9 +1012,9 @@
 		"t": "text.html.derivative meta.tag.structure.div.start.html meta.attribute.style.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-regex_coffee.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-regex_coffee.json
@@ -508,9 +508,9 @@
 		"t": "source.coffee string.regexp.multiline.coffee source.coffee.embedded.source",
 		"r": {
 			"dark_plus": "source.coffee.embedded: #9CDCFE",
-			"light_plus": "source.coffee.embedded: #FF0000",
+			"light_plus": "source.coffee.embedded: #E50000",
 			"dark_vs": "source.coffee.embedded: #9CDCFE",
-			"light_vs": "source.coffee.embedded: #FF0000",
+			"light_vs": "source.coffee.embedded: #E50000",
 			"hc_black": "source.coffee.embedded: #D4D4D4",
 			"hc_light": "source.coffee.embedded: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-variables_css.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-variables_css.json
@@ -64,9 +64,9 @@
 		"t": "source.css meta.property-list.css variable.css",
 		"r": {
 			"dark_plus": "variable.css: #9CDCFE",
-			"light_plus": "variable.css: #FF0000",
+			"light_plus": "variable.css: #E50000",
 			"dark_vs": "variable.css: #9CDCFE",
-			"light_vs": "variable.css: #FF0000",
+			"light_vs": "variable.css: #E50000",
 			"hc_black": "variable.css: #D4D4D4",
 			"hc_light": "variable.css: #264F78"
 		}
@@ -148,9 +148,9 @@
 		"t": "source.css meta.property-list.css variable.css",
 		"r": {
 			"dark_plus": "variable.css: #9CDCFE",
-			"light_plus": "variable.css: #FF0000",
+			"light_plus": "variable.css: #E50000",
 			"dark_vs": "variable.css: #9CDCFE",
-			"light_vs": "variable.css: #FF0000",
+			"light_vs": "variable.css: #E50000",
 			"hc_black": "variable.css: #D4D4D4",
 			"hc_light": "variable.css: #264F78"
 		}
@@ -352,9 +352,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_coffee.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_coffee.json
@@ -354,7 +354,7 @@
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
 			"dark_vs": "source.coffee.embedded: #9CDCFE",
-			"light_vs": "source.coffee.embedded: #FF0000",
+			"light_vs": "source.coffee.embedded: #E50000",
 			"hc_black": "variable: #9CDCFE",
 			"hc_light": "variable: #001080"
 		}
@@ -642,7 +642,7 @@
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
 			"dark_vs": "source.coffee.embedded: #9CDCFE",
-			"light_vs": "source.coffee.embedded: #FF0000",
+			"light_vs": "source.coffee.embedded: #E50000",
 			"hc_black": "variable: #9CDCFE",
 			"hc_light": "variable: #001080"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_cshtml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_cshtml.json
@@ -1312,9 +1312,9 @@
 		"t": "text.html.cshtml meta.tag.metadata.doctype.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1372,9 +1372,9 @@
 		"t": "text.html.cshtml meta.tag.structure.html.start.html meta.attribute.lang.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1636,9 +1636,9 @@
 		"t": "text.html.cshtml meta.tag.metadata.meta.void.html meta.attribute.charset.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2044,9 +2044,9 @@
 		"t": "text.html.cshtml meta.tag.structure.form.start.html meta.attribute.action.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2104,9 +2104,9 @@
 		"t": "text.html.cshtml meta.tag.structure.form.start.html meta.attribute.method.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2260,9 +2260,9 @@
 		"t": "text.html.cshtml meta.tag.structure.label.start.html meta.attribute.for.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2428,9 +2428,9 @@
 		"t": "text.html.cshtml meta.tag.structure.input.void.html meta.attribute.type.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2500,9 +2500,9 @@
 		"t": "text.html.cshtml meta.tag.structure.input.void.html meta.attribute.name.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2716,9 +2716,9 @@
 		"t": "text.html.cshtml meta.tag.structure.label.start.html meta.attribute.for.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2884,9 +2884,9 @@
 		"t": "text.html.cshtml meta.tag.structure.input.void.html meta.attribute.type.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2956,9 +2956,9 @@
 		"t": "text.html.cshtml meta.tag.structure.input.void.html meta.attribute.name.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -3172,9 +3172,9 @@
 		"t": "text.html.cshtml meta.tag.structure.input.void.html meta.attribute.type.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -3244,9 +3244,9 @@
 		"t": "text.html.cshtml meta.tag.structure.input.void.html meta.attribute.value.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_css.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_css.json
@@ -700,9 +700,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -772,9 +772,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -892,9 +892,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1036,9 +1036,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1108,9 +1108,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1192,9 +1192,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1408,9 +1408,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1480,9 +1480,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1552,9 +1552,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1708,9 +1708,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2068,9 +2068,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2224,9 +2224,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2452,9 +2452,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2524,9 +2524,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2644,9 +2644,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2836,9 +2836,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2920,9 +2920,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2992,9 +2992,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3148,9 +3148,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3220,9 +3220,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3292,9 +3292,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3448,9 +3448,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3520,9 +3520,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3592,9 +3592,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3676,9 +3676,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3916,9 +3916,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3988,9 +3988,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -4120,9 +4120,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -4288,9 +4288,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -4468,9 +4468,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -4636,9 +4636,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -4708,9 +4708,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -4840,9 +4840,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -4924,9 +4924,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5080,9 +5080,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5284,9 +5284,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5368,9 +5368,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5440,9 +5440,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5524,9 +5524,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5608,9 +5608,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5680,9 +5680,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5764,9 +5764,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5836,9 +5836,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5956,9 +5956,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -6040,9 +6040,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -6184,9 +6184,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -6256,9 +6256,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -6448,9 +6448,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -6532,9 +6532,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -6688,9 +6688,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -6844,9 +6844,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -6976,9 +6976,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7048,9 +7048,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7288,9 +7288,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7372,9 +7372,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7516,9 +7516,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7744,9 +7744,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7888,9 +7888,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7972,9 +7972,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8044,9 +8044,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8116,9 +8116,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8284,9 +8284,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8428,9 +8428,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8632,9 +8632,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8716,9 +8716,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8800,9 +8800,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9016,9 +9016,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9232,9 +9232,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9388,9 +9388,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9592,9 +9592,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9664,9 +9664,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9748,9 +9748,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9820,9 +9820,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9904,9 +9904,9 @@
 		"t": "source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_handlebars.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_handlebars.json
@@ -40,9 +40,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html entity.other.attribute-name.html entity.other.attribute-name.generic.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -52,9 +52,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html entity.other.attribute-name.html punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -856,9 +856,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html entity.other.attribute-name.html entity.other.attribute-name.generic.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -868,9 +868,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html entity.other.attribute-name.html punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1048,9 +1048,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html entity.other.attribute-name.html entity.other.attribute-name.generic.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1060,9 +1060,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html entity.other.attribute-name.html punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1612,9 +1612,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html meta.attribute-with-value.id.html entity.other.attribute-name.id.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1840,9 +1840,9 @@
 		"t": "text.html.handlebars meta.tag.inline.any.html entity.other.attribute-name.html entity.other.attribute-name.generic.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1852,9 +1852,9 @@
 		"t": "text.html.handlebars meta.tag.inline.any.html entity.other.attribute-name.html punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_hbs.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_hbs.json
@@ -124,9 +124,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html meta.attribute-with-value.id.html entity.other.attribute-name.id.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -352,9 +352,9 @@
 		"t": "text.html.handlebars meta.tag.inline.any.html entity.other.attribute-name.html entity.other.attribute-name.generic.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -364,9 +364,9 @@
 		"t": "text.html.handlebars meta.tag.inline.any.html entity.other.attribute-name.html punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1072,9 +1072,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html entity.other.attribute-name.html entity.other.attribute-name.generic.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1084,9 +1084,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html entity.other.attribute-name.html punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1528,9 +1528,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html entity.other.attribute-name.html entity.other.attribute-name.generic.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1540,9 +1540,9 @@
 		"t": "text.html.handlebars meta.tag.block.any.html entity.other.attribute-name.html punctuation.separator.key-value.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1662,7 +1662,7 @@
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "variable: #9CDCFE",
 			"hc_light": "variable: #001080"
 		}
@@ -1672,9 +1672,9 @@
 		"t": "text.html.handlebars meta.function.inline.other.handlebars entity.other.attribute-name.handlebars",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1974,7 +1974,7 @@
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "variable: #9CDCFE",
 			"hc_light": "variable: #001080"
 		}
@@ -1984,9 +1984,9 @@
 		"t": "text.html.handlebars meta.function.inline.other.handlebars entity.other.attribute-name.handlebars",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_html.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_html.json
@@ -124,9 +124,9 @@
 		"t": "text.html.derivative meta.tag.metadata.meta.void.html meta.attribute.charset.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -340,9 +340,9 @@
 		"t": "text.html.derivative meta.tag.metadata.link.void.html meta.attribute.href.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -412,9 +412,9 @@
 		"t": "text.html.derivative meta.tag.metadata.link.void.html meta.attribute.rel.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -544,9 +544,9 @@
 		"t": "text.html.derivative meta.embedded.block.html meta.tag.metadata.style.start.html meta.attribute.type.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -676,9 +676,9 @@
 		"t": "text.html.derivative meta.embedded.block.html source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -748,9 +748,9 @@
 		"t": "text.html.derivative meta.embedded.block.html source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1024,9 +1024,9 @@
 		"t": "text.html.derivative meta.tag.structure.div.start.html meta.attribute.id.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1240,9 +1240,9 @@
 		"t": "text.html.derivative meta.embedded.block.html meta.tag.metadata.script.start.html meta.attribute.src.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1408,9 +1408,9 @@
 		"t": "text.html.derivative meta.embedded.block.html meta.tag.metadata.script.start.html meta.attribute.src.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2512,9 +2512,9 @@
 		"t": "text.html.derivative meta.tag.structure.div.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2632,9 +2632,9 @@
 		"t": "text.html.derivative meta.tag.inline.span.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2764,9 +2764,9 @@
 		"t": "text.html.derivative meta.tag.inline.span.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2884,9 +2884,9 @@
 		"t": "text.html.derivative meta.tag.inline.a.start.html meta.attribute.href.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -3088,9 +3088,9 @@
 		"t": "text.html.derivative meta.tag.inline.span.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -3208,9 +3208,9 @@
 		"t": "text.html.derivative meta.tag.inline.a.start.html meta.attribute.href.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_jsx.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_jsx.json
@@ -1948,9 +1948,9 @@
 		"t": "source.js.jsx meta.var.expr.js.jsx meta.objectliteral.js.jsx meta.object.member.js.jsx meta.function.expression.js.jsx meta.block.js.jsx meta.tag.without-attributes.js.jsx meta.jsx.children.js.jsx meta.tag.js.jsx meta.tag.attributes.js.jsx entity.other.attribute-name.js.jsx",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2008,9 +2008,9 @@
 		"t": "source.js.jsx meta.var.expr.js.jsx meta.objectliteral.js.jsx meta.object.member.js.jsx meta.function.expression.js.jsx meta.block.js.jsx meta.tag.without-attributes.js.jsx meta.jsx.children.js.jsx meta.tag.js.jsx meta.tag.attributes.js.jsx entity.other.attribute-name.js.jsx",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2380,9 +2380,9 @@
 		"t": "source.js.jsx meta.tag.js.jsx meta.tag.attributes.js.jsx entity.other.attribute-name.js.jsx",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -2452,9 +2452,9 @@
 		"t": "source.js.jsx meta.tag.js.jsx meta.tag.attributes.js.jsx entity.other.attribute-name.js.jsx",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_less.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_less.json
@@ -340,9 +340,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -352,9 +352,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -436,9 +436,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -448,9 +448,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -484,9 +484,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -496,9 +496,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -592,9 +592,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -604,9 +604,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -664,9 +664,9 @@
 		"t": "source.css.less meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -700,9 +700,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -712,9 +712,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -736,9 +736,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -748,9 +748,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -808,9 +808,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -820,9 +820,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -856,9 +856,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -868,9 +868,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -1012,9 +1012,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -1024,9 +1024,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -1108,9 +1108,9 @@
 		"t": "source.css.less meta.property-list.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -1120,9 +1120,9 @@
 		"t": "source.css.less meta.property-list.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -1408,9 +1408,9 @@
 		"t": "source.css.less meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1468,9 +1468,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -1480,9 +1480,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -1576,9 +1576,9 @@
 		"t": "source.css.less meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1636,9 +1636,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -1648,9 +1648,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -2116,9 +2116,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2200,9 +2200,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2344,9 +2344,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2476,9 +2476,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-list.css meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2620,9 +2620,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-list.css meta.property-list.css meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2764,9 +2764,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -2776,9 +2776,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -2848,9 +2848,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -2860,9 +2860,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -2920,9 +2920,9 @@
 		"t": "source.css.less variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -2932,9 +2932,9 @@
 		"t": "source.css.less variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -3052,9 +3052,9 @@
 		"t": "source.css.less meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3100,9 +3100,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -3112,9 +3112,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -3208,9 +3208,9 @@
 		"t": "source.css.less meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3244,9 +3244,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -3256,9 +3256,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -3292,9 +3292,9 @@
 		"t": "source.css.less meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3340,9 +3340,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -3352,9 +3352,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -3508,9 +3508,9 @@
 		"t": "source.css.less meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3556,9 +3556,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -3568,9 +3568,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -3664,9 +3664,9 @@
 		"t": "source.css.less meta.property-list.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3724,9 +3724,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less punctuation.definition.variable.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}
@@ -3736,9 +3736,9 @@
 		"t": "source.css.less meta.property-list.css meta.property-value.css variable.other.less",
 		"r": {
 			"dark_plus": "variable.other.less: #9CDCFE",
-			"light_plus": "variable.other.less: #FF0000",
+			"light_plus": "variable.other.less: #E50000",
 			"dark_vs": "variable.other.less: #9CDCFE",
-			"light_vs": "variable.other.less: #FF0000",
+			"light_vs": "variable.other.less: #E50000",
 			"hc_black": "variable.other.less: #D4D4D4",
 			"hc_light": "variable.other.less: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_md.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_md.json
@@ -424,9 +424,9 @@
 		"t": "text.html.markdown meta.tag.structure.div.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -496,9 +496,9 @@
 		"t": "text.html.markdown meta.tag.structure.div.start.html meta.attribute.unrecognized.markdown.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -724,9 +724,9 @@
 		"t": "text.html.markdown meta.embedded.block.html meta.tag.metadata.script.start.html meta.attribute.type.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -916,9 +916,9 @@
 		"t": "text.html.markdown meta.tag.inline.b.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1156,9 +1156,9 @@
 		"t": "text.html.markdown meta.embedded.block.html source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_pug.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_pug.json
@@ -112,9 +112,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -436,9 +436,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -964,9 +964,9 @@
 		"t": "text.pug entity.other.attribute-name.class.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1132,9 +1132,9 @@
 		"t": "text.pug entity.other.attribute-name.class.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1180,9 +1180,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1228,9 +1228,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1276,9 +1276,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1360,9 +1360,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1408,9 +1408,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1492,9 +1492,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1540,9 +1540,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1624,9 +1624,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1672,9 +1672,9 @@
 		"t": "text.pug meta.tag.other entity.other.attribute-name.tag.pug",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_scss.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_scss.json
@@ -280,9 +280,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -436,9 +436,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -568,9 +568,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -736,9 +736,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -940,9 +940,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1060,9 +1060,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1204,9 +1204,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1540,9 +1540,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1588,9 +1588,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -1672,9 +1672,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2776,9 +2776,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -2980,9 +2980,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3100,9 +3100,9 @@
 		"t": "source.css.scss meta.definition.variable.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -3172,9 +3172,9 @@
 		"t": "source.css.scss meta.definition.variable.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -3340,9 +3340,9 @@
 		"t": "source.css.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -3424,9 +3424,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -3460,9 +3460,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -3496,9 +3496,9 @@
 		"t": "source.css.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -3580,9 +3580,9 @@
 		"t": "source.css.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -3712,9 +3712,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -3760,9 +3760,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -3808,9 +3808,9 @@
 		"t": "source.css.scss meta.definition.variable.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -3856,9 +3856,9 @@
 		"t": "source.css.scss meta.definition.variable.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -3952,9 +3952,9 @@
 		"t": "source.css.scss entity.other.attribute-name.class.css variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -4024,9 +4024,9 @@
 		"t": "source.css.scss meta.property-list.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -4180,9 +4180,9 @@
 		"t": "source.css.scss meta.definition.variable.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -4504,9 +4504,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -4720,9 +4720,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -4864,9 +4864,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -4996,9 +4996,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5356,9 +5356,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5560,9 +5560,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -5620,9 +5620,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -5692,9 +5692,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -5776,9 +5776,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -5908,9 +5908,9 @@
 		"t": "source.css.scss meta.definition.variable.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -5980,9 +5980,9 @@
 		"t": "source.css.scss meta.definition.variable.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -6112,9 +6112,9 @@
 		"t": "source.css.scss meta.at-rule.function.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -6208,9 +6208,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.at-rule.return.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -6256,9 +6256,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.at-rule.return.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -6316,9 +6316,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.at-rule.return.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -6424,9 +6424,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.at-rule.return.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -6520,9 +6520,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -6760,9 +6760,9 @@
 		"t": "source.css.scss meta.definition.variable.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -7024,9 +7024,9 @@
 		"t": "source.css.scss meta.at-rule.import.scss string.quoted.double.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -7336,9 +7336,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7516,9 +7516,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.at-rule.media.scss meta.property-list.media-query.scss meta.property-name.media-query.scss support.type.property-name.media.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7612,9 +7612,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7816,9 +7816,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -7936,9 +7936,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8164,9 +8164,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8284,9 +8284,9 @@
 		"t": "source.css.scss entity.other.attribute-name.placeholder.css punctuation.definition.entity.css",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -8296,9 +8296,9 @@
 		"t": "source.css.scss entity.other.attribute-name.placeholder.css",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -8344,9 +8344,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8416,9 +8416,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8488,9 +8488,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -8668,9 +8668,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.at-rule.extend.scss entity.other.attribute-name.placeholder.css punctuation.definition.entity.css",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -8680,9 +8680,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.at-rule.extend.scss entity.other.attribute-name.placeholder.css",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -8884,9 +8884,9 @@
 		"t": "source.css.scss meta.at-rule.mixin.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -8908,9 +8908,9 @@
 		"t": "source.css.scss meta.at-rule.mixin.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -9028,9 +9028,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.at-rule.if.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -9160,9 +9160,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.at-rule.warn.scss string.quoted.double.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -9232,9 +9232,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -9328,9 +9328,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -9448,9 +9448,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.at-rule.if.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -9580,9 +9580,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.at-rule.warn.scss string.quoted.double.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -9652,9 +9652,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -9748,9 +9748,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -9808,9 +9808,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9880,9 +9880,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9916,9 +9916,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -9952,9 +9952,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -9988,9 +9988,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -10324,9 +10324,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -10588,9 +10588,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -10780,9 +10780,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -10948,9 +10948,9 @@
 		"t": "source.css.scss meta.definition.variable.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -11080,9 +11080,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.at-rule.if.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -11152,9 +11152,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -11296,9 +11296,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -11464,9 +11464,9 @@
 		"t": "source.css.scss meta.at-rule.for.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -11644,9 +11644,9 @@
 		"t": "source.css.scss meta.property-list.scss entity.other.attribute-name.class.css variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -11704,9 +11704,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -11800,9 +11800,9 @@
 		"t": "source.css.scss meta.property-list.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -11932,9 +11932,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -12052,9 +12052,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.property-list.scss entity.other.attribute-name.class.css variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -12124,9 +12124,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -12220,9 +12220,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.property-list.scss meta.property-list.scss meta.property-value.scss string.quoted.single.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -12364,9 +12364,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -12448,9 +12448,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -12580,9 +12580,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss entity.other.attribute-name.class.css variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -12640,9 +12640,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -12736,9 +12736,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -12796,9 +12796,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -12832,9 +12832,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -13012,9 +13012,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.at-rule.function.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -13048,9 +13048,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.at-rule.function.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -13144,9 +13144,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.for.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -13240,9 +13240,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.for.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -13360,9 +13360,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.at-rule.if.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -13492,9 +13492,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.at-rule.if.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -13528,9 +13528,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.at-rule.if.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -13636,9 +13636,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -13900,9 +13900,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.return.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -14104,9 +14104,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -14176,9 +14176,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -14260,9 +14260,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -14356,9 +14356,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -14572,9 +14572,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -14752,9 +14752,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.at-rule.mixin.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -14776,9 +14776,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.at-rule.mixin.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -14884,9 +14884,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -14932,9 +14932,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -14968,9 +14968,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -15004,9 +15004,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -15040,9 +15040,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -15436,9 +15436,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.at-rule.mixin.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -15508,9 +15508,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.vendored.property-name.css",
 		"r": {
 			"dark_plus": "support.type.vendored.property-name: #9CDCFE",
-			"light_plus": "support.type.vendored.property-name: #FF0000",
+			"light_plus": "support.type.vendored.property-name: #E50000",
 			"dark_vs": "support.type.vendored.property-name: #9CDCFE",
-			"light_vs": "support.type.vendored.property-name: #FF0000",
+			"light_vs": "support.type.vendored.property-name: #E50000",
 			"hc_black": "support.type.vendored.property-name: #D4D4D4",
 			"hc_light": "support.type.vendored.property-name: #264F78"
 		}
@@ -15544,9 +15544,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -15580,9 +15580,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.vendored.property-name.css",
 		"r": {
 			"dark_plus": "support.type.vendored.property-name: #9CDCFE",
-			"light_plus": "support.type.vendored.property-name: #FF0000",
+			"light_plus": "support.type.vendored.property-name: #E50000",
 			"dark_vs": "support.type.vendored.property-name: #9CDCFE",
-			"light_vs": "support.type.vendored.property-name: #FF0000",
+			"light_vs": "support.type.vendored.property-name: #E50000",
 			"hc_black": "support.type.vendored.property-name: #D4D4D4",
 			"hc_light": "support.type.vendored.property-name: #264F78"
 		}
@@ -15616,9 +15616,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -15652,9 +15652,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -15688,9 +15688,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -16252,9 +16252,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.at-rule.mixin.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -16276,9 +16276,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.at-rule.mixin.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -16300,9 +16300,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.at-rule.mixin.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -16360,9 +16360,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -16396,9 +16396,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -16432,9 +16432,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -16468,9 +16468,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -16504,9 +16504,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -16540,9 +16540,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-value.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -16576,9 +16576,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -16828,9 +16828,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.include.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -17284,9 +17284,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -17464,9 +17464,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.at-rule.if.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -17668,9 +17668,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.attribute-selector.scss entity.other.attribute-name.attribute.scss",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -18016,9 +18016,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -18100,9 +18100,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -18364,9 +18364,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -19036,9 +19036,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.at-rule.extend.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -19084,9 +19084,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -19144,9 +19144,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -19324,9 +19324,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.mixin.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -19468,9 +19468,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.at-rule.extend.scss entity.other.attribute-name.class.css variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -19564,9 +19564,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.at-rule.extend.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -20152,9 +20152,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -20224,9 +20224,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -20440,9 +20440,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss entity.other.attribute-name.class.css variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -20524,9 +20524,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -20644,9 +20644,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -20740,9 +20740,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -20788,9 +20788,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -20896,9 +20896,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss variable.interpolation.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -21136,9 +21136,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.keyframes.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -21280,9 +21280,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.keyframes.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -21484,9 +21484,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.keyframes.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -21628,9 +21628,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.keyframes.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -21736,9 +21736,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-name.scss support.type.vendored.property-name.css",
 		"r": {
 			"dark_plus": "support.type.vendored.property-name: #9CDCFE",
-			"light_plus": "support.type.vendored.property-name: #FF0000",
+			"light_plus": "support.type.vendored.property-name: #E50000",
 			"dark_vs": "support.type.vendored.property-name: #9CDCFE",
-			"light_vs": "support.type.vendored.property-name: #FF0000",
+			"light_vs": "support.type.vendored.property-name: #E50000",
 			"hc_black": "support.type.vendored.property-name: #D4D4D4",
 			"hc_light": "support.type.vendored.property-name: #264F78"
 		}
@@ -21832,9 +21832,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -21952,9 +21952,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.property-list.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -22180,9 +22180,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.keyframes.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -22324,9 +22324,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.at-rule.keyframes.scss meta.property-list.scss meta.property-name.scss support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}
@@ -22468,9 +22468,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss meta.attribute-selector.scss entity.other.attribute-name.attribute.scss",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -22720,9 +22720,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}
@@ -22804,9 +22804,9 @@
 		"t": "source.css.scss meta.at-rule.each.scss meta.at-rule.while.scss meta.property-list.scss variable.scss",
 		"r": {
 			"dark_plus": "variable.scss: #9CDCFE",
-			"light_plus": "variable.scss: #FF0000",
+			"light_plus": "variable.scss: #E50000",
 			"dark_vs": "variable.scss: #9CDCFE",
-			"light_vs": "variable.scss: #FF0000",
+			"light_vs": "variable.scss: #E50000",
 			"hc_black": "variable.scss: #D4D4D4",
 			"hc_light": "variable.scss: #264F78"
 		}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_xml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_xml.json
@@ -88,9 +88,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -208,9 +208,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -328,9 +328,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -400,9 +400,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -568,9 +568,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -640,9 +640,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -952,9 +952,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1552,9 +1552,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1624,9 +1624,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1744,9 +1744,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1816,9 +1816,9 @@
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

@gregvanl ran Accessibility Insights on the website and noticed that there wasn't enough contrast between the red text and white background (such as with `charset` below). The website currently uses @shikijs for highlighting, which pulls the theme from VS Code itself.

![Accessibility Insights window shows an error about the red text contrast being too low](https://user-images.githubusercontent.com/7199958/195168594-740d58b6-7718-4f85-8d97-9281d7f708d0.png)
