### PR TITLE
Swap list/tree icons to reflect current state instead of target state 

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1514,7 +1514,7 @@ class SetListViewModeAction extends ViewAction<SCMViewPane>  {
 			title: localize('setListViewMode', "View as List"),
 			viewId: VIEW_PANE_ID,
 			f1: false,
-			icon: Codicon.listFlat,
+			icon: Codicon.listTree,
 			toggled: ContextKeys.ViewModelMode.isEqualTo(ViewModelMode.List),
 			menu: { id: Menus.ViewSort, group: '1_viewmode', ...menu }
 		});
@@ -1543,7 +1543,7 @@ class SetTreeViewModeAction extends ViewAction<SCMViewPane>  {
 			title: localize('setTreeViewMode', "View as Tree"),
 			viewId: VIEW_PANE_ID,
 			f1: false,
-			icon: Codicon.listTree,
+			icon: Codicon.listFlat,
 			toggled: ContextKeys.ViewModelMode.isEqualTo(ViewModelMode.Tree),
 			menu: { id: Menus.ViewSort, group: '1_viewmode', ...menu }
 		});

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -546,7 +546,7 @@ registerAction2(class ViewAsTreeAction extends Action2 {
 				original: 'View as Tree'
 			},
 			category,
-			icon: searchShowAsTree,
+			icon: searchShowAsList,
 			f1: true,
 			precondition: ContextKeyExpr.and(Constants.HasSearchResults, Constants.InTreeViewKey.toNegated()),
 			menu: [{
@@ -575,7 +575,7 @@ registerAction2(class ViewAsListAction extends Action2 {
 				original: 'View as List'
 			},
 			category,
-			icon: searchShowAsList,
+			icon: searchShowAsTree,
 			f1: true,
 			precondition: ContextKeyExpr.and(Constants.HasSearchResults, Constants.InTreeViewKey),
 			menu: [{


### PR DESCRIPTION
Ref #162595

Swaps flat list and tree list icons in the Search and SCM views to represent what you're currently looking at instead of what you can toggle to.

https://user-images.githubusercontent.com/25163139/198418618-70c8bc3e-1a19-42ee-ad18-1f8571f3d01e.mp4

cc @andreamah @lszomoru 
