### PR TITLE
Add names to scm status bar items

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/activity.ts
+++ b/src/vs/workbench/contrib/scm/browser/activity.ts
@@ -154,8 +154,22 @@ export class SCMStatusController implements IWorkbenchContribution {
 			const command = commands[index];
 			const tooltip = `${label}${command.tooltip ? ` - ${command.tooltip}` : ''}`;
 
+			// Get a repository agnostic name for the status bar action, derive this from the
+			// first command argument which is in the form "git.<command>/<number>"
+			let repoAgnosticActionName = command.arguments?.[0];
+			if (repoAgnosticActionName && typeof repoAgnosticActionName === 'string') {
+				repoAgnosticActionName = repoAgnosticActionName
+					.substring(0, repoAgnosticActionName.lastIndexOf('/'))
+					.replace(/^git\./, '');
+				if (repoAgnosticActionName.length > 1) {
+					repoAgnosticActionName = repoAgnosticActionName[0].toLocaleUpperCase() + repoAgnosticActionName.slice(1);
+				}
+			} else {
+				repoAgnosticActionName = '';
+			}
+
 			disposables.add(this.statusbarService.addEntry({
-				name: localize('status.scm', "Source Control"),
+				name: localize('status.scm', "Source Control") + (repoAgnosticActionName ? ` ${repoAgnosticActionName}` : ''),
 				text: command.title,
 				ariaLabel: tooltip,
 				tooltip,


### PR DESCRIPTION
Fixes #168221

There's probably a nicer way of doing this by wiring an action type through the exthost, but I believe this does fix the issue.

After hiding the checkout item and switching to another repo:

![image](https://user-images.githubusercontent.com/2193314/206029474-71b40a28-07ae-4b1c-8e3b-642f69bfb44b.png)
