### PR TITLE
Fix text of IW command palette entries (#164860)

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -722,7 +722,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'interactive.input.focus',
-			title: { value: localize('interactive.input.focus', "Focus input editor in the interactive window"), original: 'Focus input editor in the interactive window' },
+			title: { value: localize('interactive.input.focus', "Focus Input Editor"), original: 'Focus Input Editor' },
 			category: interactiveWindowCategory,
 			f1: true
 		});
@@ -757,7 +757,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'interactive.history.focus',
-			title: { value: localize('interactive.history.focus', "Focus history in the interactive window"), original: 'Focus input editor in the interactive window' },
+			title: { value: localize('interactive.history.focus', "Focus History"), original: 'Focus History' },
 			category: interactiveWindowCategory,
 			f1: true,
 			precondition: ContextKeyExpr.equals('resourceScheme', Schemas.vscodeInteractive),


### PR DESCRIPTION
This PR fixes #164860

![image](https://user-images.githubusercontent.com/6726799/198541823-04372b1f-b022-4af0-bcc6-5fbeb498b45e.png)

Equivalent correction also made to the `Focus history in the interactive window` command, which only appears in palette when focus is in the IW Input Editor.




