### PR TITLE
debug: bump js-debug

### DIFF
--- a/product.json
+++ b/product.json
@@ -47,7 +47,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.74.0",
+			"version": "1.74.1",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
This PR contains the following changes: https://github.com/microsoft/vscode-js-debug/compare/c30942566f58d0bf6d6516bc3b59d08cc9cd5999...release/1.74.1

It addresses https://github.com/microsoft/vscode-js-debug/issues/1469, which was caused by the generation of pathological regexes that took 100ms+ to match. While the code change included diff is not simple, the severity of crashing the extension host may warrant this being included in a recovery release.