### PR TITLE
Standardize "can not" to "cannot" in errors

### DIFF
--- a/extensions/php/build/update-grammar.mjs
+++ b/extensions/php/build/update-grammar.mjs
@@ -15,7 +15,7 @@ function adaptInjectionScope(grammar) {
 	const injections = grammar.injections;
 	const injection = injections[oldInjectionKey];
 	if (!injection) {
-		throw new Error("Can not find PHP injection to patch");
+		throw new Error("Cannot find PHP injection to patch");
 	}
 	delete injections[oldInjectionKey];
 	injections[newInjectionKey] = injection;

--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -935,7 +935,7 @@ export class AsyncEmitter<T extends IWaitUntil> extends Emitter<T> {
 				token,
 				waitUntil: (p: Promise<unknown>): void => {
 					if (Object.isFrozen(thenables)) {
-						throw new Error('waitUntil can NOT be called asynchronous');
+						throw new Error('waitUntil cannot be called asynchronously');
 					}
 					if (promiseJoin) {
 						p = promiseJoin(p, listener.callback);

--- a/src/vs/base/common/jsonEdit.ts
+++ b/src/vs/base/common/jsonEdit.ts
@@ -35,7 +35,7 @@ export function setProperty(text: string, originalPath: JSONPath, value: any, fo
 	if (!parent) {
 		// empty document
 		if (value === undefined) { // delete
-			throw new Error('Can not delete in empty document');
+			throw new Error('Cannot delete in empty document');
 		}
 		return withFormatting(text, { offset: root ? root.offset : 0, length: root ? root.length : 0, content: JSON.stringify(value) }, formattingOptions);
 	} else if (parent.type === 'object' && typeof lastSegment === 'string' && Array.isArray(parent.children)) {
@@ -115,7 +115,7 @@ export function setProperty(text: string, originalPath: JSONPath, value: any, fo
 			return withFormatting(text, edit, formattingOptions);
 		}
 	} else {
-		throw new Error(`Can not add ${typeof lastSegment !== 'number' ? 'index' : 'property'} to parent of type ${parent.type}`);
+		throw new Error(`Cannot add ${typeof lastSegment !== 'number' ? 'index' : 'property'} to parent of type ${parent.type}`);
 	}
 }
 

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -792,10 +792,10 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 				type: 'info',
 				buttons: [mnemonicButtonLabel(localize({ key: 'ok', comment: ['&& denotes a mnemonic'] }, "&&OK"))],
 				defaultId: 0,
-				message: uri.scheme === Schemas.file ? localize('pathNotExistTitle', "Path does not exist") : localize('uriInvalidTitle', "URI can not be opened"),
+				message: uri.scheme === Schemas.file ? localize('pathNotExistTitle', "Path does not exist") : localize('uriInvalidTitle', "URI cannot be opened"),
 				detail: uri.scheme === Schemas.file ?
 					localize('pathNotExistDetail', "The path '{0}' does not exist on this computer.", getPathLabel(uri, { os: OS, tildify: this.environmentMainService })) :
-					localize('uriInvalidDetail', "The URI '{0}' is not valid and can not be opened.", uri.toString(true)),
+					localize('uriInvalidDetail', "The URI '{0}' is not valid and cannot be opened.", uri.toString(true)),
 				noLink: true
 			};
 

--- a/src/vs/workbench/api/browser/mainThreadTask.ts
+++ b/src/vs/workbench/api/browser/mainThreadTask.ts
@@ -480,7 +480,7 @@ export class MainThreadTask implements MainThreadTaskShape {
 						if (task) {
 							tasks.push(task);
 						} else {
-							console.error(`Task System: can not convert task: ${JSON.stringify(dto.definition, undefined, 0)}. Task will be dropped`);
+							console.error(`Task System: cannot convert task: ${JSON.stringify(dto.definition, undefined, 0)}. Task will be dropped`);
 						}
 					}
 					return {

--- a/src/vs/workbench/api/common/extHostDocumentSaveParticipant.ts
+++ b/src/vs/workbench/api/common/extHostDocumentSaveParticipant.ts
@@ -111,7 +111,7 @@ export class ExtHostDocumentSaveParticipant implements ExtHostDocumentSavePartic
 			reason,
 			waitUntil(p: Promise<any | vscode.TextEdit[]>) {
 				if (Object.isFrozen(promises)) {
-					throw illegalState('waitUntil can not be called async');
+					throw illegalState('waitUntil cannot be called async');
 				}
 				promises.push(Promise.resolve(p));
 			}

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
@@ -238,7 +238,7 @@ class DeleteOperation implements IFileOperation {
 				fileStat = await this._fileService.resolve(edit.oldUri, { resolveMetadata: true });
 			} catch (err) {
 				if (!edit.options.ignoreIfNotExists) {
-					throw new Error(`${edit.oldUri} does not exist and can not be deleted`);
+					throw new Error(`${edit.oldUri} does not exist and cannot be deleted`);
 				}
 				continue;
 			}

--- a/src/vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint.ts
@@ -587,7 +587,7 @@ const schema: IJSONSchema = {
 		},
 		autoCloseBefore: {
 			default: ';:.,=}])> \n\t',
-			description: nls.localize('schema.autoCloseBefore', 'Defines what characters must be after the cursor in order for bracket or quote autoclosing to occur when using the \'languageDefined\' autoclosing setting. This is typically the set of characters which can not start an expression.'),
+			description: nls.localize('schema.autoCloseBefore', 'Defines what characters must be after the cursor in order for bracket or quote autoclosing to occur when using the \'languageDefined\' autoclosing setting. This is typically the set of characters which cannot start an expression.'),
 			type: 'string',
 		},
 		surroundingPairs: {

--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -98,7 +98,7 @@ export class AdapterManager extends Disposable implements IAdapterManager {
 			delta.added.forEach(added => {
 				added.value.forEach(rawAdapter => {
 					if (!rawAdapter.type || (typeof rawAdapter.type !== 'string')) {
-						added.collector.error(nls.localize('debugNoType', "Debugger 'type' can not be omitted and must be of type 'string'."));
+						added.collector.error(nls.localize('debugNoType', "Debugger 'type' cannot be omitted and must be of type 'string'."));
 					}
 
 					if (rawAdapter.type !== '*') {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -397,7 +397,7 @@ export class DebugService implements IDebugService {
 						if (launchesMatchingConfigData.length === 1) {
 							launchForName = launchesMatchingConfigData[0];
 						} else {
-							throw new Error(nls.localize('noFolderWithName', "Can not find folder with name '{0}' for configuration '{1}' in compound '{2}'.", configData.folder, configData.name, compound!.name));
+							throw new Error(nls.localize('noFolderWithName', "Cannot find folder with name '{0}' for configuration '{1}' in compound '{2}'.", configData.folder, configData.name, compound!.name));
 						}
 					}
 
@@ -538,7 +538,7 @@ export class DebugService implements IDebugService {
 				if (err && err.message) {
 					await this.showError(err.message);
 				} else if (this.contextService.getWorkbenchState() === WorkbenchState.EMPTY) {
-					await this.showError(nls.localize('noFolderWorkspaceDebugError', "The active file can not be debugged. Make sure it is saved and that you have a debug extension installed for that file type."));
+					await this.showError(nls.localize('noFolderWorkspaceDebugError', "The active file cannot be debugged. Make sure it is saved and that you have a debug extension installed for that file type."));
 				}
 				if (launch && !initCancellationToken.token.isCancellationRequested) {
 					await launch.openConfigFile({ preserveFocus: true }, initCancellationToken.token);

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -325,7 +325,7 @@ export class DebugSession implements IDebugSession {
 	 */
 	async launchOrAttach(config: IConfig): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'launch or attach'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'launch or attach'));
 		}
 		if (this.parentSession && this.parentSession.state === State.Inactive) {
 			throw canceled();
@@ -393,7 +393,7 @@ export class DebugSession implements IDebugSession {
 	 */
 	async restart(): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'restart'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'restart'));
 		}
 
 		this.cancelAllRequests();
@@ -406,7 +406,7 @@ export class DebugSession implements IDebugSession {
 
 	async sendBreakpoints(modelUri: URI, breakpointsToSend: IBreakpoint[], sourceModified: boolean): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'breakpoints'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'breakpoints'));
 		}
 
 		if (!this.raw.readyForBreakpoints) {
@@ -440,7 +440,7 @@ export class DebugSession implements IDebugSession {
 
 	async sendFunctionBreakpoints(fbpts: IFunctionBreakpoint[]): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'function breakpoints'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'function breakpoints'));
 		}
 
 		if (this.raw.readyForBreakpoints) {
@@ -457,7 +457,7 @@ export class DebugSession implements IDebugSession {
 
 	async sendExceptionBreakpoints(exbpts: IExceptionBreakpoint[]): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'exception breakpoints'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'exception breakpoints'));
 		}
 
 		if (this.raw.readyForBreakpoints) {
@@ -486,7 +486,7 @@ export class DebugSession implements IDebugSession {
 
 	async dataBreakpointInfo(name: string, variablesReference?: number): Promise<{ dataId: string | null; description: string; canPersist?: boolean } | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'data breakpoints info'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'data breakpoints info'));
 		}
 		if (!this.raw.readyForBreakpoints) {
 			throw new Error(localize('sessionNotReadyForBreakpoints', "Session is not ready for breakpoints"));
@@ -498,7 +498,7 @@ export class DebugSession implements IDebugSession {
 
 	async sendDataBreakpoints(dataBreakpoints: IDataBreakpoint[]): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'data breakpoints'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'data breakpoints'));
 		}
 
 		if (this.raw.readyForBreakpoints) {
@@ -515,7 +515,7 @@ export class DebugSession implements IDebugSession {
 
 	async sendInstructionBreakpoints(instructionBreakpoints: IInstructionBreakpoint[]): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'instruction breakpoints'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'instruction breakpoints'));
 		}
 
 		if (this.raw.readyForBreakpoints) {
@@ -532,7 +532,7 @@ export class DebugSession implements IDebugSession {
 
 	async breakpointsLocations(uri: URI, lineNumber: number): Promise<IPosition[]> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'breakpoints locations'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'breakpoints locations'));
 		}
 
 		const source = this.getRawSource(uri);
@@ -552,7 +552,7 @@ export class DebugSession implements IDebugSession {
 
 	customRequest(request: string, args: any): Promise<DebugProtocol.Response | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", request));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", request));
 		}
 
 		return this.raw.custom(request, args);
