### PR TITLE
Show progress when nb extensions are activating.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/kernelDetection/notebookKernelDetection.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/kernelDetection/notebookKernelDetection.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { Extensions as WorkbenchExtensions, IWorkbenchContribution, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
+import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+
+class NotebookKernelDetection extends Disposable implements IWorkbenchContribution {
+	private _detectionMap = new Map<string, IDisposable>();
+	private _localDisposableStore = new DisposableStore();
+	constructor(
+		@INotebookKernelService private readonly _notebookKernelService: INotebookKernelService,
+		@IExtensionService private readonly _extensionService: IExtensionService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+	) {
+		super();
+
+		this._registerListeners();
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectedKeys.includes('notebook.kernelPicker.type')) {
+				this._registerListeners();
+			}
+		}));
+	}
+
+	private _registerListeners() {
+		this._localDisposableStore.clear();
+
+		const kernelPickerType = this._configurationService.getValue<'all' | 'mru'>('notebook.kernelPicker.type');
+
+		if (kernelPickerType === 'mru') {
+			this._localDisposableStore.add(this._extensionService.onWillActivateByEvent(e => {
+				if (e.event.startsWith('onNotebook:')) {
+					if (this._extensionService.activationEventIsDone(e.event)) {
+						return;
+					}
+
+					// parse the event to get the notebook type
+					const notebookType = e.event.substring('onNotebook:'.length);
+
+					let shouldStartDetection = false;
+
+					const extensionStatus = this._extensionService.getExtensionsStatus();
+					this._extensionService.extensions.forEach(extension => {
+						if (extensionStatus[extension.identifier.value].activationTimes) {
+							// already activated
+							return;
+						}
+						if (extension.activationEvents?.includes(e.event)) {
+							shouldStartDetection = true;
+						}
+					});
+
+					if (shouldStartDetection) {
+						const task = this._notebookKernelService.registerNotebookKernelDetectionTask({
+							notebookType: notebookType
+						});
+
+						this._detectionMap.set(notebookType, task);
+					}
+				}
+			}));
+
+			this._register(this._extensionService.onDidChangeExtensionsStatus(() => {
+				for (const [notebookType, task] of this._detectionMap) {
+					if (this._extensionService.activationEventIsDone(`onNotebook:${notebookType}`)) {
+						task.dispose();
+					}
+				}
+			}));
+		}
+	}
+}
+
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(NotebookKernelDetection, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -88,6 +88,7 @@ import 'vs/workbench/contrib/notebook/browser/contrib/viewportCustomMarkdown/vie
 import 'vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout';
 import 'vs/workbench/contrib/notebook/browser/contrib/breakpoints/notebookBreakpoints';
 import 'vs/workbench/contrib/notebook/browser/contrib/execute/executionEditorProgress';
+import 'vs/workbench/contrib/notebook/browser/contrib/kernelDetection/notebookKernelDetection';
 
 // Diff Editor Contribution
 import 'vs/workbench/contrib/notebook/browser/diff/notebookDiffActions';


### PR DESCRIPTION
Show detection progress when notebook extension are still activating. ipynb extension is activated first to ensure users to see the notebook ASAP, but the kernel extensions' activation is delayed.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
