### PR TITLE
Highlight label should not create extra span nodes

### DIFF
--- a/src/vs/base/browser/ui/highlightedlabel/highlightedLabel.ts
+++ b/src/vs/base/browser/ui/highlightedlabel/highlightedLabel.ts
@@ -85,7 +85,7 @@ export class HighlightedLabel {
 
 	private render(): void {
 
-		const children: HTMLSpanElement[] = [];
+		const children: Array<HTMLSpanElement | string> = [];
 		let pos = 0;
 
 		for (const highlight of this.highlights) {
@@ -95,7 +95,11 @@ export class HighlightedLabel {
 
 			if (pos < highlight.start) {
 				const substring = this.text.substring(pos, highlight.start);
-				children.push(dom.$('span', undefined, ...this.supportIcons ? renderLabelWithIcons(substring) : [substring]));
+				if (this.supportIcons) {
+					children.push(...renderLabelWithIcons(substring));
+				} else {
+					children.push(substring);
+				}
 				pos = highlight.start;
 			}
 
@@ -112,7 +116,11 @@ export class HighlightedLabel {
 
 		if (pos < this.text.length) {
 			const substring = this.text.substring(pos,);
-			children.push(dom.$('span', undefined, ...this.supportIcons ? renderLabelWithIcons(substring) : [substring]));
+			if (this.supportIcons) {
+				children.push(...renderLabelWithIcons(substring));
+			} else {
+				children.push(substring);
+			}
 		}
 
 		dom.reset(this.domNode, ...children);

--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -237,7 +237,7 @@
 	vertical-align: text-bottom;
 }
 
-.quick-input-list .quick-input-list-rows .monaco-highlighted-label span {
+.quick-input-list .quick-input-list-rows .monaco-highlighted-label > * {
 	opacity: 1;
 }
 

--- a/src/vs/base/test/browser/highlightedLabel.test.ts
+++ b/src/vs/base/test/browser/highlightedLabel.test.ts
@@ -19,12 +19,12 @@ suite('HighlightedLabel', () => {
 
 	test('no decorations', function () {
 		label.set('hello');
-		assert.strictEqual(label.element.innerHTML, '<span>hello</span>');
+		assert.strictEqual(label.element.innerHTML, 'hello');
 	});
 
 	test('escape html', function () {
 		label.set('hel<lo');
-		assert.strictEqual(label.element.innerHTML, '<span>hel&lt;lo</span>');
+		assert.strictEqual(label.element.innerHTML, 'hel&lt;lo');
 	});
 
 	test('everything highlighted', function () {
@@ -34,17 +34,17 @@ suite('HighlightedLabel', () => {
 
 	test('beginning highlighted', function () {
 		label.set('hellothere', [{ start: 0, end: 5 }]);
-		assert.strictEqual(label.element.innerHTML, '<span class="highlight">hello</span><span>there</span>');
+		assert.strictEqual(label.element.innerHTML, '<span class="highlight">hello</span>there');
 	});
 
 	test('ending highlighted', function () {
 		label.set('goodbye', [{ start: 4, end: 7 }]);
-		assert.strictEqual(label.element.innerHTML, '<span>good</span><span class="highlight">bye</span>');
+		assert.strictEqual(label.element.innerHTML, 'good<span class="highlight">bye</span>');
 	});
 
 	test('middle highlighted', function () {
 		label.set('foobarfoo', [{ start: 3, end: 6 }]);
-		assert.strictEqual(label.element.innerHTML, '<span>foo</span><span class="highlight">bar</span><span>foo</span>');
+		assert.strictEqual(label.element.innerHTML, 'foo<span class="highlight">bar</span>foo');
 	});
 
 	test('escapeNewLines', () => {

--- a/test/automation/src/quickinput.ts
+++ b/test/automation/src/quickinput.ts
@@ -12,7 +12,7 @@ export class QuickInput {
 	private static QUICK_INPUT_ROW = `${QuickInput.QUICK_INPUT} .quick-input-list .monaco-list-row`;
 	private static QUICK_INPUT_FOCUSED_ELEMENT = `${QuickInput.QUICK_INPUT_ROW}.focused .monaco-highlighted-label`;
 	private static QUICK_INPUT_ENTRY_LABEL = `${QuickInput.QUICK_INPUT_ROW} .label-name`;
-	private static QUICK_INPUT_ENTRY_LABEL_SPAN = `${QuickInput.QUICK_INPUT_ROW} .monaco-highlighted-label span`;
+	private static QUICK_INPUT_ENTRY_LABEL_SPAN = `${QuickInput.QUICK_INPUT_ROW} .monaco-highlighted-label`;
 
 	constructor(private code: Code) { }
 


### PR DESCRIPTION
I noticed that the `HighlightedLabel` class creates extra `span` elements for text ranges. These should not be needed. Using text children directly should be faster for creation and also reduce the number of nodes in the document

I also replaced the conditional spread with a longer version that uses a simple call to push. This is worth doing since `HighlightedLabel` is so widely used in the editor

