### PR TITLE
Lazily compute icon classes of quick input items

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/taskQuickPick.ts
+++ b/src/vs/workbench/contrib/tasks/browser/taskQuickPick.ts
@@ -99,12 +99,12 @@ export class TaskQuickPick extends Disposable {
 		}
 	}
 
-	private _createTaskEntry(task: Task | ConfiguringTask, extraButtons: readonly IQuickInputButton[] = []): ITaskTwoLevelQuickPickEntry {
-		const entry: ITaskTwoLevelQuickPickEntry = { label: TaskQuickPick.getTaskLabelWithIcon(task, this._guessTaskLabel(task)), description: this._taskService.getTaskDescription(task), task, detail: this._showDetail() ? task.configurationProperties.detail : undefined };
-		entry.buttons = [
+	private _createTaskEntry(task: Task | ConfiguringTask, extraButtons: IQuickInputButton[] = []): ITaskTwoLevelQuickPickEntry {
+		const buttons: IQuickInputButton[] = [
 			{ iconClass: ThemeIcon.asClassName(configureTaskIcon), tooltip: nls.localize('configureTask', "Configure Task") },
-			...extraButtons,
+			...extraButtons
 		];
+		const entry: ITaskTwoLevelQuickPickEntry = { label: TaskQuickPick.getTaskLabelWithIcon(task, this._guessTaskLabel(task)), description: this._taskService.getTaskDescription(task), task, detail: this._showDetail() ? task.configurationProperties.detail : undefined, buttons };
 		TaskQuickPick.applyColorStyles(task, entry, this._themeService);
 		return entry;
 	}


### PR DESCRIPTION
When showing a file list in quick input, we are eagerly resolving all the icon class (even for items that are not visible). In the vscode workspace, this results in 512 calls into `getLanguageIds` every time the full quick input list is updated (512 is the max number of quick input files we show)

This updates the icon classes to instead be resolved lazily when the quick input items are rendered. This cuts the time of `getFilePicks` in half

Before:

![Screen Shot 2022-10-17 at 12 29 31 PM](https://user-images.githubusercontent.com/12821956/196267087-fdb74ae3-aa52-4a0b-8a57-9ca8d3f2e7c1.png)


After:

![Screen Shot 2022-10-17 at 12 33 30 PM](https://user-images.githubusercontent.com/12821956/196267105-29a2a972-7bba-4e6a-8b7e-b4dafd61799c.png)

