### PR TITLE
Add placeholder types for fixing issues with `TestInstantiationService`

### DIFF
--- a/src/vs/editor/test/common/modes/textToHtmlTokenizer.test.ts
+++ b/src/vs/editor/test/common/modes/textToHtmlTokenizer.test.ts
@@ -293,7 +293,7 @@ suite('Editor Modes - textToHtmlTokenizer', () => {
 
 class Mode extends Disposable {
 
-	private readonly languageId = 'textToHtmlTokenizerMode';
+	public readonly languageId = 'textToHtmlTokenizerMode';
 
 	constructor(
 		@ILanguageService languageService: ILanguageService

--- a/src/vs/platform/instantiation/common/instantiation.ts
+++ b/src/vs/platform/instantiation/common/instantiation.ts
@@ -38,7 +38,7 @@ export const IInstantiationService = createDecorator<IInstantiationService>('ins
  * Given a list of arguments as a tuple, attempt to extract the leading, non-service arguments
  * to their own tuple.
  */
-type GetLeadingNonServiceArgs<Args> =
+export type GetLeadingNonServiceArgs<Args> =
 	Args extends [...BrandedService[]] ? []
 	: Args extends [infer A, ...BrandedService[]] ? [A]
 	: Args extends [infer A, ...infer R] ? [A, ...GetLeadingNonServiceArgs<R>]

--- a/src/vs/platform/instantiation/common/instantiationService.ts
+++ b/src/vs/platform/instantiation/common/instantiationService.ts
@@ -7,9 +7,9 @@ import { IdleValue } from 'vs/base/common/async';
 import { Event } from 'vs/base/common/event';
 import { illegalState } from 'vs/base/common/errors';
 import { toDisposable } from 'vs/base/common/lifecycle';
-import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { SyncDescriptor, SyncDescriptor0 } from 'vs/platform/instantiation/common/descriptors';
 import { Graph } from 'vs/platform/instantiation/common/graph';
-import { IInstantiationService, ServiceIdentifier, ServicesAccessor, _util } from 'vs/platform/instantiation/common/instantiation';
+import { GetLeadingNonServiceArgs, IInstantiationService, ServiceIdentifier, ServicesAccessor, _util } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { LinkedList } from 'vs/base/common/linkedList';
 
@@ -72,6 +72,9 @@ export class InstantiationService implements IInstantiationService {
 		}
 	}
 
+	createInstance(ctorOrDescriptor: any | SyncDescriptor<any>, ...rest: any[]): any; // Comment out this line to fix type issues
+	createInstance<T>(descriptor: SyncDescriptor0<T>): T;
+	createInstance<Ctor extends new (...args: any[]) => any, R extends InstanceType<Ctor>>(ctor: Ctor, ...args: GetLeadingNonServiceArgs<ConstructorParameters<Ctor>>): R;
 	createInstance(ctorOrDescriptor: any | SyncDescriptor<any>, ...rest: any[]): any {
 		let _trace: Trace;
 		let result: any;


### PR DESCRIPTION
`TestInstantiationService` has the wrong typings, but fixing them introduces around 80 errors into the codebase

This change adds the correct types hidden behind the original signature. It will let other folks on the team investigate each individual typing issue and address it