### PR TITLE
change search badge to show recursive match number

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -168,7 +168,7 @@ export class FolderMatchRenderer extends Disposable implements ICompressibleTree
 	}
 
 	private renderFolderDetails(folder: FolderMatch, templateData: IFolderMatchTemplate) {
-		const count = this.searchView.isTreeLayoutViewVisible ? folder.count() : folder.recursiveFileCount();
+		const count = folder.recursiveMatchCount();
 		templateData.badge.setCount(count);
 		templateData.badge.setTitleFormat(count > 1 ? nls.localize('searchFileMatches', "{0} files found", count) : nls.localize('searchFileMatch', "{0} file found", count));
 

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -662,6 +662,10 @@ export class FolderMatch extends Disposable {
 		return this.downstreamFileMatches().length;
 	}
 
+	recursiveMatchCount(): number {
+		return this.downstreamFileMatches().reduce<number>((prev, match) => prev + match.count(), 0);
+	}
+
 	get query(): ITextQuery | null {
 		return this._query;
 	}


### PR DESCRIPTION
<img width="514" alt="image" src="https://user-images.githubusercontent.com/31675041/195731969-5ffae7a9-783b-4e61-ba55-bdad525a3126.png">

The search count badge now shows the number of recursive matches instead of the number of immediate child nodes. 

Fixes #162627