### PR TITLE
Support fuzzy matching on the absolute paths of files/resources

### DIFF
--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -568,7 +568,14 @@ export function isSerializedFileMatch(arg: ISerializedSearchProgressItem): arg i
 
 export function isFilePatternMatch(candidate: IRawFileMatch, normalizedFilePatternLowercase: string): boolean {
 	const pathToMatch = candidate.searchPath ? candidate.searchPath : candidate.relativePath;
-	return fuzzyContains(pathToMatch, normalizedFilePatternLowercase);
+	if (fuzzyContains(pathToMatch, normalizedFilePatternLowercase)) {
+		return true;
+	}
+	// Also try matching against the absolute path of the file.
+	if (candidate.base) {
+		return fuzzyContains(paths.join(candidate.base, candidate.relativePath), normalizedFilePatternLowercase);
+	}
+	return false;
 }
 
 export interface ISerializedFileMatch {

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -417,6 +417,9 @@ const FileMatchItemAccessor = new class implements IItemAccessor<IRawFileMatch> 
 	}
 
 	getItemPath(match: IRawFileMatch): string {
+		if (match.base) {
+			return join(match.base, match.relativePath);  // e.g. /home/user/some/path/to/file/myFile.txt
+		}
 		return match.relativePath; // e.g. some/path/to/file/myFile.txt
 	}
 };

--- a/src/vs/workbench/services/search/test/node/search.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/search.integrationTest.ts
@@ -205,7 +205,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.strictEqual(count, 7);
+			assert.strictEqual(count, 11);
 			done();
 		});
 	});
@@ -224,7 +224,7 @@ flakySuite('FileSearchEngine', () => {
 			}
 		}, () => { }, (error) => {
 			assert.ok(!error);
-			assert.strictEqual(count, 3);
+			assert.strictEqual(count, 7);
 			done();
 		});
 	});


### PR DESCRIPTION
We now apply fuzzy matching on the (absolute) path of files/resources, which allows fuzzy matching to work even if the user has a partial absolute path or subpath which is rooted in folders outside of the workspace folders.

The main motivation is that we have files in our code-workspaces which are referenced currently via their folder-relative path, but in many places elsewhere, the paths given are relative to the monorepo. This causes issues when searching, since the monorepo path is longer than the relative path and then search doesn't work.

I'm open to other suggestions - I'm not sure if plain fuzzy matching on the entire path makes sense - for instance, this causes quiet a bit of test failures since the fuzzy matching doesn't have any minimum score requirement so it can match across many fragments of a path.
