### PR TITLE
Re-use DisposableStores when rendering explorer items

### DIFF
--- a/src/vs/workbench/contrib/files/test/browser/explorerView.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/explorerView.test.ts
@@ -12,7 +12,7 @@ import { getContext } from 'vs/workbench/contrib/files/browser/views/explorerVie
 import { listInvalidItemForeground } from 'vs/platform/theme/common/colorRegistry';
 import { CompressedNavigationController } from 'vs/workbench/contrib/files/browser/views/explorerViewer';
 import * as dom from 'vs/base/browser/dom';
-import { Disposable } from 'vs/base/common/lifecycle';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { provideDecorations } from 'vs/workbench/contrib/files/browser/views/explorerDecorationsProvider';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 const $ = dom.$;
@@ -84,7 +84,7 @@ suite('Files - ExplorerView', () => {
 
 		const navigationController = new CompressedNavigationController('id', [s1, s2, s3], {
 			container,
-			elementDisposable: Disposable.None,
+			elementDisposables: new DisposableStore(),
 			label: <any>{
 				container: label,
 				onDidRender: emitter.event


### PR DESCRIPTION
While trying to debug an performance issue with scrolling the explorer, I noticed that the explorer list renderer creates a new `DisposableStore` every time it renders an item

For performance, it's better to create a `DisposableStore` for each template and then re-use this store when rendering elements. This store is cleared in the `disposeElement` function
