### PR TITLE
Enable opening a local terminal while the remote resolver is running

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
@@ -85,11 +85,13 @@ export class TerminalInstanceService extends Disposable implements ITerminalInst
 	}
 
 	async getBackend(remoteAuthority?: string): Promise<ITerminalBackend | undefined> {
-		if (remoteAuthority) {
+		let backend = Registry.as<ITerminalBackendRegistry>(TerminalExtensions.Backend).getTerminalBackend(remoteAuthority);
+		if (!backend) {
+			// Ensure all backends are initialized and try again
 			await this._lifecycleService.when(LifecyclePhase.Restored);
+			backend = Registry.as<ITerminalBackendRegistry>(TerminalExtensions.Backend).getTerminalBackend(remoteAuthority);
 		}
-
-		return Registry.as<ITerminalBackendRegistry>(TerminalExtensions.Backend).getTerminalBackend(remoteAuthority);
+		return backend;
 	}
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
@@ -85,7 +85,10 @@ export class TerminalInstanceService extends Disposable implements ITerminalInst
 	}
 
 	async getBackend(remoteAuthority?: string): Promise<ITerminalBackend | undefined> {
-		await this._lifecycleService.when(LifecyclePhase.Restored);
+		if (remoteAuthority) {
+			await this._lifecycleService.when(LifecyclePhase.Restored);
+		}
+
 		return Registry.as<ITerminalBackendRegistry>(TerminalExtensions.Backend).getTerminalBackend(remoteAuthority);
 	}
 }

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/terminal.contribution.ts
@@ -21,5 +21,8 @@ registerSingleton(ITerminalProfileResolverService, ElectronTerminalProfileResolv
 
 // Register workbench contributions
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
+
+// This contribution needs to be active during the Startup phase to be available when a remote resolver tries to open a local
+// terminal while connecting to the remote.
 workbenchRegistry.registerWorkbenchContribution(LocalTerminalBackendContribution, LifecyclePhase.Starting);
 workbenchRegistry.registerWorkbenchContribution(TerminalNativeContribution, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/terminal.contribution.ts
@@ -21,5 +21,5 @@ registerSingleton(ITerminalProfileResolverService, ElectronTerminalProfileResolv
 
 // Register workbench contributions
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
-workbenchRegistry.registerWorkbenchContribution(LocalTerminalBackendContribution, LifecyclePhase.Restored);
+workbenchRegistry.registerWorkbenchContribution(LocalTerminalBackendContribution, LifecyclePhase.Starting);
 workbenchRegistry.registerWorkbenchContribution(TerminalNativeContribution, LifecyclePhase.Restored);


### PR DESCRIPTION
Fix microsoft/vscode-remote-release#7324

Need to unblock the path to opening a local terminal, triggered by a remote resolver, before the workbench has loaded (ie connected to a remote)
