### PR TITLE
Fix buggy error cleaning

### DIFF
--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -54,7 +54,7 @@ export class TelemetryService implements ITelemetryService {
 		this._sendErrorTelemetry = !!config.sendErrorTelemetry;
 
 		// static cleanup pattern for: `vscode-file:///DANGEROUS/PATH/resources/app/Useful/Information`
-		this._cleanupPatterns = [/vscode-file:\/\/\/.*?\/resources\/app\//gi];
+		this._cleanupPatterns = [/(vscode-)?file:\/\/\/.*?\/resources\/app\//gi];
 
 		for (const piiPath of this._piiPaths) {
 			this._cleanupPatterns.push(new RegExp(escapeRegExpCharacters(piiPath), 'gi'));

--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -53,8 +53,8 @@ export class TelemetryService implements ITelemetryService {
 		this._piiPaths = config.piiPaths || [];
 		this._sendErrorTelemetry = !!config.sendErrorTelemetry;
 
-		// static cleanup pattern for: `file:///DANGEROUS/PATH/resources/app/Useful/Information`
-		this._cleanupPatterns = [/file:\/\/\/.*?\/resources\/app\//gi];
+		// static cleanup pattern for: `vscode-file:///DANGEROUS/PATH/resources/app/Useful/Information`
+		this._cleanupPatterns = [/vscode-file:\/\/\/.*?\/resources\/app\//gi];
 
 		for (const piiPath of this._piiPaths) {
 			this._cleanupPatterns.push(new RegExp(escapeRegExpCharacters(piiPath), 'gi'));

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -311,7 +311,7 @@ function anonymizeFilePaths(stack: string, cleanupPatterns: RegExp[]): string {
 			break;
 		}
 		// Anoynimize user file paths that do not need to be retained or cleaned up.
-		if (!nodeModulesRegex.test(result[0]) && cleanUpIndexes.every(([x, y]) => result.index < x || result.index >= y)) {
+		if (!nodeModulesRegex.test(result[0]) && cleanUpIndexes.every(([x, y]) => result.index > x && fileRegex.lastIndex > y)) {
 			updatedStack += stack.substring(lastIndex, result.index) + '<REDACTED: user-file-path>';
 			lastIndex = fileRegex.lastIndex;
 		}

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -310,8 +310,12 @@ function anonymizeFilePaths(stack: string, cleanupPatterns: RegExp[]): string {
 		if (!result) {
 			break;
 		}
-		// Anoynimize user file paths that do not need to be retained or cleaned up.
-		if (!nodeModulesRegex.test(result[0]) && cleanUpIndexes.every(([x, y]) => result.index > x && fileRegex.lastIndex > y)) {
+
+		// Check to see if the any cleanupIndexes partially overlap with this match
+		const overlappingRange = cleanUpIndexes.some(([start, end]) => result.index < end && start < fileRegex.lastIndex);
+
+		// anoynimize user file paths that do not need to be retained or cleaned up.
+		if (!nodeModulesRegex.test(result[0]) && !overlappingRange) {
 			updatedStack += stack.substring(lastIndex, result.index) + '<REDACTED: user-file-path>';
 			lastIndex = fileRegex.lastIndex;
 		}

--- a/src/vs/workbench/services/telemetry/electron-sandbox/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/electron-sandbox/telemetryService.ts
@@ -75,7 +75,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 	}
 
 	publicLogError2<E extends ClassifiedEvent<OmitMetadata<T>> = never, T extends IGDPRProperty = never>(eventName: string, data?: StrictPropertyCheck<T, E>) {
-		return this.publicLog(eventName, data as ITelemetryData);
+		return this.publicLogError(eventName, data as ITelemetryData);
 	}
 
 


### PR DESCRIPTION
Error cleaning was incorrectly over-redacting paths.

This preferences the cleanup patterns over the more generalized error cleaning logic