### PR TITLE
Fix `workspace.onDidChangeNotebookDocument` event for multi-cell moves

### DIFF
--- a/src/vs/workbench/api/common/extHostNotebookDocument.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocument.ts
@@ -247,7 +247,7 @@ export class ExtHostNotebookDocument {
 				this._spliceNotebookCells(rawEvent.changes, false, result.contentChanges);
 
 			} else if (rawEvent.kind === notebookCommon.NotebookCellsChangeType.Move) {
-				this._moveCell(rawEvent.index, rawEvent.newIdx, result.contentChanges);
+				this._moveCells(rawEvent.index, rawEvent.length, rawEvent.newIdx, result.contentChanges);
 
 			} else if (rawEvent.kind === notebookCommon.NotebookCellsChangeType.Output) {
 				this._setCellOutputs(rawEvent.index, rawEvent.outputs);
@@ -387,8 +387,8 @@ export class ExtHostNotebookDocument {
 		}
 	}
 
-	private _moveCell(index: number, newIdx: number, bucket: vscode.NotebookDocumentContentChange[]): void {
-		const cells = this._cells.splice(index, 1);
+	private _moveCells(index: number, length: number, newIdx: number, bucket: vscode.NotebookDocumentContentChange[]): void {
+		const cells = this._cells.splice(index, length);
 		this._cells.splice(newIdx, 0, ...cells);
 		const changes = [
 			new RawContentChangeEvent(index, 1, cells.map(c => c.apiCell), []),

--- a/src/vs/workbench/api/common/extHostNotebookDocument.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocument.ts
@@ -391,7 +391,7 @@ export class ExtHostNotebookDocument {
 		const cells = this._cells.splice(index, length);
 		this._cells.splice(newIdx, 0, ...cells);
 		const changes = [
-			new RawContentChangeEvent(index, 1, cells.map(c => c.apiCell), []),
+			new RawContentChangeEvent(index, length, cells.map(c => c.apiCell), []),
 			new RawContentChangeEvent(newIdx, 0, [], cells)
 		];
 		for (const change of changes) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #163517

`ExtHostNotebookDocument._moveCells` should accept a count of cells to move rather than assuming that only one cell is moving. Obtain that count from `NotebookCellsModelMoveEvent.length`.

Any move of multi-selected cells that includes at least two contiguous cells will exercise this code.