### PR TITLE
Use prominent color for walkthrough step title

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors.ts
@@ -14,3 +14,5 @@ export const welcomePageTileHoverBackground = registerColor('welcomePage.tileHov
 
 export const welcomePageProgressBackground = registerColor('welcomePage.progress.background', { light: inputBackground, dark: inputBackground, hcDark: inputBackground, hcLight: inputBackground }, localize('welcomePage.progress.background', 'Foreground color for the Welcome page progress bars.'));
 export const welcomePageProgressForeground = registerColor('welcomePage.progress.foreground', { light: textLinkForeground, dark: textLinkForeground, hcDark: textLinkForeground, hcLight: textLinkForeground }, localize('welcomePage.progress.foreground', 'Background color for the Welcome page progress bars.'));
+
+export const walkthroughStepTitleForeground = registerColor('walkthrough.stepTitle.foreground', { light: '#000000', dark: '#ffffff', hcDark: null, hcLight: null }, localize('walkthrough.stepTitle.foreground', 'Foreground color of the heading of each walkthrough step'));

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -411,6 +411,10 @@
 	border: 1px solid var(--vscode-editorWidget-border);
 }
 
+.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step.expanded h3 {
+	color: var(--vscode-walkthrough-stepTitle-foreground);
+}
+
 .monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step.expanded>.codicon {
 	cursor: pointer !important;
 }


### PR DESCRIPTION
Ref #165846

- Adds new color token for walkthrough step titles to make it stand out more compared to the step description

## Before

<img width="455" alt="CleanShot 2022-11-18 at 12 34 01@2x" src="https://user-images.githubusercontent.com/25163139/202797421-c198f8bb-e64c-485b-a727-eefb00a7cf61.png">

## After 

<img width="474" alt="CleanShot 2022-11-18 at 12 32 38@2x" src="https://user-images.githubusercontent.com/25163139/202797383-1647d462-feb8-43fe-8d18-848726408e2d.png">