### PR TITLE
Improve layout of search input

### DIFF
--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -47,7 +47,7 @@
 
 .search-view .search-widget .monaco-inputbox > .ibwrapper > .mirror,
 .search-view .search-widget .monaco-inputbox > .ibwrapper > textarea.input {
-	padding: 3px 0px 3px 4px;
+	padding: 3px 0px 3px 6px;
 }
 
 /* NOTE: height is also used in searchWidget.ts as a constant*/

--- a/src/vs/workbench/contrib/searchEditor/browser/media/searchEditor.css
+++ b/src/vs/workbench/contrib/searchEditor/browser/media/searchEditor.css
@@ -124,7 +124,6 @@
 .search-editor .includes-excludes {
 	min-height: 1em;
 	position: relative;
-	margin: 0;
 }
 
 .search-editor .includes-excludes .expand {

--- a/src/vs/workbench/contrib/searchEditor/browser/media/searchEditor.css
+++ b/src/vs/workbench/contrib/searchEditor/browser/media/searchEditor.css
@@ -34,7 +34,7 @@
 
 .search-editor .search-widget .search-container,
 .search-editor .search-widget .replace-container {
-	margin-left: 18px;
+	margin-left: 17px;
 	display: flex;
 	align-items: center;
 }
@@ -52,7 +52,7 @@
 .search-editor .search-widget .monaco-inputbox > .ibwrapper > .mirror,
 .search-editor .search-widget .monaco-inputbox > .ibwrapper > textarea.input {
 	padding: 3px;
-	padding-left: 4px;
+	padding-left: 6px;
 }
 
 .search-editor .search-widget .monaco-inputbox > .ibwrapper > .mirror {

--- a/src/vs/workbench/contrib/searchEditor/browser/media/searchEditor.css
+++ b/src/vs/workbench/contrib/searchEditor/browser/media/searchEditor.css
@@ -13,7 +13,7 @@
 }
 
 .search-editor .query-container {
-	margin: 0px 12px 12px 2px;
+	margin: 0px 12px 12px 19px;
 	padding-top: 6px;
 }
 
@@ -34,7 +34,6 @@
 
 .search-editor .search-widget .search-container,
 .search-editor .search-widget .replace-container {
-	margin-left: 17px;
 	display: flex;
 	align-items: center;
 }
@@ -125,7 +124,7 @@
 .search-editor .includes-excludes {
 	min-height: 1em;
 	position: relative;
-	margin: 0 0 0 17px;
+	margin: 0;
 }
 
 .search-editor .includes-excludes .expand {
@@ -165,7 +164,7 @@
 }
 
 .search-editor .message {
-	padding-left: 22px;
+	padding-left: 7px;
 	padding-right: 22px;
 	padding-top: 0px;
 }


### PR DESCRIPTION
Since 1.73.0, I came across this minor UI issue of search input on search-view and search-editor as illustrated on the screenshots below.
Looking at related history it seems like a padding was introduced on the include/exclude inputs but not on the search input.
I haven't created an issue, and I haven't found any existing one, went straight with this proposed fix.

Before:
<img width="423" alt="before" src="https://user-images.githubusercontent.com/1112194/201035181-80b655dd-1018-4b71-b657-c77b1a7cdfa8.png">
After:
<img width="428" alt="after" src="https://user-images.githubusercontent.com/1112194/201035213-c9014c73-fb44-47d9-8554-ddaecd819b3b.png">

Fixes #168324