### PR TITLE
Add rollup icon to rollup.config.mjs

### DIFF
--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -1824,6 +1824,7 @@
 		"ionic.project": "_ionic",
 		"platformio.ini": "_platformio",
 		"rollup.config.js": "_rollup",
+		"rollup.config.mjs": "_rollup",
 		"sass-lint.yml": "_sass",
 		"stylelint.config.js": "_stylelint",
 		"stylelint.config.cjs": "_stylelint",


### PR DESCRIPTION
With rollup 3, now it's possible to use a module instead of cjs