### PR TITLE
Update bootstrap-node.js to check for Array.isArray

### DIFF
--- a/src/bootstrap-node.js
+++ b/src/bootstrap-node.js
@@ -77,12 +77,15 @@ exports.removeGlobalNodeModuleLookupPaths = function () {
 
 	// @ts-ignore
 	Module._resolveLookupPaths = function (moduleName, parent) {
-		const paths = originalResolveLookupPaths(moduleName, parent);
-		let commonSuffixLength = 0;
-		while (commonSuffixLength < paths.length && paths[paths.length - 1 - commonSuffixLength] === globalPaths[globalPaths.length - 1 - commonSuffixLength]) {
-			commonSuffixLength++;
+		if (Array.isArray(paths)) {
+			const paths = originalResolveLookupPaths(moduleName, parent);
+			let commonSuffixLength = 0;
+			while (commonSuffixLength < paths.length && paths[paths.length - 1 - commonSuffixLength] === globalPaths[globalPaths.length - 1 - commonSuffixLength]) {
+				commonSuffixLength++;
+			}
+			return paths.slice(0, paths.length - commonSuffixLength);
 		}
-		return paths.slice(0, paths.length - commonSuffixLength);
+		return paths;
 	};
 };
 

--- a/src/bootstrap-node.js
+++ b/src/bootstrap-node.js
@@ -77,8 +77,8 @@ exports.removeGlobalNodeModuleLookupPaths = function () {
 
 	// @ts-ignore
 	Module._resolveLookupPaths = function (moduleName, parent) {
+		const paths = originalResolveLookupPaths(moduleName, parent);
 		if (Array.isArray(paths)) {
-			const paths = originalResolveLookupPaths(moduleName, parent);
 			let commonSuffixLength = 0;
 			while (commonSuffixLength < paths.length && paths[paths.length - 1 - commonSuffixLength] === globalPaths[globalPaths.length - 1 - commonSuffixLength]) {
 				commonSuffixLength++;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Issue: #165288

As mentioned in the issue, we're seeing 

```
[85180:1102/151514.317775:INFO:CONSOLE(231)] "%c  ERR color: #f33 [Extension Host] TypeError: Cannot read properties of null (reading 'length')
	at Module._resolveLookupPaths (/Users/zube/vscode-distro/out/bootstrap-node.js:83:38)
	at Module._resolveLookupPaths (/Users/zube/vscode-distro/out/bootstrap.js:84:18)
	at node_module._resolveLookupPaths (/Users/zube/vscode-distro/out/vs/workbench/api/node/extHostExtensionService.js:23:39)
	at Module._resolveFilename (node:internal/modules/cjs/loader:941:20)
	at o._resolveFilename (node:electron/js2c/utility_process_init:17:848)
	at Module._load (node:internal/modules/cjs/loader:832:27)
```

on the console at startup in our fork.  Adding the Array.isArray() check resolves this issue from throwing the exception.  It is also noted that this check is done in a similar block within bootstrap.js so this diff mimics that behavior.
