### PR TITLE
joh/inadequate vicuna

### DIFF
--- a/src/vs/base/common/stopwatch.ts
+++ b/src/vs/base/common/stopwatch.ts
@@ -27,6 +27,11 @@ export class StopWatch {
 		this._stopTime = this._now();
 	}
 
+	public reset(): void {
+		this._startTime = this._now();
+		this._stopTime = -1;
+	}
+
 	public elapsed(): number {
 		if (this._stopTime !== -1) {
 			return this._stopTime - this._startTime;

--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -164,9 +164,7 @@ export interface ICommonNativeHostService {
 	sendInputEvent(event: MouseInputEvent): Promise<void>;
 
 	// Perf Introspection
-	startHeartbeat(session: string): Promise<boolean>;
-	sendHeartbeat(session: string): Promise<boolean>;
-	stopHeartbeat(session: string): Promise<boolean>;
+	profileRenderer(session: string, duration: number, perfBaseline: number): Promise<boolean>;
 
 	// Connectivity
 	resolveProxy(url: string): Promise<string | undefined>;

--- a/src/vs/platform/profiling/common/profilingModel.ts
+++ b/src/vs/platform/profiling/common/profilingModel.ts
@@ -361,7 +361,6 @@ export function bottomUp(profileOrModel: IV8Profile | IProfileModel, topN: numbe
 
 	const result = Object.values(root.children)
 		.sort((a, b) => b.selfTime - a.selfTime)
-		// .filter(a => !isSpecial(a.callFrame))
 		.slice(0, topN);
 
 
@@ -383,8 +382,8 @@ export function bottomUp(profileOrModel: IV8Profile | IProfileModel, topN: numbe
 	for (const node of result) {
 
 		const sample: BottomUpSample = {
-			selfTime: node.selfTime / 1000,
-			totalTime: node.aggregateTime / 1000,
+			selfTime: Math.round(node.selfTime / 1000),
+			totalTime: Math.round(node.aggregateTime / 1000),
 			location: printCallFrame(node.callFrame),
 			url: node.callFrame.url,
 			caller: [],

--- a/src/vs/platform/profiling/common/profilingTelemetrySpec.ts
+++ b/src/vs/platform/profiling/common/profilingTelemetrySpec.ts
@@ -8,6 +8,7 @@ export type TelemetrySampleData = {
 	selfTime: number;
 	totalTime: number;
 	percentage: number;
+	perfBaseline: number;
 	functionName: string;
 	callstack: string;
 	extensionId: string;
@@ -20,6 +21,7 @@ export type TelemetrySampleDataClassification = {
 	selfTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Self time of the sample' };
 	totalTime: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total time of the sample' };
 	percentage: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Relative time (percentage) of the sample' };
+	perfBaseline: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Performance baseline for the machine' };
 	functionName: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The name of the sample' };
 	callstack: { classification: 'CallstackOrException'; purpose: 'PerformanceAndHealth'; comment: 'The stacktrace leading into the sample' };
 	extensionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The extension for the sample (iff applicable)' };

--- a/src/vs/workbench/contrib/performance/electron-sandbox/rendererAutoProfiler.ts
+++ b/src/vs/workbench/contrib/performance/electron-sandbox/rendererAutoProfiler.ts
@@ -3,186 +3,81 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { runWhenIdle } from 'vs/base/common/async';
-import { DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
-import { StopWatch } from 'vs/base/common/stopwatch';
+import { timeout } from 'vs/base/common/async';
 import { generateUuid } from 'vs/base/common/uuid';
-import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { ILogService } from 'vs/platform/log/common/log';
 import { INativeHostService } from 'vs/platform/native/electron-sandbox/native';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { IViewDescriptorService } from 'vs/workbench/common/views';
-import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { parseExtensionDevOptions } from 'vs/workbench/services/extensions/common/extensionDevOptions';
+import { ITimerService } from 'vs/workbench/services/timer/browser/timerService';
 
 export class RendererProfiling {
 
-	private readonly _disposables = new DisposableStore();
+	private _observer?: PerformanceObserver;
 
 	constructor(
 		@INativeHostService nativeHostService: INativeHostService,
+		@IEnvironmentService environmentService: IEnvironmentService,
 		@ILogService logService: ILogService,
-		@ICommandService commandService: ICommandService,
-		@ITelemetryService telemetryService: ITelemetryService,
-		@IViewDescriptorService viewsDescriptorService: IViewDescriptorService,
-		@IEditorService editorService: IEditorService,
+		@ITimerService timerService: ITimerService,
 	) {
 
-		this._computePerformanceBaseline().then(value => {
-			if (value < 0) {
+		const devOpts = parseExtensionDevOptions(environmentService);
+		if (devOpts.isExtensionDevTestFromCli) {
+			// disabled when running extension tests
+			return;
+		}
+
+		timerService.perfBaseline.then(perfBaseline => {
+			logService.info(`[perf] Render performance baseline is ${perfBaseline}ms`);
+
+			if (perfBaseline < 0) {
 				// too slow
 				return;
 			}
 
 			// SLOW threshold
-			const slowThreshold = value * 10; // 200ms on MY machine
+			const slowThreshold = perfBaseline * 10; // ~10 frames at 64fps on MY machine
 
-			// Keep a record of the last events
-			const eventHistory = new RingBuffer<{ command: string; timestamp: number }>(5);
-			this._disposables.add(commandService.onWillExecuteCommand(e => eventHistory.push({ command: e.commandId, timestamp: Date.now() })));
+			const obs = new PerformanceObserver(async list => {
 
-
-			const obs = new PerformanceObserver(list => {
-
-				let maxDuration = 0;
-				for (const entry of list.getEntries()) {
-					maxDuration = Math.max(maxDuration, entry.duration);
-				}
 				obs.takeRecords();
+				const maxDuration = list.getEntries()
+					.map(e => e.duration)
+					.reduce((p, c) => Math.max(p, c), 0);
 
 				if (maxDuration < slowThreshold) {
 					return;
 				}
 
 				const sessionId = generateUuid();
-
-				// all visible views
-				const views = viewsDescriptorService.viewContainers.map(container => {
-					const model = viewsDescriptorService.getViewContainerModel(container);
-					return model.visibleViewDescriptors.map(view => view.id);
-				});
-
-				const editors = editorService.visibleEditors.map(editor => editor.typeId);
-
-				// send telemetry event
-				telemetryService.publicLog2<TelemetryEventData, TelemetryEventClassification>('perf.freeze.events', {
-					sessionId: sessionId,
-					timestamp: Date.now() - maxDuration,
-					recentCommands: JSON.stringify(eventHistory.values()),
-					views: JSON.stringify(views.flat()),
-					editors: JSON.stringify(editors),
-				});
-
 				// start heartbeat monitoring
-				const sessionDisposables = this._disposables.add(new DisposableStore());
-				logService.warn(`[perf] Renderer reported VERY LONG TASK (${maxDuration}ms), starting auto profiling session '${sessionId}'`);
+				logService.warn(`[perf] Renderer reported VERY LONG TASK (${maxDuration}ms), starting profiling session '${sessionId}'`);
+
 				// pause observation, we'll take a detailed look
 				obs.disconnect();
-				nativeHostService.startHeartbeat(sessionId).then(success => {
-					if (!success) {
-						logService.warn('[perf] FAILED to start heartbeat sending');
-						return;
+
+				// profile for 5secs and wait after that, try for max 1min or until we
+				// found something interesting
+				for (let i = 0; i < 3; i++) {
+					const good = await nativeHostService.profileRenderer(sessionId, 5000, perfBaseline);
+					if (good) {
+						break;
 					}
+					timeout(15000); // wait 15s
+				}
 
-					// start sending a repeated heartbeat which is expected to be received by the main side
-					const handle1 = setInterval(() => nativeHostService.sendHeartbeat(sessionId), 500);
-
-					// stop heartbeat after 20s
-					const handle2 = setTimeout(() => sessionDisposables.clear(), 20 * 1000);
-
-					// cleanup
-					// - stop heartbeat
-					// - reconnect perf observer
-					sessionDisposables.add(toDisposable(() => {
-						clearInterval(handle1);
-						clearTimeout(handle2);
-						nativeHostService.stopHeartbeat(sessionId);
-						logService.warn(`[perf] STOPPING to send heartbeat`);
-						obs.observe({ entryTypes: ['longtask'] });
-					}));
-				});
+				// reconnect the observer
+				obs.observe({ entryTypes: ['longtask'] });
 			});
 
-			this._disposables.add(toDisposable(() => obs.disconnect()));
 			obs.observe({ entryTypes: ['longtask'] });
+			this._observer = obs;
+
 		});
 	}
 
 	dispose(): void {
-		this._disposables.dispose();
-	}
-
-	private async _computePerformanceBaseline(): Promise<number> {
-		return new Promise(resolve => {
-			runWhenIdle(() => {
-
-				// we use fibonacci numbers to have a performance baseline that indicates
-				// how slow/fast THIS machine actually is.
-				const sw = new StopWatch(true);
-				let tooSlow = false;
-				function fib(n: number): number {
-					if (tooSlow) {
-						return 0;
-					}
-					if (sw.elapsed() >= 1000) {
-						tooSlow = true;
-					}
-					if (n <= 2) {
-						return n;
-					}
-					return fib(n - 1) + fib(n - 2);
-				}
-
-				// On my machine the 26th fibonacci take ~20ms to compute. We derive performance observations
-				// from that and we bail if that took too long (>1s)
-				sw.reset();
-				fib(26);
-				const fib26 = sw.elapsed();
-
-				resolve(tooSlow ? -1 : fib26);
-			});
-		});
-	}
-}
-
-type TelemetryEventData = {
-	sessionId: string;
-	timestamp: number;
-	recentCommands: string;
-	views: string;
-	editors: string;
-};
-
-type TelemetryEventClassification = {
-	owner: 'jrieken';
-	comment: 'Insight about what happened before/while a long task was reported';
-	sessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Session identifier that allows to correlate CPU samples and events' };
-	timestamp: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Unix time at which the long task approximately happened' };
-	recentCommands: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Events prior to the long task' };
-	views: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Visible views' };
-	editors: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Visible editor' };
-};
-
-class RingBuffer<T> {
-
-	private static _value = {};
-
-	private readonly _data: any[];
-
-	private _index: number = 0;
-	private _size: number = 0;
-
-	constructor(size: number) {
-		this._size = size;
-		this._data = new Array(size);
-		this._data.fill(RingBuffer._value, 0, size);
-	}
-
-	push(value: T): void {
-		this._data[this._index] = value;
-		this._index = (this._index + 1) % this._size;
-	}
-
-	values(): T[] {
-		return [...this._data.slice(this._index), ...this._data.slice(0, this._index)].filter(a => a !== RingBuffer._value);
+		this._observer?.disconnect();
 	}
 }

--- a/src/vs/workbench/services/timer/browser/timerService.ts
+++ b/src/vs/workbench/services/timer/browser/timerService.ts
@@ -12,10 +12,11 @@ import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecyc
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { Barrier } from 'vs/base/common/async';
+import { Barrier, timeout } from 'vs/base/common/async';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
 import { ViewContainerLocation } from 'vs/workbench/common/views';
+import { StopWatch } from 'vs/base/common/stopwatch';
 
 /* __GDPR__FRAGMENT__
 	"IMemoryInfo" : {
@@ -398,6 +399,14 @@ export interface ITimerService {
 	whenReady(): Promise<boolean>;
 
 	/**
+	 * A baseline performance indicator for this machine. The value will only available
+	 * late after startup because computing it takes away CPU resources
+	 *
+	 * NOTE that this returns -1 if the machine is hopelessly slow...
+	 */
+	perfBaseline: Promise<number>;
+
+	/**
 	 * Startup metrics. Can ONLY be accessed after `whenReady` has resolved.
 	 */
 	readonly startupMetrics: IStartupMetrics;
@@ -461,7 +470,10 @@ export abstract class AbstractTimerService implements ITimerService {
 
 	private readonly _barrier = new Barrier();
 	private readonly _marks = new PerfMarks();
+
 	private _startupMetrics?: IStartupMetrics;
+
+	readonly perfBaseline: Promise<number>;
 
 	constructor(
 		@ILifecycleService private readonly _lifecycleService: ILifecycleService,
@@ -487,6 +499,38 @@ export abstract class AbstractTimerService implements ITimerService {
 			this._reportStartupTimes(metrics);
 			this._barrier.open();
 		});
+
+
+		this.perfBaseline = this._barrier.wait()
+			.then(() => this._lifecycleService.when(LifecyclePhase.Eventually))
+			.then(() => timeout(this._startupMetrics!.timers.ellapsedRequire))
+			.then(() => {
+
+				// we use fibonacci numbers to have a performance baseline that indicates
+				// how slow/fast THIS machine actually is.
+				const sw = new StopWatch(true);
+				let tooSlow = false;
+				function fib(n: number): number {
+					if (tooSlow) {
+						return 0;
+					}
+					if (sw.elapsed() >= 1000) {
+						tooSlow = true;
+					}
+					if (n <= 2) {
+						return n;
+					}
+					return fib(n - 1) + fib(n - 2);
+				}
+
+				// the following operation took ~16ms (one frame at 64FPS) to complete on my machine. We derive performance observations
+				// from that. We also bail if that took too long (>1s)
+				sw.reset();
+				fib(24);
+				const value = Math.round(sw.elapsed());
+
+				return (tooSlow ? -1 : value);
+			});
 	}
 
 	whenReady(): Promise<boolean> {

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -275,9 +275,7 @@ export class TestNativeHostService implements INativeHostService {
 	async hasClipboard(format: string, type?: 'selection' | 'clipboard' | undefined): Promise<boolean> { return false; }
 	async sendInputEvent(event: MouseInputEvent): Promise<void> { }
 	async windowsGetStringRegKey(hive: 'HKEY_CURRENT_USER' | 'HKEY_LOCAL_MACHINE' | 'HKEY_CLASSES_ROOT' | 'HKEY_USERS' | 'HKEY_CURRENT_CONFIG', path: string, name: string): Promise<string | undefined> { return undefined; }
-	async startHeartbeat(): Promise<boolean> { return false; }
-	async sendHeartbeat(): Promise<boolean> { return false; }
-	async stopHeartbeat(): Promise<boolean> { return false; }
+	async profileRenderer(): Promise<boolean> { return false; }
 }
 
 export function workbenchInstantiationService(disposables = new DisposableStore()): ITestInstantiationService {


### PR DESCRIPTION
- use fib(26) as performance baseline, not code loading
- * simplify renderer profiling, no more heartbeat but just profile for a bit * ignore profilings that don't reveal much * include perf base in telemetry events * move perfBaseline-math into timer service
