### PR TITLE
MRU: single controller should be rendered in kernel picker

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
@@ -757,11 +757,15 @@ export class KernelPickerMRUStrategy extends KernelPickerStrategyBase {
 		}
 
 		const info = notebookKernelService.getMatchingKernel(notebook);
+		const suggested = (info.suggestions.length === 1 ? info.suggestions[0] : undefined)
+			?? (info.all.length === 1) ? info.all[0] : undefined;
 
-		if (info.selected) {
-			action.label = info.selected.label;
+		const selectedOrSuggested = info.selected ?? suggested;
+
+		if (selectedOrSuggested) {
+			action.label = selectedOrSuggested.label;
 			action.class = ThemeIcon.asClassName(selectKernelIcon);
-			action.tooltip = info.selected.description ?? info.selected.detail ?? '';
+			action.tooltip = selectedOrSuggested.description ?? selectedOrSuggested.detail ?? '';
 		} else {
 			action.label = localize('select', "Select Kernel");
 			action.class = ThemeIcon.asClassName(selectKernelIcon);


### PR DESCRIPTION
bug: newly created notebook doesn't show the only controller name in the kernel status.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