@@ -560,7 +560,7 @@ export class DebugSession implements IDebugSession {
 
 	stackTrace(threadId: number, startFrame: number, levels: number, token: CancellationToken): Promise<DebugProtocol.StackTraceResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'stackTrace'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'stackTrace'));
 		}
 
 		const sessionToken = this.getNewCancellationToken(threadId, token);
@@ -569,7 +569,7 @@ export class DebugSession implements IDebugSession {
 
 	async exceptionInfo(threadId: number): Promise<IExceptionInfo | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'exceptionInfo'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'exceptionInfo'));
 		}
 
 		const response = await this.raw.exceptionInfo({ threadId });
@@ -587,7 +587,7 @@ export class DebugSession implements IDebugSession {
 
 	scopes(frameId: number, threadId: number): Promise<DebugProtocol.ScopesResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'scopes'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'scopes'));
 		}
 
 		const token = this.getNewCancellationToken(threadId);
@@ -596,7 +596,7 @@ export class DebugSession implements IDebugSession {
 
 	variables(variablesReference: number, threadId: number | undefined, filter: 'indexed' | 'named' | undefined, start: number | undefined, count: number | undefined): Promise<DebugProtocol.VariablesResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'variables'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'variables'));
 		}
 
 		const token = threadId ? this.getNewCancellationToken(threadId) : undefined;
