### PR TITLE
joh/representative canidae

### DIFF
--- a/src/bootstrap-fork.js
+++ b/src/bootstrap-fork.js
@@ -38,14 +38,7 @@ if (process.env['VSCODE_PARENT_PID']) {
 }
 
 // VSCODE_GLOBALS: node_modules
-globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
-	get(target, mod) {
-		if (!target[mod] && typeof mod === 'string') {
-			target[mod] = require(mod);
-		}
-		return target[mod];
-	}
-});
+globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), { get: (_target, mod) => require(String(mod)) });
 
 // VSCODE_GLOBALS: package/product.json
 globalThis._VSCODE_PRODUCT_JSON = require('../product.json');

--- a/src/bootstrap-fork.js
+++ b/src/bootstrap-fork.js
@@ -47,10 +47,12 @@ globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
 	}
 });
 
+// VSCODE_GLOBALS: package/product.json
+globalThis._VSCODE_PRODUCT_JSON = require('../product.json');
+globalThis._VSCODE_PACKAGE_JSON = require('../package.json');
 
 // Load AMD entry point
 require('./bootstrap-amd').load(process.env['VSCODE_AMD_ENTRYPOINT']);
-
 
 //#region Helpers
 

--- a/src/bootstrap-fork.js
+++ b/src/bootstrap-fork.js
@@ -37,6 +37,17 @@ if (process.env['VSCODE_PARENT_PID']) {
 	terminateWhenParentTerminates();
 }
 
+// VSCODE_GLOBALS: node_modules
+globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
+	get(target, mod) {
+		if (!target[mod] && typeof mod === 'string') {
+			target[mod] = require(mod);
+		}
+		return target[mod];
+	}
+});
+
+
 // Load AMD entry point
 require('./bootstrap-amd').load(process.env['VSCODE_AMD_ENTRYPOINT']);
 

--- a/src/bootstrap-window.js
+++ b/src/bootstrap-window.js
@@ -113,14 +113,7 @@
 		window['MonacoEnvironment'] = {};
 
 		// VSCODE_GLOBALS: node_modules
-		globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
-			get(target, mod) {
-				if (!target[mod] && typeof mod === 'string') {
-					target[mod] = (require.__$__nodeRequire ?? require)(mod);
-				}
-				return target[mod];
-			}
-		});
+		globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), { get: (_target, mod) => (require.__$__nodeRequire ?? require)(String(mod)) });
 
 		// VSCODE_GLOBALS: package/product.json
 		globalThis._VSCODE_PRODUCT_JSON = (require.__$__nodeRequire ?? require)(configuration.appRoot + '/product.json');

--- a/src/bootstrap-window.js
+++ b/src/bootstrap-window.js
@@ -112,6 +112,16 @@
 
 		window['MonacoEnvironment'] = {};
 
+		// VSCODE_GLOBALS: node_modules
+		globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
+			get(target, mod) {
+				if (!target[mod] && typeof mod === 'string') {
+					target[mod] = (require.__$__nodeRequire ?? require)(mod);
+				}
+				return target[mod];
+			}
+		});
+
 		const loaderConfig = {
 			baseUrl: `${bootstrapLib.fileUriFromPath(configuration.appRoot, { isWindows: safeProcess.platform === 'win32', scheme: 'vscode-file', fallbackAuthority: 'vscode-app' })}/out`,
 			'vs/nls': nlsConfig,

--- a/src/bootstrap-window.js
+++ b/src/bootstrap-window.js
@@ -122,6 +122,10 @@
 			}
 		});
 
