### PR TITLE
Remove unneeded exports in areas I own

### DIFF
--- a/src/vs/base/node/shell.ts
+++ b/src/vs/base/node/shell.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { release, userInfo } from 'os';
+import { userInfo } from 'os';
 import * as platform from 'vs/base/common/platform';
 import { getFirstAvailablePowerShellInstallation } from 'vs/base/node/powershell';
 import * as processes from 'vs/base/node/processes';
@@ -17,18 +17,6 @@ export async function getSystemShell(os: platform.OperatingSystem, env: platform
 	if (os === platform.OperatingSystem.Windows) {
 		if (platform.isWindows) {
 			return getSystemShellWindows();
-		}
-		// Don't detect Windows shell when not on Windows
-		return processes.getWindowsShell(env);
-	}
-
-	return getSystemShellUnixLike(os, env);
-}
-
-export function getSystemShellSync(os: platform.OperatingSystem, env: platform.IProcessEnvironment): string {
-	if (os === platform.OperatingSystem.Windows) {
-		if (platform.isWindows) {
-			return getSystemShellWindowsSync(env);
 		}
 		// Don't detect Windows shell when not on Windows
 		return processes.getWindowsShell(env);
@@ -79,15 +67,4 @@ async function getSystemShellWindows(): Promise<string> {
 		_TERMINAL_DEFAULT_SHELL_WINDOWS = (await getFirstAvailablePowerShellInstallation())!.exePath;
 	}
 	return _TERMINAL_DEFAULT_SHELL_WINDOWS;
-}
-
-function getSystemShellWindowsSync(env: platform.IProcessEnvironment): string {
-	if (_TERMINAL_DEFAULT_SHELL_WINDOWS) {
-		return _TERMINAL_DEFAULT_SHELL_WINDOWS;
-	}
-
-	const isAtLeastWindows10 = platform.isWindows && parseFloat(release()) >= 10;
-	const is32ProcessOn64Windows = env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
-	const powerShellPath = `${env['windir']}\\${is32ProcessOn64Windows ? 'Sysnative' : 'System32'}\\WindowsPowerShell\\v1.0\\powershell.exe`;
-	return isAtLeastWindows10 ? powerShellPath : processes.getWindowsShell(env);
 }

--- a/src/vs/base/parts/quickinput/browser/quickInputList.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInputList.ts
@@ -794,7 +794,7 @@ export class QuickInputList {
 	}
 }
 
