### PR TITLE
build: parallelize cli build

### DIFF
--- a/build/azure-pipelines/darwin/cli-build-darwin.yml
+++ b/build/azure-pipelines/darwin/cli-build-darwin.yml
@@ -3,8 +3,10 @@ parameters:
     type: string
   - name: VSCODE_BUILD_MACOS
     type: boolean
+    default: false
   - name: VSCODE_BUILD_MACOS_ARM64
     type: boolean
+    default: false
   - name: channel
     type: string
     default: stable

--- a/build/azure-pipelines/linux/cli-build-linux.yml
+++ b/build/azure-pipelines/linux/cli-build-linux.yml
@@ -37,18 +37,25 @@ steps:
     displayName: Extract openssl prebuilt
 
   # inspired by: https://github.com/emk/rust-musl-builder/blob/main/Dockerfile
-  - bash: |
-      set -e
-      sudo apt-get update
-      sudo apt-get install -yq build-essential curl file git graphviz musl-dev musl-tools linux-libc-dev pkgconf zip unzip xutils-dev ninja-build
-      sudo ln -s "/usr/bin/g++" "/usr/bin/musl-g++" || echo "link exists"
-    displayName: Install build dependencies
+  - ${{ if or(eq(parameters.VSCODE_BUILD_LINUX_ALPINE_ARM64, true), eq(parameters.VSCODE_BUILD_LINUX_ALPINE, true)) }}:
+    - bash: |
+        set -e
+        sudo apt-get update
+        sudo apt-get install -yq build-essential musl-dev musl-tools linux-libc-dev pkgconf xutils-dev
+        sudo ln -s "/usr/bin/g++" "/usr/bin/musl-g++" || echo "link exists"
+      displayName: Install musl build dependencies
 
   - ${{ if eq(parameters.VSCODE_BUILD_LINUX_ARMHF, true) }}:
     - bash: |
         set -e
         sudo apt-get install -yq gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
-      displayName: Install cross compilation toolchains
+      displayName: Install arm32 toolchains
+
+  - ${{ if eq(parameters.VSCODE_BUILD_LINUX_ARM64, true) }}:
+    - bash: |
+        set -e
+        sudo apt-get install -yq gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+      displayName: Install arm64 toolchains
 
   - task: NodeTool@0
     inputs:
@@ -107,6 +114,7 @@ steps:
         VSCODE_CLI_TARGET: aarch64-unknown-linux-gnu
         VSCODE_CLI_ARTIFACT: vscode_cli_linux_arm64_cli
         VSCODE_CLI_ENV:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-linux/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-linux/include
 

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -180,7 +180,7 @@ stages:
       dependsOn: []
       jobs:
         - ${{ if or(eq(parameters.VSCODE_BUILD_LINUX, true), eq(parameters.VSCODE_BUILD_LINUX_ALPINE, true)) }}:
-          - job: Linux
+          - job: LinuxX64
             pool: vscode-1es-linux
             steps:
               - template: ./linux/cli-build-linux.yml
@@ -189,11 +189,19 @@ stages:
                   VSCODE_BUILD_LINUX: ${{ parameters.VSCODE_BUILD_LINUX }}
                   VSCODE_BUILD_LINUX_ALPINE: ${{ parameters.VSCODE_BUILD_LINUX_ALPINE }}
 
-        - ${{ if or(eq(parameters.VSCODE_BUILD_LINUX_ALPINE_ARM64, true), eq(parameters.VSCODE_BUILD_LINUX_ARM64, true), eq(parameters.VSCODE_BUILD_LINUX_ARMHF, true)) }}:
-          - job: LinuxArm64
+        - ${{ if or(eq(parameters.VSCODE_BUILD_LINUX_ARMHF, true), eq(parameters.VSCODE_BUILD_LINUX_ARM64, true)) }}:
+          - job: LinuxGnuARM
+            pool: vscode-1es-linux
+            steps:
+              - template: ./linux/cli-build-linux.yml
+                parameters:
+                  VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
+                  VSCODE_BUILD_LINUX_ARMHF: ${{ parameters.VSCODE_BUILD_LINUX_ARMHF }}
+                  VSCODE_BUILD_LINUX_ARM64: ${{ parameters.VSCODE_BUILD_LINUX_ARM64 }}
+
+        - ${{ if eq(parameters.VSCODE_BUILD_LINUX_ALPINE_ARM64, true) }}:
+          - job: LinuxAlpineARM64
             pool: vscode-1es-linux-20.04-arm64
