### PR TITLE
Enable pasting of image attachments by default for ipynb

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -32,14 +32,11 @@
 		"configuration": [
 			{
 				"properties": {
-					"ipynb.experimental.pasteImages.enabled": {
+					"ipynb.pasteImagesAsAttachments.enabled": {
 						"type": "boolean",
 						"scope": "resource",
-						"markdownDescription": "%ipynb.experimental.pasteImages.enabled%",
-						"default": false,
-						"tags": [
-							"experimental"
-						]
+						"markdownDescription": "%ipynb.pasteImagesAsAttachments.enabled%",
+						"default": true
 					}
 				}
 			}

--- a/extensions/ipynb/package.nls.json
+++ b/extensions/ipynb/package.nls.json
@@ -1,5 +1,5 @@
 {
 	"displayName": ".ipynb Support",
 	"description": "Provides basic support for opening and reading Jupyter's .ipynb notebook files",
-	"ipynb.experimental.pasteImages.enabled":"Enable/Disable pasting images into markdown cells within ipynb files. Requires enabling `#editor.experimental.pasteActions.enabled#`."
+	"ipynb.pasteImagesAsAttachments.enabled": "Enable/disable pasting of images into Markdown cells in ipynb notebook files. Pasted images are inserted as attachments to the cell."
 }

--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -85,7 +85,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(notebookImagePasteSetup());
 
-	const enabled = vscode.workspace.getConfiguration('ipynb').get('experimental.pasteImages.enabled', false);
+	const enabled = vscode.workspace.getConfiguration('ipynb').get('pasteImagesAsAttachments.enabled', false);
 	if (enabled) {
 		const cleaner = new AttachmentCleaner();
 		context.subscriptions.push(cleaner);

--- a/extensions/ipynb/src/notebookImagePaste.ts
+++ b/extensions/ipynb/src/notebookImagePaste.ts
@@ -15,7 +15,7 @@ class CopyPasteEditProvider implements vscode.DocumentPasteEditProvider {
 		_token: vscode.CancellationToken
 	): Promise<vscode.DocumentPasteEdit | undefined> {
 
-		const enabled = vscode.workspace.getConfiguration('ipynb', document).get('experimental.pasteImages.enabled', false);
+		const enabled = vscode.workspace.getConfiguration('ipynb', document).get('pasteImagesAsAttachments.enabled', false);
 		if (!enabled) {
 			return undefined;
 		}

--- a/src/vs/editor/contrib/copyPaste/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/copyPaste/browser/copyPasteController.ts
@@ -10,6 +10,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { createStringDataTransferItem, UriList, VSDataTransfer } from 'vs/base/common/dataTransfer';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Mimes } from 'vs/base/common/mime';
+import { Schemas } from 'vs/base/common/network';
 import { generateUuid } from 'vs/base/common/uuid';
 import { toVSDataTransfer } from 'vs/editor/browser/dnd';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
@@ -69,9 +70,12 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 	}
 
 	private arePasteActionsEnabled(model: ITextModel): boolean {
-		return this._configurationService.getValue('editor.experimental.pasteActions.enabled', {
-			resource: model.uri
-		});
+		if (this._configurationService.getValue('editor.experimental.pasteActions.enabled', { resource: model.uri })) {
+			return true;
+		}
+
+		// TODO: This check is only here to support enabling `ipynb.pasteImagesAsAttachments.enabled` by default
+		return model.uri.scheme === Schemas.vscodeNotebookCell;
 	}
 
 	private handleCopy(e: ClipboardEvent) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/11987

Also renames the setting so that it is no longer experimental 
