### PR TITLE
shellIntegration.ps1: escape values in "E" (executed command) and "P" (property KV) codes

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -18,7 +18,17 @@ $Global:__VSCodeOriginalPrompt = $function:Prompt
 $Global:__LastHistoryId = -1
 
 function Global:__VSCode-Escape-Value([string]$value) {
-	$value.Replace("\", "\\").Replace("`n", "\x0a").Replace(";", "\x3b")
+	# NOTE: In PowerShell v6.1+, this can be written `$value -replace '…', { … }` instead of `[regex]::Replace`.
+	# Replace any non-alphanumeric characters.
+	[regex]::Replace($value, '[^a-zA-Z0-9]', { param($match)
+		# Backslashes must be doubled.
+		if ($match.Value -eq '\') {
+			'\\'
+		} else {
+			# Any other character is encoded as hex.
+			'\x{0:x2}' -f [int][char]$match.Value
+		}
+	})
 }
 
 function Global:Prompt() {

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -16,10 +16,9 @@ if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
 $Global:__VSCodeOriginalPrompt = $function:Prompt
 
 $Global:__LastHistoryId = -1
-function Set-Serialized {
-	param ([string] $toSerialize)
-	$toSerialize = $toSerialize.Replace("\", "\\").Replace("`n", "\x0a").Replace(";", "\x3b")
-	return $toSerialize
+
+function Global:__VSCode-Escape-Value([string]$value) {
+	$value.Replace("\", "\\").Replace("`n", "\x0a").Replace(";", "\x3b")
 }
 
 function Global:Prompt() {
@@ -43,7 +42,7 @@ function Global:Prompt() {
 			} else {
 				$CommandLine = ""
 			}
-			$Result += Set-Serialized($CommandLine)
+			$Result += $(__VSCode-Escape-Value $CommandLine)
 			$Result += "`a"
 			# Command finished exit code
 			# OSC 633 ; D [; <ExitCode>] ST

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -25,8 +25,11 @@ function Global:__VSCode-Escape-Value([string]$value) {
 		if ($match.Value -eq '\') {
 			'\\'
 		} else {
-			# Any other character is encoded as hex.
-			'\x{0:x2}' -f [int][char]$match.Value
+			# Any other characters are encoded as their UTF-8 hex values.
+			-Join (
+				[System.Text.Encoding]::UTF8.GetBytes($match.Value)
+				| ForEach-Object { '\x{0:x2}' -f $_ }
+			)
 		}
 	})
 }

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -64,7 +64,7 @@ function Global:Prompt() {
 	$Result += "$([char]0x1b)]633;A`a"
 	# Current working directory
 	# OSC 633 ; <Property>=<Value> ST
-	$Result += if($pwd.Provider.Name -eq 'FileSystem'){"$([char]0x1b)]633;P;Cwd=$($pwd.ProviderPath)`a"}
+	$Result += if($pwd.Provider.Name -eq 'FileSystem'){"$([char]0x1b)]633;P;Cwd=$(__VSCode-Escape-Value $pwd.ProviderPath)`a"}
 	# Before running the original prompt, put $? back to what it was:
 	if ($FakeCode -ne 0) {
 		Write-Error "failure" -ea ignore


### PR DESCRIPTION
This implements the string escaping scheme documented for the "E" (executed) and "P" (property KV) codes. This is "pure" `zsh` and relies on no external utilities.

Although currently the only "required" escapes are backslash, semicolon, `\a`, and perhaps newlines, this conservatively escapes all non-alphanumeric characters.

Backslashes are doubled, non-alphanumerics are hex-escaped.

Sibling to:
* #165631
* #165632
* #165633
* #165635

Relates to or resolves parts of:
* #157546
* #155639

### Caveat
Unaddressed here, but more plain to see than in the other shells, is that the encoding of multibyte codepoints is not currently well-defined by the escaping scheme. This chooses to encode as UTF-8 in order to make them byte-representable at all. Regardless, `shellIntegrationAddon.ts` severely mishandles the interpretation of escapes anyway, even in the ASCII range, so the point is slightly moot.