### PR TITLE
Render immediately when typing

### DIFF
--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -316,6 +316,9 @@ export class View extends ViewEventHandler {
 		this.domNode.setClassName(this._getEditorClassName());
 		return false;
 	}
+	public override onRenderNowRequest(e: viewEvents.ViewRenderNowRequestEvent): void {
+		this._renderNow();
+	}
 	public override onThemeChanged(e: viewEvents.ViewThemeChangedEvent): boolean {
 		this._context.theme.update(e.theme);
 		this.domNode.setClassName(this._getEditorClassName());

--- a/src/vs/editor/common/viewEventHandler.ts
+++ b/src/vs/editor/common/viewEventHandler.ts
@@ -69,6 +69,8 @@ export class ViewEventHandler extends Disposable {
 	public onLinesInserted(e: viewEvents.ViewLinesInsertedEvent): boolean {
 		return false;
 	}
+	public onRenderNowRequest(e: viewEvents.ViewRenderNowRequestEvent): void {
+	}
 	public onRevealRangeRequest(e: viewEvents.ViewRevealRangeRequestEvent): boolean {
 		return false;
 	}
@@ -169,6 +171,10 @@ export class ViewEventHandler extends Disposable {
 					if (this.onLinesInserted(e)) {
 						shouldRender = true;
 					}
+					break;
+
+				case viewEvents.ViewEventType.ViewRenderNowRequest:
+					this.onRenderNowRequest(e);
 					break;
 
 				case viewEvents.ViewEventType.ViewRevealRangeRequest:

--- a/src/vs/editor/common/viewEvents.ts
+++ b/src/vs/editor/common/viewEvents.ts
@@ -24,6 +24,7 @@ export const enum ViewEventType {
 	ViewLinesChanged,
 	ViewLinesDeleted,
 	ViewLinesInserted,
+	ViewRenderNowRequest,
 	ViewRevealRangeRequest,
 	ViewScrollChanged,
 	ViewThemeChanged,
@@ -176,6 +177,13 @@ export class ViewLinesInsertedEvent {
 	}
 }
 
+export class ViewRenderNowRequestEvent {
+
+	public readonly type = ViewEventType.ViewRenderNowRequest;
+
+	constructor() { }
+}
+
 export const enum VerticalRevealType {
 	Simple = 0,
 	Center = 1,
@@ -311,6 +319,7 @@ export type ViewEvent = (
 	| ViewLinesChangedEvent
 	| ViewLinesDeletedEvent
 	| ViewLinesInsertedEvent
+	| ViewRenderNowRequestEvent
 	| ViewRevealRangeRequestEvent
 	| ViewScrollChangedEvent
 	| ViewThemeChangedEvent

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -1032,7 +1032,10 @@ export class ViewModel extends Disposable implements IViewModel {
 		this._executeCursorEdit(eventsCollector => this._cursor.endComposition(eventsCollector, source));
 	}
 	public type(text: string, source?: string | null | undefined): void {
-		this._executeCursorEdit(eventsCollector => this._cursor.type(eventsCollector, text, source));
+		this._executeCursorEdit(eventsCollector => {
+			this._cursor.type(eventsCollector, text, source);
+			eventsCollector.requestRenderNow();
+		});
 	}
 	public compositionType(text: string, replacePrevCharCnt: number, replaceNextCharCnt: number, positionDelta: number, source?: string | null | undefined): void {
 		this._executeCursorEdit(eventsCollector => this._cursor.compositionType(eventsCollector, text, replacePrevCharCnt, replaceNextCharCnt, positionDelta, source));


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode/issues/161622

Explores doing rendering immediately after handling typing and before sending events to the editor's API listeners.

@Tyriar Could you please give this a try, I've heard you have a monitor with a very high refresh rate

| Before | After |
|---|---|
| <img width="535" alt="Screenshot 2022-10-21 at 00 35 43" src="https://user-images.githubusercontent.com/5047891/197071907-c4ef13e2-9dfa-4355-bec8-050df49bb1d3.png"> | <img width="612" alt="Screenshot 2022-10-21 at 00 34 21" src="https://user-images.githubusercontent.com/5047891/197071877-dbb8f7e8-fc8e-4f65-80d7-260a60984582.png"> |

---

I wanted to see if this change is observable, and I looked up this old article I bookmarked some time ago: https://pavelfatin.com/typing-with-pleasure/

### Findings
**Unfortunately I cannot clearly say that this PR improves things, but it does seem to be faster sometimes (lower mins and lower maxs). I think we should try this tool again on a PC which has a high refresh rate monitor, mine has 60Hz and I think that is introducing 17ms "slack time" to all editors and terminals and hiding latencies below this value.**

**Edit1:** **I found that Chromium can be launched with `--disable-gpu-vsync --disable-frame-rate-limit` to disable vsync and I also tried that but the results were similar to launching without those flags**. I've added the graph below.

**Edit2:** **I tried a <textarea> in Electron with `--disable-gpu-vsync --disable-frame-rate-limit` and also got an average of 16.7ms, making me think that I'm hitting the 60Hz monitor limit**. I've added the graph below.

### Setup:
* couldn't get it to run on macOS, had to use Windows
* I had to install an old version of a JRE --> https://adoptium.net/en-GB/temurin/releases/?version=8
* I downloaded and ran [typometer-1.0.1-bin.zip](https://github.com/pavelfatin/typometer/releases/download/v1.0.1/typometer-1.0.1-bin.zip)
* The tool would not work until I reduced my monitor count to 1
* I ran into quite a lot of problems where the tool would not work after 20 or 30 characters, but I found that a combination of increasing the font size and reducing the editor width leads to the tool working
* I measured Sublime, VS Code Insiders, VS Code PR (this change), Notepad, VS Code Terminal, Windows PowerShell and Command Prompt

### Results

| Tool | Min (ms) | Max (ms) | Avg (ms) | SD (ms) | Obs |
|---|---|---|---|---|---|
| VS Code Terminal | 33.1 | 67.3 | 47.2 | 7.0 | |
| Windows PowerShell | 30.1 | 51.0 | 42.9 | 8.0 | |
| Sublime | 33.0 | 66.6 | 34.2 | 2.3 | |
| Command Prompt | 19.6 | 34.4 | 32.6 | 2.7 | |
| VS Code PR no v-sync | 10.9 | 24.4 | 18.5 | 1.1 | (this PR) |
| VS Code Insiders | 15.0 | 38.5 | 17.8 | 2.8 | |
| VS Code PR | 8.0 | 34.0 | 17.6 | 2.3 | (this PR) |
| Electron textarea no v-sync | 5.9 | 22.9 | 16.7 | 1.7 | (lower limit for our tech stack) |
| Notepad | 7.2 | 23.6 | 17.4 | 1.5 | |


### Individual Series
* VS Code Terminal:
![VS Code Terminal](https://user-images.githubusercontent.com/5047891/197150016-c50d5a46-7763-46b2-8fdf-3e44446acc9a.png)

* WIndows PowerShell:
![Windows PowerShell](https://user-images.githubusercontent.com/5047891/197150033-28848a2e-ed75-4afa-914b-0108f87a4bce.png)

* Sublime:
![Sublime](https://user-images.githubusercontent.com/5047891/197150025-9d4bc28e-b2ba-438e-ad47-c7ec744f38b4.png)

* Command Prompt:
![Command Prompt](https://user-images.githubusercontent.com/5047891/197150029-9a3107cb-9614-4a11-b336-96d079ea2814.png)

* VS Code PR (this change) no vsync: with --disable-gpu-vsync --disable-frame-rate-limit
![VS Code PR no vsync](https://user-images.githubusercontent.com/5047891/197155428-a738ee69-4292-4def-a334-d63f49a3e5d0.png)

* VS Code Insiders:
![VS Code Insiders](https://user-images.githubusercontent.com/5047891/197150023-03dd0fe6-c0c5-46fc-aad2-5a8d7951bc39.png)

* VS Code PR (this change):
![VS Code PR](https://user-images.githubusercontent.com/5047891/197150019-67f4f21b-516f-4cdd-a0b0-7b583b5ddb92.png)

* Electron textarea with --disable-gpu-vsync --disable-frame-rate-limit
![Browser input](https://user-images.githubusercontent.com/5047891/197167752-1e2b8d03-69a5-4c1d-91ab-9afe5120b0fc.png)

* Notepad:
![Notepad](https://user-images.githubusercontent.com/5047891/197150026-d64ed81d-7c54-470c-a3a2-29e8e34ee101.png)





### Example
![TO_UPLOAD](https://user-images.githubusercontent.com/5047891/197149869-130e41d3-28f3-453d-a39e-65d871f0b350.gif)
