### PR TITLE
Linux: Support `XDG_CONFIG_HOME` for `argv.json` location

### DIFF
--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -105,7 +105,9 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 			return URI.file(join(vscodePortable, 'argv.json'));
 		}
 
-		return joinPath(this.userHome, this.productService.dataFolderName, 'argv.json');
+		return joinPath(this.userHome, '.config', this.productService.dataFolderName.replace(/^\./, ''), 'argv.json');
+		// TODO: how do we fall back to this?
+		// return joinPath(this.userHome, this.productService.dataFolderName, 'argv.json');
 	}
 
 	@memoize


### PR DESCRIPTION
If it's not available, fall back to reading and/or creating `~/.[product-name]/argv.json`.

This addresses https://github.com/microsoft/vscode/issues/162712

Unfortunately, there is an issue in that
`AbstractNativeEnvironmentService.argvResource()` does not have access
to the filesystem directly. It will need further work to fall back from
one location to another.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
