### PR TITLE
Include {} in shell env json regex match

### DIFF
--- a/src/vs/platform/shell/node/shellEnv.ts
+++ b/src/vs/platform/shell/node/shellEnv.ts
@@ -106,7 +106,7 @@ async function doResolveUnixShellEnv(logService: ILogService, token: Cancellatio
 	logService.trace('getUnixShellEnvironment#noAttach', noAttach);
 
 	const mark = generateUuid().replace(/-/g, '').substr(0, 12);
-	const regex = new RegExp(mark + '(.*)' + mark);
+	const regex = new RegExp(mark + '({.*})' + mark);
 
 	const env = {
 		...process.env,


### PR DESCRIPTION
This fixes an issue where users would add something like the following to their ~/bashrc file:

trap 'echo -ne "\033]0;$BASH_COMMAND\007"' DEBUG

What this does is it echos a signal to the terminal to change the title of the terminal. This ends up coming through in the result being parsed which now includes 4 marks instead of 2. The change ensures { and } are following and before the 2 expected marks.

If the match doesn't exist it will still fallback to {} as it did before.

Fixes #147630