+		// VSCODE_GLOBALS: package/product.json
+		globalThis._VSCODE_PRODUCT_JSON = (require.__$__nodeRequire ?? require)(configuration.appRoot + '/product.json');
+		globalThis._VSCODE_PACKAGE_JSON = (require.__$__nodeRequire ?? require)(configuration.appRoot + '/package.json');
+
 		const loaderConfig = {
 			baseUrl: `${bootstrapLib.fileUriFromPath(configuration.appRoot, { isWindows: safeProcess.platform === 'win32', scheme: 'vscode-file', fallbackAuthority: 'vscode-app' })}/out`,
 			'vs/nls': nlsConfig,

--- a/src/main.js
+++ b/src/main.js
@@ -151,6 +151,10 @@ function startup(codeCachePath, nlsConfig) {
 		}
 	});
 
+	// VSCODE_GLOBALS: package/product.json
+	globalThis._VSCODE_PRODUCT_JSON = require('../product.json');
+	globalThis._VSCODE_PACKAGE_JSON = require('../package.json');
+
 	// Load main in AMD
 	perf.mark('code/willLoadMainBundle');
 	require('./bootstrap-amd').load('vs/code/electron-main/main', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -142,14 +142,7 @@ function startup(codeCachePath, nlsConfig) {
 	process.env['VSCODE_CODE_CACHE_PATH'] = codeCachePath || '';
 
 	// VSCODE_GLOBALS: node_modules
-	globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
-		get(target, mod) {
-			if (!target[mod] && typeof mod === 'string') {
-				target[mod] = require(mod);
-			}
-			return target[mod];
-		}
-	});
+	globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), { get: (_target, mod) => require(String(mod)) });
 
 	// VSCODE_GLOBALS: package/product.json
 	globalThis._VSCODE_PRODUCT_JSON = require('../product.json');

--- a/src/main.js
+++ b/src/main.js
@@ -141,6 +141,16 @@ function startup(codeCachePath, nlsConfig) {
 	process.env['VSCODE_NLS_CONFIG'] = JSON.stringify(nlsConfig);
 	process.env['VSCODE_CODE_CACHE_PATH'] = codeCachePath || '';
 
+	// VSCODE_GLOBALS: node_modules
+	globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
+		get(target, mod) {
+			if (!target[mod] && typeof mod === 'string') {
+				target[mod] = require(mod);
+			}
+			return target[mod];
+		}
+	});
+
 	// Load main in AMD
 	perf.mark('code/willLoadMainBundle');
 	require('./bootstrap-amd').load('vs/code/electron-main/main', () => {
@@ -318,6 +328,7 @@ function getArgvConfigPath() {
 		dataFolderName = `${dataFolderName}-dev`;
 	}
 
+	// @ts-ignore
 	return path.join(os.homedir(), dataFolderName, 'argv.json');
 }
 

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -258,6 +258,19 @@ function loadCode() {
 	return new Promise((resolve, reject) => {
 		const path = require('path');
 
+		// VSCODE_GLOBALS: node_modules
+		globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
+			get(target, mod) {
+				if (!target[mod] && typeof mod === 'string') {
+					target[mod] = require(mod);
+				}
+				return target[mod];
+			}
+		});
+		// VSCODE_GLOBALS: package/product.json
+		globalThis._VSCODE_PRODUCT_JSON = require('../product.json');
+		globalThis._VSCODE_PACKAGE_JSON = require('../package.json');
+
 		delete process.env['ELECTRON_RUN_AS_NODE']; // Keep bootstrap-amd.js from redefining 'fs'.
 
 		// See https://github.com/microsoft/vscode-remote-release/issues/6543

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -259,14 +259,8 @@ function loadCode() {
 		const path = require('path');
 
 		// VSCODE_GLOBALS: node_modules
-		globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
-			get(target, mod) {
-				if (!target[mod] && typeof mod === 'string') {
-					target[mod] = require(mod);
-				}
-				return target[mod];
-			}
-		});
+		globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), { get: (_target, mod) => require(String(mod)) });
+
 		// VSCODE_GLOBALS: package/product.json
 		globalThis._VSCODE_PRODUCT_JSON = require('../product.json');
 		globalThis._VSCODE_PACKAGE_JSON = require('../package.json');

