### PR TITLE
Use message as fallback, not key

### DIFF
--- a/src/vs/workbench/api/common/extHostLocalizationService.ts
+++ b/src/vs/workbench/api/common/extHostLocalizationService.ts
@@ -46,7 +46,7 @@ export class ExtHostLocalizationService implements ExtHostLocalizationShape {
 		if (!str) {
 			this.logService.warn(`Using default string since no string found in i18n bundle that has the key: ${key}`);
 		}
-		return format2(str ?? key, (args ?? {}));
+		return format2(str ?? message, (args ?? {}));
 	}
 
 	getBundle(extensionId: string): { [key: string]: string } | undefined {


### PR DESCRIPTION
Because `key` will also contain comments like:
```
my message/i'm a comment the user shouldn't see
```

The other part of microsoft/vscode#165735

fixes microsoft/vscode#165735

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
