### PR TITLE
Fix electron webviews not always updating `_webviewKeyboardHandler` when focus changes

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -37,7 +37,7 @@ import { areWebviewContentOptionsEqual, IWebview, WebviewContentOptions, Webview
 import { WebviewFindDelegate, WebviewFindWidget } from 'vs/workbench/contrib/webview/browser/webviewFindWidget';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 
-export const enum WebviewMessageChannels {
+const enum WebviewMessageChannels {
 	onmessage = 'onmessage',
 	didClickLink = 'did-click-link',
 	didScroll = 'did-scroll',
@@ -303,12 +303,12 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 			this.handleFocusChange(true);
 		}));
 
-		this._register(this.on(WebviewMessageChannels.wheel, (event: IMouseWheelEvent) => {
-			this._onDidWheel.fire(event);
-		}));
-
 		this._register(this.on(WebviewMessageChannels.didBlur, () => {
 			this.handleFocusChange(false);
+		}));
+
+		this._register(this.on(WebviewMessageChannels.wheel, (event: IMouseWheelEvent) => {
+			this._onDidWheel.fire(event);
 		}));
 
 		this._register(this.on(WebviewMessageChannels.didFind, (didFind: boolean) => {
@@ -379,7 +379,6 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 		}));
 
 		this._register(Event.runAndSubscribe(webviewThemeDataProvider.onThemeDataChanged, () => this.style()));
-
 		this._register(_accessibilityService.onDidChangeReducedMotion(() => this.style()));
 		this._register(_accessibilityService.onDidChangeScreenReaderOptimized(() => this.style()));
 
@@ -468,7 +467,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 		return this._send('message', { message, transfer });
 	}
 
-	protected async _send(channel: string, data?: any, transferable: Transferable[] = []): Promise<boolean> {
+	private async _send(channel: string, data?: any, transferable: Transferable[] = []): Promise<boolean> {
 		if (this._state.type === WebviewState.Type.Initializing) {
 			let resolve: (x: boolean) => void;
 			const promise = new Promise<boolean>(r => resolve = r);
@@ -524,7 +523,6 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 		if (options.purpose) {
 			params.purpose = options.purpose;
 		}
-
 
 		COI.addSearchParam(params, true, true);
 
@@ -596,7 +594,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 		return false;
 	}
 
-	protected on<T = unknown>(channel: WebviewMessageChannels, handler: (data: T, e: MessageEvent) => void): IDisposable {
+	private on<T = unknown>(channel: WebviewMessageChannels, handler: (data: T, e: MessageEvent) => void): IDisposable {
 		let handlers = this._messageHandlers.get(channel);
 		if (!handlers) {
 			handlers = new Set();
@@ -724,7 +722,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 		this._webviewFindWidget?.updateTheme(this.webviewThemeDataProvider.getTheme());
 	}
 
-	private handleFocusChange(isFocused: boolean): void {
+	protected handleFocusChange(isFocused: boolean): void {
 		this._focused = isFocused;
 		if (isFocused) {
 			this._onDidFocus.fire();

--- a/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
@@ -23,7 +23,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ITunnelService } from 'vs/platform/tunnel/common/tunnel';
 import { FindInFrameOptions, IWebviewManagerService } from 'vs/platform/webview/common/webviewManagerService';
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
-import { WebviewElement, WebviewInitInfo, WebviewMessageChannels } from 'vs/workbench/contrib/webview/browser/webviewElement';
+import { WebviewElement, WebviewInitInfo } from 'vs/workbench/contrib/webview/browser/webviewElement';
 import { WindowIgnoreMenuShortcutsManager } from 'vs/workbench/contrib/webview/electron-sandbox/windowIgnoreMenuShortcutsManager';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 
@@ -67,14 +67,6 @@ export class ElectronWebviewElement extends WebviewElement {
 		this._webviewKeyboardHandler = new WindowIgnoreMenuShortcutsManager(configurationService, mainProcessService, nativeHostService);
 
 		this._webviewMainService = ProxyChannel.toService<IWebviewManagerService>(mainProcessService.getChannel('webview'));
-
-		this._register(this.on(WebviewMessageChannels.didFocus, () => {
-			this._webviewKeyboardHandler.didFocus();
-		}));
-
-		this._register(this.on(WebviewMessageChannels.didBlur, () => {
-			this._webviewKeyboardHandler.didBlur();
-		}));
 
 		if (initInfo.options.enableFindWidget) {
 			this._register(this.onDidHtmlChange((newContent) => {
@@ -166,5 +158,14 @@ export class ElectronWebviewElement extends WebviewElement {
 			keepSelection
 		});
 		this._onDidStopFind.fire();
+	}
+
+	protected override handleFocusChange(isFocused: boolean): void {
+		super.handleFocusChange(isFocused);
+		if (isFocused) {
+			this._webviewKeyboardHandler.didFocus();
+		} else {
+			this._webviewKeyboardHandler.didBlur();
+		}
 	}
 }


### PR DESCRIPTION
I believe any focus changes should also update the `_webviewKeyboardHandler`. Right now programatic focuses don't go through this path

This also lets us make more parts of webview communication private

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
