### PR TITLE
Avoid using dynamic stylesheet in FilesRenderer

### DIFF
--- a/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
+++ b/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
@@ -83,6 +83,10 @@
 	text-decoration: underline;
 }
 
+.explorer-viewlet .explorer-item.align-nest-icon-with-parent-icon {
+	margin-left: var(--vscode-explorer-align-offset-margin-left);
+}
+
 .monaco-workbench.linux .explorer-viewlet .explorer-item .monaco-inputbox,
 .monaco-workbench.mac .explorer-viewlet .explorer-item .monaco-inputbox {
 	height: 22px;

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -392,7 +392,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 		this._register(explorerLabels);
 
 		const updateWidth = (stat: ExplorerItem) => this.tree.updateWidth(stat);
-		this.renderer = this.instantiationService.createInstance(FilesRenderer, explorerLabels, updateWidth);
+		this.renderer = this.instantiationService.createInstance(FilesRenderer, container, explorerLabels, updateWidth);
 		this._register(this.renderer);
 
 		this._register(createFileIconThemableTreeContainerScope(container, this.themeService));

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -267,7 +267,6 @@ export interface IFileTemplateData {
 export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, FuzzyScore, IFileTemplateData>, IListAccessibilityProvider<ExplorerItem>, IDisposable {
 	static readonly ID = 'file';
 
-	private styler: HTMLStyleElement;
 	private config: IFilesConfiguration;
 	private configListener: IDisposable;
 	private compressedNavigationControllers = new Map<ExplorerItem, CompressedNavigationController>();
@@ -276,6 +275,7 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 	readonly onDidChangeActiveDescendant = this._onDidChangeActiveDescendant.event;
 
 	constructor(
+		container: HTMLElement,
 		private labels: ResourceLabels,
 		private updateWidth: (stat: ExplorerItem) => void,
 		@IContextViewService private readonly contextViewService: IContextViewService,
@@ -287,12 +287,10 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 	) {
 		this.config = this.configurationService.getValue<IFilesConfiguration>();
 
-		this.styler = DOM.createStyleSheet();
-		const buildOffsetStyles = () => {
+		const updateOffsetStyles = () => {
 			const indent = this.configurationService.getValue<number>('workbench.tree.indent');
 			const offset = Math.max(22 - indent, 0); // derived via inspection
-			const rule = `.explorer-viewlet .explorer-item.align-nest-icon-with-parent-icon { margin-left: ${offset}px }`;
-			if (this.styler.innerText !== rule) { this.styler.innerText = rule; }
+			container.style.setProperty(`--vscode-explorer-align-offset-margin-left`, `${offset}px`);
 		};
 
 		this.configListener = this.configurationService.onDidChangeConfiguration(e => {
@@ -300,11 +298,11 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 				this.config = this.configurationService.getValue();
 			}
 			if (e.affectsConfiguration('workbench.tree.indent')) {
-				buildOffsetStyles();
+				updateOffsetStyles();
 			}
 		});
 
-		buildOffsetStyles();
+		updateOffsetStyles();
 	}
 
 	getWidgetAriaLabel(): string {

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -595,7 +595,6 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 
 	dispose(): void {
 		this.configListener.dispose();
-		this.styler.innerText = '';
 	}
 }
 


### PR DESCRIPTION
The FilesRenderer currently creates a dynamic stylesheet just to pass along one value. This ends up being expensive, as it forces a re-style when the stylesheet is updated

In this case, we can use a css variable to pass along this value instead

Before:

<img width="776" alt="Screen Shot 2022-10-19 at 8 39 47 PM" src="https://user-images.githubusercontent.com/12821956/196851560-78526aca-3ae4-4f24-9599-fd64a8807846.png">

After:

<img width="1074" alt="Screen Shot 2022-10-19 at 8 40 33 PM" src="https://user-images.githubusercontent.com/12821956/196851577-47c6788d-c103-4ff0-8421-916feef72dec.png">


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
