### PR TITLE
Allow trailing commas while minifying json resources

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -37,7 +37,7 @@ function minifyExtensionResources(input) {
         .pipe(buffer())
         .pipe(es.mapSync((f) => {
         const errors = [];
-        const value = jsoncParser.parse(f.contents.toString('utf8'), errors);
+        const value = jsoncParser.parse(f.contents.toString('utf8'), errors, { allowTrailingComma: true });
         if (errors.length === 0) {
             // file parsed OK => just stringify to drop whitespace and comments
             f.contents = Buffer.from(JSON.stringify(value));

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -39,7 +39,7 @@ function minifyExtensionResources(input: Stream): Stream {
 		.pipe(buffer())
 		.pipe(es.mapSync((f: File) => {
 			const errors: jsoncParser.ParseError[] = [];
-			const value = jsoncParser.parse(f.contents.toString('utf8'), errors);
+			const value = jsoncParser.parse(f.contents.toString('utf8'), errors, { allowTrailingComma: true });
 			if (errors.length === 0) {
 				// file parsed OK => just stringify to drop whitespace and comments
 				f.contents = Buffer.from(JSON.stringify(value));


### PR DESCRIPTION
I noticed a few of our built-in extension's json resources were not being minified. The root cause appears to be trailing commas in the source json.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
