### PR TITLE
shellIntegration.fish: escape values in "E" (executed command) and "P" (property KV) codes

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
@@ -63,7 +63,7 @@ end
 # Sent whenever a new fish prompt is about to be displayed.
 # Updates the current working directory.
 function __vsc_update_cwd --on-event fish_prompt
-	__vsc_esc P "Cwd=$PWD"
+	__vsc_esc P "Cwd=$(__vsc_escape_value "$PWD")"
 
 	# If a command marker exists, remove it.
 	# Otherwise, the commandline is empty and no command was run.

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
@@ -24,7 +24,7 @@ set --global VSCODE_SHELL_INTEGRATION 1
 
 # Helper function
 function __vsc_esc -d "Emit escape sequences for VS Code shell integration"
-	builtin printf "\e]633;%s\007" (string join ";" $argv)
+	builtin printf "\e]633;%s\a" (string join ";" $argv)
 end
 
 # Sent right before executing an interactive command.
@@ -44,8 +44,8 @@ function __vsc_escape_cmd
 	# `string replace` automatically breaks its input apart on any newlines.
 	# Then `string join` at the end will bring it all back together.
 	string replace --all '\\' '\\\\' $commandline \
-		| string replace --all ';' '\x3b' \
-		| string join '\x0a'
+		| string replace --all ';' '\\x3b' \
+		| string join '\\x0a'
 end
 
 # Sent right after an interactive command has finished executing.

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
@@ -39,13 +39,25 @@ end
 
 
 # Escape a value for use in the 'P' ("Property") or 'E' ("Command Line") sequences.
+# Backslashes are doubled and non-alphanumeric characters are hex encoded.
 function __vsc_escape_value
-	set -l commandline "$argv"
-	# `string replace` automatically breaks its input apart on any newlines.
-	# Then `string join` at the end will bring it all back together.
-	string replace --all '\\' '\\\\' $commandline \
-		| string replace --all ';' '\\x3b' \
-		| string join '\\x0a'
+	# Replace all non-alnum characters with %XX hex form.
+	string escape --style=url "$argv" \
+	# The characters [-./_~] are not encoded in the builtin url escaping, despite not being alphanumeric.
+	# See: https://github.com/fish-shell/fish-shell/blob/f82537bcdcb32f85a530395f00e7be1aa9afc592/src/common.cpp#L738
+	# For consistency, also encode those characters.
+	| string replace --all '-' '%2D' \
+	| string replace --all '.' '%2E' \
+	| string replace --all '/' '%2F' \
+	| string replace --all '_' '%5F' \
+	| string replace --all '~' '%7E' \
+	# Now everything is either alphanumeric [0-9A-Za-z] or %XX escapes.
+	# Change the hex escape representation from '%' to '\x'. (e.g. ' ' → '%20' → '\x20').
+	# Note that all '%' characters are escapes: literal '%' will already have been encoded.
+	| string replace --all '%' '\\x' \
+	# For readability, prefer to represent literal backslashes with doubling. ('\' → '%5C' → '\x5C' → '\\').
+	| string replace --all --ignore-case '%5C' '\\\\' \
+	;
 end
 
 # Sent right after an interactive command has finished executing.

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
@@ -31,15 +31,15 @@ end
 # Marks the beginning of command output.
 function __vsc_cmd_executed --on-event fish_preexec
 	__vsc_esc C
-	__vsc_esc E (__vsc_escape_cmd "$argv")
+	__vsc_esc E (__vsc_escape_value "$argv")
 
 	# Creates a marker to indicate a command was run.
 	set --global _vsc_has_cmd
 end
 
 
-# Escapes backslashes, newlines, and semicolons to serialize the command line.
-function __vsc_escape_cmd
+# Escape a value for use in the 'P' ("Property") or 'E' ("Command Line") sequences.
+function __vsc_escape_value
 	set -l commandline "$argv"
 	# `string replace` automatically breaks its input apart on any newlines.
 	# Then `string join` at the end will bring it all back together.


### PR DESCRIPTION
This implements the string escaping scheme documented for the "E" (executed) and "P" (property KV) codes. This is "pure" fish and relies on no external utilities.

Although currently the only "required" escapes are backslash, semicolon, \x07, and perhaps newlines, this conservatively escapes all non-alphanumeric characters.

Backslashes are doubled, non-alphanumerics are hex-escaped.

Sibling to:
 * #165632
 * #165633
 * #165634
 * #165635

Relates to:
 * #139400
 * #157546
 * #155639

and others.