### PR TITLE
Don't depend on typescript protocol.d.ts

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/completions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/completions.ts
@@ -521,7 +521,7 @@ class MyCompletionItem extends vscode.CompletionItem {
 	}
 }
 
-function getScriptKindDetails(tsEntry: protocol.CompletionEntry,): string | undefined {
+function getScriptKindDetails(tsEntry: Proto.CompletionEntry,): string | undefined {
 	if (!tsEntry.kindModifiers || tsEntry.kind !== PConst.Kind.script) {
 		return;
 	}

--- a/extensions/typescript-language-features/src/protocol.d.ts
+++ b/extensions/typescript-language-features/src/protocol.d.ts
@@ -1,13 +1,19 @@
-import * as Proto from 'typescript/lib/protocol';
-export = Proto;
+import * as ts from 'typescript/lib/tsserverlibrary';
+export = ts.server.protocol;
+
 
 declare enum ServerType {
 	Syntax = 'syntax',
 	Semantic = 'semantic',
 }
-declare module 'typescript/lib/protocol' {
 
-	interface Response {
-		readonly _serverType?: ServerType;
+declare module 'typescript/lib/tsserverlibrary' {
+	namespace server.protocol {
+		type TextInsertion = ts.TextInsertion;
+		type ScriptElementKind = ts.ScriptElementKind;
+
+		interface Response {
+			readonly _serverType?: ServerType;
+		}
 	}
 }

--- a/extensions/typescript-language-features/src/utils/configuration.ts
+++ b/extensions/typescript-language-features/src/utils/configuration.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as objects from '../utils/objects';
+import * as Proto from '../protocol';
 
 export enum TsServerLogLevel {
 	Off,
@@ -112,7 +113,7 @@ export interface TypeScriptServiceConfiguration {
 	readonly enableProjectDiagnostics: boolean;
 	readonly maxTsServerMemory: number;
 	readonly enablePromptUseWorkspaceTsdk: boolean;
-	readonly watchOptions: protocol.WatchOptions | undefined;
+	readonly watchOptions: Proto.WatchOptions | undefined;
 	readonly includePackageJsonAutoImports: 'auto' | 'on' | 'off' | undefined;
 	readonly enableTsServerTracing: boolean;
 }
@@ -196,8 +197,8 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 		return configuration.get<boolean>('typescript.tsserver.experimental.enableProjectDiagnostics', false);
 	}
 
-	protected readWatchOptions(configuration: vscode.WorkspaceConfiguration): protocol.WatchOptions | undefined {
-		return configuration.get<protocol.WatchOptions>('typescript.tsserver.watchOptions');
+	protected readWatchOptions(configuration: vscode.WorkspaceConfiguration): Proto.WatchOptions | undefined {
+		return configuration.get<Proto.WatchOptions>('typescript.tsserver.watchOptions');
 	}
 
 	protected readIncludePackageJsonAutoImports(configuration: vscode.WorkspaceConfiguration): 'auto' | 'on' | 'off' | undefined {

--- a/extensions/typescript-language-features/src/utils/tsconfig.ts
+++ b/extensions/typescript-language-features/src/utils/tsconfig.ts
@@ -163,7 +163,7 @@ export async function openProjectConfigForFile(
 		return;
 	}
 
-	let res: ServerResponse.Response<protocol.ProjectInfoResponse> | undefined;
+	let res: ServerResponse.Response<Proto.ProjectInfoResponse> | undefined;
 	try {
 		res = await client.execute('projectInfo', { file, needFileNameList: false }, nulToken);
 	} catch {


### PR DESCRIPTION
For TS 5.0, we're making some major build changes and package cleanups stemming from our conversion from namespaces to modules. protocol.d.ts is one file I'm trying to eliminate, as it's tricky to produce in the new build. See also:

- https://github.com/microsoft/TypeScript/issues/50758
- https://github.com/microsoft/TypeScript/pull/51026
- https://github.com/microsoft/TypeScript/issues/49332

Rather than using this a d.ts file, we can depend on the same namespace as exported by `tsserverlibrary` instead, a file that is definitely not going away.

This actually reveals a couple of interesting things:

- The ambient `protocol` namespace was being used in a couple places where it shouldn't have been.
- Two types needed to be reexported via the protocol, implying that our protocol is not self-contained. That's something to address on the TS side, but nothing new.
