### PR TITLE
Revert "Pick up latest markdown LS (#164763)"

### DIFF
--- a/extensions/markdown-language-features/server/package.json
+++ b/extensions/markdown-language-features/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageserver",
   "description": "Markdown language server",
-  "version": "0.2.0-alpha.7",
+  "version": "0.2.0-alpha.6",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {
@@ -17,7 +17,7 @@
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.5",
     "vscode-languageserver-types": "^3.17.1",
-    "vscode-markdown-languageservice": "^0.2.0-alpha.7",
+    "vscode-markdown-languageservice": "^0.2.0-alpha.6",
     "vscode-nls": "^5.2.0",
     "vscode-uri": "^3.0.3"
   },

--- a/extensions/markdown-language-features/server/yarn.lock
+++ b/extensions/markdown-language-features/server/yarn.lock
@@ -42,10 +42,10 @@ vscode-languageserver@^8.0.2:
   dependencies:
     vscode-languageserver-protocol "3.17.2"
 
-vscode-markdown-languageservice@^0.2.0-alpha.7:
-  version "0.2.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.2.0-alpha.7.tgz#1f5fd345630e9d0d585cb00155d433c2320fa9c2"
-  integrity sha512-5QYz1+LpvazK21Hphx8wZiZIXE9cQ9R3jzhQr+I89xNHJi+NWTEBA555ZFkaaYR68B7SI7OQ4jihjkGLZTUTnw==
+vscode-markdown-languageservice@^0.2.0-alpha.6:
+  version "0.2.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.2.0-alpha.6.tgz#c4aa6331f81ee2f0834e376245701b007d3bfb3a"
+  integrity sha512-kL7IAztlW1FB0E8FVbxzIyromIm+IhzCzkg06DjQ4EwYM8OhCTMKhNMI7/oqPt/SA2CMnnpC0N+Z/8toTNRXuA==
   dependencies:
     picomatch "^2.3.1"
     vscode-languageserver-textdocument "^1.0.5"


### PR DESCRIPTION
This reverts commit d1af68711d90e9b6c2e689279e23ed78cd4e6940.

Seems like another case of https://github.com/MicrosoftDocs/azure-devops-docs/issues/8382

We can't pick this up until dev ops ingests the published package: https://dev.azure.com/monacotools/Monaco/_artifacts/feed/vscode/Npm/vscode-markdown-languageservice/upstreams/0.2.0-alpha.7