### PR TITLE
fix: unhandled rejection with debugadaptertrackers

### DIFF
--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -768,12 +768,7 @@ export abstract class ExtHostDebugServiceBase implements IExtHostDebugService, E
 				}
 				return undefined;
 			}),
-			new Promise<never>((resolve, reject) => {
-				const timeout = setTimeout(() => {
-					clearTimeout(timeout);
-					reject(new Error('timeout'));
-				}, 1000);
-			})
+			new Promise<undefined>(resolve => setTimeout(() => resolve(undefined), 1000)),
 		]).catch(err => {
 			// ignore errors
 			return undefined;


### PR DESCRIPTION
Fixes #103477

Errors were caught as `undefined` anyway, so just resolve to undefined instead.