### PR TITLE
Restrict hover focus trap behaviour to Settings indicators

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -77,7 +77,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 		hoverPosition: HoverPosition.BELOW,
 		showPointer: true,
 		compact: false,
-		addFocusTraps: true
+		trapFocus: true
 	};
 
 	private addHoverDisposables(disposables: DisposableStore, element: HTMLElement, showHover: (focus: boolean) => IHoverWidget | undefined) {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -76,7 +76,8 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 	private defaultHoverOptions: Partial<IHoverOptions> = {
 		hoverPosition: HoverPosition.BELOW,
 		showPointer: true,
-		compact: false
+		compact: false,
+		addFocusTraps: true
 	};
 
 	private addHoverDisposables(disposables: DisposableStore, element: HTMLElement, showHover: (focus: boolean) => IHoverWidget | undefined) {

--- a/src/vs/workbench/services/hover/browser/hover.ts
+++ b/src/vs/workbench/services/hover/browser/hover.ts
@@ -119,6 +119,12 @@ export interface IHoverOptions {
 	 * another in the same group so it looks like the hover is moving from one element to the other.
 	 */
 	skipFadeInAnimation?: boolean;
+
+	/**
+	 * Whether to add focus traps so that when the hover closes, focus goes to the last focused element,
+	 * and when tabbing, focus stays inside of the hover.
+	 */
+	addFocusTraps?: boolean;
 }
 
 export interface IHoverAction {

--- a/src/vs/workbench/services/hover/browser/hover.ts
+++ b/src/vs/workbench/services/hover/browser/hover.ts
@@ -121,10 +121,11 @@ export interface IHoverOptions {
 	skipFadeInAnimation?: boolean;
 
 	/**
-	 * Whether to add focus traps so that when the hover closes, focus goes to the last focused element,
-	 * and when tabbing, focus stays inside of the hover.
+	 * Whether to trap focus in the following ways:
+	 * - When the hover closes, focus goes to the element that had focus before the hover opened
+	 * - If there are elements in the hover to focus, focus stays inside of the hover when tabbing
 	 */
-	addFocusTraps?: boolean;
+	trapFocus?: boolean;
 }
 
 export interface IHoverAction {

--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -39,7 +39,7 @@ export class HoverService implements IHoverService {
 			return undefined;
 		}
 		this._currentHoverOptions = options;
-		if (options.addFocusTraps && document.activeElement) {
+		if (options.trapFocus && document.activeElement) {
 			this._lastFocusedElementBeforeOpen = document.activeElement as HTMLElement;
 		} else {
 			this._lastFocusedElementBeforeOpen = undefined;
@@ -120,7 +120,7 @@ export class HoverService implements IHoverService {
 		if (keybinding.getSingleModifierDispatchParts().some(value => !!value) || this._keybindingService.softDispatch(event, event.target)) {
 			return;
 		}
-		if (!this._currentHoverOptions?.addFocusTraps || e.key !== 'Tab') {
+		if (!this._currentHoverOptions?.trapFocus || e.key !== 'Tab') {
 			this.hideHover();
 			this._lastFocusedElementBeforeOpen?.focus();
 		}

--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -39,8 +39,10 @@ export class HoverService implements IHoverService {
 			return undefined;
 		}
 		this._currentHoverOptions = options;
-		if (document.activeElement) {
+		if (options.addFocusTraps && document.activeElement) {
 			this._lastFocusedElementBeforeOpen = document.activeElement as HTMLElement;
+		} else {
+			this._lastFocusedElementBeforeOpen = undefined;
 		}
 
 		const hoverDisposables = new DisposableStore();
@@ -118,7 +120,7 @@ export class HoverService implements IHoverService {
 		if (keybinding.getSingleModifierDispatchParts().some(value => !!value) || this._keybindingService.softDispatch(event, event.target)) {
 			return;
 		}
-		if (e.key !== 'Tab') {
+		if (!this._currentHoverOptions?.addFocusTraps || e.key !== 'Tab') {
 			this.hideHover();
 			this._lastFocusedElementBeforeOpen?.focus();
 		}

--- a/src/vs/workbench/services/hover/browser/hoverWidget.ts
+++ b/src/vs/workbench/services/hover/browser/hoverWidget.ts
@@ -111,7 +111,7 @@ export class HoverWidget extends Widget {
 		if (options.forcePosition) {
 			this._forcePosition = true;
 		}
-		if (options.addFocusTraps) {
+		if (options.trapFocus) {
 			this._enableFocusTraps = true;
 		}
 

--- a/src/vs/workbench/services/hover/browser/hoverWidget.ts
+++ b/src/vs/workbench/services/hover/browser/hoverWidget.ts
@@ -52,6 +52,7 @@ export class HoverWidget extends Widget {
 	private _x: number = 0;
 	private _y: number = 0;
 	private _isLocked: boolean = false;
+	private _enableFocusTraps: boolean = false;
 	private _addedFocusTrap: boolean = false;
 
 	get isDisposed(): boolean { return this._isDisposed; }
@@ -109,6 +110,9 @@ export class HoverWidget extends Widget {
 		}
 		if (options.forcePosition) {
 			this._forcePosition = true;
+		}
+		if (options.addFocusTraps) {
+			this._enableFocusTraps = true;
 		}
 
 		this._hoverPosition = options.hoverPosition ?? HoverPosition.ABOVE;
@@ -224,7 +228,7 @@ export class HoverWidget extends Widget {
 	}
 
 	private addFocusTrap() {
-		if (this._addedFocusTrap) {
+		if (!this._enableFocusTraps || this._addedFocusTrap) {
 			return;
 		}
 		this._addedFocusTrap = true;


### PR DESCRIPTION
Fixes #167520

~~This reverts commit dbe96ecc1ec325d3bd45c497b8265fe3ea3a25a5.~~

This PR adds a feature flag so that the new hover focus trap behaviour is enabled only for the Settings indicators.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
