### PR TITLE
Maindhfhfhththth

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -544,10 +544,10 @@ export class CodeApplication extends Disposable {
 
 		// Post Open Windows Tasks
 		appInstantiationService.invokeFunction(accessor => this.afterWindowOpen(accessor, sharedProcess));
-
 		// Set lifecycle phase to `Eventually` after a short delay and when idle (min 2.5sec, max 5sec)
 		const eventuallyPhaseScheduler = this._register(new RunOnceScheduler(() => {
 			this._register(runWhenIdle(() => this.lifecycleMainService.phase = LifecycleMainPhase.Eventually, 2500));
+			this.windowsMainService?.sendToAll('vscode.accessibilitySupportChanged', app.isAccessibilitySupportEnabled());
 		}, 2500));
 		eventuallyPhaseScheduler.schedule();
 	}
@@ -1137,8 +1137,6 @@ export class CodeApplication extends Disposable {
 
 		// Crash reporter
 		this.updateCrashReporterEnablement();
-
-		this.windowsMainService?.sendToAll('vscode.accessibilitySupportChanged', app.isAccessibilitySupportEnabled());
 	}
 
 	private async installMutex(): Promise<void> {

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1137,6 +1137,8 @@ export class CodeApplication extends Disposable {
 
 		// Crash reporter
 		this.updateCrashReporterEnablement();
+
+		this.windowsMainService?.sendToAll('vscode.accessibilitySupportChanged', app.isAccessibilitySupportEnabled());
 	}
 
 	private async installMutex(): Promise<void> {

--- a/src/vs/platform/accessibility/browser/accessibilityService.ts
+++ b/src/vs/platform/accessibility/browser/accessibilityService.ts
@@ -107,7 +107,7 @@ export class AccessibilityService extends Disposable implements IAccessibilitySe
 		if (this._accessibilitySupport === accessibilitySupport) {
 			return;
 		}
-
+		console.log('set accessibility support', accessibilitySupport);
 		this._accessibilitySupport = accessibilitySupport;
 		this._onDidChangeScreenReaderOptimized.fire();
 	}


### PR DESCRIPTION

On the plane I was reverse-engineering ipc.ts to implement it in Rust
and see if we could have a "service mode" for the CLI that we could
interact with like any other vscode process.

In doing so, I noticed that numbers in the protocol--which are used at
least twice in the message header and ID--were encoded as JSON. I was
curious what benefits we'd get from encoding them as variable-length
integers instead.

It makes the message shorter, as expected. Encode/decode time are very,
very slightly lower. I'm not sure it's worth the extra complexity, but
I have included it here for your consideration.

* fixup tests

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
