### PR TITLE
adjust title bar appearance in web

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1074,6 +1074,11 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			return true;
 		}
 
+		// with the command center enabled, we should always show
+		if (this.configurationService.getValue<boolean>('window.commandCenter')) {
+			return true;
+		}
+
 		// if WCO is visible, we have to show the title bar
 		if (isWCOVisible()) {
 			return true;

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -175,6 +175,10 @@
 	flex-wrap: nowrap;
 }
 
+.monaco-workbench.web .part.titlebar>.titlebar-container>.menubar {
+	margin-left: 4px;
+}
+
 .monaco-workbench .part.titlebar>.titlebar-container.counter-zoom > .menubar .menubar-menu-button > .menubar-menu-items-holder.monaco-menu-container {
 	zoom: var(--zoom-factor);
 }

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -236,7 +236,7 @@ export class TitlebarPart extends Part implements ITitleService {
 		this.dragRegion = prepend(this.rootContainer, $('div.titlebar-drag-region'));
 
 		// App Icon (Native Windows/Linux and Web)
-		if (!isMacintosh || isWeb) {
+		if (!isMacintosh && !isWeb) {
 			this.appIcon = prepend(this.rootContainer, $('a.window-appicon'));
 
 			// Web-only home indicator and menu


### PR DESCRIPTION
refs VS Code for the Web: title area shows up in pre-existing sessions #161948

This removes the app icon in web and brings back the title bar if the command center is enabled.

<img width="735" alt="image" src="https://user-images.githubusercontent.com/6561887/199080888-f33153d4-8f23-419b-96c8-aaadb815831f.png">

I wonder if we should move the compact menubar from the activity bar automatically into the titlebar in this case

![image](https://user-images.githubusercontent.com/6561887/199080967-7608cace-e067-446f-a395-5e1561fbe48e.png)


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
