### PR TITLE
Fix path sep for markdown drop on windows

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/dropIntoEditor.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/dropIntoEditor.ts
@@ -103,10 +103,11 @@ export function createUriListSnippet(document: vscode.TextDocument, uris: readon
 function getMdPath(dir: vscode.Uri | undefined, file: vscode.Uri) {
 	if (dir && dir.scheme === file.scheme && dir.authority === file.authority) {
 		if (file.scheme === Schemes.file) {
-			// On windows, we must use the native `path.resolve` to generate the relative path
+			// On windows, we must use the native `path.relative` to generate the relative path
 			// so that drive-letters are resolved cast insensitively. However we then want to
 			// convert back to a posix path to insert in to the document.
-			return encodeURI(path.posix.normalize(path.relative(dir.fsPath, file.fsPath)));
+			const relativePath = path.relative(dir.fsPath, file.fsPath);
+			return encodeURI(path.posix.normalize(relativePath.split(path.sep).join(path.posix.sep)));
 		}
 
 		return encodeURI(path.posix.relative(dir.path, file.path));


### PR DESCRIPTION
Fixes #167824

This converts windows path separators to posix path separators (`/`)