### PR TITLE
Use `Array`.from for mapping instead of separate call to map in more places

### DIFF
--- a/src/vs/base/test/browser/ui/tree/compressedObjectTreeModel.test.ts
+++ b/src/vs/base/test/browser/ui/tree/compressedObjectTreeModel.test.ts
@@ -17,7 +17,7 @@ interface IResolvedCompressedTreeElement<T> extends ICompressedTreeElement<T> {
 
 function resolve<T>(treeElement: ICompressedTreeElement<T>): IResolvedCompressedTreeElement<T> {
 	const result: any = { element: treeElement.element };
-	const children = [...Iterable.map(Iterable.from(treeElement.children), resolve)];
+	const children = Array.from(Iterable.from(treeElement.children), resolve);
 
 	if (treeElement.incompressible) {
 		result.incompressible = true;

--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -117,7 +117,7 @@ class ConfigAwareContextValuesContainer extends Context {
 		this._listener = this._configurationService.onDidChangeConfiguration(event => {
 			if (event.source === ConfigurationTarget.DEFAULT) {
 				// new setting, reset everything
-				const allKeys = Array.from(Iterable.map(this._values, ([k]) => k));
+				const allKeys = Array.from(this._values, ([k]) => k);
 				this._values.clear();
 				emitter.fire(new ArrayContextKeyChangeEvent(allKeys));
 			} else {

--- a/src/vs/platform/diagnostics/node/diagnosticsService.ts
+++ b/src/vs/platform/diagnostics/node/diagnosticsService.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as osLib from 'os';
-import { Iterable } from 'vs/base/common/iterator';
 import { Promises } from 'vs/base/common/async';
 import { getNodeType, parse, ParseError } from 'vs/base/common/json';
 import { Schemas } from 'vs/base/common/network';
@@ -161,9 +160,8 @@ export async function collectWorkspaceStats(folder: string, filter: string[]): P
 }
 
 function asSortedItems(items: Map<string, number>): WorkspaceStatItem[] {
-	return [
-		...Iterable.map(items.entries(), ([name, count]) => ({ name: name, count: count }))
-	].sort((a, b) => b.count - a.count);
+	return Array.from(items.entries(), ([name, count]) => ({ name: name, count: count }))
+		.sort((a, b) => b.count - a.count);
 }
 
 export function getMachineInfo(): IMachineInfo {

--- a/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree.ts
@@ -25,7 +25,6 @@ import { IThemeService, ThemeIcon } from 'vs/platform/theme/common/themeService'
 import { compare } from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
 import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
-import { Iterable } from 'vs/base/common/iterator';
 import { ResourceFileEdit } from 'vs/editor/browser/services/bulkEditService';
 import { ILanguageConfigurationService } from 'vs/editor/common/languages/languageConfigurationRegistry';
 import { ILanguageService } from 'vs/editor/common/languages/language';
@@ -207,7 +206,7 @@ export class BulkEditDataSource implements IAsyncDataSource<BulkFileOperations, 
 
 		// category
 		if (element instanceof CategoryElement) {
-			return [...Iterable.map(element.category.fileOperations, op => new FileElement(element, op))];
+			return Array.from(element.category.fileOperations, op => new FileElement(element, op));
 		}
 
 		// file: text edit


### PR DESCRIPTION
- For `Array.from(iter).map(mapper)`, we can use `Array.from(iter, mapper)` which avoids the extra `map`

- For cases where we were using `Array.from(Iterable.map(iter, mapper))`, this can be replaced with `Array.from(iter, mapper)`  which avoids the call to `Iterable.map` and going through our custom generator for mapping