@@ -605,7 +605,7 @@ export class DebugSession implements IDebugSession {
 
 	evaluate(expression: string, frameId: number, context?: string): Promise<DebugProtocol.EvaluateResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'evaluate'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'evaluate'));
 		}
 
 		return this.raw.evaluate({ expression, frameId, context });
@@ -613,7 +613,7 @@ export class DebugSession implements IDebugSession {
 
 	async restartFrame(frameId: number, threadId: number): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'restartFrame'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'restartFrame'));
 		}
 
 		await this.raw.restartFrame({ frameId }, threadId);
@@ -628,7 +628,7 @@ export class DebugSession implements IDebugSession {
 
 	async next(threadId: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'next'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'next'));
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
@@ -637,7 +637,7 @@ export class DebugSession implements IDebugSession {
 
 	async stepIn(threadId: number, targetId?: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'stepIn'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'stepIn'));
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
@@ -646,7 +646,7 @@ export class DebugSession implements IDebugSession {
 
 	async stepOut(threadId: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'stepOut'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'stepOut'));
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
@@ -655,7 +655,7 @@ export class DebugSession implements IDebugSession {
 
 	async stepBack(threadId: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'stepBack'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'stepBack'));
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
@@ -664,7 +664,7 @@ export class DebugSession implements IDebugSession {
 
 	async continue(threadId: number): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'continue'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'continue'));
 		}
 
 		await this.raw.continue({ threadId });
