### PR TITLE
chore: update electron@19.1.3

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,4 +1,4 @@
 disturl "https://electronjs.org/headers"
-target "19.0.17"
+target "19.1.3"
 runtime "electron"
 build_from_source "true"

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -528,12 +528,12 @@
 				"git": {
 					"name": "electron",
 					"repositoryUrl": "https://github.com/electron/electron",
-					"commitHash": "0e6da36264d52656d5cd36a4c15937a6a6ca778e"
+					"commitHash": "83077e9b97c55cd4f9f641530442bcfd1c2ab949"
 				}
 			},
 			"isOnlyProductionDependency": true,
 			"license": "MIT",
-			"version": "19.0.17"
+			"version": "19.1.3"
 		},
 		{
 			"component": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "cssnano": "^4.1.11",
     "debounce": "^1.0.0",
     "deemon": "^1.4.0",
-    "electron": "19.0.17",
+    "electron": "19.1.3",
     "eslint": "8.7.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-jsdoc": "^39.3.2",


### PR DESCRIPTION
Bumps Electron to 19.1.3. Not many changes, however it fixes 8 security vulnerabilities and contains a few bugfixes vs Electron 19.0.17.

There is no changelog after 19.1.1, but from checking the commit log, 19.1.2 and 19.1.3 only backport a few fixes from the Chromium codebase.