### PR TITLE
Refactor preferencesWidget to use CSS variables

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/preferences.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/preferences.css
@@ -101,16 +101,12 @@
 	display: none;
 }
 
-.settings-tabs-widget > .monaco-action-bar .action-item .action-label:focus,
-.settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked {
-	border-bottom: 1px solid;
-}
-
 .settings-tabs-widget > .monaco-action-bar .action-item .action-label {
 	color: var(--vscode-panelTitle-inactiveForeground);
 }
 
 .settings-tabs-widget > .monaco-action-bar .action-item .action-label:focus {
+	border-bottom: 1px solid;
 	border-bottom-color: var(--vscode-focusBorder) !important;
 	outline: none;
 }
@@ -119,9 +115,7 @@
 .settings-tabs-widget > .monaco-action-bar .action-item .action-label:hover {
 	color: var(--vscode-panelTitle-activeForeground);
 	border-bottom-color: var(--vscode-panelTitle-activeBorder);
-	outline-color: var(--vscode-contrastActiveBorder);
-	outline-width: 1px;
-	outline-style: solid;
+	outline: 1px solid var(--vscode-contrastActiveBorder);
 	border-bottom: none;
 	padding-bottom: 0;
 	outline-offset: -1px;

--- a/src/vs/workbench/contrib/preferences/browser/media/preferences.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/preferences.css
@@ -101,6 +101,36 @@
 	display: none;
 }
 
+.settings-tabs-widget > .monaco-action-bar .action-item .action-label:focus,
+.settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked {
+	border-bottom: 1px solid;
+}
+
+.settings-tabs-widget > .monaco-action-bar .action-item .action-label {
+	color: var(--vscode-panelTitle-inactiveForeground);
+}
+
+.settings-tabs-widget > .monaco-action-bar .action-item .action-label:focus {
+	border-bottom-color: var(--vscode-focusBorder) !important;
+	outline: none;
+}
+
+.settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked,
+.settings-tabs-widget > .monaco-action-bar .action-item .action-label:hover {
+	color: var(--vscode-panelTitle-activeForeground);
+	border-bottom-color: var(--vscode-panelTitle-activeBorder);
+	outline-color: var(--vscode-contrastActiveBorder);
+	outline-width: 1px;
+	outline-style: solid;
+	border-bottom: none;
+	padding-bottom: 0;
+	outline-offset: -1px;
+}
+
+.settings-tabs-widget > .monaco-action-bar .action-item .action-label:not(.checked):hover {
+	outline-style: dashed;
+}
+
 .preferences-header > .settings-header-widget {
 	flex: 1;
 	display: flex;

--- a/src/vs/workbench/contrib/preferences/browser/media/preferences.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/preferences.css
@@ -105,19 +105,17 @@
 	color: var(--vscode-panelTitle-inactiveForeground);
 }
 
-.settings-tabs-widget > .monaco-action-bar .action-item .action-label:focus {
-	border-bottom: 1px solid;
-	border-bottom-color: var(--vscode-focusBorder) !important;
-	outline: none;
-}
-
 .settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked,
 .settings-tabs-widget > .monaco-action-bar .action-item .action-label:hover {
 	color: var(--vscode-panelTitle-activeForeground);
-	border-bottom-color: var(--vscode-panelTitle-activeBorder);
-	outline: 1px solid var(--vscode-contrastActiveBorder);
-	border-bottom: none;
-	padding-bottom: 0;
+	border-bottom: 1px solid var(--vscode-panelTitle-activeBorder);
+	outline: 1px solid var(--vscode-contrastActiveBorder, transparent);
+	outline-offset: -1px;
+}
+
+.settings-tabs-widget > .monaco-action-bar .action-item .action-label:focus {
+	border-bottom: 1px solid var(--vscode-focusBorder);
+	outline: 1px solid transparent;
 	outline-offset: -1px;
 }
 

