### PR TITLE
Command duration: use a higher-precision for telemetry

### DIFF
--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -25,6 +25,7 @@ import { TestItemImpl } from 'vs/workbench/api/common/extHostTestItem';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
+import { StopWatch } from 'vs/base/common/stopwatch';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 
 interface CommandHandler {
@@ -235,7 +236,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 			}
 		}
 
-		const start = Date.now();
+		const stopWatch = StopWatch.create();
 		try {
 			return await callback.apply(thisArg, args);
 		} catch (err) {
@@ -262,7 +263,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 			};
 		}
 		finally {
-			this._reportTelemetry(command, id, Date.now() - start);
+			this._reportTelemetry(command, id, stopWatch.elapsed());
 		}
 	}
 


### PR DESCRIPTION
Date.now has a poor precision, and many commands take less than 2ms to complete.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This is a followup to #165599