### PR TITLE
Add static preloads notebook contribution

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor.ts
@@ -410,11 +410,11 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 			}
 		}));
 
-		await this._createOriginalWebview(generateUuid(), this._model.original.resource);
+		await this._createOriginalWebview(generateUuid(), this._model.original.viewType, this._model.original.resource);
 		if (this._originalWebview) {
 			this._modifiedResourceDisposableStore.add(this._originalWebview);
 		}
-		await this._createModifiedWebview(generateUuid(), this._model.modified.resource);
+		await this._createModifiedWebview(generateUuid(), this._model.modified.viewType, this._model.modified.resource);
 		if (this._modifiedWebview) {
 			this._modifiedResourceDisposableStore.add(this._modifiedWebview);
 		}
@@ -466,10 +466,10 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 		}));
 	}
 
-	private async _createModifiedWebview(id: string, resource: URI): Promise<void> {
+	private async _createModifiedWebview(id: string, viewType: string, resource: URI): Promise<void> {
 		this._modifiedWebview?.dispose();
 
-		this._modifiedWebview = this.instantiationService.createInstance(BackLayerWebView, this, id, resource, {
+		this._modifiedWebview = this.instantiationService.createInstance(BackLayerWebView, this, id, viewType, resource, {
 			...this._notebookOptions.computeDiffWebviewOptions(),
 			fontFamily: this._generateFontFamily()
 		}, undefined) as BackLayerWebView<IDiffCellInfo>;
@@ -483,10 +483,10 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 		return this._fontInfo?.fontFamily ?? `"SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace`;
 	}
 
-	private async _createOriginalWebview(id: string, resource: URI): Promise<void> {
+	private async _createOriginalWebview(id: string, viewType: string, resource: URI): Promise<void> {
 		this._originalWebview?.dispose();
 
-		this._originalWebview = this.instantiationService.createInstance(BackLayerWebView, this, id, resource, {
+		this._originalWebview = this.instantiationService.createInstance(BackLayerWebView, this, id, viewType, resource, {
 			...this._notebookOptions.computeDiffWebviewOptions(),
 			fontFamily: this._generateFontFamily()
 		}, undefined) as BackLayerWebView<IDiffCellInfo>;

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1236,7 +1236,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}
 
 		if (!this._webview) {
-			this._createWebview(this.getId(), this.textModel.uri);
+			this._createWebview(this.getId(), this.textModel.viewType, this.textModel.uri);
 		}
 
 		this._webviewResolvePromise = (async () => {
@@ -1273,7 +1273,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		return this._webviewResolvePromise;
 	}
 
-	private async _createWebview(id: string, resource: URI): Promise<void> {
+	private async _createWebview(id: string, viewType: string, resource: URI): Promise<void> {
 		const that = this;
 
 		this._webview = this.instantiationService.createInstance(BackLayerWebView, {
@@ -1294,7 +1294,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			didDropMarkupCell: that._didDropMarkupCell.bind(that),
 			didEndDragMarkupCell: that._didEndDragMarkupCell.bind(that),
 			didResizeOutput: that._didResizeOutput.bind(that)
-		}, id, resource, {
+		}, id, viewType, resource, {
 			...this._notebookOptions.computeWebviewOptions(),
 			fontFamily: this._generateFontFamily()
 		}, this.notebookRendererMessaging.getScoped(this._uuid));
@@ -1306,7 +1306,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 	}
 
 	private async _attachModel(textModel: NotebookTextModel, viewState: INotebookEditorViewState | undefined, perf?: NotebookPerfMarks) {
-		await this._createWebview(this.getId(), textModel.uri);
+		await this._createWebview(this.getId(), textModel.viewType, textModel.uri);
 		this.viewModel = this.instantiationService.createInstance(NotebookViewModel, textModel.viewType, textModel, this._viewContext, this.getLayoutInfo(), { isReadOnly: this._readOnly });
 		this._viewContext.eventDispatcher.emit([new NotebookLayoutChangedEvent({ width: true, fontInfo: true }, this.getLayoutInfo())]);
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookExtensionPoint.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookExtensionPoint.ts
@@ -42,6 +42,16 @@ export interface INotebookRendererContribution {
 	readonly [NotebookRendererContribution.requiresMessaging]: RendererMessagingSpec;
 }
 
+const NotebookPreloadContribution = Object.freeze({
+	type: 'type',
+	entrypoint: 'entrypoint',
+});
+
+export interface INotebookPreloadContribution {
+	readonly [NotebookPreloadContribution.type]: string;
+	readonly [NotebookPreloadContribution.entrypoint]: string;
+}
+
 const notebookProviderContribution: IJSONSchema = {
 	description: nls.localize('contributes.notebook.provider', 'Contributes notebook document provider.'),
 	type: 'array',
@@ -139,7 +149,6 @@ const notebookRendererContribution: IJSONSchema = {
 							'optional',
 							'never',
 						],
-
 						enumDescriptions: [
 							nls.localize('contributes.notebook.renderer.requiresMessaging.always', 'Messaging is required. The renderer will only be used when it\'s part of an extension that can be run in an extension host.'),
 							nls.localize('contributes.notebook.renderer.requiresMessaging.optional', 'The renderer is better with messaging available, but it\'s not requried.'),
@@ -198,14 +207,40 @@ const notebookRendererContribution: IJSONSchema = {
 	}
 };
 
-export const notebooksExtensionPoint = ExtensionsRegistry.registerExtensionPoint<INotebookEditorContribution[]>(
-	{
-		extensionPoint: 'notebooks',
-		jsonSchema: notebookProviderContribution
-	});
+const notebookPreloadContribution: IJSONSchema = {
+	description: nls.localize('contributes.preload.provider', 'Contributes notebook preloads.'),
+	type: 'array',
+	defaultSnippets: [{ body: [{ type: '', entrypoint: '' }] }],
+	items: {
+		type: 'object',
+		required: [
+			NotebookPreloadContribution.type,
+			NotebookPreloadContribution.entrypoint
+		],
+		properties: {
+			[NotebookPreloadContribution.type]: {
+				type: 'string',
+				description: nls.localize('contributes.preload.provider.viewType', 'Type of the notebook.'),
+			},
+			[NotebookPreloadContribution.entrypoint]: {
+				type: 'string',
+				description: nls.localize('contributes.preload.entrypoint', 'Path to file loaded in the webview.'),
+			},
+		}
+	}
+};
 
-export const notebookRendererExtensionPoint = ExtensionsRegistry.registerExtensionPoint<INotebookRendererContribution[]>(
-	{
-		extensionPoint: 'notebookRenderer',
-		jsonSchema: notebookRendererContribution
-	});
+export const notebooksExtensionPoint = ExtensionsRegistry.registerExtensionPoint<INotebookEditorContribution[]>({
+	extensionPoint: 'notebooks',
+	jsonSchema: notebookProviderContribution
+});
+
+export const notebookRendererExtensionPoint = ExtensionsRegistry.registerExtensionPoint<INotebookRendererContribution[]>({
+	extensionPoint: 'notebookRenderer',
+	jsonSchema: notebookRendererContribution
+});
+
+export const notebookPreloadExtensionPoint = ExtensionsRegistry.registerExtensionPoint<INotebookPreloadContribution[]>({
+	extensionPoint: 'notebookPreload',
+	jsonSchema: notebookPreloadContribution,
+});

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -281,6 +281,10 @@ export interface RendererMetadata {
 	readonly isBuiltin: boolean;
 }
 
+export interface StaticPreloadMetadata {
+	readonly entrypoint: string;
+}
+
 export interface IUpdateRenderersMessage {
 	readonly type: 'updateRenderers';
 	readonly rendererData: readonly RendererMetadata[];

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -69,6 +69,7 @@ interface PreloadContext {
 	readonly style: PreloadStyles;
 	readonly options: PreloadOptions;
 	readonly rendererData: readonly webviewMessages.RendererMetadata[];
+	readonly staticPreloadsData: readonly webviewMessages.StaticPreloadMetadata[];
 	readonly isWorkspaceTrusted: boolean;
 	readonly lineLimit: number;
 }
@@ -199,7 +200,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 		}
 	};
 
-	async function loadScriptSource(url: string, originalUri = url): Promise<string> {
+	async function loadScriptSource(url: string, originalUri: string): Promise<string> {
 		const res = await fetch(url);
 		const text = await res.text();
 		if (!res.ok) {
@@ -246,11 +247,11 @@ async function webviewPreloads(ctx: PreloadContext) {
 		return new Function(...args.map(([k]) => k), functionSrc)(...args.map(([, v]) => v));
 	};
 
-	const runKernelPreload = async (url: string, originalUri: string): Promise<void> => {
+	const runKernelPreload = async (url: string, originalUri: string, forceLoadAsModule: boolean): Promise<void> => {
 		const text = await loadScriptSource(url, originalUri);
 		const isModule = /\bexport\b.*\bactivate\b/.test(text);
 		try {
-			if (isModule) {
+			if (isModule || forceLoadAsModule) {
 				const module: KernelPreloadModule = await __import(url);
 				if (!module.activate) {
 					console.error(`Notebook preload (${url}) looks like a module but does not export an activate function`);
@@ -1140,7 +1141,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 			case 'preload': {
 				const resources = event.data.resources;
 				for (const { uri, originalUri } of resources) {
-					kernelPreloads.load(uri, originalUri);
+					kernelPreloads.load(uri, originalUri, false);
 				}
 				break;
 			}
@@ -1360,9 +1361,9 @@ async function webviewPreloads(ctx: PreloadContext) {
 		 * @param uri URI to load from
 		 * @param originalUri URI to show in an error message if the preload is invalid.
 		 */
-		public load(uri: string, originalUri: string) {
+		public load(uri: string, originalUri: string, forceLoadAsModule: boolean) {
 			const promise = Promise.all([
-				runKernelPreload(uri, originalUri),
+				runKernelPreload(uri, originalUri, forceLoadAsModule),
 				this.waitForAllCurrent(),
 			]);
 
@@ -2126,6 +2127,10 @@ async function webviewPreloads(ctx: PreloadContext) {
 		type: 'initialized'
 	});
 
+	for (const preload of ctx.staticPreloadsData) {
+		kernelPreloads.load(preload.entrypoint, preload.entrypoint, true);
+	}
+
 	function postNotebookMessage<T extends webviewMessages.FromWebviewMessage>(
 		type: T['type'],
 		properties: Omit<T, '__vscode_notebook_message' | 'type'>
@@ -2355,11 +2360,12 @@ async function webviewPreloads(ctx: PreloadContext) {
 	}();
 }
 
-export function preloadsScriptStr(styleValues: PreloadStyles, options: PreloadOptions, renderers: readonly webviewMessages.RendererMetadata[], isWorkspaceTrusted: boolean, lineLimit: number, nonce: string) {
+export function preloadsScriptStr(styleValues: PreloadStyles, options: PreloadOptions, renderers: readonly webviewMessages.RendererMetadata[], preloads: readonly webviewMessages.StaticPreloadMetadata[], isWorkspaceTrusted: boolean, lineLimit: number, nonce: string) {
 	const ctx: PreloadContext = {
 		style: styleValues,
 		options,
 		rendererData: renderers,
+		staticPreloadsData: preloads,
 		isWorkspaceTrusted,
 		lineLimit,
 		nonce,

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -176,6 +176,11 @@ export interface INotebookRendererInfo {
 	matches(mimeType: string, kernelProvides: ReadonlyArray<string>): NotebookRendererMatch;
 }
 
+export interface INotebookStaticPreloadInfo {
+	readonly type: string;
+	readonly entrypoint: URI;
+	readonly extensionLocation: URI;
+}
 
 export interface IOrderedMimeType {
 	mimeType: string;

--- a/src/vs/workbench/contrib/notebook/common/notebookOutputRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookOutputRenderer.ts
@@ -8,7 +8,7 @@ import { Iterable } from 'vs/base/common/iterator';
 import { joinPath } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
-import { INotebookRendererInfo, ContributedNotebookRendererEntrypoint, NotebookRendererMatch, RendererMessagingSpec, NotebookRendererEntrypoint } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { INotebookRendererInfo, ContributedNotebookRendererEntrypoint, NotebookRendererMatch, RendererMessagingSpec, NotebookRendererEntrypoint, INotebookStaticPreloadInfo as INotebookStaticPreloadInfo } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 
 class DependencyList {
 	private readonly value: ReadonlySet<string>;
@@ -116,5 +116,23 @@ export class NotebookOutputRendererInfo implements INotebookRendererInfo {
 		}
 
 		return this.mimeTypeGlobs.some(pattern => pattern(mimeType)) || this.mimeTypes.some(pattern => pattern === mimeType);
+	}
+}
+
+export class NotebookStaticPreloadInfo implements INotebookStaticPreloadInfo {
+
+	readonly type: string;
+	readonly entrypoint: URI;
+	readonly extensionLocation: URI;
+
+	constructor(descriptor: {
+		readonly type: string;
+		readonly entrypoint: string;
+		readonly extension: IExtensionDescription;
+	}) {
+		this.type = descriptor.type;
+
+		this.entrypoint = joinPath(descriptor.extension.extensionLocation, descriptor.entrypoint);
+		this.extensionLocation = descriptor.extension.extensionLocation;
 	}
 }

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -7,7 +7,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 import { URI } from 'vs/base/common/uri';
 import { NotebookProviderInfo } from 'vs/workbench/contrib/notebook/common/notebookProvider';
 import { Event } from 'vs/base/common/event';
-import { INotebookRendererInfo, NotebookData, TransientOptions, IOrderedMimeType, IOutputDto, INotebookContributionData, NotebookExtensionDescription } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { INotebookRendererInfo, NotebookData, TransientOptions, IOrderedMimeType, IOutputDto, INotebookContributionData, NotebookExtensionDescription, INotebookStaticPreloadInfo } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellTextModel';
@@ -72,6 +72,8 @@ export interface INotebookService {
 
 	getRendererInfo(id: string): INotebookRendererInfo | undefined;
 	getRenderers(): INotebookRendererInfo[];
+
+	getStaticPreloads(viewType: string): Iterable<INotebookStaticPreloadInfo>;
 
 	/** Updates the preferred renderer for the given mimetype in the workspace. */
 	updateMimePreferredRenderer(viewType: string, mimeType: string, rendererId: string, otherMimetypes: readonly string[]): void;

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -14,6 +14,7 @@ export const allApiProposals = Object.freeze({
 	contribLabelFormatterWorkspaceTooltip: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribLabelFormatterWorkspaceTooltip.d.ts',
 	contribMenuBarHome: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribMenuBarHome.d.ts',
 	contribMergeEditorMenus: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribMergeEditorMenus.d.ts',
+	contribNotebookStaticPreloads: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribNotebookStaticPreloads.d.ts',
 	contribRemoteHelp: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribRemoteHelp.d.ts',
 	contribShareMenu: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribShareMenu.d.ts',
 	contribViewsRemote: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribViewsRemote.d.ts',

--- a/src/vscode-dts/vscode.proposed.contribNotebookStaticPreloads.d.ts
+++ b/src/vscode-dts/vscode.proposed.contribNotebookStaticPreloads.d.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// empty placeholder declaration for the `notebookPreload` contribution point


### PR DESCRIPTION
For #163511

@DonJayamanne Right now I'm forcing all of these static preloads to be loaded as modules that export an activate function. You can then use this to load additional scripts into the webview

If we need to, we can instead explore loading these preloads as non-module scripts. However these would only be evaluated in the global scope. I do not want to support the old school kernel preload API where we injected global variables with context info 