### PR TITLE
Move quick input list element cleanup to `disposeElement`

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInputList.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInputList.ts
@@ -158,7 +158,6 @@ class ListElementRenderer implements IListRenderer<ListElement, IListElementTemp
 	}
 
 	renderElement(element: ListElement, index: number, data: IListElementTemplateData): void {
-		data.toDisposeElement = dispose(data.toDisposeElement);
 		data.element = element;
 		const mainItem: QuickPickItem = element.item ? element.item : element.separator!;
 
@@ -206,7 +205,6 @@ class ListElementRenderer implements IListRenderer<ListElement, IListElementTemp
 		data.entry.classList.toggle('quick-input-list-separator-border', !!element.separator);
 
 		// Actions
-		data.actionBar.clear();
 		const buttons = mainItem.buttons;
 		if (buttons && buttons.length) {
 			data.actionBar.push(buttons.map((button, index) => {
@@ -236,6 +234,7 @@ class ListElementRenderer implements IListRenderer<ListElement, IListElementTemp
 
 	disposeElement(element: ListElement, index: number, data: IListElementTemplateData): void {
 		data.toDisposeElement = dispose(data.toDisposeElement);
+		data.actionBar.clear();
 	}
 
 	disposeTemplate(data: IListElementTemplateData): void {


### PR DESCRIPTION
For the element disposables, we are currently trying to dispose of these values twice (the call in `renderElement` does nothing)

The action bar should also be cleared in `disposeElement` instead of relying on `renderElement` being called again

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
