### PR TITLE
Remove webview.id public field

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadCodeInsets.ts
+++ b/src/vs/workbench/api/browser/mainThreadCodeInsets.ts
@@ -90,7 +90,6 @@ export class MainThreadEditorInsets implements MainThreadEditorInsetsShape {
 		const disposables = new DisposableStore();
 
 		const webview = this._webviewService.createWebviewElement({
-			id: 'mainThreadCodeInsets_' + handle,
 			options: {
 				enableFindWidget: false,
 			},

--- a/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadCustomEditors.ts
@@ -14,6 +14,7 @@ import { Schemas } from 'vs/base/common/network';
 import { basename } from 'vs/base/common/path';
 import { isEqual, isEqualOrParent, toLocalResource } from 'vs/base/common/resources';
 import { URI, UriComponents } from 'vs/base/common/uri';
+import { generateUuid } from 'vs/base/common/uuid';
 import { localize } from 'vs/nls';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { FileOperation, IFileService } from 'vs/platform/files/common/files';
@@ -131,7 +132,7 @@ export class MainThreadCustomEditors extends Disposable implements extHostProtoc
 				return webviewInput instanceof CustomEditorInput && webviewInput.viewType === viewType;
 			},
 			resolveWebview: async (webviewInput: CustomEditorInput, cancellation: CancellationToken) => {
-				const handle = webviewInput.id;
+				const handle = generateUuid();
 				const resource = webviewInput.resource;
 
 				this.mainThreadWebviewPanels.addWebviewInput(handle, webviewInput, { serializeBuffersForPostMessage });
@@ -652,7 +653,6 @@ class MainThreadCustomEditorModel extends ResourceWorkingCopy implements ICustom
 				location: primaryEditor.extension.location!,
 			} : undefined,
 			webview: {
-				id: primaryEditor.id,
 				origin: primaryEditor.webview.origin,
 				options: primaryEditor.webview.options,
 				state: primaryEditor.webview.state,

--- a/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
@@ -6,6 +6,7 @@
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { Disposable, DisposableMap } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
+import { generateUuid } from 'vs/base/common/uuid';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
@@ -161,7 +162,6 @@ export class MainThreadWebviewPanels extends Disposable implements extHostProtoc
 		const origin = this.webviewOriginStore.getOrigin(viewType, extension.id);
 
 		const webview = this._webviewWorkbenchService.openWebview({
-			id: handle,
 			origin,
 			providedViewType: viewType,
 			options: reviveWebviewOptions(initData.panelOptions),
@@ -261,7 +261,7 @@ export class MainThreadWebviewPanels extends Disposable implements extHostProtoc
 					return;
 				}
 
-				const handle = webviewInput.id;
+				const handle = generateUuid();
 
 				this.addWebviewInput(handle, webviewInput, options);
 

--- a/src/vs/workbench/api/browser/mainThreadWebviewViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviewViews.ts
@@ -6,6 +6,7 @@
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { Disposable, DisposableMap } from 'vs/base/common/lifecycle';
+import { generateUuid } from 'vs/base/common/uuid';
 import { MainThreadWebviews, reviveWebviewExtension } from 'vs/workbench/api/browser/mainThreadWebviews';
 import * as extHostProtocol from 'vs/workbench/api/common/extHost.protocol';
 import { IViewBadge } from 'vs/workbench/common/views';
@@ -63,7 +64,7 @@ export class MainThreadWebviewsViews extends Disposable implements extHostProtoc
 
 		const registration = this._webviewViewService.register(viewType, {
 			resolve: async (webviewView: WebviewView, cancellation: CancellationToken) => {
-				const handle = webviewView.webview.id;
+				const handle = generateUuid();
 
 				this._webviewViews.set(handle, webviewView);
 				this.mainThreadWebviews.addWebview(handle, webviewView.webview, { serializeBuffersForPostMessage: options.serializeBuffersForPostMessage });

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -10,7 +10,6 @@ import { basename } from 'vs/base/common/path';
 import { dirname, isEqual } from 'vs/base/common/resources';
 import { assertIsDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
-import { generateUuid } from 'vs/base/common/uuid';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IResourceEditorInput } from 'vs/platform/editor/common/editor';
 import { FileSystemProviderCapabilities, IFileService } from 'vs/platform/files/common/files';
@@ -20,14 +19,13 @@ import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
 import { EditorInputCapabilities, GroupIdentifier, IMoveResult, IRevertOptions, ISaveOptions, IUntypedEditorInput, Verbosity } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { ICustomEditorModel, ICustomEditorService } from 'vs/workbench/contrib/customEditor/common/customEditor';
-import { IWebviewService, IOverlayWebview } from 'vs/workbench/contrib/webview/browser/webview';
+import { IOverlayWebview, IWebviewService } from 'vs/workbench/contrib/webview/browser/webview';
 import { IWebviewWorkbenchService, LazilyResolvedWebviewEditorInput } from 'vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService';
 import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
 
 interface CustomEditorInputInitInfo {
 	readonly resource: URI;
 	readonly viewType: string;
-	readonly id: string;
 }
 
 export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
@@ -43,15 +41,13 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 			// If it's an untitled file we must populate the untitledDocumentData
 			const untitledString = accessor.get(IUntitledTextEditorService).getValue(resource);
 			const untitledDocumentData = untitledString ? VSBuffer.fromString(untitledString) : undefined;
-			const id = generateUuid();
 			const webview = accessor.get(IWebviewService).createWebviewOverlay({
-				id,
 				providedViewType: viewType,
 				options: { customClasses: options?.customClasses },
 				contentOptions: {},
 				extension: undefined,
 			});
-			const input = instantiationService.createInstance(CustomEditorInput, { resource, viewType, id }, webview, { untitledDocumentData: untitledDocumentData, oldResource: options?.oldResource });
+			const input = instantiationService.createInstance(CustomEditorInput, { resource, viewType }, webview, { untitledDocumentData: untitledDocumentData, oldResource: options?.oldResource });
 			if (typeof group !== 'undefined') {
 				input.updateGroup(group);
 			}
@@ -85,7 +81,7 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 		@IUndoRedoService private readonly undoRedoService: IUndoRedoService,
 		@IFileService private readonly fileService: IFileService
 	) {
-		super({ id: init.id, providedId: init.viewType, viewType: init.viewType, name: '' }, webview, webviewWorkbenchService);
+		super({ providedId: init.viewType, viewType: init.viewType, name: '' }, webview, webviewWorkbenchService);
 		this._editorResource = init.resource;
 		this.oldResource = options.oldResource;
 		this._defaultDirtyState = options.startsDirty;

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInputFactory.ts
@@ -30,7 +30,6 @@ export interface CustomDocumentBackupData extends IWorkingCopyBackupMeta {
 	};
 
 	readonly webview: {
-		readonly id: string;
 		readonly origin: string | undefined;
 		readonly options: SerializedWebviewOptions;
 		readonly state: any;
@@ -92,7 +91,7 @@ export class CustomEditorInputSerializer extends WebviewEditorInputSerializer {
 		const data = this.fromJson(JSON.parse(serializedEditorInput));
 
 		const webview = reviveWebview(this._webviewService, data);
-		const customInput = this._instantiationService.createInstance(CustomEditorInput, { resource: data.editorResource, viewType: data.viewType, id: data.id }, webview, { startsDirty: data.dirty, backupId: data.backupId });
+		const customInput = this._instantiationService.createInstance(CustomEditorInput, { resource: data.editorResource, viewType: data.viewType }, webview, { startsDirty: data.dirty, backupId: data.backupId });
 		if (typeof data.group === 'number') {
 			customInput.updateGroup(data.group);
 		}
@@ -100,9 +99,8 @@ export class CustomEditorInputSerializer extends WebviewEditorInputSerializer {
 	}
 }
 
-function reviveWebview(webviewService: IWebviewService, data: { id: string; origin: string | undefined; viewType: string; state: any; webviewOptions: WebviewOptions; contentOptions: WebviewContentOptions; extension?: WebviewExtensionDescription }) {
+function reviveWebview(webviewService: IWebviewService, data: { origin: string | undefined; viewType: string; state: any; webviewOptions: WebviewOptions; contentOptions: WebviewContentOptions; extension?: WebviewExtensionDescription }) {
 	const webview = webviewService.createWebviewOverlay({
-		id: data.id,
 		providedViewType: data.viewType,
 		origin: data.origin,
 		options: {
@@ -168,10 +166,8 @@ export class ComplexCustomWorkingCopyEditorHandler extends Disposable implements
 				}
 
 				const backupData = backup.meta;
-				const id = backupData.webview.id;
 				const extension = reviveWebviewExtensionDescription(backupData.extension?.id, backupData.extension?.location);
 				const webview = reviveWebview(this._webviewService, {
-					id,
 					viewType: backupData.viewType,
 					origin: backupData.webview.origin,
 					webviewOptions: restoreWebviewOptions(backupData.webview.options),
@@ -180,7 +176,7 @@ export class ComplexCustomWorkingCopyEditorHandler extends Disposable implements
 					extension,
 				});
 
-				const editor = this._instantiationService.createInstance(CustomEditorInput, { resource: URI.revive(backupData.editorResource), viewType: backupData.viewType, id }, webview, { backupId: backupData.backupId });
+				const editor = this._instantiationService.createInstance(CustomEditorInput, { resource: URI.revive(backupData.editorResource), viewType: backupData.viewType }, webview, { backupId: backupData.backupId });
 				editor.updateGroup(0);
 				return editor;
 			}

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -681,7 +681,6 @@ export class ExtensionEditor extends EditorPane {
 			}
 
 			const webview = this.contentDisposables.add(this.webviewService.createWebviewOverlay({
-				id: generateUuid(),
 				options: {
 					enableFindWidget: true,
 					tryRestoreScrollPosition: true,

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -138,7 +138,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 
 	constructor(
 		public notebookEditor: INotebookDelegateForWebview,
-		public readonly id: string,
+		private readonly id: string,
 		public readonly notebookViewType: string,
 		public readonly documentUri: URI,
 		private options: BacklayerWebviewOptions,
@@ -952,7 +952,6 @@ var requirejs = (function() {
 	private _createInset(webviewService: IWebviewService, content: string) {
 		this.localResourceRootsCache = this._getResourceRootsCache();
 		const webview = webviewService.createWebviewElement({
-			id: this.id,
 			origin: BackLayerWebView.getOriginStore(this.storageService).getOrigin(this.notebookViewType, undefined),
 			options: {
 				purpose: WebviewContentPurpose.NotebookRenderer,

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -76,7 +76,6 @@ export class ReleaseNotesManager {
 		} else {
 			this._currentReleaseNotes = this._webviewWorkbenchService.openWebview(
 				{
-					id: generateUuid(),
 					options: {
 						tryRestoreScrollPosition: true,
 						enableFindWidget: true,

--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -40,7 +40,6 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 	private _findWidgetEnabled: IContextKey<boolean> | undefined;
 	private _shouldShowFindWidgetOnRestore = false;
 
-	public readonly id: string;
 	public readonly providedViewType?: string;
 	public readonly origin: string;
 
@@ -54,7 +53,6 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 	) {
 		super();
 
-		this.id = initInfo.id;
 		this.providedViewType = initInfo.providedViewType;
 		this.origin = initInfo.origin ?? generateUuid();
 
@@ -95,7 +93,6 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 
 		if (!this._container) {
 			const node = document.createElement('div');
-			node.id = `webview-${this.id}`;
 			node.style.position = 'absolute';
 			node.style.overflow = 'hidden';
 			this._container = new FastDomNode(node);
@@ -187,7 +184,6 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 
 		if (!this._webview.value) {
 			const webview = this._webviewService.createWebviewElement({
-				id: this.id,
 				providedViewType: this.providedViewType,
 				origin: this.origin,
 				options: this._options,

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -68,7 +68,6 @@ export interface IWebviewService {
 }
 
 export interface WebviewInitInfo {
-	readonly id: string;
 	readonly providedViewType?: string;
 	readonly origin?: string;
 
@@ -169,11 +168,6 @@ export interface WebviewMessageReceivedEvent {
 }
 
 export interface IWebview extends IDisposable {
-
-	/**
-	 * External identifier of this webview.
-	 */
-	readonly id: string;
 
 	/**
 	 * The origin this webview itself is loaded from. May not be unique

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -74,10 +74,7 @@ const webviewIdContext = 'webviewId';
 
 export class WebviewElement extends Disposable implements IWebview, WebviewFindDelegate {
 
-	/**
-	 * External identifier of this webview.
-	 */
-	public readonly id: string;
+	protected readonly id = generateUuid();
 
 	/**
 	 * The provided identifier of this webview.
@@ -88,11 +85,6 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 	 * The origin this webview itself is loaded from. May not be unique
 	 */
 	public readonly origin: string;
-
-	/**
-	 * Unique internal identifier of this webview's iframe element.
-	 */
-	private readonly _iframeId: string;
 
 	private readonly _encodedWebviewOriginPromise: Promise<string>;
 	private _encodedWebviewOrigin: string | undefined;
@@ -164,10 +156,8 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 	) {
 		super();
 
-		this.id = initInfo.id;
 		this.providedViewType = initInfo.providedViewType;
-		this._iframeId = generateUuid();
-		this.origin = initInfo.origin ?? this._iframeId;
+		this.origin = initInfo.origin ?? this.id;
 
 		this._encodedWebviewOriginPromise = parentOriginHash(window.origin, this.origin).then(id => this._encodedWebviewOrigin = id);
 
@@ -190,7 +180,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 
 
 		const subscription = this._register(addDisposableListener(window, 'message', (e: MessageEvent) => {
-			if (!this._encodedWebviewOrigin || e?.data?.target !== this._iframeId) {
+			if (!this._encodedWebviewOrigin || e?.data?.target !== this.id) {
 				return;
 			}
 
@@ -458,7 +448,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 	private _initElement(encodedWebviewOrigin: string, extension: WebviewExtensionDescription | undefined, options: WebviewOptions) {
 		// The extensionId and purpose in the URL are used for filtering in js-debug:
 		const params: { [key: string]: string } = {
-			id: this._iframeId,
+			id: this.id,
 			origin: this.origin,
 			swVersion: String(this._expectedServiceWorkerVersion),
 			extensionId: extension?.id.value ?? '',

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewEditorInput.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewEditorInput.ts
@@ -5,13 +5,13 @@
 
 import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
+import { generateUuid } from 'vs/base/common/uuid';
 import { EditorInputCapabilities, GroupIdentifier, IUntypedEditorInput, Verbosity } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { IOverlayWebview } from 'vs/workbench/contrib/webview/browser/webview';
 import { WebviewIconManager, WebviewIcons } from 'vs/workbench/contrib/webviewPanel/browser/webviewIconManager';
 
 export interface WebviewInputInitInfo {
-	readonly id: string;
 	readonly viewType: string;
 	readonly providedId: string | undefined;
 	readonly name: string;
@@ -33,6 +33,8 @@ export class WebviewInput extends EditorInput {
 		return EditorInputCapabilities.Readonly | EditorInputCapabilities.Singleton | EditorInputCapabilities.CanDropIntoEditor;
 	}
 
+	private readonly _resourceId = generateUuid();
+
 	private _name: string;
 	private _iconPath?: WebviewIcons;
 	private _group?: GroupIdentifier;
@@ -44,11 +46,10 @@ export class WebviewInput extends EditorInput {
 	get resource() {
 		return URI.from({
 			scheme: Schemas.webviewPanel,
-			path: `webview-panel/webview-${this.id}`
+			path: `webview-panel/webview-${this._resourceId}`
 		});
 	}
 
-	public readonly id: string;
 	public readonly viewType: string;
 	public readonly providedId: string | undefined;
 
@@ -59,7 +60,6 @@ export class WebviewInput extends EditorInput {
 	) {
 		super();
 
-		this.id = init.id;
 		this.viewType = init.viewType;
 		this.providedId = init.providedId;
 
@@ -107,7 +107,7 @@ export class WebviewInput extends EditorInput {
 
 	public set iconPath(value: WebviewIcons | undefined) {
 		this._iconPath = value;
-		this._iconManager.setIcons(this.id, value);
+		this._iconManager.setIcons(this._resourceId, value);
 	}
 
 	public override matches(other: EditorInput | IUntypedEditorInput): boolean {

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewEditorInputSerializer.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewEditorInputSerializer.ts
@@ -20,7 +20,6 @@ interface SerializedIconPath {
 }
 
 export interface SerializedWebview {
-	readonly id: string;
 	readonly origin: string | undefined;
 	readonly viewType: string;
 	readonly providedId: string | undefined;
@@ -34,7 +33,6 @@ export interface SerializedWebview {
 }
 
 export interface DeserializedWebview {
-	readonly id: string;
 	readonly origin: string | undefined;
 	readonly viewType: string;
 	readonly providedId: string | undefined;
@@ -79,7 +77,6 @@ export class WebviewEditorInputSerializer implements IEditorSerializer {
 		const data = this.fromJson(JSON.parse(serializedEditorInput));
 		return this._webviewWorkbenchService.openRevivedWebview({
 			webviewInitInfo: {
-				id: data.id,
 				providedViewType: data.providedId,
 				origin: data.origin,
 				options: data.webviewOptions,
@@ -107,7 +104,6 @@ export class WebviewEditorInputSerializer implements IEditorSerializer {
 
 	protected toJson(input: WebviewInput): SerializedWebview {
 		return {
-			id: input.id,
 			origin: input.webview.origin,
 			viewType: input.viewType,
 			providedId: input.providedId,

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.ts
@@ -281,7 +281,7 @@ export class WebviewEditorService extends Disposable implements IWebviewWorkbenc
 		showOptions: IWebViewShowOptions,
 	): WebviewInput {
 		const webview = this._webviewService.createWebviewOverlay(webviewInitInfo);
-		const webviewInput = this._instantiationService.createInstance(WebviewInput, { id: webviewInitInfo.id, viewType, name: title, providedId: webviewInitInfo.providedViewType }, webview, this.iconManager);
+		const webviewInput = this._instantiationService.createInstance(WebviewInput, { viewType, name: title, providedId: webviewInitInfo.providedViewType }, webview, this.iconManager);
 		this._editorService.openEditor(webviewInput, {
 			pinned: true,
 			preserveFocus: showOptions.preserveFocus,
@@ -332,7 +332,7 @@ export class WebviewEditorService extends Disposable implements IWebviewWorkbenc
 		const webview = this._webviewService.createWebviewOverlay(options.webviewInitInfo);
 		webview.state = options.state;
 
-		const webviewInput = this._instantiationService.createInstance(LazilyResolvedWebviewEditorInput, { id: options.webviewInitInfo.id, viewType: options.viewType, providedId: options.webviewInitInfo.providedViewType, name: options.title }, webview);
+		const webviewInput = this._instantiationService.createInstance(LazilyResolvedWebviewEditorInput, { viewType: options.viewType, providedId: options.webviewInitInfo.providedViewType, name: options.title }, webview);
 		webviewInput.iconPath = options.iconPath;
 
 		if (typeof options.group === 'number') {

--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -8,7 +8,6 @@ import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { Emitter } from 'vs/base/common/event';
 import { DisposableStore, IDisposable, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { withNullAsUndefined } from 'vs/base/common/types';
-import { generateUuid } from 'vs/base/common/uuid';
 import { MenuId } from 'vs/platform/actions/common/actions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -174,10 +173,8 @@ export class WebviewViewPane extends ViewPane {
 
 		this._activated = true;
 
-		const webviewId = generateUuid();
 		const origin = this.extensionId ? WebviewViewPane.getOriginStore(this.storageService).getOrigin(this.id, this.extensionId) : undefined;
 		const webview = this.webviewService.createWebviewOverlay({
-			id: webviewId,
 			origin,
 			providedViewType: this.id,
 			options: { purpose: WebviewContentPurpose.WebviewView },

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -154,7 +154,6 @@ export class GettingStartedPage extends EditorPane {
 
 	private detailsRenderer: GettingStartedDetailsRenderer;
 
-	private webviewID = generateUuid();
 	private categoriesSlideDisposables: DisposableStore;
 
 	constructor(
@@ -532,7 +531,7 @@ export class GettingStartedPage extends EditorPane {
 			this.stepsContent.classList.remove('markdown');
 
 			const media = stepToExpand.media;
-			const webview = this.stepDisposables.add(this.webviewService.createWebviewElement({ id: this.webviewID, options: {}, contentOptions: {}, extension: undefined }));
+			const webview = this.stepDisposables.add(this.webviewService.createWebviewElement({ options: {}, contentOptions: {}, extension: undefined }));
 			webview.mountTo(this.stepMediaComponent);
 
 			webview.html = await this.detailsRenderer.renderSVG(media.path);
@@ -573,7 +572,7 @@ export class GettingStartedPage extends EditorPane {
 
 			const media = stepToExpand.media;
 
-			const webview = this.stepDisposables.add(this.webviewService.createWebviewElement({ id: this.webviewID, options: {}, contentOptions: { localResourceRoots: [media.root], allowScripts: true }, extension: undefined }));
+			const webview = this.stepDisposables.add(this.webviewService.createWebviewElement({ options: {}, contentOptions: { localResourceRoots: [media.root], allowScripts: true }, extension: undefined }));
 			webview.mountTo(this.stepMediaComponent);
 
 			const rawHTML = await this.detailsRenderer.renderMarkdown(media.path, media.base);


### PR DESCRIPTION
The id is now separate from the origin. It should always be randomly generated instead of relying on callers to do so