@@ -672,7 +672,7 @@ export class DebugSession implements IDebugSession {
 
 	async reverseContinue(threadId: number): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'reverse continue'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'reverse continue'));
 		}
 
 		await this.raw.reverseContinue({ threadId });
@@ -680,7 +680,7 @@ export class DebugSession implements IDebugSession {
 
 	async pause(threadId: number): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'pause'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'pause'));
 		}
 
 		await this.raw.pause({ threadId });
@@ -688,7 +688,7 @@ export class DebugSession implements IDebugSession {
 
 	async terminateThreads(threadIds?: number[]): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'terminateThreads'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'terminateThreads'));
 		}
 
 		await this.raw.terminateThreads({ threadIds });
@@ -696,7 +696,7 @@ export class DebugSession implements IDebugSession {
 
 	setVariable(variablesReference: number, name: string, value: string): Promise<DebugProtocol.SetVariableResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'setVariable'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'setVariable'));
 		}
 
 		return this.raw.setVariable({ variablesReference, name, value });
@@ -704,7 +704,7 @@ export class DebugSession implements IDebugSession {
 
 	setExpression(frameId: number, expression: string, value: string): Promise<DebugProtocol.SetExpressionResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'setExpression'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'setExpression'));
 		}
 
 		return this.raw.setExpression({ expression, value, frameId });
@@ -712,7 +712,7 @@ export class DebugSession implements IDebugSession {
 
 	gotoTargets(source: DebugProtocol.Source, line: number, column?: number): Promise<DebugProtocol.GotoTargetsResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'gotoTargets'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'gotoTargets'));
 		}
 
 		return this.raw.gotoTargets({ source, line, column });
@@ -720,7 +720,7 @@ export class DebugSession implements IDebugSession {
 
 	goto(threadId: number, targetId: number): Promise<DebugProtocol.GotoResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'goto'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'goto'));
 		}
 
 		return this.raw.goto({ threadId, targetId });
@@ -728,7 +728,7 @@ export class DebugSession implements IDebugSession {
 
 	loadSource(resource: URI): Promise<DebugProtocol.SourceResponse | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'loadSource')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'loadSource')));
 		}
 
 		const source = this.getSourceForUri(resource);
