### PR TITLE
Ensure 'undefined' does not make it into tsserver.web.js

### DIFF
--- a/extensions/typescript-language-features/extension-browser.webpack.config.js
+++ b/extensions/typescript-language-features/extension-browser.webpack.config.js
@@ -70,8 +70,14 @@ module.exports = withBrowserDefaults({
 						const dynamicImportCompatPath = path.join(__dirname, '..', 'node_modules', 'typescript', 'lib', 'dynamicImportCompat.js');
 						const prefix = fs.existsSync(dynamicImportCompatPath) ? fs.readFileSync(dynamicImportCompatPath) : undefined;
 						const output = await Terser.minify(content.toString());
+						if (!output.code) {
+							throw new Error('Terser returned undefined code');
+						}
 
-						return prefix + '\n' + output.code;
+						if (prefix) {
+							return prefix.toString() + '\n' + output.code;
+						}
+						return output.code;
 					},
 					transformPath: (targetPath) => {
 						return targetPath.replace('tsserver.js', 'tsserver.web.js');


### PR DESCRIPTION
TS 5.0 won't include `dynamicImportCompat`; I noticed while vetting VS Code's usage of it that if the file doesn't exist, it accidentally puts `undefined` into the output file.

This technically works because of automatic semicolon insertion (there's a newline after `undefined`), but there's no reason to include that expression in the file if we don't have to, and now we can avoid doing string manipulation for TS 5.0+ which will make the build slightly faster.