### PR TITLE
Port md fixes to release branch

### DIFF
--- a/extensions/markdown-language-features/server/package.json
+++ b/extensions/markdown-language-features/server/package.json
@@ -17,7 +17,7 @@
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.5",
     "vscode-languageserver-types": "^3.17.1",
-    "vscode-markdown-languageservice": "^0.2.0-alpha.7",
+    "vscode-markdown-languageservice": "^0.2.0-alpha.8",
     "vscode-nls": "^5.2.0",
     "vscode-uri": "^3.0.3"
   },

--- a/extensions/markdown-language-features/server/src/workspace.ts
+++ b/extensions/markdown-language-features/server/src/workspace.ts
@@ -65,7 +65,7 @@ class VsCodeDocument implements md.ITextDocument {
 	}
 
 	hasInMemoryDoc(): boolean {
-		return !this.inMemoryDoc;
+		return !!this.inMemoryDoc;
 	}
 
 	isDetached(): boolean {
@@ -176,7 +176,7 @@ export class VsCodeClientWorkspace implements md.IWorkspaceWithWatching {
 			// Check that if file has been deleted on disk.
 			// This can happen when directories are renamed / moved. VS Code's file system watcher does not
 			// notify us when this happens.
-			if (await this.statBypassingCache(uri) === undefined) {
+			if (!(await this.statBypassingCache(uri))) {
 				if (this._documentCache.get(uri) === doc && !doc.hasInMemoryDoc()) {
 					this.doDeleteDocument(uri);
 					return;
@@ -355,7 +355,8 @@ export class VsCodeClientWorkspace implements md.IWorkspaceWithWatching {
 		if (this.documents.get(uri)) {
 			return { isDirectory: false };
 		}
-		return this.connection.sendRequest(protocol.fs_stat, { uri });
+		const fsResult = await this.connection.sendRequest(protocol.fs_stat, { uri });
+		return fsResult ?? undefined; // Force convert null to undefined
 	}
 
 	async readDirectory(resource: URI): Promise<[string, md.FileStat][]> {

--- a/extensions/markdown-language-features/server/yarn.lock
+++ b/extensions/markdown-language-features/server/yarn.lock
@@ -42,10 +42,10 @@ vscode-languageserver@^8.0.2:
   dependencies:
     vscode-languageserver-protocol "3.17.2"
 
-vscode-markdown-languageservice@^0.2.0-alpha.7:
-  version "0.2.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.2.0-alpha.7.tgz#1f5fd345630e9d0d585cb00155d433c2320fa9c2"
-  integrity sha512-5QYz1+LpvazK21Hphx8wZiZIXE9cQ9R3jzhQr+I89xNHJi+NWTEBA555ZFkaaYR68B7SI7OQ4jihjkGLZTUTnw==
+vscode-markdown-languageservice@^0.2.0-alpha.8:
+  version "0.2.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.2.0-alpha.8.tgz#f77c20adea2ddafdad88b99b09be1778c358ca42"
+  integrity sha512-kydgGkSarjFk71culFover7lBym82wmJdvuqCzS3IPZV+fhW1l0poca/Dt4bDku3ioda0kNH9xdmi0fiHkIDUQ==
   dependencies:
     picomatch "^2.3.1"
     vscode-languageserver-textdocument "^1.0.5"


### PR DESCRIPTION
This is a cherry pick of two fixes:

- #164945 which fixes #164932 by picking up a new md language service version

- #164942 which fixes #164562 by fixing a bug with the md workspace implementation

