### PR TITLE
Avoid extra work when lightbulb is already hidden

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -184,6 +184,9 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 	}
 
 	public hide(): void {
+		if (this.state === LightBulbState.Hidden) {
+			return;
+		}
 		this.state = LightBulbState.Hidden;
 		this._editor.layoutContentWidget(this);
 	}


### PR DESCRIPTION
Part of #161622

Testing methodology explained in https://github.com/microsoft/vscode/issues/161622#issuecomment-1279172489

The actual runtime varies somewhat, not sure why, but this looks like an easy win to shave off ~1.5-2.5% of the keypress event's runtime. It's so high mainly because of state setter called `_updateLightBulbTitleAndIcon`.

Measured these on my Windows desktop:

Before:

![image](https://user-images.githubusercontent.com/2193314/196200686-5477380d-104d-4f16-952e-7895af0efd38.png)

After:

![image](https://user-images.githubusercontent.com/2193314/196200644-2b468ca7-a32d-404e-828d-8f396014f5b0.png)
