### PR TITLE
Fixes #160462

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/view/colors.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/colors.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { registerColor } from 'vs/platform/theme/common/colorRegistry';
+import { mergeCurrentHeaderBackground, mergeIncomingHeaderBackground, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
 
 export const diff = registerColor(
 	'mergeEditor.change.background',
@@ -70,4 +70,17 @@ export const conflictingLinesBackground = registerColor(
 	'mergeEditor.conflictingLines.background',
 	{ dark: '#ffea0047', light: '#ffea0047', hcDark: '#ffea0047', hcLight: '#ffea0047', },
 	localize('mergeEditor.conflictingLines.background', 'The background of the "Conflicting Lines" text.')
+);
+
+const contentTransparency = 0.4;
+export const conflictInput1Background = registerColor(
+	'mergeEditor.conflict.input1.background',
+	{ dark: transparent(mergeCurrentHeaderBackground, contentTransparency), light: transparent(mergeCurrentHeaderBackground, contentTransparency), hcDark: transparent(mergeCurrentHeaderBackground, contentTransparency), hcLight: transparent(mergeCurrentHeaderBackground, contentTransparency) },
+	localize('mergeEditor.conflict.input1.background', 'The background color of decorations in input 1.')
+);
+
+export const conflictInput2Background = registerColor(
+	'mergeEditor.conflict.input2.background',
+	{ dark: transparent(mergeIncomingHeaderBackground, contentTransparency), light: transparent(mergeIncomingHeaderBackground, contentTransparency), hcDark: transparent(mergeIncomingHeaderBackground, contentTransparency), hcLight: transparent(mergeIncomingHeaderBackground, contentTransparency) },
+	localize('mergeEditor.conflict.input2.background', 'The background color of decorations in input 2.')
 );

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/codeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/codeEditorView.ts
@@ -66,7 +66,12 @@ export abstract class CodeEditorView extends Disposable {
 
 	protected readonly showDeletionMarkers = observableFromEvent<boolean>(
 		this.configurationService.onDidChangeConfiguration,
-		() => /** @description showDeletionMarkers */ this.configurationService.getValue('mergeEditor.showDeletionMarkers')
+		() => /** @description showDeletionMarkers */ this.configurationService.getValue('mergeEditor.showDeletionMarkers') ?? true
+	);
+
+	protected readonly useSimplifiedDecorations = observableFromEvent<boolean>(
+		this.configurationService.onDidChangeConfiguration,
+		() => /** @description useSimplifiedDecorations */ this.configurationService.getValue('mergeEditor.useSimplifiedDecorations') ?? false
 	);
 
 	public readonly editor = this.instantiationService.createInstance(

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView.ts
@@ -130,6 +130,8 @@ export class InputCodeEditorView extends CodeEditorView {
 
 		const showNonConflictingChanges = viewModel.showNonConflictingChanges.read(reader);
 		const showDeletionMarkers = this.showDeletionMarkers.read(reader);
+		const diffWithThis = viewModel.baseCodeEditorView.read(reader) !== undefined && viewModel.baseShowDiffAgainst.read(reader) === this.inputNumber;
+		const useSimplifiedDecorations = !diffWithThis && this.useSimplifiedDecorations.read(reader);
 
 		for (const modifiedBaseRange of model.modifiedBaseRanges.read(reader)) {
 			const range = modifiedBaseRange.getInputRange(this.inputNumber);
@@ -148,11 +150,15 @@ export class InputCodeEditorView extends CodeEditorView {
 			if (modifiedBaseRange.isConflicting) {
 				blockClassNames.push('conflicting');
 			}
-			const inputClassName = this.inputNumber === 1 ? 'input 1' : 'input 2';
+			const inputClassName = this.inputNumber === 1 ? 'input i1' : 'input i2';
 			blockClassNames.push(inputClassName);
 
 			if (!modifiedBaseRange.isConflicting && !showNonConflictingChanges && isHandled) {
 				continue;
+			}
+
+			if (useSimplifiedDecorations && !isHandled) {
+				blockClassNames.push('use-simplified-decorations');
 			}
 
 			result.push({
@@ -173,7 +179,7 @@ export class InputCodeEditorView extends CodeEditorView {
 				}
 			});
 
-			if (modifiedBaseRange.isConflicting || !model.isHandled(modifiedBaseRange).read(reader)) {
+			if (!useSimplifiedDecorations && (modifiedBaseRange.isConflicting || !model.isHandled(modifiedBaseRange).read(reader))) {
 				const inputDiffs = modifiedBaseRange.getInputDiffs(this.inputNumber);
 				for (const diff of inputDiffs) {
 					const range = diff.outputRange.toInclusiveRange();

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/media/mergeEditor.css
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/media/mergeEditor.css
@@ -109,6 +109,14 @@
 	background-color: var(--vscode-mergeEditor-conflict-handledFocused-background);
 }
 
+.merge-editor-simplified.input.i1, .merge-editor-block.use-simplified-decorations.input.i1 {
+	background-color: var(--vscode-mergeEditor-conflict-input1-background);
+}
+
+.merge-editor-simplified.input.i2, .merge-editor-block.use-simplified-decorations.input.i2 {
+	background-color: var(--vscode-mergeEditor-conflict-input2-background);
+}
+
 /* END: .merge-editor-block */
 
 .gutter.monaco-editor>div {


### PR DESCRIPTION
Fixes #160462

I added a hidden setting `mergeEditor.useSimplifiedDecorations` (default false) so we can play with the idea. @jrieken

Personally, I think it hides many important decorations, but I'm open to exploring it.

Enabled:
![image](https://user-images.githubusercontent.com/2931520/197530678-74958427-e6bb-4944-840a-68bc8dbed5d4.png)

Disabled:
![image](https://user-images.githubusercontent.com/2931520/197530727-c93ce476-288d-442f-9e88-c1ae25328fe0.png)


The background color disappears when the conflict is handled or when the base view is opened.