### PR TITLE
Add previously selected kernel to MRU on switching.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
@@ -638,6 +638,11 @@ export class KernelPickerMRUStrategy extends KernelPickerStrategyBase {
 	}
 
 	protected override _selecteKernel(notebook: NotebookTextModel, kernel: INotebookKernel): void {
+		const currentInfo = this._notebookKernelService.getMatchingKernel(notebook);
+		if (currentInfo.selected) {
+			// there is already a selected kernel
+			this._notebookKernelHistoryService.addMostRecentKernel(currentInfo.selected);
+		}
 		super._selecteKernel(notebook, kernel);
 		this._notebookKernelHistoryService.addMostRecentKernel(kernel);
 	}


### PR DESCRIPTION
The MRU might not have the currently selected controller, thus we add it to the list on switching. However we don't want to add every previously selected controller to the MRU list on document open otherwise reading notebooks will change the MRU unexpectedly.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
