### PR TITLE
Pickup bundle.l10n.json

### DIFF
--- a/build/lib/i18n.js
+++ b/build/lib/i18n.js
@@ -513,18 +513,36 @@ function createL10nBundleForExtension(extensionFolderName) {
         // For source code of extensions
         `extensions/${extensionFolderName}/src/**/*.{ts,tsx}`,
         // For any dependencies pulled in (think vscode-css-languageservice or @vscode/emmet-helper)
-        `extensions/${extensionFolderName}/node_modules/**/*.{js,jsx}`
+        `extensions/${extensionFolderName}/node_modules/**/*.{js,jsx}`,
+        // For any dependencies pulled in that bundle @vscode/l10n. They needed to export the bundle
+        `extensions/${extensionFolderName}/node_modules/**/bundle.l10n.json`,
     ]).pipe((0, event_stream_1.writeArray)((err, files) => {
         if (err) {
             result.emit('error', err);
             return;
         }
-        const json = (0, l10n_dev_1.getL10nJson)(files
-            .filter(file => file.isBuffer())
+        const buffers = files.filter(file => file.isBuffer());
+        const json = (0, l10n_dev_1.getL10nJson)(buffers
+            .filter(file => path.extname(file.path) !== '.json')
             .map(file => ({
             contents: file.contents.toString('utf8'),
             extension: path.extname(file.path)
         })));
+        buffers
+            .filter(file => path.extname(file.path) === '.json')
+            .forEach(file => {
+            const bundleJson = JSON.parse(file.contents.toString('utf8'));
+            for (const key in bundleJson) {
+                if (
+                // some validation of the bundle.l10n.json format
+                typeof bundleJson[key] !== 'string' &&
+                    (typeof bundleJson[key].message !== 'string' || !Array.isArray(bundleJson[key].comment))) {
+                    console.error(`Invalid bundle.l10n.json file. The value for key ${key} is not in the expected format. Skipping key...`);
+                    continue;
+                }
+                json[key] = bundleJson[key];
+            }
+        });
         if (Object.keys(json).length > 0) {
             result.emit('data', new File({
                 path: `extensions/${extensionFolderName}/bundle.l10n.json`,

--- a/build/lib/i18n.ts
+++ b/build/lib/i18n.ts
@@ -585,19 +585,40 @@ function createL10nBundleForExtension(extensionFolderName: string): ThroughStrea
 		// For source code of extensions
 		`extensions/${extensionFolderName}/src/**/*.{ts,tsx}`,
 		// For any dependencies pulled in (think vscode-css-languageservice or @vscode/emmet-helper)
-		`extensions/${extensionFolderName}/node_modules/**/*.{js,jsx}`
+		`extensions/${extensionFolderName}/node_modules/**/*.{js,jsx}`,
+		// For any dependencies pulled in that bundle @vscode/l10n. They needed to export the bundle
+		`extensions/${extensionFolderName}/node_modules/**/bundle.l10n.json`,
 	]).pipe(writeArray((err, files: File[]) => {
 		if (err) {
 			result.emit('error', err);
 			return;
 		}
 
-		const json = getL10nJson(files
-			.filter(file => file.isBuffer())
+		const buffers = files.filter(file => file.isBuffer());
+
+		const json = getL10nJson(buffers
+			.filter(file => path.extname(file.path) !== '.json')
 			.map(file => ({
 				contents: file.contents.toString('utf8'),
 				extension: path.extname(file.path)
 			})));
+
+		buffers
+			.filter(file => path.extname(file.path) === '.json')
+			.forEach(file => {
+				const bundleJson = JSON.parse(file.contents.toString('utf8'));
+				for (const key in bundleJson) {
+					if (
+						// some validation of the bundle.l10n.json format
+						typeof bundleJson[key] !== 'string' &&
+						(typeof bundleJson[key].message !== 'string' || !Array.isArray(bundleJson[key].comment))
+					) {
+						console.error(`Invalid bundle.l10n.json file. The value for key ${key} is not in the expected format. Skipping key...`);
+						continue;
+					}
+					json[key] = bundleJson[key];
+				}
+			});
 
 		if (Object.keys(json).length > 0) {
 			result.emit('data', new File({


### PR DESCRIPTION
For npm modules that have bundled `@vscode/l10n`, they can export their strings to a bundle.l10n.json file which will get picked up by this change and included in the overall bundle for the extension.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
