### PR TITLE
Match quick pick button height to input height

### DIFF
--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -125,7 +125,7 @@
 	font-size: 11px;
 	padding: 0 6px;
 	display: flex;
-	height: 27.5px;
+	height: 25px;
 	align-items: center;
 }
 


### PR DESCRIPTION
Fix #158606

## Before

<img width="167" alt="CleanShot 2022-12-06 at 15 21 19@2x" src="https://user-images.githubusercontent.com/25163139/206046639-c75e9d54-e20c-45bf-b9ea-925cd50fce56.png">

## After

<img width="187" alt="CleanShot 2022-12-06 at 15 21 09@2x" src="https://user-images.githubusercontent.com/25163139/206046655-112c8949-b5a5-4843-af48-cbada78814df.png">

