### PR TITLE
Add min-height to work around clipping

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -298,6 +298,7 @@
 }
 
 .settings-editor > .settings-body .settings-tree-container .monaco-list-rows {
+	min-height: 175px; /* Avoid the hover being cut off. See #164602 */
 	overflow: visible !important; /* Allow validation errors to flow out of the tree container. Override inline style from ScrollableElement. */
 }
 


### PR DESCRIPTION
Fixes #164602

The hover is currently clipped by `.monaco-list-rows` not being tall enough. This PR provides a workaround to let the Settings editor hover that shows up when clicking the gear icon fully render. The whole Settings editor is still cut off by the status bar, still, but that is wanted behaviour.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
