### PR TITLE
Revert "Clean up how the notebook renderer entrypoint is passed around (#163373)"

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookExtensionPoint.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookExtensionPoint.ts
@@ -6,7 +6,7 @@
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
 import { ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
-import { NotebookEditorPriority, ContributedNotebookRendererEntrypoint, RendererMessagingSpec } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { NotebookEditorPriority, NotebookRendererEntrypoint, RendererMessagingSpec } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 
 const NotebookEditorContribution = Object.freeze({
 	type: 'type',
@@ -36,7 +36,7 @@ export interface INotebookRendererContribution {
 	readonly [NotebookRendererContribution.id]?: string;
 	readonly [NotebookRendererContribution.displayName]: string;
 	readonly [NotebookRendererContribution.mimeTypes]?: readonly string[];
-	readonly [NotebookRendererContribution.entrypoint]: ContributedNotebookRendererEntrypoint;
+	readonly [NotebookRendererContribution.entrypoint]: NotebookRendererEntrypoint;
 	readonly [NotebookRendererContribution.hardDependencies]: readonly string[];
 	readonly [NotebookRendererContribution.optionalDependencies]: readonly string[];
 	readonly [NotebookRendererContribution.requiresMessaging]: RendererMessagingSpec;

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -403,14 +403,12 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Disposable {
 
 	private getRendererData(): RendererMetadata[] {
 		return this.notebookService.getRenderers().map((renderer): RendererMetadata => {
-			const entrypoint = {
-				extends: renderer.entrypoint.extends,
-				path: this.asWebviewUri(renderer.entrypoint.path, renderer.extensionLocation).toString()
-			};
+			const entrypoint = this.asWebviewUri(renderer.entrypoint, renderer.extensionLocation).toString();
 			return {
 				id: renderer.id,
 				entrypoint,
 				mimeTypes: renderer.mimeTypes,
+				extends: renderer.extends,
 				messaging: renderer.messaging !== RendererMessagingSpec.Never,
 				isBuiltin: renderer.isBuiltin
 			};
@@ -925,7 +923,7 @@ var requirejs = (function() {
 		const notebookDir = this.getNotebookBaseUri();
 		return [
 			...this.notebookService.getNotebookProviderResourceRoots(),
-			...this.notebookService.getRenderers().map(x => dirname(x.entrypoint.path)),
+			...this.notebookService.getRenderers().map(x => dirname(x.entrypoint)),
 			...workspaceFolders,
 			notebookDir,
 			...this.getBuiltinLocalResourceRoots()

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -275,8 +275,9 @@ export interface IUpdateControllerPreloadsMessage {
 
 export interface RendererMetadata {
 	readonly id: string;
-	readonly entrypoint: { readonly extends: string | undefined; readonly path: string };
+	readonly entrypoint: string;
 	readonly mimeTypes: readonly string[];
+	readonly extends: string | undefined;
 	readonly messaging: boolean;
 	readonly isBuiltin: boolean;
 }

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1314,7 +1314,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 
 		/** Inner function cached in the _loadPromise(). */
 		private async _load(): Promise<rendererApi.RendererApi | undefined> {
-			const module: RendererModule = await __import(this.data.entrypoint.path);
+			const module: RendererModule = await __import(this.data.entrypoint);
 			if (!module) {
 				return;
 			}
@@ -1324,7 +1324,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 			// Load all renderers that extend this renderer
 			await Promise.all(
 				ctx.rendererData
-					.filter(d => d.entrypoint.extends === this.data.id)
+					.filter(d => d.extends === this.data.id)
 					.map(async d => {
 						const renderer = renderers.getRenderer(d.id);
 						if (!renderer) {
@@ -1436,7 +1436,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 		}
 
 		private rendererEqual(a: webviewMessages.RendererMetadata, b: webviewMessages.RendererMetadata) {
-			if (a.id !== b.id || a.entrypoint.path !== b.entrypoint.path || a.entrypoint.extends !== b.entrypoint.extends || a.messaging !== b.messaging) {
+			if (a.entrypoint !== b.entrypoint || a.id !== b.id || a.extends !== b.extends || a.messaging !== b.messaging) {
 				return false;
 			}
 
@@ -1497,7 +1497,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 					.find((renderer) => renderer.data.id === preferredRendererId);
 			} else {
 				const renderers = Array.from(this._renderers.values())
-					.filter((renderer) => renderer.data.mimeTypes.includes(info.mime) && !renderer.data.entrypoint.extends);
+					.filter((renderer) => renderer.data.mimeTypes.includes(info.mime) && !renderer.data.extends);
 
 				if (renderers.length) {
 					// De-prioritize built-in renderers

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -75,7 +75,7 @@ export const RENDERER_EQUIVALENT_EXTENSIONS: ReadonlyMap<string, ReadonlySet<str
 
 export const RENDERER_NOT_AVAILABLE = '_notAvailable';
 
-export type ContributedNotebookRendererEntrypoint = string | { readonly extends: string; readonly path: string };
+export type NotebookRendererEntrypoint = string | { readonly extends: string; readonly path: string };
 
 export enum NotebookRunState {
 	Running = 1,
@@ -158,17 +158,19 @@ export const enum RendererMessagingSpec {
 	Optional = 'optional',
 }
 
-export type NotebookRendererEntrypoint = { readonly extends: string | undefined; readonly path: URI };
-
 export interface INotebookRendererInfo {
-	readonly id: string;
-	readonly displayName: string;
-	readonly entrypoint: NotebookRendererEntrypoint;
-	readonly extensionLocation: URI;
-	readonly extensionId: ExtensionIdentifier;
-	readonly messaging: RendererMessagingSpec;
+	id: string;
+	displayName: string;
+	extends?: string;
+	entrypoint: URI;
+	preloads: ReadonlyArray<URI>;
+	extensionLocation: URI;
+	extensionId: ExtensionIdentifier;
+	messaging: RendererMessagingSpec;
 
 	readonly mimeTypes: readonly string[];
+
+	readonly dependencies: readonly string[];
 
 	readonly isBuiltin: boolean;
 

--- a/src/vs/workbench/contrib/notebook/common/notebookOutputRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookOutputRenderer.ts
@@ -8,7 +8,7 @@ import { Iterable } from 'vs/base/common/iterator';
 import { joinPath } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
-import { INotebookRendererInfo, ContributedNotebookRendererEntrypoint, NotebookRendererMatch, RendererMessagingSpec, NotebookRendererEntrypoint } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { INotebookRendererInfo, NotebookRendererEntrypoint, NotebookRendererMatch, RendererMessagingSpec } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 
 class DependencyList {
 	private readonly value: ReadonlySet<string>;
@@ -17,6 +17,10 @@ class DependencyList {
 	constructor(value: Iterable<string>) {
 		this.value = new Set(value);
 		this.defined = this.value.size > 0;
+	}
+
+	public values(): string[] {
+		return Array.from(this.value);
 	}
 
 	/** Gets whether any of the 'available' dependencies match the ones in this list */
@@ -30,13 +34,17 @@ class DependencyList {
 export class NotebookOutputRendererInfo implements INotebookRendererInfo {
 
 	readonly id: string;
-	readonly entrypoint: NotebookRendererEntrypoint;
+	readonly extends?: string;
+	readonly entrypoint: URI;
 	readonly displayName: string;
 	readonly extensionLocation: URI;
 	readonly extensionId: ExtensionIdentifier;
 	readonly hardDependencies: DependencyList;
 	readonly optionalDependencies: DependencyList;
+	/** @see RendererMessagingSpec */
 	readonly messaging: RendererMessagingSpec;
+	// todo: re-add preloads in pure renderer API
+	readonly preloads: ReadonlyArray<URI> = [];
 
 	readonly mimeTypes: readonly string[];
 	private readonly mimeTypeGlobs: glob.ParsedPattern[];
@@ -46,7 +54,7 @@ export class NotebookOutputRendererInfo implements INotebookRendererInfo {
 	constructor(descriptor: {
 		readonly id: string;
 		readonly displayName: string;
-		readonly entrypoint: ContributedNotebookRendererEntrypoint;
+		readonly entrypoint: NotebookRendererEntrypoint;
 		readonly mimeTypes: readonly string[];
 		readonly extension: IExtensionDescription;
 		readonly dependencies: readonly string[] | undefined;
@@ -59,15 +67,10 @@ export class NotebookOutputRendererInfo implements INotebookRendererInfo {
 		this.isBuiltin = descriptor.extension.isBuiltin;
 
 		if (typeof descriptor.entrypoint === 'string') {
-			this.entrypoint = {
-				extends: undefined,
-				path: joinPath(this.extensionLocation, descriptor.entrypoint)
-			};
+			this.entrypoint = joinPath(this.extensionLocation, descriptor.entrypoint);
 		} else {
-			this.entrypoint = {
-				extends: descriptor.entrypoint.extends,
-				path: joinPath(this.extensionLocation, descriptor.entrypoint.path)
-			};
+			this.extends = descriptor.entrypoint.extends;
+			this.entrypoint = joinPath(this.extensionLocation, descriptor.entrypoint.path);
 		}
 
 		this.displayName = descriptor.displayName;
@@ -76,6 +79,10 @@ export class NotebookOutputRendererInfo implements INotebookRendererInfo {
 		this.hardDependencies = new DependencyList(descriptor.dependencies ?? Iterable.empty());
 		this.optionalDependencies = new DependencyList(descriptor.optionalDependencies ?? Iterable.empty());
 		this.messaging = descriptor.requiresMessaging ?? RendererMessagingSpec.Never;
+	}
+
+	public get dependencies(): string[] {
+		return this.hardDependencies.values();
 	}
 
 	public matchesWithoutKernel(mimeType: string) {
@@ -111,7 +118,7 @@ export class NotebookOutputRendererInfo implements INotebookRendererInfo {
 	}
 
 	private matchesMimeTypeOnly(mimeType: string) {
-		if (!URI.isUri(this.entrypoint)) { // We're extending another renderer
+		if (this.extends !== undefined) {
 			return false;
 		}
 


### PR DESCRIPTION
This reverts commit 8b0248854a4c6996ddea13e30dcc4fb0b56ef53b.

Workaround for https://github.com/microsoft/vscode/issues/163415
