### PR TITLE
Corrected Turkish context menu texts' encoding errors.

### DIFF
--- a/build/win32/i18n/messages.tr.isl
+++ b/build/win32/i18n/messages.tr.isl
@@ -1,9 +1,9 @@
 [CustomMessages]
-AddContextMenuFiles=Windows Gezgini bağlam menüsüne "%1 İle Aç" eylemini ekle
-AddContextMenuFolders=Windows Gezgini dizin bağlam menüsüne "%1 İle Aç" eylemini ekle
-AssociateWithFiles=%1 uygulamasını desteklenen dosya türleri için bir düzenleyici olarak kayıt et
-AddToPath=PATH'e ekle (yeniden başlattıktan sonra kullanılabilir)
-RunAfter=Kurulumdan sonra %1 uygulamasını çalıştır.
-Other=Diğer:
-SourceFile=%1 Kaynak Dosyası
-OpenWithCodeContextMenu=%1 İle Aç
+AddContextMenuFiles=Windows Gezgini baÄŸlam menÃ¼sÃ¼ne "%1 Ä°le AÃ§" eylemini ekle
+AddContextMenuFolders=Windows Gezgini dizin baÄŸlam menÃ¼sÃ¼ne "%1 Ä°le AÃ§" eylemini ekle
+AssociateWithFiles=%1 uygulamasÄ±nÄ± desteklenen dosya tÃ¼rleri iÃ§in bir dÃ¼zenleyici olarak kayÄ±t et
+AddToPath=PATH'e ekle (yeniden baÅŸlattÄ±ktan sonra kullanÄ±labilir)
+RunAfter=Kurulumdan sonra %1 uygulamasÄ±nÄ± Ã§alÄ±ÅŸtÄ±r.
+Other=DiÄŸer:
+SourceFile=%1 Kaynak DosyasÄ±
+OpenWithCodeContextMenu=%1 Ä°le AÃ§


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Corrected Turkish context menu texts' encoding errors. For example, `Windows Gezgini ba�lam men�s�ne "%1 �le A�" eylemini ekle` changed to `Windows Gezgini dizin bağlam menüsüne "%1 İle Aç" eylemini ekle`.