### PR TITLE
Fix incorrect machine id

### DIFF
--- a/src/vs/platform/telemetry/electron-main/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/electron-main/telemetryUtils.ts
@@ -9,7 +9,7 @@ import { resolveMachineId as resolveNodeMachineId } from 'vs/platform/telemetry/
 
 export async function resolveMachineId(stateService: IStateMainService) {
 	// Call the node layers implementation to avoid code duplication
-	const machineId = resolveNodeMachineId(stateService);
+	const machineId = await resolveNodeMachineId(stateService);
 	stateService.setItem(machineIdKey, machineId);
 	return machineId;
 }

--- a/src/vs/platform/telemetry/node/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/node/telemetryUtils.ts
@@ -13,7 +13,7 @@ export async function resolveMachineId(stateService: IStateService) {
 	// We cache the machineId for faster lookups
 	// and resolve it only once initially if not cached or we need to replace the macOS iBridge device
 	let machineId = stateService.getItem<string>(machineIdKey);
-	if (!machineId || (isMacintosh && machineId === '6c9d2bc8f91b89624add29c0abeae7fb42bf539fa1cdb2e3e57cd668fa9bcead')) {
+	if (typeof machineId !== 'string' || (isMacintosh && machineId === '6c9d2bc8f91b89624add29c0abeae7fb42bf539fa1cdb2e3e57cd668fa9bcead')) {
 		machineId = await getMachineId();
 	}
 


### PR DESCRIPTION
This was caused by a forgotten await which would set the machine id to an object. This can  cause crashes when a string is expected