### PR TITLE
[themes] Make focus indicator noticeable (#165386)

### DIFF
--- a/extensions/theme-monokai/themes/monokai-color-theme.json
+++ b/extensions/theme-monokai/themes/monokai-color-theme.json
@@ -61,7 +61,7 @@
 		"pickerGroup.foreground": "#75715E",
 		"input.background": "#414339",
 		"inputOption.activeBorder": "#75715E",
-		"focusBorder": "#75715E",
+		"focusBorder": "#a59a61",
 		"editorWidget.background": "#1e1f1c",
 		"debugToolBar.background": "#1e1f1c",
 		"diffEditor.insertedTextBackground": "#4b661680", // middle of #272822 and #a6e22e

--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -476,7 +476,7 @@
       	}
 	],
 	"colors": {
-		"focusBorder": "#A6B39B",
+		"focusBorder": "#56b800",
 		"pickerGroup.foreground": "#A6B39B",
 		"pickerGroup.border": "#749351",
 		"list.activeSelectionForeground": "#6c6c6c",

--- a/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
+++ b/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
@@ -327,7 +327,7 @@
 	"colors": {
 		// Base
 		// "foreground": "",
-		"focusBorder": "#D3AF86",
+		"focusBorder": "#d18126",
 		// "contrastActiveBorder": "",
 		// "contrastBorder": "",
 		// "widget.shadow": "",


### PR DESCRIPTION
At themes monokai, quiet light, solarized light
focusBorder and inputOption.activeBorder hold the same values. User can't see focus indicator due to the similar values. Changes focusBorder values to create contrast.
Focus now can be noticed in those themes.

Fixes issue #165386 - more info and GIF preview before and after the change at the issue

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
