### PR TITLE
Revert "Fix tree data provider being accessed after disposed"

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -125,13 +125,6 @@ export class MainThreadTreeViews extends Disposable implements MainThreadTreeVie
 		return controller.resolveDropFileData(requestId, dataItemId);
 	}
 
-	public async $disposeTree(treeViewId: string): Promise<void> {
-		const viewer = this.getTreeView(treeViewId);
-		if (viewer) {
-			viewer.dataProvider = undefined;
-		}
-	}
-
 	private async reveal(treeView: ITreeView, dataProvider: TreeViewDataProvider, itemIn: ITreeItem, parentChain: ITreeItem[], options: IRevealOptions): Promise<void> {
 		options = options ? options : { select: false, focus: false };
 		const select = isUndefinedOrNull(options.select) ? false : options.select;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -266,7 +266,6 @@ export interface MainThreadTreeViewsShape extends IDisposable {
 	$setTitle(treeViewId: string, title: string, description: string | undefined): void;
 	$setBadge(treeViewId: string, badge: IViewBadge | undefined): void;
 	$resolveDropFileData(destinationViewId: string, requestId: number, dataItemId: string): Promise<VSBuffer>;
-	$disposeTree(treeViewId: string): Promise<void>;
 }
 
 export interface MainThreadDownloadServiceShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -957,6 +957,5 @@ class ExtHostTreeView<T> extends Disposable {
 		this._refreshCancellationSource.dispose();
 
 		this.clearAll();
-		this.proxy.$disposeTree(this.viewId);
 	}
 }

--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -67,7 +67,6 @@ import { ITreeViewsService } from 'vs/workbench/services/views/browser/treeViews
 import { CodeDataTransfers } from 'vs/platform/dnd/browser/dnd';
 import { addExternalEditorsDropData, toVSDataTransfer } from 'vs/editor/browser/dnd';
 import { CheckboxStateHandler, TreeItemCheckbox } from 'vs/workbench/browser/parts/views/checkbox';
-import { setTimeout0 } from 'vs/base/common/platform';
 
 export class TreeViewPane extends ViewPane {
 
@@ -535,10 +534,6 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 	}
 
 	setVisibility(isVisible: boolean): void {
-		// Throughout setVisibility we need to check if the tree view's data provider still exists.
-		// This can happen because the `getChildren` call to the extension can return
-		// after the tree has been disposed.
-
 		this.initialize();
 		isVisible = !!isVisible;
 		if (this.isVisible === isVisible) {
@@ -554,17 +549,13 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 				DOM.hide(this.tree.getHTMLElement()); // make sure the tree goes out of the tabindex world by hiding it
 			}
 
-			if (this.isVisible && this.elementsToRefresh.length && this.dataProvider) {
+			if (this.isVisible && this.elementsToRefresh.length) {
 				this.doRefresh(this.elementsToRefresh);
 				this.elementsToRefresh = [];
 			}
 		}
 
-		setTimeout0(() => {
-			if (this.dataProvider) {
-				this._onDidChangeVisibility.fire(this.isVisible);
-			}
-		});
+		this._onDidChangeVisibility.fire(this.isVisible);
 
 		if (this.visible) {
 			this.activate();
@@ -1447,11 +1438,6 @@ class TreeMenus extends Disposable implements IDisposable {
 			menu.dispose();
 		}
 		return result;
-	}
-
-	override dispose() {
-		this.contextKeyService = undefined;
-		super.dispose();
 	}
 }
 


### PR DESCRIPTION
Reverts microsoft/vscode#165087
Fixes https://github.com/microsoft/vscode/issues/165739

@alexr00 Reverting this fix because it breaks other tree views - settings sync views are no longer showing data

![image](https://user-images.githubusercontent.com/10746682/200913688-67653e2c-5c22-44a5-bab2-6d502fad59c3.png)
