### PR TITLE
Increase min-height to 100%

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -324,7 +324,7 @@
 }
 
 .settings-editor > .settings-body .settings-tree-container .monaco-list-rows {
-	min-height: 175px; /* Avoid the hover being cut off. See #164602 */
+	min-height: 100%; /* Avoid the hover being cut off. See #164602 and #165518 */
 	overflow: visible !important; /* Allow validation errors to flow out of the tree container. Override inline style from ScrollableElement. */
 }
 


### PR DESCRIPTION
Fixes #165518

A min-height of 100% makes sense because the list of settings is often over 100% in height. In other words, one often has to scroll to see the entire list of settings.

I have confirmed neither the settings list nor the gear icon hover element overlap with the taskbar.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