--- a/src/tsconfig.monaco.json
+++ b/src/tsconfig.monaco.json
@@ -18,6 +18,7 @@
 	"include": [
 		"typings/require.d.ts",
 		"typings/thenable.d.ts",
+		"typings/vscode-globals-product.d.ts",
 		"vs/loader.d.ts",
 		"vs/monaco.d.ts",
 		"vs/editor/*",

--- a/src/typings/require.d.ts
+++ b/src/typings/require.d.ts
@@ -45,10 +45,17 @@ interface NodeRequire {
 	 * @deprecated use `FileAccess.asFileUri()` for node.js contexts or `FileAccess.asBrowserUri` for browser contexts.
 	 */
 	toUrl(path: string): string;
+
+	/**
+	 * @deprecated MUST not be used anymore
+	 *
+	 * With the move from AMD to ESM we cannot use this anymore. There will be NO MORE node require like this.
+	 */
+	__$__nodeRequire<T>(moduleName: string): T;
+
 	(dependencies: string[], callback: (...args: any[]) => any, errorback?: (err: any) => void): any;
 	config(data: any): any;
 	onError: Function;
-	__$__nodeRequire<T>(moduleName: string): T;
 	getStats?(): ReadonlyArray<LoaderEvent>;
 	hasDependencyCycle?(): boolean;
 	define(amdModuleId: string, dependencies: string[], callback: (...args: any[]) => any): any;

--- a/src/typings/vscode-globals-modules.d.ts
+++ b/src/typings/vscode-globals-modules.d.ts
@@ -3,16 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-declare global {
+// AMD2ESM mirgation relevant
 
-	/**
-	 * @deprecated You MUST use `IProductService` whenever possible.
-	 */
-	var _VSCODE_PRODUCT_JSON: Record<string, any>;
-	/**
-	 * @deprecated You MUST use `IProductService` whenever possible.
-	 */
-	var _VSCODE_PACKAGE_JSON: Record<string, any>;
+declare global {
 
 	/**
 	 * @deprecated node modules that are in used in a context that

--- a/src/typings/vscode-globals-product.d.ts
+++ b/src/typings/vscode-globals-product.d.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// AMD2ESM mirgation relevant
+
+declare global {
+
+	/**
+	 * @deprecated You MUST use `IProductService` whenever possible.
+	 */
+	var _VSCODE_PRODUCT_JSON: Record<string, any>;
+	/**
+	 * @deprecated You MUST use `IProductService` whenever possible.
+	 */
+	var _VSCODE_PACKAGE_JSON: Record<string, any>;
+
+}
+
+// fake export to make global work
+export { }

--- a/src/typings/vscode-globals.d.ts
+++ b/src/typings/vscode-globals.d.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare global {
+
+	/**
+	 * @deprecated node modules that are in used in a context that
+	 * shouldn't have access to node_modules (node-free renderer or
+	 * shared process)
+	 */
+	var _VSCODE_NODE_MODULES: {
+		crypto: typeof import('crypto');
+		zlib: typeof import('zlib');
+		net: typeof import('net');
+		os: typeof import('os');
+		module: typeof import('module');
+		['native-watchdog']: typeof import('native-watchdog')
+		perf_hooks: typeof import('perf_hooks');
+
+		['vsda']: any
+		['vscode-encrypt']: any
+	}
+}
+
+// fake export to make global work
+export { }

--- a/src/typings/vscode-globals.d.ts
+++ b/src/typings/vscode-globals.d.ts
@@ -6,6 +6,15 @@
 declare global {
 
 	/**
+	 * @deprecated You MUST use `IProductService` whenever possible.
+	 */
+	var _VSCODE_PRODUCT_JSON: Record<string, any>;
+	/**
+	 * @deprecated You MUST use `IProductService` whenever possible.
+	 */
+	var _VSCODE_PACKAGE_JSON: Record<string, any>;
+
+	/**
 	 * @deprecated node modules that are in used in a context that
 	 * shouldn't have access to node_modules (node-free renderer or
 	 * shared process)

--- a/src/vs/base/common/performance.js
+++ b/src/vs/base/common/performance.js
@@ -78,7 +78,7 @@
 		} else if (typeof process === 'object') {
 			// node.js: use the normal polyfill but add the timeOrigin
 			// from the node perf_hooks API as very first mark
-			const timeOrigin = Math.round((require.nodeRequire || require)('perf_hooks').performance.timeOrigin);
+			const timeOrigin = Math.round((require.__$__nodeRequire || require)('perf_hooks').performance.timeOrigin);
 			return _definePolyfillMarks(timeOrigin);
 
 		} else {

--- a/src/vs/base/parts/ipc/node/ipc.net.ts
+++ b/src/vs/base/parts/ipc/node/ipc.net.ts
@@ -20,10 +20,10 @@ import { ChunkStream, Client, ISocket, Protocol, SocketCloseEvent, SocketCloseEv
 // TODO@bpasero remove me once electron utility process has landed
 function getNodeDependencies() {
 	return {
-		crypto: (require.__$__nodeRequire('crypto') as any) as typeof import('crypto'),
-		zlib: (require.__$__nodeRequire('zlib') as any) as typeof import('zlib'),
-		net: (require.__$__nodeRequire('net') as any) as typeof import('net'),
-		os: (require.__$__nodeRequire('os') as any) as typeof import('os')
+		crypto: globalThis._VSCODE_NODE_MODULES.crypto,
+		zlib: globalThis._VSCODE_NODE_MODULES.zlib,
+		net: globalThis._VSCODE_NODE_MODULES.net,
+		os: globalThis._VSCODE_NODE_MODULES.os,
 	};
 }
 

--- a/src/vs/platform/environment/test/node/nativeModules.test.ts
+++ b/src/vs/platform/environment/test/node/nativeModules.test.ts
@@ -58,7 +58,7 @@ flakySuite('Native Modules (all platforms)', () => {
 
 	test('vscode-encrypt', async () => {
 		try {
-			const vscodeEncrypt: Encryption = require.__$__nodeRequire('vscode-encrypt');
+			const vscodeEncrypt: Encryption = globalThis._VSCODE_NODE_MODULES['vscode-encrypt'];
 			const encrypted = await vscodeEncrypt.encrypt('salt', 'value');
 			const decrypted = await vscodeEncrypt.decrypt('salt', encrypted);
 
@@ -73,7 +73,7 @@ flakySuite('Native Modules (all platforms)', () => {
 
 	test('vsda', async () => {
 		try {
-			const vsda: any = require.__$__nodeRequire('vsda');
+			const vsda: any = globalThis._VSCODE_NODE_MODULES['vsda'];
 			const signer = new vsda.signer();
 			const signed = await signer.sign('value');
 			assert.ok(typeof signed === 'string', testErrorMessage('vsda'));

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -3,11 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { FileAccess } from 'vs/base/common/network';
 import { globals } from 'vs/base/common/platform';
 import { env } from 'vs/base/common/process';
 import { IProductConfiguration } from 'vs/base/common/product';
-import { dirname, joinPath } from 'vs/base/common/resources';
 import { ISandboxConfiguration } from 'vs/base/parts/sandbox/common/sandboxTypes';
 
 /**
@@ -24,14 +22,10 @@ if (typeof globals.vscode !== 'undefined' && typeof globals.vscode.context !== '
 		throw new Error('Sandbox: unable to resolve product configuration from preload script.');
 	}
 }
-
-// Native node.js environment
-else if (typeof require?.__$__nodeRequire === 'function') {
-
-	// Obtain values from product.json and package.json
-	const rootPath = dirname(FileAccess.asFileUri(''));
-
-	product = require.__$__nodeRequire(joinPath(rootPath, 'product.json').fsPath);
+// _VSCODE environment
+else if (globalThis._VSCODE_PRODUCT_JSON && globalThis._VSCODE_PACKAGE_JSON) {
+	// Obtain values from product.json and package.json-data
+	product = globalThis._VSCODE_PRODUCT_JSON as IProductConfiguration;
 
 	// Running out of sources
 	if (env['VSCODE_DEV']) {
@@ -47,7 +41,7 @@ else if (typeof require?.__$__nodeRequire === 'function') {
 	// want to have it running out of sources so we
 	// read it from package.json only when we need it.
 	if (!product.version) {
-		const pkg = require.__$__nodeRequire(joinPath(rootPath, 'package.json').fsPath) as { version: string };
+		const pkg = globalThis._VSCODE_PACKAGE_JSON as { version: string };
 
 		Object.assign(product, {
 			version: pkg.version

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -727,7 +727,7 @@ export async function createServer(address: string | net.AddressInfo | null, arg
 		const hasVSDA = fs.existsSync(join(FileAccess.asFileUri('').fsPath, '../node_modules/vsda'));
 		if (hasVSDA) {
 			try {
-				return <typeof vsda>require.__$__nodeRequire('vsda');
+				return <typeof vsda>globalThis._VSCODE_NODE_MODULES['vsda'];
 			} catch (err) {
 				logService.error(err);
 			}

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -22,7 +22,7 @@ class NodeModuleRequireInterceptor extends RequireInterceptor {
 
 	protected _installInterceptor(): void {
 		const that = this;
-		const node_module = <any>require.__$__nodeRequire('module');
+		const node_module = <any>globalThis._VSCODE_NODE_MODULES.module;
 		const originalLoad = node_module._load;
 		node_module._load = function load(request: string, parent: { filename: string }, isMain: boolean) {
 			request = applyAlternatives(request);

--- a/src/vs/workbench/api/node/extensionHostProcess.ts
+++ b/src/vs/workbench/api/node/extensionHostProcess.ts
@@ -81,7 +81,7 @@ const args = minimist(process.argv.slice(2), {
 // happening we essentially blocklist this module from getting loaded in any
 // extension by patching the node require() function.
 (function () {
-	const Module = require.__$__nodeRequire('module') as any;
+	const Module = globalThis._VSCODE_NODE_MODULES.module as any;
 	const originalLoad = Module._load;
 
 	Module._load = function (request: string) {
@@ -325,7 +325,7 @@ function connectToRenderer(protocol: IMessagePassingProtocol): Promise<IRenderer
 				// So also use the native node module to do it from a separate thread
 				let watchdog: typeof nativeWatchdog;
 				try {
-					watchdog = require.__$__nodeRequire('native-watchdog');
+					watchdog = globalThis._VSCODE_NODE_MODULES['native-watchdog'];
 					watchdog.start(initData.parentPid);
 				} catch (err) {
 					// no problem...

--- a/src/vs/workbench/api/node/proxyResolver.ts
+++ b/src/vs/workbench/api/node/proxyResolver.ts
@@ -97,7 +97,7 @@ const modulesCache = new Map<IExtensionDescription | undefined, { http?: typeof 
 function configureModuleLoading(extensionService: ExtHostExtensionService, lookup: ReturnType<typeof createPatchedModules>): Promise<void> {
 	return extensionService.getExtensionPathIndex()
 		.then(extensionPaths => {
-			const node_module = <any>require.__$__nodeRequire('module');
+			const node_module = <any>globalThis._VSCODE_NODE_MODULES.module;
 			const original = node_module._load;
 			node_module._load = function load(request: string, parent: { filename: string }, isMain: boolean) {
 				if (request === 'tls') {

--- a/test/unit/electron/renderer.js
+++ b/test/unit/electron/renderer.js
@@ -81,6 +81,9 @@ globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
 		return target[mod];
 	}
 });
+// VSCODE_GLOBALS: package/product.json
+globalThis._VSCODE_PRODUCT_JSON = (require.__$__nodeRequire ?? require)('../../../product.json');
+globalThis._VSCODE_PACKAGE_JSON = (require.__$__nodeRequire ?? require)('../../../package.json');
 
 const _tests_glob = '**/test/**/*.test.js';
 let loader;

--- a/test/unit/electron/renderer.js
+++ b/test/unit/electron/renderer.js
@@ -73,14 +73,8 @@ if (util.inspect && util.inspect['defaultOptions']) {
 }
 
 // VSCODE_GLOBALS: node_modules
-globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
-	get(target, mod) {
-		if (!target[mod] && typeof mod === 'string') {
-			target[mod] = (require.__$__nodeRequire ?? require)(mod);
-		}
-		return target[mod];
-	}
-});
+globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), { get: (_target, mod) => (require.__$__nodeRequire ?? require)(String(mod)) });
+
 // VSCODE_GLOBALS: package/product.json
 globalThis._VSCODE_PRODUCT_JSON = (require.__$__nodeRequire ?? require)('../../../product.json');
 globalThis._VSCODE_PACKAGE_JSON = (require.__$__nodeRequire ?? require)('../../../package.json');

