### PR TITLE
Re #164715. Better error handling of notebook opening

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -290,7 +290,8 @@ export class NotebookEditor extends EditorPane implements IEditorPaneWithSelecti
 				}
 			}
 		} catch (e) {
-			const error = createErrorWithActions(e instanceof Error ? e : new Error(e.message), [
+			console.warn(e);
+			const error = createErrorWithActions(e instanceof Error ? e : new Error((e ? e.message : '')), [
 				toAction({
 					id: 'workbench.notebook.action.openInTextEditor', label: localize('notebookOpenInTextEditor', "Open in Text Editor"), run: async () => {
 						const activeEditorPane = this._editorService.activeEditorPane;


### PR DESCRIPTION
It might not give us right error message of why the notebook file opening fails, but it won't throw npe.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
