### PR TITLE
Search `DiffIdentityProvider`

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -579,6 +579,7 @@ export class SearchView extends ViewPane {
 
 	private createFolderIterator(folderMatch: FolderMatch, collapseResults: ISearchConfigurationProperties['collapseResults'], childFolderIncompressible: boolean): Iterable<ICompressedTreeElement<RenderableMatch>> {
 		const sortOrder = this.searchConfig.sortOrder;
+
 		const matchArray = this.isTreeLayoutViewVisible ? folderMatch.matches() : folderMatch.downstreamFileMatches();
 		const matches = matchArray.sort((a, b) => searchMatchComparer(a, b, sortOrder));
 
@@ -590,10 +591,7 @@ export class SearchView extends ViewPane {
 				children = this.createFolderIterator(match, collapseResults, false);
 			}
 			let nodeExists = true;
-			try { this.tree.getNode(match); } catch (e) {
-				nodeExists = false;
-				console.log('here');
-			}
+			try { this.tree.getNode(match); } catch (e) { nodeExists = false; }
 
 			const collapsed = nodeExists ? undefined :
 				(collapseResults === 'alwaysCollapse' || (match.count() > 10 && collapseResults !== 'alwaysExpand'));

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -536,7 +536,7 @@ export class SearchView extends ViewPane {
 	}
 
 	refreshTree(event?: IChangeEvent): void {
-		const setChildrenOpts: IObjectTreeSetChildrenOptions<RenderableMatch> = { diffIdentityProvider: { getId(element: RenderableMatch) { return element.idForDiff(); }, } };
+		const setChildrenOpts: IObjectTreeSetChildrenOptions<RenderableMatch> = { diffIdentityProvider: { getId(element: RenderableMatch) { return element.id(); }, } };
 		const collapseResults = this.searchConfig.collapseResults;
 		if (!event || event.added || event.removed) {
 			// Refresh whole tree

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -536,7 +536,7 @@ export class SearchView extends ViewPane {
 	}
 
 	refreshTree(event?: IChangeEvent): void {
-		const setChildrenOpts: IObjectTreeSetChildrenOptions<RenderableMatch> = { diffIdentityProvider: { getId(element: RenderableMatch) { return element.id; }, }, diffDepth: 100 };
+		const setChildrenOpts: IObjectTreeSetChildrenOptions<RenderableMatch> = { diffIdentityProvider: { getId(element: RenderableMatch) { return element.id(); }, }, diffDepth: 100 };
 		const collapseResults = this.searchConfig.collapseResults;
 		if (!event || event.added || event.removed) {
 			// Refresh whole tree

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -536,7 +536,7 @@ export class SearchView extends ViewPane {
 	}
 
 	refreshTree(event?: IChangeEvent): void {
-		const setChildrenOpts: IObjectTreeSetChildrenOptions<RenderableMatch> = { diffIdentityProvider: { getId(element: RenderableMatch) { return element.id(); }, }, diffDepth: 100 };
+		const setChildrenOpts: IObjectTreeSetChildrenOptions<RenderableMatch> = { diffIdentityProvider: { getId(element: RenderableMatch) { return element.id(); }, } };
 		const collapseResults = this.searchConfig.collapseResults;
 		if (!event || event.added || event.removed) {
 			// Refresh whole tree

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -536,7 +536,7 @@ export class SearchView extends ViewPane {
 	}
 
 	refreshTree(event?: IChangeEvent): void {
-		const setChildrenOpts: IObjectTreeSetChildrenOptions<RenderableMatch> = { diffIdentityProvider: { getId(element: RenderableMatch) { return element.id(); }, } };
+		const setChildrenOpts: IObjectTreeSetChildrenOptions<RenderableMatch> = { diffIdentityProvider: { getId(element: RenderableMatch) { return element.idForDiff(); }, } };
 		const collapseResults = this.searchConfig.collapseResults;
 		if (!event || event.added || event.removed) {
 			// Refresh whole tree

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -579,10 +579,12 @@ export class FolderMatch extends Disposable {
 		folderMatch.onDispose(() => disposable.dispose());
 	}
 
-	clear(clearingAll = false): void {
+	clear(clearingAll = false, shouldRefreshTree = true): void {
 		const changed: FileMatch[] = this.downstreamFileMatches();
 		this.disposeMatches();
-		this._onChange.fire({ elements: changed, removed: true, added: false, clearingAll });
+		if (shouldRefreshTree) {
+			this._onChange.fire({ elements: changed, removed: true, added: false, clearingAll });
+		}
 	}
 
 	remove(matches: FileMatch | FolderMatchWithResource | (FileMatch | FolderMatchWithResource)[]): void {
@@ -1110,7 +1112,7 @@ export class SearchResult extends Disposable {
 		// When updating the query we could change the roots, so keep a reference to them to clean up when we trigger `disposePastResults`
 		const oldFolderMatches = this.folderMatches();
 		new Promise<void>(resolve => this.disposePastResults = resolve)
-			.then(() => oldFolderMatches.forEach(match => match.clear()))
+			.then(() => oldFolderMatches.forEach(match => match.clear(false, false)))
 			.then(() => oldFolderMatches.forEach(match => match.dispose()))
 			.then(() => this._isDirty = false);
 

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -579,12 +579,10 @@ export class FolderMatch extends Disposable {
 		folderMatch.onDispose(() => disposable.dispose());
 	}
 
-	clear(clearingAll = false, shouldRefreshTree = true): void {
+	clear(clearingAll = false): void {
 		const changed: FileMatch[] = this.downstreamFileMatches();
 		this.disposeMatches();
-		if (shouldRefreshTree) {
-			this._onChange.fire({ elements: changed, removed: true, added: false, clearingAll });
-		}
+		this._onChange.fire({ elements: changed, removed: true, added: false, clearingAll });
 	}
 
 	remove(matches: FileMatch | FolderMatchWithResource | (FileMatch | FolderMatchWithResource)[]): void {
@@ -1112,7 +1110,7 @@ export class SearchResult extends Disposable {
 		// When updating the query we could change the roots, so keep a reference to them to clean up when we trigger `disposePastResults`
 		const oldFolderMatches = this.folderMatches();
 		new Promise<void>(resolve => this.disposePastResults = resolve)
-			.then(() => oldFolderMatches.forEach(match => match.clear(false, false)))
+			.then(() => oldFolderMatches.forEach(match => match.clear()))
 			.then(() => oldFolderMatches.forEach(match => match.dispose()))
 			.then(() => this._isDirty = false);
 

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -59,10 +59,14 @@ export class Match {
 
 		this._fullPreviewRange = _fullPreviewRange;
 
-		this._id = this._parent.id() + '>' + this._range + this.getMatchString();
+		this._id = this._parent.id() + '>' + this._range;
 	}
 
 	id(): string {
+		return this._id + this.getMatchString();
+	}
+
+	idForDiff(): string {
 		return this._id;
 	}
 
@@ -365,6 +369,10 @@ export class FileMatch extends Disposable implements IFileMatch {
 		return this.resource.toString();
 	}
 
+	idForDiff(): string {
+		return this.id();
+	}
+
 	parent(): FolderMatch {
 		return this._parent;
 	}
@@ -536,6 +544,10 @@ export class FolderMatch extends Disposable {
 
 	id(): string {
 		return this._id;
+	}
+
+	idForDiff(): string {
+		return this.id();
 	}
 
 	get resource(): URI | null {

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -59,14 +59,10 @@ export class Match {
 
 		this._fullPreviewRange = _fullPreviewRange;
 
-		this._id = this._parent.id() + '>' + this._range;
+		this._id = this._parent.id() + '>' + this._range + this.getMatchString();
 	}
 
 	id(): string {
-		return this._id + this.getMatchString();
-	}
-
-	idForDiff(): string {
 		return this._id;
 	}
 
@@ -369,10 +365,6 @@ export class FileMatch extends Disposable implements IFileMatch {
 		return this.resource.toString();
 	}
 
-	idForDiff(): string {
-		return this.id();
-	}
-
 	parent(): FolderMatch {
 		return this._parent;
 	}
@@ -544,10 +536,6 @@ export class FolderMatch extends Disposable {
 
 	id(): string {
 		return this._id;
-	}
-
-	idForDiff(): string {
-		return this.id();
 	}
 
 	get resource(): URI | null {


### PR DESCRIPTION
Fixes #127621

In a multi-root workspace with `vscode` and `vscode-livepreview`, going from the results of `container` to `contain`:

With changes:
<img width="339" alt="image" src="https://user-images.githubusercontent.com/31675041/196503221-dca6ef74-df72-4b58-97fa-1788132b6506.png">

Current insiders:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/31675041/196503122-2caa51cd-1cc5-49a5-b72b-367a8c461846.png">


