### PR TITLE
ipc: use vql for uint types

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -164,7 +164,47 @@ interface IWriter {
 	write(buffer: VSBuffer): void;
 }
 
-class BufferReader implements IReader {
+
+/**
+ * @see https://en.wikipedia.org/wiki/Variable-length_quantity
+ */
+function readUIntVQL(reader: IReader) {
+	let value = 0;
+	for (let n = 0; ; n += 7) {
+		const next = reader.read(1);
+		value |= (next.buffer[0] & 0b01111111) << n;
+		if (!(next.buffer[0] & 0b10000000)) {
+			return value;
+		}
+	}
+}
+
+/**
+ * @see https://en.wikipedia.org/wiki/Variable-length_quantity
+ */
+function writeUIntVQL(writer: IWriter, value: number) {
+	if (value < 0 || !Number.isInteger(value) || value > Number.MAX_SAFE_INTEGER) {
+		throw new Error(`writeVQL only supports positive safe integers, and ${value} is not`);
+	}
+
+	let len = 1;
+	for (let v2 = value >>> 7; v2 > 0; v2 = v2 >>> 7) {
+		len++;
+	}
+
+	const scratch = VSBuffer.alloc(len);
+	for (let i = 0; value > 0; i++) {
+		scratch.buffer[i] = value & 0b01111111;
+		value = value >>> 7;
+		if (value > 0) {
+			scratch.buffer[i] |= 0b10000000;
+		}
+	}
+
+	writer.write(scratch);
+}
+
+export class BufferReader implements IReader {
 
 	private pos = 0;
 
@@ -196,17 +236,8 @@ enum DataType {
 	Buffer = 2,
 	VSBuffer = 3,
 	Array = 4,
-	Object = 5
-}
-
-function createSizeBuffer(size: number): VSBuffer {
-	const result = VSBuffer.alloc(4);
-	result.writeUInt32BE(size, 0);
-	return result;
-}
-
-function readSizeBuffer(reader: IReader): number {
-	return reader.read(4).readUInt32BE(0);
+	Object = 5,
+	Uint = 6
 }
 
 function createOneByteBuffer(value: number): VSBuffer {
@@ -222,53 +253,57 @@ const BufferPresets = {
 	VSBuffer: createOneByteBuffer(DataType.VSBuffer),
 	Array: createOneByteBuffer(DataType.Array),
 	Object: createOneByteBuffer(DataType.Object),
+	Uint: createOneByteBuffer(DataType.Uint),
 };
 
 declare const Buffer: any;
 const hasBuffer = (typeof Buffer !== 'undefined');
 
-function serialize(writer: IWriter, data: any): void {
+export function serialize(writer: IWriter, data: any): void {
 	if (typeof data === 'undefined') {
 		writer.write(BufferPresets.Undefined);
 	} else if (typeof data === 'string') {
 		const buffer = VSBuffer.fromString(data);
 		writer.write(BufferPresets.String);
-		writer.write(createSizeBuffer(buffer.byteLength));
+		writeUIntVQL(writer, buffer.byteLength);
 		writer.write(buffer);
 	} else if (hasBuffer && Buffer.isBuffer(data)) {
 		const buffer = VSBuffer.wrap(data);
 		writer.write(BufferPresets.Buffer);
-		writer.write(createSizeBuffer(buffer.byteLength));
+		writeUIntVQL(writer, buffer.byteLength);
 		writer.write(buffer);
 	} else if (data instanceof VSBuffer) {
 		writer.write(BufferPresets.VSBuffer);
-		writer.write(createSizeBuffer(data.byteLength));
+		writeUIntVQL(writer, data.byteLength);
 		writer.write(data);
 	} else if (Array.isArray(data)) {
 		writer.write(BufferPresets.Array);
-		writer.write(createSizeBuffer(data.length));
+		writeUIntVQL(writer, data.length);
 
 		for (const el of data) {
 			serialize(writer, el);
 		}
+	} else if (typeof data === 'number' && Number.isInteger(data)) {
+		writer.write(BufferPresets.Uint);
+		writeUIntVQL(writer, data);
 	} else {
 		const buffer = VSBuffer.fromString(JSON.stringify(data));
 		writer.write(BufferPresets.Object);
-		writer.write(createSizeBuffer(buffer.byteLength));
+		writeUIntVQL(writer, buffer.byteLength);
 		writer.write(buffer);
 	}
 }
 
-function deserialize(reader: IReader): any {
+export function deserialize(reader: IReader): any {
 	const type = reader.read(1).readUInt8(0);
 
 	switch (type) {
 		case DataType.Undefined: return undefined;
-		case DataType.String: return reader.read(readSizeBuffer(reader)).toString();
-		case DataType.Buffer: return reader.read(readSizeBuffer(reader)).buffer;
-		case DataType.VSBuffer: return reader.read(readSizeBuffer(reader));
+		case DataType.String: return reader.read(readUIntVQL(reader)).toString();
+		case DataType.Buffer: return reader.read(readUIntVQL(reader)).buffer;
+		case DataType.VSBuffer: return reader.read(readUIntVQL(reader));
 		case DataType.Array: {
-			const length = readSizeBuffer(reader);
+			const length = readUIntVQL(reader);
 			const result: any[] = [];
 
 			for (let i = 0; i < length; i++) {
@@ -277,7 +312,8 @@ function deserialize(reader: IReader): any {
 
 			return result;
 		}
-		case DataType.Object: return JSON.parse(reader.read(readSizeBuffer(reader)).toString());
+		case DataType.Object: return JSON.parse(reader.read(readUIntVQL(reader)).toString());
+		case DataType.Uint: return readUIntVQL(reader);
 	}
 }
 

--- a/src/vs/base/parts/ipc/test/common/ipc.test.ts
+++ b/src/vs/base/parts/ipc/test/common/ipc.test.ts
@@ -11,7 +11,7 @@ import { canceled } from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { isEqual } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
-import { ClientConnectionEvent, IChannel, IMessagePassingProtocol, IPCClient, IPCServer, IServerChannel, ProxyChannel } from 'vs/base/parts/ipc/common/ipc';
+import { BufferReader, BufferWriter, ClientConnectionEvent, deserialize, IChannel, IMessagePassingProtocol, IPCClient, IPCServer, IServerChannel, ProxyChannel, serialize } from 'vs/base/parts/ipc/common/ipc';
 
 class QueueProtocol implements IMessagePassingProtocol {
 
@@ -318,6 +318,22 @@ suite('Base IPC', function () {
 		test('buffers in arrays', async function () {
 			const r = await ipcService.buffersLength([VSBuffer.alloc(2), VSBuffer.alloc(3)]);
 			return assert.strictEqual(r, 5);
+		});
+
+		test('round trips numbers', () => {
+			const input = [
+				0,
+				1,
+				-1,
+				12345,
+				-12345,
+				42.6,
+				123412341234
+			];
+
+			const writer = new BufferWriter();
+			serialize(writer, input);
+			assert.deepStrictEqual(deserialize(new BufferReader(writer.buffer)), input);
 		});
 	});
 

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -27,7 +27,7 @@ Unit tests from layers `common` and `browser` are run inside `chromium`, `webkit
 
 ## Run (with node)
 
-    yarn run mocha --ui tdd --run src/vs/editor/test/browser/controller/cursor.test.ts
+    yarn test-node --run src/vs/editor/test/browser/controller/cursor.test.ts
 
 ## Coverage
 


### PR DESCRIPTION
On the plane I was reverse-engineering ipc.ts to implement it in Rust and see if we could have a "service mode" for the CLI that we could interact with like any other vscode process. (And maybe reuse it if we have more native processes in the future)

In doing so, I noticed that numbers in the protocol--which are used at least twice in the message header and ID--were encoded as JSON. I was curious what benefits we'd get from encoding them as variable-length integers instead.

It makes the message shorter, as expected. Encode/decode time are very, very slightly lower. I'm not sure it's worth the extra complexity, but I have included it here for your consideration.

### Encode speed

```
old length 12
old messages/s 1204819
new length 9
new messages/s 1219512
```

<details>

```ts
const encode = (serialize: any) => {
	const writer = new BufferWriter();
	serialize(writer, [201, 1234]);
	serialize(writer, undefined);
	return writer.buffer.byteLength;
};

const n = 10_000;
for (let i = 0; i < n * 5; i++) { // warmup
	encode(serialize);
	encode(serializeOld);
}

const a = performance.now();
for (let i = 0; i < n; i++) {
	encode(serializeOld);
}
const b = performance.now();
for (let i = 0; i < n; i++) {
	encode(serialize);
}
const c = performance.now();
```

</details>

### Decode speed

```ts
old messages/s 793651
new messages/s 806452
```

<details>

```ts
const newData = VSBuffer.fromByteArray([4, 2, 6, 201, 1, 6, 210, 9, 0]);
const oldData = VSBuffer.fromByteArray([4, 0, 0, 0, 2, 6, 201, 1, 6, 210, 9, 0]);

const n = 10_000;
for (let i = 0; i < n * 5; i++) { // warmup
	deserialize(new BufferReader(newData));
	deserializeOld(new BufferReader(oldData));
}
const a = performance.now();
for (let i = 0; i < n; i++) {
	deserialize(new BufferReader(newData));
}
const b = performance.now();
for (let i = 0; i < n; i++) {
	deserializeOld(new BufferReader(oldData));
}
const c = performance.now();
```

</details>
