### PR TITLE
Update quick pick placeholders and/or remove titles

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2007,8 +2007,8 @@ export class CommandCenter {
 		const quickpick = window.createQuickPick();
 		quickpick.items = picks;
 		quickpick.placeholder = opts?.detached
-			? l10n.t('Select a ref to checkout in detached mode')
-			: l10n.t('Select a ref to checkout');
+			? l10n.t('Select a branch or tag to checkout in detached mode')
+			: l10n.t('Select a branch or tag to checkout');
 
 		quickpick.show();
 

--- a/extensions/json-language-features/client/src/languageStatus.ts
+++ b/extensions/json-language-features/client/src/languageStatus.ts
@@ -149,8 +149,7 @@ function showSchemaList(input: ShowSchemasInput) {
 	items.push({ label: localize('schema.showdocs', 'Learn more about JSON schema configuration...'), uri: Uri.parse('https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings') });
 
 	const quickPick = window.createQuickPick<ShowSchemasItem>();
-	quickPick.title = localize('schemaPicker.title', 'JSON Schemas used for {0}', input.uri);
-	//	quickPick.placeholder = items.length ? localize('schemaPicker.placeholder', 'Select the schema to open') : undefined;
+	quickPick.placeholder = items.length ? localize('schemaPicker.placeholder', 'Select the schema to use for {0}', input.uri) : undefined;
 	quickPick.items = items;
 	quickPick.show();
 	quickPick.onDidAccept(() => {

--- a/extensions/npm/src/commands.ts
+++ b/extensions/npm/src/commands.ts
@@ -41,8 +41,7 @@ export async function selectAndRunScriptFromFolder(context: vscode.ExtensionCont
 
 	if (taskList && taskList.length > 0) {
 		const quickPick = vscode.window.createQuickPick<IFolderTaskItem>();
-		quickPick.title = 'Run NPM script in Folder';
-		quickPick.placeholder = 'Select an npm script';
+		quickPick.placeholder = 'Select an npm script to run in folder';
 		quickPick.items = taskList;
 
 		const toDispose: vscode.Disposable[] = [];

--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -747,8 +747,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 		const workspaceContext = this.contextService.getWorkbenchState() === WorkbenchState.FOLDER
 			? this.contextService.getWorkspace().folders[0].name
 			: this.contextService.getWorkspace().folders.map((folder) => folder.name).join(', ');
-		quickPick.title = localize('continueEditSessionPick.title', "Continue {0} on", `'${workspaceContext}'`);
-		quickPick.placeholder = localize('continueEditSessionPick.placeholder', 'Choose how you would like to continue working');
+		quickPick.placeholder = localize('continueEditSessionPick.title', "Select option to continue {0} on", `'${workspaceContext}'`);
 		quickPick.items = this.createPickItems();
 
 		const command = await new Promise<string | undefined>((resolve, reject) => {

--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
@@ -294,9 +294,8 @@ export class EditSessionsWorkbenchService extends Disposable implements IEditSes
 	 */
 	private async getAccountPreference(fromContinueOn: boolean): Promise<AuthenticationSession & { providerId: string } | undefined> {
 		const quickpick = this.quickInputService.createQuickPick<ExistingSession | AuthenticationProviderOption | IQuickPickItem>();
-		quickpick.title = localize('account preference', 'Turn on Edit Sessions to bring your working changes with you');
 		quickpick.ok = false;
-		quickpick.placeholder = localize('choose account placeholder', "Select an account to sign in");
+		quickpick.placeholder = localize('choose account placeholder', "Select an account to turn on Edit Sessions");
 		quickpick.ignoreFocusOut = true;
 		quickpick.items = await this.createQuickpickItems(fromContinueOn);
 

--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -472,6 +472,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 		};
 
 		const quickPick = this.quickInputService.createQuickPick();
+		quickPick.placeholder = nls.localize('remoteActions', "Select an option to open a Remote Window");
 		quickPick.items = computeItems();
 		quickPick.sortByLabel = false;
 		quickPick.canSelectMany = false;

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -260,9 +260,8 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 
 	private async getAccountPreference(): Promise<ExistingSessionItem | undefined> {
 		const quickpick = this.quickInputService.createQuickPick<ExistingSessionItem | AuthenticationProviderOption | IQuickPickItem>();
-		quickpick.title = localize('accountPreference.title', 'Enable remote access by signing up to remote tunnels.');
 		quickpick.ok = false;
-		quickpick.placeholder = localize('accountPreference.placeholder', "Select an account to sign in");
+		quickpick.placeholder = localize('accountPreference.placeholder', "Sign in to an account to enable remote access");
 		quickpick.ignoreFocusOut = true;
 		quickpick.items = await this.createQuickpickItems();
 

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfileActions.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfileActions.ts
@@ -219,7 +219,7 @@ export class RenameProfileAction extends Action2 {
 
 		const name = await quickInputService.input({
 			value: profile.name,
-			title: localize('edit settings profile', "Rename Settings Profile..."),
+			title: localize('select settings profile to rename', 'Rename {0}', profile.name),
 			validateInput: async (value: string) => {
 				if (profile!.name !== value && userDataProfilesService.profiles.some(p => p.name === value)) {
 					return localize('profileExists', "Settings Profile with name {0} already exists.", value);
@@ -248,6 +248,7 @@ export class RenameProfileAction extends Action2 {
 				profile
 			})),
 			{
+				title: localize('rename specific settings profile', "Rename Settings Profile..."),
 				placeHolder: localize('pick profile to rename', "Select Settings Profile to Rename"),
 			});
 		return pick?.profile;
@@ -294,6 +295,7 @@ registerAction2(class DeleteProfileAction extends Action2 {
 					profile
 				})),
 				{
+					title: localize('delete specific settings profile', "Delete Settings Profile..."),
 					placeHolder: localize('pick profile to delete', "Select Settings Profiles to Delete"),
 					canPickMany: true
 				});

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -232,7 +232,7 @@ registerAction2(class extends Action2 {
 		quickPick.canSelectMany = false;
 		quickPick.matchOnDescription = true;
 		quickPick.matchOnDetail = true;
-		quickPick.title = localize('pickWalkthroughs', "Open Walkthrough...");
+		quickPick.placeholder = localize('pickWalkthroughs', 'Select a walkthrough to open');
 		quickPick.items = this.getQuickPickItems(contextService, gettingStartedService);
 		quickPick.busy = true;
 		quickPick.onDidAccept(() => {


### PR DESCRIPTION
Partially fixes #158895 by either..
- Removing unnecessary quick pick titles and using placeholders instead
- Just updating placeholder text to better describe quick pick's purpose

## Modified quick picks
- Checkout branch/tag
- JSON schema picker 
- Run NPM scripts from foler
- Turn on edit sessions
- Open remote window
- Enable remote access
- Rename settings profiles
- Open walkthrough