### PR TITLE
Restore bracket match CSS syntax (#166109)

### DIFF
--- a/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.css
+++ b/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.css
@@ -6,5 +6,5 @@
 .monaco-editor .bracket-match {
 	box-sizing: border-box;
 	background-color: var(--vscode-editorBracketMatch-background);
-	border: var(--vscode-editorBracketMatch-border);
+	border: 1px solid var(--vscode-editorBracketMatch-border);
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This restores the CSS border syntax for matching bracket hilighting (#166109).

Prior 83b528d4dcd37110052b947ee69cdb198099d8d2 it was `border: 1px solid ${bracketMatchBorder}`.  The current `border: var(--vscode-editorBracketMatch-border)`, as set by the above commit, likely accidentally omits _line-width_ and _line-style_ values that were previously set (`1px` and `solid` correspondingly).  

As the initial line-style is `none` the border is not visible ([source](https://www.w3.org/TR/css-backgrounds-3/#border-width)).