-            variables:
-              VSCODE_ARCH: arm64
             steps:
               - task: NodeTool@0
                 displayName: Install Node.js
@@ -207,11 +215,9 @@ stages:
                 parameters:
                   VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                   VSCODE_BUILD_LINUX_ALPINE_ARM64: ${{ parameters.VSCODE_BUILD_LINUX_ALPINE_ARM64 }}
-                  VSCODE_BUILD_LINUX_ARM64: ${{ parameters.VSCODE_BUILD_LINUX_ARM64 }}
-                  VSCODE_BUILD_LINUX_ARMHF: ${{ parameters.VSCODE_BUILD_LINUX_ARMHF }}
 
-        - ${{ if eq(variables.VSCODE_BUILD_STAGE_MACOS, true) }}:
-          - job: MacOS
+        - ${{ if eq(parameters.VSCODE_BUILD_MACOS, true) }}:
+          - job: MacOSX64
             pool:
               vmImage: macOS-11
             steps:
@@ -219,17 +225,42 @@ stages:
                 parameters:
                   VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                   VSCODE_BUILD_MACOS: ${{ parameters.VSCODE_BUILD_MACOS }}
+
+        - ${{ if eq(parameters.VSCODE_BUILD_MACOS_ARM64, true) }}:
+          - job: MacOSARM64
+            pool:
+              vmImage: macOS-11
+            steps:
+              - template: ./darwin/cli-build-darwin.yml
+                parameters:
+                  VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                   VSCODE_BUILD_MACOS_ARM64: ${{ parameters.VSCODE_BUILD_MACOS_ARM64 }}
 
-        - ${{ if eq(variables.VSCODE_BUILD_STAGE_WINDOWS, true) }}:
-          - job: Windows
+        - ${{ if eq(parameters.VSCODE_BUILD_WIN32, true) }}:
+          - job: WindowsX64
             pool: vscode-1es-windows
             steps:
               - template: ./win32/cli-build-win32.yml
                 parameters:
                   VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                   VSCODE_BUILD_WIN32: ${{ parameters.VSCODE_BUILD_WIN32 }}
+
+        - ${{ if eq(parameters.VSCODE_BUILD_WIN32_ARM64, true) }}:
+          - job: WindowsARM64
+            pool: vscode-1es-windows
+            steps:
+              - template: ./win32/cli-build-win32.yml
+                parameters:
+                  VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                   VSCODE_BUILD_WIN32_ARM64: ${{ parameters.VSCODE_BUILD_WIN32_ARM64 }}
+
+        - ${{ if eq(parameters.VSCODE_BUILD_WIN32_32BIT, true) }}:
+          - job: WindowsX86
+            pool: vscode-1es-windows
+            steps:
+              - template: ./win32/cli-build-win32.yml
+                parameters:
+                  VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                   VSCODE_BUILD_WIN32_32BIT: ${{ parameters.VSCODE_BUILD_WIN32_32BIT }}
 
   - ${{ if and(eq(parameters.VSCODE_COMPILE_ONLY, false), eq(variables['VSCODE_BUILD_STAGE_WINDOWS'], true)) }}:

--- a/build/azure-pipelines/win32/cli-build-win32.yml
+++ b/build/azure-pipelines/win32/cli-build-win32.yml
@@ -1,10 +1,13 @@
 parameters:
   - name: VSCODE_BUILD_WIN32
     type: boolean
+    default: false
   - name: VSCODE_BUILD_WIN32_32BIT
     type: boolean
+    default: false
   - name: VSCODE_BUILD_WIN32_ARM64
     type: boolean
+    default: false
   - name: VSCODE_QUALITY
     type: string
   - name: channel


### PR DESCRIPTION
Put all win and macOS builds on their own machine, since they take a minute. Build the two GNU ARM builds together on an x64 machine, since they're faster and can cross-compile in ~5 minutes.

This makes the CompileCLI step take a little less time than the VS Code "Compile" step.

Fixes https://github.com/microsoft/vscode/issues/164421
