### PR TITLE
Telemetry: log command execution time

### DIFF
--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -237,11 +237,8 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 
 		const start = Date.now();
 		try {
-			const result = await callback.apply(thisArg, args);
-			this._reportTelemetry(command, id, Date.now() - start);
-			return result;
+			return await callback.apply(thisArg, args);
 		} catch (err) {
-			this._reportTelemetry(command, id, Date.now() - start);
 			// The indirection-command from the converter can fail when invoking the actual
 			// command and in that case it is better to blame the correct command
 			if (id === this.converter.delegatingCommandId) {
@@ -264,6 +261,9 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 				}
 			};
 		}
+		finally {
+			this._reportTelemetry(command, id, Date.now() - start);
+		}
 	}
 
 	private _reportTelemetry(command: CommandHandler, id: string, duration: number) {
@@ -278,7 +278,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		type ExtensionActionTelemetryMeta = {
 			extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The id of the extension handling the command, informing which extensions provide most-used functionality.' };
 			id: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The id of the command, to understand which specific extension features are most popular.' };
-			duration: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The duration of the command execution, to detect performance issues' };
+			duration: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The duration of the command execution, to detect performance issues' };
 			owner: 'digitarald';
 			comment: 'Used to gain insight on the most popular commands used from extensions';
 		};


### PR DESCRIPTION
Monitoring execution time can be useful when investigating performance issues and detecting performance regressions.

VS Code already logs the extension activation times (ExtensionActivationTimesClassification). Logging command execution times seems consistent.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
