### PR TITLE
Do not preprocess Unicode newlines in Markdown preview

### DIFF
--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -13,8 +13,6 @@ import { ITextDocument } from './types/textDocument';
 import { WebviewResourceProvider } from './util/resources';
 import { isOfScheme, Schemes } from './util/schemes';
 
-const UNICODE_NEWLINE_REGEX = /\u2028|\u2029/g;
-
 /**
  * Adds begin line index to the output via the 'data-line' data attribute.
  */
@@ -189,7 +187,7 @@ export class MarkdownItEngine implements IMdParser {
 	private _tokenizeString(text: string, engine: MarkdownIt) {
 		this._resetSlugCount();
 
-		return engine.parse(text.replace(UNICODE_NEWLINE_REGEX, ''), {});
+		return engine.parse(text, {});
 	}
 
 	private _resetSlugCount(): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Remove Unicode newline characters U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR preprocessing from the Markdown preview.

This behavior was introduced in #63936 to address #63749, but it breaks the document in multiple ways:

- double-click word selection does not work as expected,
- screen readers may announce the text incorrectly,
- line wrapping and hyphenation does not work correctly,
- markdown-it plugins that rely on \b or \s may work incorrectly,
- even linkify fails:
```
https://foo.bar/baz<LS>Lorem ipsum
(Expected link: https://foo.bar/baz)
(Received link: https://foo.bar/bazLorem)
```
- and so on.

Since then it was fixed at the markdown-it side, and #63936 is no longer needed:

- https://github.com/markdown-it/markdown-it/commit/d9cb3ccb6709898f6d0744f6b2be4e82ed6efeb6
- https://github.com/markdown-it/markdown-it/commit/faecae0ba706f495eb6b559bc9632f199a6be84f
- https://github.com/markdown-it/markdown-it/blob/9.1.0/lib/rules_core/normalize.js

Fixes #166015
