### PR TITLE
cli: build the tunnel cli by default

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -80,7 +80,7 @@ parameters:
   - name: VSCODE_BUILD_TUNNEL_CLI
     displayName: "Build Tunnel CLI"
     type: boolean
-    default: false
+    default: true
   - name: VSCODE_PUBLISH
     displayName: "Publish to builds.code.visualstudio.com"
     type: boolean


### PR DESCRIPTION
Following https://github.com/microsoft/vscode/pull/163971, we're now fully good to go for compliance in builds, and we can enable this by default (though will potentially turn it off for the stable release this iteration)