### PR TITLE
Use simple `IAction` instead of `Action`in quick input

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInputList.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInputList.ts
@@ -10,7 +10,7 @@ import { IconLabel, IIconLabelValueOptions } from 'vs/base/browser/ui/iconLabel/
 import { KeybindingLabel } from 'vs/base/browser/ui/keybindingLabel/keybindingLabel';
 import { IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { IListAccessibilityProvider, IListOptions, IListStyles, List } from 'vs/base/browser/ui/list/listWidget';
-import { Action } from 'vs/base/common/actions';
+import { IAction } from 'vs/base/common/actions';
 import { range } from 'vs/base/common/arrays';
 import { getCodiconAriaLabel } from 'vs/base/common/codicons';
 import { compareAnything } from 'vs/base/common/comparers';
@@ -207,24 +207,29 @@ class ListElementRenderer implements IListRenderer<ListElement, IListElementTemp
 		// Actions
 		const buttons = mainItem.buttons;
 		if (buttons && buttons.length) {
-			data.actionBar.push(buttons.map((button, index) => {
+			data.actionBar.push(buttons.map((button, index): IAction => {
 				let cssClasses = button.iconClass || (button.iconPath ? getIconClass(button.iconPath) : undefined);
 				if (button.alwaysVisible) {
 					cssClasses = cssClasses ? `${cssClasses} always-visible` : 'always-visible';
 				}
-				const action = new Action(`id-${index}`, '', cssClasses, true, async () => {
-					mainItem.type !== 'separator'
-						? element.fireButtonTriggered({
-							button,
-							item: mainItem
-						})
-						: element.fireSeparatorButtonTriggered({
-							button,
-							separator: mainItem
-						});
-				});
-				action.tooltip = button.tooltip || '';
-				return action;
+				return {
+					id: `id-${index}`,
+					class: cssClasses,
+					enabled: true,
+					label: '',
+					tooltip: button.tooltip || '',
+					run: () => {
+						mainItem.type !== 'separator'
+							? element.fireButtonTriggered({
+								button,
+								item: mainItem
+							})
+							: element.fireSeparatorButtonTriggered({
+								button,
+								separator: mainItem
+							});
+					}
+				};
 			}), { icon: true, label: false });
 			data.entry.classList.add('has-actions');
 		} else {


### PR DESCRIPTION
For actions that are static, it is better to use `IAction`. This avoids creating an extra disposable, emitter, and event listener (when used with an action bar)

This is helpful in the quick input list as we need to render elements rapidly while scrolling
