### PR TITLE
fix anyScore firstMatchCanBeWeak

### DIFF
--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -381,7 +381,7 @@ export function matchesFuzzy2(pattern: string, word: string): IMatch[] | null {
 export function anyScore(pattern: string, lowPattern: string, patternPos: number, word: string, lowWord: string, wordPos: number): FuzzyScore {
 	const max = Math.min(13, pattern.length);
 	for (; patternPos < max; patternPos++) {
-		const result = fuzzyScore(pattern, lowPattern, patternPos, word, lowWord, wordPos, { firstMatchCanBeWeak: false, boostFullMatch: true });
+		const result = fuzzyScore(pattern, lowPattern, patternPos, word, lowWord, wordPos, { firstMatchCanBeWeak: true, boostFullMatch: true });
 		if (result) {
 			return result;
 		}

--- a/src/vs/base/test/common/filters.test.ts
+++ b/src/vs/base/test/common/filters.test.ts
@@ -562,6 +562,11 @@ suite('Filters', () => {
 		assertMatches('.', 'log', 'log', anyScore);
 	});
 
+	test('anyScore should not require a strong first match', function () {
+		assertMatches('bar', 'foobAr', 'foo^b^A^r', anyScore);
+		assertMatches('bar', 'foobar', 'foo^b^a^r', anyScore);
+	});
+
 	test('configurable full match boost', function () {
 		const prefix = 'create';
 		const a = 'createModelServices';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes #168265 

given a completion item with `filterText = "x_fooBar"` and `label = "fooBar"`, and a pattern of `"ob"`, `anyScore` is called because the filterText != label:

https://github.com/microsoft/vscode/blob/220f9387c973de4cc44c545642ad2c90170bd3ef/src/vs/editor/contrib/suggest/browser/completionModel.ts#L213

`anyScore` calls `fuzzyScore` with `firstMatchCanBeWeak = false`, which means that `fuzzyScore("ob", ..., "fooBar", ...)` does not match. then it tries `fuzzyScore("b", ..., "fooBar", ...)`, which does match, so it highlights `foo^Bar` instead of `fo^o^Bar` (the `o` is not highlighted).

the fix is to pass `firstMatchCanBeWeak = true`, since `anyScore` is intentionally trying to match anywhere in the word.