### PR TITLE
Enable telemetry logging only in OSS

### DIFF
--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -110,10 +110,38 @@ export function configurationTelemetry(telemetryService: ITelemetryService, conf
  * If false telemetry is disabled throughout the product
  * @param productService
  * @param environmentService
+ * @param ignoreBuiltCheck Whether or not to ignore the check to see if the product is built. This allows to actually check if telemetry is supported
  * @returns false - telemetry is completely disabled, true - telemetry is logged locally, but may not be sent
  */
 export function supportsTelemetry(productService: IProductService, environmentService: IEnvironmentService): boolean {
+	// If it's OSS and telemetry isn't disabled via the CLI we will allow it for logging only purposes
+	if (!environmentService.isBuilt && !environmentService.disableTelemetry) {
+		return true;
+	}
 	return !(environmentService.disableTelemetry || !productService.enableTelemetry || environmentService.extensionTestsLocationURI);
+}
+
+/**
+ * Checks if we're only logging to the output channels for debug purposes and telemetry is not actually being sent
+ * @param productService
+ * @param environmentService
+ * @returns True if telemetry is actually disabled and we're only logging for debug purposes
+ */
+export function isLoggingOnly(productService: IProductService, environmentService: IEnvironmentService): boolean {
+	// Logging only mode is only for OSS
+	if (environmentService.isBuilt) {
+		return false;
+	}
+
+	if (environmentService.disableTelemetry) {
+		return false;
+	}
+
+	if (productService.enableTelemetry && productService.aiConfig?.ariaKey) {
+		return false;
+	}
+
+	return true;
 }
 
 /**

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -121,7 +121,8 @@ export function supportsTelemetry(productService: IProductService, environmentSe
 }
 
 /**
- * Checks if we're only logging to the output channels for debug purposes and telemetry is not actually being sent
+ * Checks to see if we're in logging only mode to debug telemetry.
+ * This is if telemetry is enabled and we're in OSS, but no telemetry key is provided so it's not being sent just logged.
  * @param productService
  * @param environmentService
  * @returns True if telemetry is actually disabled and we're only logging for debug purposes

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -110,7 +110,6 @@ export function configurationTelemetry(telemetryService: ITelemetryService, conf
  * If false telemetry is disabled throughout the product
  * @param productService
  * @param environmentService
- * @param ignoreBuiltCheck Whether or not to ignore the check to see if the product is built. This allows to actually check if telemetry is supported
  * @returns false - telemetry is completely disabled, true - telemetry is logged locally, but may not be sent
  */
 export function supportsTelemetry(productService: IProductService, environmentService: IEnvironmentService): boolean {

--- a/src/vs/workbench/api/browser/mainThreadTelemetry.ts
+++ b/src/vs/workbench/api/browser/mainThreadTelemetry.ts
@@ -8,7 +8,7 @@ import { IEnvironmentService } from 'vs/platform/environment/common/environment'
 import { IProductService } from 'vs/platform/product/common/productService';
 import { ClassifiedEvent, IGDPRProperty, OmitMetadata, StrictPropertyCheck } from 'vs/platform/telemetry/common/gdprTypings';
 import { ITelemetryService, TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
-import { supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
+import { isLoggingOnly, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
 import { ExtHostContext, ExtHostTelemetryShape, MainContext, MainThreadTelemetryShape } from '../common/extHost.protocol';
 
@@ -33,8 +33,8 @@ export class MainThreadTelemetry extends Disposable implements MainThreadTelemet
 				this._proxy.$onDidChangeTelemetryLevel(level);
 			}));
 		}
-
-		this._proxy.$initializeTelemetryLevel(this.telemetryLevel, this._productService.enabledTelemetryLevels);
+		const loggingOnly = isLoggingOnly(this._productService, this._environmentService);
+		this._proxy.$initializeTelemetryLevel(this.telemetryLevel, loggingOnly, this._productService.enabledTelemetryLevels);
 	}
 
 	private get telemetryLevel(): TelemetryLevel {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1789,7 +1789,7 @@ export interface ExtHostQuickOpenShape {
 }
 
 export interface ExtHostTelemetryShape {
-	$initializeTelemetryLevel(level: TelemetryLevel, productConfig?: { usage: boolean; error: boolean }): void;
+	$initializeTelemetryLevel(level: TelemetryLevel, debugLoggingOnly: boolean, productConfig?: { usage: boolean; error: boolean }): void;
 	$onDidChangeTelemetryLevel(level: TelemetryLevel): void;
 }
 

--- a/src/vs/workbench/api/common/extHostTelemetry.ts
+++ b/src/vs/workbench/api/common/extHostTelemetry.ts
@@ -27,6 +27,7 @@ export class ExtHostTelemetry implements ExtHostTelemetryShape {
 	private _productConfig: { usage: boolean; error: boolean } = { usage: true, error: true };
 	private _level: TelemetryLevel = TelemetryLevel.NONE;
 	private _oldTelemetryEnablement: boolean | undefined;
+	private _inLoggingOnlyMode: boolean = false;
 	private readonly _outputLogger: ILogger;
 	private readonly _telemetryLoggers = new Map<string, ExtHostTelemetryLogger>();
 
@@ -53,14 +54,22 @@ export class ExtHostTelemetry implements ExtHostTelemetryShape {
 
 	instantiateLogger(extension: IExtensionDescription, appender: vscode.TelemetryAppender) {
 		const telemetryDetails = this.getTelemetryDetails();
-		const logger = new ExtHostTelemetryLogger(appender, extension, this._outputLogger, this.getBuiltInCommonProperties(extension), { isUsageEnabled: telemetryDetails.isUsageEnabled, isErrorsEnabled: telemetryDetails.isErrorsEnabled });
+		const logger = new ExtHostTelemetryLogger(
+			appender,
+			extension,
+			this._outputLogger,
+			this._inLoggingOnlyMode,
+			this.getBuiltInCommonProperties(extension),
+			{ isUsageEnabled: telemetryDetails.isUsageEnabled, isErrorsEnabled: telemetryDetails.isErrorsEnabled }
+		);
 		this._telemetryLoggers.set(extension.identifier.value, logger);
 		return logger.apiTelemetryLogger;
 	}
 
-	$initializeTelemetryLevel(level: TelemetryLevel, productConfig?: { usage: boolean; error: boolean }): void {
+	$initializeTelemetryLevel(level: TelemetryLevel, loggingOnlyMode: boolean, productConfig?: { usage: boolean; error: boolean }): void {
 		this._level = level;
-		this._productConfig = productConfig || { usage: true, error: true };
+		this._inLoggingOnlyMode = loggingOnlyMode;
+		this._productConfig = productConfig ?? { usage: true, error: true };
 	}
 
 	getBuiltInCommonProperties(extension: IExtensionDescription): Record<string, string | boolean | number | undefined> {
@@ -126,8 +135,10 @@ export class ExtHostTelemetryLogger {
 		appender: vscode.TelemetryAppender,
 		private readonly _extension: IExtensionDescription,
 		private readonly _logger: ILogger,
+		private readonly _inLoggingOnlyMode: boolean,
 		private readonly _commonProperties: Record<string, any>,
-		telemetryEnablements: { isUsageEnabled: boolean; isErrorsEnabled: boolean }) {
+		telemetryEnablements: { isUsageEnabled: boolean; isErrorsEnabled: boolean }
+	) {
 		this._appender = appender;
 		this._telemetryEnablements = { isUsageEnabled: telemetryEnablements.isUsageEnabled, isErrorsEnabled: telemetryEnablements.isErrorsEnabled };
 	}
@@ -173,7 +184,9 @@ export class ExtHostTelemetryLogger {
 			eventName = this._extension.identifier.value + '/' + eventName;
 		}
 		data = this.mixInCommonPropsAndCleanData(data || {});
-		this._appender.logEvent(eventName, data);
+		if (!this._inLoggingOnlyMode) {
+			this._appender.logEvent(eventName, data);
+		}
 		this._logger.trace(eventName, data);
 	}
 

--- a/src/vs/workbench/api/test/browser/extHostTelemetry.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTelemetry.test.ts
@@ -68,7 +68,7 @@ suite('ExtHostTelemetry', function () {
 			override telemetryInfo: ITelemetryInfo = mockTelemetryInfo;
 			override remote = mockRemote;
 		}, new TestTelemetryLoggerService(DEFAULT_LOG_LEVEL));
-		extensionTelemetry.$initializeTelemetryLevel(TelemetryLevel.USAGE, { usage: true, error: true });
+		extensionTelemetry.$initializeTelemetryLevel(TelemetryLevel.USAGE, false, { usage: true, error: true });
 		return extensionTelemetry;
 	};
 
@@ -100,19 +100,19 @@ suite('ExtHostTelemetry', function () {
 		assert.strictEqual(config.isErrorsEnabled, true);
 
 		// Initialize would never be called twice, but this is just for testing
-		extensionTelemetry.$initializeTelemetryLevel(TelemetryLevel.ERROR, { usage: true, error: true });
+		extensionTelemetry.$initializeTelemetryLevel(TelemetryLevel.ERROR, false, { usage: true, error: true });
 		config = extensionTelemetry.getTelemetryDetails();
 		assert.strictEqual(config.isCrashEnabled, true);
 		assert.strictEqual(config.isUsageEnabled, false);
 		assert.strictEqual(config.isErrorsEnabled, true);
 
-		extensionTelemetry.$initializeTelemetryLevel(TelemetryLevel.CRASH, { usage: true, error: true });
+		extensionTelemetry.$initializeTelemetryLevel(TelemetryLevel.CRASH, false, { usage: true, error: true });
 		config = extensionTelemetry.getTelemetryDetails();
 		assert.strictEqual(config.isCrashEnabled, true);
 		assert.strictEqual(config.isUsageEnabled, false);
 		assert.strictEqual(config.isErrorsEnabled, false);
 
-		extensionTelemetry.$initializeTelemetryLevel(TelemetryLevel.USAGE, { usage: false, error: true });
+		extensionTelemetry.$initializeTelemetryLevel(TelemetryLevel.USAGE, false, { usage: false, error: true });
 		config = extensionTelemetry.getTelemetryDetails();
 		assert.strictEqual(config.isCrashEnabled, true);
 		assert.strictEqual(config.isUsageEnabled, false);
@@ -181,7 +181,7 @@ suite('ExtHostTelemetry', function () {
 			override telemetryInfo: ITelemetryInfo = mockTelemetryInfo;
 			override remote = mockRemote;
 		}, loggerService);
-		extensionTelemetry.$initializeTelemetryLevel(TelemetryLevel.USAGE, { usage: true, error: true });
+		extensionTelemetry.$initializeTelemetryLevel(TelemetryLevel.USAGE, false, { usage: true, error: true });
 
 		const functionSpy: TelemetryLoggerSpy = { dataArr: [], exceptionArr: [], flushCalled: false };
 

--- a/src/vs/workbench/contrib/logs/common/logs.contribution.ts
+++ b/src/vs/workbench/contrib/logs/common/logs.contribution.ts
@@ -17,7 +17,7 @@ import { Disposable, toDisposable } from 'vs/base/common/lifecycle';
 import { ILogService, LogLevel } from 'vs/platform/log/common/log';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
+import { isLoggingOnly, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { URI } from 'vs/base/common/uri';
 
@@ -55,8 +55,11 @@ class LogOutputChannels extends Disposable implements IWorkbenchContribution {
 
 		const registerTelemetryChannel = () => {
 			if (supportsTelemetry(this.productService, this.environmentService) && this.logService.getLevel() === LogLevel.Trace) {
-				this.registerLogChannel(Constants.telemetryLogChannelId, nls.localize('telemetryLog', "Telemetry"), this.environmentService.telemetryLogResource);
-				this.registerLogChannel(Constants.extensionTelemetryLogChannelId, nls.localize('extensionTelemetryLog', "Extension Telemetry"), this.environmentService.extHostTelemetryLogFile);
+				// Not a perfect check, but a nice way to indicate if we only have logging enabled for debug purposes and nothing is actually being sent
+				const justLoggingAndNotSending = isLoggingOnly(this.productService, this.environmentService);
+				const logSuffix = justLoggingAndNotSending ? ' (Logging Only)' : '';
+				this.registerLogChannel(Constants.telemetryLogChannelId, nls.localize('telemetryLog', "Telemetry{0}", logSuffix), this.environmentService.telemetryLogResource);
+				this.registerLogChannel(Constants.extensionTelemetryLogChannelId, nls.localize('extensionTelemetryLog', "Extension Telemetry{0}", logSuffix), this.environmentService.extHostTelemetryLogFile);
 				return true;
 			}
 			return false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Telemetry bugs seem to occur more and more due to the hard to debug nature of telemetry when building VS Code. To make this easier this PR enables debug only logging and makes it clear in the output channel that no telemetry is actually being sent.