### PR TITLE
Fix bugs with close of markdown docs

### DIFF
--- a/extensions/markdown-language-features/server/src/workspace.ts
+++ b/extensions/markdown-language-features/server/src/workspace.ts
@@ -178,7 +178,6 @@ export class VsCodeClientWorkspace implements md.IWorkspaceWithWatching {
 			// notify us when this happens.
 			if (!(await this.statBypassingCache(uri))) {
 				if (this._documentCache.get(uri) === doc && !doc.hasInMemoryDoc()) {
-					console.log('state close 4 real');
 					this.doDeleteDocument(uri);
 					return;
 				}

--- a/extensions/markdown-language-features/server/src/workspace.ts
+++ b/extensions/markdown-language-features/server/src/workspace.ts
@@ -65,7 +65,7 @@ class VsCodeDocument implements md.ITextDocument {
 	}
 
 	hasInMemoryDoc(): boolean {
-		return !this.inMemoryDoc;
+		return !!this.inMemoryDoc;
 	}
 
 	isDetached(): boolean {
@@ -176,8 +176,9 @@ export class VsCodeClientWorkspace implements md.IWorkspaceWithWatching {
 			// Check that if file has been deleted on disk.
 			// This can happen when directories are renamed / moved. VS Code's file system watcher does not
 			// notify us when this happens.
-			if (await this.statBypassingCache(uri) === undefined) {
+			if (!(await this.statBypassingCache(uri))) {
 				if (this._documentCache.get(uri) === doc && !doc.hasInMemoryDoc()) {
+					console.log('state close 4 real');
 					this.doDeleteDocument(uri);
 					return;
 				}
@@ -355,7 +356,8 @@ export class VsCodeClientWorkspace implements md.IWorkspaceWithWatching {
 		if (this.documents.get(uri)) {
 			return { isDirectory: false };
 		}
-		return this.connection.sendRequest(protocol.fs_stat, { uri });
+		const fsResult = await this.connection.sendRequest(protocol.fs_stat, { uri });
+		return fsResult ?? undefined; // Force convert null to undefined
 	}
 
 	async readDirectory(resource: URI): Promise<[string, md.FileStat][]> {


### PR DESCRIPTION
This is for #164562

There are two bugs here:

- Something in the lsp is converting a value from `undefined` to `null`. To fix this, I've updated us just to check for falsy values instead

- The `hasInMemoryDoc` implementation was incorrect. It needs to verify that the value of `this.inMemoryDoc` is not null/undefined

