### PR TITLE
Quick input lays itself out even when it is not visible

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1792,7 +1792,7 @@ export class QuickInputController extends Disposable {
 	}
 
 	private updateLayout() {
-		if (this.ui) {
+		if (this.ui && this.isDisplayed()) {
 			this.ui.container.style.top = `${this.titleBarOffset}px`;
 
 			const style = this.ui.container.style;


### PR DESCRIPTION
Repo:

1. Open quick input
1. Close it again
1. Expand or collapse the sidebar

**Bug**
The quick input widget gets layed out again even though it is not visible

![Screen Shot 2022-10-21 at 2 25 06 PM](https://user-images.githubusercontent.com/12821956/197291504-fae84b66-fc92-476d-b570-5a124c6a1050.png)


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