--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -28,11 +28,10 @@ import { IContextMenuService, IContextViewService } from 'vs/platform/contextvie
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ILabelService } from 'vs/platform/label/common/label';
-import { activeContrastBorder, badgeBackground, badgeForeground, contrastBorder, focusBorder } from 'vs/platform/theme/common/colorRegistry';
+import { badgeBackground, badgeForeground, contrastBorder } from 'vs/platform/theme/common/colorRegistry';
 import { attachInputBoxStyler, attachStylerCallback } from 'vs/platform/theme/common/styler';
-import { IColorTheme, ICssStyleCollector, IThemeService, registerThemingParticipant, ThemeIcon } from 'vs/platform/theme/common/themeService';
+import { IThemeService, ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { isWorkspaceFolder, IWorkspaceContextService, IWorkspaceFolder, WorkbenchState } from 'vs/platform/workspace/common/workspace';
-import { PANEL_ACTIVE_TITLE_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_INACTIVE_TITLE_FOREGROUND } from 'vs/workbench/common/theme';
 import { settingsEditIcon, settingsScopeDropDownIcon } from 'vs/workbench/contrib/preferences/browser/preferencesIcons';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
@@ -575,72 +574,3 @@ export class EditPreferenceWidget<T> extends Disposable {
 		super.dispose();
 	}
 }
-
-registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {
-
-	collector.addRule(`
-		.settings-tabs-widget > .monaco-action-bar .action-item .action-label:focus,
-		.settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked {
-			border-bottom: 1px solid;
-		}
-	`);
-	// Title Active
-	const titleActive = theme.getColor(PANEL_ACTIVE_TITLE_FOREGROUND);
-	const titleActiveBorder = theme.getColor(PANEL_ACTIVE_TITLE_BORDER);
-	if (titleActive || titleActiveBorder) {
-		collector.addRule(`
-			.settings-tabs-widget > .monaco-action-bar .action-item .action-label:hover,
-			.settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked {
-				color: ${titleActive};
-				border-bottom-color: ${titleActiveBorder};
-			}
-		`);
-	}
-
-	// Title Inactive
-	const titleInactive = theme.getColor(PANEL_INACTIVE_TITLE_FOREGROUND);
-	if (titleInactive) {
-		collector.addRule(`
-			.settings-tabs-widget > .monaco-action-bar .action-item .action-label {
-				color: ${titleInactive};
-			}
-		`);
-	}
-
-	// Title focus
-	const focusBorderColor = theme.getColor(focusBorder);
-	if (focusBorderColor) {
-		collector.addRule(`
-			.settings-tabs-widget > .monaco-action-bar .action-item .action-label:focus {
-				border-bottom-color: ${focusBorderColor} !important;
-			}
-			`);
-		collector.addRule(`
-			.settings-tabs-widget > .monaco-action-bar .action-item .action-label:focus {
-				outline: none;
-			}
-			`);
-	}
-
-	// Styling with Outline color (e.g. high contrast theme)
-	const outline = theme.getColor(activeContrastBorder);
-	if (outline) {
-		const outline = theme.getColor(activeContrastBorder);
-
-		collector.addRule(`
-			.settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked,
-			.settings-tabs-widget > .monaco-action-bar .action-item .action-label:hover {
-				outline-color: ${outline};
-				outline-width: 1px;
-				outline-style: solid;
-				border-bottom: none;
-				padding-bottom: 0;
-				outline-offset: -1px;
-			}
-
-			.settings-tabs-widget > .monaco-action-bar .action-item .action-label:not(.checked):hover {
-				outline-style: dashed;
-			}
-		`);
-	}
-});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
 Ref https://github.com/microsoft/vscode/issues/165169

This PR changes some styles to use CSS variables rather than `registerThemingParticipant`.
It also eliminates some contradictory rules, like how `.action-label:hover` had a `border-bottom: none` rule in one style and a `border-bottom: 1px solid;` rule in another.
