### PR TITLE
Don't use IObservableValue

### DIFF
--- a/src/vs/base/common/observableValue.ts
+++ b/src/vs/base/common/observableValue.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Emitter, Event } from 'vs/base/common/event';
-import { Disposable } from 'vs/base/common/lifecycle';
+import { Event } from 'vs/base/common/event';
 //@ts-ignore
 import type { IObservable } from 'vs/base/common/observable';
 
@@ -16,34 +15,3 @@ export interface IObservableValue<T> {
 	readonly value: T;
 }
 
-/**
- * @deprecated Use {@link IObservable} instead.
- */
-export const staticObservableValue = <T>(value: T): IObservableValue<T> => ({
-	onDidChange: Event.None,
-	value,
-});
-
-/**
- * @deprecated Use {@link IObservable} instead.
- */
-export class MutableObservableValue<T> extends Disposable implements IObservableValue<T> {
-	private readonly changeEmitter = this._register(new Emitter<T>());
-
-	public readonly onDidChange = this.changeEmitter.event;
-
-	public get value() {
-		return this._value;
-	}
-
-	public set value(v: T) {
-		if (v !== this._value) {
-			this._value = v;
-			this.changeEmitter.fire(v);
-		}
-	}
-
-	constructor(private _value: T) {
-		super();
-	}
-}

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -85,7 +85,6 @@ import { MarkerService } from 'vs/platform/markers/common/markerService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { IStorageService, InMemoryStorageService } from 'vs/platform/storage/common/storage';
-import { staticObservableValue } from 'vs/base/common/observableValue';
 
 import 'vs/editor/common/services/languageFeaturesService';
 import { DefaultConfigurationModel } from 'vs/platform/configuration/common/configurations';
