### PR TITLE
Add a fast check to determine if a preferences renderer needs to be created

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
@@ -35,7 +35,9 @@ export class SettingsEditorContribution extends Disposable {
 		this.currentRenderer = undefined;
 
 		const model = this.editor.getModel();
-		if (model) {
+		if (model && /\.(json|code-workspace)$/.test(model.uri.path)) {
+			// Fast check: the preferences renderer can only appear
+			// in settings files or workspace files
 			const settingsModel = await this.preferencesService.createPreferencesEditorModel(model.uri);
 			if (settingsModel instanceof SettingsEditorModel && this.editor.getModel()) {
 				this.disposables.add(settingsModel);


### PR DESCRIPTION
Helps with #164171

Determining if a preferences renderer needs to be created can be quite expensive in itself, since it needs many services to be instantiated. With this quick check, we can rule out most files immediately.