### PR TITLE
Git - Show progress indicator while running fetch

### DIFF
--- a/extensions/git/src/autofetch.ts
+++ b/extensions/git/src/autofetch.ts
@@ -114,7 +114,7 @@ export class AutoFetcher {
 
 			try {
 				if (this._fetchAll) {
-					await this.repository.fetchAll();
+					await this.repository.fetchAll({ silent: true });
 				} else {
 					await this.repository.fetchDefault({ silent: true });
 				}

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -325,6 +325,7 @@ export const enum Operation {
 	Reset = 'Reset',
 	Remote = 'Remote',
 	Fetch = 'Fetch',
+	FetchNoProgress = 'FetchNoProgress',
 	Pull = 'Pull',
 	Push = 'Push',
 	CherryPick = 'CherryPick',
@@ -377,7 +378,7 @@ function isReadOnly(operation: Operation): boolean {
 
 function shouldShowProgress(operation: Operation): boolean {
 	switch (operation) {
-		case Operation.Fetch:
+		case Operation.FetchNoProgress:
 		case Operation.CheckIgnore:
 		case Operation.GetObjectDetails:
 		case Operation.Show:
@@ -1469,8 +1470,8 @@ export class Repository implements Disposable {
 	}
 
 	@throttle
-	async fetchAll(cancellationToken?: CancellationToken): Promise<void> {
-		await this._fetch({ all: true, cancellationToken });
+	async fetchAll(options: { silent?: boolean } = {}, cancellationToken?: CancellationToken): Promise<void> {
+		await this._fetch({ all: true, silent: options.silent, cancellationToken });
 	}
 
 	async fetch(options: FetchOptions): Promise<void> {
@@ -1484,7 +1485,8 @@ export class Repository implements Disposable {
 			options.prune = prune;
 		}
 
-		await this.run(Operation.Fetch, async () => this.repository.fetch(options));
+		const operation = options.silent === true ? Operation.FetchNoProgress : Operation.Fetch;
+		await this.run(operation, async () => this.repository.fetch(options));
 	}
 
 	@throttle
@@ -1588,7 +1590,7 @@ export class Repository implements Disposable {
 				const fn = async (cancellationToken?: CancellationToken) => {
 					// When fetchOnPull is enabled, fetch all branches when pulling
 					if (fetchOnPull) {
-						await this.fetchAll(cancellationToken);
+						await this.fetchAll({}, cancellationToken);
 					}
 
 					if (await this.checkIfMaybeRebased(this.HEAD?.name)) {


### PR DESCRIPTION
Use the existing `silent` fetch option to decide whether to show progress while running the fetch operation. No progress will be shown for auto-fetch operations.

Fixes #162179 