### PR TITLE
Always mark notebook list rendering `elementDisposables` as disposed

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditorBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditorBrowser.ts
@@ -75,7 +75,6 @@ export interface CellDiffSingleSideRenderTemplate extends CellDiffCommonRenderTe
 	readonly metadataInfoContainer: HTMLElement;
 	readonly outputHeaderContainer: HTMLElement;
 	readonly outputInfoContainer: HTMLElement;
-
 }
 
 

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffList.ts
@@ -147,6 +147,7 @@ export class CellDiffSingleSideRenderer implements IListRenderer<SingleSideDiffE
 	disposeTemplate(templateData: CellDiffSingleSideRenderTemplate): void {
 		templateData.container.innerText = '';
 		templateData.sourceEditor.dispose();
+		templateData.elementDisposables.dispose();
 	}
 
 	disposeElement(element: SingleSideDiffElementViewModel, index: number, templateData: CellDiffSingleSideRenderTemplate): void {
@@ -275,6 +276,7 @@ export class CellDiffSideBySideRenderer implements IListRenderer<SideBySideDiffE
 		templateData.container.innerText = '';
 		templateData.sourceEditor.dispose();
 		templateData.toolbar?.dispose();
+		templateData.elementDisposables.dispose();
 	}
 
 	disposeElement(element: SideBySideDiffElementViewModel, index: number, templateData: CellDiffSideBySideRenderTemplate): void {

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookRenderingCommon.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookRenderingCommon.ts
@@ -92,12 +92,12 @@ export interface INotebookCellList {
 }
 
 export interface BaseCellRenderTemplate {
-	rootContainer: HTMLElement;
-	editorPart: HTMLElement;
-	cellInputCollapsedContainer: HTMLElement;
-	instantiationService: IInstantiationService;
-	container: HTMLElement;
-	cellContainer: HTMLElement;
+	readonly rootContainer: HTMLElement;
+	readonly editorPart: HTMLElement;
+	readonly cellInputCollapsedContainer: HTMLElement;
+	readonly instantiationService: IInstantiationService;
+	readonly container: HTMLElement;
+	readonly cellContainer: HTMLElement;
 	readonly templateDisposables: DisposableStore;
 	readonly elementDisposables: DisposableStore;
 	currentRenderedCell?: ICellViewModel;
@@ -106,8 +106,8 @@ export interface BaseCellRenderTemplate {
 }
 
 export interface MarkdownCellRenderTemplate extends BaseCellRenderTemplate {
-	editorContainer: HTMLElement;
-	foldingIndicator: HTMLElement;
+	readonly editorContainer: HTMLElement;
+	readonly foldingIndicator: HTMLElement;
 	currentEditor?: ICodeEditor;
 }
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
@@ -214,7 +214,8 @@ export class MarkupCellRenderer extends AbstractCellRenderer implements IListRen
 	}
 
 	disposeTemplate(templateData: MarkdownCellRenderTemplate): void {
-		templateData.templateDisposables.clear();
+		templateData.elementDisposables.dispose();
+		templateData.templateDisposables.dispose();
 	}
 
 	disposeElement(_element: ICellViewModel, _index: number, templateData: MarkdownCellRenderTemplate): void {


### PR DESCRIPTION
This updates `disposeTemplate` for notebook list rendering to mark the `elementDisposables` as disposed instead of simply clearing them. This is helpful if you are using `TRACK_DISPOSABLES`, and will also log if you try adding to the disposable after it has been disposed of

Also marks more template fields as readonly

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
