### PR TITLE
Allow editor contributions to mark themselves as instantiated on idle

### DIFF
--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -47,7 +47,7 @@ export enum EditorContributionInstantiation {
 export interface IEditorContributionDescription {
 	readonly id: string;
 	readonly ctor: IEditorContributionCtor;
-	readonly instantiation: EditorContributionInstantiation;
+	readonly instantiation?: EditorContributionInstantiation;
 }
 
 export interface IDiffEditorContributionDescription {

--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -47,7 +47,7 @@ export enum EditorContributionInstantiation {
 export interface IEditorContributionDescription {
 	readonly id: string;
 	readonly ctor: IEditorContributionCtor;
-	readonly instantiation?: EditorContributionInstantiation;
+	readonly instantiation: EditorContributionInstantiation;
 }
 
 export interface IDiffEditorContributionDescription {

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -342,15 +342,9 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 				if (desc.instantiation === EditorContributionInstantiation.Idle) {
 					const contribution = new IdleValue(() => {
 						// Replace the original entry in _contributions with the resolved contribution
-						try {
-							const instance = this._instantiationService.createInstance(desc.ctor, this);
-							this._contributions.set(desc.id, instance);
-							return instance;
-						} catch (err) {
-							this._contributions.deleteAndDispose(desc.id);
-							onUnexpectedError(err);
-						}
-						return Disposable.None;
+						const instance = this._instantiationService.createInstance(desc.ctor, this);
+						this._contributions.set(desc.id, instance);
+						return instance;
 					});
 					this._contributions.set(desc.id, contribution);
 				} else {

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -18,7 +18,7 @@ import { Disposable, IDisposable, dispose, DisposableStore, DisposableMap } from
 import { Schemas } from 'vs/base/common/network';
 import { EditorConfiguration, IEditorConstructionOptions } from 'vs/editor/browser/config/editorConfiguration';
 import * as editorBrowser from 'vs/editor/browser/editorBrowser';
-import { EditorExtensionsRegistry, IEditorContributionDescription } from 'vs/editor/browser/editorExtensions';
+import { EditorContributionInstantiation, EditorExtensionsRegistry, IEditorContributionDescription } from 'vs/editor/browser/editorExtensions';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { ICommandDelegate } from 'vs/editor/browser/view/viewController';
 import { IContentWidgetData, IOverlayWidgetData, View } from 'vs/editor/browser/view';
@@ -60,6 +60,7 @@ import { applyFontInfo } from 'vs/editor/browser/config/domFontInfo';
 import { IEditorConfiguration } from 'vs/editor/common/config/editorConfiguration';
 import { IDimension } from 'vs/editor/common/core/dimension';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
+import { IdleValue } from 'vs/base/common/async';
 
 let EDITOR_ID = 0;
 
@@ -241,7 +242,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	private readonly _id: number;
 	private readonly _configuration: IEditorConfiguration;
 
-	protected readonly _contributions = new DisposableMap<string, editorCommon.IEditorContribution>();
+	protected readonly _contributions = new DisposableMap<string, editorCommon.IEditorContribution | IdleValue<editorCommon.IEditorContribution>>();
 	protected readonly _actions = new Map<string, editorCommon.IEditorAction>();
 
 	// --- Members logically associated to a model
@@ -338,8 +339,24 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 				continue;
 			}
 			try {
-				const contribution = this._instantiationService.createInstance(desc.ctor, this);
-				this._contributions.set(desc.id, contribution);
+				if (desc.instantiation === EditorContributionInstantiation.Idle) {
+					const contribution = new IdleValue(() => {
+						// Replace the original entry in _contributions with the resolved contribution
+						try {
+							const instance = this._instantiationService.createInstance(desc.ctor, this);
+							this._contributions.set(desc.id, instance);
+							return instance;
+						} catch (err) {
+							this._contributions.deleteAndDispose(desc.id);
+							onUnexpectedError(err);
+						}
+						return Disposable.None;
+					});
+					this._contributions.set(desc.id, contribution);
+				} else {
+					const contribution = this._instantiationService.createInstance(desc.ctor, this);
+					this._contributions.set(desc.id, contribution);
+				}
 			} catch (err) {
 				onUnexpectedError(err);
 			}
@@ -993,7 +1010,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		const contributionsState: { [key: string]: any } = {};
 
 		for (const [id, contribution] of this._contributions) {
-			if (typeof contribution.saveViewState === 'function') {
+			if (!(contribution instanceof IdleValue) && typeof contribution.saveViewState === 'function') {
 				contributionsState[id] = contribution.saveViewState();
 			}
 		}
@@ -1025,7 +1042,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 
 			const contributionsState = codeEditorState.contributionsState || {};
 			for (const [id, contribution] of this._contributions) {
-				if (typeof contribution.restoreViewState === 'function') {
+				if (!(contribution instanceof IdleValue) && typeof contribution.restoreViewState === 'function') {
 					contribution.restoreViewState(contributionsState[id]);
 				}
 			}
@@ -1045,7 +1062,12 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	}
 
 	public getContribution<T extends editorCommon.IEditorContribution>(id: string): T | null {
-		return <T>(this._contributions.get(id) || null);
+		const entry = this._contributions.get(id);
+		if (!entry) {
+			return null;
+		}
+
+		return (entry instanceof IdleValue ? entry.value : entry) as T;
 	}
 
 	public getActions(): editorCommon.IEditorAction[] {

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -29,7 +29,6 @@ import { IMarkerService } from 'vs/platform/markers/common/markers';
 import { IEditorProgressService } from 'vs/platform/progress/common/progress';
 import { CodeActionModel, CodeActionsState, SUPPORTED_CODE_ACTIONS } from './codeActionModel';
 import { CodeActionAutoApply, CodeActionCommandArgs, CodeActionFilter, CodeActionItem, CodeActionKind, CodeActionSet, CodeActionTrigger, CodeActionTriggerSource } from '../common/types';
-import { IdleValue } from 'vs/base/common/async';
 
 function contextKeyForSupportedActions(kind: CodeActionKind) {
 	return ContextKeyExpr.regex(
@@ -93,7 +92,7 @@ export class CodeActionController extends Disposable implements IEditorContribut
 	}
 
 	private readonly _editor: ICodeEditor;
-	private readonly _model: IdleValue<CodeActionModel>;
+	private readonly _model: CodeActionModel;
 	private readonly _ui: Lazy<CodeActionUi>;
 
 	constructor(
@@ -108,13 +107,9 @@ export class CodeActionController extends Disposable implements IEditorContribut
 
 		this._editor = editor;
 
-		this._model = this._register(new IdleValue(() => {
-			const model = this._register(new CodeActionModel(this._editor, languageFeaturesService.codeActionProvider, markerService, contextKeyService, progressService));
+		this._model = this._register(new CodeActionModel(this._editor, languageFeaturesService.codeActionProvider, markerService, contextKeyService, progressService));
 
-			this._register(model.onDidChangeState(newState => this.update(newState)));
-
-			return model;
-		}));
+		this._register(this._model.onDidChangeState(newState => this.update(newState)));
 
 		this._ui = new Lazy(() =>
 			this._register(_instantiationService.createInstance(CodeActionUi, editor, QuickFixAction.Id, AutoFixAction.Id, {
@@ -156,7 +151,7 @@ export class CodeActionController extends Disposable implements IEditorContribut
 	}
 
 	private _trigger(trigger: CodeActionTrigger) {
-		return this._model.value.trigger(trigger);
+		return this._model.trigger(trigger);
 	}
 
 	private _applyCodeAction(action: CodeActionItem, preview: boolean): Promise<void> {

--- a/src/vs/editor/contrib/codeAction/browser/codeActionContributions.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionContributions.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { registerEditorAction, registerEditorCommand, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
+import { EditorContributionInstantiation, registerEditorAction, registerEditorCommand, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { editorConfigurationBaseNode } from 'vs/editor/common/config/editorConfigurationSchema';
 import { AutoFixAction, CodeActionCommand, CodeActionController, FixAllAction, OrganizeImportsAction, QuickFixAction, RefactorAction, RefactorPreview, SourceAction } from 'vs/editor/contrib/codeAction/browser/codeActionCommands';
 import * as nls from 'vs/nls';
 import { ConfigurationScope, Extensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
 
-registerEditorContribution(CodeActionController.ID, CodeActionController);
+registerEditorContribution(CodeActionController.ID, CodeActionController, EditorContributionInstantiation.Idle);
 registerEditorAction(QuickFixAction);
 registerEditorAction(RefactorAction);
 registerEditorAction(RefactorPreview);

--- a/src/vs/editor/contrib/rename/browser/rename.ts
+++ b/src/vs/editor/contrib/rename/browser/rename.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { alert } from 'vs/base/browser/ui/aria/aria';
-import { IdleValue, raceCancellation } from 'vs/base/common/async';
+import { raceCancellation } from 'vs/base/common/async';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
@@ -13,7 +13,7 @@ import { assertType } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { CodeEditorStateFlag, EditorStateCancellationTokenSource } from 'vs/editor/contrib/editorState/browser/editorState';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { EditorAction, EditorCommand, registerEditorAction, registerEditorCommand, registerEditorContribution, registerModelAndPositionCommand, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
+import { EditorAction, EditorCommand, EditorContributionInstantiation, registerEditorAction, registerEditorCommand, registerEditorContribution, registerModelAndPositionCommand, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { IBulkEditService } from 'vs/editor/browser/services/bulkEditService';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { IPosition, Position } from 'vs/editor/common/core/position';
@@ -131,7 +131,7 @@ class RenameController implements IEditorContribution {
 		return editor.getContribution<RenameController>(RenameController.ID);
 	}
 
-	private readonly _renameInputField: IdleValue<RenameInputField>;
+	private readonly _renameInputField: RenameInputField;
 	private readonly _disposableStore = new DisposableStore();
 	private _cts: CancellationTokenSource = new CancellationTokenSource();
 
@@ -145,7 +145,7 @@ class RenameController implements IEditorContribution {
 		@ITextResourceConfigurationService private readonly _configService: ITextResourceConfigurationService,
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
 	) {
-		this._renameInputField = this._disposableStore.add(new IdleValue(() => this._disposableStore.add(this._instaService.createInstance(RenameInputField, this.editor, ['acceptRenameInput', 'acceptRenameInputWithPreview']))));
+		this._renameInputField = this._instaService.createInstance(RenameInputField, this.editor, ['acceptRenameInput', 'acceptRenameInputWithPreview']);
 	}
 
 	dispose(): void {
@@ -207,7 +207,7 @@ class RenameController implements IEditorContribution {
 		}
 
 		const supportPreview = this._bulkEditService.hasPreviewHandler() && this._configService.getValue<boolean>(this.editor.getModel().uri, 'editor.rename.enablePreview');
-		const inputFieldResult = await this._renameInputField.value.getInput(loc.range, loc.text, selectionStart, selectionEnd, supportPreview, this._cts.token);
+		const inputFieldResult = await this._renameInputField.getInput(loc.range, loc.text, selectionStart, selectionEnd, supportPreview, this._cts.token);
 
 		// no result, only hint to focus the editor or not
 		if (typeof inputFieldResult === 'boolean') {
@@ -260,11 +260,11 @@ class RenameController implements IEditorContribution {
 	}
 
 	acceptRenameInput(wantsPreview: boolean): void {
-		this._renameInputField.value.acceptInput(wantsPreview);
+		this._renameInputField.acceptInput(wantsPreview);
 	}
 
 	cancelRenameInput(): void {
-		this._renameInputField.value.cancelInput(true);
+		this._renameInputField.cancelInput(true);
 	}
 }
 
@@ -319,7 +319,7 @@ export class RenameAction extends EditorAction {
 	}
 }
 
-registerEditorContribution(RenameController.ID, RenameController);
+registerEditorContribution(RenameController.ID, RenameController, EditorContributionInstantiation.Idle);
 registerEditorAction(RenameAction);
 
 const RenameCommand = EditorCommand.bindToContribution<RenameController>(RenameController.get);

--- a/src/vs/editor/contrib/rename/browser/rename.ts
+++ b/src/vs/editor/contrib/rename/browser/rename.ts
@@ -145,7 +145,7 @@ class RenameController implements IEditorContribution {
 		@ITextResourceConfigurationService private readonly _configService: ITextResourceConfigurationService,
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
 	) {
-		this._renameInputField = this._instaService.createInstance(RenameInputField, this.editor, ['acceptRenameInput', 'acceptRenameInputWithPreview']);
+		this._renameInputField = this._disposableStore.add(this._instaService.createInstance(RenameInputField, this.editor, ['acceptRenameInput', 'acceptRenameInputWithPreview']));
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
+++ b/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
-import { EditorAction, EditorExtensionsRegistry, IEditorContributionDescription } from 'vs/editor/browser/editorExtensions';
+import { EditorAction, EditorContributionInstantiation, EditorExtensionsRegistry, IEditorContributionDescription } from 'vs/editor/browser/editorExtensions';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { CodeEditorWidget, ICodeEditorWidgetOptions } from 'vs/editor/browser/widget/codeEditorWidget';
 import { IContextKeyService, RawContextKey, IContextKey } from 'vs/platform/contextkey/common/contextkey';
@@ -51,11 +51,11 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
 			isSimpleWidget: true,
 			contributions: <IEditorContributionDescription[]>[
-				{ id: MenuPreventer.ID, ctor: MenuPreventer },
-				{ id: ContextMenuController.ID, ctor: ContextMenuController },
-				{ id: SuggestController.ID, ctor: SuggestController },
-				{ id: SnippetController2.ID, ctor: SnippetController2 },
-				{ id: TabCompletionController.ID, ctor: TabCompletionController },
+				{ id: MenuPreventer.ID, ctor: MenuPreventer, instantiation: EditorContributionInstantiation.Eager },
+				{ id: ContextMenuController.ID, ctor: ContextMenuController, instantiation: EditorContributionInstantiation.Eager },
+				{ id: SuggestController.ID, ctor: SuggestController, instantiation: EditorContributionInstantiation.Eager },
+				{ id: SnippetController2.ID, ctor: SnippetController2, instantiation: EditorContributionInstantiation.Eager },
+				{ id: TabCompletionController.ID, ctor: TabCompletionController, instantiation: EditorContributionInstantiation.Eager },
 			]
 		};
 


### PR DESCRIPTION
For #164171

Editor contributions are currently created eagerly when editors are instantiated. In many cases however, the contribution is not needed instantly. A contributed widget for example may only be shown after a user action, or the information that an editor contribution shows in an editor may not be needed the very instant the editor is opened. Contributions like these can be lazily created, but actually adopting lazy instantiation for individual contributions is a lot of work

Instead this PR lets editor contributions tell VS Code that the entire contribution does not need to be eagerly created and can be instead on idle

With `EditorContributionInstantiation.Idle`, the contribution will be created:

- Either when the editor is idle
- Or when the contribution is explicitly requested.

Idle contributions cannot participate in saving and restoring of editor view states

This change will make it easier to lazily create editor contributions and also lets us remove existing code that was added to make individual editor contributions lazy
