### PR TITLE
Scroll webview to top if unmatched fragment is #top

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -536,8 +536,13 @@
 						event.view.scrollTo(0, 0);
 					} else if (node.hash && (node.getAttribute('href') === node.hash || (baseElement && node.href === baseElement.href + node.hash))) {
 						const fragment = node.hash.slice(1);
-						const scrollTarget = event.view.document.getElementById(fragment) ?? event.view.document.getElementById(decodeURIComponent(fragment));
-						scrollTarget?.scrollIntoView();
+						const decodedFragment = decodeURIComponent(fragment);
+						const scrollTarget = event.view.document.getElementById(fragment) ?? event.view.document.getElementById(decodedFragment);
+						if (scrollTarget) {
+							scrollTarget.scrollIntoView();
+						} else if (decodedFragment.toLowerCase() === 'top') {
+							event.view.scrollTo(0, 0);
+						}
 					} else {
 						hostMessaging.postMessage('did-click-link', node.href.baseVal || node.href);
 					}

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-WedTLLcy1WD2tkMNIDWTY7p5GAXwF+3pVt9Bd3nh6x4=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-lC8sxUeeYqUtmkCpPt/OX/HQdE0JbHG1Z3dzrilsRU0=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -537,8 +537,13 @@
 						event.view.scrollTo(0, 0);
 					} else if (node.hash && (node.getAttribute('href') === node.hash || (baseElement && node.href === baseElement.href + node.hash))) {
 						const fragment = node.hash.slice(1);
-						const scrollTarget = event.view.document.getElementById(fragment) ?? event.view.document.getElementById(decodeURIComponent(fragment));
-						scrollTarget?.scrollIntoView();
+						const decodedFragment = decodeURIComponent(fragment);
+						const scrollTarget = event.view.document.getElementById(fragment) ?? event.view.document.getElementById(decodedFragment);
+						if (scrollTarget) {
+							scrollTarget.scrollIntoView();
+						} else if (decodedFragment.toLowerCase() === 'top') {
+							event.view.scrollTo(0, 0);
+						}
 					} else {
 						hostMessaging.postMessage('did-click-link', node.href.baseVal || node.href);
 					}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
In the HTML Standard, [section 7.11.9 “Navigating to a fragment”](https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid) states that when looking for the indicated part of the document, if the fragment doesn’t match any element, but is the special value “top”, then the top of the document is indicated:

> If decodedFragment is an [ASCII case-insensitive](https://infra.spec.whatwg.org/#ascii-case-insensitive) match for the string top, then [the indicated part of the document](https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document) is the top of the document; return.

This PR updates the logic for webviews to follow the spec. Can be tested by putting a link to `#top` in a Markdown document and previewing the document.

cc @mjbvz 