### PR TITLE
Allow to open either side of a diff editor as editor (fix #153786)

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -1351,14 +1351,16 @@ function registerOtherEditorCommands(): void {
 			const editorService = accessor.get(IEditorService);
 			const originalEditor = (editorService.activeTextEditorControl as IDiffEditor).getOriginalEditor();
 			if (originalEditor.hasTextFocus()) {
-				editor = (editorService.activeEditor as DiffEditorInput).original;
+				editor = (editorService.activeEditor as DiffEditorInput)?.original;
 			} else {
 				// Default back to modified editor
-				editor = (editorService.activeEditor as DiffEditorInput).modified;
+				editor = (editorService.activeEditor as DiffEditorInput)?.modified;
 			}
-			editorService.openEditor(
-				editor,
-			);
+			if (editor) {
+				editorService.openEditor(
+					editor,
+				);
+			}
 		}
 	});
 

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -1347,18 +1347,18 @@ function registerOtherEditorCommands(): void {
 		when: EditorContextKeys.inDiffEditor,
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.Shift | KeyCode.KeyO),
 		handler: async (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
-			let resource: URI | undefined;
+			let editor: EditorInput | undefined;
 			const editorService = accessor.get(IEditorService);
 			const originalEditor = (editorService.activeTextEditorControl as IDiffEditor).getOriginalEditor();
 			if (originalEditor.hasTextFocus()) {
-				resource = (editorService.activeEditor as DiffEditorInput).original.resource;
+				editor = (editorService.activeEditor as DiffEditorInput).original;
 			} else {
 				// Default back to modified editor
-				resource = (editorService.activeEditor as DiffEditorInput).modified.resource;
+				editor = (editorService.activeEditor as DiffEditorInput).modified;
 			}
-			editorService.openEditor({
-				resource,
-			});
+			editorService.openEditor(
+				editor,
+			);
 		}
 	});
 

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -37,6 +37,8 @@ import { IEditorResolverService } from 'vs/workbench/services/editor/common/edit
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { extname } from 'vs/base/common/resources';
+import { IDiffEditor } from 'vs/editor/common/editorCommon';
+import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 
 export const CLOSE_SAVED_EDITORS_COMMAND_ID = 'workbench.action.closeUnmodifiedEditors';
 export const CLOSE_EDITORS_IN_GROUP_COMMAND_ID = 'workbench.action.closeEditorsInGroup';
@@ -53,6 +55,7 @@ export const LAYOUT_EDITOR_GROUPS_COMMAND_ID = 'layoutEditorGroups';
 export const KEEP_EDITOR_COMMAND_ID = 'workbench.action.keepEditor';
 export const TOGGLE_KEEP_EDITORS_COMMAND_ID = 'workbench.action.toggleKeepEditors';
 export const TOGGLE_LOCK_GROUP_COMMAND_ID = 'workbench.action.toggleEditorGroupLock';
+export const OPEN_FILE_IN_EDITOR = 'workbench.action.openFileInEditor';
 export const LOCK_GROUP_COMMAND_ID = 'workbench.action.lockEditorGroup';
 export const UNLOCK_GROUP_COMMAND_ID = 'workbench.action.unlockEditorGroup';
 export const SHOW_EDITORS_IN_GROUP = 'workbench.action.showEditorsInGroup';
@@ -1335,6 +1338,27 @@ function registerOtherEditorCommands(): void {
 			if (group && editor) {
 				return group.stickEditor(editor);
 			}
+		}
+	});
+
+	KeybindingsRegistry.registerCommandAndKeybindingRule({
+		id: OPEN_FILE_IN_EDITOR,
+		weight: KeybindingWeight.WorkbenchContrib,
+		when: EditorContextKeys.inDiffEditor,
+		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.Shift | KeyCode.KeyO),
+		handler: async (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
+			let resource: URI | undefined;
+			const editorService = accessor.get(IEditorService);
+			const originalEditor = (editorService.activeTextEditorControl as IDiffEditor).getOriginalEditor();
+			if (originalEditor.hasTextFocus()) {
+				resource = (editorService.activeEditor as DiffEditorInput).original.resource;
+			} else {
+				// Default back to modified editor
+				resource = (editorService.activeEditor as DiffEditorInput).modified.resource;
+			}
+			editorService.openEditor({
+				resource,
+			});
 		}
 	});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This is an attempt to implement https://github.com/microsoft/vscode/issues/153786 by offering a way of going back to a single window from a diff. It should also be possible to display either side of the diff in a single window (other editors allow this).

When doing code reviews on GitHub you can open a file fully for context, then click back into the diff when done viewing. It should be just as easy to do this in VSCode.

This change would greatly improve productivity as it helps with navigating around changes and not needing to learn different keybindings/commands from other extensions.

Things that are needed:
- ~To know which side of the diff has focus so I can open the right file, currently this doesn't seem possible as neither [textDiffEditor](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/browser/parts/editor/textDiffEditor.ts) nor [diffEditorInput](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/common/editor/diffEditorInput.ts) support showing which side has focus.~
- ~Back currently doesn't work, once you open up an editor you can't go back to the diff view~ Addressed in https://github.com/microsoft/vscode/issues/166805
- ~Eventually an opportunity for a keybinding to open a window for each split you’re focused on. This increases productivity quite a bit as you can view the full file for context then go back to the diff.~

![diffToSingle](https://user-images.githubusercontent.com/936006/200439811-9897c72f-b24c-4ef2-8f19-b78440ccd6c7.gif)
