### PR TITLE
Fix code action navigation

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -177,7 +177,7 @@ export class ActionList<T extends IActionItem> extends Disposable {
 			new ActionItemRenderer<IListMenuItem<IActionItem>>(resolver, this._keybindingService),
 			new HeaderRenderer()
 		], {
-			keyboardSupport: true,
+			keyboardSupport: false,
 			accessibilityProvider: {
 				getAriaLabel: element => {
 					if (element.kind === 'action') {

--- a/src/vs/platform/instantiation/common/instantiationService.ts
+++ b/src/vs/platform/instantiation/common/instantiationService.ts
@@ -309,6 +309,9 @@ export class InstantiationService implements IInstantiationService {
 				set(_target: T, p: PropertyKey, value: any): boolean {
 					idle.value[p] = value;
 					return true;
+				},
+				getPrototypeOf(_target: T) {
+					return ctor.prototype;
 				}
 			});
 		}


### PR DESCRIPTION
Fixes #166997
Fixes #166996

This disables the default list keybindings so that we instead use our custom commands

It also adds a `getPrototypeOf` implementation to proxy services, which fixes `instanceof` checks on services (we were using these in the action widget commands)

