### PR TITLE
Allow to configure the separator for all paths instead of just relative pahts

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -236,11 +236,10 @@ async function resourcesToClipboard(resources: URI[], relative: boolean, clipboa
 		const lineDelimiter = isWindows ? '\r\n' : '\n';
 
 		let separator: '/' | '\\' | undefined = undefined;
-		if (relative) {
-			const relativeSeparator = configurationService.getValue('explorer.copyRelativePathSeparator');
-			if (relativeSeparator === '/' || relativeSeparator === '\\') {
-				separator = relativeSeparator;
-			}
+
+		const configuredSeparator = configurationService.getValue('explorer.copyPathSeparator');
+		if (configuredSeparator === '/' || configuredSeparator === '\\') {
+			separator = configuredSeparator;
 		}
 
 		const text = resources.map(resource => labelService.getUriLabel(resource, { relative, noPrefix: true, separator })).join(lineDelimiter);

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -459,7 +459,7 @@ configurationRegistry.registerConfiguration({
 			'description': nls.localize('compressSingleChildFolders', "Controls whether the explorer should render folders in a compact form. In such a form, single child folders will be compressed in a combined tree element. Useful for Java package structures, for example."),
 			'default': true
 		},
-		'explorer.copyRelativePathSeparator': {
+		'explorer.copyPathSeparator': {
 			'type': 'string',
 			'enum': [
 				'/',
@@ -467,11 +467,11 @@ configurationRegistry.registerConfiguration({
 				'auto'
 			],
 			'enumDescriptions': [
-				nls.localize('copyRelativePathSeparator.slash', "Use slash as path separation character."),
-				nls.localize('copyRelativePathSeparator.backslash', "Use backslash as path separation character."),
-				nls.localize('copyRelativePathSeparator.auto', "Uses operating system specific path separation character."),
+				nls.localize('copyPathSeparator.slash', "Use slash as path separation character."),
+				nls.localize('copyPathSeparator.backslash', "Use backslash as path separation character."),
+				nls.localize('copyPathSeparator.auto', "Uses operating system specific path separation character."),
 			],
-			'description': nls.localize('copyRelativePathSeparator', "The path separation character used when copying relative file paths."),
+			'description': nls.localize('copyPathSeparator', "The path separation character used when copying file paths."),
 			'default': 'auto'
 		},
 		'explorer.excludeGitIgnore': {


### PR DESCRIPTION
I just opened an issue (#164153) in order to support configuring slashes when copying a path an not just relative paths 

I have removed the `if` that checks if a relative path is copied and removed `relative` from the setting and description.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
