### PR TITLE
🎁 Add `search` to file location methods in tasks

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -23,7 +23,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { IMarkerService, MarkerSeverity } from 'vs/platform/markers/common/markers';
 import { IWorkspaceContextService, IWorkspaceFolder, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { Markers } from 'vs/workbench/contrib/markers/common/markers';
-import { Config, ProblemMatcher, ProblemMatcherRegistry /*, ProblemPattern, getResource */ } from 'vs/workbench/contrib/tasks/common/problemMatcher';
+import { ProblemMatcher, ProblemMatcherRegistry /*, ProblemPattern, getResource */ } from 'vs/workbench/contrib/tasks/common/problemMatcher';
 
 import { Codicon } from 'vs/base/common/codicons';
 import { Schemas } from 'vs/base/common/network';

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -16,6 +16,7 @@ import * as resources from 'vs/base/common/resources';
 import Severity from 'vs/base/common/severity';
 import * as Types from 'vs/base/common/types';
 import * as nls from 'vs/nls';
+import { asArray } from 'vs/base/common/arrays';
 
 import { IModelService } from 'vs/editor/common/services/model';
 import { IFileService } from 'vs/platform/files/common/files';
@@ -1660,7 +1661,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 				if (Types.isString(matcher.filePrefix)) {
 					this._collectVariables(variables, matcher.filePrefix);
 				} else {
-					for (const fp of [...matcher.filePrefix.include, ...(matcher.filePrefix.exclude ?? [])]) {
+					for (const fp of [...asArray(matcher.filePrefix.include), ...asArray(matcher.filePrefix.exclude ?? [])]) {
 						this._collectVariables(variables, fp);
 					}
 				}
@@ -1725,13 +1726,17 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 					copy.uriProvider = taskSystemInfo.uriProvider;
 				}
 				if (hasFilePrefix) {
-					if (Types.isString(matcher.filePrefix)) {
-						copy.filePrefix = await this._resolveVariable(resolver, copy.filePrefix as string);
-					} else {
-						const copyFilePrefix = copy.filePrefix as Config.SearchFileLocationArgs;
-						copyFilePrefix.include = await Promise.all(copyFilePrefix.include.map(x => this._resolveVariable(resolver, x)));
-						if (copyFilePrefix.exclude) {
-							copyFilePrefix.exclude = await Promise.all(copyFilePrefix.exclude.map(x => this._resolveVariable(resolver, x)));
+					const filePrefix = copy.filePrefix;
+					if (Types.isString(filePrefix)) {
+						copy.filePrefix = await this._resolveVariable(resolver, filePrefix);
+					} else if (filePrefix !== undefined) {
+						filePrefix.include = Array.isArray(filePrefix.include)
+							? await Promise.all(filePrefix.include.map(x => this._resolveVariable(resolver, x)))
+							: await this._resolveVariable(resolver, filePrefix.include);
+						if (filePrefix.exclude) {
+							filePrefix.exclude = Array.isArray(filePrefix.exclude)
+								? await Promise.all(filePrefix.exclude.map(x => this._resolveVariable(resolver, x)))
+								: await this._resolveVariable(resolver, filePrefix.exclude);
 						}
 					}
 				}

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -1661,7 +1661,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 				if (Types.isString(matcher.filePrefix)) {
 					this._collectVariables(variables, matcher.filePrefix);
 				} else {
-					for (const fp of [...asArray(matcher.filePrefix.include), ...asArray(matcher.filePrefix.exclude ?? [])]) {
+					for (const fp of [...asArray(matcher.filePrefix.include || []), ...asArray(matcher.filePrefix.exclude || [])]) {
 						this._collectVariables(variables, fp);
 					}
 				}
@@ -1730,9 +1730,11 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 					if (Types.isString(filePrefix)) {
 						copy.filePrefix = await this._resolveVariable(resolver, filePrefix);
 					} else if (filePrefix !== undefined) {
-						filePrefix.include = Array.isArray(filePrefix.include)
-							? await Promise.all(filePrefix.include.map(x => this._resolveVariable(resolver, x)))
-							: await this._resolveVariable(resolver, filePrefix.include);
+						if (filePrefix.include) {
+							filePrefix.include = Array.isArray(filePrefix.include)
+								? await Promise.all(filePrefix.include.map(x => this._resolveVariable(resolver, x)))
+								: await this._resolveVariable(resolver, filePrefix.include);
+						}
 						if (filePrefix.exclude) {
 							filePrefix.exclude = Array.isArray(filePrefix.exclude)
 								? await Promise.all(filePrefix.exclude.map(x => this._resolveVariable(resolver, x)))

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1678,7 +1678,11 @@ export namespace Schemas {
 						type: 'array',
 						items: {
 							type: 'string'
-						}
+						},
+						examples: [
+							['relative', '${workspaceFolder}'],
+							['autoDetect', '${workspaceFolder}'],
+						]
 					},
 					{
 						type: 'array',

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -17,6 +17,7 @@ import { URI } from 'vs/base/common/uri';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { ValidationStatus, ValidationState, IProblemReporter, Parser } from 'vs/base/common/parsers';
 import { IStringDictionary } from 'vs/base/common/collections';
+import { asArray } from 'vs/base/common/arrays';
 
 import { IMarkerData, MarkerSeverity } from 'vs/platform/markers/common/markers';
 import { ExtensionsRegistry, ExtensionMessageCollector } from 'vs/workbench/services/extensions/common/extensionsRegistry';
@@ -244,7 +245,7 @@ export async function getResource(filename: string, matcher: ProblemMatcher, fil
 }
 
 async function searchForFileLocation(filename: string, fsProvider: IFileSystemProvider, args: Config.SearchFileLocationArgs): Promise<URI | undefined> {
-	const exclusions = new Set(args.exclude?.map(x => URI.file(x).path) ?? []);
+	const exclusions = new Set(asArray(args.exclude || []).map(x => URI.file(x).path));
 	async function search(dir: URI): Promise<URI | undefined> {
 		if (exclusions.has(dir.path)) {
 			return undefined;
@@ -273,7 +274,7 @@ async function searchForFileLocation(filename: string, fsProvider: IFileSystemPr
 		return undefined;
 	}
 
-	for (const dir of args.include) {
+	for (const dir of asArray(args.include)) {
 		const hit = await search(URI.file(dir));
 		if (hit) {
 			return hit;
@@ -850,7 +851,7 @@ export namespace Config {
 		*  - ["autodetect", "path value"]: the filename is treated
 		*    relative to the given path value, and if it does not
 		*    exist, it is treated as absolute.
-		*  - ["search", { include: []; exclude?: [] }]: The filename
+		*  - ["search", { include: "" | []; exclude?: "" | [] }]: The filename
 		*    needs to be searched under the directories named by the "include"
 		*    property and their nested subdirectories. With "exclude" property
 		*    present, the directories should be removed from the search.
@@ -883,8 +884,8 @@ export namespace Config {
 	}
 
 	export type SearchFileLocationArgs = {
-		include: string[];
-		exclude?: string[];
+		include: string | string[];
+		exclude?: string | string[];
 	};
 
 	export type ProblemMatcherType = string | ProblemMatcher | Array<string | ProblemMatcher>;

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -265,7 +265,7 @@ async function searchForFileLocation(filename: string, fsProvider: IFileSystemPr
 		}
 
 		for (const subdir of subdirs) {
-			const result = search(subdir);
+			const result = await search(subdir);
 			if (result) {
 				return result;
 			}

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -244,7 +244,12 @@ export async function getResource(filename: string, matcher: ProblemMatcher, fil
 }
 
 async function searchForFileLocation(filename: string, fsProvider: IFileSystemProvider, args: Config.SearchFileLocationArgs): Promise<URI | undefined> {
+	const exclusions = new Set(args.exclude?.map(x => URI.file(x).path) ?? []);
 	async function search(dir: URI): Promise<URI | undefined> {
+		if (exclusions.has(dir.path)) {
+			return undefined;
+		}
+
 		const entries = await fsProvider.readdir(dir);
 		const subdirs: URI[] = [];
 

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -261,8 +261,19 @@ async function searchForFileLocation(filename: string, fsProvider: IFileSystemPr
 				continue;
 			}
 
-			if (fileType === FileType.File && name === filename) {
-				return URI.joinPath(dir, name);
+			if (fileType === FileType.File) {
+				/**
+				 * Note that sometimes the given `filename` could be a relative
+				 * path (not just the "name.ext" part). For example, the
+				 * `filename` can be "/subdir/name.ext". So, just comparing
+				 * `name` as `filename` is not sufficient. The workaround here
+				 * is to form the URI with `dir` and `name` and check if it ends
+				 * with the given `filename`.
+				 */
+				const fullUri = URI.joinPath(dir, name);
+				if (fullUri.path.endsWith(filename)) {
+					return fullUri;
+				}
 			}
 		}
 

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -18,6 +18,7 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { ValidationStatus, ValidationState, IProblemReporter, Parser } from 'vs/base/common/parsers';
 import { IStringDictionary } from 'vs/base/common/collections';
 import { asArray } from 'vs/base/common/arrays';
+import { Schemas as NetworkSchemas } from 'vs/base/common/network';
 
 import { IMarkerData, MarkerSeverity } from 'vs/platform/markers/common/markers';
 import { ExtensionsRegistry, ExtensionMessageCollector } from 'vs/workbench/services/extensions/common/extensionsRegistry';
@@ -217,7 +218,7 @@ export async function getResource(filename: string, matcher: ProblemMatcher, fil
 		matcherClone.fileLocation = FileLocationKind.Absolute;
 		return getResource(filename, matcherClone);
 	} else if (kind === FileLocationKind.Search && fileService) {
-		const fsProvider = fileService.getProvider('file');
+		const fsProvider = fileService.getProvider(NetworkSchemas.file);
 		if (fsProvider) {
 			const uri = await searchForFileLocation(filename, fsProvider, matcher.filePrefix as Config.SearchFileLocationArgs);
 			fullPath = uri?.path;

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1687,16 +1687,30 @@ export namespace Schemas {
 							{
 								type: 'object',
 								properties: {
-									'include': { type: 'array', items: { type: 'string' } },
-									'exclude': { type: 'array', items: { type: 'string' } },
+									'include': {
+										oneOf: [
+											{ type: 'string' },
+											{ type: 'array', items: { type: 'string' } }
+										]
+									},
+									'exclude': {
+										oneOf: [
+											{ type: 'string' },
+											{ type: 'array', items: { type: 'string' } }
+										]
+									},
 								},
 								required: ['include']
 							}
 						],
 						additionalItems: false,
+						examples: [
+							['search', { 'include': ['${workspaceFolder}'] }],
+							['search', { 'include': ['${workspaceFolder}'], 'exclude': [] }]
+						],
 					}
 				],
-				description: localize('ProblemMatcherSchema.fileLocation', 'Defines how file names reported in a problem pattern should be interpreted. A relative fileLocation may be an array, where the second element of the array is the path of the relative file location.')
+				description: localize('ProblemMatcherSchema.fileLocation', 'Defines how file names reported in a problem pattern should be interpreted. A relative fileLocation may be an array, where the second element of the array is the path of the relative file location. The search fileLocation mode, performs a deep (and, possibly, heavy) file system search within the directories specified by the include/exclude properties of the second element.')
 			},
 			background: {
 				type: 'object',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #160771

A new `fileLocation` method, named `search`, is added to problem matches. The usage of this file location method is as:

```jsonc
"problemMatcher": {
    "fileLocation": [
        "search",
        {
            "include": [ // (Required)
                "${workspaceFolder}/subdir1",
                "${workspaceFolder}/subdir2"
            ],
            "exclude": [ // (Optional)
                "${workspaceFolder}/subdir1/subdir-to-ignore",
                "${workspaceFolder}/subdir2/subdir-to-ignore"
            ]
        }
    ]
```

The `include` field is required, but the `exclude` is not.

To verify this PR, you can use [babakks/vscode-verify-search-file-location](https://github.com/babakks/vscode-verify-search-file-location) repo as the test workspace.