### PR TITLE
Don't use @microsoft.com in source code

### DIFF
--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -44,7 +44,7 @@ suite('git smoke test', function () {
 		fs.writeFileSync(file('index.pug'), 'hello', 'utf8');
 		cp.execSync('git init -b main', { cwd });
 		cp.execSync('git config user.name testuser', { cwd });
-		cp.execSync('git config user.email monacotools@microsoft.com', { cwd });
+		cp.execSync('git config user.email monacotools@example.com', { cwd });
 		cp.execSync('git config commit.gpgsign false', { cwd });
 		cp.execSync('git add .', { cwd });
 		cp.execSync('git commit -m "initial commit"', { cwd });

--- a/src/vs/workbench/api/test/browser/extHostTelemetry.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTelemetry.test.ts
@@ -171,7 +171,7 @@ suite('ExtHostTelemetry', function () {
 		// Log an event with a bunch of PII, this should all get cleaned out
 		logger.logUsage('test-event', {
 			'fake-password': 'pwd=123',
-			'fake-email': 'no-reply@microsoft.com',
+			'fake-email': 'no-reply@example.com',
 			'fake-token': 'token=123',
 			'fake-slack-token': 'xoxp-123',
 			'fake-path': '/Users/username/.vscode/extensions',


### PR DESCRIPTION
@microsoft.com emails in source code can incorrectly trigger secret scanning thinking it's an Azure login. Safer to use @example.com or some other random address for fake emails