### PR TITLE
fix #154064 which was running the wrong taskgroups

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2994,9 +2994,9 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 				const relativePath = workspaceFolder?.uri ? (resources.relativePath(workspaceFolder.uri, absoluteURI) ?? absoluteURI.path) : absoluteURI.path;
 
 				taskGroupTasks = await this._findWorkspaceTasks((task) => {
-					const taskGroup = task.configurationProperties.group;
-					if (taskGroup && typeof taskGroup !== 'string' && typeof taskGroup.isDefault === 'string') {
-						return (taskGroup._id === taskGroup._id && glob.match(taskGroup.isDefault, relativePath));
+					const currentTaskGroup = task.configurationProperties.group;
+					if (currentTaskGroup && typeof currentTaskGroup !== 'string' && typeof currentTaskGroup.isDefault === 'string') {
+						return (currentTaskGroup._id === taskGroup._id && glob.match(currentTaskGroup.isDefault, relativePath));
 					}
 
 					return false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/154064

This fixes the issue where "Run Test Task" would trigger a build task and vice versa. This is behaviour which shouldn't happen.

The bug was [here](https://github.com/microsoft/vscode/compare/main...jasonwilliams:fixBrokenTasks?expand=1#diff-f77e08d48fa5a43f6cd385c0bac2c04ee2123565ead5f0f4b60e23c8af821b76L2999) where we were doing `taskGroup._id === taskGroup._id` so the group was being tested against itself and would always be true. So this would execute the first task where the file glob matched (even if the task group was not the one you asked for). 

Now we properly check the correct task group matches before executing.
I'm surprised TypeScript didn't catch this as we were just comparing the same value with itself.

@alexr00 