### PR TITLE
Do not retry during the initial connection attempt if the resolver throws a `RemoteAuthorityResolverError.NotAvailable` error

### DIFF
--- a/src/vs/platform/remote/common/remoteAuthorityResolver.ts
+++ b/src/vs/platform/remote/common/remoteAuthorityResolver.ts
@@ -64,6 +64,10 @@ export enum RemoteAuthorityResolverErrorCode {
 
 export class RemoteAuthorityResolverError extends ErrorNoTelemetry {
 
+	public static isNotAvailable(err: any): boolean {
+		return (err instanceof RemoteAuthorityResolverError) && err._code === RemoteAuthorityResolverErrorCode.NotAvailable;
+	}
+
 	public static isTemporarilyNotAvailable(err: any): boolean {
 		return (err instanceof RemoteAuthorityResolverError) && err._code === RemoteAuthorityResolverErrorCode.TemporarilyNotAvailable;
 	}

--- a/src/vs/workbench/services/extensions/electron-sandbox/electronExtensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/electronExtensionService.ts
@@ -431,6 +431,11 @@ export abstract class ElectronExtensionService extends AbstractExtensionService 
 					throw err;
 				}
 
+				if (RemoteAuthorityResolverError.isNotAvailable(err)) {
+					// The resolver is not available and asked us to not retry
+					throw err;
+				}
+
 				if (attempt >= MAX_ATTEMPTS) {
 					// Too many failed attempts, give up
 					throw err;


### PR DESCRIPTION
Fixes #162590