### PR TITLE
Fix rendering of the editor.wrappingIndent setting

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4461,6 +4461,8 @@ class WrappingIndentOption extends BaseEditorOption<EditorOption.wrappingIndent,
 		super(EditorOption.wrappingIndent, 'wrappingIndent', WrappingIndent.Same,
 			{
 				'editor.wrappingIndent': {
+					type: 'string',
+					enum: ['none', 'same', 'indent', 'deepIndent'],
 					enumDescriptions: [
 						nls.localize('wrappingIndent.none', "No indentation. Wrapped lines begin at column 1."),
 						nls.localize('wrappingIndent.same', "Wrapped lines get the same indentation as the parent."),
@@ -4468,6 +4470,7 @@ class WrappingIndentOption extends BaseEditorOption<EditorOption.wrappingIndent,
 						nls.localize('wrappingIndent.deepIndent', "Wrapped lines get +2 indentation toward the parent."),
 					],
 					description: nls.localize('wrappingIndent', "Controls the indentation of wrapped lines."),
+					default: 'same'
 				}
 			}
 		);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes the following regression:
1. Run Code OSS
2. Open the Settings editor
3. Reload the Settings editor
4. :bug: The table of contents doesn't show up
