### PR TITLE
Don't refresh list if list is not defined

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -96,6 +96,10 @@ export class OpenEditorsView extends ViewPane {
 		this.structuralRefreshDelay = 0;
 		let labelChangeListeners: IDisposable[] = [];
 		this.listRefreshScheduler = new RunOnceScheduler(() => {
+			// No need to refresh the list if it's not rendered
+			if (!this.list) {
+				return;
+			}
 			labelChangeListeners = dispose(labelChangeListeners);
 			const previousLength = this.list.length;
 			const elements = this.getElements();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/167536


Unable to reproduce on my end, and now sure why the list might be undefined but if it is no need to run the refresh scheduler.