### PR TITLE
Add git stash staged only command

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -516,6 +516,11 @@
         "category": "Git"
       },
       {
+        "command": "git.stashStagedOnly",
+        "title": "%command.stashStagedOnly%",
+        "category": "Git"
+      },
+      {
         "command": "git.stash",
         "title": "%command.stash%",
         "category": "Git"
@@ -982,6 +987,10 @@
         {
           "command": "git.stashIncludeUntracked",
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
+        },
+        {
+          "command": "git.stashStagedOnly",
+          "when": "config.git.enabled && git.canStashStagedOnly && !git.missing && gitOpenRepositoryCount != 0"
         },
         {
           "command": "git.stash",
@@ -1809,28 +1818,32 @@
           "group": "stash@2"
         },
         {
-          "command": "git.stashApplyLatest",
+          "command": "git.stashStagedOnly",
           "group": "stash@3"
         },
         {
-          "command": "git.stashApply",
+          "command": "git.stashApplyLatest",
           "group": "stash@4"
         },
         {
-          "command": "git.stashPopLatest",
+          "command": "git.stashApply",
           "group": "stash@5"
         },
         {
-          "command": "git.stashPop",
+          "command": "git.stashPopLatest",
           "group": "stash@6"
         },
         {
-          "command": "git.stashDrop",
+          "command": "git.stashPop",
           "group": "stash@7"
         },
         {
-          "command": "git.stashDropAll",
+          "command": "git.stashDrop",
           "group": "stash@8"
+        },
+        {
+          "command": "git.stashDropAll",
+          "group": "stash@9"
         }
       ],
       "git.tags": [

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -87,6 +87,7 @@
 	"command.revealFileInOS.windows": "Reveal in File Explorer",
 	"command.rebaseAbort": "Abort Rebase",
 	"command.stashIncludeUntracked": "Stash (Include Untracked)",
+	"command.stashStagedOnly": "Stash (Staged Only)",
 	"command.stash": "Stash",
 	"command.stashPop": "Pop Stash...",
 	"command.stashPopLatest": "Pop Latest Stash",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2896,7 +2896,7 @@ export class CommandCenter {
 		await commands.executeCommand('revealFileInOS', resourceState.resourceUri);
 	}
 
-	private async _stash(repository: Repository, includeUntracked = false): Promise<void> {
+	private async _stash(repository: Repository, includeUntracked = false, onlyIncludeStaged = false): Promise<void> {
 		const noUnstagedChanges = repository.workingTreeGroup.resourceStates.length === 0
 			&& (!includeUntracked || repository.untrackedGroup.resourceStates.length === 0);
 		const noStagedChanges = repository.indexGroup.resourceStates.length === 0;
@@ -2950,7 +2950,7 @@ export class CommandCenter {
 			return;
 		}
 
-		await repository.createStash(message, includeUntracked);
+		await repository.createStash(message, includeUntracked, onlyIncludeStaged);
 	}
 
 	@command('git.stash', { repository: true })
@@ -2961,6 +2961,11 @@ export class CommandCenter {
 	@command('git.stashIncludeUntracked', { repository: true })
 	stashIncludeUntracked(repository: Repository): Promise<void> {
 		return this._stash(repository, true);
+	}
+
+	@command('git.stashStagedOnly', { repository: true })
+	stashStagedOnly(repository: Repository): Promise<void> {
+		return this._stash(repository, false, true);
 	}
 
 	@command('git.stashPop', { repository: true })

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1851,12 +1851,16 @@ export class Repository {
 		}
 	}
 
-	async createStash(message?: string, includeUntracked?: boolean): Promise<void> {
+	async createStash(message?: string, includeUntracked?: boolean, onlyIncludeStaged?: boolean): Promise<void> {
 		try {
 			const args = ['stash', 'push'];
 
 			if (includeUntracked) {
 				args.push('-u');
+			}
+
+			if (onlyIncludeStaged) {
+				args.push('-S');
 			}
 
 			if (message) {

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -87,7 +87,7 @@ async function createModel(context: ExtensionContext, logger: LogOutputChannel, 
 		env: environment,
 	});
 
-	commands.executeCommand('setContext', 'git.canStashStagedOnly', git.compareGitVersionTo('2.38') !== -1);
+	commands.executeCommand('setContext', 'git.canStashStagedOnly', git.compareGitVersionTo('2.35') !== -1);
 
 	const model = new Model(git, askpass, context.globalState, logger, telemetryReporter);
 	disposables.push(model);

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -86,6 +86,9 @@ async function createModel(context: ExtensionContext, logger: LogOutputChannel, 
 		version: info.version,
 		env: environment,
 	});
+
+	commands.executeCommand('setContext', 'git.canStashStagedOnly', git.compareGitVersionTo('2.38') !== -1);
+
 	const model = new Model(git, askpass, context.globalState, logger, telemetryReporter);
 	disposables.push(model);
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1755,14 +1755,14 @@ export class Repository implements Disposable {
 		return await this.repository.getStashes();
 	}
 
-	async createStash(message?: string, includeUntracked?: boolean): Promise<void> {
+	async createStash(message?: string, includeUntracked?: boolean, onlyIncludeStaged?: boolean): Promise<void> {
 		const indexResources = [...this.indexGroup.resourceStates.map(r => r.resourceUri.fsPath)];
 		const workingGroupResources = [
 			...this.workingTreeGroup.resourceStates.map(r => r.resourceUri.fsPath),
 			...includeUntracked ? this.untrackedGroup.resourceStates.map(r => r.resourceUri.fsPath) : []];
 
 		return await this.run(Operation.Stash, async () => {
-			this.repository.createStash(message, includeUntracked);
+			this.repository.createStash(message, includeUntracked, onlyIncludeStaged);
 			this.closeDiffEditors(indexResources, workingGroupResources);
 		});
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Git 2.35 introduced the ability to stash only the currently staged files. This PR adds a command that exposes that functionality. This was requested in #165353.