### PR TITLE
storage - do not eager parse extension storage (fix #163446)

### DIFF
--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -594,7 +594,7 @@ export interface MainThreadStatusBarShape extends IDisposable {
 }
 
 export interface MainThreadStorageShape extends IDisposable {
-	$initializeExtensionStorage(shared: boolean, extensionId: string): Promise<object | undefined>;
+	$initializeExtensionStorage(shared: boolean, extensionId: string): Promise<string | undefined>;
 	$setValue(shared: boolean, extensionId: string, value: object): Promise<void>;
 	$registerExtensionStorageKeysToSync(extension: IExtensionIdWithVersion, keys: string[]): void;
 }
@@ -2139,7 +2139,7 @@ export interface ExtHostInteractiveShape {
 }
 
 export interface ExtHostStorageShape {
-	$acceptValue(shared: boolean, extensionId: string, value: object | undefined): void;
+	$acceptValue(shared: boolean, extensionId: string, value: string): void;
 }
 
 export interface ExtHostThemingShape {

--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -154,7 +154,7 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 		this._myRegistry = new ExtensionDescriptionRegistry(
 			filterExtensions(this._globalRegistry, myExtensionsSet)
 		);
-		this._storage = new ExtHostStorage(this._extHostContext);
+		this._storage = new ExtHostStorage(this._extHostContext, this._logService);
 		this._secretState = new ExtHostSecretState(this._extHostContext);
 		this._storagePath = storagePath;
 

--- a/src/vs/workbench/api/common/extHostStorage.ts
+++ b/src/vs/workbench/api/common/extHostStorage.ts
@@ -8,6 +8,7 @@ import { Emitter } from 'vs/base/common/event';
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IExtensionIdWithVersion } from 'vs/platform/extensionManagement/common/extensionStorage';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export interface IStorageChangeEvent {
 	shared: boolean;
@@ -24,7 +25,10 @@ export class ExtHostStorage implements ExtHostStorageShape {
 	private readonly _onDidChangeStorage = new Emitter<IStorageChangeEvent>();
 	readonly onDidChangeStorage = this._onDidChangeStorage.event;
 
-	constructor(mainContext: IExtHostRpcService) {
+	constructor(
+		mainContext: IExtHostRpcService,
+		private readonly _logService: ILogService
+	) {
 		this._proxy = mainContext.getProxy(MainContext.MainThreadStorage);
 	}
 
@@ -32,16 +36,38 @@ export class ExtHostStorage implements ExtHostStorageShape {
 		this._proxy.$registerExtensionStorageKeysToSync(extension, keys);
 	}
 
-	initializeExtensionStorage(shared: boolean, key: string, defaultValue?: object): Promise<object | undefined> {
-		return this._proxy.$initializeExtensionStorage(shared, key).then(value => value || defaultValue);
+	async initializeExtensionStorage(shared: boolean, key: string, defaultValue?: object): Promise<object | undefined> {
+		const value = await this._proxy.$initializeExtensionStorage(shared, key);
+
+		let parsedValue: object | undefined;
+		if (value) {
+			parsedValue = this.safeParseValue(shared, key, value);
+		}
+
+		return parsedValue || defaultValue;
 	}
 
 	setValue(shared: boolean, key: string, value: object): Promise<void> {
 		return this._proxy.$setValue(shared, key, value);
 	}
 
-	$acceptValue(shared: boolean, key: string, value: object): void {
-		this._onDidChangeStorage.fire({ shared, key, value });
+	$acceptValue(shared: boolean, key: string, value: string): void {
+		const parsedValue = this.safeParseValue(shared, key, value);
+		if (parsedValue) {
+			this._onDidChangeStorage.fire({ shared, key, value: parsedValue });
+		}
+	}
+
+	private safeParseValue(shared: boolean, key: string, value: string): object | undefined {
+		try {
+			return JSON.parse(value);
+		} catch (error) {
+			// Do not fail this call but log it for diagnostics
+			// https://github.com/microsoft/vscode/issues/132777
+			this._logService.error(`[extHostStorage] unexpected error parsing storage contents (extensionId: ${key}, global: ${shared}): ${error}`);
+		}
+
+		return undefined;
 	}
 }
 


### PR DESCRIPTION
This is for #163446. As it turns out, the storage service will not do any `JSON.parse` eagerly. Storage values are primitives but never objects. However, we seem to be doing some `JSON.parse` from here specifically for extensions:

https://github.com/microsoft/vscode/blob/5f383ab073f363472f6b0f34082fe7d4d0b3eb6b/src/vs/platform/extensionManagement/common/extensionStorage.ts#L151

I tried to reduce calls to this method in the renderer in favour of the new `getExtensionStateRaw` and move the parsing to the extension host to avoid large stalls in the renderer. In addition, I am logging a warning when an extension storage value exceeds 500kb.

@sandy081 there are still some calls to `getExtensionState` in your area which are probably needed but I think they also happen from another process?

//cc @alexdima 