### PR TITLE
Emphasize the setting value not being effective

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -82,8 +82,8 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 	private createWorkspaceTrustElement(): HTMLElement {
 		const workspaceTrustElement = $('span.setting-item-workspace-trust');
 		const workspaceTrustLabel = new SimpleIconLabel(workspaceTrustElement);
-		workspaceTrustLabel.text = localize('workspaceUntrustedLabel', "Requires Workspace Trust");
-		const contentFallback = localize('trustLabel', "This setting can only be applied in a trusted workspace.");
+		workspaceTrustLabel.text = '$(warning) ' + localize('workspaceUntrustedLabel', "Setting value not effective");
+		const contentFallback = localize('trustLabel', "The setting value can only be applied in a trusted workspace.");
 
 		const contentMarkdownString = contentFallback + ` [${localize('manageWorkspaceTrust', "Manage Workspace Trust")}](manage-workspace-trust).`;
 		const content: ITooltipMarkdownString = {
@@ -128,7 +128,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 	}
 
 	private render() {
-		const elementsToShow = [this.scopeOverridesElement, this.workspaceTrustElement, this.syncIgnoredElement, this.defaultOverrideIndicatorElement].filter(element => {
+		const elementsToShow = [this.workspaceTrustElement, this.scopeOverridesElement, this.syncIgnoredElement, this.defaultOverrideIndicatorElement].filter(element => {
 			return element.style.display !== 'none';
 		});
 
@@ -181,10 +181,8 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 			this.scopeOverridesElement.style.display = 'inline';
 			this.scopeOverridesElement.classList.add('with-custom-hover');
 
-			const policyText = localize('policyLabelText', "Managed by policy");
-			this.scopeOverridesLabel.text = policyText;
-
-			const contentFallback = localize('policyDescription', "This setting is managed by your organization.");
+			this.scopeOverridesLabel.text = '$(warning) ' + localize('policyLabelText', "Setting value not effective");
+			const contentFallback = localize('policyDescription', "This setting is managed by your organization and its effective value cannot be changed.");
 			const contentMarkdownString = contentFallback + ` [${localize('policyFilterLink', "View policy settings")}](policy-settings).`;
 			const content: ITooltipMarkdownString = {
 				markdown: {
@@ -366,7 +364,7 @@ export function getIndicatorsLabelAriaLabel(element: SettingsTreeSettingElement,
 
 	const profilesEnabled = userDataProfilesService.isEnabled();
 	if (element.hasPolicyValue) {
-		ariaLabelSections.push(localize('policyDescriptionAccessible', "Managed by organization policy"));
+		ariaLabelSections.push(localize('policyDescriptionAccessible', "Setting managed by organization policy; value will not take effect"));
 	} else if (profilesEnabled && element.matchesScope(ConfigurationTarget.APPLICATION, false)) {
 		ariaLabelSections.push(localize('applicationSettingDescriptionAccessible', "Setting value retained when switching profiles"));
 	} else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Ref #157564

This PR:
- Changes the workspace trust indicator to be the left-most indicator
- Changes both the workspace trust and policy indicator labels to contain warning icons and emphasize that the setting value cannot take effect. The reason for the setting value not taking effect is moved to the hovers. - - Adds to the aria text for the policy indicator. The indicators are not currently accessible, so alternative text is being provided for screenreaders.

I really wanted to use the word "effected" but that might be a bit too fancy.