### PR TITLE
Pass associated notebook document to kernel source command

### DIFF
--- a/src/vs/base/common/marshallingIds.ts
+++ b/src/vs/base/common/marshallingIds.ts
@@ -17,6 +17,7 @@ export const enum MarshalledId {
 	CommentThreadNode,
 	TimelineActionContext,
 	NotebookCellActionContext,
+	NotebookActionContext,
 	TestItemContext,
 	Date
 }

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -92,6 +92,13 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 						return cell.apiCell;
 					}
 				}
+				if (arg && arg.$mid === MarshalledId.NotebookActionContext) {
+					const notebookUri = arg.uri;
+					const data = this._documents.get(notebookUri);
+					if (data) {
+						return data.apiNotebook;
+					}
+				}
 				return arg;
 			}
 		});


### PR DESCRIPTION
Kernel commands don't need to check for `activeNotebookEditor.notebook` anymore.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
