### PR TITLE
server: allow underscores in connection token

### DIFF
--- a/src/vs/server/node/serverConnectionToken.ts
+++ b/src/vs/server/node/serverConnectionToken.ts
@@ -13,7 +13,7 @@ import { connectionTokenCookieName, connectionTokenQueryName } from 'vs/base/com
 import { ServerParsedArgs } from 'vs/server/node/serverEnvironmentService';
 import { Promises } from 'vs/base/node/pfs';
 
-const connectionTokenRegex = /^[0-9A-Za-z-]+$/;
+const connectionTokenRegex = /^[0-9A-Za-z_-]+$/;
 
 export const enum ServerConnectionTokenType {
 	None,


### PR DESCRIPTION
Underscores are URL and path safe. Allowing them lets connection tokens
be generated by standard base64 URL encoding without additional escaping
or replacements.

Fixes #167631

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
