### PR TITLE
Fix paste removing indent

### DIFF
--- a/src/vs/editor/common/languages/autoIndent.ts
+++ b/src/vs/editor/common/languages/autoIndent.ts
@@ -53,6 +53,10 @@ function getPrecedingValidLine(model: IVirtualModel, lineNumber: number, indentR
 
 			return lastLineNumber;
 		}
+
+		if (lastLineNumber === 0) {
+			return 0;
+		}
 	}
 
 	return -1;

--- a/src/vs/editor/common/languages/autoIndent.ts
+++ b/src/vs/editor/common/languages/autoIndent.ts
@@ -53,10 +53,6 @@ function getPrecedingValidLine(model: IVirtualModel, lineNumber: number, indentR
 
 			return lastLineNumber;
 		}
-
-		if (lastLineNumber === 0) {
-			return 0;
-		}
 	}
 
 	return -1;
@@ -95,6 +91,19 @@ export function getInheritIndentForLine(
 			indentation: '',
 			action: null
 		};
+	}
+
+	// Use no indent if this is the first non-blank line
+	for (let priorLineNumber = lineNumber - 1; priorLineNumber > 0; priorLineNumber--) {
+		if (model.getLineContent(priorLineNumber) !== '') {
+			break;
+		}
+		if (priorLineNumber === 1) {
+			return {
+				indentation: '',
+				action: null
+			};
+		}
 	}
 
 	const precedingUnIgnoredLine = getPrecedingValidLine(model, lineNumber, indentRulesSupport);


### PR DESCRIPTION
This seems to solve #167299. You can test by following the instructions in https://github.com/microsoft/vscode/issues/167299#issue-1465111764.

Based on the JSDoc for `getPrecedingValidLine`, it's supposed to return -1 when it run into the boundary of embedded languages and 0 if every line above are invalid. So I'm pretty sure is sure it should return 0 if it has processed all the lines up to the top of the file. Currently, it's returning -1 as if it's the boundary of an embedded language.