### PR TITLE
Suppress save while applying code action save participant

### DIFF
--- a/src/vs/editor/browser/services/bulkEditService.ts
+++ b/src/vs/editor/browser/services/bulkEditService.ts
@@ -121,4 +121,6 @@ export interface IBulkEditService {
 	setPreviewHandler(handler: IBulkEditPreviewHandler): IDisposable;
 
 	apply(edit: ResourceEdit[] | WorkspaceEdit, options?: IBulkEditOptions): Promise<IBulkEditResult>;
+
+	whileSuppressingAutosave(task: () => Promise<void>): Promise<void>;
 }

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -834,6 +834,10 @@ class StandaloneBulkEditService implements IBulkEditService {
 			isApplied: totalEdits > 0
 		};
 	}
+
+	whileSuppressingAutosave(task: () => Promise<void>): Promise<void> {
+		return task();
+	}
 }
 
 class StandaloneUriLabelService implements ILabelService {


### PR DESCRIPTION
For #165326

With  `files.refactoring.autoSave`, we can currently get into a loop that looks like the following:

1. File saved
1. Code action 1 is run by `editor.codeActionsOnSave`
1. Code action 1 triggers a workspace edit
1. This triggers an autosave
1. Code action 1 is run by `editor.codeActionsOnSave`
1. Code action 1 returns no edits since it has already applied
1. Code action 2 is run by `editor.codeActionsOnSave`
1. This triggers an autosave
1. Code action 1 is run by `editor.codeActionsOnSave`
1. Code action 1 triggers a workspace edit
1. This triggers an autosave
1. ...

To fix this, we need to stop the bulk edit service from autosaving if a save is already happening. In the case of code actions, these saves can either be triggered by a workspace edit or through a command

I've added a `whileSuppressingAutosave` function that `saveParticipants` uses to do stop autosave while a save is already happening

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
