### PR TITLE
Re-use button definitions for quick input symbols

### DIFF
--- a/src/vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess.ts
@@ -17,7 +17,7 @@ import { DocumentSymbol, SymbolKind, SymbolKinds, SymbolTag } from 'vs/editor/co
 import { IOutlineModelService } from 'vs/editor/contrib/documentSymbols/browser/outlineModel';
 import { AbstractEditorNavigationQuickAccessProvider, IEditorNavigationQuickAccessOptions, IQuickAccessTextEditorContext } from 'vs/editor/contrib/quickAccess/browser/editorNavigationQuickAccess';
 import { localize } from 'vs/nls';
-import { IQuickPick, IQuickPickItem, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
+import { IQuickInputButton, IQuickPick, IQuickPickItem, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { Position } from 'vs/editor/common/core/position';
 import { findLast } from 'vs/base/common/arrays';
@@ -244,6 +244,16 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 		}
 
 		// Convert to symbol picks and apply filtering
+
+		let buttons: IQuickInputButton[] | undefined;
+		const openSideBySideDirection = this.options?.openSideBySideDirection?.();
+		if (openSideBySideDirection) {
+			buttons = [{
+				iconClass: openSideBySideDirection === 'right' ? Codicon.splitHorizontal.classNames : Codicon.splitVertical.classNames,
+				tooltip: openSideBySideDirection === 'right' ? localize('openToSide', "Open to the Side") : localize('openToBottom', "Open to the Bottom")
+			}];
+		}
+
 		const filteredSymbolPicks: IGotoSymbolQuickPickItem[] = [];
 		for (let index = 0; index < symbols.length; index++) {
 			const symbol = symbols[index];
@@ -323,19 +333,7 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 					decoration: symbol.range
 				},
 				strikethrough: deprecated,
-				buttons: (() => {
-					const openSideBySideDirection = this.options?.openSideBySideDirection ? this.options?.openSideBySideDirection() : undefined;
-					if (!openSideBySideDirection) {
-						return undefined;
-					}
-
-					return [
-						{
-							iconClass: openSideBySideDirection === 'right' ? Codicon.splitHorizontal.classNames : Codicon.splitVertical.classNames,
-							tooltip: openSideBySideDirection === 'right' ? localize('openToSide', "Open to the Side") : localize('openToBottom', "Open to the Bottom")
-						}
-					];
-				})()
+				buttons
 			});
 		}
 


### PR DESCRIPTION
These don't change across the list of symbols

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
