### PR TITLE
Interactive window- don't leave space for insert toolbar

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -148,7 +148,7 @@ export class InteractiveEditor extends EditorPane {
 		this.#notebookExecutionStateService = notebookExecutionStateService;
 		this.#extensionService = extensionService;
 
-		this.#notebookOptions = new NotebookOptions(configurationService, notebookExecutionStateService, { cellToolbarInteraction: 'hover', globalToolbar: true, defaultCellCollapseConfig: { codeCell: { inputCollapsed: true } } });
+		this.#notebookOptions = new NotebookOptions(configurationService, notebookExecutionStateService, { cellToolbarInteraction: 'hover', globalToolbar: true, defaultCellCollapseConfig: { codeCell: { inputCollapsed: true } }, insertToolbarBetweenCells: false });
 		this.#editorMemento = this.getEditorMemento<InteractiveEditorViewState>(editorGroupService, textResourceConfigurationService, INTERACTIVE_EDITOR_VIEW_STATE_PREFERENCE_KEY);
 
 		codeEditorService.registerDecorationType('interactive-decoration', DECORATION_KEY, {});

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -556,7 +556,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			collapsedIndicatorHeight,
 			compactView,
 			focusIndicator,
-			insertToolbarPosition,
+			insertToolbarBetweenCells,
 			insertToolbarAlignment,
 			fontSize,
 			focusIndicatorLeftMargin,
@@ -674,7 +674,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}
 
 		// between cell insert toolbar
-		if (insertToolbarPosition === 'betweenCells' || insertToolbarPosition === 'both') {
+		if (insertToolbarBetweenCells) {
 			styleSheets.push(`.monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-bottom-toolbar-container { display: flex; }`);
 			styleSheets.push(`.monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .cell-list-top-cell-toolbar-container { display: flex; }`);
 		} else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Interactive window is more compact than Notebook now, by not leaving space for the insert cell toolbar(which has no items anyway in the interactive window)

However, you need to apply 
```json
    "notebook.cellToolbarLocation": {
        "default": "hidden" // non default setting
    },
```

to see this. With the default setting, the space is reserved anyway for the notebook cell toolbar.

Note, readonly notebooks (other than interactive window) are still leaving space for the insert cell toolbar even though it has no items.

![image](https://user-images.githubusercontent.com/1485998/198148258-53659095-d9f2-42d8-887b-71f75b716276.png)

