### PR TITLE
Restore previous behavior that "Indent Using Spaces" changes both indentSize and tabSize

### DIFF
--- a/src/vs/editor/contrib/indentation/browser/indentation.ts
+++ b/src/vs/editor/contrib/indentation/browser/indentation.ts
@@ -252,7 +252,7 @@ export class ChangeIndentationSizeAction extends EditorAction {
 							});
 						} else {
 							model.updateOptions({
-								tabSize: this.insertSpaces ? undefined : pickedVal,
+								tabSize: pickedVal,
 								indentSize: pickedVal,
 								insertSpaces: this.insertSpaces
 							});


### PR DESCRIPTION
Fixes #167571