### PR TITLE
fix browser password autofill on quick input

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -176,6 +176,8 @@ export class InputBox extends Widget {
 			this._register(this.onDidHeightChange(this.updateScrollDimensions, this));
 		} else {
 			this.input.type = this.options.type || 'text';
+			// prevent password autofill for irrelavant input types
+			this.input.name = this.options.type || 'text';
 			this.input.setAttribute('wrap', 'off');
 		}
 

--- a/src/vs/base/parts/quickinput/browser/quickInputBox.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInputBox.ts
@@ -88,6 +88,8 @@ export class QuickInputBox extends Disposable {
 
 	set password(password: boolean) {
 		this.findInput.inputBox.inputElement.type = password ? 'password' : 'text';
+		// prevent browser from prompting autofill password on web
+		this.findInput.inputBox.inputElement.name = password ? 'password' : 'text';
 	}
 
 	set enabled(enabled: boolean) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #164679
though `autocomplete=off` doesn't work on chrome/edge, we can add a `name` attribute for non-password inputs to let the browser distinguish them