### PR TITLE
Pick up latest markdown language service

### DIFF
--- a/extensions/markdown-language-features/server/package.json
+++ b/extensions/markdown-language-features/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageserver",
   "description": "Markdown language server",
-  "version": "0.2.0-alpha.5",
+  "version": "0.2.0-alpha.6",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {
@@ -17,7 +17,7 @@
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.5",
     "vscode-languageserver-types": "^3.17.1",
-    "vscode-markdown-languageservice": "^0.2.0-alpha.5",
+    "vscode-markdown-languageservice": "^0.2.0-alpha.6",
     "vscode-nls": "^5.2.0",
     "vscode-uri": "^3.0.3"
   },

--- a/extensions/markdown-language-features/server/yarn.lock
+++ b/extensions/markdown-language-features/server/yarn.lock
@@ -42,10 +42,10 @@ vscode-languageserver@^8.0.2:
   dependencies:
     vscode-languageserver-protocol "3.17.2"
 
-vscode-markdown-languageservice@^0.2.0-alpha.5:
-  version "0.2.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.2.0-alpha.5.tgz#5424a93eef7997aa0e3c54c4cafcfdab1869820e"
-  integrity sha512-Z3tIaLvC74W9JJrgOQUDp9DqGy/KeV79pNGHMebb+/hoxxsyu7dVSIQWYRA9Pt8mYXlu7+QdsK8gKuCO7vHf2Q==
+vscode-markdown-languageservice@^0.2.0-alpha.6:
+  version "0.2.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.2.0-alpha.6.tgz#c4aa6331f81ee2f0834e376245701b007d3bfb3a"
+  integrity sha512-kL7IAztlW1FB0E8FVbxzIyromIm+IhzCzkg06DjQ4EwYM8OhCTMKhNMI7/oqPt/SA2CMnnpC0N+Z/8toTNRXuA==
   dependencies:
     picomatch "^2.3.1"
     vscode-languageserver-textdocument "^1.0.5"


### PR DESCRIPTION
Confirmed that alpha 6 is now in the devops feed too  https://dev.azure.com/monacotools/Monaco/_artifacts/feed/vscode/Npm/vscode-markdown-languageservice/upstreams/0.2.0-alpha.6