### PR TITLE
use the actual extension id as the id in the language pack

### DIFF
--- a/build/lib/i18n.js
+++ b/build/lib/i18n.js
@@ -36,12 +36,6 @@ exports.extraLanguages = [
     { id: 'hu', folderName: 'hun' },
     { id: 'tr', folderName: 'trk' }
 ];
-// non built-in extensions also that are transifex and need to be part of the language packs
-const externalExtensionsWithTranslations = {
-    'vscode-chrome-debug': 'msjsdiag.debugger-for-chrome',
-    'vscode-node-debug': 'ms-vscode.node-debug',
-    'vscode-node-debug2': 'ms-vscode.node-debug2'
-};
 var LocalizeInfo;
 (function (LocalizeInfo) {
     function is(value) {
@@ -508,10 +502,10 @@ function createXlfFilesForCoreBundle() {
     });
 }
 exports.createXlfFilesForCoreBundle = createXlfFilesForCoreBundle;
-function createL10nBundleForExtension(extensionName) {
+function createL10nBundleForExtension(extensionFolderName) {
     const result = (0, event_stream_1.through)();
     gulp.src([
-        `extensions/${extensionName}/src/**/*.ts`,
+        `extensions/${extensionFolderName}/src/**/*.ts`,
     ]).pipe((0, event_stream_1.writeArray)((err, files) => {
         if (err) {
             result.emit('error', err);
@@ -522,7 +516,7 @@ function createL10nBundleForExtension(extensionName) {
         }));
         if (Object.keys(json).length > 0) {
             result.emit('data', new File({
-                path: `${extensionName}/bundle.l10n.json`,
+                path: `extensions/${extensionFolderName}/bundle.l10n.json`,
                 contents: Buffer.from(JSON.stringify(json), 'utf8')
             }));
         }
@@ -540,10 +534,14 @@ function createXlfFilesForExtensions() {
         if (!stat.isDirectory()) {
             return;
         }
-        const extensionName = path.basename(extensionFolder.path);
-        if (extensionName === 'node_modules') {
+        const extensionFolderName = path.basename(extensionFolder.path);
+        if (extensionFolderName === 'node_modules') {
             return;
         }
+        // Get extension id and use that as the id
+        const manifest = fs.readFileSync(path.join(extensionFolder.path, 'package.json'), 'utf-8');
+        const manifestJson = JSON.parse(manifest);
+        const extensionId = manifestJson.publisher + '.' + manifestJson.name;
         counter++;
         let _l10nMap;
         function getL10nMap() {
@@ -552,17 +550,17 @@ function createXlfFilesForExtensions() {
             }
             return _l10nMap;
         }
-        (0, event_stream_1.merge)(gulp.src([`.build/extensions/${extensionName}/package.nls.json`, `.build/extensions/${extensionName}/**/nls.metadata.json`], { allowEmpty: true }), createL10nBundleForExtension(extensionName)).pipe((0, event_stream_1.through)(function (file) {
+        (0, event_stream_1.merge)(gulp.src([`.build/extensions/${extensionFolderName}/package.nls.json`, `.build/extensions/${extensionFolderName}/**/nls.metadata.json`], { allowEmpty: true }), createL10nBundleForExtension(extensionFolderName)).pipe((0, event_stream_1.through)(function (file) {
             if (file.isBuffer()) {
                 const buffer = file.contents;
                 const basename = path.basename(file.path);
                 if (basename === 'package.nls.json') {
                     const json = JSON.parse(buffer.toString('utf8'));
-                    getL10nMap().set(`extensions/${extensionName}/package`, json);
+                    getL10nMap().set(`extensions/${extensionId}/package`, json);
                 }
                 else if (basename === 'nls.metadata.json') {
                     const json = JSON.parse(buffer.toString('utf8'));
-                    const relPath = path.relative(`.build/extensions/${extensionName}`, path.dirname(file.path));
+                    const relPath = path.relative(`.build/extensions/${extensionFolderName}`, path.dirname(file.path));
                     for (const file in json) {
                         const fileContent = json[file];
                         const info = Object.create(null);
@@ -573,12 +571,12 @@ function createXlfFilesForExtensions() {
                                 : { key: fileContent.keys[i], comment: undefined };
                             info[key] = comment ? { message, comment } : message;
                         }
-                        getL10nMap().set(`extensions/${extensionName}/${relPath}/${file}`, info);
+                        getL10nMap().set(`extensions/${extensionId}/${relPath}/${file}`, info);
                     }
                 }
                 else if (basename === 'bundle.l10n.json') {
                     const json = JSON.parse(buffer.toString('utf8'));
-                    getL10nMap().set(`extensions/${extensionName}/bundle`, json);
+                    getL10nMap().set(`extensions/${extensionId}/bundle`, json);
                 }
                 else {
                     this.emit('error', new Error(`${file.path} is not a valid extension nls file`));
@@ -588,7 +586,7 @@ function createXlfFilesForExtensions() {
         }, function () {
             if (_l10nMap?.size > 0) {
                 const xlfFile = new File({
-                    path: path.join(extensionsProject, extensionName + '.xlf'),
+                    path: path.join(extensionsProject, extensionId + '.xlf'),
                     contents: Buffer.from((0, l10n_dev_1.getL10nXlf)(_l10nMap), 'utf8')
                 });
                 folderStream.queue(xlfFile);
@@ -707,18 +705,14 @@ function prepareI18nPackFiles(resultingTranslationPaths) {
                 const path = file.name;
                 const firstSlash = path.indexOf('/');
                 if (project === extensionsProject) {
+                    // resource will be the extension id
                     let extPack = extensionsPacks[resource];
                     if (!extPack) {
                         extPack = extensionsPacks[resource] = { version: i18nPackVersion, contents: {} };
                     }
-                    const externalId = externalExtensionsWithTranslations[resource];
-                    if (!externalId) { // internal extension: remove 'extensions/extensionId/' segnent
-                        const secondSlash = path.indexOf('/', firstSlash + 1);
-                        extPack.contents[path.substring(secondSlash + 1)] = getRecordFromL10nJsonFormat(file.messages);
-                    }
-                    else {
-                        extPack.contents[path] = getRecordFromL10nJsonFormat(file.messages);
-                    }
+                    // remove 'extensions/extensionId/' segment
+                    const secondSlash = path.indexOf('/', firstSlash + 1);
+                    extPack.contents[path.substring(secondSlash + 1)] = getRecordFromL10nJsonFormat(file.messages);
                 }
                 else {
                     mainPack.contents[path.substring(firstSlash + 1)] = getRecordFromL10nJsonFormat(file.messages);
@@ -736,16 +730,10 @@ function prepareI18nPackFiles(resultingTranslationPaths) {
             const translatedMainFile = createI18nFile('./main', mainPack);
             resultingTranslationPaths.push({ id: 'vscode', resourceName: 'main.i18n.json' });
             this.queue(translatedMainFile);
-            for (const extension in extensionsPacks) {
-                const translatedExtFile = createI18nFile(`extensions/${extension}`, extensionsPacks[extension]);
+            for (const extensionId in extensionsPacks) {
+                const translatedExtFile = createI18nFile(`extensions/${extensionId}`, extensionsPacks[extensionId]);
                 this.queue(translatedExtFile);
-                const externalExtensionId = externalExtensionsWithTranslations[extension];
-                if (externalExtensionId) {
-                    resultingTranslationPaths.push({ id: externalExtensionId, resourceName: `extensions/${extension}.i18n.json` });
-                }
-                else {
-                    resultingTranslationPaths.push({ id: `vscode.${extension}`, resourceName: `extensions/${extension}.i18n.json` });
-                }
+                resultingTranslationPaths.push({ id: extensionId, resourceName: `extensions/${extensionId}.i18n.json` });
             }
             this.queue(null);
         })

--- a/build/lib/i18n.ts
+++ b/build/lib/i18n.ts
@@ -49,13 +49,6 @@ export const extraLanguages: Language[] = [
 	{ id: 'tr', folderName: 'trk' }
 ];
 
-// non built-in extensions also that are transifex and need to be part of the language packs
-const externalExtensionsWithTranslations: Record<string, string> = {
-	'vscode-chrome-debug': 'msjsdiag.debugger-for-chrome',
-	'vscode-node-debug': 'ms-vscode.node-debug',
-	'vscode-node-debug2': 'ms-vscode.node-debug2'
-};
-
 interface Item {
 	id: string;
 	message: string;
@@ -586,10 +579,10 @@ export function createXlfFilesForCoreBundle(): ThroughStream {
 	});
 }
 
-function createL10nBundleForExtension(extensionName: string): ThroughStream {
+function createL10nBundleForExtension(extensionFolderName: string): ThroughStream {
 	const result = through();
 	gulp.src([
-		`extensions/${extensionName}/src/**/*.ts`,
+		`extensions/${extensionFolderName}/src/**/*.ts`,
 	]).pipe(writeArray((err, files: File[]) => {
 		if (err) {
 			result.emit('error', err);
@@ -602,7 +595,7 @@ function createL10nBundleForExtension(extensionName: string): ThroughStream {
 
 		if (Object.keys(json).length > 0) {
 			result.emit('data', new File({
-				path: `${extensionName}/bundle.l10n.json`,
+				path: `extensions/${extensionFolderName}/bundle.l10n.json`,
 				contents: Buffer.from(JSON.stringify(json), 'utf8')
 			}));
 		}
@@ -622,10 +615,15 @@ export function createXlfFilesForExtensions(): ThroughStream {
 		if (!stat.isDirectory()) {
 			return;
 		}
-		const extensionName = path.basename(extensionFolder.path);
-		if (extensionName === 'node_modules') {
+		const extensionFolderName = path.basename(extensionFolder.path);
+		if (extensionFolderName === 'node_modules') {
 			return;
 		}
+		// Get extension id and use that as the id
+		const manifest = fs.readFileSync(path.join(extensionFolder.path, 'package.json'), 'utf-8');
+		const manifestJson = JSON.parse(manifest);
+		const extensionId = manifestJson.publisher + '.' + manifestJson.name;
+
 		counter++;
 		let _l10nMap: Map<string, l10nJsonFormat>;
 		function getL10nMap() {
@@ -635,18 +633,18 @@ export function createXlfFilesForExtensions(): ThroughStream {
 			return _l10nMap;
 		}
 		merge(
-			gulp.src([`.build/extensions/${extensionName}/package.nls.json`, `.build/extensions/${extensionName}/**/nls.metadata.json`], { allowEmpty: true }),
-			createL10nBundleForExtension(extensionName)
+			gulp.src([`.build/extensions/${extensionFolderName}/package.nls.json`, `.build/extensions/${extensionFolderName}/**/nls.metadata.json`], { allowEmpty: true }),
+			createL10nBundleForExtension(extensionFolderName)
 		).pipe(through(function (file: File) {
 			if (file.isBuffer()) {
 				const buffer: Buffer = file.contents as Buffer;
 				const basename = path.basename(file.path);
 				if (basename === 'package.nls.json') {
 					const json: l10nJsonFormat = JSON.parse(buffer.toString('utf8'));
-					getL10nMap().set(`extensions/${extensionName}/package`, json);
+					getL10nMap().set(`extensions/${extensionId}/package`, json);
 				} else if (basename === 'nls.metadata.json') {
 					const json: BundledExtensionFormat = JSON.parse(buffer.toString('utf8'));
-					const relPath = path.relative(`.build/extensions/${extensionName}`, path.dirname(file.path));
+					const relPath = path.relative(`.build/extensions/${extensionFolderName}`, path.dirname(file.path));
 					for (const file in json) {
 						const fileContent = json[file];
 						const info: l10nJsonFormat = Object.create(null);
@@ -658,11 +656,11 @@ export function createXlfFilesForExtensions(): ThroughStream {
 
 							info[key] = comment ? { message, comment } : message;
 						}
-						getL10nMap().set(`extensions/${extensionName}/${relPath}/${file}`, info);
+						getL10nMap().set(`extensions/${extensionId}/${relPath}/${file}`, info);
 					}
 				} else if (basename === 'bundle.l10n.json') {
 					const json: l10nJsonFormat = JSON.parse(buffer.toString('utf8'));
-					getL10nMap().set(`extensions/${extensionName}/bundle`, json);
+					getL10nMap().set(`extensions/${extensionId}/bundle`, json);
 				} else {
 					this.emit('error', new Error(`${file.path} is not a valid extension nls file`));
 					return;
@@ -671,7 +669,7 @@ export function createXlfFilesForExtensions(): ThroughStream {
 		}, function () {
 			if (_l10nMap?.size > 0) {
 				const xlfFile = new File({
-					path: path.join(extensionsProject, extensionName + '.xlf'),
+					path: path.join(extensionsProject, extensionId + '.xlf'),
 					contents: Buffer.from(getL10nXlf(_l10nMap), 'utf8')
 				});
 				folderStream.queue(xlfFile);
@@ -813,17 +811,14 @@ export function prepareI18nPackFiles(resultingTranslationPaths: TranslationPath[
 					const firstSlash = path.indexOf('/');
 
 					if (project === extensionsProject) {
+						// resource will be the extension id
 						let extPack = extensionsPacks[resource];
 						if (!extPack) {
 							extPack = extensionsPacks[resource] = { version: i18nPackVersion, contents: {} };
 						}
-						const externalId = externalExtensionsWithTranslations[resource];
-						if (!externalId) { // internal extension: remove 'extensions/extensionId/' segnent
-							const secondSlash = path.indexOf('/', firstSlash + 1);
-							extPack.contents[path.substring(secondSlash + 1)] = getRecordFromL10nJsonFormat(file.messages);
-						} else {
-							extPack.contents[path] = getRecordFromL10nJsonFormat(file.messages);
-						}
+						// remove 'extensions/extensionId/' segment
+						const secondSlash = path.indexOf('/', firstSlash + 1);
+						extPack.contents[path.substring(secondSlash + 1)] = getRecordFromL10nJsonFormat(file.messages);
 					} else {
 						mainPack.contents[path.substring(firstSlash + 1)] = getRecordFromL10nJsonFormat(file.messages);
 					}
@@ -842,17 +837,11 @@ export function prepareI18nPackFiles(resultingTranslationPaths: TranslationPath[
 				resultingTranslationPaths.push({ id: 'vscode', resourceName: 'main.i18n.json' });
 
 				this.queue(translatedMainFile);
-				for (const extension in extensionsPacks) {
-					const translatedExtFile = createI18nFile(`extensions/${extension}`, extensionsPacks[extension]);
+				for (const extensionId in extensionsPacks) {
+					const translatedExtFile = createI18nFile(`extensions/${extensionId}`, extensionsPacks[extensionId]);
 					this.queue(translatedExtFile);
 
-					const externalExtensionId = externalExtensionsWithTranslations[extension];
-					if (externalExtensionId) {
-						resultingTranslationPaths.push({ id: externalExtensionId, resourceName: `extensions/${extension}.i18n.json` });
-					} else {
-						resultingTranslationPaths.push({ id: `vscode.${extension}`, resourceName: `extensions/${extension}.i18n.json` });
-					}
-
+					resultingTranslationPaths.push({ id: extensionId, resourceName: `extensions/${extensionId}.i18n.json` });
 				}
 				this.queue(null);
 			})


### PR DESCRIPTION
Past behavior caused 404s to be thrown by the unpkg service because core was trying to load:

`${extensionId}` -> `vscode.markdown`

and not what the build creates in the language packs:
`vscode.${extensionFolder}` -> `vscode.markdown-basics`

this aligns build time and runtime.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
