### PR TITLE
Include JS files in XLF creation for extensions

### DIFF
--- a/build/lib/i18n.js
+++ b/build/lib/i18n.js
@@ -510,15 +510,21 @@ exports.createXlfFilesForCoreBundle = createXlfFilesForCoreBundle;
 function createL10nBundleForExtension(extensionFolderName) {
     const result = (0, event_stream_1.through)();
     gulp.src([
-        `extensions/${extensionFolderName}/src/**/*.ts`,
+        // For source code of extensions
+        `extensions/${extensionFolderName}/src/**/*.{ts,tsx}`,
+        // For any dependencies pulled in (think vscode-css-languageservice or @vscode/emmet-helper)
+        `extensions/${extensionFolderName}/node_modules/**/*.{js,jsx}`
     ]).pipe((0, event_stream_1.writeArray)((err, files) => {
         if (err) {
             result.emit('error', err);
             return;
         }
-        const json = (0, l10n_dev_1.getL10nJson)(files.map(file => {
-            return file.contents.toString('utf8');
-        }));
+        const json = (0, l10n_dev_1.getL10nJson)(files
+            .filter(file => file.isBuffer())
+            .map(file => ({
+            contents: file.contents.toString('utf8'),
+            extension: path.extname(file.path)
+        })));
         if (Object.keys(json).length > 0) {
             result.emit('data', new File({
                 path: `extensions/${extensionFolderName}/bundle.l10n.json`,

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/experimental-utils": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
-    "@vscode/l10n-dev": "0.0.15",
+    "@vscode/l10n-dev": "0.0.18",
     "@vscode/telemetry-extractor": "^1.9.8",
     "@vscode/test-web": "^0.0.32",
     "ansi-colors": "^3.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,10 +1252,10 @@
   resolved "https://registry.yarnpkg.com/@vscode/iconv-lite-umd/-/iconv-lite-umd-0.7.0.tgz#d2f1e0664ee6036408f9743fee264ea0699b0e48"
   integrity sha512-bRRFxLfg5dtAyl5XyiVWz/ZBPahpOpPrNYnnHpOpUZvam4tKH35wdhP4Kj6PbM0+KdliOsPzbGWpkxcdpNB/sg==
 
-"@vscode/l10n-dev@0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@vscode/l10n-dev/-/l10n-dev-0.0.15.tgz#677b527987ccd39e32c50956f139736a788061d6"
-  integrity sha512-zLuo/pa+FtnFrVq/7M8VHshgejNZ6TvnRW9/um1pLkg92PZ9glDgmwXUv1AdpBu5KNzgH9odiMKS4YQDkS12wQ==
+"@vscode/l10n-dev@0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@vscode/l10n-dev/-/l10n-dev-0.0.18.tgz#80a8cf6ef13c7fe1796be7b0007d71993bd1832f"
+  integrity sha512-pEKLMnlg7hlxFrZLqcyJe08olmj6KVs2Rof7MVB5rN0D6NOKPBRtkQ176TuMUmW863EDV5WQUgNzOGa2nHBSSQ==
   dependencies:
     deepmerge-json "^1.5.0"
     glob "^8.0.3"


### PR DESCRIPTION
* Bumps @vscode/l10n-dev to a version that supports JS files
* Pulls in JS files (and TSX & JSX) in addition to TS to account for scenarios like Emmet which pulls in @vscode/emmet-helper as an npm package

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
