### PR TITLE
Fix tab close icon margin when positioned on the left

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -171,10 +171,6 @@
 	position: static; /** disable sticky positions for sticky compact/shrink tabs if the available space is too little */
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-left .action-label {
-	margin-right: 4px !important;
-}
-
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.tab-actions-left::after,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.tab-actions-off::after {
 	content: '';


### PR DESCRIPTION
Fix #158625

## Before

<img width="154" alt="CleanShot 2022-12-06 at 15 26 26@2x" src="https://user-images.githubusercontent.com/25163139/206047281-adc76557-b0a9-4af3-8ee9-eec12f534fec.png">

## After

<img width="160" alt="CleanShot 2022-12-06 at 15 26 10@2x" src="https://user-images.githubusercontent.com/25163139/206047262-8622ebd6-5b21-4784-8eea-8e6476837438.png">




