### PR TITLE
tunnels: add preview dialog for turning on tunnel access

### DIFF
--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -595,7 +595,7 @@ pub enum TunnelSubcommand {
 	#[clap(subcommand)]
 	User(TunnelUserSubCommands),
 
-	/// Manages the tunnel when installed as a system service,
+	/// (Preview) Manages the tunnel when installed as a system service,
 	#[clap(subcommand)]
 	Service(TunnelServiceSubCommands),
 }

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -494,7 +494,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 				if (!didNotifyPreview) {
 					const result = await dialogService.confirm({
 						message: localize('tunnel.preview', 'Remote Tunnels is currently in preview. Please report any problems using the "Help: Report Issue" command.'),
-						primaryButton: localize('ok', 'OK'),
+						primaryButton: localize('enable', 'Enable'),
 						secondaryButton: localize('cancel', 'Cancel'),
 					});
 					if (!result.confirmed) {

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -52,6 +52,7 @@ export const REMOTE_TUNNEL_CONNECTION_STATE = new RawContextKey<CONTEXT_KEY_STAT
 const SESSION_ID_STORAGE_KEY = 'remoteTunnelAccountPreference';
 
 const REMOTE_TUNNEL_USED_STORAGE_KEY = 'remoteTunnelServiceUsed';
+const REMOTE_TUNNEL_PROMPTED_PREVIEW_STORAGE_KEY = 'remoteTunnelServicePromptedPreview';
 const REMOTE_TUNNEL_EXTENSION_RECOMMENDED_KEY = 'remoteTunnelExtensionRecommended';
 
 type ExistingSessionItem = { session: AuthenticationSession; providerId: string; label: string; description: string };
@@ -487,6 +488,21 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 				const clipboardService = accessor.get(IClipboardService);
 				const commandService = accessor.get(ICommandService);
 				const storageService = accessor.get(IStorageService);
+				const dialogService = accessor.get(IDialogService);
+
+				const didNotifyPreview = storageService.getBoolean(REMOTE_TUNNEL_PROMPTED_PREVIEW_STORAGE_KEY, StorageScope.APPLICATION, false);
+				if (!didNotifyPreview) {
+					const result = await dialogService.confirm({
+						message: localize('tunnel.preview', 'Remote Tunnels is currently in preview. Please report any problems using the "Help: Report Issue" command, or on Github.'),
+						primaryButton: localize('ok', 'OK'),
+						secondaryButton: localize('cancel', 'Cancel'),
+					});
+					if (!result.confirmed) {
+						return;
+					}
+
+					storageService.store(REMOTE_TUNNEL_PROMPTED_PREVIEW_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+				}
 
 				const connectionInfo = await that.startTunnel(false);
 				if (connectionInfo) {
@@ -548,7 +564,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 			constructor() {
 				super({
 					id: RemoteTunnelCommandIds.connecting,
-					title: localize('remoteTunnel.actions.manage.connecting', 'Remote Tunnel Access in Connecting'),
+					title: localize('remoteTunnel.actions.manage.connecting', 'Remote Tunnel Access is Connecting'),
 					category: REMOTE_TUNNEL_CATEGORY,
 					menu: [{
 						id: MenuId.AccountsContext,

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -493,7 +493,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 				const didNotifyPreview = storageService.getBoolean(REMOTE_TUNNEL_PROMPTED_PREVIEW_STORAGE_KEY, StorageScope.APPLICATION, false);
 				if (!didNotifyPreview) {
 					const result = await dialogService.confirm({
-						message: localize('tunnel.preview', 'Remote Tunnels is currently in preview. Please report any problems using the "Help: Report Issue" command, or on Github.'),
+						message: localize('tunnel.preview', 'Remote Tunnels is currently in preview. Please report any problems using the "Help: Report Issue" command.'),
 						primaryButton: localize('ok', 'OK'),
 						secondaryButton: localize('cancel', 'Cancel'),
 					});


### PR DESCRIPTION
Cherry pick of https://github.com/microsoft/vscode/pull/167950

Adds a dialog that notifies the user about the preview status of the feature, shown the first time the user turns on remote tunnel access. Also marks the "service" feature of the CLI explicitly as preview pending https://github.com/microsoft/vscode/issues/167741