### PR TITLE
Defer updating screen reader content when no in a11y mode

### DIFF
--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -575,7 +575,11 @@ export class TextAreaHandler extends ViewPart {
 	public override onCursorStateChanged(e: viewEvents.ViewCursorStateChangedEvent): boolean {
 		this._selections = e.selections.slice(0);
 		this._modelSelections = e.modelSelections.slice(0);
-		this._textAreaInput.writeScreenReaderContent('selection changed');
+		if (this._accessibilitySupport === AccessibilitySupport.Enabled) {
+			this._textAreaInput.writeScreenReaderContent('selection changed');
+		} else {
+			setTimeout(() => this._textAreaInput.writeScreenReaderContent('selection changed'), 0);
+		}
 		return true;
 	}
 	public override onDecorationsChanged(e: viewEvents.ViewDecorationsChangedEvent): boolean {

--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -34,6 +34,7 @@ import { MOUSE_CURSOR_TEXT_CSS_CLASS_NAME } from 'vs/base/browser/ui/mouseCursor
 import { TokenizationRegistry } from 'vs/editor/common/languages';
 import { ColorId, ITokenPresentation } from 'vs/editor/common/encodedTokenAttributes';
 import { Color } from 'vs/base/common/color';
+import { TimeoutTimer } from 'vs/base/common/async';
 
 export interface IVisibleRangeProvider {
 	visibleRangeForPosition(position: Position): HorizontalPosition | null;
@@ -112,6 +113,7 @@ export class TextAreaHandler extends ViewPart {
 
 	private _accessibilitySupport!: AccessibilitySupport;
 	private _accessibilityPageSize!: number;
+	private _accessibilityWriteTimer: TimeoutTimer;
 	private _contentLeft: number;
 	private _contentWidth: number;
 	private _contentHeight: number;
@@ -149,6 +151,7 @@ export class TextAreaHandler extends ViewPart {
 		const layoutInfo = options.get(EditorOption.layoutInfo);
 
 		this._setAccessibilityOptions(options);
+		this._accessibilityWriteTimer = this._register(new TimeoutTimer());
 		this._contentLeft = layoutInfo.contentLeft;
 		this._contentWidth = layoutInfo.contentWidth;
 		this._contentHeight = layoutInfo.height;
@@ -575,10 +578,10 @@ export class TextAreaHandler extends ViewPart {
 	public override onCursorStateChanged(e: viewEvents.ViewCursorStateChangedEvent): boolean {
 		this._selections = e.selections.slice(0);
 		this._modelSelections = e.modelSelections.slice(0);
-		if (this._accessibilitySupport === AccessibilitySupport.Enabled) {
-			this._textAreaInput.writeScreenReaderContent('selection changed');
+		if (this._accessibilitySupport === AccessibilitySupport.Disabled) {
+			this._accessibilityWriteTimer.cancelAndSet(() => this._textAreaInput.writeScreenReaderContent('selection changed'), 0);
 		} else {
-			setTimeout(() => this._textAreaInput.writeScreenReaderContent('selection changed'), 0);
+			this._textAreaInput.writeScreenReaderContent('selection changed');
 		}
 		return true;
 	}


### PR DESCRIPTION
Before `TextAreaHandler.onCursorStateChanged` was taking approximately 4-16% of the total keypress task's runtime (it varies pretty wildly). After this is becomes < 0.5ms

Part of #161622

---

Testing methodology outlined in https://github.com/microsoft/vscode/issues/161622#issuecomment-1279172489

Before:

<img width="993" alt="Screen Shot 2022-10-14 at 11 10 07 am" src="https://user-images.githubusercontent.com/2193314/195913119-b82e76be-d913-445a-9875-9ae05c6dcc31.png">

After:

<img width="1005" alt="Screen Shot 2022-10-14 at 11 09 03 am" src="https://user-images.githubusercontent.com/2193314/195912966-c8fda613-a1f1-4f0b-a449-664f56467c25.png">


@alexdima anything in particular I should test here? The behavior should be the same when a11y mode is on and text input seems to work fine when it's off.