### PR TITLE
Use moduleignore to try excluding unused ts files

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -147,6 +147,11 @@ prebuild-install/**/*
 **/*.ts
 !typescript/**/*.d.ts
 
+# Exclude TS files that aren't needed by TS extension
+typescript/lib/tsc.js
+typescript/lib/typescriptServices.js
+typescript/lib/tsserverlibrary.js
+
 jschardet/index.js
 jschardet/src/**
 jschardet/dist/jschardet.js
@@ -167,5 +172,3 @@ xterm-addon-*/src/**
 xterm-addon-*/fixtures/**
 xterm-addon-*/out/**
 xterm-addon-*/out-test/**
-
-

--- a/extensions/.vscodeignore
+++ b/extensions/.vscodeignore
@@ -1,3 +1,0 @@
-node_modules/typescript/lib/tsc.js
-node_modules/typescript/lib/typescriptServices.js
-node_modules/typescript/lib/tsserverlibrary.js


### PR DESCRIPTION
Fixes #166652

The `.vscodeignore` is not used here because it's not actually under an extension 