### PR TITLE
Remove forgoten reference to typescript/lib/protocol

### DIFF
--- a/extensions/typescript-language-features/src/test/unit/previewer.test.ts
+++ b/extensions/typescript-language-features/src/test/unit/previewer.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import 'mocha';
-import { SymbolDisplayPart } from 'typescript/lib/protocol';
+import { SymbolDisplayPart } from '../../protocol';
 import { Uri } from 'vscode';
 import { IFilePathToResourceConverter, markdownDocumentation, plainWithLinks, tagsMarkdownPreview } from '../../utils/previewer';
 


### PR DESCRIPTION
In #163365 I removed the main use of `typescript/lib/protocol`, but I didn't think to search for direct accesses.

Change this one to import from the centralized protocol module instead.