### PR TITLE
Remove some old -moz and -webkit css property usages

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -146,7 +146,6 @@
 
 .monaco-dialog-box > .dialog-buttons-row > .dialog-buttons > .monaco-button {
 	width: fit-content;
-	width: -moz-fit-content;
 	padding: 5px 10px;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isFirefox } from 'vs/base/browser/browser';
 import { DataTransfers, IDragAndDropData } from 'vs/base/browser/dnd';
 import { $, addDisposableListener, animate, getContentHeight, getContentWidth, getTopLeftOffset, scheduleAtNextAnimationFrame } from 'vs/base/browser/dom';
 import { DomEmitter } from 'vs/base/browser/event';
@@ -844,7 +843,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 			return;
 		}
 
-		item.row.domNode.style.width = isFirefox ? '-moz-fit-content' : 'fit-content';
+		item.row.domNode.style.width = 'fit-content';
 		item.width = getContentWidth(item.row.domNode);
 		const style = window.getComputedStyle(item.row.domNode);
 

--- a/src/vs/workbench/browser/parts/editor/media/editorstatus.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorstatus.css
@@ -48,5 +48,4 @@
 	padding-right: 12px;
 	margin-right: 5px;
 	max-width: fit-content;
-	max-width: -moz-fit-content;
 }

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -118,7 +118,6 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit {
 	width: 120px;
 	min-width: fit-content;
-	min-width: -moz-fit-content;
 	flex-shrink: 0;
 }
 
@@ -131,7 +130,6 @@
 	flex-basis: 0; /* all tabs are even */
 	flex-grow: 1; /* all tabs grow even */
 	max-width: fit-content;
-	max-width: -moz-fit-content;
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit.sticky-compact,

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
@@ -116,7 +116,6 @@
 
 .monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-buttons-container .monaco-text-button {
 	width: fit-content;
-	width: -moz-fit-content;
 	padding: 5px 10px;
 	display: inline-block;	/* to enable ellipsis in text overflow */
 	font-size: 12px;

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -171,7 +171,6 @@
 	flex: 1;
 	flex-shrink: 0;
 	min-width: fit-content;
-	min-width: -moz-fit-content;
 }
 
 .debug-pane .debug-call-stack .stack-frame.subtle {

--- a/src/vs/workbench/contrib/extensions/browser/media/runtimeExtensionsEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/runtimeExtensionsEditor.css
@@ -83,5 +83,4 @@
 	font-size: 80%;
 	padding-left: 6px;
 	min-width: fit-content;
-	min-width: -moz-fit-content;
 }

--- a/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
+++ b/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
@@ -50,7 +50,6 @@
 
 .explorer-viewlet .pane-header .count {
 	min-width: fit-content;
-	min-width: -moz-fit-content;
 	display: flex;
 	align-items: center;
 }

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -157,7 +157,6 @@
 .scm-view .monaco-list .monaco-list-row .resource > .name > .monaco-icon-label > .actions {
 	display: none;
 	max-width: fit-content;
-	max-width: -moz-fit-content;
 }
 
 .scm-view .monaco-list .monaco-list-row:hover .resource-group > .actions,

--- a/src/vs/workbench/contrib/workspace/browser/media/workspaceTrustEditor.css
+++ b/src/vs/workbench/contrib/workspace/browser/media/workspaceTrustEditor.css
@@ -184,7 +184,6 @@
 .workspace-trust-editor .workspace-trust-features .workspace-trust-buttons-row .workspace-trust-buttons .monaco-button,
 .workspace-trust-editor .workspace-trust-settings .trusted-uris-button-bar .monaco-button {
 	width: fit-content;
-	width: -moz-fit-content;
 	padding: 5px 10px;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/vs/workbench/services/hover/browser/media/hover.css
+++ b/src/vs/workbench/services/hover/browser/media/hover.css
@@ -51,26 +51,18 @@
 .monaco-workbench .workbench-hover-pointer.bottom { bottom: 3px; }
 
 .monaco-workbench .workbench-hover-pointer.left:after {
-	-moz-transform: rotate(135deg);
-	-webkit-transform: rotate(135deg);
 	transform: rotate(135deg);
 }
 
 .monaco-workbench .workbench-hover-pointer.right:after {
-	-moz-transform: rotate(315deg);
-	-webkit-transform: rotate(315deg);
 	transform: rotate(315deg);
 }
 
 .monaco-workbench .workbench-hover-pointer.top:after {
-	-moz-transform: rotate(225deg);
-	-webkit-transform: rotate(225deg);
 	transform: rotate(225deg);
 }
 
 .monaco-workbench .workbench-hover-pointer.bottom:after {
-	-moz-transform: rotate(45deg);
-	-webkit-transform: rotate(45deg);
 	transform: rotate(45deg);
 }
 


### PR DESCRIPTION
- Firefox supports `fit-content` since 94
- Browsers have supported `transform` for a long time

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
