### PR TITLE
Set contain on monaco-list-rows

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -342,6 +342,8 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		const transformOptimization = options.transformOptimization ?? DefaultOptions.transformOptimization;
 		if (transformOptimization) {
 			this.rowsContainer.style.transform = 'translate3d(0px, 0px, 0px)';
+			this.rowsContainer.style.overflow = 'hidden';
+			this.rowsContainer.style.contain = 'strict';
 		}
 
 		this.disposables.add(Gesture.addTarget(this.rowsContainer));


### PR DESCRIPTION
This sets contain and overflow on `monaco-list-rows` to reduce the number of re-paints needed while scrolling

I've tested most of the lists I can think of in the editor and it doesn't seem to cause any problems. It doesn't help repaints on the quick input for unknown reasons, but does seem to help in the explorer, custom trees, the extension list, and settings view

I've disabled it for lists that disable the transform optimization, as these lists don't follow strict containment.

# Before (scrolling explorer)

![Screen Shot 2022-10-12 at 9 29 13 PM (2)](https://user-images.githubusercontent.com/12821956/195506666-5d71a3a1-dac6-4fde-baf1-36747bdf2262.png)

# After (scrolling explorer)

![Screen Shot 2022-10-12 at 10 08 29 PM (2)](https://user-images.githubusercontent.com/12821956/195506786-2b049917-ac89-4843-8f69-e7d0ec58c2bb.png)

