### PR TITLE
cli: use connection token for CLI connections

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -229,6 +229,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "atty",
+ "base64",
  "chrono",
  "clap",
  "clap_lex",
@@ -254,6 +255,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tar",
  "tempfile",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,6 +47,8 @@ url = "2.3"
 async-trait = "0.1"
 log = "0.4"
 const_format = "0.2"
+sha2 = "0.10"
+base64 = "0.13"
 
 [build-dependencies]
 serde = { version = "1.0" }

--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -17,7 +17,13 @@ pub const CONTROL_PORT: u16 = 31545;
 ///  1 - Initial protocol version
 ///  2 - Addition of `serve.compressed` property to control whether servermsg's
 ///      are compressed bidirectionally.
-pub const PROTOCOL_VERSION: u32 = 2;
+///  3 - The server's connection token is set to a SHA256 hash of the tunnel ID
+pub const PROTOCOL_VERSION: u32 = 3;
+
+/// Prefix for the tunnel tag that includes the version.
+pub const PROTOCOL_VERSION_TAG_PREFIX: &str = "protocolv";
+/// Tag for the current protocol version, which is included in dev tunnels.
+pub const PROTOCOL_VERSION_TAG: &str = concatcp!("protocolv", PROTOCOL_VERSION);
 
 pub const VSCODE_CLI_VERSION: Option<&'static str> = option_env!("VSCODE_CLI_VERSION");
 pub const VSCODE_CLI_AI_KEY: Option<&'static str> = option_env!("VSCODE_CLI_AI_KEY");

--- a/cli/src/tunnels/code_server.rs
+++ b/cli/src/tunnels/code_server.rs
@@ -534,7 +534,6 @@ impl<'a, Http: SimpleHttp + Send + Sync + Clone + 'static> ServerBuilder<'a, Htt
 
 		let mut cmd = self.get_base_command();
 		cmd.arg("--start-server")
-			.arg("--without-connection-token")
 			.arg("--enable-remote-auto-shutdown")
 			.arg(format!("--socket-path={}", socket.display()));
 

--- a/cli/src/tunnels/dev_tunnels.rs
+++ b/cli/src/tunnels/dev_tunnels.rs
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 use crate::auth;
-use crate::constants::{CONTROL_PORT, TUNNEL_SERVICE_USER_AGENT};
+use crate::constants::{
+	CONTROL_PORT, PROTOCOL_VERSION_TAG, PROTOCOL_VERSION_TAG_PREFIX, TUNNEL_SERVICE_USER_AGENT,
+};
 use crate::state::{LauncherPaths, PersistedState};
 use crate::util::errors::{
 	wrap, AnyError, DevTunnelError, InvalidTunnelName, TunnelCreationFailed, WrappedError,
@@ -138,6 +140,8 @@ pub struct DevTunnels {
 pub struct ActiveTunnel {
 	/// Name of the tunnel
 	pub name: String,
+	/// Underlying dev tunnels ID
+	pub id: String,
 	manager: ActiveTunnelManager,
 }
 
@@ -378,7 +382,7 @@ impl DevTunnels {
 		preferred_name: Option<String>,
 		use_random_name: bool,
 	) -> Result<ActiveTunnel, AnyError> {
-		let (tunnel, persisted) = match self.launcher_tunnel.load() {
+		let (mut tunnel, persisted) = match self.launcher_tunnel.load() {
 			Some(mut persisted) => {
 				if let Some(name) = preferred_name {
 					if persisted.name.ne(&name) {
@@ -403,6 +407,12 @@ impl DevTunnels {
 				(full_tunnel, persisted)
 			}
 		};
+
+		if !tunnel.tags.iter().any(|t| t == PROTOCOL_VERSION_TAG) {
+			tunnel = self
+				.update_protocol_version_tag(tunnel, &HOST_TUNNEL_REQUEST_OPTIONS)
+				.await?;
+		}
 
 		let locator = TunnelLocator::try_from(&tunnel).unwrap();
 		let host_token = get_host_token_from_tunnel(&tunnel);
@@ -462,7 +472,11 @@ impl DevTunnels {
 		let mut tried_recycle = false;
 
 		let new_tunnel = Tunnel {
-			tags: vec![name.to_string(), VSCODE_CLI_TUNNEL_TAG.to_string()],
+			tags: vec![
+				name.to_string(),
+				PROTOCOL_VERSION_TAG.to_string(),
+				VSCODE_CLI_TUNNEL_TAG.to_string(),
+			],
 			..Default::default()
 		};
 
@@ -505,6 +519,40 @@ impl DevTunnels {
 				}
 			}
 		}
+	}
+
+	/// Ensures the tunnel contains a tag for the current PROTCOL_VERSION, and no
+	/// other version tags.
+	async fn update_protocol_version_tag(
+		&self,
+		tunnel: Tunnel,
+		options: &TunnelRequestOptions,
+	) -> Result<Tunnel, AnyError> {
+		debug!(
+			self.log,
+			"Updating tunnel protocol version tag to {}", PROTOCOL_VERSION_TAG
+		);
+		let mut new_tags: Vec<String> = tunnel
+			.tags
+			.into_iter()
+			.filter(|t| !t.starts_with(PROTOCOL_VERSION_TAG_PREFIX))
+			.collect();
+		new_tags.push(PROTOCOL_VERSION_TAG.to_string());
+
+		let tunnel_update = Tunnel {
+			tags: new_tags,
+			tunnel_id: tunnel.tunnel_id.clone(),
+			cluster_id: tunnel.cluster_id.clone(),
+			..Default::default()
+		};
+
+		let result = spanf!(
+			self.log,
+			self.log.span("dev-tunnel.protocol-tag-update"),
+			self.client.update_tunnel(&tunnel_update, options)
+		);
+
+		result.map_err(|e| wrap(e, "tunnel tag update failed").into())
 	}
 
 	/// Tries to delete an unused tunnel, and then creates a tunnel with the
@@ -690,6 +738,7 @@ impl DevTunnels {
 
 		Ok(ActiveTunnel {
 			name: tunnel_details.name.clone(),
+			id: tunnel_details.id.clone(),
 			manager,
 		})
 	}


### PR DESCRIPTION
This uses a hash of the tunnel ID to create the connection token, which should be sufficient to resolve the issues.

We also now publish the protocol version in the tunnel tags, since the connection token must be supplied in the resolver, which is before we start connecting to the tunnel.

See https://github.com/microsoft/vscode-internalbacklog/issues/3287
