### PR TITLE
don't register the notebook editor for *.interactive

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -177,9 +177,7 @@ export class InteractiveDocumentContribution extends Disposable implements IWork
 
 		const info = notebookService.getContributedNotebookType('interactive');
 
-		if (info) {
-			info.update({ selectors: ['*.interactive'] });
-		} else {
+		if (!info) {
 			this._register(notebookService.registerContributedNotebookType('interactive', {
 				providerDisplayName: 'Interactive Notebook',
 				displayName: 'Interactive',

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -177,6 +177,9 @@ export class InteractiveDocumentContribution extends Disposable implements IWork
 
 		const info = notebookService.getContributedNotebookType('interactive');
 
+		// We need to contribute a notebook type for the Interactive Window to provide notebook models.
+		// Don't add a file selector for the notebook type to avoid having the notebook Service create an editor for it.
+		// The IW editor is registered below, and we don't want it overwritten by the notebook Service.
 		if (!info) {
 			this._register(notebookService.registerContributedNotebookType('interactive', {
 				providerDisplayName: 'Interactive Notebook',


### PR DESCRIPTION
by not setting the selectors field on the contributed notebook type for interactive, a notebook editor will not be registered for the interactive window - Interactive.Contribution already registered its own
