### PR TITLE
add "toggled" to command extension api

### DIFF
--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -499,6 +499,7 @@ namespace schema {
 		title: string | ILocalizedString;
 		shortTitle?: string | ILocalizedString;
 		enablement?: string;
+		toggled?: string;
 		category?: string | ILocalizedString;
 		icon?: IUserFriendlyIcon;
 	}
@@ -585,6 +586,10 @@ namespace schema {
 				description: localize('vscode.extension.contributes.commandType.precondition', '(Optional) Condition which must be true to enable the command in the UI (menu and keybindings). Does not prevent executing the command by other means, like the `executeCommand`-api.'),
 				type: 'string'
 			},
+			toggled: {
+				description: localize('vscode.extension.contributes.commandType.toggled', '(Optional) Condition which must be true to show a check-mark in the UI (menu).'),
+				type: 'string'
+			},
 			icon: {
 				description: localize({ key: 'vscode.extension.contributes.commandType.icon', comment: ['do not translate or change `\\$(zap)`, \\ in front of $ is important.'] }, '(Optional) Icon which is used to represent the command in the UI. Either a file path, an object with file paths for dark and light themes, or a theme icon references, like `\\$(zap)`'),
 				anyOf: [{
@@ -634,7 +639,7 @@ commandsExtensionPoint.setHandler(extensions => {
 			return;
 		}
 
-		const { icon, enablement, category, title, shortTitle, command } = userFriendlyCommand;
+		const { icon, enablement, category, title, shortTitle, command, toggled } = userFriendlyCommand;
 
 		let absoluteIcon: { dark: URI; light?: URI } | ThemeIcon | undefined;
 		if (icon) {
@@ -660,6 +665,7 @@ commandsExtensionPoint.setHandler(extensions => {
 			tooltip: title,
 			category,
 			precondition: ContextKeyExpr.deserialize(enablement),
+			toggled: ContextKeyExpr.deserialize(toggled),
 			icon: absoluteIcon
 		}));
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Solves #109306

[See here for a test extension demonstrating the new feature](https://github.com/mxsdev/vscode-toggle-extension), which adds a command, "Toggle Test Command," to the editor title menu. (Run this test by either installing the vsix or passing its root directory to the `--extensionDevelopmentPath` argument to `scripts/code-cli.sh`)
