### PR TITLE
Git - Only use `this.dotGit.path` when resolving HEAD

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2083,7 +2083,7 @@ export class Repository {
 	}
 
 	async getHEADFS(): Promise<Ref> {
-		const raw = await fs.readFile(path.join(this.dotGit.commonPath ?? this.dotGit.path, 'HEAD'), 'utf8');
+		const raw = await fs.readFile(path.join(this.dotGit.path, 'HEAD'), 'utf8');
 
 		// Branch
 		const branchMatch = raw.match(/^ref: refs\/heads\/(?<name>.*)$/m);


### PR DESCRIPTION
Related #164363