### PR TITLE
Change/copyedit to "Context Lines” wording in UI

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -314,7 +314,7 @@ configurationRegistry.registerConfiguration({
 		'search.searchEditor.defaultNumberOfContextLines': {
 			type: ['number', 'null'],
 			default: 1,
-			markdownDescription: nls.localize('search.searchEditor.defaultNumberOfContextLines', "The default number of surrounding context lines to use when creating new Search Editors. If using `#search.searchEditor.reusePriorSearchConfiguration#`, this can be set to `null` (empty) to use the prior Search Editor's configuration.")
+			markdownDescription: nls.localize('search.searchEditor.defaultNumberOfContextLines', "The default number of surrounding lines to show in new Search Editors. If empty (null), `#search.searchEditor.reusePriorSearchConfiguration#`, set by the prior Search Editor, will be used.")
 		},
 		'search.sortOrder': {
 			'type': 'string',

--- a/src/vs/workbench/contrib/search/browser/searchWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/searchWidget.ts
@@ -364,7 +364,7 @@ export class SearchWidget extends Widget {
 
 		this.showContextToggle = new Toggle({
 			isChecked: false,
-			title: appendKeyBindingLabel(nls.localize('showContext', "Toggle Context Lines"), this.keybindingService.lookupKeybinding(ToggleSearchEditorContextLinesCommandId), this.keybindingService),
+			title: appendKeyBindingLabel(nls.localize('showContext', "Show/hide surrounding lines"), this.keybindingService.lookupKeybinding(ToggleSearchEditorContextLinesCommandId), this.keybindingService),
 			icon: searchShowContextIcon,
 			...defaultToggleStyles
 		});

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -492,7 +492,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: IncreaseSearchEditorContextLinesCommandId,
-			title: { original: 'Increase Context Lines', value: localize('searchEditor.action.increaseSearchEditorContextLines', "Increase Context Lines") },
+			title: { original: 'Increase number of surrounding lines', value: localize('searchEditor.action.increaseSearchEditorContextLines', "Increase number of surrounding lines") },
 			category,
 			f1: true,
 			precondition: SearchEditorConstants.InSearchEditor,
@@ -509,7 +509,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: DecreaseSearchEditorContextLinesCommandId,
-			title: { original: 'Decrease Context Lines', value: localize('searchEditor.action.decreaseSearchEditorContextLines', "Decrease Context Lines") },
+			title: { original: 'Decrease number of surrounding lines', value: localize('searchEditor.action.decreaseSearchEditorContextLines', "Decrease number of surrounding lines") },
 			category,
 			f1: true,
 			precondition: SearchEditorConstants.InSearchEditor,

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -472,7 +472,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: SearchEditorConstants.ToggleSearchEditorContextLinesCommandId,
-			title: { value: localize('searchEditor.action.toggleSearchEditorContextLines', "Toggle Context Lines"), original: 'Toggle Context Lines"' },
+			title: { value: localize('searchEditor.action.toggleSearchEditorContextLines', "Show/hide surrounding lines"), original: 'Show/hide surrounding lines"' },
 			category,
 			f1: true,
 			precondition: SearchEditorConstants.InSearchEditor,


### PR DESCRIPTION
This PR suggests some changes to the wording in the UI of the “Context lines” feature in Search editors. Though the underlying variables are named in line with the idea of the displayed lines providing context to the user, I think the wording I’ve chosen here (“surrounding lines”) is more natural and makes more sense in terms of UI writing.