### PR TITLE
Command Center With Help

### DIFF
--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -7,7 +7,7 @@ import { timeout } from 'vs/base/common/async';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import { IKeyMods, IQuickPickDidAcceptEvent, IQuickPickSeparator } from 'vs/base/parts/quickinput/common/quickInput';
-import { IQuickAccessProvider } from 'vs/platform/quickinput/common/quickAccess';
+import { IQuickAccessProvider, IQuickAccessProviderRunOptions } from 'vs/platform/quickinput/common/quickAccess';
 import { IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 
 export enum TriggerAction {
@@ -97,7 +97,7 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 		super();
 	}
 
-	provide(picker: IQuickPick<T>, token: CancellationToken): IDisposable {
+	provide(picker: IQuickPick<T>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
 		const disposables = new DisposableStore();
 
 		// Apply options if any
@@ -122,7 +122,7 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 			// Collect picks and support both long running and short or combined
 			const picksToken = picksCts.token;
 			const picksFilter = picker.value.substr(this.prefix.length).trim();
-			const providedPicks = this._getPicks(picksFilter, picksDisposables, picksToken);
+			const providedPicks = this._getPicks(picksFilter, picksDisposables, picksToken, runOptions);
 
 			const applyPicks = (picks: Picks<T>, skipEmpty?: boolean): boolean => {
 				let items: readonly Pick<T>[];
@@ -338,5 +338,5 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 	 * @returns the picks either directly, as promise or combined fast and slow results.
 	 * Pickers can return `null` to signal that no change in picks is needed.
 	 */
-	protected abstract _getPicks(filter: string, disposables: DisposableStore, token: CancellationToken): Picks<T> | Promise<Picks<T>> | FastAndSlowPicks<T> | null;
+	protected abstract _getPicks(filter: string, disposables: DisposableStore, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): Picks<T> | Promise<Picks<T>> | FastAndSlowPicks<T> | null;
 }

--- a/src/vs/platform/quickinput/common/quickAccess.ts
+++ b/src/vs/platform/quickinput/common/quickAccess.ts
@@ -10,6 +10,19 @@ import { ItemActivation } from 'vs/base/parts/quickinput/common/quickInput';
 import { IQuickNavigateConfiguration, IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { Registry } from 'vs/platform/registry/common/platform';
 
+/**
+ * Provider specific options for this particular showing of the
+ * quick access.
+ */
+export interface IQuickAccessProviderRunOptions { }
+
+/**
+ * The specific options for the AnythingQuickAccessProvider. Put here to share between layers.
+ */
+export interface AnythingQuickAccessProviderRunOptions extends IQuickAccessProviderRunOptions {
+	includeHelp?: boolean;
+}
+
 export interface IQuickAccessOptions {
 
 	/**
@@ -28,6 +41,12 @@ export interface IQuickAccessOptions {
 	 * from any existing value if quick access is visible.
 	 */
 	preserveValue?: boolean;
+
+	/**
+	 * Provider specific options for this particular showing of the
+	 * quick access.
+	 */
+	providerOptions?: IQuickAccessProviderRunOptions;
 }
 
 export interface IQuickAccessController {
@@ -80,10 +99,12 @@ export interface IQuickAccessProvider {
 	 * a long running operation or from event handlers because it could be that the
 	 * picker has been closed or changed meanwhile. The token can be used to find out
 	 * that the picker was closed without picking an entry (e.g. was canceled by the user).
+	 * @param options additional configuration specific for this provider that will
+	 * influence what picks will be shown.
 	 * @return a disposable that will automatically be disposed when the picker
 	 * closes or is replaced by another picker.
 	 */
-	provide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken): IDisposable;
+	provide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken, options?: IQuickAccessProviderRunOptions): IDisposable;
 }
 
 export interface IQuickAccessProviderHelp {

--- a/src/vs/workbench/browser/actions/quickAccessActions.ts
+++ b/src/vs/workbench/browser/actions/quickAccessActions.ts
@@ -13,6 +13,7 @@ import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { inQuickPickContext, defaultQuickAccessContext, getQuickNavigateHandler } from 'vs/workbench/browser/quickaccess';
 import { ILocalizedString } from 'vs/platform/action/common/action';
+import { AnythingQuickAccessProviderRunOptions } from 'vs/platform/quickinput/common/quickAccess';
 
 //#region Quick access management commands and keys
 
@@ -139,6 +140,24 @@ registerAction2(class QuickAccessAction extends Action2 {
 				secondary: globalQuickAccessKeybinding.secondary,
 				mac: globalQuickAccessKeybinding.mac
 			},
+			f1: true
+		});
+	}
+
+	run(accessor: ServicesAccessor, prefix: undefined): void {
+		const quickInputService = accessor.get(IQuickInputService);
+		quickInputService.quickAccess.show(typeof prefix === 'string' ? prefix : undefined, { preserveValue: typeof prefix === 'string' /* preserve as is if provided */ });
+	}
+});
+
+registerAction2(class QuickAccessAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.quickOpenWithModes',
+			title: {
+				value: localize('quickOpenWithModes', "Launch Command Center"),
+				original: 'Launch Command Center'
+			},
 			f1: true,
 			menu: {
 				id: MenuId.CommandCenter,
@@ -147,9 +166,13 @@ registerAction2(class QuickAccessAction extends Action2 {
 		});
 	}
 
-	run(accessor: ServicesAccessor, prefix: undefined): void {
+	run(accessor: ServicesAccessor): void {
 		const quickInputService = accessor.get(IQuickInputService);
-		quickInputService.quickAccess.show(typeof prefix === 'string' ? prefix : undefined, { preserveValue: typeof prefix === 'string' /* preserve as is if provided */ });
+		quickInputService.quickAccess.show(undefined, {
+			providerOptions: {
+				includeHelp: true,
+			} as AnythingQuickAccessProviderRunOptions
+		});
 	}
 });
 

