### PR TITLE
don't clean attachments for a cell that is removed

### DIFF
--- a/extensions/ipynb/src/notebookAttachmentCleaner.ts
+++ b/extensions/ipynb/src/notebookAttachmentCleaner.ts
@@ -187,7 +187,7 @@ export class AttachmentCleaner implements vscode.CodeActionProvider {
 			}
 		}
 
-		if (!objectEquals(markdownAttachmentsInUse, cell.metadata.attachments)) {
+		if (cell.index > -1 && !objectEquals(markdownAttachmentsInUse, cell.metadata.attachments)) {
 			const updateMetadata: { [key: string]: any } = deepClone(cell.metadata);
 			updateMetadata.attachments = markdownAttachmentsInUse;
 			const metadataEdit = vscode.NotebookEdit.updateCellMetadata(cell.index, updateMetadata);


### PR DESCRIPTION
for #166254

I'm not sure how this code is triggered during Jupyter's CI runs since I don't think we have any test that involve attachments in markup cells, but it's still a bug that should be fixed.