### PR TITLE
Pick up latest TS for building VS code

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "ts-loader": "^9.2.7",
     "ts-node": "^10.9.1",
     "tsec": "0.1.4",
-    "typescript": "^5.0.0-dev.20221108",
+    "typescript": "^5.0.0-dev.20221201",
     "typescript-formatter": "7.1.0",
     "underscore": "^1.12.1",
     "util": "^0.12.4",

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -385,6 +385,8 @@ export const enum CompletionItemTag {
 }
 
 export const enum CompletionItemInsertTextRule {
+	None = 0,
+
 	/**
 	 * Adjust whitespace/indentation of multiline insert texts to
 	 * match the current line indentation.

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -21,6 +21,7 @@ export enum CodeActionTriggerType {
 }
 
 export enum CompletionItemInsertTextRule {
+	None = 0,
 	/**
 	 * Adjust whitespace/indentation of multiline insert texts to
 	 * match the current line indentation.

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -94,6 +94,7 @@ class LineSuffix {
 }
 
 const enum InsertFlags {
+	None = 0,
 	NoBeforeUndoStop = 1,
 	NoAfterUndoStop = 2,
 	KeepAlternativeSuggestions = 4,
@@ -146,7 +147,7 @@ export class SuggestController implements IEditorContribution {
 			const widget = this._instantiationService.createInstance(SuggestWidget, this.editor);
 
 			this._toDispose.add(widget);
-			this._toDispose.add(widget.onDidSelect(item => this._insertSuggestion(item, 0), this));
+			this._toDispose.add(widget.onDidSelect(item => this._insertSuggestion(item, InsertFlags.None), this));
 
 			// Wire up logic to accept a suggestion on certain characters
 			const commitCharacterController = new CommitCharacterController(this.editor, widget, this.model, item => this._insertSuggestion(item, InsertFlags.NoAfterUndoStop));

--- a/src/vs/editor/test/common/model/tokensStore.test.ts
+++ b/src/vs/editor/test/common/model/tokensStore.test.ts
@@ -19,7 +19,7 @@ import { ILanguageConfigurationService, LanguageConfigurationService } from 'vs/
 
 suite('TokensStore', () => {
 
-	const SEMANTIC_COLOR: ColorId = 5;
+	const SEMANTIC_COLOR = 5 as ColorId;
 
 	function parseTokensState(state: string[]): { text: string; tokens: SparseMultilineTokens } {
 		const text: string[] = [];

--- a/src/vs/editor/test/common/modes/textToHtmlTokenizer.test.ts
+++ b/src/vs/editor/test/common/modes/textToHtmlTokenizer.test.ts
@@ -305,9 +305,9 @@ class Mode extends Disposable {
 			tokenize: undefined!,
 			tokenizeEncoded: (line: string, hasEOL: boolean, state: IState): EncodedTokenizationResult => {
 				const tokensArr: number[] = [];
-				let prevColor: ColorId = -1;
+				let prevColor = -1 as ColorId;
 				for (let i = 0; i < line.length; i++) {
-					const colorId: ColorId = line.charAt(i) === '.' ? 7 : 9;
+					const colorId = (line.charAt(i) === '.' ? 7 : 9) as ColorId;
 					if (prevColor !== colorId) {
 						tokensArr.push(i);
 						tokensArr.push((

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6463,6 +6463,7 @@ declare namespace monaco.languages {
 	}
 
 	export enum CompletionItemInsertTextRule {
+		None = 0,
 		/**
 		 * Adjust whitespace/indentation of multiline insert texts to
 		 * match the current line indentation.

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -442,6 +442,11 @@ export interface IWatchOptions {
 export const enum FileSystemProviderCapabilities {
 
 	/**
+	 * No capabilities.
+	 */
+	None = 0,
+
+	/**
 	 * Provider supports unbuffered read/write.
 	 */
 	FileReadWrite = 1 << 1,

--- a/src/vs/platform/instantiation/common/instantiationService.ts
+++ b/src/vs/platform/instantiation/common/instantiationService.ts
@@ -330,7 +330,10 @@ export class InstantiationService implements IInstantiationService {
 //#region -- tracing ---
 
 const enum TraceType {
-	Creation, Invocation, Branch
+	None = 0,
+	Creation = 1,
+	Invocation = 2,
+	Branch = 3,
 }
 
 export class Trace {
@@ -338,7 +341,7 @@ export class Trace {
 	static all = new Set<string>();
 
 	private static readonly _None = new class extends Trace {
-		constructor() { super(-1, null); }
+		constructor() { super(TraceType.None, null); }
 		override stop() { }
 		override branch() { return this; }
 	};

--- a/src/vs/platform/uriIdentity/test/common/uriIdentityService.test.ts
+++ b/src/vs/platform/uriIdentity/test/common/uriIdentityService.test.ts
@@ -34,7 +34,7 @@ suite('URI Identity', function () {
 	setup(function () {
 		_service = new UriIdentityService(new FakeFileService(new Map([
 			['bar', FileSystemProviderCapabilities.PathCaseSensitive],
-			['foo', 0]
+			['foo', FileSystemProviderCapabilities.None]
 		])));
 	});
 

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1021,7 +1021,7 @@ class CompletionsAdapter {
 			[extHostProtocol.ISuggestDataDtoField.sortText]: item.sortText !== item.label ? item.sortText : undefined,
 			[extHostProtocol.ISuggestDataDtoField.filterText]: item.filterText !== item.label ? item.filterText : undefined,
 			[extHostProtocol.ISuggestDataDtoField.preselect]: item.preselect || undefined,
-			[extHostProtocol.ISuggestDataDtoField.insertTextRules]: item.keepWhitespace ? languages.CompletionItemInsertTextRule.KeepWhitespace : 0,
+			[extHostProtocol.ISuggestDataDtoField.insertTextRules]: item.keepWhitespace ? languages.CompletionItemInsertTextRule.KeepWhitespace : languages.CompletionItemInsertTextRule.None,
 			[extHostProtocol.ISuggestDataDtoField.commitCharacters]: item.commitCharacters?.join(''),
 			[extHostProtocol.ISuggestDataDtoField.additionalTextEdits]: item.additionalTextEdits && item.additionalTextEdits.map(typeConvert.TextEdit.from),
 			[extHostProtocol.ISuggestDataDtoField.commandIdent]: command?.$ident,

--- a/src/vs/workbench/api/test/browser/extHostDiagnostics.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostDiagnostics.test.ts
@@ -505,7 +505,7 @@ suite('ExtHostDiagnostics', () => {
 				startColumn: 1,
 				endLineNumber: 1,
 				endColumn: 1,
-				severity: 3
+				severity: MarkerSeverity.Info
 			}];
 
 			const p1 = Event.toPromise(diags.onDidChangeDiagnostics);

--- a/src/vs/workbench/api/test/browser/extHostTextEditor.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTextEditor.test.ts
@@ -21,7 +21,7 @@ suite('ExtHostTextEditor', () => {
 	], '\n', 1, 'text', false);
 
 	setup(() => {
-		editor = new ExtHostTextEditor('fake', null!, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4, indentSize: 4 }, [], 1);
+		editor = new ExtHostTextEditor('fake', null!, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: TextEditorCursorStyle.Line, insertSpaces: true, lineNumbers: 1, tabSize: 4, indentSize: 4 }, [], 1);
 	});
 
 	test('disposed editor', () => {
@@ -48,7 +48,7 @@ suite('ExtHostTextEditor', () => {
 					applyCount += 1;
 					return Promise.resolve(true);
 				}
-			}, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: 0, insertSpaces: true, lineNumbers: 1, tabSize: 4, indentSize: 4 }, [], 1);
+			}, new NullLogService(), new Lazy(() => doc.document), [], { cursorStyle: TextEditorCursorStyle.Line, insertSpaces: true, lineNumbers: 1, tabSize: 4, indentSize: 4 }, [], 1);
 
 		await editor.value.edit(edit => { });
 		assert.strictEqual(applyCount, 0);

--- a/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview.ts
@@ -83,7 +83,7 @@ export const enum BulkFileOperationType {
 
 export class BulkFileOperation {
 
-	type: BulkFileOperationType = 0;
+	type = 0;
 	textEdits: BulkTextEdit[] = [];
 	originalEdits = new Map<number, ResourceTextEdit | ResourceFileEdit>();
 	newUri?: URI;

--- a/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
@@ -421,10 +421,10 @@ registerAction2(class ChangeCellLanguageAction extends NotebookCellAction<ICellR
 			...mainItems
 		];
 
-		const selection = await quickInputService.pick(picks, { placeHolder: localize('pickLanguageToConfigure', "Select Language Mode") }) as ILanguagePickInput | undefined;
+		const selection = await quickInputService.pick(picks, { placeHolder: localize('pickLanguageToConfigure', "Select Language Mode") });
 		const languageId = selection === autoDetectMode
 			? await languageDetectionService.detectLanguage(context.cell.uri)
-			: selection?.languageId;
+			: (selection as ILanguagePickInput)?.languageId;
 
 		if (languageId) {
 			await this.setLanguage(context, languageId);

--- a/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
@@ -14,7 +14,7 @@ import { TestConfigurationService } from 'vs/platform/configuration/test/common/
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { USLayoutResolvedKeybinding } from 'vs/platform/keybinding/common/usLayoutResolvedKeybinding';
-import { IFileMatch } from 'vs/workbench/services/search/common/search';
+import { IFileMatch, QueryType } from 'vs/workbench/services/search/common/search';
 import { getElementToFocusAfterRemoved, getLastNodeFromSameType } from 'vs/workbench/contrib/search/browser/searchActionsRemoveReplace';
 import { FileMatch, FileMatchOrMatch, FolderMatch, Match, SearchModel } from 'vs/workbench/contrib/search/common/searchModel';
 import { MockObjectTree } from 'vs/workbench/contrib/search/test/browser/mockSearchTree';
@@ -112,7 +112,7 @@ suite('Search Actions', () => {
 
 		const searchModel = instantiationService.createInstance(SearchModel);
 		const folderMatch = instantiationService.createInstance(FolderMatch, URI.file('somepath'), '', 0, {
-			type: 1, folderQueries: [{ folder: createFileUriFromPathFromRoot() }], contentPattern: {
+			type: QueryType.Text, folderQueries: [{ folder: createFileUriFromPathFromRoot() }], contentPattern: {
 				pattern: ''
 			}
 		}, searchModel.searchResult, searchModel, null);

--- a/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
@@ -177,7 +177,7 @@ suite('Search - Viewlet', () => {
 	function aFolderMatch(path: string, index: number, parent?: SearchResult): FolderMatch {
 		const searchModel = instantiation.createInstance(SearchModel);
 		return instantiation.createInstance(FolderMatch, createFileUriFromPathFromRoot(path), path, index, {
-			type: 1, folderQueries: [{ folder: createFileUriFromPathFromRoot() }], contentPattern: {
+			type: QueryType.Text, folderQueries: [{ folder: createFileUriFromPathFromRoot() }], contentPattern: {
 				pattern: ''
 			}
 		}, parent ?? aSearchResult().folderMatches()[0], searchModel, null);
@@ -186,7 +186,7 @@ suite('Search - Viewlet', () => {
 	function aSearchResult(): SearchResult {
 		const searchModel = instantiation.createInstance(SearchModel);
 		searchModel.searchResult.query = {
-			type: 1, folderQueries: [{ folder: createFileUriFromPathFromRoot() }], contentPattern: {
+			type: QueryType.Text, folderQueries: [{ folder: createFileUriFromPathFromRoot() }], contentPattern: {
 				pattern: ''
 			}
 		};

--- a/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
@@ -13,7 +13,7 @@ import { ModelService } from 'vs/editor/common/services/modelService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
-import { IFileMatch, IFileSearchStats, IFolderQuery, ISearchComplete, ISearchProgressItem, ISearchQuery, ISearchService, ITextSearchMatch, OneLineRange, TextSearchMatch } from 'vs/workbench/services/search/common/search';
+import { IFileMatch, IFileSearchStats, IFolderQuery, ISearchComplete, ISearchProgressItem, ISearchQuery, ISearchService, ITextSearchMatch, OneLineRange, QueryType, TextSearchMatch } from 'vs/workbench/services/search/common/search';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
 import { SearchModel } from 'vs/workbench/contrib/search/common/searchModel';
@@ -137,7 +137,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, searchServiceWithResults(results));
 
 		const testObject: SearchModel = instantiationService.createInstance(SearchModel);
-		await testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
+		await testObject.search({ contentPattern: { pattern: 'somestring' }, type: QueryType.Text, folderQueries });
 
 		const actual = testObject.searchResult.matches();
 
@@ -168,7 +168,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, searchServiceWithResults(results));
 
 		const testObject: SearchModel = instantiationService.createInstance(SearchModel);
-		await testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
+		await testObject.search({ contentPattern: { pattern: 'somestring' }, type: QueryType.Text, folderQueries });
 
 		assert.ok(target.calledThrice);
 		const data = target.args[2];
@@ -185,7 +185,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, searchServiceWithResults([]));
 
 		const testObject = instantiationService.createInstance(SearchModel);
-		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
+		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: QueryType.Text, folderQueries });
 
 		return result.then(() => {
 			return timeout(1).then(() => {
@@ -206,7 +206,7 @@ suite('SearchModel', () => {
 			{ results: [], stats: testSearchStats, messages: [] }));
 
 		const testObject = instantiationService.createInstance(SearchModel);
-		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
+		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: QueryType.Text, folderQueries });
 
 		return result.then(() => {
 			return timeout(1).then(() => {
@@ -228,7 +228,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, searchServiceWithError(new Error('error')));
 
 		const testObject = instantiationService.createInstance(SearchModel);
-		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
+		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: QueryType.Text, folderQueries });
 
 		return result.then(() => { }, () => {
 			return timeout(1).then(() => {
@@ -249,7 +249,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, 'textSearch', deferredPromise.p);
 
 		const testObject = instantiationService.createInstance(SearchModel);
-		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
+		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: QueryType.Text, folderQueries });
 
 		deferredPromise.cancel();
 
@@ -271,12 +271,12 @@ suite('SearchModel', () => {
 				new TextSearchMatch('preview 2', lineOneRange))];
 		instantiationService.stub(ISearchService, searchServiceWithResults(results));
 		const testObject: SearchModel = instantiationService.createInstance(SearchModel);
-		await testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
+		await testObject.search({ contentPattern: { pattern: 'somestring' }, type: QueryType.Text, folderQueries });
 		assert.ok(!testObject.searchResult.isEmpty());
 
 		instantiationService.stub(ISearchService, searchServiceWithResults([]));
 
-		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
+		testObject.search({ contentPattern: { pattern: 'somestring' }, type: QueryType.Text, folderQueries });
 		assert.ok(testObject.searchResult.isEmpty());
 	});
 
@@ -285,9 +285,9 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, canceleableSearchService(tokenSource));
 		const testObject: SearchModel = instantiationService.createInstance(SearchModel);
 
-		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
+		testObject.search({ contentPattern: { pattern: 'somestring' }, type: QueryType.Text, folderQueries });
 		instantiationService.stub(ISearchService, searchServiceWithResults([]));
-		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
+		testObject.search({ contentPattern: { pattern: 'somestring' }, type: QueryType.Text, folderQueries });
 
 		assert.ok(tokenSource.token.isCancellationRequested);
 	});
@@ -300,24 +300,24 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, searchServiceWithResults(results));
 
 		const testObject: SearchModel = instantiationService.createInstance(SearchModel);
-		await testObject.search({ contentPattern: { pattern: 're' }, type: 1, folderQueries });
+		await testObject.search({ contentPattern: { pattern: 're' }, type: QueryType.Text, folderQueries });
 		testObject.replaceString = 'hello';
 		let match = testObject.searchResult.matches()[0].matches()[0];
 		assert.strictEqual('hello', match.replaceString);
 
-		await testObject.search({ contentPattern: { pattern: 're', isRegExp: true }, type: 1, folderQueries });
+		await testObject.search({ contentPattern: { pattern: 're', isRegExp: true }, type: QueryType.Text, folderQueries });
 		match = testObject.searchResult.matches()[0].matches()[0];
 		assert.strictEqual('hello', match.replaceString);
 
-		await testObject.search({ contentPattern: { pattern: 're(?:vi)', isRegExp: true }, type: 1, folderQueries });
+		await testObject.search({ contentPattern: { pattern: 're(?:vi)', isRegExp: true }, type: QueryType.Text, folderQueries });
 		match = testObject.searchResult.matches()[0].matches()[0];
 		assert.strictEqual('hello', match.replaceString);
 
-		await testObject.search({ contentPattern: { pattern: 'r(e)(?:vi)', isRegExp: true }, type: 1, folderQueries });
+		await testObject.search({ contentPattern: { pattern: 'r(e)(?:vi)', isRegExp: true }, type: QueryType.Text, folderQueries });
 		match = testObject.searchResult.matches()[0].matches()[0];
 		assert.strictEqual('hello', match.replaceString);
 
-		await testObject.search({ contentPattern: { pattern: 'r(e)(?:vi)', isRegExp: true }, type: 1, folderQueries });
+		await testObject.search({ contentPattern: { pattern: 'r(e)(?:vi)', isRegExp: true }, type: QueryType.Text, folderQueries });
 		testObject.replaceString = 'hello$1';
 		match = testObject.searchResult.matches()[0].matches()[0];
 		assert.strictEqual('helloe', match.replaceString);

--- a/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
@@ -483,7 +483,7 @@ suite('SearchResult', () => {
 	function aSearchResult(): SearchResult {
 		const searchModel = instantiationService.createInstance(SearchModel);
 		searchModel.searchResult.query = {
-			type: 1, folderQueries: [{ folder: createFileUriFromPathFromRoot() }], contentPattern: {
+			type: QueryType.Text, folderQueries: [{ folder: createFileUriFromPathFromRoot() }], contentPattern: {
 				pattern: ''
 			}
 		};

--- a/src/vs/workbench/contrib/testing/common/testItemCollection.ts
+++ b/src/vs/workbench/contrib/testing/common/testItemCollection.ts
@@ -673,7 +673,7 @@ export const createTestItemChildren = <T extends ITestItemLike>(api: ITestItemAp
 
 			for (const item of items) {
 				if (!(item instanceof checkCtor)) {
-					throw new InvalidTestItemError(item.id);
+					throw new InvalidTestItemError((item as ITestItemLike).id);
 				}
 
 				const itemController = getApi(item).controllerId;
@@ -705,7 +705,7 @@ export const createTestItemChildren = <T extends ITestItemLike>(api: ITestItemAp
 		/** @inheritdoc */
 		add(item: T) {
 			if (!(item instanceof checkCtor)) {
-				throw new InvalidTestItemError(item.id);
+				throw new InvalidTestItemError((item as ITestItemLike).id);
 			}
 
 			mapped.set(item.id, item);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10858,10 +10858,10 @@ typescript@^4.7.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
-typescript@^5.0.0-dev.20221108:
-  version "5.0.0-dev.20221108"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.0-dev.20221108.tgz#52cecdf226b983a33eadb2e6c9a8c040f7a7349f"
-  integrity sha512-np7hLTLHztenzHetS6xnYYo/P+VcjgUYWkblyl8jCeKgrC7fHJt1QlcjL83uC7YQiHLz5o9zgMZKtZbQBHPzkg==
+typescript@^5.0.0-dev.20221201:
+  version "5.0.0-dev.20221201"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.0-dev.20221201.tgz#b2d9cf51176cbe0b3f495247c5e5510fba53c1c6"
+  integrity sha512-0GunPFtrZITqx11PJQThb8MdXJwjk88mhOgNBXeme1d9i0mJzymceJysDpwu6sfajognk2yiN86P82xAvbJ0Lw==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Fixes a number of cases around enums: https://github.com/microsoft/TypeScript/pull/50528

- Adds `None` entries for a number of bitfield enums
- Adds casts for `ColorId`, which is open ended


/cc @jrieken @alexdima @connor4312 