### PR TITLE
Fix arrows in side-by-side diff view

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/diff/diffComponents.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/diffComponents.ts
@@ -94,6 +94,7 @@ export const fixedDiffEditorOptions: IDiffEditorConstructionOptions = {
 	glyphMargin: true,
 	enableSplitViewResizing: false,
 	renderIndicators: true,
+	renderMarginRevertIcon: false,
 	readOnly: false,
 	isInEmbeddedEditor: true,
 	renderOverviewRuler: false,


### PR DESCRIPTION
This PR:

- is a partial fix for #165189 - the arrows now won't show up in the notebook diff view. This is a fixed behavior, regardless of what the user setting is, following the existing example of other notebook diff configs.
- addresses the issue that arrows show up even when the right-hand-side editor is readonly (not sure if this is mentioned in an issue before).
- addresses the issue that sometimes an arrow reverts the wrong deleted block (not mentioned in an issue before as far as I know), please see following gifs for demo:

Before fix: 
![bug-revert-in-diff](https://user-images.githubusercontent.com/15076498/199826853-4966b411-7e85-4bbb-b748-fa619569b71a.gif)

After fix:
![fix-revert-in-diff](https://user-images.githubusercontent.com/15076498/199826881-150c6ae1-64d7-47dd-b75c-3dea9226691a.gif)


CC @hediet 

I think these are small fixes, but please let me know if I should create additional issues for them, or if anything needs to be fixed / improved in the code. Thanks!