### PR TITLE
`FolderMatch.hasFileUriDownstream()` and `RenderableMatch.name()` have performance overhead

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -363,7 +363,7 @@ export class SearchAccessibilityProvider implements IListAccessibilityProvider<R
 
 	getAriaLabel(element: RenderableMatch): string | null {
 		if (element instanceof FolderMatch) {
-			const count = element.downstreamFileMatches().reduce((total, current) => total + current.count(), 0);
+			const count = element.allDownstreamFileMatches().reduce((total, current) => total + current.count(), 0);
 			return element.resource ?
 				nls.localize('folderMatchAriaLabel', "{0} matches in folder root {1}, Search result", count, element.name()) :
 				nls.localize('otherFilesAriaLabel', "{0} matches outside of the workspace, Search result", count);

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -580,7 +580,7 @@ export class SearchView extends ViewPane {
 	private createFolderIterator(folderMatch: FolderMatch, collapseResults: ISearchConfigurationProperties['collapseResults'], childFolderIncompressible: boolean): Iterable<ICompressedTreeElement<RenderableMatch>> {
 		const sortOrder = this.searchConfig.sortOrder;
 
-		const matchArray = this.isTreeLayoutViewVisible ? folderMatch.matches() : folderMatch.downstreamFileMatches();
+		const matchArray = this.isTreeLayoutViewVisible ? folderMatch.matches() : folderMatch.allDownstreamFileMatches();
 		const matches = matchArray.sort((a, b) => searchMatchComparer(a, b, sortOrder));
 
 		return Iterable.map(matches, match => {

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -226,14 +226,14 @@ export class FileMatch extends Disposable implements IFileMatch {
 		private _closestRoot: FolderMatchWorkspaceRoot | null,
 		@IModelService private readonly modelService: IModelService,
 		@IReplaceService private readonly replaceService: IReplaceService,
-		@ILabelService private readonly labelService: ILabelService,
+		@ILabelService readonly labelService: ILabelService,
 	) {
 		super();
 		this._resource = this.rawMatch.resource;
 		this._matches = new Map<string, Match>();
 		this._removedMatches = new Set<string>();
 		this._updateScheduler = new RunOnceScheduler(this.updateMatchesForModel.bind(this), 250);
-		this._name = this.labelService.getUriBasenameLabel(this.resource);
+		this._name = labelService.getUriBasenameLabel(this.resource);
 		this.createMatches();
 	}
 
@@ -510,7 +510,7 @@ export class FolderMatch extends Disposable {
 		private _closestRoot: FolderMatchWorkspaceRoot | null,
 		@IReplaceService private readonly replaceService: IReplaceService,
 		@IInstantiationService protected readonly instantiationService: IInstantiationService,
-		@ILabelService private readonly labelService: ILabelService,
+		@ILabelService readonly labelService: ILabelService,
 		@IUriIdentityService protected readonly uriIdentityService: IUriIdentityService
 	) {
 		super();
@@ -519,7 +519,7 @@ export class FolderMatch extends Disposable {
 		this._folderMatchesMap = TernarySearchTree.forUris<FolderMatchWithResource>(key => this.uriIdentityService.extUri.ignorePathCasing(key));
 		this._unDisposedFileMatches = new ResourceMap<FileMatch>();
 		this._unDisposedFolderMatches = new ResourceMap<FolderMatchWithResource>();
-		this._name = this.resource ? this.labelService.getUriBasenameLabel(this.resource) : '';
+		this._name = this.resource ? labelService.getUriBasenameLabel(this.resource) : '';
 		this._recursiveFileMatches = new ResourceMap<FileMatch>();
 	}
 

--- a/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
@@ -20,6 +20,7 @@ import { FileMatch, FileMatchOrMatch, Match } from 'vs/workbench/contrib/search/
 import { MockObjectTree } from 'vs/workbench/contrib/search/test/browser/mockSearchTree';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
+import { ILabelService } from 'vs/platform/label/common/label';
 
 suite('Search Actions', () => {
 
@@ -30,6 +31,7 @@ suite('Search Actions', () => {
 		instantiationService = new TestInstantiationService();
 		instantiationService.stub(IModelService, stubModelService(instantiationService));
 		instantiationService.stub(IKeybindingService, {});
+		instantiationService.stub(ILabelService, { getUriBasenameLabel: (uri: URI) => '' });
 		instantiationService.stub(IKeybindingService, 'resolveKeybinding', (keybinding: Keybinding) => [new USLayoutResolvedKeybinding(keybinding, OS)]);
 		instantiationService.stub(IKeybindingService, 'lookupKeybinding', (id: string) => null);
 		instantiationService.stub(IKeybindingService, 'lookupKeybinding', (id: string) => null);

--- a/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
@@ -24,6 +24,7 @@ import { NullLogService } from 'vs/platform/log/common/log';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService';
 import { isWindows } from 'vs/base/common/platform';
+import { ILabelService } from 'vs/platform/label/common/label';
 
 const nullEvent = new class {
 	id: number = -1;
@@ -72,6 +73,7 @@ suite('SearchModel', () => {
 		restoreStubs = [];
 		instantiationService = new TestInstantiationService();
 		instantiationService.stub(ITelemetryService, NullTelemetryService);
+		instantiationService.stub(ILabelService, { getUriBasenameLabel: (uri: URI) => '' });
 		instantiationService.stub(IModelService, stubModelService(instantiationService));
 		instantiationService.stub(ISearchService, {});
 		instantiationService.stub(ISearchService, 'textSearch', Promise.resolve({ results: [] }));

--- a/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
@@ -348,11 +348,11 @@ suite('SearchResult', () => {
 		const testObject = getPopulatedSearchResult();
 
 		const folderMatch = testObject.folderMatches()[0];
-		const fileMatch = testObject.folderMatches()[1].downstreamFileMatches()[0];
-		const match = testObject.folderMatches()[1].downstreamFileMatches()[1].matches()[0];
+		const fileMatch = testObject.folderMatches()[1].allDownstreamFileMatches()[0];
+		const match = testObject.folderMatches()[1].allDownstreamFileMatches()[1].matches()[0];
 
 		const arrayToRemove = [folderMatch, fileMatch, match];
-		const expectedArrayResult = folderMatch.downstreamFileMatches().concat([fileMatch, match.parent()]);
+		const expectedArrayResult = folderMatch.allDownstreamFileMatches().concat([fileMatch, match.parent()]);
 
 		testObject.onChange(target);
 		testObject.batchRemove(arrayToRemove);
@@ -376,10 +376,10 @@ suite('SearchResult', () => {
 		const testObject = getPopulatedSearchResult();
 
 		const folderMatch = testObject.folderMatches()[0];
-		const fileMatch = testObject.folderMatches()[1].downstreamFileMatches()[0];
-		const match = testObject.folderMatches()[1].downstreamFileMatches()[1].matches()[0];
+		const fileMatch = testObject.folderMatches()[1].allDownstreamFileMatches()[0];
+		const match = testObject.folderMatches()[1].allDownstreamFileMatches()[1].matches()[0];
 
-		const firstExpectedMatch = folderMatch.downstreamFileMatches()[0];
+		const firstExpectedMatch = folderMatch.allDownstreamFileMatches()[0];
 
 		const arrayToRemove = [folderMatch, fileMatch, match];
 
@@ -401,9 +401,9 @@ suite('SearchResult', () => {
 		const root2 = testObject.folderMatches()[2];
 		const root3 = testObject.folderMatches()[3];
 
-		const root0DownstreamFiles = root0.downstreamFileMatches();
+		const root0DownstreamFiles = root0.allDownstreamFileMatches();
 		assert.deepStrictEqual(root0DownstreamFiles, [...root0.fileMatchesIterator(), ...getFolderMatchAtIndex(root0, 0).fileMatchesIterator()]);
-		assert.deepStrictEqual(getFolderMatchAtIndex(root0, 0).downstreamFileMatches(), Array.from(getFolderMatchAtIndex(root0, 0).fileMatchesIterator()));
+		assert.deepStrictEqual(getFolderMatchAtIndex(root0, 0).allDownstreamFileMatches(), Array.from(getFolderMatchAtIndex(root0, 0).fileMatchesIterator()));
 		assert.deepStrictEqual(getFileMatchAtIndex(getFolderMatchAtIndex(root0, 0), 0).parent(), getFolderMatchAtIndex(root0, 0));
 		assert.deepStrictEqual(getFolderMatchAtIndex(root0, 0).parent(), root0);
 		assert.deepStrictEqual(getFolderMatchAtIndex(root0, 0).closestRoot, root0);
@@ -411,23 +411,23 @@ suite('SearchResult', () => {
 			assert.deepStrictEqual(e.closestRoot, root0);
 		});
 
-		const root1DownstreamFiles = root1.downstreamFileMatches();
-		assert.deepStrictEqual(root1.downstreamFileMatches(), [...root1.fileMatchesIterator(), ...getFolderMatchAtIndex(root1, 0).fileMatchesIterator()]); // excludes the matches from nested root
+		const root1DownstreamFiles = root1.allDownstreamFileMatches();
+		assert.deepStrictEqual(root1.allDownstreamFileMatches(), [...root1.fileMatchesIterator(), ...getFolderMatchAtIndex(root1, 0).fileMatchesIterator()]); // excludes the matches from nested root
 		assert.deepStrictEqual(getFileMatchAtIndex(getFolderMatchAtIndex(root1, 0), 0).parent(), getFolderMatchAtIndex(root1, 0));
 		root1DownstreamFiles.forEach((e) => {
 			assert.deepStrictEqual(e.closestRoot, root1);
 		});
 
-		const root2DownstreamFiles = root2.downstreamFileMatches();
+		const root2DownstreamFiles = root2.allDownstreamFileMatches();
 		assert.deepStrictEqual(root2DownstreamFiles, Array.from(root2.fileMatchesIterator()));
 		assert.deepStrictEqual(getFileMatchAtIndex(root2, 0).parent(), root2);
 		assert.deepStrictEqual(getFileMatchAtIndex(root2, 0).closestRoot, root2);
 
 
-		const root3DownstreamFiles = root3.downstreamFileMatches();
+		const root3DownstreamFiles = root3.allDownstreamFileMatches();
 		const root3Level3Folder = getFolderMatchAtIndex(getFolderMatchAtIndex(root3, 0), 0);
 		assert.deepStrictEqual(root3DownstreamFiles, [...root3.fileMatchesIterator(), ...getFolderMatchAtIndex(root3Level3Folder, 0).fileMatchesIterator(), ...getFolderMatchAtIndex(root3Level3Folder, 1).fileMatchesIterator()].flat());
-		assert.deepStrictEqual(root3Level3Folder.downstreamFileMatches(), getFolderMatchAtIndex(root3, 0).downstreamFileMatches());
+		assert.deepStrictEqual(root3Level3Folder.allDownstreamFileMatches(), getFolderMatchAtIndex(root3, 0).allDownstreamFileMatches());
 
 		assert.deepStrictEqual(getFileMatchAtIndex(getFolderMatchAtIndex(root3Level3Folder, 1), 0).parent(), getFolderMatchAtIndex(root3Level3Folder, 1));
 		assert.deepStrictEqual(getFolderMatchAtIndex(root3Level3Folder, 1).parent(), root3Level3Folder);
@@ -444,7 +444,7 @@ suite('SearchResult', () => {
 
 		const folderMatch = getFolderMatchAtIndex(getFolderMatchAtIndex(getFolderMatchAtIndex(testObject.folderMatches()[3], 0), 0), 0);
 
-		const expectedArrayResult = folderMatch.downstreamFileMatches();
+		const expectedArrayResult = folderMatch.allDownstreamFileMatches();
 
 		testObject.onChange(target);
 		testObject.remove(folderMatch);
@@ -458,7 +458,7 @@ suite('SearchResult', () => {
 
 		const folderMatch = getFolderMatchAtIndex(testObject.folderMatches()[3], 0);
 
-		const expectedArrayResult = folderMatch.downstreamFileMatches();
+		const expectedArrayResult = folderMatch.allDownstreamFileMatches();
 
 		testObject.onChange(target);
 		await testObject.batchReplace([folderMatch]);

--- a/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
@@ -426,7 +426,7 @@ suite('SearchResult', () => {
 
 		const root3DownstreamFiles = root3.downstreamFileMatches();
 		const root3Level3Folder = getFolderMatchAtIndex(getFolderMatchAtIndex(root3, 0), 0);
-		assert.deepStrictEqual(root3DownstreamFiles, [...getFolderMatchAtIndex(root3Level3Folder, 0).fileMatchesIterator(), ...getFolderMatchAtIndex(root3Level3Folder, 1).fileMatchesIterator(), ...root3.fileMatchesIterator()].flat());
+		assert.deepStrictEqual(root3DownstreamFiles, [...root3.fileMatchesIterator(), ...getFolderMatchAtIndex(root3Level3Folder, 0).fileMatchesIterator(), ...getFolderMatchAtIndex(root3Level3Folder, 1).fileMatchesIterator()].flat());
 		assert.deepStrictEqual(root3Level3Folder.downstreamFileMatches(), getFolderMatchAtIndex(root3, 0).downstreamFileMatches());
 
 		assert.deepStrictEqual(getFileMatchAtIndex(getFolderMatchAtIndex(root3Level3Folder, 1), 0).parent(), getFolderMatchAtIndex(root3Level3Folder, 1));

--- a/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
@@ -426,7 +426,7 @@ suite('SearchResult', () => {
 
 		const root3DownstreamFiles = root3.downstreamFileMatches();
 		const root3Level3Folder = getFolderMatchAtIndex(getFolderMatchAtIndex(root3, 0), 0);
-		assert.deepStrictEqual(root3DownstreamFiles, [...root3.fileMatchesIterator(), ...getFolderMatchAtIndex(root3Level3Folder, 0).fileMatchesIterator(), ...getFolderMatchAtIndex(root3Level3Folder, 1).fileMatchesIterator()].flat());
+		assert.deepStrictEqual(root3DownstreamFiles, [...getFolderMatchAtIndex(root3Level3Folder, 0).fileMatchesIterator(), ...getFolderMatchAtIndex(root3Level3Folder, 1).fileMatchesIterator(), ...root3.fileMatchesIterator()].flat());
 		assert.deepStrictEqual(root3Level3Folder.downstreamFileMatches(), getFolderMatchAtIndex(root3, 0).downstreamFileMatches());
 
 		assert.deepStrictEqual(getFileMatchAtIndex(getFolderMatchAtIndex(root3Level3Folder, 1), 0).parent(), getFolderMatchAtIndex(root3Level3Folder, 1));

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorSerialization.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorSerialization.ts
@@ -236,7 +236,7 @@ export const serializeSearchResultForEditor =
 			flattenSearchResultSerializations(
 				flatten(
 					searchResult.folderMatches().sort(matchComparer)
-						.map(folderMatch => folderMatch.downstreamFileMatches().sort(matchComparer)
+						.map(folderMatch => folderMatch.allDownstreamFileMatches().sort(matchComparer)
 							.map(fileMatch => fileMatchToSearchResultFormat(fileMatch, labelFormatter)))));
 
 		return {


### PR DESCRIPTION
Fixes #164072
Caching results for `name`. 
- SearchMatchComparer time went from around ~1.8% of total time to ~0.3%

Limiting the paths for `hasFileUriDownstream`.
- Similar timing because of `findFolder` call, but cleaner code.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

