### PR TITLE
Fix hover tabbing behaviour

### DIFF
--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -64,10 +64,7 @@ export class HoverService implements IHoverService {
 			hoverDisposables.add(addDisposableListener(document, EventType.KEY_DOWN, e => this._keyDown(e, hover)));
 			hoverDisposables.add(addDisposableListener(focusedElement, EventType.KEY_UP, e => this._keyUp(e, hover)));
 			hoverDisposables.add(addDisposableListener(document, EventType.KEY_UP, e => this._keyUp(e, hover)));
-		}
-		if (options.hideOnKeyDown) {
-			const focusedElement = document.activeElement;
-			if (focusedElement) {
+			if (options.hideOnKeyDown) {
 				hoverDisposables.add(addDisposableListener(focusedElement, EventType.KEY_DOWN, () => this.hideHover()));
 			}
 		}

--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -23,6 +23,8 @@ export class HoverService implements IHoverService {
 	private _currentHoverOptions: IHoverOptions | undefined;
 	private _currentHover: HoverWidget | undefined;
 
+	private _lastFocusedElement: HTMLElement | null = null;
+
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IContextViewService private readonly _contextViewService: IContextViewService,
@@ -37,6 +39,7 @@ export class HoverService implements IHoverService {
 			return undefined;
 		}
 		this._currentHoverOptions = options;
+		this._lastFocusedElement = <HTMLElement | null>document.activeElement;
 
 		const hoverDisposables = new DisposableStore();
 		const hover = this._instantiationService.createInstance(HoverWidget, options);
@@ -123,6 +126,7 @@ export class HoverService implements IHoverService {
 		if (e.key === 'Tab') {
 			const focusedElement = <HTMLElement | null>document.activeElement;
 			if (!focusedElement || !this._currentHover || !this._currentHover.domNode.contains(focusedElement)) {
+				this._lastFocusedElement?.focus();
 				this.hideHover();
 			}
 		}

--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -107,7 +107,9 @@ export class HoverService implements IHoverService {
 		if (keybinding.getSingleModifierDispatchParts().some(value => !!value) || this._keybindingService.softDispatch(event, event.target)) {
 			return;
 		}
-		this.hideHover();
+		if (e.key !== 'Tab') {
+			this.hideHover();
+		}
 	}
 
 	private _keyUp(e: KeyboardEvent, hover: HoverWidget) {
@@ -115,6 +117,12 @@ export class HoverService implements IHoverService {
 			hover.isLocked = false;
 			// Hide if alt is released while the mouse os not over hover/target
 			if (!hover.isMouseIn) {
+				this.hideHover();
+			}
+		}
+		if (e.key === 'Tab') {
+			const focusedElement = <HTMLElement | null>document.activeElement;
+			if (!focusedElement || !this._currentHover || !this._currentHover.domNode.contains(focusedElement)) {
 				this.hideHover();
 			}
 		}

--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -23,7 +23,7 @@ export class HoverService implements IHoverService {
 	private _currentHoverOptions: IHoverOptions | undefined;
 	private _currentHover: HoverWidget | undefined;
 
-	private _lastFocusedElementBeforeOpen: HTMLElement | null = null;
+	private _lastFocusedElementBeforeOpen: HTMLElement | undefined;
 
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -39,11 +39,16 @@ export class HoverService implements IHoverService {
 			return undefined;
 		}
 		this._currentHoverOptions = options;
-		this._lastFocusedElementBeforeOpen = <HTMLElement | null>document.activeElement;
+		if (document.activeElement) {
+			this._lastFocusedElementBeforeOpen = document.activeElement as HTMLElement;
+		}
 
 		const hoverDisposables = new DisposableStore();
 		const hover = this._instantiationService.createInstance(HoverWidget, options);
 		hover.onDispose(() => {
+			// Required to handle cases such as closing the hover with the escape key
+			this._lastFocusedElementBeforeOpen?.focus();
+
 			// Only clear the current options if it's the current hover, the current options help
 			// reduce flickering when the same hover is shown multiple times
 			if (this._currentHoverOptions === options) {

--- a/src/vs/workbench/services/hover/browser/hoverWidget.ts
+++ b/src/vs/workbench/services/hover/browser/hoverWidget.ts
@@ -45,6 +45,7 @@ export class HoverWidget extends Widget {
 	private readonly _hoverContainer: HTMLElement;
 	private readonly _target: IHoverTarget;
 	private readonly _linkHandler: (url: string) => any;
+	private readonly _lastFocusedElement: HTMLElement | null;
 
 	private _isDisposed: boolean = false;
 	private _hoverPosition: HoverPosition;
@@ -88,6 +89,8 @@ export class HoverWidget extends Widget {
 	) {
 		super();
 
+		this._lastFocusedElement = <HTMLElement | null>document.activeElement;
+
 		this._linkHandler = options.linkHandler || (url => {
 			return openLinkFromMarkdown(this._openerService, url, isMarkdownString(options.content) ? options.content.isTrusted : undefined);
 		});
@@ -119,6 +122,7 @@ export class HoverWidget extends Widget {
 		// Hide hover on escape
 		this.onkeydown(this._hover.containerDomNode, e => {
 			if (e.equals(KeyCode.Escape)) {
+				this._lastFocusedElement?.focus();
 				this.dispose();
 			}
 		});


### PR DESCRIPTION
Ref #159088

Previously, when pressing the escape key from a focused hover, the user loses the previously focused element and has to tab back to it. This PR attempts to fix that scenario by placing the focus back to the previously focused element.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
