### PR TITLE
💄 Include file system path in debug mode's URI/link hovers

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
+++ b/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
@@ -93,7 +93,7 @@ export function renderExpressionValue(expressionOrValue: IExpressionContainer | 
 	if (options.linkDetector) {
 		container.textContent = '';
 		const session = (expressionOrValue instanceof ExpressionContainer) ? expressionOrValue.getSession() : undefined;
-		container.appendChild(options.linkDetector.linkify(value, false, session ? session.root : undefined));
+		container.appendChild(options.linkDetector.linkify(value, false, session ? session.root : undefined, true));
 	} else {
 		container.textContent = value;
 	}

--- a/src/vs/workbench/contrib/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -193,7 +193,10 @@ export class LinkDetector {
 	private decorateLink(link: HTMLElement, uri: URI, onClick: (preserveFocus: boolean) => void) {
 		link.classList.add('link');
 		const followLink = this.tunnelService.canTunnel(uri) ? localize('followForwardedLink', "follow link using forwarded port") : localize('followLink', "follow link");
-		link.title = platform.isMacintosh ? localize('fileLinkMac', "Cmd + click to {0}", followLink) : localize('fileLink', "Ctrl + click to {0}", followLink);
+		const filePath = (!uri.scheme || uri.scheme === Schemas.file) ? uri.fsPath : undefined;
+		link.title = filePath
+			? (platform.isMacintosh ? localize('fileLinkWithPathMac', "Cmd + click to {0}\n({1})", followLink, filePath) : localize('fileLinkWithPath', "Ctrl + click to {0}\n({1})", followLink, filePath))
+			: (platform.isMacintosh ? localize('fileLinkMac', "Cmd + click to {0}", followLink) : localize('fileLink', "Ctrl + click to {0}", followLink));
 		link.onmousemove = (event) => { link.classList.toggle('pointer', platform.isMacintosh ? event.metaKey : event.ctrlKey); };
 		link.onmouseleave = () => link.classList.remove('pointer');
 		link.onclick = (event) => {

--- a/src/vs/workbench/contrib/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -57,7 +57,7 @@ export class LinkDetector {
 	 * When splitLines is true, each line of the text, even if it contains no links, is wrapped in a <span>
 	 * and added as a child of the returned <span>.
 	 */
-	linkify(text: string, splitLines?: boolean, workspaceFolder?: IWorkspaceFolder): HTMLElement {
+	linkify(text: string, splitLines?: boolean, workspaceFolder?: IWorkspaceFolder, includeFulltext?: boolean): HTMLElement {
 		if (splitLines) {
 			const lines = text.split('\n');
 			for (let i = 0; i < lines.length - 1; i++) {
@@ -67,7 +67,7 @@ export class LinkDetector {
 				// Remove the last element ('') that split added.
 				lines.pop();
 			}
-			const elements = lines.map(line => this.linkify(line, false, workspaceFolder));
+			const elements = lines.map(line => this.linkify(line, false, workspaceFolder, includeFulltext));
 			if (elements.length === 1) {
 				// Do not wrap single line with extra span.
 				return elements[0];
@@ -85,13 +85,13 @@ export class LinkDetector {
 						container.appendChild(document.createTextNode(part.value));
 						break;
 					case 'web':
-						container.appendChild(this.createWebLink(text, part.value));
+						container.appendChild(this.createWebLink(includeFulltext ? text : undefined, part.value));
 						break;
 					case 'path': {
 						const path = part.captures[0];
 						const lineNumber = part.captures[1] ? Number(part.captures[1]) : 0;
 						const columnNumber = part.captures[2] ? Number(part.captures[2]) : 0;
-						container.appendChild(this.createPathLink(text, part.value, path, lineNumber, columnNumber, workspaceFolder));
+						container.appendChild(this.createPathLink(includeFulltext ? text : undefined, part.value, path, lineNumber, columnNumber, workspaceFolder));
 						break;
 					}
 				}
@@ -102,7 +102,7 @@ export class LinkDetector {
 		return container;
 	}
 
-	private createWebLink(fulltext: string, url: string): Node {
+	private createWebLink(fulltext: string | undefined, url: string): Node {
 		const link = this.createLink(url);
 
 		let uri = URI.parse(url);
@@ -146,7 +146,7 @@ export class LinkDetector {
 		return link;
 	}
 
-	private createPathLink(fulltext: string, text: string, path: string, lineNumber: number, columnNumber: number, workspaceFolder: IWorkspaceFolder | undefined): Node {
+	private createPathLink(fulltext: string | undefined, text: string, path: string, lineNumber: number, columnNumber: number, workspaceFolder: IWorkspaceFolder | undefined): Node {
 		if (path[0] === '/' && path[1] === '/') {
 			// Most likely a url part which did not match, for example ftp://path.
 			return document.createTextNode(text);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #164486

With this PR, only file system URIs (i.e., URIs with `file://` scheme or no scheme at all) are also included in the hover box content:

![With file path in hover](https://user-images.githubusercontent.com/36728931/200334813-440ffbf6-bd5d-483b-a0d7-dc4e497b830e.png)

Note that the current behavior is kept for other URI schemes (e.g., `http`/`https`):

![Without file path in hover](https://user-images.githubusercontent.com/36728931/200334828-41d3274d-b299-4f4f-b6be-70b6edc9e327.png)