--- a/test/unit/electron/renderer.js
+++ b/test/unit/electron/renderer.js
@@ -72,6 +72,16 @@ if (util.inspect && util.inspect['defaultOptions']) {
 	util.inspect['defaultOptions'].customInspect = false;
 }
 
+// VSCODE_GLOBALS: node_modules
+globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
+	get(target, mod) {
+		if (!target[mod] && typeof mod === 'string') {
+			target[mod] = (require.__$__nodeRequire ?? require)(mod);
+		}
+		return target[mod];
+	}
+});
+
 const _tests_glob = '**/test/**/*.test.js';
 let loader;
 let _out;

--- a/test/unit/node/index.js
+++ b/test/unit/node/index.js
@@ -58,14 +58,7 @@ if (majorRequiredNodeVersion !== currentMajorNodeVersion) {
 function main() {
 
 	// VSCODE_GLOBALS: node_modules
-	globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
-		get(target, mod) {
-			if (!target[mod] && typeof mod === 'string') {
-				target[mod] = require(mod);
-			}
-			return target[mod];
-		}
-	});
+	globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), { get: (_target, mod) => require(String(mod)) });
 
 	// VSCODE_GLOBALS: package/product.json
 	globalThis._VSCODE_PRODUCT_JSON = require(`${REPO_ROOT}/product.json`);

--- a/test/unit/node/index.js
+++ b/test/unit/node/index.js
@@ -56,6 +56,22 @@ if (majorRequiredNodeVersion !== currentMajorNodeVersion) {
 }
 
 function main() {
+
+	// VSCODE_GLOBALS: node_modules
+	globalThis._VSCODE_NODE_MODULES = new Proxy(Object.create(null), {
+		get(target, mod) {
+			if (!target[mod] && typeof mod === 'string') {
+				target[mod] = require(mod);
+			}
+			return target[mod];
+		}
+	});
+
+	// VSCODE_GLOBALS: package/product.json
+	globalThis._VSCODE_PRODUCT_JSON = require(`${REPO_ROOT}/product.json`);
+	globalThis._VSCODE_PACKAGE_JSON = require(`${REPO_ROOT}/package.json`);
+
+
 	process.on('uncaughtException', function (e) {
 		console.error(e.stack || e);
 	});


### PR DESCRIPTION
helps with https://github.com/microsoft/vscode/issues/160416

- add global for node_modules access 
- remove most usages of require.__$__nodeRequire 
- stop using require.nodeRequire
- don't use `__$__nodeRequire` to fetch product configuration
- deprecate and scrary message for `__$__nodeRequire`
