### PR TITLE
cli: fix service failing to install on older systemd

### DIFF
--- a/cli/src/tunnels/service_linux.rs
+++ b/cli/src/tunnels/service_linux.rs
@@ -92,6 +92,19 @@ impl ServiceManager for SystemdService {
 
 		info!(self.log, "Successfully registered service...");
 
+		// note: enablement is implicit in recent systemd version, but required for older systems
+		// https://github.com/microsoft/vscode/issues/167489#issuecomment-1331222826
+		proxy
+			.enable_unit_files(
+				vec![SystemdService::service_name_string()],
+				/* 'runtime only'= */ false,
+				/* replace existing = */ true,
+			)
+			.await
+			.map_err(|e| wrap(e, "error enabling unit files for service"))?;
+
+		info!(self.log, "Successfully enabled unit files...");
+
 		proxy
 			.start_unit(SystemdService::service_name_string(), "replace".to_string())
 			.await


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/167671

In newer systemd, enablement is apparently implicit with 'link', but it must be called for older setups.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
