### PR TITLE
WIP: Sorting tabs in most recently used order

### DIFF
--- a/src/vs/workbench/api/common/extHostEditorTabs.ts
+++ b/src/vs/workbench/api/common/extHostEditorTabs.ts
@@ -120,7 +120,9 @@ class ExtHostEditorTabGroup {
 			if (tabDto.isActive) {
 				this._activeTabId = tabDto.id;
 			}
-			this._tabs.push(new ExtHostEditorTab(tabDto, this, () => this.activeTabId()));
+			// When opening tabs, we want to move them to the front (most recently used)
+			this._tabs.splice(0, 0, new ExtHostEditorTab(tabDto, this, () => this.activeTabId()));
+			//this._tabs.push(new ExtHostEditorTab(tabDto, this, () => this.activeTabId()));
 		}
 	}
 
@@ -165,7 +167,9 @@ class ExtHostEditorTabGroup {
 		if (operation.kind === TabModelOperationKind.TAB_OPEN) {
 			const tab = new ExtHostEditorTab(operation.tabDto, this, () => this.activeTabId());
 			// Insert tab at editor index
-			this._tabs.splice(operation.index, 0, tab);
+			// Insert tab at the front (Most recently used)
+			// this._tabs.splice(operation.index, 0, tab);
+			this._tabs.splice(0, 0, tab);
 			if (operation.tabDto.isActive) {
 				this._activeTabId = tab.tabId;
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Tackling the feature requested here of giving users the option to sort tabs in order of most recently used. Issue link: https://github.com/microsoft/vscode/issues/161500

In the changes made, we tried to insert the tabs in the beginning of the _tabs array on TAB_OPEN. However, we were not sure where the logic was for actually rendering the tabs in sorted order. Would love some help on this if possible!
