### PR TITLE
Remove resource scopes

### DIFF
--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -74,7 +74,6 @@
             "type": "string"
           },
           "default": {},
-          "scope": "resource",
           "markdownDescription": "%emmetIncludeLanguages%"
         },
         "emmet.variables": {
@@ -93,13 +92,11 @@
             "type": "string"
           },
           "default": {},
-          "scope": "resource",
           "markdownDescription": "%emmetVariables%"
         },
         "emmet.syntaxProfiles": {
           "type": "object",
           "default": {},
-          "scope": "resource",
           "markdownDescription": "%emmetSyntaxProfiles%"
         },
         "emmet.excludeLanguages": {
@@ -110,7 +107,6 @@
           "default": [
             "markdown"
           ],
-          "scope": "resource",
           "markdownDescription": "%emmetExclude%"
         },
         "emmet.extensionsPath": {
@@ -137,7 +133,6 @@
         "emmet.preferences": {
           "type": "object",
           "default": {},
-          "scope": "resource",
           "markdownDescription": "%emmetPreferences%",
           "properties": {
             "css.intUnit": {

--- a/extensions/emmet/src/test/abbreviationAction.test.ts
+++ b/extensions/emmet/src/test/abbreviationAction.test.ts
@@ -48,7 +48,7 @@ const invokeCompletionContext: CompletionContext = {
 
 suite('Tests for Expand Abbreviations (HTML)', () => {
 	const oldValueForExcludeLanguages = workspace.getConfiguration('emmet').inspect('excludeLanguages');
-	const oldValueForIncludeLanguages = workspace.getConfiguration('emmet', null).inspect('includeLanguages');
+	const oldValueForIncludeLanguages = workspace.getConfiguration('emmet').inspect('includeLanguages');
 	teardown(closeAllEditors);
 
 	test('Expand snippets (HTML)', () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #164049

This change removes the resource scope from various Emmet settings. This change shouldn't cause any behavioural differences because adding a resource scope to the JSON file isn't actually enough to make a setting a resource setting; when accessing the setting, one must pass in a specific resource URL or `null` as a second parameter to `getConfiguration`.

TODO: verify whether any of the getConfiguration calls need to be changed back.
