### PR TITLE
joh/evil shark

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3922,6 +3922,10 @@ export interface ISuggestOptions {
 	 */
 	shareSuggestSelections?: boolean;
 	/**
+	 * Select suggestions when triggered via quick suggest or trigger characters
+	 */
+	selectQuickSuggestions?: boolean;
+	/**
 	 * Enable or disable icons in suggestions. Defaults to true.
 	 */
 	showIcons?: boolean;
@@ -4073,6 +4077,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 			snippetsPreventQuickSuggestions: true,
 			localityBonus: false,
 			shareSuggestSelections: false,
+			selectQuickSuggestions: true,
 			showIcons: true,
 			showStatusBar: false,
 			preview: false,
@@ -4334,6 +4339,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 			snippetsPreventQuickSuggestions: boolean(input.snippetsPreventQuickSuggestions, this.defaultValue.filterGraceful),
 			localityBonus: boolean(input.localityBonus, this.defaultValue.localityBonus),
 			shareSuggestSelections: boolean(input.shareSuggestSelections, this.defaultValue.shareSuggestSelections),
+			selectQuickSuggestions: boolean(input.selectQuickSuggestions, this.defaultValue.selectQuickSuggestions),
 			showIcons: boolean(input.showIcons, this.defaultValue.showIcons),
 			showStatusBar: boolean(input.showStatusBar, this.defaultValue.showStatusBar),
 			preview: boolean(input.preview, this.defaultValue.preview),

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -516,7 +516,7 @@ export class SuggestWidget implements IDisposable {
 		}
 	}
 
