### PR TITLE
shellIntegrationAddon: fix broken `deserializeMessage()` implementation + add tests

### DIFF
--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -517,7 +517,7 @@ export function deserializeMessage(message: string): string {
 	const deserializeRegex = /\\x([0-9a-f]{2})/i;
 	while (true) {
 		const match = result.match(deserializeRegex);
-		if (!match?.index || match.length < 2) {
+		if (match?.index == null || match.length < 2) {
 			break;
 		}
 		result = result.slice(0, match.index) + String.fromCharCode(parseInt(match[1], 16)) + result.slice(match.index + 4);

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -513,16 +513,12 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 }
 
 export function deserializeMessage(message: string): string {
-	let result = message.replace(/\\\\/g, '\\');
-	const deserializeRegex = /\\x([0-9a-f]{2})/i;
-	while (true) {
-		const match = result.match(deserializeRegex);
-		if (match?.index == null || match.length < 2) {
-			break;
-		}
-		result = result.slice(0, match.index) + String.fromCharCode(parseInt(match[1], 16)) + result.slice(match.index + 4);
-	}
-	return result;
+	return message.replaceAll(
+		// Backslash ('\') followed by an escape operator: either another '\', or 'x' and two hex chars.
+		/\\(\\|x([0-9a-f]{2}))/gi,
+		// If it's a hex value, parse it to a character.
+		// Otherwise the operator is '\', which we return literally, now unescaped.
+		(_match: string, op: string, hex?: string) => hex ? String.fromCharCode(parseInt(hex, 16)) : op);
 }
 
 export function parseKeyValueAssignment(message: string): { key: string; value: string | undefined } {

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
@@ -288,15 +288,9 @@ suite('deserializeMessage', () => {
 	];
 
 	const BROKEN: readonly string[] = [
-		'escaped semicolon',
-		'escaped semicolon (upper hex)',
-		// only "passing" due to interaction between two separate bugs:
-		// 'escaped backslash followed by literal "x3b" is not a semicolon',
+		'escaped backslash followed by literal "x3b" is not a semicolon',
 		'non-initial escaped backslash followed by literal "x3b" is not a semicolon',
-		'escaped newline',
-		'escaped newline (upper hex)',
-		// only "passing" due to interaction between two separate bugs:
-		// 'escaped backslash followed by literal "x0a" is not a newline',
+		'escaped backslash followed by literal "x0a" is not a newline',
 		'non-initial escaped backslash followed by literal "x0a" is not a newline',
 	];
 

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
@@ -7,7 +7,7 @@ import { Terminal } from 'xterm';
 import { strictEqual, deepStrictEqual, deepEqual } from 'assert';
 import { timeout } from 'vs/base/common/async';
 import * as sinon from 'sinon';
-import { parseKeyValueAssignment, parseMarkSequence, ShellIntegrationAddon } from 'vs/platform/terminal/common/xterm/shellIntegrationAddon';
+import { parseKeyValueAssignment, parseMarkSequence, deserializeMessage, ShellIntegrationAddon } from 'vs/platform/terminal/common/xterm/shellIntegrationAddon';
 import { ITerminalCapabilityStore, TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { ILogService, NullLogService } from 'vs/platform/log/common/log';
@@ -254,6 +254,59 @@ suite('ShellIntegrationAddon', () => {
 				deepEqual(parseMarkSequence(['Id=4555', 'Hidden']), { id: "4555", hidden: true });
 			});
 		});
+	});
+});
+
+suite('deserializeMessage', () => {
+	// A single literal backslash, in order to avoid confusion about whether we are escaping test data or testing escapes.
+	const Backslash = '\\' as const;
+	const Newline = '\n' as const;
+	const Semicolon = ';' as const;
+
+	type TestCase = [title: string, input: string, expected: string];
+	const cases: TestCase[] = [
+		['empty', '', ''],
+		['basic', 'value', 'value'],
+		['space', 'some thing', 'some thing'],
+		['escaped backslash', `${Backslash}${Backslash}`, Backslash],
+		['non-initial escaped backslash', `foo${Backslash}${Backslash}`, `foo${Backslash}`],
+		['two escaped backslashes', `${Backslash}${Backslash}${Backslash}${Backslash}`, `${Backslash}${Backslash}`],
+		['escaped backslash amidst text', `Hello${Backslash}${Backslash}there`, `Hello${Backslash}there`],
+		['backslash escaped literally and as hex', `${Backslash}${Backslash} is same as ${Backslash}x5c`, `${Backslash} is same as ${Backslash}`],
+		['escaped semicolon', `${Backslash}x3b`, Semicolon],
+		['non-initial escaped semicolon', `foo${Backslash}x3b`, `foo${Semicolon}`],
+		['escaped semicolon (upper hex)', `${Backslash}x3B`, Semicolon],
+		['escaped backslash followed by literal "x3b" is not a semicolon', `${Backslash}${Backslash}x3b`, `${Backslash}x3b`],
+		['non-initial escaped backslash followed by literal "x3b" is not a semicolon', `foo${Backslash}${Backslash}x3b`, `foo${Backslash}x3b`],
+		['escaped backslash followed by escaped semicolon', `${Backslash}${Backslash}${Backslash}x3b`, `${Backslash}${Semicolon}`],
+		['escaped semicolon amidst text', `some${Backslash}x3bthing`, `some${Semicolon}thing`],
+		['escaped newline', `${Backslash}x0a`, Newline],
+		['non-initial escaped newline', `foo${Backslash}x0a`, `foo${Newline}`],
+		['escaped newline (upper hex)', `${Backslash}x0A`, Newline],
+		['escaped backslash followed by literal "x0a" is not a newline', `${Backslash}${Backslash}x0a`, `${Backslash}x0a`],
+		['non-initial escaped backslash followed by literal "x0a" is not a newline', `foo${Backslash}${Backslash}x0a`, `foo${Backslash}x0a`],
+	];
+
+	const BROKEN: readonly string[] = [
+		'escaped semicolon',
+		'escaped semicolon (upper hex)',
+		// only "passing" due to interaction between two separate bugs:
+		// 'escaped backslash followed by literal "x3b" is not a semicolon',
+		'non-initial escaped backslash followed by literal "x3b" is not a semicolon',
+		'escaped newline',
+		'escaped newline (upper hex)',
+		// only "passing" due to interaction between two separate bugs:
+		// 'escaped backslash followed by literal "x0a" is not a newline',
+		'non-initial escaped backslash followed by literal "x0a" is not a newline',
+	];
+
+	cases.forEach(([title, input, expected]) => {
+		const fn = () => strictEqual(deserializeMessage(input), expected);
+		if (BROKEN.includes(title)) {
+			test.skip(title, fn);
+		} else {
+			test(title, fn);
+		}
 	});
 });
 

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/shellIntegrationAddon.test.ts
@@ -287,20 +287,8 @@ suite('deserializeMessage', () => {
 		['non-initial escaped backslash followed by literal "x0a" is not a newline', `foo${Backslash}${Backslash}x0a`, `foo${Backslash}x0a`],
 	];
 
-	const BROKEN: readonly string[] = [
-		'escaped backslash followed by literal "x3b" is not a semicolon',
-		'non-initial escaped backslash followed by literal "x3b" is not a semicolon',
-		'escaped backslash followed by literal "x0a" is not a newline',
-		'non-initial escaped backslash followed by literal "x0a" is not a newline',
-	];
-
 	cases.forEach(([title, input, expected]) => {
-		const fn = () => strictEqual(deserializeMessage(input), expected);
-		if (BROKEN.includes(title)) {
-			test.skip(title, fn);
-		} else {
-			test(title, fn);
-		}
+		test(title, () => strictEqual(deserializeMessage(input), expected));
 	});
 });
 


