### PR TITLE
Fix .ipynb extension name capitalization

### DIFF
--- a/extensions/ipynb/package.nls.json
+++ b/extensions/ipynb/package.nls.json
@@ -1,5 +1,5 @@
 {
-	"displayName": ".ipynb support",
+	"displayName": ".ipynb Support",
 	"description": "Provides basic support for opening and reading Jupyter's .ipynb notebook files",
 	"ipynb.experimental.pasteImages.enabled":"Enable/Disable pasting images into markdown cells within ipynb files. Requires enabling `#editor.experimental.pasteActions.enabled#`."
 }


### PR DESCRIPTION
Towards microsoft/vscode-jupyter#11773
