### PR TITLE
Disable passing in locale to Electron on macOS

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -112,7 +112,7 @@ const electronLocale = (!locale || locale === 'qps-ploc') ? 'en' : locale;
 // For now, don't pass in the locale on macOS due to
 // https://github.com/microsoft/vscode/issues/167543
 
-if (os.platform() !== 'darwin') {
+if (process.platform === 'win32') {
 	app.commandLine.appendSwitch('lang', electronLocale);
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -100,19 +100,15 @@ if (locale) {
 }
 
 // Pass in the locale to Electron so that the
-// Windows Control Overlay is rendered correctly on Windows,
-// and so that the traffic lights are rendered properly
-// on macOS when using a custom titlebar.
+// Windows Control Overlay is rendered correctly on Windows.
+// For now, don't pass in the locale on macOS due to
+// https://github.com/microsoft/vscode/issues/167543.
 // If the locale is `qps-ploc`, the Microsoft
 // Pseudo Language Language Pack is being used.
 // In that case, use `en` as the Electron locale.
 
-const electronLocale = (!locale || locale === 'qps-ploc') ? 'en' : locale;
-
-// For now, don't pass in the locale on macOS due to
-// https://github.com/microsoft/vscode/issues/167543
-
 if (process.platform === 'win32') {
+	const electronLocale = (!locale || locale === 'qps-ploc') ? 'en' : locale;
 	app.commandLine.appendSwitch('lang', electronLocale);
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -108,7 +108,13 @@ if (locale) {
 // In that case, use `en` as the Electron locale.
 
 const electronLocale = (!locale || locale === 'qps-ploc') ? 'en' : locale;
-app.commandLine.appendSwitch('lang', electronLocale);
+
+// For now, don't pass in the locale on macOS due to
+// https://github.com/microsoft/vscode/issues/167543
+
+if (os.platform() !== 'darwin') {
+	app.commandLine.appendSwitch('lang', electronLocale);
+}
 
 // Load our code once ready
 app.once('ready', function () {


### PR DESCRIPTION
Fixes #167543

This fix reverts the behaviour back to #164397, which is also buggy, but is not as bad, because with the old buggy behaviour, the user could at least see all the traffic light buttons.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
