### PR TITLE
only renderBody when view is visible/expanded

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -58,6 +58,7 @@ export abstract class Pane extends Disposable implements IView {
 
 	private expandedSize: number | undefined = undefined;
 	private _headerVisible = true;
+	private _bodyRendered = false;
 	private _minimumBodySize: number;
 	private _maximumBodySize: number;
 	private _ariaHeaderLabel: string;
@@ -158,6 +159,11 @@ export abstract class Pane extends Disposable implements IView {
 		this.updateHeader();
 
 		if (expanded) {
+			if (!this._bodyRendered) {
+				this.renderBody(this.body);
+				this._bodyRendered = true;
+			}
+
 			if (typeof this.animationTimer === 'number') {
 				clearTimeout(this.animationTimer);
 			}
@@ -249,7 +255,13 @@ export abstract class Pane extends Disposable implements IView {
 		});
 
 		this.body = append(this.element, $('.pane-body'));
-		this.renderBody(this.body);
+
+		// Only render the body if it will be visible
+		// Otherwise, render it when the pane is expanded
+		if (!this._bodyRendered && this.isExpanded()) {
+			this.renderBody(this.body);
+			this._bodyRendered = true;
+		}
 
 		if (!this.isExpanded()) {
 			this.body.remove();


### PR DESCRIPTION
fixes PaneView calls renderBody even when the pane is collapsed #164662

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

cc @joaomoreno 
