### PR TITLE
# Fix console errors on undefined viewBadge values

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2448,8 +2448,8 @@ export namespace ViewBadge {
 	export function isViewBadge(thing: any): thing is vscode.ViewBadge {
 		const viewBadgeThing = thing as vscode.ViewBadge;
 
-		if (!isNumber(viewBadgeThing.value)) {
-			console.log('INVALID view badge, invalid value', viewBadgeThing.value);
+		if (!isNumber(viewBadgeThing?.value)) {
+			console.log('INVALID view badge, invalid value', viewBadgeThing?.value);
 			return false;
 		}
 		if (viewBadgeThing.tooltip && !isString(viewBadgeThing.tooltip)) {


### PR DESCRIPTION
ViewBadge `isViewBadge()` can throw errors on invocation with undefined badge.
Should add the optional check for the value to avoid unneccessary errors.