### PR TITLE
cli: pin rust (and clippy) version for builds

### DIFF
--- a/build/azure-pipelines/cli/install-rust-posix.yml
+++ b/build/azure-pipelines/cli/install-rust-posix.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: channel
     type: string
-    default: stable
+    default: 1.65.0
   - name: targets
     default: []
     type: object

--- a/build/azure-pipelines/cli/install-rust-posix.yml
+++ b/build/azure-pipelines/cli/install-rust-posix.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: channel
     type: string
-    default: 1.65.0
+    default: 1.64.0
   - name: targets
     default: []
     type: object

--- a/build/azure-pipelines/cli/install-rust-win32.yml
+++ b/build/azure-pipelines/cli/install-rust-win32.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: channel
     type: string
-    default: stable
+    default: 1.65.0
   - name: targets
     default: []
     type: object

--- a/build/azure-pipelines/cli/install-rust-win32.yml
+++ b/build/azure-pipelines/cli/install-rust-win32.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: channel
     type: string
-    default: 1.65.0
+    default: 1.64.0
   - name: targets
     default: []
     type: object

--- a/build/azure-pipelines/cli/test.yml
+++ b/build/azure-pipelines/cli/test.yml
@@ -1,16 +1,5 @@
-parameters:
-  - name: VSCODE_CLI_TARGETS
-    default: []
-    type: object
-  - name: VSCODE_CLI_RUST_CHANNEL
-    type: string
-    default: stable
-
 steps:
   - template: ./install-rust-posix.yml
-    parameters:
-      targets: []
-      channel: ${{ parameters.VSCODE_CLI_RUST_CHANNEL }}
 
   - script: rustup component add clippy && cargo clippy -- -D warnings
     workingDirectory: cli

--- a/build/azure-pipelines/darwin/cli-build-darwin.yml
+++ b/build/azure-pipelines/darwin/cli-build-darwin.yml
@@ -7,9 +7,6 @@ parameters:
   - name: VSCODE_BUILD_MACOS_ARM64
     type: boolean
     default: false
-  - name: channel
-    type: string
-    default: stable
 
 steps:
   - task: Npm@1

--- a/build/azure-pipelines/linux/cli-build-linux.yml
+++ b/build/azure-pipelines/linux/cli-build-linux.yml
@@ -16,9 +16,6 @@ parameters:
     default: false
   - name: VSCODE_QUALITY
     type: string
-  - name: channel
-    type: string
-    default: stable
 
 steps:
   - task: Npm@1

--- a/build/azure-pipelines/win32/cli-build-win32.yml
+++ b/build/azure-pipelines/win32/cli-build-win32.yml
@@ -10,9 +10,6 @@ parameters:
     default: false
   - name: VSCODE_QUALITY
     type: string
-  - name: channel
-    type: string
-    default: stable
 
 steps:
   - task: Npm@1


### PR DESCRIPTION
Port #165773 to release/1.73

Locking to rustc 1.64.0 as used in VS Code 1.73.0