### PR TITLE
box-shadow

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
@@ -477,7 +477,7 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 			toast.style.background = backgroundColor ? backgroundColor : '';
 
 			const widgetShadowColor = this.getColor(widgetShadow);
-			toast.style.boxShadow = widgetShadowColor ? `0 0 8px 2px ${widgetShadowColor}` : '';
+			toast.style.boxShadow = widgetShadowColor ? `2px 0 8px 2px ${widgetShadowColor}` : '';
 
 			const borderColor = this.getColor(NOTIFICATIONS_TOAST_BORDER);
 			toast.style.border = borderColor ? `1px solid ${borderColor}` : '';


### PR DESCRIPTION
#165705
Gives terminal find widget a bottom box shadow. 
Test this by opening the terminal find and checking if it has a bottom box shadow. 