### PR TITLE
Wait for disconnect response before terminating DA

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -569,7 +569,7 @@ export class RawDebugSession implements IDisposable {
 						args.suspendDebuggee = suspendDebuggee;
 					}
 
-					this.send('disconnect', args, undefined, 2000);
+					await this.send('disconnect', args, undefined, 2000);
 				} catch (e) {
 					// Catch the potential 'disconnect' error - no need to show it to the user since the adapter is shutting down
 				} finally {


### PR DESCRIPTION
Fix #165138

Hey @isidorn, my interpretation is that we lost the await in https://github.com/microsoft/vscode/commit/239bc433cb7295a95ff37384f360b058e20531d6#diff-49c3ba2b3a19798acff4543b9901d78f4c0e66af6fc5b8e5c00f146255d3c8d0R514, and it's safe/correct to keep it. Please take a quick look and let me know if you remember any reason it actually shouldn't be there, thanks