### PR TITLE
change conditional branch

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -536,9 +536,12 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		let deleted: IItem<T>[];
 
 		// TODO@joao: improve this optimization to catch even more cases
-		if (start === 0 && deleteCount >= this.items.length) {
+		if (start === 0 && deleteCount >= this.items.length && this.lastRenderTop === 0) {
 			this.rangeMap = new RangeMap();
 			this.rangeMap.splice(0, 0, inserted);
+			deleted = this.items;
+			this.items = inserted;
+		} else if (start === 0 && deleteCount >= this.items.length) {
 			deleted = this.items;
 			this.items = inserted;
 		} else {


### PR DESCRIPTION
This fixes [#145589](https://github.com/microsoft/vscode/issues/145589).
I think that #145589 is caused by creating new RangeMap object.
This change is based on the idea that there is no need to refresh all elements when we switch tabs. 
