### PR TITLE
Revert "Bump version for Nov. (#165091)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.74.0",
+  "version": "1.73.0",
   "distro": "51e5bb745ed01b333d96df102d750c9ec33ffe23",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
This reverts commit 8b4642ab23a9b8c7fd00a37c70af545c121cc2ef.

This seems to be causing our builds to fail: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=191117&view=logs&j=4801dce2-64f3-53d6-b366-d49a1977c639&t=d3816dfe-5f5f-5b74-f77f-0a43291213b6&l=22

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
