### PR TITLE
eslint: add a new rule to enforce `declare _serviceBrand: undefined`

### DIFF
--- a/.eslintplugin/code-declare-service-brand.ts
+++ b/.eslintplugin/code-declare-service-brand.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as eslint from 'eslint';
+
+export = new class DeclareServiceBrand implements eslint.Rule.RuleModule {
+
+	readonly meta: eslint.Rule.RuleMetaData = {
+		fixable: 'code'
+	};
+
+	create(context: eslint.Rule.RuleContext): eslint.Rule.RuleListener {
+		return {
+			['PropertyDefinition[key.name="_serviceBrand"][value]']: (node: any) => {
+				return context.report({
+					node,
+					message: `The '_serviceBrand'-property should not have a value`,
+					fix: (fixer) => {
+						return fixer.replaceText(node, 'declare _serviceBrand: undefined;')
+					}
+				});
+			}
+		};
+	}
+};

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,6 +72,7 @@
 		"local/code-no-nls-in-standalone-editor": "warn",
 		"local/code-no-standalone-editor": "warn",
 		"local/code-no-unexternalized-strings": "warn",
+		"local/code-declare-service-brand": "warn",
 		"local/code-layering": [
 			"warn",
 			{
@@ -331,7 +332,7 @@
 							"vs/base/parts/*/~",
 							"vs/platform/*/~",
 							"tas-client-umd", // node module allowed even in /common/
-							"@microsoft/1ds-core-js",// node module allowed even in /common/
+							"@microsoft/1ds-core-js", // node module allowed even in /common/
 							"@microsoft/1ds-post-js" // node module allowed even in /common/
 						]
 					},

--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
@@ -35,7 +35,7 @@ type AuthenticationProviderOption = IQuickPickItem & { provider: IAuthentication
 const configureContinueOnPreference = { iconClass: Codicon.settingsGear.classNames, tooltip: localize('configure continue on', 'Configure this preference in settings') };
 export class EditSessionsWorkbenchService extends Disposable implements IEditSessionsStorageService {
 
-	_serviceBrand = undefined;
+	declare _serviceBrand: undefined;
 
 	private serverConfiguration = this.productService['editSessions.store'];
 	private storeClient: EditSessionsStoreClient | undefined;


### PR DESCRIPTION
The `_serviceBrand` property is only needed for type checking, not at runtime. This rule enforces no value is set which in return means no output is generated. Saves a few bytes