### PR TITLE
command center colors

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -21,7 +21,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import * as colors from 'vs/platform/theme/common/colorRegistry';
 import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
-import { MENUBAR_SELECTION_BACKGROUND, MENUBAR_SELECTION_FOREGROUND, PANEL_BORDER, TITLE_BAR_ACTIVE_FOREGROUND } from 'vs/workbench/common/theme';
+import { MENUBAR_SELECTION_BACKGROUND, MENUBAR_SELECTION_FOREGROUND, TITLE_BAR_ACTIVE_FOREGROUND, TITLE_BAR_INACTIVE_FOREGROUND } from 'vs/workbench/common/theme';
 
 export class CommandCenterControl {
 
@@ -176,6 +176,12 @@ colors.registerColor(
 	localize('commandCenter-activeForeground', "Active foreground color of the command center"),
 	false
 );
+colors.registerColor(
+	'commandCenter.inactiveForeground',
+	{ dark: TITLE_BAR_INACTIVE_FOREGROUND, hcDark: TITLE_BAR_INACTIVE_FOREGROUND, light: TITLE_BAR_INACTIVE_FOREGROUND, hcLight: TITLE_BAR_INACTIVE_FOREGROUND },
+	localize('commandCenter-inactiveForeground', "Foreground color of the command center when the window is inactive"),
+	false
+);
 // background (inactive and active)
 colors.registerColor(
 	'commandCenter.background',
@@ -191,7 +197,13 @@ colors.registerColor(
 );
 // border: defaults to active background
 colors.registerColor(
-	'commandCenter.border', { dark: PANEL_BORDER, hcDark: PANEL_BORDER, light: PANEL_BORDER, hcLight: PANEL_BORDER },
+	'commandCenter.border', { dark: colors.transparent(TITLE_BAR_ACTIVE_FOREGROUND, .25), hcDark: colors.transparent(TITLE_BAR_ACTIVE_FOREGROUND, .25), light: colors.transparent(TITLE_BAR_ACTIVE_FOREGROUND, .25), hcLight: colors.transparent(TITLE_BAR_ACTIVE_FOREGROUND, .25) },
 	localize('commandCenter-border', "Border color of the command center"),
+	false
+);
+// border: defaults to active background
+colors.registerColor(
+	'commandCenter.inactiveBorder', { dark: colors.transparent(TITLE_BAR_INACTIVE_FOREGROUND, .25), hcDark: colors.transparent(TITLE_BAR_INACTIVE_FOREGROUND, .25), light: colors.transparent(TITLE_BAR_INACTIVE_FOREGROUND, .25), hcLight: colors.transparent(TITLE_BAR_INACTIVE_FOREGROUND, .25) },
+	localize('commandCenter-inactiveBorder', "Border color of the command center when the window is inactive"),
 	false
 );

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -100,6 +100,18 @@
 	display: none;
 }
 
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title>.command-center .action-item>.action-label {
+	color: var(--vscode-titleBar-foreground);
+}
+
+.monaco-workbench .part.titlebar.inactive>.titlebar-container>.window-title>.command-center .action-item>.action-label {
+	color: var(--vscode-titleBar-inactiveForeground);
+}
+
+.monaco-workbench .part.titlebar>.titlebar-container>.window-title>.command-center .codicon {
+	color: inherit;
+}
+
 .monaco-workbench .part.titlebar>.titlebar-container>.window-title>.command-center .action-item.command-center {
 	display: flex;
 	align-items: stretch;
@@ -113,9 +125,13 @@
 	border-top-right-radius: 6px;
 	border-bottom-right-radius: 6px;
 
-
 	width: 38vw;
 	max-width: 600px;
+}
+
+.monaco-workbench .part.titlebar.inactive>.titlebar-container>.window-title>.command-center .action-item.command-center {
+	color: var(--vscode-titleBar-inactiveForeground);
+	border-color: var(--vscode-commandCenter-inactiveBorder) !important;
 }
 
 .monaco-workbench .part.titlebar>.titlebar-container>.window-title>.command-center .action-item.command-center .left {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/162920

* add `commandCenter.inactiveForeground`, defaults to inactive foreground of titlebar 
* add `commandCenter.inactiveBorder`, default to 25% of inactive foreground of titlebar
* change `commandCenter.border` to be 25% of title bar active foreground