### PR TITLE
swc: generate sourcemaps

### DIFF
--- a/build/lib/tsb/transpiler.ts
+++ b/build/lib/tsb/transpiler.ts
@@ -341,6 +341,9 @@ export class SwcTranspiler implements ITranspiler {
 			options = SwcTranspiler._swcrcCommonJS;
 		}
 
+		// TODO enable sourcemaps only on demand
+		options.sourceMaps = true;
+
 		this._jobs.push(swc.transform(tsSrc, options).then(output => {
 
 			// check if output of a DTS-files isn't just "empty" and iff so


### PR DESCRIPTION
i want to build vscode with swc (#150025)
because swc is 10x faster than tsc

(todo: add a gulp task for this, maybe `compile-build-swc`)

to enable swc in the `compile-build` task, im patching `build/lib/compilation.js`

```diff
-createCompile(src, build, true, false)
+createCompile(src, build, true, { swc: true })
```

<details>
<summary>
patching JS files in Nix buildPhase
</summary>

```sh
    # force building with SWC (10x faster than typescript)
    substituteInPlace build/lib/compilation.js \
      --replace 'createCompile(src, build, true, false)' 'createCompile(src, build, true, { swc: true })'
    # swc: generate sourcemaps for build/lib/nls.js
    # fix: Error: File vs/nls.build.js does not have sourcemaps.
    substituteInPlace build/lib/tsb/transpiler.js \
      --replace 'this._jobs.push(swc.transform' 'options.sourceMaps = true; this._jobs.push(swc.transform'
```

</details>

but then i get

```
Error: File vs/nls.build.js does not have sourcemaps.
```

<details>

```
Using gulpfile ~/gulpfile.js
Starting 'compile-build'...
Starting clean-out-build ...
Finished clean-out-build after 10 ms
Starting build-web-node-paths ...
Finished build-web-node-paths after 13 ms
Starting <anonymous> ...
Starting compilation...
'compile-build' errored after 35 s
Error: File vs/nls.build.js does not have sourcemaps.
    at Stream.<anonymous> (/build/source/build/lib/nls.js:59:39)
```

</details>

... because by default, swc does not generate sourcemaps

swc.Options type: [swc/node-swc/src/types.ts](https://github.com/swc-project/swc/blob/a50b5aeeb169f4415cc8cef4fd96d84e3c7dd77b/node-swc/src/types.ts#L579)

with this patch, the `compile-build` task still fails with

### WIP

```
Error: File vs/nls.mock.js does not have sourcemaps.
```

todo: `options.sourceMaps = "inline"; options.inlineSourcesContent = true;`

### TODO enable sourcemaps only on demand

maybe pass this option as `transpileOnly = { swc: { sourceMaps: true } }`

https://github.com/microsoft/vscode/blob/d49452248d0a52ed6d7f35f6fc41dea268a1b99f/build/lib/compilation.ts#L42

with

```diff
-transpileOnly: boolean | { swc: boolean }
+transpileOnly: boolean | { swc: boolean | swc.Options }
```

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