-	showSuggestions(completionModel: CompletionModel, selectionIndex: number, isFrozen: boolean, isAuto: boolean): void {
+	showSuggestions(completionModel: CompletionModel, selectionIndex: number, isFrozen: boolean, isAuto: boolean, noFocus: boolean): void {
 
 		this._contentWidget.setPosition(this.editor.getPosition());
 		this._loadingTimeout?.dispose();
@@ -554,8 +554,8 @@ export class SuggestWidget implements IDisposable {
 		try {
 			this._list.splice(0, this._list.length, this._completionModel.items);
 			this._setState(isFrozen ? State.Frozen : State.Open);
-			if (selectionIndex >= 0) {
-				this._list.reveal(selectionIndex, 0);
+			this._list.reveal(selectionIndex, 0);
+			if (!noFocus) {
 				this._list.setFocus([selectionIndex]);
 			}
 		} finally {

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -571,6 +571,15 @@ export class SuggestWidget implements IDisposable {
 		});
 	}
 
+	focusSelected(): void {
+		const selection = this._list.getSelection();
+		if (selection.length !== 1) {
+			this._list.setFocus([0]);
+		} else {
+			this._list.setFocus([selection[0]]);
+		}
+	}
+
 	selectNextPage(): boolean {
 		switch (this._state) {
 			case State.Hidden:

--- a/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
@@ -253,7 +253,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			return Promise.all([
 
 				assertEvent(model.onDidTrigger, function () {
-					model.trigger({ auto: true, shy: false, noSelect: false });
+					model.trigger({ auto: true, shy: false });
 				}, function (event) {
 					assert.strictEqual(event.auto, true);
 
@@ -265,13 +265,13 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				}),
 
 				assertEvent(model.onDidTrigger, function () {
-					model.trigger({ auto: true, shy: false, noSelect: false });
+					model.trigger({ auto: true, shy: false });
 				}, function (event) {
 					assert.strictEqual(event.auto, true);
 				}),
 
 				assertEvent(model.onDidTrigger, function () {
-					model.trigger({ auto: false, shy: false, noSelect: false });
+					model.trigger({ auto: false, shy: false });
 				}, function (event) {
 					assert.strictEqual(event.auto, false);
 				})
@@ -287,12 +287,12 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 		return withOracle(model => {
 			return Promise.all([
 				assertEvent(model.onDidCancel, function () {
-					model.trigger({ auto: true, shy: false, noSelect: false });
+					model.trigger({ auto: true, shy: false });
 				}, function (event) {
 					assert.strictEqual(event.retrigger, false);
 				}),
 				assertEvent(model.onDidSuggest, function () {
-					model.trigger({ auto: false, shy: false, noSelect: false });
+					model.trigger({ auto: false, shy: false });
 				}, function (event) {
 					assert.strictEqual(event.auto, false);
 					assert.strictEqual(event.isFrozen, false);
@@ -343,7 +343,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 
 			return assertEvent(model.onDidSuggest, () => {
 				// make sure completionModel starts here!
-				model.trigger({ auto: true, shy: false, noSelect: false });
+				model.trigger({ auto: true, shy: false });
 			}, event => {
 
 				return assertEvent(model.onDidSuggest, () => {
@@ -456,7 +456,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			editor.setPosition({ lineNumber: 1, column: 3 });
 
 			return assertEvent(model.onDidSuggest, () => {
-				model.trigger({ auto: false, shy: false, noSelect: false });
+				model.trigger({ auto: false, shy: false });
 			}, event => {
 				assert.strictEqual(event.auto, false);
 				assert.strictEqual(event.isFrozen, false);
@@ -481,7 +481,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			editor.setPosition({ lineNumber: 1, column: 3 });
 
 			return assertEvent(model.onDidSuggest, () => {
-				model.trigger({ auto: false, shy: false, noSelect: false });
+				model.trigger({ auto: false, shy: false });
 			}, event => {
 				assert.strictEqual(event.auto, false);
 				assert.strictEqual(event.isFrozen, false);
@@ -518,7 +518,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			editor.setPosition({ lineNumber: 1, column: 4 });
 
 			return assertEvent(model.onDidSuggest, () => {
-				model.trigger({ auto: false, shy: false, noSelect: false });
+				model.trigger({ auto: false, shy: false });
 			}, event => {
 				assert.strictEqual(event.auto, false);
 				assert.strictEqual(event.completionModel.incomplete.size, 1);
@@ -555,7 +555,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			editor.setPosition({ lineNumber: 1, column: 4 });
 
 			return assertEvent(model.onDidSuggest, () => {
-				model.trigger({ auto: false, shy: false, noSelect: false });
+				model.trigger({ auto: false, shy: false });
 			}, event => {
 				assert.strictEqual(event.auto, false);
 				assert.strictEqual(event.completionModel.incomplete.size, 1);
@@ -714,7 +714,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 
 			await assertEvent(sugget.onDidSuggest, () => {
 				editor.setPosition({ lineNumber: 1, column: 3 });
-				sugget.trigger({ auto: false, shy: false, noSelect: false });
+				sugget.trigger({ auto: false, shy: false });
 			}, event => {
 
 				assert.strictEqual(event.completionModel.items.length, 1);
@@ -938,21 +938,6 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			}, event => {
 				assert.strictEqual(event.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 2);
-			});
-		});
-	});
-
-	test('noSelect-flag makes it from request to suggest event', function () {
-
-		disposables.add(registry.register({ scheme: 'test' }, alwaysSomethingSupport));
-
-		return withOracle((model, editor) => {
-			return assertEvent(model.onDidSuggest, () => {
-				model.trigger({ auto: false, noSelect: true, shy: false });
-			}, event => {
-				assert.strictEqual(event.noSelect, true);
-				assert.strictEqual(event.auto, false);
-				assert.strictEqual(event.shy, false);
 			});
 		});
 	});

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4239,6 +4239,10 @@ declare namespace monaco.editor {
 		 */
 		shareSuggestSelections?: boolean;
 		/**
+		 * Select suggestions when triggered via quick suggest or trigger characters
+		 */
+		selectQuickSuggestions?: boolean;
+		/**
 		 * Enable or disable icons in suggestions. Defaults to true.
 		 */
 		showIcons?: boolean;


### PR DESCRIPTION
for https://github.com/microsoft/vscode/issues/151336

- add (undocumented) option `editor.suggest.selectQuickSuggestions` which makes suggest items not be selected when triggered automatically (quick suggest and trigger characters)
- always set selection and only control focus, some :lipstick: with selector logic
