### PR TITLE
Lazily create notebook find widget

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -58,7 +58,7 @@ import { NOTEBOOK_KERNEL } from 'vs/workbench/contrib/notebook/common/notebookCo
 import { ICursorPositionChangedEvent } from 'vs/editor/common/cursorEvents';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { isEqual } from 'vs/base/common/resources';
-import { NotebookFindWidget } from 'vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget';
+import { NotebookFindContrib } from 'vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget';
 import { INTERACTIVE_WINDOW_EDITOR_ID } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 
 const DECORATION_KEY = 'interactiveInputDecoration';
@@ -329,7 +329,7 @@ export class InteractiveEditor extends EditorPane {
 			contributions: NotebookEditorExtensionsRegistry.getSomeEditorContributions([
 				ExecutionStateCellStatusBarContrib.id,
 				TimerCellStatusBarContrib.id,
-				NotebookFindWidget.id
+				NotebookFindContrib.id
 			]),
 			menuIds: {
 				notebookToolbar: MenuId.InteractiveToolbar,

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
@@ -18,7 +18,7 @@ import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { IShowNotebookFindWidgetOptions, NotebookFindWidget } from 'vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget';
+import { IShowNotebookFindWidgetOptions, NotebookFindContrib } from 'vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget';
 import { getNotebookEditorFromEditorPane } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { registerNotebookContribution } from 'vs/workbench/contrib/notebook/browser/notebookEditorExtensions';
 import { CellUri } from 'vs/workbench/contrib/notebook/common/notebookCommon';
@@ -26,7 +26,7 @@ import { INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR, KEYBINDING_CONTEXT_NOTEBOOK_FIND_W
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 
-registerNotebookContribution(NotebookFindWidget.id, NotebookFindWidget);
+registerNotebookContribution(NotebookFindContrib.id, NotebookFindContrib);
 
 registerAction2(class extends Action2 {
 	constructor() {
@@ -49,7 +49,7 @@ registerAction2(class extends Action2 {
 			return;
 		}
 
-		const controller = editor.getContribution<NotebookFindWidget>(NotebookFindWidget.id);
+		const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
 		controller.hide();
 		editor.focus();
 	}
@@ -76,7 +76,7 @@ registerAction2(class extends Action2 {
 			return;
 		}
 
-		const controller = editor.getContribution<NotebookFindWidget>(NotebookFindWidget.id);
+		const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
 		controller.show();
 	}
 });
@@ -139,7 +139,7 @@ StartFindAction.addImplementation(100, (accessor: ServicesAccessor, codeEditor: 
 		}
 	}
 
-	const controller = editor.getContribution<NotebookFindWidget>(NotebookFindWidget.id);
+	const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
 
 	const searchStringOptions = getSearchStringOptions(codeEditor, {
 		forceRevealReplace: false,
@@ -180,7 +180,7 @@ StartFindReplaceAction.addImplementation(100, (accessor: ServicesAccessor, codeE
 		return false;
 	}
 
-	const controller = editor.getContribution<NotebookFindWidget>(NotebookFindWidget.id);
+	const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
 
 	const searchStringOptions = getSearchStringOptions(codeEditor, {
 		forceRevealReplace: false,

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -59,7 +59,7 @@ import { IViewPaneOptions, ViewPane } from 'vs/workbench/browser/parts/views/vie
 import { IEditorPane } from 'vs/workbench/common/editor';
 import { Memento, MementoObject } from 'vs/workbench/common/memento';
 import { IViewDescriptorService } from 'vs/workbench/common/views';
-import { NotebookFindWidget } from 'vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget';
+import { NotebookFindContrib } from 'vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget';
 import { NotebookEditor } from 'vs/workbench/contrib/notebook/browser/notebookEditor';
 import { ExcludePatternInputWidget, IncludePatternInputWidget } from 'vs/workbench/contrib/search/browser/patternInputWidget';
 import { appendKeyBindingLabel, IFindInFilesArgs } from 'vs/workbench/contrib/search/browser/searchActions';
@@ -1789,7 +1789,7 @@ export class SearchView extends ViewPane {
 		}
 
 		if (editor instanceof NotebookEditor) {
-			const controller = editor.getControl()?.getContribution<NotebookFindWidget>(NotebookFindWidget.id);
+			const controller = editor.getControl()?.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
 			const matchIndex = element instanceof Match ? element.parent().matches().findIndex(e => e.id() === element.id()) : undefined;
 			controller?.show(this.searchWidget.searchInput.getValue(), { matchIndex, focus: false });
 		}


### PR DESCRIPTION
The notebook find widget is currently created when the notebook is opened. This is somewhat expensive, so we should defer this until the find widget is needed