@@ -746,7 +746,7 @@ export class DebugSession implements IDebugSession {
 
 	async getLoadedSources(): Promise<Source[]> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'getLoadedSources')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'getLoadedSources')));
 		}
 
 		const response = await this.raw.loadedSources({});
@@ -759,7 +759,7 @@ export class DebugSession implements IDebugSession {
 
 	async completions(frameId: number | undefined, threadId: number, text: string, position: Position, overwriteBefore: number, token: CancellationToken): Promise<DebugProtocol.CompletionsResponse | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'completions')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'completions')));
 		}
 		const sessionCancelationToken = this.getNewCancellationToken(threadId, token);
 
@@ -773,7 +773,7 @@ export class DebugSession implements IDebugSession {
 
 	async stepInTargets(frameId: number): Promise<{ id: number; label: string }[] | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'stepInTargets')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'stepInTargets')));
 		}
 
 		const response = await this.raw.stepInTargets({ frameId });
@@ -782,7 +782,7 @@ export class DebugSession implements IDebugSession {
 
 	async cancel(progressId: string): Promise<DebugProtocol.CancelResponse | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'cancel')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'cancel')));
 		}
 
 		return this.raw.cancel({ progressId });
@@ -790,7 +790,7 @@ export class DebugSession implements IDebugSession {
 
 	async disassemble(memoryReference: string, offset: number, instructionOffset: number, instructionCount: number): Promise<DebugProtocol.DisassembledInstruction[] | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'disassemble')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'disassemble')));
 		}
 
 		const response = await this.raw.disassemble({ memoryReference, offset, instructionOffset, instructionCount, resolveSymbols: true });
@@ -799,7 +799,7 @@ export class DebugSession implements IDebugSession {
 
 	readMemory(memoryReference: string, offset: number, count: number): Promise<DebugProtocol.ReadMemoryResponse | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'readMemory')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'readMemory')));
 		}
 
 		return this.raw.readMemory({ count, memoryReference, offset });
@@ -807,7 +807,7 @@ export class DebugSession implements IDebugSession {
 
 	writeMemory(memoryReference: string, offset: number, data: string, allowPartial?: boolean): Promise<DebugProtocol.WriteMemoryResponse | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'disassemble')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'disassemble')));
 		}
 
 		return this.raw.writeMemory({ memoryReference, offset, allowPartial, data });

--- a/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
@@ -154,7 +154,7 @@ export class DebugTaskRunner {
 			return Promise.resolve(null);
 		}
 		if (!root) {
-			return Promise.reject(new Error(nls.localize('invalidTaskReference', "Task '{0}' can not be referenced from a launch configuration that is in a different workspace folder.", typeof taskId === 'string' ? taskId : taskId.type)));
+			return Promise.reject(new Error(nls.localize('invalidTaskReference', "Task '{0}' cannot be referenced from a launch configuration that is in a different workspace folder.", typeof taskId === 'string' ? taskId : taskId.type)));
 		}
 		// run a task before starting a debug session
 		const task = await this.taskService.getTask(root, taskId);

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -261,7 +261,7 @@ export class RawDebugSession implements IDisposable {
 	 */
 	async start(): Promise<void> {
 		if (!this.debugAdapter) {
-			return Promise.reject(new Error(nls.localize('noDebugAdapterStart', "No debug adapter, can not start debug session.")));
+			return Promise.reject(new Error(nls.localize('noDebugAdapterStart', "No debug adapter, cannot start debug session.")));
 		}
 
 		await this.debugAdapter.startSession();
@@ -725,7 +725,7 @@ export class RawDebugSession implements IDisposable {
 					// We are in shutdown silently complete
 					completeDispatch(undefined);
 				} else {
-					errorDispatch(new Error(nls.localize('noDebugAdapter', "No debugger available found. Can not send '{0}'.", command)));
+					errorDispatch(new Error(nls.localize('noDebugAdapter', "No debugger available found. Cannot send '{0}'.", command)));
 				}
 				return;
 			}

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1387,7 +1387,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 
 	async setLanguage(extension: IExtension): Promise<void> {
 		if (!this.canSetLanguage(extension)) {
-			throw new Error('Can not set language');
+			throw new Error('Cannot set language');
 		}
 		const locale = this.languagePackService.getLocale(extension.gallery!);
 		if (locale === language) {

--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -196,7 +196,7 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 			if (filePath) {
 				return filePath;
 			}
-			throw new VariableError(variableKind, (localize('canNotResolveFile', "Variable {0} can not be resolved. Please open an editor.", match)));
+			throw new VariableError(variableKind, (localize('canNotResolveFile', "Variable {0} cannot be resolved. Please open an editor.", match)));
 		};
 
 		// common error handling for all variables that require an open editor
@@ -209,7 +209,7 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 					return folderPath;
 				}
 			}
