### PR TITLE
Fix over sanitization of user agents

### DIFF
--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -110,13 +110,13 @@ export class TelemetryService implements ITelemetryService {
 
 		return this._commonProperties.then(values => {
 
-			// (next) add experiment properties
+			// add experiment properties
 			data = mixin(data, this._experimentProperties);
 
-			// (last) remove all PII from data
+			// remove all PII from data
 			data = cleanData(data as Record<string, any>, this._cleanupPatterns);
 
-			// (first) add common properties
+			// add common properties
 			data = mixin(data, values);
 
 			// Log to the appenders of sufficient level

--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -110,14 +110,14 @@ export class TelemetryService implements ITelemetryService {
 
 		return this._commonProperties.then(values => {
 
-			// (first) add common properties
-			data = mixin(data, values);
-
 			// (next) add experiment properties
 			data = mixin(data, this._experimentProperties);
 
 			// (last) remove all PII from data
 			data = cleanData(data as Record<string, any>, this._cleanupPatterns);
+
+			// (first) add common properties
+			data = mixin(data, values);
 
 			// Log to the appenders of sufficient level
 			this._appenders.forEach(a => a.log(eventName, data));

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -286,6 +286,12 @@ export function getPiiPathsFromEnvironment(paths: IPathEnvironment): string[] {
  * @returns The cleaned stack
  */
 function anonymizeFilePaths(stack: string, cleanupPatterns: RegExp[]): string {
+	// Detect if it's a user agent and don't sanitize it
+	// As the / is a false positive for file paths
+	if (stack.indexOf('Mozilla/') >= 0) {
+		return stack;
+	}
+
 	let updatedStack = stack;
 
 	const cleanUpIndexes: [number, number][] = [];

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -286,9 +286,8 @@ export function getPiiPathsFromEnvironment(paths: IPathEnvironment): string[] {
  * @returns The cleaned stack
  */
 function anonymizeFilePaths(stack: string, cleanupPatterns: RegExp[]): string {
-	// Detect if it's a user agent and don't sanitize it
-	// As the / is a false positive for file paths
-	if (stack.indexOf('Mozilla/') >= 0) {
+	// Detect if the satck is a user agent, as those are not file paths and trigger false positives
+	if (stack.startsWith('Mozilla/') || stack.startsWith('Opera/')) {
 		return stack;
 	}
 

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -286,10 +286,6 @@ export function getPiiPathsFromEnvironment(paths: IPathEnvironment): string[] {
  * @returns The cleaned stack
  */
 function anonymizeFilePaths(stack: string, cleanupPatterns: RegExp[]): string {
-	// Detect if the satck is a user agent, as those are not file paths and trigger false positives
-	if (stack.startsWith('Mozilla/') || stack.startsWith('Opera/')) {
-		return stack;
-	}
 
 	let updatedStack = stack;
 


### PR DESCRIPTION
This fixes falsly labeling user agents as file stacks leading to the data gettng cleaned and us being unable to identify what browser is being used