--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -50,7 +50,7 @@ export class CommandCenterControl {
 			telemetrySource: 'commandCenter',
 			actionViewItemProvider: (action) => {
 
-				if (action instanceof MenuItemAction && action.id === 'workbench.action.quickOpen') {
+				if (action instanceof MenuItemAction && action.id === 'workbench.action.quickOpenWithModes') {
 
 					class CommandCenterViewItem extends BaseActionViewItem {
 

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/anythingQuickAccess';
-import { IQuickInputButton, IKeyMods, quickPickItemScorerAccessor, QuickPickItemScorerAccessor, IQuickPick, IQuickPickItemWithResource, QuickInputHideReason } from 'vs/platform/quickinput/common/quickInput';
+import { IQuickInputButton, IKeyMods, quickPickItemScorerAccessor, QuickPickItemScorerAccessor, IQuickPick, IQuickPickItemWithResource, QuickInputHideReason, IQuickInputService, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
 import { IPickerQuickAccessItem, PickerQuickAccessProvider, TriggerAction, FastAndSlowPicks, Picks, PicksWithActive } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { prepareQuery, IPreparedQuery, compareItemsByFuzzyScore, scoreItemFuzzy, FuzzyScorerCache } from 'vs/base/common/fuzzyScorer';
 import { IFileQueryBuilderOptions, QueryBuilder } from 'vs/workbench/services/search/common/queryBuilder';
@@ -40,7 +40,7 @@ import { Schemas } from 'vs/base/common/network';
 import { IFilesConfigurationService, AutoSaveMode } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
 import { ResourceMap } from 'vs/base/common/map';
 import { SymbolsQuickAccessProvider } from 'vs/workbench/contrib/search/browser/symbolsQuickAccess';
-import { DefaultQuickAccessFilterValue } from 'vs/platform/quickinput/common/quickAccess';
+import { AnythingQuickAccessProviderRunOptions, DefaultQuickAccessFilterValue } from 'vs/platform/quickinput/common/quickAccess';
 import { IWorkbenchQuickAccessConfiguration } from 'vs/workbench/browser/quickaccess';
 import { GotoSymbolQuickAccessProvider } from 'vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
@@ -52,6 +52,10 @@ import { withNullAsUndefined } from 'vs/base/common/types';
 import { Codicon } from 'vs/base/common/codicons';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { stripIcons } from 'vs/base/common/iconLabels';
+import { HelpQuickAccessProvider } from 'vs/platform/quickinput/browser/helpQuickAccess';
+import { CommandsQuickAccessProvider } from 'vs/workbench/contrib/quickaccess/browser/commandsQuickAccess';
+import { DEBUG_QUICK_ACCESS_PREFIX } from 'vs/workbench/contrib/debug/browser/debugCommands';
+import { TasksQuickAccessProvider } from 'vs/workbench/contrib/tasks/browser/tasksQuickAccess';
 
 interface IAnythingQuickPickItem extends IPickerQuickAccessItem, IQuickPickItemWithResource { }
 
@@ -178,7 +182,8 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		@IHistoryService private readonly historyService: IHistoryService,
 		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService,
 		@ITextModelService private readonly textModelService: ITextModelService,
-		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
+		@IQuickInputService private readonly quickInputService: IQuickInputService,
 	) {
 		super(AnythingQuickAccessProvider.PREFIX, {
 			canAcceptInBackground: true,
@@ -202,7 +207,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		};
 	}
 
-	override provide(picker: IQuickPick<IAnythingQuickPickItem>, token: CancellationToken): IDisposable {
+	override provide(picker: IQuickPick<IAnythingQuickPickItem>, token: CancellationToken, runOptions?: AnythingQuickAccessProviderRunOptions): IDisposable {
 		const disposables = new DisposableStore();
 
 		// Update the pick state for this run
@@ -233,7 +238,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		}));
 
 		// Start picker
-		disposables.add(super.provide(picker, token));
+		disposables.add(super.provide(picker, token, runOptions));
 
 		return disposables;
 	}
@@ -261,7 +266,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		return toDisposable(() => this.clearDecorations(activeEditorControl));
 	}
 
-	protected _getPicks(originalFilter: string, disposables: DisposableStore, token: CancellationToken): Picks<IAnythingQuickPickItem> | Promise<Picks<IAnythingQuickPickItem>> | FastAndSlowPicks<IAnythingQuickPickItem> | null {
+	protected _getPicks(originalFilter: string, disposables: DisposableStore, token: CancellationToken, runOptions?: AnythingQuickAccessProviderRunOptions): Picks<IAnythingQuickPickItem> | Promise<Picks<IAnythingQuickPickItem>> | FastAndSlowPicks<IAnythingQuickPickItem> | null {
 
 		// Find a suitable range from the pattern looking for ":", "#" or ","
 		// unless we have the `@` editor symbol character inside the filter
@@ -316,10 +321,15 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		// search without prior filtering, you could not paste a file name
 		// including the `@` character to open it (e.g. /some/file@path)
 		// refs: https://github.com/microsoft/vscode/issues/93845
-		return this.doGetPicks(filter, { enableEditorSymbolSearch: lastWasFiltering }, disposables, token);
+		return this.doGetPicks(filter, { enableEditorSymbolSearch: lastWasFiltering, includeHelp: runOptions?.includeHelp }, disposables, token);
 	}
 
-	private doGetPicks(filter: string, options: { enableEditorSymbolSearch: boolean }, disposables: DisposableStore, token: CancellationToken): Picks<IAnythingQuickPickItem> | Promise<Picks<IAnythingQuickPickItem>> | FastAndSlowPicks<IAnythingQuickPickItem> {
+	private doGetPicks(
+		filter: string,
+		options: AnythingQuickAccessProviderRunOptions & { enableEditorSymbolSearch: boolean },
+		disposables: DisposableStore,
+		token: CancellationToken
+	): Picks<IAnythingQuickPickItem> | Promise<Picks<IAnythingQuickPickItem>> | FastAndSlowPicks<IAnythingQuickPickItem> {
 		const query = prepareQuery(filter);
 
 		// Return early if we have editor symbol picks. We support this by:
@@ -343,16 +353,24 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		// Otherwise return normally with history and file/symbol results
 		const historyEditorPicks = this.getEditorHistoryPicks(query);
 
+		let picks: Array<IAnythingQuickPickItem | IQuickPickSeparator>;
+		if (this.pickState.isQuickNavigating) {
+			picks = historyEditorPicks;
+		} else {
+			picks = [];
+			if (options.includeHelp) {
+				picks.concat(this.getHelpPicks(query, token));
+			}
+			if (historyEditorPicks.length !== 0) {
+				picks.push({ type: 'separator', label: localize('recentlyOpenedSeparator', "recently opened") } as IQuickPickSeparator);
+				picks.concat(historyEditorPicks);
+			}
+		}
+
 		return {
 
-			// Fast picks: editor history
-			picks:
-				(this.pickState.isQuickNavigating || historyEditorPicks.length === 0) ?
-					historyEditorPicks :
-					[
-						{ type: 'separator', label: localize('recentlyOpenedSeparator', "recently opened") },
-						...historyEditorPicks
-					],
+			// Fast picks: help (if included) & editor history
+			picks,
 
 			// Slow picks: files and symbols
 			additionalPicks: (async (): Promise<Picks<IAnythingQuickPickItem>> => {
@@ -732,6 +750,67 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 	//#endregion
 
+	//#region Help (if enabled)
+
+	private helpQuickAccess = this.instantiationService.createInstance(HelpQuickAccessProvider);
+
+	private getHelpPicks(query: IPreparedQuery, token: CancellationToken): IAnythingQuickPickItem[] {
+		// If there's a filter, we don't show the help
+		if (query.normalized) {
+			return [];
+		}
+
+		type IHelpAnythingQuickPickItem = IAnythingQuickPickItem & { prefix: string };
+		const providers: Array<IHelpAnythingQuickPickItem> = this.helpQuickAccess.getQuickAccessProviders();
+		const mapOfProviders = new Map<string, IHelpAnythingQuickPickItem>();
+		for (const provider of providers) {
+			mapOfProviders.set(provider.prefix, provider);
+		}
+
+		const importantProviders: Array<IHelpAnythingQuickPickItem> = [];
+		const AddProvider = (prefix: string, modifications: Partial<IAnythingQuickPickItem> = {}) => {
+			if (mapOfProviders.has(prefix)) {
+				const provider = mapOfProviders.get(prefix)!;
+
+				// We swap the label and description in this to emphasize the ability
+				// not the prefix.
+				provider.label = provider.description!;
+				provider.description = provider.prefix;
+
+				// If the user chooses 'Go to File' the help should go away as if they were
+				// entering a new mode
+				const providerSpecificOptions = provider.prefix === AnythingQuickAccessProvider.PREFIX
+					? undefined
+					: { includeModes: true };
+
+				importantProviders.push({
+					...mapOfProviders.get(prefix)!,
+					...modifications,
+					accept: () => {
+						this.quickInputService.quickAccess.show(provider.prefix, {
+							preserveValue: true,
+							providerOptions: providerSpecificOptions
+						});
+					}
+				});
+			}
+		};
+
+		// Acts as the ordering too
+		AddProvider(AnythingQuickAccessProvider.PREFIX);
+		AddProvider(CommandsQuickAccessProvider.PREFIX);
+		AddProvider(GotoSymbolQuickAccessProvider.PREFIX);
+		AddProvider(DEBUG_QUICK_ACCESS_PREFIX);
+		AddProvider(TasksQuickAccessProvider.PREFIX);
+		AddProvider(HelpQuickAccessProvider.PREFIX, {
+			// More concise
+			label: localize('more', 'More')
+		});
+
+		return importantProviders;
+	}
+
+	//#endregion
 
 	//#region Workspace Symbols (if enabled)
 

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -359,11 +359,11 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		} else {
 			picks = [];
 			if (options.includeHelp) {
-				picks.concat(this.getHelpPicks(query, token));
+				picks.push(...this.getHelpPicks(query, token));
 			}
 			if (historyEditorPicks.length !== 0) {
 				picks.push({ type: 'separator', label: localize('recentlyOpenedSeparator', "recently opened") } as IQuickPickSeparator);
-				picks.concat(historyEditorPicks);
+				picks.push(...historyEditorPicks);
 			}
 		}
 
@@ -779,9 +779,9 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 				// If the user chooses 'Go to File' the help should go away as if they were
 				// entering a new mode
-				const providerSpecificOptions = provider.prefix === AnythingQuickAccessProvider.PREFIX
+				const providerSpecificOptions: AnythingQuickAccessProviderRunOptions | undefined = provider.prefix === AnythingQuickAccessProvider.PREFIX
 					? undefined
-					: { includeModes: true };
+					: { includeHelp: true };
 
 				importantProviders.push({
 					...mapOfProviders.get(prefix)!,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #158638

Now when you launch the command center you get:
<img width="663" alt="image" src="https://user-images.githubusercontent.com/2644648/195826293-75eb28cd-28ba-4ce4-9e67-6fac3b49fb4b.png">
Additionally, if you go into a provider (say `>`) and then backspace out of it, thus returning to `Go to file...` you still get the Help.

To be clear, this only shows when you click on the command center. Cmd+P is not impacted at all.

we can improve on this later with pills and whatnot, but this gives the command center a bit more utility than just launching Cmd+P.

cc @daviddossett 

gonna cc @bpasero for a late review when you're back from being OOF 