### PR TITLE
Use the word "applied" instead of "effective"

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -82,7 +82,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 	private createWorkspaceTrustElement(): HTMLElement {
 		const workspaceTrustElement = $('span.setting-item-workspace-trust');
 		const workspaceTrustLabel = new SimpleIconLabel(workspaceTrustElement);
-		workspaceTrustLabel.text = '$(warning) ' + localize('workspaceUntrustedLabel', "Setting value not effective");
+		workspaceTrustLabel.text = '$(warning) ' + localize('workspaceUntrustedLabel', "Setting value not applied");
 		const contentFallback = localize('trustLabel', "The setting value can only be applied in a trusted workspace.");
 
 		const contentMarkdownString = contentFallback + ` [${localize('manageWorkspaceTrust', "Manage Workspace Trust")}](manage-workspace-trust).`;
@@ -181,8 +181,8 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 			this.scopeOverridesElement.style.display = 'inline';
 			this.scopeOverridesElement.classList.add('with-custom-hover');
 
-			this.scopeOverridesLabel.text = '$(warning) ' + localize('policyLabelText', "Setting value not effective");
-			const contentFallback = localize('policyDescription', "This setting is managed by your organization and its effective value cannot be changed.");
+			this.scopeOverridesLabel.text = '$(warning) ' + localize('policyLabelText', "Setting value not applied");
+			const contentFallback = localize('policyDescription', "This setting is managed by your organization and its applied value cannot be changed.");
 			const contentMarkdownString = contentFallback + ` [${localize('policyFilterLink', "View policy settings")}](policy-settings).`;
 			const content: ITooltipMarkdownString = {
 				markdown: {
@@ -359,12 +359,12 @@ export function getIndicatorsLabelAriaLabel(element: SettingsTreeSettingElement,
 
 	// Add workspace trust text
 	if (element.isUntrusted) {
-		ariaLabelSections.push(localize('workspaceUntrustedAriaLabel', "Workspace untrusted; setting value will not take effect"));
+		ariaLabelSections.push(localize('workspaceUntrustedAriaLabel', "Workspace untrusted; setting value not applied"));
 	}
 
 	const profilesEnabled = userDataProfilesService.isEnabled();
 	if (element.hasPolicyValue) {
-		ariaLabelSections.push(localize('policyDescriptionAccessible', "Setting managed by organization policy; value will not take effect"));
+		ariaLabelSections.push(localize('policyDescriptionAccessible', "Managed by organization policy; setting value not applied"));
 	} else if (profilesEnabled && element.matchesScope(ConfigurationTarget.APPLICATION, false)) {
 		ariaLabelSections.push(localize('applicationSettingDescriptionAccessible', "Setting value retained when switching profiles"));
 	} else {


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/issues/157564

This wording change brings the indicator text
in line with the Manage workspace trust view.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
