### PR TITLE
Fixes #167766: Return DocumentHighlightKind.Read for the textual occurences

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -155,7 +155,7 @@ class TextualOccurenceAtPositionRequest extends OccurenceAtPositionRequest {
 			return matches.map(m => {
 				return {
 					range: m.range,
-					kind: DocumentHighlightKind.Text
+					kind: DocumentHighlightKind.Read
 				};
 			});
 		});


### PR DESCRIPTION
Issue https://github.com/microsoft/vscode/issues/167766 makes a reasonable argument to use the word highlighting colors for textual occurrences (i.e. non semantic).

The thing is that this is all driven by `DocumentHighlightKind`, which can be: `Read`, `Write` or `Text`:
* `Read` uses `editor.wordHighlightBackground` / `editor.wordHighlightBorder`
* `Write` uses `editor.wordHighlightStrongBackground ` / `editor.wordHighlightStrongBorder `
* `Text` uses `editor.selectionHighlightBackground` / `editor.selectionHighlightBorder`

Perhaps there are many extensions which use `DocumentHighlightKind.Text` and expect that they get the `editor.selectionHighlightBackground` color, so this proposed change is to modify that the textual computer (the one that isn't semantic) to return `DocumentHighlightKind.Read`.

An alternative change would have been to introduce a new color for `DocumentHighlightKind.Text` that would not be `editor.selectionHighlightBackground`.

Thoughts?