### PR TITLE
Use new Key Vault account

### DIFF
--- a/build/azure-pipelines/cli/cli-win32-sign.yml
+++ b/build/azure-pipelines/cli/cli-win32-sign.yml
@@ -8,7 +8,7 @@ steps:
     displayName: "Azure Key Vault: Get Secrets"
     inputs:
       azureSubscription: "vscode-builds-subscription"
-      KeyVaultName: vscode
+      KeyVaultName: vscode-build-secrets
       SecretsFilter: "ESRP-PKI,esrp-aad-username,esrp-aad-password"
 
   - task: UseDotNet@2
@@ -20,16 +20,16 @@ steps:
     displayName: "Use ESRP client"
 
   - ${{ each target in parameters.VSCODE_CLI_ARTIFACTS }}:
-    - task: DownloadPipelineArtifact@2
-      displayName: Download artifacts
-      inputs:
-        artifact: ${{ target }}
-        path: $(Build.ArtifactStagingDirectory)/pkg/${{ target }}
+      - task: DownloadPipelineArtifact@2
+        displayName: Download artifacts
+        inputs:
+          artifact: ${{ target }}
+          path: $(Build.ArtifactStagingDirectory)/pkg/${{ target }}
 
-    - task: ExtractFiles@1
-      inputs:
-        archiveFilePatterns: $(Build.ArtifactStagingDirectory)/pkg/${{ target }}/*.zip
-        destinationFolder: $(Build.ArtifactStagingDirectory)/sign/${{ target }}
+      - task: ExtractFiles@1
+        inputs:
+          archiveFilePatterns: $(Build.ArtifactStagingDirectory)/pkg/${{ target }}/*.zip
+          destinationFolder: $(Build.ArtifactStagingDirectory)/sign/${{ target }}
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
@@ -49,17 +49,17 @@ steps:
     displayName: "Code sign"
 
   - ${{ each target in parameters.VSCODE_CLI_ARTIFACTS }}:
-    - powershell: |
-        $ASSET_ID = "${{ target }}".replace("unsigned_", "");
-        echo "##vso[task.setvariable variable=ASSET_ID]$ASSET_ID"
-      displayName: Set asset id variable
+      - powershell: |
+          $ASSET_ID = "${{ target }}".replace("unsigned_", "");
+          echo "##vso[task.setvariable variable=ASSET_ID]$ASSET_ID"
+        displayName: Set asset id variable
 
-    - task: ArchiveFiles@2
-      inputs:
-        rootFolderOrFile: $(Build.ArtifactStagingDirectory)/sign/${{ target }}/code.exe
-        includeRootFolder: false
-        archiveType: zip
-        archiveFile: $(Build.ArtifactStagingDirectory)/$(ASSET_ID).zip
+      - task: ArchiveFiles@2
+        inputs:
+          rootFolderOrFile: $(Build.ArtifactStagingDirectory)/sign/${{ target }}/code.exe
+          includeRootFolder: false
+          archiveType: zip
+          archiveFile: $(Build.ArtifactStagingDirectory)/$(ASSET_ID).zip
 
-    - publish: $(Build.ArtifactStagingDirectory)/$(ASSET_ID).zip
-      artifact: $(ASSET_ID)
+      - publish: $(Build.ArtifactStagingDirectory)/$(ASSET_ID).zip
+        artifact: $(ASSET_ID)

--- a/build/azure-pipelines/darwin/product-build-darwin-cli-sign.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-cli-sign.yml
@@ -13,7 +13,7 @@ steps:
     displayName: "Azure Key Vault: Get Secrets"
     inputs:
       azureSubscription: "vscode-builds-subscription"
-      KeyVaultName: vscode
+      KeyVaultName: vscode-build-secrets
       SecretsFilter: "github-distro-mixin-password,ESRP-PKI,esrp-aad-username,esrp-aad-password"
 
   - script: |

--- a/build/azure-pipelines/darwin/product-build-darwin-sign.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-sign.yml
@@ -7,7 +7,7 @@ steps:
     displayName: "Azure Key Vault: Get Secrets"
     inputs:
       azureSubscription: "vscode-builds-subscription"
-      KeyVaultName: vscode
+      KeyVaultName: vscode-build-secrets
       SecretsFilter: "github-distro-mixin-password,ESRP-PKI,esrp-aad-username,esrp-aad-password"
 
   - script: |

--- a/build/azure-pipelines/darwin/product-build-darwin-universal.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-universal.yml
@@ -7,7 +7,7 @@ steps:
     displayName: "Azure Key Vault: Get Secrets"
     inputs:
       azureSubscription: "vscode-builds-subscription"
-      KeyVaultName: vscode
+      KeyVaultName: vscode-build-secrets
       SecretsFilter: "github-distro-mixin-password,macos-developer-certificate,macos-developer-certificate-key"
 
   - script: |

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -27,7 +27,7 @@ steps:
         displayName: "Azure Key Vault: Get Secrets"
         inputs:
           azureSubscription: "vscode-builds-subscription"
-          KeyVaultName: vscode
+          KeyVaultName: vscode-build-secrets
           SecretsFilter: "github-distro-mixin-password,macos-developer-certificate,macos-developer-certificate-key"
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:

--- a/build/azure-pipelines/distro-build.yml
+++ b/build/azure-pipelines/distro-build.yml
@@ -15,7 +15,7 @@ steps:
     displayName: "Azure Key Vault: Get Secrets"
     inputs:
       azureSubscription: "vscode-builds-subscription"
-      KeyVaultName: vscode
+      KeyVaultName: vscode-build-secrets
       SecretsFilter: "github-distro-mixin-password"
 
   - script: |

--- a/build/azure-pipelines/exploration-build.yml
+++ b/build/azure-pipelines/exploration-build.yml
@@ -13,7 +13,7 @@ steps:
     displayName: "Azure Key Vault: Get Secrets"
     inputs:
       azureSubscription: "vscode-builds-subscription"
-      KeyVaultName: vscode
+      KeyVaultName: vscode-build-secrets
       SecretsFilter: "github-distro-mixin-password"
 
   - script: |

--- a/build/azure-pipelines/linux/product-build-alpine.yml
+++ b/build/azure-pipelines/linux/product-build-alpine.yml
@@ -7,7 +7,7 @@ steps:
     displayName: "Azure Key Vault: Get Secrets"
     inputs:
       azureSubscription: "vscode-builds-subscription"
-      KeyVaultName: vscode
+      KeyVaultName: vscode-build-secrets
       SecretsFilter: "github-distro-mixin-password"
 
   - task: DownloadPipelineArtifact@2

--- a/build/azure-pipelines/linux/product-build-linux-client.yml
+++ b/build/azure-pipelines/linux/product-build-linux-client.yml
@@ -27,7 +27,7 @@ steps:
         displayName: "Azure Key Vault: Get Secrets"
         inputs:
           azureSubscription: "vscode-builds-subscription"
-          KeyVaultName: vscode
+          KeyVaultName: vscode-build-secrets
           SecretsFilter: "github-distro-mixin-password,ESRP-PKI,esrp-aad-username,esrp-aad-password"
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:

--- a/build/azure-pipelines/linux/product-build-linux-server.yml
+++ b/build/azure-pipelines/linux/product-build-linux-server.yml
@@ -12,7 +12,7 @@ steps:
         displayName: "Azure Key Vault: Get Secrets"
         inputs:
           azureSubscription: "vscode-builds-subscription"
-          KeyVaultName: vscode
+          KeyVaultName: vscode-build-secrets
           SecretsFilter: "github-distro-mixin-password,ESRP-PKI,esrp-aad-username,esrp-aad-password"
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:

--- a/build/azure-pipelines/mixin-distro-posix.yml
+++ b/build/azure-pipelines/mixin-distro-posix.yml
@@ -4,37 +4,37 @@ parameters:
 
 steps:
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - task: AzureKeyVault@1
-      displayName: "Azure Key Vault: Get Secrets"
-      inputs:
-        azureSubscription: "vscode-builds-subscription"
-        KeyVaultName: vscode
-        SecretsFilter: "github-distro-mixin-password"
+      - task: AzureKeyVault@1
+        displayName: "Azure Key Vault: Get Secrets"
+        inputs:
+          azureSubscription: "vscode-builds-subscription"
+          KeyVaultName: vscode-build-secrets
+          SecretsFilter: "github-distro-mixin-password"
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - script: |
-        set -e
-        cat << EOF > ~/.netrc
-        machine github.com
-        login vscode
-        password $(github-distro-mixin-password)
-        EOF
+      - script: |
+          set -e
+          cat << EOF > ~/.netrc
+          machine github.com
+          login vscode
+          password $(github-distro-mixin-password)
+          EOF
 
-        git config user.email "vscode@microsoft.com"
-        git config user.name "VSCode"
-      displayName: Prepare tooling
-
-  - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - script: |
-        set -e
-        git fetch https://github.com/$(VSCODE_MIXIN_REPO).git $VSCODE_DISTRO_REF
-        echo "##vso[task.setvariable variable=VSCODE_DISTRO_COMMIT;]$(git rev-parse FETCH_HEAD)"
-        git checkout FETCH_HEAD
-      condition: and(succeeded(), ne(variables.VSCODE_DISTRO_REF, ' '))
-      displayName: Checkout override commit
+          git config user.email "vscode@microsoft.com"
+          git config user.name "VSCode"
+        displayName: Prepare tooling
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - script: |
-        set -e
-        git pull --no-rebase https://github.com/$(VSCODE_MIXIN_REPO).git $(node -p "require('./package.json').distro")
-      displayName: Merge distro
+      - script: |
+          set -e
+          git fetch https://github.com/$(VSCODE_MIXIN_REPO).git $VSCODE_DISTRO_REF
+          echo "##vso[task.setvariable variable=VSCODE_DISTRO_COMMIT;]$(git rev-parse FETCH_HEAD)"
+          git checkout FETCH_HEAD
+        condition: and(succeeded(), ne(variables.VSCODE_DISTRO_REF, ' '))
+        displayName: Checkout override commit
+
+  - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
+      - script: |
+          set -e
+          git pull --no-rebase https://github.com/$(VSCODE_MIXIN_REPO).git $(node -p "require('./package.json').distro")
+        displayName: Merge distro

--- a/build/azure-pipelines/mixin-distro-win32.yml
+++ b/build/azure-pipelines/mixin-distro-win32.yml
@@ -4,37 +4,37 @@ parameters:
 
 steps:
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - task: AzureKeyVault@1
-      displayName: "Azure Key Vault: Get Secrets"
-      inputs:
-        azureSubscription: "vscode-builds-subscription"
-        KeyVaultName: vscode
-        SecretsFilter: "github-distro-mixin-password"
+      - task: AzureKeyVault@1
+        displayName: "Azure Key Vault: Get Secrets"
+        inputs:
+          azureSubscription: "vscode-builds-subscription"
+          KeyVaultName: vscode-build-secrets
+          SecretsFilter: "github-distro-mixin-password"
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - powershell: |
-        . build/azure-pipelines/win32/exec.ps1
-        $ErrorActionPreference = "Stop"
-        "machine github.com`nlogin vscode`npassword $(github-distro-mixin-password)" | Out-File "$env:USERPROFILE\_netrc" -Encoding ASCII
+      - powershell: |
+          . build/azure-pipelines/win32/exec.ps1
+          $ErrorActionPreference = "Stop"
+          "machine github.com`nlogin vscode`npassword $(github-distro-mixin-password)" | Out-File "$env:USERPROFILE\_netrc" -Encoding ASCII
 
-        exec { git config user.email "vscode@microsoft.com" }
-        exec { git config user.name "VSCode" }
-      displayName: Prepare tooling
-
-  - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - powershell: |
-        . build/azure-pipelines/win32/exec.ps1
-        $ErrorActionPreference = "Stop"
-
-        exec { git fetch https://github.com/$(VSCODE_MIXIN_REPO).git $(VSCODE_DISTRO_REF) }
-        Write-Host "##vso[task.setvariable variable=VSCODE_DISTRO_COMMIT;]$(git rev-parse FETCH_HEAD)"
-        exec { git checkout FETCH_HEAD }
-      condition: and(succeeded(), ne(variables.VSCODE_DISTRO_REF, ' '))
-      displayName: Checkout override commit
+          exec { git config user.email "vscode@microsoft.com" }
+          exec { git config user.name "VSCode" }
+        displayName: Prepare tooling
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - powershell: |
-        . build/azure-pipelines/win32/exec.ps1
-        $ErrorActionPreference = "Stop"
-        exec { git pull --no-rebase https://github.com/$(VSCODE_MIXIN_REPO).git $(node -p "require('./package.json').distro") }
-      displayName: Merge distro
+      - powershell: |
+          . build/azure-pipelines/win32/exec.ps1
+          $ErrorActionPreference = "Stop"
+
+          exec { git fetch https://github.com/$(VSCODE_MIXIN_REPO).git $(VSCODE_DISTRO_REF) }
+          Write-Host "##vso[task.setvariable variable=VSCODE_DISTRO_COMMIT;]$(git rev-parse FETCH_HEAD)"
+          exec { git checkout FETCH_HEAD }
+        condition: and(succeeded(), ne(variables.VSCODE_DISTRO_REF, ' '))
+        displayName: Checkout override commit
+
+  - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
+      - powershell: |
+          . build/azure-pipelines/win32/exec.ps1
+          $ErrorActionPreference = "Stop"
+          exec { git pull --no-rebase https://github.com/$(VSCODE_MIXIN_REPO).git $(node -p "require('./package.json').distro") }
+        displayName: Merge distro

--- a/build/azure-pipelines/product-publish.yml
+++ b/build/azure-pipelines/product-publish.yml
@@ -7,7 +7,7 @@ steps:
     displayName: "Azure Key Vault: Get Secrets"
     inputs:
       azureSubscription: "vscode-builds-subscription"
-      KeyVaultName: vscode
+      KeyVaultName: vscode-build-secrets
       SecretsFilter: "github-distro-mixin-password"
 
   # allow-any-unicode-next-line

--- a/build/azure-pipelines/sdl-scan.yml
+++ b/build/azure-pipelines/sdl-scan.yml
@@ -53,7 +53,7 @@ stages:
             displayName: "Azure Key Vault: Get Secrets"
             inputs:
               azureSubscription: "vscode-builds-subscription"
-              KeyVaultName: vscode
+              KeyVaultName: vscode-build-secrets
               SecretsFilter: "github-distro-mixin-password"
 
           - powershell: |
@@ -167,7 +167,7 @@ stages:
             displayName: "Azure Key Vault: Get Secrets"
             inputs:
               azureSubscription: "vscode-builds-subscription"
-              KeyVaultName: vscode
+              KeyVaultName: vscode-build-secrets
               SecretsFilter: "github-distro-mixin-password"
 
           - script: |

--- a/build/azure-pipelines/web/product-build-web.yml
+++ b/build/azure-pipelines/web/product-build-web.yml
@@ -7,7 +7,7 @@ steps:
     displayName: "Azure Key Vault: Get Secrets"
     inputs:
       azureSubscription: "vscode-builds-subscription"
-      KeyVaultName: vscode
+      KeyVaultName: vscode-build-secrets
       SecretsFilter: "github-distro-mixin-password"
 
   - task: DownloadPipelineArtifact@2

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -32,7 +32,7 @@ steps:
         displayName: "Azure Key Vault: Get Secrets"
         inputs:
           azureSubscription: "vscode-builds-subscription"
-          KeyVaultName: vscode
+          KeyVaultName: vscode-build-secrets
           SecretsFilter: "github-distro-mixin-password,ESRP-PKI,esrp-aad-username,esrp-aad-password"
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:


### PR DESCRIPTION
This moves the usage of secrets over to a new Key Vault account.

Tested by running a full build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=192563&view=results