### PR TITLE
get tasks to reconnect even when panel is originally hidden

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
@@ -132,7 +132,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	id: TERMINAL_VIEW_ID,
 	name: nls.localize('terminal', "Terminal"),
 	containerIcon: terminalViewIcon,
-	canToggleVisibility: false,
+	canToggleVisibility: true,
 	canMoveView: true,
 	ctorDescriptor: new SyncDescriptor(TerminalViewPane),
 	openCommandActionDescriptor: {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -230,9 +230,8 @@ export class TerminalService implements ITerminalService {
 				}
 			});
 			if (this._storageService.getBoolean(reconnectToTaskKey, StorageScope.WORKSPACE)) {
-				this._viewsService.openView(TERMINAL_VIEW_ID).then(() => {
-					this._storageService.store(reconnectToTaskKey, false, StorageScope.WORKSPACE, StorageTarget.USER);
-				});
+				this._viewsService.getViewWithId(TERMINAL_VIEW_ID)?.setExpanded(true);
+				this._storageService.store(reconnectToTaskKey, false, StorageScope.WORKSPACE, StorageTarget.USER);
 			}
 		}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -167,23 +167,24 @@ export class TerminalViewPane extends ViewPane {
 				const hadTerminals = !!this._terminalGroupService.groups.length;
 				// Ensure the primary backend is registered as it's important to do before
 				// initializeTerminals is called.
-				await this._terminalService.primaryBackendRegistered;
-				if (this._terminalService.isProcessSupportRegistered) {
-					if (this._terminalsInitialized) {
-						if (!hadTerminals) {
-							this._terminalService.createTerminal({ location: TerminalLocation.Panel });
+				this._terminalService.primaryBackendRegistered.then(async () => {
+					if (this._terminalService.isProcessSupportRegistered) {
+						if (this._terminalsInitialized) {
+							if (!hadTerminals) {
+								this._terminalService.createTerminal({ location: TerminalLocation.Panel });
+							}
+						} else {
+							this._terminalsInitialized = true;
+							this._terminalService.initializeTerminals();
 						}
 					} else {
-						this._terminalsInitialized = true;
-						this._terminalService.initializeTerminals();
+						this._onDidChangeViewWelcomeState.fire();
 					}
-				} else {
-					this._onDidChangeViewWelcomeState.fire();
-				}
-				// we don't know here whether or not it should be focused, so
-				// defer focusing the panel to the focus() call
-				// to prevent overriding preserveFocus for extensions
-				this._terminalGroupService.showPanel(false);
+					// we don't know here whether or not it should be focused, so
+					// defer focusing the panel to the focus() call
+					// to prevent overriding preserveFocus for extensions
+					this._terminalGroupService.showPanel(false);
+				});
 			} else {
 				for (const instance of this._terminalGroupService.instances) {
 					instance.resetFocusContextKey();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #159639

`this._viewsService.openView(TERMINAL_VIEW_ID)` does not cause `onDidChangeViewVisibility` to fire, which is why the original fix wasn't working. `setExpanded` does the right thing here

