### PR TITLE
🖊 Include branch name in commit button popup

### DIFF
--- a/extensions/git/src/actionButton.ts
+++ b/extensions/git/src/actionButton.ts
@@ -145,8 +145,12 @@ export class ActionButtonCommand {
 				command: 'git.publish',
 				title: l10n.t({ message: '{0} Publish Branch', args: [icon], comment: ['{Locked="Branch"}', 'Do not translate "Branch" as it is a git term'] }),
 				tooltip: this.state.isSyncInProgress ?
-					l10n.t({ message: 'Publishing Branch...', comment: ['{Locked="Branch"}', 'Do not translate "Branch" as it is a git term'] }) :
-					l10n.t({ message: 'Publish Branch', comment: ['{Locked="Branch"}', 'Do not translate "Branch" as it is a git term'] }),
+					(this.state.HEAD?.name ?
+						l10n.t({ message: 'Publishing Branch \'{0}\'...', args: [this.state.HEAD.name], comment: ['{Locked="Branch"}', 'Do not translate "Branch" as it is a git term'] }) :
+						l10n.t({ message: 'Publishing Branch...', comment: ['{Locked="Branch"}', 'Do not translate "Branch" as it is a git term'] })) :
+					(this.repository.HEAD?.name ?
+						l10n.t({ message: 'Publish Branch \'{0}\'', args: [this.state.HEAD?.name], comment: ['{Locked="Branch"}', 'Do not translate "Branch" as it is a git term'] }) :
+						l10n.t({ message: 'Publish Branch', comment: ['{Locked="Branch"}', 'Do not translate "Branch" as it is a git term'] })),
 				arguments: [this.repository.sourceControl],
 			},
 			enabled: !this.state.isSyncInProgress

--- a/extensions/git/src/postCommitCommands.ts
+++ b/extensions/git/src/postCommitCommands.ts
@@ -173,9 +173,12 @@ export class CommitCommandsCenter {
 		const icon = alwaysPrompt ? '$(lock)' : alwaysCommitToNewBranch ? '$(git-branch)' : undefined;
 
 		// Tooltip (default)
-		let tooltip = !alwaysCommitToNewBranch ?
-			l10n.t('Commit Changes') :
-			l10n.t('Commit Changes to New Branch');
+		const branch = this.repository.HEAD?.name;
+		let tooltip = alwaysCommitToNewBranch ?
+			l10n.t('Commit Changes to New Branch') :
+			branch ?
+				l10n.t('Commit Changes on \'{0}\'', branch) :
+				l10n.t('Commit Changes');
 
 		// Tooltip (in progress)
 		if (this.repository.operations.isRunning(Operation.Commit)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #167545

The branch name, if available, is now displayed on the "Commit" button popup.

![Branch name included in the "Commit" button popup](https://user-images.githubusercontent.com/36728931/205034662-49c95bcf-78a6-498f-a676-4c5dbf3e15fd.png)

This PR also updates the "Publish Branch" button's popups:

![publish-popup](https://user-images.githubusercontent.com/36728931/205044228-0ea82bf6-2042-49de-bff7-afd7a584207b.png)
![publishing-popup](https://user-images.githubusercontent.com/36728931/205044220-53606a57-4b3a-4a86-bad4-5b873e0d5902.png)