### PR TITLE
Disable canSelectFolders in markdown link inserter

### DIFF
--- a/extensions/markdown-language-features/src/commands/insertResource.ts
+++ b/extensions/markdown-language-features/src/commands/insertResource.ts
@@ -24,7 +24,7 @@ export class InsertLinkFromWorkspace implements Command {
 
 		resources ??= await vscode.window.showOpenDialog({
 			canSelectFiles: true,
-			canSelectFolders: true,
+			canSelectFolders: false,
 			canSelectMany: true,
 			openLabel: localize('insertLink.openLabel', "Insert link"),
 			title: localize('insertLink.title', "Insert link"),


### PR DESCRIPTION
Fixes #164549

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
