### PR TITLE
Make `IAction` properties readonly

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionViewItems.ts
+++ b/src/vs/base/browser/ui/actionbar/actionViewItems.ts
@@ -26,12 +26,12 @@ export interface IBaseActionViewItemOptions {
 	hoverDelegate?: IHoverDelegate;
 }
 
-export class BaseActionViewItem extends Disposable implements IActionViewItem {
+export class BaseActionViewItem<ActionType extends IAction = IAction> extends Disposable implements IActionViewItem {
 
 	element: HTMLElement | undefined;
 
 	_context: unknown;
-	readonly _action: IAction;
+	readonly _action: ActionType;
 
 	private customHover?: ICustomHover;
 
@@ -41,7 +41,7 @@ export class BaseActionViewItem extends Disposable implements IActionViewItem {
 
 	private _actionRunner: IActionRunner | undefined;
 
-	constructor(context: unknown, action: IAction, protected options: IBaseActionViewItemOptions = {}) {
+	constructor(context: unknown, action: ActionType, protected options: IBaseActionViewItemOptions = {}) {
 		super();
 
 		this._context = context || this;
@@ -263,14 +263,14 @@ export interface IActionViewItemOptions extends IBaseActionViewItemOptions {
 	keybinding?: string | null;
 }
 
-export class ActionViewItem extends BaseActionViewItem {
+export class ActionViewItem<ActionType extends IAction = IAction> extends BaseActionViewItem<ActionType> {
 
 	protected label: HTMLElement | undefined;
 	protected override options: IActionViewItemOptions;
 
 	private cssClass?: string;
 
-	constructor(context: unknown, action: IAction, options: IActionViewItemOptions = {}) {
+	constructor(context: unknown, action: ActionType, options: IActionViewItemOptions = {}) {
 		super(context, action, options);
 
 		this.options = options;

--- a/src/vs/base/browser/ui/toggle/toggle.ts
+++ b/src/vs/base/browser/ui/toggle/toggle.ts
@@ -6,7 +6,7 @@
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { BaseActionViewItem, IActionViewItemOptions } from 'vs/base/browser/ui/actionbar/actionViewItems';
 import { Widget } from 'vs/base/browser/ui/widget';
-import { IAction } from 'vs/base/common/actions';
+import { Action } from 'vs/base/common/actions';
 import { Codicon, CSSIcon } from 'vs/base/common/codicons';
 import { Color } from 'vs/base/common/color';
 import { Emitter, Event } from 'vs/base/common/event';
@@ -39,11 +39,11 @@ const defaultOpts = {
 	inputActiveOptionBackground: Color.fromHex('#0E639C50')
 };
 
-export class ToggleActionViewItem extends BaseActionViewItem {
+export class ToggleActionViewItem extends BaseActionViewItem<Action> {
 
 	protected readonly toggle: Toggle;
 
-	constructor(context: any, action: IAction, options: IActionViewItemOptions | undefined) {
+	constructor(context: any, action: Action, options: IActionViewItemOptions | undefined) {
 		super(context, action, options);
 		this.toggle = this._register(new Toggle({
 			actionClassName: this._action.class,

--- a/src/vs/base/common/actions.ts
+++ b/src/vs/base/common/actions.ts
@@ -25,13 +25,17 @@ export type WorkbenchActionExecutedEvent = {
 	from: string;
 };
 
+/**
+ * An action that can be shown in the UI.
+ */
 export interface IAction {
 	readonly id: string;
-	label: string;
-	tooltip: string;
-	class: string | undefined;
-	enabled: boolean;
-	checked?: boolean;
+	readonly label: string;
+	readonly tooltip: string;
+	readonly class: string | undefined;
+	readonly enabled: boolean;
+	readonly checked?: boolean;
+
 	run(event?: unknown): unknown;
 }
 
@@ -50,6 +54,11 @@ export interface IActionChangeEvent {
 	readonly checked?: boolean;
 }
 
+/**
+ * A generic, mutable action that can be shown in the UI.
+ *
+ * Note that unlike {@linkcode IAction}, this class is disposable and must be disposed of once it is no longer needed.
+ */
 export class Action extends Disposable implements IAction {
 
 	protected _onDidChange = this._register(new Emitter<IActionChangeEvent>());

--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1702,10 +1702,16 @@ export class QuickInputController extends Disposable {
 		if (enabled !== this.enabled) {
 			this.enabled = enabled;
 			for (const item of this.getUI().leftActionBar.viewItems) {
-				(item as ActionViewItem).action.enabled = enabled;
+				const action = (item as ActionViewItem).action;
+				if (action instanceof Action) {
+					action.enabled = enabled;
+				}
 			}
 			for (const item of this.getUI().rightActionBar.viewItems) {
-				(item as ActionViewItem).action.enabled = enabled;
+				const action = (item as ActionViewItem).action;
+				if (action instanceof Action) {
+					action.enabled = enabled;
+				}
 			}
 			this.getUI().checkAll.disabled = !enabled;
 			this.getUI().inputBox.enabled = enabled;

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -119,7 +119,7 @@ export interface IMenuEntryActionViewItemOptions {
 	hoverDelegate?: IHoverDelegate;
 }
 
-export class MenuEntryActionViewItem extends ActionViewItem {
+export class MenuEntryActionViewItem extends ActionViewItem<MenuItemAction> {
 
 	private _wantsAltCommand: boolean = false;
 	private readonly _itemClassDispose = this._register(new MutableDisposable());
@@ -139,7 +139,7 @@ export class MenuEntryActionViewItem extends ActionViewItem {
 	}
 
 	protected get _menuItemAction(): MenuItemAction {
-		return <MenuItemAction>this._action;
+		return this._action;
 	}
 
 	protected get _commandAction(): MenuItemAction {

--- a/src/vs/workbench/browser/parts/compositeBar.ts
+++ b/src/vs/workbench/browser/parts/compositeBar.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { IAction, toAction } from 'vs/base/common/actions';
+import { Action, IAction, toAction } from 'vs/base/common/actions';
 import { illegalArgument } from 'vs/base/common/errors';
 import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { IBadge } from 'vs/workbench/services/activity/common/activity';
@@ -151,7 +151,7 @@ export interface ICompositeBarOptions {
 	readonly preventLoopNavigation?: boolean;
 
 	readonly getActivityAction: (compositeId: string) => ActivityAction;
-	readonly getCompositePinnedAction: (compositeId: string) => IAction;
+	readonly getCompositePinnedAction: (compositeId: string) => Action;
 	readonly getOnCompositeClickAction: (compositeId: string) => IAction;
 	readonly fillExtraContextMenuActions: (actions: IAction[], e?: MouseEvent | GestureEvent) => void;
 	readonly getContextMenuActionsForComposite: (compositeId: string) => IAction[];
@@ -667,7 +667,7 @@ export class CompositeBar extends Widget implements ICompositeBar {
 
 interface ICompositeBarModelItem extends ICompositeBarItem {
 	readonly activityAction: ActivityAction;
-	readonly pinnedAction: IAction;
+	readonly pinnedAction: Action;
 	readonly activity: ICompositeActivity[];
 }
 

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -496,7 +496,6 @@ export class CompositeOverflowActivityActionViewItem extends ActivityActionViewI
 	private getActions(): IAction[] {
 		return this.getOverflowingComposites().map(composite => {
 			const action = this.getCompositeOpenAction(composite.id);
-			action.checked = this.getActiveCompositeId() === action.id;
 
 			const badge = this.getBadge(composite.id);
 			let suffix: string | number | undefined;
@@ -506,13 +505,14 @@ export class CompositeOverflowActivityActionViewItem extends ActivityActionViewI
 				suffix = badge.text;
 			}
 
+			let label: string;
 			if (suffix) {
-				action.label = localize('numberBadge', "{0} ({1})", composite.name, suffix);
+				label = localize('numberBadge', "{0} ({1})", composite.name, suffix);
 			} else {
-				action.label = composite.name || '';
+				label = composite.name || '';
 			}
 
-			return action;
+			return { ...action, checked: this.getActiveCompositeId() === action.id, label };
 		});
 	}
 
@@ -657,7 +657,16 @@ export class CompositeActionViewItem extends ActivityActionViewItem {
 	}
 
 	private showContextMenu(container: HTMLElement): void {
-		const actions: IAction[] = [this.toggleCompositePinnedAction];
+		const isPinned = this.compositeBar.isPinned(this.activity.id);
+		const toggleCompositePinnedAction = { ...this.toggleCompositePinnedAction };
+		if (isPinned) {
+			toggleCompositePinnedAction.label = localize('hide', "Hide '{0}'", this.activity.name);
+			toggleCompositePinnedAction.checked = false;
+		} else {
+			toggleCompositePinnedAction.label = localize('keep', "Keep '{0}'", this.activity.name);
+		}
+
+		const actions: IAction[] = [toggleCompositePinnedAction];
 
 		const compositeContextMenuActions = this.compositeContextMenuActionsProvider(this.activity.id);
 		if (compositeContextMenuActions.length) {
@@ -667,14 +676,6 @@ export class CompositeActionViewItem extends ActivityActionViewItem {
 		if ((<any>this.compositeActivityAction.activity).extensionId) {
 			actions.push(new Separator());
 			actions.push(CompositeActionViewItem.manageExtensionAction);
-		}
-
-		const isPinned = this.compositeBar.isPinned(this.activity.id);
-		if (isPinned) {
-			this.toggleCompositePinnedAction.label = localize('hide', "Hide '{0}'", this.activity.name);
-			this.toggleCompositePinnedAction.checked = false;
-		} else {
-			this.toggleCompositePinnedAction.label = localize('keep', "Keep '{0}'", this.activity.name);
 		}
 
 		const otherActions = this.contextMenuActionsProvider();

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -545,7 +545,7 @@ export class CompositeActionViewItem extends ActivityActionViewItem {
 	constructor(
 		options: IActivityActionViewItemOptions,
 		private readonly compositeActivityAction: ActivityAction,
-		private readonly toggleCompositePinnedAction: IAction,
+		private readonly toggleCompositePinnedAction: Action,
 		private readonly compositeContextMenuActionsProvider: (compositeId: string) => IAction[],
 		private readonly contextMenuActionsProvider: () => IAction[],
 		private readonly dndHandler: ICompositeDragAndDrop,
@@ -657,16 +657,7 @@ export class CompositeActionViewItem extends ActivityActionViewItem {
 	}
 
 	private showContextMenu(container: HTMLElement): void {
-		const isPinned = this.compositeBar.isPinned(this.activity.id);
-		const toggleCompositePinnedAction = { ...this.toggleCompositePinnedAction };
-		if (isPinned) {
-			toggleCompositePinnedAction.label = localize('hide', "Hide '{0}'", this.activity.name);
-			toggleCompositePinnedAction.checked = false;
-		} else {
-			toggleCompositePinnedAction.label = localize('keep', "Keep '{0}'", this.activity.name);
-		}
-
-		const actions: IAction[] = [toggleCompositePinnedAction];
+		const actions: IAction[] = [this.toggleCompositePinnedAction];
 
 		const compositeContextMenuActions = this.compositeContextMenuActionsProvider(this.activity.id);
 		if (compositeContextMenuActions.length) {
@@ -676,6 +667,14 @@ export class CompositeActionViewItem extends ActivityActionViewItem {
 		if ((<any>this.compositeActivityAction.activity).extensionId) {
 			actions.push(new Separator());
 			actions.push(CompositeActionViewItem.manageExtensionAction);
+		}
+
+		const isPinned = this.compositeBar.isPinned(this.activity.id);
+		if (isPinned) {
+			this.toggleCompositePinnedAction.label = localize('hide', "Hide '{0}'", this.activity.name);
+			this.toggleCompositePinnedAction.checked = false;
+		} else {
+			this.toggleCompositePinnedAction.label = localize('keep', "Keep '{0}'", this.activity.name);
 		}
 
 		const otherActions = this.contextMenuActionsProvider();

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -557,28 +557,28 @@ export class CustomMenubarControl extends MenubarControl {
 				return null;
 
 			case StateType.Idle:
-				return new Action('update.check', localize({ key: 'checkForUpdates', comment: ['&& denotes a mnemonic'] }, "Check for &&Updates..."), undefined, true, () =>
+				return new Action('update.check', mnemonicMenuLabel(localize({ key: 'checkForUpdates', comment: ['&& denotes a mnemonic'] }, "Check for &&Updates...")), undefined, true, () =>
 					this.updateService.checkForUpdates(true));
 
 			case StateType.CheckingForUpdates:
-				return new Action('update.checking', localize('checkingForUpdates', "Checking for Updates..."), undefined, false);
+				return new Action('update.checking', mnemonicMenuLabel(localize('checkingForUpdates', "Checking for Updates...")), undefined, false);
 
 			case StateType.AvailableForDownload:
-				return new Action('update.downloadNow', localize({ key: 'download now', comment: ['&& denotes a mnemonic'] }, "D&&ownload Update"), undefined, true, () =>
+				return new Action('update.downloadNow', mnemonicMenuLabel(localize({ key: 'download now', comment: ['&& denotes a mnemonic'] }, "D&&ownload Update")), undefined, true, () =>
 					this.updateService.downloadUpdate());
 
 			case StateType.Downloading:
-				return new Action('update.downloading', localize('DownloadingUpdate', "Downloading Update..."), undefined, false);
+				return new Action('update.downloading', mnemonicMenuLabel(localize('DownloadingUpdate', "Downloading Update...")), undefined, false);
 
 			case StateType.Downloaded:
-				return new Action('update.install', localize({ key: 'installUpdate...', comment: ['&& denotes a mnemonic'] }, "Install &&Update..."), undefined, true, () =>
+				return new Action('update.install', mnemonicMenuLabel(localize({ key: 'installUpdate...', comment: ['&& denotes a mnemonic'] }, "Install &&Update...")), undefined, true, () =>
 					this.updateService.applyUpdate());
 
 			case StateType.Updating:
-				return new Action('update.updating', localize('installingUpdate', "Installing Update..."), undefined, false);
+				return new Action('update.updating', mnemonicMenuLabel(localize('installingUpdate', "Installing Update...")), undefined, false);
 
 			case StateType.Ready:
-				return new Action('update.restart', localize({ key: 'restartToUpdate', comment: ['&& denotes a mnemonic'] }, "Restart to &&Update"), undefined, true, () =>
+				return new Action('update.restart', mnemonicMenuLabel(localize({ key: 'restartToUpdate', comment: ['&& denotes a mnemonic'] }, "Restart to &&Update")), undefined, true, () =>
 					this.updateService.quitAndInstall());
 		}
 	}
@@ -608,7 +608,6 @@ export class CustomMenubarControl extends MenubarControl {
 				if (!isMacintosh && !isWeb) {
 					const updateAction = this.getUpdateAction();
 					if (updateAction) {
-						updateAction.label = mnemonicMenuLabel(updateAction.label);
 						target.push(updateAction);
 						target.push(new Separator());
 					}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
@@ -153,7 +153,7 @@ class NotebookFindInput extends FindInput {
 	private _filterButtonContainer: HTMLElement;
 	private _actionbar: ActionBar | null = null;
 	private _filterChecked: boolean = false;
-	private _filtersAction: IAction;
+	private _filtersAction: Action;
 
 	constructor(
 		readonly filters: NotebookFindFilters,

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelActionViewItem.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelActionViewItem.ts
@@ -15,7 +15,7 @@ import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/no
 import { INotebookEditor } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
-export class NotebooKernelActionViewItem extends ActionViewItem {
+export class NotebooKernelActionViewItem extends ActionViewItem<Action> {
 
 	private _kernelLabel?: HTMLAnchorElement;
 

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -54,7 +54,7 @@ const $ = DOM.$;
 
 class ThemableToggleActionViewItem extends ToggleActionViewItem {
 
-	constructor(context: any, action: IAction, options: IActionViewItemOptions, private readonly themeService: IThemeService) {
+	constructor(context: any, action: Action, options: IActionViewItemOptions, private readonly themeService: IThemeService) {
 		super(context, action, options);
 	}
 
@@ -364,7 +364,7 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 		const toolBar = this._register(new ToolBar(this.actionsContainer, this.contextMenuService, {
 			actionViewItemProvider: (action: IAction) => {
 				if (action.id === this.sortByPrecedenceAction.id || action.id === this.recordKeysAction.id) {
-					return new ThemableToggleActionViewItem(null, action, { keybinding: this.keybindingsService.lookupKeybinding(action.id)?.getLabel() }, this.themeService);
+					return new ThemableToggleActionViewItem(null, action as Action, { keybinding: this.keybindingsService.lookupKeybinding(action.id)?.getLabel() }, this.themeService);
 				}
 				return undefined;
 			},

--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -39,7 +39,7 @@ import { IPreferencesService } from 'vs/workbench/services/preferences/common/pr
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { CONTEXT_SETTINGS_EDITOR_IN_USER_TAB } from 'vs/workbench/contrib/preferences/common/preferences';
 
-export class FolderSettingsActionViewItem extends BaseActionViewItem {
+export class FolderSettingsActionViewItem extends BaseActionViewItem<Action> {
 
 	private _folder: IWorkspaceFolder | null;
 	private _folderSettingCounts = new Map<string, number>();
@@ -51,7 +51,7 @@ export class FolderSettingsActionViewItem extends BaseActionViewItem {
 	private dropDownElement!: HTMLElement;
 
 	constructor(
-		action: IAction,
+		action: Action,
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IPreferencesService private readonly preferencesService: IPreferencesService,

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -47,7 +47,6 @@ import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
 
 export class TerminalViewPane extends ViewPane {
-	private _actions: IAction[] | undefined;
 	private _fontStyleElement: HTMLElement | undefined;
 	private _parentDomElement: HTMLElement | undefined;
 	private _terminalTabbedView?: TerminalTabbedView;
@@ -81,11 +80,6 @@ export class TerminalViewPane extends ViewPane {
 	) {
 		super(options, keybindingService, _contextMenuService, _configurationService, _contextKeyService, viewDescriptorService, _instantiationService, openerService, themeService, telemetryService);
 		this._register(this._terminalService.onDidRegisterProcessSupport(() => {
-			if (this._actions) {
-				for (const action of this._actions) {
-					action.enabled = true;
-				}
-			}
 			this._onDidChangeViewWelcomeState.fire();
 		}));
 
@@ -405,12 +399,13 @@ class SingleTerminalTabActionViewItem extends MenuEntryActionViewItem {
 		this._register(this._terminalService.onDidChangeInstanceColor(e => this.updateLabel(e.instance)));
 		this._register(this._terminalService.onDidChangeInstanceTitle(e => {
 			if (e === this._terminalGroupService.activeInstance) {
-				this._action.tooltip = getSingleTabTooltip(e, this._terminalService.configHelper.config.tabs.separator);
+				// TODO: Fix types
+				(this._action as unknown as Action).tooltip = getSingleTabTooltip(e, this._terminalService.configHelper.config.tabs.separator);
 				this.updateLabel();
 			}
 		}));
 		this._register(this._terminalService.onDidChangeInstanceCapability(e => {
-			this._action.tooltip = getSingleTabTooltip(e, this._terminalService.configHelper.config.tabs.separator);
+			(this._action as unknown as Action).tooltip = getSingleTabTooltip(e, this._terminalService.configHelper.config.tabs.separator);
 			this.updateLabel(e);
 		}));
 


### PR DESCRIPTION
The `IAction` interface is primarily used to passing around information about actions. However most properties on `IAction` are currently writable. This is bad as it makes code more difficult to reason about since callers are free to change these properties in sometimes unexpected ways.

Worse, some current implementers of `IAction` assume that the properties should are readonly. You can see this happening with [`MenuItemAction`](https://github.com/microsoft/vscode/blob/9c802415e11bf11230720bc4a93397c338121da8/src/vs/platform/actions/common/actions.ts#L401), which declares all of its properties as `readonly` but can then can see these properties be mutated if it is passed as an `IAction`

---

In order to prevent problems like the above, and also to hopefully increase the number of places where we can safely use simple a `IAction` instead of the more heavyweight `Action` class (see #164842 for an example of why this can be beneficial),  I've updated `IAction` to be the readonly representation of an action. This also required updating a few types like `ActionViewItems` to let callers know which type of actions are being used

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
