### PR TITLE
Allow machne id generation in main process

### DIFF
--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -51,7 +51,7 @@ import { RequestService } from 'vs/platform/request/node/requestService';
 import { IStateService } from 'vs/platform/state/node/state';
 import { StateService } from 'vs/platform/state/node/stateService';
 import { resolveCommonProperties } from 'vs/platform/telemetry/common/commonProperties';
-import { ITelemetryService, machineIdKey } from 'vs/platform/telemetry/common/telemetry';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ITelemetryServiceConfig, TelemetryService } from 'vs/platform/telemetry/common/telemetryService';
 import { supportsTelemetry, NullTelemetryService, getPiiPathsFromEnvironment, isInternalTelemetry, ITelemetryAppender } from 'vs/platform/telemetry/common/telemetryUtils';
 import { OneDataSystemAppender } from 'vs/platform/telemetry/node/1dsAppender';
@@ -60,6 +60,7 @@ import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity'
 import { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService';
 import { IUserDataProfilesService, PROFILES_ENABLEMENT_CONFIG } from 'vs/platform/userDataProfile/common/userDataProfile';
 import { UserDataProfilesService } from 'vs/platform/userDataProfile/node/userDataProfile';
+import { resolveMachineId } from 'vs/platform/telemetry/node/telemetryUtils';
 
 class CliMain extends Disposable {
 
@@ -205,8 +206,7 @@ class CliMain extends Disposable {
 				commonProperties: (async () => {
 					let machineId: string | undefined = undefined;
 					try {
-						const storageContents = await Promises.readFile(environmentService.stateResource.fsPath);
-						machineId = JSON.parse(storageContents.toString())[machineIdKey];
+						machineId = await resolveMachineId(stateService);
 					} catch (error) {
 						if (error.code !== 'ENOENT') {
 							logService.error(error);

--- a/src/vs/platform/telemetry/electron-main/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/electron-main/telemetryUtils.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IStateMainService } from 'vs/platform/state/electron-main/state';
+import { machineIdKey } from 'vs/platform/telemetry/common/telemetry';
+import { resolveMachineId as resolveNodeMachineId } from 'vs/platform/telemetry/node/telemetryUtils';
+
+export async function resolveMachineId(stateService: IStateMainService) {
+	// Call the node layers implementation to avoid code duplication
+	const machineId = resolveNodeMachineId(stateService);
+	stateService.setItem(machineIdKey, machineId);
+	return machineId;
+}

--- a/src/vs/platform/telemetry/node/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/node/telemetryUtils.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isMacintosh } from 'vs/base/common/platform';
+import { getMachineId } from 'vs/base/node/id';
+import { IStateService } from 'vs/platform/state/node/state';
+import { machineIdKey } from 'vs/platform/telemetry/common/telemetry';
+
+
+export async function resolveMachineId(stateService: IStateService) {
+	// We cache the machineId for faster lookups
+	// and resolve it only once initially if not cached or we need to replace the macOS iBridge device
+	let machineId = stateService.getItem<string>(machineIdKey);
+	if (!machineId || (isMacintosh && machineId === '6c9d2bc8f91b89624add29c0abeae7fb42bf539fa1cdb2e3e57cd668fa9bcead')) {
+		machineId = await getMachineId();
+	}
+
+	return machineId;
+}

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -30,7 +30,7 @@ import { IProductService } from 'vs/platform/product/common/productService';
 import { IProtocolMainService } from 'vs/platform/protocol/electron-main/protocol';
 import { resolveMarketplaceHeaders } from 'vs/platform/externalServices/common/marketplace';
 import { IApplicationStorageMainService, IStorageMainService } from 'vs/platform/storage/electron-main/storageMainService';
-import { ITelemetryService, machineIdKey } from 'vs/platform/telemetry/common/telemetry';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 import { IThemeMainService } from 'vs/platform/theme/electron-main/themeMainService';
 import { getMenuBarVisibility, getTitleBarStyle, IFolderToOpen, INativeWindowConfiguration, IWindowSettings, IWorkspaceToOpen, MenuBarVisibility, useWindowControlsOverlay, WindowMinimumSize, zoomLevelToZoomFactor } from 'vs/platform/window/common/window';
@@ -49,6 +49,7 @@ import { ITelemetryServiceConfig, TelemetryService } from 'vs/platform/telemetry
 import { getPiiPathsFromEnvironment, isInternalTelemetry, ITelemetryAppender, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 import { resolveCommonProperties } from 'vs/platform/telemetry/common/commonProperties';
 import { hostname, release } from 'os';
+import { resolveMachineId } from 'vs/platform/telemetry/electron-main/telemetryUtils';
 
 export interface IWindowCreationOptions {
 	state: IWindowState;
@@ -782,11 +783,12 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 			}
 
 			const { installSourcePath } = this.environmentMainService;
+			const machineId = await resolveMachineId(this.stateMainService);
 
 			const config: ITelemetryServiceConfig = {
 				appenders,
 				sendErrorTelemetry: false,
-				commonProperties: resolveCommonProperties(this.fileService, release(), hostname(), process.arch, this.productService.commit, this.productService.version, this.stateMainService.getItem<string>(machineIdKey), isInternal, installSourcePath),
+				commonProperties: resolveCommonProperties(this.fileService, release(), hostname(), process.arch, this.productService.commit, this.productService.version, machineId, isInternal, installSourcePath),
 				piiPaths: getPiiPathsFromEnvironment(this.environmentMainService)
 			};
 


### PR DESCRIPTION
Switch to using state service in the CLI process and attempt to generate machine id. Moves some logic to the telemetry utils.