-			throw new VariableError(variableKind, localize('canNotResolveFolderForFile', "Variable {0}: can not find workspace folder of '{1}'.", match, paths.basename(filePath)));
+			throw new VariableError(variableKind, localize('canNotResolveFolderForFile', "Variable {0}: cannot find workspace folder of '{1}'.", match, paths.basename(filePath)));
 		};
 
 		// common error handling for all variables that require an open folder and accept a folder name argument
@@ -220,7 +220,7 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 				if (folder) {
 					return folder;
 				}
-				throw new VariableError(variableKind, localize('canNotFindFolder', "Variable {0} can not be resolved. No such folder '{1}'.", match, argument));
+				throw new VariableError(variableKind, localize('canNotFindFolder', "Variable {0} cannot be resolved. No such folder '{1}'.", match, argument));
 			}
 
 			if (folderUri) {
@@ -228,9 +228,9 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 			}
 
 			if (this._context.getWorkspaceFolderCount() > 1) {
-				throw new VariableError(variableKind, localize('canNotResolveWorkspaceFolderMultiRoot', "Variable {0} can not be resolved in a multi folder workspace. Scope this variable using ':' and a workspace folder name.", match));
+				throw new VariableError(variableKind, localize('canNotResolveWorkspaceFolderMultiRoot', "Variable {0} cannot be resolved in a multi folder workspace. Scope this variable using ':' and a workspace folder name.", match));
 			}
-			throw new VariableError(variableKind, localize('canNotResolveWorkspaceFolder', "Variable {0} can not be resolved. Please open a folder.", match));
+			throw new VariableError(variableKind, localize('canNotResolveWorkspaceFolder', "Variable {0} cannot be resolved. Please open a folder.", match));
 		};
 
 
@@ -248,20 +248,20 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 					// For `env` we should do the same as a normal shell does - evaluates undefined envs to an empty string #46436
 					return '';
 				}
-				throw new VariableError(VariableKind.Env, localize('missingEnvVarName', "Variable {0} can not be resolved because no environment variable name is given.", match));
+				throw new VariableError(VariableKind.Env, localize('missingEnvVarName', "Variable {0} cannot be resolved because no environment variable name is given.", match));
 
 			case 'config':
 				if (argument) {
 					const config = this._context.getConfigurationValue(folderUri, argument);
 					if (types.isUndefinedOrNull(config)) {
-						throw new VariableError(VariableKind.Config, localize('configNotFound', "Variable {0} can not be resolved because setting '{1}' not found.", match, argument));
+						throw new VariableError(VariableKind.Config, localize('configNotFound', "Variable {0} cannot be resolved because setting '{1}' not found.", match, argument));
 					}
 					if (types.isObject(config)) {
-						throw new VariableError(VariableKind.Config, localize('configNoString', "Variable {0} can not be resolved because '{1}' is a structured value.", match, argument));
+						throw new VariableError(VariableKind.Config, localize('configNoString', "Variable {0} cannot be resolved because '{1}' is a structured value.", match, argument));
 					}
 					return config;
 				}
