### PR TITLE
Remove logException from proposed API surface

### DIFF
--- a/src/vs/workbench/api/common/extHostTelemetry.ts
+++ b/src/vs/workbench/api/common/extHostTelemetry.ts
@@ -191,8 +191,12 @@ export class ExtHostTelemetryLogger {
 		if (typeof eventNameOrException === 'string') {
 			this.logEvent(eventNameOrException, data);
 		} else {
-			// TODO @lramos15, implement cleaning for and logging for this case
-			this._appender.logException(eventNameOrException, data);
+			// Dealing with events with eventNames is much easier, so mirror our core unhandlederror event
+			this.logEvent('unhandlederror', {
+				callstack: eventNameOrException.stack,
+				msg: eventNameOrException.message,
+				...data
+			});
 		}
 	}
 

--- a/src/vs/workbench/api/test/browser/extHostTelemetry.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTelemetry.test.ts
@@ -79,9 +79,6 @@ suite('ExtHostTelemetry', function () {
 			logEvent: (eventName: string, data) => {
 				functionSpy.dataArr.push({ eventName, data });
 			},
-			logException: (exception, data) => {
-				functionSpy.exceptionArr.push({ exception, data });
-			},
 			ignoreBuiltInCommonProperties: false,
 			flush: () => {
 				functionSpy.flushCalled = true;
@@ -136,8 +133,7 @@ suite('ExtHostTelemetry', function () {
 		assert.strictEqual(functionSpy.dataArr.length, 3);
 
 		logger.logError(new Error('test-error'), { 'test-data': 'test-data' });
-		assert.strictEqual(functionSpy.dataArr.length, 3);
-		assert.strictEqual(functionSpy.exceptionArr.length, 1);
+		assert.strictEqual(functionSpy.dataArr.length, 4);
 
 
 		// Assert not flushed

--- a/src/vscode-dts/vscode.proposed.telemetryLogger.d.ts
+++ b/src/vscode-dts/vscode.proposed.telemetryLogger.d.ts
@@ -28,7 +28,8 @@ declare module 'vscode' {
 		logError(eventName: string, data?: Record<string, any>): void;
 
 		/**
-		 * Calls `TelemetryAppender.logException`. Does cleaning, telemetry checks, and data mix-in.
+		 * Specifically for logging an Error trace. Will be converted to an `extension/unhandlederror` eventName with the error in the data payload.
+		 * Does cleaning, telemetry checks, and data mix-in.
 		 * Automatically supports echoing to extension telemetry output channel.
 		 * Will also automatically log any exceptions thrown within the extension host process.
 		 * @param exception The error object which contains the stack trace cleaned of PII
@@ -56,13 +57,6 @@ declare module 'vscode' {
 		 * @param data A serializable key value pair that is being logged
 		 */
 		logEvent(eventName: string, data?: Record<string, any>): void;
-
-		/**
-		 * User-defined function which logs an error, used within the TelemetryLogger
-		 * @param exception The exception being logged
-		 * @param data Any additional data to be collected with the exception
-		 */
-		logException(exception: Error, data?: Record<string, any>): void;
 
 		/**
 		 * Optional flush function which will give your appender one last chance to send any remaining events as the TelemetryLogger is being disposed


### PR DESCRIPTION
The `logException` entry in the appender is always a bit confusing because how do you really translate an event sent to a database without some sort of event name? The idea here is that we remove it from the appender and instead translate the exception from the logger into an `unhandlederror` event. None of our first part extensions even support `logException` on the appender.