### PR TITLE
Do not render synchronously when restoring the state, the desired `scrollLeft` is maintained even if the `scrollWidth` is small

### DIFF
--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -425,11 +425,11 @@ export class View extends ViewEventHandler {
 	}
 
 	public restoreState(scrollPosition: { scrollLeft: number; scrollTop: number }): void {
-		this._context.viewModel.viewLayout.setScrollPosition({ scrollTop: scrollPosition.scrollTop }, ScrollType.Immediate);
+		this._context.viewModel.viewLayout.setScrollPosition({
+			scrollTop: scrollPosition.scrollTop,
+			scrollLeft: scrollPosition.scrollLeft
+		}, ScrollType.Immediate);
 		this._context.viewModel.tokenizeViewport();
-		this._renderNow();
-		this._viewLines.updateLineWidths();
-		this._context.viewModel.viewLayout.setScrollPosition({ scrollLeft: scrollPosition.scrollLeft }, ScrollType.Immediate);
 	}
 
 	public getOffsetForColumn(modelLineNumber: number, modelColumn: number): number {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