-				throw new VariableError(VariableKind.Config, localize('missingConfigName', "Variable {0} can not be resolved because no settings name is given.", match));
+				throw new VariableError(VariableKind.Config, localize('missingConfigName', "Variable {0} cannot be resolved because no settings name is given.", match));
 
 			case 'command':
 				return this.resolveFromMap(VariableKind.Command, match, argument, commandValueMapping, 'command');
@@ -273,11 +273,11 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 				if (argument) {
 					const ext = await this._context.getExtension(argument);
 					if (!ext) {
-						throw new VariableError(VariableKind.ExtensionInstallFolder, localize('extensionNotInstalled', "Variable {0} can not be resolved because the extension {1} is not installed.", match, argument));
+						throw new VariableError(VariableKind.ExtensionInstallFolder, localize('extensionNotInstalled', "Variable {0} cannot be resolved because the extension {1} is not installed.", match, argument));
 					}
 					return this.fsPath(ext.extensionLocation);
 				}
-				throw new VariableError(VariableKind.ExtensionInstallFolder, localize('missingExtensionName', "Variable {0} can not be resolved because no extension name is given.", match));
+				throw new VariableError(VariableKind.ExtensionInstallFolder, localize('missingExtensionName', "Variable {0} cannot be resolved because no extension name is given.", match));
 
 			default: {
 
@@ -297,7 +297,7 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 						if (environment.userHome) {
 							return environment.userHome;
 						}
-						throw new VariableError(VariableKind.UserHome, localize('canNotResolveUserHome', "Variable {0} can not be resolved. UserHome path is not defined", match));
+						throw new VariableError(VariableKind.UserHome, localize('canNotResolveUserHome', "Variable {0} cannot be resolved. UserHome path is not defined", match));
 					}
 
 					case 'lineNumber': {
@@ -305,14 +305,14 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 						if (lineNumber) {
 							return lineNumber;
 						}
-						throw new VariableError(VariableKind.LineNumber, localize('canNotResolveLineNumber', "Variable {0} can not be resolved. Make sure to have a line selected in the active editor.", match));
+						throw new VariableError(VariableKind.LineNumber, localize('canNotResolveLineNumber', "Variable {0} cannot be resolved. Make sure to have a line selected in the active editor.", match));
 					}
 					case 'selectedText': {
 						const selectedText = this._context.getSelectedText();
 						if (selectedText) {
 							return selectedText;
 						}
-						throw new VariableError(VariableKind.SelectedText, localize('canNotResolveSelectedText', "Variable {0} can not be resolved. Make sure to have some text selected in the active editor.", match));
+						throw new VariableError(VariableKind.SelectedText, localize('canNotResolveSelectedText', "Variable {0} cannot be resolved. Make sure to have some text selected in the active editor.", match));
 					}
 					case 'file':
 						return getFilePath(VariableKind.File);
@@ -385,7 +385,7 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 			if (typeof v === 'string') {
 				return v;
 			}
-			throw new VariableError(variableKind, localize('noValueForCommand', "Variable {0} can not be resolved because the command has no value.", match));
+			throw new VariableError(variableKind, localize('noValueForCommand', "Variable {0} cannot be resolved because the command has no value.", match));
 		}
 		return match;
 	}

--- a/src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts
+++ b/src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts
@@ -203,7 +203,7 @@ suite('RPCProtocol', () => {
 		});
 	});
 
