### PR TITLE
Add select all

### DIFF
--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -25,6 +25,7 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { ILogService } from 'vs/platform/log/common/log';
 
+const CLIPBOARD_CONTEXT_MENU_GROUP = '9_cutcopypaste';
 
 export type ServicesAccessor = InstantiationServicesAccessor;
 export type IEditorContributionCtor = IConstructorSignature<IEditorContribution, [ICodeEditor]>;
@@ -630,5 +631,15 @@ export const SelectAllCommand = registerCommand(new MultiCommand({
 		group: '',
 		title: nls.localize('selectAll', "Select All"),
 		order: 1
+	}, {
+		menuId: MenuId.EditorContext,
+		group: CLIPBOARD_CONTEXT_MENU_GROUP,
+		title: nls.localize('selectAll', "Select All"),
+		order: 3
+	}, {
+		menuId: MenuId.SimpleEditorContext.id,
+		group: CLIPBOARD_CONTEXT_MENU_GROUP,
+		title: nls.localize('selectAll', "Select All"),
+		order: 3
 	}]
 }));

--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -27,7 +27,6 @@ import { ILogService } from 'vs/platform/log/common/log';
 
 const CLIPBOARD_CONTEXT_MENU_GROUP = '9_cutcopyselectallpaste';
 
-
 export type ServicesAccessor = InstantiationServicesAccessor;
 export type IEditorContributionCtor = IConstructorSignature<IEditorContribution, [ICodeEditor]>;
 export type IDiffEditorContributionCtor = IConstructorSignature<IDiffEditorContribution, [IDiffEditor]>;

--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -25,8 +25,6 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { ILogService } from 'vs/platform/log/common/log';
 
-const CLIPBOARD_CONTEXT_MENU_GROUP = '9_cutcopypaste';
-
 export type ServicesAccessor = InstantiationServicesAccessor;
 export type IEditorContributionCtor = IConstructorSignature<IEditorContribution, [ICodeEditor]>;
 export type IDiffEditorContributionCtor = IConstructorSignature<IDiffEditorContribution, [IDiffEditor]>;
@@ -631,15 +629,5 @@ export const SelectAllCommand = registerCommand(new MultiCommand({
 		group: '',
 		title: nls.localize('selectAll', "Select All"),
 		order: 1
-	}, {
-		menuId: MenuId.EditorContext,
-		group: CLIPBOARD_CONTEXT_MENU_GROUP,
-		title: nls.localize('selectAll', "Select All"),
-		order: 3
-	}, {
-		menuId: MenuId.SimpleEditorContext.id,
-		group: CLIPBOARD_CONTEXT_MENU_GROUP,
-		title: nls.localize('selectAll', "Select All"),
-		order: 3
 	}]
 }));

--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -25,6 +25,8 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { ILogService } from 'vs/platform/log/common/log';
 
+const CLIPBOARD_CONTEXT_MENU_GROUP = '9_cutcopyselectallpaste';
+
 
 export type ServicesAccessor = InstantiationServicesAccessor;
 export type IEditorContributionCtor = IConstructorSignature<IEditorContribution, [ICodeEditor]>;
@@ -626,9 +628,19 @@ export const SelectAllCommand = registerCommand(new MultiCommand({
 		title: nls.localize({ key: 'miSelectAll', comment: ['&& denotes a mnemonic'] }, "&&Select All"),
 		order: 1
 	}, {
+		menuId: MenuId.EditorContext,
+		group: CLIPBOARD_CONTEXT_MENU_GROUP,
+		title: nls.localize('selectAll', "Select All"),
+		order: 3
+	}, {
 		menuId: MenuId.CommandPalette,
 		group: '',
 		title: nls.localize('selectAll', "Select All"),
 		order: 1
+	}, {
+		menuId: MenuId.SimpleEditorContext,
+		group: CLIPBOARD_CONTEXT_MENU_GROUP,
+		title: nls.localize('selectAll', "Select All"),
+		order: 3
 	}]
 }));

--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -19,7 +19,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 
-const CLIPBOARD_CONTEXT_MENU_GROUP = '9_cutcopypaste';
+const CLIPBOARD_CONTEXT_MENU_GROUP = '9_cutcopyselectallpaste';
 
 const supportsCut = (platform.isNative || document.queryCommandSupported('cut'));
 const supportsCopy = (platform.isNative || document.queryCommandSupported('copy'));

--- a/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
@@ -67,7 +67,7 @@ export interface IActionDescriptor {
 	 * The context menu of the editor has these default:
 	 *   navigation - The navigation group comes first in all cases.
 	 *   1_modification - This group comes next and contains commands that modify your code.
-	 *   9_cutcopypaste - The last default group with the basic editing commands.
+	 *   9_cutcopyselectallpaste - The last default group with the basic editing commands.
 	 * You can also create your own group.
 	 * Defaults to null (don't show in context menu).
 	 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1134,7 +1134,7 @@ declare namespace monaco.editor {
 		 * The context menu of the editor has these default:
 		 *   navigation - The navigation group comes first in all cases.
 		 *   1_modification - This group comes next and contains commands that modify your code.
-		 *   9_cutcopypaste - The last default group with the basic editing commands.
+		 *   9_cutcopyselectallpaste - The last default group with the basic editing commands.
 		 * You can also create your own group.
 		 * Defaults to null (don't show in context menu).
 		 */

--- a/src/vs/workbench/browser/actions/textInputActions.ts
+++ b/src/vs/workbench/browser/actions/textInputActions.ts
@@ -39,9 +39,10 @@ export class TextInputActionsProvider extends Disposable implements IWorkbenchCo
 			new Action('redo', localize('redo', "Redo"), undefined, true, async () => document.execCommand('redo')),
 			new Separator(),
 
-			// Cut / Copy / Paste
+			// Cut / Copy / Select All / Paste
 			new Action('editor.action.clipboardCutAction', localize('cut', "Cut"), undefined, true, async () => document.execCommand('cut')),
 			new Action('editor.action.clipboardCopyAction', localize('copy', "Copy"), undefined, true, async () => document.execCommand('copy')),
+			new Action('editor.action.selectAll', localize('selectAll', "Select All"), undefined, true, async () => document.execCommand('selectAll')),
 			new Action('editor.action.clipboardPasteAction', localize('paste', "Paste"), undefined, true, async element => {
 
 				// Native: paste is supported
@@ -64,11 +65,7 @@ export class TextInputActionsProvider extends Disposable implements IWorkbenchCo
 						element.selectionEnd = element.selectionStart;
 					}
 				}
-			}),
-			new Separator(),
-
-			// Select All
-			new Action('editor.action.selectAll', localize('selectAll', "Select All"), undefined, true, async () => document.execCommand('selectAll'))
+			})
 		);
 	}
 


### PR DESCRIPTION
This PR fixes [#163674](https://github.com/microsoft/vscode/issues/163674)
We added select All button in the context menu when right clicked on editor. 
Moreover we changed the order of the context menu options when right clicked on command palette.
As a result, 'select all' button was added in all context menus, and they became same style as the context menu of terminal.
