### PR TITLE
debug: activate auto launch onStartupFinished

### DIFF
--- a/extensions/debug-auto-launch/package.json
+++ b/extensions/debug-auto-launch/package.json
@@ -16,7 +16,7 @@
     }
   },
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "main": "./out/extension",
   "scripts": {


### PR DESCRIPTION
For https://github.com/microsoft/vscode-internalbacklog/issues/3209

We still need to activate it for every workspace, but since Daniel's improvements to environment variable application a few months ago, using onStartupFinished should be pretty safe and seamless.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
