### PR TITLE
Don't ship yarn.lock file with the markdown extension

### DIFF
--- a/extensions/markdown-language-features/.vscodeignore
+++ b/extensions/markdown-language-features/.vscodeignore
@@ -21,3 +21,5 @@ server/extension-browser.webpack.config.js
 server/tsconfig.json
 server/.vscode/**
 server/node_modules/**
+server/yarn.lock
+server/.npmignore


### PR DESCRIPTION
This unblocks the build because we would end up storing `yarn.lock` in the Compilation artifacts, which would then, due to node modules caching/restoring differ across a build which has a cache miss and a build which has a cache hit. Finally, this would lead to the universal macos build to fail due to the difference.