### PR TITLE
Do not require `manifest.activationEvents` to generate implicit events

### DIFF
--- a/src/vs/platform/extensionManagement/common/implicitActivationEvents.ts
+++ b/src/vs/platform/extensionManagement/common/implicitActivationEvents.ts
@@ -19,10 +19,13 @@ export class ImplicitActivationEventsImpl {
 	}
 
 	public updateManifest(manifest: IExtensionManifest) {
-		if (!Array.isArray(manifest.activationEvents) || !manifest.contributes) {
+		if (typeof manifest.main === 'undefined' && typeof manifest.browser === 'undefined') {
 			return;
 		}
-		if (typeof manifest.main === 'undefined' && typeof manifest.browser === 'undefined') {
+		if (manifest.activationEvents === undefined) {
+			Object.assign(manifest, { activationEvents: [] });
+		}
+		if (!Array.isArray(manifest.activationEvents) || !manifest.contributes) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/167512