### PR TITLE
Only use string of the `remote/web/package.json` `browser` field

### DIFF
--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -302,7 +302,8 @@ function acquireWebNodePaths() {
     for (const key of Object.keys(webPackages)) {
         const packageJSON = path.join(root, 'node_modules', key, 'package.json');
         const packageData = JSON.parse(fs.readFileSync(packageJSON, 'utf8'));
-        let entryPoint = packageData.browser ?? packageData.main;
+        // Only cases where the browser is a string are handled
+        let entryPoint = typeof packageData.browser === 'string' ? packageData.browser : packageData.main;
         // On rare cases a package doesn't have an entrypoint so we assume it has a dist folder with a min.js
         if (!entryPoint) {
             // TODO @lramos15 remove this when jschardet adds an entrypoint so we can warn on all packages w/out entrypoint

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -371,7 +371,8 @@ export function acquireWebNodePaths() {
 	for (const key of Object.keys(webPackages)) {
 		const packageJSON = path.join(root, 'node_modules', key, 'package.json');
 		const packageData = JSON.parse(fs.readFileSync(packageJSON, 'utf8'));
-		let entryPoint: string = packageData.browser ?? packageData.main;
+		// Only cases where the browser is a string are handled
+		let entryPoint: string = typeof packageData.browser === 'string' ? packageData.browser : packageData.main;
 
 		// On rare cases a package doesn't have an entrypoint so we assume it has a dist folder with a min.js
 		if (!entryPoint) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Close #165162.  I think it is possible to simply ignore the situation where the `browser` is an object.
