### PR TITLE
Don't create more than one notebook detection task per-type

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/kernelDetection/notebookKernelDetection.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/kernelDetection/notebookKernelDetection.ts
@@ -58,7 +58,7 @@ class NotebookKernelDetection extends Disposable implements IWorkbenchContributi
 						}
 					});
 
-					if (shouldStartDetection) {
+					if (shouldStartDetection && !this._detectionMap.has(notebookType)) {
 						const task = this._notebookKernelService.registerNotebookKernelDetectionTask({
 							notebookType: notebookType
 						});


### PR DESCRIPTION
This is creating detection tasks to cover the period between opening a notebook, and the notebook extension activating and starting its own detection task. This code is a bit more complex than necessary, and it would be simpler to manage the lifecycle of this task from the `activateByEvent` promise.
Fix #167875

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
