### PR TITLE
Make `ActionList` take a list of menu items directly

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -140,7 +140,8 @@ class ActionItemRenderer<T extends IListMenuItem<IActionItem>> implements IListR
 
 export class ActionList<T extends IActionItem> extends Disposable {
 
-	readonly domNode: HTMLElement;
+	public readonly domNode: HTMLElement;
+
 	private readonly _list: List<IListMenuItem<IActionItem>>;
 
 	private readonly _actionLineHeight = 24;
@@ -148,17 +149,11 @@ export class ActionList<T extends IActionItem> extends Disposable {
 
 	private readonly _allMenuItems: IListMenuItem<IActionItem>[];
 
-	private focusCondition(element: IListMenuItem<IActionItem>): boolean {
-		return !element.disabled && element.kind === ActionListItemKind.Action;
-	}
-
 	constructor(
 		user: string,
-		items: readonly T[],
-		showHeaders: boolean,
+		items: IListMenuItem<T>[],
 		private readonly _delegate: IRenderDelegate,
 		resolver: IActionKeybindingResolver | undefined,
-		toMenuItems: (inputActions: readonly T[], showHeaders: boolean) => IListMenuItem<T>[],
 		@IContextViewService private readonly _contextViewService: IContextViewService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService
 	) {
@@ -194,9 +189,13 @@ export class ActionList<T extends IActionItem> extends Disposable {
 		this._register(this._list.onDidChangeFocus(() => this._list.domFocus()));
 		this._register(this._list.onDidChangeSelection(e => this.onListSelection(e)));
 
-		this._allMenuItems = toMenuItems(items, showHeaders);
+		this._allMenuItems = items;
 		this._list.splice(0, this._list.length, this._allMenuItems);
 		this.focusNext();
+	}
+
+	private focusCondition(element: IListMenuItem<IActionItem>): boolean {
+		return !element.disabled && element.kind === ActionListItemKind.Action;
 	}
 
 	hide(didCancel?: boolean): void {

--- a/src/vs/platform/actionWidget/browser/actionWidget.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidget.ts
@@ -89,7 +89,7 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 
 		this._currentShowingContext = { user, toMenuItems, delegate, actions, anchor, container, options, resolver };
 
-		const list = this._instantiationService.createInstance(ActionList, user, actionsToShow, true, delegate, resolver, toMenuItems);
+		const list = this._instantiationService.createInstance(ActionList, user, toMenuItems(actionsToShow, true), delegate, resolver);
 		this.contextViewService.showContextView({
 			getAnchor: () => anchor,
 			render: (container: HTMLElement) => {


### PR DESCRIPTION
The extra abstraction of calling `toMenuItems`  is not needed inside `Actionlist`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
