### PR TITLE
Avoid expensive markdown cell aria updates in non-screen reader mode

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
@@ -17,6 +17,7 @@ import { ILanguageService } from 'vs/editor/common/languages/language';
 import { tokenizeToStringSync } from 'vs/editor/common/languages/textToHtmlTokenizer';
 import { IReadonlyTextBuffer } from 'vs/editor/common/model';
 import { localize } from 'vs/nls';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -48,6 +49,7 @@ export class MarkupCell extends Disposable {
 		private readonly viewCell: MarkupCellViewModel,
 		private readonly templateData: MarkdownCellRenderTemplate,
 		private readonly renderedEditors: Map<ICellViewModel, ICodeEditor | undefined>,
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@INotebookCellStatusBarService readonly notebookCellStatusBarService: INotebookCellStatusBarService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -70,6 +72,10 @@ export class MarkupCell extends Disposable {
 		this.templateData.cellParts.forEach(cellPart => cellPart.renderCell(this.viewCell));
 		this._register(toDisposable(() => {
 			this.templateData.cellParts.forEach(cellPart => cellPart.unrenderCell(this.viewCell));
+		}));
+
+		this._register(this.accessibilityService.onDidChangeScreenReaderOptimized(() => {
+			this.viewUpdate();
 		}));
 
 		this.updateForHover();
@@ -384,7 +390,11 @@ export class MarkupCell extends Disposable {
 
 		this.markdownAccessibilityContainer.innerText = '';
 		if (this.viewCell.renderedHtml) {
-			DOM.safeInnerHtml(this.markdownAccessibilityContainer, this.viewCell.renderedHtml);
+			if (this.accessibilityService.isScreenReaderOptimized()) {
+				DOM.safeInnerHtml(this.markdownAccessibilityContainer, this.viewCell.renderedHtml);
+			} else {
+				DOM.clearNode(this.markdownAccessibilityContainer);
+			}
 		}
 
 		this.notebookEditor.createMarkupPreview(this.viewCell);


### PR DESCRIPTION
Updating the aria data for markdown cells is fairly expensive since we need to parse and render html. This makes notebook scrolling feel choppy:

<img width="1326" alt="Screen Shot 2022-10-18 at 5 02 12 PM" src="https://user-images.githubusercontent.com/12821956/196567587-ab513c04-26ea-4d05-86ef-13a2460a3c92.png">

This PR lets us skip this if the editor is not in screen reader optimized mode
