### PR TITLE
improve Git Bash integration on Windows (#151105)

### DIFF
--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -208,7 +208,7 @@ async function initializeWindowsProfiles(testPwshSourcePaths?: string[]): Promis
 			`${process.env['LocalAppData']}\\Programs\\Git\\bin\\bash.exe`,
 			`${process.env['UserProfile']}\\scoop\\apps\\git-with-openssh\\current\\bin\\bash.exe`,
 		],
-		args: ['--login']
+		args: ['--login', '-i']
 	});
 	profileSources.set('PowerShell', {
 		profileName: 'PowerShell',


### PR DESCRIPTION
Bash sessions should be started as interactive (`-i`) sessions to enable history commands by default.
This is the same setup used by the official Git for Windows JSON fragment extension for Windows Terminal.

This does not fix the issue at this time, however, because bash signal handling on Windows for quit/close/kill signals does not work as expected.