### PR TITLE
Fix renderHeight being undefined

### DIFF
--- a/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
+++ b/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
@@ -328,7 +328,7 @@ export class TimelinePane extends ViewPane {
 		let pageSize = this.configurationService.getValue<number | null | undefined>('timeline.pageSize');
 		if (pageSize === undefined || pageSize === null) {
 			// If we are paging when scrolling, then add an extra item to the end to make sure the "Load more" item is out of view
-			pageSize = Math.max(20, Math.floor((this.tree.renderHeight / ItemHeight) + (this.pageOnScroll ? 1 : -1)));
+			pageSize = Math.max(20, Math.floor((this.tree?.renderHeight ?? 0 / ItemHeight) + (this.pageOnScroll ? 1 : -1)));
 		}
 		return pageSize;
 	}


### PR DESCRIPTION
Fixes #165343

Not sure if there was a cahnge recently to optimize how we render views, but seems like `renderBody` now doesn't get called if a view is collapsed meaning the tree stays undefined. This wasn't caught because the tree is non-null asserted. I didn't change that, but I do catch the case when we try to render without a tree.