### PR TITLE
Revert "Newline in tree item label makes label unreadable"

### DIFF
--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -119,10 +119,6 @@
 	overflow: hidden;
 	flex-wrap: nowrap;
 	padding-left: 3px;
-	/* Supported everywhere: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp#browser_compatibility */
-	-webkit-line-clamp: 1;
-	display: -webkit-box;
-	-webkit-box-orient: vertical;
 }
 
 .customview-tree .monaco-list .monaco-list-row .custom-view-tree-node-item .custom-view-tree-node-item-checkbox {


### PR DESCRIPTION
Reverts microsoft/vscode#163345 due to the timeline view being broken:

![image](https://user-images.githubusercontent.com/5047891/196648156-f6472ddf-42a0-4684-918a-2bdac4ebe324.png)

FYI @alexr00 