### PR TITLE
cli: add service integration for macos, observability

### DIFF
--- a/cli/src/bin/code/main.rs
+++ b/cli/src/bin/code/main.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 use clap::Parser;
 use cli::{
 	commands::{args, tunnels, update, version, CommandContext},
+	constants::get_default_user_agent,
 	desktop, log as own_log,
 	state::LauncherPaths,
 	util::{
@@ -38,16 +39,12 @@ async fn main() -> Result<(), std::convert::Infallible> {
 
 	let core = parsed.core();
 	let context = CommandContext {
-		http: reqwest::Client::new(),
+		http: reqwest::ClientBuilder::new()
+			.user_agent(get_default_user_agent())
+			.build()
+			.unwrap(),
 		paths: LauncherPaths::new(&core.global_options.cli_data_dir).unwrap(),
-		log: own_log::Logger::new(
-			SdkTracerProvider::builder().build().tracer("codecli"),
-			if core.global_options.verbose {
-				own_log::Level::Trace
-			} else {
-				core.global_options.log.unwrap_or(own_log::Level::Info)
-			},
-		),
+		log: make_logger(core),
 		args: core.clone(),
 	};
 
@@ -111,6 +108,23 @@ async fn main() -> Result<(), std::convert::Infallible> {
 	}
 }
 
+fn make_logger(core: &args::CliCore) -> own_log::Logger {
+	let log_level = if core.global_options.verbose {
+		own_log::Level::Trace
+	} else {
+		core.global_options.log.unwrap_or(own_log::Level::Info)
+	};
+
+	let tracer = SdkTracerProvider::builder().build().tracer("codecli");
+	let mut log = own_log::Logger::new(tracer, log_level);
+	if let Some(f) = &core.global_options.log_to_file {
+		log =
+			log.tee(own_log::FileLogSink::new(log_level, f).expect("expected to make file logger"))
+	}
+
+	log
+}
+
 fn print_and_exit<E>(err: E) -> !
 where
 	E: std::fmt::Display,
@@ -143,7 +157,12 @@ async fn start_code(context: CommandContext, args: Vec<String>) -> Result<i32, A
 		.args(args)
 		.status()
 		.map(|s| s.code().unwrap_or(1))
-		.map_err(|e| wrap(e, format!("error running VS Code from {}", binary.display())))?;
+		.map_err(|e| {
+			wrap(
+				e,
+				format!("error running VS Code from {}", binary.display()),
+			)
+		})?;
 
 	Ok(code)
 }

--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-use std::fmt;
+use std::{fmt, path::PathBuf};
 
 use crate::{constants, log, options, tunnels::code_server::CodeServerArgs};
 use clap::{ArgEnum, Args, Parser, Subcommand};
@@ -394,6 +394,10 @@ pub struct GlobalOptions {
 	#[clap(long, global = true)]
 	pub verbose: bool,
 
+	/// Log to a file in addition to stdout. Used when running as a service.
+	#[clap(long, global = true, hide = true)]
+	pub log_to_file: Option<PathBuf>,
+
 	/// Log level to use.
 	#[clap(long, arg_enum, value_name = "level", global = true)]
 	pub log: Option<log::Level>,
@@ -595,6 +599,9 @@ pub enum TunnelServiceSubCommands {
 
 	/// Uninstalls and stops the tunnel service.
 	Uninstall,
+
+	/// Shows logs for the running service.
+	Log,
 
 	/// Internal command for running the service
 	#[clap(hide = true)]

--- a/cli/src/commands/tunnels.rs
+++ b/cli/src/commands/tunnels.rs
@@ -74,7 +74,7 @@ impl ServiceContainer for TunnelServiceContainer {
 		&mut self,
 		log: log::Logger,
 		launcher_paths: LauncherPaths,
-		shutdown_rx: mpsc::Receiver<ShutdownSignal>,
+		shutdown_rx: mpsc::UnboundedReceiver<ShutdownSignal>,
 	) -> Result<(), AnyError> {
 		let csa = (&self.args).into();
 		serve_with_csa(
@@ -126,7 +126,6 @@ pub async fn service(
 			let current_exe =
 				std::env::current_exe().map_err(|e| wrap(e, "could not get current exe"))?;
 
-			println!("calling register");
 			manager
 				.register(
 					current_exe,
@@ -240,7 +239,7 @@ async fn serve_with_csa(
 	log: Logger,
 	gateway_args: TunnelServeArgs,
 	csa: CodeServerArgs,
-	shutdown_rx: Option<mpsc::Receiver<ShutdownSignal>>,
+	shutdown_rx: Option<mpsc::UnboundedReceiver<ShutdownSignal>>,
 ) -> Result<i32, AnyError> {
 	// Intentionally read before starting the server. If the server updated and
 	// respawn is requested, the old binary will get renamed, and then
@@ -260,7 +259,7 @@ async fn serve_with_csa(
 	let shutdown_tx = if let Some(tx) = shutdown_rx {
 		tx
 	} else {
-		let (tx, rx) = mpsc::channel::<ShutdownSignal>(2);
+		let (tx, rx) = mpsc::unbounded_channel::<ShutdownSignal>();
 		if let Some(process_id) = gateway_args.parent_process_id {
 			match Pid::from_str(&process_id) {
 				Ok(pid) => {
@@ -271,7 +270,7 @@ async fn serve_with_csa(
 						while s.refresh_process(pid) {
 							sleep(Duration::from_millis(2000)).await;
 						}
-						tx.send(ShutdownSignal::ParentProcessKilled).await.ok();
+						tx.send(ShutdownSignal::ParentProcessKilled).ok();
 					});
 				}
 				Err(_) => {
@@ -281,7 +280,7 @@ async fn serve_with_csa(
 		}
 		tokio::spawn(async move {
 			tokio::signal::ctrl_c().await.ok();
-			tx.send(ShutdownSignal::CtrlC).await.ok();
+			tx.send(ShutdownSignal::CtrlC).ok();
 		});
 		rx
 	};

--- a/cli/src/commands/tunnels.rs
+++ b/cli/src/commands/tunnels.rs
@@ -116,13 +116,11 @@ pub async fn service(
 	match service_args {
 		TunnelServiceSubCommands::Install => {
 			// ensure logged in, otherwise subsequent serving will fail
-			println!("authing");
 			Auth::new(&ctx.paths, ctx.log.clone())
 				.get_credential()
 				.await?;
 
 			// likewise for license consent
-			println!("consent");
 			legal::require_consent(&ctx.paths, false)?;
 
 			let current_exe =
@@ -146,6 +144,9 @@ pub async fn service(
 		}
 		TunnelServiceSubCommands::Uninstall => {
 			manager.unregister().await?;
+		}
+		TunnelServiceSubCommands::Log => {
+			manager.show_logs().await?;
 		}
 		TunnelServiceSubCommands::InternalRun => {
 			manager

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -137,6 +137,11 @@ impl LauncherPaths {
 		&self.root
 	}
 
+	/// Suggested path for tunnel service logs, when using file logs
+	pub fn service_log_file(&self) -> PathBuf {
+		self.root.join("tunnel-service.log")
+	}
+
 	/// Removes the launcher data directory.
 	pub fn remove(&self) -> Result<(), WrappedError> {
 		remove_dir_all(&self.root).map_err(|e| {

--- a/cli/src/tunnels.rs
+++ b/cli/src/tunnels.rs
@@ -21,6 +21,8 @@ mod service;
 mod service_linux;
 #[cfg(target_os = "windows")]
 mod service_windows;
+#[cfg(target_os = "macos")]
+mod service_macos;
 
 pub use control_server::serve;
 pub use service::{

--- a/cli/src/tunnels/control_server.rs
+++ b/cli/src/tunnels/control_server.rs
@@ -167,7 +167,7 @@ pub async fn serve(
 	launcher_paths: &LauncherPaths,
 	code_server_args: &CodeServerArgs,
 	platform: Platform,
-	shutdown_rx: mpsc::Receiver<ShutdownSignal>,
+	shutdown_rx: mpsc::UnboundedReceiver<ShutdownSignal>,
 ) -> Result<ServerTermination, AnyError> {
 	let mut port = tunnel.add_port_direct(CONTROL_PORT).await?;
 	print_listening(log, &tunnel.name);

--- a/cli/src/tunnels/service.rs
+++ b/cli/src/tunnels/service.rs
@@ -40,6 +40,9 @@ pub trait ServiceManager {
 		handle: impl 'static + ServiceContainer,
 	) -> Result<(), AnyError>;
 
+	/// Show logs from the running service to standard out.
+	async fn show_logs(&self) -> Result<(), AnyError>;
+
 	/// Unregisters the current executable as a service.
 	async fn unregister(&self) -> Result<(), AnyError>;
 }
@@ -50,12 +53,16 @@ pub type ServiceManagerImpl = super::service_windows::WindowsService;
 #[cfg(target_os = "linux")]
 pub type ServiceManagerImpl = super::service_linux::SystemdService;
 
-#[cfg(not(any(target_os = "windows", target_os = "linux")))]
-pub type ServiceManagerImpl = UnimplementedServiceManager;
+#[cfg(target_os = "macos")]
+pub type ServiceManagerImpl = super::service_macos::LaunchdService;
 
 #[allow(unreachable_code)]
 #[allow(unused_variables)]
 pub fn create_service_manager(log: log::Logger, paths: &LauncherPaths) -> ServiceManagerImpl {
+	#[cfg(target_os = "macos")]
+	{
+		super::service_macos::LaunchdService::new(log, paths)
+	}
 	#[cfg(target_os = "windows")]
 	{
 		super::service_windows::WindowsService::new(log)
@@ -63,37 +70,5 @@ pub fn create_service_manager(log: log::Logger, paths: &LauncherPaths) -> Servic
 	#[cfg(target_os = "linux")]
 	{
 		super::service_linux::SystemdService::new(log, paths.clone())
-	}
-	#[cfg(not(any(target_os = "windows", target_os = "linux")))]
-	{
-		UnimplementedServiceManager::new()
-	}
-}
-
-pub struct UnimplementedServiceManager();
-
-#[allow(dead_code)]
-impl UnimplementedServiceManager {
-	fn new() -> Self {
-		Self()
-	}
-}
-
-#[async_trait]
-impl ServiceManager for UnimplementedServiceManager {
-	async fn register(&self, _exe: PathBuf, _args: &[&str]) -> Result<(), AnyError> {
-		unimplemented!("Service management is not supported on this platform");
-	}
-
-	async fn run(
-		self,
-		_launcher_paths: LauncherPaths,
-		_handle: impl 'static + ServiceContainer,
-	) -> Result<(), AnyError> {
-		unimplemented!("Service management is not supported on this platform");
-	}
-
-	async fn unregister(&self) -> Result<(), AnyError> {
-		unimplemented!("Service management is not supported on this platform");
 	}
 }

--- a/cli/src/tunnels/service.rs
+++ b/cli/src/tunnels/service.rs
@@ -74,13 +74,14 @@ pub fn create_service_manager(log: log::Logger, paths: &LauncherPaths) -> Servic
 	}
 }
 
+#[allow(dead_code)] // unused on Linux
 pub(crate) async fn tail_log_file(log_file: &Path) -> Result<(), AnyError> {
 	if !log_file.exists() {
 		println!("The tunnel service has not started yet.");
 		return Ok(());
 	}
 
-	let file = std::fs::File::open(&log_file).map_err(|e| wrap(e, "error opening log file"))?;
+	let file = std::fs::File::open(log_file).map_err(|e| wrap(e, "error opening log file"))?;
 	let mut rx = tailf(file, 20);
 	while let Some(line) = rx.recv().await {
 		match line {

--- a/cli/src/tunnels/service_macos.rs
+++ b/cli/src/tunnels/service_macos.rs
@@ -1,0 +1,188 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+use std::{
+	fs::{remove_file, File},
+	io::{self, Write},
+	path::{Path, PathBuf},
+};
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use crate::{
+	commands::tunnels::ShutdownSignal,
+	constants::APPLICATION_NAME,
+	log,
+	state::LauncherPaths,
+	util::{
+		command::capture_command_and_check_status,
+		errors::{wrap, AnyError, MissingHomeDirectory},
+		io::{tailf, TailEvent},
+	},
+};
+
+use super::ServiceManager;
+
+pub struct LaunchdService {
+	log: log::Logger,
+	log_file: PathBuf,
+}
+
+impl LaunchdService {
+	pub fn new(log: log::Logger, paths: &LauncherPaths) -> Self {
+		Self {
+			log,
+			log_file: paths.service_log_file(),
+		}
+	}
+}
+
+#[async_trait]
+impl ServiceManager for LaunchdService {
+	async fn register(
+		&self,
+		exe: std::path::PathBuf,
+		args: &[&str],
+	) -> Result<(), crate::util::errors::AnyError> {
+		let service_file = get_service_file_path()?;
+		write_service_file(&service_file, &self.log_file, exe, args)
+			.map_err(|e| wrap(e, "error creating service file"))?;
+
+		info!(self.log, "Successfully registered service...");
+
+		capture_command_and_check_status(
+			"launchctl",
+			&["load", service_file.as_os_str().to_string_lossy().as_ref()],
+		)
+		.await?;
+
+		capture_command_and_check_status("launchctl", &["start", &get_service_label()]).await?;
+
+		info!(self.log, "Tunnel service successfully started");
+
+		Ok(())
+	}
+
+	async fn show_logs(&self) -> Result<(), AnyError> {
+		if !self.log_file.exists() {
+			println!("The tunnel service has not started yet.");
+			return Ok(());
+		}
+
+		let file =
+			std::fs::File::open(&self.log_file).map_err(|e| wrap(e, "error opening log file"))?;
+		let mut rx = tailf(file, 20);
+		while let Some(line) = rx.recv().await {
+			match line {
+				TailEvent::Line(l) => print!("{}", l),
+				TailEvent::Reset => println!("== Tunnel service restarted =="),
+				TailEvent::Err(e) => return Err(wrap(e, "error reading log file").into()),
+			}
+		}
+
+		Ok(())
+	}
+
+	async fn run(
+		self,
+		launcher_paths: crate::state::LauncherPaths,
+		mut handle: impl 'static + super::ServiceContainer,
+	) -> Result<(), crate::util::errors::AnyError> {
+		let (tx, rx) = mpsc::channel::<ShutdownSignal>(1);
+		tokio::spawn(async move {
+			tokio::signal::ctrl_c().await.ok();
+			tx.send(ShutdownSignal::CtrlC).await.ok();
+		});
+
+		handle.run_service(self.log, launcher_paths, rx).await
+	}
+
+	async fn unregister(&self) -> Result<(), crate::util::errors::AnyError> {
+		let service_file = get_service_file_path()?;
+
+		match capture_command_and_check_status("launchctl", &["stop", &get_service_label()]).await {
+			Ok(_) => {}
+			// status 3 == "no such process"
+			Err(AnyError::CommandFailed(e)) if e.output.status.code() == Some(3) => {}
+			Err(e) => return Err(e),
+		};
+
+		info!(self.log, "Successfully stopped service...");
+
+		capture_command_and_check_status(
+			"launchctl",
+			&[
+				"unload",
+				service_file.as_os_str().to_string_lossy().as_ref(),
+			],
+		)
+		.await?;
+
+		info!(self.log, "Tunnel service uninstalled");
+
+		if let Ok(f) = get_service_file_path() {
+			remove_file(f).ok();
+		}
+
+		Ok(())
+	}
+}
+
+fn get_service_label() -> String {
+	format!("com.visualstudio.{}.tunnel", &*APPLICATION_NAME)
+}
+
+fn get_service_file_path() -> Result<PathBuf, MissingHomeDirectory> {
+	match dirs::home_dir() {
+		Some(mut d) => {
+			d.push(format!("{}.plist", get_service_label()));
+			Ok(d)
+		}
+		None => Err(MissingHomeDirectory()),
+	}
+}
+
+fn write_service_file(
+	path: &PathBuf,
+	log_file: &Path,
+	exe: std::path::PathBuf,
+	args: &[&str],
+) -> io::Result<()> {
+	let mut f = File::create(path)?;
+	let log_file = log_file.as_os_str().to_string_lossy();
+	// todo: we may be able to skip file logging and use the ASL instead
+	// if/when we no longer need to support older macOS versions.
+	write!(
+		&mut f,
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+		<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+		<plist version=\"1.0\">\n\
+		<dict>\n\
+			<key>Label</key>\n\
+			<string>{}</string>\n\
+			<key>LimitLoadToSessionType</key>\n\
+			<string>Aqua</string>\n\
+			<key>ProgramArguments</key>\n\
+			<array>\n\
+				<string>{}</string>\n\
+				<string>{}</string>\n\
+			</array>\n\
+			<key>KeepAlive</key>\n\
+			<true/>\n\
+			<key>StandardErrorPath</key>\n\
+			<string>{}</string>\n\
+			<key>StandardOutPath</key>\n\
+			<string>{}</string>\n\
+		</dict>\n\
+		</plist>",
+		get_service_label(),
+		exe.into_os_string().to_string_lossy(),
+		args.join("</string><string>"),
+		log_file,
+		log_file
+	)?;
+	Ok(())
+}

--- a/cli/src/tunnels/service_windows.rs
+++ b/cli/src/tunnels/service_windows.rs
@@ -6,7 +6,7 @@
 use async_trait::async_trait;
 use dialoguer::{theme::ColorfulTheme, Input, Password};
 use lazy_static::lazy_static;
-use std::{ffi::OsString, sync::Mutex, thread, time::Duration};
+use std::{ffi::OsString, path::PathBuf, sync::Mutex, thread, time::Duration};
 use tokio::sync::mpsc;
 use windows_service::{
 	define_windows_service,
@@ -21,7 +21,7 @@ use windows_service::{
 
 use crate::{
 	commands::tunnels::ShutdownSignal,
-	util::errors::{wrap, AnyError, WindowsNeedsElevation},
+	util::errors::{wrap, wrapdbg, AnyError, WindowsNeedsElevation},
 };
 use crate::{
 	log::{self, FileLogSink},
@@ -29,19 +29,23 @@ use crate::{
 };
 
 use super::service::{
-	ServiceContainer, ServiceManager as CliServiceManager, SERVICE_LOG_FILE_NAME,
+	tail_log_file, ServiceContainer, ServiceManager as CliServiceManager, SERVICE_LOG_FILE_NAME,
 };
 
 pub struct WindowsService {
 	log: log::Logger,
+	log_file: PathBuf,
 }
 
 const SERVICE_NAME: &str = "code_tunnel";
 const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
 impl WindowsService {
-	pub fn new(log: log::Logger) -> Self {
-		Self { log }
+	pub fn new(log: log::Logger, paths: &LauncherPaths) -> Self {
+		Self {
+			log,
+			log_file: paths.service_log_file(),
+		}
 	}
 }
 
@@ -54,6 +58,10 @@ impl CliServiceManager for WindowsService {
 		)
 		.map_err(|e| WindowsNeedsElevation(format!("error getting service manager: {}", e)))?;
 
+		let mut args = args.iter().map(OsString::from).collect::<Vec<OsString>>();
+		args.push(OsString::from("--log-to-file"));
+		args.push(self.log_file.as_os_str().to_os_string());
+
 		let mut service_info = ServiceInfo {
 			name: OsString::from(SERVICE_NAME),
 			display_name: OsString::from("VS Code Tunnel"),
@@ -61,7 +69,7 @@ impl CliServiceManager for WindowsService {
 			start_type: ServiceStartType::AutoStart,
 			error_control: ServiceErrorControl::Normal,
 			executable_path: exe,
-			launch_arguments: args.iter().map(OsString::from).collect(),
+			launch_arguments: args,
 			dependencies: vec![],
 			account_name: None,
 			account_password: None,
@@ -74,7 +82,7 @@ impl CliServiceManager for WindowsService {
 		let service = if let Ok(service) = existing_service {
 			service
 				.change_config(&service_info)
-				.map_err(|e| wrap(e, "error updating existing service"))?;
+				.map_err(|e| wrapdbg(e, "error updating existing service"))?;
 			service
 		} else {
 			loop {
@@ -112,7 +120,7 @@ impl CliServiceManager for WindowsService {
 		if status == ServiceState::Stopped {
 			service
 				.start::<&str>(&[])
-				.map_err(|e| wrap(e, "error starting service"))?;
+				.map_err(|e| wrapdbg(e, "error starting service"))?;
 		}
 
 		info!(self.log, "Tunnel service successfully started");
@@ -120,7 +128,7 @@ impl CliServiceManager for WindowsService {
 	}
 
 	async fn show_logs(&self) -> Result<(), AnyError> {
-		todo!();
+		tail_log_file(&self.log_file).await
 	}
 
 	#[allow(unused_must_use)] // triggers incorrectly on `define_windows_service!`
@@ -136,7 +144,7 @@ impl CliServiceManager for WindowsService {
 			Ok(sink) => self.log.tee(sink),
 			Err(e) => {
 				warning!(self.log, "Failed to create service log file: {}", e);
-				self.log.clone()
+				self.log
 			}
 		};
 
@@ -176,12 +184,12 @@ impl CliServiceManager for WindowsService {
 
 		let service_status = service
 			.query_status()
-			.map_err(|e| wrap(e, "error getting service status"))?;
+			.map_err(|e| wrapdbg(e, "error getting service status"))?;
 
 		if service_status.current_state != ServiceState::Stopped {
 			service
 				.stop()
-				.map_err(|e| wrap(e, "error getting stopping service"))?;
+				.map_err(|e| wrapdbg(e, "error getting stopping service"))?;
 
 			while let Ok(ServiceState::Stopped) = service.query_status().map(|s| s.current_state) {
 				info!(self.log, "Polling for service to stop...");
@@ -191,7 +199,7 @@ impl CliServiceManager for WindowsService {
 
 		service
 			.delete()
-			.map_err(|e| wrap(e, "error deleting service"))?;
+			.map_err(|e| wrapdbg(e, "error deleting service"))?;
 
 		Ok(())
 	}
@@ -212,7 +220,7 @@ fn service_main(_arguments: Vec<OsString>) -> Result<(), AnyError> {
 	let mut service = SERVICE_IMPL.lock().unwrap().take().unwrap();
 
 	// Create a channel to be able to poll a stop event from the service worker loop.
-	let (shutdown_tx, shutdown_rx) = mpsc::channel::<ShutdownSignal>(5);
+	let (shutdown_tx, shutdown_rx) = mpsc::unbounded_channel::<ShutdownSignal>();
 	let mut shutdown_tx = Some(shutdown_tx);
 
 	// Define system service event handler that will be receiving service events.
@@ -222,7 +230,7 @@ fn service_main(_arguments: Vec<OsString>) -> Result<(), AnyError> {
 			ServiceControl::Stop => {
 				shutdown_tx
 					.take()
-					.and_then(|tx| tx.blocking_send(ShutdownSignal::ServiceStopped).ok());
+					.and_then(|tx| tx.send(ShutdownSignal::ServiceStopped).ok());
 				ServiceControlHandlerResult::NoError
 			}
 			_ => ServiceControlHandlerResult::NotImplemented,
@@ -244,6 +252,13 @@ fn service_main(_arguments: Vec<OsString>) -> Result<(), AnyError> {
 			process_id: None,
 		})
 		.map_err(|e| wrap(e, "error marking service as running"))?;
+
+	info!(service.log, "Starting service loop...");
+
+	let panic_log = service.log.clone();
+	std::panic::set_hook(Box::new(move |p| {
+		error!(panic_log, "Service panic: {:?}", p);
+	}));
 
 	let result = tokio::runtime::Builder::new_multi_thread()
 		.enable_all()

--- a/cli/src/tunnels/service_windows.rs
+++ b/cli/src/tunnels/service_windows.rs
@@ -119,6 +119,10 @@ impl CliServiceManager for WindowsService {
 		Ok(())
 	}
 
+	async fn show_logs(&self) -> Result<(), AnyError> {
+		todo!();
+	}
+
 	#[allow(unused_must_use)] // triggers incorrectly on `define_windows_service!`
 	async fn run(
 		self,

--- a/cli/src/util/command.rs
+++ b/cli/src/util/command.rs
@@ -2,9 +2,33 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-use super::errors::{wrap, WrappedError};
-use std::{ffi::OsStr, process::Stdio};
+use super::errors::{wrap, AnyError, CommandFailed, WrappedError};
+use std::{ffi::OsStr, process::Stdio, borrow::Cow};
 use tokio::process::Command;
+
+pub async fn capture_command_and_check_status(
+	command_str: impl AsRef<OsStr>,
+	args: &[impl AsRef<OsStr>],
+) -> Result<std::process::Output, AnyError> {
+	let output = capture_command(&command_str, args).await?;
+
+	if !output.status.success() {
+		return Err(CommandFailed {
+			command: format!(
+				"{} {}",
+				command_str.as_ref().to_string_lossy(),
+				args.iter()
+					.map(|a| a.as_ref().to_string_lossy())
+					.collect::<Vec<Cow<'_, str>>>()
+					.join(" ")
+			),
+			output,
+		}
+		.into());
+	}
+
+	Ok(output)
+}
 
 pub async fn capture_command<A, I, S>(
 	command_str: A,

--- a/cli/src/util/errors.rs
+++ b/cli/src/util/errors.rs
@@ -371,6 +371,37 @@ impl std::fmt::Display for CorruptDownload {
 	}
 }
 
+#[derive(Debug)]
+pub struct MissingHomeDirectory();
+
+impl std::fmt::Display for MissingHomeDirectory {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "Could not find your home directory. Please ensure this command is running in the context of an normal user.")
+	}
+}
+
+#[derive(Debug)]
+pub struct CommandFailed {
+	pub output: std::process::Output,
+	pub command: String,
+}
+
+impl std::fmt::Display for CommandFailed {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(
+			f,
+			"Failed to run command \"{}\" (code {}): {}",
+			self.command,
+			self.output.status,
+			String::from_utf8_lossy(if self.output.stderr.is_empty() {
+				&self.output.stdout
+			} else {
+				&self.output.stderr
+			})
+		)
+	}
+}
+
 // Makes an "AnyError" enum that contains any of the given errors, in the form
 // `enum AnyError { FooError(FooError) }` (when given `makeAnyError!(FooError)`).
 // Useful to easily deal with application error types without making tons of "From"
@@ -433,7 +464,9 @@ makeAnyError!(
 	ServiceAlreadyRegistered,
 	WindowsNeedsElevation,
 	UpdatesNotConfigured,
-	CorruptDownload
+	CorruptDownload,
+	MissingHomeDirectory,
+	CommandFailed
 );
 
 impl From<reqwest::Error> for AnyError {

--- a/cli/src/util/errors.rs
+++ b/cli/src/util/errors.rs
@@ -43,6 +43,17 @@ impl From<reqwest::Error> for WrappedError {
 	}
 }
 
+pub fn wrapdbg<T, S>(original: T, message: S) -> WrappedError
+where
+	T: std::fmt::Debug,
+	S: Into<String>,
+{
+	WrappedError {
+		message: message.into(),
+		original: format!("{:?}", original),
+	}
+}
+
 pub fn wrap<T, S>(original: T, message: S) -> WrappedError
 where
 	T: Display,


### PR DESCRIPTION
Adds support for running the tunnel as a service on macOS via launchservices.

It also hooks up observability (`code tunnel service log`) on macOS and Linux. On macOS--and later Windows, hence the manual implementation of `tail`--it saves output to a log file and watches it. On Linux, it simply delegates to journalctl.

The "tailing" is implemented via simple polling of the file size. I didn't want to pull in a giant set of dependencies for inotify/kqueue/etc just for this use case; performance when polling a single log file is not a huge concern.

Once I hook up logging on Windows, https://github.com/microsoft/vscode-cli/issues/367 will be done.

---

Edit: I added the windows side of things, so this now fixes https://github.com/microsoft/vscode-cli/issues/367