### PR TITLE
Add some basic perf logging for notebook renderers

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -26,13 +26,13 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IFileService } from 'vs/platform/files/common/files';
+import { ILogger, ILoggerService, ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService, matchesScheme, matchesSomeScheme } from 'vs/platform/opener/common/opener';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { editorFindMatch, editorFindMatchHighlight } from 'vs/platform/theme/common/colorRegistry';
 import { IThemeService, Themable } from 'vs/platform/theme/common/themeService';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
-import { asWebviewUri, webviewGenericCspSource } from 'vs/workbench/contrib/webview/common/webview';
 import { CellEditState, ICellOutputViewModel, ICellViewModel, ICommonCellInfo, IDisplayOutputLayoutUpdateRequest, IDisplayOutputViewModel, IFocusNotebookCellOptions, IGenericCellViewModel, IInsetRenderOutput, INotebookEditorCreationOptions, INotebookWebviewMessage, RenderOutputType } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NOTEBOOK_WEBVIEW_BOUNDARY } from 'vs/workbench/contrib/notebook/browser/view/notebookCellList';
 import { preloadsScriptStr } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads';
@@ -44,8 +44,10 @@ import { IScopedRendererMessaging } from 'vs/workbench/contrib/notebook/common/n
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
 import { IWebviewElement, IWebviewService, WebviewContentPurpose, WebviewOriginStore } from 'vs/workbench/contrib/webview/browser/webview';
 import { WebviewWindowDragMonitor } from 'vs/workbench/contrib/webview/browser/webviewWindowDragMonitor';
+import { asWebviewUri, webviewGenericCspSource } from 'vs/workbench/contrib/webview/common/webview';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { registerLogChannel } from 'vs/workbench/services/output/common/output';
 import { FromWebviewMessage, IAckOutputHeight, IClickedDataUrlMessage, ICodeBlockHighlightRequest, IContentWidgetTopRequest, IControllerPreload, ICreationContent, ICreationRequestMessage, IFindMatch, IMarkupCellInitialization, RendererMetadata, StaticPreloadMetadata, ToWebviewMessage } from './webviewMessages';
 
 export interface ICachedInset<K extends ICommonCellInfo> {
@@ -99,6 +101,8 @@ interface BacklayerWebviewOptions {
 	readonly outputLineHeight: number;
 }
 
+const logChannelId = 'notebook.rendering';
+
 export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 
 	private static _originStore?: WebviewOriginStore;
@@ -126,6 +130,8 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 	private firstInit = true;
 	private initializeMarkupPromise?: { readonly requestId: string; readonly p: DeferredPromise<void>; readonly isFirstInit: boolean };
 
+	private readonly _renderLogger: ILogger;
+
 	private readonly nonce = UUID.generateUuid();
 
 	constructor(
@@ -150,9 +156,17 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
 		@IStorageService private readonly storageService: IStorageService,
+		@ILoggerService loggerService: ILoggerService,
+		@ILogService logService: ILogService,
 		@IThemeService themeService: IThemeService,
 	) {
 		super(themeService);
+
+		const logsPath = joinPath(environmentService.windowLogsPath, 'notebook.rendering.log');
+		this._renderLogger = this._register(loggerService.createLogger(logsPath, { name: 'notebook.rendering' }));
+		registerLogChannel(logChannelId, nls.localize('renderChannelName', "Notebook rendering"), logsPath, fileService, logService);
+
+		this._logRendererDebugMessage('Creating backlayer webview for notebook');
 
 		this.element = document.createElement('div');
 
@@ -196,6 +210,10 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		this.options = options;
 		this._updateStyles();
 		this._updateOptions();
+	}
+
+	private _logRendererDebugMessage(msg: string) {
+		this._renderLogger.debug(`${this.id} - ${msg}`);
 	}
 
 	private _updateStyles() {
@@ -859,6 +877,10 @@ var requirejs = (function() {
 						requestId: data.requestId,
 						output: output ? { mime: output.mime, valueBytes: output.data.buffer } : undefined,
 					});
+					break;
+				}
+				case 'logRendererDebugMessage': {
+					this._logRendererDebugMessage(`${data.message}${data.data ? ' ' + JSON.stringify(data.data, null, 4) : ''}`);
 					break;
 				}
 			}

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -446,6 +446,12 @@ export interface IReturnOutputItemMessage {
 	readonly output: OutputItemEntry | undefined;
 }
 
+export interface ILogRendererDebugMessage extends BaseToWebviewMessage {
+	readonly type: 'logRendererDebugMessage';
+	readonly message: string;
+	readonly data?: Record<string, string>;
+}
+
 
 export type FromWebviewMessage = WebviewInitialized |
 	IDimensionMessage |
@@ -476,7 +482,8 @@ export type FromWebviewMessage = WebviewInitialized |
 	IDidFindMessage |
 	IDidFindHighlightMessage |
 	IOutputResizedMessage |
-	IGetOutputItemMessage;
+	IGetOutputItemMessage |
+	ILogRendererDebugMessage;
 
 export type ToWebviewMessage = IClearMessage |
 	IFocusOutputMessage |


### PR DESCRIPTION
For #154873

Adds a new log file for the webview of a notebook. This is currently used to log the load, activation, and render times of notebook renderers
