### PR TITLE
cli: look for libstdc++ in the right location for 32 bit installs

### DIFF
--- a/cli/src/util/prereqs.rs
+++ b/cli/src/util/prereqs.rs
@@ -157,7 +157,10 @@ async fn check_is_nixos() -> bool {
 async fn check_glibcxx_version() -> Result<(), String> {
 	let mut libstdc_path: Option<String> = None;
 
+	#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 	const DEFAULT_LIB_PATH: &str = "/usr/lib64/libstdc++.so.6";
+	#[cfg(any(target_arch = "x86", target_arch = "arm"))]
+	const DEFAULT_LIB_PATH: &str = "/usr/lib/libstdc++.so.6";
 	const LDCONFIG_PATH: &str = "/sbin/ldconfig";
 
 	if fs::metadata(DEFAULT_LIB_PATH).await.is_ok() {


### PR DESCRIPTION
See https://github.com/microsoft/vscode-remote-release/issues/7495#issuecomment-1320331537
