### PR TITLE
Use `IAction` instead of `Action` for search item action

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchActions.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActions.ts
@@ -5,7 +5,7 @@
 
 import * as DOM from 'vs/base/browser/dom';
 import { ITreeNavigator } from 'vs/base/browser/ui/tree/tree';
-import { Action } from 'vs/base/common/actions';
+import { Action, IAction } from 'vs/base/common/actions';
 import { createKeybinding, ResolvedKeybinding } from 'vs/base/common/keybindings';
 import { isWindows, OS } from 'vs/base/common/platform';
 import * as nls from 'vs/nls';
@@ -420,21 +420,27 @@ class ReplaceActionRunner {
 	}
 }
 
-export class RemoveAction extends Action {
+export class RemoveAction implements IAction {
 
 	static readonly LABEL = nls.localize('RemoveAction.label', "Dismiss");
 
+	readonly id = Constants.RemoveActionId;
+	public class = ThemeIcon.asClassName(searchRemoveIcon);
+	public label: string;
+	public tooltip = '';
+	public enabled = true;
+
 	constructor(
-		private viewer: WorkbenchCompressibleObjectTree<RenderableMatch>,
-		private element: RenderableMatch,
+		private readonly viewer: WorkbenchCompressibleObjectTree<RenderableMatch>,
+		private readonly element: RenderableMatch,
 		@IKeybindingService keyBindingService: IKeybindingService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IViewsService private readonly viewsService: IViewsService,
 	) {
-		super(Constants.RemoveActionId, appendKeyBindingLabel(RemoveAction.LABEL, keyBindingService.lookupKeybinding(Constants.RemoveActionId), keyBindingService), ThemeIcon.asClassName(searchRemoveIcon));
+		this.label = appendKeyBindingLabel(RemoveAction.LABEL, keyBindingService.lookupKeybinding(Constants.RemoveActionId), keyBindingService);
 	}
 
-	override async run(): Promise<any> {
+	run(): void {
 		const opInfo = getElementsToOperateOnInfo(this.viewer, this.element, this.configurationService.getValue<ISearchConfigurationProperties>('search'));
 		const elementsToRemove = opInfo.elements;
 		let focusElement = this.viewer.getFocus()[0];

--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -180,7 +180,6 @@ export class FolderMatchRenderer extends Disposable implements ICompressibleTree
 		}
 		const removeAction = this.instantiationService.createInstance(RemoveAction, this.searchView.getControl(), folder);
 		actions.push(removeAction);
-		templateData.disposableActions.add(removeAction);
 
 		templateData.actions.push(actions, { icon: true, label: false });
 	}


### PR DESCRIPTION
For actions that are static, it is better to use `IAction` instead of `Action`. This avoids creating an extra disposable, emitter, and event listener (when used with an action bar). It also means you don't have to dispose of the action

This small optimization is useful here because we create one of these actions for every search item in the list as you scroll

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