### PR DESCRIPTION
The `deserializeMessage()` implementation was broken and did not contain useful tests.

This adds tests (initially failing) and fixes the main correctness issues:
* `deserializeMessage()` would not recognize escape sequences at the start of a string, due to a mistaken falsey check on `match?.index` which could be validly `0` instead of `null`.
  In other words: `"Foo\x3bBar"` would decode to `"Foo;Bar"`, but the string `"\x3bBar"` would not be recognized as containing an escape sequence.
* `deserializeMessage()` confused escaped and un-escaped sequences due to squashing each adjacent pair of backslashes prior to parsing.

Unlike encoding, decoding cannot be performed in passes: it must be sequential across the string, because of the potential for overlapping patterns (e.g. the third backslash in `\\\x3b`). The original implementation wrongly threw away the escaping information by replacing each adjacent pairs of backslashes with a single backslash, regardless of whether escaping was in effect on _those_ backslashes or not.

<table>
<tr>
    <th>Original literal value
    <th>Escaped representation
    <th>Current (buggy) decoding
    <th>Correct decoding
<tr>
	<td><pre>Packing\Stuff\x3BEarmuffs</pre>
	<td><pre>Packing\\Stuff\\x3BEarmuffs</pre>
	<td>✅<pre>Packing\Stuff\x3BEarmuffs</pre>
	<td>✅<pre>Packing\Stuff\x3BEarmuffs</pre>
<tr>
	<td><pre>Packing\Stuff;Earmuffs</pre>
	<td><pre>Packing\\Stuff\x3BEarmuffs</pre>
	<td>❌<pre>Packing\Stuff\x3BEarmuffs</pre>
	<td>✅<pre>Packing\Stuff;Earmuffs</pre>
</table> 

This replaces the implementation with a single sequential regex, which matches the escape sequences and replaces each match.

This PR leaves unresolved the incorrect handling of multibyte characters, however, which is the only remaining deficiency I'm aware of.

This relates to #155639. Certainly there must be other bugs filed caused by this, too, but since the shell integrations themselves don't perform escaping (see following PRs), it's hard to tell which issues are caused by the interpretation here vs. the lack of escaping there.

PRs implementing the escaping scheme for various shells:
* #165631
* #165632
* #165633
* #165634