### PR TITLE
Use the session access flow

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -261,12 +261,14 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		}
 
 		// passive flows (silent or default)
-
-		const validSession = sessions.find(s => this.authenticationService.isAccessAllowed(providerId, s.account.label, extensionId));
-		if (!options.silent && !validSession) {
-			await this.authenticationService.requestNewSession(providerId, scopes, extensionId, extensionName);
+		if (!options.silent) {
+			// If there is a potential session, but the extension doesn't have access to it, use the "grant access" flow,
+			// otherwise request a new one.
+			sessions.length
+				? this.authenticationService.requestSessionAccess(providerId, extensionId, extensionName, scopes, sessions)
+				: await this.authenticationService.requestNewSession(providerId, scopes, extensionId, extensionName);
 		}
-		return validSession;
+		return undefined;
 	}
 
 	async $getSession(providerId: string, scopes: string[], extensionId: string, extensionName: string, options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined> {

--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -199,12 +199,6 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		return choice === 0;
 	}
 
-	private async setTrustedExtensionAndAccountPreference(providerId: string, accountName: string, extensionId: string, extensionName: string, sessionId: string): Promise<void> {
-		this.authenticationService.updatedAllowedExtension(providerId, accountName, extensionId, extensionName, true);
-		this.storageService.store(`${extensionName}-${providerId}`, sessionId, StorageScope.APPLICATION, StorageTarget.MACHINE);
-
-	}
-
 	private async doGetSession(providerId: string, scopes: string[], extensionId: string, extensionName: string, options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined> {
 		const sessions = await this.authenticationService.getSessions(providerId, scopes, true);
 		const supportsMultipleAccounts = this.authenticationService.supportsMultipleAccounts(providerId);
@@ -224,9 +218,12 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		if (!options.forceNewSession && sessions.length) {
 			if (supportsMultipleAccounts) {
 				if (options.clearSessionPreference) {
-					this.storageService.remove(`${extensionName}-${providerId}`, StorageScope.APPLICATION);
+					// Clearing the session preference is usually paired with createIfNone, so just remove the preference and
+					// defer to the rest of the logic in this function to choose the session.
+					this.authenticationService.removeSessionPreference(providerId, extensionId, scopes);
 				} else {
-					const existingSessionPreference = this.storageService.get(`${extensionName}-${providerId}`, StorageScope.APPLICATION);
+					// If we have an existing session preference, use that. If not, we'll return any valid session at the end of this function.
+					const existingSessionPreference = this.authenticationService.getSessionPreference(providerId, extensionId, scopes);
 					if (existingSessionPreference) {
 						const matchingSession = sessions.find(session => session.id === existingSessionPreference);
 						if (matchingSession && this.authenticationService.isAccessAllowed(providerId, matchingSession.account.label, extensionId)) {
@@ -256,8 +253,25 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 			const session = sessions?.length && !options.forceNewSession && supportsMultipleAccounts
 				? await this.authenticationService.selectSession(providerId, extensionId, extensionName, scopes, sessions)
 				: await this.authenticationService.createSession(providerId, scopes, true);
-			await this.setTrustedExtensionAndAccountPreference(providerId, session.account.label, extensionId, extensionName, session.id);
+			this.authenticationService.updateAllowedExtension(providerId, session.account.label, extensionId, extensionName, true);
+			this.authenticationService.updateSessionPreference(providerId, extensionId, session);
 			return session;
+		}
+
+		// For the silent flows, if we have a session, even though it may not be the user's preference, we'll return it anyway because it might be for a specific
+		// set of scopes.
+		const validSession = sessions.find(session => this.authenticationService.isAccessAllowed(providerId, session.account.label, extensionId));
+		if (validSession) {
+			// Migration. If we have a valid session, but no preference, we'll set the preference to the valid session.
+			// TODO: Remove this after in a few releases.
+			if (!this.storageService.get(`${extensionId}-${providerId}-${scopes.join(' ')}`, StorageScope.APPLICATION)) {
+				if (this.storageService.get(`${extensionName}-${providerId}`, StorageScope.APPLICATION)) {
+					this.storageService.remove(`${extensionName}-${providerId}`, StorageScope.APPLICATION);
+				}
+				this.authenticationService.updateAllowedExtension(providerId, validSession.account.label, extensionId, extensionName, true);
+				this.authenticationService.updateSessionPreference(providerId, extensionId, validSession);
+			}
+			return validSession;
 		}
 
 		// passive flows (silent or default)

--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -264,7 +264,7 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		if (validSession) {
 			// Migration. If we have a valid session, but no preference, we'll set the preference to the valid session.
 			// TODO: Remove this after in a few releases.
-			if (!this.storageService.get(`${extensionId}-${providerId}-${scopes.join(' ')}`, StorageScope.APPLICATION)) {
+			if (!this.authenticationService.getSessionPreference(providerId, extensionId, scopes)) {
 				if (this.storageService.get(`${extensionName}-${providerId}`, StorageScope.APPLICATION)) {
 					this.storageService.remove(`${extensionName}-${providerId}`, StorageScope.APPLICATION);
 				}

--- a/src/vs/workbench/api/test/browser/extHostAuthentication.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostAuthentication.test.ts
@@ -171,9 +171,9 @@ suite('ExtHostAuthentication', () => {
 			scopes,
 			{});
 
-		assert.strictEqual(session.id, session2?.id);
-		assert.strictEqual(session.scopes[0], session2?.scopes[0]);
-		assert.strictEqual(session.accessToken, session2?.accessToken);
+		assert.strictEqual(session2?.id, session.id);
+		assert.strictEqual(session2?.scopes[0], session.scopes[0]);
+		assert.strictEqual(session2?.accessToken, session.accessToken);
 	});
 
 	// should behave the same as createIfNone: false
@@ -312,9 +312,9 @@ suite('ExtHostAuthentication', () => {
 
 		// clearing session preference causes us to get the first session
 		// because it would normally show a quick pick for the user to choose
-		assert.strictEqual(session.id, session3?.id);
-		assert.strictEqual(session.scopes[0], session3?.scopes[0]);
-		assert.strictEqual(session.accessToken, session3?.accessToken);
+		assert.strictEqual(session3?.id, session.id);
+		assert.strictEqual(session3?.scopes[0], session.scopes[0]);
+		assert.strictEqual(session3?.accessToken, session.accessToken);
 	});
 
 	test('silently getting session should return a session (if any) regardless of preference - fixes #137819', async () => {
@@ -347,18 +347,18 @@ suite('ExtHostAuthentication', () => {
 			'test-multiple',
 			scopes,
 			{});
-		assert.strictEqual(session.id, shouldBeSession1?.id);
-		assert.strictEqual(session.scopes[0], shouldBeSession1?.scopes[0]);
-		assert.strictEqual(session.accessToken, shouldBeSession1?.accessToken);
+		assert.strictEqual(shouldBeSession1?.id, session.id);
+		assert.strictEqual(shouldBeSession1?.scopes[0], session.scopes[0]);
+		assert.strictEqual(shouldBeSession1?.accessToken, session.accessToken);
 
 		const shouldBeSession2 = await extHostAuthentication.getSession(
 			extensionDescription,
 			'test-multiple',
 			scopes2,
 			{});
-		assert.strictEqual(session2.id, shouldBeSession2?.id);
-		assert.strictEqual(session2.scopes[0], shouldBeSession2?.scopes[0]);
-		assert.strictEqual(session2.accessToken, shouldBeSession2?.accessToken);
+		assert.strictEqual(shouldBeSession2?.id, session2.id);
+		assert.strictEqual(shouldBeSession2?.scopes[0], session2.scopes[0]);
+		assert.strictEqual(shouldBeSession2?.accessToken, session2.accessToken);
 	});
 
 	//#endregion

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -387,7 +387,7 @@ export class AuthenticationService extends Disposable implements IAuthentication
 		return undefined;
 	}
 
-	async updatedAllowedExtension(providerId: string, accountName: string, extensionId: string, extensionName: string, isAllowed: boolean): Promise<void> {
+	updateAllowedExtension(providerId: string, accountName: string, extensionId: string, extensionName: string, isAllowed: boolean): void {
 		const allowList = readAllowedExtensions(this.storageService, providerId, accountName);
 		const index = allowList.findIndex(extension => extension.id === extensionId);
 		if (index === -1) {
@@ -396,8 +396,28 @@ export class AuthenticationService extends Disposable implements IAuthentication
 			allowList[index].allowed = isAllowed;
 		}
 
-		await this.storageService.store(`${providerId}-${accountName}`, JSON.stringify(allowList), StorageScope.APPLICATION, StorageTarget.USER);
+		this.storageService.store(`${providerId}-${accountName}`, JSON.stringify(allowList), StorageScope.APPLICATION, StorageTarget.USER);
 	}
+
+	//#region Session Preference
+
+	updateSessionPreference(providerId: string, extensionId: string, session: AuthenticationSession): void {
+		// The 3 parts of this key are important:
+		// * Extension id: The extension that has a preference
+		// * Provider id: The provider that the preference is for
+		// * The scopes: The subset of sessions that the preference applies to
+		this.storageService.store(`${extensionId}-${providerId}-${session.scopes.join(' ')}`, session.id, StorageScope.APPLICATION, StorageTarget.MACHINE);
+	}
+
+	getSessionPreference(providerId: string, extensionId: string, scopes: string[]): string | undefined {
+		return this.storageService.get(`${extensionId}-${providerId}-${scopes.join(' ')}`, StorageScope.APPLICATION, undefined);
+	}
+
+	removeSessionPreference(providerId: string, extensionId: string, scopes: string[]): void {
+		this.storageService.remove(`${extensionId}-${providerId}-${scopes.join(' ')}`, StorageScope.APPLICATION);
+	}
+
+	//#endregion
 
 	async showGetSessionPrompt(providerId: string, accountName: string, extensionId: string, extensionName: string): Promise<boolean> {
 		const providerName = this.getLabel(providerId);
@@ -413,7 +433,7 @@ export class AuthenticationService extends Disposable implements IAuthentication
 		const cancelled = choice === 2;
 		const allowed = choice === 0;
 		if (!cancelled) {
-			this.updatedAllowedExtension(providerId, accountName, extensionId, extensionName, allowed);
+			this.updateAllowedExtension(providerId, accountName, extensionId, extensionName, allowed);
 			this.removeAccessRequest(providerId, extensionId);
 		}
 
@@ -458,10 +478,9 @@ export class AuthenticationService extends Disposable implements IAuthentication
 				const session = quickPick.selectedItems[0].session ?? await this.createSession(providerId, scopes);
 				const accountName = session.account.label;
 
-				this.updatedAllowedExtension(providerId, accountName, extensionId, extensionName, true);
-
+				this.updateAllowedExtension(providerId, accountName, extensionId, extensionName, true);
+				this.updateSessionPreference(providerId, extensionId, session);
 				this.removeAccessRequest(providerId, extensionId);
-				this.storageService.store(`${extensionName}-${providerId}`, session.id, StorageScope.APPLICATION, StorageTarget.MACHINE);
 
 				quickPick.dispose();
 				resolve(session);
@@ -595,14 +614,10 @@ export class AuthenticationService extends Disposable implements IAuthentication
 			id: commandId,
 			handler: async (accessor) => {
 				const authenticationService = accessor.get(IAuthenticationService);
-				const storageService = accessor.get(IStorageService);
 				const session = await authenticationService.createSession(providerId, scopes);
 
-				// Add extension to allow list since user explicitly signed in on behalf of it
-				this.updatedAllowedExtension(providerId, session.account.label, extensionId, extensionName, true);
-
-				// And also set it as the preferred account for the extension
-				storageService.store(`${extensionName}-${providerId}`, session.id, StorageScope.APPLICATION, StorageTarget.MACHINE);
+				this.updateAllowedExtension(providerId, session.account.label, extensionId, extensionName, true);
+				this.updateSessionPreference(providerId, extensionId, session);
 			}
 		});
 

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -551,9 +551,10 @@ export class AuthenticationService extends Disposable implements IAuthentication
 			// since this is sync and returns a disposable. So, wait for registration event to fire that indicates the
 			// provider is now in the map.
 			await new Promise<void>((resolve, _) => {
-				this.onDidRegisterAuthenticationProvider(e => {
+				const dispose = this.onDidRegisterAuthenticationProvider(e => {
 					if (e.id === providerId) {
 						provider = this._authenticationProviders.get(providerId);
+						dispose.dispose();
 						resolve();
 					}
 				});

--- a/src/vs/workbench/services/authentication/common/authentication.ts
+++ b/src/vs/workbench/services/authentication/common/authentication.ts
@@ -37,7 +37,10 @@ export interface IAuthenticationService {
 	registerAuthenticationProvider(id: string, provider: IAuthenticationProvider): void;
 	unregisterAuthenticationProvider(id: string): void;
 	isAccessAllowed(providerId: string, accountName: string, extensionId: string): boolean | undefined;
-	updatedAllowedExtension(providerId: string, accountName: string, extensionId: string, extensionName: string, isAllowed: boolean): Promise<void>;
+	updateAllowedExtension(providerId: string, accountName: string, extensionId: string, extensionName: string, isAllowed: boolean): void;
+	updateSessionPreference(providerId: string, extensionId: string, session: AuthenticationSession): void;
+	getSessionPreference(providerId: string, extensionId: string, scopes: string[]): string | undefined;
+	removeSessionPreference(providerId: string, extensionId: string, scopes: string[]): void;
 	showGetSessionPrompt(providerId: string, accountName: string, extensionId: string, extensionName: string): Promise<boolean>;
 	selectSession(providerId: string, extensionId: string, extensionName: string, scopes: string[], possibleSessions: readonly AuthenticationSession[]): Promise<AuthenticationSession>;
 	requestSessionAccess(providerId: string, extensionId: string, extensionName: string, scopes: string[], possibleSessions: readonly AuthenticationSession[]): void;


### PR DESCRIPTION
At some point I accidentally stopped using `requestSessionAccess`. It helps a ton when you have multiple extensions that are requesting the same scopes. This re-uses it.

Also fixed a leaking disposable.

The initial commit exposed another bigger problem... session preference wasn't factoring scopes. An extension should be able to have 2 sessions from the same auth provider with a different set of scopes and each of those provider/scopes combo should have a "preference"... The next commit does just this by making session preference a extension/provider/scope concept... and moves it into the AuthService instead of it being all over the place. Thankfully I had a test for this exact scenario already :) 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