-	test('issue #81424: SerializeRequest should throw if an argument can not be serialized', () => {
+	test('issue #81424: SerializeRequest should throw if an argument cannot be serialized', () => {
 		const badObject = {};
 		(<any>badObject).loop = badObject;
 

--- a/src/vs/workbench/services/themes/common/colorExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/colorExtensionPoint.ts
@@ -32,7 +32,7 @@ const configurationExtPoint = ExtensionsRegistry.registerExtensionPoint<IColorEx
 					type: 'string',
 					description: nls.localize('contributes.color.id', 'The identifier of the themable color'),
 					pattern: colorIdPattern,
-					patternErrorMessage: nls.localize('contributes.color.id.format', 'Identifiers must only contain letters, digits and dots and can not start with a dot'),
+					patternErrorMessage: nls.localize('contributes.color.id.format', 'Identifiers must only contain letters, digits and dots and cannot start with a dot'),
 				},
 				description: {
 					type: 'string',
@@ -107,15 +107,15 @@ export class ColorExtensionPoint {
 
 				for (const colorContribution of extensionValue) {
 					if (typeof colorContribution.id !== 'string' || colorContribution.id.length === 0) {
-						collector.error(nls.localize('invalid.id', "'configuration.colors.id' must be defined and can not be empty"));
+						collector.error(nls.localize('invalid.id', "'configuration.colors.id' must be defined and cannot be empty"));
 						return;
 					}
 					if (!colorContribution.id.match(colorIdPattern)) {
-						collector.error(nls.localize('invalid.id.format', "'configuration.colors.id' must only contain letters, digits and dots and can not start with a dot"));
+						collector.error(nls.localize('invalid.id.format', "'configuration.colors.id' must only contain letters, digits and dots and cannot start with a dot"));
 						return;
 					}
 					if (typeof colorContribution.description !== 'string' || colorContribution.id.length === 0) {
-						collector.error(nls.localize('invalid.description', "'configuration.colors.description' must be defined and can not be empty"));
+						collector.error(nls.localize('invalid.description', "'configuration.colors.description' must be defined and cannot be empty"));
 						return;
 					}
 					const defaults = colorContribution.defaults;

--- a/src/vs/workbench/services/themes/common/iconExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/iconExtensionPoint.ts
@@ -90,7 +90,7 @@ export class IconExtensionPoint {
 					}
 					const iconContribution = extensionValue[id];
 					if (typeof iconContribution.description !== 'string' || iconContribution.description.length === 0) {
-						collector.error(nls.localize('invalid.icons.description', "'configuration.icons.description' must be defined and can not be empty"));
+						collector.error(nls.localize('invalid.icons.description', "'configuration.icons.description' must be defined and cannot be empty"));
 						return;
 					}
 					const defaultIcon = iconContribution.default;

--- a/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
@@ -109,7 +109,7 @@ export class TokenClassificationExtensionPoints {
 	constructor() {
 		function validateTypeOrModifier(contribution: ITokenTypeExtensionPoint | ITokenModifierExtensionPoint, extensionPoint: string, collector: ExtensionMessageCollector): boolean {
 			if (typeof contribution.id !== 'string' || contribution.id.length === 0) {
-				collector.error(nls.localize('invalid.id', "'configuration.{0}.id' must be defined and can not be empty", extensionPoint));
+				collector.error(nls.localize('invalid.id', "'configuration.{0}.id' must be defined and cannot be empty", extensionPoint));
 				return false;
 			}
 			if (!contribution.id.match(typeAndModifierIdPattern)) {
@@ -122,7 +122,7 @@ export class TokenClassificationExtensionPoints {
 				return false;
 			}
 			if (typeof contribution.description !== 'string' || contribution.id.length === 0) {
-				collector.error(nls.localize('invalid.description', "'configuration.{0}.description' must be defined and can not be empty", extensionPoint));
+				collector.error(nls.localize('invalid.description', "'configuration.{0}.description' must be defined and cannot be empty", extensionPoint));
 				return false;
 			}
 			return true;


### PR DESCRIPTION
Fixes #165670

This is a minor style edit to ensure that all user-facing errors use "cannot" and not "can not", which is non-standard.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
