### PR TITLE
Support shell integration in Windows PowerShell

### DIFF
--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -127,7 +127,7 @@ export function getShellIntegrationInjection(
 
 	// Windows
 	if (isWindows) {
-		if (shell === 'pwsh.exe') {
+		if (shell === 'pwsh.exe' || shell === 'powershell.exe') {
 			if (!originalArgs || arePwshImpliedArgs(originalArgs)) {
 				newArgs = shellIntegrationArgs.get(ShellIntegrationExecutable.WindowsPwsh);
 			} else if (arePwshLoginArgs(originalArgs)) {

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -25,12 +25,12 @@ function Global:Prompt() {
 	if ($Global:__LastHistoryId -ne -1) {
 		if ($LastHistoryEntry.Id -eq $Global:__LastHistoryId) {
 			# Don't provide a command line or exit code if there was no history entry (eg. ctrl+c, enter on no command)
-			$Result  = "`e]633;E`a"
-			$Result += "`e]633;D`a"
+			$Result  = "$([char]0x1b)]633;E`a"
+			$Result += "$([char]0x1b)]633;D`a"
 		} else {
 			# Command finished command line
 			# OSC 633 ; A ; <CommandLine?> ST
-			$Result  = "`e]633;E;"
+			$Result  = "$([char]0x1b)]633;E;"
 			# Sanitize the command line to ensure it can get transferred to the terminal and can be parsed
 			# correctly. This isn't entirely safe but good for most cases, it's important for the Pt parameter
 			# to only be composed of _printable_ characters as per the spec.
@@ -43,21 +43,21 @@ function Global:Prompt() {
 			$Result += "`a"
 			# Command finished exit code
 			# OSC 633 ; D [; <ExitCode>] ST
-			$Result += "`e]633;D;$FakeCode`a"
+			$Result += "$([char]0x1b)]633;D;$FakeCode`a"
 		}
 	}
 	# Prompt started
 	# OSC 633 ; A ST
-	$Result += "`e]633;A`a"
+	$Result += "$([char]0x1b)]633;A`a"
 	# Current working directory
 	# OSC 633 ; <Property>=<Value> ST
-	$Result += if($pwd.Provider.Name -eq 'FileSystem'){"`e]633;P;Cwd=$($pwd.ProviderPath)`a"}
+	$Result += if($pwd.Provider.Name -eq 'FileSystem'){"$([char]0x1b)]633;P;Cwd=$($pwd.ProviderPath)`a"}
 	# Before running the original prompt, put $? back to what it was:
 	if ($FakeCode -ne 0) { Write-Error "failure" -ea ignore }
 	# Run the original prompt
 	$Result += $Global:__VSCodeOriginalPrompt.Invoke()
 	# Write command started
-	$Result += "`e]633;B`a"
+	$Result += "$([char]0x1b)]633;B`a"
 	$Global:__LastHistoryId = $LastHistoryEntry.Id
 	return $Result
 }
@@ -69,13 +69,13 @@ if (Get-Module -Name PSReadLine) {
 	function Global:PSConsoleHostReadLine {
 		$tmp = $__VSCodeOriginalPSConsoleHostReadLine.Invoke()
 		# Write command executed sequence directly to Console to avoid the new line from Write-Host
-		[Console]::Write("`e]633;C`a")
+		[Console]::Write("$([char]0x1b)]633;C`a")
 		$tmp
 	}
 }
 
 # Set IsWindows property
-[Console]::Write("`e]633;P;IsWindows=$($IsWindows)`a")
+[Console]::Write("$([char]0x1b)]633;P;IsWindows=$($IsWindows)`a")
 
 # Set always on key handlers which map to default VS Code keybindings
 function Set-MappedKeyHandler {


### PR DESCRIPTION
By replacing backtick-e with `$([char]0x1b)`, we allow shell integration to work with Windows PowerShell, as the only problem seemed to be use of backtick-e, which was an escape character added only to PowerShell Core, but the `[char]` equivalent works fine.

I built and tested this on Windows and it sure seems fine!

<img width="520" alt="Screenshot 2022-11-22 at 4 58 36 PM" src="https://user-images.githubusercontent.com/2226434/203450688-27d85711-d10b-4d96-8e90-9163093cca5f.png">
<img width="731" alt="Screenshot 2022-11-22 at 4 59 00 PM" src="https://user-images.githubusercontent.com/2226434/203450693-6f4996e1-faa9-45b1-93af-528f42ab5eeb.png">


/cc @Tyriar