### PR TITLE
Simplify action widget api

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -128,8 +128,8 @@ export class CodeActionController extends Disposable implements IEditorContribut
 		this._ui.getValue().update(newState);
 	}
 
-	public showCodeActions(trigger: CodeActionTrigger, actions: CodeActionSet, at: IAnchor | IPosition) {
-		return this._ui.getValue().showCodeActionList(trigger, actions, at, { includeDisabledActions: false, fromLightbulb: false });
+	public showCodeActions(_trigger: CodeActionTrigger, actions: CodeActionSet, at: IAnchor | IPosition) {
+		return this._ui.getValue().showCodeActionList(actions, at, { includeDisabledActions: false, fromLightbulb: false });
 	}
 
 	public manualTriggerAtCurrentPosition(

--- a/src/vs/editor/contrib/codeAction/common/types.ts
+++ b/src/vs/editor/contrib/codeAction/common/types.ts
@@ -215,4 +215,11 @@ export class CodeActionItem implements IActionItem {
 export interface CodeActionSet extends ActionSet<CodeActionItem> {
 	readonly validActions: readonly CodeActionItem[];
 	readonly allActions: readonly CodeActionItem[];
+
+	readonly documentation: readonly {
+		id: string;
+		title: string;
+		tooltip?: string;
+		commandArguments?: any[];
+	}[];
 }

--- a/src/vs/platform/actionWidget/browser/actionWidget.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidget.ts
@@ -12,8 +12,7 @@ import 'vs/css!./actionWidget';
 import { localize } from 'vs/nls';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
 import { acceptSelectedActionCommand, ActionList, IListMenuItem, previewSelectedActionCommand } from 'vs/platform/actionWidget/browser/actionList';
-import { ActionSet, IActionItem, IActionKeybindingResolver } from 'vs/platform/actionWidget/common/actionWidget';
-import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IActionItem, IActionKeybindingResolver } from 'vs/platform/actionWidget/common/actionWidget';
 import { IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
@@ -30,18 +29,13 @@ export interface IRenderDelegate<T extends IActionItem> {
 	onSelect(action: IActionItem, preview?: boolean): Promise<any>;
 }
 
-export interface IActionShowOptions {
-	readonly includeDisabledActions: boolean;
-	readonly fromLightbulb?: boolean;
-	readonly showHeaders?: boolean;
-}
-
 export const IActionWidgetService = createDecorator<IActionWidgetService>('actionWidgetService');
 
 export interface IActionWidgetService {
 	readonly _serviceBrand: undefined;
 
-	show(user: string, toMenuItems: (inputQuickFixes: readonly any[], showHeaders: boolean) => IListMenuItem<IActionItem>[], delegate: IRenderDelegate<any>, actions: ActionSet<any>, anchor: IAnchor, container: HTMLElement | undefined, options: IActionShowOptions): Promise<void>;
+	show(user: string, items: IListMenuItem<IActionItem>[], delegate: IRenderDelegate<any>, anchor: IAnchor, container: HTMLElement | undefined, actionBarActions?: readonly IAction[]): Promise<void>;
+
 	hide(): void;
 
 	readonly isVisible: boolean;
@@ -54,22 +48,9 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		return ActionWidgetContextKeys.Visible.getValue(this._contextKeyService) || false;
 	}
 
-	private _showDisabled = false;
-	private _currentShowingContext?: {
-		readonly user: string;
-		readonly toMenuItems: (inputItems: readonly any[], showHeaders: boolean) => IListMenuItem<any>[];
-		readonly options: IActionShowOptions;
-		readonly anchor: IAnchor;
-		readonly container: HTMLElement | undefined;
-		readonly actions: ActionSet<unknown>;
-		readonly delegate: IRenderDelegate<any>;
-		readonly resolver?: IActionKeybindingResolver;
-	};
-
 	private readonly _list = this._register(new MutableDisposable<ActionList<any>>());
 
 	constructor(
-		@ICommandService private readonly _commandService: ICommandService,
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService
@@ -77,24 +58,15 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		super();
 	}
 
-	async show(user: string, toMenuItems: (inputQuickFixes: readonly IActionItem[], showHeaders: boolean) => IListMenuItem<IActionItem>[], delegate: IRenderDelegate<any>, actions: ActionSet<any>, anchor: IAnchor, container: HTMLElement | undefined, options: IActionShowOptions, resolver?: IActionKeybindingResolver): Promise<void> {
-		this._currentShowingContext = undefined;
+	async show(user: string, items: IListMenuItem<IActionItem>[], delegate: IRenderDelegate<any>, anchor: IAnchor, container: HTMLElement | undefined, actionBarActions?: readonly IAction[], resolver?: IActionKeybindingResolver): Promise<void> {
 		const visibleContext = ActionWidgetContextKeys.Visible.bindTo(this._contextKeyService);
 
-		const actionsToShow = options.includeDisabledActions && (this._showDisabled || actions.validActions.length === 0) ? actions.allActions : actions.validActions;
-		if (!actionsToShow.length) {
-			visibleContext.reset();
-			return;
-		}
-
-		this._currentShowingContext = { user, toMenuItems, delegate, actions, anchor, container, options, resolver };
-
-		const list = this._instantiationService.createInstance(ActionList, user, toMenuItems(actionsToShow, true), delegate, resolver);
+		const list = this._instantiationService.createInstance(ActionList, user, items, delegate, resolver);
 		this.contextViewService.showContextView({
 			getAnchor: () => anchor,
 			render: (container: HTMLElement) => {
 				visibleContext.set(true);
-				return this._renderWidget(container, list, actions, options);
+				return this._renderWidget(container, list, actionBarActions ?? []);
 			},
 			onHide: (didCancel) => {
 				visibleContext.reset();
@@ -124,7 +96,7 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		this._list.clear();
 	}
 
-	private _renderWidget(element: HTMLElement, list: ActionList<any>, actions: ActionSet<any>, options: IActionShowOptions): IDisposable {
+	private _renderWidget(element: HTMLElement, list: ActionList<any>, actionBarActions: readonly IAction[]): IDisposable {
 		const widget = document.createElement('div');
 		widget.classList.add('action-widget');
 		element.appendChild(widget);
@@ -154,8 +126,8 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 
 		// Action bar
 		let actionBarWidth = 0;
-		if (!options.fromLightbulb) {
-			const actionBar = this._createActionBar('.action-widget-action-bar', actions, options);
+		if (actionBarActions.length) {
+			const actionBar = this._createActionBar('.action-widget-action-bar', actionBarActions);
 			if (actionBar) {
 				widget.appendChild(actionBar.getContainer().parentElement!);
 				renderDisposables.add(actionBar);
@@ -172,8 +144,7 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		return renderDisposables;
 	}
 
-	private _createActionBar(className: string, inputActions: ActionSet<any>, options: IActionShowOptions): ActionBar | undefined {
-		const actions = this._getActionBarActions(inputActions, options);
+	private _createActionBar(className: string, actions: readonly IAction[]): ActionBar | undefined {
 		if (!actions.length) {
 			return undefined;
 		}
@@ -184,54 +155,7 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		return actionBar;
 	}
 
-	private _getActionBarActions(actions: ActionSet<any>, options: IActionShowOptions): IAction[] {
-		const resultActions = actions.documentation.map((command): IAction => ({
-			id: command.id,
-			label: command.title,
-			tooltip: command.tooltip ?? '',
-			class: undefined,
-			enabled: true,
-			run: () => this._commandService.executeCommand(command.id, ...(command.commandArguments ?? [])),
-		}));
-
-		if (options.includeDisabledActions && actions.validActions.length > 0 && actions.allActions.length !== actions.validActions.length) {
-			resultActions.push(this._showDisabled ? {
-				id: 'hideMoreActions',
-				label: localize('hideMoreActions', 'Hide Disabled'),
-				enabled: true,
-				tooltip: '',
-				class: undefined,
-				run: () => this._toggleShowDisabled(false)
-			} : {
-				id: 'showMoreActions',
-				label: localize('showMoreActions', 'Show Disabled'),
-				enabled: true,
-				tooltip: '',
-				class: undefined,
-				run: () => this._toggleShowDisabled(true)
-			});
-		}
-
-		return resultActions;
-	}
-
-	/**
-	 * Toggles whether the disabled actions in the action widget are visible or not.
-	 */
-	private _toggleShowDisabled(newShowDisabled: boolean): void {
-		const previousCtx = this._currentShowingContext;
-
-		this.hide();
-
-		this._showDisabled = newShowDisabled;
-
-		if (previousCtx) {
-			this.show(previousCtx.user, previousCtx.toMenuItems, previousCtx.delegate, previousCtx.actions, previousCtx.anchor, previousCtx.container, previousCtx.options, previousCtx.resolver);
-		}
-	}
-
 	private _onWidgetClosed(didCancel?: boolean): void {
-		this._currentShowingContext = undefined;
 		this._list.value?.hide(didCancel);
 	}
 }

--- a/src/vs/platform/actionWidget/common/actionWidget.ts
+++ b/src/vs/platform/actionWidget/common/actionWidget.ts
@@ -10,13 +10,6 @@ export interface ActionSet<T> extends IDisposable {
 	readonly validActions: readonly T[];
 	readonly allActions: readonly T[];
 	readonly hasAutoFix: boolean;
-
-	readonly documentation: readonly {
-		id: string;
-		title: string;
-		tooltip?: string;
-		commandArguments?: any[];
-	}[];
 }
 
 export interface IActionItem {

--- a/src/vs/workbench/contrib/terminal/browser/terminalQuickFixBuiltinActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalQuickFixBuiltinActions.ts
@@ -8,6 +8,7 @@ import { TerminalQuickFixMatchResult, ITerminalQuickFixOptions, ITerminalInstanc
 import { ITerminalCommand } from 'vs/workbench/contrib/terminal/common/terminal';
 import { IExtensionTerminalQuickFix } from 'vs/platform/terminal/common/terminal';
 import { TerminalQuickFixType } from 'vs/workbench/contrib/terminal/browser/widgets/terminalQuickFixMenuItems';
+
 export const GitCommandLineRegex = /git/;
 export const GitPushCommandLineRegex = /git\s+push/;
 export const GitTwoDashesRegex = /error: did you mean `--(.+)` \(with two dashes\)\?/;

--- a/src/vs/workbench/contrib/terminal/browser/xterm/quickFixAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/quickFixAddon.ts
@@ -253,12 +253,7 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 						this._terminal?.focus();
 					},
 				};
-				this._actionWidgetService.show('quickFixWidget', toMenuItems, delegate, actionSet, anchor, parentElement,
-					{
-						showHeaders: true,
-						includeDisabledActions: false,
-						fromLightbulb: true
-					});
+				this._actionWidgetService.show('quickFixWidget', toMenuItems(actionSet.validActions, true), delegate, anchor, parentElement);
 			}));
 		});
 	}


### PR DESCRIPTION
This changes the action widget take a static list of items and a list of action bar actions. This simplifies using the action widget service and lets us move code action specific code (such as documentation items) up into the codeActionUi

