### PR TITLE
SCM - Fix When typing Chinese in git commit editor, There are overlapping shadows on the text. #165682

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -200,14 +200,6 @@
 	border-radius: 2px;
 }
 
-.scm-view .scm-input .margin {
-	width: 6px !important;
-}
-
-.scm-input .monaco-scrollable-element {
-	left: 6px !important;
-}
-
 .scm-view .scm-editor-container .monaco-editor {
 	border-radius: 2px !important;
 }

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1932,7 +1932,7 @@ class SCMInputWidget {
 
 		const editorOptions: IEditorConstructionOptions = {
 			...getSimpleEditorOptions(),
-			lineDecorationsWidth: 4,
+			lineDecorationsWidth: 6,
 			dragAndDrop: true,
 			cursorWidth: 1,
 			fontSize: fontSize,


### PR DESCRIPTION
Fixes #165682