### PR TITLE
fixes #156855

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -97,7 +97,7 @@
 }
 
 .monaco-workbench .part.titlebar>.titlebar-container>.window-title>.command-center.hide {
-	display: none;
+	visibility: hidden;
 }
 
 .monaco-workbench .part.titlebar>.titlebar-container>.window-title>.command-center .action-item>.action-label {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


The problem here was that when the command center is clicked, it was hiding completely and changing its dimensions in the title bar causing unnecessary relayout. We would have to wait for the command center to come back in, get repositioned and the adjust the menu. Instead of that, I think we should keep it simple and just preserve the position/size with visibility.