### PR TITLE
don't re-register an editor for the interactive window

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -236,20 +236,23 @@ export class NotebookProviderInfoStore extends Disposable {
 				}
 			}));
 
-			// Register the notebook editor
-			disposables.add(this._editorResolverService.registerEditor(
-				globPattern,
-				notebookEditorInfo,
-				notebookEditorOptions,
-				notebookFactoryObject,
-			));
-			// Then register the schema handler as exclusive for that notebook
-			disposables.add(this._editorResolverService.registerEditor(
-				`${Schemas.vscodeNotebookCell}:/**/${globPattern}`,
-				{ ...notebookEditorInfo, priority: RegisteredEditorPriority.exclusive },
-				notebookEditorOptions,
-				notebookCellFactoryObject
-			));
+			// The interactive editor is registered separately, so don't overwrite it here
+			if (notebookEditorInfo.id !== 'interactive') {
+				// Register the notebook editor
+				disposables.add(this._editorResolverService.registerEditor(
+					globPattern,
+					notebookEditorInfo,
+					notebookEditorOptions,
+					notebookFactoryObject,
+				));
+				// Then register the schema handler as exclusive for that notebook
+				disposables.add(this._editorResolverService.registerEditor(
+					`${Schemas.vscodeNotebookCell}:/**/${globPattern}`,
+					{ ...notebookEditorInfo, priority: RegisteredEditorPriority.exclusive },
+					notebookEditorOptions,
+					notebookCellFactoryObject
+				));
+			}
 		}
 
 		return disposables;


### PR DESCRIPTION
for https://github.com/microsoft/vscode/issues/163469

registering an editor with the same ID and glob pattern from the notebook contribution will cause contention between the two and the notebook contribution doesn't support interactive scheme editors.