-export function matchesContiguousIconAware(query: string, target: IParsedLabelWithIcons): IMatch[] | null {
+function matchesContiguousIconAware(query: string, target: IParsedLabelWithIcons): IMatch[] | null {
 
 	const { text, iconOffsets } = target;
 

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -649,7 +649,7 @@ function getOutputForCommand(executedMarker: IMarker | undefined, endMarker: IMa
 	return output === '' ? undefined : output;
 }
 
-export function getOutputMatchForCommand(executedMarker: IMarker | undefined, endMarker: IMarker | undefined, buffer: IBuffer, cols: number, outputMatcher: ITerminalOutputMatcher): ITerminalOutputMatch | undefined {
+function getOutputMatchForCommand(executedMarker: IMarker | undefined, endMarker: IMarker | undefined, buffer: IBuffer, cols: number, outputMatcher: ITerminalOutputMatcher): ITerminalOutputMatch | undefined {
 	if (!executedMarker || !endMarker) {
 		return undefined;
 	}

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -465,7 +465,7 @@ const enum InteractionState {
 	Session = 'Session'
 }
 
-export class PersistentTerminalProcess extends Disposable {
+class PersistentTerminalProcess extends Disposable {
 
 	private readonly _bufferer: TerminalDataBufferer;
 	private readonly _autoReplies: Map<string, TerminalAutoResponder> = new Map();
@@ -951,7 +951,7 @@ function printTime(ms: number): string {
 	return `${_h}${_m}${_s}${_ms}`;
 }
 
-export interface ITerminalSerializer {
+interface ITerminalSerializer {
 	handleData(data: string): void;
 	freeRawReviveBuffer(): void;
 	handleResize(cols: number, rows: number): void;

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -216,7 +216,7 @@ export function getShellIntegrationInjection(
 	return undefined;
 }
 
-export enum ShellIntegrationExecutable {
+enum ShellIntegrationExecutable {
 	WindowsPwsh = 'windows-pwsh',
 	WindowsPwshLogin = 'windows-pwsh-login',
 	Pwsh = 'pwsh',
@@ -226,7 +226,7 @@ export enum ShellIntegrationExecutable {
 	Bash = 'bash'
 }
 
-export const shellIntegrationArgs: Map<ShellIntegrationExecutable, string[]> = new Map();
+const shellIntegrationArgs: Map<ShellIntegrationExecutable, string[]> = new Map();
 // The try catch swallows execution policy errors in the case of the archive distributable
 shellIntegrationArgs.set(ShellIntegrationExecutable.WindowsPwsh, ['-noexit', '-command', 'try { . \"{0}\\out\\vs\\workbench\\contrib\\terminal\\browser\\media\\shellIntegration.ps1\" } catch {}{1}']);
 shellIntegrationArgs.set(ShellIntegrationExecutable.WindowsPwshLogin, ['-l', '-noexit', '-command', 'try { . \"{0}\\out\\vs\\workbench\\contrib\\terminal\\browser\\media\\shellIntegration.ps1\" } catch {}{1}']);

--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -365,10 +365,6 @@ export interface IFsProvider {
 	readFile(path: string): Promise<Buffer>;
 }
 
-export interface IProfileVariableResolver {
-	resolve(text: string[]): Promise<string[]>;
-}
-
 interface IPotentialTerminalProfile {
 	profileName: string;
 	paths: string[];

--- a/src/vs/workbench/api/common/extHostTerminalService.ts
+++ b/src/vs/workbench/api/common/extHostTerminalService.ts
@@ -248,7 +248,7 @@ export class ExtHostTerminal {
 	}
 }
 
-export class ExtHostPseudoterminal implements ITerminalChildProcess {
+class ExtHostPseudoterminal implements ITerminalChildProcess {
 	readonly id = 0;
 	readonly shouldPersist = false;
 
@@ -861,7 +861,7 @@ export abstract class BaseExtHostTerminalService extends Disposable implements I
 	}
 }
 
-export class EnvironmentVariableCollection implements vscode.EnvironmentVariableCollection {
+class EnvironmentVariableCollection implements vscode.EnvironmentVariableCollection {
 	readonly map: Map<string, vscode.EnvironmentVariableMutator> = new Map();
 	private _persistent: boolean = true;
 

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLink.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLink.ts
@@ -9,15 +9,10 @@ import * as dom from 'vs/base/browser/dom';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { convertBufferRangeToViewport } from 'vs/workbench/contrib/terminal/browser/links/terminalLinkHelpers';
 import { isMacintosh } from 'vs/base/common/platform';
-import { localize } from 'vs/nls';
 import { Emitter, Event } from 'vs/base/common/event';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { TerminalLinkType } from 'vs/workbench/contrib/terminal/browser/links/links';
 import { IHoverAction } from 'vs/workbench/services/hover/browser/hover';
-
-export const OPEN_FILE_LABEL = localize('openFile', 'Open file in editor');
-export const FOLDER_IN_WORKSPACE_LABEL = localize('focusFolder', 'Focus folder in explorer');
-export const FOLDER_NOT_IN_WORKSPACE_LABEL = localize('openFolder', 'Open folder in new window');
 
 export class TerminalLink extends DisposableStore implements ILink {
 	decorations: ILinkDecorations;

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkHelpers.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkHelpers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { IViewportRange, IBufferRange, IBufferLine, IBufferCellPosition, IBuffer } from 'xterm';
+import type { IViewportRange, IBufferRange, IBufferLine, IBuffer } from 'xterm';
 import { IRange } from 'vs/editor/common/core/range';
 import { OperatingSystem } from 'vs/base/common/platform';
 import { IPath, posix, win32 } from 'vs/base/common/path';
@@ -139,18 +139,18 @@ export function getXtermLineContent(buffer: IBuffer, lineStart: number, lineEnd:
 }
 
 
-export function positionIsInRange(position: IBufferCellPosition, range: IBufferRange): boolean {
-	if (position.y < range.start.y || position.y > range.end.y) {
-		return false;
-	}
-	if (position.y === range.start.y && position.x < range.start.x) {
-		return false;
-	}
-	if (position.y === range.end.y && position.x > range.end.x) {
-		return false;
-	}
-	return true;
-}
+// export function positionIsInRange(position: IBufferCellPosition, range: IBufferRange): boolean {
+// 	if (position.y < range.start.y || position.y > range.end.y) {
+// 		return false;
+// 	}
+// 	if (position.y === range.start.y && position.x < range.start.x) {
+// 		return false;
+// 	}
+// 	if (position.y === range.end.y && position.x > range.end.x) {
+// 		return false;
+// 	}
+// 	return true;
+// }
 
 /**
  * For shells with the CommandDetection capability, the cwd for a command relative to the line of

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkManager.ts
@@ -36,7 +36,6 @@ import { convertBufferRangeToViewport } from 'vs/workbench/contrib/terminal/brow
 import { RunOnceScheduler } from 'vs/base/common/async';
 
 export type XtermLinkMatcherHandler = (event: MouseEvent | undefined, link: string) => Promise<void>;
-export type XtermLinkMatcherValidationCallback = (uri: string, callback: (isValid: boolean) => void) => void;
 
 interface IPath {
 	join(...paths: string[]): string;

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -414,14 +414,6 @@ export interface ISearchOptions {
 	incremental?: boolean;
 }
 
-export interface ITerminalBeforeHandleLinkEvent {
-	terminal?: ITerminalInstance;
-	/** The text of the link */
-	link: string;
-	/** Call with whether the link was handled by the interceptor */
-	resolve(wasHandled: boolean): void;
-}
-
 export interface ITerminalInstance {
 	/**
 	 * The ID of the terminal instance, this is an arbitrary number only used to uniquely identify

--- a/src/vs/workbench/contrib/terminal/browser/terminalQuickFixBuiltinActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalQuickFixBuiltinActions.ts
@@ -12,7 +12,7 @@ import { TerminalQuickFixType } from 'vs/workbench/contrib/terminal/browser/widg
 export const GitCommandLineRegex = /git/;
 export const GitPushCommandLineRegex = /git\s+push/;
 export const GitTwoDashesRegex = /error: did you mean `--(.+)` \(with two dashes\)\?/;
-export const AnyCommandLineRegex = /.+/;
+const AnyCommandLineRegex = /.+/;
 export const GitSimilarOutputRegex = /(?:(most similar (command|commands) (is|are)))((\n\s*(?<fixedCommand>[^\s]+))+)/m;
 export const FreePortOutputRegex = /address already in use (0\.0\.0\.0|127\.0\.0\.1|localhost|::):(?<portNumber>\d{4,5})|Unable to bind [^ ]*:(\d{4,5})|can't listen on port (\d{4,5})|listen EADDRINUSE [^ ]*:(\d{4,5})/;
 export const GitPushOutputRegex = /git push --set-upstream origin (?<branchName>[^\s]+)/;

--- a/src/vs/workbench/contrib/terminal/test/browser/links/terminalLinkOpeners.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/links/terminalLinkOpeners.test.ts
@@ -27,7 +27,7 @@ import { IFileQuery, ISearchComplete, ISearchService } from 'vs/workbench/servic
 import { SearchService } from 'vs/workbench/services/search/common/searchService';
 import { ITerminalOutputMatcher } from 'vs/platform/terminal/common/xterm/terminalQuickFix';
 
-export interface ITerminalLinkActivationResult {
+interface ITerminalLinkActivationResult {
 	source: 'editor' | 'search';
 	link: string;
 	selection?: ITextEditorSelection;


### PR DESCRIPTION
Part of #164941

---

Symbols that are correctly exported because they are referenced in other symbols that are exported:

- `IMenuEntryActionViewItemOptions`
- `ILinuxEnv`
- `EnvironmentVariableMutatorType`
- `IEnvironmentVariableMutator`
- `IBaseUnresolvedTerminalProfile`
- `ITerminalFormatMessageOptions`
- `ISearchOptions`
- `TerminalQuickFixCallback`
- `IProfileContextProvider`
- `IEventEmitter`
- `ITerminalExternalLinkType`
- `IResolvedValidLink`
- `IActivateLinkEvent`
- `IShowHoverEvent`
- `ConfirmOnExit`

Symbols that are correctly exported because they are referenced in tests:

- `deserializeMessage`