### PR TITLE
Fix snippet overtyping feature

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -380,9 +380,6 @@ export class SuggestController implements IEditorContribution {
 			insertText = SnippetParser.escape(insertText);
 		}
 
-		// cancel -> stops all listening and closes widget
-		this.model.cancel();
-
 		snippetController.insert(insertText, {
 			overwriteBefore: info.overwriteBefore,
 			overwriteAfter: info.overwriteAfter,
@@ -392,6 +389,9 @@ export class SuggestController implements IEditorContribution {
 			clipboardText: event.model.clipboardText,
 			overtypingCapturer: this._overtypingCapturer.value
 		});
+
+		// cancel -> stops all listening and closes widget
+		this.model.cancel();
 
 		if (!(flags & InsertFlags.NoAfterUndoStop)) {
 			this.editor.pushUndoStop();

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -380,6 +380,9 @@ export class SuggestController implements IEditorContribution {
 			insertText = SnippetParser.escape(insertText);
 		}
 
+		// cancel -> stops all listening and closes widget
+		this.model.cancel();
+
 		snippetController.insert(insertText, {
 			overwriteBefore: info.overwriteBefore,
 			overwriteAfter: info.overwriteAfter,
@@ -389,9 +392,6 @@ export class SuggestController implements IEditorContribution {
 			clipboardText: event.model.clipboardText,
 			overtypingCapturer: this._overtypingCapturer.value
 		});
-
-		// cancel -> stops all listening and closes widget
-		this.model.cancel();
 
 		if (!(flags & InsertFlags.NoAfterUndoStop)) {
 			this.editor.pushUndoStop();


### PR DESCRIPTION
Fix snippet overtyping feature #105440 which stopped working during 1.72 ... 1.73 due to 1e662b070fd9f847dfefbdf3f45d0fe538d7e974