### PR TITLE
Use more generic button title for jsconfig create/open

### DIFF
--- a/extensions/typescript-language-features/src/ui/intellisenseStatus.ts
+++ b/extensions/typescript-language-features/src/ui/intellisenseStatus.ts
@@ -46,7 +46,7 @@ namespace IntellisenseState {
 export class IntellisenseStatus extends Disposable {
 
 	public readonly openOpenConfigCommandId = '_typescript.openConfig';
-	public readonly createConfigCommandId = '_typescript.createConfig';
+	public readonly createOrOpenConfigCommandId = '_typescript.createOrOpenConfig';
 
 	private _statusItem?: vscode.LanguageStatusItem;
 
@@ -71,7 +71,7 @@ export class IntellisenseStatus extends Disposable {
 			},
 		});
 		commandManager.register({
-			id: this.createConfigCommandId,
+			id: this.createOrOpenConfigCommandId,
 			execute: async (rootPath: string, projectType: ProjectType) => {
 				await openOrCreateConfig(projectType, rootPath, this._client.configuration);
 			},
@@ -178,10 +178,10 @@ export class IntellisenseStatus extends Disposable {
 					statusItem.text = noConfigFileText;
 					statusItem.detail = undefined;
 					statusItem.command = {
-						command: this.createConfigCommandId,
+						command: this.createOrOpenConfigCommandId,
 						title: this._state.projectType === ProjectType.TypeScript
-							? vscode.l10n.t("Create tsconfig")
-							: vscode.l10n.t("Create jsconfig"),
+							? vscode.l10n.t("Configure tsconfig")
+							: vscode.l10n.t("Configure jsconfig"),
 						arguments: [rootPath],
 					};
 				} else {


### PR DESCRIPTION
For #166808

This button will either create a new config file or open an existing one. Using `Configure` to make this more generic (while avoiding having to actually check the FS until you click the button)
