### PR TITLE
tunnel: fix tunnel command when running compiled

### DIFF
--- a/src/vs/platform/remoteTunnel/electron-browser/remoteTunnelService.ts
+++ b/src/vs/platform/remoteTunnel/electron-browser/remoteTunnelService.ts
@@ -21,7 +21,6 @@ import { localize } from 'vs/nls';
 
 import { hostname } from 'os';
 
-
 type RemoteTunnelEnablementClassification = {
 	owner: 'aeschli';
 	comment: 'Reporting when Remote Tunnel access is turned on or off';
@@ -190,7 +189,7 @@ export class RemoteTunnelService extends Disposable implements IRemoteTunnelServ
 				} else {
 					const tunnelCommand = join(dirname(process.execPath), 'bin', `${this.productService.tunnelApplicationName}${isWindows ? '.exe' : ''}`);
 					this._logger.info(`${logLabel} Spawning: ${tunnelCommand} ${commandArgs.join(' ')}`);
-					tunnelProcess = spawn(tunnelCommand, commandArgs);
+					tunnelProcess = spawn(tunnelCommand, ['tunnel', ...commandArgs]);
 				}
 
 				tunnelProcess.stdout!.on('data', data => {


### PR DESCRIPTION
The `tunnel` prefix should always be there, even in "integrated" mode.