@@ -690,7 +689,7 @@ class StandaloneResourcePropertiesService implements ITextResourcePropertiesServ
 class StandaloneTelemetryService implements ITelemetryService {
 	declare readonly _serviceBrand: undefined;
 
-	public telemetryLevel = staticObservableValue(TelemetryLevel.NONE);
+	public telemetryLevel = TelemetryLevel.NONE;
 	public sendErrorTelemetry = false;
 
 	public setEnabled(value: boolean): void {

--- a/src/vs/platform/telemetry/common/telemetry.ts
+++ b/src/vs/platform/telemetry/common/telemetry.ts
@@ -5,7 +5,6 @@
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { ClassifiedEvent, IGDPRProperty, OmitMetadata, StrictPropertyCheck } from 'vs/platform/telemetry/common/gdprTypings';
-import { IObservableValue } from 'vs/base/common/observableValue';
 
 export const ITelemetryService = createDecorator<ITelemetryService>('telemetryService');
 
@@ -53,7 +52,7 @@ export interface ITelemetryService {
 
 	setExperimentProperty(name: string, value: string): void;
 
-	readonly telemetryLevel: IObservableValue<TelemetryLevel>;
+	readonly telemetryLevel: TelemetryLevel;
 }
 
 export interface ITelemetryEndpoint {

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -5,7 +5,6 @@
 
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { cloneAndChange, safeStringify } from 'vs/base/common/objects';
-import { staticObservableValue } from 'vs/base/common/observableValue';
 import { isObject } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { ConfigurationTarget, ConfigurationTargetToString, IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -42,7 +41,7 @@ export class NullTelemetryServiceShape implements ITelemetryService {
 	}
 
 	setExperimentProperty() { }
-	telemetryLevel = staticObservableValue(TelemetryLevel.NONE);
+	telemetryLevel = TelemetryLevel.NONE;
 	getTelemetryInfo(): Promise<ITelemetryInfo> {
 		return Promise.resolve({
 			instanceId: 'someValue.instanceId',

--- a/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
@@ -800,15 +800,15 @@ suite('TelemetryService', () => {
 			}
 		}(), TestProductService);
 
-		assert.strictEqual(service.telemetryLevel.value, TelemetryLevel.NONE);
+		assert.strictEqual(service.telemetryLevel, TelemetryLevel.NONE);
 
 		telemetryLevel = TelemetryConfiguration.ON;
 		emitter.fire({});
-		assert.strictEqual(service.telemetryLevel.value, TelemetryLevel.USAGE);
+		assert.strictEqual(service.telemetryLevel, TelemetryLevel.USAGE);
 
 		telemetryLevel = TelemetryConfiguration.ERROR;
 		emitter.fire({});
-		assert.strictEqual(service.telemetryLevel.value, TelemetryLevel.ERROR);
+		assert.strictEqual(service.telemetryLevel, TelemetryLevel.ERROR);
 
 		service.dispose();
 	});

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -15,8 +15,6 @@ import type { IProductConfiguration } from 'vs/base/common/product';
 import type { ICredentialsProvider } from 'vs/platform/credentials/common/credentials';
 import type { TunnelProviderFeatures } from 'vs/platform/tunnel/common/tunnel';
 import type { IProgress, IProgressCompositeOptions, IProgressDialogOptions, IProgressNotificationOptions, IProgressOptions, IProgressStep, IProgressWindowOptions } from 'vs/platform/progress/common/progress';
-import type { IObservableValue } from 'vs/base/common/observableValue';
-import type { TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
 import type { ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import type { EditorGroupLayout } from 'vs/workbench/services/editor/common/editorGroupsService';
 
@@ -77,11 +75,6 @@ export interface IWorkbench {
 		 * workbench.
 		 */
 		openUri(target: URI): Promise<boolean>;
-
-		/**
-		 * Current workbench telemetry level.
-		 */
-		readonly telemetryLevel: IObservableValue<TelemetryLevel>;
 	};
 
 	window: {

--- a/src/vs/workbench/browser/web.factory.ts
+++ b/src/vs/workbench/browser/web.factory.ts
@@ -13,8 +13,6 @@ import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { DeferredPromise } from 'vs/base/common/async';
 import { asArray } from 'vs/base/common/arrays';
 import { IProgress, IProgressCompositeOptions, IProgressDialogOptions, IProgressNotificationOptions, IProgressOptions, IProgressStep, IProgressWindowOptions } from 'vs/platform/progress/common/progress';
-import { IObservableValue } from 'vs/base/common/observableValue';
-import { TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
 import { LogLevel } from 'vs/platform/log/common/log';
 
 let created = false;
@@ -133,11 +131,6 @@ export namespace env {
 
 		return workbench.env.openUri(target);
 	}
-
-	/**
-	 * {@linkcode IWorkbench.env IWorkbench.env.telemetryLevel}
-	 */
-	export const telemetryLevel: Promise<IObservableValue<TelemetryLevel>> = workbenchPromise.p.then(workbench => workbench.env.telemetryLevel);
 }
 
 export namespace window {

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -138,7 +138,6 @@ export class BrowserMain extends Disposable {
 			const timerService = accessor.get(ITimerService);
 			const openerService = accessor.get(IOpenerService);
 			const productService = accessor.get(IProductService);
-			const telemetryService = accessor.get(ITelemetryService);
 			const progressService = accessor.get(IProgressService);
 			const environmentService = accessor.get(IBrowserWorkbenchEnvironmentService);
 			const instantiationService = accessor.get(IInstantiationService);
@@ -152,7 +151,6 @@ export class BrowserMain extends Disposable {
 					executeCommand: (command, ...args) => commandService.executeCommand(command, ...args)
 				},
 				env: {
-					telemetryLevel: telemetryService.telemetryLevel,
 					async getUriScheme(): Promise<string> {
 						return productService.urlProtocol;
 					},

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1088,7 +1088,7 @@ export class DebugSession implements IDebugSession {
 					// only log telemetry events from debug adapter if the debug extension provided the telemetry key
 					// and the user opted in telemetry
 					const telemetryEndpoint = this.raw.dbgr.getCustomTelemetryEndpoint();
-					if (telemetryEndpoint && this.telemetryService.telemetryLevel.value !== TelemetryLevel.NONE) {
+					if (telemetryEndpoint && this.telemetryService.telemetryLevel !== TelemetryLevel.NONE) {
 						// __GDPR__TODO__ We're sending events in the name of the debug extension and we can not ensure that those are declared correctly.
 						let data = event.body.data;
 						if (!telemetryEndpoint.sendErrorTelemetry && event.body.data) {

--- a/src/vs/workbench/contrib/search/test/electron-browser/textsearch.perf.integrationTest.ts
+++ b/src/vs/workbench/contrib/search/test/electron-browser/textsearch.perf.integrationTest.ts
@@ -43,7 +43,6 @@ import { TestContextService, TestTextResourcePropertiesService } from 'vs/workbe
 import { TestEnvironmentService } from 'vs/workbench/test/electron-browser/workbenchTestServices';
 import { LanguageFeatureDebounceService } from 'vs/editor/common/services/languageFeatureDebounce';
 import { LanguageFeaturesService } from 'vs/editor/common/services/languageFeaturesService';
-import { staticObservableValue } from 'vs/base/common/observableValue';
 
 // declare var __dirname: string;
 
@@ -183,7 +182,7 @@ suite.skip('TextSearch performance (integration)', () => {
 
 class TestTelemetryService implements ITelemetryService {
 	public _serviceBrand: undefined;
-	public telemetryLevel = staticObservableValue(TelemetryLevel.USAGE);
+	public telemetryLevel = TelemetryLevel.USAGE;
 	public sendErrorTelemetry = true;
 
 	public events: any[] = [];

--- a/src/vs/workbench/contrib/tags/electron-sandbox/workspaceTags.ts
+++ b/src/vs/workbench/contrib/tags/electron-sandbox/workspaceTags.ts
@@ -36,7 +36,7 @@ export class WorkspaceTags implements IWorkbenchContribution {
 		@IProductService private readonly productService: IProductService,
 		@INativeHostService private readonly nativeHostService: INativeHostService
 	) {
-		if (this.telemetryService.telemetryLevel.value === TelemetryLevel.USAGE) {
+		if (this.telemetryService.telemetryLevel === TelemetryLevel.USAGE) {
 			this.report();
 		}
 	}

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from 'vs/base/common/lifecycle';
-import { IObservableValue } from 'vs/base/common/observableValue';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ILoggerService } from 'vs/platform/log/common/log';
@@ -83,7 +82,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 		return this.impl.setExperimentProperty(name, value);
 	}
 
-	get telemetryLevel(): IObservableValue<TelemetryLevel> {
+	get telemetryLevel(): TelemetryLevel {
 		return this.impl.telemetryLevel;
 	}
 

--- a/src/vs/workbench/services/telemetry/electron-sandbox/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/electron-sandbox/telemetryService.ts
@@ -17,7 +17,6 @@ import { TelemetryService as BaseTelemetryService, ITelemetryServiceConfig } fro
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ClassifiedEvent, StrictPropertyCheck, OmitMetadata, IGDPRProperty } from 'vs/platform/telemetry/common/gdprTypings';
 import { IFileService } from 'vs/platform/files/common/files';
-import { IObservableValue } from 'vs/base/common/observableValue';
 
 export class TelemetryService extends Disposable implements ITelemetryService {
 
@@ -58,7 +57,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 		return this.impl.setExperimentProperty(name, value);
 	}
 
-	get telemetryLevel(): IObservableValue<TelemetryLevel> {
+	get telemetryLevel(): TelemetryLevel {
 		return this.impl.telemetryLevel;
 	}
 


### PR DESCRIPTION
Reverts #146931

This web API isn't being used and uses the deprecated `IObservableValue` so let's remove this code