### PR TITLE
Remove expired event

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-sandbox/extensionsAutoProfiler.ts
+++ b/src/vs/workbench/contrib/extensions/electron-sandbox/extensionsAutoProfiler.ts
@@ -221,19 +221,6 @@ export class ExtensionsAutoProfiler implements IWorkbenchContribution {
 		}
 		this._blame.add(ExtensionIdentifier.toKey(extension.identifier));
 
-		type UnresponsivePromptData = {
-			id: string;
-		};
-		type UnresponsivePromptDataClassification = {
-			owner: 'digitarald';
-			comment: 'Users got a warning about an extension hanging the extension process';
-			expiration: '1.73';
-			id: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Extension id that froze the extension process' };
-		};
-		this._telemetryService.publicLog2<UnresponsivePromptData, UnresponsivePromptDataClassification>('exthostunresponsiveprompt', {
-			id: ExtensionIdentifier.toKey(extension.identifier),
-		});
-
 		// user-facing message when very bad...
 		this._notificationService.prompt(
 			Severity.Warning,


### PR DESCRIPTION
This event has expried, I've just gone ahead and removed it since the tooling suppressed it already. If this is not the course of action we wish to take please open a new PR extending the expiration.