### PR TITLE
try hybrid model for editor features menu

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
@@ -28,7 +28,7 @@ export class ToggleStickyScroll extends Action2 {
 			},
 			menu: [
 				{ id: MenuId.CommandPalette },
-				{ id: MenuId.MenubarEditorFeaturesMenu, order: 6 },
+				{ id: MenuId.MenubarViewMenu, group: '5_editor', order: 2 },
 				{ id: MenuId.StickyScrollContext }
 			]
 		});

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -82,7 +82,6 @@ export class MenuId {
 	static readonly MenubarGoMenu = new MenuId('MenubarGoMenu');
 	static readonly MenubarHelpMenu = new MenuId('MenubarHelpMenu');
 	static readonly MenubarLayoutMenu = new MenuId('MenubarLayoutMenu');
-	static readonly MenubarEditorFeaturesMenu = new MenuId('MenubarEditorFeaturesMenu');
 	static readonly MenubarNewBreakpointMenu = new MenuId('MenubarNewBreakpointMenu');
 	static readonly MenubarPanelAlignmentMenu = new MenuId('MenubarPanelAlignmentMenu');
 	static readonly MenubarPanelPositionMenu = new MenuId('MenubarPanelPositionMenu');

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -515,7 +515,7 @@ registerAction2(class ToggleBreadcrumb extends Action2 {
 			},
 			menu: [
 				{ id: MenuId.CommandPalette },
-				{ id: MenuId.MenubarEditorFeaturesMenu, order: 3 },
+				{ id: MenuId.MenubarAppearanceMenu, group: '4_editor', order: 2 },
 				{ id: MenuId.NotebookToolbar, group: 'notebookLayout', order: 2 },
 				{ id: MenuId.StickyScrollContext }
 			]

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -779,14 +779,6 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	order: 9
 });
 
-// Features menu
-MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
-	group: '2_appearance',
-	title: localize({ key: 'miEditorFeatures', comment: ['&& denotes a mnemonic'] }, "Editor &&Features"),
-	submenu: MenuId.MenubarEditorFeaturesMenu,
-	order: 3
-});
-
 // Main Menu Bar Contributions:
 
 MenuRegistry.appendMenuItem(MenuId.MenubarGoMenu, {

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleMinimap.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleMinimap.ts
@@ -26,8 +26,9 @@ export class ToggleMinimapAction extends Action2 {
 			f1: true,
 			toggled: ContextKeyExpr.equals('config.editor.minimap.enabled', true),
 			menu: {
-				id: MenuId.MenubarEditorFeaturesMenu,
-				order: 2
+				id: MenuId.MenubarAppearanceMenu,
+				group: '4_editor',
+				order: 1
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter.ts
@@ -26,8 +26,9 @@ export class ToggleRenderControlCharacterAction extends Action2 {
 			f1: true,
 			toggled: ContextKeyExpr.equals('config.editor.renderControlCharacters', true),
 			menu: {
-				id: MenuId.MenubarEditorFeaturesMenu,
-				order: 5
+				id: MenuId.MenubarAppearanceMenu,
+				group: '4_editor',
+				order: 4
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
@@ -26,8 +26,9 @@ class ToggleRenderWhitespaceAction extends Action2 {
 			f1: true,
 			toggled: ContextKeyExpr.notEquals('config.editor.renderWhitespace', 'none'),
 			menu: {
-				id: MenuId.MenubarEditorFeaturesMenu,
-				order: 4
+				id: MenuId.MenubarAppearanceMenu,
+				group: '4_editor',
+				order: 3
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleWordWrap.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleWordWrap.ts
@@ -349,12 +349,13 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
 
 
 // View menu
-MenuRegistry.appendMenuItem(MenuId.MenubarEditorFeaturesMenu, {
+MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	command: {
 		id: TOGGLE_WORD_WRAP_ID,
 		title: nls.localize({ key: 'miToggleWordWrap', comment: ['&& denotes a mnemonic'] }, "&&Word Wrap"),
 		toggled: EDITOR_WORD_WRAP,
 		precondition: CAN_TOGGLE_WORD_WRAP
 	},
-	order: 1
+	order: 1,
+	group: '5_editor'
 });

--- a/src/vs/workbench/electron-sandbox/actions/windowActions.ts
+++ b/src/vs/workbench/electron-sandbox/actions/windowActions.ts
@@ -104,7 +104,7 @@ export class ZoomInAction extends BaseZoomAction {
 			},
 			menu: {
 				id: MenuId.MenubarAppearanceMenu,
-				group: '3_zoom',
+				group: '5_zoom',
 				order: 1
 			}
 		});
@@ -138,7 +138,7 @@ export class ZoomOutAction extends BaseZoomAction {
 			},
 			menu: {
 				id: MenuId.MenubarAppearanceMenu,
-				group: '3_zoom',
+				group: '5_zoom',
 				order: 2
 			}
 		});
@@ -167,7 +167,7 @@ export class ZoomResetAction extends BaseZoomAction {
 			},
 			menu: {
 				id: MenuId.MenubarAppearanceMenu,
-				group: '3_zoom',
+				group: '5_zoom',
 				order: 3
 			}
 		});


### PR DESCRIPTION
fixes #158458

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

cc @jrieken @daviddossett 
This outcome:
- is a hybrid model
- puts the most frequently used command in the same old place
- allows us to reduce the length of the main view menu
- reduces our distinction between editor and workbench actions which are not important here

![image](https://user-images.githubusercontent.com/6561887/197611843-56268561-0e0b-4e30-9316-687107a137e9.png)
