### PR TITLE
Forward the configured value for `editor.cursorBlinking` (for accessibility purposes)

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -646,6 +646,9 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 		const config = this.configurationService.getValue<IDebugConfiguration>('debug');
 		options.acceptSuggestionOnEnter = config.console.acceptSuggestionOnEnter === 'on' ? 'on' : 'off';
 		options.ariaLabel = localize('debugConsole', "Debug Console");
+		// We must respect some accessibility related settings
+		options.accessibilitySupport = this.configurationService.getValue<'auto' | 'off' | 'on'>('editor.accessibilitySupport');
+		options.cursorBlinking = this.configurationService.getValue<'blink' | 'smooth' | 'phase' | 'expand' | 'solid'>('editor.cursorBlinking');
 
 		this.replInput = this.scopedInstantiationService.createInstance(CodeEditorWidget, this.replInputContainer, options, getSimpleCodeEditorWidgetOptions());
 

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1920,9 +1920,9 @@ class SCMInputWidget {
 		const fontFamily = this.getInputEditorFontFamily();
 		const fontSize = this.getInputEditorFontSize();
 		const lineHeight = this.computeLineHeight(fontSize);
-		// We respect the configured `editor.accessibilitySupport` setting to be able to have wrapping
-		// even when a screen reader is attached.
+		// We must respect some accessibility related settings
 		const accessibilitySupport = this.configurationService.getValue<'auto' | 'off' | 'on'>('editor.accessibilitySupport');
+		const cursorBlinking = this.configurationService.getValue<'blink' | 'smooth' | 'phase' | 'expand' | 'solid'>('editor.cursorBlinking');
 
 		this.setPlaceholderFontStyles(fontFamily, fontSize, lineHeight);
 
@@ -1945,7 +1945,8 @@ class SCMInputWidget {
 			overflowWidgetsDomNode,
 			renderWhitespace: 'none',
 			dropIntoEditor: { enabled: true },
-			accessibilitySupport
+			accessibilitySupport,
+			cursorBlinking
 		};
 
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
@@ -2004,10 +2005,11 @@ class SCMInputWidget {
 			'scm.inputFontFamily',
 			'editor.fontFamily', // When `scm.inputFontFamily` is 'editor', we use it as an effective value
 			'scm.inputFontSize',
-			'editor.accessibilitySupport'
+			'editor.accessibilitySupport',
+			'editor.cursorBlinking'
 		];
 
-		const onInputFontFamilyChanged = Event.filter(
+		const onRelevantSettingChanged = Event.filter(
 			this.configurationService.onDidChangeConfiguration,
 			(e) => {
 				for (const setting of relevantSettings) {
@@ -2019,17 +2021,19 @@ class SCMInputWidget {
 			},
 			this.disposables
 		);
-		this.disposables.add(onInputFontFamilyChanged(() => {
+		this.disposables.add(onRelevantSettingChanged(() => {
 			const fontFamily = this.getInputEditorFontFamily();
 			const fontSize = this.getInputEditorFontSize();
 			const lineHeight = this.computeLineHeight(fontSize);
 			const accessibilitySupport = this.configurationService.getValue<'auto' | 'off' | 'on'>('editor.accessibilitySupport');
+			const cursorBlinking = this.configurationService.getValue<'blink' | 'smooth' | 'phase' | 'expand' | 'solid'>('editor.cursorBlinking');
 
 			this.inputEditor.updateOptions({
 				fontFamily: fontFamily,
 				fontSize: fontSize,
 				lineHeight: lineHeight,
-				accessibilitySupport
+				accessibilitySupport,
+				cursorBlinking
 			});
 
 			this.setPlaceholderFontStyles(fontFamily, fontSize, lineHeight);


### PR DESCRIPTION
Fixes #131941