### PR TITLE
Pick up latest markdown language service

### DIFF
--- a/extensions/markdown-language-features/server/package.json
+++ b/extensions/markdown-language-features/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageserver",
   "description": "Markdown language server",
-  "version": "0.2.0-alpha.4",
+  "version": "0.2.0-alpha.5",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {
@@ -17,7 +17,7 @@
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.5",
     "vscode-languageserver-types": "^3.17.1",
-    "vscode-markdown-languageservice": "^0.2.0-alpha.4",
+    "vscode-markdown-languageservice": "^0.2.0-alpha.5",
     "vscode-nls": "^5.2.0",
     "vscode-uri": "^3.0.3"
   },

--- a/extensions/markdown-language-features/server/yarn.lock
+++ b/extensions/markdown-language-features/server/yarn.lock
@@ -42,10 +42,10 @@ vscode-languageserver@^8.0.2:
   dependencies:
     vscode-languageserver-protocol "3.17.2"
 
-vscode-markdown-languageservice@^0.2.0-alpha.4:
-  version "0.2.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.2.0-alpha.4.tgz#51856ffa9750782bf952fe97765fb29c3ec27c06"
-  integrity sha512-a08s+AEwPTYqilMW8ZF3FAeDf+5pUo+XOgynPHvc70ABFTTr9fNVlg99quFUQINvi/eihH8+cd3/j/Qijeauew==
+vscode-markdown-languageservice@^0.2.0-alpha.5:
+  version "0.2.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.2.0-alpha.5.tgz#5424a93eef7997aa0e3c54c4cafcfdab1869820e"
+  integrity sha512-Z3tIaLvC74W9JJrgOQUDp9DqGy/KeV79pNGHMebb+/hoxxsyu7dVSIQWYRA9Pt8mYXlu7+QdsK8gKuCO7vHf2Q==
   dependencies:
     picomatch "^2.3.1"
     vscode-languageserver-textdocument "^1.0.5"


### PR DESCRIPTION
This failed yesterday due to a cache issue in dev ops. We need this version for testing

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
