### PR TITLE
remote tunnel: extract log from LogOutputChannels & EnvService

### DIFF
--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -69,9 +69,6 @@ export interface IEnvironmentService {
 	editSessionId?: string;
 	editSessionsLogResource: URI;
 
-	// remote tunnel
-	remoteTunnelLogResource: URI;
-
 	// --- extension development
 	debugExtensionHost: IExtensionHostDebugParams;
 	isExtensionDevelopment: boolean;

--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -86,9 +86,6 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 	get editSessionsLogResource(): URI { return URI.file(join(this.logsPath, 'editSessions.log')); }
 
 	@memoize
-	get remoteTunnelLogResource(): URI { return URI.file(join(this.logsPath, 'remoteTunnel.log')); }
-
-	@memoize
 	get sync(): 'on' | 'off' | undefined { return this.args.sync; }
 
 	@memoize

--- a/src/vs/platform/remoteTunnel/common/remoteTunnel.ts
+++ b/src/vs/platform/remoteTunnel/common/remoteTunnel.ts
@@ -6,7 +6,6 @@
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Event } from 'vs/base/common/event';
 
-
 export interface IRemoteTunnelAccount {
 	readonly authenticationProviderId: string;
 	readonly token: string;
@@ -61,3 +60,7 @@ export interface ConnectionInfo {
 
 export const CONFIGURATION_KEY_PREFIX = 'remote.tunnels.access';
 export const CONFIGURATION_KEY_HOST_NAME = CONFIGURATION_KEY_PREFIX + '.hostNameOverride';
+
+export const LOG_FILE_NAME = 'remoteTunnelService.log';
+export const LOGGER_NAME = 'remoteTunnelService';
+export const LOG_CHANNEL_ID = 'remoteTunnelServiceLog';

--- a/src/vs/platform/remoteTunnel/electron-browser/remoteTunnelService.ts
+++ b/src/vs/platform/remoteTunnel/electron-browser/remoteTunnelService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CONFIGURATION_KEY_HOST_NAME, ConnectionInfo, IRemoteTunnelAccount, IRemoteTunnelService, TunnelStates, TunnelStatus } from 'vs/platform/remoteTunnel/common/remoteTunnel';
+import { CONFIGURATION_KEY_HOST_NAME, ConnectionInfo, IRemoteTunnelAccount, IRemoteTunnelService, LOGGER_NAME, LOG_FILE_NAME, TunnelStates, TunnelStatus } from 'vs/platform/remoteTunnel/common/remoteTunnel';
 import { Emitter } from 'vs/base/common/event';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { INativeEnvironmentService } from 'vs/platform/environment/common/environment';
@@ -18,6 +18,7 @@ import { ISharedProcessLifecycleService } from 'vs/platform/lifecycle/electron-b
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { localize } from 'vs/nls';
 import { hostname, homedir } from 'os';
+import { URI } from 'vs/base/common/uri';
 
 type RemoteTunnelEnablementClassification = {
 	owner: 'aeschli';
@@ -65,7 +66,8 @@ export class RemoteTunnelService extends Disposable implements IRemoteTunnelServ
 		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super();
-		this._logger = this._register(loggerService.createLogger(environmentService.remoteTunnelLogResource, { name: 'remoteTunnel' }));
+		const remoteTunnelLogResource = URI.file(join(environmentService.logsPath, LOG_FILE_NAME));
+		this._logger = this._register(loggerService.createLogger(remoteTunnelLogResource, { name: LOGGER_NAME }));
 		this._startTunnelProcessDelayer = new Delayer(100);
 
 		this._register(sharedProcessLifecycleService.onWillShutdown(e => {

--- a/src/vs/workbench/contrib/logs/common/logConstants.ts
+++ b/src/vs/workbench/contrib/logs/common/logConstants.ts
@@ -10,7 +10,6 @@ export const telemetryLogChannelId = 'telemetryLog';
 export const extensionTelemetryLogChannelId = 'extensionTelemetryLog';
 export const userDataSyncLogChannelId = 'userDataSyncLog';
 export const editSessionsLogChannelId = 'editSessionsSyncLog';
-export const remoteTunnelLogChannelId = 'remoteTunnelLog';
 export const remoteServerLog = 'remoteServerLog';
 export const remotePtyHostLog = 'remotePtyHostLog';
 

--- a/src/vs/workbench/contrib/logs/common/logs.contribution.ts
+++ b/src/vs/workbench/contrib/logs/common/logs.contribution.ts
@@ -50,7 +50,6 @@ class LogOutputChannels extends Disposable implements IWorkbenchContribution {
 	private registerCommonContributions(): void {
 		this.registerLogChannel(Constants.userDataSyncLogChannelId, nls.localize('userDataSyncLog', "Settings Sync"), this.environmentService.userDataSyncLogResource);
 		this.registerLogChannel(Constants.editSessionsLogChannelId, nls.localize('editSessionsLog', "Edit Sessions"), this.environmentService.editSessionsLogResource);
-		this.registerLogChannel(Constants.remoteTunnelLogChannelId, nls.localize('remoteTunnelLog', "Remote Tunnel"), this.environmentService.remoteTunnelLogResource);
 		this.registerLogChannel(Constants.rendererLogChannelId, nls.localize('rendererLog', "Window"), this.environmentService.logFile);
 
 		const registerTelemetryChannel = () => {

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -6,7 +6,7 @@
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IProductService } from 'vs/platform/product/common/productService';
-import { CONFIGURATION_KEY_HOST_NAME, CONFIGURATION_KEY_PREFIX, ConnectionInfo, IRemoteTunnelService } from 'vs/platform/remoteTunnel/common/remoteTunnel';
+import { CONFIGURATION_KEY_HOST_NAME, CONFIGURATION_KEY_PREFIX, ConnectionInfo, IRemoteTunnelService, LOGGER_NAME, LOG_CHANNEL_ID, LOG_FILE_NAME } from 'vs/platform/remoteTunnel/common/remoteTunnel';
 import { AuthenticationSession, AuthenticationSessionsChangeEvent, IAuthenticationService } from 'vs/workbench/services/authentication/common/authentication';
 import { localize } from 'vs/nls';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from 'vs/workbench/common/contributions';
@@ -21,7 +21,7 @@ import { INativeEnvironmentService } from 'vs/platform/environment/common/enviro
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IStringDictionary } from 'vs/base/common/collections';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator, QuickPickItem } from 'vs/platform/quickinput/common/quickInput';
-import { IOutputService } from 'vs/workbench/services/output/common/output';
+import { IOutputService, registerLogChannel } from 'vs/workbench/services/output/common/output';
 import { IFileService } from 'vs/platform/files/common/files';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
 import { IProgress, IProgressService, IProgressStep, ProgressLocation } from 'vs/platform/progress/common/progress';
@@ -32,11 +32,11 @@ import { IPreferencesService } from 'vs/workbench/services/preferences/common/pr
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { Action } from 'vs/base/common/actions';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
-import * as Constants from 'vs/workbench/contrib/logs/common/logConstants';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
 import { joinPath } from 'vs/base/common/resources';
+import { join } from 'vs/base/common/path';
 
 export const REMOTE_TUNNEL_CATEGORY: ILocalizedString = {
 	original: 'Remote Tunnels',
@@ -106,7 +106,9 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 	) {
 		super();
 
-		this.logger = this._register(loggerService.createLogger(environmentService.remoteTunnelLogResource, { name: 'remoteTunnel' }));
+		const remoteTunnelServiceLogResource = URI.file(join(environmentService.logsPath, LOG_FILE_NAME));
+
+		this.logger = this._register(loggerService.createLogger(remoteTunnelServiceLogResource, { name: LOGGER_NAME }));
 
 		this.connectionStateContext = REMOTE_TUNNEL_CONNECTION_STATE.bindTo(this.contextKeyService);
 
@@ -153,6 +155,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 			this.initialize(true);
 		}
 
+		registerLogChannel(LOG_CHANNEL_ID, localize('remoteTunnelLog', "Remote Tunnel Service"), remoteTunnelServiceLogResource, fileService, logService);
 	}
 
 	private get existingSessionId() {
@@ -542,7 +545,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 
 			async run(accessor: ServicesAccessor) {
 				const outputService = accessor.get(IOutputService);
-				outputService.showChannel(Constants.remoteTunnelLogChannelId);
+				outputService.showChannel(LOG_CHANNEL_ID);
 			}
 		}));
 

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -112,9 +112,6 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 	get editSessionsLogResource(): URI { return joinPath(this.logsHome, 'editSessions.log'); }
 
 	@memoize
-	get remoteTunnelLogResource(): URI { return joinPath(this.logsHome, 'remoteTunnel.log'); }
-
-	@memoize
 	get sync(): 'on' | 'off' | undefined { return undefined; }
 
 	@memoize


### PR DESCRIPTION
Keep it local to the contribution. Fixes warning in the browser.
Rename to  Remote Tunnel Service to distinguish from the extension